### PR TITLE
[swift-inspect][Reflection] Improve actor job lists and avoid infinite output.

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -421,10 +421,17 @@ fileprivate class ConcurrencyDumper {
         print("    no jobs queued")
       } else {
         print("    job queue: \(jobStr(job))")
-        while job != 0 {
+        let limit = 1000
+        for i in 1 ... limit {
           job = swift_reflection_nextJob(context, job);
           if job != 0 {
             print("               \(jobStr(job))")
+          } else {
+            break
+          }
+
+          if i == limit {
+            print("               ...truncated...")
           }
         }
       }


### PR DESCRIPTION
If `swift-inspect` identifies an allocation as an actor when it isn't, it can end up in an infinite loop trying to print all the enqueued jobs if the memory happens to be structured like a circular linked list.

Our `metadataIsActor` check had a lot of false positives due to the `ownsAddress` check being much more accepting than we wanted it to be. Fix that by specifically checking descriptor addresses against the registered images' TEXT segments.

Add a backstop to `swift-inspect` to stop printing enqueued jobs after 1,000 entries.

rdar://113417637