### PR TITLE
[Sema] Fix raw layout deserialization

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3369,6 +3369,13 @@ ResolveRawLayoutLikeTypeRequest::evaluate(Evaluator &evaluator,
                                           StructDecl *sd,
                                           RawLayoutAttr *attr) const {
   assert(attr->LikeType);
+
+  // If the attribute has a fixed type representation, then it was likely
+  // deserialized and the type has already been computed.
+  if (auto fixedTy = dyn_cast<FixedTypeRepr>(attr->LikeType)) {
+    return fixedTy->getType();
+  }
+
   // Resolve the like type in the struct's context.
   return TypeResolution::resolveContextualType(
         attr->LikeType, sd, llvm::None,

--- a/test/Serialization/Inputs/raw_layout.swift
+++ b/test/Serialization/Inputs/raw_layout.swift
@@ -1,0 +1,7 @@
+public protocol Foo {}
+extension Bool: Foo {}
+
+@_rawLayout(like: T)
+public struct Fred<T: Foo>: ~Copyable {
+  public init() {}
+}

--- a/test/Serialization/raw_layout.swift
+++ b/test/Serialization/raw_layout.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-experimental-feature RawLayout -module-name raw_layout_fred -o %t %S/Inputs/raw_layout.swift
+// RUN: %target-swift-frontend -I %t -emit-ir %s -verify | %FileCheck %s
+
+import raw_layout_fred
+
+// CHECK: %T15raw_layout_fred4FredVySbG = type <{ [1 x i8] }>
+
+do {
+  // CHECK: {{%.*}} = alloca %T15raw_layout_fred4FredVySbG
+  // CHECK: call swiftcc void @"$s15raw_layout_fred4FredVACyxGycfC"
+  let _ = Fred<Bool>()
+}


### PR DESCRIPTION
If we happened to serialize a type with `@_rawLayout(like: T)` then deserializing it would come with a canonical fixed type representation with archetypes and using the like type request would unconditionally call into the type resolver when we've already sort of resolved this type.