### PR TITLE
[Concurrency] Diagnose non-sendable 'self' arguments crossing isolation boundaries.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1834,6 +1834,18 @@ bool swift::diagnoseApplyArgSendability(ApplyExpr *apply, const DeclContext *dec
   if (!fnExprType)
     return false;
 
+  // Check the 'self' argument.
+  if (auto *selfApply = dyn_cast<SelfApplyExpr>(apply->getFn())) {
+    auto *base = selfApply->getBase();
+    if (diagnoseNonSendableTypes(
+            base->getType(),
+            declContext, base->getStartLoc(),
+            diag::non_sendable_call_argument,
+            isolationCrossing.value().exitsIsolation(),
+            isolationCrossing.value().getDiagnoseIsolation()))
+      return true;
+  }
+
   auto fnType = fnExprType->getAs<FunctionType>();
   if (!fnType)
     return false;

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -145,6 +145,7 @@ struct S: P {
 func checkConformer(_ s: S, _ p: any P, _ ma: MyActor) async {
   s.m(thing: ma)
   await p.m(thing: ma)
+  // expected-warning@-1 {{passing argument of non-sendable type 'any P' into actor-isolated context may introduce data races}}
 }
 
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -230,3 +230,29 @@ func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> 
   await a.f(s)
   await a.g(f)
 }
+
+@available(SwiftStdlib 5.1, *)
+final class NonSendable {
+  // expected-note@-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  var value = ""
+
+  @MainActor
+  func update() {
+    value = "update"
+  }
+
+  func call() async {
+    await update()
+    // expected-warning@-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
+
+    await self.update()
+    // expected-warning@-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func testNonSendableBaseArg() async {
+  let t = NonSendable()
+  await t.update()
+  // expected-warning@-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
+}


### PR DESCRIPTION
Otherwise, the following code can reference the state of a non-`Sendable` class across different actor isolation domains:

```swift
final class NonSendable {
  var value = ""

  @MainActor
  func update() {
    value = "update"
  }
}

func test() async {
  let t = NonSendable()
  await t.update() // Sending an instance of 'NonSendable' to the MainActor here!
}
```

Resolves rdar://111470341