### PR TITLE
[SIL] Represent copies to and from @sil_weak values.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5191,8 +5191,9 @@ case, the strong reference count will be incremented before any changes to the
 weak reference count.
 
 This operation must be atomic with respect to the final ``strong_release`` on
-the operand heap object.  It need not be atomic with respect to ``store_weak``
-or ``load_weak``/``strong_copy_weak_value`` operations on the same address.
+the operand heap object.  It need not be atomic with respect to
+``store_weak``/``weak_copy_value`` or ``load_weak``/``strong_copy_weak_value``
+operations on the same address.
 
 strong_copy_weak_value
 ``````````````````````
@@ -5212,8 +5213,9 @@ its strong reference count and produces the value ``Optional.some`` holding the
 object.  Otherwise, produces the value ``Optional.none``.
 
 This operation must be atomic with respect to the final ``strong_release`` on
-the operand heap object.  It need not be atomic with respect to ``store_weak``
-or ``load_weak``/``strong_copy_weak_value`` operations on the same address.
+the operand heap object.  It need not be atomic with respect to
+``store_weak``/``weak_copy_value`` or ``load_weak``/``strong_copy_weak_value``
+operations on the same address.
 
 store_weak
 ``````````
@@ -5239,8 +5241,30 @@ currently be initialized. After the evaluation:
 
 This operation must be atomic with respect to the final ``strong_release`` on
 the operand (source) heap object.  It need not be atomic with respect to
