### PR TITLE
Sema: Fix a couple of problems in checkContextualRequirements()

### DIFF
--- a/test/Sema/Inputs/where_clause_across_module_boundaries_module.swift
+++ b/test/Sema/Inputs/where_clause_across_module_boundaries_module.swift
@@ -23,3 +23,11 @@ public extension DefaultsSerializable where Self: RawRepresentable {
 
 public struct ModuleAFoo: Codable, DefaultsSerializable {
 }
+
+public struct AliasTest<T> {
+  public typealias A = T.Element where T: Collection
+}
+
+extension AliasTest where T: Collection {
+  public typealias B = T.Element
+}

--- a/test/Sema/where_clause_across_module_boundaries.swift
+++ b/test/Sema/where_clause_across_module_boundaries.swift
@@ -14,3 +14,10 @@ struct ModuleBFoo: Codable, DefaultsSerializable {
 enum ModuleBBar: Int, Codable, DefaultsSerializable { // expected-error {{type 'ModuleBBar' does not conform to protocol 'DefaultsSerializable'}}
   case foo, bar
 }
+
+func foo() {
+  _ = AliasTest<Int>.A.self // expected-error {{type 'Int' does not conform to protocol 'Collection'}}
+  _ = AliasTest<Int>.B.self // expected-error {{type 'Int' does not conform to protocol 'Collection'}}
+  _ = AliasTest<String>.A.self
+  _ = AliasTest<String>.B.self
+}

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -114,3 +114,16 @@ func testLookup<T: OuterForUFI.Inner>(_ x: T) {
   x.req()
   x.extMethod()
 }
+
+// rdar://problem/113103854
+
+protocol Q {
+  associatedtype A
+}
+
+struct OuterNonGeneric {
+  protocol P: Q where Self.A == Int {}
+  // expected-error@-1 {{protocol 'P' cannot be nested inside another declaration}}
+}
+
+func usesProtoWithWhereClause<T: OuterNonGeneric.P>(_: T) {}

--- a/validation-test/compiler_crashers_2_fixed/0161-issue-49119.swift
+++ b/validation-test/compiler_crashers_2_fixed/0161-issue-49119.swift
@@ -9,7 +9,7 @@ protocol P {
 struct Type<Param> {}
 extension Type: P where Param: P, Param.A == Type<Param> {
   // expected-error@-1 6{{extension of generic struct 'Type' has self-referential generic requirements}}
-  // expected-note@-2 5{{through reference here}}
+  // expected-note@-2 6{{through reference here}}
   // expected-error@-3 {{type 'Type<Param>' does not conform to protocol 'P'}}
   typealias A = Param
   // expected-note@-1 2{{through reference here}}

--- a/validation-test/compiler_crashers_2_fixed/0161-issue-49119.swift
+++ b/validation-test/compiler_crashers_2_fixed/0161-issue-49119.swift
@@ -8,7 +8,7 @@ protocol P {
 
 struct Type<Param> {}
 extension Type: P where Param: P, Param.A == Type<Param> {
-  // expected-error@-1 5{{extension of generic struct 'Type' has self-referential generic requirements}}
+  // expected-error@-1 6{{extension of generic struct 'Type' has self-referential generic requirements}}
   // expected-note@-2 5{{through reference here}}
   // expected-error@-3 {{type 'Type<Param>' does not conform to protocol 'P'}}
   typealias A = Param


### PR DESCRIPTION
The original bug was a crash-on-invalid with a missing '}', but it actually exposed a bug with nested protocols (SE-0404) and another long-time bug.

- Whatever we do, we should skip this for protocols because their 'Self' parameter is not bound from context.

- getTrailingWhereClause() is not the right proxy for "has a generic signature different than its parent", in particular it doesn't round-trip through serialization. Instead, just compare generic signatures for pointer equality in the early return check.

The first problem was that a protocol with a `where` clause was treated as contextually generic and we went down a bogus code path. The protocol `where` clause describes the protocol's _requirement_ signature and not its generic signature, so in this case the syntactic check was also wrong.

The second change meant that it was possible to write a nested type with a `where` clause and use it contradicting its requirements across a module boundary, so this fix is source breaking.

Fixes rdar://113103854.