### PR TITLE
Revert "[rebranch] Pass memory effects through to `getRuntimeFn`"

### DIFF
--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -44,7 +44,6 @@ llvm::Constant *getRuntimeFn(llvm::Module &Module, llvm::Constant *&cache,
                              llvm::ArrayRef<llvm::Type *> retTypes,
                              llvm::ArrayRef<llvm::Type *> argTypes,
                              llvm::ArrayRef<llvm::Attribute::AttrKind> attrs,
-                             llvm::ArrayRef<llvm::MemoryEffects> memEffects,
                              irgen::IRGenModule *IGM = nullptr);
 
 llvm::FunctionType *getRuntimeFnType(llvm::Module &Module,

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -224,7 +224,7 @@ private:
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_retain" : "swift_retain",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {ObjectPtrTy},
-        {ObjectPtrTy}, {NoUnwind, FirstParamReturned}, {});
+        {ObjectPtrTy}, {NoUnwind, FirstParamReturned});
 
     return Retain.get();
   }
@@ -241,7 +241,7 @@ private:
                            isNonAtomic(OrigI) ? "swift_nonatomic_release"
                                               : "swift_release",
                            DefaultCC, RuntimeAvailability::AlwaysAvailable,
-                           {VoidTy}, {ObjectPtrTy}, {NoUnwind}, {});
+                           {VoidTy}, {ObjectPtrTy}, {NoUnwind});
 
     return Release.get();
   }
@@ -277,7 +277,7 @@ private:
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_retain_n" : "swift_retain_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {ObjectPtrTy},
-        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned}, {});
+        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned});
 
     return RetainN.get();
   }
@@ -295,7 +295,7 @@ private:
                             isNonAtomic(OrigI) ? "swift_nonatomic_release_n"
                                                : "swift_release_n",
                             DefaultCC, RuntimeAvailability::AlwaysAvailable,
-                            {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind}, {});
+                            {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
 
     return ReleaseN.get();
   }
@@ -314,7 +314,7 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_unknownObjectRetain_n"
                            : "swift_unknownObjectRetain_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {ObjectPtrTy},
-        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned}, {});
+        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned});
 
     return UnknownObjectRetainN.get();
   }
@@ -333,7 +333,7 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_unknownObjectRelease_n"
                            : "swift_unknownObjectRelease_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {VoidTy},
-        {ObjectPtrTy, Int32Ty}, {NoUnwind}, {});
+        {ObjectPtrTy, Int32Ty}, {NoUnwind});
 
     return UnknownObjectReleaseN.get();
   }
@@ -351,7 +351,7 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRetain_n"
                            : "swift_bridgeObjectRetain_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {BridgeObjectPtrTy},
-        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind}, {});
+        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
     return BridgeRetainN.get();
   }
 
@@ -370,7 +370,7 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRelease_n"
                            : "swift_bridgeObjectRelease_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {VoidTy},
-        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind}, {});
+        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
     return BridgeReleaseN.get();
   }
 

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -349,7 +349,7 @@ func testBlocksWithGenerics(hba: HasBlockArray) -> Any {
 // CHECK: load ptr, ptr @"\01L_selector(initWithInt:)"
 // CHECK: call ptr @objc_msgSend
 
-// CHECK: attributes [[NOUNWIND]] = { nounwind memory(read) }
+// CHECK: attributes [[NOUNWIND]] = { nounwind readonly }
 
 // CHECK: ![[SWIFT_NAME_ALIAS_VAR]] = !DILocalVariable(name: "obj", arg: 1, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])
 // CHECK: ![[LET_SWIFT_NAME_ALIAS_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -102,5 +102,5 @@ public struct P0Impl : P0 {
 // CHECK: define{{.*}} swiftcc ptr @"$s16associated_types6P0ImplVAA0C0AA9ErrorTypeAaDP_s0E0PWT"(ptr %P0Impl.ErrorType, ptr %P0Impl, ptr %P0Impl.P0)
 // CHECK:  ret ptr @"$ss5ErrorWS"
 
-// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind willreturn memory(none) }
+// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone willreturn }
 

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -124,5 +124,5 @@ func objc_enum_method_calls(_ x: ObjCEnumMethods) {
   x.prop = x.enumOut()
 }
 
-// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind memory(none) }
+// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
 

--- a/test/IRGen/readonly.sil
+++ b/test/IRGen/readonly.sil
@@ -17,7 +17,7 @@ sil @XXX_ctor : $@convention(method) (@owned XXX) -> @owned XXX
 // to the LLVM read only attribute, unless IRGen can prove by analyzing
 // the function body that this function is really read only.
 
-// CHECK-NOT: ; Function Attrs:{{.*}}memory(read)
+// CHECK-NOT: ; Function Attrs: readonly
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_foo(
 sil [readonly] @function_foo : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
@@ -30,7 +30,7 @@ bb0(%0 : $Int):
 // to the LLVM read only attribute, unless IRGen can prove by analyzing
 // the function body that this function is really read only or read none.
 
-// CHECK-NOT: ; Function Attrs:{{.*}}memory(read)
+// CHECK-NOT: ; Function Attrs: readonly
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_foo2(
 sil [readnone] @function_foo2 : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
@@ -41,7 +41,7 @@ bb0(%0 : $Int):
 // There's an @owned parameter, and destructors can call arbitrary code
 // -- function is not read only at LLVM level
 
-// CHECK-NOT: ; Function Attrs:{{.*}}memory(read)
+// CHECK-NOT: ; Function Attrs: readonly
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_bar(
 sil [readonly] @function_bar : $@convention(thin) (@owned XXX) -> () {
 bb0(%0 : $XXX):
@@ -52,7 +52,7 @@ bb0(%0 : $XXX):
 
 // There's an @out parameter -- function is not read only at LLVM level
 
-// CHECK-NOT: ; Function Attrs:{{.*}}memory(read)
+// CHECK-NOT: ; Function Attrs: readonly
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_baz(
 sil [readonly] @function_baz : $@convention(thin) () -> (@out Any) {
 bb0(%0 : $*Any):


### PR DESCRIPTION
Reverts apple/swift#67807

Experimental revert to see whether this fixes the failure on the incremental bot.

https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch-incremental-RA-macos-apple-silicon/