### PR TITLE
[Explicit Module Builds] Write '-clang-target' to serialized debugging options

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -208,6 +208,10 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   } else {
     serializationOpts.ExtraClangOptions = getClangImporterOptions().ExtraArgs;
   }
+  if (LangOpts.ClangTarget) {
+    serializationOpts.ExtraClangOptions.push_back("-triple");
+    serializationOpts.ExtraClangOptions.push_back(LangOpts.ClangTarget->str());
+  }
 
   serializationOpts.PluginSearchOptions =
       getSearchPathOptions().PluginSearchOpts;

--- a/test/Serialization/clang-target-option.swift
+++ b/test/Serialization/clang-target-option.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name ClangTargetModule -emit-module-path %t/has_clang_target.swiftmodule -parse-as-library -serialize-debugging-options -clang-target arm64e-apple-macos12.12 %s
+
+// Check the serialized flags paths.
+// RUN: llvm-bcanalyzer -dump %t/has_clang_target.swiftmodule > %t/has_clang_target.swiftmodule.txt
+// RUN: %FileCheck %s < %t/has_clang_target.swiftmodule.txt
+
+// CHECK-LABEL: <OPTIONS_BLOCK
+// CHECK:      <XCC abbrevid={{[0-9]+}}/> blob data = '-triple'
+// CHECK-NEXT: <XCC abbrevid={{[0-9]+}}/> blob data = 'arm64e-apple-macos12.12'
+// CHECK: </OPTIONS_BLOCK>


### PR DESCRIPTION
Otherwise LLDB's ClangImporter instance will be instantiated against a mismatching triple.

Resolves rdar://113005724