### PR TITLE
[cxx-interop] test, enable more tests on windows

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++17)
 //
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
 
 import StdlibUnittest
 import StdOptional

--- a/test/Interop/Cxx/stdlib/use-std-pair-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair-typechecker.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
-// REQUIRES: OS=macosx || OS=linux-gnu
 
 import StdPair
 

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
-//
-// REQUIRES: OS=macosx || OS=linux-gnu
 
 import StdlibUnittest
 import StdPair


### PR DESCRIPTION
These tests require the C++ standard library
