### PR TITLE
[ConstraintSystem] Allow inference to bind AnyKeyPath as a KeyPath

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1058,22 +1058,6 @@ public:
   }
 };
 
-class LocatorPathElt::KeyPathType final
-    : public StoredPointerElement<TypeBase> {
-public:
-  KeyPathType(Type valueType)
-      : StoredPointerElement(PathElementKind::KeyPathType,
-                             valueType.getPointer()) {
-    assert(valueType);
-  }
-
-  Type getValueType() const { return getStoredPointer(); }
-
-  static bool classof(const LocatorPathElt *elt) {
-    return elt->getKind() == PathElementKind::KeyPathType;
-  }
-};
-
 class LocatorPathElt::ConstructorMemberType final
     : public StoredIntegerElement<1> {
 public:

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -123,7 +123,7 @@ CUSTOM_LOCATOR_PATH_ELT(KeyPathDynamicMember)
 SIMPLE_LOCATOR_PATH_ELT(KeyPathRoot)
 
 /// The type of the key path expression.
-CUSTOM_LOCATOR_PATH_ELT(KeyPathType)
+SIMPLE_LOCATOR_PATH_ELT(KeyPathType)
 
 /// The value of a key path.
 SIMPLE_LOCATOR_PATH_ELT(KeyPathValue)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3031,6 +3031,20 @@ public:
       return std::get<1>(result->second);
     return nullptr;
   }
+  
+  TypeVariableType *getKeyPathRootType(const KeyPathExpr *keyPath) const {
+    auto result = getKeyPathRootTypeIfAvailable(keyPath);
+    assert(result);
+    return result;
+  }
+
+  TypeVariableType *
+  getKeyPathRootTypeIfAvailable(const KeyPathExpr *keyPath) const {
+    auto result = KeyPaths.find(keyPath);
+    if (result != KeyPaths.end())
+      return std::get<0>(result->second);
+    return nullptr;
+  }
 
   TypeBase* getFavoredType(Expr *E) {
     assert(E != nullptr);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3822,7 +3822,7 @@ namespace {
       // The type of key path depends on the overloads chosen for the key
       // path components.
       auto typeLoc =
-          CS.getConstraintLocator(locator, LocatorPathElt::KeyPathType(value));
+          CS.getConstraintLocator(locator, LocatorPathElt::KeyPathType());
 
       Type kpTy = CS.createTypeVariable(typeLoc, TVO_CanBindToNoEscape |
                                                      TVO_CanBindToHole);


### PR DESCRIPTION
similar to how PartialKeyPath is bound as KeyPath<Root, Value>. 

```
struct S { var s: String }

let anyKP: AnyKeyPath
anyKP = \S.s
```
For the above example, the solver will now generate a general KeyPath binding for the type variable representing the keypath type:

```
$T_ [allows bindings to: noescape, hole] [involves_type_vars: $T(root), $T(value)] [with possible bindings: (subtypes of) KeyPath<$T(root), $T(value)>])
```
The solver already generates the following two constraints, amongst others:

```
$T_ key path from $T(root) → $T(value)
$T_ conv AnyKeyPath
```
which are simplified to produce the following binding that has a more specific key path type:
```
$T_ := WritableKeyPath<S, $T(value)>
```
