### PR TITLE
[Runtime] Fix up the heap destroyer in objc_setClassCopyFixupHandler.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -81,6 +81,9 @@ struct HeapObject;
 class WeakReference;
 struct UnownedReference;
 
+using HeapObjectDestroyer =
+  SWIFT_CC(swift) void(SWIFT_CONTEXT HeapObject *);
+
 /// The result of requesting type metadata.  Generally the return value of
 /// a function.
 ///
@@ -514,9 +517,6 @@ struct TargetOpaqueMetadata {
   TargetMetadata<Runtime> base;
 };
 
-using HeapObjectDestroyer =
-  SWIFT_CC(swift) void(SWIFT_CONTEXT HeapObject *);
-
 /// The prefix on a heap metadata.
 template <typename Runtime>
 struct TargetHeapMetadataHeaderPrefix {
@@ -561,6 +561,14 @@ struct TargetHeapMetadata : TargetMetadata<Runtime> {
     : TargetMetadata<Runtime>(kind) {}
   constexpr TargetHeapMetadata(TargetAnyClassMetadataObjCInterop<Runtime> *isa)
     : TargetMetadata<Runtime>(isa) {}
+
+  HeapObjectDestroyer *getHeapObjectDestroyer() const {
+    return asFullMetadata(this)->destroy;
+  }
+
+  void setHeapObjectDestroyer(HeapObjectDestroyer *destroy) {
+    asFullMetadata(this)->destroy = destroy;
+  }
 };
 using HeapMetadata = TargetHeapMetadata<InProcess>;
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -510,9 +510,11 @@ static void swift_objc_classCopyFixupHandler(Class oldClass, Class newClass) {
   if (!oldClassMetadata->isTypeMetadata())
    return;
 
-  // Copy the value witness table pointer for pointer authentication.
+  // Copy the value witness table and pointer and heap object destroyer for
+  // pointer authentication.
   auto newClassMetadata = reinterpret_cast<ClassMetadata *>(newClass);
   newClassMetadata->setValueWitnesses(oldClassMetadata->getValueWitnesses());
+  newClassMetadata->setHeapObjectDestroyer(oldClassMetadata->getHeapObjectDestroyer());
 
  // Otherwise, re-sign v-table entries using the extra discriminators stored
  // in the v-table descriptor.

--- a/test/Interpreter/SDK/dynamic_subclass.swift
+++ b/test/Interpreter/SDK/dynamic_subclass.swift
@@ -6,22 +6,37 @@
 import Foundation
 import ObjectiveC
 
-func DoSwizzle(_ c: AnyClass) -> AnyClass {
+func DoSwizzle<T: AnyObject>(_ c: T.Type) -> T.Type {
     let name = String(utf8String: class_getName(c))!
     let subclass: AnyClass = objc_allocateClassPair(c, "\(name)Subclass", 0)!
     objc_registerClassPair(subclass);
     let subclassSubclass: AnyClass = objc_allocateClassPair(subclass, "\(name)SubclassSubclass", 0)!
     objc_registerClassPair(subclassSubclass);
-    return subclassSubclass
-}
-
-class MySwiftClassToBeSwizzled: NSObject {
+    return subclassSubclass as! T.Type
 }
 
 _ = DoSwizzle(NSArray.self)
 print("Swizzled NSArray")
 // CHECK: Swizzled NSArray
 
-_ = DoSwizzle(MySwiftClassToBeSwizzled.self)
+// Ensure that we can dynamically subclass, instantiate, and destroy Swift
+// classes, both NSObject-inheriting and native Swift.
+class MySwiftClassToBeSwizzled {
+  required init() {}
+}
+
+let swiftSubclass = DoSwizzle(MySwiftClassToBeSwizzled.self)
 print("Swizzled MySwiftClassToBeSwizzled")
 // CHECK: Swizzled MySwiftClassToBeSwizzled
+print("Instantiated the subclass: \(swiftSubclass.init())")
+// CHECK: Instantiated the subclass:
+
+class MyNSObjectSwiftClassToBeSwizzled: NSObject {
+  required override init() {}
+}
+
+let swiftNSObjectSubclass = DoSwizzle(MyNSObjectSwiftClassToBeSwizzled.self)
+print("Swizzled MyNSObjectSwiftClassToBeSwizzled")
+// CHECK: Swizzled MyNSObjectSwiftClassToBeSwizzled
+print("Instantiated the subclass: \(swiftNSObjectSubclass.init())")
+// CHECK: Instantiated the subclass:


### PR DESCRIPTION
We fix up the VWT pointer, but not the heap destroyer. This doesn't matter for classes which use ObjC refcounting, which is the common case for dynamic subclasses, because that doesn't use the heap destroyer pointer. But it does matter for classes that use native Swift refcounting, such as classes that don't inherit from NSObject, or actors.

rdar://113657917