### PR TITLE
[cxx-interop] Import `NSStreamDelegate.stream` correctly

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2609,6 +2609,9 @@ ArgumentAttrs ClangImporter::Implementation::inferDefaultArgument(
   if (isFirstParameter && camel_case::getFirstWord(baseNameStr) == "set")
     return DefaultArgumentKind::None;
 
+  if (auto elaboratedTy = type->getAs<clang::ElaboratedType>())
+    type = elaboratedTy->desugar();
+
   // Some nullable parameters default to 'nil'.
   if (clangOptionality == OTK_Optional) {
     // Nullable trailing closure parameters default to 'nil'.
@@ -2660,6 +2663,8 @@ ArgumentAttrs ClangImporter::Implementation::inferDefaultArgument(
         if (camel_case::sameWordIgnoreFirstCase(word, "domain"))
           return argumentAttrs;
         if (camel_case::sameWordIgnoreFirstCase(word, "action"))
+          return argumentAttrs;
+        if (camel_case::sameWordIgnoreFirstCase(word, "event"))
           return argumentAttrs;
         if (camel_case::sameWordIgnoreFirstCase(word, "events") &&
             next != camelCaseWords.rend() &&

--- a/test/Interop/Cxx/objc-correctness/Inputs/CFOptions.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/CFOptions.h
@@ -1,0 +1,6 @@
+#define __CF_OPTIONS_ATTRIBUTES __attribute__((flag_enum,enum_extensibility(open)))
+#if (__cplusplus)
+#define CF_OPTIONS(_type, _name) __attribute__((availability(swift,unavailable))) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _name
+#else
+#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type _name; enum _name : _type
+#endif

--- a/test/Interop/Cxx/objc-correctness/Inputs/NSOptionsMangling.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/NSOptionsMangling.h
@@ -1,9 +1,4 @@
-#define __CF_OPTIONS_ATTRIBUTES __attribute__((flag_enum,enum_extensibility(open)))
-#if (__cplusplus)
-#define CF_OPTIONS(_type, _name) __attribute__((availability(swift,unavailable))) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _name
-#else
-#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type _name; enum _name : _type
-#endif
+#include "CFOptions.h"
 
 typedef CF_OPTIONS(unsigned, UIControlState) { UIControlStateNormal = 0 };
 

--- a/test/Interop/Cxx/objc-correctness/Inputs/NSStreamDelegate.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/NSStreamDelegate.h
@@ -1,0 +1,25 @@
+#include "CFOptions.h"
+
+typedef CF_OPTIONS(int, NSStreamEvent) {
+  NSStreamEventNone = 0,
+  NSStreamEventOpenCompleted = 1UL << 0,
+  NSStreamEventHasBytesAvailable = 1UL << 1,
+  NSStreamEventHasSpaceAvailable = 1UL << 2,
+  NSStreamEventErrorOccurred = 1UL << 3,
+  NSStreamEventEndEncountered = 1UL << 4
+};
+
+@protocol NSObject
+@end
+
+__attribute__((objc_root_class))
+@interface NSObject <NSObject>
+@end
+
+@interface NSStream : NSObject
+@end
+
+@protocol NSStreamDelegate <NSObject>
+@optional
+- (void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode;
+@end

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -19,6 +19,11 @@ module NSNofiticationBridging {
   requires cplusplus
 }
 
+module NSStreamDelegate {
+  header "NSStreamDelegate.h"
+  requires objc
+}
+
 module OSObject {
   header "os-object.h"
   requires objc

--- a/test/Interop/Cxx/objc-correctness/nsstreamdelegate.swift
+++ b/test/Interop/Cxx/objc-correctness/nsstreamdelegate.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-objc-interop -enable-experimental-cxx-interop
+// REQUIRES: objc_interop
+
+import NSStreamDelegate
+
+func foo<T: NSStreamDelegate>(_ delegate: T, stream: NSStream) {
+  delegate.stream!(stream, handle: NSStreamEvent.openCompleted)
+}


### PR DESCRIPTION
This Objective-C method
```
- (void)stream:(NSStream *)aStream
   handleEvent:(NSStreamEvent)eventCode;
```
should be imported as
```
optional func stream(
    _ aStream: Stream,
    handle eventCode: Stream.Event)
```
and not
```
optional func stream(
    _ aStream: Stream,
    handleEvent eventCode: Stream.Event)
```
in order to stay compatible with Objective-C interop mode.

rdar://113208675