### PR TITLE
[rebranch] Fix memory effects attributes

### DIFF
--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -44,6 +44,7 @@ llvm::Constant *getRuntimeFn(llvm::Module &Module, llvm::Constant *&cache,
                              llvm::ArrayRef<llvm::Type *> retTypes,
                              llvm::ArrayRef<llvm::Type *> argTypes,
                              llvm::ArrayRef<llvm::Attribute::AttrKind> attrs,
+                             llvm::ArrayRef<llvm::MemoryEffects> memEffects,
                              irgen::IRGenModule *IGM = nullptr);
 
 llvm::FunctionType *getRuntimeFnType(llvm::Module &Module,

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -79,7 +79,7 @@ FUNCTION(ProjectBox, swift_projectBox, C_CC, AlwaysAvailable,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, WillReturn),
          EFFECT(NoEffect),
-         MEMEFFECTS(ReadOnly, ArgMemOnly))
+         MEMEFFECTS(ArgMemReadOnly))
 
 FUNCTION(AllocEmptyBox, swift_allocEmptyBox, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
@@ -1214,7 +1214,7 @@ FUNCTION(GetObjCClassFromObject, swift_getObjCClassFromObject,
          ARGS(ObjCPtrTy),
          ATTRS(NoUnwind, WillReturn),
          EFFECT(NoEffect), // ?
-         MEMEFFECTS(ReadOnly, ArgMemOnly))
+         MEMEFFECTS(ArgMemReadOnly))
 
 // MetadataResponse swift_getTupleTypeMetadata(MetadataRequest request,
 //                                             TupleTypeFlags flags,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -753,6 +753,7 @@ namespace RuntimeConstants {
   const auto ReadNone = llvm::MemoryEffects::none();
   const auto ReadOnly = llvm::MemoryEffects::readOnly();
   const auto ArgMemOnly = llvm::MemoryEffects::argMemOnly();
+  const auto ArgMemReadOnly = llvm::MemoryEffects::argMemOnly(llvm::ModRefInfo::Ref);
   const auto NoReturn = llvm::Attribute::NoReturn;
   const auto NoUnwind = llvm::Attribute::NoUnwind;
   const auto ZExt = llvm::Attribute::ZExt;
@@ -936,6 +937,16 @@ static bool isReturnedAttribute(llvm::Attribute::AttrKind Attr) {
   return Attr == llvm::Attribute::Returned;
 }
 
