### PR TITLE
[silgen] Rename forTrivialObjectRValue -> forObjectRValueWithoutOwnership and change a bunch of forUnmanaged to use this API

### DIFF
--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -423,8 +423,8 @@ public:
 
   /// Create a CMV for a value of trivial type.
   static ConsumableManagedValue forUnmanaged(SILValue value) {
-    return { ManagedValue::forUnmanaged(value),
-             CastConsumptionKind::TakeAlways };
+    return {ManagedValue::forObjectRValueWithoutOwnership(value),
+            CastConsumptionKind::TakeAlways};
   }
 
   /// Create a CMV for an owned value.

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -165,7 +165,7 @@ public:
   }
 
   /// Create a managed value for a +0 trivial object rvalue.
-  static ManagedValue forTrivialObjectRValue(SILValue value) {
+  static ManagedValue forObjectRValueWithoutOwnership(SILValue value) {
     assert(value->getType().isObject() && "Expected an object");
     assert(value->getOwnershipKind() == OwnershipKind::None);
     return ManagedValue(value, false, CleanupHandle::invalid());
@@ -181,7 +181,7 @@ public:
   /// Create a managed value for a +0 trivial rvalue.
   static ManagedValue forTrivialRValue(SILValue value) {
     if (value->getType().isObject())
-      return ManagedValue::forTrivialObjectRValue(value);
+      return ManagedValue::forObjectRValueWithoutOwnership(value);
     return ManagedValue::forTrivialAddressRValue(value);
   }
 

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -895,8 +895,8 @@ public:
             loc, SILType::getPrimitiveObjectType(continuationTy),
             {continuation});
 
-        auto continuationMV =
-            ManagedValue::forUnmanaged(SILValue(wrappedContinuation));
+        auto continuationMV = ManagedValue::forObjectRValueWithoutOwnership(
+            SILValue(wrappedContinuation));
         SGF.emitApplyOfLibraryIntrinsic(
             loc, errorIntrinsic, subs,
             {continuationMV,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6967,11 +6967,12 @@ ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,
 
   // The intrinsic returns a pointer to the address of the result value inside
   // the async let task context.
-  emitApplyOfLibraryIntrinsic(loc, asyncLetGet, {},
-                   {ManagedValue::forTrivialObjectRValue(childTask.asyncLet),
-                    ManagedValue::forTrivialObjectRValue(childTask.resultBuf)},
-                   SGFContext());
-  
+  emitApplyOfLibraryIntrinsic(
+      loc, asyncLetGet, {},
+      {ManagedValue::forObjectRValueWithoutOwnership(childTask.asyncLet),
+       ManagedValue::forObjectRValueWithoutOwnership(childTask.resultBuf)},
+      SGFContext());
+
   auto resultAddr = B.createPointerToAddress(loc, childTask.resultBuf,
                 loweredOpaquePatternType.getAddressType(),
                 /*strict*/ true,
@@ -7054,10 +7055,11 @@ void SILGenFunction::emitFinishAsyncLet(
     SILLocation loc, SILValue asyncLet, SILValue resultPtr) {
   // This runtime function cancels the task, awaits its completion, and
   // destroys the value in the result buffer if necessary.
-  emitApplyOfLibraryIntrinsic(loc, SGM.getFinishAsyncLet(), {},
-                             {ManagedValue::forTrivialObjectRValue(asyncLet),
-                              ManagedValue::forTrivialObjectRValue(resultPtr)},
-                             SGFContext());
+  emitApplyOfLibraryIntrinsic(
+      loc, SGM.getFinishAsyncLet(), {},
+      {ManagedValue::forObjectRValueWithoutOwnership(asyncLet),
+       ManagedValue::forObjectRValueWithoutOwnership(resultPtr)},
+      SGFContext());
   // This builtin ends the lifetime of the allocation for the async let.
   auto &ctx = getASTContext();
   B.createBuiltin(loc,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -218,7 +218,7 @@ static ManagedValue borrowedCastToOriginalSelfType(SILGenFunction &SGF,
   if (originalSelfType.is<AnyMetatypeType>()) {
     assert(originalSelfType.isTrivial(SGF.F) &&
            "Metatypes should always be trivial");
-    return ManagedValue::forUnmanaged(originalSelf);
+    return ManagedValue::forObjectRValueWithoutOwnership(originalSelf);
   }
 
   // Otherwise, we have a non-metatype. Use a borrow+unchecked_ref_cast.
@@ -629,14 +629,14 @@ public:
       auto constantInfo =
           SGF.getConstantInfo(SGF.getTypeExpansionContext(), *constant);
       SILValue ref = SGF.emitGlobalFunctionRef(Loc, *constant, constantInfo);
-      return ManagedValue::forUnmanaged(ref);
+      return ManagedValue::forObjectRValueWithoutOwnership(ref);
     }
     case Kind::StandaloneFunctionDynamicallyReplaceableImpl: {
       auto constantInfo =
           SGF.getConstantInfo(SGF.getTypeExpansionContext(), *constant);
       SILValue ref =
           SGF.emitGlobalFunctionRef(Loc, *constant, constantInfo, true);
-      return ManagedValue::forUnmanaged(ref);
+      return ManagedValue::forObjectRValueWithoutOwnership(ref);
     }
     case Kind::ClassMethod: {
       auto methodTy = SGF.SGM.Types.getConstantOverrideType(
@@ -655,7 +655,7 @@ public:
             SILType::getPrimitiveObjectType(methodTy));
       }
       S.pop();
-      return ManagedValue::forUnmanaged(methodVal);
+      return ManagedValue::forObjectRValueWithoutOwnership(methodVal);
     }
     case Kind::SuperMethod: {
       ArgumentScope S(SGF, Loc);
@@ -709,7 +709,7 @@ public:
                                     *constant, constantInfo.getSILType());
       }
       S.pop();
-      return ManagedValue::forUnmanaged(fn);
+      return ManagedValue::forObjectRValueWithoutOwnership(fn);
     }
     case Kind::DynamicMethod: {
       auto closureType = getDynamicMethodLoweredType(
@@ -720,7 +720,7 @@ public:
           Loc, borrowedSelf->getValue(), *constant,
           closureType);
       S.pop();
-      return ManagedValue::forUnmanaged(fn);
+      return ManagedValue::forObjectRValueWithoutOwnership(fn);
     }
     }
     llvm_unreachable("unhandled kind");
@@ -1010,7 +1010,7 @@ public:
       llvm_unreachable("shouldn't happen");
     }
 
-    auto result = ManagedValue::forUnmanaged(convertedValue);
+    auto result = ManagedValue::forObjectRValueWithoutOwnership(convertedValue);
     return {result, SGF.getLoweredType(instanceType)};
   }
 
