### PR TITLE
[ConstraintSystem] Handle incorrect key path member references earlier

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -275,6 +275,9 @@ public:
   /// a key path component.
   bool isForKeyPathComponentResult() const;
 
+  /// Determine whether this locator points to a key path component.
+  bool isForKeyPathComponent() const;
+
   /// Determine whether this locator points to the generic parameter.
   bool isForGenericParameter() const;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10332,7 +10332,9 @@ static ConstraintFix *fixMemberRef(
         return fix;
     }
 
-    if (locator->isForKeyPathDynamicMemberLookup()) {
+    if (locator->isForKeyPathDynamicMemberLookup() ||
+        locator->isForKeyPathComponent() ||
+        locator->isKeyPathSubscriptComponent()) {
       if (auto *fix = AllowInvalidRefInKeyPath::forRef(cs, decl, locator))
         return fix;
     }
@@ -12303,11 +12305,9 @@ ConstraintSystem::simplifyKeyPathConstraint(
 
       auto storage = dyn_cast<AbstractStorageDecl>(choice.getDecl());
 
-      if (auto *fix = AllowInvalidRefInKeyPath::forRef(
-              *this, choice.getDecl(), calleeLoc)) {
-        if (!hasFixFor(calleeLoc, FixKind::AllowTypeOrInstanceMember))
-          if (!shouldAttemptFixes() || recordFix(fix))
-            return SolutionKind::Error;
+      if (hasFixFor(calleeLoc, FixKind::AllowInvalidRefInKeyPath)) {
+        if (!shouldAttemptFixes())
+          return SolutionKind::Error;
 
         // If this was a method reference let's mark it as read-only.
         if (!storage) {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -598,6 +598,10 @@ bool ConstraintLocator::isForKeyPathComponentResult() const {
   return isLastElement<LocatorPathElt::KeyPathComponentResult>();
 }
 
+bool ConstraintLocator::isForKeyPathComponent() const {
+  return isLastElement<LocatorPathElt::KeyPathComponent>();
+}
+
 bool ConstraintLocator::isForGenericParameter() const {
   return isLastElement<LocatorPathElt::GenericParameter>();
 }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -795,7 +795,8 @@ func test_keypath_with_method_refs() {
 
   let _: KeyPath<S, Int> = \.foo // expected-error {{key path cannot refer to instance method 'foo()'}}
   // expected-error@-1 {{key path value type '() -> Int' cannot be converted to contextual type 'Int'}}
-  let _: KeyPath<S, Int> = \.bar // expected-error {{key path cannot refer to static member 'bar()'}}
+  let _: KeyPath<S, Int> = \.bar // expected-error {{key path cannot refer to static method 'bar()'}}
+  // expected-error@-1 {{key path value type '() -> Int' cannot be converted to contextual type 'Int'}}
   let _ = \S.Type.bar // expected-error {{key path cannot refer to static method 'bar()'}}
 
   struct A {
@@ -808,7 +809,7 @@ func test_keypath_with_method_refs() {
   }
 
   let _: KeyPath<A, Int> = \.foo.bar // expected-error {{key path cannot refer to instance method 'foo()'}}
-  let _: KeyPath<A, Int> = \.faz.bar // expected-error {{key path cannot refer to static member 'faz()'}}
+  let _: KeyPath<A, Int> = \.faz.bar // expected-error {{key path cannot refer to static method 'faz()'}}
   let _ = \A.foo.bar // expected-error {{key path cannot refer to instance method 'foo()'}}
   let _ = \A.Type.faz.bar // expected-error {{key path cannot refer to static method 'faz()'}}
 }


### PR DESCRIPTION
These changes move the check for invalid member reference in a keypath out of `simplifyKeyPathConstraint` and into `fixMemberRef` so that it can be handled earlier in the typechecking process. Previously, it was skipped in `simplifyKeyPathConstraint` because the keypath components incorrectly appear to be fully resolved.