### PR TITLE
[cxx-interop] Memberwise init is not synthesized for C++ type with templated using decl

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2236,7 +2236,9 @@ namespace {
         Decl *member = Impl.importDecl(nd, getActiveSwiftVersion());
 
         if (!member) {
-          if (!isa<clang::TypeDecl>(nd) && !isa<clang::FunctionDecl>(nd)) {
+          if (!isa<clang::TypeDecl>(nd) && !isa<clang::FunctionDecl>(nd) &&
+              !isa<clang::TypeAliasTemplateDecl>(nd) &&
+              !isa<clang::FunctionTemplateDecl>(nd)) {
             // We don't know what this member is.
             // Assume it may be important in C.
             hasUnreferenceableStorage = true;

--- a/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
+++ b/test/Interop/Cxx/class/Inputs/memberwise-initializer.h
@@ -1,6 +1,10 @@
 #ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERWISE_INITIALIZER_H
 #define TEST_INTEROP_CXX_CLASS_INPUTS_MEMBERWISE_INITIALIZER_H
 
+template <typename T>
+struct TemplatedType {};
+
+
 struct StructPrivateOnly {
 private:
   int varPrivate;
@@ -50,6 +54,22 @@ struct ClassWithUnimportedMemberFunction {
 public:
   int varPublic;
   int ClassWithUnimportedMemberFunction::* unimportedMemberFunction();
+};
+
+struct ClassWithTemplatedFunction {
+public:
+  int varPublic;
+
+  template <int I>
+  void foo();
+};
+
+struct ClassWithTemplatedUsingDecl {
+public:
+  int varPublic;
+
+  template <typename T>
+  using MyUsing = TemplatedType<T>;
 };
 
 #endif

--- a/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
@@ -42,3 +42,13 @@
 // CHECK-NEXT:   init(varPublic: Int32)
 // CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
+// CHECK-NEXT: struct ClassWithTemplatedFunction {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT: }
+// CHECK-NEXT: struct ClassWithTemplatedUsingDecl {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   var varPublic: Int32
+// CHECK-NEXT: }


### PR DESCRIPTION
When Swift fails to import a member of a struct, it checks to see if this member could affect the memory layout of the struct, and if it can, Swift doesn't synthesize the memberwise initializer for this struct. This logic was overly restrictive and treated templated using-decls as potentially affecting the memory layout of the struct.

rdar://113044949