### PR TITLE
Revert "AST: Spot fix for AbstractStorageDecl::isResilient()"

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2810,26 +2810,13 @@ bool AbstractStorageDecl::isResilient() const {
   return getModuleContext()->isResilient();
 }
 
-static bool isOriginallyDefinedIn(const Decl *D, const ModuleDecl* MD) {
-  if (!MD)
-    return false;
-  if (D->getAlternateModuleName().empty())
-    return false;
-  return D->getAlternateModuleName() == MD->getName().str();
-}
-
 bool AbstractStorageDecl::isResilient(ModuleDecl *M,
                                       ResilienceExpansion expansion) const {
   switch (expansion) {
   case ResilienceExpansion::Minimal:
     return isResilient();
   case ResilienceExpansion::Maximal:
-    // We consider this decl belongs to the module either it's currently
-    // defined in this module or it's originally defined in this module, which
-    // is specified by @_originallyDefinedIn
-    return (M != getModuleContext() &&
-            !isOriginallyDefinedIn(this, M) &&
-            isResilient());
+    return M != getModuleContext() && isResilient();
   }
   llvm_unreachable("bad resilience expansion");
 }
@@ -4782,6 +4769,14 @@ DestructorDecl *NominalTypeDecl::getValueTypeDestructor() {
   return cast<DestructorDecl>(found[0]);
 }
 
+static bool isOriginallyDefinedIn(const Decl *D, const ModuleDecl* MD) {
+  if (!MD)
+    return false;
+  if (D->getAlternateModuleName().empty())
+    return false;
+  return D->getAlternateModuleName() == MD->getName().str();
+}
+
 bool NominalTypeDecl::isResilient(ModuleDecl *M,
                                   ResilienceExpansion expansion) const {
   switch (expansion) {
@@ -4791,9 +4786,8 @@ bool NominalTypeDecl::isResilient(ModuleDecl *M,
     // We consider this decl belongs to the module either it's currently
     // defined in this module or it's originally defined in this module, which
     // is specified by @_originallyDefinedIn
-    return (M != getModuleContext() &&
-            !isOriginallyDefinedIn(this, M) &&
-            isResilient());
+    return M != getModuleContext() && !isOriginallyDefinedIn(this, M) &&
+      isResilient();
   }
   llvm_unreachable("bad resilience expansion");
 }

--- a/test/SILGen/Inputs/library_evolution_property_originally_defined_in_current_module_NewModule.swift
+++ b/test/SILGen/Inputs/library_evolution_property_originally_defined_in_current_module_NewModule.swift
@@ -1,0 +1,11 @@
+@available(macOS 10.15, *)
+@_originallyDefinedIn(module: "OldModule", macOS 12.0)
+public struct OldModuleType {
+    public let value: UInt32
+
+    public static let property = OldModuleType(value: 0xFFFF_FFFF)
+
+    public init(value: UInt32) {
+      self.value = value
+    }
+}

--- a/test/SILGen/library_evolution_property_originally_defined_in_current_module.swift
+++ b/test/SILGen/library_evolution_property_originally_defined_in_current_module.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-library-evolution -module-name NewModule -emit-module-path %t/NewModule.swiftmodule -emit-module %S/Inputs/library_evolution_property_originally_defined_in_current_module_NewModule.swift
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos12 -I %t -module-name OldModule -emit-silgen %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+import NewModule
+
+@inline(never)
+public func use2<T>(_ t: T) {
+    print(t)
+}
+
+// CHECK-NOT: @{{.*}}8property{{.*}}vau :
+
+public func use() {
+    // We should access `OldModuleType.property` via its getter exported from
+    // NewModule, even though it was _originallyDefinedIn our module.
+    // CHECK: function_ref @{{.*}}8property{{.*}}vgZ :
+    use2(OldModuleType.property)
+    print(OldModuleType.property)
+}
+// CHECK-NOT: @{{.*}}8property{{.*}}vau :


### PR DESCRIPTION
This reverts commit d5b354fd5f93a2ce9fce9e55f24d993b1bef5381. It causes miscompiles when accessing properties declared with `@_originallyDefinedIn` that are now defined in modules with library evolution enabled from the module that the property was originally defined in. Just because the property used to be declared in the current module doesn't mean it can bypass the stable ABI of the module that the property now belongs to.

It looks like the logic that this PR replaced is also faulty, since `@_originallyDefinedIn` really oughtn't factor into the resilience computation at any level, but let's unwind one level of brokenness at a time.

Fixes rdar://113935401.