### PR TITLE
[AddressLowering] Rewrite lifetime-ends last.

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -26,6 +26,7 @@
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/Test.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -119,6 +120,15 @@ void SILInstruction::moveFront(SILBasicBlock *Block) {
 void SILInstruction::moveBefore(SILInstruction *Later) {
   SILBasicBlock::moveInstruction(this, Later);
 }
+
+namespace swift::test {
+FunctionTest MoveBeforeTest("instruction-move-before",
+                            [](auto &function, auto &arguments, auto &test) {
+                              auto *inst = arguments.takeInstruction();
+                              auto *other = arguments.takeInstruction();
+                              inst->moveBefore(other);
+                            });
+} // end namespace swift::test
 
 /// Unlink this instruction from its current basic block and insert it into
 /// the basic block that Earlier lives in, right after Earlier.

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -4169,19 +4169,19 @@ static void rewriteFunction(AddressLoweringState &pass) {
 
     // Collect end_borrows and rewrite them last so that when rewriting other
     // users the lifetime ends of a borrow introducer can be used.
-    StackList<EndBorrowInst *> endBorrows(pass.function);
+    StackList<Operand *> lifetimeEndingUses(pass.function);
     SmallPtrSet<Operand *, 8> originalUses;
     SmallVector<Operand *, 8> uses(valueDef->getUses());
     for (auto *oper : uses) {
       originalUses.insert(oper);
-      if (auto *ebi = dyn_cast<EndBorrowInst>(oper->getUser())) {
-        endBorrows.push_back(ebi);
+      if (oper->isLifetimeEnding()) {
+        lifetimeEndingUses.push_back(oper);
         continue;
       }
       UseRewriter::rewriteUse(oper, pass);
     }
-    for (auto *ebi : endBorrows) {
-      UseRewriter::rewriteUse(&ebi->getOperandRef(), pass);
+    for (auto *oper : lifetimeEndingUses) {
+      UseRewriter::rewriteUse(oper, pass);
     }
     // Rewrite every new use that was added.
     uses.clear();

--- a/test/SILOptimizer/address_lowering_preprocessed.sil
+++ b/test/SILOptimizer/address_lowering_preprocessed.sil
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-sil-opt -test-runner -address-lowering -enable-sil-opaque-values -emit-sorted-sil -sil-verify-none %s > %t/out.sil
+// RUN: %target-sil-opt -emit-sorted-sil -sil-verify-all %t/out.sil | %FileCheck %s
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct Box<T> {
+    var _value : T
+}
+
+// Verify that the isCopyValue assertion in
+// AddressMaterialization::materializeDefProjection is not triggered.  This is
+// possible because the destroy_value is rewritten last.  Rewriting it last
+// enables the lifetime analysis done in isStoreCopy to remain valid until the
+// lifetime-ending uses are rewritten.
+// CHECK-LABEL: sil [ossa] @destroy_before_copy_in_use_list : {{.*}} {
+// CHECK:       bb0([[T:%[^,]+]] : $*T, [[BOX:%[^,]+]] :
+// CHECK:         [[FIELD_ADDR:%[^,]+]] = struct_element_addr [[BOX]] : {{.*}}, #Box._value
+// CHECK:         copy_addr [[T]] to [[FIELD_ADDR]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         destroy_addr [[T]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'destroy_before_copy_in_use_list'
+sil [ossa] @destroy_before_copy_in_use_list : $@convention(thin) <T> (@in T, @inout Box<T>) -> () {
+bb0(%t : @owned $T, %box : $*Box<T>):
+  // The destroy_value appears first in the textual SIL in order to be first in
+  // the use list.  Before running AddressLowering, it's sunk to after the
+  // end_access.
+  test_specification "instruction-move-before @instruction @instruction[+5]"
+  destroy_value %t : $T
+  %copy = copy_value %t : $T
+  %field_addr = struct_element_addr %box : $*Box<T>, #Box._value
+  store %copy to [assign] %field_addr : $*T
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Previously, `end_borrow`s were rewritten last in order to be able to find them when inserting `end_borrow`s on behalf of newly created `load_borrow`s. Generalize this to rewriting all lifetime-ending users last.  This is necessary for the lifetime utilities used by `isLoadCopy` to remain accurate when rewriting a `copy_value` previously determined to be from a load-copy pair.
