### PR TITLE
[Macros] Fix handling of extension macro conformances and witnesses

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -175,9 +175,6 @@ enum class ConformanceLookupKind : unsigned {
   /// All conformances except structurally-derived conformances, of which
   /// Sendable is the only one.
   NonStructural,
-  /// Exclude conformances added by a macro that has not been expanded
-  /// yet.
-  ExcludeUnexpandedMacros,
 };
 
 /// Describes a diagnostic for a conflict between two protocol

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -552,6 +552,8 @@ public:
     assert((sourceKind == ConformanceEntryKind::Implied) ==
                (bool)implyingConformance &&
            "an implied conformance needs something that implies it");
+    assert(sourceKind != ConformanceEntryKind::PreMacroExpansion &&
+           "cannot create conformance pre-macro-expansion");
     SourceKindAndImplyingConformance = {implyingConformance, sourceKind};
   }
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -892,6 +892,16 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
   if (!conformingDC)
     return nullptr;
 
+  // Never produce a conformance for a pre-macro-expansion conformance. They
+  // are placeholders that will be superseded.
+  if (entry->getKind() == ConformanceEntryKind::PreMacroExpansion) {
+    if (auto supersedingEntry = entry->SupersededBy) {
+      return getConformance(nominal, supersedingEntry);
+    }
+
+    return nullptr;
+  }
+
   auto *conformingNominal = conformingDC->getSelfNominalTypeDecl();
 
   // Form the conformance.
@@ -929,6 +939,16 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
           ? conformingNominal->getLoc()
           : cast<ExtensionDecl>(conformingDC)->getLoc();
 
