### PR TITLE
Fix LoadableByAddress to use @in_guaranteed for unowned values and enable SIL verification for on-stack partial_apply ownership

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -402,14 +402,16 @@ SILParameterInfo LargeSILTypeMapper::getNewParameter(GenericEnvironment *env,
       return param;
     }
   } else if (isLargeLoadableType(env, storageType, IGM)) {
-    if (param.getConvention() == ParameterConvention::Direct_Guaranteed)
-      return SILParameterInfo(storageType.getASTType(),
-                              ParameterConvention::Indirect_In_Guaranteed,
-                              param.getDifferentiability());
-    else
+    if (param.getConvention() == ParameterConvention::Direct_Owned) {
       return SILParameterInfo(storageType.getASTType(),
                               ParameterConvention::Indirect_In,
                               param.getDifferentiability());
+    }
+    assert(param.getConvention() == ParameterConvention::Direct_Guaranteed
+           || param.getConvention() == ParameterConvention::Direct_Unowned);
+    return SILParameterInfo(storageType.getASTType(),
+                            ParameterConvention::Indirect_In_Guaranteed,
+                            param.getDifferentiability());
   } else {
     auto newType = getNewSILType(env, storageType, IGM);
     return SILParameterInfo(newType.getASTType(),

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1956,12 +1956,16 @@ public:
     unsigned appliedArgStartIdx =
         substConv.getNumSILArguments() - PAI->getNumArguments();
     for (auto p : llvm::enumerate(PAI->getArguments())) {
+      unsigned argIdx = appliedArgStartIdx + p.index();
       requireSameType(
           p.value()->getType(),
-          substConv.getSILArgumentType(appliedArgStartIdx + p.index(),
-                                       F.getTypeExpansionContext()),
+          substConv.getSILArgumentType(argIdx, F.getTypeExpansionContext()),
           "applied argument types do not match suffix of function type's "
           "inputs");
+      if (PAI->isOnStack()) {
+        require(!substConv.getSILArgumentConvention(argIdx).isOwnedConvention(),
+          "on-stack closures do not support owned arguments");
+      }
     }
 
     // The arguments to the result function type must match the prefix of the

--- a/test/AutoDiff/IRGen/loadable_by_address.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address.swift
@@ -39,8 +39,8 @@ func large2large(_ foo: Large) -> Large {
 
 // `large2large` old verification error:
 // SIL verification failed: JVP type does not match expected JVP type
-// $@callee_guaranteed (@in Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector)
-// $@callee_guaranteed (@in Large) -> (@out Large, @owned @callee_guaranteed (@in Large.TangentVector) -> @out Large.TangentVector)
+// $@callee_guaranteed (@in_guaranteed Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector)
+// $@callee_guaranteed (@in_guaranteed Large) -> (@out Large, @owned @callee_guaranteed (@in_guaranteed Large.TangentVector) -> @out Large.TangentVector)
 
 @_silgen_name("large2small")
 @differentiable(reverse)
@@ -50,26 +50,26 @@ func large2small(_ foo: Large) -> Float {
 
 // `large2small` old verification error:
 // SIL verification failed: JVP type does not match expected JVP type
-//   $@callee_guaranteed (@in Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float)
-//   $@callee_guaranteed (@in Large) -> (Float, @owned @callee_guaranteed (@in Large.TangentVector) -> Float)
+//   $@callee_guaranteed (@in_guaranteed Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float)
+//   $@callee_guaranteed (@in_guaranteed Large) -> (Float, @owned @callee_guaranteed (@in_guaranteed Large.TangentVector) -> Float)
 
 // CHECK-SIL: sil {{.*}}@large2large : $@convention(thin) (Large) -> Large {
-// CHECK-LBA-SIL: sil {{.*}}@large2large : $@convention(thin) (@in Large) -> @out Large {
+// CHECK-LBA-SIL: sil {{.*}}@large2large : $@convention(thin) (@in_guaranteed Large) -> @out Large {
 
 // CHECK-SIL-LABEL: sil {{.*}}@large2small : $@convention(thin) (Large) -> Float {
-// CHECK-LBA-SIL: sil {{.*}}@large2small : $@convention(thin) (@in Large) -> Float {
+// CHECK-LBA-SIL: sil {{.*}}@large2small : $@convention(thin) (@in_guaranteed Large) -> Float {
 
 // CHECK-SIL: sil {{.*}}@large2largeTJfSpSr : $@convention(thin) (Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
-// CHECK-LBA-SIL: sil {{.*}}@large2largeTJfSpSr : $@convention(thin) (@in Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil {{.*}}@large2largeTJfSpSr : $@convention(thin) (@in_guaranteed Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
 
 // CHECK-SIL: sil {{.*}}@large2largeTJrSpSr : $@convention(thin) (Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
-// CHECK-LBA-SIL: sil {{.*}}@large2largeTJrSpSr : $@convention(thin) (@in Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil {{.*}}@large2largeTJrSpSr : $@convention(thin) (@in_guaranteed Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
 
 // CHECK-SIL: sil {{.*}}@large2smallTJfSpSr : $@convention(thin) (Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float) {
-// CHECK-LBA-SIL: sil {{.*}}@large2smallTJfSpSr : $@convention(thin) (@in Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float) {
+// CHECK-LBA-SIL: sil {{.*}}@large2smallTJfSpSr : $@convention(thin) (@in_guaranteed Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float) {
 
 // CHECK-SIL: sil {{.*}}@large2smallTJrSpSr : $@convention(thin) (Large) -> (Float, @owned @callee_guaranteed (Float) -> Large.TangentVector) {
-// CHECK-LBA-SIL: sil {{.*}}@large2smallTJrSpSr : $@convention(thin) (@in Large) -> (Float, @owned @callee_guaranteed (Float) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil {{.*}}@large2smallTJrSpSr : $@convention(thin) (@in_guaranteed Large) -> (Float, @owned @callee_guaranteed (Float) -> Large.TangentVector) {
 
 LBATests.test("Correctness") {
   let one = Large.TangentVector(a: 1, b: 1, c: 1, d: 1)

--- a/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-frontend -c -Xllvm -sil-print-after=loadable-address %S/Inputs/loadable_by_address_cross_module.swift 2>&1 | %FileCheck %s -check-prefix=CHECK-MODULE-POST-LBA
 
 // CHECK-MODULE-PRE-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, LargeLoadableType<T>) -> Float
-// CHECK-MODULE-POST-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, @in LargeLoadableType<T>) -> Float
+// CHECK-MODULE-POST-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, @in_guaranteed LargeLoadableType<T>) -> Float
 
 // Compile the module.
 
@@ -24,8 +24,8 @@
 // CHECK-CLIENT-PRE-LBA: differentiability_witness_function [jvp] [reverse] [parameters 0 1] [results 0] <T> @${{.*}}LBAModifiedFunction{{.*}} : $@convention(method) <τ_0_0> (Float, LargeLoadableType<τ_0_0>) -> Float
 // CHECK-CLIENT-PRE-LBA: differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] <T> @${{.*}}LBAModifiedFunction{{.*}} : $@convention(method) <τ_0_0> (Float, LargeLoadableType<τ_0_0>) -> Float
 
-// CHECK-CLIENT-POST-LBA: differentiability_witness_function [jvp] [reverse] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float, τ_0_0) -> Float for <LargeLoadableType<τ_0_0>>)
-// CHECK-CLIENT-POST-LBA: differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> (Float, τ_0_0) for <LargeLoadableType<τ_0_0>>)
+// CHECK-CLIENT-POST-LBA: differentiability_witness_function [jvp] [reverse] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in_guaranteed LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in_guaranteed LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float, τ_0_0) -> Float for <LargeLoadableType<τ_0_0>>)
+// CHECK-CLIENT-POST-LBA: differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in_guaranteed LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in_guaranteed LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> (Float, τ_0_0) for <LargeLoadableType<τ_0_0>>)
 
 // Finally, execute the test.
 

--- a/test/IRGen/big_types.sil
+++ b/test/IRGen/big_types.sil
@@ -26,6 +26,8 @@ public struct ContainsClosure {
 sil @make_big_struct : $@convention(thin) () -> BigStruct
 sil @use_big_struct : $@convention(thin) (BigStruct) -> ()
 
+sil @takeClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+
 // CHECK-LABEL: sil_global @globalWithClosureInStruct : $ContainsClosure = {
 // CHECK:         %0 = function_ref @make_big_struct : $@convention(thin) () -> @out BigStruct
 // CHECK-NEXT:    %1 = thin_to_thick_function %0 : $@convention(thin) () -> @out BigStruct to $@callee_guaranteed () -> @out BigStruct
@@ -37,7 +39,7 @@ sil_global @globalWithClosureInStruct : $ContainsClosure = {
   %initval = struct $ContainsClosure (%1 : $@callee_guaranteed () -> BigStruct)
 }
 
-// CHECK-LABEL: sil @test_yield_big : $@yield_once @convention(thin) () -> @yields @in BigStruct {
+// CHECK-LABEL: sil @test_yield_big : $@yield_once @convention(thin) () -> @yields @in_guaranteed BigStruct {
 // CHECK:       bb0:
 // CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $BigStruct
 // CHECK-NEXT:    // function_ref
@@ -69,13 +71,13 @@ unwind:
 // CHECK:       bb0:
 // CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $BigStruct
 // CHECK-NEXT:    // function_ref
-// CHECK-NEXT:    [[CORO:%.*]] = function_ref @test_yield_big : $@yield_once @convention(thin) () -> @yields @in BigStruct
+// CHECK-NEXT:    [[CORO:%.*]] = function_ref @test_yield_big : $@yield_once @convention(thin) () -> @yields @in_guaranteed BigStruct
 // CHECK-NEXT:    ([[ADDR:%.*]], [[TOKEN:%.*]]) = begin_apply [[CORO]]()
 //   TODO: this isn't very efficient
 // CHECK-NEXT:    [[T0:%.*]] = load [[ADDR]] : $*BigStruct
 // CHECK-NEXT:    store [[T0]] to [[TEMP]] : $*BigStruct
 // CHECK-NEXT:    // function_ref
-// CHECK-NEXT:    [[USE:%.*]] = function_ref @use_big_struct : $@convention(thin) (@in BigStruct) -> ()
+// CHECK-NEXT:    [[USE:%.*]] = function_ref @use_big_struct : $@convention(thin) (@in_guaranteed BigStruct) -> ()
 // CHECK-NEXT:    apply [[USE]]([[TEMP]])
 // CHECK-NEXT:    end_apply [[TOKEN]]
 // CHECK-NEXT:    [[RET:%.*]] = tuple ()
@@ -133,3 +135,26 @@ unwind:
   unwind
 }
 
+// Test that partial apply captured arguments are converted to
+// @in_guaranteed, unless they are actually owned, which is not
+// allowed for on-stack closures.
+//
+// CHECK-LABEL: sil hidden @testLoadableCapture : $@convention(thin) (@in_guaranteed BigStruct) -> () {
+// CHECK: partial_apply [callee_guaranteed] [on_stack] %{{.*}}(%0) : $@convention(thin) (@in_guaranteed BigStruct) -> ()
+// CHECK-LABEL: // end sil function 'testLoadableCapture'
+sil hidden @testLoadableCapture : $@convention(thin) (BigStruct) -> () {
+bb0(%0 : $BigStruct):
+  %2 = function_ref @testLoadableCaptureClosure : $@convention(thin) (BigStruct) -> () // user: %3
+  %3 = partial_apply [callee_guaranteed] [on_stack] %2(%0) : $@convention(thin) (BigStruct) -> () // users: %6, %5
+  %4 = function_ref @takeClosure : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> () // user: %5
+  %5 = apply %4(%3) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  dealloc_stack %3 : $@noescape @callee_guaranteed () -> () // id: %6
+  %7 = tuple ()                                   // user: %8
+  return %7 : $()                                 // id: %8
+}
+
+sil private @testLoadableCaptureClosure : $@convention(thin) (BigStruct) -> () {
+bb0(%0 : @closureCapture $BigStruct):
+  %2 = tuple ()
+  return %2 : $()
+}

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -47,8 +47,8 @@ let bigStructGlobalArray : [BigStruct] = [
 ]
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$s22big_types_corner_cases21OptionalInoutFuncTypeC7executeyys5Error_pSgFyyXEfU_"(ptr nocapture dereferenceable({{.*}}) %0, ptr %1, ptr nocapture dereferenceable({{.*}})
-// CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegig_SgWOe
-// CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegig_SgWOy
+// CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegng_SgWOe
+// CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegng_SgWOy
 // CHECK: ret void
 
 public func f1_returns_BigType(_ x: BigStruct) -> BigStruct {

--- a/test/IRGen/distributed_func_indirect_in_parameter.swift
+++ b/test/IRGen/distributed_func_indirect_in_parameter.swift
@@ -21,7 +21,7 @@ public struct LargeValue : Codable {
 distributed actor D {
   typealias ActorSystem = LocalTestingDistributedActorSystem
 
-  // CHECK: sil hidden [distributed] @takeLarge : $@convention(method) (@in LargeValue, @guaranteed D) -> () {
+  // CHECK: sil hidden [distributed] @takeLarge : $@convention(method) (@in_guaranteed LargeValue, @guaranteed D) -> () {
   @_silgen_name("takeLarge")
   distributed func takeLarge(_ l: LargeValue) {}
 }

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -70,9 +70,12 @@ entry(%o : $*Huge, %x : $Huge):
 // CHECK:         [[CLOSURE:%.*]] = call noalias ptr @swift_allocObject
 // CHECK:         call swiftcc {{.*}} @"$s24huge_partial_applicationTA{{(\.ptrauth)?}}"{{.*}}(ptr noalias nocapture dereferenceable({{.*}}) %0, ptr swiftself [[CLOSURE]])
 // CHECK:       define internal swiftcc void @"$s24huge_partial_applicationTA"(ptr noalias nocapture dereferenceable({{.*}}) %0, ptr swiftself %1)
-// CHECK:         [[TMP_ARG:%.*]] = alloca
+// CHECK-NOT:     alloca
+// CHECK:         [[GEP:%.*]] = getelementptr inbounds <{ %swift.refcounted, %T17indirect_argument4HugeV }>, ptr %1, i32 0, i32 1
+// CHECK-NOT:     alloca
 // CHECK-NOT:     tail
-// CHECK:         call swiftcc void @huge_partial_application(ptr noalias nocapture dereferenceable({{.*}}) %0, ptr noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]])
+// CHECK:         call swiftcc void @huge_partial_application(ptr noalias nocapture dereferenceable({{.*}}) %0, ptr noalias nocapture dereferenceable({{.*}}) [[GEP]]
+// CHECK:         call void @swift_release(ptr %1)
 sil @huge_partial_application : $@convention(thin) (Huge, Huge) -> () {
 entry(%x : $Huge, %y : $Huge):
   %f = function_ref @huge_partial_application : $@convention(thin) (Huge, Huge) -> ()
@@ -86,9 +89,12 @@ entry(%x : $Huge, %y : $Huge):
 // CHECK:         [[CLOSURE:%.*]] = call noalias ptr @swift_allocObject
 // CHECK:         call swiftcc {{.*}} @"$s30huge_partial_application_stretTA{{(\.ptrauth)?}}"{{.*}}(ptr noalias nocapture sret({{.*}}) [[TMP_RET]], ptr noalias nocapture dereferenceable({{.*}}) %1, ptr swiftself [[CLOSURE]])
 // CHECK:       define internal swiftcc void @"$s30huge_partial_application_stretTA"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture dereferenceable({{.*}}) %1, ptr swiftself %2)
-// CHECK:         [[TMP_ARG:%.*]] = alloca
+// CHECK-NOT:     alloca
+// CHECK:         [[GEP:%.*]] = getelementptr inbounds <{ %swift.refcounted, %T17indirect_argument4HugeV }>, ptr %2, i32 0, i32 1
+// CHECK-NOT:     alloca
 // CHECK-NOT:     tail
-// CHECK:         call swiftcc void @huge_partial_application_stret(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture dereferenceable({{.*}}) %1, ptr noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]])
+// CHECK:         call swiftcc void @huge_partial_application_stret(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture dereferenceable({{.*}}) %1, ptr noalias nocapture dereferenceable({{.*}}) [[GEP]])
+// CHECK:         call void @swift_release(ptr %2)
 sil @huge_partial_application_stret : $@convention(thin) (Huge, Huge) -> Huge {
 entry(%x : $Huge, %y : $Huge):
   %f = function_ref @huge_partial_application_stret : $@convention(thin) (Huge, Huge) -> Huge

--- a/test/SILOptimizer/closure_specialize_attrs.sil
+++ b/test/SILOptimizer/closure_specialize_attrs.sil
@@ -16,35 +16,34 @@ struct Val {}
 // CHECK:           {{bb[0-9]+}}({{%[^,]+}} : @_eagerMove @owned $C, {{%[^,]+}} :
 // CHECK-LABEL: } // end sil function '$s12take_closure0B04main1CCTf1nc_n'
 
-sil [ossa] [noinline] @take_closure : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@owned C, @owned C) -> ()) -> () {
-bb0(%c : @_eagerMove @owned $C, %0 : @guaranteed $@noescape @callee_guaranteed (@owned C, @owned C) -> ()):
+sil [ossa] [noinline] @take_closure : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()) -> () {
+bb0(%c : @_eagerMove @owned $C, %0 : @guaranteed $@noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()):
   %getC = function_ref @getC : $@convention(thin) () -> @owned C
   %c1 = apply %getC() : $@convention(thin) () -> @owned C
   %c2 = apply %getC() : $@convention(thin) () -> @owned C
-  %3 = apply %0(%c1, %c2) : $@noescape @callee_guaranteed (@owned C, @owned C) -> ()
+  %3 = apply %0(%c1, %c2) : $@noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()
+  destroy_value %c2 : $C
+  destroy_value %c1 : $C
   destroy_value %c : $C
   %retval = tuple()
   return %retval : $()
 }
 
-sil shared [ossa] @closure : $@convention(thin) (@owned C, @owned C, @owned C) -> () {
-bb0(%0 : @owned $C, %1 : @owned $C, %2 : @owned $C):
-  destroy_value %0 : $C
-  destroy_value %1 : $C
-  destroy_value %2 : $C
+sil shared [ossa] @closure : $@convention(thin) (@guaranteed C, @guaranteed C, @guaranteed C) -> () {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $C, %2 : @guaranteed $C):
   %15 = tuple ()
   return %15 : $()
 }
 
 sil @caller : $@convention(thin) (@owned C) -> () {
 bb0(%0 : $C):
-  %3 = function_ref @closure : $@convention(thin) (@owned C, @owned C, @owned C) -> ()
-  %4 = partial_apply [callee_guaranteed] [on_stack] %3(%0) : $@convention(thin) (@owned C, @owned C, @owned C) -> ()
-  %take_closure = function_ref @take_closure : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@owned C, @owned C) -> ()) -> ()
+  %3 = function_ref @closure : $@convention(thin) (@guaranteed C, @guaranteed C, @guaranteed C) -> ()
+  %4 = partial_apply [callee_guaranteed] [on_stack] %3(%0) : $@convention(thin) (@guaranteed C, @guaranteed C, @guaranteed C) -> ()
+  %take_closure = function_ref @take_closure : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()) -> ()
   strong_retain %0 : $C
-  %5 = apply %take_closure(%0, %4) : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@owned C, @owned C) -> ()) -> ()
+  %5 = apply %take_closure(%0, %4) : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()) -> ()
   strong_release %0 : $C
-  dealloc_stack %4 : $@noescape @callee_guaranteed (@owned C, @owned C) -> ()
+  dealloc_stack %4 : $@noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()
   %retval = tuple()
   return %retval : $()
 }


### PR DESCRIPTION
LoadableByAddress was accidentally changing ownership of
direct_unowned values to @in (owned). This generates unsupported SIL
for on-stack partial applies, which now breaks SIL verification.

This also resulted in extra copies of values inside of closure
contexts. Before calling the original function, the value would need to
be copied onto the stack and the context would be destroyed. Now, we
simply pass a pointer directly from the closure context.  See
IRGen/indirect_argument.sil+huge_partial_application.

I'm pretty sure fixing this has no effect on the mangling of public symbols.