-``store_weak`` or ``load_weak``/``strong_copy_weak_value`` operations on the
-same address.
+``store_weak``/``weak_copy_value`` or ``load_weak``/``strong_copy_weak_value``
+operations on the same address.
+
+weak_copy_value
+```````````````
+::
+
+  sil-instruction ::= 'weak_copy_value' sil-operand
+
+  %1 = weak_copy_value %0 : $Optional<T>
+  // %1 will be an @owned value of type $@sil_weak Optional<T>.
+  // $T must be a reference type
+  // $@sil_weak Optional<T> must be address-only
+
+Only valid in opaque values mode.  Lowered by AddressLowering to store_weak.
+
+If ``%0`` is non-nil, produces the value ``@sil_weak Optional.some`` holding the
+object and increments the weak reference count by 1.  Otherwise, produces the
+value ``Optional.none`` wrapped in a ``@sil_weak`` box.
+
+This operation must be atomic with respect to the final ``strong_release`` on
+the operand (source) heap object.  It need not be atomic with respect to
+``store_weak``/``weak_copy_value`` or ``load_weak``/``strong_copy_weak_value``
+operations on the same address.
 
 load_unowned
 ````````````

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5192,7 +5192,7 @@ weak reference count.
 
 This operation must be atomic with respect to the final ``strong_release`` on
 the operand heap object.  It need not be atomic with respect to ``store_weak``
-operations on the same address.
+or ``load_weak`` operations on the same address.
 
 store_weak
 ``````````

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5192,7 +5192,28 @@ weak reference count.
 
 This operation must be atomic with respect to the final ``strong_release`` on
 the operand heap object.  It need not be atomic with respect to ``store_weak``
-or ``load_weak`` operations on the same address.
+or ``load_weak``/``strong_copy_weak_value`` operations on the same address.
+
+strong_copy_weak_value
+``````````````````````
+::
+
+  sil-instruction ::= 'strong_copy_weak_value' sil-operand
+
+  %1 = strong_copy_weak_value %0 : $@sil_weak Optional<T>
+  // %1 will be a strong @owned value of type $Optional<T>.
+  // $T must be a reference type
+  // $@sil_weak Optional<T> must be address-only
+
+Only valid in opaque values mode.  Lowered by AddressLowering to load_weak.
+
+If the heap object referenced by ``%0`` has not begun deallocation, increments
+its strong reference count and produces the value ``Optional.some`` holding the
+object.  Otherwise, produces the value ``Optional.none``.
+
+This operation must be atomic with respect to the final ``strong_release`` on
+the operand heap object.  It need not be atomic with respect to ``store_weak``
+or ``load_weak``/``strong_copy_weak_value`` operations on the same address.
 
 store_weak
 ``````````
@@ -5218,7 +5239,8 @@ currently be initialized. After the evaluation:
 
 This operation must be atomic with respect to the final ``strong_release`` on
 the operand (source) heap object.  It need not be atomic with respect to
-``store_weak`` or ``load_weak`` operations on the same address.
+``store_weak`` or ``load_weak``/``strong_copy_weak_value`` operations on the
+same address.
 
 load_unowned
 ````````````

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1061,20 +1061,28 @@ public:
         getSILDebugLocation(Loc), ArgumentsSpecification, getModule()));
   }
 
-#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  Load##Name##Inst *createLoad##Name(SILLocation Loc, \
-                                     SILValue src, \
-                                     IsTake_t isTake) { \
-    return insert(new (getModule()) \
-      Load##Name##Inst(getSILDebugLocation(Loc), src, isTake)); \
-  } \
-  Store##Name##Inst *createStore##Name(SILLocation Loc, \
-                                       SILValue value, \
-                                       SILValue dest, \
-                                       IsInitialization_t isInit) { \
-    return insert(new (getModule()) \
-      Store##Name##Inst(getSILDebugLocation(Loc), value, dest, isInit)); \
+#define COPYABLE_STORAGE_HELPER(Name)                                          \
+  StrongCopy##Name##ValueInst *createStrongCopy##Name##Value(                  \
+      SILLocation Loc, SILValue operand) {                                     \
+    auto type = getFunction().getLoweredType(                                  \
+        operand->getType().getASTType().getReferenceStorageReferent());        \
+    return insert(new (getModule()) StrongCopy##Name##ValueInst(               \
+        getSILDebugLocation(Loc), operand, type));                             \
   }
+
+#define LOADABLE_STORAGE_HELPER(Name)                                          \
+  Load##Name##Inst *createLoad##Name(SILLocation Loc, SILValue src,            \
+                                     IsTake_t isTake) {                        \
+    return insert(new (getModule()) Load##Name##Inst(getSILDebugLocation(Loc), \
+                                                     src, isTake));            \
+  }                                                                            \
+  Store##Name##Inst *createStore##Name(SILLocation Loc, SILValue value,        \
+                                       SILValue dest,                          \
+                                       IsInitialization_t isInit) {            \
+    return insert(new (getModule()) Store##Name##Inst(                         \
+        getSILDebugLocation(Loc), value, dest, isInit));                       \
+  }
+
 #define LOADABLE_REF_STORAGE_HELPER(Name)                                      \
   Name##ToRefInst *create##Name##ToRef(SILLocation Loc, SILValue op,           \
                                        SILType ty) {                           \
@@ -1085,41 +1093,45 @@ public:
                                        SILType ty) {                           \
     return insert(new (getModule())                                            \
                       RefTo##Name##Inst(getSILDebugLocation(Loc), op, ty));    \
-  }                                                                            \
-  StrongCopy##Name##ValueInst *createStrongCopy##Name##Value(                  \
-      SILLocation Loc, SILValue operand) {                                     \
-    auto type = getFunction().getLoweredType(                                  \
-        operand->getType().getASTType().getReferenceStorageReferent());        \
-    return insert(new (getModule()) StrongCopy##Name##ValueInst(               \
-        getSILDebugLocation(Loc), operand, type));                             \
   }
 
-#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  LOADABLE_REF_STORAGE_HELPER(Name) \
-  StrongRetain##Name##Inst *createStrongRetain##Name(SILLocation Loc, \
-                                                     SILValue Operand, \
-                                                     Atomicity atomicity) { \
-    return insert(new (getModule()) \
-      StrongRetain##Name##Inst(getSILDebugLocation(Loc), Operand, atomicity)); \
-  } \
-  Name##RetainInst *create##Name##Retain(SILLocation Loc, SILValue Operand, \
-                                         Atomicity atomicity) { \
-    return insert(new (getModule()) \
-      Name##RetainInst(getSILDebugLocation(Loc), Operand, atomicity)); \
-  } \
-  Name##ReleaseInst *create##Name##Release(SILLocation Loc, \
-                                           SILValue Operand, \
-                                           Atomicity atomicity) { \
-    return insert(new (getModule()) \
-      Name##ReleaseInst(getSILDebugLocation(Loc), Operand, atomicity)); \
+#define RETAINABLE_STORAGE_HELPER(Name)                                        \
+  StrongRetain##Name##Inst *createStrongRetain##Name(                          \
+      SILLocation Loc, SILValue Operand, Atomicity atomicity) {                \
+    return insert(new (getModule()) StrongRetain##Name##Inst(                  \
+        getSILDebugLocation(Loc), Operand, atomicity));                        \
+  }                                                                            \
+  Name##RetainInst *create##Name##Retain(SILLocation Loc, SILValue Operand,    \
+                                         Atomicity atomicity) {                \
+    return insert(new (getModule()) Name##RetainInst(getSILDebugLocation(Loc), \
+                                                     Operand, atomicity));     \
+  }                                                                            \
+  Name##ReleaseInst *create##Name##Release(SILLocation Loc, SILValue Operand,  \
+                                           Atomicity atomicity) {              \
+    return insert(new (getModule()) Name##ReleaseInst(                         \
+        getSILDebugLocation(Loc), Operand, atomicity));                        \
   }
-#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, "...") \
-  ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, "...")
-#define UNCHECKED_REF_STORAGE(Name, ...) \
+
+#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
+  COPYABLE_STORAGE_HELPER(Name)                                                \
+  LOADABLE_REF_STORAGE_HELPER(Name)                                            \
+  RETAINABLE_STORAGE_HELPER(Name)
+#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
+  COPYABLE_STORAGE_HELPER(Name)                                                \
+  LOADABLE_REF_STORAGE_HELPER(Name)                                            \
+  LOADABLE_STORAGE_HELPER(Name)                                                \
+  RETAINABLE_STORAGE_HELPER(Name)
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  COPYABLE_STORAGE_HELPER(Name)                                                \
+  LOADABLE_STORAGE_HELPER(Name)
+#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+  COPYABLE_STORAGE_HELPER(Name)                                                \
   LOADABLE_REF_STORAGE_HELPER(Name)
 #include "swift/AST/ReferenceStorage.def"
+#undef LOADABLE_STORAGE_HELPER
 #undef LOADABLE_REF_STORAGE_HELPER
+#undef COPYABLE_STORAGE_HELPER
+#undef RETAINABLE_STORAGE_HELPER
 
   CopyAddrInst *createCopyAddr(SILLocation Loc, SILValue srcAddr,
                                SILValue destAddr, IsTake_t isTake,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1061,6 +1061,16 @@ public:
         getSILDebugLocation(Loc), ArgumentsSpecification, getModule()));
   }
 
+  WeakCopyValueInst *createWeakCopyValue(SILLocation Loc, SILValue operand) {
+    assert(!getFunction().getModule().useLoweredAddresses());
+    auto type = operand->getType()
+                    .getReferenceStorageType(getFunction().getASTContext(),
+                                             ReferenceOwnership::Weak)
+                    .getObjectType();
+    return insert(new (getModule()) WeakCopyValueInst(getSILDebugLocation(Loc),
+                                                      operand, type));
+  }
+
 #define COPYABLE_STORAGE_HELPER(Name)                                          \
   StrongCopy##Name##ValueInst *createStrongCopy##Name##Value(                  \
       SILLocation Loc, SILValue operand) {                                     \

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1407,7 +1407,17 @@ SILCloner<ImplClass>::visitDebugStepInst(DebugStepInst *Inst) {
   recordClonedInstruction(Inst, getBuilder().createDebugStep(Inst->getLoc()));
 }
 
-#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...)                    \
+#define COPYABLE_STORAGE_HELPER(Name, name)                                    \
+  template <typename ImplClass>                                                \
+  void SILCloner<ImplClass>::visitStrongCopy##Name##ValueInst(                 \
+      StrongCopy##Name##ValueInst *Inst) {                                     \
+    getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));      \
+    recordClonedInstruction(Inst, getBuilder().createStrongCopy##Name##Value(  \
+                                      getOpLocation(Inst->getLoc()),           \
+                                      getOpValue(Inst->getOperand())));        \
+  }
+
+#define LOADABLE_STORAGE_HELPER(Name, name)                                    \
   template <typename ImplClass>                                                \
   void SILCloner<ImplClass>::visitLoad##Name##Inst(Load##Name##Inst *Inst) {   \
     getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));      \
@@ -1441,17 +1451,8 @@ SILCloner<ImplClass>::visitDebugStepInst(DebugStepInst *Inst) {
         Inst, getBuilder().create##Name##ToRef(getOpLocation(Inst->getLoc()),  \
                                                getOpValue(Inst->getOperand()), \
                                                getOpType(Inst->getType())));   \
-  }                                                                            \
-  template <typename ImplClass>                                                \
-  void SILCloner<ImplClass>::visitStrongCopy##Name##ValueInst(                 \
-      StrongCopy##Name##ValueInst *Inst) {                                     \
-    getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));      \
-    recordClonedInstruction(Inst, getBuilder().createStrongCopy##Name##Value(  \
-                                      getOpLocation(Inst->getLoc()),           \
-                                      getOpValue(Inst->getOperand())));        \
   }
-#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...)                   \
-  LOADABLE_REF_STORAGE_HELPER(Name, name)                                      \
+#define RETAINABLE_STORAGE_HELPER(Name, name)                                  \
   template <typename ImplClass>                                                \
   void SILCloner<ImplClass>::visitStrongRetain##Name##Inst(                    \
       StrongRetain##Name##Inst *Inst) {                                        \
@@ -1478,13 +1479,26 @@ SILCloner<ImplClass>::visitDebugStepInst(DebugStepInst *Inst) {
                                       getOpValue(Inst->getOperand()),          \
                                       Inst->getAtomicity()));                  \
   }
-#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
-  NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, "...") \
-  ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, name, "...")
-#define UNCHECKED_REF_STORAGE(Name, name, ...) \
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...)                    \
+  COPYABLE_STORAGE_HELPER(Name, name)                                          \
+  LOADABLE_STORAGE_HELPER(Name, name)
+#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...)                   \
+  COPYABLE_STORAGE_HELPER(Name, name)                                          \
+  LOADABLE_REF_STORAGE_HELPER(Name, name)                                      \
+  RETAINABLE_STORAGE_HELPER(Name, name)
+#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...)                \
+  COPYABLE_STORAGE_HELPER(Name, name)                                          \
+  LOADABLE_REF_STORAGE_HELPER(Name, name)                                      \
+  LOADABLE_STORAGE_HELPER(Name, name)                                          \
+  RETAINABLE_STORAGE_HELPER(Name, name)
+#define UNCHECKED_REF_STORAGE(Name, name, ...)                                 \
+  COPYABLE_STORAGE_HELPER(Name, name)                                          \
   LOADABLE_REF_STORAGE_HELPER(Name, name)
 #include "swift/AST/ReferenceStorage.def"
+#undef LOADABLE_STORAGE_HELPER
 #undef LOADABLE_REF_STORAGE_HELPER
+#undef COPYABLE_STORAGE_HELPER
+#undef RETAINABLE_STORAGE_HELPER
 
 template<typename ImplClass>
 void

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1407,6 +1407,14 @@ SILCloner<ImplClass>::visitDebugStepInst(DebugStepInst *Inst) {
   recordClonedInstruction(Inst, getBuilder().createDebugStep(Inst->getLoc()));
 }
 
+template <typename ImplClass>
+void SILCloner<ImplClass>::visitWeakCopyValueInst(WeakCopyValueInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  recordClonedInstruction(
+      Inst, getBuilder().createWeakCopyValue(getOpLocation(Inst->getLoc()),
+                                             getOpValue(Inst->getOperand())));
+}
+
 #define COPYABLE_STORAGE_HELPER(Name, name)                                    \
   template <typename ImplClass>                                                \
   void SILCloner<ImplClass>::visitStrongCopy##Name##ValueInst(                 \

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8098,6 +8098,17 @@ class ExplicitCopyValueInst
       : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {}
 };
 
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  class StrongCopy##Name##ValueInst                                            \
+      : public UnaryInstructionBase<                                           \
+            SILInstructionKind::StrongCopy##Name##ValueInst,                   \
+            SingleValueInstruction> {                                          \
+    friend class SILBuilder;                                                   \
+    StrongCopy##Name##ValueInst(SILDebugLocation DebugLoc, SILValue operand,   \
+                                SILType type)                                  \
+        : UnaryInstructionBase(DebugLoc, operand,                              \
+                               type.getReferenceStorageReferentType()) {}      \
+  };
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   class StrongCopy##Name##ValueInst                                            \
       : public UnaryInstructionBase<                                           \
@@ -8108,7 +8119,6 @@ class ExplicitCopyValueInst
                                 SILType type)                                  \
         : UnaryInstructionBase(DebugLoc, operand, type) {}                     \
   };
-
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
   class StrongCopy##Name##ValueInst                                            \
       : public UnaryInstructionBase<                                           \

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8098,6 +8098,17 @@ class ExplicitCopyValueInst
       : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {}
 };
 
+class WeakCopyValueInst
+    : public UnaryInstructionBase<SILInstructionKind::WeakCopyValueInst,
+                                  SingleValueInstruction> {
+  friend class SILBuilder;
+  WeakCopyValueInst(SILDebugLocation DebugLoc, SILValue operand, SILType type)
+      : UnaryInstructionBase(DebugLoc, operand, type) {
+    assert(type.getReferenceStorageOwnership() == ReferenceOwnership::Weak);
+    assert(type.getReferenceStorageReferentType() == operand->getType());
+  }
+};
+
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
   class StrongCopy##Name##ValueInst                                            \
       : public UnaryInstructionBase<                                           \

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -453,10 +453,7 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // alone by OSSA optimizations.
   SINGLE_VALUE_INST(ExplicitCopyValueInst, explicit_copy_value,
                     SingleValueInstruction, None, DoesNotRelease)
-#define UNCHECKED_REF_STORAGE(Name, name, ...) \
-  SINGLE_VALUE_INST(StrongCopy##Name##ValueInst, strong_copy_##name##_value, \
-                    SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
+#define REF_STORAGE(Name, name, ...) \
   SINGLE_VALUE_INST(StrongCopy##Name##ValueInst, strong_copy_##name##_value, \
                     SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
 #include "swift/AST/ReferenceStorage.def"

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -453,6 +453,8 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // alone by OSSA optimizations.
   SINGLE_VALUE_INST(ExplicitCopyValueInst, explicit_copy_value,
                     SingleValueInstruction, None, DoesNotRelease)
+  SINGLE_VALUE_INST(WeakCopyValueInst, weak_copy_value,
+                    SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
 #define REF_STORAGE(Name, name, ...) \
   SINGLE_VALUE_INST(StrongCopy##Name##ValueInst, strong_copy_##name##_value, \
                     SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1503,6 +1503,7 @@ public:
 
   void visitHasSymbolInst(HasSymbolInst *i);
 
+  void visitWeakCopyValueInst(swift::WeakCopyValueInst *i);
 #define LOADABLE_REF_STORAGE_HELPER(Name)                                      \
   void visitRefTo##Name##Inst(RefTo##Name##Inst *i);                           \
   void visit##Name##ToRefInst(Name##ToRefInst *i);
@@ -5354,6 +5355,10 @@ void IRGenSILFunction::visitStrongCopyWeakValueInst(
     swift::StrongCopyWeakValueInst *i) {
   llvm::report_fatal_error(
       "strong_copy_weak_value not lowered by AddressLowering!?");
+}
+
+void IRGenSILFunction::visitWeakCopyValueInst(swift::WeakCopyValueInst *i) {
+  llvm::report_fatal_error("weak_copy_value not lowered by AddressLowering!?");
 }
 
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1505,23 +1505,35 @@ public:
 
 #define LOADABLE_REF_STORAGE_HELPER(Name)                                      \
   void visitRefTo##Name##Inst(RefTo##Name##Inst *i);                           \
-  void visit##Name##ToRefInst(Name##ToRefInst *i);                             \
+  void visit##Name##ToRefInst(Name##ToRefInst *i);
+#define COPYABLE_STORAGE_HELPER(Name)                                          \
   void visitStrongCopy##Name##ValueInst(StrongCopy##Name##ValueInst *i);
-#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  void visitLoad##Name##Inst(Load##Name##Inst *i); \
+#define LOADABLE_STORAGE_HELPER(Name)                                          \
+  void visitLoad##Name##Inst(Load##Name##Inst *i);                             \
   void visitStore##Name##Inst(Store##Name##Inst *i);
-#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
-  LOADABLE_REF_STORAGE_HELPER(Name)                                            \
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  LOADABLE_STORAGE_HELPER(Name)                                                \
+  COPYABLE_STORAGE_HELPER(Name)
+#define RETAINABLE_STORAGE_HELPER(Name)                                        \
   void visitStrongRetain##Name##Inst(StrongRetain##Name##Inst *i);             \
   void visit##Name##RetainInst(Name##RetainInst *i);                           \
   void visit##Name##ReleaseInst(Name##ReleaseInst *i);
-#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, "...") \
-  ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, "...")
-#define UNCHECKED_REF_STORAGE(Name, ...) \
+#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
+  LOADABLE_REF_STORAGE_HELPER(Name)                                            \
+  RETAINABLE_STORAGE_HELPER(Name)
+#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
+  LOADABLE_STORAGE_HELPER(Name)                                                \
+  COPYABLE_STORAGE_HELPER(Name)                                                \
+  LOADABLE_REF_STORAGE_HELPER(Name)                                            \
+  RETAINABLE_STORAGE_HELPER(Name)
+#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+  COPYABLE_STORAGE_HELPER(Name)                                                \
   LOADABLE_REF_STORAGE_HELPER(Name)
 #include "swift/AST/ReferenceStorage.def"
 #undef LOADABLE_REF_STORAGE_HELPER
+#undef LOADABLE_STORAGE_HELPER
+#undef COPYABLE_STORAGE_HELPER
+#undef RETAINABLE_STORAGE_HELPER
 };
 
 } // end anonymous namespace
@@ -5336,6 +5348,12 @@ static const ReferenceTypeInfo &getReferentTypeInfo(IRGenFunction &IGF,
   if (auto ty = type->getOptionalObjectType())
     type = ty->getCanonicalType();
   return cast<ReferenceTypeInfo>(IGF.getTypeInfoForLowered(type));
+}
+
+void IRGenSILFunction::visitStrongCopyWeakValueInst(
+    swift::StrongCopyWeakValueInst *i) {
+  llvm::report_fatal_error(
+      "strong_copy_weak_value not lowered by AddressLowering!?");
 }
 
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -220,6 +220,7 @@ OPERAND_OWNERSHIP(InstantaneousUse, ClassMethod)
 OPERAND_OWNERSHIP(InstantaneousUse, SuperMethod)
 OPERAND_OWNERSHIP(InstantaneousUse, ClassifyBridgeObject)
 OPERAND_OWNERSHIP(InstantaneousUse, SetDeallocating)
+OPERAND_OWNERSHIP(InstantaneousUse, WeakCopyValue)
 #define REF_STORAGE(Name, ...)                                                 \
   OPERAND_OWNERSHIP(InstantaneousUse, StrongCopy##Name##Value)
 #include "swift/AST/ReferenceStorage.def"

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -220,9 +220,7 @@ OPERAND_OWNERSHIP(InstantaneousUse, ClassMethod)
 OPERAND_OWNERSHIP(InstantaneousUse, SuperMethod)
 OPERAND_OWNERSHIP(InstantaneousUse, ClassifyBridgeObject)
 OPERAND_OWNERSHIP(InstantaneousUse, SetDeallocating)
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
-  OPERAND_OWNERSHIP(InstantaneousUse, StrongCopy##Name##Value)
-#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+#define REF_STORAGE(Name, ...)                                                 \
   OPERAND_OWNERSHIP(InstantaneousUse, StrongCopy##Name##Value)
 #include "swift/AST/ReferenceStorage.def"
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2141,6 +2141,10 @@ public:
     *this << getIDAndType(I->getOperand());
   }
 
+  void visitWeakCopyValueInst(WeakCopyValueInst *I) {
+    *this << getIDAndType(I->getOperand());
+  }
+
 #define REF_STORAGE(Name, ...)                                                 \
   void visitStrongCopy##Name##ValueInst(StrongCopy##Name##ValueInst *I) {      \
     *this << getIDAndType(I->getOperand());                                    \

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2141,12 +2141,7 @@ public:
     *this << getIDAndType(I->getOperand());
   }
 
-#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
-  void visitStrongCopy##Name##ValueInst(StrongCopy##Name##ValueInst *I) {      \
-    *this << getIDAndType(I->getOperand());                                    \
-  }
-
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
+#define REF_STORAGE(Name, ...)                                                 \
   void visitStrongCopy##Name##ValueInst(StrongCopy##Name##ValueInst *I) {      \
     *this << getIDAndType(I->getOperand());                                    \
   }

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -49,15 +49,18 @@ public:
     return OwnershipKind::OWNERSHIP;                                           \
   }
 
-#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  CONSTANT_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)                      \
   CONSTANT_OWNERSHIP_INST(Owned, Load##Name)
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
   CONSTANT_OWNERSHIP_INST(Unowned, RefTo##Name)                                \
   CONSTANT_OWNERSHIP_INST(Unowned, Name##ToRef)                                \
   CONSTANT_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)
-#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, "...") \
-  ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, "...")
+#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
+  CONSTANT_OWNERSHIP_INST(Owned, Load##Name)                                   \
+  CONSTANT_OWNERSHIP_INST(Unowned, RefTo##Name)                                \
+  CONSTANT_OWNERSHIP_INST(Unowned, Name##ToRef)                                \
+  CONSTANT_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   CONSTANT_OWNERSHIP_INST(None, RefTo##Name)                                   \
   CONSTANT_OWNERSHIP_INST(Unowned, Name##ToRef)                                \

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -49,6 +49,7 @@ public:
     return OwnershipKind::OWNERSHIP;                                           \
   }
 
+CONSTANT_OWNERSHIP_INST(Owned, WeakCopyValue)
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
   CONSTANT_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)                      \
   CONSTANT_OWNERSHIP_INST(Owned, Load##Name)

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3646,6 +3646,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     REFCOUNTING_INSTRUCTION(RetainValue)
     REFCOUNTING_INSTRUCTION(ReleaseValueAddr)
     REFCOUNTING_INSTRUCTION(RetainValueAddr)
+    UNARY_INSTRUCTION(WeakCopyValue)
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   UNARY_INSTRUCTION(StrongCopy##Name##Value)
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3648,6 +3648,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     REFCOUNTING_INSTRUCTION(RetainValueAddr)
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   UNARY_INSTRUCTION(StrongCopy##Name##Value)
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  UNARY_INSTRUCTION(StrongCopy##Name##Value)
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
   REFCOUNTING_INSTRUCTION(StrongRetain##Name)                                  \
   REFCOUNTING_INSTRUCTION(Name##Retain)                                        \

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -848,6 +848,8 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
 #include "swift/AST/ReferenceStorage.def"
 #undef ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE
 
+  case SILInstructionKind::WeakCopyValueInst:
+    return RuntimeEffect::RefCounting;
 #define REF_STORAGE(Name, ...)                                                 \
   case SILInstructionKind::StrongCopy##Name##ValueInst:                        \
     return RuntimeEffect::RefCounting;

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -848,10 +848,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
 #include "swift/AST/ReferenceStorage.def"
 #undef ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE
 
-#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
-  case SILInstructionKind::StrongCopy##Name##ValueInst:                        \
-    return RuntimeEffect::RefCounting;
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
+#define REF_STORAGE(Name, ...)                                                 \
   case SILInstructionKind::StrongCopy##Name##ValueInst:                        \
     return RuntimeEffect::RefCounting;
 #include "swift/AST/ReferenceStorage.def"

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2975,6 +2975,13 @@ public:
             "'MoveOnly' types can only be copied in Raw SIL?!");
   }
 
+  void checkStrongCopyWeakValueInst(StrongCopyWeakValueInst *I) {
+    require(!F.getModule().useLoweredAddresses(),
+            "strong_copy_weak_value is only valid in opaque values");
+    require(I->getOperand()->getType().isAddressOnly(F),
+            "strong_copy_weak_value requires an address-only operand");
+  }
+
   void checkExplicitCopyValueInst(ExplicitCopyValueInst *I) {
     require(F.hasOwnership(), "explicit_copy_* is only valid in OSSA.");
     require(I->getOperand()->getType().isObject(),

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2975,6 +2975,13 @@ public:
             "'MoveOnly' types can only be copied in Raw SIL?!");
   }
 
+  void checkWeakCopyValueInst(WeakCopyValueInst *I) {
+    require(!F.getModule().useLoweredAddresses(),
+            "weak_copy_value is only valid in opaque values");
+    require(I->getType().isAddressOnly(F),
+            "weak_copy_value must produce an address-only value");
+  }
+
   void checkStrongCopyWeakValueInst(StrongCopyWeakValueInst *I) {
     require(!F.getModule().useLoweredAddresses(),
             "strong_copy_weak_value is only valid in opaque values");

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2798,8 +2798,12 @@ public:
     requireReferenceStorageCapableValue(I->getOperand(),                       \
                                         "Operand of ref_to_" #name);           \
     auto operandType = I->getOperand()->getType().getASTType();                \
+    require(!I->getOperand()->getType().isAddressOnly(F),                      \
+            "ref_to_" #name " may not take an address-only operand");          \
     auto resultType =                                                          \
         requireObjectType(Name##StorageType, I, "Result of ref_to_" #name);    \
+    require(!I->getType().isAddressOnly(F),                                    \
+            "ref_to_" #name " must not produce an address-only value");        \
     requireSameType(resultType.getReferentType(), operandType,                 \
                     "Result of ref_to_" #name " does not have the "            \
                     "operand's type as its referent type");                    \
@@ -2807,8 +2811,12 @@ public:
   void check##Name##ToRefInst(Name##ToRefInst *I) {                            \
     auto operandType = requireObjectType(Name##StorageType, I->getOperand(),   \
                                          "Operand of " #name "_to_ref");       \
+    require(!I->getOperand()->getType().isAddressOnly(F),                      \
+            #name "_to_ref may not take an address-only operand");             \
     requireReferenceStorageCapableValue(I, "Result of " #name "_to_ref");      \
     auto resultType = I->getType().getASTType();                               \
+    require(!I->getType().isAddressOnly(F),                                    \
+            #name "_to_ref may not produce an address-only value");            \
     requireSameType(operandType.getReferentType(), resultType,                 \
                     "Operand of " #name "_to_ref does not have the "           \
                     "operand's type as its referent type");                    \

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -175,6 +175,18 @@ ManagedValue SILGenBuilder::createCopyValue(SILLocation loc,
   return SGF.emitManagedRValueWithCleanup(result, lowering);
 }
 
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  ManagedValue SILGenBuilder::createStrongCopy##Name##Value(                   \
+      SILLocation loc, ManagedValue originalValue) {                           \
+    assert(!SGF.useLoweredAddresses());                                        \
+    auto ty = originalValue.getType();                                         \
+    assert(ty.isAddressOnly(SGF.F));                                           \
+    auto storageTy = originalValue.getType().castTo<Name##StorageType>();      \
+    (void)storageTy;                                                           \
+    SILValue result =                                                          \
+        createStrongCopy##Name##Value(loc, originalValue.getValue());          \
+    return SGF.emitManagedRValueWithCleanup(result);                           \
+  }
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
   ManagedValue SILGenBuilder::createStrongCopy##Name##Value(                   \
       SILLocation loc, ManagedValue originalValue) {                           \

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -132,6 +132,10 @@ public:
   /// values.
   ManagedValue createExplicitCopyValue(SILLocation Loc, ManagedValue operand);
 
+  using SILBuilder::createWeakCopyValue;
+
+  ManagedValue createWeakCopyValue(SILLocation loc, ManagedValue originalValue);
+
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
   using SILBuilder::createStrongCopy##Name##Value;                             \
   ManagedValue createStrongCopy##Name##Value(SILLocation loc,                  \

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -132,6 +132,10 @@ public:
   /// values.
   ManagedValue createExplicitCopyValue(SILLocation Loc, ManagedValue operand);
 
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  using SILBuilder::createStrongCopy##Name##Value;                             \
+  ManagedValue createStrongCopy##Name##Value(SILLocation loc,                  \
+                                             ManagedValue originalValue);
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
   using SILBuilder::createStrongCopy##Name##Value;                             \
   ManagedValue createStrongCopy##Name##Value(SILLocation loc,                  \

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -210,6 +210,7 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:
   case SILInstructionKind::MoveOnlyWrapperToCopyableValueInst:
+  case SILInstructionKind::WeakCopyValueInst:
 #define REF_STORAGE(Name, ...)                                                 \
   case SILInstructionKind::StrongCopy##Name##ValueInst:
 #include "swift/AST/ReferenceStorage.def"

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -210,13 +210,9 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:
   case SILInstructionKind::MoveOnlyWrapperToCopyableValueInst:
-#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
-  case SILInstructionKind::StrongCopy##Name##ValueInst:
-#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
+#define REF_STORAGE(Name, ...)                                                 \
   case SILInstructionKind::StrongCopy##Name##ValueInst:
 #include "swift/AST/ReferenceStorage.def"
-#undef UNCHECKED_REF_STORAGE
-#undef ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE
   case SILInstructionKind::UncheckedOwnershipConversionInst:
   case SILInstructionKind::IsUniqueInst:
   case SILInstructionKind::IsEscapingClosureInst:

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -1126,17 +1126,19 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::Name##ToRefInst:                                    \
   case SILInstructionKind::RefTo##Name##Inst:                                  \
   case SILInstructionKind::StrongCopy##Name##ValueInst:
-#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  case SILInstructionKind::Load##Name##Inst: \
-  case SILInstructionKind::Store##Name##Inst:
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  case SILInstructionKind::Load##Name##Inst:                                   \
+  case SILInstructionKind::Store##Name##Inst:                                  \
+  case SILInstructionKind::StrongCopy##Name##ValueInst:
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
   COMMON_ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name)                \
   case SILInstructionKind::Name##RetainInst:                                   \
   case SILInstructionKind::Name##ReleaseInst:                                  \
   case SILInstructionKind::StrongRetain##Name##Inst:
-#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, "...") \
-  ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, "...")
+#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
+  case SILInstructionKind::Load##Name##Inst:                                   \
+  case SILInstructionKind::Store##Name##Inst:                                  \
+    ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, "...")
 #define UNCHECKED_REF_STORAGE(Name, ...) \
   COMMON_ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name)
 #include "swift/AST/ReferenceStorage.def"

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -1122,6 +1122,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::HopToExecutorInst:
   case SILInstructionKind::ExtractExecutorInst:
   case SILInstructionKind::HasSymbolInst:
+  case SILInstructionKind::WeakCopyValueInst:
 #define COMMON_ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name)          \
   case SILInstructionKind::Name##ToRefInst:                                    \
   case SILInstructionKind::RefTo##Name##Inst:                                  \

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2089,6 +2089,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   REFCOUNTING_INSTRUCTION(Name##Release)                                       \
   REFCOUNTING_INSTRUCTION(StrongRetain##Name)                                  \
   UNARY_INSTRUCTION(StrongCopy##Name##Value)
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  UNARY_INSTRUCTION(StrongCopy##Name##Value)
 #include "swift/AST/ReferenceStorage.def"
   REFCOUNTING_INSTRUCTION(RetainValue)
   REFCOUNTING_INSTRUCTION(RetainValueAddr)

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2082,6 +2082,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         (Atomicity)Attr);                                                      \
     break;
 
+    UNARY_INSTRUCTION(WeakCopyValue)
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   UNARY_INSTRUCTION(StrongCopy##Name##Value)
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 797; // checked_cast_br takes a formal type
+const uint16_t SWIFTMODULE_VERSION_MINOR = 798; // added strong_copy_weak_value
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 798; // added strong_copy_weak_value
+const uint16_t SWIFTMODULE_VERSION_MINOR = 799; // added weak_copy_value
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1444,16 +1444,20 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   case SILInstructionKind::StrongCopy##Name##ValueInst:
-#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
+  case SILInstructionKind::StrongCopy##Name##ValueInst:                        \
   case SILInstructionKind::Load##Name##Inst:
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
   case SILInstructionKind::Name##RetainInst:                                   \
   case SILInstructionKind::Name##ReleaseInst:                                  \
   case SILInstructionKind::StrongRetain##Name##Inst:                           \
   case SILInstructionKind::StrongCopy##Name##ValueInst:
-#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, "...") \
-  ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, "...")
+#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
+  case SILInstructionKind::Load##Name##Inst:                                   \
+  case SILInstructionKind::Name##RetainInst:                                   \
+  case SILInstructionKind::Name##ReleaseInst:                                  \
+  case SILInstructionKind::StrongRetain##Name##Inst:                           \
+  case SILInstructionKind::StrongCopy##Name##ValueInst:
 #include "swift/AST/ReferenceStorage.def"
   case SILInstructionKind::RetainValueInst:
   case SILInstructionKind::DestructureStructInst:

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1442,6 +1442,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         ListOfValues);
     break;
   }
+  case SILInstructionKind::WeakCopyValueInst:
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   case SILInstructionKind::StrongCopy##Name##ValueInst:
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \

--- a/test/SIL/Parser/opaque_values_parse.sil
+++ b/test/SIL/Parser/opaque_values_parse.sil
@@ -114,3 +114,17 @@ bb0(%instance : @guaranteed $WeakBox<T>):
   %strong_optional = strong_copy_weak_value %weak_optional : $@sil_weak Optional<T>
   return %strong_optional : $Optional<T>
 }
+
+// Test weak_copy_value parsing.
+
+// CHECK-LABEL: sil [ossa] @test_weak_copy_value_1 : {{.*}} {
+// CHECK:       bb0([[VALUE:%[^,]+]] :
+// CHECK:         weak_copy_value [[VALUE]]
+// CHECK-LABEL: } // end sil function 'test_weak_copy_value_1'
+sil [ossa] @test_weak_copy_value_1 : $@convention(thin) <T where T : AnyObject> (@owned Optional<T>) -> @out WeakBox<T> {
+bb0(%value : @owned $Optional<T>):
+  %weak_value = weak_copy_value %value : $Optional<T>
+  destroy_value %value : $Optional<T>
+  %retval = struct $WeakBox<T> (%weak_value : $@sil_weak Optional<T>)
+  return %retval : $WeakBox<T>
+}

--- a/test/SIL/Parser/opaque_values_parse.sil
+++ b/test/SIL/Parser/opaque_values_parse.sil
@@ -96,3 +96,21 @@ bb0(%0 : $S):
   return %t : $()
 }
 // CHECK-LABEL: } // end sil function 'parse_mutating'
+
+struct WeakBox<T : AnyObject> {
+  weak var t: T?
+}
+
+// Test strong_copy_weak_value parsing.
+
+// CHECK-LABEL: sil [ossa] @test_strong_copy_weak_value : {{.*}} {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         [[WEAK_OPTIONAL:%[^,]+]] = struct_extract [[INSTANCE]]
+// CHECK:         strong_copy_weak_value [[WEAK_OPTIONAL]]
+// CHECK-LABEL: } // end sil function 'test_strong_copy_weak_value'
+sil [ossa] @test_strong_copy_weak_value : $@convention(thin) <T where T : AnyObject> (@in_guaranteed WeakBox<T>) -> @owned Optional<T> {
+bb0(%instance : @guaranteed $WeakBox<T>):
+  %weak_optional = struct_extract %instance : $WeakBox<T>, #WeakBox.t
+  %strong_optional = strong_copy_weak_value %weak_optional : $@sil_weak Optional<T>
+  return %strong_optional : $Optional<T>
+}

--- a/test/SIL/Serialization/opaque_values_serialize.sil
+++ b/test/SIL/Serialization/opaque_values_serialize.sil
@@ -82,3 +82,19 @@ bb0(%0 : $S):
   return %t : $()
 }
 // CHECK-LABEL: } // end sil function 'serialize_mutating'
+
+struct WeakBox<T : AnyObject> {
+  weak var t: T?
+}
+
+// CHECK-LABEL: sil [ossa] @test_strong_copy_weak_value : {{.*}} {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         [[WEAK_OPTIONAL:%[^,]+]] = struct_extract [[INSTANCE]]
+// CHECK:         strong_copy_weak_value [[WEAK_OPTIONAL]]
+// CHECK-LABEL: } // end sil function 'test_strong_copy_weak_value'
+sil [ossa] @test_strong_copy_weak_value : $@convention(thin) <T where T : AnyObject> (@in_guaranteed WeakBox<T>) -> @owned Optional<T> {
+bb0(%instance : @guaranteed $WeakBox<T>):
+  %weak_optional = struct_extract %instance : $WeakBox<T>, #WeakBox.t
+  %strong_optional = strong_copy_weak_value %weak_optional : $@sil_weak Optional<T>
+  return %strong_optional : $Optional<T>
+}

--- a/test/SIL/Serialization/opaque_values_serialize.sil
+++ b/test/SIL/Serialization/opaque_values_serialize.sil
@@ -98,3 +98,15 @@ bb0(%instance : @guaranteed $WeakBox<T>):
   %strong_optional = strong_copy_weak_value %weak_optional : $@sil_weak Optional<T>
   return %strong_optional : $Optional<T>
 }
+
+// CHECK-LABEL: sil [ossa] @test_weak_copy_value_1 : {{.*}} {
+// CHECK:       bb0([[VALUE:%[^,]+]] :
+// CHECK:         weak_copy_value [[VALUE]]
+// CHECK-LABEL: } // end sil function 'test_weak_copy_value_1'
+sil [ossa] @test_weak_copy_value_1 : $@convention(thin) <T where T : AnyObject> (@owned Optional<T>) -> @out WeakBox<T> {
+bb0(%value : @owned $Optional<T>):
+  %weak_value = weak_copy_value %value : $Optional<T>
+  destroy_value %value : $Optional<T>
+  %retval = struct $WeakBox<T> (%weak_value : $@sil_weak Optional<T>)
+  return %retval : $WeakBox<T>
+}

--- a/test/SIL/cloning_opaque_values.sil
+++ b/test/SIL/cloning_opaque_values.sil
@@ -28,3 +28,26 @@ bb0(%instance : @guaranteed $WeakBox<T>):
   %strong_optional = strong_copy_weak_value %weak_optional : $@sil_weak Optional<T>
   return %strong_optional : $Optional<T>
 }
+
+// CHECK-LABEL: sil [ossa] @weak_copy_value_caller : {{.*}} {
+// CHECK:       bb0([[STRONG_OPTIONAL:%[^,]+]] :
+// CHECK:         [[WEAK_OPTIONAL:%[^,]+]] = weak_copy_value [[STRONG_OPTIONAL]]
+// CHECK:         destroy_value [[STRONG_OPTIONAL]]
+// CHECK:         [[RETVAL:%[^,]+]] = struct $WeakBox<T> ([[WEAK_OPTIONAL]] :
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'weak_copy_value_caller'
+sil [ossa] @weak_copy_value_caller : $@convention(thin) <T where T : AnyObject> (@owned Optional<T>) -> @out WeakBox<T> {
+bb0(%value : @owned $Optional<T>):
+  %callee = function_ref @weak_copy_value : $@convention(thin) <T where T : AnyObject> (@owned Optional<T>) -> @out WeakBox<T>
+  %retval = apply %callee<T>(%value) : $@convention(thin) <T where T : AnyObject> (@owned Optional<T>) -> @out WeakBox<T>
+  return %retval : $WeakBox<T>
+}
+
+sil [always_inline] [ossa] @weak_copy_value : $@convention(thin) <T where T : AnyObject> (@owned Optional<T>) -> @out WeakBox<T> {
+bb0(%value : @owned $Optional<T>):
+  %weak_value = weak_copy_value %value : $Optional<T>
+  destroy_value %value : $Optional<T>
+  %retval = struct $WeakBox<T> (%weak_value : $@sil_weak Optional<T>)
+  return %retval : $WeakBox<T>
+}
+

--- a/test/SIL/cloning_opaque_values.sil
+++ b/test/SIL/cloning_opaque_values.sil
@@ -1,0 +1,30 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-sil-opaque-values -inline %s | %FileCheck %s
+
+// Check cloning of instructions that are only legal in opaque values mode.
+
+import Swift
+
+struct WeakBox<T : AnyObject> {
+  weak var t: T?
+}
+
+
+// CHECK-LABEL: sil [ossa] @strong_copy_weak_value_caller : {{.*}} {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         [[WEAK_OPTIONAL:%[^,]+]] = struct_extract [[INSTANCE]]
+// CHECK:         [[STRONG_OPTIONAL:%[^,]+]] = strong_copy_weak_value [[WEAK_OPTIONAL]]
+// CHECK:         return [[STRONG_OPTIONAL]]
+// CHECK-LABEL: } // end sil function 'strong_copy_weak_value_caller'
+sil [ossa] @strong_copy_weak_value_caller : $@convention(thin) <T where T : AnyObject> (@in_guaranteed WeakBox<T>) -> @owned Optional<T> {
+bb0(%instance : @guaranteed $WeakBox<T>):
+  %callee = function_ref @strong_copy_weak_value : $@convention(thin) <T where T : AnyObject> (@in_guaranteed WeakBox<T>) -> @owned Optional<T>
+  %retval = apply %callee<T>(%instance) : $@convention(thin) <T where T : AnyObject> (@in_guaranteed WeakBox<T>) -> @owned Optional<T>
+  return %retval : $Optional<T>
+}
+
+sil [always_inline] [ossa] @strong_copy_weak_value : $@convention(thin) <T where T : AnyObject> (@in_guaranteed WeakBox<T>) -> @owned Optional<T> {
+bb0(%instance : @guaranteed $WeakBox<T>):
+  %weak_optional = struct_extract %instance : $WeakBox<T>, #WeakBox.t
+  %strong_optional = strong_copy_weak_value %weak_optional : $@sil_weak Optional<T>
+  return %strong_optional : $Optional<T>
+}

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -Xllvm -sil-full-demangle -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 // Test SILGen -enable-sil-opaque-values with tests that depend on the stdlib.
 
@@ -742,4 +742,21 @@ protocol MutatingFooable {
 @_silgen_name("callMutatingFooOnInoutExistential")
 func callMutatingFooOnInoutExistential(_ i: inout any MutatingFooable) {
   i.foo()
+}
+
+// CHECK-LABEL: sil {{.*}}[ossa] @$s20opaque_values_silgen7WeakBoxV1txSgvg : {{.*}} {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         [[WEAK_OPTIONAL:%[^,]+]] = struct_extract [[INSTANCE]]
+// CHECK:         [[STRONG_OPTIONAL:%[^,]+]] = strong_copy_weak_value [[WEAK_OPTIONAL]]
+// CHECK:         return [[STRONG_OPTIONAL]]
+// CHECK-LABEL: } // end sil function '$s20opaque_values_silgen7WeakBoxV1txSgvg'
+// CHECK-LABEL: sil {{.*}}[ossa] @$s20opaque_values_silgen7WeakBoxV1tACyxGxSg_tcfC : {{.*}} {
+// CHECK:       bb0([[STRONG_OPTIONAL:%[^,]+]] :
+// CHECK:         [[WEAK_OPTIONAL:%[^,]+]] = weak_copy_value [[STRONG_OPTIONAL]]
+// CHECK:         destroy_value [[STRONG_OPTIONAL]]
+// CHECK:         [[INSTANCE:%[^,]+]] = struct $WeakBox<T> ([[WEAK_OPTIONAL]] :
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function '$s20opaque_values_silgen7WeakBoxV1tACyxGxSg_tcfC'
+struct WeakBox<T : AnyObject> {
+  weak var t: T?
 }

--- a/test/SILOptimizer/address_lowering_lib.sil
+++ b/test/SILOptimizer/address_lowering_lib.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -address-lowering -enable-sil-opaque-values -sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -address-lowering -emit-sorted-sil -enable-sil-opaque-values -sil-verify-all %s | %FileCheck %s
 //
 import Builtin
 import Swift
@@ -28,4 +28,35 @@ bb0(%0 : @owned $Error):
   destroy_value %0 : $Error
   %ret = tuple ()
   return %ret : $()
+}
+
+struct WeakBox<T : AnyObject> {
+  weak var t: T?
+}
+
+// CHECK-LABEL: sil [ossa] @test_strong_copy_weak_value : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[BOX_ADDR:%[^,]+]] :
+// CHECK:         [[VALUE_ADDR:%[^,]+]] = struct_element_addr [[BOX_ADDR]] : {{.*}}, #WeakBox.t
+// CHECK:         [[VALUE:%[^,]+]] = load_weak [[VALUE_ADDR]] : $*@sil_weak Optional<T>
+// CHECK:         return [[VALUE]] : $Optional<T>
+// CHECK-LABEL: } // end sil function 'test_strong_copy_weak_value'
+sil [ossa] @test_strong_copy_weak_value : $@convention(thin) <T where T : AnyObject> (@in_guaranteed WeakBox<T>) -> @owned Optional<T> {
+bb0(%instance : @guaranteed $WeakBox<T>):
+  %weak_optional = struct_extract %instance : $WeakBox<T>, #WeakBox.t
+  %strong_optional = strong_copy_weak_value %weak_optional : $@sil_weak Optional<T>
+  return %strong_optional : $Optional<T>
+}
+
+// CHECK-LABEL: sil [ossa] @test_weak_copy_value_1 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[RETVAL:%[^,]+]] : $*WeakBox<T>, [[VALUE:%[^,]+]] :
+// CHECK:         [[VALUE_ADDR:%[^,]+]] = struct_element_addr [[RETVAL]] : {{.*}}, #WeakBox.t
+// CHECK:         store_weak [[VALUE]] to [init] [[VALUE_ADDR]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK-LABEL: } // end sil function 'test_weak_copy_value_1'
+sil [ossa] @test_weak_copy_value_1 : $@convention(thin) <T where T : AnyObject> (@owned Optional<T>) -> @out WeakBox<T> {
+bb0(%value : @owned $Optional<T>):
+  %weak_value = weak_copy_value %value : $Optional<T>
+  destroy_value %value : $Optional<T>
+  %retval = struct $WeakBox<T> (%weak_value : $@sil_weak Optional<T>)
+  return %retval : $WeakBox<T>
 }


### PR DESCRIPTION
Introduce two new instructions:
- `strong_copy_weak_value`
- `weak_copy_value`

These are transformed by AddressLowering to, respectively:
- `load_weak`
- `store_weak`

The effect of `strong_copy_weak_value %o : $@sil_weak Optional<T>` is to
increment the strong reference count of the value in the `.some` if any.

The effect of `weak_copy_value %o : $Optional<T>` is to increment the weak
reference count of the value in the `.some` case if any.
