### PR TITLE
[test] Mark test as REQUIRES differentiable_programming

### DIFF
--- a/test/IRGen/debug_scope_distinct.swift
+++ b/test/IRGen/debug_scope_distinct.swift
@@ -1,3 +1,5 @@
+// REQUIRES: differentiable_programming
+
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -DM -emit-module -emit-module-path %t/M.swiftmodule %s -module-name M
 // RUN: %target-swiftc_driver -O -g -I %t -c %s -emit-ir -o - | %FileCheck %s


### PR DESCRIPTION
Test tries to import `_Differentiation`, but is not marked as requiring that feature to be available, so it will fail to pass for people that do not compile with differentiable programming enabled.

/cc @asavonic 