### PR TITLE
[Macros] Fix init synthesis for peer macro introduced properties

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -516,6 +516,27 @@ extension PropertyWrapperSkipsComputedMacro: AccessorMacro, Macro {
   }
 }
 
+public struct InitWithProjectedValueWrapperMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        return [
+        """
+        private var _value: Wrapper
+        var _$value: Wrapper {
+            @storageRestrictions(initializes: _value)
+            init {
+                self._value = newValue
+            }
+            get { _value }
+        }
+        """
+        ]
+    }
+}
+
 public struct WrapAllProperties: MemberAttributeMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/init_accessor.swift
+++ b/test/Macros/init_accessor.swift
@@ -1,0 +1,29 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5 -enable-experimental-feature InitAccessors
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5 -enable-experimental-feature InitAccessors
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+@attached(peer, names: named(_value), named(_$value))
+macro Wrapped() = #externalMacro(module: "MacroDefinition",
+                                 type: "InitWithProjectedValueWrapperMacro")
+
+@propertyWrapper
+struct Wrapper {
+    var wrappedValue: Int {
+        1
+    }
+    var projectedValue: Wrapper {
+        self
+    }
+}
+
+struct Foo {
+    @Wrapped
+    var value: Int { 1 }
+}
+
+let foo = Foo(_$value: Wrapper())


### PR DESCRIPTION
<!-- What's in this pull request? -->
Consider peer macro introduced properties when synthesizing default and member-wise initializer

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Fix rdar://112153201

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
