### PR TITLE
[AddressLowering] Handle indexing into variadic tuples.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -6403,6 +6403,23 @@ tuple_extract
 
 Extracts an element from a loadable tuple value.
 
+
+tuple_pack_extract
+``````````````````
+::
+
+  sil-instruction ::= 'tuple_pack_extract' sil-value 'of' sil-operand 'as' sil-type
+
+  %value = tuple_pack_extract %index of %tuple : $(repeat each T) as $@pack_element("01234567-89AB-CDEF-0123-000000000000") U
+  // %index must be of $Builtin.PackIndex type
+  // %tuple must be of tuple type
+  // %addr will be the result type specified by the 'as' clause
+
+Extracts a value at a dynamic index from a tuple value.
+
+Only valid in opaque values mode.  Lowered by AddressLowering to
+tuple_pack_element_addr.  For more details, see that instruction.
+
 tuple_element_addr
 ``````````````````
 ::

--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -304,6 +304,7 @@ public:
   bool canForwardGuaranteedCompatibleValuesOnly() {
     switch (forwardingInst->getKind()) {
     case SILInstructionKind::TupleExtractInst:
+    case SILInstructionKind::TuplePackExtractInst:
     case SILInstructionKind::StructExtractInst:
     case SILInstructionKind::DifferentiableFunctionExtractInst:
     case SILInstructionKind::LinearFunctionExtractInst:

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2150,6 +2150,16 @@ public:
                               packIndex, tupleAddr, elementType));
   }
 
+  TuplePackExtractInst *createTuplePackExtract(SILLocation loc,
+                                               SILValue packIndex,
+                                               SILValue tuple,
+                                               SILType elementType) {
+    assert(!getFunction().getModule().useLoweredAddresses());
+    return insert(TuplePackExtractInst::create(
+        getFunction(), getSILDebugLocation(loc), packIndex, tuple, elementType,
+        tuple->getOwnershipKind()));
+  }
+
   ProjectBlockStorageInst *createProjectBlockStorage(SILLocation Loc,
                                                      SILValue Storage) {
     auto CaptureTy = Storage->getType()

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2780,6 +2780,27 @@ void SILCloner<ImplClass>::visitTuplePackElementAddrInst(
                                                     newElementType));
 }
 
+template <typename ImplClass>
+void SILCloner<ImplClass>::visitTuplePackExtractInst(
+    TuplePackExtractInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  auto loc = getOpLocation(Inst->getLoc());
+  auto newIndex = getOpValue(Inst->getIndex());
+  auto newTuple = getOpValue(Inst->getTuple());
+  auto newElementType = getOpType(Inst->getElementType());
+
+  // If the tuple-ness of the operand disappears due to substitution,
+  // replace this instruction with an unchecked_value_cast.
+  if (doesOpTupleDisappear(Inst->getTupleType())) {
+    recordClonedInstruction(Inst, getBuilder().createUncheckedValueCast(
+                                      loc, newTuple, newElementType));
+    return;
+  }
+
+  recordClonedInstruction(Inst, getBuilder().createTuplePackExtract(
+                                    loc, newIndex, newTuple, newElementType));
+}
+
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitCopyBlockInst(CopyBlockInst *Inst) {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7805,6 +7805,45 @@ public:
   }
 };
 
+/// Extracts a tuple element as appropriate for the given
+/// pack element index.  The pack index must index into a pack with
+/// the same shape as the tuple element type list.
+///
+/// Legal only in opaque values mode.  Transformed by AddressLowering to
+/// TuplePackElementAddrInst.
+class TuplePackExtractInst final
+    : public InstructionBaseWithTrailingOperands<
+          SILInstructionKind::TuplePackExtractInst, TuplePackExtractInst,
+          OwnershipForwardingSingleValueInstruction> {
+public:
+  enum { IndexOperand = 0, TupleOperand = 1 };
+
+private:
+  friend SILBuilder;
+
+  TuplePackExtractInst(SILDebugLocation debugLoc,
+                       ArrayRef<SILValue> allOperands, SILType elementType,
+                       ValueOwnershipKind forwardingOwnershipKind)
+      : InstructionBaseWithTrailingOperands(allOperands, debugLoc, elementType,
+                                            forwardingOwnershipKind) {}
+
+  static TuplePackExtractInst *
+  create(SILFunction &F, SILDebugLocation debugLoc, SILValue indexOperand,
+         SILValue tupleOperand, SILType elementType,
+         ValueOwnershipKind forwardingOwnershipKind);
+
+public:
+  SILValue getIndex() const { return getAllOperands()[IndexOperand].get(); }
+
+  SILValue getTuple() const { return getAllOperands()[TupleOperand].get(); }
+
+  CanTupleType getTupleType() const {
+    return getTuple()->getType().castTo<TupleType>();
+  }
+
+  SILType getElementType() const { return getType(); }
+};
+
 /// Projects the capture storage address from a @block_storage address.
 class ProjectBlockStorageInst
   : public UnaryInstructionBase<SILInstructionKind::ProjectBlockStorageInst,
