### PR TITLE
[TaskGroup] Fix unlock order, add missing detaches and add more assertions

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1349,8 +1349,7 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
       _swift_taskGroup_detachChild(asAbstract(this), completedTask);
       return unlock();
     }
-    swift_Concurrency_fatalError(0, "expected to early return from when "
-                                    "handling offer of last task in group");
+    swift_unreachable("expected to early return from when handling offer of last task in group");
   }
 
   assert(!hadErrorResult && "only successfully completed tasks can reach here");
@@ -1560,15 +1559,11 @@ AsyncTask* DiscardingTaskGroup::resumeWaitingTaskWithError(
                 waitingTask->ResumeContext);
 
         fillGroupNextResult(waitingContext, result);
-
         _swift_tsan_acquire(static_cast<Job *>(waitingTask));
-//        // TODO: allow the caller to suggest an executor
-//        waitingTask->flagAsAndEnqueueOnExecutor(ExecutorRef::generic());
         return waitingTask;
       } // TODO: what in the else???
 #endif
-//    }
-//  }
+      return nullptr;
 }
 
 SWIFT_CC(swiftasync)

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -660,7 +660,7 @@ void TaskGroupBase::runWaitingTask(PreparedWaitingTask prepared) {
   assert(prepared.waitingTask == nullptr &&
          "unexpected task to schedule in TASK_TO_THREAD_MODEL!"
          "In this mode we should have run the task in-line, "
-         "rather than return it for scheduling.")
+         "rather than return it for scheduling.");
 #endif
   if (auto waitingTask = prepared.waitingTask) {
     // TODO: allow the caller to suggest an executor

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -64,7 +64,7 @@
 
 using namespace swift;
 
-#if 1
+#if 0
 #define SWIFT_TASK_GROUP_DEBUG_LOG_ENABLED 1
 #define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...)                     \
 fprintf(stderr, "[%#lx] [%s:%d][group(%p%s)] (%s) " fmt "\n",           \

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -781,8 +781,10 @@ struct AsyncTask::PrivateStorage {
 
   // Destroy the opaque storage of the task
   void destroy() {
+#ifndef NDEBUG
     auto oldStatus = _status().load(std::memory_order_relaxed);
     assert(oldStatus.isComplete());
+#endif
 
     this->~PrivateStorage();
   }

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -267,7 +267,7 @@ bool isPrivileged() {
 } // namespace
 
 BacktraceInitializer::BacktraceInitializer() {
-  const char *backtracing = "enable=yes,color=yes";// swift::runtime::environment::SWIFT_BACKTRACE();
+  const char *backtracing = swift::runtime::environment::SWIFT_BACKTRACE();
 
   // Force off for setuid processes.
   if (isPrivileged()) {

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -267,7 +267,7 @@ bool isPrivileged() {
 } // namespace
 
 BacktraceInitializer::BacktraceInitializer() {
-  const char *backtracing = swift::runtime::environment::SWIFT_BACKTRACE();
+  const char *backtracing = "enable=yes,color=yes";// swift::runtime::environment::SWIFT_BACKTRACE();
 
   // Force off for setuid processes.
   if (isPrivileged()) {

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -6,8 +6,6 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: OS=linux-gnu
 
-// REQUIRES: rdar86028226
-
 struct Boom: Error {}
 
 func boom() async throws -> Int {
@@ -18,7 +16,7 @@ func boom() async throws -> Int {
 func test_taskGroup_next() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
-      group.spawn {
+      group.addTask {
         return n.isMultiple(of: 3) ? try await boom() : n
       }
     }
@@ -51,7 +49,7 @@ func test_taskGroup_next() async {
 func test_taskGroup_for_in() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
-      group.spawn {
+      group.addTask {
         return n.isMultiple(of: 3) ? try await boom() : n
       }
     }
@@ -82,7 +80,7 @@ func test_taskGroup_for_in() async {
 func test_taskGroup_asyncIterator() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
-      group.spawn {
+      group.addTask {
         return n.isMultiple(of: 3) ? try await boom() : n
       }
     }
@@ -120,7 +118,7 @@ func test_taskGroup_asyncIterator() async {
 func test_taskGroup_contains() async {
   let sum = await withTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...4 {
-      group.spawn {
+      group.addTask {
         return n
       }
     }
@@ -129,7 +127,7 @@ func test_taskGroup_contains() async {
     print("three = \(three)") // CHECK: three = true
 
     for n in 5...7 {
-      group.spawn {
+      group.addTask {
         return n
       }
     }

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
@@ -108,6 +108,8 @@ func testTwo() async {
   // CHECK-DAG: deinit, id: race-boom
   // CHECK-DAG: deinit, id: race-boom
   await latch.wait()
+  try? await Task.sleep(for: .milliseconds(300))
+
   print("done") // CHECK: done
 }
 
@@ -133,6 +135,8 @@ func manyOk() async {
   // CHECK-DAG: deinit, id: many-ok
 
   await latch.wait()
+  try? await Task.sleep(for: .milliseconds(300))
+
   print("done") // CHECK: done
 }
 
@@ -164,6 +168,8 @@ func manyThrows() async {
   }
 
   await latch.wait()
+  try? await Task.sleep(for: .milliseconds(300))
+
   print("done") // CHECK: done
 }
 
@@ -197,7 +203,6 @@ func manyValuesThrows() async {
       throw Boom(id: "mixed-error")
     }
 
-
     return 12
   }
 
@@ -212,6 +217,8 @@ func manyValuesThrows() async {
   // CHECK-DAG: deinit, id: mixed
 
   await latch.wait()
+  try? await Task.sleep(for: .milliseconds(300))
+
   print("done") // CHECK: done
 }
 

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
 // TODO: move to target-run-simple-leaks-swift once CI is using at least Xcode 14.3
 
-// rdar://109998145 - Temporarily disable this test
-// REQUIRES: rdar109998145
-
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
@@ -15,6 +12,37 @@
 // UNSUPPORTED: OS=windows-msvc
 
 import _Concurrency
+
+actor SimpleCountDownLatch {
+  let from: Int
+  var count: Int
+
+  var continuation: CheckedContinuation<Void, Never>?
+
+  init(from: Int) {
+    self.from = from
+    self.count = from
+  }
+
+  func hit() {
+    defer { count -= 1 }
+    if count == 0 {
+      fatalError("Counted down more times than expected! (From: \(from))")
+    } else if count == 1 {
+      continuation?.resume()
+    }
+  }
+
+  func wait() async {
+    guard self.count > 0 else {
+      return // we're done
+    }
+
+    return await withCheckedContinuation { cc in
+      self.continuation = cc
+    }
+  }
+}
 
 final class PrintDeinit {
   let id: String
@@ -60,96 +88,138 @@ final class SomeClass: @unchecked Sendable {
 
 // NOTE: Not as StdlibUnittest/TestSuite since these types of tests are unreasonably slow to load/debug.
 
-@main struct Main {
-  static func main() async {
-    _ = try? await withThrowingDiscardingTaskGroup() { group in
-      group.addTask {
-        throw Boom(id: "race-boom-class")
-      }
-      group.addTask {
-        SomeClass(id: "race-boom-class") // will be discarded
-      }
-      // since values may deinit in any order, we just assert their count basically
-      // CHECK-DAG: deinit, id: race-boom-class
-      // CHECK-DAG: deinit, id: race-boom-class
+func testTwo() async {
+  let latch = SimpleCountDownLatch(from: 2)
 
-      return 12
+  _ = try? await withThrowingDiscardingTaskGroup() { group in
+    group.addTask {
+      await latch.hit()
+      throw Boom(id: "race-boom")
+    }
+    group.addTask {
+      await latch.hit()
+      SomeClass(id: "race-boom-class") // will be discarded
     }
 
-    // many ok
-    _ = try? await withThrowingDiscardingTaskGroup() { group in
+    return 12
+  }
+
+  // since values may deinit in any order, we just assert their count basically
+  // CHECK-DAG: deinit, id: race-boom
+  // CHECK-DAG: deinit, id: race-boom
+  await latch.wait()
+  print("done") // CHECK: done
+}
+
+func manyOk() async {
+  let latch = SimpleCountDownLatch(from: 6)
+
+  _ = try? await withThrowingDiscardingTaskGroup() { group in
+    for i in 0..<6 {
+      group.addTask {
+        await latch.hit()
+        _ = SomeClass(id: "many-ok") // will be discarded
+      }
+    }
+
+    return 12
+  }
+  // since values may deinit in any order, we just assert their count basically
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+
+  await latch.wait()
+  print("done") // CHECK: done
+}
+
+func manyThrows() async {
+  let latch = SimpleCountDownLatch(from: 6)
+
+  do {
+    let value: Void = try await withThrowingDiscardingTaskGroup() { group in
       for i in 0..<6 {
         group.addTask {
-          SomeClass(id: "many-ok") // will be discarded
+          await latch.hit()
+          throw BoomClass(id: "many-error") // will be rethrown
         }
-        // since values may deinit in any order, we just assert their count basically
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-      }
-
-      return 12
-    }
-
-    // many throws
-    do {
-      let value = try await withThrowingDiscardingTaskGroup() { group in
-        for i in 0..<6 {
-          group.addTask {
-            throw BoomClass(id: "many-error") // will be rethrown
-          }
-        }
-
-        // since values may deinit in any order, we just assert their count basically
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-
-        12 // must be ignored
-      }
-      preconditionFailure("Should throw")
-    } catch {
-      precondition("\(error)" == "main.BoomClass", "error was: \(error)")
-    }
-
-    // many errors, many values
-    _ = try? await withThrowingDiscardingTaskGroup() { group in
-      group.addTask {
-        SomeClass(id: "mixed-ok") // will be discarded
-      }
-      group.addTask {
-        SomeClass(id: "mixed-ok") // will be discarded
-      }
-      group.addTask {
-        SomeClass(id: "mixed-ok") // will be discarded
-      }
-      group.addTask {
-        throw Boom(id: "mixed-error")
-      }
-      group.addTask {
-        throw Boom(id: "mixed-error")
-      }
-      group.addTask {
-        throw Boom(id: "mixed-error")
       }
 
       // since values may deinit in any order, we just assert their count basically
-      // three ok's
-      // CHECK-DAG: deinit, id: mixed
-      // CHECK-DAG: deinit, id: mixed
-      // CHECK-DAG: deinit, id: mixed
-      // three errors
-      // CHECK-DAG: deinit, id: mixed
-      // CHECK-DAG: deinit, id: mixed
-      // CHECK-DAG: deinit, id: mixed
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
 
-      return 12
+      12 // must be ignored
     }
+    preconditionFailure("Should throw")
+  } catch {
+    precondition("\(error)" == "main.BoomClass", "error was: \(error)")
+  }
+
+  await latch.wait()
+  print("done") // CHECK: done
+}
+
+func manyValuesThrows() async {
+  let latch = SimpleCountDownLatch(from: 6)
+
+  // many errors, many values
+  _ = try? await withThrowingDiscardingTaskGroup() { group in
+    group.addTask {
+      await latch.hit()
+      _ = SomeClass(id: "mixed-ok") // will be discarded
+    }
+    group.addTask {
+      await latch.hit()
+      _ = SomeClass(id: "mixed-ok") // will be discarded
+    }
+    group.addTask {
+      await latch.hit()
+      _ = SomeClass(id: "mixed-ok") // will be discarded
+    }
+    group.addTask {
+      await latch.hit()
+      throw Boom(id: "mixed-error")
+    }
+    group.addTask {
+      await latch.hit()
+      throw Boom(id: "mixed-error")
+    }
+    group.addTask {
+      await latch.hit()
+      throw Boom(id: "mixed-error")
+    }
+
+
+    return 12
+  }
+
+  // since values may deinit in any order, we just assert their count basically
+  // three ok's
+  // CHECK-DAG: deinit, id: mixed
+  // CHECK-DAG: deinit, id: mixed
+  // CHECK-DAG: deinit, id: mixed
+  // three errors
+  // CHECK-DAG: deinit, id: mixed
+  // CHECK-DAG: deinit, id: mixed
+  // CHECK-DAG: deinit, id: mixed
+
+  await latch.wait()
+  print("done") // CHECK: done
+}
+
+@main struct Main {
+  static func main() async {
+    await testTwo()
+    await manyOk()
+    await manyThrows()
+    await manyValuesThrows()
   }
 }

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
@@ -14,14 +14,14 @@ import Dispatch
 func test_skipCallingNext_butInvokeCancelAll() async {
   let numbers = [1, 1]
 
-  let result = try! await withTaskGroup(of: Int.self) { (group) async -> Int in
+  let result = await withTaskGroup(of: Int.self) { (group) async -> Int in
     for n in numbers {
-      print("group.spawn { \(n) }")
-      group.spawn { [group] () async -> Int in
+      print("group.addTask { \(n) }")
+      group.addTask { [group] () async -> Int in
         await Task.sleep(1_000_000_000)
-        print("  inside group.spawn { \(n) }")
-        print("  inside group.spawn { \(n) } (group cancelled: \(group.isCancelled))")
-        print("  inside group.spawn { \(n) } (group child task cancelled: \(Task.isCancelled))")
+        print("  inside group.addTask { \(n) }")
+        print("  inside group.addTask { \(n) } (group cancelled: \(group.isCancelled))")
+        print("  inside group.addTask { \(n) } (group child task cancelled: \(Task.isCancelled))")
         return n
       }
     }
@@ -34,13 +34,13 @@ func test_skipCallingNext_butInvokeCancelAll() async {
     return 0
   }
 
-  // CHECK: group.spawn { 1 }
+  // CHECK: group.addTask { 1 }
   //
   // CHECK: return immediately 0 (group cancelled: true)
   // CHECK: return immediately 0 (task cancelled: false)
   //
-  // CHECK: inside group.spawn { 1 } (group cancelled: true)
-  // CHECK: inside group.spawn { 1 } (group child task cancelled: true)
+  // CHECK: inside group.addTask { 1 } (group cancelled: true)
+  // CHECK: inside group.addTask { 1 } (group child task cancelled: true)
 
   // CHECK: result: 0
   print("result: \(result)")

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_pending.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_pending.swift
@@ -4,10 +4,7 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
-// rdar://76038845
 // REQUIRES: concurrency_runtime
-
-// REQUIRES: rdar75096485
 
 import Dispatch
 

--- a/test/Sanitizers/tsan/async_taskgroup_next.swift
+++ b/test/Sanitizers/tsan/async_taskgroup_next.swift
@@ -1,8 +1,5 @@
 // RUN: %target-run-simple-swift( %import-libdispatch -parse-as-library -sanitize=thread)
 
-// Segfaulted in CI on TSan bot. rdar://78264164
-// REQUIRES: rdar78264164
-
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch


### PR DESCRIPTION
**Description:** A task group resumes the "waiting task" in numerous situations. Currently tasks were scheduled and then the group was unlocked -- this can lead to races between the scheduled task and the group unlock and unpredictable behavior. Instead, we must unlock the group and THEN schedule the waiting task on order to avoid potential use-after free of the lock (as the unlock() happens).
**Risk:** Medium, the change reorganizes code in order to allow us to unlock and THEN schedule the task. This forced some general refactoring in order to be able to get this pattern.
**Reward** Medium, resolves very rare crashes which could occur when just the right scheduling timing would happen. These issues are very rare, and have remained undetected until recently.
**Review by:** @mikeash  @DougGregor
**Testing:** CI testing, enabled all task group tests for the first time in a long time and all passing consistently on all platforms.
**Radar:** rdar://113331923 (test reenable rdar://113016918)
**Related Radar:** The following was the same issue however in a more crucial code path: rdar://113032582

----

Picked it over to 5.9 as well: https://github.com/apple/swift/pull/67819