### PR TITLE
[5.9][TypeChecker/DI] InitAccessors: Treat properties without "initializes" as stored fix default initialization handling

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4962,6 +4962,8 @@ public:
   SILValue getInitializer() const { return Operands[2].get(); }
   SILValue getSetter() { return  Operands[3].get(); }
 
+  VarDecl *getProperty() const;
+
   Mode getMode() const {
     return Mode(sharedUInt8().AssignOrInitInst.mode);
   }

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1283,6 +1283,12 @@ bool AssignOrInitInst::isPropertyAlreadyInitialized(unsigned propertyIdx) {
   return Assignments.test(propertyIdx);
 }
 
+VarDecl *AssignOrInitInst::getProperty() const {
+  auto *accessor = getReferencedInitAccessor();
+  assert(accessor);
+  return cast<VarDecl>(accessor->getStorage());
+}
+
 StringRef AssignOrInitInst::getPropertyName() const {
   auto *accessor = getReferencedInitAccessor();
   assert(accessor);

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1182,6 +1182,12 @@ void LifetimeChecker::doIt() {
     while (returnBB != F.end()) {
       auto *terminator = returnBB->getTerminator();
 
+      // If this is an unreachable block, let's ignore it.
+      if (isa<UnreachableInst>(terminator)) {
+        ++returnBB;
+        continue;
+      }
+
       if (!isInitializedAtUse(DIMemoryUse(terminator, DIUseKind::Load, 0, 1)))
         diagnoseMissingInit();
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -491,11 +491,16 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
     }
   }
 
+  auto isInitAccessorProperty = [](Pattern *pattern) {
+    auto *var = pattern->getSingleVar();
+    return var && var->getAccessor(AccessorKind::Init);
+  };
+
   // If we have a type but no initializer, check whether the type is
   // default-initializable. If so, do it.
   if (!pbe.isInitialized() &&
       binding->isDefaultInitializable(entryNumber) &&
-      pattern->hasStorage()) {
+      (pattern->hasStorage() || isInitAccessorProperty(pattern))) {
     if (auto defaultInit = TypeChecker::buildDefaultInitializer(patternType)) {
       // If we got a default initializer, install it and re-type-check it
       // to make sure it is properly coerced to the pattern type.

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -800,3 +800,49 @@ do {
 }
 // CHECK: Person(name: P)
 // CHECK-NEXT: Person(name: O)
+
+do {
+  struct TestDefaultInitializable : CustomStringConvertible {
+    var description: String {
+      "TestDefaultInitializable(a: \(a))"
+    }
+
+    var _a: Int?
+    var a: Int? {
+      @storageRestrictions(initializes: _a)
+      init { _a = newValue }
+      get { _a }
+    }
+  }
+
+  print(TestDefaultInitializable())
+  print(TestDefaultInitializable(a: 42))
+
+  struct TestMixedDefaultInitalizable : CustomStringConvertible {
+    var description: String {
+      "TestMixedDefaultInitalizable(a: \(a), b: \(b))"
+    }
+
+    var a: Int? {
+      init {}
+      get { nil }
+    }
+
+    var _b: String
+    var b: String? {
+      @storageRestrictions(initializes: _b)
+      init { self._b = (newValue ?? "") }
+      get { _b }
+      set { _b = newValue ?? "" }
+    }
+  }
+
+  print(TestMixedDefaultInitalizable())
+  print(TestMixedDefaultInitalizable(b: "Hello"))
+  print(TestMixedDefaultInitalizable(a: 42))
+}
+// CHECK: TestDefaultInitializable(a: nil)
+// CHECK-NEXT: TestDefaultInitializable(a: Optional(42))
+// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional(""))
+// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional("Hello"))
+// CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional(""))

--- a/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
@@ -268,3 +268,73 @@ do {
     }
   }
 }
+
+// Test that init accessor without "initializes" is required
+do {
+  struct Test {
+    var a: Int {
+      init {}
+      get { 42 }
+      set {}
+    }
+    var b: Int { // expected-note 2 {{'self' not initialized}}
+      init {}
+      get { 0 }
+      set { }
+    }
+
+    init(a: Int) {
+      self.a = a
+    } // expected-error {{return from initializer without initializing all stored properties}}
+
+    init(a: Int, b: Int) {
+      if a == 0 {
+        self.a = a
+        self.b = b
+      } else {
+        self.a = 0
+      }
+    } // expected-error {{return from initializer without initializing all stored properties}}
+
+    init() { // Ok
+      self.a = 0
+      self.b = 0
+    }
+  }
+
+  struct TestWithStored {
+    var _value: Int = 0
+
+    var a: Int {
+      @storageRestrictions(accesses: _value)
+      init {}
+      get { _value }
+      set { _value = newValue }
+    }
+  }
+
+  _ = TestWithStored(a: 42) // Ok
+  _ = TestWithStored(_value: 1, a: 42) // Ok
+
+  class TestWithStoredExplicit {
+    var _value: Int = 0
+    var _other: String = ""
+
+    var a: Int { // expected-note 2 {{'self' not initialized}}
+      @storageRestrictions(accesses: _value)
+      init {}
+      get { _value }
+      set { _value = newValue }
+    }
+
+    init(data: Int) {
+      self._value = data
+    } // expected-error {{return from initializer without initializing all stored properties}}
+
+    init() {} // expected-error {{return from initializer without initializing all stored properties}}
+
+    init(a: Int) {
+      self.a = a // Ok
+    }
+  }
+}

--- a/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/init_accessor_definite_init_diagnostics.swift
@@ -190,6 +190,17 @@ class TestInitWithGuard {
 }
 
 do {
+  struct TestPropertyInitWithUnreachableBlocks {
+    var _a: Int
+    var a: Int? {
+      @storageRestrictions(initializes: _a)
+      init { _a = newValue ?? 0 } // Ok
+      get { 42 }
+    }
+  }
+}
+
+do {
   class Base<T: Collection> {
     private var _v: T
 

--- a/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
+++ b/test/SILOptimizer/init_accessor_raw_sil_lowering.swift
@@ -46,11 +46,11 @@ final class TestIndirectionThroughStorage {
   // CHECK: [[STORAGE_INIT:%.*]] = function_ref @$s23assign_or_init_lowering29TestIndirectionThroughStorageC8_storage33_DE106275C2F16FB3D05881E72FBD87C8LLAA0H0_pAC1TAaFPRts_XPvpfi : $@convention(thin) () -> @out any Storage<TestIndirectionThroughStorage>
   // CHECK-NEXT: {{.*}} = apply [[STORAGE_INIT]]([[STORAGE_REF]]) : $@convention(thin) () -> @out any Storage<TestIndirectionThroughStorage>
   // Initialization:
-  // CHECK: assign_or_init [set] self %2 : $TestIndirectionThroughStorage, value {{.*}} : $String, init {{.*}} : $@convention(thin) (@owned String, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
-  // CHECK: assign_or_init [set] self %2 : $TestIndirectionThroughStorage, value {{.*}} : $Optional<Int>, init {{.*}} : $@convention(thin) (Optional<Int>, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (Optional<Int>) -> (
+  // CHECK: assign_or_init [init] self %2 : $TestIndirectionThroughStorage, value {{.*}} : $String, init {{.*}} : $@convention(thin) (@owned String, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
+  // CHECK: assign_or_init [init] self %2 : $TestIndirectionThroughStorage, value {{.*}} : $Optional<Int>, init {{.*}} : $@convention(thin) (Optional<Int>, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (Optional<Int>) -> ()
   // Explicit set:
   // CHECK: assign_or_init [set] self %2 : $TestIndirectionThroughStorage, value {{.*}} : $String, init {{.*}} : $@convention(thin) (@owned String, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
-  // CHECK: assign_or_init [set] self %2 : $TestIndirectionThroughStorage, value {{.*}} : $Optional<Int>, init {{.*}} : $@convention(thin) (Optional<Int>, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (Optional<Int>) -> (
+  // CHECK: assign_or_init [set] self %2 : $TestIndirectionThroughStorage, value {{.*}} : $Optional<Int>, init {{.*}} : $@convention(thin) (Optional<Int>, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (Optional<Int>) -> ()
   init(name: String, age: Int) {
     self.name = name
     self.age = age
@@ -61,8 +61,8 @@ final class TestIndirectionThroughStorage {
   // CHECK: [[STORAGE_INIT:%.*]] = function_ref @$s23assign_or_init_lowering29TestIndirectionThroughStorageC8_storage33_DE106275C2F16FB3D05881E72FBD87C8LLAA0H0_pAC1TAaFPRts_XPvpfi : $@convention(thin) () -> @out any Storage<TestIndirectionThroughStorage>
   // CHECK-NEXT: {{.*}} = apply [[STORAGE_INIT]]([[STORAGE_REF]]) : $@convention(thin) () -> @out any Storage<TestIndirectionThroughStorage>
   // Initialization:
-  // CHECK: assign_or_init [set] self %1 : $TestIndirectionThroughStorage, value {{.*}} : $String, init {{.*}} : $@convention(thin) (@owned String, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
-  // CHECK: assign_or_init [set] self %1 : $TestIndirectionThroughStorage, value {{.*}} : $Optional<Int>, init {{.*}} : $@convention(thin) (Optional<Int>, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (Optional<Int>) -> ()
+  // CHECK: assign_or_init [init] self %1 : $TestIndirectionThroughStorage, value {{.*}} : $String, init {{.*}} : $@convention(thin) (@owned String, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (@owned String) -> ()
+  // CHECK: assign_or_init [init] self %1 : $TestIndirectionThroughStorage, value {{.*}} : $Optional<Int>, init {{.*}} : $@convention(thin) (Optional<Int>, @inout any Storage<TestIndirectionThroughStorage>) -> (), set {{.*}} : $@callee_guaranteed (Optional<Int>) -> ()
   // Explicit set:
   // CHECK: [[STORAGE_SETTER:%.*]] = function_ref @$s23assign_or_init_lowering29TestIndirectionThroughStorageC7storageAA0H0_pAC1TAaEPRts_XPvs : $@convention(method) (@in any Storage<TestIndirectionThroughStorage>, @guaranteed TestIndirectionThroughStorage) -> ()
   // CHECK-NEXT: {{.*}} = apply [[STORAGE_SETTER]]({{.*}}, %1) : $@convention(method) (@in any Storage<TestIndirectionThroughStorage>, @guaranteed TestIndirectionThroughStorage) -> ()
@@ -102,8 +102,8 @@ struct TestAccessOfOnePatternVars {
   // CHECK-NEXT: {{.*}} = apply [[Y_INIT]]() : $@convention(thin) () -> @owned String
   // CHECK-NOT: [[X_REF:%.*]] = struct_element_addr %3 : $*TestAccessOfOnePatternVars, #TestAccessOfOnePatternVars.x
   // CHECK-NOT: [[Y_REF:%.*]] = struct_element_addr {{.*}} : $*TestAccessOfOnePatternVars, #TestAccessOfOnePatternVars.y
-  // CHECK: assign_or_init [set] self {{.*}} : $*TestAccessOfOnePatternVars, value {{.*}} : $(Int, String), init {{.*}} : $@convention(thin) (Int, @owned String, @inout Int, @inout String) -> (), set {{.*}} : $@callee_guaranteed (Int, @owned String) -> ()
-  // CHECK: assign_or_init [set] self {{.*}} : $*TestAccessOfOnePatternVars, value {{.*}} : $Bool, init {{.*}} : $@convention(thin) (Bool, @inout Int) -> (), set {{.*}} : $@callee_guaranteed (Bool) -> ()
+  // CHECK: assign_or_init [init] self {{.*}} : $*TestAccessOfOnePatternVars, value {{.*}} : $(Int, String), init {{.*}} : $@convention(thin) (Int, @owned String, @inout Int, @inout String) -> (), set {{.*}} : $@callee_guaranteed (Int, @owned String) -> ()
+  // CHECK: assign_or_init [init] self {{.*}} : $*TestAccessOfOnePatternVars, value {{.*}} : $Bool, init {{.*}} : $@convention(thin) (Bool, @inout Int) -> (), set {{.*}} : $@callee_guaranteed (Bool) -> ()
   init(x: Int, y: String) {
     self.x = x
     self.y = y
@@ -196,7 +196,7 @@ struct Test {
   // CHECK-LABEL: sil hidden [ossa] @$s23assign_or_init_lowering4TestV1vACSi_tcfC : $@convention(method) (Int, @thin Test.Type) -> Test
   init(v: Int) {
     // CHECK: [[INIT_REF:%.*]] = function_ref @$s23assign_or_init_lowering4TestV4testSivi : $@convention(thin) (Int) -> ()
-    // CHECK: assign_or_init [set] self {{.*}}, value %0 : $Int, init [[INIT_REF]] : $@convention(thin) (Int) -> (), set {{.*}} : $@callee_guaranteed (Int) -> ()
+    // CHECK: assign_or_init [init] self {{.*}}, value %0 : $Int, init [[INIT_REF]] : $@convention(thin) (Int) -> (), set {{.*}} : $@callee_guaranteed (Int) -> ()
     self.test = v
   }
 }

--- a/test/SILOptimizer/init_accessors.swift
+++ b/test/SILOptimizer/init_accessors.swift
@@ -73,9 +73,12 @@ struct TestSetter {
   }
 
   // CHECK-LABEL: sil hidden [ossa] @$s14init_accessors10TestSetterV1x1yACSi_SitcfC : $@convention(method) (Int, Int, @thin TestSetter.Type) -> TestSetter
-  // CHECK: [[SETTER_REF:%.*]] = function_ref @$s14init_accessors10TestSetterV5pointSi_Sitvs : $@convention(method) (Int, Int, @inout TestSetter) -> ()
-  // CHECK-NEXT: [[SETTER_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[SETTER_REF]]([[SELF_VALUE:%.*]]) : $@convention(method) (Int, Int, @inout TestSetter) -> ()
-  // CHECK: {{.*}} = apply [[SETTER_CLOSURE]]({{.*}}) : $@callee_guaranteed (Int, Int) -> ()
+  // CHECK: [[INIT_ACCESSOR:%.*]] = function_ref @$s14init_accessors10TestSetterV5pointSi_Sitvi : $@convention(thin) (Int, Int, @inout Int, @inout Int) -> ()
+  // CHECK: [[SELF:%.*]] = begin_access [modify] [dynamic] %14 : $*TestSetter
+  // CHECK-NEXT: ([[X:%.*]], [[Y:%.*]]) = destructure_tuple {{.*}} : $(Int, Int)
+  // CHECK-NEXT: [[X_REF:%.*]] = struct_element_addr [[SELF]] : $*TestSetter, #TestSetter.x
+  // CHECK-NEXT: [[Y_REF:%.*]] = struct_element_addr [[SELF]] : $*TestSetter, #TestSetter.y
+  // CHECK-NEXT: {{.*}} = apply [[INIT_ACCESSOR]]([[X]], [[Y]], [[X_REF]], [[Y_REF]]) : $@convention(thin) (Int, Int, @inout Int, @inout Int) -> ()
   init(x: Int, y: Int) {
     self.x = x
     self.y = y

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -530,7 +530,7 @@ extension TestStructPropWithoutSetter {
 }
 
 do {
-  class TestClassPropWithoutSetter {
+  class TestClassPropWithoutSetter { // expected-error {{class 'TestClassPropWithoutSetter' has no initializers}}
     var x: Int {
       init {
       }
@@ -538,6 +538,44 @@ do {
       get { 0 }
     }
   }
+
+  // This should generate only memberwise initializer because `a` doesn't have a default
+  struct TestStructWithoutSetter { // expected-note {{'init(a:)' declared here}}
+    var a: Int {
+      init {
+      }
+      get { 0 }
+    }
+  }
+
+  _ = TestStructWithoutSetter() // expected-error {{missing argument for parameter 'a' in call}}
+  _ = TestStructWithoutSetter(a: 42) // Ok
+
+  struct TestDefaultInitializable {
+    var a: Int? {
+      init {}
+      get { nil }
+    }
+  }
+
+  _ = TestDefaultInitializable() // Ok (`a` is initialized to `nil`)
+
+  struct TestMixedDefaultInitializable {
+    var a: Int? {
+      init {}
+      get { nil }
+    }
+
+    var _b: String
+    var b: String? {
+      @storageRestrictions(initializes: _b)
+      init { _b = newValue ?? "" }
+      get { _b }
+      set { _b = newValue ?? "" }
+    }
+  }
+
+  _ = TestMixedDefaultInitializable() // Ok (both `a` and `b` are initialized to `nil`)
 
   class SubTestPropWithoutSetter : TestClassPropWithoutSetter {
     init(otherV: Int) {

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -620,3 +620,33 @@ func test_invalid_storage_restrictions() {
     init() {}
   }
 }
+
+do {
+  struct Test1 {
+    var q: String
+    var a: Int? {
+      init {}
+      get { 42 }
+    }
+  }
+
+  _ = Test1(q: "some question") // Ok `a` is default initialized to `nil`
+  _ = Test1(q: "ultimate question", a: 42)
+
+  struct Test2 {
+    var q: String
+
+    var _a: Int?
+    var a: Int? {
+      @storageRestrictions(initializes: _a)
+      init {
+        _a = newValue
+      }
+      get { _a }
+      set { _a = newValue }
+    }
+  }
+
+  _ = Test2(q: "some question") // Ok `a` is default initialized to `nil`
+  _ = Test2(q: "ultimate question", a: 42)
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/67763, https://github.com/apple/swift/pull/67769

---

- Explanation:

A couple of improvements to init accessors feature to align implementation with the proposal.

  - If an init accessor property doesn't initialize any stored properties it has to be initialized explicitly unless it has initializer expression;
  - Init accessor properties without initializer expressions suppress default initializers;

- Scope: Init accessors that do not initialize stored properties.

- Main Branch PRs: https://github.com/apple/swift/pull/67763, https://github.com/apple/swift/pull/67769

- Resolves: rdar://113401979, rdar://113421273

- Risk: Low

- Reviewed By: @hborla

- Testing: Added test-cases to the suite.

Resolves: rdar://113401979
Resolves: rdar://113421273


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
