### PR TITLE
[consume-operator] Emit a better error message when failing to consume globals or escaping captures.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -840,6 +840,9 @@ ERROR(sil_movechecking_bug_exclusivity_violation, none,
 ERROR(sil_movekillscopyablevalue_move_applied_to_unsupported_move, none,
       "'consume' applied to value that the compiler does not support. This is a compiler bug. Please file a bug with a small example of the bug",
       ())
+ERROR(sil_movekillscopyable_move_applied_to_nonlocal_memory, none,
+      "'consume' cannot be applied to %select{globals|escaping captures}0",
+      (unsigned))
 
 
 // Implicit inout-to-UnsafeRawPointer conversions

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars.swift
@@ -588,7 +588,7 @@ public func nonEscapingpartialApplyTest<T : P>(_ x: __owned T) {
 public func partialApplyTest<T : P>(_ x: __owned T) -> () -> () {
     var x2 = x
     x2 = x
-    let _ = consume x2 // expected-error {{'consume' applied to value that the compiler does not support}}
+    let _ = consume x2 // expected-error {{'consume' cannot be applied to escaping captures}}
     let f = {
         print(x2)
     }

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.swift
@@ -260,11 +260,11 @@ let myLetGlobal = Klass()
 var myVarGlobal = Klass()
 
 public func performMoveOnVarGlobalError() {
-    let _ = consume myVarGlobal // expected-error {{'consume' applied to value that the compiler does not support}}
+    let _ = consume myVarGlobal // expected-error {{'consume' cannot be applied to globals}}
 }
 
 public func performMoveOnLetGlobalError() {
-    let _ = consume myVarGlobal // expected-error {{'consume' applied to value that the compiler does not support}}
+    let _ = consume myVarGlobal // expected-error {{'consume' cannot be applied to globals}}
 }
 
 public func multipleVarsWithSubsequentBorrows() -> Bool {

--- a/test/SILOptimizer/consume_operator_nonlocalmemory.swift
+++ b/test/SILOptimizer/consume_operator_nonlocalmemory.swift
@@ -1,0 +1,51 @@
+// RUN: %target-swift-frontend -verify %s -emit-sil -o /dev/null
+
+// This file tests that we emit good errors for global lets/vars,
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class Klass {
+  var s1 = "123"
+  let s2 = "123"
+}
+struct LoadableStruct { var k = Klass() }
+
+struct AddressOnlyStruct<T> { var t: T? = nil }
+
+////////////////////////
+// MARK: Global Tests //
+////////////////////////
+
+let globalLoadableLet = LoadableStruct()
+let _ = consume globalLoadableLet // expected-error {{'consume' cannot be applied to globals}}
+
+let globalAddressOnlyLet = AddressOnlyStruct<Any>()
+let _ = consume globalAddressOnlyLet // expected-error {{'consume' cannot be applied to globals}}
+
+var globalLoadableVar = LoadableStruct()
+let _ = consume globalLoadableVar // expected-error {{'consume' cannot be applied to globals}}
+
+var globalAddressOnlyVar = AddressOnlyStruct<Any>()
+let _ = consume globalAddressOnlyVar // expected-error {{'consume' cannot be applied to globals}}
+
+////////////////////////////
+// MARK: Mutable Captures //
+////////////////////////////
+
+func accessMutableCapture() -> (() -> ()) {
+  func useKlassInOut(_ x: inout Klass) {}
+  func useAddressOnlyStructInOut<T>(_ x: inout AddressOnlyStruct<T>) {}
+
+  var x = Klass()
+  var x2 = AddressOnlyStruct<Any>()
+  var f: () -> () = {}
+  f = {
+    useKlassInOut(&x)
+    useAddressOnlyStructInOut(&x2)
+  }
+  let _ = consume x // expected-error {{'consume' cannot be applied to escaping captures}}
+  let _ = consume x2 // expected-error {{'consume' cannot be applied to escaping captures}}
+  return f
+}


### PR DESCRIPTION
Specifically, we previously emitted a "compiler doesn't understand error", so we were always emitting an error appropriately. This just gives a better error message saying instead that the compiler did understand what happened and that one cannot apply consume to globals or escaping captures.

https://github.com/apple/swift/issues/67755
rdar://112561671
