### PR TITLE
[ClangImporter] Move incremental processing to the new language option

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -728,6 +728,9 @@ importer::getNormalInvocationArguments(
       }
     }
   }
+
+  invocationArgStrs.push_back("-Xclang");
+  invocationArgStrs.push_back("-fincremental-extensions");
 }
 
 static void
@@ -1346,7 +1349,6 @@ ClangImporter::create(ASTContext &ctx,
     return nullptr; // there was an error related to the compiler arguments.
 
   clang::Preprocessor &clangPP = instance.getPreprocessor();
-  clangPP.enableIncrementalProcessing();
 
   // Setup Preprocessor callbacks before initialing the parser to make sure
   // we catch implicit includes.


### PR DESCRIPTION
`IncrementalProcessing` is now a language option
`IncrementalExtensions`, which also means it is now part of the module hash.

When compiling a clang module, the output file path would be generated in the `BeginSourceFile` prior to `enableIncrementalProcessing` being called on the preprocessor. The hash would then be generated again when compiling the module (after the `enableIncrementalProcessing` call) and included in the PCM, leading to a mismatch between the path and the hash in the module.

This could be fixed by moving `enableIncrementalProcessing` above `BeginSourceFile`, but now that it's an option we can instead just add it to the invocation arguments.

Resolves rdar://112993659.