### PR TITLE
build-script: Fix log file not found in dry run mode

### DIFF
--- a/utils/swift_build_support/swift_build_support/utils.py
+++ b/utils/swift_build_support/swift_build_support/utils.py
@@ -48,6 +48,10 @@ def clear_log_time():
 
 
 def log_time(event, command, duration=0):
+    # NOTE: When running a dry run, the log file isn't created
+    if not os.path.exists(log_time_path()):
+        return
+
     f = open(log_time_path(), "a")
 
     log_event = {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Running build-script in dry run mode fails because the log file is not found (not created because of dry run).

We could check for `args.dry_run` but a simpler solution is to just check if the file exists.