### PR TITLE
tests: enable some tests on Windows

### DIFF
--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -61,9 +61,6 @@ DependentTypesTestSuite.test("Takes const ref and returns dependent type.") {
   expectEqual(m.getValue(), 42)
 }
 
-// We still have some problems calling methods on Windows
-// (https://github.com/apple/swift/issues/55575 and rdar://88391102).
-#if !os(Windows)
 DependentTypesTestSuite.test("Function template methods") {
   let m = M<Int>(value: 42)
   let m2 = m.memberDependentReturnType(CInt(32)) as! M<CInt>
@@ -100,8 +97,6 @@ DependentTypesTestSuite.test("Complex different dependent argument and return ty
   let m2 = complexDependantReturnTypeSameAsArg(42, T: Int.self) as! Int
   expectEqual(m2, 42)
 }
-
-#endif // Windows
 
 //TODO: Import issue: rdar://89028943
 // DependentTypesTestSuite.test("Dependent to Reference") {


### PR DESCRIPTION
The dependent type C++ interop tests should be possible to enable now.  Do so to get more test coverage parity on Windows.