### PR TITLE
[cxx-interop] do not add friend decls as a member of Swift type that …

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8930,6 +8930,11 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
       continue;
     }
 
+    // A friend C++ decl is not a member of the Swift type.
+    if (member->getClangDecl() &&
+        member->getClangDecl()->getFriendObjectKind() != clang::Decl::FOK_None)
+      continue;
+
     // FIXME: constructors are added eagerly, but shouldn't be
     // FIXME: subscripts are added eagerly, but shouldn't be
     if (!isa<AccessorDecl>(member) &&

--- a/test/Interop/Cxx/class/friend-class-member-in-interface.swift
+++ b/test/Interop/Cxx/class/friend-class-member-in-interface.swift
@@ -1,0 +1,35 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -print-module -module-to-print=Test -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Test {
+    header "test.h"
+    requires cplusplus
+}
+
+//--- Inputs/test.h
+struct A {
+    void memberInA(int x);
+};
+
+struct B {
+    friend void A::memberInA(int);
+
+    void memberInB();
+};
+
+struct C: B {
+    void memberInC();
+};
+
+// CHECK: struct A {
+// CHECK:  mutating func memberInA(_ x: Int32)
+// CHECK-NEXT: }
+// CHECK: struct B {
+// CHECK:  mutating func memberInB()
+// CHECK-NEXT: }
+// CHECK: struct C {
+// CHECK:  mutating func memberInC()
+// CHECK-NEXT:  mutating func memberInB()
+// CHECK-NEXT: }


### PR DESCRIPTION
…represents a C++ class

Fixes an assertion when printing a module interface with such condition.