### PR TITLE
[5.9] Two fixes for extension macros with conformances

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -172,9 +172,6 @@ enum class ConformanceLookupKind : unsigned {
   /// All conformances except structurally-derived conformances, of which
   /// Sendable is the only one.
   NonStructural,
-  /// Exclude conformances added by a macro that has not been expanded
-  /// yet.
-  ExcludeUnexpandedMacros,
 };
 
 /// Describes a diagnostic for a conflict between two protocol

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -552,6 +552,8 @@ public:
     assert((sourceKind == ConformanceEntryKind::Implied) ==
                (bool)implyingConformance &&
            "an implied conformance needs something that implies it");
+    assert(sourceKind != ConformanceEntryKind::PreMacroExpansion &&
+           "cannot create conformance pre-macro-expansion");
     SourceKindAndImplyingConformance = {implyingConformance, sourceKind};
   }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1302,8 +1302,8 @@ IterableDeclContext::getLocalConformances(ConformanceLookupKind lookupKind)
            switch (conformance->getSourceKind()) {
            case ConformanceEntryKind::Explicit:
            case ConformanceEntryKind::Synthesized:
+               return true;
            case ConformanceEntryKind::PreMacroExpansion:
-             return true;
            case ConformanceEntryKind::Implied:
            case ConformanceEntryKind::Inherited:
              return false;
@@ -1314,34 +1314,22 @@ IterableDeclContext::getLocalConformances(ConformanceLookupKind lookupKind)
            case ConformanceEntryKind::Explicit:
            case ConformanceEntryKind::Synthesized:
            case ConformanceEntryKind::Implied:
-           case ConformanceEntryKind::PreMacroExpansion:
              return true;
            case ConformanceEntryKind::Inherited:
+           case ConformanceEntryKind::PreMacroExpansion:
              return false;
            }
 
          case ConformanceLookupKind::All:
          case ConformanceLookupKind::NonStructural:
            return true;