@@ -1550,9 +1550,12 @@ public:
         self = SGF.emitUndef(selfFormalType);
       } else if (SGF.AllocatorMetatype) {
         self = emitCorrespondingSelfValue(
-            ManagedValue::forUnmanaged(SGF.AllocatorMetatype), arg);
+            ManagedValue::forObjectRValueWithoutOwnership(
+                SGF.AllocatorMetatype),
+            arg);
       } else {
-        self = ManagedValue::forUnmanaged(SGF.emitMetatypeOfValue(expr, arg));
+        self = ManagedValue::forObjectRValueWithoutOwnership(
+            SGF.emitMetatypeOfValue(expr, arg));
       }
     } else {
       // If we haven't allocated "self" yet at this point, do so.
@@ -1565,10 +1568,10 @@ public:
           // initializer is @objc.
           usesObjCAllocation = true;
         }
-        
-        self = allocateObject(
-                      ManagedValue::forUnmanaged(SGF.AllocatorMetatype), arg,
-                      usesObjCAllocation);
+
+        self = allocateObject(ManagedValue::forObjectRValueWithoutOwnership(
+                                  SGF.AllocatorMetatype),
+                              arg, usesObjCAllocation);
 
         // Perform any adjustments needed to 'self'.
         self = emitCorrespondingSelfValue(self, arg);
@@ -1819,7 +1822,8 @@ static PreparedArguments emitStringLiteralArgs(SILGenFunction &SGF, SILLocation 
     AnyFunctionType::Param param(Int32Ty.getASTType());
     PreparedArguments args(llvm::ArrayRef<AnyFunctionType::Param>{param});
     args.add(E, RValue(SGF, E, Int32Ty.getASTType(),
-                       ManagedValue::forUnmanaged(UnicodeScalarValue)));
+                       ManagedValue::forObjectRValueWithoutOwnership(
+                           UnicodeScalarValue)));
     return args;
   }
   }
