### PR TITLE
[Dependency Scanning] Separate module output path from Clang scanner's module cache

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -945,6 +945,8 @@ private:
   std::string mainScanModuleName;
   /// The context hash of the current scanning invocation
   std::string scannerContextHash;
+  /// The location of where the built modules will be output to
+  std::string moduleOutputPath;
   /// The Clang dependency scanner tool
   clang::tooling::dependencies::DependencyScanningTool clangScanningTool;
 
@@ -958,6 +960,7 @@ private:
 public:
   ModuleDependenciesCache(SwiftDependencyScanningService &globalScanningService,
                           std::string mainScanModuleName,
+                          std::string moduleOutputPath,
                           std::string scanningContextHash);
   ModuleDependenciesCache(const ModuleDependenciesCache &) = delete;
   ModuleDependenciesCache &operator=(const ModuleDependenciesCache &) = delete;
@@ -979,6 +982,9 @@ public:
   }
   void addSeenClangModule(clang::tooling::dependencies::ModuleID newModule) {
     alreadySeenClangModules.insert(newModule);
+  }
+  std::string getModuleOutputPath() {
+    return moduleOutputPath;
   }
 
   /// Look for module dependencies for a module with the given name

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -811,6 +811,9 @@ namespace swift {
     /// The module cache path which the Clang importer should use.
     std::string ModuleCachePath;
 
+    /// The Scanning module cache path which the Clang Dependency Scanner should use.
+    std::string ClangScannerModuleCachePath;
+
     /// Extra arguments which should be passed to the Clang importer.
     std::vector<std::string> ExtraArgs;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -168,8 +168,16 @@ public:
     ClangImporterOpts.ModuleCachePath = Path.str();
   }
 
