### PR TITLE
IRGen: Emit labeled tuple and function type metadata containing pack expansions [5.9]

### DIFF
--- a/lib/IRGen/GenPack.h
+++ b/lib/IRGen/GenPack.h
@@ -114,6 +114,12 @@ StackAddress allocatePack(IRGenFunction &IGF, CanSILPackType packType);
 
 void deallocatePack(IRGenFunction &IGF, StackAddress addr, CanSILPackType packType);
 
+llvm::Optional<StackAddress>
+emitDynamicTupleTypeLabels(IRGenFunction &IGF,
+                           CanTupleType tupleType,
+                           CanPackType packType,
+                           llvm::Value *shapeExpression);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenPack.h
+++ b/lib/IRGen/GenPack.h
@@ -120,6 +120,12 @@ emitDynamicTupleTypeLabels(IRGenFunction &IGF,
                            CanPackType packType,
                            llvm::Value *shapeExpression);
 
+StackAddress
+emitDynamicFunctionParameterFlags(IRGenFunction &IGF,
+                                  AnyFunctionType::CanParamArrayRef params,
+                                  CanPackType packType,
+                                  llvm::Value *shapeExpression);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -640,3 +640,28 @@ irgen::getPhysicalTupleElementStructIndex(IRGenModule &IGM, SILType tupleType,
                                           unsigned fieldNo) {
   FOR_TUPLE_IMPL(IGM, tupleType, getElementStructIndex, fieldNo);
 }
+
+/// Emit a string encoding the labels in the given tuple type.
+llvm::Constant *irgen::getTupleLabelsString(IRGenModule &IGM,
+                                            CanTupleType type) {
+  bool hasLabels = false;
+  llvm::SmallString<128> buffer;
+  for (auto &elt : type->getElements()) {
+    if (elt.hasName()) {
+      hasLabels = true;
+      buffer.append(elt.getName().str());
+    }
+
+    // Each label is space-terminated.
+    buffer += ' ';
+  }
+
+  // If there are no labels, use a null pointer.
+  if (!hasLabels) {
+    return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
+  }
+
+  // Otherwise, create a new string literal.
+  // This method implicitly adds a null terminator.
+  return IGM.getAddrOfGlobalString(buffer);
+}

--- a/lib/IRGen/GenTuple.h
+++ b/lib/IRGen/GenTuple.h
@@ -67,6 +67,11 @@ namespace irgen {
   llvm::Optional<unsigned> getPhysicalTupleElementStructIndex(IRGenModule &IGM,
                                                               SILType tupleType,
                                                               unsigned fieldNo);
+
+  /// Emit a string encoding the labels in the given tuple type.
+  llvm::Constant *getTupleLabelsString(IRGenModule &IGM,
+                                       CanTupleType type);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1364,6 +1364,258 @@ static void destroyGenericArgumentsArray(IRGenFunction &IGF,
                                 IGF.IGM.getPointerSize() * args.size());
 }
 
