### PR TITLE
Fix pack conformance availability checking [5.9]

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1898,7 +1898,8 @@ static ProtocolConformanceRef getPackTypeConformance(
       auto patternConformance =
           (patternType->isTypeParameter()
            ? ProtocolConformanceRef(protocol)
-           : mod->lookupConformance(patternType, protocol));
+           : mod->lookupConformance(patternType, protocol,
+                                    /*allowMissing=*/true));
       patternConformances.push_back(patternConformance);
       continue;
     }
@@ -1906,7 +1907,8 @@ static ProtocolConformanceRef getPackTypeConformance(
     auto patternConformance =
         (packElement->isTypeParameter()
          ? ProtocolConformanceRef(protocol)
-         : mod->lookupConformance(packElement, protocol));
+         : mod->lookupConformance(packElement, protocol,
+                                  /*allowMissing=*/true));
     patternConformances.push_back(patternConformance);
   }
 

--- a/test/Sema/pack_conformance_availability.swift
+++ b/test/Sema/pack_conformance_availability.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift
+
+func f<each T: P>(_: repeat each T) {}
+
+protocol P {}
+
+struct S {}
+
+@available(*, unavailable)
+extension S: P {}
+// expected-note@-1 {{conformance of 'S' to 'P' has been explicitly marked unavailable here}}
+
+f(S())
+// expected-error@-1 {{conformance of 'S' to 'P' is unavailable}}


### PR DESCRIPTION
* Description: We forgot to walk into PackConformances when checking conformance availability, as a result you could reference an unavailable witness table pointer and get a crash at runtime.

* Origination: Never worked.

* Risk: Low, might cause the compiler to reject invalid code we used to accept.
* 
* Tested: New tests added.

* Reviewed by: @tshortli 