### PR TITLE
Sema: Fix unavailable enum element cases in derived hashable/equatable impls

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5648,9 +5648,10 @@ void PrintAST::visitCaseStmt(CaseStmt *CS) {
                [&] { Printer << ", "; });
   }
   Printer << ":";
-  Printer.printNewline();
 
-  printASTNodes((cast<BraceStmt>(CS->getBody())->getElements()));
+  if (!printASTNodes((cast<BraceStmt>(CS->getBody())->getElements())))
+    Printer.printNewline();
+  indent();
 }
 
 void PrintAST::visitFailStmt(FailStmt *stmt) {

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -342,5 +342,7 @@ void DerivedConformance::tryDiagnoseFailedComparableDerivation(
                          rawType, nominal->getDeclaredInterfaceType(),
                          comparableProto->getDeclaredInterfaceType());
     }
+    // FIXME: Diagnose potentially unavailable enum elements that are preventing
+    // Comparable synthesis.
   }
 }

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -176,6 +176,13 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
   for (auto elt : enumDecl->getAllElements()) {
     ++elementCount;
 
+    if (auto *unavailableElementCase =
+            DerivedConformance::unavailableEnumElementCaseStmt(
+                enumType, elt, eqDecl, /*subPatternCount=*/2)) {
+      cases.push_back(unavailableElementCase);
+      continue;
+    }
+
     // .<elt>(let l0, let l1, ...)
     SmallVector<VarDecl*, 3> lhsPayloadVars;
     auto lhsSubpattern = DerivedConformance::enumElementPayloadSubpattern(elt, 'l', eqDecl,
@@ -692,6 +699,13 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
   // For each enum element, generate a case statement that binds the associated
   // values so that they can be fed to the hasher.
   for (auto elt : enumDecl->getAllElements()) {
+    if (auto *unavailableElementCase =
+            DerivedConformance::unavailableEnumElementCaseStmt(enumType, elt,
+                                                               hashIntoDecl)) {
+      cases.push_back(unavailableElementCase);
+      continue;
+    }
+
     // case .<elt>(let a0, let a1, ...):
     SmallVector<VarDecl*, 3> payloadVars;
     SmallVector<ASTNode, 3> statements;

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -29,6 +29,7 @@ class AssociatedTypeDecl;
 class ASTContext;
 struct ASTNode;
 class CallExpr;
+class CaseStmt;
 class Decl;
 class DeclContext;
 class DeclRefExpr;
@@ -389,6 +390,11 @@ public:
                               ArrayRef<ProtocolConformanceRef> conformances,
                                      ArrayRef<Expr *> args);
 
+  /// Build a call to the stdlib function that should be called when unavailable
+  /// code is reached unexpectedly.
+  static CallExpr *
+  createDiagnoseUnavailableCodeReachedCallExpr(ASTContext &ctx);
+
   /// Returns true if this derivation is trying to use a context that isn't
   /// appropriate for deriving.
   ///
@@ -452,6 +458,16 @@ public:
   static Pattern *enumElementPayloadSubpattern(
       EnumElementDecl *enumElementDecl, char varPrefix, DeclContext *varContext,
       SmallVectorImpl<VarDecl *> &boundVars, bool useLabels = false);
+
+  /// Creates a synthesized case statement that has the following structure:
+  ///
+  ///     case .<elt>, ..., .<elt>:
+  ///       _diagnoseUnavailableCodeReached()
+  ///
+  /// The number of \c .<elt> matches is equal to \p subPatternCount.
+  static CaseStmt *unavailableEnumElementCaseStmt(
+      Type enumType, EnumElementDecl *enumElementDecl, DeclContext *parentDC,
+      unsigned subPatternCount = 1);
 
   static VarDecl *indexedVarDecl(char prefixChar, int index, Type type,
                                  DeclContext *varContext);

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -828,8 +828,8 @@ namespace {
           auto children = E->getAllElements();
           llvm::transform(
               children, std::back_inserter(arr), [&](EnumElementDecl *eed) {
-                // Don't force people to match unavailable cases; they can't
-                // even write them.
+                // Don't force people to match unavailable cases since they
+                // should not be instantiated at run time.
                 if (AvailableAttr::isUnavailable(eed)) {
                   return Space();
                 }

--- a/test/decl/enum/derived_hashable_equatable.swift
+++ b/test/decl/enum/derived_hashable_equatable.swift
@@ -90,3 +90,133 @@ enum HasAssociatedValues: Hashable {
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
 }
+
+// CHECK-LABEL: internal enum HasUnavailableElement : Hashable
+enum HasUnavailableElement: Hashable {
+  // CHECK:       case a
+  case a
+  // CHECK:       @available(*, unavailable)
+  // CHECK-NEXT:  case b
+  @available(*, unavailable)
+  case b
+
+  // CHECK:       @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: HasUnavailableElement, _ b: HasUnavailableElement) -> Bool {
+  // CHECK-NEXT:    private var index_a: Int
+  // CHECK-NEXT:    switch a {
+  // CHECK-NEXT:    case .a:
+  // CHECK-NEXT:      index_a = 0
+  // CHECK-NEXT:    case .b:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    private var index_b: Int
+  // CHECK-NEXT:    switch b {
+  // CHECK-NEXT:    case .a:
+  // CHECK-NEXT:      index_b = 0
+  // CHECK-NEXT:    case .b:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    return index_a == index_b
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:    private var discriminator: Int
+  // CHECK-NEXT:    switch self {
+  // CHECK-NEXT:    case .a:
+  // CHECK-NEXT:      discriminator = 0
+  // CHECK-NEXT:    case .b:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    hasher.combine(discriminator)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var hashValue: Int {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return _hashValue(for: self)
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+}
+
+// CHECK-LABEL: internal enum HasAssociatedValuesAndUnavailableElement : Hashable
+enum HasAssociatedValuesAndUnavailableElement: Hashable {
+  // CHECK:        case a(Int)
+  case a(Int)
+  // CHECK:       @available(*, unavailable)
+  // CHECK-NEXT:  case b(String)
+  @available(*, unavailable)
+  case b(String)
+
+  // CHECK:       internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:    switch self {
+  // CHECK-NEXT:    case .a(let a0):
+  // CHECK-NEXT:      hasher.combine(0)
+  // CHECK-NEXT:      hasher.combine(a0)
+  // CHECK-NEXT:    case .b:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: HasAssociatedValuesAndUnavailableElement, _ b: HasAssociatedValuesAndUnavailableElement) -> Bool {
+  // CHECK-NEXT:    switch (a, b) {
+  // CHECK-NEXT:    case (.a(let l0), .a(let r0)):
+  // CHECK-NEXT:      guard l0  r0 else {
+  // CHECK-NEXT:        return false
+  // CHECK-NEXT:      }
+  // CHECK-NEXT:      return true
+  // CHECK-NEXT:    case (.b, .b):
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    default:
+  // CHECK-NEXT:      return false
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var hashValue: Int {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return _hashValue(for: self)
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+}
+
+// CHECK-LABEL: internal enum UnavailableEnum : Hashable
+@available(*, unavailable)
+enum UnavailableEnum: Hashable {
+  // CHECK:        case a
+  case a
+  // CHECK:        case b
+  case b
+
+  // CHECK:        @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: UnavailableEnum, _ b: UnavailableEnum) -> Bool {
+  // CHECK-NEXT:     private var index_a: Int
+  // CHECK-NEXT:     switch a {
+  // CHECK-NEXT:     case .a:
+  // CHECK-NEXT:       index_a = 0
+  // CHECK-NEXT:     case .b:
+  // CHECK-NEXT:       index_a = 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     private var index_b: Int
+  // CHECK-NEXT:     switch b {
+  // CHECK-NEXT:     case .a:
+  // CHECK-NEXT:       index_b = 0
+  // CHECK-NEXT:     case .b:
+  // CHECK-NEXT:       index_b = 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     return index_a == index_b
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:     private var discriminator: Int
+  // CHECK-NEXT:     switch self {
+  // CHECK-NEXT:     case .a:
+  // CHECK-NEXT:       discriminator = 0
+  // CHECK-NEXT:     case .b:
+  // CHECK-NEXT:       discriminator = 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     hasher.combine(discriminator)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var hashValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return _hashValue(for: self)
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+}

--- a/test/decl/enum/derived_hashable_equatable.swift
+++ b/test/decl/enum/derived_hashable_equatable.swift
@@ -1,0 +1,92 @@
+// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s
+
+// CHECK-LABEL: internal enum Simple : Hashable
+enum Simple: Hashable {
+  // CHECK:        case a
+  case a
+  // CHECK:        case b
+  case b
+
+  // CHECK:        @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: Simple, _ b: Simple) -> Bool {
+  // CHECK-NEXT:     private var index_a: Int
+  // CHECK-NEXT:     switch a {
+  // CHECK-NEXT:     case .a:
+  // CHECK-NEXT:       index_a = 0
+  // CHECK-NEXT:     case .b:
+  // CHECK-NEXT:       index_a = 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     private var index_b: Int
+  // CHECK-NEXT:     switch b {
+  // CHECK-NEXT:     case .a:
+  // CHECK-NEXT:       index_b = 0
+  // CHECK-NEXT:     case .b:
+  // CHECK-NEXT:       index_b = 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     return index_a == index_b
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:     private var discriminator: Int
+  // CHECK-NEXT:     switch self {
+  // CHECK-NEXT:     case .a:
+  // CHECK-NEXT:       discriminator = 0
+  // CHECK-NEXT:     case .b:
+  // CHECK-NEXT:       discriminator = 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     hasher.combine(discriminator)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var hashValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return _hashValue(for: self)
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum HasAssociatedValues : Hashable
+enum HasAssociatedValues: Hashable {
+  // CHECK:        case a(Int)
+  case a(Int)
+  // CHECK:        case b(String)
+  case b(String)
+  // CHECK:        case c
+  case c
+
+  // CHECK:        internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:     switch self {
+  // CHECK-NEXT:     case .a(let a0):
+  // CHECK-NEXT:       hasher.combine(0)
+  // CHECK-NEXT:       hasher.combine(a0)
+  // CHECK-NEXT:     case .b(let a0):
+  // CHECK-NEXT:       hasher.combine(1)
+  // CHECK-NEXT:       hasher.combine(a0)
+  // CHECK-NEXT:     case .c:
+  // CHECK-NEXT:       hasher.combine(2)
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: HasAssociatedValues, _ b: HasAssociatedValues) -> Bool {
+  // CHECK-NEXT:     switch (a, b) {
+  // CHECK-NEXT:     case (.a(let l0), .a(let r0)):
+  // CHECK-NEXT:       guard l0  r0 else {
+  // CHECK-NEXT:         return false
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       return true
+  // CHECK-NEXT:     case (.b(let l0), .b(let r0)):
+  // CHECK-NEXT:       guard l0  r0 else {
+  // CHECK-NEXT:         return false
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       return true
+  // CHECK-NEXT:     case (.c, .c):
+  // CHECK-NEXT:       return true
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return false
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var hashValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return _hashValue(for: self)
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}

--- a/test/decl/enum/derived_hashable_equatable_macos.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos.swift
@@ -1,0 +1,78 @@
+// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.51 -print-ast %s | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL: internal enum HasElementsWithAvailability : Hashable
+enum HasElementsWithAvailability: Hashable {
+  // CHECK:       case alwaysAvailable
+  case alwaysAvailable
+  // CHECK:       @available(*, unavailable)
+  // CHECK-NEXT:  case neverAvailable
+  @available(*, unavailable)
+  case neverAvailable
+  // CHECK:       @available(macOS, unavailable)
+  // CHECK-NEXT:  case unavailableMacOS
+  @available(macOS, unavailable)
+  case unavailableMacOS
+  // CHECK:       @available(macOS, obsoleted: 10.50)
+  // CHECK-NEXT:  case obsoleted10_50
+  @available(macOS, obsoleted: 10.50)
+  case obsoleted10_50
+  // CHECK:       @available(macOS 10.50, *)
+  // CHECK-NEXT:  case introduced10_50
+  @available(macOS, introduced: 10.50)
+  case introduced10_50
+
+  // CHECK:       @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: HasElementsWithAvailability, _ b: HasElementsWithAvailability) -> Bool {
+  // CHECK-NEXT:    private var index_a: Int
+  // CHECK-NEXT:    switch a {
+  // CHECK-NEXT:    case .alwaysAvailable:
+  // CHECK-NEXT:      index_a = 0
+  // CHECK-NEXT:    case .neverAvailable:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    case .unavailableMacOS:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    case .obsoleted10_50:
+  // CHECK-NEXT:      index_a = 1
+  // CHECK-NEXT:    case .introduced10_50:
+  // CHECK-NEXT:      index_a = 2
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    private var index_b: Int
+  // CHECK-NEXT:    switch b {
+  // CHECK-NEXT:    case .alwaysAvailable:
+  // CHECK-NEXT:      index_b = 0
+  // CHECK-NEXT:    case .neverAvailable:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    case .unavailableMacOS:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    case .obsoleted10_50:
+  // CHECK-NEXT:      index_b = 1
+  // CHECK-NEXT:    case .introduced10_50:
+  // CHECK-NEXT:      index_b = 2
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    return index_a == index_b
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:    private var discriminator: Int
+  // CHECK-NEXT:    switch self {
+  // CHECK-NEXT:    case .alwaysAvailable:
+  // CHECK-NEXT:      discriminator = 0
+  // CHECK-NEXT:    case .neverAvailable:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    case .unavailableMacOS:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
+  // CHECK-NEXT:    case .obsoleted10_50:
+  // CHECK-NEXT:      discriminator = 1
+  // CHECK-NEXT:    case .introduced10_50:
+  // CHECK-NEXT:      discriminator = 2
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    hasher.combine(discriminator)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var hashValue: Int {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return _hashValue(for: self)
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+}

--- a/test/decl/protocol/special/coding/enum_coding_key_unavailable_element.swift
+++ b/test/decl/protocol/special/coding/enum_coding_key_unavailable_element.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-simple-swift(-unavailable-decl-optimization=complete)
+// RUN: %target-run-simple-swift(-Xfrontend -unavailable-decl-optimization=complete)
 
 // REQUIRES: executable_test
 

--- a/test/decl/protocol/special/comparable/comparable_unsupported.swift
+++ b/test/decl/protocol/special/comparable/comparable_unsupported.swift
@@ -24,6 +24,28 @@ enum NotComparableEnumOne: Int, Comparable {
   case value
 }
 
+// A potentially unavailable (or unconditionally unavailable) enum case prevents
+// automatic synthesis of Comparable requirements.
+// FIXME: This should be diagnosed explicitly.
+
+enum EnumWithUnavailableCase: Comparable {
+  // expected-error@-1 {{type 'EnumWithUnavailableCase' does not conform to protocol 'Comparable'}}
+  case available
+
+  @available(*, unavailable)
+  case unavailable
+}
+
+enum EnumWithUnavailableCaseAndAssociatedValue: Comparable {
+  // expected-error@-1 {{type 'EnumWithUnavailableCaseAndAssociatedValue' does not conform to protocol 'Comparable'}}
+  enum SomeComparable: Comparable {}
+
+  case none
+
+  @available(*, unavailable)
+  case some(SomeComparable)
+}
+
 // Automatic synthesis of Comparable requires associated values to be Comparable as well.
 
 enum NotComparableEnumTwo: Comparable {

--- a/test/refactoring/AddCodableImplementation/Outputs/enum/codable.swift.expected
+++ b/test/refactoring/AddCodableImplementation/Outputs/enum/codable.swift.expected
@@ -25,12 +25,10 @@ enum Payload: Codable {
     }
     switch onlyKey {
     case .plain:
-
       let nestedContainer = try container.nestedContainer(keyedBy: Payload.PlainCodingKeys.self, forKey: Payload.CodingKeys.plain)
 
       self = Payload.plain(try nestedContainer.decode(String.self, forKey: Payload.PlainCodingKeys._0))
-      case .pair:
-
+    case .pair:
       let nestedContainer = try container.nestedContainer(keyedBy: Payload.PairCodingKeys.self, forKey: Payload.CodingKeys.pair)
 
       self = Payload.pair(key: try nestedContainer.decode(String.self, forKey: Payload.PairCodingKeys.key), value: try nestedContainer.decode(String.self, forKey: Payload.PairCodingKeys.value))
@@ -42,12 +40,10 @@ enum Payload: Codable {
 
     switch self {
     case .plain(let a0):
-
       var nestedContainer = container.nestedContainer(keyedBy: Payload.PlainCodingKeys.self, forKey: Payload.CodingKeys.plain)
 
       try nestedContainer.encode(a0, forKey: Payload.PlainCodingKeys._0)
-      case .pair(let key, let value):
-
+    case .pair(let key, let value):
       var nestedContainer = container.nestedContainer(keyedBy: Payload.PairCodingKeys.self, forKey: Payload.CodingKeys.pair)
 
       try nestedContainer.encode(key, forKey: Payload.PairCodingKeys.key)

--- a/test/refactoring/AddCodableImplementation/Outputs/enum/decodable.swift.expected
+++ b/test/refactoring/AddCodableImplementation/Outputs/enum/decodable.swift.expected
@@ -30,12 +30,10 @@ enum Payload_D: Decodable {
     }
     switch onlyKey {
     case .plain:
-
       let nestedContainer = try container.nestedContainer(keyedBy: Payload_D.PlainCodingKeys.self, forKey: Payload_D.CodingKeys.plain)
 
       self = Payload_D.plain(try nestedContainer.decode(String.self, forKey: Payload_D.PlainCodingKeys._0))
-      case .pair:
-
+    case .pair:
       let nestedContainer = try container.nestedContainer(keyedBy: Payload_D.PairCodingKeys.self, forKey: Payload_D.CodingKeys.pair)
 
       self = Payload_D.pair(key: try nestedContainer.decode(String.self, forKey: Payload_D.PairCodingKeys.key), value: try nestedContainer.decode(String.self, forKey: Payload_D.PairCodingKeys.value))

--- a/test/refactoring/AddCodableImplementation/Outputs/enum/encodable.swift.expected
+++ b/test/refactoring/AddCodableImplementation/Outputs/enum/encodable.swift.expected
@@ -30,12 +30,10 @@ enum Payload_E: Encodable {
 
     switch self {
     case .plain(let a0):
-
       var nestedContainer = container.nestedContainer(keyedBy: Payload_E.PlainCodingKeys.self, forKey: Payload_E.CodingKeys.plain)
 
       try nestedContainer.encode(a0, forKey: Payload_E.PlainCodingKeys._0)
-      case .pair(let key, let value):
-
+    case .pair(let key, let value):
       var nestedContainer = container.nestedContainer(keyedBy: Payload_E.PairCodingKeys.self, forKey: Payload_E.CodingKeys.pair)
 
       try nestedContainer.encode(key, forKey: Payload_E.PairCodingKeys.key)

--- a/test/stdlib/CodableEnumUnavailableElement.swift
+++ b/test/stdlib/CodableEnumUnavailableElement.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift
-// RUN: %target-run-simple-swift(-unavailable-decl-optimization=complete)
+// RUN: %target-run-simple-swift(-Xfrontend -unavailable-decl-optimization=complete)
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
When deriving the `hash(into:)` and `==` witnesses for `Hashable`/`Equatable` enums, call `_diagnoseUnavailableCodeReached()` in the case bodies for unavailable enum elements. This is needed because the previously derived code would operate on the values associated with unavailable enum elements, which is illegal if the types of those associated values are also unavailable (these case bodies would have failed typechecking had they been hand-written). The new structure also more explicitly documents that reaching these cases is unexpected, since unavailable enum elements should not be instantiated at run time.

Includes some drive-by fixes for other tests exercising enums with unavailable elements.