### PR TITLE
5.9: [IRGen] Cast fixed-size opaque globals.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2958,9 +2958,22 @@ void IRGenSILFunction::visitGlobalAddrInst(GlobalAddrInst *i) {
   Address addr = IGM.getAddrOfSILGlobalVariable(var, ti,
                                                 NotForDefinition);
 
+  // Get the address of the type in context.
+  auto getAddressInContext = [this, &var](auto addr) -> Address {
+    SILType loweredTyInContext =
+        var->getLoweredTypeInContext(getExpansionContext());
+    auto &tiInContext = getTypeInfo(loweredTyInContext);
+    auto ptr = Builder.CreateBitOrPointerCast(
+        addr.getAddress(), tiInContext.getStorageType()->getPointerTo());
+    addr = Address(ptr, tiInContext.getStorageType(),
+                   tiInContext.getBestKnownAlignment());
+    return addr;
+  };
+
   // If the global is fixed-size in all resilience domains that can see it,
   // we allocated storage for it statically, and there's nothing to do.
   if (ti.isFixedSize(expansion)) {
+    addr = getAddressInContext(addr);
     setLoweredAddress(i, addr);
     return;
   }
@@ -2968,15 +2981,7 @@ void IRGenSILFunction::visitGlobalAddrInst(GlobalAddrInst *i) {
   // Otherwise, the static storage for the global consists of a fixed-size
   // buffer; project it.
   addr = emitProjectValueInBuffer(*this, loweredTy, addr);
-
-
-  // Get the address of the type in context.
-  SILType loweredTyInContext = var->getLoweredTypeInContext(getExpansionContext());
-  auto &tiInContext = getTypeInfo(loweredTyInContext);
-  auto ptr = Builder.CreateBitOrPointerCast(addr.getAddress(),
-                                            tiInContext.getStorageType()->getPointerTo());
-  addr = Address(ptr, tiInContext.getStorageType(),
-                 tiInContext.getBestKnownAlignment());
+  addr = getAddressInContext(addr);
   setLoweredAddress(i, addr);
 }
 

--- a/validation-test/IRGen/rdar114013709.swift
+++ b/validation-test/IRGen/rdar114013709.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -O -primary-file %s -disable-availability-checking -emit-ir | %FileCheck %s
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} i32 @main{{.*}} {
+// CHECK:      store %swift.refcounted* %{{[0-9]+}},
+// CHECK-SAME:                          %swift.refcounted**
+// CHECK-SAME:                          bitcast (
+// CHECK-SAME:                            %T13rdar1140137095ActorC** @"$s13rdar1140137091xQrvp"
+// CHECK-SAME:                            to %swift.refcounted**)
+actor Actor {}
+let x: some Actor = Actor()
+


### PR DESCRIPTION
**Description:** Add a missing cast when accessing fixed-size globals of opaque type.
**Risk:** Very low.  The change applies code already in use in one code path (non-fixed size) to another (fixed-size).
**Scope:** Narrow.  The change only affects fixed-size globals of opaque type.
**Original PR:** https://github.com/apple/swift/pull/68000
**Reviewed By:** Arnold Schwaighofer ( @aschwaighofer )
**Testing:** Added a test.
**Resolves:** rdar://114013709