### PR TITLE
ClangImporter: correct a duplicated path component

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -38,7 +38,7 @@ static llvm::Optional<Path> getActualModuleMapPath(
   if (!SDKPath.empty()) {
     result.append(SDKPath.begin(), SDKPath.end());
     llvm::sys::path::append(result, "usr", "lib", "swift");
-    llvm::sys::path::append(result, platform, arch);
+    llvm::sys::path::append(result, platform);
     if (isArchSpecific) {
       llvm::sys::path::append(result, arch);
     }


### PR DESCRIPTION
When computing the path for a non-architecture specific resource, we would append the architecture unconditionally if `-sdk` is used.  This would result in the path being miscomputed with the architecture or the architecture duplicated if it was architecture specific.

Found by inspection.