### PR TITLE
Optimizer: support statically initialized globals which contain pointers to other globals

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -19,6 +19,7 @@ swift_compiler_sources(Optimizer
   SimplifyInitEnumDataAddr.swift
   SimplifyLoad.swift
   SimplifyPartialApply.swift
+  SimplifyPointerToAddress.swift
   SimplifyRefCasts.swift
   SimplifyRetainReleaseValue.swift
   SimplifyStrongRetainRelease.swift

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPointerToAddress.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPointerToAddress.swift
@@ -1,0 +1,41 @@
+//===--- SimplifyPointerToAddress.swift -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+extension PointerToAddressInst : OnoneSimplifyable {
+
+  /// For a redundant pair of pointer-address conversions, e.g.
+  ///
+  ///   %2 = address_to_pointer %1
+  ///   %3 = pointer_to_address %2 [strict]
+  ///
+  /// replace all uses of %3 with %1.
+  ///
+  func simplify(_ context: SimplifyContext) {
+    if let atp = self.pointer as? AddressToPointerInst,
+       atp.address.type == self.type,
+       self.isStrict,
+
+       // If the pointer is within an ownership scope, the transformation can break ownership rules, e.g.
+       //   %2 = begin_borrow %1
+       //   %3 = ref_tail_addr %2
+       //   %4 = address_to_pointer %3
+       //   end_borrow %2
+       //   %5 = pointer_to_address %4             <- cannot replace %5 with %3!
+       //
+       !atp.address.accessBase.hasLocalOwnershipLifetime
+    {
+      self.uses.replaceAll(with: atp.address, context)
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
@@ -131,6 +131,25 @@ enum AccessBase : CustomStringConvertible, Hashable {
         return nil
     }
   }
+
+  /// True if this access base may be derived from a reference that is only valid within a locally
+  /// scoped OSSA lifetime. For example:
+  ///
+  ///   %reference = begin_borrow %1
+  ///   %base = ref_tail_addr %reference     <- %base must not be used outside the borrow scope
+  ///   end_borrow %reference
+  ///
+  /// This is not true for scoped storage such as alloc_stack and @in arguments.
+  ///
+  var hasLocalOwnershipLifetime: Bool {
+    if let reference = reference {
+      // Conservatively assume that everything which is a ref-counted object is within an ownership scope.
+      // TODO: we could e.g. exclude guaranteed function arguments.
+      return reference.ownership != .none
+    }
+    return false
+  }
+
   /// True, if the baseAddress is of an immutable property or global variable
   var isLet: Bool {
     switch self {

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -97,7 +97,7 @@ public struct InstructionList : CollectionLikeSequence, IteratorProtocol {
 
   public func reversed() -> ReverseInstructionList {
     if let inst = currentInstruction {
-      let lastInst = inst.parentBlock.bridged.getLastInst().instruction
+      let lastInst = inst.bridged.getLastInstOfParent().instruction
       return ReverseInstructionList(first: lastInst)
     }
     return ReverseInstructionList(first: nil)

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -145,7 +145,9 @@ extension Instruction {
          is ObjectInst,
          is ValueToBridgeObjectInst,
          is ConvertFunctionInst,
-         is ThinToThickFunctionInst:
+         is ThinToThickFunctionInst,
+         is AddressToPointerInst,
+         is GlobalAddrInst:
       return true
     default:
       return false

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -43,8 +43,18 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
     return bridged.isAvailableExternally()
   }
 
+  public var staticInitializerInstructions: InstructionList? {
+    if let firstStaticInitInst = bridged.getFirstStaticInitInst().instruction {
+      return InstructionList(first: firstStaticInitInst)
+    }
+    return nil
+  }
+
   public var staticInitValue: SingleValueInstruction? {
-    bridged.getStaticInitializerValue().instruction as? SingleValueInstruction
+    if let staticInitInsts = staticInitializerInstructions {
+      return staticInitInsts.reversed().first! as? SingleValueInstruction
+    }
+    return nil
   }
 
   /// True if the global's linkage and resilience expansion allow the global

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -457,6 +457,7 @@ class AddressToPointerInst : SingleValueInstruction, UnaryInstruction {
 final public
 class PointerToAddressInst : SingleValueInstruction, UnaryInstruction {
   public var pointer: Value { operand.value }
+  public var isStrict: Bool { bridged.PointerToAddressInst_isStrict() }
 }
 
 final public

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -546,6 +546,9 @@ struct BridgedInstruction {
     return getAs<swift::BuiltinInst>()->getSubstitutions();
   }
 
+  bool PointerToAddressInst_isStrict() const {
+    return getAs<swift::PointerToAddressInst>()->isStrict();
+  }
 
   bool AddressToPointerInst_needsStackProtection() const {
     return getAs<swift::AddressToPointerInst>()->needsStackProtection();

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -367,7 +367,7 @@ struct BridgedGlobalVar {
   }
 
   SWIFT_IMPORT_UNSAFE
-  inline OptionalBridgedInstruction getStaticInitializerValue() const;
+  inline OptionalBridgedInstruction getFirstStaticInitInst() const;
 
   bool canBeInitializedStatically() const;
   
@@ -466,6 +466,9 @@ struct BridgedInstruction {
 
   SWIFT_IMPORT_UNSAFE
   inline BridgedBasicBlock getParent() const;
+
+  SWIFT_IMPORT_UNSAFE
+  inline BridgedInstruction getLastInstOfParent() const;
 
   bool isDeleted() const {
     return getInst()->isDeleted();
@@ -1416,11 +1419,12 @@ OptionalBridgedBasicBlock BridgedFunction::getLastBlock() const {
   return {getFunction()->empty() ? nullptr : &*getFunction()->rbegin()};
 }
 
-OptionalBridgedInstruction BridgedGlobalVar::getStaticInitializerValue() const {
-  if (swift::SILInstruction *inst = getGlobal()->getStaticInitializerValue()) {
-    return {inst->asSILNode()};
+OptionalBridgedInstruction BridgedGlobalVar::getFirstStaticInitInst() const {
+  if (getGlobal()->begin() == getGlobal()->end()) {
+    return {nullptr};
   }
-  return {nullptr};
+  swift::SILInstruction *firstInst = &*getGlobal()->begin();
+  return {firstInst->asSILNode()};
 }
 
 BridgedInstruction BridgedMultiValueResult::getParent() const {
@@ -1431,6 +1435,10 @@ BridgedBasicBlock BridgedInstruction::getParent() const {
   assert(!getInst()->isStaticInitializerInst() &&
          "cannot get the parent of a static initializer instruction");
   return {getInst()->getParent()};
+}
+
+inline BridgedInstruction BridgedInstruction::getLastInstOfParent() const {
+  return {getInst()->getParent()->back().asSILNode()};
 }
 
 BridgedSuccessorArray BridgedInstruction::TermInst_getSuccessors() const {

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -42,6 +42,7 @@ class SILGlobalVariable
   static SwiftMetatype registeredMetatype;
     
 public:
+  using iterator = SILBasicBlock::iterator;
   using const_iterator = SILBasicBlock::const_iterator;
 
 private:
@@ -182,6 +183,8 @@ public:
 
   const_iterator begin() const { return StaticInitializerBlock.begin(); }
   const_iterator end() const { return StaticInitializerBlock.end(); }
+  iterator begin() { return StaticInitializerBlock.begin(); }
+  iterator end() { return StaticInitializerBlock.end(); }
 
   void dropAllReferences() {
     StaticInitializerBlock.dropAllReferences();

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -617,6 +617,10 @@ void SwiftPassInvocation::eraseInstruction(SILInstruction *inst) {
   if (silCombiner) {
     silCombiner->eraseInstFromFunction(*inst);
   } else {
-    inst->eraseFromParent();
+    if (inst->isStaticInitializerInst()) {
+      inst->getParent()->erase(inst, *getPassManager()->getModule());
+    } else {
+      inst->eraseFromParent();
+    }
   }
 }

--- a/test/SILOptimizer/global_init_with_empty.swift
+++ b/test/SILOptimizer/global_init_with_empty.swift
@@ -19,6 +19,9 @@ struct Mystruct {
   static var structglobal = Mystruct(a: 3, b: Empty(), c: 4)
   // CHECK: @{{[^ ]*tupleglobal[^ ]*}} = hidden global <{ %TSi, %TSi }> <{ %TSi <{ i{{[0-9]+}} 5 }>, %TSi <{ i{{[0-9]+}} 6 }> }>
   static var tupleglobal = (a: 5, b: Empty(), c: 6)
+
+  static var empty: () = ()
+  static var ptrToEmpty = UnsafePointer(&empty)
 }
 
 // CHECK-OUTPUT:      3
@@ -33,3 +36,6 @@ print(Mystruct.tupleglobal.a)
 print(Mystruct.tupleglobal.b)
 // CHECK-OUTPUT-NEXT: 6
 print(Mystruct.tupleglobal.c)
+// CHECK-OUTPUT-NEXT: {{0x0+$}}
+print(Mystruct.ptrToEmpty)
+

--- a/test/SILOptimizer/init_static_globals.sil
+++ b/test/SILOptimizer/init_static_globals.sil
@@ -91,6 +91,13 @@ sil_global [let] @g5 : $TwoFields
 sil_global [let] @g6 : $TwoFields
 sil_global [let] @g7 : $TwoFields
 
+// CHECK-LABEL: sil_global [let] @g8 : $UnsafePointer<Int32> = {
+// CHECK-NEXT:    %0 = global_addr @g1 : $*Int32
+// CHECK-NEXT:    %1 = address_to_pointer %0 : $*Int32 to $Builtin.RawPointer
+// CHECK-NEXT:    %initval = struct $UnsafePointer<Int32> (%1 : $Builtin.RawPointer)
+// CHECK-NEXT:  }
+sil_global [let] @g8 : $UnsafePointer<Int32>
+
 // CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_trivialglobal_func :
 // CHECK-NOT:     alloc_global
 // CHECK-NOT:     store
@@ -244,5 +251,23 @@ bb0:
   store %7 to [trivial] %4 : $*Int32
   %10 = tuple ()
   return %10 : $()
+}
+
+// CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_pointer_to_other_global :
+// CHECK-NOT:     alloc_global
+// CHECK-NOT:     store
+// CHECK:       } // end sil function 'globalinit_pointer_to_other_global'
+sil [global_init_once_fn] [ossa] @globalinit_pointer_to_other_global : $@convention(c) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  alloc_global @g8
+  %2 = global_addr @g8 : $*UnsafePointer<Int32>
+  %3 = global_addr @g1 : $*Int32
+  %4 = begin_access [read] [dynamic] %3 : $*Int32
+  %5 = address_to_pointer %4 : $*Int32 to $Builtin.RawPointer
+  end_access %4 : $*Int32
+  %7 = struct $UnsafePointer<Int32> (%5 : $Builtin.RawPointer)
+  store %7 to [trivial] %2 : $*UnsafePointer<Int32>
+  %8 = tuple ()
+  return %8 : $()
 }
 

--- a/test/SILOptimizer/objectoutliner.sil
+++ b/test/SILOptimizer/objectoutliner.sil
@@ -13,6 +13,11 @@ class Obj : Base {
   @_hasStorage var value: Int64
 }
 
+sil_global [let] @g1 : $Int32 = {
+  %0 = integer_literal $Builtin.Int32, 1
+  %initval = struct $Int32 (%0 : $Builtin.Int32)
+}
+
 // CHECK-LABEL: sil_global private @outline_global_simpleTv_ : $Obj = {
 // CHECK-NEXT:    %0 = integer_literal $Builtin.Int64, 1
 // CHECK-NEXT:    %1 = struct $Int64 (%0 : $Builtin.Int64)
@@ -45,6 +50,15 @@ class Obj : Base {
 // CHECK-NEXT:    %12 = struct $Int64 (%7 : $Builtin.Int64)
 // CHECK-NEXT:    %13 = tuple (%12 : $Int64, %5 : $Bool)
 // CHECK-NEXT:    %initval = object $Obj (%1 : $Int64, [tail_elems] %6 : $(Int64, Bool), %11 : $(Int64, Bool), %13 : $(Int64, Bool))
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: sil_global private @outline_global_addressTv_ : $Obj = {
+// CHECK-NEXT:    %0 = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT:    %1 = struct $Int64 (%0 : $Builtin.Int64)
+// CHECK-NEXT:    %2 = global_addr @g1 : $*Int32
+// CHECK-NEXT:    %3 = address_to_pointer %2 : $*Int32 to $Builtin.RawPointer
+// CHECK-NEXT:    %4 = struct $UnsafePointer<Int32> (%3 : $Builtin.RawPointer)
+// CHECK-NEXT:    %initval = object $Obj (%1 : $Int64, [tail_elems] %4 : $UnsafePointer<Int32>)
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil @outline_global_simple
@@ -341,5 +355,31 @@ bb0:
   store %13 to %28 : $*Bool
   %33 = end_cow_mutation %3 : $Obj
   return %33 : $Obj
+}
+
+// CHECK-LABEL: sil @outline_global_address :
+// CHECK:         [[G:%[0-9]+]] = global_value @outline_global_addressTv_ : $Obj
+// CHECK:         strong_retain [[G]] : $Obj
+// CHECK-NOT:     store
+// CHECK:       } // end sil function 'outline_global_address'
+sil @outline_global_address : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Word, 1
+  %1 = integer_literal $Builtin.Int64, 1
+  %4 = struct $Int64 (%1 : $Builtin.Int64)
+  %7 = alloc_ref [tail_elems $Int64 * %0 : $Builtin.Word] $Obj
+  %9 = ref_element_addr %7 : $Obj, #Obj.value
+  store %4 to %9 : $*Int64
+  %11 = ref_tail_addr %7 : $Obj, $UnsafePointer<Int32>
+  %12 = global_addr @g1 : $*Int32
+  %13 = begin_access [read] [dynamic] %12 : $*Int32
+  %14 = address_to_pointer %13 : $*Int32 to $Builtin.RawPointer
+  end_access %13 : $*Int32
+  %16 = struct $UnsafePointer<Int32> (%14 : $Builtin.RawPointer)
+  store %16 to %11 : $*UnsafePointer<Int32>
+  %18 = end_cow_mutation %7 : $Obj
+  strong_release %18 : $Obj
+  %r = tuple ()
+  return %r : $()
 }
 

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -377,3 +377,11 @@ func testNestedGenericStruct() -> NestedGenericStruct<Int> {
   return nestedGeneric
 }
 
+var x = 24
+let pointerToX = UnsafePointer(&x)
+
+@_noLocks
+func testPointerToX() -> UnsafePointer<Int> {
+  return pointerToX
+}
+

--- a/test/SILOptimizer/simplify_pointer_to_address.sil
+++ b/test/SILOptimizer/simplify_pointer_to_address.sil
@@ -1,0 +1,92 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=pointer_to_address | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+class C {}
+
+// CHECK-LABEL: sil @remove_conversion :
+// CHECK-NOT:     address_to_pointer
+// CHECK-NOT:     pointer_to_address
+// CHECK:         [[L:%.*]] = load %0
+// CHECK:         return [[L]]
+// CHECK:       } // end sil function 'remove_conversion'
+sil @remove_conversion : $@convention(thin) (@in Int) -> Int {
+bb0(%0 : $*Int):
+  %1 = address_to_pointer %0 : $*Int to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int
+  %3 = load %2 : $*Int
+  return %3 : $Int
+}
+
+// CHECK-LABEL: sil @mismatching_type :
+// CHECK:         address_to_pointer
+// CHECK:         [[A:%.*]] = pointer_to_address
+// CHECK:         [[L:%.*]] = load [[A]]
+// CHECK:         return [[L]]
+// CHECK:       } // end sil function 'mismatching_type'
+sil @mismatching_type : $@convention(thin) (@in Int) -> Bool {
+bb0(%0 : $*Int):
+  %1 = address_to_pointer %0 : $*Int to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Bool
+  %3 = load %2 : $*Bool
+  return %3 : $Bool
+}
+
+// CHECK-LABEL: sil @no_strict :
+// CHECK:         address_to_pointer
+// CHECK:         [[A:%.*]] = pointer_to_address
+// CHECK:         [[L:%.*]] = load [[A]]
+// CHECK:         return [[L]]
+// CHECK:       } // end sil function 'no_strict'
+sil @no_strict : $@convention(thin) (@in Int) -> Int {
+bb0(%0 : $*Int):
+  %1 = address_to_pointer %0 : $*Int to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to $*Int
+  %3 = load %2 : $*Int
+  return %3 : $Int
+}
+
+// CHECK-LABEL: sil [ossa] @borrow_escape :
+// CHECK:         address_to_pointer
+// CHECK:         [[A:%.*]] = pointer_to_address
+// CHECK:         [[L:%.*]] = load [trivial] [[A]]
+// CHECK:         return [[L]]
+// CHECK:       } // end sil function 'borrow_escape'
+sil [ossa] @borrow_escape : $@convention(thin) (@guaranteed C) -> Int {
+bb0(%0 : @guaranteed $C):
+  %1 = begin_borrow %0 : $C
+  %2 = ref_tail_addr %1: $C, $Int
+  %3 = address_to_pointer %2 : $*Int to $Builtin.RawPointer
+  end_borrow %1 : $C
+  %5 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Int
+  %6 = load [trivial] %5 : $*Int
+  return %6 : $Int
+}
+
+sil @createC : $@convention(thin) () -> @owned C
+
+// CHECK-LABEL: sil @non_ossa_local_ownership :
+// CHECK:         [[A:%.*]] = ref_tail_addr
+// CHECK-NOT:     address_to_pointer
+// CHECK-NOT:     pointer_to_address
+// CHECK:         [[L:%.*]] = load [[A]]
+// CHECK:         return [[L]]
+// CHECK:       } // end sil function 'non_ossa_local_ownership'
+sil @non_ossa_local_ownership : $@convention(thin) () -> Int {
+bb0:
+  %f = function_ref @createC : $@convention(thin) () -> @owned C
+  %0 = apply %f() : $@convention(thin) () -> @owned C
+  %2 = ref_tail_addr %0: $C, $Int
+  %3 = address_to_pointer %2 : $*Int to $Builtin.RawPointer
+  %5 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Int
+  %6 = load %5 : $*Int
+  strong_release %0 : $C
+  return %6 : $Int
+}
+


### PR DESCRIPTION
For example:
```
  var p = Point(x: 10, y: 20)
  let o = UnsafePointer(&p)
```

Also support outlined arrays with pointers to other globals. For example:
```
var g1 = 1
var g2 = 2

func f() -> [UnsafePointer<Int>] {
  return [UnsafePointer(&g1), UnsafePointer(&g2)]
}
```
