### PR TITLE
[rebranch] Make sure to include remote inspection headers first

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -773,6 +773,7 @@ function(add_swift_target_library_single target name)
         LINK_FLAGS
         LINK_LIBRARIES
         PRIVATE_LINK_LIBRARIES
+        PREFIX_INCLUDE_DIRS
         SWIFT_COMPILE_FLAGS
         MODULE_TARGETS)
 
@@ -1044,6 +1045,8 @@ function(add_swift_target_library_single target name)
   # to ensure that the runtime is built with our local copy of LLVMSupport
   target_include_directories(${target} BEFORE PRIVATE
     ${SWIFT_SOURCE_DIR}/stdlib/include)
+  target_include_directories(${target} BEFORE PRIVATE
+    ${SWIFTLIB_SINGLE_PREFIX_INCLUDE_DIRS})
   if(("${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_OBJECT_FORMAT}" STREQUAL "ELF" OR
       "${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_OBJECT_FORMAT}" STREQUAL "COFF"))
     if("${libkind}" STREQUAL "SHARED" AND NOT SWIFTLIB_SINGLE_NOSWIFTRT)
@@ -1748,6 +1751,7 @@ function(add_swift_target_library name)
         INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY
         LINK_FLAGS
         LINK_LIBRARIES
+        PREFIX_INCLUDE_DIRS
         PRIVATE_LINK_LIBRARIES
         SWIFT_COMPILE_FLAGS
         SWIFT_COMPILE_FLAGS_IOS
@@ -2242,6 +2246,7 @@ function(add_swift_target_library name)
         ${back_deployment_library_option}
         ENABLE_LTO "${SWIFT_STDLIB_ENABLE_LTO}"
         GYB_SOURCES ${SWIFTLIB_GYB_SOURCES}
+        PREFIX_INCLUDE_DIRS ${SWIFTLIB_PREFIX_INCLUDE_DIRS}
       )
     if(NOT SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
       add_dependencies(${VARIANT_NAME} clang)

--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -8,9 +8,10 @@ add_swift_target_library(swiftRemoteMirror
                          C_COMPILE_FLAGS
                            ${SWIFT_RUNTIME_CXX_FLAGS}
                            -DswiftRemoteMirror_EXPORTS
-                           -I${SWIFT_SOURCE_DIR}/include/swift/RemoteInspection
                          LINK_FLAGS
                            ${SWIFT_RUNTIME_LINK_FLAGS}
+                         PREFIX_INCLUDE_DIRS
+                           ${SWIFT_SOURCE_DIR}/include/swift/RemoteInspection
                          INCORPORATE_OBJECT_LIBRARIES swiftLLVMSupport
                          SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
                          DARWIN_INSTALL_NAME_DIR "${SWIFTLIB_DARWIN_INSTALL_NAME_DIR}"


### PR DESCRIPTION
These headers need to be ahead of all the LLVM headers, which are added before the flags are. Add a new parameter to pass through headers to add as a prefix.

Resolves rdar://113647684.