### PR TITLE
[OpaqueValues] Skip temporary when setting the value at a key-path.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2303,7 +2303,7 @@ namespace {
 
       auto setValue =
         std::move(value).getAsSingleValue(SGF, origType, loweredTy);
-      if (!setValue.getType().isAddress()) {
+      if (SGF.useLoweredAddresses() && !setValue.getType().isAddress()) {
         setValue = setValue.materialize(SGF, loc);
       }
 

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -647,3 +647,18 @@ func giveKeyPathString() {
 @backDeployed(before: SwiftStdlib 5.8)
 public func backDeployingReturningGeneric<T>(_ t: T) throws -> T { t }
 #endif
+
+// CHECK-LABEL: sil {{.*}}[ossa] @SetIntoContainerAtKeyPath : {{.*}} {
+// CHECK:       bb0([[CONTAINER_ADDR:%[^,]+]] : {{.*}}, [[KP:%[^,]+]] : {{.*}}, [[VALUE:%[^,]+]] :
+// CHECK:         [[KP_COPY:%[^,]+]] = copy_value [[KP]] : $WritableKeyPath<Container, Field>
+// CHECK:         [[VALUE_COPY:%[^,]+]] = copy_value [[VALUE]] : $Field
+// CHECK:         [[CONTAINER_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[CONTAINER_ADDR]] : $*Container
+// CHECK:         [[SETTER:%[^,]+]] = function_ref @swift_setAtWritableKeyPath
+// CHECK:         apply [[SETTER]]<Container, Field>([[CONTAINER_ACCESS]], [[KP_COPY]], [[VALUE_COPY]])
+// CHECK:         end_access [[CONTAINER_ACCESS]] : $*Container
+// CHECK:         destroy_value [[KP_COPY]]
+// CHECK-LABEL: } // end sil function 'SetIntoContainerAtKeyPath'
+@_silgen_name("SetIntoContainerAtKeyPath")
+func set<Container, Field>(into container: inout Container, at keyPath: WritableKeyPath<Container, Field>, _ value: Field) {
+  container[keyPath: keyPath] = value
+}


### PR DESCRIPTION
When setting a value at a key-path, in opaque values mode, don't create a temporary and store the new value into it.  That is necessary when using lowered addresses because intrinsic's signature is

```
sil @swift_setAtWritableKeyPath : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @guaranteed WritableKeyPath<τ_0_0, τ_0_1>, @in τ_0_1) -> ()
```

but is incorrect in opaque values mode where values are passed directly to `@in` parameters.
