### PR TITLE
[5.9][SILGenConstructor] InitAccessors: Make sure that accessed fields are initialized before init accessors

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1502,6 +1502,76 @@ void SILGenFunction::emitMemberInitializationViaInitAccessor(
     B.createEndAccess(loc, selfRef.getValue(), /*aborted=*/false);
 }
 
+void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
+                                           PatternBindingDecl *field,
+                                           SubstitutionMap substitutions) {
+  assert(!field->isStatic());
+
+  for (auto i : range(field->getNumPatternEntries())) {
+    auto init = field->getExecutableInit(i);
+    if (!init)
+      continue;
+
+    auto *varPattern = field->getPattern(i);
+
+    // Cleanup after this initialization.
+    FullExpr scope(Cleanups, varPattern);
+
+    // Get the type of the initialization result, in terms
+    // of the constructor context's archetypes.
+    auto resultType =
+        getInitializationTypeInContext(field->getDeclContext(), dc, varPattern);
+    AbstractionPattern origType = resultType.first;
+    CanType substType = resultType.second;
+
+    // Figure out what we're initializing.
+    auto memberInit = emitMemberInit(*this, selfDecl, varPattern);
+
+    // This whole conversion thing is about eliminating the
+    // paired orig-to-subst subst-to-orig conversions that
+    // will happen if the storage is at a different abstraction
+    // level than the constructor. When emitApply() is used
+    // to call the stored property initializer, it naturally
+    // wants to convert the result back to the most substituted
+    // abstraction level. To undo this, we use a converting
+    // initialization and rely on the peephole that optimizes
+    // out the redundant conversion.
+    SILType loweredResultTy;
+    SILType loweredSubstTy;
+
+    // A converting initialization isn't necessary if the member is
+    // a property wrapper. Though the initial value can have a
+    // reabstractable type, the result of the initialization is
+    // always the property wrapper type, which is never reabstractable.
+    bool needsConvertingInit = false;
+    auto *singleVar = varPattern->getSingleVar();
+    if (!(singleVar && singleVar->getOriginalWrappedProperty())) {
+      loweredResultTy = getLoweredType(origType, substType);
+      loweredSubstTy = getLoweredType(substType);
+      needsConvertingInit = loweredResultTy != loweredSubstTy;
+    }
+
+    if (needsConvertingInit) {
+      Conversion conversion =
+          Conversion::getSubstToOrig(origType, substType, loweredResultTy);
+
+      ConvertingInitialization convertingInit(conversion,
+                                              SGFContext(memberInit.get()));
+
+      emitAndStoreInitialValueInto(*this, varPattern, field, i, substitutions,
+                                   origType, substType, &convertingInit);
+
+      auto finalValue = convertingInit.finishEmission(
+          *this, varPattern, ManagedValue::forInContext());
+      if (!finalValue.isInContext())
+        finalValue.forwardInto(*this, varPattern, memberInit.get());
+    } else {
+      emitAndStoreInitialValueInto(*this, varPattern, field, i, substitutions,
+                                   origType, substType, memberInit.get());
+    }
+  }
+}
+
 void SILGenFunction::emitMemberInitializers(DeclContext *dc,
                                             VarDecl *selfDecl,
                                             NominalTypeDecl *nominal) {
@@ -1520,69 +1590,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         }
       }
 
-      for (auto i : range(pbd->getNumPatternEntries())) {
-        auto init = pbd->getExecutableInit(i);
-        if (!init) continue;
-
-        auto *varPattern = pbd->getPattern(i);
-
-        // Cleanup after this initialization.
-        FullExpr scope(Cleanups, varPattern);
-
-        // Get the type of the initialization result, in terms
-        // of the constructor context's archetypes.
-        auto resultType = getInitializationTypeInContext(
-            pbd->getDeclContext(), dc, varPattern);
-        AbstractionPattern origType = resultType.first;
-        CanType substType = resultType.second;
-
-        // Figure out what we're initializing.
-        auto memberInit = emitMemberInit(*this, selfDecl, varPattern);
-
-        // This whole conversion thing is about eliminating the
-        // paired orig-to-subst subst-to-orig conversions that
-        // will happen if the storage is at a different abstraction
-        // level than the constructor. When emitApply() is used
-        // to call the stored property initializer, it naturally
-        // wants to convert the result back to the most substituted
-        // abstraction level. To undo this, we use a converting
-        // initialization and rely on the peephole that optimizes
-        // out the redundant conversion.
-        SILType loweredResultTy;
-        SILType loweredSubstTy;
-
-        // A converting initialization isn't necessary if the member is
-        // a property wrapper. Though the initial value can have a
-        // reabstractable type, the result of the initialization is
-        // always the property wrapper type, which is never reabstractable.
-        bool needsConvertingInit = false;
-        auto *singleVar = varPattern->getSingleVar();
-        if (!(singleVar && singleVar->getOriginalWrappedProperty())) {
-          loweredResultTy = getLoweredType(origType, substType);
-          loweredSubstTy = getLoweredType(substType);
-          needsConvertingInit = loweredResultTy != loweredSubstTy;
-        }
-
-        if (needsConvertingInit) {
-          Conversion conversion = Conversion::getSubstToOrig(
-              origType, substType,
-              loweredResultTy);
-
-          ConvertingInitialization convertingInit(conversion,
-                                                  SGFContext(memberInit.get()));
-
-          emitAndStoreInitialValueInto(*this, varPattern, pbd, i, subs,
-                                       origType, substType, &convertingInit);
-
-          auto finalValue = convertingInit.finishEmission(
-              *this, varPattern, ManagedValue::forInContext());
-          if (!finalValue.isInContext())
-            finalValue.forwardInto(*this, varPattern, memberInit.get());
-        } else {
-          emitAndStoreInitialValueInto(*this, varPattern, pbd, i, subs,
-                                       origType, substType, memberInit.get());
-        }
-      }
+      emitMemberInitializer(dc, selfDecl, pbd, subs);
     }
   }
 }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -802,6 +802,17 @@ public:
   void emitMemberInitializers(DeclContext *dc, VarDecl *selfDecl,
                               NominalTypeDecl *nominal);
 
+  /// Generates code to initialize stored property from its
+  /// initializer.
+  ///
+  /// \param dc The DeclContext containing the current function.
+  /// \param selfDecl The 'self' declaration within the current function.
+  /// \param field The stored property that has to be initialized.
+  /// \param substitutions The substitutions to apply to initializer and setter.
+  void emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
+                             PatternBindingDecl *field,
+                             SubstitutionMap substitutions);
+
   void emitMemberInitializationViaInitAccessor(DeclContext *dc,
                                                VarDecl *selfDecl,
                                                PatternBindingDecl *member,


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/67585

-- 

- Explanation:

Initializations for all of the fields accessed by init accessor
should be emitted before init accessor property even if they are
declared after it in the source order, otherwise a call to init accessor
would reference uninitialized memory which is diagnosed by DI.

- Scope: Init accessors in situations when they appear before properties they access.

- Main Branch PRs: https://github.com/apple/swift/pull/67585

- Resolves: rdar://112984795

- Risk: Low

- Reviewed By: @hborla

- Testing: Added test-cases to the suite.

Resolves: rdar://112984795 


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
