### PR TITLE
Revert "Verify that on-stack closures do not take owned arguments"

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -390,9 +390,6 @@ public:
     case SILArgumentConvention::Pack_Inout:
       return conv;
     case SILArgumentConvention::Direct_Owned:
-      assert(!pai->isOnStack() &&
-             "on-stack closures do not support owned arguments");
-      return conv;
     case SILArgumentConvention::Direct_Unowned:
     case SILArgumentConvention::Direct_Guaranteed:
       return pai->isOnStack() ? SILArgumentConvention::Direct_Guaranteed

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1956,11 +1956,6 @@ public:
     unsigned appliedArgStartIdx =
         substConv.getNumSILArguments() - PAI->getNumArguments();
     for (auto p : llvm::enumerate(PAI->getArguments())) {
-      if (PAI->isOnStack()) {
-        require(
-          substConv.getSILArgumentConvention(appliedArgStartIdx + p.index()),
-          "on-stack closures do not support owned arguments");
-      }
       requireSameType(
           p.value()->getType(),
           substConv.getSILArgumentType(appliedArgStartIdx + p.index(),


### PR DESCRIPTION
This reverts commit 20f99b2822ae8b190483b8a3ae5f06a6403de181.

The assert triggers in in the i386 build in the function:
specialized Substring.UnicodeScalarView.replaceSubrange<A>(_:with:)