### PR TITLE
[5.9][Macros] Update help message for '-load-plugin-executable'

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1823,8 +1823,8 @@ def load_plugin_library:
 def load_plugin_executable:
   Separate<["-"], "load-plugin-executable">, Group<plugin_search_Group>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
-  HelpText<"Path to an executable compiler plugins and providing module names "
-           "such as macros">,
+  HelpText<"Path to a compiler plugin executable and a comma-separated list "
+           "of module names where the macro types are declared">,
   MetaVarName<"<path>#<module-names>">;
 
 include "FrontendOptions.td"


### PR DESCRIPTION
Cherry-pick #67834 into release/5.9

* **Explanation**: `-load-plugin-executable` compiler option is the primary supported way of using macro plugin. SwiftPM uses this when developers use `.macro()` target. The help text should clarify the format and the semantics of the arguments.
* **Scope**: Help message for `-h`
* **Risk**: Low, this is just a message change
* **Testing**: Passes current test suite
* **Issues**: rdar://113646544
* **Reviewer**: Ben Barham (@bnbarham)