### PR TITLE
build: adjust the paths for the runtime MSI packaging rules

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -967,9 +967,7 @@ move %PackageRoot%\online\Release\amd64\*.exe %BuildRoot%\artifacts\online\ || (
 move %PackageRoot%\online\Release\amd64\*.msi %BuildRoot%\artifacts\online\ || (exit /b)
 
 :: Workaround for lack of control over Jenkins ...
-for /F "tokens=*" %%F in ('dir /b %BuildRoot%\artifacts\offline\*') DO (
-  copy %F %BuildRoot%\artifacts\ || (exit /b)
-)
+copy %BuildRoot%\artifacts\offline\installer.exe %BuildRoot%\artifacts\
 
 goto :eof
 endlocal

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -966,6 +966,11 @@ move %PackageRoot%\online\Release\amd64\*.cab %BuildRoot%\artifacts\online\ || (
 move %PackageRoot%\online\Release\amd64\*.exe %BuildRoot%\artifacts\online\ || (exit /b)
 move %PackageRoot%\online\Release\amd64\*.msi %BuildRoot%\artifacts\online\ || (exit /b)
 
+:: Workaround for lack of control over Jenkins ...
+for /F "tokens=*" %%F in ('dir /b %BuildRoot%\artifacts\offline\*') DO (
+  copy %F %BuildRoot%\artifacts\ || (exit /b)
+)
+
 goto :eof
 endlocal
 

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -928,100 +928,43 @@ endlocal
 :PackageToolchain
 setlocal enableextensions enabledelayedexpansion
 
-:: Package bld.msi
-msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bld\bld.wixproj ^
+:: Package Online Installer
+msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bundle\installer.wixproj ^
+  -m ^
   -restore ^
+  -p:BundleFlavor=web ^
+  -p:BaseReleaseDownloadUrl=https://download.swift.org/development/windows ^
   -p:Configuration=Release ^
-  -p:BaseOutputPath=%PackageRoot%\bld\ ^
+  -p:BaseOutputPath=%PackageRoot%\online\ ^
   -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
-  -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
-:: TODO(compnerd) actually perform the code-signing
-:: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\bld\bld.msi
-
-:: Package cli.msi
-msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\cli\cli.wixproj ^
-  -restore ^
-  -p:Configuration=Release ^
-  -p:BaseOutputPath=%PackageRoot%\cli\ ^
-  -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
-  -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
-:: TODO(compnerd) actually perform the code-signing
-:: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\cli\cli.msi
-
-:: Package dbg.msi
-msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\dbg\dbg.wixproj ^
-  -restore ^
-  -p:Configuration=Release ^
-  -p:BaseOutputPath=%PackageRoot%\dbg\ ^
-  -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
-  -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
-:: TODO(compnerd) actually perform the code-signing
-:: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\dbg\dbg.msi
-
-:: Package ide.msi
-msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\ide\ide.wixproj ^
-  -restore ^
-  -p:Configuration=Release ^
-  -p:BaseOutputPath=%PackageRoot%\ide\ ^
-  -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
-  -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
-:: TODO(compnerd) actually perform the code-signing
-:: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\ide\ide.msi
-
-:: Package sdk.msi
-msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\sdk\sdk.wixproj ^
-  -restore ^
-  -p:Configuration=Release ^
-  -p:BaseOutputPath=%PackageRoot%\sdk\ ^
+  -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:PLATFORM_ROOT=%PlatformRoot%\ ^
   -p:SDK_ROOT=%SDKInstallRoot%\
 :: TODO(compnerd) actually perform the code-signing
-:: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\sdk\sdk.msi
+:: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\online\installer.exe
 
-:: Package runtime.msi
-msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\runtimemsi\runtimemsi.wixproj ^
-  -restore ^
-  -p:Configuration=Release ^
-  -p:BaseOutputPath=%PackageRoot%\runtime\ ^
-  -p:SDK_ROOT=%SDKInstallRoot%\
-:: TODO(compnerd) actually perform the code-signing
-:: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\runtime\runtime.msi
-
-:: Collate MSIs
-move %PackageRoot%\bld\Release\amd64\bld.msi %PackageRoot% || (exit /b)
-move %PackageRoot%\cli\Release\amd64\cli.msi %PackageRoot% || (exit /b)
-move %PackageRoot%\dbg\Release\amd64\dbg.msi %PackageRoot% || (exit /b)
-move %PackageRoot%\ide\Release\amd64\ide.msi %PackageRoot% || (exit /b)
-move %PackageRoot%\sdk\Release\amd64\sdk.msi %PackageRoot% || (exit /b)
-move %PackageRoot%\runtime\Release\amd64\runtime.msi %PackageRoot% || (exit /b)
-
-:: Build Installer
+:: Package Offline Installer
 msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bundle\installer.wixproj ^
+  -m ^
   -restore ^
+  -p:BundleFlavor=offline ^
   -p:Configuration=Release ^
-  -p:BaseOutputPath=%PackageRoot%\installer\ ^
-  -p:MSI_LOCATION=%PackageRoot%\
+  -p:BaseOutputPath=%PackageRoot%\offline\ ^
+  -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
+  -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
+  -p:PLATFORM_ROOT=%PlatformRoot%\ ^
+  -p:SDK_ROOT=%SDKInstallRoot%\
 :: TODO(compnerd) actually perform the code-signing
 :: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\installer\installer.exe
 
 :: Stage Artifacts
-md %BuildRoot%\artifacts
+md %BuildRoot%\artifacts\online
+md %BuildRoot%\artifacts\offline
 
-:: Redistributable libraries for developers
-:: bld
-move %PackageRoot%\bld.msi %BuildRoot%\artifacts || (exit /b)
-:: cli
-move %PackageRoot%\cli.msi %BuildRoot%\artifacts || (exit /b)
-:: dbg
-move %PackageRoot%\dbg.msi %BuildRoot%\artifacts || (exit /b)
-:: ide
-move %PackageRoot%\ide.msi %BuildRoot%\artifacts || (exit /b)
-:: sdk
-move %PackageRoot%\sdk.msi %BuildRoot%\artifacts || (exit /b)
-:: runtime
-move %PackageRoot%\runtime.msi %BuildRoot%\artifacts || (exit /b)
-:: installer
-move %PackageRoot%\installer\Release\amd64\installer.exe %BuildRoot%\artifacts || (exit /b)
+move %PackageRoot%\offline\Release\amd64\installer.exe %BuildRoot%\artifacts\offline || (exit /b)
+move %PackageRoot%\online\Release\amd64\*.cab %BuildRoot%\artifacts\online\ || (exit /b)
+move %PackageRoot%\online\Release\amd64\*.exe %BuildRoot%\artifacts\online\ || (exit /b)
+move %PackageRoot%\online\Release\amd64\*.msi %BuildRoot%\artifacts\online\ || (exit /b)
 
 goto :eof
 endlocal

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -932,7 +932,7 @@ setlocal enableextensions enabledelayedexpansion
 msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bundle\installer.wixproj ^
   -m ^
   -restore ^
-  -p:BundleFlavor=web ^
+  -p:BundleFlavor=online ^
   -p:BaseReleaseDownloadUrl=https://download.swift.org/development/windows ^
   -p:Configuration=Release ^
   -p:BaseOutputPath=%PackageRoot%\online\ ^


### PR DESCRIPTION
This is the build rules update to match
apple/swift-installer-scripts#224.