### PR TITLE
AST: Downgrade diagnostic for @backDeployed with opaque result type to warning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7082,7 +7082,7 @@ ERROR(attr_incompatible_with_back_deploy,none,
       "'%0' cannot be applied to a back deployed %1",
       (DeclAttribute, DescriptiveDeclKind))
 
-ERROR(backdeployed_opaque_result_not_supported,none,
+WARNING(backdeployed_opaque_result_not_supported,none,
       "'%0' is unsupported on a %1 with a 'some' return type",
       (DeclAttribute, DescriptiveDeclKind))
 

--- a/test/attr/attr_backDeployed.swift
+++ b/test/attr/attr_backDeployed.swift
@@ -266,13 +266,13 @@ public struct ConformsToTopLevelProtocol: TopLevelProtocol {
 }
 
 @available(SwiftStdlib 5.1, *)
-@backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' is unsupported on a var with a 'some' return type}}
+@backDeployed(before: macOS 12.0) // expected-warning {{'@backDeployed' is unsupported on a var with a 'some' return type}}
 public var cannotBackDeployVarWithOpaqueResultType: some TopLevelProtocol {
   return ConformsToTopLevelProtocol()
 }
 
 @available(SwiftStdlib 5.1, *)
-@backDeployed(before: macOS 12.0) // expected-error {{'@backDeployed' is unsupported on a global function with a 'some' return type}}
+@backDeployed(before: macOS 12.0) // expected-warning {{'@backDeployed' is unsupported on a global function with a 'some' return type}}
 public func cannotBackDeployFuncWithOpaqueResultType() -> some TopLevelProtocol {
   return ConformsToTopLevelProtocol()
 }


### PR DESCRIPTION
Reverts https://github.com/apple/swift/pull/67528.

Resolves rdar://113745241
