### PR TITLE
[cxx-interop] Allow mutating `std::map` from Swift

### DIFF
--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -17,14 +17,33 @@
 public protocol CxxDictionary<Key, Value> {
   associatedtype Key
   associatedtype Value
+  associatedtype Element: CxxPair<Key, Value>
   associatedtype RawIterator: UnsafeCxxInputIterator
-    where RawIterator.Pointee: CxxPair<Key, Value>
+    where RawIterator.Pointee == Element
+  associatedtype RawMutableIterator: UnsafeCxxMutableInputIterator
+    where RawMutableIterator.Pointee == Element
+  associatedtype Size: BinaryInteger
+  associatedtype InsertionResult
 
   /// Do not implement this function manually in Swift.
   func __findUnsafe(_ key: Key) -> RawIterator
 
   /// Do not implement this function manually in Swift.
+  mutating func __findMutatingUnsafe(_ key: Key) -> RawMutableIterator
+
+  /// Do not implement this function manually in Swift.
+  @discardableResult
+  mutating func __insertUnsafe(_ element: Element) -> InsertionResult
+
+  /// Do not implement this function manually in Swift.
+  @discardableResult
+  mutating func erase(_ key: Key) -> Size
+
+  /// Do not implement this function manually in Swift.
   func __endUnsafe() -> RawIterator
+
+  /// Do not implement this function manually in Swift.
+  mutating func __endMutatingUnsafe() -> RawMutableIterator
 }
 
 extension CxxDictionary {
@@ -36,6 +55,21 @@ extension CxxDictionary {
         return nil
       }
       return iter.pointee.second
+    }
+    set(newValue) {
+      guard let newValue = newValue else {
+        self.erase(key)
+        return
+      }
+      var iter = self.__findMutatingUnsafe(key)
+      if iter != self.__endMutatingUnsafe() {
+        // This key already exists in the dictionary.
+        iter.pointee.second = newValue
+      } else {
+        // Create a std::pair<key_type, mapped_type>.
+        let keyValuePair = Element(first: key, second: newValue)
+        self.__insertUnsafe(keyValuePair)
+      }
     }
   }
 }

--- a/stdlib/public/Cxx/CxxPair.swift
+++ b/stdlib/public/Cxx/CxxPair.swift
@@ -17,6 +17,8 @@ public protocol CxxPair<First, Second> {
   associatedtype First
   associatedtype Second
 
+  init(first: First, second: Second) // memberwise init, synthesized by Swift
+
   var first: First { get set }
   var second: Second { get set }
 }

--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -3,8 +3,10 @@
 
 #include <map>
 #include <unordered_map>
+#include <string>
 
 using Map = std::map<int, int>;
+using MapStrings = std::map<std::string, std::string>;
 using UnorderedMap = std::unordered_map<int, int>;
 
 inline Map initMap() { return {{1, 3}, {2, 2}, {3, 3}}; }

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -27,6 +27,27 @@ StdMapTestSuite.test("Map.subscript") {
   expectEqual(m[3], 3)
   expectNil(m[-1])
   expectNil(m[5])
+  
+  m[1] = 111
+  expectEqual(m[1], 111)
+
+  m[5] = 555
+  expectEqual(m[5], 555)
+
+  m[5] = nil
+  expectNil(m[5])
+  expectNil(m[5])
+}
+
+StdMapTestSuite.test("MapStrings.subscript") {
+  var m = MapStrings()
+  expectNil(m[std.string()])
+  expectNil(m[std.string()])
+  m[std.string()] = std.string()
+  expectNotNil(m[std.string()])
+
+  m[std.string("abc")] = std.string("qwe")
+  expectEqual(m[std.string("abc")], std.string("qwe"))
 }
 
 StdMapTestSuite.test("UnorderedMap.subscript") {
@@ -37,6 +58,16 @@ StdMapTestSuite.test("UnorderedMap.subscript") {
   expectEqual(m[3], 3)
   expectNil(m[-1])
   expectNil(m[5])
+
+  m[1] = 777
+  expectEqual(m[1], 777)
+
+  m[-1] = 228
+  expectEqual(m[-1], 228)
+
+  m[-1] = nil
+  expectNil(m[-1])
+  expectNil(m[-1])
 }
 
 StdMapTestSuite.test("Map.erase") {


### PR DESCRIPTION
This adds a setter to the `CxxDictionary` subscript which makes it possible to mutate `std::map` and `std::unordered_map` from Swift.

rdar://105399019