+static llvm::MemoryEffects mergeMemoryEffects(ArrayRef<llvm::MemoryEffects> effects) {
+    if (effects.empty())
+      return llvm::MemoryEffects::unknown();
+    llvm::MemoryEffects mergedEffects = llvm::MemoryEffects::none();
+    for (auto effect : effects)
+        mergedEffects |= effect;
+    return mergedEffects;
+}
+
+
 namespace {
 bool isStandardLibrary(const llvm::Module &M) {
   if (auto *Flags = M.getNamedMetadata("swift.module.flags")) {
@@ -975,15 +986,12 @@ llvm::FunctionType *swift::getRuntimeFnType(llvm::Module &Module,
                                  /*isVararg*/ false);
 }
 
-llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
-                      llvm::Constant *&cache,
-                      const char *name,
-                      llvm::CallingConv::ID cc,
-                      RuntimeAvailability availability,
-                      llvm::ArrayRef<llvm::Type*> retTypes,
-                      llvm::ArrayRef<llvm::Type*> argTypes,
-                      ArrayRef<Attribute::AttrKind> attrs,
-                      IRGenModule *IGM) {
+llvm::Constant *swift::getRuntimeFn(
+    llvm::Module &Module, llvm::Constant *&cache, const char *name,
+    llvm::CallingConv::ID cc, RuntimeAvailability availability,
+    llvm::ArrayRef<llvm::Type *> retTypes,
+    llvm::ArrayRef<llvm::Type *> argTypes, ArrayRef<Attribute::AttrKind> attrs,
+    ArrayRef<llvm::MemoryEffects> memEffects, IRGenModule *IGM) {
 
   if (cache)
     return cache;
@@ -1036,7 +1044,7 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
     if (!isStandardLibrary(Module) && IsExternal &&
         ::useDllStorage(llvm::Triple(Module.getTargetTriple())))
       fn->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
-    
+
     if (IsExternal && isWeakLinked
         && !::useDllStorage(llvm::Triple(Module.getTargetTriple())))
       fn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
@@ -1053,6 +1061,13 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
       else
         buildFnAttr.addAttribute(Attr);
     }
+
+    llvm::MemoryEffects mergedEffects = mergeMemoryEffects(memEffects);
+    if (mergedEffects != llvm::MemoryEffects::unknown()) {
+      buildFnAttr.addAttribute(llvm::Attribute::getWithMemoryEffects(
+          Module.getContext(), mergedEffects));
+    }
+
     fn->addFnAttrs(buildFnAttr);
     fn->addRetAttrs(buildRetAttr);
     fn->addParamAttrs(0, buildFirstParamAttr);
@@ -1112,8 +1127,8 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
 #define ATTRS(...) { __VA_ARGS__ }
 #define NO_ATTRS {}
 #define EFFECT(...) { __VA_ARGS__ }
-#define UNKNOWN_MEMEFFECTS                                                          \
-  { llvm::MemoryEffects::unknown() }
+#define UNKNOWN_MEMEFFECTS                                                     \
+  {}
 #define MEMEFFECTS(...)                                                        \
   { __VA_ARGS__ }
 
@@ -1124,15 +1139,12 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
     registerRuntimeEffect(EFFECT, #NAME);                                      \
     return getRuntimeFn(Module, ID##Fn, #NAME, CC,                             \
                         AVAILABILITY(this->Context), RETURNS, ARGS, ATTRS,     \
-                        this);                                                 \
+                        MEMEFFECTS, this);                                     \
   }                                                                            \
   FunctionPointer IRGenModule::get##ID##FunctionPointer() {                    \
     using namespace RuntimeConstants;                                          \
     auto fn = get##ID##Fn();                                                   \
     auto fnTy = get##ID##FnType();                                             \
-    llvm::MemoryEffects effects = llvm::MemoryEffects::none();                 \
-    for (auto effect : MEMEFFECTS)                                             \
-      effects |= effect;                                                       \
     llvm::AttributeList attrs;                                                 \
     SmallVector<llvm::Attribute::AttrKind, 8> theAttrs(ATTRS);                 \
     for (auto Attr : theAttrs) {                                               \
@@ -1143,9 +1155,12 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
       else                                                                     \
         attrs = attrs.addFnAttribute(getLLVMContext(), Attr);                  \
     }                                                                          \
-    attrs = attrs.addFnAttribute(                                              \
-        getLLVMContext(),                                                      \
-        llvm::Attribute::getWithMemoryEffects(getLLVMContext(), effects));     \
+    llvm::MemoryEffects effects = mergeMemoryEffects(MEMEFFECTS);              \
+    if (effects != llvm::MemoryEffects::unknown()) {                           \
+      attrs = attrs.addFnAttribute(                                            \
+          getLLVMContext(),                                                    \
+          llvm::Attribute::getWithMemoryEffects(getLLVMContext(), effects));   \
+    }                                                                          \
     auto sig = Signature(fnTy, attrs, CC);                                     \
     return FunctionPointer::forDirect(FunctionPointer::Kind::Function, fn,     \
                                       nullptr, sig);                           \

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -224,7 +224,7 @@ private:
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_retain" : "swift_retain",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {ObjectPtrTy},
-        {ObjectPtrTy}, {NoUnwind, FirstParamReturned});
+        {ObjectPtrTy}, {NoUnwind, FirstParamReturned}, {});
 
     return Retain.get();
   }
@@ -241,7 +241,7 @@ private:
                            isNonAtomic(OrigI) ? "swift_nonatomic_release"
                                               : "swift_release",
                            DefaultCC, RuntimeAvailability::AlwaysAvailable,
-                           {VoidTy}, {ObjectPtrTy}, {NoUnwind});
+                           {VoidTy}, {ObjectPtrTy}, {NoUnwind}, {});
 
     return Release.get();
   }
@@ -277,7 +277,7 @@ private:
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_retain_n" : "swift_retain_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {ObjectPtrTy},
-        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned});
+        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned}, {});
 
     return RetainN.get();
   }
@@ -295,7 +295,7 @@ private:
                             isNonAtomic(OrigI) ? "swift_nonatomic_release_n"
                                                : "swift_release_n",
                             DefaultCC, RuntimeAvailability::AlwaysAvailable,
-                            {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
+                            {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind}, {});
 
     return ReleaseN.get();
   }
@@ -314,7 +314,7 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_unknownObjectRetain_n"
                            : "swift_unknownObjectRetain_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {ObjectPtrTy},
-        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned});
+        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned}, {});
 
     return UnknownObjectRetainN.get();
   }
@@ -333,7 +333,7 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_unknownObjectRelease_n"
                            : "swift_unknownObjectRelease_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {VoidTy},
-        {ObjectPtrTy, Int32Ty}, {NoUnwind});
+        {ObjectPtrTy, Int32Ty}, {NoUnwind}, {});
 
     return UnknownObjectReleaseN.get();
   }
@@ -351,7 +351,7 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRetain_n"
                            : "swift_bridgeObjectRetain_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {BridgeObjectPtrTy},
-        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
+        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind}, {});
     return BridgeRetainN.get();
   }
 
