### PR TITLE
Use internal linkage for generated functions for Windows AArch64

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -701,7 +701,7 @@ void IRGenModule::emitRuntimeRegistration() {
   // Create a new function to contain our logic.
   auto fnTy = llvm::FunctionType::get(VoidTy, /*varArg*/ false);
   auto RegistrationFunction = llvm::Function::Create(fnTy,
-                                           llvm::GlobalValue::PrivateLinkage,
+                                           getGenFuncLinkage(),
                                            "runtime_registration",
                                            getModule());
   RegistrationFunction->setAttributes(constructInitialAttributes());
@@ -1991,7 +1991,7 @@ void IRGenerator::emitEagerClassInitialization() {
 
   llvm::Function *RegisterFn = llvm::Function::Create(
                                 llvm::FunctionType::get(IGM->VoidTy, false),
-                                llvm::GlobalValue::PrivateLinkage,
+                                IGM->getGenFuncLinkage(),
                                 "_swift_eager_class_initialization");
   IGM->Module.getFunctionList().push_back(RegisterFn);
   IRGenFunction RegisterIGF(*IGM, RegisterFn);
@@ -2035,7 +2035,7 @@ void IRGenerator::emitObjCActorsNeedingSuperclassSwizzle() {
 
   llvm::Function *RegisterFn = llvm::Function::Create(
                                 llvm::FunctionType::get(IGM->VoidTy, false),
-                                llvm::GlobalValue::PrivateLinkage,
+                                IGM->getGenFuncLinkage(),
                                 "_swift_objc_actor_initialization");
   IGM->Module.getFunctionList().push_back(RegisterFn);
   IRGenFunction RegisterIGF(*IGM, RegisterFn);
@@ -3294,7 +3294,7 @@ llvm::Constant *swift::irgen::emitCXXConstructorThunkIfNeeded(
   }
 
   llvm::Function *thunk = llvm::Function::Create(
-      assumedFnType, llvm::Function::PrivateLinkage, name, &IGM.Module);
+      assumedFnType, IGM.getGenFuncLinkage(), name, &IGM.Module);
 
   thunk->setCallingConv(IGM.getOptions().PlatformCCallingConvention);
 

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -426,7 +426,7 @@ static llvm::Function *createDtorFn(IRGenModule &IGM,
                                     const HeapLayout &layout) {
   llvm::Function *fn =
     llvm::Function::Create(IGM.DeallocatingDtorTy,
-                           llvm::Function::PrivateLinkage,
+                           IGM.getGenFuncLinkage(),
                            "objectdestroy", &IGM.Module);
   auto attrs = IGM.constructInitialAttributes();
   IGM.addSwiftSelfAttributes(attrs, 0);
@@ -475,7 +475,7 @@ static llvm::Function *createDtorFn(IRGenModule &IGM,
 llvm::Constant *HeapLayout::createSizeFn(IRGenModule &IGM) const {
   llvm::Function *fn =
     llvm::Function::Create(IGM.DeallocatingDtorTy,
-                           llvm::Function::PrivateLinkage,
+                           IGM.getGenFuncLinkage(),
                            "objectsize", &IGM.Module);
   fn->setAttributes(IGM.constructInitialAttributes());
 
@@ -1257,7 +1257,7 @@ llvm::Constant *IRGenModule::getFixLifetimeFn() {
   auto fixLifetimeTy = llvm::FunctionType::get(VoidTy, RefCountedPtrTy,
                                                /*isVarArg*/ false);
   auto fixLifetime = llvm::Function::Create(fixLifetimeTy,
-                                         llvm::GlobalValue::PrivateLinkage,
+                                         getGenFuncLinkage(),
                                          "__swift_fixLifetime",
                                          &Module);
   assert(fixLifetime->getName().equals("__swift_fixLifetime")

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -176,7 +176,7 @@ getAccessorForComputedComponent(IRGenModule &IGM,
                                            /*vararg*/ false);
   
   auto accessorThunk = llvm::Function::Create(thunkType,
-    llvm::GlobalValue::PrivateLinkage, thunkName, IGM.getModule());
+    IGM.getGenFuncLinkage(), thunkName, IGM.getModule());
   accessorThunk->setAttributes(IGM.constructInitialAttributes());
   accessorThunk->setCallingConv(IGM.SwiftCC);
 
@@ -278,7 +278,7 @@ getLayoutFunctionForComputedComponent(IRGenModule &IGM,
     retTy, { IGM.Int8PtrTy }, /*vararg*/ false);
     
   auto layoutFn = llvm::Function::Create(fnTy,
-    llvm::GlobalValue::PrivateLinkage, "keypath_get_arg_layout", IGM.getModule());
+    IGM.getGenFuncLinkage(), "keypath_get_arg_layout", IGM.getModule());
   layoutFn->setAttributes(IGM.constructInitialAttributes());
   layoutFn->setCallingConv(IGM.SwiftCC);
     
@@ -378,7 +378,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
                                                  {IGM.Int8PtrTy, IGM.SizeTy},
                                                  /*vararg*/ false);
       auto destroyFn = llvm::Function::Create(destroyType,
-        llvm::GlobalValue::PrivateLinkage, "keypath_destroy", IGM.getModule());
+        IGM.getGenFuncLinkage(), "keypath_destroy", IGM.getModule());
       destroy = destroyFn;
       destroyFn->setAttributes(IGM.constructInitialAttributes());
       destroyFn->setCallingConv(IGM.SwiftCC);
@@ -429,7 +429,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
                                                IGM.SizeTy},
                                               /*vararg*/ false);
       auto copyFn = llvm::Function::Create(copyType,
-        llvm::GlobalValue::PrivateLinkage, "keypath_copy", IGM.getModule());
+        IGM.getGenFuncLinkage(), "keypath_copy", IGM.getModule());
       copy = copyFn;
       copyFn->setAttributes(IGM.constructInitialAttributes());
       copyFn->setCallingConv(IGM.SwiftCC);
