### PR TITLE
[test] Add `REQUIRES: assert` to `ObserveAvailabilityCycle` test

### DIFF
--- a/test/stdlib/Observation/ObservableAvailabilityCycle.swift
+++ b/test/stdlib/Observation/ObservableAvailabilityCycle.swift
@@ -7,6 +7,7 @@
 // REQUIRES: observation
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
+// REQUIRES: assert
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 


### PR DESCRIPTION
ObservableAvailabilityCycle.swift uses the experimental feature `InitAccessors`, which isn’t available in non-assert compilers.

rdar://113708096