### PR TITLE
[cxx-interop] Add test for mutation of nested `std::map`

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -7,6 +7,7 @@
 
 using Map = std::map<int, int>;
 using MapStrings = std::map<std::string, std::string>;
+using NestedMap = std::map<int, Map>;
 using UnorderedMap = std::unordered_map<int, int>;
 
 inline Map initMap() { return {{1, 3}, {2, 2}, {3, 3}}; }

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -50,6 +50,24 @@ StdMapTestSuite.test("MapStrings.subscript") {
   expectEqual(m[std.string("abc")], std.string("qwe"))
 }
 
+StdMapTestSuite.test("NestedMap.subscript") {
+  var m = NestedMap()
+  expectNil(m[0])
+  expectNil(m[0])
+  m[1] = Map()
+  expectNotNil(m[1])
+
+  expectNil(m[1]![0])
+  m[1]![0] = 123
+  expectEqual(m[1]![0], 123)
+
+  m[1]![0] = nil
+  expectNil(m[1]![0])
+
+  m[1] = nil
+  expectNil(m[1])
+}
+
 StdMapTestSuite.test("UnorderedMap.subscript") {
   // This relies on the `std::unordered_map` conformance to `CxxDictionary` protocol.
   var m = initUnorderedMap()


### PR DESCRIPTION
rdar://111888891