### PR TITLE
[cxx-interop] Add `UnsafeCxxMutableRandomAccessIterator` protocol

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -119,6 +119,7 @@ PROTOCOL(CxxVector)
 PROTOCOL(UnsafeCxxInputIterator)
 PROTOCOL(UnsafeCxxMutableInputIterator)
 PROTOCOL(UnsafeCxxRandomAccessIterator)
+PROTOCOL(UnsafeCxxMutableRandomAccessIterator)
 
 PROTOCOL(AsyncSequence)
 PROTOCOL(AsyncIteratorProtocol)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1143,6 +1143,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   case KnownProtocolKind::UnsafeCxxInputIterator:
   case KnownProtocolKind::UnsafeCxxMutableInputIterator:
   case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
+  case KnownProtocolKind::UnsafeCxxMutableRandomAccessIterator:
     M = getLoadedModule(Id_Cxx);
     break;
   default:

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -563,8 +563,12 @@ void swift::conformToCxxIteratorIfNeeded(
     return;
 
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Distance"), distanceTy);
-  impl.addSynthesizedProtocolAttrs(
-      decl, {KnownProtocolKind::UnsafeCxxRandomAccessIterator});
+  if (pointeeSettable)
+    impl.addSynthesizedProtocolAttrs(
+        decl, {KnownProtocolKind::UnsafeCxxMutableRandomAccessIterator});
+  else
+    impl.addSynthesizedProtocolAttrs(
+        decl, {KnownProtocolKind::UnsafeCxxRandomAccessIterator});
 }
 
 void swift::conformToCxxOptionalIfNeeded(

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6314,6 +6314,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::UnsafeCxxInputIterator:
   case KnownProtocolKind::UnsafeCxxMutableInputIterator:
   case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
+  case KnownProtocolKind::UnsafeCxxMutableRandomAccessIterator:
   case KnownProtocolKind::Executor:
   case KnownProtocolKind::SerialExecutor:
   case KnownProtocolKind::Sendable:

--- a/stdlib/public/Cxx/UnsafeCxxIterators.swift
+++ b/stdlib/public/Cxx/UnsafeCxxIterators.swift
@@ -80,3 +80,7 @@ public protocol UnsafeCxxRandomAccessIterator: UnsafeCxxInputIterator {
 extension UnsafePointer: UnsafeCxxRandomAccessIterator {}
 
 extension UnsafeMutablePointer: UnsafeCxxRandomAccessIterator {}
+
+public protocol UnsafeCxxMutableRandomAccessIterator: UnsafeCxxRandomAccessIterator, UnsafeCxxMutableInputIterator {}
+
+extension UnsafeMutablePointer: UnsafeCxxMutableRandomAccessIterator {}

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -138,7 +138,7 @@
 // CHECK:   typealias Pointee = Int32
 // CHECK: }
 
-// CHECK: struct MutableRACIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxMutableInputIterator {
+// CHECK: struct MutableRACIterator : UnsafeCxxMutableRandomAccessIterator, UnsafeCxxMutableInputIterator {
 // CHECK:   func successor() -> MutableRACIterator
 // CHECK:   var pointee: Int32
 // CHECK:   typealias Pointee = Int32


### PR DESCRIPTION
This will be used to provide a safe overload of `std::vector::erase` in Swift.

`std::vector::erase` is not currently imported into Swift because it returns a C++ iterator.

rdar://113704853