### PR TITLE
[cxx-interop] Adjust a test

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/std-optional.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-optional.h
@@ -3,10 +3,10 @@
 
 #include <optional>
 
-using CxxOptional = std::optional<int>;
+using StdOptionalInt = std::optional<int>;
 
-inline CxxOptional getNonNilOptional() { return {123}; }
+inline StdOptionalInt getNonNilOptional() { return {123}; }
 
-inline CxxOptional getNilOptional() { return {std::nullopt}; }
+inline StdOptionalInt getNilOptional() { return {std::nullopt}; }
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_OPTIONAL_H


### PR DESCRIPTION
This prevents a name conflict between a Swift `protocol CxxOptional` and a C++ `using CxxOptional`.