### PR TITLE
[rebranch] Fix up API update in the lexer

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -101,7 +101,7 @@ static bool EncodeToUTF8(unsigned CharValue,
 
 /// CLO8 - Return the number of leading ones in the specified 8-bit value.
 static unsigned CLO8(unsigned char C) {
-  return llvm::countl_zero(uint32_t(C) << 24);
+  return llvm::countl_one(uint32_t(C) << 24);
 }
 
 /// isStartOfUTF8Character - Return true if this isn't a UTF8 continuation


### PR DESCRIPTION
This should have been `countl_one` (leading ones) rather than `countl_zero` (leading zeroes).