### PR TITLE
[Frontend/NFC] SE-0400: Enable `InitAccessors` feature by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -122,7 +122,6 @@ EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
-EXPERIMENTAL_FEATURE(InitAccessors, false)
 
 SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)", true)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3262,10 +3262,6 @@ static bool usesFeatureSymbolLinkageMarkers(Decl *decl) {
   });
 }
 
-static bool usesFeatureInitAccessors(Decl *decl) {
-  return false;
-}
-
 static bool usesFeatureLayoutPrespecialization(Decl *decl) {
   auto &attrs = decl->getAttrs();
   return std::any_of(attrs.begin(), attrs.end(), [](auto *attr) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7356,9 +7356,7 @@ static bool parseAccessorIntroducer(Parser &P,
     }
   }
 
-  bool isInitAccessor = (P.Context.LangOpts.hasFeature(Feature::InitAccessors)
-                         && P.Tok.is(tok::kw_init));
-  if (!(P.Tok.is(tok::identifier) || isInitAccessor) ||
+  if (!(P.Tok.is(tok::identifier) || P.Tok.is(tok::kw_init)) ||
       P.Tok.isEscapedIdentifier()) {
     return true;
   }

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -1,8 +1,7 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-feature -Xfrontend InitAccessors) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -enable-experimental-feature -Xfrontend InitAccessors) | %FileCheck %s
+// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-O) | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: asserts
 
 struct TestInit {
   var x: Int

--- a/test/ModuleInterface/Observable.swift
+++ b/test/ModuleInterface/Observable.swift
@@ -1,10 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -plugin-path %swift-host-lib-dir/plugins -disable-availability-checking -enable-experimental-feature InitAccessors
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -plugin-path %swift-host-lib-dir/plugins -disable-availability-checking
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library -disable-availability-checking
 // RUN: %FileCheck %s < %t/Library.swiftinterface
-
-// Asserts is required for '-enable-experimental-feature InitAccessors'.
-// REQUIRES: asserts
 
 // REQUIRES: swift_swift_parser
 // REQUIRES: observation

--- a/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature InitAccessors -enable-copy-propagation=requested-passes-only -emit-sil -primary-file %s -o /dev/null -verify
-
-// REQUIRES: asserts
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -emit-sil -primary-file %s -o /dev/null -verify
 
 struct Test1 {
   var x: Int // expected-note {{variable defined here}}

--- a/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
+++ b/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature InitAccessors -Xllvm -sil-print-after=definite-init -emit-sil -module-name assign_or_init_lowering %s -o /dev/null 2>&1 | %FileCheck %s
-
-// REQUIRES: asserts
+// RUN: %target-swift-frontend -Xllvm -sil-print-after=definite-init -emit-sil -module-name assign_or_init_lowering %s -o /dev/null 2>&1 | %FileCheck %s
 
 protocol Storage<T> {
   associatedtype T

--- a/test/SILOptimizer/init_accessors.sil
+++ b/test/SILOptimizer/init_accessors.sil
@@ -1,6 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -definite-init -raw-sil-inst-lowering -enable-experimental-feature InitAccessors %s | %FileCheck %s
-
-// REQUIRES: asserts
+// RUN: %target-sil-opt -enable-sil-verify-all -definite-init -raw-sil-inst-lowering %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/init_accessors.swift
+++ b/test/SILOptimizer/init_accessors.swift
@@ -1,8 +1,6 @@
-// RUN: %target-swift-frontend -enable-experimental-feature InitAccessors -primary-file %s -Onone -emit-sil \
+// RUN: %target-swift-frontend -primary-file %s -Onone -emit-sil \
 // RUN:   -Xllvm -sil-print-after=raw-sil-inst-lowering \
 // RUN:   -o /dev/null -module-name init_accessors 2>&1 | %FileCheck %s
-
-// REQUIRES: asserts
 
 class NSObject {}
 

--- a/test/Serialization/init_accessors.swift
+++ b/test/Serialization/init_accessors.swift
@@ -3,15 +3,11 @@
 // RUN: %empty-directory(%t/sdk)
 // RUN: split-file %s %t/src
 
-// REQUIRES: asserts
-
 // RUN: %target-swift-frontend -emit-module %t/src/PublicModule.swift \
 // RUN:   -module-name PublicModule -swift-version 5 \
-// RUN:   -emit-module-path %t/sdk/PublicModule.swiftmodule \
-// RUN:   -enable-experimental-feature InitAccessors
+// RUN:   -emit-module-path %t/sdk/PublicModule.swiftmodule
 
 // RUN: %target-swift-frontend -typecheck %t/src/Client.swift \
-// RUN:   -enable-experimental-feature InitAccessors \
 // RUN:   -module-name Client -I %t/sdk
 
 //--- PublicModule.swift

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature InitAccessors
-
-// REQUIRES: asserts
+// RUN: %target-typecheck-verify-swift
 
 func test_empty_init_accessor() {
   struct Test {

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -1,12 +1,9 @@
 // REQUIRES: swift_swift_parser, executable_test
 
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
 
 // Run this test via the swift-plugin-server
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -external-plugin-path -Xfrontend %swift-host-lib-dir/plugins#%swift-plugin-server)
-
-// Asserts is required for '-enable-experimental-feature InitAccessors'.
-// REQUIRES: asserts
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -external-plugin-path -Xfrontend %swift-host-lib-dir/plugins#%swift-plugin-server)
 
 // REQUIRES: observation
 // REQUIRES: concurrency

--- a/test/stdlib/Observation/ObservableDiagnostics.swift
+++ b/test/stdlib/Observation/ObservableDiagnostics.swift
@@ -1,9 +1,6 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -plugin-path %swift-host-lib-dir/plugins
-
-// Asserts is required for '-enable-experimental-feature InitAccessors'.
-// REQUIRES: asserts
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -plugin-path %swift-host-lib-dir/plugins
 
 // REQUIRES: observation
 // REQUIRES: concurrency

--- a/test/stdlib/Observation/ObservableDidSetWillSet.swift
+++ b/test/stdlib/Observation/ObservableDidSetWillSet.swift
@@ -1,9 +1,6 @@
 // REQUIRES: swift_swift_parser, executable_test
 
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -enable-experimental-feature InitAccessors -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins) | %FileCheck %s
-
-// Asserts is required for '-enable-experimental-feature InitAccessors'.
-// REQUIRES: asserts
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins) | %FileCheck %s
 
 // REQUIRES: observation
 // REQUIRES: concurrency


### PR DESCRIPTION
SE-400 has been accepted.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
