### PR TITLE
SwiftCompilerSources: update `Package.swift`

### DIFF
--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -14,19 +14,6 @@
 import PackageDescription
 
 private extension Target {
-  static let defaultSwiftSettings: [SwiftSetting] = [
-    .interoperabilityMode(.Cxx),
-    .unsafeFlags([
-      // Bridging modules and headers
-      "-Xcc", "-I", "-Xcc", "../include",
-      // LLVM modules and headers
-      "-Xcc", "-I", "-Xcc", "../../llvm-project/llvm/include",
-      // Clang modules and headers
-      "-Xcc", "-I", "-Xcc", "../../llvm-project/clang/include",
-      "-cross-module-optimization"
-    ]),
-  ]
-
   static func compilerModuleTarget(
     name: String,
     dependencies: [Dependency],
@@ -39,7 +26,15 @@ private extension Target {
         path: path ?? "Sources/\(name)",
         exclude: ["CMakeLists.txt"],
         sources: sources,
-        swiftSettings: defaultSwiftSettings + swiftSettings)
+        cxxSettings: [
+          .headerSearchPath("../include"),
+          .headerSearchPath("../../llvm-project/llvm/include"),
+          .headerSearchPath("../../llvm-project/clang/include"),
+        ],
+        swiftSettings: [
+          .interoperabilityMode(.Cxx),
+          .unsafeFlags(["-cross-module-optimization"]),
+        ] + swiftSettings)
     }
 }
 

--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 //===--- Package.swift.in - SwiftCompiler SwiftPM package -----------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -86,5 +86,6 @@ let package = Package(
     .compilerModuleTarget(
       name: "Optimizer",
       dependencies: ["Basic", "SIL", "Parse"]),
-  ]
+  ],
+  cxxLanguageStandard: .cxx17
 )

--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -17,8 +17,6 @@ private extension Target {
   static let defaultSwiftSettings: [SwiftSetting] = [
     .interoperabilityMode(.Cxx),
     .unsafeFlags([
-      "-Xfrontend", "-validate-tbd-against-ir=none",
-      "-Xfrontend", "-enable-experimental-cxx-interop",
       // Bridging modules and headers
       "-Xcc", "-I", "-Xcc", "../include",
       // LLVM modules and headers

--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.9
 //===--- Package.swift.in - SwiftCompiler SwiftPM package -----------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -15,6 +15,7 @@ import PackageDescription
 
 private extension Target {
   static let defaultSwiftSettings: [SwiftSetting] = [
+    .interoperabilityMode(.Cxx),
     .unsafeFlags([
       "-Xfrontend", "-validate-tbd-against-ir=none",
       "-Xfrontend", "-enable-experimental-cxx-interop",


### PR DESCRIPTION
Update the package manager manifest to properly enable C++ interoperability.  This allows us to start trying to build SwiftCompilerSources with SPM again.