### PR TITLE
test: enable yet more C++ interop tests on Windows

### DIFF
--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -7,7 +7,6 @@ import StdlibUnittest
 
 var OperatorsTestSuite = TestSuite("Operators")
 
-#if !os(Windows)    // https://github.com/apple/swift/issues/55575
 OperatorsTestSuite.test("LoadableIntWrapper.minus (inline)") {
   var lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 23)
@@ -25,7 +24,6 @@ OperatorsTestSuite.test("AddressOnlyIntWrapper.minus") {
 
    expectEqual(19, result.value)
 }
-#endif
 
 OperatorsTestSuite.test("LoadableIntWrapper.equal (inline)") {
   let lhs = LoadableIntWrapper(value: 42)
@@ -94,14 +92,12 @@ OperatorsTestSuite.test("TemplatedWithFriendOperator.equal (inline)") {
   expectTrue(result)
 }
 
-#if !os(Windows)    // https://github.com/apple/swift/issues/55575
 OperatorsTestSuite.test("LoadableBoolWrapper.exclaim (inline)") {
   var wrapper = LoadableBoolWrapper(value: true)
 
   let resultExclaim = !wrapper
   expectEqual(false, resultExclaim.value)
 }
-#endif
 
 OperatorsTestSuite.test("AddressOnlyIntWrapper.call (inline)") {
   var wrapper = AddressOnlyIntWrapper(42)
@@ -267,7 +263,6 @@ OperatorsTestSuite.test("DifferentTypesArrayByVal.subscript (inline)") {
   expectEqual(1.5.rounded(.up), resultDouble.rounded(.up))
 }
 
-#if !os(Windows)    // https://github.com/apple/swift/issues/55575
 OperatorsTestSuite.test("NonTrivialArrayByVal.subscript (inline)") {
   var arr = NonTrivialArrayByVal()
   let NonTrivialByVal = arr[0];
@@ -295,7 +290,6 @@ OperatorsTestSuite.test("DerivedFromNonTrivialArrayByVal.subscript (inline, base
   expectEqual(5, NonTrivialByVal.e)
   expectEqual(6, NonTrivialByVal.f)
 }
-#endif
 
 OperatorsTestSuite.test("PtrByVal.subscript (inline)") {
   var arr = PtrByVal()

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -11,7 +11,6 @@ import StdlibUnittest
 
 var OperatorsTestSuite = TestSuite("Operators")
 
-#if !os(Windows)    // https://github.com/apple/swift/issues/55575
 OperatorsTestSuite.test("LoadableIntWrapper.plus (out-of-line)") {
   let lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 23)
@@ -20,7 +19,6 @@ OperatorsTestSuite.test("LoadableIntWrapper.plus (out-of-line)") {
 
   expectEqual(65, result.value)
 }
-#endif
 
 OperatorsTestSuite.test("LoadableIntWrapper.call (out-of-line)") {
   let wrapper = LoadableIntWrapper(value: 42)


### PR DESCRIPTION
These tests should now work as the parameter passing issue has been resolved.