### PR TITLE
🍒[5.9][Concurrency] Fix init task group with flags availability

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -892,6 +892,10 @@ public:
   /// Get the runtime availability of support for concurrency.
   AvailabilityContext getConcurrencyAvailability();
 
+  /// Get the runtime availability of the `DiscardingTaskGroup`,
+  /// and supporting runtime functions function
+  AvailabilityContext getConcurrencyDiscardingTaskGroupAvailability();
+
   /// Get the back-deployed availability for concurrency.
   AvailabilityContext getBackDeployedConcurrencyAvailability();
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2217,7 +2217,7 @@ FUNCTION(TaskGroupInitialize,
 // void swift_taskGroup_initializeWithFlags(size_t flags, TaskGroup *group);
 FUNCTION(TaskGroupInitializeWithFlags,
          swift_taskGroup_initializeWithFlags, SwiftCC,
-         ConcurrencyAvailability,
+         ConcurrencyDiscardingTaskGroupAvailability,
          RETURNS(VoidTy),
          ARGS(SizeTy,           // flags
               Int8PtrTy,        // group

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -492,6 +492,10 @@ AvailabilityContext ASTContext::getConcurrencyAvailability() {
   return getSwift55Availability();
 }
 
+AvailabilityContext ASTContext::getConcurrencyDiscardingTaskGroupAvailability() {
+  return getSwift59Availability();
+}
+
 AvailabilityContext ASTContext::getBackDeployedConcurrencyAvailability() {
   return getSwift51Availability();
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -861,6 +861,15 @@ namespace RuntimeConstants {
     return RuntimeAvailability::AlwaysAvailable;
   }
 
+  RuntimeAvailability ConcurrencyDiscardingTaskGroupAvailability(ASTContext &context) {
+    auto featureAvailability =
+        context.getConcurrencyDiscardingTaskGroupAvailability();
+    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+      return RuntimeAvailability::ConditionallyAvailable;
+    }
+    return RuntimeAvailability::AlwaysAvailable;
+  }
+
   RuntimeAvailability DifferentiationAvailability(ASTContext &context) {
     auto featureAvailability = context.getDifferentiationAvailability();
     if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {


### PR DESCRIPTION
**Description:** The new runtime function `swift_taskGroup_initializeWithFlags` introduced to support discarding task group initialization has wrong availability. It must have availability equal to when it was introduced, but had the "general" concurrency one. Its availability must be 5.9. If we don't do this, then code like this:

```
if #available(iOS 17.0, *) {
    await withDiscardingTaskGroup {
        $0.addTask {
            try? await Task.sleep(for: .seconds(1))
        }
    }
}
```

can crash when compiled against iOS 16 target, since it'd attempt to strong refer to the symbol, but it's missing, yielding a `Symbol not found: _swift_taskGroup_initializeWithFlags`

**Risk:** Low, the method we're changing availability of cannot be called from user code, and is only called in IRGen generated code inside a method that is properly availability annotated already.
**Reward:** High, without the fix adopting discarding task groups is limited in apps which also need to support older versions of iOS which do not have this API, as the "usual" `if #available` guarding does not prevent the crash.
**Review by:** @rjmccall  @mikeash 
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift/pull/67669
**Radar:** rdar://112469076

