### PR TITLE
Fix building `LibcShims.cpp` with MSVC v14.37

### DIFF
--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -17,6 +17,7 @@
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include <io.h>
+#include <stdlib.h>
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #endif


### PR DESCRIPTION
`_swift_stdlib_configure_console_mode` reverts console codepage on Windows using `atexit`, which is declared in `stdlib.h`.

Add the missing `#include <stdlib.h>` to unblock building Swift `stdlib` with MSVC v14.37 (Visual Studio 17.7).