### PR TITLE
[Executors] Do not consider Loc validity in determining to emit error/warning about enqueue(_:)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6687,7 +6687,7 @@ WARNING(hashvalue_implementation,Deprecation,
         "conform type %0 to 'Hashable' by implementing 'hash(into:)' instead",
         (Type))
 
-WARNING(executor_enqueue_unowned_implementation,Deprecation,
+WARNING(executor_enqueue_deprecated_unowned_implementation,Deprecation,
         "'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; "
         "conform type %0 to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead",
         (Type))

--- a/test/Concurrency/custom_executor_enqueue_deprecation_on_executor_extension.swift
+++ b/test/Concurrency/custom_executor_enqueue_deprecation_on_executor_extension.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// REQUIRES: concurrency
+
+// rdar://106849189 move-only types should be supported in freestanding mode
+// UNSUPPORTED: freestanding
+
+
+extension Executor {
+  func enqueue(_ job: UnownedJob) { // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'NoneExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+    fatalError()
+  }
+}
+
+final class NoneExecutor: SerialExecutor {
+
+  // the enqueue from the extension is properly picked up,
+  // even though we do warn about deprecation on it in the extension.
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -1,11 +1,8 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 // REQUIRES: concurrency
 
 // rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
-
-// FIXME: rdar://107112715 test failing on iOS simulator, investigating
-// UNSUPPORTED: OS=ios
 
 // Such type may be encountered since Swift 5.5 (5.1 backdeployed) if someone implemented the
 // not documented, but public Executor types back then already.

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-move-only -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -verify-ignore-unknown
 // REQUIRES: concurrency
 
 // rdar://106849189 move-only types should be supported in freestanding mode


### PR DESCRIPTION
**Description:** The introduction of new protocol requirements in `protocol Executor` required careful and custom handling by the compiler in order to not break ABI/API. This logic made a wrong assumption that it can rely on valid/invalid source location information to determine if "this decl exists and is valid" -- while in reality, we cannot rely on loc _at all_ for making this decision. This happened to work in tests and swiftpm projects because source location was always available.

Symbols may not have valid loc attached just because they're in a different module and we don't have swiftsourceinfo for them. E.g. with Xcode the Archive action does not copy the swiftsourceinfo and thus we end up ALWAYS emitting the error that an implementation is missing -- even if it is there, but we simply trigger the "illegal loc!" case incorrectly.

**Solution:** Stop relying on the _incorrect assumption_ that a "valid loc" can be used to determine if we have the method or not. This worked by accident, since in swift the unit test suite we entered this missing loc code path.

Instead, we must manually inspect the witnesses and determine that at least one of them is NOT the default implementation provided in the stdlib (because we implement ALL of the requirements in order to introduce the new protocol requirement without breaking API/ABI). The same goes about warnings, since we do not want to emit warnings about the standard library when end-users do something slightly wrong in their adoption -- it is their conformance mistake we must warn about.

**Risk:** Low
**Risk details:** The primary error fix is about removing the use of loc information entirely from decision making about emitting errors, i.e. we're removing a buggy source of information from the decision making -- the primary logic all remains the same.

Due to that removal, we also add some warning suppression that previously occurred naturally (correctly "by accident"), by concretely handling the special casing of the concrete extension in `_Concurrency` module that performs actions we should not warn about in stdlib due to it implementing bin-compat concerns.

**Reward:** Medium, 
**Reward details:** Projects built in a way where `swiftsourceinfo` is not available (e.g. in Xcode by running "Archive") are now able to adopt libraries that adopted custom executors -- e.g. like Swift NIO. The reward is medium because custom executor adoption in this pattern isn't quite wide-spread yet.

**Review by:** @DougGregor @owenv 
**Testing:** Warnings and errors emitted by this are well tested; We also verified a known reproducer using Xcode and "Archive" action is resolved by a compiler with this fix.
**Scope:** This is a compiler only change.
**Radar:** rdar://113913291

