### PR TITLE
[IRGen] Cast fixed-size opaque globals.

### DIFF
--- a/validation-test/IRGen/rdar114013709.swift
+++ b/validation-test/IRGen/rdar114013709.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -O -primary-file %s -disable-availability-checking -emit-ir | %FileCheck %s
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} i32 @main{{.*}} {
+// CHECK:      store ptr %{{[0-9]+}}, ptr @"$s13rdar1140137091xQrvp"
+actor Actor {}
+let x: some Actor = Actor()
+


### PR DESCRIPTION
In https://github.com/apple/swift/pull/66560 , a bug in the lowering of `global_addr` was fixed.  Part of that fix was to postpone mapping the type of the global into context until getting the address of the global and projecting the buffer for the out-of-line value; at that point, the type is mapped into context and the address is cast.

It introduced an issue for fixed-size globals, however: the type of such globals was not mapped into context; the result was that the lowered value set for the corresponding SIL value would have the wrong type.

Fix that by extracting the code which mapped the type into context and cast the address to the appropriate lowered type into a lambda and call that lambda both in both the fixed-size (newly) and non-fixed-size (as before) cases.

rdar://114013709
