### PR TITLE
[CxxInterop] Change C++ interop header ordering

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -388,12 +388,15 @@ void ClangSyntaxPrinter::printPrimaryCxxTypeName(
 
 void ClangSyntaxPrinter::printIncludeForShimHeader(StringRef headerName) {
   printIgnoredDiagnosticBlock("non-modular-include-in-framework-module", [&] {
+    os << "// Allow user to find the header using additional include paths\n";
+    os << "#if __has_include(<swiftToCxx/" << headerName << ">)\n";
+    os << "#include <swiftToCxx/" << headerName << ">\n";
     os << "// Look for the C++ interop support header relative to clang's "
           "resource dir:\n";
     os << "//  "
           "'<toolchain>/usr/lib/clang/<version>/include/../../../swift/"
           "swiftToCxx'.\n";
-    os << "#if __has_include(<../../../swift/swiftToCxx/" << headerName
+    os << "#elif __has_include(<../../../swift/swiftToCxx/" << headerName
        << ">)\n";
     os << "#include <../../../swift/swiftToCxx/" << headerName << ">\n";
     os << "#elif __has_include(<../../../../../lib/swift/swiftToCxx/"
@@ -404,10 +407,6 @@ void ClangSyntaxPrinter::printIncludeForShimHeader(StringRef headerName) {
           "swift/swiftToCxx'.\n";
     os << "#include <../../../../../lib/swift/swiftToCxx/" << headerName
        << ">\n";
-    os << "// Alternatively, allow user to find the header using additional "
-          "include path into '<toolchain>/lib/swift'.\n";
-    os << "#elif __has_include(<swiftToCxx/" << headerName << ">)\n";
-    os << "#include <swiftToCxx/" << headerName << ">\n";
     os << "#endif\n";
   });
 }

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -94,18 +94,19 @@
 // CHECK-EMPTY:
 // CHECK-NEXT:  #endif
 // CHECK-NEXT: #define SWIFT_CXX_INTEROP_STRING_MIXIN
+
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"
+// CHECK-NEXT: // Allow user to find the header using additional include paths
+// CHECK-NEXT: #if __has_include(<swiftToCxx/_SwiftStdlibCxxOverlay.h>)
+// CHECK-NEXT: #include <swiftToCxx/_SwiftStdlibCxxOverlay.h>
 // CHECK-NEXT: // Look for the C++ interop support header relative to clang's resource dir:
-// CHECK-NEXT: //  '<toolchain>/usr/lib/clang/<version>/include/../../../swift/swiftToCxx'.
-// CHECK-NEXT: #if __has_include(<../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
+// CHECK-NEXT: // '<toolchain>/usr/lib/clang/<version>/include/../../../swift/swiftToCxx'.
+// CHECK-NEXT: #elif __has_include(<../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
 // CHECK-NEXT: #include <../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>
 // CHECK-NEXT: #elif __has_include(<../../../../../lib/swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
-// CHECK-NEXT: //  '<toolchain>/usr/local/lib/clang/<version>/include/../../../../../lib/swift/swiftToCxx'.
+// CHECK-NEXT: // '<toolchain>/usr/local/lib/clang/<version>/include/../../../../../lib/swift/swiftToCxx'.
 // CHECK-NEXT: #include <../../../../../lib/swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>
-// CHECK-NEXT: // Alternatively, allow user to find the header using additional include path into '<toolchain>/lib/swift'.
-// CHECK-NEXT: #elif __has_include(<swiftToCxx/_SwiftStdlibCxxOverlay.h>)
-// CHECK-NEXT: #include <swiftToCxx/_SwiftStdlibCxxOverlay.h>
 // CHECK-NEXT: #endif
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: private:
@@ -129,14 +130,16 @@
 
 // CHECK: #pragma clang diagnostic push
 // CHECK: #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"
-// CHECK: #if __has_include(<../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
+// CHECK-NEXT: // Allow user to find the header using additional include paths
+// CHECK-NEXT: #if __has_include(<swiftToCxx/_SwiftStdlibCxxOverlay.h>)
+// CHECK-NEXT: #include <swiftToCxx/_SwiftStdlibCxxOverlay.h>
+// CHECK-NEXT: // Look for the C++ interop support header relative to clang's resource dir:
+// CHECK-NEXT: // '<toolchain>/usr/lib/clang/<version>/include/../../../swift/swiftToCxx'.
+// CHECK-NEXT: #elif __has_include(<../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
 // CHECK-NEXT: #include <../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>
 // CHECK-NEXT: #elif __has_include(<../../../../../lib/swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)
-// CHECK-NEXT: //  '<toolchain>/usr/local/lib/clang/<version>/include/../../../../../lib/swift/swiftToCxx'.
+// CHECK-NEXT: // '<toolchain>/usr/local/lib/clang/<version>/include/../../../../../lib/swift/swiftToCxx'.
 // CHECK-NEXT: #include <../../../../../lib/swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>
-// CHECK-NEXT: // Alternatively, allow user to find the header using additional include path into '<toolchain>/lib/swift'.
-// CHECK-NEXT: #elif __has_include(<swiftToCxx/_SwiftStdlibCxxOverlay.h>)
-// CHECK-NEXT: #include <swiftToCxx/_SwiftStdlibCxxOverlay.h>
 // CHECK-NEXT: #endif
 // CHECK-NEXTZ: #pragma clang diagnostic pop
 

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -98,16 +98,16 @@
 // CHECK-NEXT:  #if defined(__cplusplus)
 // CHECK-NEXT:  #pragma clang diagnostic push
 // CHECK-NEXT:  #pragma clang diagnostic ignored "-Wnon-modular-include-in-framework-module"
+// CHECK-NEXT:  // Allow user to find the header using additional include paths
+// CHECK-NEXT:  #if __has_include(<swiftToCxx/_SwiftCxxInteroperability.h>)
+// CHECK-NEXT:  #include <swiftToCxx/_SwiftCxxInteroperability.h>
 // CHECK-NEXT:  // Look for the C++ interop support header relative to clang's resource dir:
-// CHECK-NEXT:  //  '<toolchain>/usr/lib/clang/<version>/include/../../../swift/swiftToCxx'.
-// CHECK-NEXT:  #if __has_include(<../../../swift/swiftToCxx/_SwiftCxxInteroperability.h>)
+// CHECK-NEXT:  // '<toolchain>/usr/lib/clang/<version>/include/../../../swift/swiftToCxx'.
+// CHECK-NEXT:  #elif __has_include(<../../../swift/swiftToCxx/_SwiftCxxInteroperability.h>)
 // CHECK-NEXT:  #include <../../../swift/swiftToCxx/_SwiftCxxInteroperability.h>
 // CHECK-NEXT:  #elif __has_include(<../../../../../lib/swift/swiftToCxx/_SwiftCxxInteroperability.h>)
-// CHECK-NEXT:  //  '<toolchain>/usr/local/lib/clang/<version>/include/../../../../../lib/swift/swiftToCxx'.
+// CHECK-NEXT:  // '<toolchain>/usr/local/lib/clang/<version>/include/../../../../../lib/swift/swiftToCxx'.
 // CHECK-NEXT:  #include <../../../../../lib/swift/swiftToCxx/_SwiftCxxInteroperability.h>
-// CHECK-NEXT:  // Alternatively, allow user to find the header using additional include path into '<toolchain>/lib/swift'.
-// CHECK-NEXT:  #elif __has_include(<swiftToCxx/_SwiftCxxInteroperability.h>)
-// CHECK-NEXT:  #include <swiftToCxx/_SwiftCxxInteroperability.h>
 // CHECK-NEXT:  #endif
 // CHECK-NEXT:  #pragma clang diagnostic pop
 // CHECK-NEXT:  #if __has_feature(objc_modules)


### PR DESCRIPTION
Consider the case of a toolchain that includes clang is being used to compile Swift. With the current ordering, the header will be found relative to that toolchain, which could be out of date as compared to tip. This is the case today if eg. a 5.7 toolchain is used to build main/5.9 as the shim header is missing a definition.