### PR TITLE
Platform,Shims: make `stdint` an implicit Windows module

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -105,7 +105,7 @@ module vcruntime [system] {
     export *
   }
 
-  explicit module stdint {
+  module stdint {
     header "stdint.h"
     export *
   }

--- a/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__) && (!defined(_WIN32) || !defined(__clang__))
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;


### PR DESCRIPTION
This was previously made explicit to avoid some of the conflicts from the Clang definitions and the VC Runtime definitions.  By following the default path, we avoid the conflict and can promote this module to implicit.