### PR TITLE
[Index] Write stdlib records in alphabetical order

### DIFF
--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -233,10 +233,16 @@ public:
   }
 
   void finish() override {
-    for (auto &pair : TrackerByGroup) {
-      StringRef groupName = pair.first();
-      SymbolTracker &tracker = *pair.second;
-      bool cont = onFinish(groupName, tracker);
+    SmallVector<std::pair<StringRef, SymbolTracker *>, 0> SortedGroups;
+    for (auto &entry : TrackerByGroup) {
+      SortedGroups.emplace_back(entry.first(), entry.second.get());
+    }
+    llvm::sort(SortedGroups, llvm::less_first());
+
+    for (auto &pair : SortedGroups) {
+      StringRef groupName = pair.first;
+      SymbolTracker *tracker = pair.second;
+      bool cont = onFinish(groupName, *tracker);
       if (!cont)
         break;
     }

--- a/test/Index/Store/unit-one-file-multi-file-invocation.swift
+++ b/test/Index/Store/unit-one-file-multi-file-invocation.swift
@@ -18,8 +18,8 @@
 
 // CHECK: [[SWIFT]]
 // CHECK: DEPEND START
-// CHECK: Record | system | Swift.String | [[MODULE]] | {{.+}}.swiftinterface_String-{{.*}}
 // CHECK: Record | system | Swift.Math.Floating | [[MODULE]] | {{.+}}.swiftinterface_Math_Floating-{{.*}}
+// CHECK: Record | system | Swift.String | [[MODULE]] | {{.+}}.swiftinterface_String-{{.*}}
 // CHECK: DEPEND END
 
 func test1() {


### PR DESCRIPTION
The order for writing records of the stdlib currently depends on `StringMap` iteration (in a slightly roundabout manner). Sort these alphabetically instead.