### PR TITLE
[AddressLowering] Handle unowned copies.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -179,7 +179,8 @@ ManagedValue SILGenBuilder::createCopyValue(SILLocation loc,
   ManagedValue SILGenBuilder::createStrongCopy##Name##Value(                   \
       SILLocation loc, ManagedValue originalValue) {                           \
     auto ty = originalValue.getType().castTo<Name##StorageType>();             \
-    assert(ty->isLoadable(ResilienceExpansion::Maximal));                      \
+    assert(ty->isLoadable(ResilienceExpansion::Maximal) ||                     \
+           !SGF.useLoweredAddresses());                                        \
     (void)ty;                                                                  \
     SILValue result =                                                          \
         createStrongCopy##Name##Value(loc, originalValue.getValue());          \

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -Xllvm -sil-full-demangle -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 // Test SILGen -enable-sil-opaque-values with tests that depend on the stdlib.
 
@@ -647,3 +647,21 @@ func giveKeyPathString() {
 @backDeployed(before: SwiftStdlib 5.8)
 public func backDeployingReturningGeneric<T>(_ t: T) throws -> T { t }
 #endif
+
+// CHECK-LABEL: sil {{.*}}[ossa] @$s20opaque_values_silgen13UnownedVarBoxV5valuexvg : {{.*}} {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         [[UNOWNED_VALUE:%[^,]+]] = struct_extract [[INSTANCE]]
+// CHECK:         [[STRONG_VALUE:%[^,]+]] = strong_copy_unowned_value [[UNOWNED_VALUE]]
+// CHECK:         return [[STRONG_VALUE]]
+// CHECK-LABEL: } // end sil function '$s20opaque_values_silgen13UnownedVarBoxV5valuexvg'
+// CHECK-LABEL: sil {{.*}}[ossa] @$s20opaque_values_silgen13UnownedVarBoxV5valueACyxGx_tcfC : {{.*}} {
+// CHECK:       bb0([[STRONG_VALUE:%[^,]+]] :
+// CHECK:         [[UNOWNED_VALUE:%[^,]+]] = ref_to_unowned [[STRONG_VALUE]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[UNOWNED_VALUE]]
+// CHECK:         destroy_value [[STRONG_VALUE]]
+// CHECK:         [[RETVAL:%[^,]+]] = struct $UnownedVarBox<T> ([[COPY]] : $@sil_unowned T)
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function '$s20opaque_values_silgen13UnownedVarBoxV5valueACyxGx_tcfC'
+struct UnownedVarBox<T : AnyObject> {
+  unowned var value: T
+}

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -72,6 +72,10 @@ indirect enum RE<T> {
    case other(AnyObject)
 }
 
+struct UnownedVarBox<T : AnyObject> {
+  unowned var value: T
+}
+
 class TestGeneric<T> {
   init()
   @_borrowed @_hasStorage var borrowedGeneric: T { get set }
@@ -2500,6 +2504,24 @@ bb0:
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_ref_to_unowned : {{.*}} {
+// CHECK:       bb0([[INSTANCE_OUT:%[^,]+]] : {{.*}}, [[OWNED_VALUE:%[^,]+]] :
+// CHECK:         [[TMP:%[^,]+]] = alloc_stack $@sil_unowned T
+// CHECK:         store_unowned [[OWNED_VALUE]] to [init] [[TMP]]
+// CHECK:         [[FIELD_ADDR:%[^,]+]] = struct_element_addr [[INSTANCE_OUT]]
+// CHECK:         copy_addr [[TMP]] to [init] [[FIELD_ADDR]]
+// CHECK:         destroy_value [[OWNED_VALUE]]
+// CHECK:         dealloc_stack [[TMP]]
+// CHECK-LABEL: } // end sil function 'test_ref_to_unowned'
+sil [ossa] @test_ref_to_unowned : $@convention(thin) <T where T : AnyObject> (@owned T) -> @out UnownedVarBox<T> {
+bb0(%owned_value : @owned $T):
+  %unowned_value = ref_to_unowned %owned_value : $T to $@sil_unowned T
+  %unowned_copy = copy_value %unowned_value : $@sil_unowned T
+  destroy_value %owned_value : $T
+  %instance = struct $UnownedVarBox<T> (%unowned_copy : $@sil_unowned T)
+  return %instance : $UnownedVarBox<T>
+}
+
 // CHECK-LABEL: sil hidden [ossa] @test_store_1 : {{.*}} {
 // CHECK:         [[MAYBE_ADDR:%[^,]+]] = alloc_stack $Optional<Self>
 // CHECK:         [[LOAD_ADDR:%[^,]+]] = alloc_stack $Self
@@ -2551,6 +2573,19 @@ entry:
   destroy_value %instance : $T
   %retval = tuple ()
   return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_strong_copy_unowned_value : {{.*}} {
+// CHECK:       bb0([[INSTANCE_ADDR:%[^,]+]] :
+// CHECK:         [[FIELD_ADDR:%[^,]+]] = struct_element_addr [[INSTANCE_ADDR]]
+// CHECK:         [[OWNED_VALUE:%[^,]+]] = load_unowned [[FIELD_ADDR]]
+// CHECK:         return [[OWNED_VALUE]]
+// CHECK-LABEL: } // end sil function 'test_strong_copy_unowned_value'
+sil [ossa] @test_strong_copy_unowned_value : $@convention(thin) <T where T : AnyObject> (@in_guaranteed UnownedVarBox<T>) -> @owned T {
+bb0(%instance : @guaranteed $UnownedVarBox<T>):
+  %unowned_value = struct_extract %instance : $UnownedVarBox<T>, #UnownedVarBox.value
+  %owned_value = strong_copy_unowned_value %unowned_value : $@sil_unowned T
+  return %owned_value : $T
 }
 
 // CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast :


### PR DESCRIPTION
Lower the `strong_copy_unowned_value` and `ref_to_unowned` to `load_unowned` and `store_unowned` respectively.
