### PR TITLE
Look through function conversion expressions when querying the called function decl of a deprecated-renamed API in order to emit a fix-it

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2367,7 +2367,8 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
         // renaming fix-it doesn't need do be produced.
         if ((parsed.ContextName.empty() ||
              parsed.ContextName == callContextName) &&
-            CE->getCalledValue()->getBaseName() == parsed.BaseName) {
+            CE->getCalledValue(/*skipFunctionConversions=*/true)
+                    ->getBaseName() == parsed.BaseName) {
           shouldEmitRenameFixit = false;
         }
       }

--- a/test/attr/rename_function_conversion.swift
+++ b/test/attr/rename_function_conversion.swift
@@ -1,0 +1,16 @@
+// REQUIRES: concurrency
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown %s
+
+@MainActor
+@available(SwiftStdlib 5.5, *)
+public class SomeMainActorClass {
+    @available(*, deprecated, renamed: "request(at:completion:)")
+    public func request(at: Int) async throws {}
+}
+
+@available(SwiftStdlib 5.5, *)
+func asyncStuff() async throws {
+    let foo = await SomeMainActorClass()
+    try await foo.request(at: 11) // expected-warning{{'request(at:)' is deprecated: renamed to 'request(at:completion:)'}}
+    //expected-note@-1{{use 'request(at:completion:)' instead}}
+}


### PR DESCRIPTION
Resolves rdar://113768664
