### PR TITLE
runtime: add missing ` SWIFT_CC(swift)` for matching function signatures

### DIFF
--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -910,6 +910,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
 /// \returns the demangled name. Returns nullptr if the input String is not a
 /// Swift mangled name.
 SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
 char *swift_demangle(const char *mangledName,
                      size_t mangledNameLength,
                      char *outputBuffer,

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -254,6 +254,7 @@ void swift::runtime::environment::initialize(void *context) {
 #endif
 
 SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
 bool swift_COWChecksEnabled() {
   return runtime::environment::SWIFT_DEBUG_ENABLE_COW_CHECKS();
 }

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.cpp
@@ -130,6 +130,7 @@ static std::uint16_t RuntimeFunctionCountersOffsets[] = {
 /// Public APIs
 
 /// Get the runtime object state associated with an object.
+SWIFT_CC(swift)
 void _swift_getObjectRuntimeFunctionCounters(
     HeapObject *object, RuntimeFunctionCountersState *result) {
   auto &theSentinel = RuntimeObjectStateCache.get();
@@ -139,6 +140,7 @@ void _swift_getObjectRuntimeFunctionCounters(
 
 /// Set the runtime object state associated with an object from a provided
 /// state.
+SWIFT_CC(swift)
 void _swift_setObjectRuntimeFunctionCounters(
     HeapObject *object, RuntimeFunctionCountersState *state) {
   auto &theSentinel = RuntimeObjectStateCache.get();
@@ -148,6 +150,7 @@ void _swift_setObjectRuntimeFunctionCounters(
 
 /// Get the global runtime state containing the total numbers of invocations for
 /// each runtime function of interest.
+SWIFT_CC(swift)
 void _swift_getGlobalRuntimeFunctionCounters(
     RuntimeFunctionCountersState *result) {
   LazyMutex::ScopedLock lock(RuntimeGlobalFunctionCountersState.Lock);
@@ -155,6 +158,7 @@ void _swift_getGlobalRuntimeFunctionCounters(
 }
 
 /// Set the global runtime state of function pointers from a provided state.
+SWIFT_CC(swift)
 void _swift_setGlobalRuntimeFunctionCounters(
     RuntimeFunctionCountersState *state) {
   LazyMutex::ScopedLock lock(RuntimeGlobalFunctionCountersState.Lock);
@@ -164,6 +168,7 @@ void _swift_setGlobalRuntimeFunctionCounters(
 /// Return the names of the runtime functions being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeObjectState structure. All these strings are null terminated.
+SWIFT_CC(swift)
 const char **_swift_getRuntimeFunctionNames() {
   return RuntimeFunctionNames;
 }
@@ -171,11 +176,13 @@ const char **_swift_getRuntimeFunctionNames() {
 /// Return the offsets of the runtime function counters being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeObjectState structure.
+SWIFT_CC(swift)
 const std::uint16_t *_swift_getRuntimeFunctionCountersOffsets() {
   return RuntimeFunctionCountersOffsets;
 }
 
 /// Return the number of runtime functions being tracked.
+SWIFT_CC(swift)
 std::uint64_t _swift_getNumRuntimeFunctionCounters() {
   return ID_LastRuntimeFunctionName;
 }
@@ -204,6 +211,7 @@ void _swift_dumpObjectsRuntimeFunctionPointers() {
 
 /// Set mode for global runtime function counters.
 /// Return the old value of this flag.
+SWIFT_CC(swift)
 int _swift_setGlobalRuntimeFunctionCountersMode(int mode) {
   int oldMode = UpdateGlobalRuntimeFunctionCounters;
   UpdateGlobalRuntimeFunctionCounters = mode ? 1 : 0;
@@ -212,6 +220,7 @@ int _swift_setGlobalRuntimeFunctionCountersMode(int mode) {
 
 /// Set mode for per object runtime function counters.
 /// Return the old value of this flag.
+SWIFT_CC(swift)
 int _swift_setPerObjectRuntimeFunctionCountersMode(int mode) {
   int oldMode = UpdatePerObjectRuntimeFunctionCounters;
   UpdatePerObjectRuntimeFunctionCounters = mode ? 1 : 0;

--- a/stdlib/public/runtime/RuntimeInvocationsTracking.h
+++ b/stdlib/public/runtime/RuntimeInvocationsTracking.h
@@ -61,49 +61,64 @@ using RuntimeFunctionCountersUpdateHandler =
 
 /// Get the runtime object state associated with an object and store it
 /// into the result.
-SWIFT_RUNTIME_EXPORT void
-_swift_getObjectRuntimeFunctionCounters(HeapObject *object,
-                                        RuntimeFunctionCountersState *result);
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+void _swift_getObjectRuntimeFunctionCounters(HeapObject *object,
+    RuntimeFunctionCountersState *result);
 
 /// Get the global runtime state containing the total numbers of invocations for
 /// each runtime function of interest and store it into the result.
-SWIFT_RUNTIME_EXPORT void _swift_getGlobalRuntimeFunctionCounters(
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+void _swift_getGlobalRuntimeFunctionCounters(
     swift::RuntimeFunctionCountersState *result);
 
 /// Return the names of the runtime functions being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeObjectState structure.
-SWIFT_RUNTIME_EXPORT const char **_swift_getRuntimeFunctionNames();
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+const char **_swift_getRuntimeFunctionNames();
 
 /// Return the offsets of the runtime function counters being tracked.
 /// Their order is the same as the order of the counters in the
 /// RuntimeFunctionCountersState structure.
-SWIFT_RUNTIME_EXPORT const uint16_t *_swift_getRuntimeFunctionCountersOffsets();
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+const uint16_t *_swift_getRuntimeFunctionCountersOffsets();
 
 /// Return the number of runtime functions being tracked.
-SWIFT_RUNTIME_EXPORT uint64_t _swift_getNumRuntimeFunctionCounters();
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+uint64_t _swift_getNumRuntimeFunctionCounters();
 
 /// Dump all per-object runtime function pointers.
 SWIFT_RUNTIME_EXPORT void _swift_dumpObjectsRuntimeFunctionPointers();
 
 /// Set mode for global runtime function counters.
 /// Return the old value of this flag.
-SWIFT_RUNTIME_EXPORT int
-_swift_setPerObjectRuntimeFunctionCountersMode(int mode);
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+int _swift_setPerObjectRuntimeFunctionCountersMode(int mode);
 
 /// Set mode for per object runtime function counters.
 /// Return the old value of this flag.
-SWIFT_RUNTIME_EXPORT int _swift_setGlobalRuntimeFunctionCountersMode(int mode);
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+int _swift_setGlobalRuntimeFunctionCountersMode(int mode);
 
 /// Set the global runtime state of function pointers from a provided state.
-SWIFT_RUNTIME_EXPORT void _swift_setGlobalRuntimeFunctionCounters(
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+void _swift_setGlobalRuntimeFunctionCounters(
     swift::RuntimeFunctionCountersState *state);
 
 /// Set the runtime object state associated with an object from a provided
 /// state.
-SWIFT_RUNTIME_EXPORT void
-_swift_setObjectRuntimeFunctionCounters(HeapObject *object,
-                                        RuntimeFunctionCountersState *state);
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+void _swift_setObjectRuntimeFunctionCounters(HeapObject *object,
+    RuntimeFunctionCountersState *state);
 
 /// Set the global runtime function counters update handler.
 SWIFT_RUNTIME_EXPORT RuntimeFunctionCountersUpdateHandler


### PR DESCRIPTION
`test/stdlib/Runtime.swift.gyb` makes a call to this function with Swift calling convention, but the function is declared with C calling convention, which makes the compiled code invalid when targeting Wasm due to caller/callee signature mismatch.

As `@_cdecl` doesn't support function declaration without a body on the Swift side, the only possible fix right now is to add the calling convention attribute on the C++ side.
