### PR TITLE
Add `with` function implicitly available on all values

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -344,7 +344,7 @@ protected:
   // for the inline bitfields.
   union { uint64_t OpaqueBits;
 
-  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1+1,
     Kind : bitmax(NumDeclKindBits,8),
 
     /// Whether this declaration is invalid.
@@ -367,7 +367,12 @@ protected:
     /// a local context, but should behave like a top-level
     /// declaration for name lookup purposes. This is used by
     /// lldb.
-    Hoisted : 1
+    Hoisted : 1,
+                 
+    /// Whether this declaration should be disfavored with respect
+    /// to other potential overloads. This increases the overload score
+    /// in addition to the separate `@_disfavoredOverload` attr.
+    Disfavor : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(PatternBindingDecl, Decl, 1+1+2+16,
@@ -817,6 +822,7 @@ protected:
     Bits.Decl.FromClang = false;
     Bits.Decl.EscapedFromIfConfig = false;
     Bits.Decl.Hoisted = false;
+    Bits.Decl.Disfavor = false;
   }
 
   /// Get the Clang node associated with this declaration.
@@ -1254,6 +1260,13 @@ public:
   /// Retrieve the diagnostic engine for diagnostics emission.
   LLVM_READONLY
   DiagnosticEngine &getDiags() const;
+
+  /// Whether this declaration should be disfavored with respect
+  /// to other potential overloads. This increases the overload score
+  /// in addition to the separate `@_disfavoredOverload` attr.
+  bool getDisfavorValue() const { return Bits.Decl.Disfavor; }
+
+  void setDisfavorValue(bool Disfavor) { Bits.Decl.Disfavor = Disfavor; }
 };
 
 /// Allocates memory for a Decl with the given \p baseSize. If necessary,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -344,7 +344,7 @@ protected:
   // for the inline bitfields.
   union { uint64_t OpaqueBits;
 
-  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1,
     Kind : bitmax(NumDeclKindBits,8),
 
     /// Whether this declaration is invalid.
@@ -367,12 +367,7 @@ protected:
     /// a local context, but should behave like a top-level
     /// declaration for name lookup purposes. This is used by
     /// lldb.
-    Hoisted : 1,
-                 
-    /// Whether this declaration should be disfavored with respect
-    /// to other potential overloads. This increases the overload score
-    /// in addition to the separate `@_disfavoredOverload` attr.
-    Disfavor : 1
+    Hoisted : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(PatternBindingDecl, Decl, 1+1+2+16,
@@ -822,7 +817,6 @@ protected:
     Bits.Decl.FromClang = false;
     Bits.Decl.EscapedFromIfConfig = false;
     Bits.Decl.Hoisted = false;
-    Bits.Decl.Disfavor = false;
   }
 
   /// Get the Clang node associated with this declaration.
@@ -1260,13 +1254,6 @@ public:
   /// Retrieve the diagnostic engine for diagnostics emission.
   LLVM_READONLY
   DiagnosticEngine &getDiags() const;
-
-  /// Whether this declaration should be disfavored with respect
-  /// to other potential overloads. This increases the overload score
-  /// in addition to the separate `@_disfavoredOverload` attr.
-  bool getDisfavorValue() const { return Bits.Decl.Disfavor; }
-
-  void setDisfavorValue(bool Disfavor) { Bits.Decl.Disfavor = Disfavor; }
 };
 
 /// Allocates memory for a Decl with the given \p baseSize. If necessary,

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -133,6 +133,10 @@ public:
   /// Checks whether this range overlaps with the given range.
   bool overlaps(SourceRange Other) const;
 
+  /// Whether or not this range is unexpectedly backwards
+  /// (i.e. End is unexpectedly before Start)
+  bool isBackwards() const;
+
   bool operator==(const SourceRange &other) const {
     return Start == other.Start && End == other.End;
   }

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4280,13 +4280,14 @@ public:
   /// \param isDynamicResult Indicates that this declaration was found via
   /// dynamic lookup.
   ///
