### PR TITLE
[CS] Solve all conjunctions in source order

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -880,12 +880,8 @@ public:
   void setBody(BraceStmt * b) { Body = b; }
 
   SourceLoc getLoc() const { return SubExpr ? SubExpr->getLoc() : SourceLoc(); }
-  
-  SourceLoc getStartLoc() const {
-    return SubExpr ? SubExpr->getStartLoc() : SourceLoc();
-  }
 
-  SourceLoc getEndLoc() const;
+  SourceRange getSourceRange() const;
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Tap;

--- a/test/Constraints/rdar113326835.swift
+++ b/test/Constraints/rdar113326835.swift
@@ -1,0 +1,46 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://113326835 - Make sure we type-check the conjunctions in source order,
+// the first closure should be type-checked before we attempt the
+// TapExpr/SingleValueExpr conjunctions, since they rely on 'k' being resolved.
+
+func global<T>(_ x: T) -> String { "" }
+func global(_ x: Any.Type) -> String { "" }
+
+protocol P {
+  associatedtype X
+}
+
+struct Q<X>: P {
+  init() {}
+  func bar(_: String) -> Self { fatalError() }
+  func qux<U: P>(_: (X) -> U) -> Q<U.X> { fatalError() }
+}
+
+struct J<X>: P {
+  init(_: X) {}
+  func baz<T>(_ transform: (X) -> T) -> Q<T> { fatalError() }
+}
+
+func foo(a: Int) -> Q<String> {
+  J(a)
+    .baz { x in
+      ()
+      return a
+    }
+    .qux { k in
+      Q<String>().bar("\(k)")
+    }
+}
+
+func bar(a: Int) -> Q<String> {
+  J(a)
+    .baz { x in
+      ()
+      return a
+    }
+    .qux { k in
+      Q<String>().bar(if .random() { global(k) } else { global(k) })
+      // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+    }
+}


### PR DESCRIPTION
Previously we would only do source ordering for ClosureExprs, but other conjunctions need to have their source location taken into account too, in order to make sure we don't try and type-check e.g a TapExpr in a second closure before we type-check the first closure.

Also while here, switch to `std::min_element` instead of sorting, and treat invalid source locations as incomparable.

rdar://113326835