### PR TITLE
[Macros] Add back the `ExtensionMacro` feature identifier as a `LANGUAGE_FEATURE` for use in swiftinterfaces.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -105,6 +105,7 @@ LANGUAGE_FEATURE(
     FreestandingExpressionMacros, 382, "Expression macros",
         hasSwiftSwiftParser)
 LANGUAGE_FEATURE(AttachedMacros, 389, "Attached macros", hasSwiftSwiftParser)
+LANGUAGE_FEATURE(ExtensionMacros, 402, "Extension macros", hasSwiftSwiftParser)
 LANGUAGE_FEATURE(MoveOnly, 390, "noncopyable types", true)
 LANGUAGE_FEATURE(ParameterPacks, 393, "Value and type parameter packs", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(LexicalLifetimes, 0, "@_eagerMove/@_noEagerMove/@_lexicalLifetimes annotations", true)

--- a/test/Macros/Inputs/ConformanceMacroLib.swiftinterface
+++ b/test/Macros/Inputs/ConformanceMacroLib.swiftinterface
@@ -3,3 +3,10 @@
 
 @attached(conformance)
 public macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
+
+#if compiler(>=5.3) && $Macros && $AttachedMacros && $ExtensionMacros
+#if $ExtensionMacroAttr
+@attached(extension, conformances: Swift.Hashable)
+public macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacro")
+#endif
+#endif

--- a/test/Macros/imported_conformance_macro.swift
+++ b/test/Macros/imported_conformance_macro.swift
@@ -16,3 +16,9 @@ struct S {}
 
 // CHECK-DUMP: extension S: Equatable  {
 // CHECK-DUMP: }
+
+@Hashable
+struct T {}
+
+// CHECK-DUMP: extension T: Hashable  {
+// CHECK-DUMP: }


### PR DESCRIPTION
The compiler should continue to recognize `#if $ExtensionMacros` in swiftinterfaces.

Resolves rdar://113151151