### PR TITLE
[WIP] Implement dependent layouts for raw types

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -937,6 +937,10 @@ public:
   /// descriptors.
   AvailabilityContext getSignedDescriptorAvailability();
 
+  /// Get the runtime availability of the swift_initRawStructMetadata entrypoint
+  /// that fixes up the value witness table of @_rawLayout dependent types.
+  AvailabilityContext getInitRawStructMetadataAvailability();
+
   /// Get the runtime availability of features introduced in the Swift 5.2
   /// compiler for the target platform.
   AvailabilityContext getSwift52Availability();

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1038,6 +1038,14 @@ SWIFT_RUNTIME_STDLIB_SPI
 void _swift_registerConcurrencyStandardTypeDescriptors(
     const ConcurrencyStandardTypeDescriptors *descriptors);
 
+/// Initialize the value witness table for a struct using the provided like type
+/// as the basis for the layout.
+SWIFT_RUNTIME_EXPORT
+void swift_initRawStructMetadata(StructMetadata *self,
+                                 StructLayoutFlags flags,
+                                 const TypeLayout *likeType,
+                                 size_t count);
+
 #pragma clang diagnostic pop
 
 } // end namespace swift

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1044,7 +1044,7 @@ SWIFT_RUNTIME_EXPORT
 void swift_initRawStructMetadata(StructMetadata *self,
                                  StructLayoutFlags flags,
                                  const TypeLayout *likeType,
-                                 size_t count);
+                                 int32_t count);
 
 #pragma clang diagnostic pop
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2489,12 +2489,12 @@ FUNCTION(GenericInstantiateLayoutString,
 // void swift_initRawStructMetadata(Metadata *structType,
 //                                  StructLayoutFlags flags,
 //                                  const TypeLayout *likeType,
-//                                  size_t count);
+//                                  int32_t count);
 FUNCTION(InitRawStructMetadata,
          swift_initRawStructMetadata,
          C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
-         ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy->getPointerTo(0), SizeTy),
+         ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy->getPointerTo(0), Int32Ty),
          ATTRS(NoUnwind),
          EFFECT(MetaData))
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2486,6 +2486,18 @@ FUNCTION(GenericInstantiateLayoutString,
          ATTRS(NoUnwind),
          EFFECT(MetaData))
 
+// void swift_initRawStructMetadata(Metadata *structType,
+//                                  StructLayoutFlags flags,
+//                                  const TypeLayout *likeType,
+//                                  size_t count);
+FUNCTION(InitRawStructMetadata,
+         swift_initRawStructMetadata,
+         C_CC, AlwaysAvailable,
+         RETURNS(VoidTy),
+         ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy->getPointerTo(0), SizeTy),
+         ATTRS(NoUnwind),
+         EFFECT(MetaData))
+
 #undef RETURNS
 #undef ARGS
 #undef ATTRS

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -540,6 +540,11 @@ ASTContext::getSignedDescriptorAvailability() {
   return getSwift59Availability();
 }
 
