### PR TITLE
Revert "[Dependency Scanning] Add Clang modules from scan-deps querie…

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -143,11 +143,6 @@ void ClangImporter::recordModuleDependencies(
                     ModuleDependencyKind::Clang))
       continue;
 
-    // Record this module as one we have now seen, to prevent future
-    // scand unnecessarily return it as a result
-    cache.addSeenClangModule(clang::tooling::dependencies::ModuleID{
-        clangModuleDep.ID.ModuleName, clangModuleDep.ID.ContextHash});
-
     // File dependencies for this module.
     std::vector<std::string> fileDeps;
     for (const auto &fileDep : clangModuleDep.FileDeps) {


### PR DESCRIPTION
…s to the set of"

This reverts commit 0c6f212cd59d31ac5d67a5b5f482be761eba1f20.

Commit doesn't build on rebranch. Reverting until it does to unblock rebranch qualification work.
Radar tracking bringing this back: rdar://113716819