### PR TITLE
[Mem2Reg] Don't canonicalize erased values.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2195,7 +2195,7 @@ void MemoryToRegisters::canonicalizeValueLifetimes(
       /*pruneDebug=*/true, /*maximizeLifetime=*/!f.shouldOptimize(), &f,
       accessBlockAnalysis, domInfo, calleeAnalysis, deleter);
   for (auto value : owned) {
-    if (isa<SILUndef>(value))
+    if (isa<SILUndef>(value) || value->isMarkedAsDeleted())
       continue;
     auto root = CanonicalizeOSSALifetime::getCanonicalCopiedDef(value);
     if (auto *copy = dyn_cast<CopyValueInst>(root)) {
@@ -2209,7 +2209,7 @@ void MemoryToRegisters::canonicalizeValueLifetimes(
   }
   CanonicalizeBorrowScope borrowCanonicalizer(&f, deleter);
   for (auto value : guaranteed) {
-    if (isa<SILUndef>(value))
+    if (isa<SILUndef>(value) || value->isMarkedAsDeleted())
       continue;
     auto borrowee = CanonicalizeBorrowScope::getCanonicalBorrowedDef(value);
     if (!borrowee)

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -742,3 +742,22 @@ sil [ossa] @dont_canonicalize_undef : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: sil [ossa] @dont_canonicalize_erased_copy : {{.*}} {
+// CHECK:       bb0(%0 :
+// CHECK:         destroy_value %0
+// CHECK-LABEL: } // end sil function 'dont_canonicalize_erased_copy'
+sil [ossa] @dont_canonicalize_erased_copy : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %stack = alloc_stack $C
+  %copy = copy_value %instance : $C
+  store %copy to [init] %stack : $*C
+  %loaded_copy = load [take] %stack : $*C
+  destroy_value %loaded_copy : $C
+  store %instance to [init] %stack : $*C
+  %loaded_instance = load [take] %stack : $*C
+  destroy_value %loaded_instance : $C
+  dealloc_stack %stack : $*C
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
To eliminate copies which become newly spurious, Mem2Reg canonicalizes the lifetimes of values that are stored and of newly introduced phis after rewriting.

It's possible, however, for the values that are stored to be deleted during canonicalization if a value and its copy are both stored to the address.  Such values must not be canonicalized.  So check whether values have been erased before canonicalizing them.

rdar://113762355
