### PR TITLE
[Macros] Replace all uses of the `ConformanceMacro` protocol with `ExtensionMacro`.

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/OptionSetMacro.swift
@@ -123,27 +123,25 @@ public struct OptionSetMacro {
   }
 }
 
-extension OptionSetMacro: ConformanceMacro {
-  public static func expansion<
-    Decl: DeclGroupSyntax,
-    Context: MacroExpansionContext
-  >(
+extension OptionSetMacro: ExtensionMacro {
+  public static func expansion(
     of attribute: AttributeSyntax,
-    providingConformancesOf decl: Decl,
-    in context: Context
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
-    // Decode the expansion arguments.
-    guard let (structDecl, _, _) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
-      return []
-    }
-
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
     // If there is an explicit conformance to OptionSet already, don't add one.
-    if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypes,
-       inheritedTypes.contains(where: { inherited in inherited.type.trimmedDescription == "OptionSet" }) {
+    if protocols.isEmpty {
       return []
     }
 
-    return [("OptionSet", nil)]
+    let ext: DeclSyntax =
+      """
+      extension \(type.trimmed): OptionSet {}
+      """
+
+    return [ext.cast(ExtensionDeclSyntax.self)]
   }
 }
 

--- a/test/Index/index_macros.swift
+++ b/test/Index/index_macros.swift
@@ -207,14 +207,16 @@ public struct SomeAccessorMacro: AccessorMacro {
   }
 }
 
-public struct SomeConformanceMacro: ConformanceMacro {
+public struct SomeConformanceMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    providingConformancesOf decl: some DeclGroupSyntax,
+    attachedTo: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
-    let protocolName: TypeSyntax = "TestProto"
-    return [(protocolName, nil)]
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax = "extension \(type.trimmed): TestProto {}"
+    return [ext.cast(ExtensionDeclSyntax.self)]
   }
 }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1281,14 +1281,16 @@ public struct EmptyPeerMacro: PeerMacro {
   }
 }
 
-public struct EquatableMacro: ConformanceMacro {
+public struct EquatableMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    providingConformancesOf decl: some DeclGroupSyntax,
+    attachedTo: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
-    let protocolName: TypeSyntax = "Equatable"
-    return [(protocolName, nil)]
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax = "extension \(type.trimmed): Equatable {}"
+    return [ext.cast(ExtensionDeclSyntax.self)]
   }
 }
 
@@ -1316,34 +1318,37 @@ public struct ConformanceViaExtensionMacro: ExtensionMacro {
   }
 }
 
-public struct HashableMacro: ConformanceMacro {
+public struct HashableMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    providingConformancesOf decl: some DeclGroupSyntax,
+    attachedTo: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
-    let protocolName: TypeSyntax = "Hashable"
-    return [(protocolName, nil)]
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax = "extension \(type.trimmed): Hashable {}"
+    return [ext.cast(ExtensionDeclSyntax.self)]
   }
 }
 
-public struct DelegatedConformanceMacro: ConformanceMacro, MemberMacro {
+public struct DelegatedConformanceMacro: ExtensionMacro, MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    providingConformancesOf decl: some DeclGroupSyntax,
+    attachedTo: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
-    let protocolName: TypeSyntax = "P"
+  ) throws -> [ExtensionDeclSyntax] {
     let conformance: DeclSyntax =
       """
-      extension Placeholder where Element: P {}
+      extension \(type.trimmed): P where Element: P {}
       """
 
     guard let extensionDecl = conformance.as(ExtensionDeclSyntax.self) else {
       return []
     }
 
-    return [(protocolName, extensionDecl.genericWhereClause)]
+    return [extensionDecl]
   }
 
   public static func expansion(
@@ -1760,26 +1765,21 @@ public struct AddPeerStoredPropertyMacro: PeerMacro, Sendable {
   }
 }
 
-public struct InitializableMacro: ConformanceMacro, MemberMacro {
+public struct InitializableMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    providingConformancesOf decl: some DeclGroupSyntax,
+    attachedTo: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
-  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
-    return [("Initializable", nil)]
-  }
-
-  public static func expansion(
-    of node: AttributeSyntax,
-    providingMembersOf decl: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
-  ) throws -> [DeclSyntax] {
-    let requirement: DeclSyntax =
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax = 
       """
-      init(value: Int) {}
+      extension \(type.trimmed): Initializable {
+        init(value: Int) {}
+      }
       """
-
-    return [requirement]
+    return [ext.cast(ExtensionDeclSyntax.self)]
   }
 }
 

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -117,8 +117,7 @@ macro Empty<T>(_ closure: () -> T) = #externalMacro(module: "MacroDefinition", t
   S(a: 10, b: 10)
 }
 
-@attached(extension, conformances: Initializable)
-@attached(member, names: named(init))
+@attached(extension, conformances: Initializable, names: named(init))
 macro Initializable() = #externalMacro(module: "MacroDefinition", type: "InitializableMacro")
 
 protocol Initializable {


### PR DESCRIPTION
`ConformanceMacro` provides a default implementation of `ExtensionMacro` so this is effectively NFC (and most of the changes are in tests anyway).