### PR TITLE
AST/Sema: Fix a couple of minor issues with tuple conformances and add a new test case

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -261,6 +261,7 @@ bool CanType::isReferenceTypeImpl(CanType type, const GenericSignatureImpl *sig,
   case TypeKind::PackExpansion:
   case TypeKind::PackElement:
   case TypeKind::SILPack:
+  case TypeKind::BuiltinTuple:
 #define REF_STORAGE(Name, ...) \
   case TypeKind::Name##Storage:
 #include "swift/AST/ReferenceStorage.def"
@@ -270,8 +271,6 @@ bool CanType::isReferenceTypeImpl(CanType type, const GenericSignatureImpl *sig,
   case TypeKind::DependentMember:
     assert(sig && "dependent types can't answer reference semantics query");
     return sig->requiresClass(type);
-  case TypeKind::BuiltinTuple:
-    llvm_unreachable("Should not get a BuiltinTupleType here");
   }
 
   llvm_unreachable("Unhandled type kind!");

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -34,3 +34,28 @@ func useConformance() {
 
   (1, 2, 3).f()
 }
+
+////
+
+extension Builtin.TheTupleType: Equatable where repeat each Elements: Equatable {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    var result = true
+    func update<E: Equatable>(lhs: E, rhs: E) {
+      result = result && (lhs == rhs)
+    }
+
+    repeat update(lhs: each lhs, rhs: each rhs)
+    return result
+  }
+}
+
+extension Builtin.TheTupleType: Hashable where repeat each Elements: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    repeat (each self).hash(into: &hasher)
+  }
+
+  // FIXME: This should be unnecessary
+  public var hashValue: Int {
+    return 0
+  }
+}


### PR DESCRIPTION
The progress on variadic generics means we can now implement useful witnesses in a tuple conformance. The feature remains very incomplete though, today we crash in SILGen.