### PR TITLE
[stdlib] [U]Int.bitWidth: Use MemoryLayout<Self>.size instead of a direct integer constant

### DIFF
--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1362,7 +1362,16 @@ ${assignmentOperatorComment(x.operator, True)}
   /// The bit width of ${Article.lower()} `${Self}` instance is ${bits}.
 %   end
   @_transparent
-  public static var bitWidth: Int { return ${bits} }
+  public static var bitWidth: Int {
+    % if self_type.is_word:
+    // Note: This is intentionally not returning a direct integer constant, to
+    // avoid compiler warnings about `Int.bitWidth == 32` conditions always
+    // evaluating to false.
+    return MemoryLayout<$Self>.size * 8
+    % else:
+    return ${bits}
+    % end
+  }
 
   /// The number of leading zeros in this value's binary representation.
   ///

--- a/test/stdlib/IntegerDiagnostics.swift
+++ b/test/stdlib/IntegerDiagnostics.swift
@@ -4,3 +4,15 @@ func signedBitPattern() {
   _ = Int64(bitPattern: 0.0) // expected-error {{Please use Int64(bitPattern: UInt64) in combination with Double.bitPattern property.}}
   _ = Int32(bitPattern: 0.0) // expected-error {{Please use Int32(bitPattern: UInt32) in combination with Float.bitPattern property.}}
 }
+
+func bitWidthConstants() {
+  // Int64 has the same size everywhere.
+  if Int64.bitWidth == 32 { // expected-note {{condition always evaluates to false}}
+    print("1") // expected-warning {{will never be executed}}
+  }
+  // The size of Int is variable across platforms, so checking it should not
+  // lead to spurious warnings about dead code.
+  if Int.bitWidth == 32 {
+    print("2") // no warning expected
+  }
+}


### PR DESCRIPTION
This avoids spurious warnings like the one below:

```
let adjective = (Int.bitWidth == 32 ? "cozy" : "spacious")
//                                    ^^^^^^
// warning: will never be executed
// note: condition always evaluates to false
```

rdar://109525235