+static llvm::Value *getFunctionParameterRef(IRGenFunction &IGF,
+                                            AnyFunctionType::CanParam param) {
+  auto type = param.getPlainType()->getCanonicalType();
+  return IGF.emitAbstractTypeMetadataRef(type);
+}
+
+static MetadataResponse emitFunctionTypeMetadataRef(IRGenFunction &IGF,
+                                                    CanFunctionType type,
+                                                    DynamicMetadataRequest request) {
+  auto result =
+    IGF.emitAbstractTypeMetadataRef(type->getResult()->getCanonicalType());
+
+  auto params = type.getParams();
+  auto numParams = params.size();
+
+  // Retrieve the ABI parameter flags from the type-level parameter
+  // flags.
+  auto getABIParameterFlags = [](ParameterTypeFlags flags) {
+    return ParameterFlags()
+        .withValueOwnership(flags.getValueOwnership())
+        .withVariadic(flags.isVariadic())
+        .withAutoClosure(flags.isAutoClosure())
+        .withNoDerivative(flags.isNoDerivative())
+        .withIsolated(flags.isIsolated());
+  };
+
+  bool hasParameterFlags = false;
+  for (auto param : params) {
+    if (!getABIParameterFlags(param.getParameterFlags()).isNone()) {
+      hasParameterFlags = true;
+      break;
+    }
+  }
+
+  // Map the convention to a runtime metadata value.
+  FunctionMetadataConvention metadataConvention;
+  bool isEscaping = false;
+  switch (type->getRepresentation()) {
+  case FunctionTypeRepresentation::Swift:
+    metadataConvention = FunctionMetadataConvention::Swift;
+    isEscaping = !type->isNoEscape();
+    break;
+  case FunctionTypeRepresentation::Thin:
+    metadataConvention = FunctionMetadataConvention::Thin;
+    break;
+  case FunctionTypeRepresentation::Block:
+    metadataConvention = FunctionMetadataConvention::Block;
+    break;
+  case FunctionTypeRepresentation::CFunctionPointer:
+    metadataConvention = FunctionMetadataConvention::CFunctionPointer;
+    break;
+  }
+
+  FunctionMetadataDifferentiabilityKind metadataDifferentiabilityKind;
+  switch (type->getDifferentiabilityKind()) {
+  case DifferentiabilityKind::NonDifferentiable:
+    metadataDifferentiabilityKind =
+        FunctionMetadataDifferentiabilityKind::NonDifferentiable;
+    break;
+  case DifferentiabilityKind::Normal:
+    metadataDifferentiabilityKind =
+        FunctionMetadataDifferentiabilityKind::Normal;
+    break;
+  case DifferentiabilityKind::Linear:
+    metadataDifferentiabilityKind =
+        FunctionMetadataDifferentiabilityKind::Linear;
+    break;
+  case DifferentiabilityKind::Forward:
+    metadataDifferentiabilityKind =
+        FunctionMetadataDifferentiabilityKind::Forward;
+    break;
+  case DifferentiabilityKind::Reverse:
+    metadataDifferentiabilityKind =
+        FunctionMetadataDifferentiabilityKind::Reverse;
+    break;
+  }
+
+  auto flags = FunctionTypeFlags()
+                   .withNumParameters(numParams)
+                   .withConvention(metadataConvention)
+                   .withAsync(type->isAsync())
+                   .withConcurrent(type->isSendable())
+                   .withThrows(type->isThrowing())
+                   .withParameterFlags(hasParameterFlags)
+                   .withEscaping(isEscaping)
+                   .withDifferentiable(type->isDifferentiable())
+                   .withGlobalActor(!type->getGlobalActor().isNull());
+
+  auto flagsVal = llvm::ConstantInt::get(IGF.IGM.SizeTy,
+                                         flags.getIntValue());
+  llvm::Value *diffKindVal = nullptr;
+  if (type->isDifferentiable()) {
+    assert(metadataDifferentiabilityKind.isDifferentiable());
+    diffKindVal = llvm::ConstantInt::get(
+        IGF.IGM.SizeTy, metadataDifferentiabilityKind.getIntValue());
+  } else if (type->getGlobalActor()) {
+    diffKindVal = llvm::ConstantInt::get(
+        IGF.IGM.SizeTy,
+        FunctionMetadataDifferentiabilityKind::NonDifferentiable);
+  }
+
+  auto collectParameters =
+      [&](llvm::function_ref<void(unsigned, llvm::Value *,
+                                  ParameterFlags flags)>
+              processor) {
+        for (auto index : indices(params)) {
+          auto param = params[index];
+          auto flags = param.getParameterFlags();
+
+          auto parameterFlags = getABIParameterFlags(flags);
+          processor(index, getFunctionParameterRef(IGF, param),
+                    parameterFlags);
+        }
+      };
+
+  auto constructSimpleCall =
+      [&](llvm::SmallVectorImpl<llvm::Value *> &arguments)
+      -> FunctionPointer {
+    arguments.push_back(flagsVal);
+
+    collectParameters([&](unsigned i, llvm::Value *typeRef,
+                          ParameterFlags flags) {
+      arguments.push_back(typeRef);
+      if (hasParameterFlags)
+        arguments.push_back(
+            llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()));
+    });
+
+    arguments.push_back(result);
+
+    switch (params.size()) {
+    case 0:
+      return IGF.IGM.getGetFunctionMetadata0FunctionPointer();
+
+    case 1:
+      return IGF.IGM.getGetFunctionMetadata1FunctionPointer();
+
+    case 2:
+      return IGF.IGM.getGetFunctionMetadata2FunctionPointer();
+
+    case 3:
+      return IGF.IGM.getGetFunctionMetadata3FunctionPointer();
+
+    default:
+      llvm_unreachable("supports only 1/2/3 parameter functions");
+    }
+  };
+
+  switch (numParams) {
+  case 0:
+  case 1:
+  case 2:
+  case 3: {
+    if (!hasParameterFlags && !type->isDifferentiable() &&
+        !type->getGlobalActor()) {
+      llvm::SmallVector<llvm::Value *, 8> arguments;
+      auto metadataFn = constructSimpleCall(arguments);
+      auto *call = IGF.Builder.CreateCall(metadataFn, arguments);
+      call->setDoesNotThrow();
+      return MetadataResponse::forComplete(call);
+    }
+
+    // If function type has parameter flags or is differentiable or has a
+    // global actor, emit the most general function to retrieve them.
+    LLVM_FALLTHROUGH;
+  }
+
+  default:
+    assert((!params.empty() || type->isDifferentiable() ||
+            type->getGlobalActor()) &&
+           "0 parameter case should be specialized unless it is a "
+           "differentiable function or has a global actor");
+
+    auto *const Int32Ptr = IGF.IGM.Int32Ty->getPointerTo();
+    llvm::SmallVector<llvm::Value *, 8> arguments;
+
+    arguments.push_back(flagsVal);
+
+    if (diffKindVal) {
+      arguments.push_back(diffKindVal);
+    }
+
+    ConstantInitBuilder paramFlags(IGF.IGM);
+    auto flagsArr = paramFlags.beginArray();
+
+    Address parameters;
+    if (!params.empty()) {
+      auto arrayTy =
+          llvm::ArrayType::get(IGF.IGM.TypeMetadataPtrTy, numParams);
+      parameters = IGF.createAlloca(
+          arrayTy, IGF.IGM.getTypeMetadataAlignment(), "function-parameters");
+
+      IGF.Builder.CreateLifetimeStart(parameters,
+                                      IGF.IGM.getPointerSize() * numParams);
+
+      collectParameters([&](unsigned i, llvm::Value *typeRef,
+                            ParameterFlags flags) {
+        auto argPtr = IGF.Builder.CreateStructGEP(parameters, i,
+                                                  IGF.IGM.getPointerSize());
+        IGF.Builder.CreateStore(typeRef, argPtr);
+        if (i == 0)
+          arguments.push_back(argPtr.getAddress());
+
+        if (hasParameterFlags)
+          flagsArr.addInt32(flags.getIntValue());
+      });
+    } else {
+      auto parametersPtr =
+          llvm::ConstantPointerNull::get(
+            IGF.IGM.TypeMetadataPtrTy->getPointerTo());
+      arguments.push_back(parametersPtr);
+    }
+
+    if (hasParameterFlags) {
+      auto *flagsVar = flagsArr.finishAndCreateGlobal(
+          "parameter-flags", IGF.IGM.getPointerAlignment(),
+          /* constant */ true);
+      arguments.push_back(IGF.Builder.CreateBitCast(flagsVar, Int32Ptr));
+    } else {
+      flagsArr.abandon();
+      arguments.push_back(llvm::ConstantPointerNull::get(Int32Ptr));
+    }
+
+    arguments.push_back(result);
+
+    if (Type globalActor = type->getGlobalActor()) {
+      arguments.push_back(
+          IGF.emitAbstractTypeMetadataRef(globalActor->getCanonicalType()));
+    }
+
+    auto getMetadataFn =
+        type->getGlobalActor()
+            ? (IGF.IGM.isConcurrencyAvailable()
+                   ? IGF.IGM
+                         .getGetFunctionMetadataGlobalActorFunctionPointer()
+                   : IGF.IGM
+                         .getGetFunctionMetadataGlobalActorBackDeployFunctionPointer())
+        : type->isDifferentiable()
+            ? IGF.IGM.getGetFunctionMetadataDifferentiableFunctionPointer()
+            : IGF.IGM.getGetFunctionMetadataFunctionPointer();
+
+    auto call = IGF.Builder.CreateCall(getMetadataFn, arguments);
+    call->setDoesNotThrow();
+
+    if (parameters.isValid())
+      IGF.Builder.CreateLifetimeEnd(parameters,
+                                    IGF.IGM.getPointerSize() * numParams);
+
+    return MetadataResponse::forComplete(call);
+  }
+}
+
 namespace {
   /// A visitor class for emitting a reference to a metatype object.
   /// This implements a "raw" access, useful for implementing cache
@@ -1516,256 +1768,14 @@ namespace {
       return MetadataResponse::getUndef(IGF);
     }
 
-    llvm::Value *getFunctionParameterRef(AnyFunctionType::CanParam &param) {
-      auto type = param.getPlainType()->getCanonicalType();
-      return IGF.emitAbstractTypeMetadataRef(type);
-    }
-
     MetadataResponse visitFunctionType(CanFunctionType type,
                                        DynamicMetadataRequest request) {
       if (auto metatype = tryGetLocal(type, request))
         return metatype;
 
-      auto result =
-        IGF.emitAbstractTypeMetadataRef(type->getResult()->getCanonicalType());
+      auto response = emitFunctionTypeMetadataRef(IGF, type, request);
 
-      auto params = type.getParams();
-      auto numParams = params.size();
-
-      // Retrieve the ABI parameter flags from the type-level parameter
-      // flags.
-      auto getABIParameterFlags = [](ParameterTypeFlags flags) {
-        return ParameterFlags()
-            .withValueOwnership(flags.getValueOwnership())
-            .withVariadic(flags.isVariadic())
-            .withAutoClosure(flags.isAutoClosure())
-            .withNoDerivative(flags.isNoDerivative())
-            .withIsolated(flags.isIsolated());
-      };
-
-      bool hasParameterFlags = false;
-      for (auto param : params) {
-        if (!getABIParameterFlags(param.getParameterFlags()).isNone()) {
-          hasParameterFlags = true;
-          break;
-        }
-      }
-
-      // Map the convention to a runtime metadata value.
-      FunctionMetadataConvention metadataConvention;
-      bool isEscaping = false;
-      switch (type->getRepresentation()) {
-      case FunctionTypeRepresentation::Swift:
-        metadataConvention = FunctionMetadataConvention::Swift;
-        isEscaping = !type->isNoEscape();
-        break;
-      case FunctionTypeRepresentation::Thin:
-        metadataConvention = FunctionMetadataConvention::Thin;
-        break;
-      case FunctionTypeRepresentation::Block:
-        metadataConvention = FunctionMetadataConvention::Block;
-        break;
-      case FunctionTypeRepresentation::CFunctionPointer:
-        metadataConvention = FunctionMetadataConvention::CFunctionPointer;
-        break;
-      }
-
-      FunctionMetadataDifferentiabilityKind metadataDifferentiabilityKind;
-      switch (type->getDifferentiabilityKind()) {
-      case DifferentiabilityKind::NonDifferentiable:
-        metadataDifferentiabilityKind =
-            FunctionMetadataDifferentiabilityKind::NonDifferentiable;
-        break;
-      case DifferentiabilityKind::Normal:
-        metadataDifferentiabilityKind =
-            FunctionMetadataDifferentiabilityKind::Normal;
-        break;
-      case DifferentiabilityKind::Linear:
-        metadataDifferentiabilityKind =
-            FunctionMetadataDifferentiabilityKind::Linear;
-        break;
-      case DifferentiabilityKind::Forward:
-        metadataDifferentiabilityKind =
-            FunctionMetadataDifferentiabilityKind::Forward;
-        break;
-      case DifferentiabilityKind::Reverse:
-        metadataDifferentiabilityKind =
-            FunctionMetadataDifferentiabilityKind::Reverse;
-        break;
-      }
-
-      auto flags = FunctionTypeFlags()
-                       .withNumParameters(numParams)
-                       .withConvention(metadataConvention)
-                       .withAsync(type->isAsync())
-                       .withConcurrent(type->isSendable())
-                       .withThrows(type->isThrowing())
-                       .withParameterFlags(hasParameterFlags)
-                       .withEscaping(isEscaping)
-                       .withDifferentiable(type->isDifferentiable())
-                       .withGlobalActor(!type->getGlobalActor().isNull());
-
-      auto flagsVal = llvm::ConstantInt::get(IGF.IGM.SizeTy,
-                                             flags.getIntValue());
-      llvm::Value *diffKindVal = nullptr;
-      if (type->isDifferentiable()) {
-        assert(metadataDifferentiabilityKind.isDifferentiable());
-        diffKindVal = llvm::ConstantInt::get(
-            IGF.IGM.SizeTy, metadataDifferentiabilityKind.getIntValue());
-      } else if (type->getGlobalActor()) {
-        diffKindVal = llvm::ConstantInt::get(
-            IGF.IGM.SizeTy,
-            FunctionMetadataDifferentiabilityKind::NonDifferentiable);
-      }
-
-      auto collectParameters =
-          [&](llvm::function_ref<void(unsigned, llvm::Value *,
-                                      ParameterFlags flags)>
-                  processor) {
-            for (auto index : indices(params)) {
-              auto param = params[index];
-              auto flags = param.getParameterFlags();
-
-              auto parameterFlags = getABIParameterFlags(flags);
-              processor(index, getFunctionParameterRef(param), parameterFlags);
-            }
-          };
-
-      auto constructSimpleCall =
-          [&](llvm::SmallVectorImpl<llvm::Value *> &arguments)
-          -> FunctionPointer {
-        arguments.push_back(flagsVal);
-
-        collectParameters([&](unsigned i, llvm::Value *typeRef,
-                              ParameterFlags flags) {
-          arguments.push_back(typeRef);
-          if (hasParameterFlags)
-            arguments.push_back(
-                llvm::ConstantInt::get(IGF.IGM.Int32Ty, flags.getIntValue()));
-        });
-
-        arguments.push_back(result);
-
-        switch (params.size()) {
-        case 0:
-          return IGF.IGM.getGetFunctionMetadata0FunctionPointer();
-
-        case 1:
-          return IGF.IGM.getGetFunctionMetadata1FunctionPointer();
-
-        case 2:
-          return IGF.IGM.getGetFunctionMetadata2FunctionPointer();
-
-        case 3:
-          return IGF.IGM.getGetFunctionMetadata3FunctionPointer();
-
-        default:
-          llvm_unreachable("supports only 1/2/3 parameter functions");
-        }
-      };
-
-      switch (numParams) {
-      case 0:
-      case 1:
-      case 2:
-      case 3: {
-        if (!hasParameterFlags && !type->isDifferentiable() &&
-            !type->getGlobalActor()) {
-          llvm::SmallVector<llvm::Value *, 8> arguments;
-          auto metadataFn = constructSimpleCall(arguments);
-          auto *call = IGF.Builder.CreateCall(metadataFn, arguments);
-          call->setDoesNotThrow();
-          return setLocal(CanType(type), MetadataResponse::forComplete(call));
-        }
-
-        // If function type has parameter flags or is differentiable or has a
-        // global actor, emit the most general function to retrieve them.
-        LLVM_FALLTHROUGH;
-      }
-
-      default:
-        assert((!params.empty() || type->isDifferentiable() ||
-                type->getGlobalActor()) &&
-               "0 parameter case should be specialized unless it is a "
-               "differentiable function or has a global actor");
-
-        auto *const Int32Ptr = IGF.IGM.Int32Ty->getPointerTo();
-        llvm::SmallVector<llvm::Value *, 8> arguments;
-
-        arguments.push_back(flagsVal);
-
-        if (diffKindVal) {
-          arguments.push_back(diffKindVal);
-        }
-
-        ConstantInitBuilder paramFlags(IGF.IGM);
-        auto flagsArr = paramFlags.beginArray();
-
-        Address parameters;
-        if (!params.empty()) {
-          auto arrayTy =
-              llvm::ArrayType::get(IGF.IGM.TypeMetadataPtrTy, numParams);
-          parameters = IGF.createAlloca(
-              arrayTy, IGF.IGM.getTypeMetadataAlignment(), "function-parameters");
-
-          IGF.Builder.CreateLifetimeStart(parameters,
-                                          IGF.IGM.getPointerSize() * numParams);
-
-          collectParameters([&](unsigned i, llvm::Value *typeRef,
-                                ParameterFlags flags) {
-            auto argPtr = IGF.Builder.CreateStructGEP(parameters, i,
-                                                      IGF.IGM.getPointerSize());
-            IGF.Builder.CreateStore(typeRef, argPtr);
-            if (i == 0)
-              arguments.push_back(argPtr.getAddress());
-
-            if (hasParameterFlags)
-              flagsArr.addInt32(flags.getIntValue());
-          });
-        } else {
-          auto parametersPtr =
-              llvm::ConstantPointerNull::get(
-                IGF.IGM.TypeMetadataPtrTy->getPointerTo());
-          arguments.push_back(parametersPtr);
-        }
-
-        if (hasParameterFlags) {
-          auto *flagsVar = flagsArr.finishAndCreateGlobal(
-              "parameter-flags", IGF.IGM.getPointerAlignment(),
-              /* constant */ true);
-          arguments.push_back(IGF.Builder.CreateBitCast(flagsVar, Int32Ptr));
-        } else {
-          flagsArr.abandon();
-          arguments.push_back(llvm::ConstantPointerNull::get(Int32Ptr));
-        }
-
-        arguments.push_back(result);
-
-        if (Type globalActor = type->getGlobalActor()) {
-          arguments.push_back(
-              IGF.emitAbstractTypeMetadataRef(globalActor->getCanonicalType()));
-        }
-
-        auto getMetadataFn =
-            type->getGlobalActor()
-                ? (IGF.IGM.isConcurrencyAvailable()
-                       ? IGF.IGM
-                             .getGetFunctionMetadataGlobalActorFunctionPointer()
-                       : IGF.IGM
-                             .getGetFunctionMetadataGlobalActorBackDeployFunctionPointer())
-            : type->isDifferentiable()
-                ? IGF.IGM.getGetFunctionMetadataDifferentiableFunctionPointer()
-                : IGF.IGM.getGetFunctionMetadataFunctionPointer();
-
-        auto call = IGF.Builder.CreateCall(getMetadataFn, arguments);
-        call->setDoesNotThrow();
-
-        if (parameters.isValid())
-          IGF.Builder.CreateLifetimeEnd(parameters,
-                                        IGF.IGM.getPointerSize() * numParams);
-
-        return setLocal(type, MetadataResponse::forComplete(call));
-      }
+      return setLocal(type, response);
     }
 
     MetadataResponse visitMetatypeType(CanMetatypeType type,

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -709,6 +709,8 @@ MetadataResponse emitCheckTypeMetadataState(IRGenFunction &IGF,
 OperationCost getCheckTypeMetadataStateCost(DynamicMetadataRequest request,
                                             MetadataResponse response);
 
+ParameterFlags getABIParameterFlags(ParameterTypeFlags flags);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/test/Interpreter/variadic_generic_func_types.swift
+++ b/test/Interpreter/variadic_generic_func_types.swift
@@ -1,0 +1,42 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var funcs = TestSuite("VariadicGenericFuncTypes")
+
+func makeFunctionType1<each T>(_: repeat (each T).Type) -> Any.Type {
+  return ((repeat each T) -> ()).self
+}
+
+func makeFunctionType2<each T>(_: repeat (each T).Type) -> Any.Type {
+  return ((Character, repeat each T, Bool) -> ()).self
+}
+
+func makeFunctionType3<each T>(_: repeat (each T).Type) -> Any.Type {
+  return ((inout Character, repeat each T, inout Bool) -> ()).self
+}
+
+funcs.test("makeFunctionType1") {
+  expectEqual("() -> ()", _typeName(makeFunctionType1()))
+  expectEqual("(Swift.Int) -> ()", _typeName(makeFunctionType1(Int.self)))
+  expectEqual("(Swift.Int, Swift.String) -> ()", _typeName(makeFunctionType1(Int.self, String.self)))
+  expectEqual("(Swift.Int, Swift.Float, Swift.String) -> ()", _typeName(makeFunctionType1(Int.self, Float.self, String.self)))
+}
+
+funcs.test("makeFunctionType2") {
+  expectEqual("(Swift.Character, Swift.Bool) -> ()", _typeName(makeFunctionType2()))
+  expectEqual("(Swift.Character, Swift.Int, Swift.Bool) -> ()", _typeName(makeFunctionType2(Int.self)))
+  expectEqual("(Swift.Character, Swift.Int, Swift.String, Swift.Bool) -> ()", _typeName(makeFunctionType2(Int.self, String.self)))
+  expectEqual("(Swift.Character, Swift.Int, Swift.Float, Swift.String, Swift.Bool) -> ()", _typeName(makeFunctionType2(Int.self, Float.self, String.self)))
+}
+
+funcs.test("makeFunctionType3") {
+  expectEqual("(inout Swift.Character, inout Swift.Bool) -> ()", _typeName(makeFunctionType3()))
+  expectEqual("(inout Swift.Character, Swift.Int, inout Swift.Bool) -> ()", _typeName(makeFunctionType3(Int.self)))
+  expectEqual("(inout Swift.Character, Swift.Int, Swift.String, inout Swift.Bool) -> ()", _typeName(makeFunctionType3(Int.self, String.self)))
+  expectEqual("(inout Swift.Character, Swift.Int, Swift.Float, Swift.String, inout Swift.Bool) -> ()", _typeName(makeFunctionType3(Int.self, Float.self, String.self)))
+}
+
+runAllTests()

--- a/test/Interpreter/variadic_generic_tuples.swift
+++ b/test/Interpreter/variadic_generic_tuples.swift
@@ -64,4 +64,26 @@ tuples.test("expandTuple") {
   expandTupleElements(1, "hello", true)
 }
 
+func tupleLabelMix<each T, each U>(t: repeat (each T).Type, u: repeat (each U).Type) -> Any.Type {
+  return (Float, hello: Int, repeat each T, swift: String, repeat each U, Bool, world: UInt8).self
+}
+
+func oneElementLabeledTuple<each T>(t: repeat (each T).Type) -> Any.Type {
+  return (label: Int, repeat each T).self
+}
+
+tuples.test("labels") {
+  expectEqual("(Swift.Float, hello: Swift.Int, swift: Swift.String, Swift.Bool, world: Swift.UInt8)", _typeName(tupleLabelMix()))
+  expectEqual("(Swift.Float, hello: Swift.Int, swift: Swift.String, Swift.Double, Swift.Bool, world: Swift.UInt8)", _typeName(tupleLabelMix(u: Double.self)))
+  expectEqual("(Swift.Float, hello: Swift.Int, swift: Swift.String, Swift.Double, Swift.Int32, Swift.Bool, world: Swift.UInt8)", _typeName(tupleLabelMix(u: Double.self, Int32.self)))
+  expectEqual("(Swift.Float, hello: Swift.Int, Swift.Character, swift: Swift.String, Swift.Double, Swift.Bool, world: Swift.UInt8)", _typeName(tupleLabelMix(t: Character.self, u: Double.self)))
+  expectEqual("(Swift.Float, hello: Swift.Int, Swift.Character, Swift.Substring, swift: Swift.String, Swift.Double, Swift.Int32, Swift.Bool, world: Swift.UInt8)", _typeName(tupleLabelMix(t: Character.self, Substring.self, u: Double.self, Int32.self)))
+
+  // FIXME: One-element labeled tuples
+  expectEqual("Swift.Int", _typeName(oneElementLabeledTuple()))
+
+  expectEqual("(label: Swift.Int, Swift.String)", _typeName(oneElementLabeledTuple(t: String.self)))
+}
+
+
 runAllTests()


### PR DESCRIPTION
* Main PRs: #67573 #67724
* Description: IRGen didn't know how to emit metadata for tuples with labels, or function types, containing pack expansions.
* Scope of the issue: For example, we would crash if you tried to call a generic function `func f<U>(_: U)` with a substitution `U := (repeat each T, label: Int)` where `T` is a type parameter pack in the caller's context.
* Risk: Medium; there's a fair bit of new code here that runs in the variadic case, and some refactoring that moves existing code around. However I think this is an important case to support.
* Tested: Executable tests added.
* Reviewed by: @nate-chandler or @rjmccall 