### PR TITLE
Update GettingStarted with note on M1 Macs

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -196,6 +196,15 @@ toolchain as a one-off, there are a couple of differences:
 * If you installed and want to use Sccache: Run `sccache --version`; check
   that this succeeds.
 
+> **Note**  
+> If you are running on Apple Silicon hardware (M1, M2, etc), ensure you have
+> the native arm64 build of these dependencies installed and configured in your PATH.
+>
+> e.g. running `file $(which python3)` should print "arm64".
+>
+> If it prints "x86_64", you are running Python in compatibility mode (Rosetta), and building Swift will fail.
+> Running `uname -m` should also print "arm64", otherwise your terminal is running in Rosetta mode.
+
 ### The roles of different tools
 
 At this point, it is worthwhile to pause for a moment


### PR DESCRIPTION
Running the wrong version of Python will result in the build failing a long way into the process, and giving an unrelated error. This note can save new contributors several hours of frustrating troubleshooting.

Contains only documentation additions.