### PR TITLE
[ConstraintSystem] Resolve key path function applications via resolveKeyPath

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1251,7 +1251,7 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
 
   if (TypeVar->getImpl().isKeyPathType()) {
     auto objectTy = type->lookThroughAllOptionalTypes();
-    if (!isKnownKeyPathType(objectTy))
+    if (!(isKnownKeyPathType(objectTy) || objectTy->is<AnyFunctionType>()))
       return llvm::None;
     
     auto &ctx = CS.getASTContext();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6827,8 +6827,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           // unexpected state for key path diagnostics should we fail.
           if (locator->isLastElement<LocatorPathElt::KeyPathType>() &&
               type2->is<AnyFunctionType>())
-            return matchTypesBindTypeVar(typeVar1, type2, kind, flags, locator,
-                                         formUnsolvedResult);
+            return matchTypesBindTypeVar(typeVar1, type2, kind,
+                                         flags | TMF_BindingTypeVariable,
+                                         locator, formUnsolvedResult);
         }
 
         // Performance optimization: Propagate fully or partially resolved

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12191,6 +12191,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
           return locator->isInKeyPathComponent() &&
                  tv->getImpl().canBindToHole();
         })) {
+      (void)tryMatchRootAndValueFromType(keyPathTy);
       return SolutionKind::Solved;
     }
   }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -918,13 +918,12 @@ func testKeyPathHole() {
   provideValueButNotRoot(\.x.y) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
   provideValueButNotRoot(\String.foo) // expected-error {{value of type 'String' has no member 'foo'}}
 
-  func provideKPValueButNotRoot<T>(_ kp: KeyPath<T, String>) {} // expected-note {{in call to function 'provideKPValueButNotRoot'}}
+  func provideKPValueButNotRoot<T>(_ kp: KeyPath<T, String>) {} 
   provideKPValueButNotRoot(\.x) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
   provideKPValueButNotRoot(\.x.y) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
 
   provideKPValueButNotRoot(\String.foo)
   // expected-error@-1 {{value of type 'String' has no member 'foo'}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 }
 
 func testMissingMember() {


### PR DESCRIPTION
[In addition to inferring AnyKeyPath and PartialKeyPath bindings](https://github.com/apple/swift/pull/67948), `resolveKeyPath` will also handle `AnyFunctionType` key path bindings. These changes update certain pathways for checking function application bindings to go through `resolveKeyPath` for key path types. 