### PR TITLE
ClangImporter: correct a duplicated path component

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -38,7 +38,7 @@ static llvm::Optional<Path> getActualModuleMapPath(
   if (!SDKPath.empty()) {
     result.append(SDKPath.begin(), SDKPath.end());
     llvm::sys::path::append(result, "usr", "lib", "swift");
-    llvm::sys::path::append(result, platform, arch);
+    llvm::sys::path::append(result, platform);
     if (isArchSpecific) {
       llvm::sys::path::append(result, arch);
     }


### PR DESCRIPTION
When computing the path for a non-architecture specific resource, we would append the architecture unconditionally if `-sdk` is used.  This would result in the path being miscomputed with the architecture or the architecture duplicated if it was architecture specific.

Found by inspection.

**Explanation:** Correct the location for resources relative to the SDK root
**Scope:** This fixes the Windows target's use of `CxxShim` which is required for C++ interop which would not be found otherwise.
**Issue:** #67715 
**Risk:** This impacts only targets that use `-sdk` (Darwin, Windows).  However, this can be further refined to the location of resources that are SDK relative.  Darwin places the toolchain resources entirely with the toolchain and not as SDK relative like Windows, which means that those paths should _technically_ not be impacted, though the code path is shared.
Testing: What specific testing has been done or needs to be done to further validate any impact of this change?
**Reviewer:** @hyp @egorzhdan

