### PR TITLE
[cxx-interop] Add test for `INADDR_ANY` usage

### DIFF
--- a/test/Interop/Cxx/objc-correctness/Inputs/POSIX.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/POSIX.h
@@ -1,0 +1,9 @@
+typedef unsigned int __uint32_t;
+typedef unsigned int u_int32_t;
+typedef __uint32_t in_addr_t;
+
+struct in_addr {
+  in_addr_t s_addr;
+};
+
+#define INADDR_ANY (u_int32_t)0x00000000

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -38,3 +38,7 @@ module NSTextCheckingResult {
   header "NSTextCheckingResult.h"
   requires objc
 }
+
+module MockPOSIX {
+  header "POSIX.h"
+}

--- a/test/Interop/Cxx/objc-correctness/posix.swift
+++ b/test/Interop/Cxx/objc-correctness/posix.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=swift-5.9 %s
+// REQUIRES: objc_interop
+
+import MockPOSIX
+
+let _ = in_addr(s_addr: INADDR_ANY)


### PR DESCRIPTION
At some point several months ago the `INADDR_ANY` macro from `Darwin.POSIX` module was not imported into Swift correctly. The issue seems to be resolved now. This change adds a test to make sure we don't regress again.

rdar://107429566