### PR TITLE
[Compile Time Constant Extraction] Map types with archetypes out of context, before mangling them for printing.

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -85,7 +85,10 @@ std::string toFullyQualifiedProtocolNameString(const swift::ProtocolDecl &Protoc
 }
 
 std::string toMangledTypeNameString(const swift::Type &Type) {
-  return Mangle::ASTMangler().mangleTypeWithoutPrefix(Type->getCanonicalType());
+  auto PrintingType = Type;
+  if (Type->hasArchetype())
+    PrintingType = Type->mapTypeOutOfContext();
+  return Mangle::ASTMangler().mangleTypeWithoutPrefix(PrintingType->getCanonicalType());
 }
 
 } // namespace

--- a/test/ConstExtraction/ExtractArchetype.swift
+++ b/test/ConstExtraction/ExtractArchetype.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractEnums.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractEnums.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+
+public struct Foo {
+    init(bar: Any) {
+    }
+}
+
+public struct ArchetypalConformance<T>: MyProto {
+    let baz: Foo = Foo(bar: T.self)
+    public init() {}
+}
+
+// CHECK: [
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractArchetype.ArchetypalConformance<T>"
+// CHECK:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractArchetype.Foo",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "bar",
+// CHECK-NEXT:              "type": "Any",
+// CHECK-NEXT:              "valueKind": "Type",
+// CHECK-NEXT:              "value": {
+// CHECK-NEXT:                "type": "T",
+// CHECK-NEXT:                "mangledName": "x"
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }


### PR DESCRIPTION
Matching logic in the ASTPrinter. Otherwise we attempt to mangle types with archetypes in them, which cannot be done, and causes the compiler to crash.

Resolves rdar://113039215
