### PR TITLE
[cxx-interop] NFC, test, drop extern_c from a test module

### DIFF
--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -3,7 +3,7 @@ module ProtocolNamingConflict [extern_c] {
   requires objc
 }
 
-module CxxClassWithNSStringInit [extern_c] {
+module CxxClassWithNSStringInit {
   header "cxx-class-with-arc-fields-ctor.h"
   requires objc
   requires cplusplus

--- a/test/Interop/Cxx/objc-correctness/call-to-generated-init-with-nsstring.swift
+++ b/test/Interop/Cxx/objc-correctness/call-to-generated-init-with-nsstring.swift
@@ -33,14 +33,14 @@ testSdump()
 // SIL-TRIVIAL-NEXT:   apply %{{.*}}(%{{.*}}) : $@convention(cxx_method) (@in_guaranteed S) -> ()
 // SIL-TRIVIAL:      $@convention(objc_method) (@owned S, ClassWithNonTrivialDestructorIvar) -> ()
 // SIL-TRIVIAL-NEXT: apply %{{.*}}(%{{.*}}) : $@convention(objc_method) (@owned S, ClassWithNonTrivialDestructorIvar) -> ()
-// SIL-TRIVIAL: function_ref @_Z9takeSFunc : $@convention(c) (@owned S) -> ()
+// SIL-TRIVIAL: function_ref @_Z9takeSFunc1S : $@convention(c) (@owned S) -> ()
 // SIL-TRIVIAL-NEXT: apply %{{.*}}(%{{.*}}) : $@convention(c) (@owned S) -> ()
 
 // SIL-NONTRIVIAL:   function_ref @_ZNK1S4dumpEv : $@convention(cxx_method) (@in_guaranteed S) -> ()
 // SIL-NONTRIVIAL-NEXT:   apply %{{.*}}(%{{.*}}) : $@convention(cxx_method) (@in_guaranteed S) -> ()
 // SIL-NONTRIVIAL:      $@convention(objc_method) (@in S, ClassWithNonTrivialDestructorIvar) -> ()
 // SIL-NONTRIVIAL-NEXT: apply %{{.*}}(%{{.*}}) : $@convention(objc_method) (@in S, ClassWithNonTrivialDestructorIvar) -> ()
-// SIL-NONTRIVIAL: function_ref @_Z9takeSFunc : $@convention(c) (@in S) -> ()
+// SIL-NONTRIVIAL: function_ref @_Z9takeSFunc1S : $@convention(c) (@in S) -> ()
 // SIL-NONTRIVIAL-NEXT: apply %{{.*}}(%{{.*}}) : $@convention(c) (@in S) -> ()
 
 


### PR DESCRIPTION
Explanation:
A C++ interop test had incorrect `extern_c` attribute on a module.
Scope: C++ interop tests.
Risk: Low, test only change.
Testing: Unit tests.
