### PR TITLE
[CursorInfo] De-duplicate reported cursor info results

### DIFF
--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -277,6 +277,12 @@ public:
     bool IsDynamicRef;
     /// The declaration that is being referenced. Will never be \c nullptr.
     ValueDecl *ReferencedDecl;
+
+    bool operator==(const CursorInfoDeclReference &Other) const {
+      return nullableTypesEqual(BaseType, Other.BaseType) &&
+             IsDynamicRef == Other.IsDynamicRef &&
+             ReferencedDecl == Other.ReferencedDecl;
+    }
   };
 
 private:
@@ -326,8 +332,16 @@ private:
                             [&S](Expr *E) { return S.getResolvedType(E); });
     }
 
-    Results.push_back(
-        {OverloadInfo.BaseTy, IsDynamicRef, OverloadInfo.getValue()});
+    CursorInfoDeclReference NewResult = {OverloadInfo.BaseTy, IsDynamicRef,
+                                         OverloadInfo.getValue()};
+
+    if (llvm::any_of(Results, [&](const CursorInfoDeclReference &R) {
+          return R == NewResult;
+        })) {
+      return;
+    }
+
+    Results.push_back(NewResult);
   }
 
 public:

--- a/test/SourceKit/CursorInfo/cursor_ambiguous.swift
+++ b/test/SourceKit/CursorInfo/cursor_ambiguous.swift
@@ -2,16 +2,35 @@ func testAmbiguousFunctionReference() {
   func foo(a: Int) {}
   func foo(a: String) {}
 
-  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):7 %s -- %s | %FileCheck %s
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):7 %s -- %s | %FileCheck %s --check-prefix LOCAL_FUNC
   _ = foo
 
-  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):7 %s -- %s | %FileCheck %s
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):7 %s -- %s | %FileCheck %s --check-prefix LOCAL_FUNC
   _ = foo(a: UInt(1))
+
+  // LOCAL_FUNC: source.lang.swift.ref.function.free
+  // LOCAL_FUNC: <Declaration>func foo(a: <Type usr="s:Si">Int</Type>)</Declaration>
+  // LOCAL_FUNC: SECONDARY SYMBOLS BEGIN
+  // LOCAL_FUNC: source.lang.swift.ref.function.free
+  // LOCAL_FUNC: <Declaration>func foo(a: <Type usr="s:SS">String</Type>)</Declaration>
+  // LOCAL_FUNC: SECONDARY SYMBOLS END
 }
 
-// CHECK: source.lang.swift.ref.function.free (2:8-2:19)
-// CHECK: <Declaration>func foo(a: <Type usr="s:Si">Int</Type>)</Declaration>
-// CHECK: SECONDARY SYMBOLS BEGIN
-// CHECK: source.lang.swift.ref.function.free (3:8-3:22)
-// CHECK: <Declaration>func foo(a: <Type usr="s:SS">String</Type>)</Declaration>
-// CHECK: SECONDARY SYMBOLS END
+
+
+struct TestDeduplicateResults {
+  // The constraints system produces multiple solutions here for the argument type but
+  // all reference the same declaration. Check that we de-duplicate them and that we
+  // don’t report any secondary sybmols.
+  static func staticFunc(_ duration: Int) {}
+
+  func test() {
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):10 %s -- %s | %FileCheck %s --check-prefix STATIC_FUNC
+    Self.staticFunc(1 * 1e9)
+  }
+
+  // STATIC_FUNC: source.lang.swift.ref.function.method.static
+  // STATIC_FUNC: <Declaration>static func staticFunc(_ duration: <Type usr="s:Si">Int</Type>)</Declaration>
+  // STATIC_FUNC: SECONDARY SYMBOLS BEGIN
+  // STATIC_FUNC-NEXT: SECONDARY SYMBOLS END
+}


### PR DESCRIPTION
The constraint system might produce multiple solutions that all reference the same declaration. We should only report the declaration once in those cases instead of multiple times.

rdar://111814276
