### PR TITLE
[consume] Eliminate DiagnosticPrunedLiveness in favor of SSAPrunedLiveness.

### DIFF
--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -772,25 +772,3 @@ static FunctionTest MultiDefLivenessTest(
       boundary.print(llvm::outs());
     });
 } // end namespace swift::test
-
-//===----------------------------------------------------------------------===//
-//                       DiagnosticPrunedLiveness
-//===----------------------------------------------------------------------===//
-
-// FIXME: This is wrong. Why is nonLifetimeEndingUsesInLiveOut inside
-// PrunedLiveness, and what does it mean? Blocks may transition to LiveOut
-// later. Or they may already be LiveOut from a previous use. After computing
-// liveness, clients should check uses that are in PrunedLivenessBoundary.
-void DiagnosticPrunedLiveness::
-updateForUse(SILInstruction *user, bool lifetimeEnding) {
-  SSAPrunedLiveness::updateForUse(user, 0);
-
-  auto useBlockLive = getBlockLiveness(user->getParent());
-  // Record all uses of blocks on the liveness boundary. For blocks marked
-  // LiveWithin, the boundary is considered to be the last use in the block.
-  if (!lifetimeEnding && useBlockLive == PrunedLiveBlocks::LiveOut) {
-    if (nonLifetimeEndingUsesInLiveOut)
-      nonLifetimeEndingUsesInLiveOut->insert(user);
-    return;
-  }
-}

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
@@ -48,9 +48,10 @@ struct OSSACanonicalizer {
 
   OSSACanonicalizer(SILFunction *fn, DominanceInfo *domTree,
                     InstructionDeleter &deleter)
-      : canonicalizer(false /*pruneDebugMode*/,
-                      !fn->shouldOptimize() /*maximizeLifetime*/, fn,
-                      nullptr /*accessBlockAnalysis*/, domTree,
+      : canonicalizer(!fn->shouldOptimize()
+                          ? CanonicalizeOSSALifetime::Flags::MaximizeLifetime
+                          : CanonicalizeOSSALifetime::Flags::None,
+                      fn, nullptr /*accessBlockAnalysis*/, domTree,
                       nullptr /*calleeAnalysis*/, deleter) {}
 
   void clear() {

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -351,8 +351,9 @@ void SILCombiner::canonicalizeOSSALifetimes(SILInstruction *currentInst) {
 
   DominanceInfo *domTree = DA->get(&Builder.getFunction());
   CanonicalizeOSSALifetime canonicalizer(
-      false /*prune debug*/,
-      !parentTransform->getFunction()->shouldOptimize() /*maximize lifetime*/,
+      !parentTransform->getFunction()->shouldOptimize()
+          ? CanonicalizeOSSALifetime::Flags::MaximizeLifetime
+          : CanonicalizeOSSALifetime::Flags::None,
       parentTransform->getFunction(), NLABA, domTree, CA, deleter);
   CanonicalizeBorrowScope borrowCanonicalizer(parentTransform->getFunction(),
                                               deleter);

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -492,9 +492,14 @@ void CopyPropagation::run() {
 
   // canonicalizer performs all modifications through deleter's callbacks, so we
   // don't need to explicitly check for changes.
-  CanonicalizeOSSALifetime canonicalizer(
-      pruneDebug, /*maximizeLifetime=*/!getFunction()->shouldOptimize(),
-      getFunction(), accessBlockAnalysis, domTree, calleeAnalysis, deleter);
+  CanonicalizeOSSALifetime::Options options;
+  if (pruneDebug)
+    options |= CanonicalizeOSSALifetime::Flags::PruneDebugMode;
+  if (!getFunction()->shouldOptimize())
+    options |= CanonicalizeOSSALifetime::Flags::MaximizeLifetime;
+  CanonicalizeOSSALifetime canonicalizer(options, getFunction(),
+                                         accessBlockAnalysis, domTree,
+                                         calleeAnalysis, deleter);
   // NOTE: We assume that the function is in reverse post order so visiting the
   //       blocks and pushing begin_borrows as we see them and then popping them
   //       off the end will result in shrinking inner borrow scopes first.

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2191,9 +2191,12 @@ void MemoryToRegisters::canonicalizeValueLifetimes(
       break;
     }
   }
-  CanonicalizeOSSALifetime canonicalizer(
-      /*pruneDebug=*/true, /*maximizeLifetime=*/!f.shouldOptimize(), &f,
-      accessBlockAnalysis, domInfo, calleeAnalysis, deleter);
+  CanonicalizeOSSALifetime::Options options = {
+      CanonicalizeOSSALifetime::Flags::PruneDebugMode};
+  if (!f.shouldOptimize())
+    options |= CanonicalizeOSSALifetime::Flags::MaximizeLifetime;
+  CanonicalizeOSSALifetime canonicalizer(options, &f, accessBlockAnalysis,
+                                         domInfo, calleeAnalysis, deleter);
   for (auto value : owned) {
     if (isa<SILUndef>(value) || value->isMarkedAsDeleted())
       continue;

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -147,7 +147,7 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
         continue;
       }
       // Handle debug_value instructions separately.
-      if (pruneDebugMode) {
+      if (options.contains(Flags::PruneDebugMode)) {
         if (auto *dvi = dyn_cast<DebugValueInst>(user)) {
           // Only instructions potentially outside current pruned liveness are
           // interesting.
@@ -1011,7 +1011,7 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
         instsToDelete.insert(destroy);
         LLVM_DEBUG(llvm::dbgs() << "  Removing " << *destroy);
         ++NumDestroysEliminated;
-      } else if (pruneDebugMode) {
+      } else if (options.contains(Flags::PruneDebugMode)) {
         // If this destroy was marked as a final destroy, add it to liveness so
         // that we don't delete any debug instructions that occur before it.
         // (Only relevant in pruneDebugMode).
@@ -1071,7 +1071,7 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
   }
   assert(!consumes.hasUnclaimedConsumes());
 
-  if (pruneDebugMode) {
+  if (options.contains(Flags::PruneDebugMode)) {
     for (auto *dvi : debugValues) {
       if (!liveness->isWithinBoundary(dvi)) {
         LLVM_DEBUG(llvm::dbgs() << "  Removing debug_value: " << *dvi);
@@ -1131,7 +1131,7 @@ void CanonicalizeOSSALifetime::rewriteLifetimes() {
   PrunedLivenessBoundary originalBoundary;
   findOriginalBoundary(originalBoundary);
   PrunedLivenessBoundary extendedBoundary;
-  if (maximizeLifetime) {
+  if (options.contains(Flags::MaximizeLifetime)) {
     // Step 3. (optional) maximize lifetimes
     extendUnconsumedLiveness(originalBoundary);
     originalBoundary.clear();
@@ -1198,9 +1198,14 @@ static FunctionTest CanonicalizeOSSALifetimeTest(
       auto pruneDebug = arguments.takeBool();
       auto maximizeLifetimes = arguments.takeBool();
       auto respectAccessScopes = arguments.takeBool();
+      CanonicalizeOSSALifetime::Options options;
+      if (pruneDebug)
+        options |= CanonicalizeOSSALifetime::Flags::PruneDebugMode;
+      if (maximizeLifetimes)
+        options |= CanonicalizeOSSALifetime::Flags::MaximizeLifetime;
       InstructionDeleter deleter;
       CanonicalizeOSSALifetime canonicalizer(
-          pruneDebug, maximizeLifetimes, &function,
+          options, &function,
           respectAccessScopes ? accessBlockAnalysis : nullptr, domTree,
           calleeAnalysis, deleter);
       auto value = arguments.takeValue();

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.swift
@@ -319,7 +319,7 @@ public func castTestSwitchInLoop(_ x : __owned Klass) { // expected-error {{'x' 
     let _ = consume x // expected-note {{consumed here}}
 
     for _ in 0..<1024 {
-        switch x {
+        switch x { // expected-note {{used here}}
         case let k as SubKlass1:
             print(k)
         default:


### PR DESCRIPTION
Just some cleanups that also fix some tests.