### PR TITLE
[rebranch] Fix test framepointer.sil

### DIFF
--- a/test/IRGen/framepointer.sil
+++ b/test/IRGen/framepointer.sil
@@ -75,7 +75,8 @@ entry(%i : $Int32):
 // NOFP:   ret i32 %1
 // NOFP: }
 
-// NOFP: attributes [[ATTR]] = {{{.*}}"frame-pointer"="none"
+// The clang frontend's -fomit-frame-pointer no longer leads to frame-pointer=none
+// attributes [[ATTR]] = {{{.*}}"frame-pointer"="none"
 
 // Silence other os-archs.
 // CHECKASM: {{.*}}


### PR DESCRIPTION
The clang frontend's -fomit-frame-pointer no longer leads to frame-pointer=none.

rdar://113587053
