### PR TITLE
[stdlib] 2nd attempt at fixing calling convention mismatch for debugger utility functions

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -280,19 +280,19 @@ internal func _withHeapObject<R>(
 }
 
 // Utilities to get refcount(s) of class objects.
-@_alwaysEmitIntoClient
+@backDeployed(before: SwiftStdlib 5.10)
 public func _getRetainCount(_ object: AnyObject) -> UInt {
   let count = _withHeapObject(of: object) { swift_retainCount($0) }
   return UInt(bitPattern: count)
 }
 
-@_alwaysEmitIntoClient
+@backDeployed(before: SwiftStdlib 5.10)
 public func _getUnownedRetainCount(_ object: AnyObject) -> UInt {
   let count = _withHeapObject(of: object) { swift_unownedRetainCount($0) }
   return UInt(bitPattern: count)
 }
 
-@_alwaysEmitIntoClient
+@backDeployed(before: SwiftStdlib 5.10)
 public func _getWeakRetainCount(_ object: AnyObject) -> UInt {
   let count = _withHeapObject(of: object) { swift_weakRetainCount($0) }
   return UInt(bitPattern: count)


### PR DESCRIPTION
From @kateinoigakukun in https://github.com/apple/swift/pull/66531:

> The functions `swift_retainCount`, `swift_unownedRetainCount`, and `swift_weakRetainCount` are declared in `HeapObject.h` as using the C calling convention, but the Swift declarations referenced them by `@_silgen_name`, which uses the Swift calling convention. This patch fixes the mismatch without any ABI/API breakage by calling the utility functions through C interop.

This is another attempt at fixing this calling convention mismatch by replacing the bogus `@_silgen_name` forwards with native Swift forwarder implementations. This variant does not break binary compatibility with previous OS releases (if an app happens to call these for some reason), and it tries to avoid undefined behavior around `unsafeBitCast` vs reference types.

This introduces `_withHeapObject` to help retrieve a pointer to the `HeapObject` header of a Swift object. (This may also come handy for exposing other runtime functions in subsequent PRs — `swift_retain_n`/`swift_release_n` in particular.)

rdar://113660884
