### PR TITLE
Remove unnecessary `--enable-experimental-feature InitAccessors` from tests

### DIFF
--- a/test/stdlib/Observation/ObservableAvailabilityCycle.swift
+++ b/test/stdlib/Observation/ObservableAvailabilityCycle.swift
@@ -1,8 +1,8 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-feature InitAccessors -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server -primary-file %s %S/Inputs/ObservableClass.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server -primary-file %s %S/Inputs/ObservableClass.swift
 
-// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-feature InitAccessors -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server %s -primary-file %S/Inputs/ObservableClass.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server %s -primary-file %S/Inputs/ObservableClass.swift
 
 // REQUIRES: observation
 // REQUIRES: concurrency


### PR DESCRIPTION
This feature was accepted, so we no longer need to pass this flag. Worse, it triggers errors in non-Asserts compilers. Fixes rdar://113708096.
