### PR TITLE
[silgen] Eliminate more ManagedValue::forUnmanaged

### DIFF
--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -196,8 +196,9 @@ public:
     return ManagedValue(value, false, CleanupHandle::invalid());
   }
 
-  /// Create a managed value for a +0 trivial rvalue.
-  static ManagedValue forTrivialRValue(SILValue value) {
+  /// Create a managed value for a trivial address rvalue or an object rvalue
+  /// that has .none ownership.
+  static ManagedValue forRValueWithoutOwnership(SILValue value) {
     if (value->getType().isObject())
       return ManagedValue::forObjectRValueWithoutOwnership(value);
     return ManagedValue::forTrivialAddressRValue(value);

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -92,6 +92,24 @@ public:
     return ManagedValue(value, false, CleanupHandle::invalid());
   }
 
+  enum class ScopeKind {
+    Lexical,
+    FormalAccess,
+  };
+
+  /// Given a value \p value, create a copy of it and return the relevant
+  /// ManagedValue.
+  static ManagedValue forCopyOwnedObjectRValue(SILGenFunction &SGF,
+                                               SILLocation loc, SILValue value,
+                                               ScopeKind kind) {
+    assert(value && "No value specified");
+    assert(value->getType().isObject());
+    auto mv = ManagedValue::forUnmanaged(value);
+    if (kind == ScopeKind::Lexical)
+      return mv.copy(SGF, loc);
+    return mv.formalAccessCopy(SGF, loc);
+  }
+
   /// Create a managed value for a SILValue whose ownership is
   /// forwarded. Creates a new cleanup for +1 values. Forwarded +0 values
   /// require no cleanup.

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -899,8 +899,9 @@ public:
             SILValue(wrappedContinuation));
         SGF.emitApplyOfLibraryIntrinsic(
             loc, errorIntrinsic, subs,
-            {continuationMV,
-             ManagedValue::forUnmanaged(bridgedForeignError).copy(SGF, loc)},
+            {continuationMV, ManagedValue::forCopyOwnedObjectRValue(
+                                 SGF, loc, bridgedForeignError,
+                                 ManagedValue::ScopeKind::Lexical)},
             SGFContext());
 
         // Second, emit a branch from the end of the foreign error block to the

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4915,14 +4915,14 @@ SILGenFunction::emitBeginApply(SILLocation loc, ManagedValue fn,
       yields.push_back(ManagedValue::forLValue(value));
     } else if (info.isConsumed()) {
       !useLoweredAddresses && value->getType().isTrivial(getFunction())
-          ? yields.push_back(ManagedValue::forTrivialRValue(value))
+          ? yields.push_back(ManagedValue::forRValueWithoutOwnership(value))
           : yields.push_back(emitManagedRValueWithCleanup(value));
     } else if (info.isGuaranteed()) {
       !useLoweredAddresses && value->getType().isTrivial(getFunction())
-          ? yields.push_back(ManagedValue::forTrivialRValue(value))
+          ? yields.push_back(ManagedValue::forRValueWithoutOwnership(value))
           : yields.push_back(ManagedValue::forBorrowedRValue(value));
     } else {
-      yields.push_back(ManagedValue::forTrivialRValue(value));
+      yields.push_back(ManagedValue::forRValueWithoutOwnership(value));
     }
   }
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -525,7 +525,8 @@ static ManagedValue createInputFunctionArgument(
     //
     // NOTE: If we have a trivial value, the copy will do nothing, so this is
     // just a convenient way to avoid writing conditional code.
-    return ManagedValue::forUnmanaged(arg).copy(SGF, loc);
+    return ManagedValue::forCopyOwnedObjectRValue(
+        SGF, loc, arg, ManagedValue::ScopeKind::Lexical);
 
   case SILArgumentConvention::Direct_Owned:
     return SGF.emitManagedRValueWithCleanup(arg);
@@ -712,7 +713,8 @@ ManagedValue SILGenBuilder::createUncheckedBitCast(SILLocation loc,
   // identity implying that we need a copy of the casted value to be returned so
   // that the inputs/outputs of the case have separate ownership.
   if (isa<UncheckedBitwiseCastInst>(cast)) {
-    return ManagedValue::forUnmanaged(cast).copy(SGF, loc);
+    return ManagedValue::forCopyOwnedObjectRValue(
+        SGF, loc, cast, ManagedValue::ScopeKind::Lexical);
   }
 
   // Otherwise, we forward the cleanup of the input value and place the cleanup

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -764,7 +764,7 @@ ManagedValue SILGenBuilder::createOpenExistentialMetatype(SILLocation loc,
                                                           SILType openedType) {
   SILValue result = SILGenBuilder::createOpenExistentialMetatype(
       loc, value.getValue(), openedType);
-  return ManagedValue::forTrivialRValue(result);
+  return ManagedValue::forRValueWithoutOwnership(result);
 }
 
 ManagedValue SILGenBuilder::createStore(SILLocation loc, ManagedValue value,

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -707,7 +707,7 @@ ManagedValue SILGenBuilder::createUncheckedBitCast(SILLocation loc,
 
   // If we have a trivial inst, just return early.
   if (isa<UncheckedTrivialBitCastInst>(cast))
-    return ManagedValue::forUnmanaged(cast);
+    return ManagedValue::forObjectRValueWithoutOwnership(cast);
 
   // If we perform an unchecked bitwise case, then we are producing a new RC
   // identity implying that we need a copy of the casted value to be returned so

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -152,10 +152,10 @@ SILGenFunction::emitManagedBeginBorrow(SILLocation loc, SILValue v,
   assert(lowering.getLoweredType().getObjectType() ==
          v->getType().getObjectType());
   if (lowering.isTrivial())
-    return ManagedValue::forUnmanaged(v);
+    return ManagedValue::forRValueWithoutOwnership(v);
 
   if (v->getOwnershipKind() == OwnershipKind::None)
-    return ManagedValue::forUnmanaged(v);
+    return ManagedValue::forRValueWithoutOwnership(v);
 
   if (v->getOwnershipKind() == OwnershipKind::Guaranteed)
     return ManagedValue::forUnmanaged(v);
@@ -2867,7 +2867,7 @@ emitKeyPathRValueBase(SILGenFunction &subSGF,
     return ManagedValue();
 
   auto paramOrigValue = paramArg->getType().isTrivial(subSGF.F)
-                            ? ManagedValue::forTrivialRValue(paramArg)
+                            ? ManagedValue::forRValueWithoutOwnership(paramArg)
                             : ManagedValue::forBorrowedRValue(paramArg);
   paramOrigValue = paramOrigValue.copy(subSGF, loc);
   auto paramSubstValue = subSGF.emitOrigToSubstValue(loc, paramOrigValue,
@@ -3273,7 +3273,7 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
                                        indexes, indexPtrArg);
 
   auto valueOrig = valueArgTy.isTrivial(subSGF.F)
-                       ? ManagedValue::forTrivialRValue(valueArg)
+                       ? ManagedValue::forRValueWithoutOwnership(valueArg)
                        : ManagedValue::forBorrowedRValue(valueArg);
   valueOrig = valueOrig.copy(subSGF, loc);
   auto valueSubst = subSGF.emitOrigToSubstValue(loc, valueOrig,


### PR DESCRIPTION
Specifically:

1. Converted instances of ManagedValue::forUnmanaged(*).copy() -> ManagedValue::forCopyOwnedObjectRValue
2. Fixed a trivial forUnmanaged -> forObjectRValueWithoutOwnership that I missed in a previous PR.
3. Rename forTrivialRValue -> forRValueWithoutOwnership and use it in a few places to eliminate more forUnmanaged.

With this PR, I have eliminated ~55% of the forUnmanaged in SILGen.