### PR TITLE
[SourceKit] Add missing variant header include

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <memory>
 #include <unordered_set>
+#include <variant>
 
 namespace llvm {
   class MemoryBuffer;


### PR DESCRIPTION
SourceKit used `std::variant` but didn't include it directly, so that broke building on rebranch on Linux.