@@ -10543,6 +10582,7 @@ OwnershipForwardingSingleValueInstruction::classof(SILInstructionKind kind) {
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:
   case SILInstructionKind::MarkUninitializedInst:
   case SILInstructionKind::TupleExtractInst:
+  case SILInstructionKind::TuplePackExtractInst:
   case SILInstructionKind::StructExtractInst:
   case SILInstructionKind::DifferentiableFunctionExtractInst:
   case SILInstructionKind::LinearFunctionExtractInst:

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -588,6 +588,8 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                     SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(TuplePackElementAddrInst, tuple_pack_element_addr,
                     SingleValueInstruction, None, DoesNotRelease)
+  SINGLE_VALUE_INST(TuplePackExtractInst, tuple_pack_extract,
+                    SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(PackElementGetInst, pack_element_get,
                     SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(StructInst, struct,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1360,6 +1360,7 @@ public:
   void visitPackElementGetInst(PackElementGetInst *i);
   void visitPackElementSetInst(PackElementSetInst *i);
   void visitTuplePackElementAddrInst(TuplePackElementAddrInst *i);
+  void visitTuplePackExtractInst(TuplePackExtractInst *i);
 
   void visitProjectBlockStorageInst(ProjectBlockStorageInst *i);
   void visitInitBlockStorageHeaderInst(InitBlockStorageHeaderInst *i);
@@ -7195,6 +7196,11 @@ void IRGenSILFunction::visitTuplePackElementAddrInst(
                                              i->getTuple()->getType(),
                                              index, elementType);
   setLoweredAddress(i, elementAddr);
+}
+
+void IRGenSILFunction::visitTuplePackExtractInst(TuplePackExtractInst *i) {
+  llvm::report_fatal_error(
+      "tuple_pack_extract not lowered by AddressLowering!?");
 }
 
 void IRGenSILFunction::visitProjectBlockStorageInst(ProjectBlockStorageInst *i){

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -312,6 +312,7 @@ OPERAND_OWNERSHIP(PointerEscape, ExtractExecutor)
 
 // Instructions that propagate a value within a borrow scope.
 OPERAND_OWNERSHIP(GuaranteedForwarding, TupleExtract)
+OPERAND_OWNERSHIP(GuaranteedForwarding, TuplePackExtract)
 OPERAND_OWNERSHIP(GuaranteedForwarding, StructExtract)
 OPERAND_OWNERSHIP(GuaranteedForwarding, DifferentiableFunctionExtract)
 OPERAND_OWNERSHIP(GuaranteedForwarding, LinearFunctionExtract)

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2423,6 +2423,26 @@ TuplePackElementAddrInst::create(SILFunction &F,
                                                  elementType);
 }
 
+TuplePackExtractInst *
+TuplePackExtractInst::create(SILFunction &F, SILDebugLocation debugLoc,
+                             SILValue indexOperand, SILValue tupleOperand,
+                             SILType elementType,
+                             ValueOwnershipKind forwardingOwnershipKind) {
+  assert(indexOperand->getType().is<BuiltinPackIndexType>());
+  assert(tupleOperand->getType().isObject() &&
+         tupleOperand->getType().is<TupleType>());
+
+  SmallVector<SILValue, 8> allOperands;
+  allOperands.push_back(indexOperand);
+  allOperands.push_back(tupleOperand);
+  collectTypeDependentOperands(allOperands, F, elementType);
+
+  auto size = totalSizeToAlloc<swift::Operand>(allOperands.size());
+  auto buffer = F.getModule().allocateInst(size, alignof(TuplePackExtractInst));
+  return ::new (buffer) TuplePackExtractInst(debugLoc, allOperands, elementType,
+                                             forwardingOwnershipKind);
+}
+
 BeginCOWMutationInst::BeginCOWMutationInst(SILDebugLocation loc,
                                SILValue operand,
                                ArrayRef<SILType> resultTypes,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2434,6 +2434,10 @@ public:
           << getIDAndType(I->getTuple()) << " as "
           << I->getElementType();
   }
+  void visitTuplePackExtractInst(TuplePackExtractInst *I) {
+    *this << Ctx.getID(I->getIndex()) << " of " << getIDAndType(I->getTuple())
+          << " as " << I->getElementType();
+  }
   void visitProjectBlockStorageInst(ProjectBlockStorageInst *PBSI) {
     *this << getIDAndType(PBSI->getOperand());
   }

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -183,6 +183,7 @@ CONSTANT_OWNERSHIP_INST(None, TuplePackElementAddr)
   }
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, StructExtract)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, TupleExtract)
+CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, TuplePackExtract)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, DifferentiableFunctionExtract)
 CONSTANT_OR_NONE_OWNERSHIP_INST(Guaranteed, LinearFunctionExtract)
 // OpenExistentialValue opens the boxed value inside an existential

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3594,6 +3594,17 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     ResultVal = B.createTuplePackElementAddr(InstLoc, index, tuple, elementType);
     break;
   }
