### PR TITLE
Link or copy in install_symlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,12 @@ How to build the swift compiler modules. Possible values are
                                    compiler, provided in `SWIFT_NATIVE_SWIFT_TOOLS_PATH`
 ]=] OFF)
 
+option(SWIFT_USE_SYMLINKS "Use symlinks instead of copying binaries" ${CMAKE_HOST_UNIX})
+set(SWIFT_COPY_OR_SYMLINK "copy")
+if(SWIFT_USE_SYMLINKS)
+  set(SWIFT_COPY_OR_SYMLINK "create_symlink")
+endif()
+
 # The following only works with the Ninja generator in CMake >= 3.0.
 set(SWIFT_PARALLEL_LINK_JOBS "" CACHE STRING
   "Define the maximum number of linker jobs for swift.")

--- a/cmake/modules/SwiftComponents.cmake
+++ b/cmake/modules/SwiftComponents.cmake
@@ -196,6 +196,9 @@ function(swift_install_symlink_component component)
   # otherwise.
   install(DIRECTORY DESTINATION "${ARG_DESTINATION}" COMPONENT ${component})
   install(SCRIPT ${INSTALL_SYMLINK}
-          CODE "install_symlink(${ARG_LINK_NAME} ${ARG_TARGET} ${ARG_DESTINATION})"
+          CODE "install_symlink(${ARG_LINK_NAME}
+                                ${ARG_TARGET}
+                                ${ARG_DESTINATION}
+                                ${SWIFT_COPY_OR_SYMLINK})"
           COMPONENT ${component})
 endfunction()

--- a/tools/libSwiftScan/CMakeLists.txt
+++ b/tools/libSwiftScan/CMakeLists.txt
@@ -71,10 +71,12 @@ else()
        ${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}
        ${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/swift/host/lib${SWIFT_SCAN_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
   message(STATUS "Installing symlink (${target_install_relative_path}) to lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/lib${SWIFT_SCAN_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
   install(SCRIPT ${INSTALL_SYMLINK}
           CODE "install_symlink(lib${SWIFT_SCAN_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
                                 ${target_install_relative_path}
-                                lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})"
+                                lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}
+                                ${SWIFT_COPY_OR_SYMLINK})"
           COMPONENT compiler)
 endif()
 


### PR DESCRIPTION
LLVM install_symlink takes a new argument on whether to create a symlink or copy binaries when run. -- https://reviews.llvm.org/D145443

The variable that controls this in LLVM is `LLVM_USE_SYMLINKS`, which defaults to `ON` on Unix-y hosts, but otherwise is false so that Windows works. This is a configurable option, so Windows configs that can support symlinks can take advantage of symlinks and save some space. `LLVM_USE_SYMLINKS` is not exported from LLVM though, so we can't see it to use. Instead, we have `SWIFT_USE_SYMLINKS`.