### PR TITLE
test: force the target triple to macOS 14

### DIFF
--- a/test/stdlib/Observation/ObservableAvailabilityCycle.swift
+++ b/test/stdlib/Observation/ObservableAvailabilityCycle.swift
@@ -1,14 +1,16 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-feature InitAccessors -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server -primary-file %s %S/Inputs/ObservableClass.swift
+// RUN: %target-swift-frontend -target x86_64-apple-macosx14 -typecheck -parse-as-library -enable-experimental-feature InitAccessors -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server -primary-file %s %S/Inputs/ObservableClass.swift
 
-// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-feature InitAccessors -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server %s -primary-file %S/Inputs/ObservableClass.swift
+// RUN: %target-swift-frontend -target x86_64-apple-macosx14 -typecheck -parse-as-library -enable-experimental-feature InitAccessors -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server %s -primary-file %S/Inputs/ObservableClass.swift
 
 // REQUIRES: observation
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+
+// REQUIRES OS=macosx
 
 @available(SwiftStdlib 5.9, *)
 extension ObservableClass {


### PR DESCRIPTION
Observability requires macOS 14 as a baseline, and this is currently causing failures on builders which are not running that version.