### PR TITLE
[cxx-interop] Fix SwiftCompilerSources hosttools build

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -360,11 +360,18 @@ static bool synthesizeCXXOperator(ClangImporter::Implementation &impl,
 
   // Lookup the `operator==` function that will be called under the hood.
   clang::UnresolvedSet<16> operators;
+  clang::sema::DelayedDiagnosticPool diagPool{
+      impl.getClangSema().DelayedDiagnostics.getCurrentPool()};
+  auto diagState = impl.getClangSema().DelayedDiagnostics.push(diagPool);
   // Note: calling `CreateOverloadedBinOp` emits an error if the looked up
   // function is unavailable for the current target.
   auto underlyingCallResult = clangSema.CreateOverloadedBinOp(
       clang::SourceLocation(), operatorKind, operators, lhsParamRefExpr,
       rhsParamRefExpr);
+  impl.getClangSema().DelayedDiagnostics.popWithoutEmitting(diagState);
+
+  if (!diagPool.empty())
+    return false;
   if (!underlyingCallResult.isUsable())
     return false;
   auto underlyingCall = underlyingCallResult.get();

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -958,4 +958,55 @@ public:
   }
 };
 
+/// clang::StmtIteratorBase
+class ProtectedIteratorBase {
+protected:
+  int value;
+  ProtectedIteratorBase() : value(0) {}
+};
+
+/// clang::StmtIteratorImpl
+template <typename DERIVED>
+class ProtectedIteratorImpl : public ProtectedIteratorBase {
+protected:
+  ProtectedIteratorImpl(const ProtectedIteratorBase& RHS) : ProtectedIteratorBase(RHS) {}
+
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = int;
+  using difference_type = std::ptrdiff_t;
+  using pointer = int *;
+  using reference = int &;
+
+  ProtectedIteratorImpl() = default;
+
+  DERIVED& operator++() {
+    value++;
+    return static_cast<DERIVED&>(*this);
+  }
+
+  DERIVED operator++(int) {
+    DERIVED tmp = static_cast<DERIVED&>(*this);
+    operator++();
+    return tmp;
+  }
+
+  friend bool operator==(const DERIVED &LHS, const DERIVED &RHS) {
+    return LHS.value == RHS.value;
+  }
+
+  reference operator*() const {
+    return value;
+  }
+};
+
+/// StmtIterator
+struct HasInheritedProtectedCopyConstructor : public ProtectedIteratorImpl<HasInheritedProtectedCopyConstructor> {
+  HasInheritedProtectedCopyConstructor() = default;
+
+private:
+  HasInheritedProtectedCopyConstructor(const ProtectedIteratorBase &other)
+      : ProtectedIteratorImpl<HasInheritedProtectedCopyConstructor>(other) {}
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_ITERATOR_H


### PR DESCRIPTION
This fixes a compiler error when building SwiftCompilerSources in hosttools mode with a recent Xcode.

```
<unknown>:0: error: calling a private constructor of class 'clang::StmtIterator'
swift/llvm-project/clang/include/clang/AST/StmtIterator.h:137:3: note: declared private here
  StmtIterator(const StmtIteratorBase &RHS)
  ^
```

rdar://113514872