@@ -370,7 +370,7 @@ private:
         isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRelease_n"
                            : "swift_bridgeObjectRelease_n",
         DefaultCC, RuntimeAvailability::AlwaysAvailable, {VoidTy},
-        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
+        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind}, {});
     return BridgeReleaseN.get();
   }
 

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -349,7 +349,7 @@ func testBlocksWithGenerics(hba: HasBlockArray) -> Any {
 // CHECK: load ptr, ptr @"\01L_selector(initWithInt:)"
 // CHECK: call ptr @objc_msgSend
 
-// CHECK: attributes [[NOUNWIND]] = { nounwind readonly }
+// CHECK: attributes [[NOUNWIND]] = { nounwind memory(read) }
 
 // CHECK: ![[SWIFT_NAME_ALIAS_VAR]] = !DILocalVariable(name: "obj", arg: 1, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])
 // CHECK: ![[LET_SWIFT_NAME_ALIAS_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -102,5 +102,5 @@ public struct P0Impl : P0 {
 // CHECK: define{{.*}} swiftcc ptr @"$s16associated_types6P0ImplVAA0C0AA9ErrorTypeAaDP_s0E0PWT"(ptr %P0Impl.ErrorType, ptr %P0Impl, ptr %P0Impl.P0)
 // CHECK:  ret ptr @"$ss5ErrorWS"
 
-// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone willreturn }
+// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind willreturn memory(none) }
 

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -124,5 +124,5 @@ func objc_enum_method_calls(_ x: ObjCEnumMethods) {
   x.prop = x.enumOut()
 }
 
-// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
+// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind memory(none) }
 

--- a/test/IRGen/readonly.sil
+++ b/test/IRGen/readonly.sil
@@ -17,7 +17,7 @@ sil @XXX_ctor : $@convention(method) (@owned XXX) -> @owned XXX
 // to the LLVM read only attribute, unless IRGen can prove by analyzing
 // the function body that this function is really read only.
 
-// CHECK-NOT: ; Function Attrs: readonly
+// CHECK-NOT: ; Function Attrs:{{.*}}memory(read)
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_foo(
 sil [readonly] @function_foo : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
@@ -30,7 +30,7 @@ bb0(%0 : $Int):
 // to the LLVM read only attribute, unless IRGen can prove by analyzing
 // the function body that this function is really read only or read none.
 
-// CHECK-NOT: ; Function Attrs: readonly
+// CHECK-NOT: ; Function Attrs:{{.*}}memory(read)
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_foo2(
 sil [readnone] @function_foo2 : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
@@ -41,7 +41,7 @@ bb0(%0 : $Int):
 // There's an @owned parameter, and destructors can call arbitrary code
 // -- function is not read only at LLVM level
 
-// CHECK-NOT: ; Function Attrs: readonly
+// CHECK-NOT: ; Function Attrs:{{.*}}memory(read)
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_bar(
 sil [readonly] @function_bar : $@convention(thin) (@owned XXX) -> () {
 bb0(%0 : $XXX):
@@ -52,7 +52,7 @@ bb0(%0 : $XXX):
 
 // There's an @out parameter -- function is not read only at LLVM level
 
-// CHECK-NOT: ; Function Attrs: readonly
+// CHECK-NOT: ; Function Attrs:{{.*}}memory(read)
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_baz(
 sil [readonly] @function_baz : $@convention(thin) () -> (@out Any) {
 bb0(%0 : $*Any):


### PR DESCRIPTION
`ReadOnly, ArgMemOnly` previously meant `can only read argument memory`.
But with the rebranch changes, this became `(can only read *all* memory)
and (can read or write argument memory)`. Use `ArgMemReadOnly` for this
instead.

To expand on this, these attributes (prior to memory effects) used to be
split into two. There was the *kind* of access, eg.
```
readnone
readonly
writeonly
```
and the accessed *location*, eg.
```
argmemonly
inaccessiblememonly
inaccessiblemem_or_argmemonly
```

So `RuntimeFunctions.def` would use `ReadOnly, ArgMemOnly` to mean `can
only read argument memory`.

In the previous rebranch commits, this was changed such that `ReadOnly`
mapped to `MemoryEffectsBase::readOnly()` and `ArgMemOnly` to
`MemoryEffectsBase::argMemOnly()`.

And there lies the issue -
  - `MemoryEffectsBase::readOnly()` == `MemoryEffectsBase(Ref)` ie. all
    locations can only read
  - `MemoryEffectsBase::argMemOnly()` == `MemoryEffectsBase(ArgMem,
    ModRef)`, ie. can only access argument memory

But then OR'ing those together this would become:
```
ArgMem: ModRef, InaccessibleMem: Ref, Other: Ref
```
rather than the previously intended:
```
ArgMem: Ref, InaccessibleMem: NoModRef, Other: NoModRef
```