### PR TITLE
Sema: Fix two problems in checkReferencedGenericParams() analysis [5.9]

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -343,6 +343,25 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
         ReferencedGenericParams.insert(ty->getCanonicalType());
         return Action::SkipChildren;
       }
+
+      // Skip the count type, which is always a generic parameter;
+      // we don't consider it a reference because it only binds the
+      // shape and not the metadata.
+      if (auto *expansionTy = ty->getAs<PackExpansionType>()) {
+        expansionTy->getPatternType().walk(*this);
+        return Action::SkipChildren;
+      }
+
+      // Don't walk into generic type alias substitutions. This does
+      // not constrain `T`:
+      //
+      //   typealias Foo<T> = Int
+      //   func foo<T>(_: Foo<T>) {}
+      if (auto *aliasTy = dyn_cast<TypeAliasType>(ty.getPointer())) {
+        Type(aliasTy->getSinglyDesugaredType()).walk(*this);
+        return Action::SkipChildren;
+      }
+
       return Action::Continue;
     }
 

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -65,6 +65,7 @@ struct Outer<each T> {
 func packRef<each T>(_: repeat each T) where repeat each T: P {}
 
 func packMemberRef<each T>(_: repeat (each T).T) where repeat each T: P {}
+// expected-error@-1 {{generic parameter 'T' is not used in function signature}}
 
 // expected-error@+1 {{'each' cannot be applied to non-pack type 'Int'}}
 func invalidPackRefEachInt(_: each Int) {}
@@ -98,3 +99,11 @@ func golden<Z>(_ z: Z) {}
 func hour<each T>(_ t: repeat each T)  {
   _ = (repeat golden(each t))
 }
+
+func unusedParameterPack1<each T: Sequence>(_: repeat (each T).Element) {}
+// expected-error@-1 {{generic parameter 'T' is not used in function signature}}
+
+typealias First<T, U> = T
+
+func unusedParameterPack2<each T>(_: repeat First<Int, each T>) {}
+// expected-error@-1 {{generic parameter 'T' is not used in function signature}}


### PR DESCRIPTION
* Description: We require that all generic parameters are referenced in a function signature, because otherwise there is no way to call a function if a generic parameter isn't fixed by at least one constraint generated by the solver at the call site. This logic was wrong for pack expansion types, so you could in fact declare a function that cannot be called.
* Risk: Low. This might break source if someone accidentally shipped an API that cannot be called for this reason.
* Tested: New test added.
* Reviewed by: @hborla 
