### PR TITLE
utils: invoke `update-checkout` with `--reset-to-remote`

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -792,7 +792,7 @@ set "args=%args% --skip-repository swift-integration-tests"
 set "args=%args% --skip-repository swift-stress-tester"
 set "args=%args% --skip-repository swift-xcode-playground-support"
 
-call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --github-comment "%ghprbCommentBody%"
+call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --reset-to-remote --skip-history --github-comment "%ghprbCommentBody%"
 
 goto :eof
 endlocal

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -134,7 +134,7 @@ git -C "%source_root%\swift" checkout-index --force --all
 @set "skip_repositories_arg=%skip_repositories_arg% --skip-repository tensorflow-swift-apis"
 @set "skip_repositories_arg=%skip_repositories_arg% --skip-repository yams"
 
-call "%source_root%\swift\utils\update-checkout.cmd" %scheme_arg% %skip_repositories_arg% --clone --skip-history --skip-tags --github-comment "%ghprbCommentBody%" >NUL
+call "%source_root%\swift\utils\update-checkout.cmd" %scheme_arg% %skip_repositories_arg% --clone --reset-to-remote --skip-history --skip-tags --github-comment "%ghprbCommentBody%" >NUL
 
 goto :eof
 endlocal


### PR DESCRIPTION
This should hopefully prevent unstaged change errors in CI.