### PR TITLE
[AST] Handle null in `printDeclDescription`

### DIFF
--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -59,7 +59,7 @@ public:
 };
 
 void printDeclDescription(llvm::raw_ostream &out, const Decl *D,
-                          const ASTContext &Context, bool addNewline = true);
+                          bool addNewline = true);
 
 /// PrettyStackTraceDecl - Observe that we are processing a specific
 /// declaration.

--- a/lib/SIL/Utils/PrettyStackTrace.cpp
+++ b/lib/SIL/Utils/PrettyStackTrace.cpp
@@ -40,7 +40,7 @@ void swift::printSILLocationDescription(llvm::raw_ostream &out,
                                         ASTContext &Context) {
   if (loc.isASTNode()) {
     if (auto decl = loc.getAsASTNode<Decl>()) {
-      printDeclDescription(out, decl, Context);
+      printDeclDescription(out, decl);
     } else if (auto expr = loc.getAsASTNode<Expr>()) {
       printExprDescription(out, expr, Context);
     } else if (auto stmt = loc.getAsASTNode<Stmt>()) {


### PR DESCRIPTION
Sink down the null Decl printing into `printDeclDescription` such that all callers benefit from it. This is an attempt at fixing at least the secondary crash in rdar://113491294, it does not address the underlying crash.