### PR TITLE
TypeDecoder: Push one-element tuple unwrapping down into createTupleType() implementations [5.9]

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -1052,13 +1052,6 @@ protected:
           return *optError;
       }
 
-      // Unwrap unlabeled one-element tuples.
-      //
-      // FIXME: The behavior of one-element labeled tuples is inconsistent throughout
-      // the different re-implementations of type substitution and pack expansion.
-      if (elements.size() == 1 && labels[0].empty())
-        return elements[0];
-
       return Builder.createTupleType(elements, labels);
     }
     case NodeKind::TupleElement:

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -328,6 +328,17 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
 }
 
 Type ASTBuilder::createTupleType(ArrayRef<Type> eltTypes, ArrayRef<StringRef> labels) {
+  // Unwrap unlabeled one-element tuples.
+  //
+  // FIXME: The behavior of one-element labeled tuples is inconsistent
+  // throughout the different re-implementations of type substitution
+  // and pack expansion.
+  if (eltTypes.size() == 1 &&
+      !eltTypes[0]->is<PackExpansionType>() &&
+      labels[0].empty()) {
+    return eltTypes[0];
+  }
+
   SmallVector<TupleTypeElt, 4> elements;
   elements.reserve(eltTypes.size());
   for (unsigned i : indices(eltTypes)) {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1960,6 +1960,14 @@ public:
   TypeLookupErrorOr<BuiltType>
   createTupleType(llvm::ArrayRef<BuiltType> elements,
                   llvm::ArrayRef<StringRef> labels) const {
+    // Unwrap unlabeled one-element tuples.
+    //
+    // FIXME: The behavior of one-element labeled tuples is inconsistent
+    // throughout the different re-implementations of type substitution
+    // and pack expansion.
+    if (elements.size() == 1 && labels[0].empty())
+      return elements[0];
+
     for (auto element : elements) {
       if (!element.isMetadata()) {
         return TYPE_LOOKUP_ERROR_FMT("Tried to build a tuple type where "

--- a/test/DebugInfo/variadic-generics.swift
+++ b/test/DebugInfo/variadic-generics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -g -o - \
-// RUN:    -parse-as-library -module-name a | %IRGenFileCheck %s
+// RUN:    -parse-as-library -module-name a -disable-availability-checking | %IRGenFileCheck %s
 
 public func foo<each T>(args: repeat each T) {
   // CHECK: define {{.*}} @"$s1a3foo4argsyxxQp_tRvzlF"
@@ -21,3 +21,35 @@ public func foo<each T>(args: repeat each T) {
   // CHECK-DAG: ![[TYPE_PACK_TY]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD"
 }
 
+// Test ASTDemangler round-tripping of various pack expansion types
+
+public func paramExpansionWithPattern<each T>(args: repeat Array<each T>) {}
+
+public func paramExpansionWithMemberType<each T: Sequence>(args: repeat each T, elements: repeat (each T).Element) {}
+
+public func tupleExpansion<each T>(args: (repeat each T)) {}
+
+public func tupleExpansionWithPattern<each T>(args: (repeat Array<each T>)) {}
+
+// FIXME: Crashes due to unrelated bug
+// public func tupleExpansionWithMemberType<each T: Sequence>(args: repeat each T, elements: (repeat (each T).Element)) {}
+
+public func functionExpansion<each T>(args: (repeat each T) -> ()) {}
+
+public func functionExpansionWithPattern<each T>(args: (repeat Array<each T>) -> ()) {}
+
+public func functionExpansionWithMemberType<each T: Sequence>(args: repeat each T, elements: (repeat (each T).Element) -> ()) {}
+
+public struct G<each T> {}
+
+public func nominalExpansion<each T>(args: G<repeat each T>) {}
+
+public func nominalExpansionWithPattern<each T>(args: G<repeat Array<each T>>) {}
+
+public func nominalExpansionWithMemberType<each T: Sequence>(args: repeat each T, elements: G<repeat (each T).Element>) {}
+
+//
+
+public typealias First<T, U> = T
+
+public func concreteExpansion<each T>(args: repeat each T, concrete: repeat First<Int, each T>) {}


### PR DESCRIPTION
* Description: LLDB's Type reconstruction would incorrectly unwrap one-element tuples containing pack expansions. This was because the unwrapping was added in the wrong place. Move it to the implementations where we have the right information to decide if we should unwrap or not.
* Origination: A regression from https://github.com/apple/swift/pull/67180 which was cherry-picked into 5.9
* Scope of the issue: Caught by the round-trip verifier in assert builds.
* Risk: Low, this only has a functional effect in the type reconstruction case, since the other clients unconditionally unwrap.
* Tested: Added more test cases to exercise round-trip type reconstruction.
* Reviewed by: @hborla 
* Issue: https://github.com/apple/swift/issues/67322
* Radar: rdar://113595455
