### PR TITLE
[SIL] Fix memInstMustInitialize for builtins.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -221,6 +221,7 @@ bool noncopyable::memInstMustInitialize(Operand *memOper) {
       // `zeroInitializer` with an address operand zeroes out the address operand
       return true;
     }
+    return false;
   }
 
 #define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \


### PR DESCRIPTION
The function's switch previously fell-through to the `SILInstructionKind::StoreWeakInst` case which cast the instruction (a `BuiltinInst`) to `StoreWeakInst` and then called `isInitializationOfDest` on it.
