### PR TITLE
RequirementMachine: Fix potential 'pollution' from installing an invalid requirement machine

### DIFF
--- a/test/Generics/rdar113943346.swift
+++ b/test/Generics/rdar113943346.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+struct G<T, U, V> {}
+
+struct Foo<T> {}
+
+// The first extension has the same generic signature as the
+// second extension, because we drop the invalid requirement.
+//
+// But the rewrite system used for minimization with the first
+// extension should not be installed in the rewrite context,
+// because of this invalid requirement.
+
+extension G where T == Foo<V.Bar>, U == Foo<Int> {}
+// expected-error@-1 {{'Bar' is not a member type of type 'V'}}
+
+extension G where U == Foo<Int> {
+  func f() {
+    print(T.self)
+    print(U.self)
+  }
+}


### PR DESCRIPTION
If the substitution terms of a concrete type symbol contain unresolved name symbols, we have an invalid requirement that is dropped from the minimized signature. In this case, the rewrite system used for minimization cannot be installed as the official rewrite system for this generic signature, because building a rewrite system from the signature will produce a different result.

This might be the cause of the crash in rdar://114111159.