### PR TITLE
[Macros/ASTGen] Fix deprecation warnings from SwiftSyntax

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -14,7 +14,7 @@ extension ASTGenVisitor {
 
   public func visit(_ node: IntegerLiteralExprSyntax) -> ASTNode {
     let loc = bridgedSourceLoc(for: node)
-    var segment = node.digits.text
+    var segment = node.literal.text
     return .expr(
       segment.withBridgedString { bridgedSegment in
         return IntegerLiteralExpr_create(ctx, bridgedSegment, loc)
@@ -23,7 +23,7 @@ extension ASTGenVisitor {
 
   public func visit(_ node: BooleanLiteralExprSyntax) -> ASTNode {
     let loc = bridgedSourceLoc(for: node)
-    let value = node.booleanLiteral == .keyword(.true)
+    let value = node.literal == .keyword(.true)
     return .expr(BooleanLiteralExpr_create(ctx, value, loc))
   }
 

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -326,9 +326,9 @@ func checkMacroDefinition(
       return BridgedMacroDefinitionKind.externalMacro.rawValue
 
     case let .expansion(expansionSyntax, replacements: _)
-        where expansionSyntax.macro.text == "externalMacro":
+        where expansionSyntax.macroName.text == "externalMacro":
       // Extract the identifier from the "module" argument.
-      guard let firstArg = expansionSyntax.argumentList.first,
+      guard let firstArg = expansionSyntax.arguments.first,
             let firstArgLabel = firstArg.label?.text,
             firstArgLabel == "module",
             let module = identifierFromStringLiteral(firstArg.expression) else {
@@ -344,7 +344,7 @@ func checkMacroDefinition(
       }
 
       // Extract the identifier from the "type" argument.
-      guard let secondArg = expansionSyntax.argumentList.dropFirst().first,
+      guard let secondArg = expansionSyntax.arguments.dropFirst().first,
             let secondArgLabel = secondArg.label?.text,
             secondArgLabel == "type",
             let type = identifierFromStringLiteral(secondArg.expression) else {
@@ -514,9 +514,9 @@ func expandFreestandingMacroIPC(
 
   let macroName: String
   if let exprSyntax = expansionSyntax.as(MacroExpansionExprSyntax.self) {
-    macroName = exprSyntax.macro.text
+    macroName = exprSyntax.macroName.text
   } else if let declSyntax = expansionSyntax.as(MacroExpansionDeclSyntax.self) {
-    macroName = declSyntax.macro.text
+    macroName = declSyntax.macroName.text
   } else {
     fatalError("unknown syntax")
   }
@@ -1009,7 +1009,7 @@ func expandAttachedMacroInProcess(
       """
     let placeholderStruct = placeholderDecl.cast(StructDeclSyntax.self)
     if let inheritanceClause = placeholderStruct.inheritanceClause {
-      conformanceListSyntax = inheritanceClause.inheritedTypeCollection
+      conformanceListSyntax = inheritanceClause.inheritedTypes
     } else {
       conformanceListSyntax = nil
     }

--- a/lib/ASTGen/Sources/ASTGen/Misc.swift
+++ b/lib/ASTGen/Sources/ASTGen/Misc.swift
@@ -3,11 +3,11 @@ import SwiftParser
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func visit(_ node: MemberDeclListItemSyntax) -> ASTNode {
+  public func visit(_ node: MemberBlockItemSyntax) -> ASTNode {
     visit(Syntax(node.decl))
   }
 
-  public func visit(_ node: TupleExprElementSyntax) -> ASTNode {
+  public func visit(_ node: LabeledExprSyntax) -> ASTNode {
     visit(node.expression)
   }
 

--- a/lib/ASTGen/Sources/ASTGen/SourceManager.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager.swift
@@ -56,9 +56,9 @@ extension SourceManager {
 
     let detached: Node
     if let operatorTable = operatorTable {
-      detached = operatorTable.foldAll(node) { _ in }.as(Node.self)!.detach()
+      detached = operatorTable.foldAll(node) { _ in }.as(Node.self)!.detached
     } else {
-      detached = node.detach()
+      detached = node.detached
     }
 
     detachedNodes[Syntax(detached)] = (node.root, node.position.utf8Offset)

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -3,7 +3,7 @@ import SwiftParser
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func visit(_ node: SimpleTypeIdentifierSyntax) -> ASTNode {
+  public func visit(_ node: IdentifierTypeSyntax) -> ASTNode {
     let loc = bridgedSourceLoc(for: node)
 
     // If this is the bare 'Any' keyword, produce an empty composition type.
@@ -20,11 +20,11 @@ extension ASTGenVisitor {
       return .type(SimpleIdentTypeRepr_create(ctx, loc, id))
     }
 
-    let lAngle = bridgedSourceLoc(for: generics.leftAngleBracket)
-    let rAngle = bridgedSourceLoc(for: generics.rightAngleBracket)
+    let lAngle = bridgedSourceLoc(for: generics.leftAngle)
+    let rAngle = bridgedSourceLoc(for: generics.rightAngle)
     return .type(
       generics.arguments.map({
-        self.visit($0.argumentType).rawValue
+        self.visit($0.argument).rawValue
       }).withBridgedArrayRef {
           genericArgs in
           GenericIdentTypeRepr_create(
@@ -32,12 +32,12 @@ extension ASTGenVisitor {
       })
   }
 
-  public func visit(_ node: MemberTypeIdentifierSyntax) -> ASTNode {
+  public func visit(_ node: MemberTypeSyntax) -> ASTNode {
     // Gather the member components, in decreasing depth order.
     var reverseMemberComponents = [UnsafeMutableRawPointer]()
 
     var baseType = Syntax(node)
-    while let memberType = baseType.as(MemberTypeIdentifierSyntax.self) {
+    while let memberType = baseType.as(MemberTypeSyntax.self) {
       let nameToken = memberType.name
       let generics = memberType.genericArgumentClause
 
@@ -48,10 +48,10 @@ extension ASTGenVisitor {
       let nameLoc = bridgedSourceLoc(for: nameToken)
 
       if let generics = generics {
-        let lAngle = bridgedSourceLoc(for: generics.leftAngleBracket)
-        let rAngle = bridgedSourceLoc(for: generics.rightAngleBracket)
+        let lAngle = bridgedSourceLoc(for: generics.leftAngle)
+        let rAngle = bridgedSourceLoc(for: generics.rightAngle)
         reverseMemberComponents.append(
-          generics.arguments.map({ self.visit($0.argumentType).rawValue }).withBridgedArrayRef {
+          generics.arguments.map({ self.visit($0.argument).rawValue }).withBridgedArrayRef {
             genericArgs in
             GenericIdentTypeRepr_create(self.ctx, name, nameLoc, genericArgs, lAngle, rAngle)
           })
@@ -71,29 +71,29 @@ extension ASTGenVisitor {
   }
 
   public func visit(_ node: ArrayTypeSyntax) -> ASTNode {
-    let elementType = visit(node.elementType).rawValue
-    let lSquareLoc = bridgedSourceLoc(for: node.leftSquareBracket)
-    let rSquareLoc = bridgedSourceLoc(for: node.rightSquareBracket)
+    let elementType = visit(node.element).rawValue
+    let lSquareLoc = bridgedSourceLoc(for: node.leftSquare)
+    let rSquareLoc = bridgedSourceLoc(for: node.rightSquare)
     return .type(ArrayTypeRepr_create(self.ctx, elementType, lSquareLoc, rSquareLoc))
   }
 
   public func visit(_ node: DictionaryTypeSyntax) -> ASTNode {
-    let keyType = visit(node.keyType).rawValue
-    let valueType = visit(node.valueType).rawValue
+    let keyType = visit(node.key).rawValue
+    let valueType = visit(node.value).rawValue
     let colonLoc = bridgedSourceLoc(for: node.colon)
-    let lSquareLoc = bridgedSourceLoc(for: node.leftSquareBracket)
-    let rSquareLoc = bridgedSourceLoc(for: node.rightSquareBracket)
+    let lSquareLoc = bridgedSourceLoc(for: node.leftSquare)
+    let rSquareLoc = bridgedSourceLoc(for: node.rightSquare)
     return .type(
       DictionaryTypeRepr_create(self.ctx, keyType, valueType, colonLoc, lSquareLoc, rSquareLoc))
   }
 
   public func visit(_ node: MetatypeTypeSyntax) -> ASTNode {
     let baseType = visit(node.baseType).rawValue
-    let tyLoc = bridgedSourceLoc(for: node.typeOrProtocol)
-    if node.typeOrProtocol.text == "Type" {
+    let tyLoc = bridgedSourceLoc(for: node.metatypeSpecifier)
+    if node.metatypeSpecifier.text == "Type" {
       return .type(MetatypeTypeRepr_create(self.ctx, baseType, tyLoc))
     } else {
-      assert(node.typeOrProtocol.text == "Protocol")
+      assert(node.metatypeSpecifier.text == "Protocol")
       return .type(ProtocolTypeRepr_create(self.ctx, baseType, tyLoc))
     }
   }
@@ -111,7 +111,7 @@ extension ASTGenVisitor {
   }
 
   public func visit(_ node: PackExpansionTypeSyntax) -> ASTNode {
-    let base = visit(node.patternType).rawValue
+    let base = visit(node.repetitionPattern).rawValue
     let repeatLoc = bridgedSourceLoc(for: node.repeatKeyword)
     return .type(PackExpansionTypeRepr_create(self.ctx, base, repeatLoc))
   }
@@ -136,26 +136,26 @@ extension ASTGenVisitor {
   }
 
   public func visit(_ node: FunctionTypeSyntax) -> ASTNode {
-    return self.withBridgedTupleElements(node.arguments) { elements in
+    return self.withBridgedTupleElements(node.parameters) { elements in
       let lParenLoc = bridgedSourceLoc(for: node.leftParen)
       let rParenLoc = bridgedSourceLoc(for: node.rightParen)
       let args = TupleTypeRepr_create(self.ctx, elements, lParenLoc, rParenLoc)
       let asyncLoc = bridgedSourceLoc(for: node.effectSpecifiers?.asyncSpecifier)
       let throwsLoc = bridgedSourceLoc(for: node.effectSpecifiers?.throwsSpecifier)
-      let arrowLoc = bridgedSourceLoc(for: node.output.arrow)
-      let retTy = visit(node.output.returnType).rawValue
+      let arrowLoc = bridgedSourceLoc(for: node.returnClause.arrow)
+      let retTy = visit(node.returnClause.type).rawValue
       return .type(FunctionTypeRepr_create(self.ctx, args, asyncLoc, throwsLoc, arrowLoc, retTy))
     }
   }
 
   public func visit(_ node: NamedOpaqueReturnTypeSyntax) -> ASTNode {
-    let baseTy = visit(node.baseType).rawValue
+    let baseTy = visit(node.type).rawValue
     return .type(NamedOpaqueReturnTypeRepr_create(self.ctx, baseTy))
   }
 
-  public func visit(_ node: ConstrainedSugarTypeSyntax) -> ASTNode {
+  public func visit(_ node: SomeOrAnyTypeSyntax) -> ASTNode {
     let someOrAnyLoc = bridgedSourceLoc(for: node.someOrAnySpecifier)
-    let baseTy = visit(node.baseType).rawValue
+    let baseTy = visit(node.constraint).rawValue
     if node.someOrAnySpecifier.text == "some" {
       return .type(OpaqueReturnTypeRepr_create(self.ctx, someOrAnyLoc, baseTy))
     } else {
@@ -197,7 +197,7 @@ extension ASTGenVisitor {
         }
 
         // Only handle simple attribute names right now.
-        guard let identType = attribute.attributeName.as(SimpleTypeIdentifierSyntax.self) else {
+        guard let identType = attribute.attributeName.as(IdentifierTypeSyntax.self) else {
           continue
         }
 
@@ -206,7 +206,7 @@ extension ASTGenVisitor {
         let typeAttrKind = name.withBridgedString { bridgedName in
           TypeAttrKind_fromString(bridgedName)
         }
-        let atLoc = bridgedSourceLoc(for: attribute.atSignToken)
+        let atLoc = bridgedSourceLoc(for: attribute.atSign)
         let attrLoc = bridgedSourceLoc(for: nameSyntax)
         switch typeAttrKind {
           // SIL attributes
@@ -247,11 +247,11 @@ extension ASTGenVisitor {
   ) -> T {
     var elements = [BridgedTupleTypeElement]()
     for element in elementList {
-      var nameText = element.name?.text
+      var nameText = element.firstName?.text
       let name = nameText?.withBridgedString { bridgedName in
         return ASTContext_getIdentifier(ctx, bridgedName)
       } ?? nil
-      let nameLoc = bridgedSourceLoc(for: element.name)
+      let nameLoc = bridgedSourceLoc(for: element.firstName)
       var secondNameText = element.secondName?.text
       let secondName = secondNameText?.withBridgedString { bridgedName in
         return ASTContext_getIdentifier(ctx, bridgedName)

--- a/lib/Macros/Sources/ObservationMacros/Availability.swift
+++ b/lib/Macros/Sources/ObservationMacros/Availability.swift
@@ -51,7 +51,7 @@ extension IfConfigClauseSyntax {
   }
   
   var clonedAsIf: IfConfigClauseSyntax {
-    detached.with(\.poundKeyword, .poundIfKeyword())
+    detached.with(\.poundKeyword, .poundIfToken())
   }
 }
 

--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -45,7 +45,7 @@ extension VariableDeclSyntax {
     let patternBindings = bindings.compactMap { binding in
       binding.as(PatternBindingSyntax.self)
     }
-    let accessors: [AccessorListSyntax.Element] = patternBindings.compactMap { patternBinding in
+    let accessors: [AccessorDeclListSyntax.Element] = patternBindings.compactMap { patternBinding in
       switch patternBinding.accessorBlock?.accessors {
       case .accessors(let accessors):
         return accessors
@@ -217,7 +217,7 @@ extension DeclGroupSyntax {
   var memberFunctionStandins: [FunctionDeclSyntax.SignatureStandin] {
     var standins = [FunctionDeclSyntax.SignatureStandin]()
     for member in memberBlock.members {
-      if let function = member.as(MemberDeclListItemSyntax.self)?.decl.as(FunctionDeclSyntax.self) {
+      if let function = member.as(MemberBlockItemSyntax.self)?.decl.as(FunctionDeclSyntax.self) {
         standins.append(function.signatureStandin)
       }
     }
@@ -226,7 +226,7 @@ extension DeclGroupSyntax {
   
   func hasMemberFunction(equvalentTo other: FunctionDeclSyntax) -> Bool {
     for member in memberBlock.members {
-      if let function = member.as(MemberDeclListItemSyntax.self)?.decl.as(FunctionDeclSyntax.self) {
+      if let function = member.as(MemberBlockItemSyntax.self)?.decl.as(FunctionDeclSyntax.self) {
         if function.isEquivalent(to: other) {
           return true
         }
@@ -237,7 +237,7 @@ extension DeclGroupSyntax {
   
   func hasMemberProperty(equivalentTo other: VariableDeclSyntax) -> Bool {
     for member in memberBlock.members {
-      if let variable = member.as(MemberDeclListItemSyntax.self)?.decl.as(VariableDeclSyntax.self) {
+      if let variable = member.as(MemberBlockItemSyntax.self)?.decl.as(VariableDeclSyntax.self) {
         if variable.isEquivalent(to: other) {
           return true
         }
@@ -248,7 +248,7 @@ extension DeclGroupSyntax {
   
   var definedVariables: [VariableDeclSyntax] {
     memberBlock.members.compactMap { member in
-      if let variableDecl = member.as(MemberDeclListItemSyntax.self)?.decl.as(VariableDeclSyntax.self) {
+      if let variableDecl = member.as(MemberBlockItemSyntax.self)?.decl.as(VariableDeclSyntax.self) {
         return variableDecl
       }
       return nil

--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -71,7 +71,7 @@ public struct ObservableMacro {
     AttributeSyntax(
       leadingTrivia: .space,
       atSign: .atSignToken(),
-      attributeName: SimpleTypeIdentifierSyntax(name: .identifier(ignoredMacroName)),
+      attributeName: IdentifierTypeSyntax(name: .identifier(ignoredMacroName)),
       trailingTrivia: .space
     )
   }
@@ -108,10 +108,10 @@ extension DiagnosticsError {
   }
 }
 
-extension ModifierListSyntax {
-  func privatePrefixed(_ prefix: String) -> ModifierListSyntax {
+extension DeclModifierListSyntax {
+  func privatePrefixed(_ prefix: String) -> DeclModifierListSyntax {
     let modifier: DeclModifierSyntax = DeclModifierSyntax(name: "private", trailingTrivia: .space)
-    return ModifierListSyntax([modifier] + filter {
+    return [modifier] + filter {
       switch $0.name.tokenKind {
       case .keyword(let keyword):
         switch keyword {
@@ -126,7 +126,7 @@ extension ModifierListSyntax {
       default:
         return true
       }
-    })
+    }
   }
   
   init(keyword: Keyword) {
@@ -178,7 +178,7 @@ extension VariableDeclSyntax {
     return VariableDeclSyntax(
       leadingTrivia: leadingTrivia,
       attributes: newAttributes,
-      modifiers: modifiers?.privatePrefixed(prefix) ?? ModifierListSyntax(keyword: .private),
+      modifiers: modifiers?.privatePrefixed(prefix) ?? DeclModifierListSyntax(keyword: .private),
       bindingSpecifier: TokenSyntax(bindingSpecifier.tokenKind, leadingTrivia: .space, trailingTrivia: .space, presence: .present),
       bindings: bindings.privatePrefixed(prefix),
       trailingTrivia: trailingTrivia
@@ -252,7 +252,7 @@ extension ObservableMacro: MemberAttributeMacro {
     
     
     return [
-      AttributeSyntax(attributeName: SimpleTypeIdentifierSyntax(name: .identifier(ObservableMacro.trackedMacroName)))
+      AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier(ObservableMacro.trackedMacroName)))
     ]
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
@@ -47,7 +47,7 @@ private let optionsEnumNameArgumentLabel = "optionsName"
 /// eventually be overridable.
 private let defaultOptionsEnumName = "Options"
 
-extension TupleExprElementListSyntax {
+extension LabeledExprListSyntax {
   /// Retrieve the first element with the given label.
   func first(labeled name: String) -> Element? {
     return first { element in
@@ -75,7 +75,7 @@ public struct OptionSetMacro {
   ) -> (StructDeclSyntax, EnumDeclSyntax, TypeSyntax)? {
     // Determine the name of the options enum.
     let optionsEnumName: String
-    if case let .argumentList(arguments) = attribute.argument,
+    if case let .argumentList(arguments) = attribute.arguments,
        let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel) {
       // We have a options name; make sure it is a string literal.
       guard let stringLiteral = optionEnumNameArg.expression.as(StringLiteralExprSyntax.self),
@@ -99,7 +99,7 @@ public struct OptionSetMacro {
     // Find the option enum within the struct.
     let optionsEnums: [EnumDeclSyntax] = decl.memberBlock.members.compactMap({ member in
       if let enumDecl = member.decl.as(EnumDeclSyntax.self),
-         enumDecl.identifier.text == optionsEnumName {
+         enumDecl.name.text == optionsEnumName {
         return enumDecl
       }
 
@@ -112,8 +112,8 @@ public struct OptionSetMacro {
     }
 
     // Retrieve the raw type from the attribute.
-    guard let genericArgs = attribute.attributeName.as(SimpleTypeIdentifierSyntax.self)?.genericArgumentClause,
-          let rawType = genericArgs.arguments.first?.argumentType else {
+    guard let genericArgs = attribute.attributeName.as(IdentifierTypeSyntax.self)?.genericArgumentClause,
+          let rawType = genericArgs.arguments.first?.argument else {
       context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnumRawType.diagnose(at: attribute))
       return nil
     }
@@ -138,8 +138,8 @@ extension OptionSetMacro: ConformanceMacro {
     }
 
     // If there is an explicit conformance to OptionSet already, don't add one.
-    if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypeCollection,
-       inheritedTypes.contains(where: { inherited in inherited.typeName.trimmedDescription == "OptionSet" }) {
+    if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypes,
+       inheritedTypes.contains(where: { inherited in inherited.type.trimmedDescription == "OptionSet" }) {
       return []
     }
 
@@ -174,8 +174,8 @@ extension OptionSetMacro: MemberMacro {
 
     let staticVars = caseElements.map { (element) -> DeclSyntax in
       """
-      \(access) static let \(element.identifier): Self =
-        Self(rawValue: 1 << \(optionsEnum.identifier).\(element.identifier).rawValue)
+      \(access) static let \(element.name): Self =
+        Self(rawValue: 1 << \(optionsEnum.name).\(element.name).rawValue)
       """
     }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -7,14 +7,13 @@ import SwiftSyntaxMacros
 /// Replace the label of the first element in the tuple with the given
 /// new label.
 private func replaceFirstLabel(
-  of tuple: TupleExprElementListSyntax, with newLabel: String
-) -> TupleExprElementListSyntax{
-  guard let firstElement = tuple.first else {
+  of tuple: LabeledExprListSyntax, with newLabel: String
+) -> LabeledExprListSyntax{
+  if tuple.isEmpty {
     return tuple
   }
 
-  return tuple.replacing(
-    childAt: 0, with: firstElement.with(\.label, .identifier(newLabel)))
+  return tuple.with(\.[tuple.startIndex].label, .identifier(newLabel))
 }
 
 public struct ColorLiteralMacro: ExpressionMacro {
@@ -123,12 +122,12 @@ public enum AddBlocker: ExpressionMacro {
     override func visit(
       _ node: InfixOperatorExprSyntax
     ) -> ExprSyntax {
-      if let binOp = node.operatorOperand.as(BinaryOperatorExprSyntax.self) {
-        if binOp.operatorToken.text == "+" {
+      if let binOp = node.operator.as(BinaryOperatorExprSyntax.self) {
+        if binOp.operator.text == "+" {
           let messageID = MessageID(domain: "silly", id: "addblock")
           diagnostics.append(
             Diagnostic(
-              node: Syntax(node.operatorOperand),
+              node: Syntax(node.operator),
               message: SimpleDiagnosticMessage(
                 message: "blocked an add; did you mean to subtract?",
                 diagnosticID: messageID,
@@ -147,7 +146,7 @@ public enum AddBlocker: ExpressionMacro {
                   ),
                   changes: [
                     FixIt.Change.replace(
-                      oldNode: Syntax(binOp.operatorToken),
+                      oldNode: Syntax(binOp.operator),
                       newNode: Syntax(
                         TokenSyntax(
                           .binaryOperator("-"),
@@ -161,17 +160,8 @@ public enum AddBlocker: ExpressionMacro {
             )
           )
 
-          return ExprSyntax(
-            node.with(
-              \.operatorOperand,
-              ExprSyntax(
-                binOp.with(
-                  \.operatorToken,
-                  binOp.operatorToken.with(\.tokenKind, .binaryOperator("-"))
-                )
-              )
-            )
-          )
+          let minusOperator = binOp.with(\.operator.tokenKind, .binaryOperator("-"))
+          return ExprSyntax(node.with(\.operator, ExprSyntax(minusOperator)))
         }
       }
 
@@ -453,7 +443,7 @@ extension PropertyWrapperMacro: PeerMacro {
     guard let varDecl = declaration.as(VariableDeclSyntax.self),
       let binding = varDecl.bindings.first,
       let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
-      binding.accessor == nil,
+      binding.accessorBlock == nil,
       let type = binding.typeAnnotation?.type
     else {
       return []
@@ -472,7 +462,7 @@ extension AccessorBlockSyntax {
     switch self.accessors {
     case .accessors(let accessors):
       for accessor in accessors {
-        if accessor.accessorKind.text == "get" {
+        if accessor.accessorSpecifier.text == "get" {
           return true
         }
       }
@@ -494,7 +484,7 @@ extension PropertyWrapperSkipsComputedMacro: AccessorMacro, Macro {
   ) throws -> [AccessorDeclSyntax] {
     guard let varDecl = declaration.as(VariableDeclSyntax.self),
       let binding = varDecl.bindings.first,
-      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier, !(binding.accessor?.hasGetter ?? false)
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier, !(binding.accessorBlock?.hasGetter ?? false)
     else {
       return []
     }
@@ -535,7 +525,7 @@ public struct WrapAllProperties: MemberAttributeMacro {
     }
 
     let propertyWrapperAttr = AttributeSyntax(
-      attributeName: SimpleTypeIdentifierSyntax(
+      attributeName: IdentifierTypeSyntax(
         name: .identifier(wrapperTypeName)
       )
     )
@@ -556,7 +546,7 @@ extension TypeWrapperMacro: MemberAttributeMacro {
     guard let varDecl = member.as(VariableDeclSyntax.self),
       let binding = varDecl.bindings.first,
       let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
-      binding.accessor == nil
+      binding.accessorBlock == nil
     else {
       return []
     }
@@ -566,7 +556,7 @@ extension TypeWrapperMacro: MemberAttributeMacro {
     }
 
     let customAttr = AttributeSyntax(
-      attributeName: SimpleTypeIdentifierSyntax(
+      attributeName: IdentifierTypeSyntax(
         name: .identifier("accessViaStorage")
       )
     )
@@ -601,7 +591,7 @@ public struct AccessViaStorageMacro: AccessorMacro {
     guard let varDecl = declaration.as(VariableDeclSyntax.self),
       let binding = varDecl.bindings.first,
       let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
-      binding.accessor == nil
+      binding.accessorBlock == nil
     else {
       return []
     }
@@ -706,11 +696,11 @@ public struct AddArbitraryMembers: MemberMacro {
     providingMembersOf decl: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    guard let identified = decl.asProtocol(IdentifiedDeclSyntax.self) else {
+    guard let identified = decl.asProtocol(NamedDeclSyntax.self) else {
       return []
     }
 
-    let parentName = identified.identifier.trimmed
+    let parentName = identified.name.trimmed
     return [
       "struct \(parentName)1 {}",
       "struct \(parentName)2 {}",
@@ -739,7 +729,7 @@ public struct WrapStoredPropertiesMacro: MemberAttributeMacro {
       return []
     }
 
-    guard case let .argumentList(arguments) = node.argument,
+    guard case let .argumentList(arguments) = node.arguments,
         let firstElement = arguments.first,
         let stringLiteral = firstElement.expression
       .as(StringLiteralExprSyntax.self),
@@ -750,7 +740,7 @@ public struct WrapStoredPropertiesMacro: MemberAttributeMacro {
 
     return [
       AttributeSyntax(
-        attributeName: SimpleTypeIdentifierSyntax(
+        attributeName: IdentifierTypeSyntax(
           name: .identifier(wrapperName.content.text)
         )
       )
@@ -775,7 +765,7 @@ extension VariableDeclSyntax {
 
     case .accessors(let node):
       for accessor in node {
-        switch accessor.accessorKind.tokenKind {
+        switch accessor.accessorSpecifier.tokenKind {
         case .keyword(.willSet), .keyword(.didSet):
           // Observers can occur on a stored property.
           break
@@ -868,7 +858,7 @@ public struct AddCompletionHandler: PeerMacro {
     }
 
     // Form the completion handler parameter.
-    let resultType: TypeSyntax? = funcDecl.signature.output?.returnType.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
+    let resultType: TypeSyntax? = funcDecl.signature.returnClause?.type.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
 
     let completionHandlerParam =
       FunctionParameterSyntax(
@@ -878,21 +868,14 @@ public struct AddCompletionHandler: PeerMacro {
       )
 
     // Add the completion handler parameter to the parameter list.
-    let parameterList = funcDecl.signature.input.parameterList
-    let newParameterList: FunctionParameterListSyntax
-    if let lastParam = parameterList.last {
+    let parameterList = funcDecl.signature.parameterClause.parameters
+    var newParameterList = parameterList
+    if !newParameterList.isEmpty {
       // We need to add a trailing comma to the preceding list.
-      newParameterList = parameterList.removingLast()
-        .appending(
-          lastParam.with(
-            \.trailingComma,
-            .commaToken()
-          )
-        )
-        .appending(completionHandlerParam)
-    } else {
-      newParameterList = parameterList.appending(completionHandlerParam)
+      let lastIndex = newParameterList.index(before: newParameterList.endIndex)
+      newParameterList[lastIndex].trailingComma = .commaToken()
     }
+    newParameterList.append(completionHandlerParam)
 
     let callArguments: [String] = parameterList.map { param in
       let argName = param.secondName ?? param.firstName
@@ -905,7 +888,7 @@ public struct AddCompletionHandler: PeerMacro {
     }
 
     let call: ExprSyntax =
-      "\(funcDecl.identifier)(\(raw: callArguments.joined(separator: ", ")))"
+      "\(funcDecl.name)(\(raw: callArguments.joined(separator: ", ")))"
 
     // FIXME: We should make CodeBlockSyntax ExpressibleByStringInterpolation,
     // so that the full body could go here.
@@ -920,8 +903,8 @@ public struct AddCompletionHandler: PeerMacro {
     let newAttributeList = AttributeListSyntax(
       funcDecl.attributes?.filter {
         guard case let .attribute(attribute) = $0,
-              let attributeType = attribute.attributeName.as(SimpleTypeIdentifierSyntax.self),
-              let nodeType = node.attributeName.as(SimpleTypeIdentifierSyntax.self)
+              let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+              let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
         else {
           return true
         }
@@ -930,33 +913,19 @@ public struct AddCompletionHandler: PeerMacro {
       } ?? []
     )
 
-    let newFunc =
-      funcDecl
-      .with(
-        \.signature,
-        funcDecl.signature
-          .with(
-            \.effectSpecifiers,
-            funcDecl.signature.effectSpecifiers?.with(\.asyncSpecifier, nil)  // drop async
-          )
-          .with(\.output, nil)  // drop result type
-          .with(
-            \.input,  // add completion handler parameter
-            funcDecl.signature.input.with(\.parameterList, newParameterList)
-              .with(\.trailingTrivia, [])
-          )
-      )
-      .with(
-        \.body,
-        CodeBlockSyntax(
-          leftBrace: .leftBraceToken(),
-          statements: CodeBlockItemListSyntax(
-            [CodeBlockItemSyntax(item: .expr(newBody))]
-          ),
-          rightBrace: .rightBraceToken()
-        )
-      )
-      .with(\.attributes, newAttributeList)
+    var newFunc = funcDecl
+    newFunc.signature.effectSpecifiers?.asyncSpecifier = nil // drop async
+    newFunc.signature.returnClause = nil  // drop result type
+    newFunc.signature.parameterClause.parameters = newParameterList
+    newFunc.signature.parameterClause.trailingTrivia = []
+    newFunc.body = CodeBlockSyntax(
+      leftBrace: .leftBraceToken(),
+      statements: CodeBlockItemListSyntax(
+        [CodeBlockItemSyntax(item: .expr(newBody))]
+      ),
+      rightBrace: .rightBraceToken()
+    )
+    newFunc.attributes = newAttributeList
 
     return [DeclSyntax(newFunc)]
   }
@@ -1024,7 +993,7 @@ public struct WrapInType: PeerMacro {
 
     // Build a new function with the same signature that forwards arguments
     // to the the original function.
-    let parameterList = funcDecl.signature.input.parameterList
+    let parameterList = funcDecl.signature.parameterClause.parameters
     let callArguments: [String] = parameterList.map { param in
       let argName = param.secondName ?? param.firstName
 
@@ -1037,15 +1006,15 @@ public struct WrapInType: PeerMacro {
 
     let call: ExprSyntax =
       """
-      \(funcDecl.identifier)(\(raw: callArguments.joined(separator: ", ")))
+      \(funcDecl.name)(\(raw: callArguments.joined(separator: ", ")))
       """
 
     // Drop the peer macro attribute from the new declaration.
     let newAttributeList = AttributeListSyntax(
       funcDecl.attributes?.filter {
         guard case let .attribute(attribute) = $0,
-              let attributeType = attribute.attributeName.as(SimpleTypeIdentifierSyntax.self),
-              let nodeType = node.attributeName.as(SimpleTypeIdentifierSyntax.self)
+              let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+              let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
         else {
           return true
         }
@@ -1054,31 +1023,21 @@ public struct WrapInType: PeerMacro {
       } ?? []
     )
 
-    let method =
-      funcDecl
-      .with(
-        \.identifier,
-         "\(context.makeUniqueName(funcDecl.identifier.text))"
-      )
-      .with(
-        \.signature,
-        funcDecl.signature
-      )
-      .with(
-        \.body,
-        CodeBlockSyntax(
-          leftBrace: .leftBraceToken(),
-          statements: CodeBlockItemListSyntax(
-            [CodeBlockItemSyntax(item: .expr(call))]
-          ),
-          rightBrace: .rightBraceToken()
-        )
-      )
-      .with(\.attributes, newAttributeList)
+    var method = funcDecl
+    method.name = "\(context.makeUniqueName(funcDecl.name.text))"
+    method.signature = funcDecl.signature
+    method.body = CodeBlockSyntax(
+      leftBrace: .leftBraceToken(),
+      statements: CodeBlockItemListSyntax(
+        [CodeBlockItemSyntax(item: .expr(call))]
+      ),
+      rightBrace: .rightBraceToken()
+    )
+    method.attributes = newAttributeList
 
     let structType: DeclSyntax =
       """
-      struct \(context.makeUniqueName(funcDecl.identifier.text)) {
+      struct \(context.makeUniqueName(funcDecl.name.text)) {
         \(method)
       }
       """
@@ -1093,7 +1052,7 @@ private extension DeclSyntaxProtocol {
           let binding = property.bindings.first,
           let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
           identifier.text != "_registrar", identifier.text != "_storage",
-          binding.accessor == nil {
+          binding.accessorBlock == nil {
       return true
     }
 
@@ -1110,11 +1069,11 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    guard let identified = declaration.asProtocol(IdentifiedDeclSyntax.self) else {
+    guard let identified = declaration.asProtocol(NamedDeclSyntax.self) else {
       return []
     }
 
-    let parentName = identified.identifier
+    let parentName = identified.name
 
     let registrar: DeclSyntax =
       """
@@ -1144,11 +1103,9 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
       }
       """
 
-    let memberList = MemberDeclListSyntax(
-      declaration.memberBlock.members.filter {
-        $0.decl.isObservableStoredProperty
-      }
-    )
+    let memberList = declaration.memberBlock.members.filter {
+      $0.decl.isObservableStoredProperty
+    }
 
     let storageStruct: DeclSyntax =
       """
@@ -1186,7 +1143,7 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
 
     return [
       AttributeSyntax(
-        attributeName: SimpleTypeIdentifierSyntax(
+        attributeName: IdentifierTypeSyntax(
           name: .identifier("ObservableProperty")
         )
       )
@@ -1228,7 +1185,7 @@ public struct ObservablePropertyMacro: AccessorMacro {
     guard let property = declaration.as(VariableDeclSyntax.self),
       let binding = property.bindings.first,
       let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
-      binding.accessor == nil
+      binding.accessorBlock == nil
     else {
       return []
     }
@@ -1282,7 +1239,7 @@ public struct NewTypeMacro: MemberMacro {
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    guard let type = node.attributeName.as(SimpleTypeIdentifierSyntax.self),
+    guard let type = node.attributeName.as(IdentifierTypeSyntax.self),
           let genericArguments = type.genericArgumentClause?.arguments,
           genericArguments.count == 1,
           let rawType = genericArguments.first
@@ -1533,7 +1490,7 @@ public struct AddMemberWithFixIt: MemberMacro {
   }
 }
 
-extension TupleExprElementListSyntax {
+extension LabeledExprListSyntax {
   /// Retrieve the first element with the given label.
   func first(labeled name: String) -> Element? {
     return first { element in
@@ -1633,7 +1590,7 @@ public struct AddClassReferencingSelfMacro: PeerMacro {
       throw CustomError.message("Macro can only be applied to a protocol declarations.")
     }
 
-    let className = "\(protocolDecl.identifier.text)Builder"
+    let className = "\(protocolDecl.name.text)Builder"
     return [
       """
       struct \(raw: className) {
@@ -1832,10 +1789,10 @@ public struct PeerValueWithSuffixNameMacro: PeerMacro {
     providingPeersOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    guard let identified = declaration.asProtocol(IdentifiedDeclSyntax.self) else {
+    guard let identified = declaration.asProtocol(NamedDeclSyntax.self) else {
       throw CustomError.message("Macro can only be applied to an identified declarations.")
     }
-    return ["var \(raw: identified.identifier.text)_peer: Int { 1 }"]
+    return ["var \(raw: identified.name.text)_peer: Int { 1 }"]
   }
 }
 


### PR DESCRIPTION
Also use the opportunity to make some implementation improvements in `syntax_macro_definitions.swift`.