### PR TITLE
[stdlib] Fix String.hasPrefix and String.hasSuffix when self and arg are in NFC form

### DIFF
--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -124,12 +124,16 @@ extension String {
   public func hasPrefix(_ prefix: String) -> Bool {
     if _fastPath(self._guts.isNFCFastUTF8 && prefix._guts.isNFCFastUTF8) {
       guard prefix._guts.count <= self._guts.count else { return false }
-      return prefix._guts.withFastUTF8 { nfcPrefix in
+      let isPrefix = prefix._guts.withFastUTF8 { nfcPrefix in
         let prefixEnd = nfcPrefix.count
         return self._guts.withFastUTF8(range: 0..<prefixEnd) { nfcSlicedSelf in
           return _binaryCompare(nfcSlicedSelf, nfcPrefix) == 0
         }
       }
+      let endIndex = Index(_encodedOffset: prefix._guts.count)
+      // In addition to a byte comparison check, we also need to check that
+      // the prefix ends on a grapheme cluster boundary of the String
+      return isPrefix && self._guts.isOnGraphemeClusterBoundary(endIndex)
     }
 
     return starts(with: prefix)
@@ -137,13 +141,17 @@ extension String {
 
   public func hasSuffix(_ suffix: String) -> Bool {
     if _fastPath(self._guts.isNFCFastUTF8 && suffix._guts.isNFCFastUTF8) {
-      guard suffix._guts.count <= self._guts.count else { return false }
-      return suffix._guts.withFastUTF8 { nfcSuffix in
-        let suffixStart = self._guts.count - nfcSuffix.count
+      let suffixStart = self._guts.count - suffix._guts.count
+      guard suffixStart >= 0 else { return false }
+      let isSuffix = suffix._guts.withFastUTF8 { nfcSuffix in
         return self._guts.withFastUTF8(range: suffixStart..<self._guts.count) {
           nfcSlicedSelf in return _binaryCompare(nfcSlicedSelf, nfcSuffix) == 0
         }
       }
+      let startIndex = Index(_encodedOffset: suffixStart)
+      // In addition to a byte comparison check, we also need to check that
+      // the suffix starts on a grapheme cluster boundary of the String
+      return isSuffix && self._guts.isOnGraphemeClusterBoundary(startIndex)
     }
 
     return self.reversed().starts(with: suffix.reversed())

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -293,22 +293,7 @@ StringTests.test("LosslessStringConvertible") {
   checkLosslessStringConvertible(comparisonTests.map { $0.rhs })
 }
 
-// Mark the test cases that are expected to fail in checkHasPrefixHasSuffix
-
-let substringTests = tests.map {
-  (test: ComparisonTest) -> ComparisonTest in
-  switch (test.expectedUnicodeCollation, test.lhs, test.rhs) {
-
-  case (.gt, "\r\n", "\n"):
-    return test.replacingPredicate(.objCRuntime(
-      "blocked on rdar://problem/19036555"))
-
-  default:
-    return test
-  }
-}
-
-for test in substringTests {
+for test in tests {
   StringTests.test("hasPrefix,hasSuffix: line \(test.loc.line)")
     .skip(.nativeRuntime(
         "String.has{Prefix,Suffix} defined when _runtime(_ObjC)"))
@@ -530,6 +515,17 @@ StringTests.test("_isIdentical(to:)") {
   expectFalse(f._isIdentical(to: g)) // Two large, distinct native strings
   expectTrue(f._isIdentical(to: f))
   expectTrue(g._isIdentical(to: g))
+}
+
+StringTests.test("hasPrefix/hasSuffix vs Character boundaries") {
+  // https://github.com/apple/swift/issues/67427
+  let s1 = "\r\n"
+  let s2 = "\r\n" + "cafe" + "\r\n"
+
+  expectFalse(s1.hasPrefix("\r"))
+  expectFalse(s1.hasSuffix("\n"))
+  expectFalse(s2.hasPrefix("\r"))
+  expectFalse(s2.hasSuffix("\n"))
 }
 
 runAllTests()


### PR DESCRIPTION
This commit resolves #67427. When the string and argument are both in NFC form, besides performing the prefix/suffix check, we also have to perform a grapheme boundary check to make sure that the prefix/suffix are not in between an extended grapheme cluster.

In addition, it also seems to pass a test that was previously marked as failing.