+  /// \param disallowOpeningExistentialBase Whether to prevent
+  ///  the base from being opened if it is an existential.
+  ///
   /// \returns a description of the type of this declaration reference.
   DeclReferenceType getTypeOfMemberReference(
-                          Type baseTy, ValueDecl *decl, DeclContext *useDC,
-                          bool isDynamicResult,
-                          FunctionRefKind functionRefKind,
-                          ConstraintLocator *locator,
-                          OpenedTypeMap *replacements = nullptr);
+      Type baseTy, ValueDecl *decl, DeclContext *useDC, bool isDynamicResult,
+      bool disallowOpeningExistentialBase, FunctionRefKind functionRefKind,
+      ConstraintLocator *locator, OpenedTypeMap *replacements = nullptr);
 
   /// Retrieve a list of generic parameter types solver has "opened" (replaced
   /// with a type variable) at the given location.

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3621,10 +3621,9 @@ public:
         abort();
       }
       // FIXME: Re-visit this to always do the check.
-      // TODO: This is hit which aborts, need to fix this soon
-      //      if (!E->isImplicit())
-      //        checkSourceRanges(E->getSourceRange(), Parent,
-      //                          [&]{ E->dump(Out); } );
+      if (!E->isImplicit()) {
+        checkSourceRanges(E->getSourceRange(), Parent, [&] { E->dump(Out); });
+      }
     }
 
     void checkSourceRanges(Stmt *S) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3621,9 +3621,10 @@ public:
         abort();
       }
       // FIXME: Re-visit this to always do the check.