+  case SILInstructionKind::TuplePackExtractInst: {
+    SILValue index, tuple;
+    SILType elementType;
+    if (parseValueRef(index, SILType::getPackIndexType(P.Context), InstLoc,
+                      B) ||
+        parseVerbatim("of") || parseTypedValueRef(tuple, B) ||
+        parseVerbatim("as") || parseSILType(elementType))
+      return true;
+    ResultVal = B.createTuplePackExtract(InstLoc, index, tuple, elementType);
+    break;
+  }
 
 #define UNARY_INSTRUCTION(ID)                                                  \
   case SILInstructionKind::ID##Inst:                                           \

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -588,6 +588,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
     return RuntimeEffect::Allocating | RuntimeEffect::Releasing |
            RuntimeEffect::MetaData;
 
+  case SILInstructionKind::TuplePackExtractInst:
   case SILInstructionKind::TuplePackElementAddrInst:
     return RuntimeEffect::MetaData;
 

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -241,6 +241,7 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::ObjectInst:
   case SILInstructionKind::TupleInst:
   case SILInstructionKind::TupleExtractInst:
+  case SILInstructionKind::TuplePackExtractInst:
   case SILInstructionKind::TupleElementAddrInst:
   case SILInstructionKind::StructInst:
   case SILInstructionKind::StructExtractInst:

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -896,6 +896,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   // tuple_pack_element_addr is just a GEP, but getting the offset
   // can require accessing metadata, so conservatively treat it as
   // expensive.
+  case SILInstructionKind::TuplePackExtractInst:
   case SILInstructionKind::TuplePackElementAddrInst:
     return InlineCost::Expensive;
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1494,6 +1494,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                                     elementType);
     break;
   }
+  case SILInstructionKind::TuplePackExtractInst: {
+    assert(RecordKind == SIL_PACK_ELEMENT_GET);
+    auto elementType =
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
+    auto tupleType =
+        getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn);
+    auto tuple = getLocalValue(ValID2, tupleType);
+    auto indexType = SILType::getPackIndexType(MF->getContext());
+    auto index = getLocalValue(ValID3, indexType);
+    ResultInst = Builder.createTuplePackExtract(Loc, index, tuple, elementType);
+    break;
+  }
 
 #define ONEOPERAND_ONETYPE_INST(ID)                                            \
   case SILInstructionKind::ID##Inst:                                           \

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 801; // removing builtin tuple conformances
+const uint16_t SWIFTMODULE_VERSION_MINOR = 802; // added tuple_pack_extract
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1710,15 +1710,27 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     auto tupleTypeRef = S.addTypeRef(tupleType.getRawASTType());
     auto tupleRef = addValueRef(tuple);
     auto indexRef = addValueRef(TPEAI->getIndex());
