### PR TITLE
[5.9] Update macro help in driver and diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7113,9 +7113,7 @@ ERROR(macro_undefined,PointsToFirstBadToken,
       "no macro named %0", (Identifier))
 ERROR(external_macro_not_found,none,
       "external macro implementation type '%0.%1' could not be found for "
-      "macro %2; the type must be public and provided by a macro target in a "
-      "Swift package, or via '-plugin-path' or '-load-plugin-library'",
-      (StringRef, StringRef, DeclName))
+      "macro %2", (StringRef, StringRef, DeclName))
 ERROR(macro_must_be_defined,none,
       "macro %0 requires a definition", (DeclName))
 ERROR(external_macro_outside_macro_definition,none,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1823,8 +1823,8 @@ def load_plugin_library:
 def load_plugin_executable:
   Separate<["-"], "load-plugin-executable">, Group<plugin_search_Group>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
-  HelpText<"Path to an executable compiler plugins and providing module names "
-           "such as macros">,
+  HelpText<"Path to a compiler plugin executable and a comma-separated list "
+           "of module names where the macro types are declared">,
   MetaVarName<"<path>#<module-names>">;
 
 include "FrontendOptions.td"

--- a/test/Macros/macro_plugin_broken.swift
+++ b/test/Macros/macro_plugin_broken.swift
@@ -20,8 +20,8 @@
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK %s
 
 // CHECK: (null):0:0: warning: compiler plugin not loaded: {{.+}}broken-plugin; failed to initialize
-// CHECK: test.swift:1:33: warning: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro';
-// CHECK: test.swift:4:7: error: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro';
+// CHECK: test.swift:1:33: warning: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'
+// CHECK: test.swift:4:7: error: external macro implementation type 'TestPlugin.FooMacro' could not be found for macro 'fooMacro'
 // CHECK: +-{{.+}}test.swift:1:33: note: 'fooMacro' declared here
 
 //--- test.swift

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -136,7 +136,7 @@ func shadow(a: Int, b: Int, stringify: Int) {
 }
 
 func testMissing() {
-  #missingMacro1("hello") // expected-error{{external macro implementation type 'MissingModule.MissingType' could not be found for macro 'missingMacro1'; the type must be public and provided by a macro target in a Swift package, or via '-plugin-path' or '-load-plugin-library'}}
+  #missingMacro1("hello") // expected-error{{external macro implementation type 'MissingModule.MissingType' could not be found for macro 'missingMacro1'}}
 }
 
 @freestanding(expression) macro undefined() // expected-error{{macro 'undefined()' requires a definition}}


### PR DESCRIPTION
Cherry-pick #67834 and #67885 into release/5.9

* **Explanation**: `-load-plugin-executable` compiler option is the primary supported way of using macro plugin. SwiftPM uses this when developers use `.macro()` target. The driver help text should clarify the format and the semantics of the arguments. The diagnostic shouldn't mention `-plugin-path` or `-load-plugin-library`.
* **Scope**: Driver help message and diagnostic
* **Risk**: Extremely low, just some string changes
* **Testing**: Passes current test suite
* **Issues**: rdar://113646544