+  void setClangScannerModuleCachePath(StringRef Path) {
+    ClangImporterOpts.ClangScannerModuleCachePath = Path.str();
+  }
+
   StringRef getClangModuleCachePath() const {
     return ClangImporterOpts.ModuleCachePath;
+  }
+
+  StringRef getClangScannerModuleCachePath() const {
+    return ClangImporterOpts.ClangScannerModuleCachePath;
   }
 
   void setImportSearchPaths(const std::vector<std::string> &Paths) {

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -91,6 +91,10 @@ public:
   /// binary module has already been built for use by the compiler.
   std::string PrebuiltModuleCachePath;
 
+  /// The path to output explicit module dependencies. Only relevant during
+  /// dependency scanning.
+  std::string ExplicitModulesOutputPath;
+
   /// The path to look in to find backup .swiftinterface files if those found
   /// from SDKs are failing.
   std::string BackupModuleInterfaceDir;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -456,7 +456,7 @@ def localization_path : Separate<["-"], "localization-path">,
 def module_cache_path : Separate<["-"], "module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath, SwiftAPIExtractOption,
          SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
-  HelpText<"Specifies the Clang module cache path">;
+  HelpText<"Specifies the module cache path">;
 
 def enable_library_evolution : Flag<["-"], "enable-library-evolution">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1838,6 +1838,9 @@ def cas_plugin_option: Separate<["-"], "cas-plugin-option">,
   Flags<[FrontendOption, NewDriverOnlyOption]>,
   HelpText<"Option pass to CAS Plugin">, MetaVarName<"<name>=<option>">;
 
+def clang_scanner_module_cache_path : Separate<["-"], "clang-scanner-module-cache-path">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  HelpText<"Specifies the Clang dependency scanner module cache path">;
 
 // END ONLY SUPPORTED IN NEW DRIVER
 

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -41,7 +41,7 @@ namespace swift {
       InterfaceSubContextDelegate &astDelegate;
 
       /// Location where pre-built moduels are to be built into.
-      std::string moduleCachePath;
+      std::string moduleOutputPath;
 
       llvm::Optional<SwiftDependencyTracker> dependencyTracker;
 
@@ -51,13 +51,13 @@ namespace swift {
       ModuleDependencyScanner(
           ASTContext &ctx, ModuleLoadingMode LoadMode, Identifier moduleName,
           InterfaceSubContextDelegate &astDelegate,
+          StringRef moduleOutputPath,
           ScannerKind kind = MDS_plain,
           llvm::Optional<SwiftDependencyTracker> tracker = llvm::None)
           : SerializedModuleLoaderBase(ctx, nullptr, LoadMode,
                                        /*IgnoreSwiftSourceInfoFile=*/true),
             kind(kind), moduleName(moduleName), astDelegate(astDelegate),
-            moduleCachePath(getModuleCachePathFromClang(
-                ctx.getClangModuleLoader()->getClangInstance())),
+            moduleOutputPath(moduleOutputPath),
             dependencyTracker(tracker) {}
 
       std::error_code findModuleFilesInDirectory(
@@ -123,9 +123,10 @@ namespace swift {
           ASTContext &ctx, ModuleLoadingMode LoadMode, Identifier moduleName,
           StringRef PlaceholderDependencyModuleMap,
           InterfaceSubContextDelegate &astDelegate,
+          StringRef moduleOutputPath,
           llvm::Optional<SwiftDependencyTracker> tracker = llvm::None)
           : ModuleDependencyScanner(ctx, LoadMode, moduleName, astDelegate,
-                                    MDS_placeholder, tracker) {
+                                    moduleOutputPath, MDS_placeholder, tracker) {
 
         // FIXME: Find a better place for this map to live, to avoid
         // doing the parsing on every module.

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -618,9 +618,11 @@ ModuleDependenciesCache::getDependencyReferencesMap(
 
 ModuleDependenciesCache::ModuleDependenciesCache(
     SwiftDependencyScanningService &globalScanningService,
-    std::string mainScanModuleName, std::string scannerContextHash)
+    std::string mainScanModuleName, std::string moduleOutputPath,
+    std::string scannerContextHash)
     : globalScanningService(globalScanningService),
       mainScanModuleName(mainScanModuleName),
+      moduleOutputPath(moduleOutputPath),
       scannerContextHash(scannerContextHash),
       clangScanningTool(*globalScanningService.ClangScanningService,
                         globalScanningService.getClangScanningFS()) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -667,7 +667,13 @@ importer::getNormalInvocationArguments(
   }
 
   const std::string &moduleCachePath = importerOpts.ModuleCachePath;
-  if (!moduleCachePath.empty() && !importerOpts.DisableImplicitClangModules) {
+  const std::string &scannerCachePath = importerOpts.ClangScannerModuleCachePath;
+  // If a scanner cache is specified, this must be a scanning action. Prefer this
+  // path for the Clang scanner to cache its Scanning PCMs.
+  if (!scannerCachePath.empty()) {
+    invocationArgStrs.push_back("-fmodules-cache-path=");
+    invocationArgStrs.back().append(scannerCachePath);
+  } else if (!moduleCachePath.empty() && !importerOpts.DisableImplicitClangModules) {
     invocationArgStrs.push_back("-fmodules-cache-path=");
     invocationArgStrs.back().append(moduleCachePath);
   }

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -174,7 +174,7 @@ void ClangImporter::recordModuleDependencies(
 
     auto pcmPath = moduleCacheRelativeLookupModuleOutput(
         clangModuleDep.ID, ModuleOutputKind::ModuleFile,
-        getModuleCachePathFromClang(getClangInstance()));
+        cache.getModuleOutputPath());
     swiftArgs.push_back("-o");
     swiftArgs.push_back(pcmPath);
 
@@ -421,7 +421,7 @@ ClangImporter::getModuleDependencies(StringRef moduleName,
   }
   std::string workingDir = *optionalWorkingDir;
 
-  auto moduleCachePath = getModuleCachePathFromClang(getClangInstance());
+  auto moduleCachePath = cache.getModuleOutputPath();
   auto lookupModuleOutput =
       [moduleCachePath](const ModuleID &MID,
                         ModuleOutputKind MOK) -> std::string {

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -131,9 +131,10 @@ DependencyScanningTool::getDependencies(
   auto Instance = std::move(*InstanceOrErr);
 
   // Local scan cache instance, wrapping the shared global cache.
-  ModuleDependenciesCache cache(*ScanningService,
-                                Instance->getMainModule()->getNameStr().str(),
-                                Instance->getInvocation().getModuleScanningHash());
+  ModuleDependenciesCache cache(
+      *ScanningService, Instance->getMainModule()->getNameStr().str(),
+      Instance->getInvocation().getFrontendOptions().ExplicitModulesOutputPath,
+      Instance->getInvocation().getModuleScanningHash());
   // Execute the scanning action, retrieving the in-memory result
   auto DependenciesOrErr = performModuleScan(*Instance.get(), cache);
   if (DependenciesOrErr.getError())
@@ -173,9 +174,10 @@ DependencyScanningTool::getDependencies(
   auto Instance = std::move(*InstanceOrErr);
 
   // Local scan cache instance, wrapping the shared global cache.
-  ModuleDependenciesCache cache(*ScanningService,
-                                Instance->getMainModule()->getNameStr().str(),
-                                Instance->getInvocation().getModuleScanningHash());
+  ModuleDependenciesCache cache(
+      *ScanningService, Instance->getMainModule()->getNameStr().str(),
+      Instance->getInvocation().getFrontendOptions().ExplicitModulesOutputPath,
+      Instance->getInvocation().getModuleScanningHash());
   auto BatchScanResults = performBatchModuleScan(
       *Instance.get(), cache, VersionedPCMInstanceCacheCache.get(),
       Saver, BatchInput);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -64,6 +64,9 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_prebuilt_module_cache_path)) {
     Opts.PrebuiltModuleCachePath = A->getValue();
   }
+  if (const Arg *A = Args.getLastArg(OPT_module_cache_path)) {
+    Opts.ExplicitModulesOutputPath = A->getValue();
+  }
   if (const Arg *A = Args.getLastArg(OPT_backup_module_interface_path)) {
     Opts.BackupModuleInterfaceDir = A->getValue();
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1461,6 +1461,9 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
   if (const Arg *A = Args.getLastArg(OPT_module_cache_path)) {
     Opts.ModuleCachePath = A->getValue();
   }
+  if (const Arg *A = Args.getLastArg(OPT_clang_scanner_module_cache_path)) {
+    Opts.ClangScannerModuleCachePath = A->getValue();
+  }
 
   if (const Arg *A = Args.getLastArg(OPT_target_cpu))
     Opts.TargetCPU = A->getValue();

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -147,7 +147,7 @@ ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
     }
 
     // Compute the output path and add it to the command line
-    SmallString<128> outputPathBase(moduleCachePath);
+    SmallString<128> outputPathBase(moduleOutputPath);
     llvm::sys::path::append(
         outputPathBase,
         moduleName.str() + "-" + Hash + "." +
@@ -281,9 +281,11 @@ SerializedModuleLoaderBase::getModuleDependencies(
   // FIXME: submodules?
   scanners.push_back(std::make_unique<PlaceholderSwiftModuleScanner>(
       Ctx, LoadMode, moduleId, Ctx.SearchPathOpts.PlaceholderDependencyModuleMap,
-      delegate, cache.getScanService().createSwiftDependencyTracker()));
+      delegate, cache.getModuleOutputPath(),
+       cache.getScanService().createSwiftDependencyTracker()));
   scanners.push_back(std::make_unique<ModuleDependencyScanner>(
-      Ctx, LoadMode, moduleId, delegate, ModuleDependencyScanner::MDS_plain,
+      Ctx, LoadMode, moduleId, delegate, cache.getModuleOutputPath(),
+      ModuleDependencyScanner::MDS_plain,
       cache.getScanService().createSwiftDependencyTracker()));
 
   // Check whether there is a module with this name that we can import.

--- a/test/ScanDependencies/separate_clang_scan_cache.swift
+++ b/test/ScanDependencies/separate_clang_scan_cache.swift
@@ -4,12 +4,12 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache -clang-scanner-module-cache-path %t.scanner-cache %s -o %t.deps.json -I %S/Inputs/SwiftDifferent -dump-clang-diagnostics 2>&1 | %FileCheck %s --check-prefix=CHECK-CLANG-COMMAND
 // RUN: %validate-json %t.deps.json | %FileCheck %s --check-prefix=CHECK-DEPS
 
+// Ensure we prefer clang scanner module cache path
 // CHECK-CLANG-COMMAND: '-fmodules-cache-path={{.*}}.scanner-cache'
 
+// Ensure we the modules' output path is set to the module cache
 // CHECK-DEPS: "swift": "A"
 // CHECK-DEPS:            "swift": "A"
-// CHECK-DEPS-NEXT:    },
-// CHECK-DEPS-NEXT:    {
-// CHECK-DEPS-NEXT:        "modulePath": "{{.*}}.module-cache/A-{{.*}}.swiftmodule",
-// CHECK-DEPS-NEXT:      "sourceFiles": [
+// CHECK-DEPS:      "modulePath": "{{.*}}separate_clang_scan_cache.swift.tmp.module-cache{{/|\\\\}}A-{{.*}}.swiftmodule"
+
 import A

--- a/test/ScanDependencies/separate_clang_scan_cache.swift
+++ b/test/ScanDependencies/separate_clang_scan_cache.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t.module-cache)
+// RUN: %empty-directory(%t.scanner-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache -clang-scanner-module-cache-path %t.scanner-cache %s -o %t.deps.json -I %S/Inputs/SwiftDifferent -dump-clang-diagnostics 2>&1 | %FileCheck %s --check-prefix=CHECK-CLANG-COMMAND
+// RUN: %validate-json %t.deps.json | %FileCheck %s --check-prefix=CHECK-DEPS
+
+// CHECK-CLANG-COMMAND: '-fmodules-cache-path={{.*}}.scanner-cache'
+
+// CHECK-DEPS: "swift": "A"
+// CHECK-DEPS:            "swift": "A"
+// CHECK-DEPS-NEXT:    },
+// CHECK-DEPS-NEXT:    {
+// CHECK-DEPS-NEXT:        "modulePath": "{{.*}}.module-cache/A-{{.*}}.swiftmodule",
+// CHECK-DEPS-NEXT:      "sourceFiles": [
+import A


### PR DESCRIPTION
- **Add option to specify a separate Clang Dependency scanner module cache.**
Clang dependency scanning produces scanner PCMs which we may want to live in a different filesystem location than the main build module cache.

-  **Specify Explicit Module output path to the scanner explicitly.**
Instead of the code querying the compiler's built-in Clang instance, refactor the dependency scanner to explicitly keep track of module output path. It is still set according to `-module-cache-path` as it has been prior to this change, but now the scanner can use a different module cache for scanning PCMs, as specified with `-clang-scanner-module-cache-path`, without affecting module output path.