### PR TITLE
Handle scudo rename and changes for rebranch

### DIFF
--- a/include/swift/Basic/Sanitizers.def
+++ b/include/swift/Basic/Sanitizers.def
@@ -24,6 +24,6 @@ SANITIZER(0, Address,   address,    asan)
 SANITIZER(1, Thread,    thread,     tsan)
 SANITIZER(2, Undefined, undefined,  ubsan)
 SANITIZER(3, Fuzzer,    fuzzer,     fuzzer)
-SANITIZER(4, Scudo,     scudo,      scudo)
+SANITIZER(4, Scudo,     scudo,      scudo_standalone)
 
 #undef SANITIZER

--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -182,36 +182,27 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
             + toStringRef(SanitizerKind::Thread)).toStringRef(b2));
   }
 
-  // Scudo can only be run with ubsan.
-  if (sanitizerSet & SanitizerKind::Scudo) {
-    OptionSet<SanitizerKind> allowedSet;
-    allowedSet |= SanitizerKind::Scudo;
-    allowedSet |= SanitizerKind::Undefined;
-
-    auto forbiddenOptions = sanitizerSet - allowedSet;
-
-    if (forbiddenOptions) {
-      SanitizerKind forbidden;
-
-      if (forbiddenOptions & SanitizerKind::Address) {
-        forbidden = SanitizerKind::Address;
-      } else if (forbiddenOptions & SanitizerKind::Thread) {
-          forbidden = SanitizerKind::Thread;
-      } else {
-        assert(forbiddenOptions & SanitizerKind::Fuzzer);
-        forbidden = SanitizerKind::Fuzzer;
+  // Scudo must be run standalone
+  if (sanitizerSet.contains(SanitizerKind::Scudo) &&
+      !sanitizerSet.containsOnly(SanitizerKind::Scudo)) {
+    auto diagnoseSanitizerKind = [&Diags, A, &sanitizerSet](SanitizerKind kind) {
+      // Don't diagnose Scudo, but diagnose anything else
+      if (kind != SanitizerKind::Scudo && sanitizerSet.contains(kind)) {
+        SmallString<128> b1;
+        SmallString<128> b2;
+        Diags.diagnose(SourceLoc(), diag::error_argument_not_allowed_with,
+            (A->getOption().getPrefixedName()
+             + toStringRef(SanitizerKind::Scudo)).toStringRef(b1),
+            (A->getOption().getPrefixedName()
+             + toStringRef(kind)).toStringRef(b2));
       }
+    };
 
-      SmallString<128> b1;
-      SmallString<128> b2;
-      Diags.diagnose(SourceLoc(), diag::error_argument_not_allowed_with,
-          (A->getOption().getPrefixedName()
-              + toStringRef(SanitizerKind::Scudo)).toStringRef(b1),
-          (A->getOption().getPrefixedName()
-              + toStringRef(forbidden)).toStringRef(b2));
-      }
+#define SANITIZER(enm, kind, name, file) \
+    diagnoseSanitizerKind(SanitizerKind::kind);
+#include "swift/Basic/Sanitizers.def"
+
   }
-
   return sanitizerSet;
 }
 

--- a/test/Driver/sanitize_scudo.swift
+++ b/test/Driver/sanitize_scudo.swift
@@ -11,7 +11,7 @@
 
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo,address -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_ASAN %s
 // RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo,thread -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_TSAN %s
-// RUN: %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo,undefined -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_UBSAN_LINUX %s
+// RUN: not %swiftc_driver -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ -driver-print-jobs -sanitize=scudo,undefined -target x86_64-unknown-linux-gnu %s 2>&1 | %FileCheck -check-prefix=SCUDO_UBSAN %s
 
 
 /*
@@ -34,7 +34,6 @@
 
 // SCUDO_ASAN: argument '-sanitize=scudo' is not allowed with '-sanitize=address'
 // SCUDO_TSAN: argument '-sanitize=scudo' is not allowed with '-sanitize=thread'
-// SCUDO_UBSAN_LINUX: -fsanitize=undefined,scudo
+// SCUDO_UBSAN: argument '-sanitize=scudo' is not allowed with '-sanitize=undefined'
 // SCUDO_LIBRARY_LINUX: bin{{/|\\\\}}clang
 // SCUDO_LIBRARY_LINUX-NOT: -fsanitize=scudo
-

--- a/test/Sanitizers/scudo.swift
+++ b/test/Sanitizers/scudo.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swiftc_driver %s -g -sanitize=scudo -o %t_scudo-binary
-// RUN: not %target-run %t_scudo-binary 2>&1 | %FileCheck %s
+// RUN: not --crash %target-run %t_scudo-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: scudo_runtime


### PR DESCRIPTION
This patch set updates the old driver to handle changes to the scudo sanitizer in upstream LLVM.
The sanitizer is now standalone and shouldn't be used with other sanitizers. In this change, the library was renamed to `scudo_standalone` to reflect the change. As such, the driver maps the `scudo` sanitizer to the appropriate filename.

I've also included the updated logic in the driver to ensure that scudo is the only sanitizer passed to the driver, and to otherwise emit a diagnostic.

CC @Lukasa 

rdar://114209408
