### PR TITLE
IRGen: rework linking against CxxStdlib

### DIFF
--- a/test/Interop/Cxx/class/constructors-copy-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-windows.swift
@@ -1,6 +1,6 @@
 // Target-specific tests for C++ copy constructor code generation.
 
-// RUN: %swift -module-name MySwift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
+// RUN: %swift -module-name MySwift -target x86_64-unknown-windows-msvc %target-swift-flags -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
 // REQUIRES: OS=windows-msvc
 // REQUIRES: CPU=x86_64

--- a/test/Interop/Cxx/class/constructors-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-windows.swift
@@ -1,6 +1,6 @@
 // Target-specific tests for C++ constructor call code generation.
 
-// RUN: %swift -module-name MySwift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
+// RUN: %swift -module-name MySwift -target x86_64-unknown-windows-msvc %target-swift-flags -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
 // REQUIRES: OS=windows-msvc
 // REQUIRES: CPU=x86_64

--- a/test/Interop/Cxx/class/copy-move-assignment-irgen.swift
+++ b/test/Interop/Cxx/class/copy-move-assignment-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -Xcc -fignore-exceptions -O | %FileCheck %s
+// RUN: %target-swift-frontend -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -Xcc -fignore-exceptions -O | %FileCheck %s
 
 import CopyMoveAssignment
 

--- a/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s | %FileCheck %s
+// RUN: %swift %target-swift-flags -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s | %FileCheck %s
 
 import Destructors
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/move-only.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/move-only.h
@@ -2,11 +2,7 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_MOVE_ONLY_H
 
 #include <stdlib.h>
-#if defined(_WIN32)
-inline void *operator new(size_t, void *p) { return p; }
-#else
 #include <new>
-#endif
 
 #include "visibility.h"
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/nullable.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/nullable.h
@@ -2,11 +2,7 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_NULLABLE_H
 
 #include <stdlib.h>
-#if defined(_WIN32)
-inline void *operator new(size_t, void *p) { return p; }
-#else
 #include <new>
-#endif
 
 struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:immortal")))

--- a/test/Interop/Cxx/foreign-reference/Inputs/singleton.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/singleton.h
@@ -2,11 +2,7 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_SINGLETON_H
 
 #include <stdlib.h>
-#if defined(_WIN32)
-inline void *operator new(size_t, void *p) { return p; }
-#else
 #include <new>
-#endif
 
 #include "visibility.h"
 

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -1,5 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-//
+
 // REQUIRES: executable_test
 
 import StdlibUnittest
@@ -15,7 +15,6 @@ StdPairTestSuite.test("StdPairInts.init") {
   expectEqual(pi.second, 2)
 }
 
-#if !os(Windows) // FIXME: enable once swiftCxxStdlib is built on Windows (https://github.com/apple/swift/issues/67649)
 StdPairTestSuite.test("StdPairStrings.init") {
   let ps = PairStrings(first: std.string(), second: std.string())
   expectEqual(ps.first, std.string())
@@ -25,7 +24,6 @@ StdPairTestSuite.test("StdPairStrings.init") {
   expectEqual(ps2.first, std.string("abc"))
   expectEqual(ps2.second, std.string("123"))
 }
-#endif
 
 StdPairTestSuite.test("StdPair.elements") {
   var pi = getIntPair()

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -I %S/Inputs -enable-experimental-cxx-interop -enable-objc-interop -emit-ir %s -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %swift %target-swift-flags -I %S/Inputs -enable-experimental-cxx-interop -enable-objc-interop -emit-ir %s -Xcc -fignore-exceptions | %FileCheck %s
 
 import AnonymousUnionPartlyInvalid
 

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -28,13 +28,18 @@ if is_cf_options_interop_updated:
     config.available_features.add('cxx-interop-fixed-cf_options')
 
 if get_target_os() in ['windows-msvc']:
+    import os
     config.substitutions.insert(0, ('%target-abi', 'WIN'))
     # Clang should build object files with link settings equivalent to -libc MD
     # when building for the MSVC target.
     clang_opt = clang_compile_opt + '-D_MT -D_DLL -Xclang --dependent-lib=msvcrt -Xclang --dependent-lib=oldnames '
+    config.substitutions.insert(0, ('%target-swift-flags', '-vfsoverlay {}'.format(os.path.join(config.swift_obj_root,
+                                                            'stdlib',
+                                                            'windows-vfs-overlay.yaml'))))
 else:
     # FIXME(compnerd) do all the targets we currently support use SysV ABI?
     config.substitutions.insert(0, ('%target-abi', 'SYSV'))
+    config.substitutions.insert(0, ('%target-swift-flags', ''))
 
 # Enable C++ interop when compiling Swift sources.
 config.substitutions.insert(0, ('%target-interop-build-swift',


### PR DESCRIPTION
Rewrite the handling for the `CxxStdlib` implicit linking to use a slightly more functional style for filtering.  Additionally, add Windows to the list providing the overlay.  The Windows linking scenario is a slightly more complicated as the library names differ between static and dynamic variants to disambiguate between import libraries and static libraries.  Take this into account when embedding the library name so that the linker can find the appropriate content.