### PR TITLE
Frontend: Deprecate -warn-on-potentially-unavailable-enum-case option

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -206,9 +206,6 @@ namespace swift {
     /// Should conformance availability violations be diagnosed as errors?
     bool EnableConformanceAvailabilityErrors = false;
 
-    /// Should potential unavailability on enum cases be downgraded to a warning?
-    bool WarnOnPotentiallyUnavailableEnumCase = false;
-
     /// Should the editor placeholder error be downgraded to a warning?
     bool WarnOnEditorPlaceholder = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -617,7 +617,7 @@ def disable_conformance_availability_errors : Flag<["-"],
 
 def warn_on_potentially_unavailable_enum_case : Flag<["-"],
   "warn-on-potentially-unavailable-enum-case">,
-  HelpText<"Downgrade potential unavailability of enum case to a warning">;
+  HelpText<"Deprecated, will be removed in future versions">;
 
 def warn_on_editor_placeholder : Flag<["-"],
   "warn-on-editor-placeholder">,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -177,10 +177,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     arguments.push_back("-aarch64-use-tbi");
   }
 
-  if (output.getPrimaryOutputType() == file_types::TY_SwiftModuleFile) {
-    arguments.push_back("-warn-on-potentially-unavailable-enum-case");
-  }
-
   // Enable or disable ObjC interop appropriately for the platform
   if (Triple.isOSDarwin()) {
     arguments.push_back("-enable-objc-interop");

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -642,6 +642,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_check_api_availability_only))
     Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
                    "-check-api-availability-only");
+  if (Args.hasArg(OPT_warn_on_potentially_unavailable_enum_case))
+    Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
+                   "-warn-on-potentially-unavailable-enum-case");
 
   if (const Arg *A = Args.getLastArg(OPT_unavailable_decl_optimization_EQ)) {
     auto value =
@@ -667,8 +670,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_conformance_availability_errors);
   }
 
-  Opts.WarnOnPotentiallyUnavailableEnumCase |=
-      Args.hasArg(OPT_warn_on_potentially_unavailable_enum_case);
   Opts.WarnOnEditorPlaceholder |= Args.hasArg(OPT_warn_on_editor_placeholder);
 
   if (auto A = Args.getLastArg(OPT_disable_typo_correction,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4468,11 +4468,9 @@ TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
     // An enum element with an associated value cannot be potentially
     // unavailable.
     if (EED->hasAssociatedValues()) {
-      auto &ctx = DC->getASTContext();
       auto *SF = DC->getParentSourceFile();
 
-      if (SF->Kind == SourceFileKind::Interface ||
-          ctx.LangOpts.WarnOnPotentiallyUnavailableEnumCase) {
+      if (SF->Kind == SourceFileKind::Interface) {
         return diag::availability_enum_element_no_potential_warn;
       } else {
         return diag::availability_enum_element_no_potential;

--- a/test/Sema/Inputs/availability_enum_case_other.swift
+++ b/test/Sema/Inputs/availability_enum_case_other.swift
@@ -1,4 +1,4 @@
 public enum Horse {
-  @available(macOS 100, *)
+  @available(macOS 10.50, *)
   case kevin(Int)
 }

--- a/test/Sema/availability_enum_case.swift
+++ b/test/Sema/availability_enum_case.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-module %S/Inputs/availability_enum_case_other.swift -emit-module-interface-path %t/availability_enum_case_other.swiftinterface -swift-version 5 -enable-library-evolution
+// RUN: %target-build-swift -emit-module %S/Inputs/availability_enum_case_other.swift -target %target-cpu-apple-macosx10.50 -emit-module-interface-path %t/availability_enum_case_other.swiftinterface -swift-version 5 -enable-library-evolution
 // RUN: %target-typecheck-verify-swift -I %t
 
-// RUN: %target-build-swift -emit-module %S/Inputs/availability_enum_case_other.swift -emit-module-interface-path %t/availability_enum_case_other.swiftinterface -swift-version 5 -enable-library-evolution -whole-module-optimization
+// RUN: %target-build-swift -emit-module %S/Inputs/availability_enum_case_other.swift -target %target-cpu-apple-macosx10.50 -emit-module-interface-path %t/availability_enum_case_other.swiftinterface -swift-version 5 -enable-library-evolution -whole-module-optimization
 // RUN: %target-typecheck-verify-swift -I %t
 
 // REQUIRES: OS=macosx
@@ -14,6 +14,6 @@ func ride(horse: Horse) {
   // expected-note@-1 {{add @available attribute to enclosing global function}}
 
   _ = Horse.kevin
-  // expected-error@-1 {{'kevin' is only available in macOS 100 or newer}}
+  // expected-error@-1 {{'kevin' is only available in macOS 10.50 or newer}}
   // expected-note@-2 {{add 'if #available' version check}}
 }


### PR DESCRIPTION
When `-warn-on-potentially-unavailable-enum-case` was introduced, the build system was required to invoke `swift-frontend` at artificially low deployment targets when emitting `.swiftinterface` files for legacy architectures. Because the deployment target was low, some availability diagnostics needed to be de-fanged in order to allow module interface emission to succeed. Today, the build system is able to use the correct deployment target when emitting module interfaces and the `-warn-on-potentially-unavailable-enum-case` is superfluous, so deprecate it.

Resolves rdar://114092047
