### PR TITLE
[cxx-interop] Conform Swift pointers to `UnsafeCxxMutableInputIterator`

### DIFF
--- a/stdlib/public/Cxx/UnsafeCxxIterators.swift
+++ b/stdlib/public/Cxx/UnsafeCxxIterators.swift
@@ -61,6 +61,8 @@ public protocol UnsafeCxxMutableInputIterator: UnsafeCxxInputIterator {
   override var pointee: Pointee { get set }
 }
 
+extension UnsafeMutablePointer: UnsafeCxxMutableInputIterator {}
+
 /// Bridged C++ iterator that allows computing the distance between two of its
 /// instances, and advancing an instance by a given number of elements.
 ///


### PR DESCRIPTION
This is currently a no-op since we don't auto-conform custom types to any kind of `MutableCollection` protocols: `UnsafeCxxMutableInputIterator` is only used for `std::map` conformance to `CxxDictionary` in the overlay. However, this will be useful in the future if we start conforming mutable C++ containers to certain Swift protocols: that way containers that use raw non-const pointers as iterators would be treated as mutable in Swift.