### PR TITLE
XFail SceneKit_test

### DIFF
--- a/test/ClangImporter/SceneKit_test.swift
+++ b/test/ClangImporter/SceneKit_test.swift
@@ -3,6 +3,10 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
+// SceneKit has two protocols sections, which clang treats as an error now
+// rdar://113874614
+// XFAIL: *
+
 import SceneKit
 import Foundation
 


### PR DESCRIPTION
XFailing this test due to project failures in SceneKit containing two `protocols` sections, which clang treats as an error now.
- rdar://113874614
