### PR TITLE
Ensure that macro overloading via availability works

### DIFF
--- a/test/Macros/macro_availability_macos.swift
+++ b/test/Macros/macro_availability_macos.swift
@@ -1,0 +1,36 @@
+// REQUIRES: swift_swift_parser, asserts
+// REQUIRES: OS=macosx
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name MacrosTest -target %target-cpu-apple-macos50
+
+@freestanding(expression)
+macro overloadedOnAvailability(_: Any) -> Int = #externalMacro(module: "MacroLibrary", type: "MyOldMacro")
+//expected-warning@-1{{external macro implementation type 'MacroLibrary.MyOldMacro'}}
+// expected-note@-2 2{{'overloadedOnAvailability' declared here}}
+
+@available(macOS 60, *)
+@freestanding(expression)
+macro overloadedOnAvailability(_: Int) -> Double = #externalMacro(module: "MacroLibrary", type: "MyNewMacro")
+//expected-warning@-1{{external macro implementation type 'MacroLibrary.MyNewMacro'}}
+// expected-note@-2{{'overloadedOnAvailability' declared here}}
+
+
+func mutateInt(_: inout Int) { }
+func mutateDouble(_: inout Double) { }
+
+func testAvailabilityOld() {
+  var a = #overloadedOnAvailability(1)
+  mutateInt(&a)
+  // expected-error@-2{{external macro implementation type 'MacroLibrary.MyOldMacro'}}
+}
+
+@available(macOS 60, *)
+func testAvailabilitNew(a: Any) {
+  var a = #overloadedOnAvailability(1)
+  mutateDouble(&a)
+  // expected-error@-2{{external macro implementation type 'MacroLibrary.MyNewMa}}
+
+  var b = #overloadedOnAvailability(a)
+  mutateInt(&b)
+  // expected-error@-2{{external macro implementation type 'MacroLibrary.MyOldMacro'}}
+}


### PR DESCRIPTION
This was already fixed by a previous change (#67698), but this introduces a test case to ensure that we don't regress rdar://113047811.