### PR TITLE
[5.9] SILGen: Don't reference external property descriptors for @backDeployed properties

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -351,6 +351,11 @@ public:
   /// Emits a thunk from an actor function to a potentially distributed call.
   void emitDistributedThunk(SILDeclRef thunk);
 
+  /// Returns true if the given declaration must be referenced through a
+  /// back deployment thunk in a context with the given resilience expansion.
+  bool requiresBackDeploymentThunk(ValueDecl *decl,
+                                   ResilienceExpansion expansion);
+
   /// Emits a thunk that calls either the original function if it is available
   /// or otherwise calls a fallback variant of the function that was emitted
   /// into the client module.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -280,31 +280,6 @@ static void convertOwnershipConventionsGivenParamInfos(
                   });
 }
 
-static bool shouldApplyBackDeploymentThunk(ValueDecl *decl, ASTContext &ctx,
-                                           ResilienceExpansion expansion) {
-  auto backDeployBeforeVersion = decl->getBackDeployedBeforeOSVersion(ctx);
-  if (!backDeployBeforeVersion)
-    return false;
-
-  // If the context of the application is inlinable then we must always call the
-  // back deployment thunk since we can't predict the deployment targets of
-  // other modules.
-  if (expansion != ResilienceExpansion::Maximal)
-    return true;
-
-  // In resilient function bodies skip calling the back deployment thunk when
-  // the deployment target is high enough that the ABI implementation of the
-  // back deployed function is guaranteed to be available.
-  auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(ctx);
-  auto declAvailability =
-      AvailabilityContext(VersionRange::allGTE(*backDeployBeforeVersion));
-
-  if (deploymentAvailability.isContainedIn(declAvailability))
-    return false;
-
-  return true;
-}
-
 //===----------------------------------------------------------------------===//
 //                                   Callee
 //===----------------------------------------------------------------------===//
@@ -1155,7 +1130,6 @@ public:
 
   SILDeclRef getDeclRefForStaticDispatchApply(DeclRefExpr *e) {
     auto *afd = cast<AbstractFunctionDecl>(e->getDecl());
-    auto &ctx = SGF.getASTContext();
 
     // A call to a `distributed` function may need to go through a thunk.
     if (callSite && callSite->shouldApplyDistributedThunk()) {
@@ -1164,8 +1138,9 @@ public:
     }
 
     // A call to `@backDeployed` function may need to go through a thunk.
-    if (shouldApplyBackDeploymentThunk(afd, ctx,
-                                       SGF.F.getResilienceExpansion())) {
+
+    if (SGF.SGM.requiresBackDeploymentThunk(afd,
+                                            SGF.F.getResilienceExpansion())) {
       return SILDeclRef(afd).asBackDeploymentKind(
           SILDeclRef::BackDeploymentKind::Thunk);
     }
@@ -6711,7 +6686,7 @@ SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor,
                                             ResilienceExpansion expansion) {
   auto declRef = SILDeclRef(accessor, SILDeclRef::Kind::Func);
 
-  if (shouldApplyBackDeploymentThunk(accessor, getASTContext(), expansion))
+  if (requiresBackDeploymentThunk(accessor, expansion))
     return declRef.asBackDeploymentKind(SILDeclRef::BackDeploymentKind::Thunk);
 
   return declRef.asForeign(requiresForeignEntryPoint(accessor));

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3803,6 +3803,12 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
       return false;
     }
 
+    // Back deployed properties have the same restrictions as
+    // always-emit-into-client properties.
+    if (requiresBackDeploymentThunk(baseDecl, expansion)) {
+      return false;
+    }
+
     // Properties that only dispatch via ObjC lookup do not have nor
     // need property descriptors, since the selector identifies the
     // storage.

--- a/test/SILGen/back_deployed_attr_accessor.swift
+++ b/test/SILGen/back_deployed_attr_accessor.swift
@@ -45,4 +45,11 @@ func caller(_ s: TopLevelStruct) {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
   _ = s.property
+
+  // -- Verify key path
+  // CHECK: {{%.*}} = keypath $KeyPath<TopLevelStruct, TopLevelStruct>, (root $TopLevelStruct; gettable_property $TopLevelStruct,  id @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct, getter @$s11back_deploy14TopLevelStructV8propertyACvpACTK : $@convention(thin) (@in_guaranteed TopLevelStruct) -> @out TopLevelStruct)
+  _ = \TopLevelStruct.property
 }
+
+// CHECK-LABEL: sil shared [thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvpACTK : $@convention(thin) (@in_guaranteed TopLevelStruct) -> @out TopLevelStruct
+// CHECK: function_ref @$s11back_deploy14TopLevelStructV8propertyACvgTwb

--- a/test/attr/attr_backDeployed_evolution.swift
+++ b/test/attr/attr_backDeployed_evolution.swift
@@ -149,6 +149,7 @@ do {
 
   let empty = IntArray.empty
   precondition(empty.values == [])
+  precondition(empty[keyPath: \.values] == [])
 
   var array = IntArray([5])
 
@@ -177,6 +178,7 @@ do {
 do {
   let defaulted = ReferenceIntArray()
   precondition(defaulted.values == [])
+  precondition(defaulted[keyPath: \.values] == [])
 
   let empty = ReferenceIntArray.empty
   precondition(empty.values == [])


### PR DESCRIPTION
* **Explanation**: Apps that form key paths to properties declared with the `@backDeployed` attribute would crash at runtime when running on older OSes. The property descriptors of `@backDeployed` properties aren't available on OSes prior to the "back deployed before" OS version, so the descriptors cannot be referenced by clients that may run against older versions of the library that defines the property. 
* **Scope**: This change narrowly affects codegen for key path expressions formed on properties with a `@backDeployed` attribute.
* **Risk**: Low because the scope of the change is low. Properties with `@backDeployed` are not common and apps forming these references were already broken when running on older OSes.
* **Testing**: Integration test suite for `@backDeployed` was updated to include a test case that reproduces the issue.
* **Issues**: rdar://106517386
* **Reviewer**: @jckarter
* **Main branch PR**: https://github.com/apple/swift/pull/67982/
