### PR TITLE
NFC: Doc'd checked_cast_br formal type.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -8093,6 +8093,7 @@ checked_cast_br
 ::
 
   sil-terminator ::= 'checked_cast_br' sil-checked-cast-exact?
+                      sil-type 'in'
                       sil-operand 'to' sil-type ','
                       sil-identifier ',' sil-identifier
   sil-checked-cast-exact ::= '[' 'exact' ']'


### PR DESCRIPTION
Update SIL.rst's entry on `checked_cast_br` to include the formal type that the instruction now takes.