@@ -548,7 +548,7 @@ getInitializerForComputedComponent(IRGenModule &IGM,
       /*dest*/ IGM.Int8PtrTy }, /*vararg*/ false);
       
   auto initFn = llvm::Function::Create(fnTy,
-    llvm::GlobalValue::PrivateLinkage, "keypath_arg_init", IGM.getModule());
+    IGM.getGenFuncLinkage(), "keypath_arg_init", IGM.getModule());
   initFn->setAttributes(IGM.constructInitialAttributes());
   initFn->setCallingConv(IGM.SwiftCC);
     

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2410,7 +2410,7 @@ namespace {
                                             /*vararg*/ false);
 
         auto *accessor = llvm::Function::Create(
-            fnTy, llvm::GlobalValue::PrivateLinkage, symbol, IGM.getModule());
+            fnTy, IGM.getGenFuncLinkage(), symbol, IGM.getModule());
 
         accessor->setAttributes(IGM.constructInitialAttributes());
 

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -1351,7 +1351,7 @@ irgen::getOrCreateGetExtraInhabitantTagFunction(IRGenModule &IGM,
                                       false);
 
   // TODO: use a meaningful mangled name and internal/shared linkage.
-  auto fn = llvm::Function::Create(fnTy, llvm::Function::PrivateLinkage,
+  auto fn = llvm::Function::Create(fnTy, IGM.getGenFuncLinkage(),
                                    "__swift_get_extra_inhabitant_index",
                                    &IGM.Module);
   fn->setAttributes(IGM.constructInitialAttributes());
@@ -1435,7 +1435,7 @@ irgen::getOrCreateStoreExtraInhabitantTagFunction(IRGenModule &IGM,
                                       false);
 
   // TODO: use a meaningful mangled name and internal/shared linkage.
-  auto fn = llvm::Function::Create(fnTy, llvm::Function::PrivateLinkage,
+  auto fn = llvm::Function::Create(fnTy, IGM.getGenFuncLinkage(),
                                    "__swift_store_extra_inhabitant_index",
                                    &IGM.Module);
   fn->setAttributes(IGM.constructInitialAttributes());

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -244,7 +244,7 @@ getTypeRefByFunction(IRGenModule &IGM,
       auto fnTy = llvm::FunctionType::get(IGM.TypeMetadataPtrTy,
                                           {IGM.Int8PtrTy}, /*vararg*/ false);
       accessor =
-        llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage,
+        llvm::Function::Create(fnTy, IGM.getGenFuncLinkage(),
                                symbolName, IGM.getModule());
       accessor->setAttributes(IGM.constructInitialAttributes());
       
@@ -470,7 +470,7 @@ IRGenModule::emitWitnessTableRefString(CanType type,
         auto fnTy = llvm::FunctionType::get(WitnessTablePtrTy,
                                             {Int8PtrTy}, /*vararg*/ false);
         auto accessorThunk =
-          llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage,
+          llvm::Function::Create(fnTy, getGenFuncLinkage(),
                                  symbolName, getModule());
         accessorThunk->setAttributes(constructInitialAttributes());
         

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1874,6 +1874,14 @@ public:
   llvm::MDNode *createProfileWeights(uint64_t TrueCount,
                                      uint64_t FalseCount) const;
 
+  /// Return the linkage used for generated functions. It is
+  /// special-cased for Windows/AArch64 due to a linker relocation
+  /// limitation.
+  llvm::GlobalValue::LinkageTypes getGenFuncLinkage() const {
+    return (Triple.isOSWindows() && Triple.isAArch64()) ?
+        llvm::GlobalValue::InternalLinkage : llvm::GlobalValue::PrivateLinkage;
+  }
+
 private:
   void emitGlobalDecl(Decl *D);
 };

--- a/lib/IRGen/TypeLayoutVerifier.cpp
+++ b/lib/IRGen/TypeLayoutVerifier.cpp
@@ -305,7 +305,7 @@ void IRGenModule::emitTypeVerifier() {
   // Create a new function to contain our logic.
   auto fnTy = llvm::FunctionType::get(VoidTy, /*varArg*/ false);
   auto VerifierFunction = llvm::Function::Create(fnTy,
-                                             llvm::GlobalValue::PrivateLinkage,
+                                             getGenFuncLinkage(),
                                              "type_verifier",
                                              getModule());
   VerifierFunction->setAttributes(constructInitialAttributes());

--- a/test/IRGen/objc_extensions_jit.swift
+++ b/test/IRGen/objc_extensions_jit.swift
@@ -11,6 +11,6 @@ extension GenericClass {
   @objc func fn() {}
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private void @runtime_registration
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{private|internal}} void @runtime_registration
 // CHECK-NOT: @__swift_instantiateConcreteTypeFromMangledName
 // CHECK: ret void

--- a/test/IRGen/objc_properties_jit.swift
+++ b/test/IRGen/objc_properties_jit.swift
@@ -13,7 +13,7 @@ extension NSString {
   }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private void @runtime_registration
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{private|internal}} void @runtime_registration
 // CHECK:         [[NSOBJECT_UNINIT:%.*]] = load ptr, ptr @"OBJC_CLASS_REF_$_NSString"
 // CHECK:         [[NSOBJECT:%.*]] = call ptr @{{.*}}(ptr [[NSOBJECT_UNINIT]])
 // CHECK:         [[GET_CLASS_PROP:%.*]] = call ptr @sel_registerName({{.*}}(classProp)


### PR DESCRIPTION
This is to work around the linker limitation for the relocation type IMAGE_REL_ARM64_BRANCH26 with a non-zero offset.

This fixes a bunch of swift tests under Windows AArch64 that were crashing because of the relocation issue.
