### PR TITLE
[AddressLowering] Type SILFunctionArguments for @out results with opaque types substituted.

### DIFF
--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -495,6 +495,10 @@ struct SILOptOptions {
   llvm::cl::opt<bool> BypassResilienceChecks = llvm::cl::opt<bool>(
       "bypass-resilience-checks",
       llvm::cl::desc("Ignore all checks for module resilience."));
+
+  llvm::cl::opt<bool> DebugDiagnosticNames = llvm::cl::opt<bool>(
+      "debug-diagnostic-names",
+      llvm::cl::desc("Include diagnostic names when printing"));
 };
 
 /// Regular expression corresponding to the value given in one of the
@@ -609,6 +613,8 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   }
   Invocation.getLangOptions().BypassResilienceChecks =
       options.BypassResilienceChecks;
+  Invocation.getDiagnosticOptions().PrintDiagnosticNames =
+      options.DebugDiagnosticNames;
   for (auto &featureName : options.ExperimentalFeatures) {
     if (auto feature = getExperimentalFeature(featureName)) {
       Invocation.getLangOptions().Features.insert(*feature);

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -689,7 +689,9 @@ static unsigned insertIndirectReturnArgs(AddressLoweringState &pass) {
 
   unsigned argIdx = 0;
   for (auto resultTy : pass.loweredFnConv.getIndirectSILResultTypes(typeCtx)) {
-    auto bodyResultTy = pass.function->mapTypeIntoContext(resultTy);
+    auto resultTyInContext = pass.function->mapTypeIntoContext(resultTy);
+    auto bodyResultTy = pass.function->getModule().Types.getLoweredType(
+        resultTyInContext.getASTType(), *pass.function);
     auto var = new (astCtx) ParamDecl(
         SourceLoc(), SourceLoc(), astCtx.getIdentifier("$return_value"),
         SourceLoc(), astCtx.getIdentifier("$return_value"), declCtx);

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -18,6 +18,10 @@ protocol P {
   func foo()
 }
 
+struct S : P {
+  func foo()
+}
+
 enum Optional<T> {
   case none
   case some(T)
@@ -547,6 +551,23 @@ bb0(%0 : @owned $T, %1 : @owned $C):
   %f = function_ref @takeTuple : $@convention(thin) <τ_0_0> (@in_guaranteed (τ_0_0, C)) -> ()
   %c = apply %f<T>(%2) : $@convention(thin) <τ_0_0> (@in_guaranteed (τ_0_0, C)) -> ()
   return %2 : $(T, C)
+}
+
+// CHECK-LABEL: sil [ossa] @f076_opaqueResult : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[S_ADDR:%[^,]+]] : $*S):
+// CHECK:         [[GET:%[^,]+]] = function_ref @getT
+// CHECK:         [[TEMP:%[^,]+]] = alloc_stack $S
+// CHECK:         apply [[GET]]<S>([[TEMP]])
+// CHECK:         [[S:%[^,]+]] = load [trivial] [[TEMP]]
+// CHECK:         store [[S]] to [trivial] [[S_ADDR]]
+// CHECK:         dealloc_stack [[TEMP]]
+// CHECK-LABEL: } // end sil function 'f076_opaqueResult'
+// The following getS definition enables use of the type <<@_opaqueReturnTypeOf("$s5Swift4getSQryF", 0) opaque>>
+@_silgen_name("getS") public func getS() -> some P { return S() }
+sil [ossa] @f076_opaqueResult : $@convention(thin) <T> () -> @out @_opaqueReturnTypeOf("$s5Swift4getSQryF", 0) __<T> {
+  %get = function_ref @getT : $@convention(thin) <T> () -> (@out T)
+  %s = apply %get<S>() : $@convention(thin) <T> () -> (@out T)
+  return %s : $S
 }
 
 // CHECK-LABEL: sil [ossa] @f080_optional : $@convention(thin) <T> (@in T) -> @out Optional<T> {


### PR DESCRIPTION
A function which returns a value of opaque result type

    func f() -> some P { S() }

has a lowered, substituted signature similar to

    @convention(thin) () -> @out @_opaqueReturnTypeOf("$s4main1fQryF", 0) opaque

featuring an `_opaqueReturnTypeOf` attr.  The `SILFunctionArgument` for that `@out` result, however, must be of the type that the opaque result substitutes to in the expansion context of the function.

