### PR TITLE
Swift Optimizer: some reformatting in the optimization passes

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AssumeSingleThreaded.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AssumeSingleThreaded.swift
@@ -27,12 +27,12 @@
 
 import SIL
 
-let assumeSingleThreadedPass = FunctionPass(
-  name: "sil-assume-single-threaded", { function, context in
-    for inst in function.instructions {
-      guard let rcInst = inst as? RefCountingInst else { continue }
+let assumeSingleThreadedPass = FunctionPass(name: "sil-assume-single-threaded") {
+  (function: Function, context: FunctionPassContext) in
 
-      rcInst.setAtomicity(isAtomic: false, context)
-    }
+  for inst in function.instructions {
+    guard let rcInst = inst as? RefCountingInst else { continue }
+
+    rcInst.setAtomicity(isAtomic: false, context)
   }
-)
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
@@ -25,7 +25,7 @@ import SIL
 /// ```
 /// The pass does not try to change or re-compute _defined_ effects.
 ///
-let computeEscapeEffects = FunctionPass(name: "compute-escape-effects", {
+let computeEscapeEffects = FunctionPass(name: "compute-escape-effects") {
   (function: Function, context: FunctionPassContext) in
 
   var newEffects = function.effects.escapeEffects.arguments.filter {!$0.isDerived }
@@ -73,8 +73,7 @@ let computeEscapeEffects = FunctionPass(name: "compute-escape-effects", {
   context.modifyEffects(in: function) { (effects: inout FunctionEffects) in
     effects.escapeEffects.arguments = newEffects
   }
-})
-
+}
 
 /// Returns true if an argument effect was added.
 private

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -24,7 +24,7 @@ import SIL
 /// ```
 /// are computed.
 ///
-let computeSideEffects = FunctionPass(name: "compute-side-effects", {
+let computeSideEffects = FunctionPass(name: "compute-side-effects") {
   (function: Function, context: FunctionPassContext) in
 
   if function.isAvailableExternally {
@@ -71,7 +71,7 @@ let computeSideEffects = FunctionPass(name: "compute-side-effects", {
   context.modifyEffects(in: function) { (effects: inout FunctionEffects) in
     effects.sideEffects = SideEffects(arguments: collectedEffects.argumentEffects, global: collectedEffects.globalEffects)
   }
-})
+}
 
 /// The collected argument and global side effects of the function.
 private struct CollectedEffects {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
@@ -31,7 +31,7 @@ import SIL
 ///   br continue_bb(%5)
 /// continue_bb(%bridgedOptionalSwiftValue):
 /// ```
-let objCBridgingOptimization = FunctionPass(name: "objc-bridging-opt", {
+let objCBridgingOptimization = FunctionPass(name: "objc-bridging-opt") {
   (function: Function, context: FunctionPassContext) in
 
   if !function.hasOwnership { return }
@@ -54,7 +54,7 @@ let objCBridgingOptimization = FunctionPass(name: "objc-bridging-opt", {
       }
     }
   }
-})
+}
 
 //===----------------------------------------------------------------------===//
 //                      Top-level optimization functions

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -38,8 +38,8 @@ private func log(_ message: @autoclosure () -> String) {
 /// inter-procedural analysis. If this is not possible and the `enableMoveInoutStackProtection`
 /// option is set, the fallback is to move the argument into a temporary `alloc_stack`
 /// and do the unsafe pointer operations on the temporary.
-let stackProtection = ModulePass(name: "stack-protection", {
-    (context: ModulePassContext) in
+let stackProtection = ModulePass(name: "stack-protection") {
+  (context: ModulePassContext) in
 
   if !context.options.enableStackProtection {
     return
@@ -47,13 +47,13 @@ let stackProtection = ModulePass(name: "stack-protection", {
 
   var optimization = StackProtectionOptimization(enableMoveInout: context.options.enableMoveInoutStackProtection)
   optimization.processModule(context)
-})
+}
 
 /// The stack-protection optimization on function-level.
 ///
 /// In contrast to the `stack-protection` pass, this pass doesn't do any inter-procedural
 /// analysis. It runs at Onone.
-let functionStackProtection = FunctionPass(name: "function-stack-protection", {
+let functionStackProtection = FunctionPass(name: "function-stack-protection") {
   (function: Function, context: FunctionPassContext) in
 
   if !context.options.enableStackProtection {
@@ -62,7 +62,7 @@ let functionStackProtection = FunctionPass(name: "function-stack-protection", {
 
   var optimization = StackProtectionOptimization(enableMoveInout: context.options.enableMoveInoutStackProtection)
   optimization.process(function: function, context)
-})
+}
 
 /// The optimization algorithm.
 private struct StackProtectionOptimization {

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
@@ -19,7 +19,7 @@ import SIL
 /// dumps anything, but aborts if the result is wrong.
 ///
 /// This pass is used for testing `AccessUtils`.
-let accessDumper = FunctionPass(name: "dump-access", {
+let accessDumper = FunctionPass(name: "dump-access") {
   (function: Function, context: FunctionPassContext) in
   print("Accesses for \(function.name)")
 
@@ -46,7 +46,7 @@ let accessDumper = FunctionPass(name: "dump-access", {
   }
 
   print("End accesses for \(function.name)")
-})
+}
 
 private struct AccessStoragePathVisitor : ValueUseDefWalker {
   var walkUpCache = WalkerCache<Path>()

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/DeadEndBlockDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/DeadEndBlockDumper.swift
@@ -12,10 +12,9 @@
 
 import SIL
 
-let deadEndBlockDumper = FunctionPass(name: "dump-deadendblocks", {
+let deadEndBlockDumper = FunctionPass(name: "dump-deadendblocks") {
   (function: Function, context: FunctionPassContext) in
 
-  
   print("Function \(function.name)")
   
   var deadEndBlocks = DeadEndBlocks(function: function, context)
@@ -23,4 +22,4 @@ let deadEndBlockDumper = FunctionPass(name: "dump-deadendblocks", {
   defer { deadEndBlocks.deinitialize() }
 
   print("end function \(function.name)")
-})
+}

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/EscapeInfoDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/EscapeInfoDumper.swift
@@ -17,7 +17,7 @@ import SIL
 /// Dumps the EscapeInfo query results for all `alloc_stack` instructions in a function.
 ///
 /// This pass is used for testing EscapeInfo.
-let escapeInfoDumper = FunctionPass(name: "dump-escape-info", {
+let escapeInfoDumper = FunctionPass(name: "dump-escape-info") {
   (function: Function, context: FunctionPassContext) in
 
   print("Escape information for \(function.name):")
@@ -60,8 +60,7 @@ let escapeInfoDumper = FunctionPass(name: "dump-escape-info", {
     }
   }
   print("End function \(function.name)\n")
-})
-
+}
 
 /// Dumps the results of address-related escape analysis.
 ///
@@ -69,7 +68,7 @@ let escapeInfoDumper = FunctionPass(name: "dump-escape-info", {
 /// The `fix_lifetime` instruction is used as marker for addresses and values to query.
 ///
 /// This pass is used for testing EscapeInfo.
-let addressEscapeInfoDumper = FunctionPass(name: "dump-addr-escape-info", {
+let addressEscapeInfoDumper = FunctionPass(name: "dump-addr-escape-info") {
   (function: Function, context: FunctionPassContext) in
 
   print("Address escape information for \(function.name):")
@@ -159,4 +158,4 @@ let addressEscapeInfoDumper = FunctionPass(name: "dump-addr-escape-info", {
   }
   
   print("End function \(function.name)\n")
-})
+}

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/FunctionUsesDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/FunctionUsesDumper.swift
@@ -12,7 +12,7 @@
 
 import SIL
 
-let functionUsesDumper = ModulePass(name: "dump-function-uses", {
+let functionUsesDumper = ModulePass(name: "dump-function-uses") {
     (context: ModulePassContext) in
 
   var functionUses = FunctionUses()
@@ -25,4 +25,4 @@ let functionUsesDumper = ModulePass(name: "dump-function-uses", {
     print(uses)
     print("End function \(function.name)\n")
   }
-})
+}

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/RangeDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/RangeDumper.swift
@@ -12,7 +12,7 @@
 
 import SIL
 
-let rangeDumper = FunctionPass(name: "dump-ranges", {
+let rangeDumper = FunctionPass(name: "dump-ranges") {
   (function: Function, context: FunctionPassContext) in
 
   var begin: Instruction?
@@ -73,7 +73,7 @@ let rangeDumper = FunctionPass(name: "dump-ranges", {
     assert(!instRange.contains(o))
     assert(!instRange.inclusiveRangeContains(o))
   }
-})
+}
 
 private func verify(_ blockRange: BasicBlockRange, _ context: FunctionPassContext) {
   var inRange = BasicBlockSet(context)

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/RunUnitTests.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/RunUnitTests.swift
@@ -14,11 +14,11 @@ import SIL
 
 /// This pass should only be used by sil-opt to run all the unit tests.
 ///
-let runUnitTests = ModulePass(name: "run-unit-tests", {
+let runUnitTests = ModulePass(name: "run-unit-tests") {
     (context: ModulePassContext) in
 
   print("--- Run unit tests ---")
   
   print("test ProjectionPath")
   SmallProjectionPath.runUnitTests()
-})
+}


### PR DESCRIPTION
Use tail closures for all optimization passes.
NFC.
