### PR TITLE
Use LLVM runtimes build

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -697,12 +697,6 @@ reconfigure
 verbose-build
 build-ninja
 
-# TODO: remove when we will transition from LLVM_TOOL_COMPILER_RT_BUILD
-# to LLVM_USE_RUNTIMES to build compiler-rt (#60993), so we can leverage
-# the value for SANITIZER_MIN_OSX_VERSION set in cmake_product.py
-extra-cmake-options=
-  -DCLANG_COMPILER_RT_CMAKE_ARGS:STRING="-DSANITIZER_MIN_OSX_VERSION:STRING=13.0"
-
 # Do not build swift or cmark
 skip-build-swift
 skip-build-cmark

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -803,20 +803,6 @@ function set_build_options_for_host() {
     esac
 
 
-    # We don't currently support building compiler-rt for cross-compile targets.
-    # It's not clear that's useful anyway.
-    if [[ $(is_cross_tools_host "${host}") ]] ; then
-      llvm_cmake_options+=(
-          -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL=FALSE
-          -DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL=FALSE
-      )
-    else
-      llvm_cmake_options+=(
-          -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL="$(false_true ${SKIP_BUILD_COMPILER_RT})"
-          -DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL="$(false_true ${SKIP_BUILD_COMPILER_RT})"
-      )
-    fi
-
     # If we are asked to not generate test targets for LLVM and or Swift,
     # disable as many LLVM tools as we can. This improves compile time when
     # compiling with LTO.

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -123,7 +123,7 @@ def llvm_install_components():
     platforms.
     """
     components = ['llvm-ar', 'llvm-cov', 'llvm-profdata', 'IndexStore', 'clang',
-                  'clang-resource-headers', 'compiler-rt', 'clangd', 'LTO',
+                  'clang-resource-headers', 'builtins', 'runtimes', 'clangd', 'LTO',
                   'lld']
     if os.sys.platform == 'darwin':
         components.extend(['dsymutil'])

--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -381,19 +381,6 @@ class CMakeProduct(product.Product):
             # in the compiler checks CMake performs
             swift_cmake_options.define('CMAKE_OSX_ARCHITECTURES', arch)
 
-        # We don't currently support building compiler-rt for cross-compile targets.
-        # It's not clear that's useful anyway.
-        if self.is_cross_compile_target(host_target):
-            llvm_cmake_options.define('LLVM_TOOL_COMPILER_RT_BUILD:BOOL', 'FALSE')
-            llvm_cmake_options.define('LLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL', 'FALSE')
-        else:
-            llvm_cmake_options.define('LLVM_TOOL_COMPILER_RT_BUILD:BOOL',
-                                      cmake.CMakeOptions.true_false(
-                                          self.args.build_compiler_rt))
-            llvm_cmake_options.define('LLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL',
-                                      cmake.CMakeOptions.true_false(
-                                          self.args.build_compiler_rt))
-
         # If we are asked to not generate test targets for LLVM and or Swift,
         # disable as many LLVM tools as we can. This improves compile time when
         # compiling with LTO.

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -310,6 +310,10 @@ class LLVM(cmake_product.CMakeProduct):
         llvm_cmake_options.define(
             'RUNTIMES_CMAKE_ARGS',
             LLVM.compute_cmake_args_for_runtimes(host_target))
+        if system() == "Darwin":
+            llvm_cmake_options.define('LLVM_BUILTIN_TARGETS', 'arm64-apple-darwin')
+            llvm_cmake_options.define('LLVM_RUNTIME_TARGETS', 'arm64-apple-darwin')
+            llvm_cmake_options.define('RUNTIMES_BUILD_ALLOW_DARWIN', 'ON')
 
         if self.args.build_embedded_stdlib and system() == "Darwin":
             # Ask for Mach-O cross-compilation builtins (for Embedded Swift)

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -314,12 +314,20 @@ class LLVM(cmake_product.CMakeProduct):
             llvm_cmake_options.define('LLVM_BUILTIN_TARGETS', 'arm64-apple-darwin')
             llvm_cmake_options.define('LLVM_RUNTIME_TARGETS', 'arm64-apple-darwin')
             llvm_cmake_options.define('RUNTIMES_BUILD_ALLOW_DARWIN', 'ON')
+            llvm_cmake_options.define(
+                'RUNTIMES_arm64-apple-darwin_COMPILER_RT_SANITIZERS_TO_BUILD',
+                'asan;dfsan;msan;hwasan;tsan;safestack;cfi;scudo_standalone'
+                ';ubsan_minimal;gwp_asan;nsan;asan_abi')
 
         if self.args.build_embedded_stdlib and system() == "Darwin":
             # Ask for Mach-O cross-compilation builtins (for Embedded Swift)
             llvm_cmake_options.define(
                 'COMPILER_RT_FORCE_BUILD_BAREMETAL_MACHO_BUILTINS_ARCHS:STRING',
                 'armv6 armv6m armv7 armv7m armv7em')
+            llvm_cmake_options.define(
+                'BUILTINS_arm64-apple-darwin_'
+                'COMPILER_RT_FORCE_BUILD_BAREMETAL_MACHO_BUILTINS_ARCHS:'
+                'STRING=armv6 armv6m armv7 armv7m armv7em')
 
         llvm_enable_projects = ['clang']
         llvm_enable_runtimes = []

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -292,7 +292,7 @@ class LLVM(cmake_product.CMakeProduct):
         llvm_cmake_options.define('LLVM_ENABLE_LTO:STRING', self.args.lto_type)
         llvm_cmake_options.define('COMPILER_RT_INTERCEPT_LIBDISPATCH', 'ON')
         # Swift expects the old layout for the runtime directory
-        llvm_cmake_options.define('LLVM_ENABLE_PER_TARGET_RUNTIME_DIR:BOOL', 'OFF')
+        llvm_cmake_options.define('LLVM_ENABLE_PER_TARGET_RUNTIME_DIR', 'OFF')
         if host_target.startswith('linux'):
             # This preserves the behaviour we had when using
             # LLVM_BUILD_EXTERNAL COMPILER_RT --
@@ -319,7 +319,7 @@ class LLVM(cmake_product.CMakeProduct):
             llvm_cmake_options.define(
                 'BUILTINS_arm64-apple-darwin_'
                 'COMPILER_RT_FORCE_BUILD_BAREMETAL_MACHO_BUILTINS_ARCHS:'
-                'STRING=armv6 armv6m armv7 armv7m armv7em')
+                'STRING', 'armv6 armv6m armv7 armv7m armv7em')
 
         llvm_enable_projects = ['clang']
         llvm_enable_runtimes = []


### PR DESCRIPTION
LLVM plans to remove the legacy methods for building compiler-rt. This change updates build-script to use LLVM_ENABLE_RUNTIMES to build compiler-rt with the just-built clang instead of the legacy methods.

This does not update the llvm-install-components in build-presets.ini -- this is done on purpose to stress more the migration logic, some of the presets will be updated with a subsequent PRs

Addresses rdar://113972453