### PR TITLE
[NFC] pull computation of `TypeLowering::RecursiveProperties` out into a standalone type

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -31,6 +31,7 @@
 #include "swift/AST/SimpleRequest.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeResolutionStage.h"
+#include "swift/AST/TypeLayoutInfo.h"
 #include "swift/Basic/Statistic.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLExtras.h"
@@ -4431,6 +4432,26 @@ private:
                                ArrayRef<Identifier>) const;
 
 public:
+  bool isCached() const { return true; }
+};
+
+/// For an AST type, computes the type layout information used to lower the
+/// type to a SIL type.
+class TypeLayoutInfoRequest :
+    public SimpleRequest<TypeLayoutInfoRequest,
+                         Lowering::TypeLayoutInfo(CanType),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Lowering::TypeLayoutInfo evaluate(Evaluator &evaluator, CanType type) const;
+
+public:
+  // Caching.
   bool isCached() const { return true; }
 };
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -506,6 +506,9 @@ SWIFT_REQUEST(TypeChecker, InitAccessorReferencedVariablesRequest,
               ArrayRef<VarDecl *>(DeclAttribute *, AccessorDecl *,
                                   ArrayRef<Identifier>),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, TypeLayoutInfoRequest,
+              Lowering::TypeLayoutInfo(CanType),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExpandChildTypeRefinementContextsRequest,
               bool(Decl *, TypeRefinementContext *),
               Cached, NoLocationInfo)

