### PR TITLE
[CodeComplete] Avoid `let`/`var` completions in a few cases

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1017,12 +1017,18 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
     addClosureSignatureKeywordsIfApplicable(Sink, CurDeclContext);
 
     LLVM_FALLTHROUGH;
+  case CompletionKind::PostfixExprBeginning:
+    // We need to add 'let' and 'var' keywords in expression position here as
+    // we initially parse patterns as expressions.
+    // FIXME: We ought to be able to determine if we're in a pattern context and
+    // only enable 'let' and 'var' in that case.
+    addLetVarKeywords(Sink);
+
+    LLVM_FALLTHROUGH;
   case CompletionKind::ReturnStmtExpr:
   case CompletionKind::YieldStmtExpr:
-  case CompletionKind::PostfixExprBeginning:
   case CompletionKind::ForEachSequence:
     addSuperKeyword(Sink, CurDeclContext);
-    addLetVarKeywords(Sink);
     addExprKeywords(Sink, CurDeclContext);
     addAnyTypeKeyword(Sink, CurDeclContext->getASTContext().TheAnyType);
     break;

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -256,8 +256,11 @@
 //
 // let and var
 //
-// KW_EXPR-DAG: Keyword[let]/None: let{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[var]/None: var{{; name=.+$}}
+// KW_LETVAR-DAG: Keyword[let]/None: let{{; name=.+$}}
+// KW_LETVAR-DAG: Keyword[var]/None: var{{; name=.+$}}
+//
+// KW_LETVAR_NEG-NOT: Keyword[let]/None: let{{; name=.+$}}
+// KW_LETVAR_NEG-NOT: Keyword[var]/None: var{{; name=.+$}}
 //
 // Literals
 //
@@ -423,24 +426,29 @@ extension SubClass {
 }
 
 func inExpr1() {
-  (#^EXPR_1?check=KW_EXPR;check=KW_EXPR_NEG^#)
+  (#^EXPR_1?check=KW_EXPR;check=KW_LETVAR;check=KW_EXPR_NEG^#)
 }
 func inExpr2() {
-  let x = #^EXPR_2?check=KW_EXPR;check=KW_EXPR_NEG^#
+  let x = #^EXPR_2?check=KW_EXPR;check=KW_LETVAR;check=KW_EXPR_NEG^#
 }
 func inExpr3() {
-  if #^EXPR_3?check=KW_EXPR;check=KW_EXPR_NEG^# {}
+  if #^EXPR_3?check=KW_EXPR;check=KW_LETVAR;check=KW_EXPR_NEG^# {}
 }
 func inExpr4() {
   let x = 1
-  x + #^EXPR_4?check=KW_EXPR;check=KW_EXPR_NEG^#
+  x + #^EXPR_4?check=KW_EXPR;check=KW_LETVAR;check=KW_EXPR_NEG^#
 }
 func inExpr5() {
   var x: Int
-  x = #^EXPR_5?check=KW_EXPR;check=KW_EXPR_NEG^#
+  x = #^EXPR_5?check=KW_EXPR;check=KW_LETVAR;check=KW_EXPR_NEG^#
 }
 func inExpr6() -> Int {
-  return #^EXPR_6?check=KW_EXPR;check=KW_EXPR_NEG^#
+  // Make sure we don't recommend 'let' and 'var' here.
+  return #^EXPR_6?check=KW_EXPR;check=KW_EXPR_NEG;check=KW_LETVAR_NEG^#
+}
+func inExpr7() {
+  // Make sure we don't recommend 'let' and 'var' here.
+  for x in #^EXPR_7?check=KW_EXPR;check=KW_EXPR_NEG;check=KW_LETVAR_NEG^#
 }
 
 func inSwitch(val: Int) {


### PR DESCRIPTION
Don't suggest `let` or `var` in e.g the sequence expression of a `for` loop, or after a `return`. We ought to do a better job of checking whether we're in expression position before suggesting these (as opposed to a pattern), but I'm leaving that as future work for now.