### PR TITLE
[cxx-interop] Conform `std::optional` to `ExpressibleByNilLiteral`

### DIFF
--- a/stdlib/public/Cxx/CxxOptional.swift
+++ b/stdlib/public/Cxx/CxxOptional.swift
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol CxxOptional<Wrapped> {
+public protocol CxxOptional<Wrapped>: ExpressibleByNilLiteral {
   associatedtype Wrapped
+
+  init()
 
   func __convertToBool() -> Bool
 
@@ -19,6 +21,10 @@ public protocol CxxOptional<Wrapped> {
 }
 
 extension CxxOptional {
+  public init(nilLiteral: ()) {
+    self.init()
+  }
+
   @inlinable
   public var hasValue: Bool {
     get {

--- a/test/Interop/Cxx/stdlib/Inputs/std-optional.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-optional.h
@@ -2,11 +2,16 @@
 #define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_OPTIONAL_H
 
 #include <optional>
+#include <string>
 
 using StdOptionalInt = std::optional<int>;
+using StdOptionalString = std::optional<std::string>;
 
 inline StdOptionalInt getNonNilOptional() { return {123}; }
 
 inline StdOptionalInt getNilOptional() { return {std::nullopt}; }
+
+inline bool takesOptionalInt(std::optional<int> arg) { return (bool)arg; }
+inline bool takesOptionalString(std::optional<std::string> arg) { return (bool)arg; }
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_OPTIONAL_H

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -41,4 +41,12 @@ StdOptionalTestSuite.test("std::optional hasValue/value") {
   expectNil(nilOpt.value)
 }
 
+StdOptionalTestSuite.test("std::optional as ExpressibleByNilLiteral") {
+  let res1 = takesOptionalInt(nil)
+  expectFalse(res1)
+
+  let res2 = takesOptionalString(nil)
+  expectFalse(res2)
+}
+
 runAllTests()


### PR DESCRIPTION
This will allow passing `nil` as a parameter to a C++ function that takes a `std::optional<T>`.

rdar://114194600