### PR TITLE
Fix argument side effects when an argument’s only user is a partial_apply which is returned

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -137,8 +137,7 @@ private struct CollectedEffects {
 
     case let pa as PartialApplyInst:
       if pa.canBeAppliedInFunction(context) {
-        // Only if the created closure can actually be called in the function
-        // we have to consider side-effects within the closure.
+        // Only if the closure is applied or returned, consider its side-effects.
         handleApply(pa)
         checkedIfDeinitBarrier = true
       }
@@ -497,12 +496,10 @@ private extension PartialApplyInst {
     struct EscapesToApply : EscapeVisitor {
       func visitUse(operand: Operand, path: EscapePath) -> UseResult {
         switch operand.instruction {
-        case is FullApplySite:
-          // Any escape to apply - regardless if it's an argument or the callee operand - might cause
+        case is ReturnInst, is FullApplySite:
+          // Any escape to apply or return - regardless if it's an argument or the callee operand - might cause
           // the closure to be called.
           return .abort
-        case is ReturnInst:
-          return .ignore
         default:
           return .continueWalk
         }

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt %s -dead-store-elimination -enable-sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt %s -compute-side-effects -dead-store-elimination -enable-sil-verify-all | %FileCheck %s --check-prefix=CHECK-SEA-DSE
 
 // REQUIRES: swift_in_compiler
 
@@ -1631,3 +1632,32 @@ bb0(%0 : $UInt64, %1 : $Builtin.Word):
   return %76 : $Builtin.Int8
 }
 
+class Klass {}
+
+
+sil @klassClosure : $@convention(thin) (@in_guaranteed Klass) -> ()
+
+sil @test_pa_without_apply : $@convention(thin) (@in Klass) -> @callee_guaranteed () -> () {
+bb0(%0 : $*Klass):
+  %3 = function_ref @klassClosure : $@convention(thin) (@in_guaranteed Klass) -> ()
+  %4 = partial_apply [callee_guaranteed] %3(%0) : $@convention(thin) (@in_guaranteed Klass) -> ()
+  return %4 : $@callee_guaranteed ()  -> () 
+}
+
+// CHECK-SEA-DSE: sil @dont_dead_store :
+// CHECK-SEA-DSE: store
+// CHECK-SEA-DSE: } // end sil function 'dont_dead_store'
+sil @dont_dead_store : $@convention(thin) (@in_guaranteed (Klass, Klass)) -> () {
+bb0(%0 : $*(Klass, Klass)):
+  %ele = tuple_element_addr %0 : $*(Klass, Klass), 1
+  %1 = load %ele : $*Klass
+  %3 = alloc_stack $Klass
+  store %1 to %3 : $*Klass
+  strong_retain %1 : $Klass
+  %4 = function_ref @test_pa_without_apply : $@convention(thin) (@in Klass) -> @callee_guaranteed () -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@in Klass) -> @callee_guaranteed () -> ()
+  %6 = apply %5() : $@callee_guaranteed () -> ()
+  dealloc_stack %3 : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -827,8 +827,8 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: sil @not_called_partial_apply
-// CHECK-NEXT:  [global: ]
-// CHECK-NEXT:  {{^[^[]}}
+// CHECK-NEXT: [%0: read v**]
+// CHECK-NEXT: [global: read,write,copy,destroy,allocate,deinit_barrier]
 sil @not_called_partial_apply : $@convention(thin) (@in Int32) ->  @owned @callee_owned (Bool) -> Int32 {
 bb0(%0 : $*Int32):
   %2 = function_ref @closure : $@convention(thin) (Bool, @in Int32) -> Int32
@@ -837,8 +837,9 @@ bb0(%0 : $*Int32):
 }
 
 // CHECK-LABEL: sil @partial_apply_chain
-// CHECK-NEXT: [global: ]
-// CHECK-NEXT: {{^[^[]}}
+// CHECK-NEXT: [%0: read v**]
+// CHECK-NEXT: [%1: read v**]
+// CHECK-NEXT: [global: read,write,copy,destroy,allocate,deinit_barrier]
 sil @partial_apply_chain : $@convention(thin) (@in Int32, @in Int32) ->  @owned @callee_owned (Bool) -> Int32 {
 bb0(%0 : $*Int32, %1 : $*Int32):
   %3 = function_ref @closure2 : $@convention(thin) (Bool, @in Int32, @in Int32) -> Int32
@@ -1178,4 +1179,3 @@ bb0(%0 : $*T, %1 : $*T):
   %4 = tuple ()
   return %4 : $()
 }
-


### PR DESCRIPTION
In the current SideEffectAnalysis, if an argument's only user is a partial_apply which in turn is returned from the function, memory effect none is returned.

Since the returned partial_apply can be later applied via the return value, we have to be conservative here.

This resulted in a store being deleted incorrectly in DeadStoreElimination.

Fixes rdar://113339972

