### PR TITLE
[IRGen] Exiting terminators don't alloc packs.

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1341,6 +1341,12 @@ bool SILInstruction::mayRequirePackMetadata() const {
     if (isDeallocatingStack())
       return false;
 
+    // Terminators that exit the function must not result in pack metadata
+    // materialization.
+    auto *ti = dyn_cast<TermInst>(this);
+    if (ti && ti->isFunctionExiting())
+      return false;
+
     // Check results and operands for packs.  If a pack appears, lowering the
     // instruction might result in pack metadata emission.
     for (auto result : getResults()) {

--- a/test/IRGen/pack_metadata_marker_inserter.sil
+++ b/test/IRGen/pack_metadata_marker_inserter.sil
@@ -22,6 +22,9 @@ struct S1 {}
 struct S2 {}
 struct S3 {}
 
+struct GVT<each T> : Error {
+}
+
 struct GV<each T> {
   var tu: (repeat each T)
 }
@@ -141,6 +144,16 @@ entry:
   apply %take<Pack{G<T>}>() : $@convention(thin) <each T>() -> ()
   %retval = tuple ()
   return %retval : $()
+}
+
+// CHECK-SIL-LABEL: sil @return_variadic : {{.*}} {
+// CHECK-SIL:         [[RETVAL:%[^,]+]] = struct
+// CHECK-SIL:         return [[RETVAL]]
+// CHECK-SIL-LABEL: } // end sil function 'return_variadic'
+sil @return_variadic : $<each T>() -> GVT<repeat each T> {
+entry:
+  %retval = struct $GVT<repeat each T> () 
+  return %retval : $GVT<repeat each T>
 }
 
 // =============================================================================

--- a/test/IRGen/pack_metadata_marker_inserter_no_ir.sil
+++ b/test/IRGen/pack_metadata_marker_inserter_no_ir.sil
@@ -1,0 +1,23 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -pack-metadata-marker-inserter -enable-pack-metadata-stack-promotion=true | %FileCheck %s --check-prefixes CHECK-SIL
+
+// REQUIRES: asserts
+
+sil_stage lowered
+
+import Builtin
+
+protocol Error {}
+
+struct GVT<each T> {
+}
+
+// CHECK-SIL-LABEL: sil @throw_variadic : {{.*}} {
+// CHECK-SIL:         [[ERROR:%[^,]+]] = struct
+// CHECK-SIL:         throw [[ERROR]]
+// CHECK-SIL-LABEL: } // end sil function 'throw_variadic'
+sil @throw_variadic : $<each T>() -> ((), @error GVT<repeat each T>) {
+entry:
+  %retval = struct $GVT<repeat each T> () 
+  throw %retval : $GVT<repeat each T>
+}
+


### PR DESCRIPTION
Function exiting terminators don't allocate on-stack pack metadata packs.  The packs would have been materialized when the value is defined.

Fixes a SILVerifier failure resulting from a sequence like
```
alloc_pack_metadata
dealloc_pack_metadata
return
```
resulting from inserting the `alloc_pack_metadata` on behalf of the return, inserting the `dealloc_pack_metadata` on the dominance frontier, and fixing up stack nesting.
