### PR TITLE
[ConstraintSystem] Delay Contextual Type Fix record for key paths

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3815,7 +3815,7 @@ namespace {
           CS.getConstraintLocator(E, ConstraintLocator::KeyPathValue);
       auto *value = CS.createTypeVariable(valueLocator, TVO_CanBindToNoEscape |
                                                             TVO_CanBindToHole);
-      CS.addConstraint(ConstraintKind::Equal, base, value, locator);
+      CS.addConstraint(ConstraintKind::Equal, base, value, valueLocator);
       CS.recordKeyPath(E, root, value, CurDC);
 
       // The result is a KeyPath from the root to the end component.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6605,6 +6605,22 @@ bool ConstraintSystem::repairFailures(
     conversionsOrFixes.push_back(fix);
     return true;
   }
+  case ConstraintLocator::KeyPathValue: {
+    if (lhs->isPlaceholder() || rhs->isPlaceholder())
+      return true;
+    if (lhs->isTypeVariableOrMember() || rhs->isTypeVariableOrMember())
+      break;
+
+    auto kpExpr = castToExpr<KeyPathExpr>(anchor);
+    auto i = kpExpr->getComponents().size() - 1;
+    auto lastCompLoc =
+        getConstraintLocator(kpExpr, LocatorPathElt::KeyPathComponent(i));
+    if (hasFixFor(lastCompLoc, FixKind::AllowTypeOrInstanceMember))
+      return true;
+
+    conversionsOrFixes.push_back(IgnoreContextualType::create(
+        *this, lhs, rhs, getConstraintLocator(anchor)));
+  }
   default:
     break;
   }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1565,18 +1565,18 @@ func testNilCoalescingOperatorRemoveFix() {
   let _ = "" /* This is a comment */ ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{13-43=}}
 
   let _ = "" // This is a comment
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1567:13-1568:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1555:13-1556:10=}}
 
   let _ = "" // This is a comment
     /*
      * The blank line below is part of the test case, do not delete it
      */
 
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1570:13-1575:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1558:13-1563:10=}}
 
-  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1577:9-1578:9=}}
+  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1566:9=}}
       "").isEmpty {}
 
   if ("" // This is a comment
-      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1580:9-1581:12=}}
+      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1568:9-1569:12=}}
 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1039,18 +1039,6 @@ class C2_47269 {
   }
 }
 
-// rdar://problem/32101765 - Keypath diagnostics are not actionable/helpful
-
-struct R32101765 { let prop32101765 = 0 }
-let _: KeyPath<R32101765, Float> = \.prop32101765
-// expected-error@-1 {{key path value type 'Int' cannot be converted to contextual type 'Float'}}
-let _: KeyPath<R32101765, Float> = \R32101765.prop32101765
-// expected-error@-1 {{key path value type 'Int' cannot be converted to contextual type 'Float'}}
-let _: KeyPath<R32101765, Float> = \.prop32101765.unknown
-// expected-error@-1 {{type 'Int' has no member 'unknown'}}
-let _: KeyPath<R32101765, Float> = \R32101765.prop32101765.unknown
-// expected-error@-1 {{type 'Int' has no member 'unknown'}}
-
 // rdar://problem/32390726 - Bad Diagnostic: Don't suggest `var` to `let` when binding inside for-statement
 for var i in 0..<10 { // expected-warning {{variable 'i' was never mutated; consider removing 'var' to make it constant}} {{5-9=}}
   _ = i + 1

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -247,3 +247,19 @@ func test_any_key_path() {
   anyKP = \.v
   // expected-error@-1 {{cannot infer key path type from context; consider explicitly specifying a root type}}
 }
+
+// rdar://problem/32101765 - Keypath diagnostics are not actionable/helpful
+func rdar32101765() {
+  struct R32101765 {
+    let prop32101765 = 0
+  }
+  
+  let _: KeyPath<R32101765, Float> = \.prop32101765
+  // expected-error@-1 {{key path value type 'Int' cannot be converted to contextual type 'Float'}}
+  let _: KeyPath<R32101765, Float> = \R32101765.prop32101765
+  // expected-error@-1 {{key path value type 'Int' cannot be converted to contextual type 'Float'}}
+  let _: KeyPath<R32101765, Float> = \.prop32101765.unknown
+  // expected-error@-1 {{type 'Int' has no member 'unknown'}}
+  let _: KeyPath<R32101765, Float> = \R32101765.prop32101765.unknown
+  // expected-error@-1 {{type 'Int' has no member 'unknown'}}
+}

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -236,3 +236,14 @@ func issue_65965() {
   writeKP = \.v
   // expected-error@-1 {{key path value type 'KeyPath<S, String>' cannot be converted to contextual type 'WritableKeyPath<S, String>'}}
 }
+
+func test_any_key_path() {
+  struct S {
+    var v: String
+  }
+  
+  var anyKP: AnyKeyPath
+  anyKP = \S.v
+  anyKP = \.v
+  // expected-error@-1 {{cannot infer key path type from context; consider explicitly specifying a root type}}
+}


### PR DESCRIPTION
where the key path value locator already has a `AllowTypeOrInstanceMember` fix recorded on the last key path component to prioritize that fix instead of `IgnoreContextualType`

Also delay contextual type fix record for key path expressions where we have known keypath capabilities for both the binding and bound sides and one of the bases is unresolved. For example, if one key path has a resolved base

```
KeyPath<$T1, $T2> conv KeyPath<Model, String>
```
delay contextual type fix because base type `Model` can be inferred to $T1, which is enough [to determine a contextual type](https://github.com/apple/swift/pull/67297), for now.