### PR TITLE
[CSSimplify] Relax `isBindable` requirements for pack expansion variables

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11619,17 +11619,6 @@ bool ConstraintSystem::resolvePackExpansion(TypeVariableType *typeVar,
           .getOpenedType();
 
   assignFixedType(typeVar, openedExpansionType, locator);
-
-  // We have a fully resolved contextual pack expansion type, let's
-  // apply it right away.
-  if (!contextualType->isEqual(openedExpansionType)) {
-    assert(contextualType->is<PackExpansionType>() &&
-           !contextualType->hasTypeVariable());
-    auto result = matchTypes(openedExpansionType, contextualType,
-                             ConstraintKind::Equal, {}, locator);
-    return !result.isFailure();
-  }
-
   return true;
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11610,16 +11610,13 @@ bool ConstraintSystem::resolveKeyPath(TypeVariableType *typeVar,
 
 bool ConstraintSystem::resolvePackExpansion(TypeVariableType *typeVar,
                                             Type contextualType) {
+  assert(typeVar->getImpl().isPackExpansion());
+
   auto *locator = typeVar->getImpl().getLocator();
 
-  Type openedExpansionType;
-  if (auto expansionElt =
-          locator->getLastElementAs<LocatorPathElt::PackExpansionType>()) {
-    openedExpansionType = expansionElt->getOpenedType();
-  }
-
-  if (!openedExpansionType)
-    return false;
+  Type openedExpansionType =
+      locator->castLastElementTo<LocatorPathElt::PackExpansionType>()
+          .getOpenedType();
 
   assignFixedType(typeVar, openedExpansionType, locator);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4210,7 +4210,16 @@ static void enumerateOptionalConversionRestrictions(
 /// Determine whether we can bind the given type variable to the given
 /// fixed type.
 static bool isBindable(TypeVariableType *typeVar, Type type) {
-  return !ConstraintSystem::typeVarOccursInType(typeVar, type) &&
+  // Disallow recursive bindings.
+  if (ConstraintSystem::typeVarOccursInType(typeVar, type))
+    return false;
+
+  // If type variable we are about to bind represents a pack
+  // expansion type, allow the binding to happen regardless of
+  // what the \c type is, because contextual type is just a hint
+  // in this situation and type variable would be bound to its
+  // opened type instead.
+  return typeVar->getImpl().isPackExpansion() ||
          !type->is<DependentMemberType>();
 }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar112617922.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar112617922.swift
@@ -1,0 +1,27 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+enum MyError: Error {
+  case unknown
+}
+
+extension Result {
+  init<each S>(success: repeat each S, failure: Failure?) where Success == (repeat each S.Wrapped), Failure == any Error, repeat each S: OptionalProtocol {
+  }
+}
+
+protocol OptionalProtocol {
+  associatedtype Wrapped
+  var asOptional: Optional<Wrapped> { get }
+}
+
+extension Optional: OptionalProtocol {
+  var asOptional: Optional<Wrapped> { self }
+}
+
+func test<each EncodedResult: OptionalProtocol>(
+    _ transformed: @escaping (Result<(repeat each EncodedResult.Wrapped), any Error>) -> Void
+) -> ((any Error)?, repeat each EncodedResult) -> Void where repeat each EncodedResult.Wrapped: DataProtocol {
+  return {
+    transformed(Result(success: $1, failure: $0))
+  }
+}


### PR DESCRIPTION
If type variable we are about to bind represents a pack
expansion type, allow the binding to happen regardless of
what the \c type is, because contextual type is just a hint
in this situation and type variable would be bound to its
opened type instead.

Resolves: rdar://112617922

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
