### PR TITLE
Add ld-path driver option

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -890,7 +890,11 @@ def no_static_executable : Flag<["-"], "no-static-executable">,
 
 def use_ld : Joined<["-"], "use-ld=">,
   Flags<[DoesNotAffectIncrementalBuild]>,
-  HelpText<"Specifies the linker to be used">;
+  HelpText<"Specifies the flavor of the linker to be used">;
+
+def ld_path : Joined<["--"], "ld-path=">,
+  Flags<[DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  HelpText<"Specifies the path to the linker to be used">;
 
 def Xlinker : Separate<["-"], "Xlinker">,
   Flags<[DoesNotAffectIncrementalBuild]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -893,7 +893,7 @@ def use_ld : Joined<["-"], "use-ld=">,
   HelpText<"Specifies the flavor of the linker to be used">;
 
 def ld_path : Joined<["--"], "ld-path=">,
-  Flags<[DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  Flags<[HelpHidden, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Specifies the path to the linker to be used">;
 
 def Xlinker : Separate<["-"], "Xlinker">,


### PR DESCRIPTION
This PR defines an `--ld-path` option for the Swift Driver, which is forwarded to the Clang linker-driver option with the same name. This change is required to support the `toolset.linker.path` option in [SE-0387](https://github.com/apple/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md).

## See Also

Downstream: https://github.com/apple/swift-driver/pull/1416, https://github.com/apple/swift-package-manager/pull/6719.