### PR TITLE
Frontend: Migrate several options to no longer be ignorable in swiftinterfaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,7 @@
 /include/swift/IDE/                                @ahoppen @bnbarham @rintaro @hamishknight
 /include/swift/Index/                              @bnbarham
 /include/swift/Refactoring                         @ahoppen @bnbarham
+/include/swift/Option/*Options*                    @tshortli
 /include/swift/Parse/                              @ahoppen @bnbarham @CodaFi @DougGregor @rintaro
 /include/swift/PrintAsClang                        @zoecarver @hyp @egorzhdan
 # TODO: /include/swift/SIL/

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -532,7 +532,7 @@ def package_name : Separate<["-"], "package-name">,
   Flags<[FrontendOption, ModuleInterfaceOptionIgnorablePrivate]>,
   HelpText<"Name of the package the module belongs to">;
 def export_as : Separate<["-"], "export-as">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Module name to use when referenced in clients module interfaces">;
 
 def emit_module : Flag<["-"], "emit-module">,
@@ -762,7 +762,7 @@ def disable_actor_data_race_checks :
   HelpText<"Disable runtime checks for actor data races">;
 
 def enable_bare_slash_regex : Flag<["-"], "enable-bare-slash-regex">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable the use of forward slash regular-expression literal syntax">;
 
 def warn_implicit_overrides :
@@ -794,11 +794,11 @@ def strict_concurrency : Joined<["-"], "strict-concurrency=">,
 
 def enable_experimental_feature :
   Separate<["-"], "enable-experimental-feature">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable an experimental feature">;
 
 def enable_upcoming_feature : Separate<["-"], "enable-upcoming-feature">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable a feature that will be introduced in an upcoming language "
            "version">;
 
@@ -1286,7 +1286,7 @@ def explain_module_dependency : Separate<["-"], "explain-module-dependency">,
   HelpText<"Emit remark/notes describing why compilaiton may depend on a module with a given name.">;
 
 def min_inlining_target_version : Separate<["-"], "target-min-inlining-version">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Require inlinable code with no '@available' attribute to back-deploy "
            "to this version of the '-target' OS">;
 
@@ -1405,12 +1405,12 @@ def working_directory_EQ : Joined<["-"], "working-directory=">,
   Alias<working_directory>;
 
 def user_module_version : Separate<["-"], "user-module-version">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable, NewDriverOnlyOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption, NewDriverOnlyOption]>,
   HelpText<"Module version specified from Swift module authors">,
   MetaVarName<"<vers>">;
 
 def allowable_client : Separate<["-"], "allowable-client">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable, NewDriverOnlyOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption, NewDriverOnlyOption]>,
   HelpText<"Module names that are allowed to import this module">,
   MetaVarName<"<vers>">;
 // VFS

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -622,8 +622,8 @@ ModuleDependenciesCache::ModuleDependenciesCache(
     std::string scannerContextHash)
     : globalScanningService(globalScanningService),
       mainScanModuleName(mainScanModuleName),
-      moduleOutputPath(moduleOutputPath),
       scannerContextHash(scannerContextHash),
+      moduleOutputPath(moduleOutputPath),
       clangScanningTool(*globalScanningService.ClangScanningService,
                         globalScanningService.getClangScanningFS()) {
   globalScanningService.configureForContextHash(scannerContextHash);

--- a/test/ModuleInterface/allowable-client.swift
+++ b/test/ModuleInterface/allowable-client.swift
@@ -7,7 +7,7 @@
 
 // RUN: %FileCheck %s --check-prefix=INTERFACE-FLAG < %t/textual/Foo.swiftinterface
 
-// INTERFACE-FLAG: swift-module-flags-ignorable:
+// INTERFACE-FLAG: swift-module-flags:
 // INTERFACE-FLAG: -allowable-client FooFriend1 -allowable-client FooFriend2 -allowable-client FooFriend3
 
 

--- a/test/ModuleInterface/option-filtering.swift
+++ b/test/ModuleInterface/option-filtering.swift
@@ -5,7 +5,7 @@
 //
 // CHECK-SWIFTINTERFACE-NOT: -enable-experimental-feature LayoutStringValueWitnesses
 // CHECK-SWIFTINTERFACE-NOT: -enable-experimental-feature LayoutStringValueWitnessesInstantiation
-// CHECK-SWIFTINTERFACE: swift-module-flags-ignorable:
+// CHECK-SWIFTINTERFACE: swift-module-flags:
 // CHECK-SWIFTINTERFACE-SAME: -enable-experimental-feature MoveOnlyClasses
 // CHECK-SWIFTINTERFACE-SAME: -enable-experimental-feature NoImplicitCopy
 

--- a/test/ModuleInterface/option-preservation.swift
+++ b/test/ModuleInterface/option-preservation.swift
@@ -5,11 +5,10 @@
 //
 // CHECK-SWIFTINTERFACE: swift-module-flags:
 // CHECK-SWIFTINTERFACE-SAME: -enable-library-evolution
+// CHECK-SWIFTINTERFACE-SAME: -target-min-inlining-version 42
 // CHECK-SWIFTINTERFACE-SAME: -Onone
 // CHECK-SWIFTINTERFACE-SAME: -enforce-exclusivity=unchecked
 // CHECK-SWIFTINTERFACE-SAME: -autolink-force-load
-// CHECK-SWIFTINTERFACE: swift-module-flags-ignorable:
-// CHECK-SWIFTINTERFACE-SAME: -target-min-inlining-version 42
 // CHECK-SWIFTINTERFACE-SAME: -enable-bare-slash-regex
 
 // Make sure flags show up when filelists are enabled


### PR DESCRIPTION
Frontend options should only be printed under `swift-module-flags-ignored:` temporarily to prevent condfails for older development compilers that are still in use (as a rule of thumb, swiftinterfaces should be compatible with compilers that are up to 6 months old). None of the frontend flags that are currently categorized as "ignorable" need to be ignorable anymore.

I've also added myself as a CODEOWNER to volunteer to review changes to `Options.td` that might affect swiftinterface compatibility.