### PR TITLE
Add memeffects to InitRawStructMetadata

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2776,7 +2776,8 @@ FUNCTION(InitRawStructMetadata,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy->getPointerTo(0), Int32Ty),
          ATTRS(NoUnwind),
-         EFFECT(MetaData))
+         EFFECT(MetaData),
+         UNKNOWN_MEMEFFECTS)
 
 #undef RETURNS
 #undef ARGS


### PR DESCRIPTION
This patch adds the missing memory effects to InitRawStructMetadata to keep rebranch building.
