### PR TITLE
NFC: Update lit.cfg to specify -parse-as-library for module interface tests

### DIFF
--- a/test/ModuleInterface/closure.swift
+++ b/test/ModuleInterface/closure.swift
@@ -9,5 +9,5 @@
 // CHECK: public let MyClosureVar: (Swift.Int) -> Swift.Int
 public let MyClosureVar: (Int) -> Int = { $0 }
 
-// CHECK: public var MyOtherClosureVar: (_ x: Swift.Int) -> Swift.Int
-public let MyOtherClosureVar: (_ x: Int) -> Int
+// CHECK: public let MyOtherClosureVar: (_ x: Swift.Int) -> Swift.Int
+public let MyOtherClosureVar: (_ x: Int) -> Int = { x in x }

--- a/test/ModuleInterface/moveonly_interface_flag.swift
+++ b/test/ModuleInterface/moveonly_interface_flag.swift
@@ -1,4 +1,4 @@
-7// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -enable-experimental-feature MoveOnlyResilientTypes
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t -enable-experimental-feature MoveOnlyResilientTypes
 // RUN: %FileCheck %s < %t/Library.swiftinterface

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2481,7 +2481,7 @@ config.substitutions.append(('%target-msvc-runtime-opt',
 config.substitutions.append(('%target-swift-emit-module-interfaces\(([^)]+),\w*([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-emit-module-interface(\1) -emit-private-module-interface-path \2')))
 config.substitutions.append(('%target-swift-emit-module-interface\(([^)]+)\)',
-                             SubstituteCaptures(r'%target-swift-frontend -swift-version 5 -enable-library-evolution -typecheck -emit-module-interface-path \1')))
+                             SubstituteCaptures(r'%target-swift-frontend -swift-version 5 -enable-library-evolution -parse-as-library -typecheck -emit-module-interface-path \1')))
 
 config.substitutions.append(('%target-swift-typecheck-module-from-interface\(([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend -swift-version 5 -enable-library-evolution -typecheck-module-from-interface \1')))


### PR DESCRIPTION
Tests that use the `%target-swift-emit-module-interface` lit substitution are designed to test the behavior of the compiler when emitting module interfaces for resilient libraries. It therefore makes sense to pass `-parse-as-library` by default for these frontend invocations.

Fixes a few tests that were accidentally depending on parsing source files as top level code.