### PR TITLE
Platform: correct requirements for `std.unordered_set`

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -667,7 +667,7 @@ module std [system] {
   }
 
   module unordered_set {
-    requires unordered_set
+    requires cplusplus11
     header "unordered_set"
     export *
   }


### PR DESCRIPTION
This module requires C++11, not `unordered_set` which prevents the use of the module.