### PR TITLE
[AutoDiff] Emit a diagnostic for non-differentiable active values

### DIFF
--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -1866,7 +1866,7 @@ bool PullbackCloner::Implementation::run() {
 
       // Check that active values are differentiable. Otherwise we may crash
       // later when tangent space is required, but not available.
-      if (!getTangentSpace(remapType(type).getASTType()).has_value()) {
+      if (!getTangentSpace(remapType(type).getASTType())) {
         getContext().emitNondifferentiabilityError(
             v, getInvoker(), diag::autodiff_expression_not_differentiable_note);
         errorOccurred = true;

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -1804,7 +1804,7 @@ bool PullbackCloner::Implementation::run() {
   DominanceOrder domOrder(original.getEntryBlock(), domInfo);
   // Keep track of visited values.
   SmallPtrSet<SILValue, 8> visited;
-  // Also check for differentiable for all active values
+
   auto *diffProto =
       builder.getASTContext().getProtocol(KnownProtocolKind::Differentiable);
   auto *swiftModule = getModule().getSwiftModule();
@@ -1869,6 +1869,7 @@ bool PullbackCloner::Implementation::run() {
       if (Projection::isAddressProjection(v))
         return false;
 
+      // Make sure that all active values are differentiable.
       auto diffConf =
           swiftModule->lookupConformance(type.getASTType(), diffProto);
       if (diffConf.isInvalid()) {

--- a/test/AutoDiff/SILOptimizer/optional_error.swift
+++ b/test/AutoDiff/SILOptimizer/optional_error.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+import _Differentiation
+
+// expected-error @+1 {{function is not differentiable}}
+@differentiable(reverse)
+// expected-note @+1 {{when differentiating this function definition}}
+func o(ff: F) -> Double {
+    var y = ff.i?.first { $0 >= 0.0 } ?? 0.0
+    while 0.0 < y {
+        // expected-note @+1 {{expression is not differentiable}}
+	y = ff.g() ?? y
+    }
+    return y
+}
+
+public struct F: Differentiable {
+    @noDerivative var i: [Double]? {return nil}
+    func g() -> Double? {return nil}
+}


### PR DESCRIPTION
For some values we cannot compute types for differentiation (for example, tangent vector type), so it is better to diagnose them earlier. Otherwise we hit assertions when generating code for such invalid values.

The LIT test is a reduced reproducer from the issue #66996. Before the patch the compiler crashed while trying to get a tangent vector type for the following value (partial_apply):

    %54 = function_ref @$s4null1o2ffSdAA1FV_tFSdyKXEfu0_ :
      $@convention(thin) @substituted <τ_0_0> (@inout_aliasable Double)
      -> (@out τ_0_0, @error any Error) for <Double>

    %55 = partial_apply [callee_guaranteed] %54(%2) :
      $@convention(thin) @substituted <τ_0_0> (@inout_aliasable Double)
      -> (@out τ_0_0, @error any Error) for <Double>

Now we emit a diagnostic instead.

The patch resolves issues #66996 and #63331.