### PR TITLE
[rebranch] Fix dead method tests

### DIFF
--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -15,11 +15,14 @@ open class C {
   private func foo() async {}
 }
 
-// CHECK: @"$s1M1CC3foo33_{{.*}}Tu" = hidden global %swift.async_func_pointer <{ {{.*}} @_swift_dead_method_stub
+// CHECK: @"$s1M1CC3foo33_{{.*}}Tu" = hidden global %swift.async_func_pointer <{ {{.*}} @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"
 
-// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg" = hidden alias void (), ptr @_swift_dead_method_stub
-// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvs" = hidden alias void (), ptr @_swift_dead_method_stub
-// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM" = hidden alias void (), ptr @_swift_dead_method_stub
+// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvs" = hidden alias void (), ptr @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"
+// CHECK: @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM" = hidden alias void (), ptr @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"
+
+// CHECK: define hidden void @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"()
+// CHECK: entry:
+// CHECK:   tail call void @swift_deletedMethodError()
 
 //--- B.swift
 final class D: C {

--- a/test/IRGen/zombies.swift
+++ b/test/IRGen/zombies.swift
@@ -8,5 +8,8 @@ class C {
   init(i: Int) { self.i = i }
 }
 
-// CHECK: @"$s7zombies1CC1i33_{{.*}}vg" = hidden {{(dllexport )?}}alias void (), ptr @_swift_dead_method_stub
-// CHECK: define internal void @_swift_dead_method_stub()
+// CHECK: @"$s7zombies1CC1i33_{{.*}}vs" = hidden {{(dllexport )?}}alias void (), ptr @"$s7zombies1CC1i33_45489CBEFBF369AB7AEE3A799A95D78DLLSivg"
+
+// CHECK: define hidden void @"$s7zombies1CC1i33_45489CBEFBF369AB7AEE3A799A95D78DLLSivg"()
+// CHECK: entry:
+// CHECK:  tail call void @swift_deletedMethodError()


### PR DESCRIPTION
The internal method _swift_dead_method_stub is renamed by llvm optimizations to one of its aliases.

rdar://113414374
