### PR TITLE
[Concurrency] Fix crash when actor is dynamically subclassed.

### DIFF
--- a/stdlib/public/BackDeployConcurrency/Actor.cpp
+++ b/stdlib/public/BackDeployConcurrency/Actor.cpp
@@ -1712,8 +1712,10 @@ static bool isDefaultActorClass(const ClassMetadata *metadata) {
   assert(metadata->isTypeMetadata());
   while (true) {
     // Trust the class descriptor if it says it's a default actor.
-    if (metadata->getDescription()->isDefaultActor())
+    if (!metadata->isArtificialSubclass() &&
+        metadata->getDescription()->isDefaultActor()) {
       return true;
+    }
 
     // Go to the superclass.
     metadata = metadata->Superclass;

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1775,7 +1775,8 @@ static bool isDefaultActorClass(const ClassMetadata *metadata) {
   assert(metadata->isTypeMetadata());
   while (true) {
     // Trust the class descriptor if it says it's a default actor.
-    if (metadata->getDescription()->isDefaultActor()) {
+    if (!metadata->isArtificialSubclass() &&
+        metadata->getDescription()->isDefaultActor()) {
       return true;
     }
 

--- a/test/Concurrency/Runtime/actor_dynamic_subclass.swift
+++ b/test/Concurrency/Runtime/actor_dynamic_subclass.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: use_os_stdlib
+
+// Make sure the concurrency runtime tolerates dynamically-subclassed actors.
+
+import ObjectiveC
+
+actor Foo: NSObject {
+  var x = 0
+
+  func doit() async {
+    x += 1
+    try! await Task.sleep(nanoseconds: 1000)
+    x += 1
+  }
+}
+
+@main
+enum Main {
+  static func main() async {
+    let FooSub = objc_allocateClassPair(Foo.self, "FooSub", 0) as! Foo.Type
+    objc_registerClassPair(FooSub)
+    let foosub = FooSub.init()
+    await foosub.doit()
+  }
+}
+


### PR DESCRIPTION
Dynamic subclasses have a NULL type descriptor. Make sure isDefaultActorClass doesn't try to dereference that NULL descriptor.

rdar://112223265