### PR TITLE
[cxx-interop] Add test for `std.shared_ptr.pointee`

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -18,6 +18,11 @@ module StdSet {
   requires cplusplus
 }
 
+module StdSharedPtr {
+  header "std-shared-ptr.h"
+  requires cplusplus
+}
+
 module StdPair {
   header "std-pair.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-shared-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-shared-ptr.h
@@ -1,0 +1,18 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SHARED_PTR_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SHARED_PTR_H
+
+#include <memory>
+#include <string>
+
+using SharedPtrOfInt = std::shared_ptr<int>;
+using SharedPtrOfString = std::shared_ptr<std::string>;
+
+inline SharedPtrOfInt getSharedPtrOfInt() {
+  return std::make_shared<int>(123);
+}
+
+inline SharedPtrOfString getSharedPtrOfString() {
+  return std::make_shared<std::string>("abc123");
+}
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SHARED_PTR_H

--- a/test/Interop/Cxx/stdlib/use-std-shared-ptr.swift
+++ b/test/Interop/Cxx/stdlib/use-std-shared-ptr.swift
@@ -1,0 +1,34 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import CxxStdlib
+import StdSharedPtr
+
+var StdSharedPtrTestSuite = TestSuite("StdSharedPtr")
+
+StdSharedPtrTestSuite.test("SharedPtrOfInt.pointee") {
+  var s = getSharedPtrOfInt()
+  expectEqual(s.pointee, 123)
+
+  s.pointee = 456
+  expectEqual(s.pointee, 456)
+
+  s.pointee += 543
+  expectEqual(s.pointee, 999)
+}
+
+#if !os(Windows) // FIXME: enable once swiftCxxStdlib is built on Windows (https://github.com/apple/swift/issues/67649)
+StdSharedPtrTestSuite.test("SharedPtrOfString.pointee") {
+  var s = getSharedPtrOfString()
+  expectEqual(s.pointee, std.string("abc123"))
+
+  s.pointee = std.string()
+  expectEqual(s.pointee, std.string())
+
+  s.pointee = std.string("0123")
+  expectEqual(s.pointee, std.string("0123"))
+}
+#endif
+
+runAllTests()


### PR DESCRIPTION
`var pointee` property on an instantiation of `std::shared_ptr` recently became mutable (`8832d27e9`).

rdar://112693451