### PR TITLE
[cxx-interop] Partially disable a test on Linux

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -13,9 +13,11 @@ StdOptionalTestSuite.test("pointee") {
   let pointee = nonNilOpt.pointee
   expectEqual(123, pointee)
 
+#if !os(Linux) // crashes on Ubuntu 18.04 (rdar://113414160)
   var modifiedOpt = getNilOptional()
   modifiedOpt.pointee = 777
   expectEqual(777, modifiedOpt.pointee)
+#endif
 }
 
 StdOptionalTestSuite.test("std::optional => Swift.Optional") {


### PR DESCRIPTION
It crashes on Ubuntu 18.04 and Amazon Linux 2.

rdar://113414160