### PR TITLE
Use llvm's abs_path_preserve_drive

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2672,13 +2672,6 @@ if hasattr(config, 'target_link_sdk_future_version'):
     config.substitutions.append(('%target-link-sdk-future-version',
                                  config.target_link_sdk_future_version))
 
-def realpath(path):
-    if not kIsWindows:
-        return os.path.realpath(path)
-    else:
-        # For Windows, we don't expand substitute drives due to MAX_PATH limitations, matching what the llvm lit does.
-        return os.path.abspath(path)
-
 run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --use-filecheck %s %s' % (
         shell_quote(sys.executable),
         shell_quote(config.PathSanitizingFileCheck),
@@ -2688,8 +2681,8 @@ run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitiz
         # we provide we use realpath here. Because PathSanitizingFileCheck only
         # understands sanitize patterns with forward slashes, and realpath normalizes
         # the slashes, we have to replace them back to forward slashes.
-        shell_quote(realpath(swift_obj_root).replace("\\", "/")),
-        shell_quote(realpath(config.swift_src_root).replace("\\", "/")),
+        shell_quote(lit.util.abs_path_preserve_drive(swift_obj_root).replace("\\", "/")),
+        shell_quote(lit.util.abs_path_preserve_drive(config.swift_src_root).replace("\\", "/")),
         shell_quote(config.filecheck),
         '--enable-windows-compatibility' if kIsWindows else '')
 


### PR DESCRIPTION
https://github.com/apple/swift/pull/68023 fixed a regression with Windows testing by reimplementing recent lit logic to avoid using realpath on Windows. This change switches to reusing `abs_path_preserve_drive`.