### PR TITLE
[lldb] Capture error messages from parseASTSection to log from caller

### DIFF
--- a/include/swift/ASTSectionImporter/ASTSectionImporter.h
+++ b/include/swift/ASTSectionImporter/ASTSectionImporter.h
@@ -18,6 +18,8 @@
 #define SWIFT_ASTSECTION_IMPORTER_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Serialization/Validation.h"
+#include "llvm/Support/Error.h"
 #include <string>
 
 namespace llvm {
@@ -26,15 +28,47 @@ class Triple;
 namespace swift {
   class MemoryBufferSerializedModuleLoader;
 
+  class ASTSectionParseError : public llvm::ErrorInfo<ASTSectionParseError> {
+  public:
+    static char ID;
+
+    serialization::Status Error;
+    std::string ErrorMessage;
+
+    ASTSectionParseError(serialization::Status Error,
+                         StringRef ErrorMessage = {})
+        : Error(Error), ErrorMessage(ErrorMessage) {
+      assert(Error != serialization::Status::Valid);
+    }
+    ASTSectionParseError(const ASTSectionParseError &Other)
+        : ASTSectionParseError(Other.Error, Other.ErrorMessage) {}
+    ASTSectionParseError &operator=(const ASTSectionParseError &Other) {
+      Error = Other.Error;
+      ErrorMessage = Other.ErrorMessage;
+      return *this;
+    }
+
+    std::string toString() const;
+    void log(llvm::raw_ostream &OS) const override;
+    std::error_code convertToErrorCode() const override;
+  };
+
   /// Provided a memory buffer with an entire Mach-O __swift_ast section, this
   /// function makes memory buffer copies of all swift modules found in it and
   /// registers them using registerMemoryBuffer() so they can be found by
-  /// loadModule(). The access path of all modules found in the section is
-  /// appended to the vector foundModules.
+  /// loadModule().
   /// \param filter  If fully specified, only matching modules are registered.
-  /// \return true if successful.
+  /// \return a vector of the access path of all modules found in the
+  /// section if successful.
+  llvm::Expected<SmallVector<std::string, 4>>
+  parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
+                  StringRef Data, const llvm::Triple &filter);
+
+  // An old version temporarily left for remaining call site.
+  // TODO: remove this once the other version is committed and used.
   bool parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
                        StringRef Data, const llvm::Triple &filter,
                        SmallVectorImpl<std::string> &foundModules);
+
 }
 #endif

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -18,6 +18,10 @@
 #include "swift/Basic/PathRemapper.h"
 #include "llvm/Support/VersionTuple.h"
 
+#include <set>
+#include <string>
+#include <vector>
+
 namespace swift {
 
   class SerializationOptions {

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -13,7 +13,9 @@
 #ifndef SWIFT_SERIALIZATION_VALIDATION_H
 #define SWIFT_SERIALIZATION_VALIDATION_H
 
+#include "swift/AST/Identifier.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/Version.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -82,6 +84,9 @@ enum class Status {
   /// to build the client.
   SDKMismatch
 };
+
+/// Returns the string for the Status enum.
+std::string StatusToString(Status S);
 
 /// Returns true if the data looks like it contains a serialized AST.
 bool isSerializedAST(StringRef data);

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -514,6 +514,28 @@ static bool validateInputBlock(
   return false;
 }
 
+std::string serialization::StatusToString(Status S) {
+  switch (S) {
+  case Status::Valid: return "Valid";
+  case Status::FormatTooOld: return "FormatTooOld";
+  case Status::FormatTooNew: return "FormatTooNew";
+  case Status::RevisionIncompatible: return "RevisionIncompatible";
+  case Status::NotInOSSA: return "NotInOSSA";
+  case Status::MissingDependency: return "MissingDependency";
+  case Status::MissingUnderlyingModule: return "MissingUnderlyingModule";
+  case Status::CircularDependency: return "CircularDependency";
+  case Status::FailedToLoadBridgingHeader: return "FailedToLoadBridgingHeader";
+  case Status::Malformed: return "Malformed";
+  case Status::MalformedDocumentation: return "MalformedDocumentation";
+  case Status::NameMismatch: return "NameMismatch";
+  case Status::TargetIncompatible: return "TargetIncompatible";
+  case Status::TargetTooNew: return "TargetTooNew";
+  case Status::SDKMismatch: return "SDKMismatch";
+  default:
+    llvm_unreachable("The switch should cover all cases");
+  }
+}
+
 bool serialization::isSerializedAST(StringRef data) {
   StringRef signatureStr(reinterpret_cast<const char *>(SWIFTMODULE_SIGNATURE),
                          std::size(SWIFTMODULE_SIGNATURE));


### PR DESCRIPTION
This helps fix a lldb console output mixup between the lldb logging and the llvm::dbgs() messages from parseASTSection.
