### PR TITLE
Sema: Correct availability for @inlinable global var accessors bodies

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -597,7 +597,7 @@ private:
     // constrained to the deployment target. There's not much benefit to
     // checking these declarations at a lower availability version floor since
     // neither can be used by API clients.
-    if (D->isSPI() || AvailableAttr::isUnavailable(D))
+    if (D->isSPI() || D->getSemanticUnavailableAttr())
       return true;
 
     return !::isExported(D);


### PR DESCRIPTION
The bodies of unavailable functions should be typechecked as if they would always run at the deployment target, even if they are `@inlinable`. This was not the case in the bodies of unavailable `@inlinable` global var accessors, though, because the availability of the accessor, rather than enclosing var, was being queried. The fix is to use `getSemanticUnavailableAttr()`.

Resolves rdar://113642576
