### PR TITLE
Disable test that is failing CI

### DIFF
--- a/test/IRGen/debug_scope_distinct.swift
+++ b/test/IRGen/debug_scope_distinct.swift
@@ -1,3 +1,4 @@
+// REQUIRES: disabled
 // REQUIRES: differentiable_programming
 
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
Hopefully, someone can fix this soon and we can re-enable it.

```
/Users/ec2-user/jenkins/workspace/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/swift/test/IRGen/debug_scope_distinct.swift:12:11: error: CHECK: expected string not found in input
// CHECK: call void @llvm.dbg.value(metadata {{.*}} %[[ARG0]], metadata ![[VAR1:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64)), !dbg ![[LOC1:[0-9]+]]
          ^
<stdin>:1033:42: note: scanning from here
 %.sroa.013.0.copyload = load ptr, ptr %0, align 4, !dbg !305
                                         ^
<stdin>:1033:42: note: with "ARG0" equal to "\\.sroa\\.013\\.0\\.copyload"
 %.sroa.013.0.copyload = load ptr, ptr %0, align 4, !dbg !305
                                         ^
<stdin>:1040:2: note: possible intended match here
 call void @llvm.dbg.value(metadata i64 %4, metadata !299, metadata !DIExpression(DW_OP_LLVM_fragment, 40, 64)), !dbg !306
 ^
```

The input shows that line 1034 is this:
```
         1034:  call void @llvm.dbg.value(metadata ptr %.sroa.013.0.copyload, metadata !299, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 32)), !dbg !306
```
which differs in 32 vs. 64.  So I wonder if this is really an issue with integer size?

Link to a failing test:

https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/4234/
