### PR TITLE
[rebranch] Fix API changes from LLVM update

### DIFF
--- a/lib/IRGen/GenControl.cpp
+++ b/lib/IRGen/GenControl.cpp
@@ -28,7 +28,7 @@ void IRBuilder::emitBlock(llvm::BasicBlock *BB) {
   assert(ClearedIP == nullptr);
   llvm::BasicBlock *CurBB = GetInsertBlock();
   assert(CurBB && "current insertion point is invalid");
-  CurBB->getParent()->insert(CurBB->getIterator(), BB);
+  CurBB->getParent()->insert(std::next(CurBB->getIterator()), BB);
   IRBuilderBase::SetInsertPoint(BB);
 }
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -600,7 +600,7 @@ void IRGenModule::emitLazyObjCProtocolDefinition(ProtocolDecl *proto) {
 
   // Move the new record to the placeholder's position.
   Module.removeGlobalVariable(record);
-  Module.insertGlobalVariable(placeholder->getIterator(), record);
+  Module.insertGlobalVariable(std::next(placeholder->getIterator()), record);
   // Replace and destroy the placeholder.
   placeholder->replaceAllUsesWith(
                             llvm::ConstantExpr::getBitCast(record, Int8PtrTy));

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1183,7 +1183,7 @@ public:
     if (!FailBBs.empty()) {
       // Move the trap basic blocks to the end of the function.
       for (auto *FailBB : FailBBs) {
-        CurFn->splice(CurFn->end(), CurFn, llvm::Function::iterator(FailBB));
+        CurFn->splice(CurFn->end(), CurFn, FailBB->getIterator());
       }
     }
   }


### PR DESCRIPTION
`insert` inserts *before* the given iterator. The `insertAfter` calls thus need a `std::next` when converted to `insert`.

Resolves rdar://113145355.