### PR TITLE
NFC patches leading towards variadic tuple argument reabstraction

### DIFF
--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -190,14 +190,14 @@ void SILGenFunction::emitBackDeploymentThunk(SILDeclRef thunk) {
 
   // Generate the thunk prolog by collecting parameters.
   SmallVector<ManagedValue, 4> params;
-  SmallVector<SILArgument *, 4> indirectParams;
+  SmallVector<ManagedValue, 4> indirectParams;
   collectThunkParams(loc, params, &indirectParams);
 
   // Build up the list of arguments that we're going to invoke the the real
   // function with.
   SmallVector<SILValue, 8> paramsForForwarding;
   for (auto indirectParam : indirectParams) {
-    paramsForForwarding.emplace_back(indirectParam);
+    paramsForForwarding.emplace_back(indirectParam.getLValueAddress());
   }
 
   for (auto param : params) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2252,7 +2252,7 @@ public:
   /// Used for emitting SILArguments of bare functions, such as thunks.
   void collectThunkParams(
       SILLocation loc, SmallVectorImpl<ManagedValue> &params,
-      SmallVectorImpl<SILArgument *> *indirectResultParams = nullptr);
+      SmallVectorImpl<ManagedValue> *indirectResultParams = nullptr);
 
   /// Build the type of a function transformation thunk.
   CanSILFunctionType buildThunkType(CanSILFunctionType &sourceType,

--- a/lib/SILGen/TupleGenerators.h
+++ b/lib/SILGen/TupleGenerators.h
@@ -209,7 +209,7 @@ public:
   /// generating.  In the reabstraction code, this means it should only
   /// be used for *inner* types.  If the pack is an input you've
   /// received, you should call projectPackComponent.
-  SILValue createPackComponentTemporary(SILGenFunction &SGF, SILLocation loc);
+  ManagedValue createPackComponentTemporary(SILGenFunction &SGF, SILLocation loc);
 };
 
 /// A generator for visiting the addresses of the elements of


### PR DESCRIPTION
The goal here is to avoid needing to copy-and-paste a ton of code that I already wrote for `ResultPlanner` into `TranslateArguments`, since in many ways the basic structure of the code will be the same: checking for vanishing tuples, doing proper parallel traversals, and so on.  Most of the changes arise from an effort to make that not just an utter horror show of overloading and chaos: I need to converge the two classes so that they pass arguments in basically the same way, and it's convenient as part of that to make sure that they use the same terminology.

Note that I'm trying to give each of four classes in SILGenPoly its own little namespace:
- `translate` for the general value-translation code
- `process` for the argument-translation code
- `plan` for the result-translation code
-  `expand` for the shared code between those

It should be okay to collapse some of this in time — `plan` and `process` are pretty arbitrary, and there isn't too much danger of confusing them.  But argument order is definitely confusable between the general value-translation code and the specific translators, and I specifically wanted to get away from the input/output terminology.