### PR TITLE
SwiftCompilerSources: use `unsafeFlags` for header searches

### DIFF
--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -26,14 +26,14 @@ private extension Target {
         path: path ?? "Sources/\(name)",
         exclude: ["CMakeLists.txt"],
         sources: sources,
-        cxxSettings: [
-          .headerSearchPath("../include"),
-          .headerSearchPath("../../llvm-project/llvm/include"),
-          .headerSearchPath("../../llvm-project/clang/include"),
-        ],
         swiftSettings: [
           .interoperabilityMode(.Cxx),
-          .unsafeFlags(["-cross-module-optimization"]),
+          .unsafeFlags([
+            "-Xcc", "-I../include",
+            "-Xcc", "-I../../llvm-project/llvm/include",
+            "-Xcc", "-I../../llvm-project/clang/include",
+            "-cross-module-optimization",
+          ]),
         ] + swiftSettings)
     }
 }


### PR DESCRIPTION
As the headers are not part of the Swift package, the safe header search option cannot be used.  The use of the unsafe flags enables building the package on Windows.