### PR TITLE
[AST] NFC: Teach `getExpandedGenericArgs` to handle partially resolve…

### DIFF
--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -432,8 +432,17 @@ PackType::getExpandedGenericArgs(ArrayRef<GenericTypeParamType *> params,
     auto arg = args[i];
 
     if (params[i]->isParameterPack()) {
-      auto argPackElements = arg->castTo<PackType>()->getElementTypes();
-      wrappedArgs.append(argPackElements.begin(), argPackElements.end());
+      // FIXME: A temporary fix to make it possible to debug expressions
+      // with partially resolved variadic generic types. The issue stems
+      // from the fact that `BoundGenericType` is allowed to have pack
+      // parameters directly represented by type variables, as soon as
+      // that is no longer the case this check should be removed.
+      if (arg->is<TypeVariableType>()) {
+        wrappedArgs.push_back(arg);
+      } else {
+        auto argPackElements = arg->castTo<PackType>()->getElementTypes();
+        wrappedArgs.append(argPackElements.begin(), argPackElements.end());
+      }
       continue;
     }
 


### PR DESCRIPTION
…d parameter packs

A temporary fix to make it possible to debug expressions with partially resolved variadic generic types. 
The issue stems from the fact that `BoundGenericType` is allowed to have pack parameters directly 
represented by type variables, as soon as that is no longer the case this check should be removed.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
