### PR TITLE
[NFC] Update dispatch test for new preconcurrency annotations.

### DIFF
--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -17,7 +17,7 @@ func testMe() {
 func testUnsafeSendableInMainAsync() async {
   var x = 5
   DispatchQueue.main.async {
-    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 17 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }
@@ -25,7 +25,7 @@ func testUnsafeSendableInMainAsync() async {
 func testUnsafeSendableInAsync(queue: DispatchQueue) async {
   var x = 5
   queue.async {
-    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 17 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
 
   queue.sync {


### PR DESCRIPTION
In Xcode 15, `DispatchQueue.async` has a `@preconcurrency` annotation, which causes the errors about capture mutation inside the closure argument to be downgraded to warnings.

Resolves rdar://112865918