### PR TITLE
Concurrency: Restore consume in TaskLocal.withValueImpl<R>(_:operation:)

### DIFF
--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -171,7 +171,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
-    _taskLocalValuePush(key: key, value: valueDuringOperation)
+    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
 
     return try await operation()

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -171,7 +171,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
-    _taskLocalValuePush(key: key, value: valueDuringOperation)
+    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
 
     return try await operation()


### PR DESCRIPTION
It is no longer necessary to avoid using the `consume` keyword in inlinable function bodies in the standard library in order to support older compilers.

Partially reverts https://github.com/apple/swift/pull/65599.

Resolves rdar://109165937.
