### PR TITLE
[5.9] Availability checking for uses of macros

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -528,6 +528,7 @@ public:
 
     DeclVisitor<AccessControlChecker>::visit(D);
     checkGlobalActorAccess(D);
+    checkAttachedMacrosAccess(D);
   }
 
   // Force all kinds to be handled at a lower level.
@@ -1258,6 +1259,18 @@ public:
                                minDiagAccessLevel, problemIsResult);
       highlightOffendingType(diag, complainRepr);
       noteLimitingImport(MD->getASTContext(), minImportLimit, complainRepr);
+    }
+  }
+
+  void checkAttachedMacrosAccess(const Decl *D) {
+    for (auto customAttrC : D->getSemanticAttrs().getAttributes<CustomAttr>()) {
+      auto customAttr = const_cast<CustomAttr *>(customAttrC);
+      auto *macroDecl = D->getResolvedMacro(customAttr);
+      if (macroDecl) {
+        diagnoseDeclAvailability(
+          macroDecl, customAttr->getTypeRepr()->getSourceRange(), nullptr,
+          ExportContext::forDeclSignature(const_cast<Decl *>(D)), llvm::None);
+      }
     }
   }
 };

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -634,13 +634,7 @@ private:
       return Range;
     }
 
-    // For pattern binding declarations, include the attributes in the source
-    // range so that we're sure to cover any property wrappers.
-    if (auto patternBinding = dyn_cast<PatternBindingDecl>(D)) {
-      return D->getSourceRangeIncludingAttrs();
-    }
-
-    return D->getSourceRange();
+    return D->getSourceRangeIncludingAttrs();
   }
 
   // Creates an implicit decl TRC specifying the deployment

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3252,6 +3252,11 @@ public:
       }
     }
 
+    if (auto ME = dyn_cast<MacroExpansionExpr>(E)) {
+      diagnoseDeclRefAvailability(
+          ME->getMacroRef(), ME->getMacroNameLoc().getSourceRange());
+    }
+
     return Action::Continue(E);
   }
 

--- a/test/Macros/macro_availability_macos.swift
+++ b/test/Macros/macro_availability_macos.swift
@@ -1,0 +1,36 @@
+// REQUIRES: swift_swift_parser, asserts
+// REQUIRES: OS=macosx
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name MacrosTest -target %target-cpu-apple-macos50
+
+@freestanding(expression)
+macro overloadedOnAvailability(_: Any) -> Int = #externalMacro(module: "MacroLibrary", type: "MyOldMacro")
+//expected-warning@-1{{external macro implementation type 'MacroLibrary.MyOldMacro'}}
+// expected-note@-2 2{{'overloadedOnAvailability' declared here}}
+
+@available(macOS 60, *)
+@freestanding(expression)
+macro overloadedOnAvailability(_: Int) -> Double = #externalMacro(module: "MacroLibrary", type: "MyNewMacro")
+//expected-warning@-1{{external macro implementation type 'MacroLibrary.MyNewMacro'}}
+// expected-note@-2{{'overloadedOnAvailability' declared here}}
+
+
+func mutateInt(_: inout Int) { }
+func mutateDouble(_: inout Double) { }
+
+func testAvailabilityOld() {
+  var a = #overloadedOnAvailability(1)
+  mutateInt(&a)
+  // expected-error@-2{{external macro implementation type 'MacroLibrary.MyOldMacro'}}
+}
+
+@available(macOS 60, *)
+func testAvailabilitNew(a: Any) {
+  var a = #overloadedOnAvailability(1)
+  mutateDouble(&a)
+  // expected-error@-2{{external macro implementation type 'MacroLibrary.MyNewMa}}
+
+  var b = #overloadedOnAvailability(a)
+  mutateInt(&b)
+  // expected-error@-2{{external macro implementation type 'MacroLibrary.MyOldMacro'}}
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -546,3 +546,23 @@ func testExpressionAsDeclarationMacro() {
   // expected-error@-1{{macro implementation type 'StringifyMacro' doesn't conform to required protocol 'DeclarationMacro' (from macro 'stringifyAsDeclMacro')}}
 #endif
 }
+
+// Deprecated macro
+@available(*, deprecated, message: "This macro is deprecated.")
+@freestanding(expression) macro deprecatedStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+@available(*, deprecated, message: "This macro is deprecated.")
+@freestanding(declaration) macro deprecatedStringifyAsDeclMacro<T>(_ value: T) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+func testDeprecated() {
+  // expected-warning@+1{{'deprecatedStringify' is deprecated: This macro is deprecated.}}
+  _ = #deprecatedStringify(1 + 1)
+}
+
+#if TEST_DIAGNOSTICS
+struct DeprecatedStructWrapper {
+  // expected-error@+2{{macro implementation type 'StringifyMacro' doesn't conform to required protocol 'DeclarationMacro' (from macro 'deprecatedStringifyAsDeclMacro')}}
+  // expected-warning@+1{{'deprecatedStringifyAsDeclMacro' is deprecated: This macro is deprecated.}}
+  #deprecatedStringifyAsDeclMacro(1 + 1)
+}
+#endif

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -231,3 +231,18 @@ func testStructWithPeers() {
   let x = SomeStructWithPeerProperties()
   print(x)
 }
+
+
+#if TEST_DIAGNOSTICS
+@available(*, deprecated, message: "This macro is deprecated.")
+@attached(peer, names: overloaded)
+macro deprecatedAddCompletionHandler() = #externalMacro(module: "MacroDefinition", type: "AddCompletionHandler")
+
+
+// expected-warning@+1{{'deprecatedAddCompletionHandler()' is deprecated: This macro is deprecated.}}
+@deprecatedAddCompletionHandler
+func fDeprecated(a: Int, for b: String, _ value: Double) async -> String {
+  return b
+}
+
+#endif


### PR DESCRIPTION
* **Explanation**: Perform availability checking for uses of macros, to ensure that we reject (e.g.) an attempt to use a macro with availability that's newer than the current availability context.
* **Scope**: Narrow. Only affects uses of macros, to ensure that they respect availability.
* **Risk**: Low. Only affects macro uses.
* **Original pull request**: https://github.com/apple/swift/pull/67698, https://github.com/apple/swift/pull/67732, https://github.com/apple/swift/pull/67748
* **Issue**: rdar://113138432&113047811
