### PR TITLE
RequirementMachine: Fix potential 'pollution' from installing an invalid requirement machine [5.9]

### DIFF
--- a/test/Generics/rdar113943346.swift
+++ b/test/Generics/rdar113943346.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+struct G<T, U, V> {}
+
+struct Foo<T> {}
+
+// The first extension has the same generic signature as the
+// second extension, because we drop the invalid requirement.
+//
+// But the rewrite system used for minimization with the first
+// extension should not be installed in the rewrite context,
+// because of this invalid requirement.
+
+extension G where T == Foo<V.Bar>, U == Foo<Int> {}
+// expected-error@-1 {{'Bar' is not a member type of type 'V'}}
+
+extension G where U == Foo<Int> {
+  func f() {
+    print(T.self)
+    print(U.self)
+  }
+}


### PR DESCRIPTION
* Original PR: https://github.com/apple/swift/pull/68055

* Description: When we build a new generic signature, we associate the rewrite system we just built with this generic signature, to avoid building the rewrite system again. However if the signature contains invalid requirements, we cannot re-use the requirement machine. The check for invalid requirements did not walk inside concrete types, so if you had such a signature, it would "pollute" the cache.

* Origination: Always broken.

* Scope of the issue: Causes a crash-on-invalid when some other error should have been diagnosed elsewhere instead.

* Radar: I believe this is part or all of the cause of rdar://113943346, which I was unable to reproduce.

* Tested: I added a new test case which demonstrates the old broken behavior.

* Risk: Low. This disables rewrite system reuse in one new case, and it should always be safe to not reuse rewrite systems; we can always build a new one, it's just an optimization.

* Reviewed by: @hborla 