### PR TITLE
Platform: further modularise `vcruntime._Private`

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -703,7 +703,7 @@ module std [system] {
     requires cplusplus
 
     explicit module xhash {
-      header xhash
+      header "xhash"
       export *
     }
 

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -702,6 +702,11 @@ module std [system] {
   module _Private [system] {
     requires cplusplus
 
+    explicit module xhash {
+      header xhash
+      export *
+    }
+
     explicit module xmemory {
       header "xmemory"
       export *


### PR DESCRIPTION
Create an explicit module for `xhash` to correct the usage for `unordered_set`.