### PR TITLE
[Executors] tryDiagnoseExecutor must survive null witness, when using Backdeploy library

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1360,6 +1360,9 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
 
   auto concurrencyModule = C.getLoadedModule(C.Id_Concurrency);
   auto isStdlibDefaultImplDecl = [executorDecl, concurrencyModule](ValueDecl *witness) -> bool {
+    if (!witness)
+      return false;
+
     if (auto declContext = witness->getDeclContext()) {
       if (auto *extension = dyn_cast<ExtensionDecl>(declContext)) {
         auto extensionModule = extension->getParentModule();

--- a/test/Inputs/clang-importer-sdk/swift-modules-concurrency-without-job/_Concurrency.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-concurrency-without-job/_Concurrency.swift
@@ -1,10 +1,15 @@
 
 // This simulates a pre-Swift5.9 concurrency library with `Job` and `ExecutorJob` not being defined at all.
 // This is used to verify missing type handling in the SDK when a latest compiler is used.
+//
+// This also looks exactly like the Back deployment library which also does not
+// know about Job, and therefore is missing the Job based (and ExecutorJob based),
+// protocol requirements. This helps confirm we don't crash assuming that those
+// protocol requirements would always be there.
 
 public struct UnownedJob {}
 
-public protocol SerialExecutor {
-  // pretend to be a broken, empty serial executor
+public protocol Executor {
   func enqueue(_ job: UnownedJob)
 }
+public protocol SerialExecutor: Executor { }


### PR DESCRIPTION
**Description:** The recently introduced additional logic to handle missing witnesses was not expecting a null value since in CURRENT stdlib we always have a witness however, in backdeployment we would be missing witnesses and get a null here.  We do not test or build backdeployment library in CI, (not even in full tests), which meant this slipped through and was caught in other tests downstream.
**Risk:** Low, adds missing null check to avoid null pointer dereference.
**Reward:** Don't crash while building the backdeployment library. There should not be effect on other libraries building though.
**Review by:** @DougGregor @hborla 
**Testing:** 
  - CI testing - fake SDK tests were amended to closely replicate how the backdeployment library looks for real (and not just aproximately) -- the adjusted test reproduced the issue and confirms the fix. 
  - Confirmed manually our previous Xcode reproducer project, still fixed (thanks to https://github.com/apple/swift/pull/67957)
**Radar:** rdar://114029779