### PR TITLE
[5.9 🍒][Compile Time Constant Extraction] Map types with archetypes out of context, before mangling them for printing.

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -85,7 +85,10 @@ std::string toFullyQualifiedProtocolNameString(const swift::ProtocolDecl &Protoc
 }
 
 std::string toMangledTypeNameString(const swift::Type &Type) {
-  return Mangle::ASTMangler().mangleTypeWithoutPrefix(Type->getCanonicalType());
+  auto PrintingType = Type;
+  if (Type->hasArchetype())
+    PrintingType = Type->mapTypeOutOfContext();
+  return Mangle::ASTMangler().mangleTypeWithoutPrefix(PrintingType->getCanonicalType());
 }
 
 } // namespace

--- a/test/ConstExtraction/ExtractArchetype.swift
+++ b/test/ConstExtraction/ExtractArchetype.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractEnums.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractEnums.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+
+public struct Foo {
+    init(bar: Any) {
+    }
+}
+
+public struct ArchetypalConformance<T>: MyProto {
+    let baz: Foo = Foo(bar: T.self)
+    public init() {}
+}
+
+// CHECK: [
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractArchetype.ArchetypalConformance<T>"
+// CHECK:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractArchetype.Foo",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "bar",
+// CHECK-NEXT:              "type": "Any",
+// CHECK-NEXT:              "valueKind": "Type",
+// CHECK-NEXT:              "value": {
+// CHECK-NEXT:                "type": "T",
+// CHECK-NEXT:                "mangledName": "x"
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/67692
----------------------------------

Matching logic in the ASTPrinter. Otherwise we attempt to mangle types with archetypes in them, which cannot be done, and causes the compiler to crash.

––– CCC Information –––
• Train: Swift 5.9
• Explanation: We have recently made late changes to compile-time metadata extraction from the AST in the compiler, in order to gather additional info about relevant conformances. One such addition is collecting mangled names of conformances’ properties and compile-time-known type values. Extracting mangled type names of such types has an edge case that the code did not cover, specifically mangling types which contain archetypes (generic type parameters). Upon encountering such types and trying to mangle them, the compiler, unfortunately, crashes during extraction. Earlier we attempted to bypass this by [removing mangling of properties altogether](https://github.com/apple/swift/pull/67659), but this was not sufficient to address the overall issue. This change is the general fix which maps archetype-containing types out of their generic context, mapping them to the interface type, before attempting mangling. This is something the code should have been doing all along, as mangling archetypes is impossible.
• Scope of Issue: User code with nominal types which conform to the extracted protocols and have properties whose type contains a generic parameter or whose properties are initialized with a type value which is a generic parameter will crash the compiler.
• Origination: Recent changes to extraction code to augment it with additional metadata.
• Risk: Small. This change causes types which are impossible to mangle to map to their interface type before mangling, removing an otherwise-always-crashing code-path. 
• main Pull Request URL: https://github.com/apple/swift/pull/67692
• Reviewed By: @slavapestov 
• Automated Testing: Automated test added to the compiler test suite.

Resolves rdar://113039215