+AvailabilityContext
+ASTContext::getInitRawStructMetadataAvailability() {
+  return getSwiftFutureAvailability();
+}
+
 AvailabilityContext ASTContext::getSwift52Availability() {
   auto target = LangOpts.Target;
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -134,8 +134,8 @@ AsyncContextLayout::AsyncContextLayout(
     IRGenModule &IGM, LayoutStrategy strategy, ArrayRef<SILType> fieldTypes,
     ArrayRef<const TypeInfo *> fieldTypeInfos, CanSILFunctionType originalType,
     CanSILFunctionType substitutedType, SubstitutionMap substitutionMap)
-    : StructLayout(IGM, /*decl=*/nullptr, LayoutKind::NonHeapObject, strategy,
-                   fieldTypeInfos, /*typeToFill*/ nullptr),
+    : StructLayout(IGM, /*type=*/ llvm::None, LayoutKind::NonHeapObject,
+                   strategy, fieldTypeInfos, /*typeToFill*/ nullptr),
       originalType(originalType), substitutedType(substitutedType),
       substitutionMap(substitutionMap)  {
   assert(fieldTypeInfos.size() == fieldTypes.size() &&

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -211,7 +211,7 @@ public:
   }
 
   StructLayout performLayout(ArrayRef<const TypeInfo *> fieldTypes) {
-    return StructLayout(IGM, /*decl=*/nullptr, LayoutKind::NonHeapObject,
+    return StructLayout(IGM, /*type=*/ llvm::None, LayoutKind::NonHeapObject,
                         LayoutStrategy::Universal, fieldTypes);
   }
 };
@@ -383,7 +383,7 @@ public:
   }
 
   StructLayout performLayout(ArrayRef<const TypeInfo *> fieldTypes) {
-    return StructLayout(IGM, /*decl=*/nullptr, LayoutKind::NonHeapObject,
+    return StructLayout(IGM, /*type=*/ llvm::None, LayoutKind::NonHeapObject,
                         LayoutStrategy::Universal, fieldTypes);
   }
 };

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -274,7 +274,7 @@ HeapLayout::HeapLayout(IRGenModule &IGM, LayoutStrategy strategy,
                        ArrayRef<const TypeInfo *> fieldTypeInfos,
                        llvm::StructType *typeToFill,
                        NecessaryBindings &&bindings, unsigned bindingsIndex)
-    : StructLayout(IGM, /*decl=*/nullptr, LayoutKind::HeapObject, strategy,
+    : StructLayout(IGM, /*type=*/ llvm::None, LayoutKind::HeapObject, strategy,
                    fieldTypeInfos, typeToFill),
       ElementTypes(fieldTypes.begin(), fieldTypes.end()),
       Bindings(std::move(bindings)), BindingsIndex(bindingsIndex) {

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -863,7 +863,6 @@ public:
     fields.reserve(astFields.size());
     fieldTypesForLayout.reserve(astFields.size());
 
-    bool loadable = true;
     auto fieldsABIAccessible = FieldsAreABIAccessible;
 
     unsigned explosionSize = 0;
@@ -880,7 +879,6 @@ public:
 
       auto loadableFieldTI = dyn_cast<LoadableTypeInfo>(&fieldTI);
       if (!loadableFieldTI) {
-        loadable = false;
         continue;
       }
 
@@ -902,7 +900,7 @@ public:
     }
 
     // Create the type info.
-    if (loadable) {
+    if (layout.isLoadable()) {
       assert(layout.isFixedLayout());
       assert(fieldsABIAccessible);
       return asImpl()->createLoadable(fields, std::move(layout), explosionSize);

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -512,7 +512,7 @@ namespace {
     }
 
     StructLayout performLayout(ArrayRef<const TypeInfo *> fieldTypes) {
-      return StructLayout(IGM, /*decl=*/nullptr, LayoutKind::NonHeapObject,
+      return StructLayout(IGM, /*type=*/ llvm::None, LayoutKind::NonHeapObject,
                           LayoutStrategy::Universal, fieldTypes);
     }
   };

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2437,6 +2437,17 @@ namespace {
       if (IGM.isResilient(decl, ResilienceExpansion::Maximal))
         return true;
 
+      auto rawLayout = decl->getAttrs().getAttribute<RawLayoutAttr>();
+
+      // If our struct has a raw layout, it may be dependent on the like type.
+      if (rawLayout) {
+        if (auto likeType = rawLayout->getResolvedScalarLikeType(decl)) {
+          return visit((*likeType)->getCanonicalType());
+        } else if (auto likeArray = rawLayout->getResolvedArrayLikeTypeAndCount(decl)) {
+          return visit(likeArray->first->getCanonicalType());
+        }
+      }
+
       for (auto field : decl->getStoredProperties()) {
         if (visit(field->getInterfaceType()->getCanonicalType()))
           return true;

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -283,6 +283,7 @@ private:
   SmallVector<SpareBitVector, 8> CurSpareBits;
   unsigned NextNonFixedOffsetIndex = 0;
   bool IsFixedLayout = true;
+  bool IsLoadable = true;
   IsTriviallyDestroyable_t IsKnownTriviallyDestroyable = IsTriviallyDestroyable;
   IsBitwiseTakable_t IsKnownBitwiseTakable = IsBitwiseTakable;
   IsCopyable_t IsKnownCopyable = IsCopyable;
@@ -326,6 +327,9 @@ public:
 
   /// Return whether the structure has a fixed-size layout.
   bool isFixedLayout() const { return IsFixedLayout; }
+
+  /// Return whether the structure has a loadable layout.
+  bool isLoadable() const { return IsLoadable; }
 
   /// Return whether the structure is known to be POD in the local
   /// resilience scope.
@@ -402,6 +406,9 @@ class StructLayout {
   /// alignment are exact.
   bool IsFixedLayout;
 
+  /// Whether this layout 
+  bool IsLoadable;
+
   IsTriviallyDestroyable_t IsKnownTriviallyDestroyable;
   IsBitwiseTakable_t IsKnownBitwiseTakable;
   IsCopyable_t IsKnownCopyable;
@@ -419,7 +426,7 @@ public:
   ///   layout must include the reference-counting header
   /// \param typeToFill - if present, must be an opaque type whose body
   ///   will be filled with this layout
-  StructLayout(IRGenModule &IGM, NominalTypeDecl *decl,
+  StructLayout(IRGenModule &IGM, llvm::Optional<CanType> type,
                LayoutKind kind, LayoutStrategy strategy,
                ArrayRef<const TypeInfo *> fields,
                llvm::StructType *typeToFill = 0);
@@ -434,6 +441,7 @@ public:
       headerSize(builder.getHeaderSize()),
       SpareBits(builder.getSpareBits()),
       IsFixedLayout(builder.isFixedLayout()),
+      IsLoadable(builder.isLoadable()),
       IsKnownTriviallyDestroyable(builder.isTriviallyDestroyable()),
       IsKnownBitwiseTakable(builder.isBitwiseTakable()),
       IsKnownCopyable(builder.isCopyable()),
@@ -467,6 +475,7 @@ public:
   }
 
   bool isFixedLayout() const { return IsFixedLayout; }
+  bool isLoadable() const { return IsLoadable; }
   llvm::Constant *emitSize(IRGenModule &IGM) const;
   llvm::Constant *emitAlignMask(IRGenModule &IGM) const;
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2905,6 +2905,35 @@ metadata:
   }
 }
 
+/// Initialize the value witness table for a @_rawLayout struct.
+SWIFT_RUNTIME_EXPORT
+void swift::swift_initRawStructMetadata(StructMetadata *structType,
+                                        StructLayoutFlags layoutFlags,
+                                        const TypeLayout *likeTypeLayout,
+                                        size_t count) {
+  auto vwtable = getMutableVWTableForInit(structType, layoutFlags);
+
+  // The existing vwt function entries are all fine to preserve, the only thing
+  // we need to initialize is the actual type layout.
+  auto size = likeTypeLayout->size;
+  auto stride = likeTypeLayout->stride;
+  auto alignMask = likeTypeLayout->flags.getAlignmentMask();
+  auto extraInhabitantCount = likeTypeLayout->extraInhabitantCount;
+
+  // If our count is greater than or equal 0, we're dealing an array like layout.
+  if (count >= 0) {
+    stride *= count;
+    size = stride;
+  }
+
+  vwtable->size = size;
+  vwtable->stride = stride;
+  vwtable->flags = ValueWitnessFlags()
+                    .withAlignmentMask(alignMask)
+                    .withCopyable(false);
+  vwtable->extraInhabitantCount = extraInhabitantCount;
+}
+
 /***************************************************************************/
 /*** Classes ***************************************************************/
 /***************************************************************************/

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2910,7 +2910,7 @@ SWIFT_RUNTIME_EXPORT
 void swift::swift_initRawStructMetadata(StructMetadata *structType,
                                         StructLayoutFlags layoutFlags,
                                         const TypeLayout *likeTypeLayout,
-                                        size_t count) {
+                                        int32_t count) {
   auto vwtable = getMutableVWTableForInit(structType, layoutFlags);
 
   // The existing vwt function entries are all fine to preserve, the only thing

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/raw_layout.sil
-// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir %t/raw_layout.sil | %FileCheck %t/raw_layout.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir -disable-availability-checking %t/raw_layout.sil | %FileCheck %t/raw_layout.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 import Swift
 

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -64,18 +64,75 @@ struct Keymaster: ~Copyable {
     let lock3: Lock
 }
 
-/*
-TODO: Dependent layout not yet implemented
+// Dependent Layouts:
+// These types have their layouts all zeroed out and will be fixed up at
+// runtime.
 
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}4CellVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 0
+// stride
+// CHECK-SAME:  , {{i64|i32}} 0
+// flags: alignment 0, incomplete
+// CHECK-SAME:  , <i32 0x400000>
 @_rawLayout(like: T)
 struct Cell<T>: ~Copyable {}
 
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}10PaddedCellVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 0
+// stride
+// CHECK-SAME:  , {{i64|i32}} 0
+// flags: alignment 0, incomplete
+// CHECK-SAME:  , <i32 0x400000>
 @_rawLayout(likeArrayOf: T, count: 1)
 struct PaddedCell<T>: ~Copyable {}
 
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}14SmallVectorBufVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 0
+// stride
+// CHECK-SAME:  , {{i64|i32}} 0
+// flags: alignment 0, incomplete
+// CHECK-SAME:  , <i32 0x400000>
 @_rawLayout(likeArrayOf: T, count: 8)
 struct SmallVectorBuf<T>: ~Copyable {}
-*/
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}8UsesCellVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 8
+// stride
+// CHECK-SAME:  , {{i64|i32}} 8
+// flags: alignment 3, noncopyable
+// CHECK-SAME:  , <i32 0x800003>
+struct UsesCell: ~Copyable {
+    let someCondition: Bool
+    let specialInt: Cell<Int32>
+}
+
+// Dependent layout metadata initialization:
+
+// Cell<T>
+
+// CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}4CellVMr"(ptr %"Cell<T>", ptr {{.*}}, ptr {{.*}})
+// CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"Cell<T>", {{i64|i32}} 2
+// CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
+// CHECK-NEXT: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @swift_checkMetadataState({{i64|i32}} 319, ptr [[T]])
+// CHECK-NEXT: [[T:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK: [[T_VWT_ADDR:%.*]] = getelementptr inbounds ptr, ptr [[T]], {{i64|i32}} -1
+// CHECK-NEXT: [[T_VWT:%.*]] = load ptr, ptr [[T_VWT_ADDR]]
+// CHECK-NEXT: [[T_LAYOUT:%.*]] = getelementptr inbounds ptr, ptr [[T_VWT]], i32 8
+// CHECK-NEXT: call void @swift_initRawStructMetadata(ptr %"Cell<T>", {{i64|i32}} 0, ptr [[T_LAYOUT]], {{i64|i32}} -1)
+
+// PaddedCell<T>
+
+// CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}10PaddedCellVMr"(ptr %"PaddedCell<T>", ptr {{.*}}, ptr {{.*}})
+// CHECK: call void @swift_initRawStructMetadata(ptr %"PaddedCell<T>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} 1)
+
+// SmallVectorBuf<T>
+
+// CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}14SmallVectorBufVMr"(ptr %"SmallVectorBuf<T>", ptr {{.*}}, ptr {{.*}})
+// CHECK: call void @swift_initRawStructMetadata(ptr %"SmallVectorBuf<T>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} 8)
 
 sil @use_lock : $@convention(thin) (@in_guaranteed Lock) -> () {
 entry(%L: $*Lock):

--- a/test/IRGen/raw_layout_old.swift
+++ b/test/IRGen/raw_layout_old.swift
@@ -1,0 +1,62 @@
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx13.0 -enable-experimental-feature RawLayout -emit-ir %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+// Test that when targeting older OSes 
+
+@_rawLayout(like: T)
+struct Cell<T>: ~Copyable {}
+
+@_rawLayout(likeArrayOf: T, count: 1)
+struct PaddedCell<T>: ~Copyable {}
+
+@_rawLayout(likeArrayOf: T, count: 8)
+struct SmallVectorBuf<T>: ~Copyable {}
+
+// Dependent layout metadata initialization:
+
+// Cell<T>
+
+// CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}4CellVMr"(ptr %"Cell<T>", ptr {{.*}}, ptr {{.*}})
+// CHECK: [[FIELD_LAYOUTS:%.*]] = alloca [1 x ptr]
+// CHECK-NEXT: [[FIELD_OFFSETS:%.*]] = alloca i32, align 4
+// CHECK-NEXT: [[OUR_LAYOUT:%.*]] = alloca %swift.type_layout
+// CHECK: store ptr [[OUR_LAYOUT]], ptr [[FIELD_LAYOUTS]]
+// CHECK-NEXT: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"Cell<T>", {{i64|i32}} 2
+// CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
+// CHECK-NEXT: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @swift_checkMetadataState({{i64|i32}} 319, ptr [[T]])
+// CHECK-NEXT: [[T:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK: [[T_VWT_ADDR:%.*]] = getelementptr inbounds ptr, ptr [[T]], {{i64|i32}} -1
+// CHECK-NEXT: [[T_VWT:%.*]] = load ptr, ptr [[T_VWT_ADDR]]
+// CHECK-NEXT: [[T_LAYOUT:%.*]] = getelementptr inbounds ptr, ptr [[T_VWT]], i32 8
+// CHECK-NEXT: [[T_LAYOUT_LOADED:%.*]] = load %swift.type_layout, ptr [[T_LAYOUT]]
+// CHECK-NEXT: [[T_SIZE:%.*]] = extractvalue %swift.type_layout [[T_LAYOUT_LOADED]], 0
+// CHECK-NEXT: [[T_STRIDE:%.*]] = extractvalue %swift.type_layout [[T_LAYOUT_LOADED]], 1
+// CHECK-NEXT: [[T_FLAGS:%.*]] = extractvalue %swift.type_layout [[T_LAYOUT_LOADED]], 2
+// CHECK-NEXT: [[T_XI:%.*]] = extractvalue %swift.type_layout [[T_LAYOUT_LOADED]], 3
+// CHECK-NEXT: [[T_ALIGNMASK:%.*]] = and i32 [[T_FLAGS]], 255
+// CHECK-NEXT: [[OUR_FLAGS:%.*]] = or i32 [[T_ALIGNMASK]], 65536
+// CHECK-NEXT: [[OUR_LAYOUT_0:%.*]] = insertvalue %swift.type_layout undef, {{i64|i32}} [[T_SIZE]], 0
+// CHECK-NEXT: [[OUR_LAYOUT_1:%.*]] = insertvalue %swift.type_layout [[OUR_LAYOUT_0]], {{i64|i32}} [[T_STRIDE]], 1
+// CHECK-NEXT: [[OUR_LAYOUT_2:%.*]] = insertvalue %swift.type_layout [[OUR_LAYOUT_1]], i32 [[OUR_FLAGS]], 2
+// CHECK-NEXT: [[OUR_LAYOUT_3:%.*]] = insertvalue %swift.type_layout [[OUR_LAYOUT_2]], i32 [[T_XI]], 3
+// CHECK-NEXT: store %swift.type_layout [[OUR_LAYOUT_3]], ptr [[OUR_LAYOUT]]
+// CHECK-NEXT: call void @swift_initStructMetadata(ptr %"Cell<T>", {{i64|i32}} 0, {{i64|i32}} 1, ptr [[FIELD_LAYOUTS]], ptr [[FIELD_OFFSETS]])
+
+// PaddedCell<T>
+
+// CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}10PaddedCellVMr"(ptr %"PaddedCell<T>", ptr {{.*}}, ptr {{.*}})
+// CHECK: [[T_STRIDE:%.*]] = extractvalue %swift.type_layout {{%.*}}, 1
+// CHECK: [[OUR_STRIDE:%.*]] = mul {{i64|i32}} [[T_STRIDE]], 1
+// CHECK-NEXT: {{%.*}} = insertvalue %swift.type_layout undef, {{i64|i32}} [[OUR_STRIDE]], 0
+// CHECK-NEXT: {{%.*}} = insertvalue %swift.type_layout {{%.*}}, {{i64|i32}} [[OUR_STRIDE]], 1
+// CHECK: call void @swift_initStructMetadata(ptr %"PaddedCell<T>", {{i64|i32}} 0, {{i64|i32}} 1, ptr {{%.*}}, ptr {{%.*}})
+
+// SmallVectorBuf<T>
+
+// CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}14SmallVectorBufVMr"(ptr %"SmallVectorBuf<T>", ptr {{.*}}, ptr {{.*}})
+// CHECK: [[T_STRIDE:%.*]] = extractvalue %swift.type_layout {{%.*}}, 1
+// CHECK: [[OUR_STRIDE:%.*]] = mul {{i64|i32}} [[T_STRIDE]], 8
+// CHECK-NEXT: {{%.*}} = insertvalue %swift.type_layout undef, {{i64|i32}} [[OUR_STRIDE]], 0
+// CHECK-NEXT: {{%.*}} = insertvalue %swift.type_layout {{%.*}}, {{i64|i32}} [[OUR_STRIDE]], 1
+// CHECK: call void @swift_initStructMetadata(ptr %"SmallVectorBuf<T>", {{i64|i32}} 0, {{i64|i32}} 1, ptr {{%.*}}, ptr {{%.*}})

--- a/test/Interpreter/raw_layout.swift
+++ b/test/Interpreter/raw_layout.swift
@@ -1,69 +1,20 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature RawLayout -enable-builtin-module) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature RawLayout) | %FileCheck %s
 // REQUIRES: executable_test
 
-import Builtin
-
 @_rawLayout(like: T)
-struct Cell<T>: ~Copyable {
-  var address: UnsafeMutablePointer<T> {
-    UnsafeMutablePointer<T>(Builtin.unprotectedAddressOfBorrow(self))
-  }
+struct Cell<T>: ~Copyable {}
 
-  init(_ value: consuming T) {
-    address.initialize(to: value)
-  }
-
-  deinit {
-    // FIXME: discard self should work with rawLayout types
-    //address.deinitialize(count: 1)
-
-    // Note: We don't need to deallocate the address here because the memory it
-    // points to is being destroyed within this deinit.
-  }
-
-  borrowing func replace(with replacement: consuming T) -> T {
-    let previous = address.move()
-    address.initialize(to: replacement)
-    return previous
-  }
-
-  borrowing func set(_ value: consuming T) {
-    let previous = replace(with: value)
-    _ = consume previous
-  }
-
-  consuming func get() -> T {
-    // Move the value out of self and don't call our deinitializer
-    let previous = address.move()
-    discard self
-    return previous
-  }
+struct Foo<T>: ~Copyable {
+  let cell = Cell<T>()
+  let myValue = 123
 }
 
-@_eagerMove
-class SpecialInt {
-  var value: Int
-
-  init(_ value: Int) {
-    self.value = value
-  }
-
-  deinit {
-    print("Deinitializing \(value)!")
-  }
+func something<T>(_ x: borrowing Foo<T>) -> Int {
+  x.myValue
 }
 
-do {
-  let specialInt0 = SpecialInt(128)
-  let cell0 = Cell<SpecialInt>(specialInt0)
+// CHECK: 123
+print(something(Foo<Bool>()))
 
-  let specialInt0Again = cell0.replace(with: SpecialInt(316))
-
-  // CHECK: Deinitializing 316!
-  cell0.set(SpecialInt(592))
-
-  let specialInt1 = cell0.get()
-
-  // CHECK: Deinitializing 592!
-  // CHECK: Deinitializing 128!
-}
+// CHECK: 123
+print(something(Foo<Int>()))

--- a/test/Interpreter/raw_layout.swift
+++ b/test/Interpreter/raw_layout.swift
@@ -1,0 +1,71 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature RawLayout -enable-builtin-module) | %FileCheck %s
+// REQUIRES: executable_test
+
+import Builtin
+
+@_rawLayout(like: T)
+struct Cell<T>: ~Copyable {
+  var address: UnsafeMutablePointer<T> {
+    UnsafeMutablePointer<T>(Builtin.unprotectedAddressOfBorrow(self))
+  }
+
+  init(_ value: consuming T) {
+    address.initialize(to: value)
+  }
+
+  deinit {
+    address.deinitialize(count: 1)
+
+    // Note: We don't need to deallocate the address here because the memory it
+    // points to is being destroyed within this deinit.
+  }
+
+  borrowing func replace(with replacement: consuming T) -> T {
+    let previous = address.move()
+    address.initialize(to: replacement)
+    return previous
+  }
+
+  borrowing func set(_ value: consuming T) {
+    let previous = replace(with: value)
+    _ = consume previous
+  }
+
+  consuming func get() -> T {
+    // Move the value out of self and don't call our deinitializer
+    let previous = address.move()
+    discard self
+    return previous
+  }
+}
+
+@_eagerMove
+class SpecialInt {
+  var value: Int
+
+  init(_ value: Int) {
+    self.value = value
+  }
+
+  deinit {
+    print("Deinitializing \(value)!")
+  }
+}
+
+do {
+  let specialInt0 = SpecialInt(128)
+  let cell0 = Cell<SpecialInt>(specialInt0)
+
+  let specialInt0Again = cell0.replace(with: SpecialInt(316))
+
+  // CHECK: Deinitializing 128!
+  _ = consume specialInt0Again
+
+  // CHECK: Deinitializing 316!
+  cell0.set(SpecialInt(592))
+
+  let specialInt1 = cell0.get()
+
+  // CHECK: Deinitializing 592!
+  _ = consume specialInt1
+}

--- a/test/Interpreter/raw_layout.swift
+++ b/test/Interpreter/raw_layout.swift
@@ -14,7 +14,8 @@ struct Cell<T>: ~Copyable {
   }
 
   deinit {
-    address.deinitialize(count: 1)
+    // FIXME: discard self should work with rawLayout types
+    //address.deinitialize(count: 1)
 
     // Note: We don't need to deallocate the address here because the memory it
     // points to is being destroyed within this deinit.
@@ -58,14 +59,11 @@ do {
 
   let specialInt0Again = cell0.replace(with: SpecialInt(316))
 
-  // CHECK: Deinitializing 128!
-  _ = consume specialInt0Again
-
   // CHECK: Deinitializing 316!
   cell0.set(SpecialInt(592))
 
   let specialInt1 = cell0.get()
 
   // CHECK: Deinitializing 592!
-  _ = consume specialInt1
+  // CHECK: Deinitializing 128!
 }

--- a/test/Sema/raw_layout.swift
+++ b/test/Sema/raw_layout.swift
@@ -45,4 +45,3 @@ struct Butt {
 
 @_rawLayout(size: 4, alignment: 4) @_alignment(16) // expected-error{{type with @_rawLayout cannot also have an @_alignment attribute}}
 struct RawLayoutAndAlignment: ~Copyable {}
-


### PR DESCRIPTION
This allows raw types to have dependent layouts and calls into a new runtime function to handle these cases. Raw types have some other compilation issues preventing the Interpreter test from running correctly (assuming I wrote it right).