### PR TITLE
[gyb] Support -o with relative path

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1242,16 +1242,20 @@ def main():
             ast = parse_template(args.file, f.read())
     if args.dump:
         print(ast)
+
     # Allow the template to open files and import .py files relative to its own
     # directory
+    saved_cwd = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(args.file)))
     sys.path = ['.'] + sys.path
+    result_text = execute_template(ast, args.line_directive, **bindings)
 
     if args.target == '-':
-        sys.stdout.write(execute_template(ast, args.line_directive, **bindings))
+        sys.stdout.write(result_text)
     else:
+        os.chdir(saved_cwd)
         with io.open(args.target, 'w', encoding='utf-8', newline='\n') as f:
-            f.write(execute_template(ast, args.line_directive, **bindings))
+            f.write(result_text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes a surprising bug where a relative output file path would be interpreted relative to the directory of the `.gyb` file being processed rather than the current working directory upon invocation.
