### PR TITLE
[OpaqueValues] Emit RValue of AnyHashable erasure into new context.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2059,10 +2059,10 @@ RValue RValueEmitter::visitAnyHashableErasureExpr(AnyHashableErasureExpr *E,
   auto sourceOrigType = AbstractionPattern::getOpaque();
   auto subExpr = E->getSubExpr();
   auto &sourceOrigTL = SGF.getTypeLowering(sourceOrigType, subExpr->getType());
-  auto source =
-      SGF.silConv.useLoweredAddresses()
-          ? SGF.emitMaterializedRValueAsOrig(subExpr, sourceOrigType)
-          : SGF.emitRValueAsOrig(subExpr, sourceOrigType, sourceOrigTL, C);
+  auto source = SGF.silConv.useLoweredAddresses()
+                    ? SGF.emitMaterializedRValueAsOrig(subExpr, sourceOrigType)
+                    : SGF.emitRValueAsOrig(subExpr, sourceOrigType,
+                                           sourceOrigTL, SGFContext());
 
   return SGF.emitAnyHashableErasure(E, source, subExpr->getType(),
                                     E->getConformance(), C);

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -760,3 +760,25 @@ func callMutatingFooOnInoutExistential(_ i: inout any MutatingFooable) {
 struct WeakBox<T : AnyObject> {
   weak var t: T?
 }
+
+// CHECK-LABEL: sil {{.*}}[ossa] @intIntoAnyHashableVar : {{.*}} {
+// CHECK:         [[VAR_BOX_ADDR:%[^,]+]] = project_box
+// CHECK:         [[INT:%[^,]+]] = apply
+// CHECK:         [[CONVERT:%[^,]+]] = function_ref @$ss21_convertToAnyHashableys0cD0VxSHRzlF
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[CONVERT]]<Int>([[INT]])
+// CHECK:         store [[INSTANCE]] to [init] [[VAR_BOX_ADDR]]
+// CHECK-LABEL: } // end sil function 'intIntoAnyHashableVar'
+@_silgen_name("intIntoAnyHashableVar")
+func intIntoAnyHashableVar() {
+  var anyHashable: AnyHashable = 0
+}
+
+// CHECK-LABEL: sil {{.*}}[ossa] @intIntoAnyHashableLet : {{.*}} {
+// CHECK:         [[INT:%[^,]+]] = apply
+// CHECK:         [[CONVERT:%[^,]+]] = function_ref @$ss21_convertToAnyHashableys0cD0VxSHRzlF
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[CONVERT]]<Int>([[INT]])
+// CHECK-LABEL: } // end sil function 'intIntoAnyHashableLet'
+@_silgen_name("intIntoAnyHashableLet")
+func intIntoAnyHashableLet() {
+  let anyHashable: AnyHashable = 0
+}


### PR DESCRIPTION
When storing an instance of some type that conforms to Hashable into an lvalue of type AnyHashable, the source rvalue needs to be emitted within a new SGFContext.  Otherwise, the LocalVarInitialization for the var of type AnyHashable would be used and an attempt would be made to store the instance of the conforming type into the projected box.
