### PR TITLE
[DebugInfo] Update coroutine tests to expect fewer entry values

### DIFF
--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -45,7 +45,7 @@ public func forceSplit5() async {}
 
 // CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalF"(ptr swiftasync %0, ptr noalias %1, ptr %T)
 // CHECK: entry:
-// CHECK:   call void @llvm.dbg.value(metadata ptr %{{[0-9]+}}, metadata ![[SIMPLE_TEST_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK:   call void @llvm.dbg.value(metadata ptr %{{[0-9]+}}, metadata ![[SIMPLE_TEST_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
 // CHECK:   musttail call swifttailcc void
 // CHECK-NEXT: ret void
 
@@ -65,7 +65,8 @@ public func forceSplit5() async {}
 // RUN: %llvm-dwarfdump -c --name='$s3out13letSimpleTestyyxnYalF' %t/out.o | %FileCheck -check-prefix=DWARF1 %s
 // DWARF1:  DW_AT_linkage_name	("$s3out13letSimpleTestyyxnYalF")
 // DWARF1:  DW_TAG_formal_parameter
-// DWARF1-NEXT: DW_AT_location	(DW_OP_entry_value([[ASYNC_REG:DW_OP_.*]]), DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF1-NEXT: DW_AT_location
+// DWARF1-NEXT:	[[ASYNC_REG:DW_OP_.*]], DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref
 // DWARF1-NEXT:  DW_AT_name ("msg")
 //
 // RUN: %llvm-dwarfdump -c --name='$s3out13letSimpleTestyyxnYalFTQ0_' %t/out.o | %FileCheck -check-prefix=DWARF2 %s
@@ -89,7 +90,7 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 }
 
 // CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalF"(ptr swiftasync %0, ptr %1, ptr noalias %2, ptr %T)
-// CHECK:   call void @llvm.dbg.value(metadata ptr %{{[0-9]+}}, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_deref))
+// CHECK:   call void @llvm.dbg.value(metadata ptr %{{[0-9]+}}, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_deref))
 // CHECK:   musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(ptr swiftasync %{{[0-9]+}})
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -125,7 +126,8 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // DWARF4: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalF")
 // DWARF4: DW_AT_name	("varSimpleTest")
 // DWARF4: DW_TAG_formal_parameter
-// DWARF4-NEXT: DW_AT_location	(DW_OP_entry_value([[ASYNC_REG:.*]]), DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF4-NEXT: DW_AT_location
+// DWARF4-NEXT:	[[ASYNC_REG:.*]], DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref, DW_OP_deref
 // DWARF4-NEXT: DW_AT_name ("msg")
 //
 // RUN: %llvm-dwarfdump -c --name='$s3out13varSimpleTestyyxz_xtYalFTQ0_' %t/out.o | %FileCheck -check-prefix=DWARF5 %s
@@ -352,7 +354,8 @@ public func varSimpleTestVar() async {
 // DWARF17: DW_AT_name	("letArgCCFlowTrueTest")
 
 // DWARF17: DW_TAG_formal_parameter
-// DWARF17-NEXT: DW_AT_location	(DW_OP_entry_value([[ASYNC_REG:.*]]), DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF17-NEXT: DW_AT_location
+// DWARF17-NEXT: [[ASYNC_REG:.*]], DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref, DW_OP_deref
 // DWARF17-NEXT: DW_AT_name	("msg")
 //
 // RUN: %llvm-dwarfdump -c --name='$s3out20letArgCCFlowTrueTestyyxnYalFTQ0_' %t/out.o | %FileCheck -check-prefix=DWARF18 %s
@@ -437,7 +440,7 @@ public func letArgCCFlowTrueTest<T>(_ msg: __owned T) async {
 // SIL: } // end sil function '$s27move_function_dbginfo_async20varArgCCFlowTrueTestyyxzYaAA1PRzlF'
 
 // CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async20varArgCCFlowTrueTestyyxzYaAA1PRzlF"(
-// CHECK: call void @llvm.dbg.value(metadata ptr %{{[0-9]+}}, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 48, DW_OP_deref, DW_OP_deref)),
+// CHECK: call void @llvm.dbg.value(metadata ptr %{{[0-9]+}}, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 48, DW_OP_deref, DW_OP_deref)),
 // CHECK: musttail call swifttailcc void @"$s27move_function_dbginfo_async11forceSplit1yyYaF"(
 
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async20varArgCCFlowTrueTestyyxzYaAA1PRzlFTQ0_"(
@@ -488,7 +491,8 @@ public func letArgCCFlowTrueTest<T>(_ msg: __owned T) async {
 // DWARF24: DW_AT_linkage_name	("$s3out20varArgCCFlowTrueTestyyxzYaAA1PRzlF")
 // DWARF24: DW_AT_name	("varArgCCFlowTrueTest")
 // DWARF24: DW_TAG_formal_parameter
-// DWARF24-NEXT:                     DW_AT_location	(DW_OP_entry_value([[ASYNC_REG:.*]]), DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x30, DW_OP_deref)
+// DWARF24-NEXT:                     DW_AT_location
+// DWARF24-NEXT:                     [[ASYNC_REG:.*]], DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x30, DW_OP_deref, DW_OP_deref
 // DWARF24-NEXT:                     DW_AT_name	("msg")
 //
 


### PR DESCRIPTION
With https://github.com/apple/llvm-project/pull/7255, entry values are no longer generated for the entry function of coroutines.