### PR TITLE
[AST] Update source module correction logic to support @_spiOnly imports

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5851,6 +5851,11 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     // For the current module, consider both private and public imports.
     ModuleDecl::ImportFilter Filter = ModuleDecl::ImportFilterKind::Exported;
     Filter |= ModuleDecl::ImportFilterKind::Default;
+
+    // For private swiftinterfaces, also look through @_spiOnly imports.
+    if (Options.PrintSPIs)
+      Filter |= ModuleDecl::ImportFilterKind::SPIOnly;
+
     SmallVector<ImportedModule, 4> Imports;
     Options.CurrentModule->getImportedModules(Imports, Filter);
 

--- a/test/SPI/spi-only-swiftinterface-and-merged-decls.swift
+++ b/test/SPI/spi-only-swiftinterface-and-merged-decls.swift
@@ -1,0 +1,43 @@
+/// Check that we correctly refer to @_spiOnly imported modules in the private
+/// swiftinterface and not to one of the redeclarations.
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Client.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
+
+/// We print a reference to A in the private swiftinterface.
+// RUN: %FileCheck %s < %t/Client.private.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -I %t \
+// RUN:   -module-name Client
+
+//--- module.modulemap
+module A {
+    header "A.h"
+}
+
+module B {
+    header "B.h"
+}
+
+//--- A.h
+@interface MovingType
+@end
+
+//--- B.h
+@class MovingType;
+
+//--- Client.swift
+import B
+@_spiOnly import A
+
+@_spi(_)
+public func foo(_ a: MovingType) {}
+// CHECK: A.MovingType


### PR DESCRIPTION
This logic may override the module considered as the source of a decl to ensure that only visible modules are printed in the swiftinterface. This change updates it to consider `@_spiOnly` imported modules from the local module as visible when printing the private swiftinterface only.

rdar://103325332