### PR TITLE
[cxx-interop] Add `std.string.withUTF8` method

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -400,6 +400,31 @@ StdStringTestSuite.test("std::string from C string") {
     expectEqual(str, std.string("abc"))
 }
 
+
+StdStringTestSuite.test("std::string to UTF-8") {
+    std.string().withUTF8 { ptr in
+        expectEqual(ptr.count, 0)
+    }
+    std.string("abc").withUTF8 { ptr in
+        expectEqual(ptr.count, 3)
+        expectEqual(ptr.baseAddress?.pointee, 97)
+        expectEqual(ptr.baseAddress?.successor().pointee, 98)
+        expectEqual(ptr.baseAddress?.successor().successor().pointee, 99)
+    }
+
+    let bytes: [UInt8] = [0xE1, 0xC1, 0xAC]
+    var str = std.string()
+    for byte in bytes {
+        str.push_back(CChar(bitPattern: byte))
+    }
+    str.withUTF8 { ptr in
+        expectEqual(ptr.count, 3)
+        expectEqual(ptr.baseAddress?.pointee, 0xE1)
+        expectEqual(ptr.baseAddress?.successor().pointee, 0xC1)
+        expectEqual(ptr.baseAddress?.successor().successor().pointee, 0xAC)
+    }
+}
+
 #if USE_CUSTOM_STRING_API
 StdStringTestSuite.test("get from a method") {
     let box = HasMethodThatReturnsString()


### PR DESCRIPTION
This new overlay method is a safe alternative to `std.string.__c_strUnsafe()`.

rdar://112765666