--- a/include/swift/AST/TypeLayoutInfo.h
+++ b/include/swift/AST/TypeLayoutInfo.h
@@ -1,0 +1,248 @@
+//===--- TypeLayoutInfo.h ---------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines an interface for obtaining information about a type's
+//  layout. A "layout" is some property of the type's representation in-memory.
+//
+//  For example, whether a type is considered plain-old-data (POD) is a
+//  property of a representation of the type chosen by the compiler as
+//  part of how values are represented in-memory.
+//
+//  In particular, this file provides such layout information to both Sema
+//  and SIL, serving as the single-source of information about the layout of
+//  a type.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_INCLUDE_SWIFT_AST_TYPELAYOUTINFO_H
+#define SWIFT_INCLUDE_SWIFT_AST_TYPELAYOUTINFO_H
+
+#include "swift/AST/Type.h"
+#include "swift/AST/TypeExpansionContext.h"
+
+namespace swift {
+namespace Lowering {
+
+/// Is a lowered SIL type trivial?  That is, are copies ultimately just
+/// bit-copies, and it takes no work to destroy a value?
+enum IsTrivial_t : bool {
+  IsNotTrivial = false,
+  IsTrivial = true
+};
+
+/// Is a lowered SIL type the Builtin.RawPointer or a struct/tuple/enum which
+/// contains a Builtin.RawPointer?
+/// HasRawPointer is true only for types that are known to contain
+/// Builtin.RawPointer. It is not assumed true for generic or resilient types.
+enum HasRawPointer_t : bool {
+  DoesNotHaveRawPointer = false,
+  HasRawPointer = true
+};
+
+/// Is a lowered SIL type fixed-ABI?  That is, can the current context
+/// assign it a fixed size and alignment and perform value operations on it
+/// (such as copies, destroys, constructions, and projections) without
+/// metadata?
+///
+/// Note that a fully concrete type can be non-fixed-ABI without being
+/// itself resilient if it contains a subobject which is not fixed-ABI.
+///
+/// Also note that we're only concerned with the external value ABI here:
+/// resilient class types are still fixed-ABI, indirect enum cases do not
+/// affect the fixed-ABI-ness of the enum, and so on.
+enum IsFixedABI_t : bool {
+  IsNotFixedABI = false,
+  IsFixedABI = true
+};
+
+/// Is a lowered SIL type address-only?  That is, is the current context
+/// required to keep the value in memory for some reason?
+///
+/// A type might be address-only because:
+///
+///   - it is not fixed-size (e.g. because it is a resilient type) and
+///     therefore cannot be loaded into a statically-boundable set of
+///     registers; or
+///
+///   - it is semantically bound to memory, either because its storage
+///     address is used by the language runtime to implement its semantics
+///     (as with a weak reference) or because its representation is somehow
+///     address-dependent (as with something like a relative pointer).
+///
+/// An address-only type can be fixed-layout and/or trivial.
+/// A non-fixed-layout type is always address-only.
+enum IsAddressOnly_t : bool {
+  IsNotAddressOnly = false,
+  IsAddressOnly = true
+};
+
+/// Is this type somewhat like a reference-counted type?
+enum IsReferenceCounted_t : bool {
+  IsNotReferenceCounted = false,
+  IsReferenceCounted = true
+};
+
+/// Is this type address only because it's resilient?
+enum IsResilient_t : bool {
+  IsNotResilient = false,
+  IsResilient = true
+};
+
+/// Does this type contain an opaque result type that affects type lowering?
+enum IsTypeExpansionSensitive_t : bool {
+  IsNotTypeExpansionSensitive = false,
+  IsTypeExpansionSensitive = true
+};
+
+/// Is the type infinitely defined in terms of itself? (Such types can never
+/// be concretely instantiated, but may still arise from generic specialization.)
+enum IsInfiniteType_t : bool {
+  IsNotInfiniteType = false,
+  IsInfiniteType = true,
+};
+
+/// Does this type contain at least one non-trivial, non-eager-move type?
+enum IsLexical_t : bool {
+  IsNotLexical = false,
+  IsLexical = true,
+};
+
+/// TODO: describe this type
+struct TypeLayoutInfo {
+private:
+  // These are chosen so that bitwise-or merges the flags properly.
+  //
+  // clang-format off
+  enum : unsigned {
+    NonTrivialFlag             = 1 << 0,
+    NonFixedABIFlag            = 1 << 1,
+    AddressOnlyFlag            = 1 << 2,
+    ResilientFlag              = 1 << 3,
+    TypeExpansionSensitiveFlag = 1 << 4,
+    InfiniteFlag               = 1 << 5,
+    HasRawPointerFlag          = 1 << 6,
+    LexicalFlag                = 1 << 7,
+  };
+  // clang-format on
+
+  uint8_t Flags;
+
+  constexpr TypeLayoutInfo(uint8_t InitialFlags) : Flags(InitialFlags) {}
+public:
+  /// Construct a default TypeLayoutInfo, which corresponds to
+  /// a trivial, loadable, fixed-layout type.
+  constexpr TypeLayoutInfo() : Flags(0) {}
+
+  constexpr TypeLayoutInfo(
+      IsTrivial_t isTrivial, IsFixedABI_t isFixedABI,
+      IsAddressOnly_t isAddressOnly, IsResilient_t isResilient,
+      IsTypeExpansionSensitive_t isTypeExpansionSensitive =
+      IsNotTypeExpansionSensitive,
+      HasRawPointer_t hasRawPointer = DoesNotHaveRawPointer,
+      IsLexical_t isLexical = IsNotLexical)
+      : Flags((isTrivial ? 0U : NonTrivialFlag) |
+      (isFixedABI ? 0U : NonFixedABIFlag) |
+      (isAddressOnly ? AddressOnlyFlag : 0U) |
+      (isResilient ? ResilientFlag : 0U) |
+      (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0U) |
+      (hasRawPointer ? HasRawPointerFlag : 0U) |
+      (isLexical ? LexicalFlag : 0U)) {}
+
+  constexpr bool operator==(TypeLayoutInfo p) const {
+    return Flags == p.Flags;
+  }
+
+  static constexpr TypeLayoutInfo forTrivial() {
+    return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient};
+  }
+
+  static constexpr TypeLayoutInfo forRawPointer() {
+    return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient,
+            IsNotTypeExpansionSensitive, HasRawPointer};
+  }
+
+  static constexpr TypeLayoutInfo forReference() {
+    return {IsNotTrivial, IsFixedABI, IsNotAddressOnly, IsNotResilient,
+            IsNotTypeExpansionSensitive, DoesNotHaveRawPointer, IsLexical};
+  }
+
+  static constexpr TypeLayoutInfo forOpaque() {
+    return {IsNotTrivial, IsNotFixedABI, IsAddressOnly, IsNotResilient,
+            IsNotTypeExpansionSensitive, DoesNotHaveRawPointer, IsLexical};
+  }
+
+  static constexpr TypeLayoutInfo forResilient() {
+    return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsResilient};
+  }
+
+  constexpr void addSubobject(TypeLayoutInfo other) {
+    Flags |= other.Flags;
+  }
+
+  constexpr IsTrivial_t isTrivial() const {
+    return IsTrivial_t((Flags & NonTrivialFlag) == 0);
+  }
+  constexpr HasRawPointer_t isOrContainsRawPointer() const {
+    return HasRawPointer_t((Flags & HasRawPointerFlag) != 0);
+  }
+  constexpr IsFixedABI_t isFixedABI() const {
+    return IsFixedABI_t((Flags & NonFixedABIFlag) == 0);
+  }
+  constexpr IsAddressOnly_t isAddressOnly() const {
+    return IsAddressOnly_t((Flags & AddressOnlyFlag) != 0);
+  }
+  constexpr IsResilient_t isResilient() const {
+    return IsResilient_t((Flags & ResilientFlag) != 0);
+  }
+  constexpr IsTypeExpansionSensitive_t isTypeExpansionSensitive() const {
+    return IsTypeExpansionSensitive_t(
+        (Flags & TypeExpansionSensitiveFlag) != 0);
+  }
+  constexpr IsInfiniteType_t isInfinite() const {
+    return IsInfiniteType_t((Flags & InfiniteFlag) != 0);
+  }
+  constexpr IsLexical_t isLexical() const {
+    return IsLexical_t((Flags & LexicalFlag) != 0);
+  }
+
+  constexpr void setNonTrivial() { Flags |= NonTrivialFlag; }
+  constexpr void setNonFixedABI() { Flags |= NonFixedABIFlag; }
+  constexpr void setAddressOnly() { Flags |= AddressOnlyFlag; }
+  constexpr void setTypeExpansionSensitive(
+      IsTypeExpansionSensitive_t isTypeExpansionSensitive) {
+    Flags = (Flags & ~TypeExpansionSensitiveFlag) |
+        (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0);
+  }
+  constexpr void setInfinite() { Flags |= InfiniteFlag; }
+  constexpr void setLexical(IsLexical_t isLexical) {
+    Flags = (Flags & ~LexicalFlag) | (isLexical ? LexicalFlag : 0);
+  }
+
+  constexpr TypeLayoutInfo withTypeExpansionSensitive(
+      IsTypeExpansionSensitive_t isTypeExpansionSensitive) {
+    TypeLayoutInfo prop(Flags);
+    prop.setTypeExpansionSensitive(isTypeExpansionSensitive);
+    return prop;
+  }
+
+  /// TODO: describe
+  static TypeLayoutInfo get(ASTContext &ctx,
+                            CanType type,
+                            CanGenericSignature sig,
+                            TypeExpansionContext expansion);
+
+};
+
+} // Lowering
+} // swift
+
+#endif //SWIFT_INCLUDE_SWIFT_AST_TYPELAYOUTINFO_H

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -610,7 +610,7 @@ public:
     return cast<T>(getDesugaredType());
   }
 
