### PR TITLE
[cxx-interop][5.9] fix windows ABI convention for methods returning trivial records indirectly

### DIFF
--- a/test/Interop/Cxx/class/method/msvc-abi-return-indirect-trivial-record.swift
+++ b/test/Interop/Cxx/class/method/msvc-abi-return-indirect-trivial-record.swift
@@ -1,0 +1,70 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-emit-irgen -I %t/Inputs -enable-experimental-cxx-interop  -Xcc -std=c++17 %t/test.swift -module-name Test | %FileCheck %s
+
+// REQUIRES: OS=windows-msvc
+
+//--- Inputs/module.modulemap
+module MsvcUseVecIt {
+    header "test.h"
+    requires cplusplus
+}
+
+//--- Inputs/test.h
+
+#pragma once
+
+class str {
+    int x;
+};
+
+class It {
+public:
+    int x;
+
+    bool operator ==(const It &other) const ;
+    bool operator !=(const It &other) const ;
+};
+
+template<class T> class vec {
+    int x;
+public:
+    vec(const vec<T> &);
+    ~vec();
+
+    It begin() const;
+    It end() const;
+};
+
+using VecStr = vec<str>;
+
+struct LoadableIntWrapper {
+    int value;
+
+    LoadableIntWrapper operator+=(LoadableIntWrapper rhs) {
+        value += rhs.value;
+        return *this;
+    }
+};
+
+//--- test.swift
+
+import MsvcUseVecIt
+
+public func test(_ result: VecStr) -> CInt {
+    let begin = result.__beginUnsafe()
+    return begin.x
+}
+
+// CHECK: swiftcc i32 @"$s4Test4testys5Int32VSo0014vecstr_yuJCataVF"({{.*}} %[[RESULT:.*]])
+// CHECK: call void @"?begin@?$vec@Vstr@@@@QEBA?AVIt@@XZ"(ptr %[[RESULT]], ptr sret{{.*}}
+
+public func passTempForIndirectRetToVoidCall() {
+    var lhs = LoadableIntWrapper(value: 2)
+    let rhs = LoadableIntWrapper(value: 2)
+    lhs += rhs
+}
+
+// CHECK: void @"$sSo18LoadableIntWrapperV2peoiyyABz_ABtFZ"(ptr
+// CHECK: %[[OPRESULT:.*]] = alloca %struct.LoadableIntWrapper, align 16
+// CHECK: call void @"??YLoadableIntWrapper@@QEAA?AU0@U0@@Z"(ptr {{.*}}, ptr sret(%struct.LoadableIntWrapper) %[[OPRESULT]], i32

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -27,3 +27,9 @@ module StdPair {
   header "std-pair.h"
   requires cplusplus
 }
+
+module MsvcUseVecIt {
+  header "msvc-std-vector-it.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/Inputs/msvc-std-vector-it.h
+++ b/test/Interop/Cxx/stdlib/Inputs/msvc-std-vector-it.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+struct FetchProvidersResult {
+  std::vector<std::string> providers;
+};
+
+inline FetchProvidersResult *f() noexcept {
+    return new FetchProvidersResult();
+}

--- a/test/Interop/Cxx/stdlib/msvc-abi-use-vector-iterator.swift
+++ b/test/Interop/Cxx/stdlib/msvc-abi-use-vector-iterator.swift
@@ -1,0 +1,15 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++17)
+
+// REQUIRES: OS=windows-msvc
+// REQUIRES: executable_test
+
+import MsvcUseVecIt
+
+func test() -> Bool {
+    let result = f()
+    let begin = result.pointee.providers.__beginUnsafe()
+    let end = result.pointee.providers.__endUnsafe()
+    return begin != end
+}
+
+let _ = test()


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/67674

Explanation:
Windows MSVC ABI had additional problem with IRGen for C++ methods in Swift: Some methods could return loadable records indirectly, leading us to performing an `emitToMemory` call emission with wrong order of arguments between `this`, and the temporary allocated return value storage. This fixes the argument order in this case for the MSVC ABI (Itanium ABI is  already correct), and also ensures that we don't try to pass `undef` as the pointer to the indirect return value in such cases.
- Scope: C++ interop, IRGen.
- Risk: Low, the affected code changes only affect the MSVC windows target, and only affect C++ imported types, not C.
- Testing: Unit tests, manual IR inspection.
- Original PR: https://github.com/apple/swift/pull/67685