### PR TITLE
NFC: Add clang-tidy config file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,14 @@
+# See https://clang.llvm.org/extra/clang-tidy/checks/list.html
+
+Checks: '
+-*,
+llvm-*,
+misc-*,
+-misc-const-correctness,
+-misc-unused-parameters,
+-misc-non-private-member-variables-in-classes,
+-misc-no-recursion,
+-misc-use-anonymous-namespace,
+-readability-qualified-auto,
+-llvm-qualified-auto
+'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,9 @@
 # order.
 
 # TODO: /.clang-format
+
+/.clang-tidy   @egorzhdan
+
 # TODO: /.dir-locals.el
 # TODO: /.flake8
 # TODO: /.gitattributes


### PR DESCRIPTION
This makes sure that folks who use clang-tidy see consistent code analysis reports. This is especially helpful for those using IDEs with clang-tidy integration.

The config file is based on the LLVM `.clang-tidy` file: https://github.com/llvm/llvm-project/blob/main/.clang-tidy
This isn't meant to be the final edition of the config file, but this could be a starting point. We could add useful checks and remove noisy ones as we go.