-  /// getRecursiveProperties - Returns the properties defined on the
+  /// getLayoutInfo - Returns the properties defined on the
   /// structure of this type.
   RecursiveTypeProperties getRecursiveProperties() const {
     return RecursiveTypeProperties(Bits.TypeBase.Properties);

--- a/include/swift/SIL/Lifetime.h
+++ b/include/swift/SIL/Lifetime.h
@@ -26,7 +26,7 @@ namespace swift {
 /// aggressively its destroys may be hoisted.
 ///
 /// By default, types have lifetimes inferred from their structure, see
-/// TypeLowering::RecursiveProperties::isLexical.  It can be overridden both on
+/// TypeLayoutInfo::isLexical.  It can be overridden both on
 /// the type level and the value level via attributes.
 struct Lifetime {
   enum Storage : uint8_t {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -116,6 +116,7 @@ add_swift_host_library(swiftAST STATIC
   TypeCheckRequests.cpp
   TypeDeclFinder.cpp
   TypeJoinMeet.cpp
+  TypeLayoutInfo.cpp
   TypeRefinementContext.cpp
   TypeRepr.cpp
   TypeSubstitution.cpp

--- a/lib/AST/TypeLayoutInfo.cpp
+++ b/lib/AST/TypeLayoutInfo.cpp
@@ -1,0 +1,221 @@
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/CanTypeVisitor.h"
+#include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/TypeLayoutInfo.h"
+#include "swift/SIL/AbstractionPattern.h"
+
+namespace swift {
+namespace Lowering {
+/// A CRTP helper class for doing things that depends on type
+/// classification.
+template <class Impl, class RetTy>
+class TypeClassifierBase
+    : public CanTypeVisitor<Impl, RetTy, AbstractionPattern> {
+  using super =
+      CanTypeVisitor<Impl, RetTy, AbstractionPattern>;
+  Impl &asImpl() { return *static_cast<Impl *>(this); }
+protected:
+  TypeClassifierBase() {}
+public:
+
+  RetTy visit(CanType substType, AbstractionPattern origType) {
+    if (auto origEltType = origType.getVanishingTupleElementPatternType()) {
+      return visit(substType, *origEltType);
+    }
+
+    return super::visit(substType, origType);
+  }
+};
+
+class ComputeLayout : public TypeClassifierBase<ComputeLayout, TypeLayoutInfo> {
+  TypeExpansionContext Expansion;
+  IsTypeExpansionSensitive_t isSensitive;
+public:
+  ComputeLayout(TypeExpansionContext Expansion, IsTypeExpansionSensitive_t isSensitive)
+    : TypeClassifierBase(),
+                   Expansion(Expansion),
+                   isSensitive(isSensitive)
+                   {}
+
+#define NAMED_INFO(TYPE, LOWERING)                                                 \
+    TypeLayoutInfo visit##TYPE##Type(Can##TYPE##Type type,                   \
+                                     AbstractionPattern orig) {              \
+      return TypeLayoutInfo::for##LOWERING()            \
+                .withTypeExpansionSensitive(isSensitive); \
+    }
+  NAMED_INFO(BuiltinInteger, Trivial)
+  NAMED_INFO(BuiltinIntegerLiteral, Trivial)
+  NAMED_INFO(BuiltinFloat, Trivial)
+  NAMED_INFO(BuiltinRawUnsafeContinuation, Trivial)
+  NAMED_INFO(BuiltinJob, Trivial)
+  NAMED_INFO(BuiltinExecutor, Trivial)
+  NAMED_INFO(BuiltinPackIndex, Trivial)
+  NAMED_INFO(BuiltinNativeObject, Reference)
+  NAMED_INFO(BuiltinBridgeObject, Reference)
+  NAMED_INFO(BuiltinVector, Trivial)
+  NAMED_INFO(BuiltinRawPointer, RawPointer)
+  NAMED_INFO(SILToken, Trivial)
+  NAMED_INFO(AnyMetatype, Trivial)
+  NAMED_INFO(Module, Trivial)
+#undef NAMED_INFO
+
+#define MANUAL_INFO(TYPE, ...)                                               \
+    TypeLayoutInfo visit##TYPE##Type(Can##TYPE##Type type,                   \
+                                     AbstractionPattern orig) {              \
+      return TypeLayoutInfo(__VA_ARGS__);                                                          \
+    }
+  MANUAL_INFO(BuiltinDefaultActorStorage,
+              IsNotTrivial, IsFixedABI,
+              IsAddressOnly, IsNotResilient,
+              isSensitive,
+              DoesNotHaveRawPointer,
+              IsLexical)
+
+  MANUAL_INFO(BuiltinUnsafeValueBuffer,
+              IsNotTrivial, IsFixedABI,
+              IsAddressOnly, IsNotResilient,
+              isSensitive,
+              DoesNotHaveRawPointer,
+              IsLexical)
+
+  MANUAL_INFO(BuiltinNonDefaultDistributedActorStorage,
+              IsNotTrivial, IsFixedABI,
+              IsAddressOnly, IsNotResilient,
+              isSensitive,
+              DoesNotHaveRawPointer,
+              IsLexical)
+
+  MANUAL_INFO(Pack,
+              IsNotTrivial, IsFixedABI,
+              IsAddressOnly, IsNotResilient,
+              isSensitive,
+              DoesNotHaveRawPointer,
+              IsLexical)
+
+  MANUAL_INFO(SILPack,
+              IsNotTrivial, IsFixedABI,
+              IsAddressOnly, IsNotResilient,
+              isSensitive,
+              DoesNotHaveRawPointer,
+              IsLexical)
+#undef MANUAL_INFO
+
+
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
+    TypeLayoutInfo visit##Name##StorageType(Can##Name##StorageType type, \
+                                            AbstractionPattern origType) { \
+      return { IsNotTrivial, \
+               IsFixedABI, \
+               IsAddressOnly, \
+               IsNotResilient, \
+               isSensitive, \
+               DoesNotHaveRawPointer, \
+               IsLexical}; \
+    }
+#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
+    TypeLayoutInfo visit##Name##StorageType(Can##Name##StorageType type, \
+                                            AbstractionPattern origType) { \
+      return TypeLayoutInfo::forReference()            \
+                .withTypeExpansionSensitive(isSensitive); \
+    }
+#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
+    TypeLayoutInfo visitLoadable##Name##StorageType(\
+                                                Can##Name##StorageType type, \
+                                                AbstractionPattern origType) { \
+      return TypeLayoutInfo::forReference()            \
+                .withTypeExpansionSensitive(isSensitive); \
+    } \
+    TypeLayoutInfo visitAddressOnly##Name##StorageType(\
+                                                Can##Name##StorageType type, \
+                                                AbstractionPattern origType) { \
+      return { IsNotTrivial, \
+               IsFixedABI, \
+               IsAddressOnly, \
+               IsNotResilient, \
+               isSensitive, \
+               DoesNotHaveRawPointer, \
+               IsLexical}; \
+    } \
+    TypeLayoutInfo visit##Name##StorageType(Can##Name##StorageType type, \
+                                            AbstractionPattern origType) { \
+      auto referentType = \
+        type->getReferentType()->lookThroughSingleOptionalType(); \
+      auto concreteType = getConcreteReferenceStorageReferent(referentType, origType); \
+      if (Name##StorageType::get(concreteType, TC.Context) \
+            ->isLoadable(Expansion.getResilienceExpansion())) { \
+        return asImpl().visitLoadable##Name##StorageType(type, origType, \
+                                                         isSensitive); \
+      } else { \
+        return asImpl().visitAddressOnly##Name##StorageType(type, origType, \
+                                                            isSensitive); \
+      } \
+    }
+#define UNCHECKED_REF_STORAGE(Name, ...) \
+    TypeLayoutInfo visit##Name##StorageType(Can##Name##StorageType type, \
+                                            AbstractionPattern origType) { \
+      return TypeLayoutInfo::forTrivial() \
+                .withTypeExpansionSensitive(isSensitive); \
+    }
+#include "swift/AST/ReferenceStorage.def"
+
+  // Tuples depend on their elements.
+  TypeLayoutInfo visitTupleType(CanTupleType type,
+                                AbstractionPattern origType) {
+    TypeLayoutInfo props;
+    props.setTypeExpansionSensitive(isSensitive);
+    origType.forEachExpandedTupleElement(type,
+                                         [&](AbstractionPattern origEltType,
+                                             CanType substEltType,
+                                             const TupleTypeElt &elt) {
+                                           props.addSubobject(visit(substEltType,
+                                                                    origEltType));
+                                         });
+    return props;
+  }
+
+  TypeLayoutInfo visitPackExpansionType(CanPackExpansionType type,
+                                        AbstractionPattern origType) {
+    TypeLayoutInfo props;
+    props.setTypeExpansionSensitive(isSensitive);
+    props.setAddressOnly();
+    props.addSubobject(visit(type.getPatternType(),
+                             origType.getPackExpansionPatternType()));
+    return props;
+  }
+
+#define NOT_IMPLEMENTED(TYPE)                                                  \
+    TypeLayoutInfo visit##TYPE##Type(Can##TYPE##Type type,                     \
+                                     AbstractionPattern orig) {                \
+      llvm_unreachable("unknown layout for TYPE");                                                          \
+    }
+#undef NOT_IMPLEMENTED
+
+};
+
+TypeLayoutInfo TypeLayoutInfo::get(ASTContext &ctx,
+                                   CanType type,
+                                   CanGenericSignature sig,
+                                   TypeExpansionContext expansion) {
+  return evaluateOrDefault(ctx.evaluator,
+                           TypeLayoutInfoRequest{type},
+                           TypeLayoutInfo());
+}
+
+} // Lowering
+
+
+Lowering::TypeLayoutInfo TypeLayoutInfoRequest::evaluate(Evaluator &evaluator,
+                                                         CanType type) const {
+  Lowering::ComputeLayout computeLayout(TypeExpansionContext::minimal(),
+                                        Lowering::IsTypeExpansionSensitive);
+
+  // FIXME:: might be the wrong abstraction pattern and need it as an input here
+  auto info = computeLayout.visit(type, Lowering::AbstractionPattern(type));
+
+  info.setTypeExpansionSensitive(Lowering::IsTypeExpansionSensitive);
+  return info;
+}
+
+
+} // swift
+

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1639,8 +1639,8 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
   // be concretized.
   if (IGM.isResilient(D, ResilienceExpansion::Maximal)
       || IGM.getSILTypes().getTypeLowering(SILType::getPrimitiveAddressType(type),
-                                            TypeExpansionContext::minimal())
-            .getRecursiveProperties().isInfinite()) {
+                                           TypeExpansionContext::minimal())
+          .getLayoutInfo().isInfinite()) {
     auto copyable = D->isMoveOnly()
       ? IsNotCopyable : IsCopyable;
     auto structAccessible =

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -130,7 +130,7 @@ bool SILType::isNonTrivialOrContainsRawPointer(const SILFunction *f) const {
 
 bool SILType::isEmpty(const SILFunction &F) const {
   // Infinite types are never empty.
-  if (F.getTypeLowering(*this).getRecursiveProperties().isInfinite()) {
+  if (F.getTypeLowering(*this).getLayoutInfo().isInfinite()) {
     return false;
   }
   
@@ -178,7 +178,7 @@ bool SILType::isNoReturnFunction(SILModule &M,
 Lifetime SILType::getLifetime(const SILFunction &F) const {
   auto contextType = hasTypeParameter() ? F.mapTypeIntoContext(*this) : *this;
   const auto &lowering = F.getTypeLowering(contextType);
-  auto properties = lowering.getRecursiveProperties();
+  auto properties = lowering.getLayoutInfo();
   if (properties.isTrivial())
     return Lifetime::None;
   return properties.isLexical() ? Lifetime::Lexical : Lifetime::EagerMove;

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -170,7 +170,7 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
           : CaptureKind::Box);
 }
 
-using RecursiveProperties = TypeLowering::RecursiveProperties;
+using RecursiveProperties = TypeLayoutInfo;
 
 static RecursiveProperties
 classifyType(AbstractionPattern origType, CanType type,
@@ -889,7 +889,7 @@ namespace {
     handleClassificationFromLowering(CanType type, const TypeLowering &lowering,
                                      IsTypeExpansionSensitive_t isSensitive) {
       return handle(type, mergeIsTypeExpansionSensitive(
-                              isSensitive, lowering.getRecursiveProperties()));
+                              isSensitive, lowering.getLayoutInfo()));
     }
   };
 } // end anonymous namespace
@@ -2254,7 +2254,7 @@ namespace {
         auto &eltLowering =
           TC.getTypeLowering(packType->getSILElementType(i),
                              Expansion);
-        properties.addSubobject(eltLowering.getRecursiveProperties());
+        properties.addSubobject(eltLowering.getLayoutInfo());
       }
       properties = mergeIsTypeExpansionSensitive(isSensitive, properties);
 
@@ -2270,7 +2270,7 @@ namespace {
         TC.getTypeLowering(origType.getPackExpansionPatternType(),
                            packExpansionType.getPatternType(),
                            Expansion);
-      properties.addSubobject(patternLowering.getRecursiveProperties());
+      properties.addSubobject(patternLowering.getLayoutInfo());
       properties = mergeIsTypeExpansionSensitive(isSensitive, properties);
 
       return handleAddressOnly(packExpansionType, properties);
@@ -2892,7 +2892,7 @@ void TypeConverter::verifyLowering(const TypeLowering &lowering,
   // Non-trivial lowerings should always be lexical unless all non-trivial
   // fields are eager move.
   if (!lowering.isTrivial() && !lowering.isLexical()) {
-    if (lowering.getRecursiveProperties().isInfinite())
+    if (lowering.getLayoutInfo().isInfinite())
       return;
     auto getLifetimeAnnotation = [](CanType ty) -> LifetimeAnnotation {
       NominalTypeDecl *nominal;
@@ -4648,16 +4648,16 @@ void TypeLowering::print(llvm::raw_ostream &os) const {
   };
   os << "Type Lowering for lowered type: " << LoweredType << ".\n"
      << "Expansion: " << getResilienceExpansion() << "\n"
-     << "isTrivial: " << BOOL(Properties.isTrivial()) << ".\n"
-     << "isFixedABI: " << BOOL(Properties.isFixedABI()) << ".\n"
-     << "isAddressOnly: " << BOOL(Properties.isAddressOnly()) << ".\n"
-     << "isResilient: " << BOOL(Properties.isResilient()) << ".\n"
+     << "isTrivial: " << BOOL(Layout.isTrivial()) << ".\n"
+     << "isFixedABI: " << BOOL(Layout.isFixedABI()) << ".\n"
+     << "isAddressOnly: " << BOOL(Layout.isAddressOnly()) << ".\n"
+     << "isResilient: " << BOOL(Layout.isResilient()) << ".\n"
      << "isTypeExpansionSensitive: "
-     << BOOL(Properties.isTypeExpansionSensitive()) << ".\n"
-     << "isInfinite: " << BOOL(Properties.isInfinite()) << ".\n"
-     << "isOrContainsRawPointer: " << BOOL(Properties.isOrContainsRawPointer())
+     << BOOL(Layout.isTypeExpansionSensitive()) << ".\n"
+     << "isInfinite: " << BOOL(Layout.isInfinite()) << ".\n"
+     << "isOrContainsRawPointer: " << BOOL(Layout.isOrContainsRawPointer())
      << ".\n"
-     << "isLexical: " << BOOL(Properties.isLexical()) << ".\n"
+     << "isLexical: " << BOOL(Layout.isLexical()) << ".\n"
      << "\n";
 }
 


### PR DESCRIPTION
This is a NFC refactoring needed to implement `BitwiseCopyable`.