### PR TITLE
enforce under strict concurrency that globals and statics be either…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5243,6 +5243,15 @@ NOTE(actor_mutable_state,none,
 WARNING(shared_mutable_state_access,none,
         "reference to %kind0 is not concurrency-safe because it involves "
         "shared mutable state", (const ValueDecl *))
+WARNING(shared_mutable_state_decl,none,
+        "%kind0 is not concurrency-safe because it is non-isolated global "
+        "shared mutable state", (const ValueDecl *))
+NOTE(shared_mutable_state_decl_note,none,
+     "isolate %0 to a global actor, or convert it to a 'let' constant and "
+     "conform it to 'Sendable'", (const ValueDecl *))
+WARNING(shared_immutable_state_decl,none,
+        "%kind0 is not concurrency-safe because it is not either conforming to "
+        "'Sendable' or isolated to a global actor", (const ValueDecl *))
 ERROR(actor_isolated_witness,none,
      "%select{|distributed }0%1 %kind2 cannot be used to satisfy %3 protocol "
      "requirement",

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -220,6 +220,9 @@ EXPERIMENTAL_FEATURE(StrictConcurrency, true)
 /// Defer Sendable checking to SIL diagnostic phase.
 EXPERIMENTAL_FEATURE(SendNonSendable, false)
 
+/// Within strict concurrency, narrow global variable isolation requirements.
+EXPERIMENTAL_FEATURE(GlobalConcurrency, false)
+
 /// Enable extended callbacks (with additional parameters) to be used when the
 /// "playground transform" is enabled.
 EXPERIMENTAL_FEATURE(PlaygroundExtendedCallbacks, true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3504,6 +3504,8 @@ static bool usesFeatureSendNonSendable(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureGlobalConcurrency(Decl *decl) { return false; }
+
 static bool usesFeaturePlaygroundExtendedCallbacks(Decl *decl) {
   return false;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -953,14 +953,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Opts.isSwiftVersionAtLeast(6)) {
     Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
   } else if (const Arg *A = Args.getLastArg(OPT_strict_concurrency)) {
-    auto value =
-        llvm::StringSwitch<llvm::Optional<StrictConcurrency>>(A->getValue())
-            .Case("minimal", StrictConcurrency::Minimal)
-            .Case("targeted", StrictConcurrency::Targeted)
-            .Case("complete", StrictConcurrency::Complete)
-            .Default(llvm::None);
-
-    if (value)
+    if (auto value = parseStrictConcurrency(A->getValue()))
       Opts.StrictConcurrencyLevel = *value;
     else
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictConcurrency
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature StrictConcurrency=complete
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency -enable-experimental-feature GlobalConcurrency
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency
 // REQUIRES: concurrency
 
 class C1 { } // expected-note{{class 'C1' does not conform to the 'Sendable' protocol}}
@@ -19,4 +19,41 @@ struct Test1: TestProtocol { // expected-warning{{type 'Test1.Value' (aka 'C1') 
 struct Test2: TestProtocol { // expected-warning{{conformance of 'C2' to 'Sendable' is unavailable}}
   // expected-note@-1{{in associated type 'Self.Value' (inferred as 'C2')}}
   typealias Value = C2
+}
+
+@globalActor
+actor TestGlobalActor {
+  static var shared = TestGlobalActor()
+}
+
+@TestGlobalActor
+var mutableIsolatedGlobal = 1
+
+var mutableNonisolatedGlobal = 1 // expected-warning{{var 'mutableNonisolatedGlobal' is not concurrency-safe because it is non-isolated global shared mutable state}}
+// expected-note@-1{{isolate 'mutableNonisolatedGlobal' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
+
+let immutableGlobal = 1
+
+final class TestSendable: Sendable {
+  init() {}
+}
+
+final class TestNonsendable {
+  init() {}
+}
+
+struct A {
+  static let immutableExplicitSendable = TestSendable()
+  static let immutableNonsendableGlobal = TestNonsendable() // expected-warning{{static property 'immutableNonsendableGlobal' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor}}
+  static let immutableInferredSendable = 0
+  static var mutable = 0 // expected-warning{{static property 'mutable' is not concurrency-safe because it is non-isolated global shared mutable state}}
+  // expected-note@-1{{isolate 'mutable' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
+  // expected-note@-2{{static property declared here}}
+}
+
+@TestGlobalActor
+func f() {
+  print(A.immutableExplicitSendable)
+  print(A.immutableInferredSendable)
+  print(A.mutable) // expected-warning{{reference to static property 'mutable' is not concurrency-safe because it involves shared mutable state}}
 }


### PR DESCRIPTION
…isolated to a global actor or Sendable plus immutable

rdar://81629027 Global and static variable data-race safety