### PR TITLE
[move-only] Ensure that we properly nest accesses to base values if the base is noncopyable or the accessor result is noncopyable.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4392,7 +4392,17 @@ public:
 
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
+
+  using EndBorrowRange =
+      decltype(std::declval<ValueBase>().getUsersOfType<EndBorrowInst>());
+
+  /// Return a range over all EndBorrow instructions for this BeginBorrow.
+  EndBorrowRange getEndBorrows() const;
 };
+
+inline auto StoreBorrowInst::getEndBorrows() const -> EndBorrowRange {
+  return getUsersOfType<EndBorrowInst>();
+}
 
 /// Represents the end of a borrow scope of a value %val from a
 /// value or address %src.

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -129,6 +129,11 @@ SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
       continue;
     }
 
+    if (auto *sbi = dyn_cast<StoreBorrowInst>(projectionDerivedFromRoot)) {
+      projectionDerivedFromRoot = sbi->getDest();
+      continue;
+    }
+
     if (auto *m = dyn_cast<MoveOnlyWrapperToCopyableAddrInst>(
             projectionDerivedFromRoot)) {
       projectionDerivedFromRoot = m->getOperand();

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2595,7 +2595,12 @@ public:
     require(SI->getDest()->getType().isAddress(),
             "Must store to an address dest");
     // Note: This is the current implementation and the design is not final.
-    require(isa<AllocStackInst>(SI->getDest()),
+    auto isLegal = [](SILValue value) {
+      if (auto *mmci = dyn_cast<MarkMustCheckInst>(value))
+        value = mmci->getOperand();
+      return isa<AllocStackInst>(value);
+    };
+    require(isLegal(SI->getDest()),
             "store_borrow destination can only be an alloc_stack");
     requireSameType(SI->getDest()->getType().getObjectType(),
                     SI->getSrc()->getType(),

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -530,7 +530,7 @@ public:
                                  SGFAccessKind selfAccess,
                                  SGFAccessKind otherAccess);
 
-  void dump() const;
+  SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &os, unsigned indent = 0) const;
 };
   

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2918,6 +2918,8 @@ public:
       return m->getType()->isPureMoveOnly() ||
              m->getBase()->getType()->isPureMoveOnly();
     }
+    if (auto *d = dyn_cast<DeclRefExpr>(e))
+      return e->getType()->isPureMoveOnly();
     return false;
   }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -220,6 +220,9 @@ bool noncopyable::memInstMustInitialize(Operand *memOper) {
   case SILInstructionKind::Store##Name##Inst:                                  \
     return cast<Store##Name##Inst>(memInst)->isInitializationOfDest();
 #include "swift/AST/ReferenceStorage.def"
+
+  case SILInstructionKind::StoreBorrowInst:
+    return true;
   }
 }
 

--- a/test/SIL/store_borrow_verify_errors.sil
+++ b/test/SIL/store_borrow_verify_errors.sil
@@ -199,7 +199,7 @@ bb1:
 }
 
 // CHECK: Begin Error in function test_store_borrow_dest
