### PR TITLE
[Swift interface] Print declarations produced by declaration macro expansion

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1020,8 +1020,17 @@ public:
         Options.TransformContext->isPrintingSynthesizedExtension() &&
         isa<ExtensionDecl>(D);
 
+    SWIFT_DEFER {
+      D->visitAuxiliaryDecls([&](Decl *auxDecl) {
+        visit(auxDecl);
+      });
+    };
+
     if (!shouldPrint(D, true) && !Synthesize)
       return false;
+
+    if (isa<MacroExpansionDecl>(D))
+      return true;
 
     Decl *Old = Current;
     Current = D;

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -1,23 +1,23 @@
 // REQUIRES: asserts
 // REQUIRES: swift_swift_parser
-// FIXME: Swift parser is not enabled on Linux CI yet.
-// REQUIRES: OS=macosx
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-emit-module-interface(%t/Macros.swiftinterface) -enable-experimental-feature ExtensionMacros -module-name Macros %s
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../Macros/Inputs/syntax_macro_definitions.swift -no-toolchain-stdlib-rpath -swift-version 5
+
+// RUN: %target-swift-emit-module-interface(%t/Macros.swiftinterface) -enable-experimental-feature ExtensionMacros -module-name Macros %s -load-plugin-library %t/%target-library-name(MacroDefinition)
 // RUN: %FileCheck %s < %t/Macros.swiftinterface --check-prefix CHECK
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Macros.swiftinterface -o %t/Macros.swiftmodule
 
 // CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
-// CHECK-NEXT: @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
+// CHECK-NEXT: @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 // CHECK-NEXT: #endif
-@freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
+@freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
-// CHECK: @freestanding(expression) public macro labeledStringify<T>(_ value: T, label: Swift.String) -> (T, Swift.String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
+// CHECK: @freestanding(expression) public macro labeledStringify<T>(_ value: T, label: Swift.String) -> (T, Swift.String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 // CHECK-NEXT: #endif
-@freestanding(expression) public macro labeledStringify<T>(_ value: T, label: String) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
+@freestanding(expression) public macro labeledStringify<T>(_ value: T, label: String) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
 // CHECK: @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: Swift.String) -> (T, Swift.String) = #labeledStringify(value, label: "default label")
@@ -25,36 +25,47 @@
 @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: String) -> (T, String) = #labeledStringify(value, label: "default label")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
-// CHECK: @freestanding(expression) public macro publicLine<T>() -> T = #externalMacro(module: "SomeModule", type: "Line") where T : Swift.ExpressibleByIntegerLiteral
+// CHECK: @freestanding(expression) public macro publicLine<T>() -> T = #externalMacro(module: "MacroDefinition", type: "Line") where T : Swift.ExpressibleByIntegerLiteral
 // CHECK-NEXT: #endif
-@freestanding(expression) public macro publicLine<T: ExpressibleByIntegerLiteral>() -> T = #externalMacro(module: "SomeModule", type: "Line")
+@freestanding(expression) public macro publicLine<T: ExpressibleByIntegerLiteral>() -> T = #externalMacro(module: "MacroDefinition", type: "Line")
 
 // CHECK: #if compiler(>=5.3) && $Macros
-// CHECK: @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
+// CHECK: @attached(accessor) public macro myWrapper() = #externalMacro(module: "MacroDefinition", type: "Wrapper")
 // CHECK-NEXT: #endif
-@attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
+@attached(accessor) public macro myWrapper() = #externalMacro(module: "MacroDefinition", type: "Wrapper")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+// CHECK: @attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "MacroDefinition", type: "MemberwiseInitMacro")
 // CHECK-NEXT: #endif
-@attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+@attached(member, names: named(init), prefixed(`$`)) public macro MemberwiseInit() = #externalMacro(module: "MacroDefinition", type: "MemberwiseInitMacro")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInitFunc() = #externalMacro(module: "SomeModule", type: "MemberwiseInitFuncMacro")
+// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInitFunc() = #externalMacro(module: "MacroDefinition", type: "MemberwiseInitFuncMacro")
 // CHECK-NEXT: #endif
-@attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInitFunc() = #externalMacro(module: "SomeModule", type: "MemberwiseInitFuncMacro")
+@attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInitFunc() = #externalMacro(module: "MacroDefinition", type: "MemberwiseInitFuncMacro")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "SomeModule", type: "AccessorInitFuncMacro")
+// CHECK: @attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "MacroDefinition", type: "AccessorInitFuncMacro")
 // CHECK-NEXT: #endif
-@attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "SomeModule", type: "AccessorInitFuncMacro")
+@attached(accessor, names: named(init)) public macro AccessorInitFunc() = #externalMacro(module: "MacroDefinition", type: "AccessorInitFuncMacro")
 
 // CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
-// CHECK: @attached(extension, conformances: Swift.Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
+// CHECK: @attached(extension, conformances: Swift.Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableExtensionMacro")
 // CHECK-NEXT: #else
-// CHECK: @attached(member) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
+// CHECK: @attached(member) public macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableExtensionMacro")
 // CHECK-NEXT: #endif
-@attached(extension, conformances: Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "SomeModule", type: "SendableExtensionMacro")
+@attached(extension, conformances: Sendable) @attached(member) public macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableExtensionMacro")
 
 // CHECK-NOT: internalStringify
-@freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
+@freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+@freestanding(declaration, names: named(StructWithUnqualifiedLookup))
+macro structWithUnqualifiedLookup() = #externalMacro(module: "MacroDefinition", type: "DefineStructWithUnqualifiedLookupMacro")
+
+let world = 17
+
+// CHECK-NOT: structWithUnqualifiedLookup
+public
+#structWithUnqualifiedLookup
+
+// CHECK: struct StructWithUnqualifiedLookup


### PR DESCRIPTION
Don't print the uses of freestanding declaration macros in Swift interfaces. Instead, print the declarations they produce, as appropriate.

Fixes rdar://113730928. Cherry-picked from https://github.com/apple/swift/pull/68059
