### PR TITLE
[Dependency Scanning] Remove Swift Overlay dependencies from the set of direct dependencies

### DIFF
--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -124,7 +124,7 @@ using ModuleInfoLayout =
                    IdentifierIDField,            // moduleName
                    ContextHashIDField,           // contextHash
                    ImportArrayIDField,           // moduleImports
-                   DependencyIDArrayIDField      // resolvedModuleDependencies
+                   DependencyIDArrayIDField      // resolvedDirectModuleDependencies
                    >;
 
 using SwiftInterfaceModuleDetailsLayout =

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -104,7 +104,7 @@ bool ModuleDependencyInfo::isTestableImport(StringRef moduleName) const {
 }
 
 void ModuleDependencyInfo::addModuleDependency(ModuleDependencyID dependencyID) {
-  storage->resolvedModuleDependencies.push_back(dependencyID);
+  storage->resolvedDirectModuleDependencies.push_back(dependencyID);
 }
 
 void ModuleDependencyInfo::addOptionalModuleImport(
@@ -622,8 +622,8 @@ ModuleDependenciesCache::ModuleDependenciesCache(
     std::string scannerContextHash)
     : globalScanningService(globalScanningService),
       mainScanModuleName(mainScanModuleName),
-      moduleOutputPath(moduleOutputPath),
       scannerContextHash(scannerContextHash),
+      moduleOutputPath(moduleOutputPath),
       clangScanningTool(*globalScanningService.ClangScanningService,
                         globalScanningService.getClangScanningFS()) {
   globalScanningService.configureForContextHash(scannerContextHash);
@@ -687,7 +687,7 @@ void ModuleDependenciesCache::resolveDependencyImports(ModuleDependencyID module
   assert(optionalDependencyInfo.has_value() && "Resolving unknown dependency");
   // Copy the existing info to a mutable one we can then replace it with, after resolving its dependencies.
   auto dependencyInfo = *(optionalDependencyInfo.value());
-  dependencyInfo.resolveDependencies(dependencyIDs);
+  dependencyInfo.resolveDirectDependencies(dependencyIDs);
   updateDependency(moduleID, dependencyInfo);
 }
 

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -298,7 +298,7 @@ bool ModuleDependenciesCacheDeserializer::readGraph(SwiftDependencyScanningServi
         moduleDep.addModuleImport(moduleName);
 
       // Add qualified dependencies of this module
-      moduleDep.resolveDependencies(*currentModuleDependencyIDs);
+      moduleDep.resolveDirectDependencies(*currentModuleDependencyIDs);
 
       // Add bridging header file path
       if (bridgingHeaderFileID != 0) {
@@ -1114,7 +1114,7 @@ void ModuleDependenciesCacheSerializer::collectStringsAndArrays(
                      dependencyInfo->getModuleImports());
       addDependencyIDArray(
           moduleID, ModuleIdentifierArrayKind::QualifiedModuleDependencyIDs,
-          dependencyInfo->getModuleDependencies());
+          dependencyInfo->getDirectModuleDependencies());
 
       // Add the dependency-kind-specific data
       switch (dependencyInfo->getKind()) {

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -165,20 +165,26 @@ static void findAllImportedClangModules(ASTContext &ctx, StringRef moduleName,
     return;
 
   auto dependencies = optionalDependencies.value();
-  for (const auto &dep : dependencies->getModuleDependencies()) {
+  for (const auto &dep : dependencies->getDirectModuleDependencies())
     findAllImportedClangModules(ctx, dep.first, cache, allModules, knownModules);
-  }
+  for (const auto &dep : dependencies->getSwiftOverlayDependencies())
+    findAllImportedClangModules(ctx, dep.first, cache, allModules, knownModules);
 }
 
 // Get all dependencies's IDs of this module from its cached
 // ModuleDependencyInfo
-static ArrayRef<ModuleDependencyID>
-getDependencies(const ModuleDependencyID &moduleID,
-                const ModuleDependenciesCache &cache) {
+static std::vector<ModuleDependencyID>
+getAllDependencies(const ModuleDependencyID &moduleID,
+                   const ModuleDependenciesCache &cache) {
   const auto &optionalModuleInfo =
       cache.findDependency(moduleID.first, moduleID.second);
   assert(optionalModuleInfo.has_value());
-  return optionalModuleInfo.value()->getModuleDependencies();
+  auto directDependenciesRef = optionalModuleInfo.value()->getDirectModuleDependencies();
+  auto overlayDependenciesRef = optionalModuleInfo.value()->getSwiftOverlayDependencies();
+  std::vector<ModuleDependencyID> result;
+  result.insert(std::end(result), directDependenciesRef.begin(), directDependenciesRef.end());
+  result.insert(std::end(result), overlayDependenciesRef.begin(), overlayDependenciesRef.end());
+  return result;
 }
 
 /// Implements a topological sort via recursion and reverse postorder DFS.
@@ -200,7 +206,7 @@ computeTopologicalSortOfExplicitDependencies(
       return;
 
     // Otherwise, visit each adjacent node.
-    for (const auto &succID : getDependencies(moduleID, cache)) {
+    for (const auto &succID : getAllDependencies(moduleID, cache)) {
       // We don't worry if successor is already in this current stack,
       // since that would mean we have found a cycle, which should not
       // be possible because we checked for cycles earlier.
@@ -249,7 +255,7 @@ computeTransitiveClosureOfExplicitDependencies(
        it != end; ++it) {
     const auto &modID = *it;
     auto &modReachableSet = result[modID];
-    for (const auto &succID : getDependencies(modID, cache)) {
+    for (const auto &succID : getAllDependencies(modID, cache)) {
       const auto &succReachableSet = result[succID];
       llvm::set_union(modReachableSet, succReachableSet);
     }
@@ -517,10 +523,10 @@ static llvm::Error resolveExplicitModuleInputs(
 
 /// Resolve the direct dependencies of the given module.
 static std::vector<ModuleDependencyID>
-resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID moduleID,
-                          ModuleDependenciesCache &cache,
-                          InterfaceSubContextDelegate &ASTDelegate) {
-  PrettyStackTraceStringAction trace("Resolving direct dependencies of: ", moduleID.first);
+resolveDependencies(CompilerInstance &instance, ModuleDependencyID moduleID,
+                    ModuleDependenciesCache &cache,
+                    InterfaceSubContextDelegate &ASTDelegate) {
+  PrettyStackTraceStringAction trace("Resolving dependencies of: ", moduleID.first);
   auto &ctx = instance.getASTContext();
   auto optionalKnownDependencies = cache.findDependency(moduleID.first, moduleID.second);
   assert(optionalKnownDependencies.has_value());
@@ -529,7 +535,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID moduleI
   // If this dependency has already been resolved, return the result.
   if (knownDependencies->isResolved() &&
       knownDependencies->getKind() != ModuleDependencyKind::SwiftSource)
-    return knownDependencies->getModuleDependencies();
+    return getAllDependencies(moduleID, cache);
 
   auto isSwiftInterfaceOrSource = knownDependencies->isSwiftInterfaceModule() ||
                                   knownDependencies->isSwiftSourceModule();
@@ -621,10 +627,6 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID moduleI
               ctx.getSwiftModuleDependencies(clangDep, cache, ASTDelegate)) {
         if (clangDep != moduleID.first) {
           swiftOverlayDependencies.insert({clangDep, found.value()->getKind()});
-          // FIXME: Once all clients know to fetch these dependencies from
-          // `swiftOverlayDependencies`, the goal is to no longer have them in
-          // `directDependencies` so the following will need to go away.
-          directDependencies.insert({clangDep, found.value()->getKind()});
         }
       }
     }
@@ -716,7 +718,7 @@ static void discoverCrossImportOverlayDependencies(
        ++currentModuleIdx) {
     auto module = allModules[currentModuleIdx];
     auto moduleDependnencyIDs =
-        resolveDirectDependencies(instance, module, cache, ASTDelegate);
+        resolveDependencies(instance, module, cache, ASTDelegate);
     allModules.insert(moduleDependnencyIDs.begin(), moduleDependnencyIDs.end());
   }
 
@@ -1350,7 +1352,7 @@ generateFullDependencyGraph(CompilerInstance &instance,
     auto optionalDepInfo = cache.findDependency(module.first, module.second);
     assert(optionalDepInfo.has_value() && "Missing dependency info during graph generation diagnosis.");
     auto depInfo = optionalDepInfo.value();
-    auto directDependencies = depInfo->getModuleDependencies();
+    auto directDependencies = depInfo->getDirectModuleDependencies();
 
     // Generate a swiftscan_clang_details_t object based on the dependency kind
     auto getModuleDetails = [&]() -> swiftscan_module_details_t {
@@ -1490,7 +1492,7 @@ static bool diagnoseCycle(CompilerInstance &instance,
     assert(optionalDepInfo.has_value() && "Missing dependency info during cycle diagnosis.");
     auto depInfo = optionalDepInfo.value();
 
-    for (const auto &dep : depInfo->getModuleDependencies()) {
+    for (const auto &dep : getAllDependencies(lastOpen, cache)) {
       if (closeSet.count(dep))
         continue;
       if (openSet.insert(dep)) {
@@ -2009,7 +2011,14 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
        ++currentModuleIdx) {
     auto module = allModules[currentModuleIdx];
     auto discoveredModules =
-        resolveDirectDependencies(instance, module, cache, ASTDelegate);
+        resolveDependencies(instance, module, cache, ASTDelegate);
+
+    // Do not need to resolve clang modules, those come pre-resolved
+    // from the Clang dependency scanner.
+    for (const auto &moduleID : discoveredModules)
+      if (moduleID.second != ModuleDependencyKind::Clang)
+        allModules.insert(moduleID);
+
     allModules.insert(discoveredModules.begin(), discoveredModules.end());
   }
 
@@ -2161,7 +2170,7 @@ swift::dependencies::performBatchModuleScan(
              currentModuleIdx < allModules.size(); ++currentModuleIdx) {
           auto module = allModules[currentModuleIdx];
           auto discoveredModules =
-              resolveDirectDependencies(instance, module, cache, ASTDelegate);
+              resolveDependencies(instance, module, cache, ASTDelegate);
           allModules.insert(discoveredModules.begin(), discoveredModules.end());
         }
 

--- a/test/CAS/module_deps.swift
+++ b/test/CAS/module_deps.swift
@@ -62,10 +62,8 @@ import SubE
 // CHECK-NEXT: module_deps.swift
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
-// CHECK-DAG:     "swift": "A"
 // CHECK-DAG:     "clang": "C"
 // CHECK-DAG:     "swift": "E"
-// CHECK-DAG:     "swift": "F"
 // CHECK-DAG:     "swift": "G"
 // CHECK-DAG:     "swift": "SubE"
 // CHECK-DAG:     "swift": "Swift"
@@ -92,6 +90,10 @@ import SubE
 // CHECK: "moduleDependencies": [
 // CHECK-NEXT: "F"
 // CHECK-NEXT: ]
+
+// CHECK: "swiftOverlayDependencies": [
+// CHECK-DAG:     "swift": "A"
+// CHECK-DAG:     "swift": "F"
 
 /// --------Swift module A
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -57,10 +57,8 @@ import SubE
 // CHECK-NEXT: module_deps_include_tree.swift
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
-// CHECK-DAG:     "swift": "A"
 // CHECK-DAG:     "clang": "C"
 // CHECK-DAG:     "swift": "E"
-// CHECK-DAG:     "swift": "F"
 // CHECK-DAG:     "swift": "G"
 // CHECK-DAG:     "swift": "SubE"
 // CHECK-DAG:     "swift": "Swift"
@@ -86,6 +84,10 @@ import SubE
 // CHECK: "moduleDependencies": [
 // CHECK-NEXT: "F"
 // CHECK-NEXT: ]
+
+// CHECK: "swiftOverlayDependencies": [
+// CHECK-DAG:     "swift": "A"
+// CHECK-DAG:     "swift": "F"
 
 /// --------Swift module A
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",

--- a/test/CAS/plugin_cas.swift
+++ b/test/CAS/plugin_cas.swift
@@ -48,10 +48,8 @@ import SubE
 // CHECK-NEXT: plugin_cas.swift
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
-// CHECK-DAG:     "swift": "A"
 // CHECK-DAG:     "clang": "C"
 // CHECK-DAG:     "swift": "E"
-// CHECK-DAG:     "swift": "F"
 // CHECK-DAG:     "swift": "G"
 // CHECK-DAG:     "swift": "SubE"
 // CHECK-DAG:     "swift": "Swift"
@@ -77,6 +75,10 @@ import SubE
 // CHECK: "moduleDependencies": [
 // CHECK-NEXT: "F"
 // CHECK-NEXT: ]
+
+// CHECK: "swiftOverlayDependencies": [
+// CHECK-DAG:     "swift": "A"
+// CHECK-DAG:     "swift": "F"
 
 /// --------Swift module A
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -31,10 +31,9 @@ import SubE
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
 // CHECK-NEXT:   {
-// CHECK-DAG:     "swift": "A"
 // CHECK-DAG:     "clang": "C"
 // CHECK-DAG:     "swift": "E"
-// CHECK-DAG:     "swift": "F"
+// CHECK-DAG:     "clang": "F"
 // CHECK-DAG:     "swift": "G"
 // CHECK-DAG:     "swift": "SubE"
 // CHECK-DAG:     "swift": "Swift"
@@ -62,6 +61,10 @@ import SubE
 // CHECK: "moduleDependencies": [
 // CHECK-NEXT: "F"
 // CHECK-NEXT: ]
+
+// CHECK: "swiftOverlayDependencies": [
+// CHECK-DAG: "swift": "F"
+// CHECK-DAG: "swift": "A"
 
 /// --------Swift module A
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -44,7 +44,7 @@ import SomeExternalModule
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-DAG: "swift": "F"
+// CHECK-DAG: "clang": "F"
 // CHECK-DAG: "swiftPlaceholder": "SomeExternalModule"
 // CHECK-DAG: "swift": "Swift"
 // CHECK-DAG: "swift": "SwiftOnoneSupport"
@@ -52,12 +52,6 @@ import SomeExternalModule
 // CHECK-DAG: "swift": "_StringProcessing"
 // CHECK-DAG: "clang": "_SwiftConcurrencyShims"
 // CHECK: ],
-
-// CHECK:      "extraPcmArgs": [
-// CHECK-NEXT:    "-Xcc",
-// CHECK-NEXT:    "-target",
-// CHECK-NEXT:    "-Xcc",
-// CHECK:         "-fapinotes-swift-version=4"
 
 // CHECK: "bridgingHeader":
 // CHECK-NEXT: "path":
@@ -67,9 +61,21 @@ import SomeExternalModule
 // CHECK-NEXT: Bridging.h
 // CHECK-NEXT: BridgingOther.h
 
-// CHECK: "moduleDependencies": [
-// CHECK-NEXT: "F"
-// CHECK-NEXT: ]
+// CHECK:       "moduleDependencies": [
+// CHECK-NEXT:     "F"
+// CHECK-NEXT:  ],
+
+// CHECK:       "swiftOverlayDependencies": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "swift": "F"
+// CHECK-NEXT:    }
+// CHECK-NEXT:  ]
+
+// CHECK:      "extraPcmArgs": [
+// CHECK-NEXT:    "-Xcc",
+// CHECK-NEXT:    "-target",
+// CHECK-NEXT:    "-Xcc",
+// CHECK:         "-fapinotes-swift-version=4"
 
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",

--- a/test/ScanDependencies/separate_bridging_header_deps.swift
+++ b/test/ScanDependencies/separate_bridging_header_deps.swift
@@ -17,7 +17,7 @@ import E
 // CHECK-DAG:          "swift": "_StringProcessing"
 // The source of dependency on clang:F is the bridging header, ensure it is captured here
 // CHECK-DAG:          "clang": "F"
-// CHECK-DAG:          "swift": "F"
+
 
 // CHECK: "bridgingHeader": {
 // CHECK-NEXT:             "path": "{{.*}}Bridging.h",
@@ -27,3 +27,9 @@ import E
 // CHECK-NEXT:            ],
 // CHECK-NEXT:            "moduleDependencies": [
 // CHECK-NEXT:              "F"
+
+// CHECK:      "swiftOverlayDependencies": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:      "swift": "F"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]


### PR DESCRIPTION
It is valuable for clients to be able to distinguish which dependencies of a Swift module originated from 'import' statements, and which ones are implicit dependency Swift overlays of imported Clang modules.

Breaking these dependencies out into a separate category will allow incremental builds to more-precisely determine if the project source import set has changed between builds, in order to aid with incremental builds.
