### PR TITLE
[cxx-interop] Force creating a memberwise init for `std::pair`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2407,13 +2407,20 @@ namespace {
         }
       }
 
+      bool forceMemberwiseInitializer = false;
+      if (cxxRecordDecl && cxxRecordDecl->isInStdNamespace() &&
+          cxxRecordDecl->getIdentifier() &&
+          cxxRecordDecl->getName() == "pair") {
+        forceMemberwiseInitializer = true;
+      }
       // We can assume that it is possible to correctly construct the object by
       // simply initializing its member variables to arbitrary supplied values
       // only when the same is possible in C++. While we could check for that
       // exactly, checking whether the C++ class is an aggregate
       // (C++ [dcl.init.aggr]) has the same effect.
       bool isAggregate = !cxxRecordDecl || cxxRecordDecl->isAggregate();
-      if (hasReferenceableFields && hasMemberwiseInitializer && isAggregate) {
+      if ((hasReferenceableFields && hasMemberwiseInitializer && isAggregate) ||
+          forceMemberwiseInitializer) {
         // The default zero initializer suppresses the implicit value
         // constructor that would normally be formed, so we have to add that
         // explicitly as well.

--- a/test/Interop/Cxx/stdlib/Inputs/std-pair.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-pair.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <utility>
+#include <string>
 
 using PairInts = std::pair<int, int>;
+using PairStrings = std::pair<std::string, std::string>;
 
 inline const PairInts &getIntPairPointer() {
     static PairInts value = { 4, 9 };

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -9,6 +9,24 @@ import Cxx
 
 var StdPairTestSuite = TestSuite("StdPair")
 
+StdPairTestSuite.test("StdPairInts.init") {
+  let pi = PairInts(first: 1, second: 2)
+  expectEqual(pi.first, 1)
+  expectEqual(pi.second, 2)
+}
+
+#if !os(Windows) // FIXME: enable once swiftCxxStdlib is built on Windows (https://github.com/apple/swift/issues/67649)
+StdPairTestSuite.test("StdPairStrings.init") {
+  let ps = PairStrings(first: std.string(), second: std.string())
+  expectEqual(ps.first, std.string())
+  expectEqual(ps.second, std.string())
+
+  let ps2 = PairStrings(first: std.string("abc"), second: std.string("123"))
+  expectEqual(ps2.first, std.string("abc"))
+  expectEqual(ps2.second, std.string("123"))
+}
+#endif
+
 StdPairTestSuite.test("StdPair.elements") {
   var pi = getIntPair()
   expectEqual(pi.first, -5)


### PR DESCRIPTION
In libc++, `pair()` and `pair(_T1 const& __t1, _T2 const& __t2)` are templated with `enable_if`, so these initializers are not imported into Swift.

There should be a way to call `std.pair.init` from Swift, so this change makes sure Swift synthesizes a memberwise initializer for `std.pair`.

rdar://113135110