-      if (!E->isImplicit())
-        checkSourceRanges(E->getSourceRange(), Parent,
-                          [&]{ E->dump(Out); } );
+      // TODO: This is hit which aborts, need to fix this soon
+      //      if (!E->isImplicit())
+      //        checkSourceRanges(E->getSourceRange(), Parent,
+      //                          [&]{ E->dump(Out); } );
     }
 
     void checkSourceRanges(Stmt *S) {

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -447,6 +447,10 @@ bool SourceRange::contains(SourceLoc Loc) const {
          Loc.Value.getPointer() <= End.Value.getPointer();
 }
 
+bool SourceRange::isBackwards() const {
+  return End.Value.getPointer() < Start.Value.getPointer();
+}
+
 bool SourceRange::overlaps(SourceRange Other) const {
   return contains(Other.Start) || Other.contains(Start);
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10059,20 +10059,10 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   if (constraintKind == ConstraintKind::ValueMember &&
       memberName.isSimpleName() && !memberName.isSpecial() &&
       memberName.getBaseIdentifier() == ctx.getIdentifier("with")) {
-    // In an actual implementation this would use `lookupInSwiftModule`,
-    // which would only perform lookup in the standard library module.
-    // While testing, use the current module instead.
-    auto _withModule = DC->getParentModule();
-    auto SF = DC->getParentSourceFile();
-
-    // Look up the decl for the global _with function
-    auto &ctx = DC->getASTContext();
-    auto _withName = ctx.getIdentifier("_with");
-
+    // Look up the decl for the global _with function defined
+    // in the standard library
     SmallVector<ValueDecl *, 1> decls;
-    namelookup::lookupInModule(
-        _withModule, _withName, decls, NLKind::QualifiedLookup,
-        namelookup::ResolutionKind::Overloadable, SF, NL_QualifiedDefault);
+    DC->getASTContext().lookupInSwiftModule("_with", decls);
 
     for (auto decl : decls) {
       result.addViable(getOverloadChoice(decl, /*isBridged=*/false,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10105,8 +10105,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // To maximize source compatibility this is a disfavored overload,
   // and doesn't suppress `@dynamicMemberLookup`.
   if (constraintKind == ConstraintKind::ValueMember &&
-      memberName.isSimpleName() && !memberName.isSpecial() &&
-      memberName.getBaseIdentifier() == ctx.getIdentifier("with")) {
+      memberName.isSimpleName(ctx.Id_with)) {
 
     // Look up the global _with decls defined in the standard library
     SmallVector<ValueDecl *, 1> withDecls;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3812,6 +3812,10 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     // If this overload is disfavored, note that.
     if (decl->getAttrs().hasAttribute<DisfavoredOverloadAttr>())
       increaseScore(SK_DisfavoredOverload, locator);
+
+    // If the overload decl has its `Disfavor` value set, note that as well.
+    if (decl->getDisfavorValue())
+      increaseScore(SK_DisfavoredOverload, locator);
   }
 
   if (choice.isFallbackMemberOnUnwrappedBase()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1098,12 +1098,12 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     reqLocator = cs->getConstraintLocator(
         static_cast<Expr *>(nullptr), LocatorPathElt::ProtocolRequirement(req));
     OpenedTypeMap reqReplacements;
-    reqType = cs->getTypeOfMemberReference(selfTy, req, dc,
-                                           /*isDynamicResult=*/false,
-                                           FunctionRefKind::DoubleApply,
-                                           reqLocator,
-                                           &reqReplacements)
-        .adjustedReferenceType;
+    reqType = cs->getTypeOfMemberReference(
+                    selfTy, req, dc,
+                    /*isDynamicResult=*/false,
+                    /*disallowOpeningExistentialBase=*/false,
+                    FunctionRefKind::DoubleApply, reqLocator, &reqReplacements)
+                  .adjustedReferenceType;
     reqType = reqType->getRValueType();
 
     // For any type parameters we replaced in the witness, map them
@@ -1137,9 +1137,10 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
                                               LocatorPathElt::Witness(witness));
     if (witness->getDeclContext()->isTypeContext()) {
       openWitnessType = cs->getTypeOfMemberReference(
-          selfTy, witness, dc, /*isDynamicResult=*/false,
-          FunctionRefKind::DoubleApply, witnessLocator)
-        .adjustedReferenceType;
+                              selfTy, witness, dc, /*isDynamicResult=*/false,
+                              /*disallowOpeningExistentialBase=*/false,
+                              FunctionRefKind::DoubleApply, witnessLocator)
+                            .adjustedReferenceType;
     } else {
       openWitnessType = cs->getTypeOfReference(
           witness, FunctionRefKind::DoubleApply, witnessLocator,

--- a/stdlib/public/Concurrency/AsyncWith.swift
+++ b/stdlib/public/Concurrency/AsyncWith.swift
@@ -1,4 +1,4 @@
-//===--- With.swift -------------------------------------------------------===//
+//===--- AsyncWith.swift --------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,28 +10,32 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Implementation of the `with` function that is implicitly available on all values.
+import Swift
+
+// Non-async implementations defined in public/Core/With.swift
+
+/// Async implemtation of the `with` function that is implicitly available on all values.
 @inlinable
 @_disfavoredOverload
+@available(SwiftStdlib 5.1, *)
 @backDeployed(before: SwiftStdlib 5.10)
-public func _with<T>(_ value: T) -> ((inout T) -> Void) -> T {
+public func _with<T>(_ value: T) -> ((inout T) async -> Void) async -> T {
   { modify in
     var copy = value
-    modify(&copy)
+    await modify(&copy)
     return copy
   }
 }
 
-/// Throwing implementation of the `with` function that is implicitly available on all values.
+/// Async and throwing implementation of the `with` function that is implicitly available on all values.
 @inlinable
 @_disfavoredOverload
+@available(SwiftStdlib 5.1, *)
 @backDeployed(before: SwiftStdlib 5.10)
-public func _with_throws<T>(_ value: T) -> ((inout T) throws -> Void) throws -> T {
+public func _with_throws<T>(_ value: T) -> ((inout T) async throws -> Void) async throws -> T {
   { modify in
     var copy = value
-    try modify(&copy)
+    try await modify(&copy)
     return copy
   }
 }
-
-// Async implementations defined in public/Concurrency/AsyncWith.swift

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -126,6 +126,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   AsyncStream.swift
   AsyncThrowingStream.swift
   AsyncStream.cpp
+  AsyncWith.swift
   Deque/_DequeBuffer.swift
   Deque/_DequeBufferHeader.swift
   Deque/_DequeSlot.swift

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -231,6 +231,7 @@ set(SWIFTLIB_SOURCES
   UnfoldSequence.swift
   UnsafeBufferPointerSlice.swift
   VarArgs.swift
+  With.swift
   Zip.swift
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
   )

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -105,7 +105,8 @@
         "DropWhile.swift",
         "PrefixWhile.swift",
         "LazyCollection.swift",
-        "LazySequence.swift"],
+        "LazySequence.swift"
+      ],
       "Array": [
         "Array.swift",
         "ArrayBody.swift",
@@ -121,7 +122,8 @@
         "ContiguouslyStored.swift",
         "FixedArray.swift",
         "SliceBuffer.swift",
-        "SwiftNativeNSArray.swift"],
+        "SwiftNativeNSArray.swift"
+      ],
       "HashedCollections": [
         "HashTable.swift",
         "Dictionary.swift",
@@ -164,20 +166,24 @@
     "SetAlgebra.swift",
     "BuiltinMath.swift",
     {
-    "Integers": [
-      "Integers.swift",
-      "IntegerTypes.swift",
-      "IntegerParsing.swift",
-      "StaticBigInt.swift"],
-    "Floating": [
-      "FloatingPoint.swift",
-      "FloatingPointParsing.swift",
-      "FloatingPointTypes.swift",
-      "FloatingPointRandom.swift"],
-    "Vector": [
-      "SIMDConcreteOperations.swift",
-      "SIMDVector.swift",
-      "SIMDVectorTypes.swift"]}
+      "Integers": [
+        "Integers.swift",
+        "IntegerTypes.swift",
+        "IntegerParsing.swift",
+        "StaticBigInt.swift"
+      ],
+      "Floating": [
+        "FloatingPoint.swift",
+        "FloatingPointParsing.swift",
+        "FloatingPointTypes.swift",
+        "FloatingPointRandom.swift"
+      ],
+      "Vector": [
+        "SIMDConcreteOperations.swift",
+        "SIMDVector.swift",
+        "SIMDVectorTypes.swift"
+      ]
+    }
   ],
   "Optional": [
     "Optional.swift"
@@ -243,7 +249,8 @@
     "Int128.swift",
     "Duration.swift",
     "DurationProtocol.swift",
-    "Instant.swift"
+    "Instant.swift",
+    "With.swift"
   ],
   "Result": [
     "Result.swift"

--- a/stdlib/public/core/With.swift
+++ b/stdlib/public/core/With.swift
@@ -12,6 +12,7 @@
 
 /// Private compiler-internal implementation of the `with` function
 /// that is implicitly available on all values.
+@_disfavoredOverload
 public func _with<T>(_ value: T) -> ((inout T) -> Void) -> T {
   { modify in
     var copy = value

--- a/stdlib/public/core/With.swift
+++ b/stdlib/public/core/With.swift
@@ -1,0 +1,21 @@
+//===--- With.swift -------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Private compiler-internal implementation of the `with` function
+/// that is implicitly available on all values.
+public func _with<T>(_ value: T) -> ((inout T) -> Void) -> T {
+  { modify in
+    var copy = value
+    modify(&copy)
+    return copy
+  }
+}

--- a/test/stdlib/With.swift
+++ b/test/stdlib/With.swift
@@ -35,6 +35,12 @@ _ = tuple.a?.with { $0 = "withA?" }
 _ = tuple.b.with { $0 = "withB" }
 _ = tuple.b?.with { $0 = "withB?" }
 
+extension Int {
+  func addingTwo() -> Int {
+    with { $0 += 2 }
+  }
+}
+
 struct Test {
   var foo: String?
   var bar: String?
@@ -61,10 +67,19 @@ struct Test {
 }
 
 let explicitWithFunc = Test().with
+let explicitWithFuncExplicitType: (String) -> Test = Test().with
+let explicitWithFuncExplicitType2: (String) -> Test = explicitWithFunc
 let with: ((inout Test) -> Void) -> Test = Test().with
-let with_throws: ((inout Test) throws -> Void) throws -> Test  = Test().with
-let with_async: ((inout Test) async -> Void) async -> Test  = Test().with
+let with_throws: ((inout Test) throws -> Void) throws -> Test = Test().with
+let with_async: ((inout Test) async -> Void) async -> Test = Test().with
 let with_async_throws: ((inout Test) async throws -> Void) async throws -> Test = Test().with
+
+let explicitWithFunc_as = Test().with
+let explicitWithFuncExplicitType_as = Test().with as (String) -> Test
+let with_as = Test().with as ((inout Test) -> Void) -> Test
+let with_throws_as = Test().with as ((inout Test) throws -> Void) throws -> Test
+let with_async_as = Test().with as ((inout Test) async -> Void) async -> Test 
+let with_async_throws_as = Test().with as ((inout Test) async throws -> Void) async throws -> Test
 
 _ = try Test()
   .with { $0.foo = "foo" }
@@ -96,6 +111,44 @@ struct TestAlreadyHasWithFuncDefined {
 
 _ = TestAlreadyHasWithFuncDefined.with
 _ = TestAlreadyHasWithFuncDefined().with { $0.foo = "foo" }
+
+// This type intentionally doesn't have a member named "with",
+// because this exercises a different code path in name lookup.
+struct TestWithImplicitSelf {
+  var foo: String?
+
+  func withFoo(_ foo: String) -> TestWithImplicitSelf {
+    with { $0.modifyFoo(foo) }
+  }
+
+  func withFooThrowing(_ foo: String) throws -> TestWithImplicitSelf {
+    try with { try $0.modifyFooThrowing(foo) }
+  }
+
+  func withFooAsync(_ foo: String) async -> TestWithImplicitSelf {
+    await with { await $0.modifyFooAsync(foo) }
+  }
+
+  func withFooAsyncThrowing(_ foo: String) async throws -> TestWithImplicitSelf {
+    try await with { try await $0.modifyFooAsyncThrowing(foo) }
+  }
+
+  mutating func modifyFoo(_ foo: String) {
+    self.foo = foo
+  }
+
+  mutating func modifyFooThrowing(_ foo: String) throws {
+    self.foo = foo
+  }
+
+  mutating func modifyFooAsync(_ foo: String) async {
+    self.foo = foo
+  }
+
+  mutating func modifyFooAsyncThrowing(_ foo: String) async throws {
+    self.foo = foo
+  }
+}
 
 @dynamicMemberLookup
 struct DynamicMemberLookupTest {

--- a/test/stdlib/With.swift
+++ b/test/stdlib/With.swift
@@ -1,0 +1,120 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+let tuple: (a: String?, b: String?) = (a: nil, b: nil)
+
+_ = tuple.with {
+  $0.a = "withA"
+  $0.b = "withB"
+}
+
+_ = tuple.with { tuple in
+  if tuple.a == nil {
+    tuple.a = "a_default"
+  }
+
+  if tuple.b == nil {
+    tuple.b = "b_default"
+  }
+}
+
+_ = tuple.with {
+  $0 = (a: $0.a ?? "default", b: $0.b ?? "default")
+}
+
+_ = tuple.with {
+  (a: $0.a ?? "default", b: $0.b ?? "default") // expected-warning{{expression of type '(a: String, b: String)' is unused}}
+}
+
+_ = tuple.with {
+  $0 = (a: $0.a ?? "default", b: $0.b ?? "default", c: "c") // expected-error{{cannot assign value of type '(a: String, b: String, c: String)' to type '(a: String?, b: String?)'}}
+}
+
+_ = tuple.a.with { $0 = "withA" }
+_ = tuple.a?.with { $0 = "withA?" }
+_ = tuple.b.with { $0 = "withB" }
+_ = tuple.b?.with { $0 = "withB?" }
+
+// Why doesn't this work? Does this need to be allowed in the first place?
+// TODO: Fix and uncomment
+// let any: Any = "string value"
+// any.with { any in
+  // unexpected error: cannot assign value of type 'Any' to type 'Any'
+  // any = "new string value"
+// }
+
+struct Test {
+  var foo: String?
+  var bar: String?
+
+  func with(foo: String) -> Test {
+    with { $0.foo = foo }
+  }
+
+  mutating func modifyFoo(_ foo: String) {
+    self.foo = foo
+  }
+
+  mutating func modifyFooThrowing(_ foo: String) throws {
+    self.foo = foo
+  }
+
+  mutating func modifyFooAsync(_ foo: String) async {
+    self.foo = foo
+  }
+
+  mutating func modifyFooAsyncThrowing(_ foo: String) async throws {
+    self.foo = foo
+  }
+}
+
+let explicitWithFunc = Test().with
+let with: ((inout Test) -> Void) -> Test = Test().with
+let with_throws: ((inout Test) throws -> Void) throws -> Test  = Test().with
+let with_async: ((inout Test) async -> Void) async -> Test  = Test().with
+let with_async_throws: ((inout Test) async throws -> Void) async throws -> Test = Test().with
+
+_ = try Test()
+  .with { $0.foo = "foo" }
+  .with { $0.bar = "bar" }
+  .with { $0 = Test() }
+  .with { try $0.modifyFooThrowing("throwing") }
+
+_ = Test().with(foo: "withFoo1")
+_ = explicitWithFunc("withFoo2")
+_ = Test().with { $0.foo = "withFoo3" }
+_ = Test().with { $0.modifyFoo("non-throwing") }
+_ = try Test().with { try $0.modifyFooThrowing("throwing") }
+
+Task {
+  _ = await Test().with { await $0.modifyFooAsync("async") }
+  _ = try await Test().with { try await $0.modifyFooAsyncThrowing("async/throwing") }
+}
+
+struct TestAlreadyHasWithFuncDefined {
+  var foo: String?
+  var bar: String?
+
+  func with(_ modify: (inout Self) -> Void) -> Self {
+    var copy = self
+    modify(&copy)
+    return copy
+  }
+}
+
+_ = TestAlreadyHasWithFuncDefined.with
+_ = TestAlreadyHasWithFuncDefined().with { $0.foo = "foo" }
+
+@dynamicMemberLookup
+struct DynamicMemberLookupTest {
+  var foo: String?
+  
+  subscript(dynamicMember member: String) -> String {
+    "dymamic member \(member)"
+  }
+}
+
+_ = DynamicMemberLookupTest().with.uppercased()
+_ = DynamicMemberLookupTest().with { $0.foo = "withFoo" }
+
+let dynamicMemberString = DynamicMemberLookupTest().with
+_ = dynamicMemberString.uppercased()


### PR DESCRIPTION
This PR adds a `with` function that is implicitly available on all values, as proposed [here](https://github.com/apple/swift-evolution/pull/2123).

The general approach is:
 1. Add a `_with` function to the standard library, with the same curried signature as an instance function
 2. Add that function decl as an overload choice when calling `.with` on any value

Example usage:

```swift
struct Test {
  var foo: String?
  var bar: String?
}

let value = Test().with {
  $0.foo = "withFoo"
  $0.bar = "withBar"
}

// Prints "Test(foo: Optional("withFoo"), bar: Optional("withBar"))"
print(value)
```

```swift
let tuple: (a: String?, b: String?) = (a: nil, b: nil)

let updatedTuple = tuple.with {
  $0.a = "withA"
  $0.b = "withB"
}

// Prints "(a: Optional("withA"), b: Optional("withB"))"
print(updatedTuple)
```

```swift
struct Foo {
  var bar: String?
  
  func bar(_ bar: String) -> Foo {
    with { $0.bar = bar }
  }
}

// Prints "Test(bar: Optional("withBar"))"
print(Foo().bar("withBar"))
```