### PR TITLE
Rebranch: JIT/Immediate Removing extra null

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -444,7 +444,7 @@ private:
           if (ToRename.count(Sym->getName())) {
             auto NewName =
                 G.allocateCString(Twine(mangleFunctionBody(Sym->getName())));
-            Sym->setName({NewName.data(), NewName.size()});
+            Sym->setName({NewName.data(), NewName.size() - 1});
           }
         }
       }


### PR DESCRIPTION
allocateCString includes the null end character, so we ended up with two, in the symbol name. This made them not match, causing failures while attempting to run the JIT'd program.

Remove one from the symbol name length to account for the null character.

rdar://113415967