### PR TITLE
build: ensure that we push `-static` into the flags

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -455,6 +455,10 @@ function(_compile_swift_files
       MACCATALYST_BUILD_FLAVOR "${maccatalyst_build_flavor}"
       )
 
+  if(SWIFTFILE_STATIC)
+    list(APPEND swift_flags -static)
+  endif()
+
   # Determine the subdirectory where the binary should be placed.
   set(library_subdir_sdk "${SWIFTFILE_SDK}")
   if(maccatalyst_build_flavor STREQUAL "ios-like")


### PR DESCRIPTION
The CxxStdlib module is built statically only.  We would previously build the static library but indicate dynamic linking.  This would incorrectly code generate in the client on Windows making it impossible to use the module.