-
-          case ConformanceLookupKind::ExcludeUnexpandedMacros:
-           switch (conformance->getSourceKind()) {
-           case ConformanceEntryKind::PreMacroExpansion:
-             return false;
-           case ConformanceEntryKind::Explicit:
-           case ConformanceEntryKind::Synthesized:
-           case ConformanceEntryKind::Implied:
-           case ConformanceEntryKind::Inherited:
-             return true;
-           }
          }
       });
 
   // If we want to add structural conformances, do so now.
   switch (lookupKind) {
     case ConformanceLookupKind::All:
-    case ConformanceLookupKind::NonInherited:
-    case ConformanceLookupKind::ExcludeUnexpandedMacros: {
+    case ConformanceLookupKind::NonInherited: {
       // Look for a Sendable conformance globally. If it is synthesized
       // and matches this declaration context, use it.
       auto dc = getAsGenericContext();

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -238,9 +238,6 @@ class SILSymbolVisitorImpl : public ASTVisitor<SILSymbolVisitorImpl> {
   void addConformances(const IterableDeclContext *IDC) {
     for (auto conformance :
          IDC->getLocalConformances(ConformanceLookupKind::NonInherited)) {
-      if (conformance->getSourceKind() == ConformanceEntryKind::PreMacroExpansion)
-        continue;
-
       auto protocol = conformance->getProtocol();
       if (Ctx.getOpts().PublicSymbolsOnly &&
           getDeclLinkage(protocol) != FormalLinkage::PublicUnique)

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1132,9 +1132,6 @@ public:
     // are existential and do not have witness tables.
     for (auto *conformance : theType->getLocalConformances(
                                ConformanceLookupKind::NonInherited)) {
-      if (conformance->getSourceKind() == ConformanceEntryKind::PreMacroExpansion)
-        continue;
-
       assert(conformance->isComplete());
       if (auto *normal = dyn_cast<NormalProtocolConformance>(conformance))
         SGM.getWitnessTable(normal);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1597,15 +1597,7 @@ llvm::Optional<unsigned> swift::expandExtensions(CustomAttr *attr,
   for (auto protocol : potentialConformances) {
     SmallVector<ProtocolConformance *, 2> existingConformances;
     nominal->lookupConformance(protocol, existingConformances);
-
-    bool hasExistingConformance = llvm::any_of(
-        existingConformances,
-        [&](ProtocolConformance *conformance) {
-          return conformance->getSourceKind() !=
-              ConformanceEntryKind::PreMacroExpansion;
-        });
-
-    if (!hasExistingConformance) {
+    if (existingConformances.empty()) {
       introducedConformances.push_back(protocol);
     }
   }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1238,9 +1238,13 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
   {
     llvm::raw_string_ostream OS(conformanceList);
     if (role == MacroRole::Extension) {
-      for (auto *protocol : conformances) {
-        protocol->getDeclaredType()->print(OS);
-      }
+      llvm::interleave(
+          conformances,
+          [&](const ProtocolDecl *protocol) {
+            protocol->getDeclaredType()->print(OS);
+          },
+          [&] { OS << ", "; }
+      );
     } else {
       OS << "";
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6443,8 +6443,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   const auto defaultAccess = nominal->getFormalAccess();
 
   // Check each of the conformances associated with this context.
-  auto conformances = idc->getLocalConformances(
-      ConformanceLookupKind::ExcludeUnexpandedMacros);
+  auto conformances = idc->getLocalConformances();
 
   // The conformance checker bundle that checks all conformances in the context.
   auto &Context = dc->getASTContext();

--- a/test/IDE/complete_optionset.swift
+++ b/test/IDE/complete_optionset.swift
@@ -28,7 +28,6 @@ public macro OptionSet<RawType>() =
 // MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        secondDay[#ShippingOptions#]; name=secondDay
 // MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        priority[#ShippingOptions#]; name=priority
 // MEMBER_STATIC: Decl[StaticVar]/CurrNominal:        standard[#ShippingOptions#]; name=standard
-// MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        ArrayLiteralElement[#ShippingOptions#]; name=ArrayLiteralElement
 // MEMBER_STATIC: Decl[TypeAlias]/CurrNominal:        Element[#ShippingOptions#]; name=Element
 // MEMBER_STATIC: Decl[Constructor]/Super/IsSystem:   init()[#ShippingOptions#]; name=init()
 // MEMBER_STATIC: Decl[Constructor]/Super/IsSystem:   init({#(sequence): Sequence#})[#ShippingOptions#]; name=init(:)

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1481,6 +1481,24 @@ public struct ConditionallyAvailableConformance: ExtensionMacro {
   }
 }
 
+public struct AddAllConformancesMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    protocols.map { proto in
+      let decl: DeclSyntax =
+        """
+        extension \(type): \(proto) {}
+        """
+      return decl.cast(ExtensionDeclSyntax.self)
+    }
+  }
+}
+
 public struct AlwaysAddCodable: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -165,3 +165,17 @@ macro AvailableEquatable() = #externalMacro(module: "MacroDefinition", type: "Co
 struct TestAvailability {
   static let x : any Equatable.Type = TestAvailability.self
 }
+
+protocol P1 {}
+protocol P2 {}
+
+@attached(extension, conformances: P1, P2)
+macro AddAllConformances() = #externalMacro(module: "MacroDefinition", type: "AddAllConformancesMacro")
+
+@AddAllConformances
+struct MultipleConformances {}
+
+// CHECK-DUMP: extension MultipleConformances: P1 {
+// CHECK-DUMP: }
+// CHECK-DUMP: extension MultipleConformances: P2 {
+// CHECK-DUMP: }

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -179,3 +179,22 @@ struct MultipleConformances {}
 // CHECK-DUMP: }
 // CHECK-DUMP: extension MultipleConformances: P2 {
 // CHECK-DUMP: }
+
+@attached(extension, conformances: Equatable, names: named(==))
+macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableViaMembersMacro")
+
+@propertyWrapper
+struct NotEquatable<T> {
+  var wrappedValue: T
+}
+
+@Equatable
+struct HasPropertyWrappers {
+  @NotEquatable
+  var value: Int = 0
+}
+
+func requiresEquatable<T: Equatable>(_: T) { }
+func testHasPropertyWrappers(hpw: HasPropertyWrappers) {
+  requiresEquatable(hpw)
+}


### PR DESCRIPTION
Pull in fixes for two issues with extension macros defining conformances:
* https://github.com/apple/swift/pull/67889: Each protocol should be separated with a comma in the conformance list buffer.
* https://github.com/apple/swift/pull/67977: Extension macros are unable to define conformances for synthesizable conformances like Equatable or Hashable, or provide operators that satisfy conformance requirements