### PR TITLE
[ConstraintSystem] Fix locator builder `directlyAt`

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1264,11 +1264,11 @@ public:
   template <typename E>
   bool directlyAt() const {
     if (auto *expr = getAnchor().dyn_cast<Expr *>())
-      return isa<E>(expr) && hasEmptyPath();
+      return isa<E>(expr) && !last();
     return false;
   }
 
-  /// Determine whether this builder has an empty path.
+  /// Determine whether this builder has an empty path (no new elements).
   bool hasEmptyPath() const {
     return !element;
   }


### PR DESCRIPTION
`hasEmptyPath` in locator builder context means that there are no new elements
added which is different from the materialized locator, `directlyAt` has to use `!last()`
to check whether or not there are any elements in the path of this builder.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
