### PR TITLE
Expand type refinement contexts to encompass attributes

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -634,13 +634,7 @@ private:
       return Range;
     }
 
-    // For pattern binding declarations, include the attributes in the source
-    // range so that we're sure to cover any property wrappers.
-    if (auto patternBinding = dyn_cast<PatternBindingDecl>(D)) {
-      return D->getSourceRangeIncludingAttrs();
-    }
-
-    return D->getSourceRange();
+    return D->getSourceRangeIncludingAttrs();
   }
 
   // Creates an implicit decl TRC specifying the deployment


### PR DESCRIPTION
This hasty PR unbroke CI after two of my changes (https://github.com/apple/swift/pull/67642 and https://github.com/apple/swift/pull/67698) conflicted. 