### PR TITLE
[TaskGroup] reorder resumeWaiting->run and reenable async_taskgroup_discarding_dontLeak

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1182,8 +1182,8 @@ void AccumulatingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *contex
 
   // ==== a) has waiting task, so let us complete it right away
   if (assumed.hasWaitingTask()) {
+    unlock();
     resumeWaitingTask(completedTask, assumed, hadErrorResult);
-    unlock(); // TODO: remove fragment lock, and use status for synchronization
     return;
   } else {
     // ==== b) enqueue completion ------------------------------------------------

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
 // TODO: move to target-run-simple-leaks-swift once CI is using at least Xcode 14.3
 
-// rdar://109998145 - Temporarily disable this test
-// REQUIRES: rdar109998145
-
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
@@ -15,6 +12,37 @@
 // UNSUPPORTED: OS=windows-msvc
 
 import _Concurrency
+
+actor SimpleCountDownLatch {
+  let from: Int
+  var count: Int
+
+  var continuation: CheckedContinuation<Void, Never>?
+
+  init(from: Int) {
+    self.from = from
+    self.count = from
+  }
+
+  func hit() {
+    defer { count -= 1 }
+    if count == 0 {
+      fatalError("Counted down more times than expected! (From: \(from))")
+    } else if count == 1 {
+      continuation?.resume()
+    }
+  }
+
+  func wait() async {
+    guard self.count > 0 else {
+      return // we're done
+    }
+
+    return await withCheckedContinuation { cc in
+      self.continuation = cc
+    }
+  }
+}
 
 final class PrintDeinit {
   let id: String
@@ -60,96 +88,138 @@ final class SomeClass: @unchecked Sendable {
 
 // NOTE: Not as StdlibUnittest/TestSuite since these types of tests are unreasonably slow to load/debug.
 
-@main struct Main {
-  static func main() async {
-    _ = try? await withThrowingDiscardingTaskGroup() { group in
-      group.addTask {
-        throw Boom(id: "race-boom-class")
-      }
-      group.addTask {
-        SomeClass(id: "race-boom-class") // will be discarded
-      }
-      // since values may deinit in any order, we just assert their count basically
-      // CHECK-DAG: deinit, id: race-boom-class
-      // CHECK-DAG: deinit, id: race-boom-class
+func testTwo() async {
+  let latch = SimpleCountDownLatch(from: 2)
 
-      return 12
+  _ = try? await withThrowingDiscardingTaskGroup() { group in
+    group.addTask {
+      await latch.hit()
+      throw Boom(id: "race-boom")
+    }
+    group.addTask {
+      await latch.hit()
+      SomeClass(id: "race-boom-class") // will be discarded
     }
 
-    // many ok
-    _ = try? await withThrowingDiscardingTaskGroup() { group in
+    return 12
+  }
+
+  // since values may deinit in any order, we just assert their count basically
+  // CHECK-DAG: deinit, id: race-boom
+  // CHECK-DAG: deinit, id: race-boom
+  await latch.wait()
+  print("done") // CHECK: done
+}
+
+func manyOk() async {
+  let latch = SimpleCountDownLatch(from: 6)
+
+  _ = try? await withThrowingDiscardingTaskGroup() { group in
+    for i in 0..<6 {
+      group.addTask {
+        await latch.hit()
+        _ = SomeClass(id: "many-ok") // will be discarded
+      }
+    }
+
+    return 12
+  }
+  // since values may deinit in any order, we just assert their count basically
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+  // CHECK-DAG: deinit, id: many-ok
+
+  await latch.wait()
+  print("done") // CHECK: done
+}
+
+func manyThrows() async {
+  let latch = SimpleCountDownLatch(from: 6)
+
+  do {
+    let value: Void = try await withThrowingDiscardingTaskGroup() { group in
       for i in 0..<6 {
         group.addTask {
-          SomeClass(id: "many-ok") // will be discarded
+          await latch.hit()
+          throw BoomClass(id: "many-error") // will be rethrown
         }
-        // since values may deinit in any order, we just assert their count basically
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-        // CHECK-DAG: deinit, id: many-ok
-      }
-
-      return 12
-    }
-
-    // many throws
-    do {
-      let value = try await withThrowingDiscardingTaskGroup() { group in
-        for i in 0..<6 {
-          group.addTask {
-            throw BoomClass(id: "many-error") // will be rethrown
-          }
-        }
-
-        // since values may deinit in any order, we just assert their count basically
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-        // CHECK-DAG: deinit, id: many-error
-
-        12 // must be ignored
-      }
-      preconditionFailure("Should throw")
-    } catch {
-      precondition("\(error)" == "main.BoomClass", "error was: \(error)")
-    }
-
-    // many errors, many values
-    _ = try? await withThrowingDiscardingTaskGroup() { group in
-      group.addTask {
-        SomeClass(id: "mixed-ok") // will be discarded
-      }
-      group.addTask {
-        SomeClass(id: "mixed-ok") // will be discarded
-      }
-      group.addTask {
-        SomeClass(id: "mixed-ok") // will be discarded
-      }
-      group.addTask {
-        throw Boom(id: "mixed-error")
-      }
-      group.addTask {
-        throw Boom(id: "mixed-error")
-      }
-      group.addTask {
-        throw Boom(id: "mixed-error")
       }
 
       // since values may deinit in any order, we just assert their count basically
-      // three ok's
-      // CHECK-DAG: deinit, id: mixed
-      // CHECK-DAG: deinit, id: mixed
-      // CHECK-DAG: deinit, id: mixed
-      // three errors
-      // CHECK-DAG: deinit, id: mixed
-      // CHECK-DAG: deinit, id: mixed
-      // CHECK-DAG: deinit, id: mixed
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
+      // CHECK-DAG: deinit, id: many-error
 
-      return 12
+      12 // must be ignored
     }
+    preconditionFailure("Should throw")
+  } catch {
+    precondition("\(error)" == "main.BoomClass", "error was: \(error)")
+  }
+
+  await latch.wait()
+  print("done") // CHECK: done
+}
+
+func manyValuesThrows() async {
+  let latch = SimpleCountDownLatch(from: 6)
+
+  // many errors, many values
+  _ = try? await withThrowingDiscardingTaskGroup() { group in
+    group.addTask {
+      await latch.hit()
+      _ = SomeClass(id: "mixed-ok") // will be discarded
+    }
+    group.addTask {
+      await latch.hit()
+      _ = SomeClass(id: "mixed-ok") // will be discarded
+    }
+    group.addTask {
+      await latch.hit()
+      _ = SomeClass(id: "mixed-ok") // will be discarded
+    }
+    group.addTask {
+      await latch.hit()
+      throw Boom(id: "mixed-error")
+    }
+    group.addTask {
+      await latch.hit()
+      throw Boom(id: "mixed-error")
+    }
+    group.addTask {
+      await latch.hit()
+      throw Boom(id: "mixed-error")
+    }
+
+
+    return 12
+  }
+
+  // since values may deinit in any order, we just assert their count basically
+  // three ok's
+  // CHECK-DAG: deinit, id: mixed
+  // CHECK-DAG: deinit, id: mixed
+  // CHECK-DAG: deinit, id: mixed
+  // three errors
+  // CHECK-DAG: deinit, id: mixed
+  // CHECK-DAG: deinit, id: mixed
+  // CHECK-DAG: deinit, id: mixed
+
+  await latch.wait()
+  print("done") // CHECK: done
+}
+
+@main struct Main {
+  static func main() async {
+    await testTwo()
+    await manyOk()
+    await manyThrows()
+    await manyValuesThrows()
   }
 }


### PR DESCRIPTION
We had resolved rdar://109998145 via the lock ordering fix in https://github.com/apple/swift/pull/67700
This is the same kind of test and cause radar to have disabled the test, so re-enable it.

We also have the "bad order" of 
```
    resumeWaitingTask(completedTask, assumed, hadErrorResult);
    unlock(); // bad, unlock first (!)
```

that we should correct in a separate commit here.

This might be the root cause of rdar://113331923, though I'm working on additional tests to verify

I'd like to use this PR to give this a few runs to verify.