+    NormalProtocolConformance *implyingConf = nullptr;
+    if (entry->Source.getKind() == ConformanceEntryKind::Implied) {
+      auto implyingEntry = entry->Source.getImpliedSource();
+      auto origImplyingConf = getConformance(conformingNominal, implyingEntry);
+      if (!origImplyingConf)
+        return nullptr;
+
+      implyingConf = origImplyingConf->getRootNormalConformance();
+    }
+
     // Create or find the normal conformance.
     auto normalConf =
         ctx.getNormalConformance(conformingType, protocol, conformanceLoc,
@@ -939,12 +959,6 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
     // early return at the start of this function.
     entry->Conformance = normalConf;
 
-    NormalProtocolConformance *implyingConf = nullptr;
-    if (entry->Source.getKind() == ConformanceEntryKind::Implied) {
-      auto implyingEntry = entry->Source.getImpliedSource();
-      implyingConf = getConformance(conformingNominal, implyingEntry)
-                         ->getRootNormalConformance();
-    }
     normalConf->setSourceKindAndImplyingConformance(entry->Source.getKind(),
                                                     implyingConf);
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1295,8 +1295,8 @@ IterableDeclContext::getLocalConformances(ConformanceLookupKind lookupKind)
            switch (conformance->getSourceKind()) {
            case ConformanceEntryKind::Explicit:
            case ConformanceEntryKind::Synthesized:
+               return true;
            case ConformanceEntryKind::PreMacroExpansion:
-             return true;
            case ConformanceEntryKind::Implied:
            case ConformanceEntryKind::Inherited:
              return false;
@@ -1307,34 +1307,22 @@ IterableDeclContext::getLocalConformances(ConformanceLookupKind lookupKind)
            case ConformanceEntryKind::Explicit:
            case ConformanceEntryKind::Synthesized:
            case ConformanceEntryKind::Implied:
-           case ConformanceEntryKind::PreMacroExpansion:
              return true;
            case ConformanceEntryKind::Inherited:
+           case ConformanceEntryKind::PreMacroExpansion:
              return false;
            }
 
          case ConformanceLookupKind::All:
          case ConformanceLookupKind::NonStructural:
            return true;
-
-          case ConformanceLookupKind::ExcludeUnexpandedMacros:
-           switch (conformance->getSourceKind()) {
-           case ConformanceEntryKind::PreMacroExpansion:
-             return false;
-           case ConformanceEntryKind::Explicit:
-           case ConformanceEntryKind::Synthesized:
-           case ConformanceEntryKind::Implied:
-           case ConformanceEntryKind::Inherited:
-             return true;
-           }
          }
       });
 
   // If we want to add structural conformances, do so now.
   switch (lookupKind) {
     case ConformanceLookupKind::All:
-    case ConformanceLookupKind::NonInherited:
-    case ConformanceLookupKind::ExcludeUnexpandedMacros: {
+    case ConformanceLookupKind::NonInherited: {
       // Look for a Sendable conformance globally. If it is synthesized
       // and matches this declaration context, use it.
       auto dc = getAsGenericContext();

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -238,9 +238,6 @@ class SILSymbolVisitorImpl : public ASTVisitor<SILSymbolVisitorImpl> {
   void addConformances(const IterableDeclContext *IDC) {
     for (auto conformance :
          IDC->getLocalConformances(ConformanceLookupKind::NonInherited)) {
-      if (conformance->getSourceKind() == ConformanceEntryKind::PreMacroExpansion)
-        continue;
-
       auto protocol = conformance->getProtocol();
       if (Ctx.getOpts().PublicSymbolsOnly &&
           getDeclLinkage(protocol) != FormalLinkage::PublicUnique)

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1132,9 +1132,6 @@ public:
     // are existential and do not have witness tables.
     for (auto *conformance : theType->getLocalConformances(
                                ConformanceLookupKind::NonInherited)) {
-      if (conformance->getSourceKind() == ConformanceEntryKind::PreMacroExpansion)
-        continue;
-
       assert(conformance->isComplete());
       if (auto *normal = dyn_cast<NormalProtocolConformance>(conformance))
         SGM.getWitnessTable(normal);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1592,15 +1592,7 @@ swift::expandExtensions(CustomAttr *attr, MacroDecl *macro,
   for (auto protocol : potentialConformances) {
     SmallVector<ProtocolConformance *, 2> existingConformances;
     nominal->lookupConformance(protocol, existingConformances);
-
-    bool hasExistingConformance = llvm::any_of(
-        existingConformances,
-        [&](ProtocolConformance *conformance) {
-          return conformance->getSourceKind() !=
-              ConformanceEntryKind::PreMacroExpansion;
-        });
-
-    if (!hasExistingConformance) {
+    if (existingConformances.empty()) {
       introducedConformances.push_back(protocol);
     }
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6417,8 +6417,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   const auto defaultAccess = nominal->getFormalAccess();
 
   // Check each of the conformances associated with this context.
-  auto conformances = idc->getLocalConformances(
-      ConformanceLookupKind::ExcludeUnexpandedMacros);
+  auto conformances = idc->getLocalConformances();
 
   // The conformance checker bundle that checks all conformances in the context.
   auto &Context = dc->getASTContext();

--- a/test/IDE/complete_optionset.swift
+++ b/test/IDE/complete_optionset.swift
@@ -28,7 +28,6 @@ public macro OptionSet<RawType>() =
 // MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        secondDay[#ShippingOptions#]; name=secondDay
 // MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        priority[#ShippingOptions#]; name=priority
 // MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        standard[#ShippingOptions#]; name=standard
-// MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        ArrayLiteralElement[#ShippingOptions#]; name=ArrayLiteralElement
 // MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        Element[#ShippingOptions#]; name=Element
 // MEMBER_STATIC: Decl[Constructor]/Super/IsSystem:   init()[#ShippingOptions#]; name=init()
 // MEMBER_STATIC: Decl[Constructor]/Super/IsSystem:   init({#(sequence): Sequence#})[#ShippingOptions#]; name=init(:)

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1290,6 +1290,39 @@ public struct EquatableMacro: ExtensionMacro {
   }
 }
 
+public struct EquatableViaMembersMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let comparisons: [String] = decl.storedProperties().map { property in
+      guard let binding = property.bindings.first,
+            let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier else {
+        return "true"
+      }
+
+      return "lhs.\(identifier) == rhs.\(identifier)"
+    }
+
+    let condition = comparisons.joined(separator: " && ")
+    let equalOperator: DeclSyntax = """
+      static func ==(lhs: \(type.trimmed), rhs: \(type.trimmed)) -> Bool {
+        return \(raw: condition)
+      }
+      """
+
+    let ext: DeclSyntax = """
+      extension \(type.trimmed): Equatable {
+        \(equalOperator)
+      }
+      """
+    return [ext.cast(ExtensionDeclSyntax.self)]
+  }
+}
+
 public struct ConformanceViaExtensionMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -179,3 +179,22 @@ struct MultipleConformances {}
 // CHECK-DUMP: }
 // CHECK-DUMP: extension MultipleConformances: P2 {
 // CHECK-DUMP: }
+
+@attached(extension, conformances: Equatable, names: named(==))
+macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableViaMembersMacro")
+
+@propertyWrapper
+struct NotEquatable<T> {
+  var wrappedValue: T
+}
+
+@Equatable
+struct HasPropertyWrappers {
+  @NotEquatable
+  var value: Int = 0
+}
+
+func requiresEquatable<T: Equatable>(_: T) { }
+func testHasPropertyWrappers(hpw: HasPropertyWrappers) {
+  requiresEquatable(hpw)
+}


### PR DESCRIPTION
Fix two inter-related issues with extension macros that provide conformances to a protocol, the combined effect of which is that one cannot meaningfully provide extension macros that implement conformances to a protocol like Equatable or Hashable that also supports auto-synthesis.

The first issue involves name lookup of operators provided by macro expansions. The logic for performing qualified lookup in addition to unqualified lookup (for operators) did not account for extension macros in the same manner as it did for member macros, so we would not find a macro-produced operator (such as operator==) in witness matching.

The second issue is more fundamental, which is that the conformance lookup table would create `NormalProtocolConformance` instances for pre-macro-expansion conformance entries, even though these should always have been superseded by explicit conformances within the macro expansion buffers. The end result is that we could end up with two `NormalProtocolConformance` records for the same conformance. Some code was taught to ignore the pre-expansion placeholder conformances, other code was not. Instead, we now refuse to create a `NormalProtocolConformance` for the pre-expansion entries, and remove all of the special-case checks for this, so we always using the superseding explicit conformances produced by the macro expansions (or error if the macros don't produce them).

Fixes rdar://113994346 / https://github.com/apple/swift/issues/66348
