### PR TITLE
Revert 465aa22b81d96514f1813787fdfe9f23375deadc

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -453,15 +453,8 @@ extension RangeReplaceableCollection {
   @inlinable
   public mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
-    
-    let done:Void? = newElements.withContiguousStorageIfAvailable {
-      replaceSubrange(endIndex..<endIndex, with: $0)
-    }
-      
-    if done == nil {
-      for element in newElements {
-        append(element)
-      }
+    for element in newElements {
+      append(element)
     }
   }
 


### PR DESCRIPTION
reverts "Try using withContiguousStorageIfAvailable in RangeReplaceableCollection.append(contentsOf:) before falling back to a slow element-by-element loop. Fixes rdar://109059874", due to infinite recursion issues.

This reverts commit 465aa22b81d96514f1813787fdfe9f23375deadc.