### PR TITLE
[5.9.0][Macros] Always consider pre-macro-expansion conformances as subsumed by other conformance entry kinds, before considering availability.

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -565,20 +565,6 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
                                    ConformanceEntry *lhs,
                                    ConformanceEntry *rhs,
                                    bool &diagnoseSuperseded) {
-  // If only one of the conformances is unconditionally available on the
-  // current deployment target, pick that one.
-  //
-  // FIXME: Conformance lookup should really depend on source location for
-  // this to be 100% correct.
-  // FIXME: When a class and an extension with the same availability declare the
-  // same conformance, this silently takes the class and drops the extension.
-  if (lhs->getDeclContext()->isAlwaysAvailableConformanceContext() !=
-      rhs->getDeclContext()->isAlwaysAvailableConformanceContext()) {
-    return (lhs->getDeclContext()->isAlwaysAvailableConformanceContext()
-            ? Ordering::Before
-            : Ordering::After);
-  }
-
   ConformanceEntryKind lhsKind = lhs->getRankingKind();
   ConformanceEntryKind rhsKind = rhs->getRankingKind();
 
@@ -594,6 +580,20 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
               ? Ordering::Before
               : Ordering::After);
     }
+  }
+
+  // If only one of the conformances is unconditionally available on the
+  // current deployment target, pick that one.
+  //
+  // FIXME: Conformance lookup should really depend on source location for
+  // this to be 100% correct.
+  // FIXME: When a class and an extension with the same availability declare the
+  // same conformance, this silently takes the class and drops the extension.
+  if (lhs->getDeclContext()->isAlwaysAvailableConformanceContext() !=
+      rhs->getDeclContext()->isAlwaysAvailableConformanceContext()) {
+    return (lhs->getDeclContext()->isAlwaysAvailableConformanceContext()
+            ? Ordering::Before
+            : Ordering::After);
   }
 
   // If one entry is fixed and the other is not, we have our answer.

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1461,6 +1461,26 @@ public struct AlwaysAddConformance: ExtensionMacro {
   }
 }
 
+public struct ConditionallyAvailableConformance: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let decl: DeclSyntax =
+      """
+      @available(macOS 99, *)
+      extension \(raw: type.trimmedDescription): Equatable {}
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
 public struct AlwaysAddCodable: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -156,3 +156,12 @@ struct TestUndocumentedEncodable {}
 // CHECK-DIAGS: error: conformance to 'Codable' (aka 'Decodable & Encodable') is not covered by macro 'UndocumentedEncodable'
 
 #endif
+
+@attached(extension, conformances: Equatable)
+macro AvailableEquatable() = #externalMacro(module: "MacroDefinition", type: "ConditionallyAvailableConformance")
+
+@available(macOS 99, *)
+@AvailableEquatable
+struct TestAvailability {
+  static let x : any Equatable.Type = TestAvailability.self
+}


### PR DESCRIPTION
* **Explanation**: Extension macros that add conformances will have a placeholder `ConformanceEntry` so that the compiler can reason about which conformances will be added prior to macro expansion, and an explicit `ConformanceEntry` is added after the macro is expanded. However, the ranking between these conformances was considering availability before the conformance entry kind; if the macro-expanded conformance is less available than the always-available placeholder entry, the placeholder entry would be chosen. This lead to the conformance being dropped on the floor in serialization and SILGen, because the placeholder entry is just a placeholder, and when we create a `NormalProtocolConformance` for it, it's not complete. The fix is to swap the order of the availability check and the check for pre-macro-expansion placeholder conformance entries.
* **Scope**: Only impacts extension macros that introduce conformances.
* **Risk**: Very low. The change only swaps the order of two existing checks inside `ConformanceLookupTable::compareConformances`.
* **Testing**: Added a new test. Without this change, the test results in a linker error (because SILGen dropped the macro-introduced conformance).
* **Issue**: rdar://113569289
* **Reviewer**: @slavapestov
* **Main branch PR**: https://github.com/apple/swift/pull/67882
* **5.9 PR**: https://github.com/apple/swift/pull/67883