### PR TITLE
[cxx-interop] Make sure to create empty initializers for C++ structs

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2381,8 +2381,12 @@ namespace {
         hasMemberwiseInitializer = false;
       }
 
-      if (hasZeroInitializableStorage &&
-          !(cxxRecordDecl && cxxRecordDecl->hasDefaultConstructor())) {
+      bool needsEmptyInitializer = true;
+      if (cxxRecordDecl) {
+        needsEmptyInitializer = !cxxRecordDecl->hasDefaultConstructor() ||
+                                cxxRecordDecl->ctors().empty();
+      }
+      if (hasZeroInitializableStorage && needsEmptyInitializer) {
         // Add default constructor for the struct if compiling in C mode.
         // If we're compiling for C++:
         // 1. If a default constructor is declared, don't synthesize one.

--- a/test/Interop/Cxx/objc-correctness/pthread_mutexattr_t.swift
+++ b/test/Interop/Cxx/objc-correctness/pthread_mutexattr_t.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-objc-interop -enable-experimental-cxx-interop
+// REQUIRES: OS=macosx
+
+import Darwin
+
+_ = pthread_mutexattr_t() // expected-warning {{'init()' is deprecated: This zero-initializes the backing memory of the struct}}

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
@@ -35,6 +35,9 @@ public func useConcreteTemplate() {
 // CHECK-EMPTY:
 // CHECK-NEXT: public struct TemplateRecord {
 // CHECK-EMPTY:
+// CHECK-NEXT:    @available(*, deprecated, message:
+// CHECK-NEXT:    public init()
+// CHECK-EMPTY:
 // CHECK-NEXT:    public func methodFunc(_ x: Any)
 // CHECK-NEXT:}
 // CHECK-NEXT:}

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
@@ -123,14 +123,23 @@ import CxxModule
 // CHECK-EMPTY:
 // CHECK-NEXT:  struct TemplateRecord {
 // CHECK-EMPTY:
+// CHECK-NEXT:    @available(*, deprecated, message:
+// CHECK-NEXT:    public init()
+// CHECK-EMPTY:
 // CHECK-NEXT:    mutating func methodFunc(_ x: Any)
 // CHECK-EMPTY:
 // CHECK-NEXT:    struct InnerRecord {
+// CHECK-EMPTY:
+// CHECK-NEXT:      @available(*, deprecated, message:
+// CHECK-NEXT:      public init()
 // CHECK-EMPTY:
 // CHECK-NEXT:      mutating func innerMethod(_ y: Any)
 // CHECK-NEXT:    }
 // CHECK-EMPTY:
 // CHECK-NEXT:    struct InnerTemplate {
+// CHECK-EMPTY:
+// CHECK-NEXT:    @available(*, deprecated, message:
+// CHECK-NEXT:    public init()
 // CHECK-EMPTY:
 // CHECK-NEXT:      mutating func innerTemplateMethod()
 // CHECK-NEXT:    }

--- a/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
@@ -66,11 +66,17 @@ public:
 // CHECK-NEXT:    var y: Int32
 // CHECK-NEXT:  }
 // CHECK-NEXT:  struct TemplateRecord {
+// CHECK-NEXT:    @available(*, deprecated, message:
+// CHECK-NEXT:    init()
 // CHECK-NEXT:    mutating func methodFunc(_ x: Any)
 // CHECK-NEXT:    struct InnerRecord {
+// CHECK-NEXT:      @available(*, deprecated, message:
+// CHECK-NEXT:      init()
 // CHECK-NEXT:      mutating func innerMethod(_ y: Any)
 // CHECK-NEXT:    }
 // CHECK-NEXT:    struct InnerTemplate {
+// CHECK-NEXT:      @available(*, deprecated, message:
+// CHECK-NEXT:      init()
 // CHECK-NEXT:      mutating func innerTemplateMethod()
 // CHECK-NEXT:    }
 // CHECK-NEXT:    mutating func returnsTemplateMethod()
@@ -79,7 +85,11 @@ public:
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias MyType = ns.TemplateRecord
 // CHECK-NEXT: struct OuterTemp2 {
+// CHECK-NEXT:   @available(*, deprecated, message:
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   struct InnerTemp2 {
+// CHECK-NEXT:     @available(*, deprecated, message:
+// CHECK-NEXT:     init()
 // CHECK-NEXT:     init(x2: Any)
 // CHECK-NEXT:     mutating func testMe(_ p: Any, _ x: Any)
 // CHECK-NEXT:     var x2: Any


### PR DESCRIPTION
The existing synthesis mechanism had a bug: `cxxRecordDecl->hasDefaultConstructor()` returns true for C++ types with an implicit default constructor, for instance, `pthread_mutexattr_t`.

rdar://113708880