### PR TITLE
[TypeChecker] Make sure that distributed actors always get "default" init

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1490,6 +1490,12 @@ HasDefaultInitRequest::evaluate(Evaluator &evaluator,
   if (hasUserDefinedDesignatedInit(evaluator, decl))
     return false;
 
+  // Regardless of whether all of the properties are initialized or
+  // not distributed actors always get a special "default" init based
+  // on `id` and `actorSystem` synthesized properties.
+  if (decl->isDistributedActor())
+    return true;
+
   // We can only synthesize a default init if all the stored properties have an
   // initial value.
   return areAllStoredPropertiesDefaultInitializable(evaluator, decl);

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -35,10 +35,8 @@ extension DAP where ActorSystem.ActorID == String {
 }
 
 distributed actor D2 {
-  // expected-error@-1{{actor 'D2' has no initializers}}
   let actorSystem: String
   // expected-error@-1{{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-note@-2{{stored property 'actorSystem' without initial value prevents synthesized initializers}}
 }
 
 distributed actor D3 {
@@ -49,14 +47,10 @@ distributed actor D3 {
 struct OtherActorIdentity: Sendable, Hashable, Codable {}
 
 distributed actor D4 {
-  // expected-error@-1{{actor 'D4' has no initializers}}
-
   let actorSystem: String
   // expected-error@-1{{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-note@-2{{stored property 'actorSystem' without initial value prevents synthesized initializers}}
   let id: OtherActorIdentity
   // expected-error@-1{{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-note@-2{{stored property 'id' without initial value prevents synthesized initializers}}
 }
 
 protocol P1: DistributedActor {


### PR DESCRIPTION
Default initialization of stored properties doesn't play a role in default init synthesis for distributed actors.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
