### PR TITLE
[Compile Time Constant Extraction] Deprecated extraction of property mangled names

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -881,7 +881,7 @@ void writeProperties(llvm::json::OStream &JSON,
         const auto *decl = PropertyInfo.VarDecl;
         JSON.attribute("label", decl->getName().str().str());
         JSON.attribute("type", toFullyQualifiedTypeNameString(decl->getType()));
-        JSON.attribute("mangledTypeName", toMangledTypeNameString(decl->getType()));
+        JSON.attribute("mangledTypeName", "n/a - deprecated");
         JSON.attribute("isStatic", decl->isStatic() ? "true" : "false");
         JSON.attribute("isComputed", !decl->hasStorage() ? "true" : "false");
         writeLocationInformation(JSON, decl->getLoc(),

--- a/test/ConstExtraction/ExtractAnnotations.swift
+++ b/test/ConstExtraction/ExtractAnnotations.swift
@@ -42,7 +42,7 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "available1",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
@@ -67,7 +67,7 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "deprecated1",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
@@ -92,7 +92,7 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "renamed1",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",
@@ -112,7 +112,7 @@ public struct DeprecatedAnnotations: MyProto {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "introduced1",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractAnnotations.swift",

--- a/test/ConstExtraction/ExtractCalls.swift
+++ b/test/ConstExtraction/ExtractCalls.swift
@@ -51,7 +51,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "init1",
 // CHECK-NEXT:        "type": "ExtractCalls.Bar",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3BarV",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -65,7 +65,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "init2",
 // CHECK-NEXT:        "type": "ExtractCalls.Bat",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3BatV",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -92,7 +92,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "init3",
 // CHECK-NEXT:        "type": "ExtractCalls.Bat",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3BatV",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -118,7 +118,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "func1",
 // CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "mangledTypeName": "Si",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -128,7 +128,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "init4",
 // CHECK-NEXT:        "type": "Swift.Optional<ExtractCalls.Bar>",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3BarVSg",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
@@ -142,7 +142,7 @@ public struct Bat {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "ext1",
 // CHECK-NEXT:        "type": "ExtractCalls.Foo.Boo",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractCalls3FooV3BooV",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",

--- a/test/ConstExtraction/ExtractEnums.swift
+++ b/test/ConstExtraction/ExtractEnums.swift
@@ -45,7 +45,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "hashValue",
 // CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "mangledTypeName": "Si",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "valueKind": "Runtime"
@@ -83,7 +83,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "rawValue",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "valueKind": "Runtime"
@@ -153,7 +153,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum1",
 // CHECK-NEXT:        "type": "ExtractEnums.SimpleEnum",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractEnums10SimpleEnumO",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
@@ -166,7 +166,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum3",
 // CHECK-NEXT:        "type": "ExtractEnums.AssociatedEnums",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractEnums010AssociatedB0O",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
@@ -193,7 +193,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum2",
 // CHECK-NEXT:        "type": "ExtractEnums.StringEnum",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractEnums10StringEnumO",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",
@@ -206,7 +206,7 @@ public struct Enums: MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "enum4",
 // CHECK-NEXT:        "type": "ExtractEnums.AssociatedEnums",
-// CHECK-NEXT:        "mangledTypeName": "12ExtractEnums010AssociatedB0O",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractEnums.swift",

--- a/test/ConstExtraction/ExtractGroups.swift
+++ b/test/ConstExtraction/ExtractGroups.swift
@@ -50,7 +50,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "array1",
 // CHECK-NEXT:        "type": "Swift.Array<Swift.Int>",
-// CHECK-NEXT:        "mangledTypeName": "SaySiG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -74,7 +74,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "array2",
 // CHECK-NEXT:        "type": "Swift.Array<any ExtractGroups.Foo>",
-// CHECK-NEXT:        "mangledTypeName": "Say13ExtractGroups3Foo_pG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -101,7 +101,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "array3",
 // CHECK-NEXT:        "type": "Swift.Array<ExtractGroups.Bar>",
-// CHECK-NEXT:        "mangledTypeName": "Say13ExtractGroups3BarVG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -133,7 +133,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "dict1",
 // CHECK-NEXT:        "type": "Swift.Dictionary<Swift.String, Swift.Int>",
-// CHECK-NEXT:        "mangledTypeName": "SDySSSiG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -175,7 +175,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "dict2",
 // CHECK-NEXT:        "type": "Swift.Dictionary<Swift.Int, Swift.Array<Swift.String>>",
-// CHECK-NEXT:        "mangledTypeName": "SDySiSaySSGG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -225,7 +225,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "dict3",
 // CHECK-NEXT:        "type": "Swift.Dictionary<Swift.String, any ExtractGroups.Foo>",
-// CHECK-NEXT:        "mangledTypeName": "SDySS13ExtractGroups3Foo_pG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -273,7 +273,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "tuple1",
 // CHECK-NEXT:        "type": "(Swift.String, ExtractGroups.Bar)",
-// CHECK-NEXT:        "mangledTypeName": "SS_13ExtractGroups3BarVt",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -298,7 +298,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "tuple2",
 // CHECK-NEXT:        "type": "(lat: Swift.Float, lng: Swift.Float)",
-// CHECK-NEXT:        "mangledTypeName": "Sf3lat_Sf3lngt",        
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
@@ -322,7 +322,7 @@ extension String: Foo {}
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "tuple3",
 // CHECK-NEXT:        "type": "Swift.Void",
-// CHECK-NEXT:        "mangledTypeName": "yt",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",

--- a/test/ConstExtraction/ExtractLiterals.swift
+++ b/test/ConstExtraction/ExtractLiterals.swift
@@ -106,7 +106,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "bool1",
 // CHECK-NEXT:        "type": "Swift.Bool",
-// CHECK-NEXT:        "mangledTypeName": "Sb",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -117,7 +117,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "bool2",
 // CHECK-NEXT:        "type": "Swift.Optional<Swift.Bool>",
-// CHECK-NEXT:        "mangledTypeName": "SbSg",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -136,12 +136,12 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractLiterals.MyProto"
 // CHECK-NEXT:    ],
-// CHECK-NEXT:    "associatedTypeAliases": [], 
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "int1",
 // CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "mangledTypeName": "Si",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -152,7 +152,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "int2",
 // CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "mangledTypeName": "Si",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -163,7 +163,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "int3",
 // CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "mangledTypeName": "Si",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -178,7 +178,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:    "mangledTypeName": "15ExtractLiterals6FloatsV",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
-// CHECK-NEXT:    "line": 20, 
+// CHECK-NEXT:    "line": 20,
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractLiterals.MyProto"
 // CHECK-NEXT:    ],
@@ -187,7 +187,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "float1",
 // CHECK-NEXT:        "type": "Swift.Float",
-// CHECK-NEXT:        "mangledTypeName": "Sf",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -198,7 +198,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "float2",
 // CHECK-NEXT:        "type": "Swift.Float",
-// CHECK-NEXT:        "mangledTypeName": "Sf", 
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -209,7 +209,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "float3",
 // CHECK-NEXT:        "type": "Swift.Float",
-// CHECK-NEXT:        "mangledTypeName": "Sf", 
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -227,12 +227,12 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:    "conformances": [
 // CHECK-NEXT:      "ExtractLiterals.MyProto"
 // CHECK-NEXT:    ],
-// CHECK-NEXT:    "associatedTypeAliases": [], 
+// CHECK-NEXT:    "associatedTypeAliases": [],
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "string1",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -243,7 +243,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "string2",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -254,7 +254,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "string3",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -278,7 +278,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "_propertyWrapper1",
 // CHECK-NEXT:        "type": "ExtractLiterals.Buffered<Swift.String>",
-// CHECK-NEXT:        "mangledTypeName": "15ExtractLiterals8BufferedVySSG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -299,7 +299,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "_propertyWrapper2",
 // CHECK-NEXT:        "type": "ExtractLiterals.Clamping<Swift.Int>",
-// CHECK-NEXT:        "mangledTypeName": "15ExtractLiterals8ClampingVySiG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -332,7 +332,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "_propertyWrapper3",
 // CHECK-NEXT:        "type": "ExtractLiterals.Buffered<ExtractLiterals.Clamping<Swift.Int>>",
-// CHECK-NEXT:        "mangledTypeName": "15ExtractLiterals8BufferedVyAA8ClampingVySiGG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -375,7 +375,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "propertyWrapper1",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -404,7 +404,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "$propertyWrapper1",
 // CHECK-NEXT:        "type": "(Swift.String, Swift.Optional<Swift.String>)",
-// CHECK-NEXT:        "mangledTypeName": "SS_SSSgt",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -414,7 +414,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "propertyWrapper2",
 // CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "mangledTypeName": "Si",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -468,7 +468,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "propertyWrapper3",
 // CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "mangledTypeName": "Si",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
@@ -538,7 +538,7 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "$propertyWrapper3",
 // CHECK-NEXT:        "type": "(ExtractLiterals.Clamping<Swift.Int>, Swift.Optional<ExtractLiterals.Clamping<Swift.Int>>)",
-// CHECK-NEXT:        "mangledTypeName": "15ExtractLiterals8ClampingVySiG_ADSgt",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -61,7 +61,7 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "label": "foos",
 // CHECK-NEXT:          "type": "Swift.Array<ExtractResultBuilders.Foo>",
-// CHECK-NEXT:          "mangledTypeName": "Say21ExtractResultBuilders3FooVG",
+// CHECK-NEXT:          "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:          "isStatic": "true",
 // CHECK-NEXT:          "isComputed": "true",
 // CHECK-NEXT:          "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
@@ -74,7 +74,7 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "label": "fooTwo",
 // CHECK-NEXT:          "type": "Swift.Array<ExtractResultBuilders.Foo>",
-// CHECK-NEXT:          "mangledTypeName": "Say21ExtractResultBuilders3FooVG",
+// CHECK-NEXT:          "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:          "isStatic": "true",
 // CHECK-NEXT:          "isComputed": "true",
 // CHECK-NEXT:          "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",
@@ -100,7 +100,7 @@ public struct MyFooProviderInferred: FooProvider {
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "label": "foos",
 // CHECK-NEXT:          "type": "Swift.Array<ExtractResultBuilders.Foo>",
-// CHECK-NEXT:          "mangledTypeName": "Say21ExtractResultBuilders3FooVG",
+// CHECK-NEXT:          "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:          "isStatic": "true",
 // CHECK-NEXT:          "isComputed": "true",
 // CHECK-NEXT:          "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractResultBuilders.swift",

--- a/test/ConstExtraction/ExtractRuntimeMetadataAttr.swift
+++ b/test/ConstExtraction/ExtractRuntimeMetadataAttr.swift
@@ -33,7 +33,7 @@ struct A : MyProto {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "v1",
 // CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "mangledTypeName": "SS", 
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated", 
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractRuntimeMetadataAttr.swift",

--- a/test/ConstExtraction/ExtractTypeValue.swift
+++ b/test/ConstExtraction/ExtractTypeValue.swift
@@ -17,7 +17,7 @@ struct TypeValuePropertyStruct : MyProto {
 
 // CHECK:             "label": "birdTypes",
 // CHECK-NEXT:        "type": "Swift.Array<any ExtractTypeValue.Bird.Type>",
-// CHECK-NEXT:        "mangledTypeName": "Say16ExtractTypeValue4Bird_pXpG",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}ExtractTypeValue.swift",


### PR DESCRIPTION
It can often be more complex than the code can currently handle (e.g. properties whose types include archetypes), and we do not have a good motivating use-case to extract them.

Resolves rdar://113039215
