### PR TITLE
[SIL] Add source formal type to checked_cast_br.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
@@ -36,13 +36,13 @@ private extension UnaryInstruction {
   /// ```
   ///   %2 = upcast %1 : $Derived to $Base
   ///   %3 = init_existential_ref %2 : $Base : $Base, $AnyObject
-  ///   checked_cast_br %3 : $AnyObject to Derived, bb1, bb2
+  ///   checked_cast_br AnyObject in %3 : $AnyObject to Derived, bb1, bb2
   /// ```
   ///
   /// This makes it more likely that the cast can be constant folded because the source
   /// operand's type is more accurate. In the example above, the cast reduces to
   /// ```
-  ///   checked_cast_br %1 : $Derived to Derived, bb1, bb2
+  ///   checked_cast_br Derived in %1 : $Derived to Derived, bb1, bb2
   /// ```
   /// which can be trivially folded to always-succeeds.
   ///
@@ -97,13 +97,13 @@ private extension UnaryInstruction {
 /// For example:
 /// ```
 ///   %inst = upcast %sourceValue : $Derived to $Base
-///   checked_cast_br %inst : $Base to Derived, success_block, failure_block
+///   checked_cast_br Base in %inst : $Base to Derived, success_block, failure_block
 ///   ...
 /// failure_block(%oldArg : $Base):
 /// ```
 /// is converted to:
 /// ```
-///   checked_cast_br %sourceValue : $Derived to Derived, success_block, failure_block
+///   checked_cast_br Derived in %sourceValue : $Derived to Derived, success_block, failure_block
 ///   ...
 /// failure_block(%newArg : $Derived):
 ///   %3 = upcast %newArg : $Derived to $Base

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2082,7 +2082,7 @@ derived from the ARC object. As an example, consider the following Swift/SIL::
 
     // Consume '%1'. This means '%1' can no longer be used after this point. We
     // rebind '%1' in the destination blocks (bbYes, bbNo).
-    checked_cast_br %1 : $Klass to $OtherKlass, bbYes, bbNo
+    checked_cast_br Klass in %1 : $Klass to $OtherKlass, bbYes, bbNo
 
   bbYes(%2 : @owned $OtherKlass): // On success, the checked_cast_br forwards
                                   // '%1' into '%2' after casting to OtherKlass.
@@ -8097,9 +8097,9 @@ checked_cast_br
                       sil-identifier ',' sil-identifier
   sil-checked-cast-exact ::= '[' 'exact' ']'
 
-  checked_cast_br %0 : $A to $B, bb1, bb2
-  checked_cast_br %0 : $*A to $*B, bb1, bb2
-  checked_cast_br [exact] %0 : $A to $A, bb1, bb2
+  checked_cast_br A in %0 : $A to $B, bb1, bb2
+  checked_cast_br *A in %0 : $*A to $*B, bb1, bb2
+  checked_cast_br [exact] A in %0 : $A to $A, bb1, bb2
   // $A and $B must be both object types or both address types
   // bb1 must take a single argument of type $B or $*B
   // bb2 must take no arguments

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2575,17 +2575,18 @@ public:
   }
 
   CheckedCastBranchInst *
-  createCheckedCastBranch(SILLocation Loc, bool isExact, SILValue op,
-                          SILType destLoweredTy, CanType destFormalTy,
-                          SILBasicBlock *successBB,
+  createCheckedCastBranch(SILLocation Loc, bool isExact, SILValue op, 
+                          CanType srcFormalTy, SILType destLoweredTy, 
+                          CanType destFormalTy, SILBasicBlock *successBB,
                           SILBasicBlock *failureBB,
                           ProfileCounter Target1Count = ProfileCounter(),
                           ProfileCounter Target2Count = ProfileCounter());
 
   CheckedCastBranchInst *
-  createCheckedCastBranch(SILLocation Loc, bool isExact, SILValue op,
-                          SILType destLoweredTy, CanType destFormalTy,
-                          SILBasicBlock *successBB, SILBasicBlock *failureBB,
+  createCheckedCastBranch(SILLocation Loc, bool isExact, SILValue op, 
+                          CanType srcFormalTy, SILType destLoweredTy, 
+                          CanType destFormalTy, SILBasicBlock *successBB, 
+                          SILBasicBlock *failureBB,
                           ValueOwnershipKind forwardingOwnershipKind,
                           ProfileCounter Target1Count = ProfileCounter(),
                           ProfileCounter Target2Count = ProfileCounter());

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -3128,6 +3128,7 @@ SILCloner<ImplClass>::visitCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
       Inst, getBuilder().createCheckedCastBranch(
                 getOpLocation(Inst->getLoc()), Inst->isExact(),
                 getOpValue(Inst->getOperand()),
+                getOpASTType(Inst->getSourceFormalType()),
                 getOpType(Inst->getTargetLoweredType()),
                 getOpASTType(Inst->getTargetFormalType()), OpSuccBB, OpFailBB,
                 Inst->getForwardingOwnershipKind(), TrueCount, FalseCount));

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -10024,12 +10024,13 @@ class CheckedCastBranchInst final
           CastBranchInstBase<OwnershipForwardingTermInst>> {
   friend SILBuilder;
 
+  CanType SrcFormalTy;
   SILType DestLoweredTy;
   CanType DestFormalTy;
   bool IsExact;
 
   CheckedCastBranchInst(SILDebugLocation DebugLoc, bool IsExact,
-                        SILValue Operand,
+                        SILValue Operand, CanType SrcFormalTy,
                         ArrayRef<SILValue> TypeDependentOperands,
                         SILType DestLoweredTy, CanType DestFormalTy,
                         SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB,
@@ -10041,13 +10042,13 @@ class CheckedCastBranchInst final
             DebugLoc, Operand, TypeDependentOperands, SuccessBB, FailureBB,
             Target1Count, Target2Count, forwardingOwnershipKind,
             preservesOwnership),
-        DestLoweredTy(DestLoweredTy), DestFormalTy(DestFormalTy),
-        IsExact(IsExact) {}
+        SrcFormalTy(SrcFormalTy), DestLoweredTy(DestLoweredTy),
+        DestFormalTy(DestFormalTy), IsExact(IsExact) {}
 
   static CheckedCastBranchInst *
   create(SILDebugLocation DebugLoc, bool IsExact, SILValue Operand,
-         SILType DestLoweredTy, CanType DestFormalTy, SILBasicBlock *SuccessBB,
-         SILBasicBlock *FailureBB, SILFunction &F,
+         CanType SrcFormalTy, SILType DestLoweredTy, CanType DestFormalTy,
+         SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB, SILFunction &F,
          ProfileCounter Target1Count, ProfileCounter Target2Count,
          ValueOwnershipKind forwardingOwnershipKind);
 
@@ -10055,7 +10056,7 @@ public:
   bool isExact() const { return IsExact; }
 
   SILType getSourceLoweredType() const { return getOperand()->getType(); }
-  CanType getSourceFormalType() const { return getSourceLoweredType().getASTType(); }
+  CanType getSourceFormalType() const { return SrcFormalTy; }
 
   SILType getTargetLoweredType() const { return DestLoweredTy; }
   CanType getTargetFormalType() const { return DestFormalTy; }

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -125,7 +125,7 @@ FailableCastResult irgen::emitClassIdenticalCast(IRGenFunction &IGF,
   // of the metatype value to the subclass's static metatype instance.
   //
   // %1 = value_metatype $Super.Type, %0 : $A
-  // checked_cast_br [exact] %1 : $Super.Type to $Sub.Type
+  // checked_cast_br [exact] Super.Type in %1 : $Super.Type to $Sub.Type
   // =>
   // icmp eq %1, @metadata.Sub
   llvm::Value *objectMetadata = isMetatype ? from :

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -883,6 +883,7 @@ void irgen::emitScalarCheckedCast(IRGenFunction &IGF,
 
   bool sourceWrappedInOptional = false;
 
+  llvm::Optional<ConditionalDominanceScope> domScope;
   if (auto sourceOptObjectType = sourceLoweredType.getOptionalObjectType()) {
     // Translate the value from an enum representation to a possibly-null
     // representation.  Note that we assume that this projection is safe
@@ -912,6 +913,7 @@ void irgen::emitScalarCheckedCast(IRGenFunction &IGF,
       Builder.CreateCondBr(isNotNil, isNotNilContBB, nilMergeBB);
 
       Builder.emitBlock(isNotNilContBB);
+      domScope.emplace(IGF);
     }
   }
 

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -675,7 +675,7 @@ void SILBuilder::emitScopedBorrowOperation(SILLocation loc, SILValue original,
 /// Example:
 ///
 ///     %mt = metatype $@thick C.Type
-///     checked_cast_br %mt : $@thick C.Type to AnyObject.Type, bb1, bb2,
+///     checked_cast_br C.Type in %mt : $@thick C.Type to AnyObject.Type, bb1, bb2,
 ///                           forwarding: @owned
 ///   bb1(%arg : @owned AnyObject.Type):
 ///
@@ -717,30 +717,30 @@ SwitchEnumInst *SILBuilder::createSwitchEnum(
 }
 
 CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
-    SILLocation Loc, bool isExact, SILValue op,
-    SILType destLoweredTy, CanType destFormalTy,
-    SILBasicBlock *successBB, SILBasicBlock *failureBB,
-    ProfileCounter target1Count, ProfileCounter target2Count) {
+    SILLocation Loc, bool isExact, SILValue op, CanType srcFormalTy,
+    SILType destLoweredTy, CanType destFormalTy, SILBasicBlock *successBB,
+    SILBasicBlock *failureBB, ProfileCounter target1Count,
+    ProfileCounter target2Count) {
   auto forwardingOwnership =
       deriveForwardingOwnership(op, destLoweredTy, getFunction());
-  return createCheckedCastBranch(Loc, isExact, op, destLoweredTy, destFormalTy,
-                                 successBB, failureBB, forwardingOwnership,
-                                 target1Count, target2Count);
+  return createCheckedCastBranch(
+      Loc, isExact, op, srcFormalTy, destLoweredTy, destFormalTy, successBB,
+      failureBB, forwardingOwnership, target1Count, target2Count);
 }
 
 CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
-    SILLocation Loc, bool isExact, SILValue op, SILType destLoweredTy,
-    CanType destFormalTy, SILBasicBlock *successBB, SILBasicBlock *failureBB,
-    ValueOwnershipKind forwardingOwnershipKind, ProfileCounter target1Count,
-    ProfileCounter target2Count) {
+    SILLocation Loc, bool isExact, SILValue op, CanType srcFormalTy,
+    SILType destLoweredTy, CanType destFormalTy, SILBasicBlock *successBB,
+    SILBasicBlock *failureBB, ValueOwnershipKind forwardingOwnershipKind,
+    ProfileCounter target1Count, ProfileCounter target2Count) {
   assert((!hasOwnership() || !failureBB->getNumArguments() ||
           failureBB->getArgument(0)->getType() == op->getType()) &&
          "failureBB's argument doesn't match incoming argument type");
 
   return insertTerminator(CheckedCastBranchInst::create(
-      getSILDebugLocation(Loc), isExact, op, destLoweredTy, destFormalTy,
-      successBB, failureBB, getFunction(), target1Count, target2Count,
-      forwardingOwnershipKind));
+      getSILDebugLocation(Loc), isExact, op, srcFormalTy, destLoweredTy,
+      destFormalTy, successBB, failureBB, getFunction(), target1Count,
+      target2Count, forwardingOwnershipKind));
 }
 
 void SILBuilderWithScope::insertAfter(SILInstruction *inst,

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2551,8 +2551,8 @@ UnconditionalCheckedCastInst *UnconditionalCheckedCastInst::create(
 
 CheckedCastBranchInst *CheckedCastBranchInst::create(
     SILDebugLocation DebugLoc, bool IsExact, SILValue Operand,
-    SILType DestLoweredTy, CanType DestFormalTy, SILBasicBlock *SuccessBB,
-    SILBasicBlock *FailureBB, SILFunction &F,
+    CanType SrcFormalTy, SILType DestLoweredTy, CanType DestFormalTy,
+    SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB, SILFunction &F,
     ProfileCounter Target1Count, ProfileCounter Target2Count,
     ValueOwnershipKind forwardingOwnershipKind) {
   SILModule &module = F.getModule();
@@ -2561,12 +2561,12 @@ CheckedCastBranchInst *CheckedCastBranchInst::create(
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, F, DestFormalTy);
   unsigned size =
-      totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
+      totalSizeToAlloc<swift::Operand>(3 + TypeDependentOperands.size());
   void *Buffer = module.allocateInst(size, alignof(CheckedCastBranchInst));
   return ::new (Buffer) CheckedCastBranchInst(
-      DebugLoc, IsExact, Operand, TypeDependentOperands, DestLoweredTy,
-      DestFormalTy, SuccessBB, FailureBB, Target1Count, Target2Count,
-      forwardingOwnershipKind, preservesOwnership);
+      DebugLoc, IsExact, Operand, SrcFormalTy, TypeDependentOperands,
+      DestLoweredTy, DestFormalTy, SuccessBB, FailureBB, Target1Count,
+      Target2Count, forwardingOwnershipKind, preservesOwnership);
 }
 
 MetatypeInst *MetatypeInst::create(SILDebugLocation Loc, SILType Ty,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1914,6 +1914,7 @@ public:
   void visitCheckedCastBranchInst(CheckedCastBranchInst *CI) {
     if (CI->isExact())
       *this << "[exact] ";
+    *this << CI->getSourceFormalType() << " in ";
     *this << getIDAndType(CI->getOperand()) << " to " << CI->getTargetFormalType()
           << ", " << Ctx.getID(CI->getSuccessBB()) << ", "
           << Ctx.getID(CI->getFailureBB());

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -4489,6 +4489,9 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         parseSILOptional(isExact, *this, "exact"))
       return true;
 
+    if (parseASTType(SourceType) || parseVerbatim("in"))
+      return true;
+
     if (parseTypedValueRef(Val, B) || parseVerbatim("to") ||
         parseASTType(TargetType) || parseConditionalBranchDestinations())
       return true;
@@ -4501,8 +4504,9 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
 
     auto opaque = Lowering::AbstractionPattern::getOpaque();
     ResultVal = B.createCheckedCastBranch(
-        InstLoc, isExact, Val, F->getLoweredType(opaque, TargetType),
-        TargetType, getBBForReference(SuccessBBName, SuccessBBLoc),
+        InstLoc, isExact, Val, SourceType,
+        F->getLoweredType(opaque, TargetType), TargetType,
+        getBBForReference(SuccessBBName, SuccessBBLoc),
         getBBForReference(FailureBBName, FailureBBLoc), forwardingOwnership);
     break;
   }

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -1417,8 +1417,8 @@ void swift::emitIndirectConditionalCastWithScalar(
   })();
 
   auto *ccb = B.createCheckedCastBranch(
-      loc, /*exact*/ false, srcValue, targetLoweredType, targetFormalType,
-      scalarSuccBB, scalarFailBB, TrueCount, FalseCount);
+      loc, /*exact*/ false, srcValue, sourceFormalType, targetLoweredType,
+      targetFormalType, scalarSuccBB, scalarFailBB, TrueCount, FalseCount);
 
   // Emit the success block.
   B.setInsertionPoint(scalarSuccBB); {

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -600,6 +600,7 @@ ManagedValue SILGenBuilder::createUnconditionalCheckedCast(
 
 void SILGenBuilder::createCheckedCastBranch(SILLocation loc, bool isExact,
                                             ManagedValue op,
+                                            CanType sourceFormalTy,
                                             SILType destLoweredTy,
                                             CanType destFormalTy,
                                             SILBasicBlock *trueBlock,
@@ -611,9 +612,8 @@ void SILGenBuilder::createCheckedCastBranch(SILLocation loc, bool isExact,
                                          destFormalTy)) {
     op = op.ensurePlusOne(SGF, loc);
   }
-  createCheckedCastBranch(loc, isExact, op.forward(SGF),
-                          destLoweredTy, destFormalTy,
-                          trueBlock, falseBlock,
+  createCheckedCastBranch(loc, isExact, op.forward(SGF), sourceFormalTy,
+                          destLoweredTy, destFormalTy, trueBlock, falseBlock,
                           Target1Count, Target2Count);
 }
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -289,6 +289,7 @@ public:
   using SILBuilder::createCheckedCastBranch;
   void createCheckedCastBranch(SILLocation loc, bool isExact,
                                ManagedValue op,
+                               CanType sourceFormalTy,
                                SILType destLoweredTy,
                                CanType destFormalTy,
                                SILBasicBlock *trueBlock,

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -150,8 +150,9 @@ namespace {
           operandValue = operandValue.borrow(SGF, Loc);
         }
         SGF.B.createCheckedCastBranch(Loc, /*exact*/ false, operandValue,
-                                      origTargetTL.getLoweredType(), TargetType,
-                                      trueBB, falseBB, TrueCount, FalseCount);
+                                      SourceType, origTargetTL.getLoweredType(),
+                                      TargetType, trueBB, falseBB, TrueCount,
+                                      FalseCount);
       }
 
       // Emit the success block.

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -370,6 +370,7 @@ public:
     // Create a new `checked_cast_branch` instruction.
     getBuilder().createCheckedCastBranch(
         ccbi->getLoc(), ccbi->isExact(), getOpValue(ccbi->getOperand()),
+        getOpASTType(ccbi->getSourceFormalType()),
         getOpType(ccbi->getTargetLoweredType()),
         getOpASTType(ccbi->getTargetFormalType()),
         createTrampolineBasicBlock(ccbi, pbTupleVal, ccbi->getSuccessBB()),

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -956,7 +956,7 @@ enum OperandRelation {
 ///
 /// bb1:
 ///  %3 = unchecked_enum_data %0 : $Optional<X>, #Optional.Some!enumelt
-///  checked_cast_br [exact] %3 : $X to $X, bb4, bb5 // id: %4
+///  checked_cast_br [exact] X in %3 : $X to $X, bb4, bb5 // id: %4
 ///
 /// bb4(%10 : $X):                                    // Preds: bb1
 ///  strong_release %10 : $X

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -162,7 +162,8 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   // class instance is identical to the SILType.
 
   CCBI = Builder.createCheckedCastBranch(AI.getLoc(), /*exact*/ true,
-                                      CMI->getOperand(),
+                                      CMI->getOperand(), 
+                                      CMI->getOperand()->getType().getASTType(),
                                       SILType::getPrimitiveObjectType(SubType),
                                       SubType, Iden, Virt);
   It = CCBI->getIterator();

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -142,7 +142,9 @@ convertObjectToLoadableBridgeableType(SILBuilderWithScope &builder,
 
   // Ok, we need to perform the full cast optimization. This means that we are
   // going to replace the cast terminator in inst_block with a checked_cast_br.
-  auto *ccbi = builder.createCheckedCastBranch(loc, false, load, silBridgedTy,
+  auto *ccbi = builder.createCheckedCastBranch(loc, false, load, 
+                                               dynamicCast.getBridgedSourceType(), 
+                                               silBridgedTy,
                                                dynamicCast.getBridgedTargetType(),
                                                castSuccessBB, castFailBB);
   splitEdge(ccbi, /* EdgeIdx to CastFailBB */ 1);
@@ -538,6 +540,7 @@ static SILValue computeFinalCastedValue(SILBuilderWithScope &builder,
   auto loc = dynamicCast.getLocation();
   auto convTy = newAI->getType();
   bool isConditional = dynamicCast.isConditional();
+  auto sourceFormalTy = dynamicCast.getSourceFormalType();
   auto destLoweredTy = dynamicCast.getTargetLoweredType().getObjectType();
   auto destFormalTy = dynamicCast.getTargetFormalType();
   assert(destLoweredTy == dynamicCast.getLoweredBridgedTargetObjectType() &&
@@ -581,7 +584,7 @@ static SILValue computeFinalCastedValue(SILBuilderWithScope &builder,
         newAI->getFunction()->createBasicBlockAfter(newAI->getParent());
     condBrSuccessBB->createPhiArgument(destLoweredTy, OwnershipKind::Owned);
     builder.createCheckedCastBranch(loc, /* isExact*/ false, newAI,
-                                    destLoweredTy, destFormalTy,
+                                    sourceFormalTy, destLoweredTy, destFormalTy,
                                     condBrSuccessBB, failureBB);
     builder.setInsertionPoint(condBrSuccessBB, condBrSuccessBB->begin());
     return condBrSuccessBB->getArgument(0);
@@ -1151,6 +1154,7 @@ SILInstruction *CastOptimizer::optimizeCheckedCastAddrBranchInst(
           SILBuilderWithScope B(Inst, builderContext);
           auto NewI = B.createCheckedCastBranch(
               Loc, false /*isExact*/, MI,
+              Inst->getSourceFormalType(),
               Inst->getTargetLoweredType().getObjectType(),
               Inst->getTargetFormalType(),
               SuccessBB, FailureBB, Inst->getTrueBBCount(),
@@ -1193,6 +1197,9 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
     }
     return B.createCheckedCastBranch(
         dynamicCast.getLocation(), false /*isExact*/, mi,
+        // The cast is now from the the MetatypeInst, so get the source formal
+        // type from it.
+        mi->getType().getASTType(),
         dynamicCast.getTargetLoweredType(),
         dynamicCast.getTargetFormalType(),
         dynamicCast.getSuccessBlock(),

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2868,19 +2868,20 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // Format: the cast kind, a typed value, a BasicBlock ID for success,
     // a BasicBlock ID for failure. Uses SILOneTypeValuesLayout.
     bool isExact = ListOfValues[0] != 0;
-    SILType opTy = getSILType(MF->getType(ListOfValues[2]),
-                              (SILValueCategory)ListOfValues[3], Fn);
-    SILValue op = getLocalValue(ListOfValues[1], opTy);
+    CanType sourceFormalType = MF->getType(ListOfValues[1])->getCanonicalType();
+    SILType opTy = getSILType(MF->getType(ListOfValues[3]),
+                              (SILValueCategory)ListOfValues[4], Fn);
+    SILValue op = getLocalValue(ListOfValues[2], opTy);
     SILType targetLoweredType =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
-    CanType targetFormalType =
-        MF->getType(ListOfValues[4])->getCanonicalType();
-    auto *successBB = getBBForReference(Fn, ListOfValues[5]);
-    auto *failureBB = getBBForReference(Fn, ListOfValues[6]);
+    CanType targetFormalType = MF->getType(ListOfValues[5])->getCanonicalType();
+    auto *successBB = getBBForReference(Fn, ListOfValues[6]);
+    auto *failureBB = getBBForReference(Fn, ListOfValues[7]);
 
     ResultInst =
-        Builder.createCheckedCastBranch(Loc, isExact, op, targetLoweredType,
-                                        targetFormalType, successBB, failureBB,
+        Builder.createCheckedCastBranch(Loc, isExact, op, sourceFormalType, 
+                                        targetLoweredType, targetFormalType, 
+                                        successBB, failureBB,
                                         forwardingOwnership);
     break;
   }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 796; // SILFunctionType.IsUnimplemntable
+const uint16_t SWIFTMODULE_VERSION_MINOR = 797; // checked_cast_br takes a formal type
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2442,6 +2442,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const CheckedCastBranchInst *CBI = cast<CheckedCastBranchInst>(&SI);
     ValueID listOfValues[] = {
       CBI->isExact(),
+      S.addTypeRef(CBI->getSourceFormalType()),
       addValueRef(CBI->getOperand()),
       S.addTypeRef(CBI->getSourceLoweredType().getRawASTType()),
       (unsigned)CBI->getSourceLoweredType().getCategory(),

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -162,7 +162,7 @@ func checked_cast_branch(_ x: Float) -> Float {
 // CHECK: [ACTIVE]   %23 = apply %22(%0, %0, %21) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
 
 // CHECK-LABEL: sil hidden [ossa] @${{.*}}checked_cast_branch{{.*}} : $@convention(thin) (Float) -> Float {
-// CHECK:   checked_cast_br %3 : $@thick Int.Type to any Any.Type, bb1, bb2
+// CHECK:   checked_cast_br Int.Type in %3 : $@thick Int.Type to any Any.Type, bb1, bb2
 // CHECK: }
 
 @differentiable(reverse)

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -128,7 +128,7 @@ entry(%a : $@thick Any.Type):
 // CHECK:         ret { ptr, ptr } zeroinitializer
 sil @c_cast_to_class_existential : $@convention(thin) (@owned AnyObject) -> @owned CP {
 entry(%a : $AnyObject):
-  checked_cast_br %a : $AnyObject to CP, yea, nay
+  checked_cast_br AnyObject in %a : $AnyObject to CP, yea, nay
 yea(%p : $CP):
   return %p : $CP
 nay:
@@ -139,7 +139,7 @@ nay:
 // CHECK:         call { ptr, ptr } @dynamic_cast_existential_1_conditional(ptr %0, ptr %0, {{.*}} @"$s5casts2CPMp"
 sil @c_cast_to_existential_metatype : $@convention(thin) (@owned @thick Any.Type) -> @owned @thick CP.Type {
 entry(%a : $@thick Any.Type):
-  checked_cast_br %a : $@thick Any.Type to @thick CP.Type, yea, nay
+  checked_cast_br Any.Type in %a : $@thick Any.Type to @thick CP.Type, yea, nay
 yea(%p : $@thick CP.Type):
   return %p : $@thick CP.Type
 nay:
@@ -162,7 +162,7 @@ nay:
 // CHECK:         ret { ptr, ptr, ptr } zeroinitializer
 sil @c_cast_to_class_existential_2 : $@convention(thin) (@owned AnyObject) -> @owned CP & CP2 {
 entry(%a : $AnyObject):
-  checked_cast_br %a : $AnyObject to CP & CP2, yea, nay
+  checked_cast_br AnyObject in %a : $AnyObject to CP & CP2, yea, nay
 yea(%p : $CP & CP2):
   return %p : $CP & CP2
 nay:
@@ -180,7 +180,7 @@ nay:
 // CHECK:         phi ptr [ [[CAST:%.*]], %success ], [ null, %entry ]
 sil @c_cast_to_class_existential_mixed : $@convention(thin) (@owned AnyObject) -> @owned CP & OP & CP2 {
 entry(%a : $AnyObject):
-  checked_cast_br %a : $AnyObject to CP & OP & CP2, yea, nay
+  checked_cast_br AnyObject in %a : $AnyObject to CP & OP & CP2, yea, nay
 yea(%p : $CP & OP & CP2):
   return %p : $CP & OP & CP2
 nay:
@@ -195,7 +195,7 @@ nay:
 // CHECK:         call { ptr, ptr, ptr } @dynamic_cast_existential_2_conditional(ptr {{.*}}, ptr %0, {{.*}} @"$s5casts2CPMp"{{[^,]*}}, {{.*}} @"$s5casts3CP2Mp"
 sil @c_cast_to_existential_metatype_mixed : $@convention(thin) (@owned @thick Any.Type) -> @owned @thick (CP & OP & CP2).Type {
 entry(%a : $@thick Any.Type):
-  checked_cast_br %a : $@thick Any.Type to @thick (CP & OP & CP2).Type, yea, nay
+  checked_cast_br Any.Type in %a : $@thick Any.Type to @thick (CP & OP & CP2).Type, yea, nay
 yea(%p : $@thick (CP & OP & CP2).Type):
   return %p : $@thick (CP & OP & CP2).Type
 nay:
@@ -208,7 +208,7 @@ nay:
 // CHECK:         phi ptr
 sil @checked_upcast : $@convention(thin) (@owned A) -> @owned AnyObject {
 entry(%a : $A):
-  checked_cast_br %a : $A to AnyObject, yea, nay
+  checked_cast_br A in %a : $A to AnyObject, yea, nay
 yea(%o : $AnyObject):
   return %o : $AnyObject
 nay:
@@ -224,7 +224,7 @@ nay:
 // CHECK:         br i1 [[COND]]
 sil @checked_downcast_optional : $@convention(thin) (Optional<A>) -> @owned A {
 entry(%a : $Optional<A>):
-  checked_cast_br %a : $Optional<A> to A, yea, nay
+  checked_cast_br Optional<A> in %a : $Optional<A> to A, yea, nay
 yea(%aa : $A):
   return %aa : $A
 nay:
@@ -240,7 +240,7 @@ nay:
 // CHECK:         br i1 [[COND]]
 sil @checked_downcast_optional_metatype : $@convention(thin) (Optional<@thick A.Type>) -> @thick B.Type {
 entry(%a : $Optional<@thick A.Type>):
-  checked_cast_br %a : $Optional<@thick A.Type> to @thick B.Type, yea, nay
+  checked_cast_br Optional<@thick A.Type> in %a : $Optional<@thick A.Type> to @thick B.Type, yea, nay
 yea(%b : $@thick B.Type):
   return %b : $@thick B.Type
 nay:
@@ -256,7 +256,7 @@ nay:
 // CHECK:         br i1 [[COND]]
 sil @checked_downcast_optional_exmetatype : $@convention(thin) (Optional<@thick CP.Type>) -> @thick B.Type {
 entry(%a : $Optional<@thick CP.Type>):
-  checked_cast_br %a : $Optional<@thick CP.Type> to @thick B.Type, yea, nay
+  checked_cast_br Optional<@thick CP.Type> in %a : $Optional<@thick CP.Type> to @thick B.Type, yea, nay
 yea(%b : $@thick B.Type):
   return %b : $@thick B.Type
 nay:
@@ -272,7 +272,7 @@ nay:
 // CHECK:    load ptr, ptr [[V1]]
 sil @checked_downcast_optional_class_to_ex : $@convention(thin) (@guaranteed Optional<A>) -> @owned Optional<CP> {
 bb0(%0 : $Optional<A>):
-  checked_cast_br %0 : $Optional<A> to CP, bb1, bb2
+  checked_cast_br Optional<A> in %0 : $Optional<A> to CP, bb1, bb2
 
 bb1(%3 : $CP):
   %4 = enum $Optional<CP>, #Optional.some!enumelt, %3 : $CP
@@ -292,20 +292,20 @@ sil @checked_metatype_to_object_casts : $@convention(thin) <T> (@thick Any.Type)
 entry(%e : $@thick Any.Type):
   %a = metatype $@thick NotClass.Type
   // CHECK: call zeroext i1 @swift_dynamicCast({{.*}})
-  checked_cast_br %a : $@thick NotClass.Type to AnyObject, a_yea, a_nay
+  checked_cast_br NotClass.Type in %a : $@thick NotClass.Type to AnyObject, a_yea, a_nay
 a_yea(%1 : $AnyObject):
   %b = metatype $@thick A.Type
-  checked_cast_br %b : $@thick A.Type to AnyObject, b_yea, b_nay
+  checked_cast_br A.Type in %b : $@thick A.Type to AnyObject, b_yea, b_nay
 b_yea(%2 : $AnyObject):
   %c = metatype $@objc_metatype A.Type
-  checked_cast_br %c : $@objc_metatype A.Type to AnyObject, c_yea, c_nay
+  checked_cast_br @objc_metatype A.Type in %c : $@objc_metatype A.Type to AnyObject, c_yea, c_nay
 c_yea(%3 : $AnyObject):
   %d = metatype $@thick T.Type
   // CHECK: call ptr @swift_dynamicCastMetatypeToObjectConditional(ptr %T)
-  checked_cast_br %d : $@thick T.Type to AnyObject, d_yea, d_nay
+  checked_cast_br T.Type in %d : $@thick T.Type to AnyObject, d_yea, d_nay
 d_yea(%4 : $AnyObject):
   // CHECK: call ptr @swift_dynamicCastMetatypeToObjectConditional(ptr %0)
-  checked_cast_br %e : $@thick Any.Type to AnyObject, e_yea, e_nay
+  checked_cast_br Any.Type in %e : $@thick Any.Type to AnyObject, e_yea, e_nay
 e_yea(%5 : $AnyObject):
   return undef : $()
 a_nay:
@@ -362,7 +362,7 @@ sil_vtable C {}
 
 sil @cast_protocol_composition_with_anyobject : $@convention(thin) (@owned P & AnyObject ) -> @owned Optional<C & P> {
 bb0(%0: $P & AnyObject):
-  checked_cast_br %0 : $P & AnyObject to C & P, bb1, bb2
+  checked_cast_br P & AnyObject in %0 : $P & AnyObject to C & P, bb1, bb2
 
 bb1(%2 : $C & P):
   %3 = enum $Optional<C & P>, #Optional.some!enumelt, %2 : $C & P
@@ -383,7 +383,7 @@ bb3(%11 : $Optional<C & P>):
 // CHECK: call { ptr, ptr } @dynamic_cast_existential_1_superclass_conditional({{.*}}, ptr [[C_META]], ptr {{.*}}@"$s5casts10PAnyObjectMp"
 sil @cast_protocol_with_anyobject : $@convention(thin) (@owned PAnyObject ) -> @owned Optional<C & PAnyObject> {
 bb0(%0: $PAnyObject):
-  checked_cast_br %0 : $PAnyObject to C & PAnyObject, bb1, bb2
+  checked_cast_br PAnyObject in %0 : $PAnyObject to C & PAnyObject, bb1, bb2
 
 bb1(%2 : $C & PAnyObject):
   %3 = enum $Optional<C & PAnyObject>, #Optional.some!enumelt, %2 : $C & PAnyObject

--- a/test/IRGen/exactcast.sil
+++ b/test/IRGen/exactcast.sil
@@ -28,7 +28,7 @@ bb0(%0 : $Node):
 //CHECK-DIRECT-NEXT:  = icmp eq ptr
 //CHECK-INDIRECT-NEXT:  = icmp eq ptr
 //CHECK-NEXT:  br i1
-  checked_cast_br [exact] %0 : $Node to ParentNode, bb2, bb3 // id: %2
+  checked_cast_br [exact] Node in %0 : $Node to ParentNode, bb2, bb3 // id: %2
 
 bb1:                                   // Preds: bb2 bb3
   return undef : $Int
@@ -64,7 +64,7 @@ bb0(%0 : $BaseBase):
 //CHECK: load
 //CHECK: icmp eq ptr
 //CHECK: br
-  checked_cast_br [exact] %0 : $BaseBase to DerivedInt, bb2, bb3 // id: %2
+  checked_cast_br [exact] BaseBase in %0 : $BaseBase to DerivedInt, bb2, bb3 // id: %2
 
 bb1:
   return undef : $Int

--- a/test/IRGen/exactcast2.sil
+++ b/test/IRGen/exactcast2.sil
@@ -27,7 +27,7 @@ sil @_TFC4main4HashCfMS0_FT_S0_ : $@convention(thin) (@thick Hash.Type) -> @owne
 sil @_TFC4main4Hash6updatefS0_FT_T_ : $@convention(method) (@guaranteed Hash) -> () {
 bb0(%0 : $Hash):
   %1 = class_method %0 : $Hash, #Hash.hash : (Hash) -> () -> (), $@convention(method) (@guaranteed Hash) -> () // user: %9
-  checked_cast_br [exact] %0 : $Hash to MD5, bb2, bb3 // id: %2
+  checked_cast_br [exact] Hash in %0 : $Hash to MD5, bb2, bb3 // id: %2
 
 bb1:                                              // Preds: bb2 bb3
   %3 = tuple ()                                   // user: %4

--- a/test/IRGen/metatype_casts.sil
+++ b/test/IRGen/metatype_casts.sil
@@ -12,7 +12,7 @@ import Swift
 sil @archetype_metatype_cast : $@convention(thin) <T, U> () -> () {
 entry:
   %0 = metatype $@thick T.Type
-  checked_cast_br %0 : $@thick T.Type to @thick U.Type, yes, no
+  checked_cast_br T.Type in %0 : $@thick T.Type to @thick U.Type, yes, no
 yes(%1 : $@thick U.Type):
   br end
 
@@ -30,7 +30,7 @@ protocol P {}
 // CHECK:         [[T1:%.*]] = icmp ne ptr [[T0]], null
 sil @existential_archetype_metatype_cast : $@convention(thin) <T> (@thick P.Type) -> () {
 entry(%0 : $@thick P.Type):
-  checked_cast_br %0 : $@thick P.Type to @thick T.Type, yes, no
+  checked_cast_br P.Type in %0 : $@thick P.Type to @thick T.Type, yes, no
 yes(%1 : $@thick T.Type):
   br end
 
@@ -74,7 +74,7 @@ sil_vtable OtherClass {}
 sil @value_metatype_cast : $@convention(thin) (SomeClass) -> () {
 entry(%0 : $SomeClass):
   %1 = value_metatype $@thick SomeClass.Type, %0 : $SomeClass
-  checked_cast_br [exact] %1 : $@thick SomeClass.Type to @thick OtherClass.Type, yes, no
+  checked_cast_br [exact] @thick SomeClass.Type in %1 : $@thick SomeClass.Type to @thick OtherClass.Type, yes, no
 
 yes(%2 : $@thick OtherClass.Type):
   br end

--- a/test/Profiler/pgo_checked_cast.swift
+++ b/test/Profiler/pgo_checked_cast.swift
@@ -42,10 +42,10 @@ public class D : C {}
 // IR-LABEL: define swiftcc i32 @$s6pgo_checked_cast6guess1s5Int32VAD1x_tF
 // IR-OPT-LABEL: define swiftcc i32 @$s6pgo_checked_cast6guess1s5Int32VAD1x_tF
 public func check2(_ a : B) -> Int32 {
-  // SIL: checked_cast_br %0 : $B to D, {{.*}}, {{.*}} !true_count(5000)
-  // SIL: checked_cast_br %0 : $B to C, {{.*}}, {{.*}} !true_count(2)
-  // SIL-OPT: checked_cast_br %0 : $B to D, {{.*}}, {{.*}} !true_count(5000)
-  // SIL-OPT: checked_cast_br %0 : $B to C, {{.*}}, {{.*}} !true_count(2)
+  // SIL: checked_cast_br B in %0 : $B to D, {{.*}}, {{.*}} !true_count(5000)
+  // SIL: checked_cast_br B in %0 : $B to C, {{.*}}, {{.*}} !true_count(2)
+  // SIL-OPT: checked_cast_br B in %0 : $B to D, {{.*}}, {{.*}} !true_count(5000)
+  // SIL-OPT: checked_cast_br B in %0 : $B to C, {{.*}}, {{.*}} !true_count(2)
   switch a {
     case is D:
       return 42

--- a/test/SIL/OwnershipVerifier/borrow_validate.sil
+++ b/test/SIL/OwnershipVerifier/borrow_validate.sil
@@ -691,7 +691,7 @@ bb2:
 // CHECK-NOT: Function: 'test_borrow_checked_cast_switch_enum_control_flow'
 sil [ossa] @test_borrow_checked_cast_switch_enum_control_flow : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  checked_cast_br %0 : $Klass to SuperKlass, bb1, bb2
+  checked_cast_br Klass in %0 : $Klass to SuperKlass, bb1, bb2
 
 bb1(%1 : @owned $SuperKlass):
   destroy_value %1 : $SuperKlass
@@ -721,7 +721,7 @@ bb3(%borrow : @guaranteed $FakeOptional<Klass>, %mKlass : @owned $FakeOptional<K
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'test_borrow_checked_cast_switch_enum_control_flow_incorrect'
 sil [ossa] @test_borrow_checked_cast_switch_enum_control_flow_incorrect : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  checked_cast_br %0 : $Klass to SuperKlass, bb1, bb2
+  checked_cast_br Klass in %0 : $Klass to SuperKlass, bb1, bb2
 
 bb1(%1 : @owned $SuperKlass):
   destroy_value %1 : $SuperKlass

--- a/test/SIL/OwnershipVerifier/over_consume.sil
+++ b/test/SIL/OwnershipVerifier/over_consume.sil
@@ -227,7 +227,7 @@ bb3:
 sil [ossa] @checked_cast_br_guaranteed_arg_outlives_original_value : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
-  checked_cast_br %1 : $Builtin.NativeObject to SuperKlass, bb1, bb2
+  checked_cast_br Builtin.NativeObject in %1 : $Builtin.NativeObject to SuperKlass, bb1, bb2
 
 bb1(%2 : @guaranteed $SuperKlass):
   end_borrow %1 : $Builtin.NativeObject

--- a/test/SIL/OwnershipVerifier/use_verifier.sil
+++ b/test/SIL/OwnershipVerifier/use_verifier.sil
@@ -742,7 +742,7 @@ bb51:
 // We check first for objects, then for metatypes, then for guaranteed values
 sil [ossa] @checked_cast_br_test : $@convention(thin) (@owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject, %6 : @guaranteed $Builtin.NativeObject):
-  checked_cast_br %0 : $Builtin.NativeObject to SuperKlass, bb1, bb2
+  checked_cast_br Builtin.NativeObject in %0 : $Builtin.NativeObject to SuperKlass, bb1, bb2
 
 bb1(%1 : @owned $SuperKlass):
   destroy_value %1 : $SuperKlass
@@ -754,7 +754,7 @@ bb2(%2 : @owned $Builtin.NativeObject):
 
 bb3:
   %3 = metatype $@thick SuperKlass.Type
-  checked_cast_br %3 : $@thick SuperKlass.Type to @thick SubKlass.Type, bb4, bb5
+  checked_cast_br SuperKlass.Type in %3 : $@thick SuperKlass.Type to @thick SubKlass.Type, bb4, bb5
 
 bb4(%4 : $@thick SubKlass.Type):
   br bb6
@@ -763,7 +763,7 @@ bb5(%5 : $@thick SuperKlass.Type):
   br bb6
 
 bb6:
-  checked_cast_br %6 : $Builtin.NativeObject to SuperKlass, bb7, bb8
+  checked_cast_br Builtin.NativeObject in %6 : $Builtin.NativeObject to SuperKlass, bb7, bb8
 
 bb7(%7 : @guaranteed $SuperKlass):
   br bb9
@@ -1048,7 +1048,7 @@ bb0:
 sil [ossa] @transforming_terminator_undef_test : $@convention(thin) () -> () {
 bb0:
   %0 = unchecked_ref_cast undef : $Builtin.NativeObject to $Builtin.NativeObject
-  checked_cast_br %0 : $Builtin.NativeObject to SuperKlass, bb1, bb2, forwarding: @owned
+  checked_cast_br Builtin.NativeObject in %0 : $Builtin.NativeObject to SuperKlass, bb1, bb2, forwarding: @owned
 
 bb1(%1 : @owned $SuperKlass):
   destroy_value %1 : $SuperKlass

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -516,7 +516,7 @@ bb0(%0 : $B):
   store %0 to %1a : $*B
   %3 = load %1a : $*B                        // CHECK: load
   strong_retain %3 : $B
-  checked_cast_br %3 : $B to E, yes, no     // CHECK: checked_cast_br
+  checked_cast_br B in %3 : $B to E, yes, no     // CHECK: checked_cast_br
 yes(%5 : $E):
   %y = integer_literal $Builtin.Int1, 1
   br isa(%y : $Builtin.Int1)

--- a/test/SIL/Parser/forwarding_ownership.sil
+++ b/test/SIL/Parser/forwarding_ownership.sil
@@ -62,7 +62,7 @@ bb3:
 sil [ossa] @checked_cast_test : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
   %trivial = unchecked_ownership_conversion %0 : $Klass, @owned to @none
-  checked_cast_br %trivial : $Klass to SubKlass, bb1, bb2, forwarding: @guaranteed
+  checked_cast_br Klass in %trivial : $Klass to SubKlass, bb1, bb2, forwarding: @guaranteed
 
 bb1(%arg1 : @guaranteed $SubKlass):
   br bb3

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -336,8 +336,8 @@ bb3:
 
 sil @checked_cast_br_test : $() -> () {
 bb0:
-  // CHECK: checked_cast_br undef : $C to C, bb1, bb2
-  checked_cast_br undef : $C to C, bb1, bb2
+  // CHECK: checked_cast_br C in undef : $C to C, bb1, bb2
+  checked_cast_br C in undef : $C to C, bb1, bb2
 bb1(%x : $C):
   br bb3
 bb2:

--- a/test/SIL/Serialization/forwarding_ownership.sil
+++ b/test/SIL/Serialization/forwarding_ownership.sil
@@ -27,7 +27,7 @@ class SubKlass : Klass {
 sil [ossa] @checked_cast_test : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
   %trivial = unchecked_ownership_conversion %0 : $Klass, @owned to @none
-  checked_cast_br %trivial : $Klass to SubKlass, bb1, bb2, forwarding: @guaranteed
+  checked_cast_br Klass in %trivial : $Klass to SubKlass, bb1, bb2, forwarding: @guaranteed
 
 bb1(%arg1 : @guaranteed $SubKlass):
   br bb3

--- a/test/SIL/Serialization/metatype_casts.sil
+++ b/test/SIL/Serialization/metatype_casts.sil
@@ -17,7 +17,7 @@ class B : A {}
 sil @test_checked_casts_of_metatypes : $@convention(thin) () -> Builtin.Int1 {
 bb0:
   %0 = metatype $@thick B.Type.Type
-  checked_cast_br %0 : $@thick B.Type.Type to @thick A.Type.Type, bb1, bb2
+  checked_cast_br B.Type.Type in %0 : $@thick B.Type.Type to @thick A.Type.Type, bb1, bb2
 
 bb1(%2 : $@thick A.Type.Type):
   %3 = integer_literal $Builtin.Int1, -1

--- a/test/SILGen/casts.swift
+++ b/test/SILGen/casts.swift
@@ -19,7 +19,7 @@ func downcast(b: B) -> D {
 func isa(b: B) -> Bool {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $B):
   // CHECK:   [[COPIED_BORROWED_ARG:%.*]] = copy_value [[ARG]]
-  // CHECK:   checked_cast_br [[COPIED_BORROWED_ARG]] : $B to D, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[COPIED_BORROWED_ARG]] : $B to D, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
   //
   // CHECK: [[YES]]([[CASTED_VALUE:%.*]] : @owned $D):
   // CHECK:   integer_literal {{.*}} -1
@@ -55,7 +55,7 @@ func downcast_archetype<T : B>(b: B) -> T {
 // CHECK-LABEL: sil hidden [ossa] @$s5casts12is_archetype{{[_0-9a-zA-Z]*}}F
 func is_archetype<T : B>(b: B, _: T) -> Bool {
   // CHECK: bb0([[ARG1:%.*]] : @guaranteed $B, [[ARG2:%.*]] : @guaranteed $T):
-  // CHECK:   checked_cast_br {{%.*}}, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+  // CHECK:   checked_cast_br {{.*}}, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
   // CHECK: [[YES]]([[CASTED_ARG:%.*]] : @owned $T):
   // CHECK:   integer_literal {{.*}} -1
   // CHECK:   destroy_value [[CASTED_ARG]]
@@ -67,7 +67,7 @@ func is_archetype<T : B>(b: B, _: T) -> Bool {
 // CHECK: } // end sil function '$s5casts12is_archetype{{[_0-9a-zA-Z]*}}F'
 
 // CHECK: sil hidden [ossa] @$s5casts20downcast_conditional{{[_0-9a-zA-Z]*}}F
-// CHECK:   checked_cast_br {{%.*}} : $B to D
+// CHECK:   checked_cast_br B in {{%.*}} : $B to D
 // CHECK:   bb{{[0-9]+}}({{.*}} : $Optional<D>)
 func downcast_conditional(b: B) -> D? {
   return b as? D

--- a/test/SILGen/dynamic_self_cast.swift
+++ b/test/SILGen/dynamic_self_cast.swift
@@ -39,7 +39,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: sil [ossa] @$s17dynamic_self_cast9SelfCastsC02toD11ConditionalyACXDSgACFZ : $@convention(method) (@guaranteed SelfCasts, @thick SelfCasts.Type) -> @owned Optional<SelfCasts> {
-  // CHECK: checked_cast_br {{.*}} : $SelfCasts to @dynamic_self SelfCasts
+  // CHECK: checked_cast_br SelfCasts in {{.*}} : $SelfCasts to @dynamic_self SelfCasts
   // CHECK: }
   public static func toSelfConditional(_ s: SelfCasts) -> Self? {
     return s as? Self
@@ -53,7 +53,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: sil [ossa] @$s17dynamic_self_cast9SelfCastsC014classGenericToD11ConditionalyACXDSgxRlzClFZ : $@convention(method) <T where T : AnyObject> (@guaranteed T, @thick SelfCasts.Type) -> @owned Optional<SelfCasts> {
-  // CHECK: checked_cast_br {{.*}} : $T to @dynamic_self SelfCasts
+  // CHECK: checked_cast_br T in {{.*}} : $T to @dynamic_self SelfCasts
   // CHECK: }
   public static func classGenericToSelfConditional<T : AnyObject>(_ s: T) -> Self? {
     return s as? Self

--- a/test/SILGen/generic_casts.swift
+++ b/test/SILGen/generic_casts.swift
@@ -115,7 +115,7 @@ func class_archetype_to_class
 func class_archetype_is_class
 <T:ClassBound>(_ t:T) -> Bool {
   return t is C
-  // CHECK: checked_cast_br {{%.*}} to C
+  // CHECK: checked_cast_br {{.*}} to C
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s13generic_casts022opaque_existential_to_C10_archetype{{[_0-9a-zA-Z]*}}F
@@ -207,13 +207,13 @@ func class_existential_to_class(_ p: ClassBound) -> C {
 // CHECK-LABEL: sil hidden [ossa] @$s13generic_casts021class_existential_is_C0{{[_0-9a-zA-Z]*}}F
 func class_existential_is_class(_ p: ClassBound) -> Bool {
   return p is C
-  // CHECK: checked_cast_br {{%.*}} to C
+  // CHECK: checked_cast_br {{.*}} to C
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s13generic_casts27optional_anyobject_to_classyAA1CCSgyXlSgF
 func optional_anyobject_to_class(_ p: AnyObject?) -> C? {
   return p as? C
-  // CHECK: checked_cast_br {{%.*}} : $AnyObject to C
+  // CHECK: checked_cast_br AnyObject in {{%.*}} : $AnyObject to C
 }
 
 // The below tests are to ensure we don't dig into an optional operand when

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -316,7 +316,7 @@ func testAsPatternInIfLet(_ a : BaseClass?) {
   // CHECK:   br [[EXITBB:bb[0-9]+]]
 
   // CHECK: [[OPTPRESENTBB]]([[CLS:%.*]] : @owned $BaseClass):
-  // CHECK:   checked_cast_br [[CLS]] : $BaseClass to DerivedClass, [[ISDERIVEDBB:bb[0-9]+]], [[ISBASEBB:bb[0-9]+]]
+  // CHECK:   checked_cast_br BaseClass in [[CLS]] : $BaseClass to DerivedClass, [[ISDERIVEDBB:bb[0-9]+]], [[ISBASEBB:bb[0-9]+]]
 
   // CHECK: [[ISDERIVEDBB]]([[DERIVED_CLS:%.*]] : @owned $DerivedClass):
   // CHECK:   [[DERIVED_CLS_SOME:%.*]] = enum $Optional<DerivedClass>, #Optional.some!enumelt, [[DERIVED_CLS]] : $DerivedClass

--- a/test/SILGen/metatype_casts.swift
+++ b/test/SILGen/metatype_casts.swift
@@ -8,16 +8,16 @@ func t_is_u<T, U>(_: T, _: U) -> Bool {
 
 // CHECK-LABEL: sil hidden [ossa] @$s14metatype_casts8int_is_t{{[_0-9a-zA-Z]*}}F
 func int_is_t<T>() -> (Bool, T.Type?, T.Type) {
-  // CHECK: checked_cast_br {{%.*}} : $@thick Int.Type to T.Type
-  // CHECK: checked_cast_br {{%.*}} : $@thick Int.Type to T.Type
+  // CHECK: checked_cast_br Int.Type in {{%.*}} : $@thick Int.Type to T.Type
+  // CHECK: checked_cast_br Int.Type in {{%.*}} : $@thick Int.Type to T.Type
   // CHECK: unconditional_checked_cast {{%.*}} : $@thick Int.Type to T.Type
   return (Int.self is T.Type, Int.self as? T.Type, Int.self as! T.Type)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s14metatype_casts8t_is_int{{[_0-9a-zA-Z]*}}F
 func t_is_int<T>(_: T) -> (Bool, Int.Type?, Int.Type) {
-  // CHECK: checked_cast_br {{%.*}} : $@thick T.Type to Int.Type
-  // CHECK: checked_cast_br {{%.*}} : $@thick T.Type to Int.Type
+  // CHECK: checked_cast_br T.Type in {{%.*}} : $@thick T.Type to Int.Type
+  // CHECK: checked_cast_br T.Type in {{%.*}} : $@thick T.Type to Int.Type
   // CHECK: unconditional_checked_cast {{%.*}} : $@thick T.Type to Int.Type
   return (T.self is Int.Type, T.self as? Int.Type, T.self as! Int.Type)
 }

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -80,7 +80,7 @@ func openExistBox(_ x: Error) -> String {
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen11condFromAnyyyypF : $@convention(thin) (@in_guaranteed Any) -> () {
 // HECK: bb0([[ARG:%.*]] : $Any):
 // HECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// HECK:   checked_cast_br [[COPY_ARG]] : $Any to $@callee_guaranteed (@in_guaranteed (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int), bb2, bb1
+// HECK:   checked_cast_br Any in [[COPY_ARG]] : $Any to $@callee_guaranteed (@in_guaranteed (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int), bb2, bb1
 // HECK: bb2([[THUNK_PARAM:%.*]] : $@callee_guaranteed (@in_guaranteed (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)):
 // HECK:   [[THUNK_REF:%.*]] = function_ref @{{.*}} : $@convention(thin) (Int, Int, Int, Int, Int, @guaranteed @callee_guaranteed (@in_guaranteed (Int, (Int, (Int, Int)), Int)) -> @out (Int, (Int, (Int, Int)), Int)) -> (Int, Int, Int, Int, Int)
 // HECK:   partial_apply [callee_guaranteed] [[THUNK_REF]]([[THUNK_PARAM]])
@@ -394,7 +394,7 @@ func testEmptyReturnClosure() {
 //
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen24testCastClassToAnyObjectyyXlAA1CCF : $@convention(thin) (@guaranteed C) -> @owned AnyObject {
 // CHECK: bb0(%0 : @guaranteed $C):
-// CHECK:   checked_cast_br %0 : $C to AnyObject, bb2, bb1
+// CHECK:   checked_cast_br C in %0 : $C to AnyObject, bb2, bb1
 // CHECK: bb1(%{{.*}} : @guaranteed $C):
 // CHECK: bb2(%{{.*}} : @guaranteed $AnyObject):
 // CHECK-LABEL: } // end sil function
@@ -409,7 +409,7 @@ func testCastClassToAnyObject(_ c: C) -> AnyObject {
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen24testCastAnyObjectToClassyAA1CCyXlF : $@convention(thin) (@guaranteed AnyObject) -> @owned C {
 // CHECK: bb0(%0 : @guaranteed $AnyObject):
 // CHECK:   [[CP:%.*]] = copy_value %0 : $AnyObject
-// CHECK:   checked_cast_br [[CP]] : $AnyObject to C, bb1, bb2
+// CHECK:   checked_cast_br AnyObject in [[CP]] : $AnyObject to C, bb1, bb2
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen24testCastAnyObjectToClassyAA1CCyXlF'
 func testCastAnyObjectToClass(_ o: AnyObject) -> C {
   switch (o) {
@@ -424,7 +424,7 @@ func testCastAnyObjectToClass(_ o: AnyObject) -> C {
 // CHECK-LABEL: sil hidden [ossa] @$s20opaque_values_silgen024testCastClassArchetypeToF0yAA1CCxRlzClF : $@convention(thin) <T where T : AnyObject> (@guaranteed T) -> @owned C {
 // CHECK: bb0(%0 : @guaranteed $T):
 // CHECK:   [[CP:%.*]] = copy_value %0 : $T
-// CHECK:   checked_cast_br [[CP]] : $T to C, bb1, bb2
+// CHECK:   checked_cast_br T in [[CP]] : $T to C, bb1, bb2
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen024testCastClassArchetypeToF0yAA1CCxRlzClF'
 func testCastClassArchetypeToClass<T : AnyObject>(_ o: T) -> C {
   switch (o) {

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -16,7 +16,7 @@ class B : A {}
 //   If so, pull the value out and check whether it's a B.
 // CHECK:    [[IS_PRESENT]]([[VAL:%.*]] :
 // CHECK-NEXT: [[X_VALUE:%.*]] = init_enum_data_addr [[PB]] : $*Optional<B>, #Optional.some
-// CHECK-NEXT: checked_cast_br [[VAL]] : $A to B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
+// CHECK-NEXT: checked_cast_br A in [[VAL]] : $A to B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
 //
 //   If so, materialize that and inject it into x.
 // CHECK:    [[IS_B]]([[T0:%.*]] : @owned $B):
@@ -79,7 +79,7 @@ func foo(_ y : A?) {
 //
 //   If so, pull out the A and check whether it's a B.
 // CHECK:    [[PPPP]]([[VAL:%.*]] :
-// CHECK-NEXT: checked_cast_br [[VAL]] : $A to B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
+// CHECK-NEXT: checked_cast_br A in [[VAL]] : $A to B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
 //
 //   If so, inject it back into an optional.
 //   TODO: We're going to switch back out of this; we really should peephole it.
@@ -146,7 +146,7 @@ func bar(_ y : A????) {
 // CHECK:         switch_enum [[ARG_COPY]]
 // CHECK:       bb1([[VAL:%.*]] : @owned $AnyObject):
 // CHECK-NEXT:    [[X_VALUE:%.*]] = init_enum_data_addr [[PB]] : $*Optional<B>, #Optional.some
-// CHECK-NEXT:    checked_cast_br [[VAL]] : $AnyObject to B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
+// CHECK-NEXT:    checked_cast_br AnyObject in [[VAL]] : $AnyObject to B, [[IS_B:bb.*]], [[NOT_B:bb[0-9]+]]
 // CHECK:       [[IS_B]]([[CASTED_VALUE:%.*]] : @owned $B):
 // CHECK:         store [[CASTED_VALUE]] to [init] [[X_VALUE]]
 // CHECK:       [[NOT_B]]([[ORIGINAL_VALUE:%.*]] : @owned $AnyObject):

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -631,7 +631,7 @@ func testCleanupEmission<T>(_ x: T) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s10statements15test_is_patternyyAA9BaseClassCF
 func test_is_pattern(_ y : BaseClass) {
-  // checked_cast_br %0 : $BaseClass to DerivedClass
+  // checked_cast_br BaseClass in %0 : $BaseClass to DerivedClass
   guard case is DerivedClass = y else { marker_1(); return }
 
   marker_2()
@@ -641,7 +641,7 @@ func test_is_pattern(_ y : BaseClass) {
 func test_as_pattern(_ y : BaseClass) -> DerivedClass {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $BaseClass):
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-  // CHECK:   checked_cast_br [[ARG_COPY]] : $BaseClass to DerivedClass
+  // CHECK:   checked_cast_br BaseClass in [[ARG_COPY]] : $BaseClass to DerivedClass
   guard case let result as DerivedClass = y else {  }
   // CHECK: bb{{.*}}({{.*}} : @owned $DerivedClass):
 

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -288,7 +288,7 @@ func downcasts(
   derivedType: Derived.Type) {
   // CHECK: bb0([[ARG0:%.*]] : @guaranteed $any Base<Int> & P, [[ARG1:%.*]] : @guaranteed $Derived, [[ARG2:%.*]] : $@thick any (Base<Int> & P).Type, [[ARG3:%.*]] : $@thick Derived.Type):
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG0]] : $any Base<Int> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<Int> & P to Derived
+  // CHECK-NEXT: checked_cast_br any Base<Int> & P in [[COPIED]] : $any Base<Int> & P to Derived
   let _ = baseAndP as? Derived
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG0]] : $any Base<Int> & P
@@ -296,26 +296,26 @@ func downcasts(
   let _ = baseAndP as! Derived
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG0]] : $any Base<Int> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<Int> & P to any Derived & R
+  // CHECK-NEXT: checked_cast_br any Base<Int> & P in [[COPIED]] : $any Base<Int> & P to any Derived & R
   let _ = baseAndP as? (Derived & R)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG0]] : $any Base<Int> & P
   // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $any Base<Int> & P to any Derived & R
   let _ = baseAndP as! (Derived & R)
 
-  // CHECK:      checked_cast_br %3 : $@thick Derived.Type to any (Derived & R).Type
+  // CHECK:      checked_cast_br Derived.Type in %3 : $@thick Derived.Type to any (Derived & R).Type
   let _ = derivedType as? (Derived & R).Type
 
   // CHECK:      unconditional_checked_cast %3 : $@thick Derived.Type to any (Derived & R).Type
   let _ = derivedType as! (Derived & R).Type
 
-  // CHECK:      checked_cast_br %2 : $@thick any (Base<Int> & P).Type to Derived.Type
+  // CHECK:      checked_cast_br any (Base<Int> & P).Type in %2 : $@thick any (Base<Int> & P).Type to Derived.Type
   let _ = baseAndPType as? Derived.Type
 
   // CHECK:      unconditional_checked_cast %2 : $@thick any (Base<Int> & P).Type to Derived.Type
   let _ = baseAndPType as! Derived.Type
 
-  // CHECK:      checked_cast_br %2 : $@thick any (Base<Int> & P).Type to any (Derived & R).Type
+  // CHECK:      checked_cast_br any (Base<Int> & P).Type in %2 : $@thick any (Base<Int> & P).Type to any (Derived & R).Type
   let _ = baseAndPType as? (Derived & R).Type
 
   // CHECK:      unconditional_checked_cast %2 : $@thick any (Base<Int> & P).Type to any (Derived & R).Type
@@ -400,7 +400,7 @@ func archetypeDowncasts<S,
   let _ = s as! (Base<Int> & P)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG5]] : $BaseTAndP
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $BaseTAndP to any Derived & R
+  // CHECK-NEXT: checked_cast_br BaseTAndP in [[COPIED]] : $BaseTAndP to any Derived & R
   let _ = baseTAndP_archetype as? (Derived & R)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG5]] : $BaseTAndP
@@ -423,7 +423,7 @@ func archetypeDowncasts<S,
   let _ = baseTAndP_concrete as! S
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG9]] : $any Base<T> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<T> & P to BaseT
+  // CHECK-NEXT: checked_cast_br any Base<T> & P in [[COPIED]] : $any Base<T> & P to BaseT
   let _ = baseTAndP_concrete as? BaseT
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG9]] : $any Base<T> & P
@@ -431,7 +431,7 @@ func archetypeDowncasts<S,
   let _ = baseTAndP_concrete as! BaseT
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG9]] : $any Base<T> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<T> & P to BaseInt
+  // CHECK-NEXT: checked_cast_br any Base<T> & P in [[COPIED]] : $any Base<T> & P to BaseInt
   let _ = baseTAndP_concrete as? BaseInt
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG9]] : $any Base<T> & P
@@ -439,7 +439,7 @@ func archetypeDowncasts<S,
   let _ = baseTAndP_concrete as! BaseInt
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG9]] : $any Base<T> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<T> & P to BaseTAndP
+  // CHECK-NEXT: checked_cast_br any Base<T> & P in [[COPIED]] : $any Base<T> & P to BaseTAndP
   let _ = baseTAndP_concrete as? BaseTAndP
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG9]] : $any Base<T> & P
@@ -447,7 +447,7 @@ func archetypeDowncasts<S,
   let _ = baseTAndP_concrete as! BaseTAndP
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG6]] : $BaseIntAndP
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $BaseIntAndP to any Derived & R
+  // CHECK-NEXT: checked_cast_br BaseIntAndP in [[COPIED]] : $BaseIntAndP to any Derived & R
   let _ = baseIntAndP_archetype as? (Derived & R)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG6]] : $BaseIntAndP
@@ -470,7 +470,7 @@ func archetypeDowncasts<S,
   let _ = baseIntAndP_concrete as! S
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<Int> & P to DerivedT
+  // CHECK-NEXT: checked_cast_br any Base<Int> & P in [[COPIED]] : $any Base<Int> & P to DerivedT
   let _ = baseIntAndP_concrete as? DerivedT
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P
@@ -478,7 +478,7 @@ func archetypeDowncasts<S,
   let _ = baseIntAndP_concrete as! DerivedT
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<Int> & P to BaseT
+  // CHECK-NEXT: checked_cast_br any Base<Int> & P in [[COPIED]] : $any Base<Int> & P to BaseT
   let _ = baseIntAndP_concrete as? BaseT
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P
@@ -486,7 +486,7 @@ func archetypeDowncasts<S,
   let _ = baseIntAndP_concrete as! BaseT
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<Int> & P to BaseInt
+  // CHECK-NEXT: checked_cast_br any Base<Int> & P in [[COPIED]] : $any Base<Int> & P to BaseInt
   let _ = baseIntAndP_concrete as? BaseInt
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P
@@ -494,7 +494,7 @@ func archetypeDowncasts<S,
   let _ = baseIntAndP_concrete as! BaseInt
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P
-  // CHECK-NEXT: checked_cast_br [[COPIED]] : $any Base<Int> & P to BaseTAndP
+  // CHECK-NEXT: checked_cast_br any Base<Int> & P in [[COPIED]] : $any Base<Int> & P to BaseTAndP
   let _ = baseIntAndP_concrete as? BaseTAndP
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -456,7 +456,7 @@ class E : C {}
 // CHECK-LABEL: sil hidden [ossa] @$s6switch16test_isa_class_11xyAA1BC_tF : $@convention(thin) (@guaranteed B) -> () {
 func test_isa_class_1(x: B) {
   // CHECK: bb0([[X:%.*]] : @guaranteed $B):
-  // CHECK:   checked_cast_br [[X]] : $B to D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[X]] : $B to D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
   switch x {
 
   // CHECK: [[IS_D1]]([[CAST_D1:%.*]] : @guaranteed $D1):
@@ -479,7 +479,7 @@ func test_isa_class_1(x: B) {
   // CHECK-NEXT:   br [[NEXT_CASE]]
 
   // CHECK: [[NEXT_CASE]]:
-  // CHECK:   checked_cast_br [[X]] : $B to D2, [[IS_D2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[X]] : $B to D2, [[IS_D2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
   case is D2:
   // CHECK: [[IS_D2]]([[CAST_D2:%.*]] : @guaranteed $D2):
   // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
@@ -489,7 +489,7 @@ func test_isa_class_1(x: B) {
     b()
 
   // CHECK: [[IS_NOT_D2]]([[CASTFAIL_D2:%.*]] : @guaranteed $B):
-  // CHECK:   checked_cast_br [[X]] : $B to E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[X]] : $B to E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
   case is E where funged():
   // CHECK: [[IS_E]]([[CAST_E:%.*]] : @guaranteed $E):
   // CHECK:   [[CAST_E_COPY:%.*]] = copy_value [[CAST_E]]
@@ -510,7 +510,7 @@ func test_isa_class_1(x: B) {
   // CHECK:   br [[NEXT_CASE]]
 
   // CHECK: [[NEXT_CASE]]:
-  // CHECK:   checked_cast_br [[X]] : $B to C, [[IS_C:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[X]] : $B to C, [[IS_C:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
 
   case is C:
   // CHECK: [[IS_C]]([[CAST_C:%.*]] : @guaranteed $C):
@@ -539,7 +539,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK: bb0([[X:%.*]] : @guaranteed $B):
   switch x {
 
-  // CHECK:   checked_cast_br [[X]] : $B to D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[X]] : $B to D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
   case let y as D1 where runced():
   // CHECK: [[IS_D1]]([[CAST_D1:%.*]] : @guaranteed $D1):
   // CHECK:   [[CAST_D1_COPY:%.*]] = copy_value [[CAST_D1]]
@@ -565,7 +565,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK:   br [[NEXT_CASE]]
 
   // CHECK: [[NEXT_CASE]]:
-  // CHECK:   checked_cast_br [[X]] : $B to D2, [[CASE2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[X]] : $B to D2, [[CASE2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
   case let y as D2:
   // CHECK: [[CASE2]]([[CAST_D2:%.*]] : @guaranteed $D2):
   // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
@@ -580,7 +580,7 @@ func test_isa_class_2(x: B) -> AnyObject {
     return y
 
   // CHECK: [[IS_NOT_D2]]([[NOCAST_D2:%.*]] : @guaranteed $B):
-  // CHECK:   checked_cast_br [[X]] : $B to E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[X]] : $B to E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
   case let y as E where funged():
   // CHECK: [[IS_E]]([[CAST_E:%.*]] : @guaranteed $E):
   // CHECK:   [[CAST_E_COPY:%.*]] = copy_value [[CAST_E]]
@@ -606,7 +606,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK:   br [[NEXT_CASE]]
 
   // CHECK: [[NEXT_CASE]]
-  // CHECK:   checked_cast_br [[X]] : $B to C, [[CASE4:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
+  // CHECK:   checked_cast_br B in [[X]] : $B to C, [[CASE4:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
   case let y as C:
   // CHECK: [[CASE4]]([[CAST_C:%.*]] : @guaranteed $C):
   // CHECK:   [[CAST_C_COPY:%.*]] = copy_value [[CAST_C]]
@@ -1346,7 +1346,7 @@ func partial_address_only_tuple_dispatch(_ name: Klass, _ value: Any?) {
 // CHECK:   [[TUP_0:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 0
 // CHECK:   [[TUP_0_VAL:%.*]] = load_borrow [[TUP_0]]
 // CHECK:   [[TUP_1:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 1
-// CHECK:   checked_cast_br [[TUP_0_VAL]] : $Klass to AnyObject, [[IS_ANYOBJECT_BB:bb[0-9]+]], [[ISNOT_ANYOBJECT_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br Klass in [[TUP_0_VAL]] : $Klass to AnyObject, [[IS_ANYOBJECT_BB:bb[0-9]+]], [[ISNOT_ANYOBJECT_BB:bb[0-9]+]]
 //
 // CHECK: [[IS_ANYOBJECT_BB]]([[ANYOBJECT:%.*]] : @guaranteed $AnyObject):
 // CHECK:   [[ANYOBJECT_COPY:%.*]] = copy_value [[ANYOBJECT]]

--- a/test/SILGen/switch_isa.swift
+++ b/test/SILGen/switch_isa.swift
@@ -57,11 +57,11 @@ func guardFn(_ l: D, _ r: D) -> Bool { return true }
 // CHECK:       [[TUP:%.*]] = tuple ([[ARG0_COPY:%.*]] : $B, [[ARG1_COPY:%.*]] : $B)
 // CHECK:       [[BORROWED_TUP:%.*]] = begin_borrow [[TUP]]
 // CHECK:       ([[TUP_1:%.*]], [[TUP_2:%.*]]) = destructure_tuple [[BORROWED_TUP]]
-// CHECK:       checked_cast_br [[TUP_1]] : $B to D, [[R_CAST_YES:bb[0-9]+]], [[R_CAST_NO:bb[0-9]+]]
+// CHECK:       checked_cast_br B in [[TUP_1]] : $B to D, [[R_CAST_YES:bb[0-9]+]], [[R_CAST_NO:bb[0-9]+]]
 //
 // CHECK:       [[R_CAST_YES]]([[R:%.*]] : @guaranteed $D):
 // CHECK:         [[R2:%.*]] = copy_value [[R]]
-// CHECK:         checked_cast_br [[TUP_2]] : $B to D, [[L_CAST_YES:bb[0-9]+]], [[L_CAST_NO:bb[0-9]+]]
+// CHECK:         checked_cast_br B in [[TUP_2]] : $B to D, [[L_CAST_YES:bb[0-9]+]], [[L_CAST_NO:bb[0-9]+]]
 //
 // CHECK:       [[L_CAST_YES]]([[L:%.*]] : @guaranteed $D):
 // CHECK:         [[L2:%.*]] = copy_value [[L]]

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -705,7 +705,7 @@ func f(_: D) -> Bool { return true }
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}test_multiple_patterns_value_semantics
 func test_multiple_patterns_value_semantics(_ y: C) {
   switch y {
-    // CHECK:   checked_cast_br {{%.*}} : $C to D, [[AS_D:bb[0-9]+]], [[NOT_AS_D:bb[0-9]+]]
+    // CHECK:   checked_cast_br C in {{%.*}} : $C to D, [[AS_D:bb[0-9]+]], [[NOT_AS_D:bb[0-9]+]]
     // CHECK: [[AS_D]]({{.*}}):
     // CHECK:   [[ORIG_BORROW:%.*]] = begin_borrow [lexical] [[ORIG:%.*]] :
     // CHECK:   cond_br {{%.*}}, [[F_TRUE:bb[0-9]+]], [[F_FALSE:bb[0-9]+]]

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2140,7 +2140,7 @@ sil [ossa] @use_T : $@convention(thin) <T> (@in T) -> ()
 // CHECK-LABEL: } // end sil function 'test_checked_cast_br1'
 sil [ossa] @test_checked_cast_br1 : $@convention(method) <T> (@in Any) -> () {
 bb0(%0 : @owned $Any):
-   checked_cast_br %0 : $Any to T, bb1, bb2
+   checked_cast_br Any in %0 : $Any to T, bb1, bb2
 
 bb1(%3 : @owned $T):
   %f = function_ref @use_T : $@convention(thin) <T> (@in T) -> ()
@@ -2178,7 +2178,7 @@ sil [ossa] @use_C : $@convention(thin) (@owned C) -> ()
 // CHECK-LABEL: }
 sil [ossa] @test_checked_cast_br2 : $@convention(method) (@in Any) -> () {
 bb0(%0 : @owned $Any):
-   checked_cast_br %0 : $Any to C, bb1, bb2
+   checked_cast_br Any in %0 : $Any to C, bb1, bb2
 
 bb1(%3 : @owned $C):
   %f = function_ref @use_C : $@convention(thin) (@owned C) -> ()
@@ -2219,7 +2219,7 @@ sil @use_Any : $@convention(thin) (@in Any) -> ()
 // CHECK: }
 sil [ossa] @test_checked_cast_br3 : $@convention(method) (@owned C) -> () {
 bb0(%0 : @owned $C):
-   checked_cast_br %0 : $C to Any, bb1, bb2
+   checked_cast_br C in %0 : $C to Any, bb1, bb2
 
 bb1(%3 : @owned $Any):
   %f = function_ref @use_Any : $@convention(thin) (@in Any) -> ()
@@ -2250,7 +2250,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_checked_cast_br4'
 sil [ossa] @test_checked_cast_br4 : $@convention(method) <Element><T> (@owned TestGeneric<Element>) -> @out Optional<T> {
 bb0(%3 : @owned $TestGeneric<Element>):
-  checked_cast_br %3 : $TestGeneric<Element> to T, bb1, bb2
+  checked_cast_br TestGeneric<Element> in %3 : $TestGeneric<Element> to T, bb1, bb2
 
 bb1(%5 : @owned $T):
   %6 = enum $Optional<T>, #Optional.some!enumelt, %5 : $T
@@ -2280,7 +2280,7 @@ bb3(%12 : @owned $Optional<T>):
 // CHECK-LABEL: } // end sil function 'test_checked_cast_br5'
 sil [ossa] @test_checked_cast_br5 : $@convention(thin) (@owned AnyObject) -> () {
 entry(%instance : @owned $AnyObject):
-  checked_cast_br %instance : $AnyObject to any AnyObject.Type, success, failure
+  checked_cast_br AnyObject in %instance : $AnyObject to any AnyObject.Type, success, failure
 
 success(%metatype : $@thick any AnyObject.Type):
   br exit
@@ -2308,7 +2308,7 @@ exit:
 // CHECK-LABEL: } // end sil function 'test_checked_cast_br6'
 sil [ossa] @test_checked_cast_br6 : $@convention(thin) <T> (@in T) -> () {
 entry(%instance : @owned $T):
-  checked_cast_br %instance : $T to any AnyObject.Type, success, failure
+  checked_cast_br T in %instance : $T to any AnyObject.Type, success, failure
 success(%metatype : $@thick any AnyObject.Type):
   br exit
 failure(%original : @owned $T):

--- a/test/SILOptimizer/bridged_casts_folding.sil
+++ b/test/SILOptimizer/bridged_casts_folding.sil
@@ -27,7 +27,7 @@ entry(%0 : $*AnyHashable):
 // CHECK-LABEL: sil {{.*}}@anyhashable_cast_take_always
 // CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
 // CHECK-NEXT:    destroy_addr %0
-// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK-NEXT:    checked_cast_br AnyHashable in [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 sil [ossa] @anyhashable_cast_take_always : $@convention(thin) (@in AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
 entry(%0 : $*AnyHashable, %1 : @owned $NSObjectSubclass):
   %2 = alloc_stack $NSObjectSubclass
@@ -50,7 +50,7 @@ bb3(%8 : @owned $NSObjectSubclass):
 // CHECK-LABEL: sil {{.*}}@anyhashable_cast_take_on_success
 // CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
 // CHECK-NEXT:    destroy_addr %0
-// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, {{bb[0-9]+}}, {{bb[0-9]+}}
+// CHECK-NEXT:    checked_cast_br AnyHashable in [[BRIDGED]] : $NSObject to NSObjectSubclass, {{bb[0-9]+}}, {{bb[0-9]+}}
 sil [ossa] @anyhashable_cast_take_on_success : $@convention(thin) (@in AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
 entry(%0 : $*AnyHashable, %1 : @owned $NSObjectSubclass):
   %2 = alloc_stack $NSObjectSubclass
@@ -75,7 +75,7 @@ bb3(%8 : @owned $NSObjectSubclass):
 // CHECK-NOT:         copy_addr
 // CHECK:    [[BRIDGED:%.*]] = apply {{.*}}(%0)
 // CHECK-NOT:    destroy_addr
-// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK-NEXT:    checked_cast_br AnyHashable in [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 // CHECK:       [[YES]]{{.*}}:
 // CHECK-NOT:    dealloc_stack
 // CHECK:       [[NO]]{{.*}}:

--- a/test/SILOptimizer/bridged_casts_folding_ownership.sil
+++ b/test/SILOptimizer/bridged_casts_folding_ownership.sil
@@ -29,7 +29,7 @@ entry(%0 : $*AnyHashable):
 // CHECK-LABEL: sil {{.*}}@anyhashable_cast_take_always
 // CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
 // CHECK-NEXT:    destroy_addr %0
-// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK-NEXT:    checked_cast_br AnyHashable in [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 sil [ossa] @anyhashable_cast_take_always : $@convention(thin) (@in AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
 entry(%0 : $*AnyHashable, %1 : @owned $NSObjectSubclass):
   %2 = alloc_stack $NSObjectSubclass
@@ -52,7 +52,7 @@ bb3(%8 : @owned $NSObjectSubclass):
 // CHECK-LABEL: sil {{.*}}@anyhashable_cast_take_on_success
 // CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
 // CHECK-NEXT:    destroy_addr %0
-// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK-NEXT:    checked_cast_br AnyHashable in [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 sil [ossa] @anyhashable_cast_take_on_success : $@convention(thin) (@in AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
 entry(%0 : $*AnyHashable, %1 : @owned $NSObjectSubclass):
   %2 = alloc_stack $NSObjectSubclass
@@ -77,7 +77,7 @@ bb3(%8 : @owned $NSObjectSubclass):
 // CHECK-NOT:         copy_addr
 // CHECK:    [[BRIDGED:%.*]] = apply {{.*}}(%0)
 // CHECK-NOT:    destroy_addr
-// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK-NEXT:    checked_cast_br AnyHashable in [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 // CHECK:       [[YES]]{{.*}}:
 // CHECK-NOT:    dealloc_stack
 // CHECK:       [[NO]]{{.*}}:

--- a/test/SILOptimizer/cast_folding_no_bridging.sil
+++ b/test/SILOptimizer/cast_folding_no_bridging.sil
@@ -49,7 +49,7 @@ bb3:
 // CHECK: return
 sil @testObjCToObjC : $@convention(thin) (NSSet, NSSet) -> @owned NSSet {
 bb0(%0 : $NSSet, %1 : $NSSet):
-  checked_cast_br %0 : $NSSet to NSSet, bb1, bb3
+  checked_cast_br NSSet in %0 : $NSSet to NSSet, bb1, bb3
 
 bb1(%2 : $NSSet):
   br bb2(%2 : $NSSet)

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -322,7 +322,7 @@ public class MyString: NSString {}
 // CHECK:   [[BRIDGED_VALUE:%.*]] = apply [[FUNC]]([[ARG]])
 // CHECK-NOT: apply
 // CHECK-NOT: unconditional_checked_cast
-// CHECK: checked_cast_br [[BRIDGED_VALUE]] : $NSString to MyString, [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
+// CHECK: checked_cast_br String in [[BRIDGED_VALUE]] : $NSString to MyString, [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
 //
 // CHECK: [[SUCC_BB]]([[CAST_BRIDGED_VALUE:%.*]] : $MyString)
 // CHECK:   [[SOME:%.*]] = enum $Optional<MyString>, #Optional.some!enumelt, [[CAST_BRIDGED_VALUE]] : $MyString

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -1480,7 +1480,7 @@ bb0:
 
 sil [ossa] @testMetatypeCast : $@convention(thin) <T> (@thick T.Type) -> Builtin.Int1 {
 bb0(%0 : $@thick T.Type):
-  checked_cast_br %0 : $@thick T.Type to Int64.Type, bb1, bb2
+  checked_cast_br T.Type in %0 : $@thick T.Type to Int64.Type, bb1, bb2
 
 bb1(%3 : $@thick Int64.Type):
   %4 = metatype $@thin Int64.Type

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -1065,7 +1065,7 @@ class BClass : AClass {}
 sil @test_checked_cast_br_thick_class_type : $@convention(thin) (@thin P.Protocol) -> Builtin.Int1 {
 bb0(%0 : $@thin P.Protocol):
   %2 = metatype $@thick BClass.Type
-  checked_cast_br %2 : $@thick BClass.Type to AClass.Type, bb1, bb2
+  checked_cast_br BClass.Type in %2 : $@thick BClass.Type to AClass.Type, bb1, bb2
 
 bb1(%5 : $@thick AClass.Type):
   debug_value %5 : $@thick AClass.Type, let, name "type"

--- a/test/SILOptimizer/constant_propagation_castopt_analysis_invalidation.sil
+++ b/test/SILOptimizer/constant_propagation_castopt_analysis_invalidation.sil
@@ -136,7 +136,7 @@ bb0:
   debug_value %0 : $Foo2                          // id: %2
   strong_retain %0 : $Foo2                        // id: %3
   %4 = upcast %0 : $Foo2 to $Foo                  // users: %5, %6, %17, %23
-  checked_cast_br %0 : $Foo2 to Foo2, bb1, bb6    // id: %6
+  checked_cast_br Foo2 in %0 : $Foo2 to Foo2, bb1, bb6    // id: %6
 
 bb1(%7 : $Foo2):                                  // Preds: bb0
   %8 = enum $Optional<Foo2>, #Optional.some!enumelt, %7 : $Foo2 // user: %9
@@ -179,7 +179,7 @@ sil private [always_inline] @_TF4mainP33_9ACC0692747077F216D14C36CD9276715speakF
 bb0(%0 : $Foo):
   debug_value %0 : $Foo                           // id: %1
   strong_retain %0 : $Foo                         // id: %2
-  checked_cast_br %0 : $Foo to Foo2, bb1, bb2    // id: %3
+  checked_cast_br Foo in %0 : $Foo to Foo2, bb1, bb2    // id: %3
 
 bb1(%4 : $Foo2):                                  // Preds: bb0
   %5 = enum $Optional<Foo2>, #Optional.some!enumelt, %4 : $Foo2 // user: %6

--- a/test/SILOptimizer/constant_propagation_casts_ossa.sil
+++ b/test/SILOptimizer/constant_propagation_casts_ossa.sil
@@ -22,7 +22,7 @@ sil [noinline] @blackhole2 : $@convention(thin) (@guaranteed NoSubKlass) -> ()
 sil [ossa] @test_guaranteed_cast_opt1 : $@convention(thin) (@owned SubKlass) -> () {
 bb0(%0 : @owned $SubKlass):
   %borrow = begin_borrow %0 : $SubKlass
-  checked_cast_br %borrow : $SubKlass to Klass, bb1, bb2
+  checked_cast_br SubKlass in %borrow : $SubKlass to Klass, bb1, bb2
 
 bb1(%val1 : @guaranteed $Klass):
   %copy = copy_value %val1: $Klass
@@ -47,7 +47,7 @@ bb3:
 sil [ossa] @test_guaranteed_cast_opt2 : $@convention(thin) (@owned SubKlass) -> () {
 bb0(%0 : @owned $SubKlass):
   %borrow = begin_borrow %0 : $SubKlass
-  checked_cast_br %borrow : $SubKlass to Klass, bb1, bb2
+  checked_cast_br SubKlass in %borrow : $SubKlass to Klass, bb1, bb2
 
 bb1(%val1 : @guaranteed $Klass):
   %copy = copy_value %val1: $Klass
@@ -74,7 +74,7 @@ bb3:
 sil [ossa] @test_guaranteed_cast_opt3 : $@convention(thin) (@owned NoSubKlass) -> () {
 bb0(%0 : @owned $NoSubKlass):
   %borrow = begin_borrow %0 : $NoSubKlass
-  checked_cast_br %borrow : $NoSubKlass to Klass, bb1, bb2
+  checked_cast_br NoSubKlass in %borrow : $NoSubKlass to Klass, bb1, bb2
 
 bb1(%val1 : @guaranteed $Klass):
   %copy = copy_value %val1: $Klass

--- a/test/SILOptimizer/constant_propagation_objc.sil
+++ b/test/SILOptimizer/constant_propagation_objc.sil
@@ -236,7 +236,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   strong_release [[LOADED_INPUT]]
@@ -303,7 +303,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
@@ -372,7 +372,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
@@ -442,7 +442,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   strong_release [[LOADED_INPUT]]
@@ -509,7 +509,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
@@ -578,7 +578,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
@@ -648,7 +648,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   strong_release [[LOADED_INPUT]]
@@ -715,7 +715,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
@@ -784,7 +784,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
@@ -854,7 +854,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   strong_release [[LOADED_INPUT]]
@@ -921,7 +921,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
@@ -990,7 +990,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]:
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]

--- a/test/SILOptimizer/constant_propagation_ownership.sil
+++ b/test/SILOptimizer/constant_propagation_ownership.sil
@@ -1096,7 +1096,7 @@ bb0(%0 : $*Error, %1 : $*E1):
 sil [ossa] @always_fail_protocolmeta_to_concretemeta_checkedcastbr : $@convention(thin) (@thin P.Protocol) -> Builtin.Int1 {
 bb0(%0 : $@thin P.Protocol):
   %2 = metatype $@thick P.Protocol
-  checked_cast_br %2 : $@thick P.Protocol to X.Type, bb1, bb2
+  checked_cast_br P.Protocol in %2 : $@thick P.Protocol to X.Type, bb1, bb2
 
 bb1(%4 : $@thick X.Type):
   %5 = metatype $@thin X.Type
@@ -1118,7 +1118,7 @@ bb3(%11 : $Builtin.Int1):
 // CHECK: } // end sil function 'always_succeed_subtoparent'
 sil [ossa] @always_succeed_subtoparent : $@convention(thin) (@owned AnSubObject) -> Builtin.Int1 {
 bb0(%0 : @owned $AnSubObject):
-  checked_cast_br %0 : $AnSubObject to AnObject, bb1, bb2
+  checked_cast_br AnSubObject in %0 : $AnSubObject to AnObject, bb1, bb2
 
 bb1(%4 : @owned $AnObject):
   %5 = metatype $@thin X.Type

--- a/test/SILOptimizer/constant_propagation_ownership_objc.sil
+++ b/test/SILOptimizer/constant_propagation_ownership_objc.sil
@@ -143,7 +143,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
@@ -210,7 +210,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
@@ -282,7 +282,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
@@ -353,7 +353,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
@@ -420,7 +420,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
@@ -492,7 +492,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
@@ -563,7 +563,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
@@ -630,7 +630,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
@@ -702,7 +702,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
@@ -773,7 +773,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
@@ -840,7 +840,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
@@ -912,7 +912,7 @@ bb4:
 //
 // CHECK: bb1:
 // CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
-// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br NSObject in [[LOADED_INPUT]] : $NSObject to NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
 // CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
 // CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]

--- a/test/SILOptimizer/devirt_covariant_return.swift
+++ b/test/SILOptimizer/devirt_covariant_return.swift
@@ -112,7 +112,7 @@ public class Bear {
   // Check that devirtualizer can handle convenience initializers, which have covariant optional
   // return types.
   // CHECK-LABEL: sil @$s23devirt_covariant_return4BearC{{[_0-9a-zA-Z]*}}fC
-  // CHECK: checked_cast_br [exact] %{{.*}} : $@thick Bear.Type to @thick GummyBear.Type
+  // CHECK: checked_cast_br [exact] @thick Bear.Type in %{{.*}} : $@thick Bear.Type to @thick GummyBear.Type
   // CHECK: upcast %{{.*}} : $Optional<GummyBear> to $Optional<Bear>
   // CHECK: }
   public convenience init?(delegateFailure: Bool, failAfter: Bool) {
@@ -235,7 +235,7 @@ public class D2: D1 {
 // that D2.foo() is inlined thanks to this.
 // CHECK-LABEL: sil hidden [noinline] @$s23devirt_covariant_return7driver2ys5Int32VAA2D2CF
 // CHECK-NOT: class_method
-// CHECK: checked_cast_br [exact] %{{.*}} : $D1 to D2
+// CHECK: checked_cast_br [exact] D1 in %{{.*}} : $D1 to D2
 // CHECK: bb2
 // CHECK: global_addr
 // CHECK: load
@@ -279,9 +279,9 @@ class EEE : CCC {
 // Check that c.foo() is devirtualized, because the optimizer can handle the casting the return type
 // correctly, i.e. it can cast (BBB, BBB) into (AAA, AAA)
 // CHECK-LABEL: sil hidden [noinline] @$s23devirt_covariant_return37testDevirtOfMethodReturningTupleTypes_1bAA2AAC_AEtAA3CCCC_AA2BBCtF
-// CHECK: checked_cast_br [exact] %{{.*}} : $CCC to CCC
-// CHECK: checked_cast_br [exact] %{{.*}} : $CCC to DDD
-// CHECK: checked_cast_br [exact] %{{.*}} : $CCC to EEE
+// CHECK: checked_cast_br [exact] CCC in %{{.*}} : $CCC to CCC
+// CHECK: checked_cast_br [exact] CCC in %{{.*}} : $CCC to DDD
+// CHECK: checked_cast_br [exact] CCC in %{{.*}} : $CCC to EEE
 // CHECK: class_method
 // CHECK: }
 @inline(never)
@@ -319,10 +319,10 @@ class DDDD : CCCC {
 // Check devirtualization of methods with optional results, where
 // optional results need to be casted.
 // CHECK-LABEL: sil [noinline] @{{.*}}testOverridingMethodWithOptionalResult
-// CHECK: checked_cast_br [exact] %{{.*}} : $F to F
-// CHECK: checked_cast_br [exact] %{{.*}} : $F to G
+// CHECK: checked_cast_br [exact] F in %{{.*}} : $F to F
+// CHECK: checked_cast_br [exact] F in %{{.*}} : $F to G
 // CHECK: switch_enum
-// CHECK: checked_cast_br [exact] %{{.*}} : $F to H
+// CHECK: checked_cast_br [exact] F in %{{.*}} : $F to H
 // CHECK: switch_enum
 @inline(never)
 public func testOverridingMethodWithOptionalResult(_ f: F) -> (F?, Int)? {

--- a/test/SILOptimizer/devirt_default_case.swift
+++ b/test/SILOptimizer/devirt_default_case.swift
@@ -171,8 +171,8 @@ func check_static_class_devirt(_ c: C6) -> Int {
 // Check that C.bar() and D.bar() are devirtualized.
 //
 // CHECK-LABEL: sil{{( hidden)?}} [noinline] @$s19devirt_default_case019check_static_class_A0ySiAA2C6CF
-// CHECK: checked_cast_br [exact] %0 : $C6 to C6
-// CHECK: checked_cast_br [exact] %0 : $C6 to D6
+// CHECK: checked_cast_br [exact] C6 in %0 : $C6 to C6
+// CHECK: checked_cast_br [exact] C6 in %0 : $C6 to D6
 // CHECK: class_method
 // CHECK: } // end sil function '$s19devirt_default_case019check_static_class_A0ySiAA2C6CF'
   return c.bar() 

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -71,10 +71,10 @@ sil @_TF18devirt_jump_thread26jumpthread_checked_cast_brFCS_8FooClassSi : $@conv
 bb0(%0 : $FooClass):
   %1 = integer_literal $Builtin.Int32, 2           // user: %2
   %2 = struct $Int32 (%1 : $Builtin.Int32)           // users: %37, %43, %48, %54
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb5, bb6 // id: %3
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb5, bb6 // id: %3
 
 bb1(%4 : $Int32):                                   // Preds: bb5 bb6
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb7, bb8 // id: %5
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb7, bb8 // id: %5
 
 bb2(%6 : $Int32):                                   // Preds: bb7 bb8
   %7 = struct_extract %4 : $Int32, #Int32._value       // user: %10
@@ -86,7 +86,7 @@ bb2(%6 : $Int32):                                   // Preds: bb7 bb8
   cond_fail %12 : $Builtin.Int1                   // id: %13
   %14 = integer_literal $Builtin.Int32, 3          // user: %15
   %15 = struct $Int32 (%14 : $Builtin.Int32)         // users: %59, %65
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb9, bb10 // id: %16
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb9, bb10 // id: %16
 
 bb3(%17 : $Int32):                                  // Preds: bb9 bb10
   %18 = struct_extract %17 : $Int32, #Int32._value     // user: %19
@@ -96,7 +96,7 @@ bb3(%17 : $Int32):                                  // Preds: bb9 bb10
   cond_fail %21 : $Builtin.Int1                   // id: %22
   %23 = integer_literal $Builtin.Int32, 4          // user: %24
   %24 = struct $Int32 (%23 : $Builtin.Int32)         // users: %69, %74
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb11, bb12 // id: %25
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb11, bb12 // id: %25
 
 bb4(%26 : $Int32):                                  // Preds: bb11 bb12
   %27 = struct_extract %26 : $Int32, #Int32._value     // user: %28
@@ -180,10 +180,10 @@ bb12:                                             // Preds: bb3
 // devirt_jump_thread.double (devirt_jump_thread.FooClass) -> Swift.Int32
 sil @_TF18devirt_jump_thread6doubleFCS_8FooClassSi : $@convention(thin) (@guaranteed FooClass) -> Int32 {
 bb0(%0 : $FooClass):
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb3, bb4 // id: %1
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb3, bb4 // id: %1
 
 bb1(%2 : $Int32):                                   // Preds: bb3 bb4
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb5, bb6 // id: %3
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb5, bb6 // id: %3
 
 bb2(%4 : $Int32):                                   // Preds: bb5 bb6
   %5 = struct_extract %2 : $Int32, #Int32._value       // user: %8
@@ -233,11 +233,11 @@ bb6:                                              // Preds: bb1
 // CHECK: }
 sil @_TF18devirt_jump_thread6dont_jump_thread_alloc_stackFCS_8FooClassSi : $@convention(thin) (@guaranteed FooClass) -> Int32 {
 bb0(%0 : $FooClass):
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb3, bb4 // id: %1
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb3, bb4 // id: %1
 
 bb1(%2 : $Int32):                                   // Preds: bb3 bb4
   %60 = alloc_stack $Int32
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb5, bb6 // id: %3
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb5, bb6 // id: %3
 
 bb2(%4 : $Int32):                                   // Preds: bb5 bb6
   %5 = struct_extract %2 : $Int32, #Int32._value       // user: %8
@@ -288,11 +288,11 @@ bb6:                                              // Preds: bb1
 sil @_TF18devirt_jump_thread6dont_jump_thread_objc_methodFCS_8FooClassSi : $@convention(thin) (@guaranteed FooClass) -> Int32 {
 bb0(%0 : $FooClass):
   %100 = alloc_ref $Bar
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb3, bb4 // id: %1
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb3, bb4 // id: %1
 
 bb1(%2 : $Int32):                                   // Preds: bb3 bb4
   %101 = objc_method %100 : $Bar, #Bar.foo!foreign : (Bar) -> () -> (), $@convention(objc_method) (Bar) -> ()
-  checked_cast_br [exact] %0 : $FooClass to FooClass, bb5, bb6 // id: %3
+  checked_cast_br [exact] FooClass in %0 : $FooClass to FooClass, bb5, bb6 // id: %3
 
 bb2(%4 : $Int32):                                   // Preds: bb5 bb6
   %5 = struct_extract %2 : $Int32, #Int32._value       // user: %8
@@ -357,13 +357,13 @@ class C {
 // Check that checked_cast_br jump-threading works properly when both
 // conditions are arguments of the function's entry block.
 // CHECK: sil @test_checked_cast_br_jump_threading_with_entry_bb_arguments
-// CHECK: checked_cast_br %0
-// CHECK: checked_cast_br %1
+// CHECK: checked_cast_br AnyObject in %0
+// CHECK: checked_cast_br AnyObject in %1
 // CHECK: return
 sil @test_checked_cast_br_jump_threading_with_entry_bb_arguments : $@convention(thin) (@owned AnyObject, @owned AnyObject) -> Int32 {
 bb0(%0 : $AnyObject, %1 : $AnyObject):
   strong_retain %0 : $AnyObject
-  checked_cast_br %0 : $AnyObject to C, bb1, bb2
+  checked_cast_br AnyObject in %0 : $AnyObject to C, bb1, bb2
 
 bb1(%4 : $C):
   %5 = enum $Optional<C>, #Optional.some!enumelt, %4 : $C
@@ -382,7 +382,7 @@ bb4:
 
 bb5(%13 : $C):
   strong_retain %1 : $AnyObject
-  checked_cast_br %1 : $AnyObject to C, bb6, bb7
+  checked_cast_br AnyObject in %1 : $AnyObject to C, bb6, bb7
 
 bb6(%16 : $C):
   %17 = enum $Optional<C>, #Optional.some!enumelt, %16 : $C

--- a/test/SILOptimizer/devirt_jump_thread_crasher.sil
+++ b/test/SILOptimizer/devirt_jump_thread_crasher.sil
@@ -33,7 +33,7 @@ sil @method2 : $@convention(method) <τ_0_0> (@owned @callee_owned (S) -> @out �
 sil [serialized] @_TFCs28__ContiguousArrayStorageBase25withUnsafeBufferOfObjectsfS_U__FFGVs19UnsafeBufferPointerPs9AnyObject__Q_Q_ : $@convention(method) <R> (@owned @callee_owned (S) -> @out R, @guaranteed Base) -> @out R {
 bb0(%0 : $*R, %1 : $@callee_owned (S) -> @out R, %2 : $Base):
   %3 = alloc_stack $MyOptional<R>                   // users: %9, %12, %13, %15, %20, %26, %33, %42, %50, %54
-  checked_cast_br [exact] %2 : $Base to Derived1, bb1, bb2 // id: %4
+  checked_cast_br [exact] Base in %2 : $Base to Derived1, bb1, bb2 // id: %4
 
 bb1(%5 : $Derived1):                    // Preds: bb0
   %6 = function_ref @method1 : $@convention(method) <τ_0_0> (@owned @callee_owned (S) -> @out τ_0_0, @guaranteed Derived1) -> @out MyOptional<τ_0_0> // user: %9
@@ -43,7 +43,7 @@ bb1(%5 : $Derived1):                    // Preds: bb0
   br bb3                                          // id: %10
 
 bb2:                                              // Preds: bb0
-  checked_cast_br [exact] %2 : $Base to Derived2, bb6, bb7 // id: %11
+  checked_cast_br [exact] Base in %2 : $Base to Derived2, bb6, bb7 // id: %11
 
 bb3:                                              // Preds: bb1 bb6 bb8 bb10
   switch_enum_addr %3 : $*MyOptional<R>, case #MyOptional.some!enumelt: bb4, case #MyOptional.none!enumelt: bb5 // id: %12
@@ -67,7 +67,7 @@ bb6(%22 : $Derived2):             // Preds: bb2
   br bb3                                          // id: %27
 
 bb7:                                              // Preds: bb2
-  checked_cast_br [exact] %2 : $Base to Base, bb8, bb9 // id: %28
+  checked_cast_br [exact] Base in %2 : $Base to Base, bb8, bb9 // id: %28
 
 bb8(%29 : $Base):          // Preds: bb7
   %30 = function_ref @method2 : $@convention(method) <τ_0_0> (@owned @callee_owned (S) -> @out τ_0_0, @guaranteed Base) -> @out MyOptional<τ_0_0> // user: %33
@@ -78,7 +78,7 @@ bb8(%29 : $Base):          // Preds: bb7
 
 bb9:                                              // Preds: bb7
   strong_retain %1 : $@callee_owned (S) -> @out R // id: %35
-  checked_cast_br [exact] %2 : $Base to Derived1, bb11, bb12 // id: %36
+  checked_cast_br [exact] Base in %2 : $Base to Derived1, bb11, bb12 // id: %36
 
 bb10(%37 : $()):                                  // Preds: bb11 bb13
   br bb3                                          // id: %38
@@ -90,7 +90,7 @@ bb11(%39 : $Derived1):                  // Preds: bb9
   br bb10(%42 : $())                              // id: %43
 
 bb12:                                             // Preds: bb9
-  checked_cast_br [exact] %2 : $Base to Base, bb14, bb15 // id: %44
+  checked_cast_br [exact] Base in %2 : $Base to Base, bb14, bb15 // id: %44
 
 bb13(%45 : $()):                                  // Preds: bb14 bb15
   br bb10(%45 : $())                              // id: %46
@@ -109,7 +109,7 @@ bb15:                                             // Preds: bb12
 
 // CHECK-LABEL: sil @multiple_edits_in_adjacent_blocks
 // CHECK: bb0(%0 : $*Base):
-// CHECK: checked_cast_br %
+// CHECK: checked_cast_br Base in %
 // CHECK: bb1:
 // CHECK: checked_cast_br [exact]
 // CHECK-NOT: checked_cast_br
@@ -117,19 +117,19 @@ bb15:                                             // Preds: bb12
 sil @multiple_edits_in_adjacent_blocks : $@convention(method) (@in Base) -> () {
 bb0(%0 : $*Base):
   %1 = load %0 : $*Base
-  checked_cast_br %1 : $Base to Derived1, bb8, bb1
+  checked_cast_br Base in %1 : $Base to Derived1, bb8, bb1
 
 bb1:
-  checked_cast_br [exact] %1 : $Base to Derived2, bb2, bb5
+  checked_cast_br [exact] Base in %1 : $Base to Derived2, bb2, bb5
 
 bb2(%6 : $Derived2):
   %7 = upcast %6 : $Derived2 to $Base
   debug_value %7 : $Base, let, name "self", argno 1
-  checked_cast_br [exact] %7 : $Base to Base, bb3, bb6
+  checked_cast_br [exact] Base in %7 : $Base to Base, bb3, bb6
 
 bb3(%10 : $Base):
   debug_value %10 : $Base, let, name "self", argno 1
-  checked_cast_br %10 : $Base to Derived1, bb4, bb7
+  checked_cast_br Base in %10 : $Base to Derived1, bb4, bb7
 
 bb4(%13 : $Derived1):
   debug_value %13 : $Derived1, let, name "scr"

--- a/test/SILOptimizer/devirt_speculate.swift
+++ b/test/SILOptimizer/devirt_speculate.swift
@@ -37,13 +37,13 @@ class Sub7 : Base {
 }
 // CHECK: @$s16devirt_speculate28testMaxNumSpeculativeTargetsyyAA4BaseCF
 // CHECK: bb0(%0 : $Base):
-// CHECK:   checked_cast_br [exact] %0 : $Base to Base, bb2, bb3
+// CHECK:   checked_cast_br [exact] Base in %0 : $Base to Base, bb2, bb3
 
 // CHECK: bb2([[CASTED:%.*]]):
 // CHECK:   br bb1
 
 // CHECK: bb3:
-// CHECK:   checked_cast_br [exact] %0 : $Base to Sub1, bb4, bb5
+// CHECK:   checked_cast_br [exact] Base in %0 : $Base to Sub1, bb4, bb5
 
 // CHECK: bb4([[CASTED:%.*]] : $Sub1):
 // CHECK:   [[FN:%.*]] = function_ref @$s16devirt_speculate9blackHoleyyxRlzClF : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> ()
@@ -51,7 +51,7 @@ class Sub7 : Base {
 // CHECK:   br bb1
 
 // CHECK: bb5:
-// CHECK:   checked_cast_br [exact] %0 : $Base to Sub2, bb6, bb7
+// CHECK:   checked_cast_br [exact] Base in %0 : $Base to Sub2, bb6, bb7
 
 // CHECK: bb6([[CASTED:%.*]] : $Sub2):
 // CHECK:   [[FN:%.*]] = function_ref @$s16devirt_speculate9blackHoleyyxRlzClF : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> ()
@@ -59,7 +59,7 @@ class Sub7 : Base {
 // CHECK:   br bb1
 
 // CHECK: bb7:
-// CHECK:   checked_cast_br [exact] %0 : $Base to Sub3, bb8, bb9
+// CHECK:   checked_cast_br [exact] Base in %0 : $Base to Sub3, bb8, bb9
 
 // CHECK: bb8([[CASTED:%.*]] : $Sub3):
 // CHECK:   [[FN:%.*]] = function_ref @$s16devirt_speculate9blackHoleyyxRlzClF : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> ()
@@ -67,7 +67,7 @@ class Sub7 : Base {
 // CHECK:   br bb1
 
 // CHECK: bb9:
-// CHECK:   checked_cast_br [exact] %0 : $Base to Sub4, bb10, bb11
+// CHECK:   checked_cast_br [exact] Base in %0 : $Base to Sub4, bb10, bb11
 
 // CHECK: bb10([[CASTED:%.*]] : $Sub4):
 // CHECK:   [[FN:%.*]] = function_ref @$s16devirt_speculate9blackHoleyyxRlzClF : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> ()
@@ -75,7 +75,7 @@ class Sub7 : Base {
 // CHECK:   br bb1
 
 // CHECK: bb11:
-// CHECK:   checked_cast_br [exact] %0 : $Base to Sub5, bb12, bb13
+// CHECK:   checked_cast_br [exact] Base in %0 : $Base to Sub5, bb12, bb13
 
 // CHECK: bb12([[CASTED:%.*]] : $Sub5):
 // CHECK:   [[FN:%.*]] = function_ref @$s16devirt_speculate9blackHoleyyxRlzClF : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> ()
@@ -83,7 +83,7 @@ class Sub7 : Base {
 // CHECK:   br bb1
 
 // CHECK: bb13:
-// CHECK:   checked_cast_br [exact] %0 : $Base to Sub6, bb14, bb15
+// CHECK:   checked_cast_br [exact] Base in %0 : $Base to Sub6, bb14, bb15
 
 // CHECK: bb14([[CASTED:%.*]] : $Sub6):
 // CHECK:   [[FN:%.*]] = function_ref @$s16devirt_speculate9blackHoleyyxRlzClF : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> ()
@@ -112,8 +112,8 @@ class Sub7 : Base {
 // YAML-NEXT: ...
 
 // OSIZE: @$s16devirt_speculate28testMaxNumSpeculativeTargetsyyAA4BaseCF
-// OSIZE-NOT: checked_cast_br [exact] %0 : $Base to Base
-// OSIZE-NOT: checked_cast_br [exact] %0 : $Base to Sub
+// OSIZE-NOT: checked_cast_br [exact] Base in %0 : $Base to Base
+// OSIZE-NOT: checked_cast_br [exact] Base in %0 : $Base to Sub
 public func testMaxNumSpeculativeTargets(_ b: Base) {
   b.foo()
 }

--- a/test/SILOptimizer/devirt_speculative.sil
+++ b/test/SILOptimizer/devirt_speculative.sil
@@ -58,9 +58,9 @@ bb0(%0: $Base):
 // CHECK-LABEL: sil @test_objc_ancestry
 // CHECK: bb0
 // CHECK:  [[METH:%.*]] = class_method %0 : $Base, #Base.foo : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK:  checked_cast_br [exact] %0 : $Base to Base, bb{{.*}}, bb[[CHECK2:[0-9]+]]
+// CHECK:  checked_cast_br [exact] Base in %0 : $Base to Base, bb{{.*}}, bb[[CHECK2:[0-9]+]]
 // CHECK: bb[[CHECK2]]{{.*}}:
-// CHECK:  checked_cast_br [exact] %0 : $Base to Sub, bb{{.*}}, bb[[GENCALL:[0-9]+]]
+// CHECK:  checked_cast_br [exact] Base in %0 : $Base to Sub, bb{{.*}}, bb[[GENCALL:[0-9]+]]
 // CHECK: bb[[GENCALL]]{{.*}}:
 // CHECK:  apply [[METH]]
 
@@ -111,9 +111,9 @@ bb0(%0: $Base2):
 // CHECK-LABEL: sil @test_objc_ancestry2
 // CHECK: bb0
 // CHECK:  [[METH:%.*]] = class_method %0 : $Base2, #Base2.foo : (Base2) -> () -> (), $@convention(method) (@guaranteed Base2) -> ()
-// CHECK:  checked_cast_br [exact] %0 : $Base2 to Base2, bb{{.*}}, bb[[CHECK2:[0-9]+]]
+// CHECK:  checked_cast_br [exact] Base2 in %0 : $Base2 to Base2, bb{{.*}}, bb[[CHECK2:[0-9]+]]
 // CHECK: bb[[CHECK2]]{{.*}}:
-// CHECK:  checked_cast_br [exact] %0 : $Base2 to Sub2, bb{{.*}}, bb[[GENCALL:[0-9]+]]
+// CHECK:  checked_cast_br [exact] Base2 in %0 : $Base2 to Sub2, bb{{.*}}, bb[[GENCALL:[0-9]+]]
 // CHECK: bb[[GENCALL]]{{.*}}:
 // CHECK:  apply [[METH]]
 
@@ -167,7 +167,7 @@ bb0(%0 : $S2):
 }
 
 // CHECK-LABEL: sil{{.*}} @test_devirt_of_throw_without_error
-// CHECK-NOT: checked_cast_br [exact] %0 : $Throw to S1
+// CHECK-NOT: checked_cast_br [exact] Throw in %0 : $Throw to S1
 // CHECK: return
 
 sil hidden [noinline] @test_devirt_of_throw_without_error : $@convention(thin) (@owned Throw) -> () {

--- a/test/SILOptimizer/devirt_speculative_init.swift
+++ b/test/SILOptimizer/devirt_speculative_init.swift
@@ -25,7 +25,7 @@ public func make(type: Cat.Type, cats: Int) -> Cat {
 }
 
 // CHECK-LABEL: sil @$s23devirt_speculative_init4make4type4catsAA3CatCAFm_SitF : $@convention(thin) (@thick Cat.Type, Int) -> @owned Cat {
-// CHECK:   checked_cast_br [exact] %0 : $@thick Cat.Type to @thick Cat.Type, bb2, bb3
+// CHECK:   checked_cast_br [exact] @thick Cat.Type in %0 : $@thick Cat.Type to @thick Cat.Type, bb2, bb3
 // CHECK: bb1{{.*}}:
 // CHECK:   return
 // CHECK: bb2({{%.*}} : $@thick Cat.Type):

--- a/test/SILOptimizer/devirt_speculative_nested.swift
+++ b/test/SILOptimizer/devirt_speculative_nested.swift
@@ -22,7 +22,7 @@ public class Base {
 // But at least, we shouldn't crash.
 
 // CHECK-LABEL: sil @$s25devirt_speculative_nested3foo1xyAA4BaseC_tF : $@convention(thin) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] %0 : $Base to Base
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Base
 // CHECK: function_ref @$s25devirt_speculative_nested4BaseC6updateyyF
 // CHECK: class_method %0 : $Base, #Base.update
 // CHECK: return

--- a/test/SILOptimizer/devirt_unbound_generic.swift
+++ b/test/SILOptimizer/devirt_unbound_generic.swift
@@ -44,7 +44,7 @@ class Derived<T> : Base<T> {
 
 // Check that testDevirt is specialized and uses speculative devirtualization.
 // CHECK-LABEL: sil shared [noinline] @{{.*}}testDevirt
-// CHECK: checked_cast_br [exact] %{{.*}} : $CC<Int32> to CC<Int32>
+// CHECK: checked_cast_br [exact] CC<Int32> in %{{.*}} : $CC<Int32> to CC<Int32>
 // CHECK: class_method
 // CHECK: }
 @inline(never)

--- a/test/SILOptimizer/devirtualize2.sil
+++ b/test/SILOptimizer/devirtualize2.sil
@@ -55,7 +55,7 @@ bb0:
 // CHECK: return
 sil @function_with_cm_with_dynamic_type_known_from_checked_cast_br : $@convention(thin) (Bar) -> () {
 bb0(%0 : $Bar):
-  checked_cast_br [exact] %0 : $Bar to Bar, bb1, bb5
+  checked_cast_br [exact] Bar in %0 : $Bar to Bar, bb1, bb5
 
 bb1(%1 : $Bar):
   br bb2(%1 : $Bar)

--- a/test/SILOptimizer/devirtualize2_ownership.sil
+++ b/test/SILOptimizer/devirtualize2_ownership.sil
@@ -55,7 +55,7 @@ bb0:
 // CHECK: } // end sil function 'function_with_cm_with_dynamic_type_known_from_checked_cast_br'
 sil [ossa] @function_with_cm_with_dynamic_type_known_from_checked_cast_br : $@convention(thin) (@owned Bar) -> () {
 bb0(%0 : @owned $Bar):
-  checked_cast_br [exact] %0 : $Bar to Bar, bb1, bb5
+  checked_cast_br [exact] Bar in %0 : $Bar to Bar, bb1, bb5
 
 bb1(%1 : @owned $Bar):
   br bb2(%1 : $Bar)

--- a/test/SILOptimizer/dynamic_self_cast.sil
+++ b/test/SILOptimizer/dynamic_self_cast.sil
@@ -12,7 +12,7 @@ sil @$dynamic_self_cast_1 : $@convention(method) (@guaranteed SelfCasts, @thick 
 bb0(%0 : $SelfCasts, %1 : $@thick SelfCasts.Type):
   strong_retain %0 : $SelfCasts
   // CHECK: checked_cast_br
-  checked_cast_br %0 : $SelfCasts to @dynamic_self SelfCasts, bb1, bb2
+  checked_cast_br SelfCasts in %0 : $SelfCasts to @dynamic_self SelfCasts, bb1, bb2
 bb1(%7 : $SelfCasts):
   %8 = enum $Optional<SelfCasts>, #Optional.some!enumelt, %7 : $SelfCasts
   br bb3(%8 : $Optional<SelfCasts>)
@@ -31,7 +31,7 @@ sil @$dynamic_self_cast_2 : $@convention(method) (@guaranteed SelfCasts, @thick 
 bb0(%0 : $SelfCasts, %1 : $@thick SelfCasts.Type):
   strong_retain %0 : $SelfCasts
   // CHECK-NOT: checked_cast_br
-  checked_cast_br %0 : $SelfCasts to SelfCasts, bb1, bb2
+  checked_cast_br SelfCasts in %0 : $SelfCasts to SelfCasts, bb1, bb2
 bb1(%7 : $SelfCasts):
   %8 = enum $Optional<SelfCasts>, #Optional.some!enumelt, %7 : $SelfCasts
   br bb3(%8 : $Optional<SelfCasts>)

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -548,7 +548,7 @@ bb1:
   strong_retain %17 : $Test
   %19 = class_method %17 : $Test, #Test.testing : (Test) -> () -> UInt64, $@convention(method) (@guaranteed Test) -> UInt64
   %20 = load %7 : $*UInt64
-  checked_cast_br [exact] %17 : $Test to Test, bb3, bb4
+  checked_cast_br [exact] Test in %17 : $Test to Test, bb3, bb4
 bb2:
 // CHECK: bb2:
 // CHECK-NOT: strong_retain
@@ -1262,7 +1262,7 @@ bb0(%0 : $Optional<X>):
 
 bb1:                                              // Preds: bb0
   %3 = unchecked_enum_data %0 : $Optional<X>, #Optional.some!enumelt // users: %4, %13, %14, %15
-  checked_cast_br [exact] %3 : $X to X, bb4, bb5 // id: %4
+  checked_cast_br [exact] X in %3 : $X to X, bb4, bb5 // id: %4
 
 // Make sure we were able to sink the release.
 // CHECK: strong_release
@@ -1305,13 +1305,13 @@ bb5:                                              // Preds: bb1
 sil @canonicalize_casts: $@convention(thin) (@owned X) -> Int32 {
 bb0(%0 : $X):
   debug_value %0 : $X, let, name "x" // id: %1
-  checked_cast_br %0 : $X to Y, bb1, bb3         // id: %2
+  checked_cast_br X in %0 : $X to Y, bb1, bb3         // id: %2
 
 bb1(%3 : $Y):                                     // Preds: bb0
   debug_value %3 : $Y, let, name "z" // id: %4
   %5 = upcast %3 : $Y to $X                       // users: %6, %7, %21, %23
   %6 = class_method %5 : $X, #X.ping : (X) -> () -> (), $@convention(method) (@guaranteed X) -> () // users: %21, %23
-  checked_cast_br [exact] %5 : $X to Y, bb5, bb6 // id: %7
+  checked_cast_br [exact] X in %5 : $X to Y, bb5, bb6 // id: %7
 
 bb2:                                              // Preds: bb5 bb6
   //CHECK: strong_release %0

--- a/test/SILOptimizer/inline_caches.sil
+++ b/test/SILOptimizer/inline_caches.sil
@@ -17,7 +17,7 @@ sil @_TFC8testcase3FoocfMS0_FT_S0_ : $@convention(method) (@owned Foo) -> @owned
 sil @_TF8testcase7my_mainFCS_3FooT_ : $@convention(thin) (@owned Foo) -> () {
 bb0(%0 : $Foo):
 
-//CHECK: checked_cast_br [exact] %0 : $Foo to Foo
+//CHECK: checked_cast_br [exact] Foo in %0 : $Foo to Foo
 
 //CHECK: function_ref @_TFC8testcase3Foo4pingfS0_FT_T_
 //CHECK: apply
@@ -52,7 +52,7 @@ sil @_TZFC4spec1C3barfMS0_FT_T_ : $@convention(method) (@thick C.Type) -> () {
   // CHECK: bb0
 bb0(%0 : $@thick C.Type):
   // CHECK-NOT: class_method
-  // CHECK: checked_cast_br [exact] %0 : $@thick C.Type to @thick C.Type, bb2, bb3
+  // CHECK: checked_cast_br [exact] @thick C.Type in %0 : $@thick C.Type to @thick C.Type, bb2, bb3
   // CHECK: bb1
   // CHECK: return
   // CHECK: bb2

--- a/test/SILOptimizer/inlinecaches_arc.sil
+++ b/test/SILOptimizer/inlinecaches_arc.sil
@@ -15,7 +15,7 @@ sil @_TFC4main3FoocfMS0_FT_S0_ : $@convention(method) (@owned Foo) -> @owned Foo
 // CHECK-LABEL: _TF4main7my_mainFCS_3FooSi
 // CHECK: bb0
 // CHECK-NOT: strong_retain
-// CHECK: checked_cast_br [exact] %0 : $Foo to Foo
+// CHECK: checked_cast_br [exact] Foo in %0 : $Foo to Foo
 
 // CHECK: bb1
 // CHECK: class_method

--- a/test/SILOptimizer/latecodemotion.sil
+++ b/test/SILOptimizer/latecodemotion.sil
@@ -724,7 +724,7 @@ bb1:
   strong_retain %17 : $Test
   %19 = class_method %17 : $Test, #Test.testing : (Test) -> () -> UInt64, $@convention(method) (@guaranteed Test) -> UInt64
   %20 = load %7 : $*UInt64
-  checked_cast_br [exact] %17 : $Test to Test, bb3, bb4
+  checked_cast_br [exact] Test in %17 : $Test to Test, bb3, bb4
 bb2:
 // CHECK: bb2:
 // CHECK-NOT: strong_retain

--- a/test/SILOptimizer/mandatory_inlining_ossa_to_non_ossa.sil
+++ b/test/SILOptimizer/mandatory_inlining_ossa_to_non_ossa.sil
@@ -240,7 +240,7 @@ bb0(%0 : $Builtin.NativeObject):
 
 sil [transparent] [ossa] @term_ossa_callee : $@convention(thin) (@owned Builtin.NativeObject, @owned FakeOptional<Klass>) -> () {
 bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $FakeOptional<Klass>):
-  checked_cast_br %0 : $Builtin.NativeObject to Klass, bb1, bb2
+  checked_cast_br Builtin.NativeObject in %0 : $Builtin.NativeObject to Klass, bb1, bb2
 
 bb1(%1a : @owned $Klass):
   destroy_value %1a : $Klass
@@ -267,7 +267,7 @@ bb6:
 
 // CHECK-LABEL: sil @term_non_ossa_caller : $@convention(thin) (@owned Builtin.NativeObject, @owned FakeOptional<Klass>) -> () {
 // CHECK: bb0([[ARG0:%.*]] : $Builtin.NativeObject, [[ARG1:%.*]] : $FakeOptional<Klass>):
-// CHECK:   checked_cast_br [[ARG0]] : $Builtin.NativeObject to Klass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK:   checked_cast_br Builtin.NativeObject in [[ARG0]] : $Builtin.NativeObject to Klass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
 //
 // CHECK: [[YES]]([[SUCC:%.*]] :
 // CHECK:   release_value [[SUCC]]
@@ -322,7 +322,7 @@ bb3:
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
 // CHECK-NEXT:   store [[ARG]] to [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load [[SRC_ADDR]]
-// CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
+// CHECK-NEXT:   checked_cast_br Builtin.NativeObject in [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //
 // ==> On success, we store the value into dest. The destroy is not from the
 // ==> optimizer, but from the code.
@@ -378,7 +378,7 @@ bb3:
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
 // CHECK-NEXT:   store [[ARG]] to [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load [[SRC_ADDR]]
-// CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
+// CHECK-NEXT:   checked_cast_br Builtin.NativeObject in [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //
 // CHECK: [[SUCCESS_BB]]([[CAST_VALUE:%.*]] :
 // ==> On success, we store into dest and destroy dest.
@@ -433,7 +433,7 @@ bb3:
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
 // CHECK-NEXT:   store [[ARG]] to [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load [[SRC_ADDR]]
-// CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
+// CHECK-NEXT:   checked_cast_br Builtin.NativeObject in [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //
 // CHECK: [[SUCCESS_BB]]([[CAST_VALUE:%.*]] :
 // CHECK-NEXT:   strong_retain [[CAST_VALUE]]

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -300,7 +300,7 @@ bb3:
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
 // CHECK-NEXT:   store [[ARG_MOVE]] to [init] [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load [take] [[SRC_ADDR]]
-// CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
+// CHECK-NEXT:   checked_cast_br Builtin.NativeObject in [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //
 // ==> On success, we store the value into dest. The destroy is not from the
 // ==> optimizer, but from the code.
@@ -330,7 +330,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 sil [ossa] @get_klass_type : $@convention(thin) () -> @out @thick Klass.Type
 
 // CHECK-LABEL: sil [ossa] @term_nonossa_checked_cast_addr_br_takealways_caller2 :
-// CHECK: checked_cast_br {{.*}} : $@thick Klass.Type to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]], forwarding: @owned
+// CHECK: checked_cast_br Klass in {{.*}} : $@thick Klass.Type to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]], forwarding: @owned
 // CHECK: [[SUCCESS_BB]]({{.*}}@owned $AnotherKlass):
 // CHECK: [[FAILURE_BB]]([[FAILURE_ARG:%.*]] :
 // CHECK: } // end sil function 'term_nonossa_checked_cast_addr_br_takealways_caller2'
@@ -376,7 +376,7 @@ bb3:
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
 // CHECK-NEXT:   store [[ARG_MOVE]] to [init] [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load [take] [[SRC_ADDR]]
-// CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
+// CHECK-NEXT:   checked_cast_br Builtin.NativeObject in [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //
 // CHECK: [[SUCCESS_BB]]([[CAST_VALUE:%.*]] :
 // ==> On success, we store into dest and destroy dest.
@@ -433,7 +433,7 @@ bb3:
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
 // CHECK-NEXT:   store [[ARG_MOVE]] to [init] [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load_borrow [[SRC_ADDR]]
-// CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
+// CHECK-NEXT:   checked_cast_br Builtin.NativeObject in [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //
 // CHECK: [[SUCCESS_BB]]([[CAST_VALUE:%.*]] : @guaranteed
 // CHECK-NEXT:   [[CAST_VALUE_COPY:%.*]] = copy_value [[CAST_VALUE]]

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -1202,7 +1202,7 @@ one(%instance : @owned $C):
 // CHECK-LABEL: sil [ossa] @term_4 : $@convention(thin) (@owned C, @owned D) -> @owned D {
 // CHECK:       {{bb[^,]+}}([[SUPER_IN:%[^,]+]] : @owned $C, [[SUB_IN:%[^,]+]] : @owned $D):
 // CHECK:         [[LIFETIME_OWNED:%[^,]+]] = move_value [lexical] [[SUPER_IN]]
-// CHECK:         checked_cast_br [[LIFETIME_OWNED]] : $C to D, [[SUPER_IS_SUB:bb[^,]+]], [[SUPER_IS_SUPER:bb[0-9]+]]
+// CHECK:         checked_cast_br C in [[LIFETIME_OWNED]] : $C to D, [[SUPER_IS_SUB:bb[^,]+]], [[SUPER_IS_SUPER:bb[0-9]+]]
 // CHECK:       [[SUPER_IS_SUB]]([[SUPER_AS_SUB:%[^,]+]] : @owned $D):
 // CHECK:         destroy_value [[SUB_IN]]
 // CHECK:         br [[EXIT:bb[^,]+]]([[SUPER_AS_SUB]] : $D)
@@ -1217,7 +1217,7 @@ bb0(%super_in : @owned $C, %sub_in : @owned $D):
     %addr = alloc_stack [lexical] $C
     store %super_in to [init] %addr : $*C
     %super_load = load [take] %addr : $*C
-    checked_cast_br %super_load : $C to D, super_is_sub, super_is_super
+    checked_cast_br C in %super_load : $C to D, super_is_sub, super_is_super
 super_is_sub(%super_as_sub : @owned $D):
     destroy_value %sub_in : $D
     br exit(%super_as_sub : $D)

--- a/test/SILOptimizer/mm_inlinecaches_multiple.sil
+++ b/test/SILOptimizer/mm_inlinecaches_multiple.sil
@@ -28,13 +28,13 @@ bb0(%0 : $Foo):
 
 
 //CHECK-LABEL: @_TF8testcase7my_mainFCS_3FooT_
-//CHECK: checked_cast_br [exact] %0 : $Foo to Foo
+//CHECK: checked_cast_br [exact] Foo in %0 : $Foo to Foo
 //CHECK: return
-//CHECK: checked_cast_br [exact] %0 : $Foo to Bar
+//CHECK: checked_cast_br [exact] Foo in %0 : $Foo to Bar
 //CHECK: class_method
 
 //CHECK-WMO-LABEL: @_TF8testcase7my_mainFCS_3FooT_
-//CHECK-WMO: checked_cast_br [exact] %0 : $Foo to Foo
+//CHECK-WMO: checked_cast_br [exact] Foo in %0 : $Foo to Foo
 //CHECK-WMO: return
 //CHECK-WMO: unchecked_ref_cast %0 : $Foo to $Bar
 //CHECK-WMO: class_method

--- a/test/SILOptimizer/optimize_never.sil
+++ b/test/SILOptimizer/optimize_never.sil
@@ -326,7 +326,7 @@ bb0(%0 : $*T, %1 : $C):
 // CHECK-NOT: function_ref @$s14optimize_never4foo3ys5Int32Vx_AA1CCtlF
 // Presence of checked_cast_br indicates that the speculative devirtualization
 // was performed. And this is only possible, if the original call is inlined.
-// CHECK: checked_cast_br [exact] {{%.*}} : $C to C, bb2, bb3
+// CHECK: checked_cast_br [exact] C in {{%.*}} : $C to C, bb2, bb3
 // CHECK: return
 sil @$s14optimize_never4boo3ys5Int32VAA1CCF : $@convention(thin) (@owned C) -> Int32 {
 bb0(%0 : $C):
@@ -376,7 +376,7 @@ bb0(%0 : $Int32, %1 : $C):
 // CHECK-NOT: function_ref @$s14optimize_never4foo4ys5Int32VAD_AA1CCtF
 // Presence of checked_cast_br indicates that the speculative devirtualization
 // was performed. And this is only possible, if the original call is inlined.
-// CHECK: checked_cast_br [exact] {{%.*}} : $C to C, bb2, bb3
+// CHECK: checked_cast_br [exact] C in {{%.*}} : $C to C, bb2, bb3
 // CHECK: return
 sil @$s14optimize_never4boo4ys5Int32VAA1CCF : $@convention(thin) (@owned C) -> Int32 {
 bb0(%0 : $C):
@@ -455,8 +455,8 @@ bb0(%0 : $Base):
 // CHECK-LABEL: sil @$s14optimize_never23testDoNotDevirtDerived11os5Int32VAA4BaseC_tF
 // CHECK: bb0
 // CHECK: class_method {{%[0-9]+}} : $Base, #Base.boo : (Base) -> () -> Int32
-// CHECK: checked_cast_br [exact] {{%[0-9]+}} : $Base to Base
-// CHECK: checked_cast_br [exact] {{%[0-9]+}} : $Base to Derived2
+// CHECK: checked_cast_br [exact] Base in {{%[0-9]+}} : $Base to Base
+// CHECK: checked_cast_br [exact] Base in {{%[0-9]+}} : $Base to Derived2
 // CHECK-NOT: class_method
 // CHECK: }
 sil @$s14optimize_never23testDoNotDevirtDerived11os5Int32VAA4BaseC_tF : $@convention(thin) (@owned Base) -> Int32 {

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -162,7 +162,7 @@ bb1:
 
 // CHECK-LABEL: sil @checked_cast_br_lowered : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG:%.*]] : $Builtin.NativeObject):
-// CHECK:   checked_cast_br [[ARG]] : $Builtin.NativeObject to C, [[SUCCBB:bb[0-9]+]], [[FAILBB:bb[0-9]+]]
+// CHECK:   checked_cast_br Builtin.NativeObject in [[ARG]] : $Builtin.NativeObject to C, [[SUCCBB:bb[0-9]+]], [[FAILBB:bb[0-9]+]]
 //
 // CHECK: [[SUCCBB]]([[CASTED_VALUE:%.*]] : $C):
 // CHECK-NEXT:   strong_release [[CASTED_VALUE]]
@@ -173,7 +173,7 @@ bb1:
 // CHECK-NEXT:   br bb3
 sil [ossa] @checked_cast_br_lowered : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
-  checked_cast_br %0 : $Builtin.NativeObject to C, bb1, bb2
+  checked_cast_br Builtin.NativeObject in %0 : $Builtin.NativeObject to C, bb1, bb2
 
 bb1(%1 : @owned $C):
   destroy_value %1 : $C

--- a/test/SILOptimizer/polymorphic_inline_caches.sil
+++ b/test/SILOptimizer/polymorphic_inline_caches.sil
@@ -38,7 +38,7 @@ bb0(%0 : $A, %1 : $Builtin.Int32):
   %5 = class_method %0 : $A, #A.ping : (A) -> (Builtin.Int32) -> Builtin.Int32, $@convention(method) (Builtin.Int32, @guaranteed A) -> Builtin.Int32
   // CHECK-NOT: apply
   %6 = apply %5(%1, %0) : $@convention(method) (Builtin.Int32, @guaranteed A) -> Builtin.Int32
-  // CHECK: checked_cast_br [exact] %0 : $A to A, bb2, bb3
+  // CHECK: checked_cast_br [exact] A in %0 : $A to A, bb2, bb3
   // CHECK: bb1
   strong_release %0 : $A
   // CHECK: return
@@ -47,14 +47,14 @@ bb0(%0 : $A, %1 : $Builtin.Int32):
   // CHECK: [[APING:%.*]] = function_ref @_TFC25polymorphic_inline_caches1A4pingfS0_FBi32_Bi32_
   // CHECK: apply [[APING]]
   // CHECK: bb3
-  // CHECK: checked_cast_br [exact] %0 : $A to B, bb5, bb6
+  // CHECK: checked_cast_br [exact] A in %0 : $A to B, bb5, bb6
   // CHECK: bb4
   // CHECK: br bb1
   // CHECK: bb5
   // CHECK: [[BPING:%.*]] = function_ref @_TFC25polymorphic_inline_caches1B4pingfS0_FBi32_Bi32_
   // CHECK: apply [[BPING]]
   // CHECK: bb6
-  // CHECK: checked_cast_br [exact] %0 : $A to C, bb8, bb9
+  // CHECK: checked_cast_br [exact] A in %0 : $A to C, bb8, bb9
   // CHECK: bb7
   // CHECK: br bb4
   // CHECK: bb8
@@ -80,7 +80,7 @@ bb0(%0 : $A, %1 : $Builtin.Int32):
   // CHECK-NOT: apply
   %6 = apply %4(%0) : $@convention(thin) (A) -> Builtin.Int32
   %7 = apply %5(%1, %0) : $@convention(method) (Builtin.Int32, @guaranteed A) -> Builtin.Int32
-  // CHECK: checked_cast_br [exact] %0 : $A to A, bb2, bb3
+  // CHECK: checked_cast_br [exact] A in %0 : $A to A, bb2, bb3
   // CHECK: bb1
   strong_release %0 : $A
   // CHECK: return
@@ -89,14 +89,14 @@ bb0(%0 : $A, %1 : $Builtin.Int32):
   // CHECK: [[APING:%.*]] = function_ref @_TFC25polymorphic_inline_caches1A4pingfS0_FBi32_Bi32_
   // CHECK: apply [[APING]]
   // CHECK: bb3
-  // CHECK: checked_cast_br [exact] %0 : $A to B, bb5, bb6
+  // CHECK: checked_cast_br [exact] A in %0 : $A to B, bb5, bb6
   // CHECK: bb4
   // CHECK: br bb1
   // CHECK: bb5
   // CHECK: [[BPING:%.*]] = function_ref @_TFC25polymorphic_inline_caches1B4pingfS0_FBi32_Bi32_
   // CHECK: apply [[BPING]]
   // CHECK: bb6
-  // CHECK: checked_cast_br [exact] %0 : $A to C, bb8, bb9
+  // CHECK: checked_cast_br [exact] A in %0 : $A to C, bb8, bb9
   // CHECK: bb7
   // CHECK: br bb4
   // CHECK: bb8
@@ -162,7 +162,7 @@ bb0(%0 : $Builtin.NativeObject):
   strong_release %0 : $Builtin.NativeObject
   %7 = tuple ()
   return %7 : $()
-  // CHECK: checked_cast_br [exact] [[CAST]] : $E to E, bb2, bb3
+  // CHECK: checked_cast_br [exact] E in [[CAST]] : $E to E, bb2, bb3
   // CHECK: bb1
   // CHECK: strong_release %0
   // CHECK: return
@@ -171,7 +171,7 @@ bb0(%0 : $Builtin.NativeObject):
   // CHECK: strong_retain %0
   // CHECK: apply [[EFOO]]
   // CHECK: bb3
-  // CHECK: checked_cast_br [exact] [[CAST]] : $E to F, bb5, bb6
+  // CHECK: checked_cast_br [exact] E in [[CAST]] : $E to F, bb5, bb6
   // CHECK: bb4
   // CHECK: br bb1
   // CHECK: bb5
@@ -179,7 +179,7 @@ bb0(%0 : $Builtin.NativeObject):
   // CHECK: strong_retain %0
   // CHECK: apply [[FFOO]]
   // CHECK: bb6
-  // CHECK: checked_cast_br [exact] [[CAST]] : $E to G, bb8, bb9
+  // CHECK: checked_cast_br [exact] E in [[CAST]] : $E to G, bb8, bb9
   // CHECK: bb7
   // CHECK: bb8
   // CHECK: [[GFOO:%.*]] = function_ref @_TFC5casts1G3foofS0_FT_T_
@@ -204,7 +204,7 @@ bb0(%0 : $E):
   strong_release %0 : $E
   %7 = tuple ()
   return %7 : $()
-  // CHECK: checked_cast_br [exact] [[CAST]] : $F to F, bb2, bb3
+  // CHECK: checked_cast_br [exact] F in [[CAST]] : $F to F, bb2, bb3
   // CHECK: bb1
   // CHECK: strong_release %0
   // CHECK: return

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -739,7 +739,7 @@ bb2:
 sil @conditional_metatype_cast : $@convention(thin) () -> AnyObject {
 bb0:
   %0 = metatype $@thick Int.Type
-  checked_cast_br %0 : $@thick Int.Type to AnyObject, bb2, bb1
+  checked_cast_br Int.Type in %0 : $@thick Int.Type to AnyObject, bb2, bb1
 
 bb1:
   unreachable
@@ -853,12 +853,12 @@ bb0(%0 : $_ContiguousArrayBuffer<UInt64>, %1 : $Builtin.Word):
 
 // CHECK-LABEL: sil @dontMoveOverExistentialToClassCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<fuzz>
 // CHECK:    strong_retain %0
-// CHECK:    checked_cast_br %0
+// CHECK:    checked_cast_br AnyObject in %0
 // CHECK:  } // end sil function 'dontMoveOverExistentialToClassCast'
 sil @dontMoveOverExistentialToClassCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<fuzz> {
 bb0(%0 : $AnyObject):
   strong_retain %0 : $AnyObject
-  checked_cast_br %0 : $AnyObject to fuzz, bb1, bb2
+  checked_cast_br AnyObject in %0 : $AnyObject to fuzz, bb1, bb2
 
 bb1(%18 : $fuzz):
   %19 = enum $Optional<fuzz>, #Optional.some!enumelt, %18 : $fuzz
@@ -874,7 +874,7 @@ bb3(%24 : $Optional<fuzz>):
 }
 
 // CHECK-LABEL: sil @moveOverClassToExistentialCast : $@convention(thin) (@guaranteed fuzz) -> Optional<any P>
-// CHECK:    checked_cast_br %0
+// CHECK:    checked_cast_br fuzz in %0
 // CHECK:    enum $Optional<any P>, #Optional.some!enumelt
 // CHECK:    strong_retain %0
 // CHECK-NOT: release
@@ -882,7 +882,7 @@ bb3(%24 : $Optional<fuzz>):
 sil @moveOverClassToExistentialCast : $@convention(thin) (@guaranteed fuzz) -> Optional<P> {
 bb0(%0 : $fuzz):
   strong_retain %0 : $fuzz
-  checked_cast_br %0 : $fuzz to P, bb1, bb2
+  checked_cast_br fuzz in %0 : $fuzz to P, bb1, bb2
 
 bb1(%18 : $P):
   %19 = enum $Optional<P>, #Optional.some!enumelt, %18 : $P
@@ -899,12 +899,12 @@ bb3(%24 : $Optional<P>):
 
 // CHECK-LABEL: sil @dontMoveOverExistentialToExistentialCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<any P>
 // CHECK:    strong_retain %0
-// CHECK:    checked_cast_br %0
+// CHECK:    checked_cast_br AnyObject in %0
 // CHECK:  } // end sil function 'dontMoveOverExistentialToExistentialCast'
 sil @dontMoveOverExistentialToExistentialCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<P> {
 bb0(%0 : $AnyObject):
   strong_retain %0 : $AnyObject
-  checked_cast_br %0 : $AnyObject to P, bb1, bb2
+  checked_cast_br AnyObject in %0 : $AnyObject to P, bb1, bb2
 
 bb1(%18 : $P):
   %19 = enum $Optional<P>, #Optional.some!enumelt, %18 : $P

--- a/test/SILOptimizer/semantic-arc-opts-canonical.sil
+++ b/test/SILOptimizer/semantic-arc-opts-canonical.sil
@@ -451,7 +451,7 @@ bb3:
 
 // CHECK-LABEL: sil [ossa] @testTypeDependentCheckCast : $@convention(thin) (@guaranteed Klass, @thick @dynamic_self Klass.Type) -> () {
 // CHECK: bb0(%0 : @guaranteed $Klass, %1 : $@thick @dynamic_self Klass.Type):
-// CHECK:   checked_cast_br %0 : $Klass to @dynamic_self Klass, bb1, bb2 // type-defs: %1; id: %2
+// CHECK:   checked_cast_br Klass in %0 : $Klass to @dynamic_self Klass, bb1, bb2 // type-defs: %1; id: %2
 //
 // CHECK: bb1([[CAST:%.*]] : @guaranteed $Klass):
 // CHECK:   [[SOME:%.*]] = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, [[CAST]] : $Klass
@@ -473,7 +473,7 @@ bb3:
 sil [ossa] @testTypeDependentCheckCast : $@convention(thin) (@guaranteed Klass, @thick @dynamic_self Klass.Type) -> () {
 bb0(%0 : @guaranteed $Klass, %1 : $@thick @dynamic_self Klass.Type):
   %2 = copy_value %0 : $Klass
-  checked_cast_br %2 : $Klass to @dynamic_self Klass, bb1, bb2
+  checked_cast_br Klass in %2 : $Klass to @dynamic_self Klass, bb1, bb2
 
 bb1(%4 : @owned $Klass):
   %5 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %4 : $Klass

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -942,7 +942,7 @@ sil [ossa] @cast_with_optional_result_and_default_simple : $@convention(thin) (@
 bb0(%0 : @guaranteed $StructWithDataAndOwner):
   %1 = struct_extract %0 : $StructWithDataAndOwner, #StructWithDataAndOwner.owner
   %2 = copy_value %1 : $Klass
-  checked_cast_br %2 : $Klass to Builtin.NativeObject, bb1, bb2
+  checked_cast_br Klass in %2 : $Klass to Builtin.NativeObject, bb1, bb2
 
 bb1(%3 : @owned $Builtin.NativeObject):
   %4 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt, %3 : $Builtin.NativeObject
@@ -968,7 +968,7 @@ sil [ossa] @cast_with_optional_result_and_default_simple_unremoved_store : $@con
 bb0(%result : $*FakeOptional<Builtin.NativeObject>, %0 : @guaranteed $StructWithDataAndOwner):
   %1 = struct_extract %0 : $StructWithDataAndOwner, #StructWithDataAndOwner.owner
   %2 = copy_value %1 : $Klass
-  checked_cast_br %2 : $Klass to Builtin.NativeObject, bb1, bb2
+  checked_cast_br Klass in %2 : $Klass to Builtin.NativeObject, bb1, bb2
 
 bb1(%3 : @owned $Builtin.NativeObject):
   %4 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt, %3 : $Builtin.NativeObject
@@ -1001,7 +1001,7 @@ sil [ossa] @cast_with_optional_result_and_default_simple_unremoved_store_multipl
 bb0(%result : $*FakeOptional<Builtin.NativeObject>, %0 : @guaranteed $StructWithDataAndOwner):
   %1 = struct_extract %0 : $StructWithDataAndOwner, #StructWithDataAndOwner.owner
   %2 = copy_value %1 : $Klass
-  checked_cast_br %2 : $Klass to Builtin.NativeObject, bb1, bb2
+  checked_cast_br Klass in %2 : $Klass to Builtin.NativeObject, bb1, bb2
 
 bb1(%3 : @owned $Builtin.NativeObject):
   %4 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt, %3 : $Builtin.NativeObject
@@ -1034,7 +1034,7 @@ sil [ossa] @cast_with_optional_result_and_default_and_switchenum_after : $@conve
 bb0(%result : $*FakeOptional<Builtin.NativeObject>, %0 : @guaranteed $StructWithDataAndOwner):
   %1 = struct_extract %0 : $StructWithDataAndOwner, #StructWithDataAndOwner.owner
   %2 = copy_value %1 : $Klass
-  checked_cast_br %2 : $Klass to Builtin.NativeObject, bb1, bb2
+  checked_cast_br Klass in %2 : $Klass to Builtin.NativeObject, bb1, bb2
 
 bb1(%3 : @owned $Builtin.NativeObject):
   %4 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt, %3 : $Builtin.NativeObject
@@ -1076,7 +1076,7 @@ bb0(%result : $*FakeOptional<Builtin.NativeObject>, %0 : @owned $StructWithDataA
   %0a = begin_borrow %0 : $StructWithDataAndOwner
   %1 = struct_extract %0a : $StructWithDataAndOwner, #StructWithDataAndOwner.owner
   %2 = copy_value %1 : $Klass
-  checked_cast_br %2 : $Klass to Builtin.NativeObject, bb1, bb2
+  checked_cast_br Klass in %2 : $Klass to Builtin.NativeObject, bb1, bb2
 
 bb1(%3 : @owned $Builtin.NativeObject):
   %4 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt, %3 : $Builtin.NativeObject
@@ -1119,7 +1119,7 @@ bb0(%result : $*FakeOptional<Builtin.NativeObject>, %0 : @owned $StructWithDataA
   %0a = begin_borrow %0 : $StructWithDataAndOwner
   %1 = struct_extract %0a : $StructWithDataAndOwner, #StructWithDataAndOwner.owner
   %2 = copy_value %1 : $Klass
-  checked_cast_br %2 : $Klass to Builtin.NativeObject, bb1, bb2
+  checked_cast_br Klass in %2 : $Klass to Builtin.NativeObject, bb1, bb2
 
 bb1(%3 : @owned $Builtin.NativeObject):
   %4 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt, %3 : $Builtin.NativeObject
@@ -1193,7 +1193,7 @@ sil [ossa] @iterated_transforming_terminator : $@convention(method) (@guaranteed
 bb0(%0 : $*FakeOptional<Klass>, %1 : @guaranteed $Builtin.NativeObject):
   %3 = init_enum_data_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt
   %4 = copy_value %1 : $Builtin.NativeObject
-  checked_cast_br %4 : $Builtin.NativeObject to Klass, bb1, bb2
+  checked_cast_br Builtin.NativeObject in %4 : $Builtin.NativeObject to Klass, bb1, bb2
 
 bb1(%7 : @owned $Klass):
   %8 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %7 : $Klass
@@ -1505,12 +1505,12 @@ bb3:
 // CHECK-LABEL: sil [ossa] @cast_anyobject_donot_opt : $@convention(thin) (@guaranteed AnyObject) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
 // CHECK: [[COPIED_ARG:%.*]] = copy_value [[ARG]]
-// CHECK: checked_cast_br [[COPIED_ARG]] :
+// CHECK: checked_cast_br AnyObject in [[COPIED_ARG]] :
 // CHECK: } // end sil function 'cast_anyobject_donot_opt'
 sil [ossa] @cast_anyobject_donot_opt : $@convention(thin) (@guaranteed AnyObject) -> () {
 bb0(%0 : @guaranteed $AnyObject):
   %2 = copy_value %0 : $AnyObject
-  checked_cast_br %2 : $AnyObject to Builtin.NativeObject, bb1, bb2
+  checked_cast_br AnyObject in %2 : $AnyObject to Builtin.NativeObject, bb1, bb2
 
 bb1(%3 : @owned $Builtin.NativeObject):
   %4 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.some!enumelt, %3 : $Builtin.NativeObject

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2562,7 +2562,7 @@ sil @alloc_ref_dynamic_with_upcast_metatype : $() -> B {
 // CHECK: alloc_ref $B
 sil @alloc_ref_dynamic_after_successful_checked_cast_br : $(@thick B.Type) -> Builtin.Int32 {
 bb0(%1 : $@thick B.Type):
-  checked_cast_br [exact] %1 : $@thick B.Type to B.Type, bb1, bb2
+  checked_cast_br [exact] @thick B.Type in %1 : $@thick B.Type to B.Type, bb1, bb2
 
 bb1(%2 : $@thick B.Type):
   %3 = alloc_ref_dynamic %2 : $@thick B.Type, $B
@@ -2586,7 +2586,7 @@ bb3 (%10: $Builtin.Int32):
 // CHECK-NEXT: strong_release [[R]]
 sil @alloc_ref_dynamic_upcast_after_successful_checked_cast_br : $(@thick B.Type) -> Builtin.Int32 {
 bb0(%1 : $@thick B.Type):
-  checked_cast_br [exact] %1 : $@thick B.Type to E.Type, bb1, bb2
+  checked_cast_br [exact] @thick B.Type in %1 : $@thick B.Type to E.Type, bb1, bb2
 
 bb1(%2 : $@thick E.Type):
   %3 = upcast %2 : $@thick E.Type to $@thick B.Type

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -3083,7 +3083,7 @@ sil [ossa] @alloc_ref_dynamic_with_upcast_metatype : $@convention(thin) () -> @o
 // CHECK: } // end sil function 'alloc_ref_dynamic_after_successful_checked_cast_br'
 sil [ossa] @alloc_ref_dynamic_after_successful_checked_cast_br : $(@thick B.Type) -> Builtin.Int32 {
 bb0(%1 : $@thick B.Type):
-  checked_cast_br [exact] %1 : $@thick B.Type to B.Type, bb1, bb2
+  checked_cast_br [exact] @thick B.Type in %1 : $@thick B.Type to B.Type, bb1, bb2
 
 bb1(%2 : $@thick B.Type):
   %3 = alloc_ref_dynamic %2 : $@thick B.Type, $B
@@ -3108,7 +3108,7 @@ bb3 (%10: $Builtin.Int32):
 // CHECK: } // end sil function 'alloc_ref_dynamic_upcast_after_successful_checked_cast_br'
 sil [ossa] @alloc_ref_dynamic_upcast_after_successful_checked_cast_br : $(@thick B.Type) -> Builtin.Int32 {
 bb0(%1 : $@thick B.Type):
-  checked_cast_br [exact] %1 : $@thick B.Type to E.Type, bb1, bb2
+  checked_cast_br [exact] @thick B.Type in %1 : $@thick B.Type to E.Type, bb1, bb2
 
 bb1(%2 : $@thick E.Type):
   %3 = upcast %2 : $@thick E.Type to $@thick B.Type
@@ -3163,7 +3163,7 @@ sil [ossa] @alloc_ref_dynamic_stack_with_upcast_metatype : $() -> () {
 // CHECK:       } // end sil function 'alloc_ref_dynamic_stack_after_successful_checked_cast_br'
 sil [ossa] @alloc_ref_dynamic_stack_after_successful_checked_cast_br : $(@thick B.Type) -> Builtin.Int32 {
 bb0(%1 : $@thick B.Type):
-  checked_cast_br [exact] %1 : $@thick B.Type to B.Type, bb1, bb2
+  checked_cast_br [exact] @thick B.Type in %1 : $@thick B.Type to B.Type, bb1, bb2
 
 bb1(%2 : $@thick B.Type):
   %3 = alloc_ref_dynamic [stack] %2 : $@thick B.Type, $B

--- a/test/SILOptimizer/simplify-cfg-debugonly.sil
+++ b/test/SILOptimizer/simplify-cfg-debugonly.sil
@@ -24,7 +24,7 @@ bb0(%0 : $Klass):
   %1 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
   %2 = integer_literal $Builtin.Int64, 1
   %3 = apply %1() : $@convention(thin) () -> @owned Klass
-  checked_cast_br %3 : $Klass to OtherKlass, bb1, bb2
+  checked_cast_br Klass in %3 : $Klass to OtherKlass, bb1, bb2
 
 bb1(%5 : $OtherKlass):
   %6 = integer_literal $Builtin.Int1, -1
@@ -48,7 +48,7 @@ bb6:
   br bb10(%2 : $Builtin.Int64)
 
 bb7(%16 : $Klass):
-  checked_cast_br %16 : $Klass to OtherKlass, bb9, bb8
+  checked_cast_br Klass in %16 : $Klass to OtherKlass, bb9, bb8
 
 bb8:
   strong_release %16 : $Klass
@@ -59,7 +59,7 @@ bb9(%20 : $OtherKlass):
 
 bb10(%22 : $Builtin.Int64):
   %23 = apply %1() : $@convention(thin) () -> @owned Klass
-  checked_cast_br %23 : $Klass to OtherKlass, bb11, bb12
+  checked_cast_br Klass in %23 : $Klass to OtherKlass, bb11, bb12
 
 bb11(%25 : $OtherKlass):
   %26 = integer_literal $Builtin.Int1, -1

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1115,8 +1115,8 @@ sil @redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : $Base):
 // CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
-  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb2, bb7
 
 // CHECK: bb1
 bb1:
@@ -1127,7 +1127,7 @@ bb2(%5 : $Base):
 // CHECK: [[SUCCESS]]
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK-NOT: checked_cast_br
-  checked_cast_br [exact] %0 : $Base to Base, bb3, bb5
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb3, bb5
 // CHECK: [[INNER:%.*]] = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
 // CHECK: apply [[INNER]]
 // CHECK: br bb1
@@ -1163,8 +1163,8 @@ sil @not_redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> 
 bb0(%0 : $Base):
 // CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
-  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb2, bb7
 
 // CHECK: bb1:
 // CHECK: tuple ()
@@ -1199,8 +1199,8 @@ bb6(%17 : $()):
   br bb1
 
 bb7:
-// CHECK: checked_cast_br [exact] %0 : $Base to Derived
-  checked_cast_br [exact] %0 : $Base to Derived, bb3, bb5
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Derived
+  checked_cast_br [exact] Base in %0 : $Base to Derived, bb3, bb5
 }
 
 // CHECK-LABEL: sil @failing_checked_cast_br
@@ -1208,8 +1208,8 @@ sil @failing_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : $Base):
 // CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
-  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb2, bb7
 
 // CHECK-LABEL: bb1
 bb1:
@@ -1220,13 +1220,13 @@ bb2(%5 : $Base):
 // CHECK: [[SUCCESS]]
 // CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK-NOT: checked_cast_br [exact] %0 : $Base to Derived
+// CHECK-NOT: checked_cast_br [exact] Base in %0 : $Base to Derived
 // CHECK: apply [[METHOD2]]
 // Check that checked_cast_br [exact] was replaced by a branch to the failure BB of the checked_cast_br.
 // This is because bb2 is reached via the success branch of the checked_cast_br [exact] from bb0.
 // It means that the exact dynamic type of %0 is $Base. Thus it cannot be $Derived.
 // CHECK: br bb1
-  checked_cast_br [exact] %5 : $Base to Derived, bb3, bb5
+  checked_cast_br [exact] Base in %5 : $Base to Derived, bb3, bb5
 
 bb3(%9 : $Derived):
   %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
@@ -1263,7 +1263,7 @@ sil @no_checked_cast_br_threading_with_alloc_ref_stack : $@convention(method) (@
 bb0(%0 : $Base):
   %fu = function_ref @unknown : $@convention(thin) () -> ()
   %fu2 = function_ref @unknown2 : $@convention(thin) () -> ()
-  checked_cast_br [exact] %0 : $Base to Base, bb1, bb2
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb1, bb2
 
 bb1(%1 : $Base):
   apply %fu() : $@convention(thin) () -> ()
@@ -1275,7 +1275,7 @@ bb2:
 
 bb3:
   %a = alloc_ref [stack] $Base
-  checked_cast_br [exact] %0 : $Base to Base, bb4, bb5
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb4, bb5
 
 bb4(%2 : $Base):
   apply %fu() : $@convention(thin) () -> ()
@@ -1720,7 +1720,7 @@ class E : B {}
 sil @checked_cast_anyobject_metatypeinst_to_class : $@convention(thin)() -> () {
 bb0:
   %0 = metatype $@thick AnyObject.Protocol
-  checked_cast_br %0 : $@thick AnyObject.Protocol to B.Type, bb1, bb2
+  checked_cast_br AnyObject.Protocol in %0 : $@thick AnyObject.Protocol to B.Type, bb1, bb2
 
 bb1(%3 : $@thick B.Type):
   br bb3
@@ -2095,7 +2095,7 @@ bb3(%a3 : $Builtin.Int1):
 sil @successful_checked_cast_br_on_alloc_ref : $() -> Builtin.Int32 {
 bb0:
   %1 = alloc_ref $B
-  checked_cast_br [exact] %1 : $B to B, bb1, bb2
+  checked_cast_br [exact] B in %1 : $B to B, bb1, bb2
 
 bb1(%2 : $B):
   %3 = integer_literal $Builtin.Int32, 1
@@ -2122,7 +2122,7 @@ sil @failing_checked_cast_br_on_alloc_ref : $() -> Builtin.Int32 {
 bb0:
   %1 = alloc_ref $E
   %2 = upcast %1 : $E to $B
-  checked_cast_br [exact] %2 : $B to B, bb1, bb2
+  checked_cast_br [exact] B in %2 : $B to B, bb1, bb2
 
 bb1(%3 : $B):
   %4 = integer_literal $Builtin.Int32, 1
@@ -3186,7 +3186,7 @@ bb1:
 
 
 bb2(%18 : $Base):
-  checked_cast_br %18 : $Base to Derived, bb3, bb4
+  checked_cast_br Base in %18 : $Base to Derived, bb3, bb4
 
 bb3(%21 : $Derived):
   %22 = integer_literal $Builtin.Int1, -1
@@ -3201,7 +3201,7 @@ bb5(%26 : $Builtin.Int1):
   cond_br %26, bb6, bb19
 
 bb6:
-  checked_cast_br %18 : $Base to Derived, bb7, bb8
+  checked_cast_br Base in %18 : $Base to Derived, bb7, bb8
 
 
 bb7(%29 : $Derived):
@@ -3221,7 +3221,7 @@ bb10(%36 : $Derived):
   br bb11
 
 bb11:
-  checked_cast_br %18 : $Base to Derived, bb12, bb13
+  checked_cast_br Base in %18 : $Base to Derived, bb12, bb13
 
 
 bb12(%43 : $Derived):

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -92,14 +92,14 @@ bb2(%11 : $Bool):
 class A {}
 
 //CHECK-LABEL: no_remove_mandatory_dead_args
-//CHECK: checked_cast_br {{%.*}} : $AnyObject to A, bb1
+//CHECK: checked_cast_br AnyObject in {{%.*}} : $AnyObject to A, bb1
 //CHECK-NOT: bb1
 //CHECK: bb1([[VAR:%[0-9]+]] : $A)
 //CHECK-NOT: [[VAR]]
 //CHECK: return
 sil @no_remove_mandatory_dead_args : $@convention(thin) (@owned AnyObject) -> Int32 {
 bb0(%0 : $AnyObject):
-  checked_cast_br %0 : $AnyObject to A, bb1, bb2
+  checked_cast_br AnyObject in %0 : $AnyObject to A, bb1, bb2
 
 bb1(%1 : $A):
   %2 = integer_literal $Builtin.Int32, 1

--- a/test/SILOptimizer/simplify_cfg_checkcast.sil
+++ b/test/SILOptimizer/simplify_cfg_checkcast.sil
@@ -52,8 +52,8 @@ sil [ossa] @redundant_checked_cast_br : $@convention(method) (@guaranteed Base) 
 bb0(%0 : @guaranteed $Base):
 // CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
-  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb2, bb7
 
 // CHECK: bb1
 bb1:
@@ -64,7 +64,7 @@ bb2(%5 : @guaranteed $Base):
 // CHECK: [[SUCCESS]]
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // CHECK-NOT: checked_cast_br
-  checked_cast_br [exact] %0 : $Base to Base, bb3, bb5
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb3, bb5
 // CHECK: [[INNER:%.*]] = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
 // CHECK: apply [[INNER]]
 // CHECK: br bb1
@@ -98,11 +98,11 @@ bb7(%defaultBB0 : @guaranteed $Base):
 sil [ossa] @redundant_checked_cast_br_owned : $@convention(method) (@guaranteed Base) -> () {
 // CHECK: [[COPY:%.*]] = copy_value %0
 // CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+// CHECK: checked_cast_br [exact] Base in [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
 bb0(%0 : @guaranteed $Base):
   %copy = copy_value %0 : $Base
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-  checked_cast_br [exact] %copy : $Base to Base, bb2, bb7
+  checked_cast_br [exact] Base in %copy : $Base to Base, bb2, bb7
 
 // CHECK: bb1
 bb1:
@@ -119,7 +119,7 @@ bb1:
 // CHECK: br bb1
 bb2(%5 : @owned $Base):
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-  checked_cast_br [exact] %5 : $Base to Base, bb3, bb5
+  checked_cast_br [exact] Base in %5 : $Base to Base, bb3, bb5
 
 // CHECK: [[FAIL]]([[FAILARG:%.*]] : @owned $Base)
 // CHECK-NOT: function-ref
@@ -153,8 +153,8 @@ sil [ossa] @not_redundant_checked_cast_br : $@convention(method) (@guaranteed Ba
 bb0(%0 : @guaranteed $Base):
 // CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
-  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb2, bb7
 
 // CHECK: bb1:
 // CHECK: tuple ()
@@ -189,8 +189,8 @@ bb6(%17 : $()):
   br bb1
 
 bb7(%10a : @guaranteed $Base):
-// CHECK: checked_cast_br [exact] %0 : $Base to Derived
-  checked_cast_br [exact] %0 : $Base to Derived, bb3, bb5
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Derived
+  checked_cast_br [exact] Base in %0 : $Base to Derived, bb3, bb5
 }
 
 // CHECK-LABEL: sil [ossa] @failing_checked_cast_br
@@ -198,8 +198,8 @@ sil [ossa] @failing_checked_cast_br : $@convention(method) (@guaranteed Base) ->
 bb0(%0 : @guaranteed $Base):
 // CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
-  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+// CHECK: checked_cast_br [exact] Base in %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb2, bb7
 
 // CHECK-LABEL: bb1
 bb1:
@@ -210,13 +210,13 @@ bb2(%5 : @guaranteed $Base):
 // CHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @guaranteed $Base)
 // CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK-NOT: checked_cast_br [exact] %0 : $Base to Derived
+// CHECK-NOT: checked_cast_br [exact] Base in %0 : $Base to Derived
 // CHECK: apply [[METHOD2]]([[SUCCESSARG]])
 // Check that checked_cast_br [exact] was replaced by a branch to the failure BB of the checked_cast_br.
 // This is because bb2 is reached via the success branch of the checked_cast_br [exact] from bb0.
 // It means that the exact dynamic type of %0 is $Base. Thus it cannot be $Derived.
 // CHECK: br bb1
-  checked_cast_br [exact] %5 : $Base to Derived, bb3, bb5
+  checked_cast_br [exact] Base in %5 : $Base to Derived, bb3, bb5
 
 bb3(%9 : @guaranteed $Derived):
   %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
@@ -243,11 +243,11 @@ bb7(%anotherDefaultPayload : @guaranteed $Base):
 sil [ossa] @failing_checked_cast_br_owned : $@convention(method) (@guaranteed Base) -> () {
 // CHECK: [[COPY:%.*]] = copy_value %0
 // CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK: checked_cast_br [exact] [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+// CHECK: checked_cast_br [exact] Base in [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
 bb0(%0 : @guaranteed $Base):
   %copy = copy_value %0 : $Base
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-  checked_cast_br [exact] %copy : $Base to Base, bb2, bb7
+  checked_cast_br [exact] Base in %copy : $Base to Base, bb2, bb7
 
 // CHECK-LABEL: bb1
 bb1:
@@ -256,7 +256,7 @@ bb1:
 
 // CHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @owned $Base)
 // CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// CHECK-NOT: checked_cast_br [exact] %0 : $Base to Derived
+// CHECK-NOT: checked_cast_br [exact] Base in %0 : $Base to Derived
 // CHECK: apply [[METHOD2]]([[SUCCESSARG]])
 // Check that checked_cast_br [exact] was replaced by a branch to the failure BB of the checked_cast_br.
 // This is because bb2 is reached via the success branch of the checked_cast_br [exact] from bb0.
@@ -264,7 +264,7 @@ bb1:
 // CHECK: br bb1
 bb2(%5 : @owned $Base):
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-  checked_cast_br [exact] %5 : $Base to Derived, bb3, bb5
+  checked_cast_br [exact] Base in %5 : $Base to Derived, bb3, bb5
 
 bb3(%9 : @owned $Derived):
   %upcast = upcast %9 : $Derived to $Base
@@ -305,7 +305,7 @@ sil [ossa] @no_checked_cast_br_threading_with_alloc_ref_stack : $@convention(met
 bb0(%0 : @guaranteed $Base):
   %fu = function_ref @unknown : $@convention(thin) () -> ()
   %fu2 = function_ref @unknown2 : $@convention(thin) () -> ()
-  checked_cast_br [exact] %0 : $Base to Base, bb1, bb2
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb1, bb2
 
 bb1(%1 : @guaranteed $Base):
   apply %fu() : $@convention(thin) () -> ()
@@ -317,7 +317,7 @@ bb2(%1a : @guaranteed $Base):
 
 bb3:
   %a = alloc_ref [stack] $Base
-  checked_cast_br [exact] %0 : $Base to Base, bb4, bb5
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb4, bb5
 
 bb4(%2 : @guaranteed $Base):
   apply %fu() : $@convention(thin) () -> ()
@@ -341,7 +341,7 @@ bb6:
 sil [ossa] @redundant_checked_cast_br_joined_success_fail_unknown : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : @guaranteed $Base):
   %middle = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-  checked_cast_br [exact] %0 : $Base to Base, bb1, bb4
+  checked_cast_br [exact] Base in %0 : $Base to Base, bb1, bb4
 
 bb1(%successBB0 : @guaranteed $Base):
   cond_br undef, bb2, bb3
@@ -371,7 +371,7 @@ bb7(%unknown : @guaranteed $Base):
 
 bb8(%joined : @guaranteed $Base):
   %joinedCall = apply %middle(%joined) : $@convention(method) (@guaranteed Base) -> ()
-  checked_cast_br [exact] %joined : $Base to Base, bb9, bb10
+  checked_cast_br [exact] Base in %joined : $Base to Base, bb9, bb10
 
 bb9(%successBB7 : @guaranteed $Base):
   %successBB7call8 = apply %middle(%successBB7) : $@convention(method) (@guaranteed Base) -> ()
@@ -401,7 +401,7 @@ bb0(%0 : @guaranteed $Klass):
   %2 = integer_literal $Builtin.Int64, 1
   %3 = apply %1() : $@convention(thin) () -> @owned Klass
   %4 = copy_value %3 : $Klass
-  checked_cast_br %3 : $Klass to OtherKlass, bb1, bb2
+  checked_cast_br Klass in %3 : $Klass to OtherKlass, bb1, bb2
 
 bb1(%5 : @owned $OtherKlass):
   destroy_value %5 : $OtherKlass
@@ -427,7 +427,7 @@ bb6:
   br bb10(%2 : $Builtin.Int64)
 
 bb7(%16 : @owned $Klass):
-  checked_cast_br %16 : $Klass to OtherKlass, bb9, bb8
+  checked_cast_br Klass in %16 : $Klass to OtherKlass, bb9, bb8
 
 bb8(%18 : @owned $Klass):
   destroy_value %18 : $Klass
@@ -439,7 +439,7 @@ bb9(%20 : @owned $OtherKlass):
 bb10(%22 : $Builtin.Int64):
   %23 = apply %1() : $@convention(thin) () -> @owned Klass
   %24 = copy_value %23 : $Klass
-  checked_cast_br %23 : $Klass to OtherKlass, bb11, bb12
+  checked_cast_br Klass in %23 : $Klass to OtherKlass, bb11, bb12
 
 bb11(%25 : @owned $OtherKlass):
   destroy_value %25 : $OtherKlass
@@ -477,7 +477,7 @@ bb17:
 // CHECK-LABEL: sil [ossa] @redundant_checked_cast_br_rauw_guaranteed_to_owned_success : $@convention(method) (@owned Base) -> () {
 // CHECK: bb0(%0 : @owned $Base):
 // CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $Base
-// CHECK:   checked_cast_br [exact] [[BORROW]]  : $Base to Base, bb1, bb2
+// CHECK:   checked_cast_br [exact] Base in [[BORROW]]  : $Base to Base, bb1, bb2
 // CHECK: bb1([[EXACT:%.*]] : @guaranteed $Base):
 // CHECK-NEXT:   [[NEWCP:%.*]] = copy_value [[EXACT]] : $Base
 // CHECK-NEXT:   [[OLDCP:%.*]] = copy_value [[EXACT]] : $Base
@@ -497,13 +497,13 @@ sil [ossa] @redundant_checked_cast_br_rauw_guaranteed_to_owned_success : $@conve
 bb0(%0 : @owned $Base):
   %borrow = begin_borrow %0 : $Base
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-  checked_cast_br [exact] %borrow : $Base to Base, bb1, bb6
+  checked_cast_br [exact] Base in %borrow : $Base to Base, bb1, bb6
 
 bb1(%5 : @guaranteed $Base):
   %6 = copy_value %5 : $Base
   end_borrow %borrow : $Base
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-  checked_cast_br [exact] %6 : $Base to Base, bb2, bb4
+  checked_cast_br [exact] Base in %6 : $Base to Base, bb2, bb4
 
 bb2(%9 : @owned $Base):
   %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
@@ -544,7 +544,7 @@ bb7:
 // CHECK-LABEL: sil [ossa] @redundant_checked_cast_br_rauw_guaranteed_to_owned_merge : $@convention(method) (@owned Base) -> () {
 // CHECK: bb0(%0 : @owned $Base):
 // CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $Base
-// CHECK:   checked_cast_br [exact] [[BORROW]] : $Base to Base, bb1, bb3
+// CHECK:   checked_cast_br [exact] Base in [[BORROW]] : $Base to Base, bb1, bb3
 // CHECK: bb1([[ARG1:%.*]] : @guaranteed $Base):
 // CHECK:   [[NEWCOPY1:%.*]] = copy_value [[ARG1]] : $Base
 // CHECK:   apply %{{.*}}([[ARG1]]) : $@convention(method) (@guaranteed Base) -> ()
@@ -570,7 +570,7 @@ bb0(%0 : @owned $Base):
   %m = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %f = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
   %1 = begin_borrow %0 : $Base
-  checked_cast_br [exact] %1 : $Base to Base, bb1, bb2
+  checked_cast_br [exact] Base in %1 : $Base to Base, bb1, bb2
 
 bb1(%4 : @guaranteed $Base):
   %5 = apply %f(%4) : $@convention(method) (@guaranteed Base) -> ()
@@ -583,7 +583,7 @@ bb2(%7 : @guaranteed $Base):
 bb3:
   %11 = copy_value %1 : $Base
   end_borrow %1 : $Base
-  checked_cast_br [exact] %11 : $Base to Base, bb4, bb5
+  checked_cast_br [exact] Base in %11 : $Base to Base, bb4, bb5
 
 bb4(%14 : @owned $Base):
   %15 = apply %f(%14) : $@convention(method) (@guaranteed Base) -> ()
@@ -611,7 +611,7 @@ bb6:
 // CHECK-LABEL: sil [ossa] @redundant_checked_cast_br_rauw_guaranteed_to_owned_mergecopy : $@convention(method) (@owned Base) -> () {
 // CHECK: bb0(%0 : @owned $Base):
 // CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $Base
-// CHECK:   checked_cast_br [exact] [[BORROW]] : $Base to Base, bb1, bb2
+// CHECK:   checked_cast_br [exact] Base in [[BORROW]] : $Base to Base, bb1, bb2
 // CHECK: bb1([[ARG1:%.*]] : @guaranteed $Base):
 // CHECK:   [[CP1:%.*]] = copy_value [[ARG1]] : $Base
 // CHECK:   apply %2([[ARG1]]) : $@convention(method) (@guaranteed Base) -> ()
@@ -621,7 +621,7 @@ bb6:
 // CHECK:   apply %{{.*}}([[ARG2]]) : $@convention(method) (@guaranteed Base) -> ()
 // CHECK:   [[RESULT:%.*]] = apply %{{.*}}() : $@convention(thin) () -> @owned Base
 // CHECK:   end_borrow [[BORROW]] : $Base
-// CHECK:   checked_cast_br [exact] %13 : $Base to Base, bb3, bb5
+// CHECK:   checked_cast_br [exact] Base in %13 : $Base to Base, bb3, bb5
 // CHECK: bb3([[ARG3:%.*]] : @owned $Base):
 // CHECK:   br bb4(%16 : $Base)
 // CHECK: bb4([[ARG4:%.*]] : @owned $Base):
@@ -643,7 +643,7 @@ bb0(%0 : @owned $Base):
   %2 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
   %f = function_ref @get_base : $@convention(thin) () -> @owned Base
   %3 = begin_borrow %0 : $Base
-  checked_cast_br [exact] %3 : $Base to Base, bb1, bb2
+  checked_cast_br [exact] Base in %3 : $Base to Base, bb1, bb2
 
 bb1(%6 : @guaranteed $Base):
   %7 = apply %2(%6) : $@convention(method) (@guaranteed Base) -> ()
@@ -657,7 +657,7 @@ bb2(%9 : @guaranteed $Base):
 
 bb3(%12 : @owned $Base):
   end_borrow %3 : $Base
-  checked_cast_br [exact] %12 : $Base to Base, bb6, bb7
+  checked_cast_br [exact] Base in %12 : $Base to Base, bb6, bb7
 
 bb6(%16 : @owned $Base):
   %17 = apply %2(%16) : $@convention(method) (@guaranteed Base) -> ()
@@ -682,13 +682,13 @@ bb8:
 sil [ossa] @redundant_checked_cast_failure_path : $@convention(method) (@owned Base) -> () {
 bb0(%0 : @owned $Base):
   %borrow = begin_borrow %0 : $Base
-  checked_cast_br %borrow : $Base to Derived, bb1, bb2
+  checked_cast_br Base in %borrow : $Base to Derived, bb1, bb2
 
 bb1(%succ1 : @guaranteed $Derived):
   br bbexit
 
 bb2(%5 : @guaranteed $Base):
-  checked_cast_br %5 : $Base to Derived, bb3, bb4
+  checked_cast_br Base in %5 : $Base to Derived, bb3, bb4
 
 bb3(%9 : @guaranteed $Derived):
   br bbexit
@@ -712,7 +712,7 @@ bbexit:
 sil [ossa] @redundant_checked_cast_failure_path_not_idom : $@convention(method) (@owned Base) -> () {
 bb0(%0 : @owned $Base):
   %borrow = begin_borrow %0 : $Base
-  checked_cast_br %borrow : $Base to Derived, bb1, bb2
+  checked_cast_br Base in %borrow : $Base to Derived, bb1, bb2
 
 bb1(%succ1 : @guaranteed $Derived):
   br bbexit
@@ -721,7 +721,7 @@ bb2(%5 : @guaranteed $Base):
   br bb3(%5 : $Base)
 
 bb3(%6 : @guaranteed $Base):
-  checked_cast_br %6 : $Base to Derived, bb4, bb5
+  checked_cast_br Base in %6 : $Base to Derived, bb4, bb5
 
 bb4(%9 : @guaranteed $Derived):
   br bbexit

--- a/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
@@ -407,7 +407,7 @@ bb6:
 sil @test_checked_cast_br : $@convention(thin) (E, @owned Base, @owned Base, @owned Base, @owned Base) -> Builtin.Int64 {
 bb0(%0 : $E, %1 : $Base, %2 : $Base, %3 : $Base, %4 : $Base):
   %s1 = select_enum %0 : $E, case #E.A!enumelt: %1, default %2 : $Base
-  checked_cast_br %s1 : $Base to Derived1, bb1, bb2
+  checked_cast_br Base in %s1 : $Base to Derived1, bb1, bb2
 
 bb1(%a1 : $Derived1):
   %i1 = integer_literal $Builtin.Int64, 1
@@ -415,7 +415,7 @@ bb1(%a1 : $Derived1):
 
 bb2:
   %s2 = select_enum %0 : $E, case #E.B!enumelt: %3, default %4 : $Base
-  checked_cast_br %s2 : $Base to Derived1, bb3, bb4
+  checked_cast_br Base in %s2 : $Base to Derived1, bb3, bb4
 
 bb3(%a2 : $Derived1):
   %i2 = integer_literal $Builtin.Int64, 2

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -894,7 +894,7 @@ enum IntEnum : Int32 {
 sil [ossa] @checked_cast_anyobject_metatypeinst_to_class : $@convention(thin)() -> () {
 bb0:
   %0 = metatype $@thick AnyObject.Protocol
-  checked_cast_br %0 : $@thick AnyObject.Protocol to B.Type, bb1, bb2
+  checked_cast_br AnyObject.Protocol in %0 : $@thick AnyObject.Protocol to B.Type, bb1, bb2
 
 bb1(%3 : $@thick B.Type):
   br bb3
@@ -1319,7 +1319,7 @@ bb3(%a3 : $Builtin.Int1):
 sil [ossa] @successful_checked_cast_br_on_alloc_ref : $() -> Builtin.Int32 {
 bb0:
   %1 = alloc_ref $B
-  checked_cast_br [exact] %1 : $B to B, bb1, bb2
+  checked_cast_br [exact] B in %1 : $B to B, bb1, bb2
 
 bb1(%2 : @owned $B):
   destroy_value %2 : $B
@@ -1347,7 +1347,7 @@ sil [ossa] @failing_checked_cast_br_on_alloc_ref : $() -> Builtin.Int32 {
 bb0:
   %1 = alloc_ref $E
   %2 = upcast %1 : $E to $B
-  checked_cast_br [exact] %2 : $B to B, bb1, bb2
+  checked_cast_br [exact] B in %2 : $B to B, bb1, bb2
 
 bb1(%3 : @owned $B):
   destroy_value %3 : $B

--- a/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
@@ -213,14 +213,14 @@ bb3:
 }
 
 // CHECK-LABEL: test_dont_remove_mandatory_dead_args :
-// CHECK: checked_cast_br {{%.*}} : $AnyKlass to Klass, bb1
+// CHECK: checked_cast_br AnyKlass in {{%.*}} : $AnyKlass to Klass, bb1
 // CHECK: bb1([[VAR:%[0-9]+]] : @guaranteed $Klass)
 // CHECK-NOT: [[VAR]]
 // CHECK: return
 sil [ossa] @test_dont_remove_mandatory_dead_args : $@convention(thin) (@guaranteed AnyKlass) -> () {
 bb0(%0 : @guaranteed $AnyKlass):
   test_specification "simplify-cfg-simplify-argument @block[1] 0"
-  checked_cast_br %0 : $AnyKlass to Klass, bb1, bb2
+  checked_cast_br AnyKlass in %0 : $AnyKlass to Klass, bb1, bb2
 
 bb1(%1 : @guaranteed $Klass):
   %2 = integer_literal $Builtin.Int32, 1

--- a/test/SILOptimizer/simplify_cfg_ossa_jump_threading.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_jump_threading.sil
@@ -144,7 +144,7 @@ bb2:
 bb6(%4 : @owned $AnyKlass):
   destroy_value %0 : $AnyKlass
   destroy_value %1 : $AnyKlass
-  checked_cast_br %4 : $AnyKlass to Klass, bb7, bb8
+  checked_cast_br AnyKlass in %4 : $AnyKlass to Klass, bb7, bb8
 
 bb7(%k : @owned $Klass):
   destroy_value %k : $Klass

--- a/test/SILOptimizer/simplify_cfg_ossa_simplify_branch.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_simplify_branch.sil
@@ -17,7 +17,7 @@ sil [ossa] @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 sil [ossa] @test_cfg1 : $@convention(thin) (@guaranteed SuperKlass) -> @out FakeOptional<Klass> {
 bb0(%0 : $*FakeOptional<Klass>, %1 : @guaranteed $SuperKlass):
   %2 = init_enum_data_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt
-  checked_cast_br %1 : $SuperKlass to Klass, bb1, bb2
+  checked_cast_br SuperKlass in %1 : $SuperKlass to Klass, bb1, bb2
 
 bb1(%6 : @guaranteed $Klass):
   %7 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %6 : $Klass

--- a/test/SILOptimizer/simplify_cfg_select_enum.sil
+++ b/test/SILOptimizer/simplify_cfg_select_enum.sil
@@ -34,7 +34,7 @@ class Derived2 : Base { }
 sil @test_checked_cast_br : $@convention(thin) (E, @owned Base, @owned Base, @owned Base, @owned Base) -> Builtin.Int64 {
 bb0(%0 : $E, %1 : $Base, %2 : $Base, %3 : $Base, %4 : $Base):
   %s1 = select_enum %0 : $E, case #E.A!enumelt: %1, default %2 : $Base
-  checked_cast_br %s1 : $Base to Derived1, bb1, bb2
+  checked_cast_br Base in %s1 : $Base to Derived1, bb1, bb2
 
 bb1(%a1 : $Derived1):
   %i1 = integer_literal $Builtin.Int64, 1
@@ -42,7 +42,7 @@ bb1(%a1 : $Derived1):
 
 bb2:
   %s2 = select_enum %0 : $E, case #E.B!enumelt: %3, default %4 : $Base
-  checked_cast_br %s2 : $Base to Derived1, bb3, bb4
+  checked_cast_br Base in %s2 : $Base to Derived1, bb3, bb4
 
 bb3(%a2 : $Derived1):
   %i2 = integer_literal $Builtin.Int64, 2

--- a/test/SILOptimizer/simplify_checked_cast_br.sil
+++ b/test/SILOptimizer/simplify_checked_cast_br.sil
@@ -12,14 +12,14 @@ class X : B {}
 
 // CHECK-LABEL: sil @test_non_ossa :
 // CHECK:         %0 = alloc_ref
-// CHECK:         checked_cast_br %0 : $X
+// CHECK:         checked_cast_br AnyObject in %0 : $X
 // CHECK:       } // end sil function 'test_non_ossa'
 sil @test_non_ossa : $@convention(thin) () -> AnyObject {
 bb0:
   %0 = alloc_ref $X
   %1 = upcast %0 : $X to $B
   %2 = init_existential_ref %1 : $B : $B, $AnyObject
-  checked_cast_br %2 : $AnyObject to X, bb1, bb2
+  checked_cast_br AnyObject in %2 : $AnyObject to X, bb1, bb2
 
 bb1(%5 : $X):
   strong_release %5 : $X
@@ -31,8 +31,8 @@ bb2:
 
 // CHECK-LABEL: sil [ossa] @test_ossa :
 // CHECK:         %0 = alloc_ref
-// CHECK-O-NEXT:  checked_cast_br %0 : $X
-// CHECK-ONONE:   checked_cast_br %2 : $AnyObject
+// CHECK-O-NEXT:  checked_cast_br AnyObject in %0 : $X
+// CHECK-ONONE:   checked_cast_br AnyObject in %2 : $AnyObject
 // CHECK-O:     bb2([[A:%.*]] : @owned $X):
 // CHECK-O-NEXT:  [[U:%.*]] = upcast [[A]] : $X to $B
 // CHECK-O-NEXT:  [[E:%.*]] = init_existential_ref [[U]] : $B
@@ -45,7 +45,7 @@ bb0:
   %1 = upcast %0 : $X to $B
   %2 = init_existential_ref %1 : $B : $B, $AnyObject
   debug_value %2 : $AnyObject, name "x"
-  checked_cast_br %2 : $AnyObject to X, bb1, bb2
+  checked_cast_br AnyObject in %2 : $AnyObject to X, bb1, bb2
 
 bb1(%5 : @owned $X):
   return %5 : $X
@@ -56,14 +56,14 @@ bb2(%7 : @owned $AnyObject):
 }
 
 // CHECK-LABEL: sil [ossa] @test_ossa_multiple_uses :
-// CHECK:         checked_cast_br %1 : $B
+// CHECK:         checked_cast_br B in %1 : $B
 // CHECK:       } // end sil function 'test_ossa_multiple_uses'
 sil [ossa] @test_ossa_multiple_uses : $@convention(thin) () -> @owned X {
 bb0:
   %0 = alloc_ref $X
   %1 = upcast %0 : $X to $B
   fix_lifetime %1 : $B
-  checked_cast_br %1 : $B to X, bb1, bb2
+  checked_cast_br B in %1 : $B to X, bb1, bb2
 
 bb1(%5 : @owned $X):
   return %5 : $X
@@ -75,7 +75,7 @@ bb2(%7 : @owned $B):
 
 // CHECK-LABEL: sil [ossa] @test_borrow :
 // CHECK:         %1 = begin_borrow
-// CHECK-NEXT:    checked_cast_br %1 : $X
+// CHECK-NEXT:    checked_cast_br any P in %1 : $X
 // CHECK:       bb2([[A:%.*]] : @guaranteed $X):
 // CHECK-NEXT:    [[U:%.*]] = upcast [[A]] : $X to $B
 // CHECK-NEXT:    [[E:%.*]] = init_existential_ref [[U]] : $B
@@ -87,7 +87,7 @@ bb0:
   %1 = begin_borrow %0 : $X
   %2 = upcast %1 : $X to $B
   %3 = init_existential_ref %2 : $B : $B, $P
-  checked_cast_br %3 : $P to X, bb1, bb2
+  checked_cast_br P in %3 : $P to X, bb1, bb2
 
 bb1(%5 : @guaranteed $X):
   end_borrow %1 : $X

--- a/test/SILOptimizer/specialize_checked_cast_branch.swift
+++ b/test/SILOptimizer/specialize_checked_cast_branch.swift
@@ -27,7 +27,7 @@ public func ArchetypeToArchetypeCast<T1, T2>(t1 : T1, t2 : T2) -> T2 {
 
 // CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
 // CHECK: bb0([[ARG:%.*]] : $C, [[ARG2:%.*]] : $D):
-// CHECK:  checked_cast_br [[ARG]] : $C to D, bb1, bb2
+// CHECK:  checked_cast_br C in [[ARG]] : $C to D, bb1, bb2
 //
 // CHECK: bb1([[T0:%.*]] : $D):
 // CHECK:   strong_retain [[ARG]]
@@ -175,7 +175,7 @@ _ = ArchetypeToConcreteCastC(t: e)
 // x -> y where x is a super class of y.
 // CHECK-LABEL: sil shared @$s30specialize_checked_cast_branch24ArchetypeToConcreteCastD1tAA1DCx_tlFAA1CC_Tg5 : $@convention(thin) (@guaranteed C) -> @owned D {
 // CHECK: bb0([[ARG:%.*]] : $C):
-// CHECK:   checked_cast_br [[ARG]] : $C to D, [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
+// CHECK:   checked_cast_br C in [[ARG]] : $C to D, [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
 //
 // CHECK: [[SUCC_BB]]([[T0:%.*]] : $D):
 // CHECK:   strong_retain [[ARG]]
@@ -250,7 +250,7 @@ _ = ConcreteToArchetypeCastC(t: c, t2: b)
 
 // CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
 // CHECK: bb0
-// CHECK:  checked_cast_br %0 : $C to D
+// CHECK:  checked_cast_br C in %0 : $C to D
 // CHECK: bb1
 _ = ConcreteToArchetypeCastC(t: c, t2: d)
 
@@ -290,7 +290,7 @@ _ = SuperToArchetypeCastC(c: c, t: c)
 
 // CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
 // CHECK: bb0
-// CHECK:  checked_cast_br %0 : $C to D
+// CHECK:  checked_cast_br C in %0 : $C to D
 // CHECK: bb1
 _ = SuperToArchetypeCastC(c: c, t: d)
 
@@ -323,7 +323,7 @@ func ExistentialToArchetypeCast<T>(o : AnyObject, t : T) -> T {
 
 // CHECK-LABEL: sil shared {{.*}}@$s30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed C) -> @owned C
 // CHECK: bb0
-// CHECK:  checked_cast_br %0 : $AnyObject to C
+// CHECK:  checked_cast_br AnyObject in %0 : $AnyObject to C
 // CHECK: bb1
 _ = ExistentialToArchetypeCast(o: o, t: c)
 

--- a/test/SILOptimizer/split_critical_edges.sil
+++ b/test/SILOptimizer/split_critical_edges.sil
@@ -128,9 +128,9 @@ class ParentNode : Node {
 // CHECK: bb0(
 // CHECK:   cond_br %1, bb1, bb2
 // CHECK: bb1:
-// CHECK:   checked_cast_br [exact] {{.*}} : $Node to ParentNode, bb3, bb4
+// CHECK:   checked_cast_br [exact] Node in {{.*}} : $Node to ParentNode, bb3, bb4
 // CHECK: bb2:
-// CHECK:   checked_cast_br [exact] {{.*}} : $Node to ParentNode, bb5, bb6
+// CHECK:   checked_cast_br [exact] Node in {{.*}} : $Node to ParentNode, bb5, bb6
 // CHECK: bb3({{.*}} : $ParentNode):
 // CHECK:   br bb7
 // CHECK: bb4:
@@ -147,10 +147,10 @@ bb0(%0 : $Node, %2 : $Builtin.Int1):
   cond_br %2, ccb1, ccb2
 
 ccb1:
-  checked_cast_br [exact] %0 : $Node to ParentNode, bb2, bb3
+  checked_cast_br [exact] Node in %0 : $Node to ParentNode, bb2, bb3
 
 ccb2:
-  checked_cast_br [exact] %0 : $Node to ParentNode, bb4, bb5
+  checked_cast_br [exact] Node in %0 : $Node to ParentNode, bb4, bb5
 
 bb2(%5 : $ParentNode):
   br bb1

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -445,7 +445,7 @@ bb0(%0 : $B):
   store %0 to %1a : $*B
   %3 = load %1a : $*B
   strong_retain %3 : $B
-  checked_cast_br %3 : $B to E, yes, no     // CHECK: checked_cast_br
+  checked_cast_br B in %3 : $B to E, yes, no     // CHECK: checked_cast_br
 yes(%5 : $E):
   %y = integer_literal $Builtin.Int1, 1
   br isa(%y : $Builtin.Int1)


### PR DESCRIPTION
It is necessary for opaque values for casts that will newly start out as `checked_cast_br`s and be lowered to `checked_cast_addr_br`s, since the latter has the source formal type, `IRGen` relies on being able to access it, and there's no way in general to obtain the source formal type from the source lowered type.
