### PR TITLE
Platform: further modularise ucrt, vcruntime

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -35,6 +35,11 @@ module ucrt [system] {
       export *
     }
 
+    module float {
+      header "float.h"
+      export *
+    }
+
     module inttypes {
       header "inttypes.h"
       export *
@@ -102,6 +107,11 @@ module ucrt [system] {
           export *
         }
 
+        module timeb {
+          header "sys/timeb.h"
+          export *
+        }
+
         module types {
           header "sys/types.h"
           export *
@@ -120,13 +130,28 @@ module ucrt [system] {
     export *
   }
 
-  module process {
-    header "process.h"
+  module dos {
+    header "dos.h"
     export *
   }
 
   module malloc {
     header "malloc.h"
+    export *
+  }
+
+  module minmax {
+    header "minmax.h"
+    export *
+  }
+
+  module multibyte {
+    header "mbstring.h"
+    export *
+  }
+
+  module process {
+    header "process.h"
     export *
   }
 
@@ -153,8 +178,18 @@ module corecrt [system] {
     export *
   }
 
+  module malloc {
+    header "corecrt_malloc.h"
+    export *
+  }
+
   module math {
     header "corecrt_math.h"
+    export *
+  }
+
+  module share {
+    header "corecrt_share.h"
     export *
   }
 

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -702,6 +702,11 @@ module std [system] {
   module _Private [system] {
     requires cplusplus
 
+    explicit module __msvc_iter_core {
+      header "__msvc_iter_core.hpp"
+      export *
+    }
+
     explicit module xmemory {
       header "xmemory"
       export *

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -702,11 +702,6 @@ module std [system] {
   module _Private [system] {
     requires cplusplus
 
-    explicit module __msvc_iter_core {
-      header "__msvc_iter_core.hpp"
-      export *
-    }
-
     explicit module xmemory {
       header "xmemory"
       export *


### PR DESCRIPTION
Add a couple of submodules for these modules to further modularise the headers.  This might expose additional APIs now as some of these headers would not have been indirectly included and wind up in the wrong module.