### PR TITLE
🍒[cxx-interop] Fix SwiftCompilerSources hosttools build

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -830,4 +830,56 @@ struct InheritedTemplatedConstRACIteratorOutOfLineOps
 typedef InheritedTemplatedConstRACIteratorOutOfLineOps<int>
     InheritedTemplatedConstRACIteratorOutOfLineOpsInt;
 
+
+/// clang::StmtIteratorBase
+class ProtectedIteratorBase {
+protected:
+  int value;
+  ProtectedIteratorBase() : value(0) {}
+};
+
+/// clang::StmtIteratorImpl
+template <typename DERIVED>
+class ProtectedIteratorImpl : public ProtectedIteratorBase {
+protected:
+  ProtectedIteratorImpl(const ProtectedIteratorBase& RHS) : ProtectedIteratorBase(RHS) {}
+
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = int;
+  using difference_type = std::ptrdiff_t;
+  using pointer = int *;
+  using reference = int &;
+
+  ProtectedIteratorImpl() = default;
+
+  DERIVED& operator++() {
+    value++;
+    return static_cast<DERIVED&>(*this);
+  }
+
+  DERIVED operator++(int) {
+    DERIVED tmp = static_cast<DERIVED&>(*this);
+    operator++();
+    return tmp;
+  }
+
+  friend bool operator==(const DERIVED &LHS, const DERIVED &RHS) {
+    return LHS.value == RHS.value;
+  }
+
+  reference operator*() const {
+    return value;
+  }
+};
+
+/// StmtIterator
+struct HasInheritedProtectedCopyConstructor : public ProtectedIteratorImpl<HasInheritedProtectedCopyConstructor> {
+  HasInheritedProtectedCopyConstructor() = default;
+
+private:
+  HasInheritedProtectedCopyConstructor(const ProtectedIteratorBase &other)
+      : ProtectedIteratorImpl<HasInheritedProtectedCopyConstructor>(other) {}
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_ITERATOR_H


### PR DESCRIPTION
This fixes a compiler error when building SwiftCompilerSources in hosttools mode with a recent Xcode.

```
<unknown>:0: error: calling a private constructor of class 'clang::StmtIterator'
swift/llvm-project/clang/include/clang/AST/StmtIterator.h:137:3: note: declared private here
  StmtIterator(const StmtIteratorBase &RHS)
  ^
```

rdar://113514872

(cherry picked from commit c621d13711db5b2e7d47e1c32a568994a4292287)