### PR TITLE
[Test][Backtracing] Pass SWIFT_BACKTRACE through lit if it's set.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -496,6 +496,11 @@ backtrace_on_crash = lit_config.params.get('backtrace_on_crash', None)
 if backtrace_on_crash is not None:
     config.environment['SWIFT_BACKTRACE'] = 'enable=on'
 
+# Make an explicit setting in the environment override whatever we did above
+swift_backtrace = os.environ.get('SWIFT_BACKTRACE')
+if swift_backtrace:
+    config.environment['SWIFT_BACKTRACE'] = swift_backtrace
+
 config.available_features.add('lld_lto')
 
 threading = lit_config.params.get('threading', 'none')


### PR DESCRIPTION
If someone explicitly sets `SWIFT_BACKTRACE` and runs `lit`, we should probably pass it through to the tests.

rdar://113550381
