### PR TITLE
[TypeChecker] InitAccessors: Fix default initialization of init accessor properties

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1182,6 +1182,12 @@ void LifetimeChecker::doIt() {
     while (returnBB != F.end()) {
       auto *terminator = returnBB->getTerminator();
 
+      // If this is an unreachable block, let's ignore it.
+      if (isa<UnreachableInst>(terminator)) {
+        ++returnBB;
+        continue;
+      }
+
       if (!isInitializedAtUse(DIMemoryUse(terminator, DIUseKind::Load, 0, 1)))
         diagnoseMissingInit();
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -491,11 +491,16 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
     }
   }
 
+  auto isInitAccessorProperty = [](Pattern *pattern) {
+    auto *var = pattern->getSingleVar();
+    return var && var->getAccessor(AccessorKind::Init);
+  };
+
   // If we have a type but no initializer, check whether the type is
   // default-initializable. If so, do it.
   if (!pbe.isInitialized() &&
       binding->isDefaultInitializable(entryNumber) &&
-      pattern->hasStorage()) {
+      (pattern->hasStorage() || isInitAccessorProperty(pattern))) {
     if (auto defaultInit = TypeChecker::buildDefaultInitializer(patternType)) {
       // If we got a default initializer, install it and re-type-check it
       // to make sure it is properly coerced to the pattern type.

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -801,3 +801,49 @@ do {
 }
 // CHECK: Person(name: P)
 // CHECK-NEXT: Person(name: O)
+
+do {
+  struct TestDefaultInitializable : CustomStringConvertible {
+    var description: String {
+      "TestDefaultInitializable(a: \(a))"
+    }
+
+    var _a: Int?
+    var a: Int? {
+      @storageRestrictions(initializes: _a)
+      init { _a = newValue }
+      get { _a }
+    }
+  }
+
+  print(TestDefaultInitializable())
+  print(TestDefaultInitializable(a: 42))
+
+  struct TestMixedDefaultInitalizable : CustomStringConvertible {
+    var description: String {
+      "TestMixedDefaultInitalizable(a: \(a), b: \(b))"
+    }
+
+    var a: Int? {
+      init {}
+      get { nil }
+    }
+
+    var _b: String
+    var b: String? {
+      @storageRestrictions(initializes: _b)
+      init { self._b = (newValue ?? "") }
+      get { _b }
+      set { _b = newValue ?? "" }
+    }
+  }
+
+  print(TestMixedDefaultInitalizable())
+  print(TestMixedDefaultInitalizable(b: "Hello"))
+  print(TestMixedDefaultInitalizable(a: 42))
+}
+// CHECK: TestDefaultInitializable(a: nil)
+// CHECK-NEXT: TestDefaultInitializable(a: Optional(42))
+// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional(""))
+// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional("Hello"))
+// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional(""))

--- a/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
@@ -190,6 +190,17 @@ class TestInitWithGuard {
 }
 
 do {
+  struct TestPropertyInitWithUnreachableBlocks {
+    var _a: Int
+    var a: Int? {
+      @storageRestrictions(initializes: _a)
+      init { _a = newValue ?? 0 } // Ok
+      get { 42 }
+    }
+  }
+}
+
+do {
   class Base<T: Collection> {
     private var _v: T
 

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -530,7 +530,7 @@ extension TestStructPropWithoutSetter {
 }
 
 do {
-  class TestClassPropWithoutSetter {
+  class TestClassPropWithoutSetter { // expected-error {{class 'TestClassPropWithoutSetter' has no initializers}}
     var x: Int {
       init {
       }
@@ -538,6 +538,44 @@ do {
       get { 0 }
     }
   }
+
+  // This should generate only memberwise initializer because `a` doesn't have a default
+  struct TestStructWithoutSetter { // expected-note {{'init(a:)' declared here}}
+    var a: Int {
+      init {
+      }
+      get { 0 }
+    }
+  }
+
+  _ = TestStructWithoutSetter() // expected-error {{missing argument for parameter 'a' in call}}
+  _ = TestStructWithoutSetter(a: 42) // Ok
+
+  struct TestDefaultInitializable {
+    var a: Int? {
+      init {}
+      get { nil }
+    }
+  }
+
+  _ = TestDefaultInitializable() // Ok (`a` is initialized to `nil`)
+
+  struct TestMixedDefaultInitializable {
+    var a: Int? {
+      init {}
+      get { nil }
+    }
+
+    var _b: String
+    var b: String? {
+      @storageRestrictions(initializes: _b)
+      init { _b = newValue ?? "" }
+      get { _b }
+      set { _b = newValue ?? "" }
+    }
+  }
+
+  _ = TestMixedDefaultInitializable() // Ok (both `a` and `b` are initialized to `nil`)
 
   class SubTestPropWithoutSetter : TestClassPropWithoutSetter {
     init(otherV: Int) {

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -620,3 +620,33 @@ func test_invalid_storage_restrictions() {
     init() {}
   }
 }
+
+do {
+  struct Test1 {
+    var q: String
+    var a: Int? {
+      init {}
+      get { 42 }
+    }
+  }
+
+  _ = Test1(q: "some question") // Ok `a` is default initialized to `nil`
+  _ = Test1(q: "ultimate question", a: 42)
+
+  struct Test2 {
+    var q: String
+
+    var _a: Int?
+    var a: Int? {
+      @storageRestrictions(initializes: _a)
+      init {
+        _a = newValue
+      }
+      get { _a }
+      set { _a = newValue }
+    }
+  }
+
+  _ = Test2(q: "some question") // Ok `a` is default initialized to `nil`
+  _ = Test2(q: "ultimate question", a: 42)
+}


### PR DESCRIPTION
- Synthesize default init for init accessor properties

    Fixes a bug were default initializer for an init accessor property
    hasn't been synthesized even when the property is marked as default
    initializable.

- Fix handling of defaultable init accessor properties during default init synthesis

    Default initializable init properties shouldn't prevent default
    init synthesis and such properties without anything to initialize
    should be considered by it.

Resolves: rdar://113421273
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
