### PR TITLE
[Code Health] Improve eventual C++20 support.

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -89,6 +89,11 @@ public:
     /// This data is used for cross-module module dependencies.
     fine_grained_dependencies::ModuleDepGraph depGraph;
 
+    Result(bool hadAbnormalExit, int exitCode,
+           fine_grained_dependencies::ModuleDepGraph depGraph)
+        : hadAbnormalExit(hadAbnormalExit), exitCode(exitCode),
+          depGraph(depGraph) {}
+
     Result(const Result &) = delete;
     Result &operator=(const Result &) = delete;
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -680,7 +680,7 @@ class LinkEntity {
     Data = LINKENTITY_SET_FIELD(Kind, unsigned(kind));
   }
 
-  LinkEntity() = default;
+  LinkEntity() : Pointer(nullptr), SecondaryPointer(nullptr), Data(0) {}
 
   static bool isValidResilientMethodRef(SILDeclRef declRef) {
     if (declRef.isForeign)

--- a/include/swift/SILOptimizer/PassManager/PassPipeline.h
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.h
@@ -33,7 +33,28 @@
 namespace swift {
 
 class SILPassPipelinePlan;
-struct SILPassPipeline;
+
+struct SILPassPipeline final {
+  unsigned ID;
+  StringRef Name;
+  unsigned KindOffset;
+  bool isFunctionPassPipeline;
+
+  friend bool operator==(const SILPassPipeline &lhs,
+                         const SILPassPipeline &rhs) {
+    return lhs.ID == rhs.ID && lhs.Name.equals(rhs.Name) &&
+           lhs.KindOffset == rhs.KindOffset;
+  }
+
+  friend bool operator!=(const SILPassPipeline &lhs,
+                         const SILPassPipeline &rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend llvm::hash_code hash_value(const SILPassPipeline &pipeline) {
+    return llvm::hash_combine(pipeline.ID, pipeline.Name, pipeline.KindOffset);
+  }
+};
 
 enum class PassPipelineKind {
 #define PASSPIPELINE(NAME, DESCRIPTION) NAME,
@@ -120,28 +141,6 @@ public:
     return hash_combine(&plan.Options,
                         hash_combine_range(kinds.begin(), kinds.end()),
                         hash_combine_range(stages.begin(), stages.end()));
-  }
-};
-
-struct SILPassPipeline final {
-  unsigned ID;
-  StringRef Name;
-  unsigned KindOffset;
-  bool isFunctionPassPipeline;
-
-  friend bool operator==(const SILPassPipeline &lhs,
-                         const SILPassPipeline &rhs) {
-    return lhs.ID == rhs.ID && lhs.Name.equals(rhs.Name) &&
-           lhs.KindOffset == rhs.KindOffset;
-  }
-
-  friend bool operator!=(const SILPassPipeline &lhs,
-                         const SILPassPipeline &rhs) {
-    return !(lhs == rhs);
-  }
-
-  friend llvm::hash_code hash_value(const SILPassPipeline &pipeline) {
-    return llvm::hash_combine(pipeline.ID, pipeline.Name, pipeline.KindOffset);
   }
 };
 

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -20,6 +20,10 @@ struct BridgedDiagnosticImpl {
   InFlightDiagnostic inFlight;
   std::vector<StringRef> textBlobs;
 
+  BridgedDiagnosticImpl(InFlightDiagnostic inFlight,
+                        std::vector<StringRef> textBlobs)
+      : inFlight(std::move(inFlight)), textBlobs(std::move(textBlobs)) {}
+
   BridgedDiagnosticImpl(const BridgedDiagnosticImpl &) = delete;
   BridgedDiagnosticImpl(BridgedDiagnosticImpl &&) = delete;
   BridgedDiagnosticImpl &operator=(const BridgedDiagnosticImpl &) = delete;

--- a/lib/Frontend/DependencyVerifier.cpp
+++ b/lib/Frontend/DependencyVerifier.cpp
@@ -148,6 +148,9 @@ struct Obligation {
   public:
     Key() = delete;
 
+  private:
+    Key(StringRef Name, Expectation::Kind Kind) : Name(Name), Kind(Kind) {}
+
   public:
     static Key forNegative(StringRef name) {
       return Key{name, Expectation::Kind::Negative};

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_IRGEN_OUTLINING_H
 #define SWIFT_IRGEN_OUTLINING_H
 
+#include "LocalTypeDataKind.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/MapVector.h"
 
@@ -37,7 +38,6 @@ class Address;
 class Explosion;
 class IRGenFunction;
 class IRGenModule;
-class LocalTypeDataKey;
 class TypeInfo;
 
 /// A helper class for emitting outlined value operations.


### PR DESCRIPTION
This is a small set of patches we've been floating for a while, to allow Swift to be built in a C++20 configuration. This PR contains the following changes:

* Add explicit ctors for types that default or delete their ctors, when aggregate initialization is being used. (In C++20, the type is no longer an aggregate if its ctors are defaulted or deleted).
* Ensure that any types used as elements of `std::vector` are complete and not just forward-declared.
* (Not strictly a C++20 change) Ensure that `LinkEntity` is zero-initialized to avoid _use-of-uninitialized-value_ problems.

All should remain compatible with earlier C++ versions as well.