### PR TITLE
[rebranch] Fix recently added merge function test

### DIFF
--- a/test/LLVMPasses/merge_func_return_type_cast.ll
+++ b/test/LLVMPasses/merge_func_return_type_cast.ll
@@ -1,4 +1,4 @@
-; RUN: %swift-llvm-opt -swift-merge-functions -swiftmergefunc-threshold=4 -opaque-pointers %s | %FileCheck %s
+; RUN: %swift-llvm-opt -passes='swift-merge-functions' -swiftmergefunc-threshold=4 %s | %FileCheck %s
 
 ; REQUIRES: PTRSIZE=64
 


### PR DESCRIPTION
This was just added in main, but rebranch has opaque pointers enabled all the time and there's already a `merge_func.ll` test.