### PR TITLE
AST: Fix EnumDecl's hasPotentiallyUnavailableCaseValue() cache

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5968,25 +5968,29 @@ bool EnumDecl::hasOnlyCasesWithoutAssociatedValues() const {
     case AssociatedValueCheck::HasAssociatedValues:
       return false;
   }
+
+  bool hasAnyUnavailableValues = false;
+  bool hasAssociatedValues = false;
+
   for (auto elt : getAllElements()) {
     for (auto Attr : elt->getAttrs()) {
       if (auto AvAttr = dyn_cast<AvailableAttr>(Attr)) {
-        if (!AvAttr->isInvalid()) {
-          const_cast<EnumDecl*>(this)->Bits.EnumDecl.HasAnyUnavailableValues
-            = true;
-        }
+        if (!AvAttr->isInvalid())
+          hasAnyUnavailableValues = true;
       }
     }
 
-    if (elt->hasAssociatedValues()) {
-      const_cast<EnumDecl*>(this)->Bits.EnumDecl.HasAssociatedValues
-        = static_cast<unsigned>(AssociatedValueCheck::HasAssociatedValues);
-      return false;
-    }
+    if (elt->hasAssociatedValues())
+      hasAssociatedValues = true;
   }
-  const_cast<EnumDecl*>(this)->Bits.EnumDecl.HasAssociatedValues
-    = static_cast<unsigned>(AssociatedValueCheck::NoAssociatedValues);
-  return true;
+
+  EnumDecl *enumDecl = const_cast<EnumDecl *>(this);
+
+  enumDecl->Bits.EnumDecl.HasAnyUnavailableValues = hasAnyUnavailableValues;
+  enumDecl->Bits.EnumDecl.HasAssociatedValues = static_cast<unsigned>(
+      hasAssociatedValues ? AssociatedValueCheck::HasAssociatedValues
+                          : AssociatedValueCheck::NoAssociatedValues);
+  return !hasAssociatedValues;
 }
 
 bool EnumDecl::isFormallyExhaustive(const DeclContext *useDC) const {

--- a/test/decl/protocol/special/comparable/comparable_unsupported.swift
+++ b/test/decl/protocol/special/comparable/comparable_unsupported.swift
@@ -46,6 +46,16 @@ enum EnumWithUnavailableCaseAndAssociatedValue: Comparable {
   case some(SomeComparable)
 }
 
+enum EnumWithUnavailableCaseAndAssociatedValue2: Comparable {
+  // expected-error@-1 {{type 'EnumWithUnavailableCaseAndAssociatedValue2' does not conform to protocol 'Comparable'}}
+  enum SomeComparable: Comparable {}
+
+  case this(SomeComparable)
+
+  @available(*, unavailable)
+  case that(SomeComparable)
+}
+
 // Automatic synthesis of Comparable requires associated values to be Comparable as well.
 
 enum NotComparableEnumTwo: Comparable {


### PR DESCRIPTION
The cached values for `hasOnlyCasesWithoutAssociatedValues()` and `hasPotentiallyUnavailableCaseValue()` are computed in a single pass over the elements of an `EnumDecl`. However, the pass would return early after finding an element with an associated value, without checking whether any of the rest of the elements were potentially unavailable. This made `Comparable` synthesis succeed for any enum with potentially unavailable elements so long as the first element in the enum has an associated value.
