### PR TITLE
[CSSimplify] Adjust {Any, Partial}KeyPath bindings right before resolving

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar113760727.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar113760727.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Value {
+  var data: String
+}
+
+func testAnyKeyPath<T>(field: AnyKeyPath, _: UnsafePointer<T>) {}
+func testPartialKeyPath<T>(field: PartialKeyPath<T>, _: UnsafePointer<T>) {}
+
+struct Test {
+  func test(ptr: UnsafePointer<Int64>) {
+    ptr.withMemoryRebound(to: Value.self, capacity: 2) { newPtr in
+      for idx in 0 ..< 2 {
+        var elt = newPtr[idx]
+        testAnyKeyPath(field: \Value.data, &elt)
+        testPartialKeyPath(field: \Value.data, &elt)
+      }
+    }
+  }
+}


### PR DESCRIPTION
A type variable that represents a key path literal cannot be bound directly to
`AnyKeyPath` or `PartialKeyPath`, such types could only be used for conversions.
It used to be the task of the binding inference to infer `AnyKeyPath` and
`PartiaKeyPath` as a `KeyPath` using previously generated type variables for
a root and value associated with key path literal (previously stored in the locator).

Recently we switched over to storing key path information in the constraint system 
and introduced `resolveKeyPath` method to gain more control over how key path 
type variable gets assigned.

Getting information from the constraint system creates a problem for the inference
because "undo" for some bindings would be run after solver scope has been erased, 
so instead of modifying bindings in `inferFromRelational`, let's do that in `resolveKeyPath`
right before the key path type variable gets bound which seems to be a better place for 
that logic anyway.

Resolves: rdar://113760727

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
