### PR TITLE
[DebugInfo] Require 64-bit arch for debug info fragment LIT tests

### DIFF
--- a/test/IRGen/debug_fragment_merge.sil
+++ b/test/IRGen/debug_fragment_merge.sil
@@ -3,7 +3,7 @@
 // Checking the below on 32 bit architectures would be cumbersome: each
 // fragment is 32 bits long, which changes the number of checks as well as the
 // arithmethic on the bounds of each fragment.
-// REQUIRES: CPU=arm64 || CPU=x86_64
+// REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=arm64e
 
 // CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_fragment, 192, 64){{.*}} !dbg ![[LOC1:[0-9]+]]
 // CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 128, 64){{.*}} !dbg ![[LOC1]]

--- a/test/IRGen/debug_fragment_merge.sil
+++ b/test/IRGen/debug_fragment_merge.sil
@@ -3,7 +3,7 @@
 // Checking the below on 32 bit architectures would be cumbersome: each
 // fragment is 32 bits long, which changes the number of checks as well as the
 // arithmethic on the bounds of each fragment.
-// UNSUPPORTED: OS=watchos
+// REQUIRES: CPU=arm64 || CPU=x86_64
 
 // CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_fragment, 192, 64){{.*}} !dbg ![[LOC1:[0-9]+]]
 // CHECK-DAG: llvm.dbg.value{{.*}} metadata ![[VAR]], metadata !DIExpression(DW_OP_LLVM_fragment, 128, 64){{.*}} !dbg ![[LOC1]]

--- a/test/IRGen/debug_fragment_merge.swift
+++ b/test/IRGen/debug_fragment_merge.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-sil -O -g | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-ir -disable-llvm-optzns -O -g | %FileCheck %s
 
-// UNSUPPORTED: OS=watchos
+// REQUIRES: CPU=arm64 || CPU=x86_64
 
 protocol External {
   func use(str: String);

--- a/test/IRGen/debug_fragment_merge.swift
+++ b/test/IRGen/debug_fragment_merge.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-sil -O -g | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-ir -disable-llvm-optzns -O -g | %FileCheck %s
 
-// REQUIRES: CPU=arm64 || CPU=x86_64
+// REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=arm64e
 
 protocol External {
   func use(str: String);

--- a/test/IRGen/debug_scope_distinct.swift
+++ b/test/IRGen/debug_scope_distinct.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swiftc_driver -O -g -I %t -c %s -emit-ir -o - | %FileCheck %s
 // RUN: %target-swiftc_driver -O -g -I %t -c %s -o /dev/null
 
-// REQUIRES: CPU=arm64 || CPU=x86_64
+// REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=arm64e
 
 // CHECK: define {{.*}} void @"$s4main1TV4move2byyAC13TangentVectorV_tF"
 // CHECK-SAME: ptr {{.*}} %[[ARG_PTR:.*]],

--- a/test/IRGen/debug_scope_distinct.swift
+++ b/test/IRGen/debug_scope_distinct.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swiftc_driver -O -g -I %t -c %s -emit-ir -o - | %FileCheck %s
 // RUN: %target-swiftc_driver -O -g -I %t -c %s -o /dev/null
 
+// REQUIRES: CPU=arm64 || CPU=x86_64
+
 // CHECK: define {{.*}} void @"$s4main1TV4move2byyAC13TangentVectorV_tF"
 // CHECK-SAME: ptr {{.*}} %[[ARG_PTR:.*]],
 //


### PR DESCRIPTION
These tests depend on the target layout, and there were issues reported for Android armv7 (see #66744) and watchOS (#66879) targets.