### PR TITLE
[5.9][Macros] Add back the `ExtensionMacro` feature identifier as a `LANGUAGE_FEATURE` for use in swiftinterfaces.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -105,6 +105,7 @@ LANGUAGE_FEATURE(
     FreestandingExpressionMacros, 382, "Expression macros",
         hasSwiftSwiftParser)
 LANGUAGE_FEATURE(AttachedMacros, 389, "Attached macros", hasSwiftSwiftParser)
+LANGUAGE_FEATURE(ExtensionMacros, 402, "Extension macros", hasSwiftSwiftParser)
 LANGUAGE_FEATURE(MoveOnly, 390, "noncopyable types", true)
 LANGUAGE_FEATURE(ParameterPacks, 393, "Value and type parameter packs", true)
 LANGUAGE_FEATURE(FreestandingMacros, 397, "freestanding declaration macros", true)

--- a/test/Macros/Inputs/ConformanceMacroLib.swiftinterface
+++ b/test/Macros/Inputs/ConformanceMacroLib.swiftinterface
@@ -3,3 +3,10 @@
 
 @attached(conformance)
 public macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
+
+#if compiler(>=5.3) && $Macros && $AttachedMacros && $ExtensionMacros
+#if $ExtensionMacroAttr
+@attached(extension, conformances: Swift.Hashable)
+public macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacro")
+#endif
+#endif

--- a/test/Macros/imported_conformance_macro.swift
+++ b/test/Macros/imported_conformance_macro.swift
@@ -16,3 +16,9 @@ struct S {}
 
 // CHECK-DUMP: extension S: Equatable  {
 // CHECK-DUMP: }
+
+@Hashable
+struct T {}
+
+// CHECK-DUMP: extension T: Hashable  {
+// CHECK-DUMP: }


### PR DESCRIPTION
* **Explanation**: The experimental `ExtensionMacros` feature identifier was recently removed with the acceptance of SE-0402. However, if a swiftinterfaces uses `#if $ExtensionMacros`, this condition will now evaluate to false for compilers that have the implementation of extension macros, but have the experimental feature removed. Add the identifier back as a language feature to preserve the behavior of `#if $ExtensionMacros` in swiftinterfaces.
* **Scope**: Only impacts rebuilding modules from old swiftinterface produced by older compilers.
* **Risk**: Very low.
* **Testing**: Added a test that rebuilds a swiftinterface using `#if $ExtensionMacros` and applies the macro declared inside the condition.
* **Issue**: rdar://113151151
* **Reviewer**: @bnbarham 
* **Main branch PR**: https://github.com/apple/swift/pull/67627