### PR TITLE
Handle inherited required inits in @objcImpl

### DIFF
--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -157,6 +157,12 @@
 
 @end
 
+@interface ObjCImplSubclass : ObjCClass
+
+@end
+
+
+
 struct ObjCStruct {
   int foo;
 };

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -386,6 +386,13 @@ protocol EmptySwiftProto {}
   func nonPointerArgument(_: CInt!) {} // expected-error {{method cannot be implicitly @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 
+@_objcImplementation extension ObjCImplSubclass {
+    @objc(initFromProtocol1:)
+    required public init?(fromProtocol1: CInt) {
+      // OK
+    }
+}
+
 @_objcImplementation extension ObjCClass {}
 // expected-error@-1 {{duplicate implementation of Objective-C class 'ObjCClass'}}
 


### PR DESCRIPTION
Because `required init`s do not have the `override` keyword, they are treated as member implementations. However, these methods sometimes actually are overrides, and when they are, they should not be treated as candidates. Hack around this by separately checking for this situation and skipping the affected members.

Fixes rdar://112910098.