### PR TITLE
Experimentally allow for Optional to be parameterized on a noncopyable type.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -228,6 +228,9 @@ EXPERIMENTAL_FEATURE(PlaygroundExtendedCallbacks, true)
 /// Enable the `@_rawLayout` attribute.
 EXPERIMENTAL_FEATURE(RawLayout, true)
 
+/// Enable noncopyable `Optional` types.
+EXPERIMENTAL_FEATURE(NonCopyableOptional, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3467,6 +3467,11 @@ static bool usesFeatureRawLayout(Decl *decl) {
   return decl->getAttrs().hasAttribute<RawLayoutAttr>();
 }
 
+static bool usesFeatureNonCopyableOptional(Decl *decl) {
+  return false;
+  #warning "todo"
+}
+
 static bool hasParameterPacks(Decl *decl) {
   if (auto genericContext = decl->getAsGenericContext()) {
     auto sig = genericContext->getGenericSignature();

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2070,7 +2070,7 @@ LookupConformanceInModuleRequest::evaluate(
       }
     } else if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
       // Only move-only nominals are not Copyable
-      if (nominal->isMoveOnly()) {
+      if (type->isPureMoveOnly()) {
         return ProtocolConformanceRef::forInvalid();
       } else {
         // Specifically do not create a concrete conformance to Copyable. At

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -156,6 +156,11 @@ bool TypeBase::isMarkerExistential() {
 }
 
 bool TypeBase::isPureMoveOnly() {
+  // If `Optional` wraps a move-only type, it is also move-only.
+  if (auto wrappedTy = getOptionalObjectType()) {
+    return wrappedTy->isPureMoveOnly();
+  }
+
   if (auto *nom = getAnyNominal())
     return nom->isMoveOnly();
 
@@ -165,7 +170,7 @@ bool TypeBase::isPureMoveOnly() {
       if (eltTy->isPureMoveOnly())
         return true;
   }
-
+  
   return false;
 }
 

--- a/test/Sema/moveonly_optional.swift
+++ b/test/Sema/moveonly_optional.swift
@@ -1,0 +1,79 @@
+// RUN: %target-swift-frontend -enable-experimental-feature NonCopyableOptional -typecheck -verify %s
+
+struct Butt: ~Copyable {
+    var value: Int
+}
+
+extension Optional {
+    func stillRequiresCopyable() {}
+}
+
+func stillRequiresCopyableGeneric<T>(_: Optional<T>) {} // expected-note* {{}}
+
+extension Optional where Wrapped == Butt {
+    func buttSpecific() {}
+}
+extension Optional<Butt> {
+    func buttSpecific2() {}
+}
+
+func canPassToNongenericOptional(_: borrowing Optional<Butt>) {}
+
+func requiresCopyable<T>(_: T) {} // expected-note* {{}}
+func requiresAny(_: Any) {}
+
+func forgotModifierOnOptionalNoncopyable(
+  x: Butt?, // expected-error{{noncopyable parameter must specify its ownership}} expected-note * {{}}
+  y: Optional<Butt>, // expected-error{{noncopyable parameter must specify its ownership}} expected-note * {{}}
+  z: Butt!, // expected-error{{noncopyable parameter must specify its ownership}} expected-note * {{}}
+  w: Butt?? // expected-error{{noncopyable parameter must specify its ownership}} expected-note * {{}}
+)
+{}
+
+func foo(x: consuming Optional<Butt>,
+         y: consuming Butt?,
+         z: consuming Optional<Butt>,
+         w: consuming Butt!) { // OK to instantiate Optional with a noncopyable type
+    _ = x! // OK to use optional operators
+    _ = x!.value
+    _ = x?.value
+
+    // TODO: special ?? operator
+    //_ = x ?? y
+
+    // OK to match with `if let`
+    if let d = consume y { }
+    guard let e = consume z else { }
+
+    // OK to match with `switch`
+    switch consume w {
+    case .some(let f):
+        break
+
+    case .none:
+        break
+    }
+
+    // Can't call generic methods on Optional or functions that take
+    // generic Optional
+    x.stillRequiresCopyable() // expected-error{{noncopyable type 'Butt' cannot be substituted}}
+    stillRequiresCopyableGeneric(x) // expected-error{{noncopyable type 'Butt' cannot be substituted}}
+
+    // Can call functions constrained to specific type
+    canPassToNongenericOptional(x)
+
+    // TODO: can call extension methods applied specifically to Optional<Noncopyable>
+    //x.buttSpecific()
+    //x.buttSpecific2()
+
+    // TODO: Can use the blessed `take()` method
+    // let g = x.take()
+
+    // Can't pass Optional<MoveOnly> as a generic parameter or existential
+    requiresCopyable(x) // expected-error{{noncopyable type 'Optional<Butt>' cannot be substituted}}
+    requiresAny(x) // expected-error{{noncopyable type 'Optional<Butt>' cannot be converted}}
+
+    // TODO: Can infer a noncopyable type for Optional's generic parameter
+    //let g: Optional = x
+    //let h: Optional = y!
+}


### PR DESCRIPTION
Baseline type checker support to allow for Optional types with noncopyable wrapped types.