-    SILPackElementGetLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILPackElementGetLayout::Code],
-        (unsigned)SI.getKind(),
-        elementTypeRef,
-        (unsigned) elementType.getCategory(),
-        tupleTypeRef,
-        (unsigned) tupleType.getCategory(),
-        tupleRef,
-        indexRef);
+    SILPackElementGetLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILPackElementGetLayout::Code],
+        (unsigned)SI.getKind(), elementTypeRef,
+        (unsigned)elementType.getCategory(), tupleTypeRef,
+        (unsigned)tupleType.getCategory(), tupleRef, indexRef);
+    break;
+  }
+  case SILInstructionKind::TuplePackExtractInst: {
+    auto TPEI = cast<TuplePackExtractInst>(&SI);
+    auto elementType = TPEI->getElementType();
+    auto elementTypeRef = S.addTypeRef(elementType.getRawASTType());
+    auto tuple = TPEI->getTuple();
+    auto tupleType = tuple->getType();
+    auto tupleTypeRef = S.addTypeRef(tupleType.getRawASTType());
+    auto tupleRef = addValueRef(tuple);
+    auto indexRef = addValueRef(TPEI->getIndex());
+    SILPackElementGetLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILPackElementGetLayout::Code],
+        (unsigned)SI.getKind(), elementTypeRef,
+        (unsigned)elementType.getCategory(), tupleTypeRef,
+        (unsigned)tupleType.getCategory(), tupleRef, indexRef);
     break;
   }
   case SILInstructionKind::TailAddrInst: {

--- a/test/SIL/Parser/opaque_values_parse.sil
+++ b/test/SIL/Parser/opaque_values_parse.sil
@@ -115,6 +115,24 @@ bb0(%instance : @guaranteed $WeakBox<T>):
   return %strong_optional : $Optional<T>
 }
 
+// Test tuple_pack_extract parsing.
+
+// CHECK-LABEL: sil [ossa] @test_tuple_pack_extract : {{.*}} {
+// CHECK:       bb0([[TUPLE:%[^,]+]] :
+// CHECK:         [[ZERO:%[^,]+]] = integer_literal
+// CHECK:         [[INDEX:%[^,]+]] = dynamic_pack_index [[ZERO]]
+// CHECK:         [[ELT:%[^,]+]] = tuple_pack_extract [[INDEX]] of [[TUPLE]]
+// CHECK-LABEL: } // end sil function 'test_tuple_pack_extract'
+sil [ossa] @test_tuple_pack_extract : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> () {
+entry(%tuple : @guaranteed $(repeat each T)):
+  %zero = integer_literal $Builtin.Word, 0
+  %index = dynamic_pack_index %zero of $Pack{repeat each T}
+  %opened = open_pack_element %index of <each U_1> at <Pack{repeat each T}>, shape $U_1, uuid "00000000-0000-0000-0000-000000000000"
+  %elt = tuple_pack_extract %index of %tuple : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // Test weak_copy_value parsing.
 
 // CHECK-LABEL: sil [ossa] @test_weak_copy_value_1 : {{.*}} {

--- a/test/SIL/Serialization/opaque_values_serialize.sil
+++ b/test/SIL/Serialization/opaque_values_serialize.sil
@@ -99,6 +99,24 @@ bb0(%instance : @guaranteed $WeakBox<T>):
   return %strong_optional : $Optional<T>
 }
 
