### PR TITLE
Remove redundant SILType::isMoveOnlyNominalType (NFC)

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -756,10 +756,6 @@ public:
   /// deinitialization beyond destruction of its members.
   bool isValueTypeWithDeinit() const;
 
-  /// Returns true if and only if this type is a first class move only
-  /// type. NOTE: Returns false if the type is a move only wrapped type.
-  bool isMoveOnlyNominalType() const;
-
   /// Returns true if this SILType is a move only wrapper type.
   ///
   /// Canonical way to check if a SILType is move only. Using is/getAs/castTo

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1030,7 +1030,7 @@ SILType::getSingletonAggregateFieldType(SILModule &M,
 
 bool SILType::isMoveOnly() const {
   // Nominal types are move-only if declared as such.
-  if (isMoveOnlyNominalType())
+  if (isPureMoveOnly())
     return true;
 
 
@@ -1048,19 +1048,11 @@ bool SILType::isMoveOnly() const {
   return isMoveOnlyWrapped();
 }
 
-bool SILType::isMoveOnlyNominalType() const {
-  if (auto *nom = getNominalOrBoundGenericNominal())
-    if (nom->isMoveOnly())
-      return true;
-  return false;
+bool SILType::isPureMoveOnly() const {
+  return getASTType()->isPureMoveOnly();
 }
 
-bool SILType::isPureMoveOnly() const {
-  if (auto *nom = getNominalOrBoundGenericNominal())
-    if (nom->isMoveOnly())
-      return true;
-  return false;
-}
+
 
 bool SILType::isValueTypeWithDeinit() const {
   // Do not look inside an aggregate type that has a user-deinit, for which

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6016,7 +6016,7 @@ public:
     auto type = ddi->getType();
     require(type == ddi->getOperand()->getType(),
             "Result and operand must have the same type.");
-    require(type.isMoveOnlyNominalType(),
+    require(type.isPureMoveOnly(),
             "drop_deinit only allowed for move-only types");
     require(type.getNominalOrBoundGenericNominal()
             ->getValueTypeDestructor(), "drop_deinit only allowed for "


### PR DESCRIPTION
and implement `SILType::isPureMoveOnly` in terms of `Type::isPureMoveOnly`.