### PR TITLE
[Macros] Fix the formatting of the conformance list buffer for extension macro expansion.

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1235,9 +1235,13 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
   {
     llvm::raw_string_ostream OS(conformanceList);
     if (role == MacroRole::Extension) {
-      for (auto *protocol : conformances) {
-        protocol->getDeclaredType()->print(OS);
-      }
+      llvm::interleave(
+          conformances,
+          [&](const ProtocolDecl *protocol) {
+            protocol->getDeclaredType()->print(OS);
+          },
+          [&] { OS << ", "; }
+      );
     } else {
       OS << "";
     }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1443,6 +1443,24 @@ public struct ConditionallyAvailableConformance: ExtensionMacro {
   }
 }
 
+public struct AddAllConformancesMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    protocols.map { proto in
+      let decl: DeclSyntax =
+        """
+        extension \(type): \(proto) {}
+        """
+      return decl.cast(ExtensionDeclSyntax.self)
+    }
+  }
+}
+
 public struct AlwaysAddCodable: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -165,3 +165,17 @@ macro AvailableEquatable() = #externalMacro(module: "MacroDefinition", type: "Co
 struct TestAvailability {
   static let x : any Equatable.Type = TestAvailability.self
 }
+
+protocol P1 {}
+protocol P2 {}
+
+@attached(extension, conformances: P1, P2)
+macro AddAllConformances() = #externalMacro(module: "MacroDefinition", type: "AddAllConformancesMacro")
+
+@AddAllConformances
+struct MultipleConformances {}
+
+// CHECK-DUMP: extension MultipleConformances: P1 {
+// CHECK-DUMP: }
+// CHECK-DUMP: extension MultipleConformances: P2 {
+// CHECK-DUMP: }


### PR DESCRIPTION
Each protocol should be separated with a comma in the conformance list buffer.

Resolves rdar://113668922