### PR TITLE
NFC: Remove duplicated RUN lines from SILOptimizer tests

### DIFF
--- a/test/SILOptimizer/access_enforcement_noescape_error.swift
+++ b/test/SILOptimizer/access_enforcement_noescape_error.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -module-name access_enforcement_noescape -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -verify -parse-as-library %s
-// RUN: %target-swift-frontend -module-name access_enforcement_noescape -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -verify -parse-as-library %s
 // REQUIRES: asserts
 
 // This is the subset of tests from access_enforcement_noescape.swift

--- a/test/SILOptimizer/access_wmo_diagnose.swift
+++ b/test/SILOptimizer/access_wmo_diagnose.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -enforce-exclusivity=checked -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -enforce-exclusivity=checked -primary-file %s -o /dev/null -verify
 
 // AccessEnforcementWMO assumes that the only way to address a global or static
 // property is via a formal begin_access. If we ever allow keypaths for static

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/cast_folding_objc_generics.swift
+++ b/test/SILOptimizer/cast_folding_objc_generics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name cast_folding_objc_generics -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name cast_folding_objc_generics -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -emit-sil %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/constant_propagation_diagnostics.swift
+++ b/test/SILOptimizer/constant_propagation_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -o /dev/null -verify
 
 // <rdar://problem/18213320> enum with raw values that are too big are not diagnosed
 enum EnumWithTooLargeElements : UInt8 {

--- a/test/SILOptimizer/definite_init_address_only_let.swift
+++ b/test/SILOptimizer/definite_init_address_only_let.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
-// RUN: %target-swift-frontend -emit-sil -verify %s
 
 func foo<T>(a: Bool, t: T) {
   let x: T

--- a/test/SILOptimizer/definite_init_diagnostics_globals.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_globals.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 
 import Swift
 

--- a/test/SILOptimizer/definite_init_diagnostics_objc.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_objc.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify
+
 // REQUIRES: objc_interop
 
 import Swift

--- a/test/SILOptimizer/definite_init_existential_let.swift
+++ b/test/SILOptimizer/definite_init_existential_let.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
-// RUN: %target-swift-frontend -emit-sil -verify %s
 
 // rdar://problem/29716016 - Check that we properly enforce DI on `let`
 // variables and class properties.

--- a/test/SILOptimizer/definite_init_extension.swift
+++ b/test/SILOptimizer/definite_init_extension.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s -o /dev/null
-// RUN: %target-swift-frontend -emit-sil -verify %s -o /dev/null
 
 struct S<T> {
   let t: T // expected-note {{'self.t.1' not initialized}}

--- a/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
-// RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
 
 // High-level tests that DI rejects certain invalid idioms for early
 // return from initializers.

--- a/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
+++ b/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
-// RUN: %target-swift-frontend -emit-sil -disable-objc-attr-requires-foundation-module -verify %s
 
 // High-level tests that DI rejects passing let constants to
 // mutating witness methods

--- a/test/SILOptimizer/definite_init_value_types_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_value_types_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
 
 struct EmptyStruct {}
 

--- a/test/SILOptimizer/diagnostic_constant_propagation-swift4.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation-swift4.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
 //
 // These are tests for diagnostics produced by constant propagation pass.
 // These are specific to Swift 4.

--- a/test/SILOptimizer/diagnostic_constant_propagation.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 //
 // These are tests for diagnostics produced by constant propagation pass.
 // Due to the change in the implementation of Integer initializers some of the

--- a/test/SILOptimizer/diagnostic_constant_propagation_floats.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_floats.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 //
 // These are tests for diagnostics produced by constant propagation pass
 // on floating-point operations.

--- a/test/SILOptimizer/diagnostic_constant_propagation_floats_nonx86.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_floats_nonx86.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 //
 // REQUIRES: !(CPU=i386 || CPU=x86_64)
 //

--- a/test/SILOptimizer/diagnostic_constant_propagation_floats_x86.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation_floats_x86.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 //
 // REQUIRES: CPU=i386 || CPU=x86_64
 // UNSUPPORTED: OS=windows-msvc

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
 
 import Swift
 

--- a/test/SILOptimizer/exclusivity_static_diagnostics_objc.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_objc.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/optional_closure_bridging.h -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/optional_closure_bridging.h -enforce-exclusivity=checked -swift-version 4 -emit-sil -primary-file %s -o /dev/null -verify
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILOptimizer/generalized_accessors.swift
+++ b/test/SILOptimizer/generalized_accessors.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 //
 // Tests for yield-once diagnostics emitted for generalized accessors.
 

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil %s -verify
-// RUN: %target-swift-frontend -emit-sil %s -verify
 
 func takesEscaping(_: @escaping () -> ()) {}
 

--- a/test/SILOptimizer/mandatory_inlining_circular.swift
+++ b/test/SILOptimizer/mandatory_inlining_circular.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -sil-verify-all -emit-sil %s -o /dev/null -verify
-// RUN: %target-swift-frontend -sil-verify-all -emit-sil %s -o /dev/null -verify
 
 @_transparent func waldo(_ x: Double) -> Double {
   return fred(x); // expected-error {{inlining 'transparent' functions forms circular loop}} expected-note 1 {{while inlining here}}

--- a/test/SILOptimizer/noescape_param_exclusivity.swift
+++ b/test/SILOptimizer/noescape_param_exclusivity.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil %s -verify
-// RUN: %target-swift-frontend -emit-sil %s -verify
 
 func test0(a: (() -> ()) -> (), b: () -> ()) {
   a(b) // expected-error {{passing a non-escaping function parameter 'b' to a call to a non-escaping function parameter can allow re-entrant modification of a variable}}

--- a/test/SILOptimizer/polymorphic_builtins_diagnostics.swift
+++ b/test/SILOptimizer/polymorphic_builtins_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -parse-stdlib -emit-sil -verify %s
-// RUN: %target-swift-frontend -parse-stdlib -emit-sil -verify %s
 
 import Swift
 

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -enable-experimental-static-assert -emit-sil %s -verify
-// RUN: %target-swift-frontend -enable-experimental-static-assert -emit-sil %s -verify
 // REQUIRES: asserts
 
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/pound_assert_test_recursive.swift
+++ b/test/SILOptimizer/pound_assert_test_recursive.swift
@@ -1,5 +1,4 @@
 // RUN: not %target-swift-frontend -enable-experimental-static-assert -emit-sil %s 2>&1 | %FileCheck %s
-// RUN: not %target-swift-frontend -enable-experimental-static-assert -emit-sil %s 2>&1 | %FileCheck %s
 
 // This is a special FileCheck test for testing that we properly catch that we
 // are recursing here. The reason why this is separate from the other


### PR DESCRIPTION
A previous PR (https://github.com/apple/swift/pull/32407) that mass-modified tests left some duplicate `RUN:` lines behind.
