### PR TITLE
Revert "[stdlib] Fix calling convention mismatch for debugger utility functions"

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -269,12 +269,9 @@ public func _stringForPrintObject(_ value: Any) -> String {
 public func _debuggerTestingCheckExpect(_: String, _: String) { }
 
 // Utilities to get refcount(s) of class objects.
-public func _getRetainCount(_ Value: AnyObject) -> UInt {
-  return UInt(bitPattern: swift_retainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
-}
-public func _getUnownedRetainCount(_ Value: AnyObject) -> UInt {
-  return UInt(bitPattern: swift_unownedRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
-}
-public func _getWeakRetainCount(_ Value: AnyObject) -> UInt {
-  return UInt(bitPattern: swift_weakRetainCount(unsafeBitCast(Value, to: UnsafeMutablePointer<HeapObject>.self)))
-}
+@_silgen_name("swift_retainCount")
+public func _getRetainCount(_ Value: AnyObject) -> UInt
+@_silgen_name("swift_unownedRetainCount")
+public func _getUnownedRetainCount(_ Value: AnyObject) -> UInt
+@_silgen_name("swift_weakRetainCount")
+public func _getWeakRetainCount(_ Value: AnyObject) -> UInt


### PR DESCRIPTION
Reverts apple/swift#66531

This was an ABI-breaking change, which unfortunately the "ABI checker" does not diagnose because of the use of _silgen_name. 