-// CHECK: SIL verification failed: store_borrow destination can only be an alloc_stack: isa<AllocStackInst>(SI->getDest())
+// CHECK: SIL verification failed: store_borrow destination can only be an alloc_stack: isLegal(SI->getDest())
 // CHECK: Verifying instruction:
 // CHECK:    %0 = argument of bb0 : $Klass                  // user: %3
 // CHECK:      %2 = struct_element_addr %1 : $*NonTrivialStruct, #NonTrivialStruct.val // user: %3

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -818,13 +818,10 @@ func enumSwitchTest1(_ e: borrowing EnumSwitchTests.E) {
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9letGlobalAA16NonTrivialStructVvp :
 // CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [no_consume_or_assign] [[GLOBAL]]
-// FIXME: this copy probably shouldn't be here when accessing through the letGlobal, but maybe it's cleaned up?
-// CHECK: [[LOADED_VAL:%.*]] = load [copy] [[MARKED_GLOBAL]] : $*NonTrivialStruct
-// CHECK: [[LOADED_BORROWED_VAL:%.*]] = begin_borrow [[LOADED_VAL]]
-// CHECK: [[LOADED_GEP:%.*]] = struct_extract [[LOADED_BORROWED_VAL]] : $NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
+// CHECK: [[LOADED_VAL:%.*]] = load_borrow [[MARKED_GLOBAL]] : $*NonTrivialStruct
+// CHECK: [[LOADED_GEP:%.*]] = struct_extract [[LOADED_VAL]] : $NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK: apply {{%.*}}([[LOADED_GEP]])
-// CHECK: end_borrow [[LOADED_BORROWED_VAL]]
-// CHECK: destroy_value [[LOADED_VAL]]
+// CHECK: end_borrow [[LOADED_VAL]]
 // CHECK: } // end sil function '$s8moveonly16testGlobalBorrowyyF'
 func testGlobalBorrow() {
     borrowVal(varGlobal)
@@ -856,13 +853,11 @@ func testGlobalBorrow() {
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9letGlobalAA16NonTrivialStructVvp :
 // CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [no_consume_or_assign] [[GLOBAL]]
-// CHECK: [[LOADED_VAL:%.*]] = load [copy] [[MARKED_GLOBAL]]
-// CHECK: [[LOADED_BORROWED_VAL:%.*]] = begin_borrow [[LOADED_VAL]]
-// CHECK: [[LOADED_GEP:%.*]] = struct_extract [[LOADED_BORROWED_VAL]]
+// CHECK: [[LOADED_VAL:%.*]] = load_borrow [[MARKED_GLOBAL]]
+// CHECK: [[LOADED_GEP:%.*]] = struct_extract [[LOADED_VAL]]
 // CHECK: [[LOADED_GEP_COPY:%.*]] = copy_value [[LOADED_GEP]]
-// CHECK: end_borrow [[LOADED_BORROWED_VAL]]
-// CHECK: destroy_value [[LOADED_VAL]]
 // CHECK: apply {{%.*}}([[LOADED_GEP_COPY]])
+// CHECK: end_borrow [[LOADED_VAL]]
 //
 // CHECK: } // end sil function '$s8moveonly17testGlobalConsumeyyF'
 func testGlobalConsume() {
@@ -1833,11 +1828,8 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Var() {
 // CHECK: [[MARK:%.*]] = mark_must_check [no_consume_or_assign] [[PROJECT]]
 // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}({{%.*}}, [[LOAD_BORROW]])
-// CHECK: [[TEMP:%.*]] = alloc_stack $AddressOnlyProtocol
-// CHECK: copy_addr [[CORO_RESULT]] to [init] [[TEMP]]
+// CHECK: apply {{%.*}}([[CORO_RESULT]])
 // CHECK: end_apply [[CORO_TOKEN]]
-// CHECK: apply {{%.*}}([[TEMP]])
-// CHECK: destroy_addr [[TEMP]]
 // CHECK: end_borrow [[LOAD_BORROW]]
 // CHECK: } // end sil function '$s8moveonly58testSubscriptReadModify_BaseLoadable_ResultAddressOnly_LetyyF'
 public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Let() {

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -1265,10 +1265,9 @@ public class LoadableSubscriptGetOnlyTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $LoadableSubscriptGetOnlyTester
-// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
-// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
-// CHECK: store [[CORO_RESULT_COPY]] to [init] [[TEMP_MARK]]
-// CHECK: [[LOAD:%.*]] = load_borrow [[TEMP_MARK]]
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [no_consume_or_assign] [[TEMP]]
+// CHECK: [[TEMP_MARK_BORROW:%.*]] = store_borrow [[CORO_RESULT]] to [[TEMP_MARK]]
+// CHECK: [[LOAD:%.*]] = load_borrow [[TEMP_MARK_BORROW]]
 // CHECK: [[TEMP2:%.*]] = alloc_stack $
 // CHECK: [[TEMP2_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP2]]
 // CHECK: apply {{%.*}}([[TEMP2_MARK]], {{%.*}}, [[LOAD]])
@@ -1284,10 +1283,9 @@ public class LoadableSubscriptGetOnlyTesterClassParent {
 // CHECK: [[BORROW_COPYABLE_CLASS:%.*]] = begin_borrow [[COPYABLE_CLASS]]
 // CHECK: ([[CORO_RESULT:%.*]], [[CORO_TOKEN:%.*]]) = begin_apply {{%.*}}([[BORROW_COPYABLE_CLASS]])
 // CHECK: [[TEMP:%.*]] = alloc_stack $LoadableSubscriptGetOnlyTester
-// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP]]
-// CHECK: [[CORO_RESULT_COPY:%.*]] = copy_value [[CORO_RESULT]]
-// CHECK: store [[CORO_RESULT_COPY]] to [init] [[TEMP_MARK]]
-// CHECK: [[GEP:%.*]] = struct_element_addr [[TEMP_MARK]]
+// CHECK: [[TEMP_MARK:%.*]] = mark_must_check [no_consume_or_assign] [[TEMP]]
+// CHECK: [[TEMP_MARK_BORROW:%.*]] = store_borrow [[CORO_RESULT]] to [[TEMP_MARK]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[TEMP_MARK_BORROW]]
 // CHECK: [[LOAD:%.*]] = load_borrow [[GEP]]
 // CHECK: [[TEMP2:%.*]] = alloc_stack $
 // CHECK: [[TEMP2_MARK:%.*]] = mark_must_check [consumable_and_assignable] [[TEMP2]]

--- a/test/SILGen/moveonly_library_evolution.swift
+++ b/test/SILGen/moveonly_library_evolution.swift
@@ -38,14 +38,8 @@ public struct DeinitTest : ~Copyable {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $CopyableKlass):
 // CHECK:    [[ADDR:%.*]] = ref_element_addr [[ARG]]
 // CHECK:    [[MARKED_ADDR:%.*]] = mark_must_check [no_consume_or_assign] [[ADDR]]
-// CHECK:    [[LOADED_VALUE:%.*]] = load [copy] [[MARKED_ADDR]]
-// CHECK:    [[BORROWED_LOADED_VALUE:%.*]] = begin_borrow [[LOADED_VALUE]]
-// CHECK:    [[EXT:%.*]] = struct_extract [[BORROWED_LOADED_VALUE]]
-// CHECK:    [[SPILL:%.*]] = alloc_stack $EmptyStruct
-// CHECK:    [[STORE_BORROW:%.*]] = store_borrow [[EXT]] to [[SPILL]]
-// CHECK:    apply {{%.*}}([[STORE_BORROW]]) : $@convention(thin) (@in_guaranteed EmptyStruct) -> ()
-// CHECK:    end_borrow [[STORE_BORROW]]
-// CHECK:    end_borrow [[BORROWED_LOADED_VALUE]]
+// CHECK:    [[GEP:%.*]] = struct_element_addr [[MARKED_ADDR]]
+// CHECK:    apply {{%.*}}([[GEP]]) : $@convention(thin) (@in_guaranteed EmptyStruct) -> ()
 // CHECK: } // end sil function '$s26moveonly_library_evolution29callerArgumentSpillingTestArgyyAA13CopyableKlassCF'
 public func callerArgumentSpillingTestArg(_ x: CopyableKlass) {
     borrowVal(x.letStruct.e)

--- a/test/SILGen/read_accessor.swift
+++ b/test/SILGen/read_accessor.swift
@@ -112,6 +112,7 @@ struct TupleReader {
 // CHECK-NEXT:    [[TUPLE:%.*]] = load [copy] [[TEMP]]
 // CHECK-NEXT:    destructure_tuple
 // CHECK-NEXT:    destructure_tuple
+// CHECK-NEXT:    destroy_addr [[TEMP]]
 // CHECK-NEXT:    end_apply
 // CHECK-LABEL: } // end sil function '$s13read_accessor11TupleReaderV11useReadableyyF'
   func useReadable() {

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -844,3 +844,18 @@ bb0(%0 : $Int, %1a : $*NonCopyableNativeObjectPair):
   %16 = tuple ()
   return %16 : $()
 }
+
+sil [ossa] @testSupportStoreBorrow : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct
+  %1a = mark_must_check [no_consume_or_assign] %1 : $*NonTrivialStruct
+  %borrow = store_borrow %0 to %1a : $*NonTrivialStruct
+  %f = function_ref @useNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %l = load_borrow %borrow : $*NonTrivialStruct
+  apply %f(%l) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  end_borrow %l : $NonTrivialStruct
+  end_borrow %borrow : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -1,8 +1,6 @@
 // RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
 // RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
 
-// TODO: Add FileCheck
-
 // This file contains specific SIL test cases that we expect to emit
 // diagnostics. These are cases where we want to make it easy to validate
 // independent of potential changes in the frontend's emission that this
@@ -77,6 +75,7 @@ sil @get_aggstruct : $@convention(thin) () -> @owned AggStruct
 sil @nonConsumingUseKlass : $@convention(thin) (@guaranteed Klass) -> ()
 sil @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
 sil @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+sil @inUseNonTrivialStruct : $@convention(thin) (@in NonTrivialStruct) -> ()
 sil @classConsume : $@convention(thin) (@owned Klass) -> () // user: %18
 sil @copyableClassConsume : $@convention(thin) (@owned CopyableKlass) -> () // user: %24
 sil @copyableClassUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed CopyableKlass) -> () // user: %16
@@ -527,5 +526,117 @@ bb0(%0 : @owned $NonTrivialStruct):
   // expected-note @-1 {{consumed again here}}
   dealloc_stack %1 : $*NonTrivialStruct
   %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testSupportStoreBorrow1 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed
+// CHECK:   [[STACK:%.*]] = alloc_stack
+// CHECK:   [[BORROW:%.*]] = store_borrow [[ARG]] to [[STACK]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[BORROW]]
+// CHECK:   apply {{%.*}}([[LOAD]])
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   dealloc_stack [[STACK]]
+// CHECK: } // end sil function 'testSupportStoreBorrow1'
+sil [ossa] @testSupportStoreBorrow1 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct
+  %1a = mark_must_check [no_consume_or_assign] %1 : $*NonTrivialStruct
+  %borrow = store_borrow %0 to %1a : $*NonTrivialStruct
+  %f = function_ref @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %l = load_borrow %borrow : $*NonTrivialStruct
+  apply %f(%l) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  end_borrow %l : $NonTrivialStruct
+  end_borrow %borrow : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testSupportStoreBorrow2 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed
+// CHECK:   [[STACK:%.*]] = alloc_stack
+// CHECK:   [[BORROW:%.*]] = store_borrow [[ARG]] to [[STACK]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[BORROW]]
+// CHECK:   apply {{%.*}}([[LOAD]])
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   dealloc_stack [[STACK]]
+// CHECK: } // end sil function 'testSupportStoreBorrow2'
+sil [ossa] @testSupportStoreBorrow2 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct
+  %1a = mark_must_check [no_consume_or_assign] %1 : $*NonTrivialStruct
+  %borrow = store_borrow %0 to %1a : $*NonTrivialStruct
+  %f = function_ref @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %l = load [copy] %borrow : $*NonTrivialStruct
+  apply %f(%l) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  destroy_value %l : $NonTrivialStruct
+  end_borrow %borrow : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testSupportStoreBorrow3 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed
+// CHECK:   [[STACK:%.*]] = alloc_stack
+// CHECK:   [[BORROW:%.*]] = store_borrow [[ARG]] to [[STACK]]
+// CHECK:   [[LOAD:%.*]] = load_borrow [[BORROW]]
+// CHECK:   apply {{%.*}}([[LOAD]])
+// CHECK:   end_borrow [[LOAD]]
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   dealloc_stack [[STACK]]
+// CHECK: } // end sil function 'testSupportStoreBorrow3'
+sil [ossa] @testSupportStoreBorrow3 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct
+  %1a = mark_must_check [no_consume_or_assign] %1 : $*NonTrivialStruct
+  %borrow = store_borrow %0 to %1a : $*NonTrivialStruct
+  %f = function_ref @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %l = load_borrow %borrow : $*NonTrivialStruct
+  %l2 = copy_value %l : $NonTrivialStruct
+  apply %f(%l2) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  destroy_value %l2 : $NonTrivialStruct
+  end_borrow %l : $NonTrivialStruct
+  end_borrow %borrow : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @testSupportStoreBorrow4 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct
+  %1a = mark_must_check [no_consume_or_assign] %1 : $*NonTrivialStruct
+  // expected-error @-1 {{noncopyable 'unknown' cannot be consumed when captured by an escaping closure}}
+  %borrow = store_borrow %0 to %1a : $*NonTrivialStruct
+  %f = function_ref @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  %l = load_borrow %borrow : $*NonTrivialStruct
+  %l2 = copy_value %l : $NonTrivialStruct
+  apply %f(%l2) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  end_borrow %l : $NonTrivialStruct
+  end_borrow %borrow : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @testSupportStoreBorrow5 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %1 = alloc_stack $NonTrivialStruct
+  %1a = mark_must_check [no_consume_or_assign] %1 : $*NonTrivialStruct
+  // expected-error @-1 {{'unknown' is borrowed and cannot be consumed}}
+  %borrow = store_borrow %0 to %1a : $*NonTrivialStruct
+  %f = function_ref @consumingUseNonTrivialStruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  %a = alloc_stack $NonTrivialStruct
+  copy_addr %borrow to [init] %a : $*NonTrivialStruct
+  // expected-note @-1 {{consumed here}}
+  destroy_addr %a : $*NonTrivialStruct
+  dealloc_stack %a : $*NonTrivialStruct
+  end_borrow %borrow : $*NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %9999 = tuple ()
   return %9999 : $()
 }

--- a/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
@@ -203,7 +203,6 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Var() {
 public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Let() {
     let m = LoadableSubscriptReadModifyTester()
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
 }
 
 public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_InOut(m: inout LoadableSubscriptReadModifyTester) {

--- a/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
@@ -83,9 +83,7 @@ public func testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressOnl
     var m = LoadableSubscriptGetOnlyTesterClassParent()
     m = LoadableSubscriptGetOnlyTesterClassParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.testerParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester[0].nonMutatingFunc()
 }
 

--- a/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addressonly_subscript_diagnostics.swift
@@ -87,7 +87,6 @@ public func testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressOnl
     m.testerParent.tester[0].nonMutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
 }
 
 // MARK: Getter + Setter.
@@ -178,7 +177,6 @@ public func testSubscriptGetSetThroughParentClass_BaseLoadable_ResultAddressOnly
     m.testerParent.tester[0].nonMutatingFunc()
     m.testerParent.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
     m.computedTester2[0].mutatingFunc()
 }
@@ -272,7 +270,6 @@ public func testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultAddress
     m.testerParent.tester[0].nonMutatingFunc()
     m.testerParent.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
     m.computedTester2[0].mutatingFunc()
 }
@@ -359,7 +356,6 @@ public func testSubscriptGetModifyThroughParentClass_BaseLoadable_ResultAddressO
     m.testerParent.tester[0].nonMutatingFunc()
     m.testerParent.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
     m.computedTester2[0].mutatingFunc()
 }

--- a/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
@@ -200,7 +200,6 @@ public func testSubscriptReadModify_BaseLoadable_ResultLoadable_Var() {
 public func testSubscriptReadModify_BaseLoadable_ResultLoadable_Let() {
     let m = LoadableSubscriptReadModifyTester()
     m[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
 }
 
 public func testSubscriptReadModify_BaseLoadable_ResultLoadable_InOut(m: inout LoadableSubscriptReadModifyTester) {

--- a/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
@@ -80,9 +80,7 @@ public func testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultLoadable_V
     var m = LoadableSubscriptGetOnlyTesterClassParent()
     m = LoadableSubscriptGetOnlyTesterClassParent()
     m.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.testerParent.tester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester[0].nonMutatingFunc()
 }
 

--- a/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_loadable_subscript_diagnostics.swift
@@ -84,7 +84,6 @@ public func testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultLoadable_V
     m.testerParent.tester[0].nonMutatingFunc()
     // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
 }
 
 // MARK: Getter + Setter.
@@ -175,7 +174,6 @@ public func testSubscriptGetSetThroughParentClass_BaseLoadable_ResultLoadable_Va
     m.testerParent.tester[0].nonMutatingFunc()
     m.testerParent.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
     m.computedTester2[0].mutatingFunc()
 }
@@ -269,7 +267,6 @@ public func testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultLoadabl
     m.testerParent.tester[0].nonMutatingFunc()
     m.testerParent.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
     m.computedTester2[0].mutatingFunc()
 }
@@ -356,7 +353,6 @@ public func testSubscriptGetModifyThroughParentClass_BaseLoadable_ResultLoadable
     m.testerParent.tester[0].nonMutatingFunc()
     m.testerParent.tester[0].mutatingFunc()
     m.computedTester[0].nonMutatingFunc()
-    // expected-error @-1 {{copy of noncopyable typed value}}
     m.computedTester2[0].nonMutatingFunc()
     m.computedTester2[0].mutatingFunc()
 }

--- a/test/SILOptimizer/moveonly_partial_consumption.swift
+++ b/test/SILOptimizer/moveonly_partial_consumption.swift
@@ -224,11 +224,10 @@ func addressOnlyTestArg(_ x: borrowing AddressOnlyType) {
     // expected-error @-1 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-2 {{'x' is borrowed and cannot be consumed}}
     // expected-error @-3 {{'x' is borrowed and cannot be consumed}}
-    // expected-error @-4 {{'x' is borrowed and cannot be consumed}}
     let _ = x.e // expected-note {{consumed here}}
     let _ = x.k
     let _ = x.l.e // expected-note {{consumed here}}
-    let _ = x.l.k // expected-note {{consumed here}}
+    let _ = x.l.k
     switch x.lEnum { // expected-note {{consumed here}}
     case .first:
         break


### PR DESCRIPTION
This PR contains 3 commits that together ensure that if:

1. The base value of an accessor is noncopyable.
2. The return value of an accessor is noncopyable.

We properly nest the borrows. This has the affect of ensuring that /all/ cases in tree where we emit copy of noncopyable error due to us emitting the base incorrectly as an rvalue (causing us to emit copies since the lifetime ends early) are eliminated.

It of course handles corourtines/etc correctly as well.