+// Test tuple_pack_extract parsing.
+
+// CHECK-LABEL: sil [ossa] @test_tuple_pack_extract : {{.*}} {
+// CHECK:       bb0([[TUPLE:%[^,]+]] :
+// CHECK:         [[ZERO:%[^,]+]] = integer_literal
+// CHECK:         [[INDEX:%[^,]+]] = dynamic_pack_index [[ZERO]]
+// CHECK:         [[ELT:%[^,]+]] = tuple_pack_extract [[INDEX]] of [[TUPLE]]
+// CHECK-LABEL: } // end sil function 'test_tuple_pack_extract'
+sil [ossa] @test_tuple_pack_extract : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> () {
+entry(%tuple : @guaranteed $(repeat each T)):
+  %zero = integer_literal $Builtin.Word, 0
+  %index = dynamic_pack_index %zero of $Pack{repeat each T}
+  %opened = open_pack_element %index of <each U_1> at <Pack{repeat each T}>, shape $U_1, uuid "00000000-0000-0000-0000-000000000000"
+  %elt = tuple_pack_extract %index of %tuple : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil [ossa] @test_weak_copy_value_1 : {{.*}} {
 // CHECK:       bb0([[VALUE:%[^,]+]] :
 // CHECK:         weak_copy_value [[VALUE]]

--- a/test/SIL/cloning_opaque_values.sil
+++ b/test/SIL/cloning_opaque_values.sil
@@ -2,6 +2,7 @@
 
 // Check cloning of instructions that are only legal in opaque values mode.
 
+import Builtin
 import Swift
 
 struct WeakBox<T : AnyObject> {
@@ -26,6 +27,30 @@ bb0(%instance : @guaranteed $WeakBox<T>):
   %weak_optional = struct_extract %instance : $WeakBox<T>, #WeakBox.t
   %strong_optional = strong_copy_weak_value %weak_optional : $@sil_weak Optional<T>
   return %strong_optional : $Optional<T>
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_pack_extract_caller : {{.*}} {
+// CHECK:       bb0([[TUPLE:%[^,]+]] :
+// CHECK:         [[ZERO:%[^,]+]] = integer_literal
+// CHECK:         [[INDEX:%[^,]+]] = dynamic_pack_index [[ZERO]]
+// CHECK:         open_pack_element [[INDEX]] of <each U_1> at <Pack{repeat each T}>, shape $each U_1, uuid [[UUID:"[A-F0-9\-]+"]]
+// CHECK:         tuple_pack_extract [[INDEX]] of [[TUPLE]] : $(repeat each T) as $@pack_element([[UUID]]) each U_1
+// CHECK-LABEL: } // end sil function 'tuple_pack_extract_caller'
+sil [ossa] @tuple_pack_extract_caller : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> () {
+entry(%tuple : @guaranteed $(repeat each T)):
+  %callee = function_ref @tuple_pack_extract : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> ()
+  %retval = apply %callee<Pack{repeat each T}>(%tuple) : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> ()
+  return %retval : $()
+}
+
+sil [always_inline] [ossa] @tuple_pack_extract : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> () {
+entry(%tuple : @guaranteed $(repeat each T)):
+  %zero = integer_literal $Builtin.Word, 0
+  %index = dynamic_pack_index %zero of $Pack{repeat each T}
+  %opened = open_pack_element %index of <each U_1> at <Pack{repeat each T}>, shape $U_1, uuid "00000000-0000-0000-0000-000000000000"
+  %elt = tuple_pack_extract %index of %tuple : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1
+  %retval = tuple ()
+  return %retval : $()
 }
 
 // CHECK-LABEL: sil [ossa] @weak_copy_value_caller : {{.*}} {

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2688,6 +2688,26 @@ entry:
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_tuple_pack_extract : {{.*}} {
+// CHECK:       bb0([[TUPLE_PACK_ADDR:%[^,]+]] :
+// CHECK:         [[INDEX:%[^,]+]] = dynamic_pack_index
+// CHECK:         open_pack_element [[INDEX]] of <each U_1> at <Pack{repeat each T}>, shape $each U_1, uuid [[UUID:".*"]]
+// CHECK:         [[BORROW:%[^,]+]] = function_ref @borrowT
+// CHECK:         [[ELEMENT_ADDR:%[^,]+]] = tuple_pack_element_addr [[INDEX]] of [[TUPLE_PACK_ADDR]] : {{.*}} as $*@pack_element([[UUID]]) each U_1
+// CHECK:         apply [[BORROW]]<@pack_element([[UUID]]) each U_1>([[ELEMENT_ADDR]])
+// CHECK-LABEL: } // end sil function 'test_tuple_pack_extract'
+sil [ossa] @test_tuple_pack_extract : $@convention(thin) <each T> (@in_guaranteed (repeat each T)) -> () {
+entry(%tuple : @guaranteed $(repeat each T)):
+  %zero = integer_literal $Builtin.Word, 0
+  %index = dynamic_pack_index %zero of $Pack{repeat each T}
+  %opened = open_pack_element %index of <each U_1> at <Pack{repeat each T}>, shape $U_1, uuid "00000000-0000-0000-0000-000000000002"
+  %elt = tuple_pack_extract %index of %tuple : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000002") U_1
+  %borrow = function_ref @borrowT : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %borrow<@pack_element("00000000-0000-0000-0000-000000000002") U_1>(%elt) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast :
 // CHECK: bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 // CHECK:   [[STK:%.*]] = alloc_stack $T


### PR DESCRIPTION
Although variadic values have their own conventions (`@pack_owned`, `@pack_guaranteed`) which have not yet been made direct in opaque values mode, variadic tuples use standard indirect conventions (`@in`, `@in_guaranteed`).  Consequently, in opaque values mode, a function with a variadic tuple parameter (e.g. `@in_guaranteed (repeat each T)`) will have a direct variadic tuple value in the entry block (`%tuple : @guaranteed $(repeat each T)`).

Elements are accessed from indirect variadic tuples via the `tuple_pack_element_addr` instruction.  For direct variadic tuples, the new instruction `tuple_pack_extract` is added here.  The new instruction is transformed by AddressLowering to `tuple_pack_element_addr`.  This is analogous to the situation with `tuple_extract` being transformed to `tuple_element_addr`.
