### PR TITLE
Add missing cmath header to TypeCheckStmt.cpp

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -52,6 +52,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/Timer.h"
+#include <cmath>
 #include <iterator>
 
 using namespace swift;


### PR DESCRIPTION
Working toward getting the Linux bots building.
This file calls `ceil` in `llvm::errs() << llvm::format("%0.2f", ceil(elapsed * 100000) / 100) << "ms\t";`, which is no longer transitively included on rebranch.