@@ -1836,10 +1840,9 @@ static PreparedArguments emitStringLiteralArgs(SILGenFunction &SGF, SILLocation 
   auto *isASCIIInst = SGF.B.createIntegerLiteral(E, Int1Ty, isASCII);
 
   ManagedValue EltsArray[] = {
-    ManagedValue::forUnmanaged(string),
-    ManagedValue::forUnmanaged(lengthInst),
-    ManagedValue::forUnmanaged(isASCIIInst)
-  };
+      ManagedValue::forObjectRValueWithoutOwnership(string),
+      ManagedValue::forObjectRValueWithoutOwnership(lengthInst),
+      ManagedValue::forObjectRValueWithoutOwnership(isASCIIInst)};
 
   AnyFunctionType::Param TypeEltsArray[] = {
     AnyFunctionType::Param(EltsArray[0].getType().getASTType()),
@@ -2043,7 +2046,8 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
   auto i1Ty = SILType::getBuiltinIntegerType(1, SGF.getASTContext());
   SILValue boolValue = SGF.B.createIntegerLiteral(booleanLiteral, i1Ty,
                                                   booleanLiteral->getValue());
-  ManagedValue boolManaged = ManagedValue::forUnmanaged(boolValue);
+  ManagedValue boolManaged =
+      ManagedValue::forObjectRValueWithoutOwnership(boolValue);
   CanType ty = boolManaged.getType().getASTType()->getCanonicalType();
   builtinLiteralArgs.emplace(AnyFunctionType::Param(ty));
   builtinLiteralArgs.add(booleanLiteral, RValue(SGF, {boolManaged}, ty));
@@ -2055,7 +2059,7 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
                         IntegerLiteralExpr *integerLiteral) {
   PreparedArguments builtinLiteralArgs;
   ManagedValue integerManaged =
-      ManagedValue::forUnmanaged(SGF.B.createIntegerLiteral(
+      ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createIntegerLiteral(
           integerLiteral,
           SILType::getBuiltinIntegerLiteralType(SGF.getASTContext()),
           integerLiteral->getRawValue()));
@@ -2071,7 +2075,7 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
   PreparedArguments builtinLiteralArgs;
   auto *litTy = floatLiteral->getBuiltinType()->castTo<BuiltinFloatType>();
   ManagedValue floatManaged =
-      ManagedValue::forUnmanaged(SGF.B.createFloatLiteral(
+      ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createFloatLiteral(
           floatLiteral,
           SILType::getBuiltinFloatType(litTy->getFPKind(), SGF.getASTContext()),
           floatLiteral->getValue()));
@@ -2100,7 +2104,7 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
   // The version of the regex string.
   // %3 = integer_literal $Builtin.IntLiteral <version>
   auto versionIntLiteral =
-      ManagedValue::forUnmanaged(SGF.B.createIntegerLiteral(
+      ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createIntegerLiteral(
           expr, SILType::getBuiltinIntegerLiteralType(SGF.getASTContext()),
           expr->getVersion()));
 
@@ -2187,7 +2191,8 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
     auto silTy = SILType::getBuiltinIntegerLiteralType(ctx);
     auto ty = silTy.getASTType();
     SILValue integer = SGF.B.createIntegerLiteral(magicLiteral, silTy, Value);
-    ManagedValue integerManaged = ManagedValue::forUnmanaged(integer);
+    ManagedValue integerManaged =
+        ManagedValue::forObjectRValueWithoutOwnership(integer);
     PreparedArguments builtinLiteralArgs;
     builtinLiteralArgs.emplace(AnyFunctionType::Param(ty));
     builtinLiteralArgs.add(magicLiteral, RValue(SGF, {integerManaged}, ty));
@@ -6090,7 +6095,7 @@ RValue SILGenFunction::emitApplyAllocatingInitializer(SILLocation loc,
     if (selfMetaTy != selfParamMetaTy)
       selfMeta = B.createUpcast(loc, selfMeta, selfParamMetaTy);
 
-    selfMetaVal = ManagedValue::forUnmanaged(selfMeta);
+    selfMetaVal = ManagedValue::forObjectRValueWithoutOwnership(selfMeta);
   }
 
   // Form the callee.
@@ -6221,10 +6226,9 @@ SILGenFunction::emitUninitializedArrayAllocation(Type ArrayTy,
   // Invoke the intrinsic, which returns a tuple.
   auto subMap = ArrayTy->getContextSubstitutionMap(SGM.M.getSwiftModule(),
                                                    Ctx.getArrayDecl());
-  auto result = emitApplyOfLibraryIntrinsic(Loc, allocate,
-                                            subMap,
-                                            ManagedValue::forUnmanaged(Length),
-                                            SGFContext());
+  auto result = emitApplyOfLibraryIntrinsic(
+      Loc, allocate, subMap,
+      ManagedValue::forObjectRValueWithoutOwnership(Length), SGFContext());
 
   // Explode the tuple.
   SmallVector<ManagedValue, 2> resultElts;
@@ -6935,7 +6939,7 @@ ManagedValue SILGenFunction::emitAsyncLetStart(
       getLoweredType(ctx.TheRawPointerType), subs,
       {taskOptions, taskFunction.getValue(), resultBuf});
 
-  return ManagedValue::forUnmanaged(apply);
+  return ManagedValue::forObjectRValueWithoutOwnership(apply);
 }
 
 ManagedValue SILGenFunction::emitCancelAsyncTask(
@@ -6946,7 +6950,7 @@ ManagedValue SILGenFunction::emitCancelAsyncTask(
       ctx.getIdentifier(getBuiltinName(BuiltinValueKind::CancelAsyncTask)),
       getLoweredType(ctx.TheEmptyTupleType), SubstitutionMap(),
       { task });
-  return ManagedValue::forUnmanaged(apply);
+  return ManagedValue::forObjectRValueWithoutOwnership(apply);
 }
 
 ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -243,11 +243,11 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF, SILLocation loc,
   ResultPlanPtr resultPlan =
       ResultPlanBuilder::computeResultPlan(SGF, calleeTypeInfo, loc, context);
   ArgumentScope argScope(SGF, loc);
-  RValue result =
-      SGF.emitApply(std::move(resultPlan), std::move(argScope), loc,
-                    ManagedValue::forUnmanaged(witnessRef), subs,
-                    {objcValue, ManagedValue::forUnmanaged(metatypeValue)},
-                    calleeTypeInfo, ApplyOptions(), context, llvm::None);
+  RValue result = SGF.emitApply(
+      std::move(resultPlan), std::move(argScope), loc,
+      ManagedValue::forObjectRValueWithoutOwnership(witnessRef), subs,
+      {objcValue, ManagedValue::forObjectRValueWithoutOwnership(metatypeValue)},
+      calleeTypeInfo, ApplyOptions(), context, llvm::None);
   return std::move(result).getAsSingleValue(SGF, loc);
 }
 
@@ -2297,8 +2297,8 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     ArgumentScope argScope(*this, fd);
     ManagedValue resultMV =
         emitApply(std::move(resultPlan), std::move(argScope), fd,
-                  ManagedValue::forUnmanaged(fn), subs, args, calleeTypeInfo,
-                  ApplyOptions(), context, llvm::None)
+                  ManagedValue::forObjectRValueWithoutOwnership(fn), subs, args,
+                  calleeTypeInfo, ApplyOptions(), context, llvm::None)
             .getAsSingleValue(*this, fd);
 
     if (indirectResult) {

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -233,6 +233,8 @@ ManagedValue SILGenBuilder::createPhi(SILType type,
     return SGF.emitManagedBorrowedArgumentWithCleanup(arg);
 
   case OwnershipKind::None:
+    return ManagedValue::forObjectRValueWithoutOwnership(arg);
+
   case OwnershipKind::Unowned:
     return ManagedValue::forUnmanaged(arg);
   }
@@ -387,7 +389,7 @@ SILGenBuilder::bufferForExpr(SILLocation loc, SILType ty,
 
   // Add a cleanup for the temporary we allocated.
   if (lowering.isTrivial())
-    return ManagedValue::forUnmanaged(address);
+    return ManagedValue::forTrivialAddressRValue(address);
 
   return SGF.emitManagedBufferWithCleanup(address);
 }
@@ -415,7 +417,7 @@ ManagedValue SILGenBuilder::formalAccessBufferForExpr(
 
   // Add a cleanup for the temporary we allocated.
   if (lowering.isTrivial())
-    return ManagedValue::forUnmanaged(address);
+    return ManagedValue::forTrivialAddressRValue(address);
 
   return SGF.emitFormalAccessManagedBufferWithCleanup(loc, address);
 }
@@ -465,7 +467,7 @@ ManagedValue SILGenBuilder::createLoadTake(SILLocation loc, ManagedValue v,
   SILValue result =
       lowering.emitLoadOfCopy(*this, loc, v.forward(SGF), IsTake);
   if (lowering.isTrivial())
-    return ManagedValue::forUnmanaged(result);
+    return ManagedValue::forObjectRValueWithoutOwnership(result);
   assert((!lowering.isAddressOnly() || !SGF.silConv.useLoweredAddresses()) &&
          "cannot retain an unloadable type");
   return SGF.emitManagedRValueWithCleanup(result, lowering);
@@ -482,7 +484,7 @@ ManagedValue SILGenBuilder::createLoadCopy(SILLocation loc, ManagedValue v,
   SILValue result =
       lowering.emitLoadOfCopy(*this, loc, v.getValue(), IsNotTake);
   if (lowering.isTrivial())
-    return ManagedValue::forUnmanaged(result);
+    return ManagedValue::forObjectRValueWithoutOwnership(result);
   assert((!lowering.isAddressOnly()
           || !SGF.silConv.useLoweredAddresses()) &&
          "cannot retain an unloadable type");
@@ -649,7 +651,7 @@ ManagedValue SILGenBuilder::createManagedOptionalNone(SILLocation loc,
   if (!type.isAddressOnly(getFunction()) ||
       !SGF.silConv.useLoweredAddresses()) {
     SILValue noneValue = createOptionalNone(loc, type);
-    return ManagedValue::forUnmanaged(noneValue);
+    return ManagedValue::forObjectRValueWithoutOwnership(noneValue);
   }
 
   SILValue tempResult = SGF.emitTemporaryAllocation(loc, type);

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -65,7 +65,7 @@ static ManagedValue emitBuiltinRetain(SILGenFunction &SGF,
   // we must allow for the cleanup and emit a new unmanaged retain value.
   SGF.B.createUnmanagedRetainValue(loc, args[0].getValue(),
                                    SGF.B.getDefaultAtomicity());
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));    
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 static ManagedValue emitBuiltinRelease(SILGenFunction &SGF,
@@ -78,7 +78,7 @@ static ManagedValue emitBuiltinRelease(SILGenFunction &SGF,
   // release.
   SGF.B.createUnmanagedReleaseValue(loc, args[0].getValue(),
                                     SGF.B.getDefaultAtomicity());
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));    
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 static ManagedValue emitBuiltinAutorelease(SILGenFunction &SGF,
@@ -88,7 +88,7 @@ static ManagedValue emitBuiltinAutorelease(SILGenFunction &SGF,
                                            SGFContext C) {
   SGF.B.createUnmanagedAutoreleaseValue(loc, args[0].getValue(),
                                         SGF.B.getDefaultAtomicity());
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));    
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 /// Specialized emitter for Builtin.load and Builtin.take.
@@ -184,8 +184,9 @@ static ManagedValue emitBuiltinDestroy(SILGenFunction &SGF,
   
   // Destroy is a no-op for trivial types.
   if (ti.isTrivial())
-    return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
-  
+    return ManagedValue::forObjectRValueWithoutOwnership(
+        SGF.emitEmptyTuple(loc));
+
   SILType destroyType = ti.getLoweredType();
 
   // Convert the pointer argument to a SIL address.
@@ -198,8 +199,8 @@ static ManagedValue emitBuiltinDestroy(SILGenFunction &SGF,
   // Destroy the value indirectly. Canonicalization will promote to loads
   // and releases if appropriate.
   SGF.B.createDestroyAddr(loc, addr);
-  
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 static ManagedValue emitBuiltinAssign(SILGenFunction &SGF,
@@ -228,7 +229,7 @@ static ManagedValue emitBuiltinAssign(SILGenFunction &SGF,
   
   std::move(src).ensurePlusOne(SGF, loc).assignInto(SGF, loc, addr);
 
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 /// Emit Builtin.initialize by evaluating the operand directly into
@@ -240,7 +241,8 @@ static ManagedValue emitBuiltinInit(SILGenFunction &SGF,
                                     SGFContext C) {
   auto argsOrError = decomposeArguments(SGF, loc, std::move(preparedArgs), 2);
   if (!argsOrError)
-    return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+    return ManagedValue::forObjectRValueWithoutOwnership(
+        SGF.emitEmptyTuple(loc));
 
   auto args = *argsOrError;
 
@@ -257,7 +259,7 @@ static ManagedValue emitBuiltinInit(SILGenFunction &SGF,
   TemporaryInitialization init(addr, CleanupHandle::invalid());
   SGF.emitExprInto(args[0], &init);
 
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 /// Specialized emitter for Builtin.fixLifetime.
@@ -269,7 +271,7 @@ static ManagedValue emitBuiltinFixLifetime(SILGenFunction &SGF,
   for (auto arg : args) {
     SGF.B.createFixLifetime(loc, arg.getValue());
   }
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 static ManagedValue emitCastToReferenceType(SILGenFunction &SGF,
@@ -380,7 +382,7 @@ static ManagedValue emitBuiltinBridgeToRawPointer(SILGenFunction &SGF,
   SILType rawPointerType = SILType::getRawPointerType(SGF.F.getASTContext());
   SILValue result = SGF.B.createRefToRawPointer(loc, args[0].getValue(),
                                                 rawPointerType);
-  return ManagedValue::forUnmanaged(result);
+  return ManagedValue::forObjectRValueWithoutOwnership(result);
 }
 
 /// Specialized emitter for Builtin.bridgeFromRawPointer.
@@ -435,7 +437,7 @@ static ManagedValue emitBuiltinAddressOfBuiltins(SILGenFunction &SGF,
   // Take the address argument and cast it to RawPointer.
   SILValue result = SGF.B.createAddressToPointer(loc, addr, rawPointerType,
                                                  stackProtected);
-  return ManagedValue::forUnmanaged(result);
+  return ManagedValue::forObjectRValueWithoutOwnership(result);
 }
 
 /// Specialized emitter for Builtin.addressof.
@@ -497,7 +499,7 @@ static ManagedValue emitBuiltinAddressOfBorrowBuiltins(SILGenFunction &SGF,
   // Take the address argument and cast it to RawPointer.
   SILValue result = SGF.B.createAddressToPointer(loc, addr, rawPointerType,
                                                  stackProtected);
-  return ManagedValue::forUnmanaged(result);
+  return ManagedValue::forObjectRValueWithoutOwnership(result);
 }
 
 /// Specialized emitter for Builtin.addressOfBorrow.
@@ -531,7 +533,7 @@ static ManagedValue emitBuiltinGepRaw(SILGenFunction &SGF,
   SILValue offsetPtr = SGF.B.createIndexRawPointer(loc,
                                                  args[0].getUnmanagedValue(),
                                                  args[1].getUnmanagedValue());
-  return ManagedValue::forUnmanaged(offsetPtr);
+  return ManagedValue::forObjectRValueWithoutOwnership(offsetPtr);
 }
 
 /// Specialized emitter for Builtin.gep.
@@ -556,7 +558,7 @@ static ManagedValue emitBuiltinGep(SILGenFunction &SGF,
   addr = SGF.B.createAddressToPointer(loc, addr, RawPtrType,
                                       /*needsStackProtection=*/ true);
 
-  return ManagedValue::forUnmanaged(addr);
+  return ManagedValue::forObjectRValueWithoutOwnership(addr);
 }
 
 /// Specialized emitter for Builtin.getTailAddr.
@@ -582,7 +584,7 @@ static ManagedValue emitBuiltinGetTailAddr(SILGenFunction &SGF,
   addr = SGF.B.createAddressToPointer(loc, addr, RawPtrType,
                                       /*needsStackProtection=*/ false);
 
-  return ManagedValue::forUnmanaged(addr);
+  return ManagedValue::forObjectRValueWithoutOwnership(addr);
 }
 
 /// Specialized emitter for Builtin.beginUnpairedModifyAccess.
@@ -616,7 +618,7 @@ static ManagedValue emitBuiltinBeginUnpairedModifyAccess(SILGenFunction &SGF,
                                   /*noNestedConflict*/ false,
                                   /*fromBuiltin*/ true);
 
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 /// Specialized emitter for Builtin.performInstantaneousReadAccess
@@ -654,7 +656,7 @@ static ManagedValue emitBuiltinPerformInstantaneousReadAccess(
                                   /*noNestedConflict*/ true,
                                   /*fromBuiltin*/ true);
 
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 /// Specialized emitter for Builtin.endUnpairedAccessModifyAccess.
@@ -680,7 +682,7 @@ static ManagedValue emitBuiltinEndUnpairedAccess(SILGenFunction &SGF,
                                 /*aborted*/ false,
                                 /*fromBuiltin*/ true);
 
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 /// Specialized emitter for the legacy Builtin.condfail.
@@ -693,7 +695,7 @@ static ManagedValue emitBuiltinLegacyCondFail(SILGenFunction &SGF,
 
   SGF.B.createCondFail(loc, args[0].getUnmanagedValue(),
     "unknown runtime failure");
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 /// Specialized emitter for Builtin.castReference.
@@ -889,7 +891,7 @@ static ManagedValue emitBuiltinCastBitPatternFromBridgeObject(
   SILType wordType = SILType::getBuiltinWordType(SGF.getASTContext());
   SILValue result = SGF.B.createBridgeObjectToWord(loc, args[0].getValue(),
                                                    wordType);
-  return ManagedValue::forUnmanaged(result);
+  return ManagedValue::forObjectRValueWithoutOwnership(result);
 }
 
 static ManagedValue emitBuiltinClassifyBridgeObject(SILGenFunction &SGF,
@@ -901,7 +903,7 @@ static ManagedValue emitBuiltinClassifyBridgeObject(SILGenFunction &SGF,
   assert(subs.empty() && "classify should not have subs");
 
   SILValue result = SGF.B.createClassifyBridgeObject(loc, args[0].getValue());
-  return ManagedValue::forUnmanaged(result);
+  return ManagedValue::forObjectRValueWithoutOwnership(result);
 }
 
 static ManagedValue emitBuiltinValueToBridgeObject(SILGenFunction &SGF,
@@ -941,8 +943,8 @@ static ManagedValue emitBuiltinIsUnique(SILGenFunction &SGF,
   assert((args[0].getType().isAddress() && !args[0].hasCleanup()) &&
          "Builtin.isUnique takes an address.");
 
-  return ManagedValue::forUnmanaged(
-    SGF.B.createIsUnique(loc, args[0].getValue()));
+  return ManagedValue::forObjectRValueWithoutOwnership(
+      SGF.B.createIsUnique(loc, args[0].getValue()));
 }
 
 // This force-casts the incoming address to NativeObject assuming the caller has
@@ -963,7 +965,7 @@ emitBuiltinIsUnique_native(SILGenFunction &SGF,
     SILType::getNativeObjectType(SGF.getASTContext()).getAddressType();
   auto toAddr = SGF.B.createUncheckedAddrCast(loc, args[0].getValue(), ToType);
   SILValue result = SGF.B.createIsUnique(loc, toAddr);
-  return ManagedValue::forUnmanaged(result);
+  return ManagedValue::forObjectRValueWithoutOwnership(result);
 }
 
 static ManagedValue
@@ -981,7 +983,8 @@ emitBuiltinBeginCOWMutation(SILGenFunction &SGF,
   auto *ref = SGF.B.createLoad(loc, refAddr, LoadOwnershipQualifier::Take);
   BeginCOWMutationInst *beginCOW = SGF.B.createBeginCOWMutation(loc, ref, /*isNative*/ false);
   SGF.B.createStore(loc, beginCOW->getBufferResult(), refAddr, StoreOwnershipQualifier::Init);
-  return ManagedValue::forUnmanaged(beginCOW->getUniquenessResult());
+  return ManagedValue::forObjectRValueWithoutOwnership(
+      beginCOW->getUniquenessResult());
 }
 
 static ManagedValue
@@ -999,7 +1002,8 @@ emitBuiltinBeginCOWMutation_native(SILGenFunction &SGF,
   auto *ref = SGF.B.createLoad(loc, refAddr, LoadOwnershipQualifier::Take);
   BeginCOWMutationInst *beginCOW = SGF.B.createBeginCOWMutation(loc, ref, /*isNative*/ true);
   SGF.B.createStore(loc, beginCOW->getBufferResult(), refAddr, StoreOwnershipQualifier::Init);
-  return ManagedValue::forUnmanaged(beginCOW->getUniquenessResult());
+  return ManagedValue::forObjectRValueWithoutOwnership(
+      beginCOW->getUniquenessResult());
 }
 
 static ManagedValue
@@ -1017,7 +1021,7 @@ emitBuiltinEndCOWMutation(SILGenFunction &SGF,
   auto ref = SGF.B.createLoad(loc, refAddr, LoadOwnershipQualifier::Take);
   auto endRef = SGF.B.createEndCOWMutation(loc, ref);
   SGF.B.createStore(loc, endRef, refAddr, StoreOwnershipQualifier::Init);
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 static ManagedValue emitBuiltinBindMemory(SILGenFunction &SGF,
@@ -1035,7 +1039,7 @@ static ManagedValue emitBuiltinBindMemory(SILGenFunction &SGF,
   auto *bindMemory = SGF.B.createBindMemory(loc, args[0].getValue(),
                                             args[1].getValue(), boundType);
 
-  return ManagedValue::forUnmanaged(bindMemory);
+  return ManagedValue::forObjectRValueWithoutOwnership(bindMemory);
 }
 
 static ManagedValue emitBuiltinRebindMemory(SILGenFunction &SGF,
@@ -1049,7 +1053,7 @@ static ManagedValue emitBuiltinRebindMemory(SILGenFunction &SGF,
   auto *rebindMemory = SGF.B.createRebindMemory(loc, args[0].getValue(),
                                                 args[1].getValue());
 
-  return ManagedValue::forUnmanaged(rebindMemory);
+  return ManagedValue::forObjectRValueWithoutOwnership(rebindMemory);
 }
 
 static ManagedValue emitBuiltinAllocWithTailElems(SILGenFunction &SGF,
@@ -1107,7 +1111,7 @@ static ManagedValue emitBuiltinProjectTailElems(SILGenFunction &SGF,
   SILType rawPointerType = SILType::getRawPointerType(SGF.F.getASTContext());
   result = SGF.B.createAddressToPointer(loc, result, rawPointerType,
                                         /*needsStackProtection=*/ false);
-  return ManagedValue::forUnmanaged(result);
+  return ManagedValue::forObjectRValueWithoutOwnership(result);
 }
 
 /// Specialized emitter for type traits.
@@ -1145,8 +1149,8 @@ static ManagedValue emitBuiltinTypeTrait(SILGenFunction &SGF,
                                      C.getIdentifier(getBuiltinName(Kind)),
                                      SILType::getPrimitiveObjectType(int8Ty),
                                      substitutions, args[0].getValue());
-    
-    return ManagedValue::forUnmanaged(apply);
+
+    return ManagedValue::forObjectRValueWithoutOwnership(apply);
   }
   }
   
@@ -1154,7 +1158,7 @@ static ManagedValue emitBuiltinTypeTrait(SILGenFunction &SGF,
   auto val = SGF.B.createIntegerLiteral(
       loc, SILType::getBuiltinIntegerType(8, SGF.getASTContext()),
       (uintmax_t)result);
-  return ManagedValue::forUnmanaged(val);
+  return ManagedValue::forObjectRValueWithoutOwnership(val);
 }
 
 static ManagedValue emitBuiltinAutoDiffApplyDerivativeFunction(
@@ -1347,7 +1351,8 @@ static ManagedValue emitBuiltinConvertStrongToUnownedUnsafe(
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto argsOrError = decomposeArguments(SGF, loc, std::move(preparedArgs), 2);
   if (!argsOrError)
-    return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+    return ManagedValue::forObjectRValueWithoutOwnership(
+        SGF.emitEmptyTuple(loc));
 
   auto args = *argsOrError;
 
@@ -1389,7 +1394,7 @@ static ManagedValue emitBuiltinConvertStrongToUnownedUnsafe(
       loc, objectSrcValue, unmanagedOptType.getObjectType());
   SGF.B.emitStoreValueOperation(loc, unownedObjectSrcValue, inoutDest,
                                 StoreOwnershipQualifier::Trivial);
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 /// Emit SIL for the named builtin: convertUnownedUnsafeToGuaranteed.
@@ -1403,7 +1408,8 @@ static ManagedValue emitBuiltinConvertUnownedUnsafeToGuaranteed(
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto argsOrError = decomposeArguments(SGF, loc, std::move(preparedArgs), 2);
   if (!argsOrError)
-    return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+    return ManagedValue::forObjectRValueWithoutOwnership(
+        SGF.emitEmptyTuple(loc));
 
   auto args = *argsOrError;
 
@@ -1479,34 +1485,25 @@ static ManagedValue emitBuiltinSizeof(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
-  return ManagedValue::forUnmanaged(
-    SGF.B.createBuiltin(loc,
-      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Sizeof)),
-      SILType::getBuiltinWordType(ctx),
-      subs,
-      {}));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
+      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Sizeof)),
+      SILType::getBuiltinWordType(ctx), subs, {}));
 }
 static ManagedValue emitBuiltinStrideof(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
-  return ManagedValue::forUnmanaged(
-    SGF.B.createBuiltin(loc,
-      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Strideof)),
-      SILType::getBuiltinWordType(ctx),
-      subs,
-      {}));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
+      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Strideof)),
+      SILType::getBuiltinWordType(ctx), subs, {}));
 }
 static ManagedValue emitBuiltinAlignof(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     PreparedArguments &&preparedArgs, SGFContext C) {
   auto &ctx = SGF.getASTContext();
-  return ManagedValue::forUnmanaged(
-    SGF.B.createBuiltin(loc,
-      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Alignof)),
-      SILType::getBuiltinWordType(ctx),
-      subs,
-      {}));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.B.createBuiltin(
+      loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::Alignof)),
+      SILType::getBuiltinWordType(ctx), subs, {}));
 }
 
 // Helper to lower a function argument to be usable as the entry point of a
@@ -1707,7 +1704,7 @@ static ManagedValue emitBuiltinHopToActor(SILGenFunction &SGF, SILLocation loc,
                                           ArrayRef<ManagedValue> args,
                                           SGFContext C) {
   SGF.emitHopToActorValue(loc, args[0]);
-  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+  return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }
 
 static ManagedValue emitBuiltinAutoDiffCreateLinearMapContext(
@@ -1735,7 +1732,7 @@ static ManagedValue emitBuiltinAutoDiffProjectTopLevelSubcontext(
       SILType::getRawPointerType(ctx),
       subs,
       /*args*/ {args[0].borrow(SGF, loc).getValue()});
-  return ManagedValue::forUnmanaged(builtinApply);
+  return ManagedValue::forObjectRValueWithoutOwnership(builtinApply);
 }
 
 static ManagedValue emitBuiltinAutoDiffAllocateSubcontext(
@@ -1749,7 +1746,7 @@ static ManagedValue emitBuiltinAutoDiffAllocateSubcontext(
       SILType::getRawPointerType(ctx),
       subs,
       /*args*/ {args[0].borrow(SGF, loc).getValue(), args[1].getValue()});
-  return ManagedValue::forUnmanaged(builtinApply);
+  return ManagedValue::forObjectRValueWithoutOwnership(builtinApply);
 }
 
 // The only reason these need special attention is that we want these to

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1540,12 +1540,16 @@ ManagedValue emitBuiltinCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
       ProtocolCompositionType::get(ctx, { }, false))->getCanonicalType();
   auto &anyTypeTL = SGF.getTypeLowering(anyTypeType);
   auto &futureResultTL = SGF.getTypeLowering(futureResultType);
-  auto futureResultMetadata = SGF.emitExistentialErasure(
-      loc, futureResultType, futureResultTL, anyTypeTL, { }, C,
-      [&](SGFContext C) -> ManagedValue {
-    return ManagedValue::forTrivialObjectRValue(
-      SGF.B.createMetatype(loc, SGF.getLoweredType(futureResultType)));
-  }).borrow(SGF, loc).forward(SGF);
+  auto futureResultMetadata =
+      SGF.emitExistentialErasure(
+             loc, futureResultType, futureResultTL, anyTypeTL, {}, C,
+             [&](SGFContext C) -> ManagedValue {
+               return ManagedValue::forObjectRValueWithoutOwnership(
+                   SGF.B.createMetatype(loc,
+                                        SGF.getLoweredType(futureResultType)));
+             })
+          .borrow(SGF, loc)
+          .forward(SGF);
 
   // Ensure that the closure has the appropriate type.
   auto extInfo =
@@ -1598,12 +1602,16 @@ static ManagedValue emitBuiltinCreateAsyncTaskInGroup(
       ProtocolCompositionType::get(ctx, { }, false))->getCanonicalType();
   auto &anyTypeTL = SGF.getTypeLowering(anyTypeType);
   auto &futureResultTL = SGF.getTypeLowering(futureResultType);
-  auto futureResultMetadata = SGF.emitExistentialErasure(
-      loc, futureResultType, futureResultTL, anyTypeTL, { }, C,
-      [&](SGFContext C) -> ManagedValue {
-    return ManagedValue::forTrivialObjectRValue(
-      SGF.B.createMetatype(loc, SGF.getLoweredType(futureResultType)));
-  }).borrow(SGF, loc).forward(SGF);
+  auto futureResultMetadata =
+      SGF.emitExistentialErasure(
+             loc, futureResultType, futureResultTL, anyTypeTL, {}, C,
+             [&](SGFContext C) -> ManagedValue {
+               return ManagedValue::forObjectRValueWithoutOwnership(
+                   SGF.B.createMetatype(loc,
+                                        SGF.getLoweredType(futureResultType)));
+             })
+          .borrow(SGF, loc)
+          .forward(SGF);
 
   auto function = emitFunctionArgumentForAsyncTaskEntryPoint(SGF, loc, args[2],
                                                              futureResultType);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5955,7 +5955,7 @@ SILGenFunction::emitArrayToPointer(SILLocation loc, ManagedValue array,
   pointer = B.createMarkDependence(loc, pointer, owner.getValue());
 
   // The owner's already in its own cleanup.  Return the pointer.
-  return {ManagedValue::forTrivialObjectRValue(pointer), owner};
+  return {ManagedValue::forObjectRValueWithoutOwnership(pointer), owner};
 }
 
 RValue RValueEmitter::visitStringToPointerExpr(StringToPointerExpr *E,
@@ -5989,7 +5989,7 @@ SILGenFunction::emitStringToPointer(SILLocation loc, ManagedValue stringValue,
   auto pointer = results[1].forward(*this);
   pointer = B.createMarkDependence(loc, pointer, owner.getValue());
 
-  return {ManagedValue::forTrivialObjectRValue(pointer), owner};
+  return {ManagedValue::forObjectRValueWithoutOwnership(pointer), owner};
 }
 
 RValue RValueEmitter::visitPointerToPointerExpr(PointerToPointerExpr *E,

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -521,8 +521,8 @@ SILGenFunction::emitSiblingMethodRef(SILLocation loc,
   methodTy =
       methodTy.substGenericArgs(SGM.M, subMap, getTypeExpansionContext());
 
-  return std::make_tuple(ManagedValue::forUnmanaged(methodValue),
-                         methodTy);
+  return std::make_tuple(
+      ManagedValue::forObjectRValueWithoutOwnership(methodValue), methodTy);
 }
 
 void SILGenFunction::emitCaptures(SILLocation loc,
@@ -563,7 +563,8 @@ void SILGenFunction::emitCaptures(SILLocation loc,
       SILType dynamicSILType = getLoweredType(dynamicSelfMetatype);
 
       SILValue value = B.createMetatype(loc, dynamicSILType);
-      capturedArgs.push_back(ManagedValue::forUnmanaged(value));
+      capturedArgs.push_back(
+          ManagedValue::forObjectRValueWithoutOwnership(value));
       continue;
     }
 
@@ -964,7 +965,7 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
   }
   
   if (loweredCaptureInfo.getCaptures().empty() && !wasSpecialized) {
-    auto result = ManagedValue::forUnmanaged(functionRef);
+    auto result = ManagedValue::forObjectRValueWithoutOwnership(functionRef);
     if (!alreadyConverted)
       result = emitOrigToSubstValue(loc, result,
                                     AbstractionPattern(expectedType),
@@ -1396,10 +1397,11 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
                              taskCreationFlagMask.getOpaqueValue());
 
   SILValue task =
-      emitBuiltinCreateAsyncTask(*this, moduleLoc, subs,
-                                 {ManagedValue::forUnmanaged(taskFlags),
-                                  ManagedValue::forUnmanaged(mainFunctionRef)},
-                                 {})
+      emitBuiltinCreateAsyncTask(
+          *this, moduleLoc, subs,
+          {ManagedValue::forObjectRValueWithoutOwnership(taskFlags),
+           ManagedValue::forObjectRValueWithoutOwnership(mainFunctionRef)},
+          {})
           .forward(*this);
   DestructureTupleInst *structure = B.createDestructureTuple(moduleLoc, task);
   task = structure->getResult(0);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2374,7 +2374,7 @@ static ManagedValue manageYield(SILGenFunction &SGF, SILValue value,
       return ManagedValue::forBorrowedAddressRValue(value);
     }
     if (value->getType().isTrivial(SGF.F)) {
-      return ManagedValue::forTrivialObjectRValue(value);
+      return ManagedValue::forObjectRValueWithoutOwnership(value);
     }
     return ManagedValue::forBorrowedObjectRValue(value);
   }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -660,7 +660,7 @@ ManagedValue Transform::transformMetatype(ManagedValue meta,
     result = SGF.B.createUpcast(Loc, meta.getUnmanagedValue(), expectedType);
   }
 
-  return ManagedValue::forUnmanaged(result);
+  return ManagedValue::forObjectRValueWithoutOwnership(result);
 }
 
 /// Explode a managed tuple into a bunch of managed elements.
@@ -2367,7 +2367,7 @@ static ManagedValue manageYield(SILGenFunction &SGF, SILValue value,
   case ParameterConvention::Direct_Unowned:
   case ParameterConvention::Pack_Guaranteed:
     if (value->getOwnershipKind() == OwnershipKind::None)
-      return ManagedValue::forUnmanaged(value);
+      return ManagedValue::forObjectRValueWithoutOwnership(value);
     return ManagedValue::forBorrowedObjectRValue(value);
   case ParameterConvention::Indirect_In_Guaranteed: {
     if (SGF.silConv.useLoweredAddresses()) {
@@ -4503,7 +4503,7 @@ static ManagedValue createPartialApplyOfThunk(SILGenFunction &SGF,
   if (dynamicSelfType) {
     SILType dynamicSILType = SGF.getLoweredType(dynamicSelfType);
     SILValue value = SGF.B.createMetatype(loc, dynamicSILType);
-    thunkArgs.push_back(ManagedValue::forUnmanaged(value));
+    thunkArgs.push_back(ManagedValue::forObjectRValueWithoutOwnership(value));
   }
 
   return
@@ -5336,7 +5336,7 @@ SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
     auto canClassMetatype = classMetatype->getCanonicalType();
     auto *metatype = thunkSGF.B.createMetatype(
         loc, SILType::getPrimitiveObjectType(canClassMetatype));
-    params.push_back(ManagedValue::forUnmanaged(metatype));
+    params.push_back(ManagedValue::forObjectRValueWithoutOwnership(metatype));
   }
 
   // Collect thunk arguments, converting ownership.

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1471,8 +1471,8 @@ SILValue SILGenFunction::emitLoadGlobalActorExecutor(Type globalActor) {
 
   CanType actorMetaType = CanMetatypeType::get(actorType, metaRepr);
   ManagedValue actorMetaTypeValue =
-    ManagedValue::forUnmanaged(B.createMetatype(loc,
-      SILType::getPrimitiveObjectType(actorMetaType)));
+      ManagedValue::forObjectRValueWithoutOwnership(B.createMetatype(
+          loc, SILType::getPrimitiveObjectType(actorMetaType)));
 
   RValue actorInstanceRV = emitRValueForStorageLoad(loc, actorMetaTypeValue,
     actorMetaType, /*isSuper*/ false, sharedInstanceDecl, PreparedArguments(),
@@ -1585,15 +1585,11 @@ void SILGenFunction::emitPreconditionCheckExpectedExecutor(
   // Call the library function that performs the checking.
   auto args = emitSourceLocationArgs(loc.getSourceLoc(), loc);
 
-  emitApplyOfLibraryIntrinsic(loc, checkExecutor, SubstitutionMap(),
-                              {
-                                args.filenameStartPointer,
-                                args.filenameLength,
-                                args.filenameIsAscii,
-                                args.line,
-                                ManagedValue::forUnmanaged(executor)
-                              },
-                              SGFContext());
+  emitApplyOfLibraryIntrinsic(
+      loc, checkExecutor, SubstitutionMap(),
+      {args.filenameStartPointer, args.filenameLength, args.filenameIsAscii,
+       args.line, ManagedValue::forObjectRValueWithoutOwnership(executor)},
+      SGFContext());
 }
 
 bool SILGenFunction::unsafelyInheritsExecutor() {

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -84,14 +84,15 @@ SILGenFunction::emitDynamicMethodRef(SILLocation loc, SILDeclRef constant,
   if (constant.isForeignToNativeThunk()) {
     if (!SGM.hasFunction(constant))
       SGM.emitForeignToNativeThunk(constant);
-    return ManagedValue::forUnmanaged(B.createFunctionRefFor(
+    return ManagedValue::forObjectRValueWithoutOwnership(B.createFunctionRefFor(
         loc, SGM.getFunction(constant, NotForDefinition)));
   }
 
   // Otherwise, we need a dynamic dispatch thunk.
   SILFunction *F = SGM.getDynamicThunk(constant, constantTy);
 
-  return ManagedValue::forUnmanaged(B.createFunctionRefFor(loc, F));
+  return ManagedValue::forObjectRValueWithoutOwnership(
+      B.createFunctionRefFor(loc, F));
 }
 
 void SILGenModule::emitForeignToNativeThunk(SILDeclRef thunk) {
@@ -295,7 +296,8 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       auto continuationAddr = SGF.B.createProjectBlockStorage(loc, blockStorage);
       auto continuationVal = SGF.B.createLoad(loc, continuationAddr,
                                            LoadOwnershipQualifier::Trivial);
-      auto continuation = ManagedValue::forUnmanaged(continuationVal);
+      auto continuation =
+          ManagedValue::forObjectRValueWithoutOwnership(continuationVal);
 
       // Check for an error if the convention includes one.
       // Increment the error and flag indices if present.  They do not account


### PR DESCRIPTION
I am in the process of attempting to embed a bit into ManagedValue to say if a value is formal access scoped or lexical access scoped. As part of this, I need to get rid of the API forUnmanaged value since it is a way in SILGen that people have historically used to create both lexical and formal access scoped borrowed values. This also means I need to cleanup other usages of forUnmanaged value as well. As part of that in this PR, I am converting a bunch of cases where forUnmanaged was used with values that did not have ownership to instead use forObjectRValueWithoutOwnership.