### PR TITLE
Fix some swift tests due to the substitute drive paths on Windows.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2672,6 +2672,13 @@ if hasattr(config, 'target_link_sdk_future_version'):
     config.substitutions.append(('%target-link-sdk-future-version',
                                  config.target_link_sdk_future_version))
 
+def realpath(path):
+    if not kIsWindows:
+        return os.path.realpath(path)
+    else:
+        # For Windows, we don't expand substitute drives due to MAX_PATH limitations, matching what the llvm lit does.
+        return os.path.abspath(path)
+
 run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --use-filecheck %s %s' % (
         shell_quote(sys.executable),
         shell_quote(config.PathSanitizingFileCheck),
@@ -2681,8 +2688,8 @@ run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitiz
         # we provide we use realpath here. Because PathSanitizingFileCheck only
         # understands sanitize patterns with forward slashes, and realpath normalizes
         # the slashes, we have to replace them back to forward slashes.
-        shell_quote(os.path.realpath(swift_obj_root).replace("\\", "/")),
-        shell_quote(os.path.realpath(config.swift_src_root).replace("\\", "/")),
+        shell_quote(realpath(swift_obj_root).replace("\\", "/")),
+        shell_quote(realpath(config.swift_src_root).replace("\\", "/")),
         shell_quote(config.filecheck),
         '--enable-windows-compatibility' if kIsWindows else '')
 


### PR DESCRIPTION
After
https://github.com/apple/llvm-project/commit/05d613ea931b6de1b46dfe04b8e55285359047f4 17 tests started to fail on Windows when when the SOURCE_DIR is on a substitute drive due to the path expansion difference.

This fixes 7 of these tests.
