### PR TITLE
Temporarily mute LLVM deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1321,6 +1321,15 @@ endif()
 add_subdirectory(include)
 
 if(SWIFT_INCLUDE_TOOLS)
+
+  # TODO Remove this once release/5.9 is done and we can finish migrating Swift
+  #      off of `llvm::None`/`llvm::Optional`, and `llvm::makeArrayRef`.
+  # This is to silence the avalanche of deprecation warnings from LLVM headers
+  # until we can actually do something about them. This is nasty, but it's
+  # better than losing context due to the sheer number in-actionable deprecation
+  # warnings or the massive number of merge-conflicts we would get otherwise.
+  add_definitions(-DSWIFT_TARGET)
+
   add_subdirectory(lib)
 
   # SwiftCompilerSources must come before "tools".


### PR DESCRIPTION
Swift can't do anything with the None warnings until the release/5.9 branch is well and dead and folks don't need to cherry-pick things back anymore. The wall of warnings is mostly unhelpful as it masks actual issues.

 - Tracking proper upgrades in rdar://112153764