### PR TITLE
re-enable `executor_deinit1.swift`

### DIFF
--- a/test/Concurrency/Runtime/executor_deinit1.swift
+++ b/test/Concurrency/Runtime/executor_deinit1.swift
@@ -6,11 +6,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// https://github.com/apple/swift/issues/56817
-// UNSUPPORTED: OS=linux-gnu
-
-// REQUIRES: rdar78325660
-
 // doesn't matter that it's bool identity function or not
 func boolIdentityFn(_ x : Bool) -> Bool { return x }
 


### PR DESCRIPTION
I put this test in originally XFAIL'd because the deinit for the actor was not being run before program exit. It was expected to run because it's not top-level code so there is a release of the object before returning from RunIt.main.

My guess is that the root cause of the original
bug of it not running the deinit was because of
the "executor stickiness" that was present in
Swift concurrency prior to SE-338. Today it
seems that this isn't an issue so we may as well
have this test back.

resolves rdar://77397981
resolves https://github.com/apple/swift/issues/56817
