### PR TITLE
Remove `vcruntime._Private.xstddef`

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -707,11 +707,6 @@ module std [system] {
       export *
     }
 
-    explicit module xstddef {
-      header "xstddef"
-      export *
-    }
-
     explicit module xstring {
       header "xstring"
       export *


### PR DESCRIPTION
`<xstddef>` was removed since MSVC 14.37 (see https://github.com/microsoft/STL/pull/3654). It isn't meant to be used by most users, but the reference will break all clients of `vcruntime`, including Swift standard library itself.

An alternative is to provide an empty `xstddef` file through VFS overlay, which doesn't seem a reasonable workaround for private stubs.