### PR TITLE
Reenable compat lib in a couple tests

### DIFF
--- a/test/DebugInfo/ASTSection_linker.swift
+++ b/test/DebugInfo/ASTSection_linker.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -runtime-compatibility-version none -c -Xcc -DA -Xcc -DB -emit-module -o %t %S/ASTSection.swift -swift-version 4
+// RUN: %target-swift-frontend -c -Xcc -DA -Xcc -DB -emit-module -o %t %S/ASTSection.swift -swift-version 4
 // RUN: %swift-ide-test -test-CompilerInvocation-from-module -source-filename=%t/ASTSection.swiftmodule
 
 // Test the inline section mechanism.

--- a/test/IRGen/entrypoint-section-run-main_swift.cpp
+++ b/test/IRGen/entrypoint-section-run-main_swift.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang %s -std=c++11 -isysroot %sdk -o %t/main
 // RUN: %target-codesign %t/main
-// RUN: %target-swift-frontend -runtime-compatibility-version none -c %S/Inputs/entry-point-section/main.swift -O -o %t/howdy.o -module-name Howdy
+// RUN: %target-swift-frontend -c %S/Inputs/entry-point-section/main.swift -O -o %t/howdy.o -module-name Howdy
 // RUN: %target-ld %t/howdy.o -syslibroot %sdk -lSystem -dylib -o %t/libHowdy.dylib
 // RUN: %target-codesign %t/libHowdy.dylib
 // RUN: %target-run %t/main %t/libHowdy.dylib | %FileCheck %s


### PR DESCRIPTION
This patch re-enables the compat library on a couple of tests. The issue was that the compat library was pulling in compiler-rt symbols for determining system version. That was fixed with a little dlsym action in 188c7bd626a9ba7a8eac598591f7bdeaedc48de6. It was using the symbols to determine if we had `voucher_needs_adopt`. It just took a while to re-enable it in these tests.

Finishing up: rdar://100868842