### PR TITLE
PerformanceDiagnostics: fix handling of nested closures

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -259,6 +259,8 @@ bool PerformanceDiagnostics::checkClosureValue(SILValue closure,
       closure = bb->getOperand();
     } else if (auto *cv = dyn_cast<ConvertFunctionInst>(closure)) {
       closure = cv->getOperand();
+    } else if (auto *md = dyn_cast<MarkDependenceInst>(closure)) {
+      closure = md->getValue();
     } else if (acceptFunctionArgs && isa<SILFunctionArgument>(closure)) {
       // We can assume that a function closure argument is already checked at
       // the call site.

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -385,3 +385,23 @@ func testPointerToX() -> UnsafePointer<Int> {
   return pointerToX
 }
 
+func foo<T>(_ body: () -> (T)) -> T {
+    return body()
+}
+
+func bar<T>(_ body: () -> (T)) -> T {
+    return body()
+}
+
+func baz<T>(t: T) -> T {
+    foo {
+        bar {
+            return t
+        }
+    }
+}
+
+@_noLocks
+func nestedClosures() -> Int {
+    return baz(t: 42)
+}


### PR DESCRIPTION
Need to handle `mark_dependence` instruction in the use-def walk for the closure value.

Fixes a false performance error.

rdar://114008787
