### PR TITLE
SILGen: Don't reference external property descriptors for @backDeployed properties

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -351,6 +351,11 @@ public:
   /// Emits a thunk from an actor function to a potentially distributed call.
   void emitDistributedThunk(SILDeclRef thunk);
 
+  /// Returns true if the given declaration must be referenced through a
+  /// back deployment thunk in a context with the given resilience expansion.
+  bool requiresBackDeploymentThunk(ValueDecl *decl,
+                                   ResilienceExpansion expansion);
+
   /// Emits a thunk that calls either the original function if it is available
   /// or otherwise calls a fallback variant of the function that was emitted
   /// into the client module.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3821,6 +3821,12 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
       return false;
     }
 
+    // Back deployed properties have the same restrictions as
+    // always-emit-into-client properties.
+    if (requiresBackDeploymentThunk(baseDecl, expansion)) {
+      return false;
+    }
+
     // Properties that only dispatch via ObjC lookup do not have nor
     // need property descriptors, since the selector identifies the
     // storage.

--- a/test/SILGen/back_deployed_attr_accessor.swift
+++ b/test/SILGen/back_deployed_attr_accessor.swift
@@ -45,4 +45,11 @@ func caller(_ s: TopLevelStruct) {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
   _ = s.property
+
+  // -- Verify key path
+  // CHECK: {{%.*}} = keypath $KeyPath<TopLevelStruct, TopLevelStruct>, (root $TopLevelStruct; gettable_property $TopLevelStruct,  id @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct, getter @$s11back_deploy14TopLevelStructV8propertyACvpACTK : $@convention(thin) (@in_guaranteed TopLevelStruct) -> @out TopLevelStruct)
+  _ = \TopLevelStruct.property
 }
+
+// CHECK-LABEL: sil shared [thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvpACTK : $@convention(thin) (@in_guaranteed TopLevelStruct) -> @out TopLevelStruct
+// CHECK: function_ref @$s11back_deploy14TopLevelStructV8propertyACvgTwb

--- a/test/attr/attr_backDeployed_evolution.swift
+++ b/test/attr/attr_backDeployed_evolution.swift
@@ -149,6 +149,7 @@ do {
 
   let empty = IntArray.empty
   precondition(empty.values == [])
+  precondition(empty[keyPath: \.values] == [])
 
   var array = IntArray([5])
 
@@ -177,6 +178,7 @@ do {
 do {
   let defaulted = ReferenceIntArray()
   precondition(defaulted.values == [])
+  precondition(defaulted[keyPath: \.values] == [])
 
   let empty = ReferenceIntArray.empty
   precondition(empty.values == [])


### PR DESCRIPTION
The property descriptors of `@backDeployed` properties aren't available on OSes prior to the "back deployed before" OS version, so the descriptors cannot be referenced by clients that may run against older versions of the library that defines the property.

See https://github.com/apple/swift/pull/59214 for prior art.

Resolves rdar://106517386
