### PR TITLE
Generate appropriate LLVM IR attributes for custom optimization modes set on a SILFunction

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1902,6 +1902,21 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
   if (f->getLoweredFunctionType()->isCoroutine()) {
     CurFn->addFnAttr(llvm::Attribute::NoInline);
   }
+
+  auto optMode = f->getOptimizationMode();
+  if (optMode != OptimizationMode::NotSet &&
+      optMode != f->getModule().getOptions().OptMode) {
+    if (optMode == OptimizationMode::NoOptimization) {
+      CurFn->addFnAttr(llvm::Attribute::OptimizeNone);
+      // LLVM requires noinline attribute along with optnone
+      CurFn->addFnAttr(llvm::Attribute::NoInline);
+    }
+    if (optMode == OptimizationMode::ForSize) {
+      CurFn->addFnAttr(llvm::Attribute::OptimizeForSize);
+    }
+    // LLVM doesn't have an attribute for -O
+  }
+
   // Emit the thunk that calls the previous implementation if this is a dynamic
   // replacement.
   if (f->getDynamicallyReplacedFunction()) {

--- a/test/IRGen/optmode.swift
+++ b/test/IRGen/optmode.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swiftc_driver %s -emit-ir -O | %FileCheck %s 
+
+// CHECK: @"$s7optmode7square11nS2i_tF"{{.*}}[[ATTR1:#[0-9]+]]
+@_optimize(none)
+func square1(n: Int) -> Int {
+    return n * n
+}
+
+// CHECK: @"$s7optmode7square21nS2i_tF"{{.*}}[[ATTR2:#[0-9]+]]
+@_optimize(size)
+func square2(n: Int) -> Int {
+    return n * n
+}
+
+// CHECK: attributes [[ATTR1]] = { {{.*}}noinline optnone{{.*}} }
+// CHECK: attributes [[ATTR2]] = { {{.*}}optsize{{.*}} }


### PR DESCRIPTION
Fixes rdar://113584125