### PR TITLE
[5.9] Eliminate Observable circular reference errors via lazier TypeRefinementContext building

### DIFF
--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -380,6 +380,13 @@ public:
 
 };
 
+/// Given a declaration upon which an availability attribute would appear in
+/// concrete syntax, return a declaration to which the parser
+/// actually attaches the attribute in the abstract syntax tree. We use this
+/// function to determine whether the concrete syntax already has an
+/// availability attribute.
+const Decl *abstractSyntaxDeclForAvailableAttribute(const Decl *D);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -63,6 +63,7 @@ class TypeAliasDecl;
 class TypeLoc;
 class Witness;
 class TypeResolution;
+class TypeRefinementContext;
 struct TypeWitnessAndDecl;
 class ValueDecl;
 enum class OpaqueReadOwnership: uint8_t;
@@ -4382,6 +4383,25 @@ private:
   ArrayRef<VarDecl *> evaluate(Evaluator &evaluator, DeclAttribute *attr,
                                AccessorDecl *attachedTo,
                                ArrayRef<Identifier>) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
+/// Expand the children of the type refinement context for the given
+/// declaration.
+class ExpandChildTypeRefinementContextsRequest
+    : public SimpleRequest<ExpandChildTypeRefinementContextsRequest,
+                           bool(Decl *, TypeRefinementContext *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, Decl *decl,
+                TypeRefinementContext *parentTRC) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -500,3 +500,6 @@ SWIFT_REQUEST(TypeChecker, InitAccessorReferencedVariablesRequest,
               ArrayRef<VarDecl *>(DeclAttribute *, AccessorDecl *,
                                   ArrayRef<Identifier>),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ExpandChildTypeRefinementContextsRequest,
+              bool(Decl *, TypeRefinementContext *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -297,6 +297,9 @@ public:
   static StringRef getReasonName(Reason R);
 };
 
+void simple_display(llvm::raw_ostream &out,
+                    const TypeRefinementContext *trc);
+
 } // end namespace swift
 
 #endif

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -224,6 +224,8 @@ AvailabilityInference::attrForAnnotatedAvailableRange(const Decl *D,
                                                       ASTContext &Ctx) {
   const AvailableAttr *bestAvailAttr = nullptr;
 
+  D = abstractSyntaxDeclForAvailableAttribute(D);
+
   for (auto Attr : D->getAttrs()) {
     auto *AvailAttr = dyn_cast<AvailableAttr>(Attr);
     if (AvailAttr == nullptr || !AvailAttr->Introduced.has_value() ||
@@ -743,4 +745,32 @@ ASTContext::getSwift5PlusAvailability(llvm::VersionTuple swiftVersion) {
   llvm::report_fatal_error(
       Twine("Missing call to getSwiftXYAvailability for Swift ") +
       swiftVersion.getAsString());
+}
+
+const Decl *
+swift::abstractSyntaxDeclForAvailableAttribute(const Decl *ConcreteSyntaxDecl) {
+  // This function needs to be kept in sync with its counterpart,
+  // concreteSyntaxDeclForAvailableAttribute().
+
+  if (auto *PBD = dyn_cast<PatternBindingDecl>(ConcreteSyntaxDecl)) {
+    // Existing @available attributes in the AST are attached to VarDecls
+    // rather than PatternBindingDecls, so we return the first VarDecl for
+    // the pattern binding declaration.
+    // This is safe, even though there may be multiple VarDecls, because
+    // all parsed attribute that appear in the concrete syntax upon on the
+    // PatternBindingDecl are added to all of the VarDecls for the pattern
+    // binding.
+    for (auto index : range(PBD->getNumPatternEntries())) {
+      if (auto VD = PBD->getAnchoringVarDecl(index))
+        return VD;
+    }
+  } else if (auto *ECD = dyn_cast<EnumCaseDecl>(ConcreteSyntaxDecl)) {
+    // Similar to the PatternBindingDecl case above, we return the
+    // first EnumElementDecl.
+    if (auto *Elem = ECD->getFirstElement()) {
+      return Elem;
+    }
+  }
+
+  return ConcreteSyntaxDecl;
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2079,19 +2079,23 @@ bool VarDecl::isLayoutExposedToClients() const {
   if (!parent) return false;
   if (isStatic()) return false;
 
-  if (!hasStorage() &&
-      !getAttrs().hasAttribute<LazyAttr>() &&
-      !hasAttachedPropertyWrapper()) {
-    return false;
-  }
 
   auto nominalAccess =
     parent->getFormalAccessScope(/*useDC=*/nullptr,
                                  /*treatUsableFromInlineAsPublic=*/true);
   if (!nominalAccess.isPublic()) return false;
 
-  return (parent->getAttrs().hasAttribute<FrozenAttr>() ||
-          parent->getAttrs().hasAttribute<FixedLayoutAttr>());
+  if (!parent->getAttrs().hasAttribute<FrozenAttr>() &&
+      !parent->getAttrs().hasAttribute<FixedLayoutAttr>())
+    return false;
+
+  if (!hasStorage() &&
+      !getAttrs().hasAttribute<LazyAttr>() &&
+      !hasAttachedPropertyWrapper()) {
+    return false;
+  }
+
+  return true;
 }
 
 /// Check whether the given type representation will be

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -367,6 +367,10 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
       OS << "extension." << ED->getExtendedType().getString();
     } else if (isa<TopLevelCodeDecl>(D)) {
       OS << "<top-level-code>";
+    } else if (auto PBD = dyn_cast<PatternBindingDecl>(D)) {
+      if (auto VD = PBD->getAnchoringVarDecl(0)) {
+        OS << VD->getName();
+      }
     }
   }
 

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeRefinementContext.h"
 #include "swift/Basic/SourceManager.h"
 
@@ -191,6 +192,18 @@ TypeRefinementContext::findMostRefinedSubContext(SourceLoc Loc,
   if (SrcRange.isValid() &&
       !rangeContainsTokenLocWithGeneratedSource(SM, SrcRange, Loc))
     return nullptr;
+
+  // If this context is for a declaration, ensure that we've expanded the
+  // children of the declaration.
+  if (Node.getReason() == Reason::Decl ||
+      Node.getReason() == Reason::DeclImplicit) {
+    if (auto decl = Node.getAsDecl()) {
+      ASTContext &ctx = decl->getASTContext();
+      (void)evaluateOrDefault(
+          ctx.evaluator, ExpandChildTypeRefinementContextsRequest{decl, this},
+          false);
+    }
+  }
 
   // For the moment, we perform a linear search here, but we can and should
   // do something more efficient.
@@ -410,4 +423,9 @@ StringRef TypeRefinementContext::getReasonName(Reason R) {
   }
 
   llvm_unreachable("Unhandled Reason in switch.");
+}
+
+void swift::simple_display(
+    llvm::raw_ostream &out, const TypeRefinementContext *trc) {
+  out << "TRC @" << trc;
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -608,7 +608,7 @@ private:
         getCurrentTRC()->getAvailabilityInfo();
     AvailabilityContext EffectiveAvailability =
         getEffectiveAvailabilityForDeclSignature(D, CurrentAvailability);
-    if (isa<VarDecl>(D) ||
+    if ((isa<VarDecl>(D) && refinementSourceRangeForDecl(D).isValid()) ||
         CurrentAvailability.isSupersetOf(EffectiveAvailability))
       return TypeRefinementContext::createForDeclImplicit(
           Context, D, getCurrentTRC(), EffectiveAvailability,

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1741,3 +1741,25 @@ func useHasUnavailableExtension(_ s: HasUnavailableExtension) {
   s.inheritsUnavailable() // expected-error {{'inheritsUnavailable()' is unavailable in macOS}}
   s.moreAvailableButStillUnavailable() // expected-error {{'moreAvailableButStillUnavailable()' is unavailable in macOS}}
 }
+
+@available(macOS 10.15, *)
+func f() -> Int { 17 }
+
+class StoredPropertiesWithAvailabilityInClosures {
+  private static let value: Int = {
+    if #available(macOS 10.15, *) {
+      return f()
+    }
+
+    return 0
+  }()
+
+  @available(macOS 10.14, *)
+  private static let otherValue: Int = {
+    if #available(macOS 10.15, *) {
+      return f()
+    }
+
+    return 0
+  }()
+}

--- a/test/stdlib/Observation/Inputs/ObservableClass.swift
+++ b/test/stdlib/Observation/Inputs/ObservableClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import Observation
+
+@available(SwiftStdlib 5.9, *)
+@Observable final public class ObservableClass {
+  public var state: State = .unused
+}

--- a/test/stdlib/Observation/ObservableAvailabilityCycle.swift
+++ b/test/stdlib/Observation/ObservableAvailabilityCycle.swift
@@ -1,0 +1,19 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-feature InitAccessors -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server -primary-file %s %S/Inputs/ObservableClass.swift
+
+// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-feature InitAccessors -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server %s -primary-file %S/Inputs/ObservableClass.swift
+
+// REQUIRES: observation
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+@available(SwiftStdlib 5.9, *)
+extension ObservableClass {
+  @frozen public enum State: Sendable {
+    case unused
+    case used
+  }
+}


### PR DESCRIPTION
* **Explanation**: Eager expansion of type refinement contexts (TRCs) for variables within pattern binding declarations is causing cyclic references in some places involving macros. Make this expansion lazy, triggered by walking into these pattern binding declarations as part of availability queries. Also be careful to avoid "has property wrapper" queries as part of building the type refinement context, because they tend to cause circularities.
* **Scope**: Moderate. All Swift code uses type refinement contexts for availability checking.
* **Risk**: Moderate. This makes an eagerly-computed data structure more lazy, and that data structure is used for all availability checking.
* **Reviewed by**: @tshortli 
* **Original pull request**: https://github.com/apple/swift/pull/67642
* **Issue**: rdar://112079160
