### PR TITLE
[cxx-interop] Remove deprecated attribute spelling: `import_as_ref`

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1240,7 +1240,7 @@ using ForeignClassMetadata = TargetForeignClassMetadata<InProcess>;
 /// The structure of metadata objects for foreign reference types.
 /// A foreign reference type is a non-Swift, non-Objective-C foreign type with
 /// reference semantics. Foreign reference types are pointers/reference to
-/// value types marked with the "import_as_ref" attribute.
+/// value types marked with the "import_reference" attribute.
 ///
 /// Foreign reference types may have *custom* reference counting operations, or
 /// they may be immortal (and therefore trivial).

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6500,12 +6500,17 @@ SourceLoc ClangImporter::importSourceLocation(clang::SourceLocation loc) {
 static bool hasImportAsRefAttr(const clang::RecordDecl *decl) {
   return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
            if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-             return swiftAttr->getAttribute() == "import_reference" ||
-                    // TODO: Remove this once libSwift hosttools no longer
-                    // requires it.
-                    swiftAttr->getAttribute() == "import_as_ref";
+             return swiftAttr->getAttribute() == "import_reference";
            return false;
          });
+}
+
+bool ClangImporter::Implementation::recordHasReferenceSemantics(
+    const clang::RecordDecl *decl, ASTContext &ctx) {
+  if (!isa<clang::CXXRecordDecl>(decl) && !ctx.LangOpts.CForeignReferenceTypes)
+    return false;
+
+  return hasImportAsRefAttr(decl);
 }
 
 // Is this a pointer to a foreign reference type.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -134,21 +134,6 @@ void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
   }
 }
 
-bool ClangImporter::Implementation::recordHasReferenceSemantics(
-    const clang::RecordDecl *decl, ASTContext &ctx) {
-  if (!isa<clang::CXXRecordDecl>(decl) && !ctx.LangOpts.CForeignReferenceTypes)
-    return false;
-
-  return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
-           if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-             return swiftAttr->getAttribute() == "import_reference" ||
-                    // TODO: Remove this once libSwift hosttools no longer
-                    // requires it.
-                    swiftAttr->getAttribute() == "import_as_ref";
-           return false;
-         });
-}
-
 #ifndef NDEBUG
 static bool verifyNameMapping(MappedTypeNameKind NameMapping,
                               StringRef left, StringRef right) {

--- a/test/Interop/C/struct/Inputs/foreign-reference.h
+++ b/test/Interop/C/struct/Inputs/foreign-reference.h
@@ -27,7 +27,7 @@
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 struct
-    __attribute__((swift_attr("import_as_ref")))
+    __attribute__((swift_attr("import_reference")))
     __attribute__((swift_attr("retain:LCRetain")))
     __attribute__((swift_attr("release:LCRelease")))
 LocalCount {
@@ -46,7 +46,7 @@ static inline void LCRelease(struct LocalCount *x) { x->value--; }
 static int globalCount = 0;
 
 struct
-    __attribute__((swift_attr("import_as_ref")))
+    __attribute__((swift_attr("import_reference")))
     __attribute__((swift_attr("retain:GCRetain")))
     __attribute__((swift_attr("release:GCRelease")))
 GlobalCount {};

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -12,7 +12,7 @@ static int finalLocalRefCount = 100;
 
 namespace NS {
 
-struct __attribute__((swift_attr("import_as_ref")))
+struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:LCRetain")))
 __attribute__((swift_attr("release:LCRelease"))) LocalCount {
   int value = 0;
@@ -35,7 +35,7 @@ inline void LCRelease(NS::LocalCount *x) {
 
 static int globalCount = 0;
 
-struct __attribute__((swift_attr("import_as_ref")))
+struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:GCRetain")))
 __attribute__((swift_attr("release:GCRelease"))) GlobalCount {
   static GlobalCount *create() {

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -53,7 +53,7 @@ namespace ns {
     };
 
     #define IMMORTAL_REF                                \
-         __attribute__((swift_attr("import_as_ref")))   \
+         __attribute__((swift_attr("import_reference")))\
          __attribute__((swift_attr("retain:immortal"))) \
          __attribute__((swift_attr("release:immortal")))
     struct IMMORTAL_REF Immortal {


### PR DESCRIPTION
This spelling is no longer used in SwiftCompilerSources, which means we can now migrate to `swift_attr("import_reference")`.