### PR TITLE
[CodeComplete] Avoid dropping "is for code completion" bit

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -880,21 +880,6 @@ bool ConjunctionStep::attempt(const ConjunctionElement &element) {
     CS.Timer.emplace(element.getLocator(), CS);
   }
 
-  assert(!ModifiedOptions.has_value() &&
-         "Previously modified options should have been restored in resume");
-  if (CS.isForCodeCompletion() &&
-      !element.mightContainCodeCompletionToken(CS) &&
-      !getLocator()->isForSingleValueStmtConjunctionOrBrace()) {
-    ModifiedOptions.emplace(CS.Options);
-    // If we know that this conjunction element doesn't contain the code
-    // completion token, type check it in normal mode without any special
-    // behavior that is intended for the code completion token.
-    // Avoid doing this for SingleValueStmtExprs, because we can more eagerly
-    // prune branches in that case, which requires us to detect the code
-    // completion option while solving the conjunction.
-    CS.Options -= ConstraintSystemFlags::ForCodeCompletion;
-  }
-
   auto success = element.attempt(CS);
 
   // If element attempt has failed, mark whole conjunction
@@ -906,9 +891,6 @@ bool ConjunctionStep::attempt(const ConjunctionElement &element) {
 }
 
 StepResult ConjunctionStep::resume(bool prevFailed) {
-  // Restore the old ConstraintSystemOptions if 'attempt' modified them.
-  ModifiedOptions.reset();
-
   // Return from the follow-up splitter step that
   // attempted to apply information gained from the
   // isolated constraint to the outer context.

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -942,11 +942,6 @@ class ConjunctionStep : public BindingStep<ConjunctionElementProducer> {
   /// in isolated mode.
   SmallVector<Solution, 4> IsolatedSolutions;
 
-  /// If \c ConjunctionStep::attempt modified the constraint system options,
-  /// it will store the original options in this \c llvm::SaveAndRestore.
-  /// Upon \c resume, these values will be restored.
-  llvm::Optional<llvm::SaveAndRestore<ConstraintSystemOptions>> ModifiedOptions;
-
 public:
   ConjunctionStep(ConstraintSystem &cs, Constraint *conjunction,
                   SmallVectorImpl<Solution> &solutions)


### PR DESCRIPTION
This should no longer be needed now that we check for a code completion token when increasing the score. It should also allow us to skip more conjunction elements, as that requires the bit being set.