### PR TITLE
[OpaqueValues] Emit consume expr for addr-only as loadable.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6199,7 +6199,7 @@ RValue RValueEmitter::visitConsumeExpr(ConsumeExpr *E, SGFContext C) {
     return RValue(SGF, {optTemp->getManagedAddress()}, subType.getASTType());
   }
 
-  if (subType.isLoadable(SGF.F)) {
+  if (subType.isLoadable(SGF.F) || !SGF.useLoweredAddresses()) {
     ManagedValue mv = SGF.emitRValue(subExpr).getAsSingleValue(SGF, subExpr);
     if (mv.getType().isTrivial(SGF.F))
       return RValue(SGF, {mv}, subType.getASTType());

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -672,7 +672,7 @@ func set<Container, Field>(into container: inout Container, at keyPath: Writable
 // CHECK-SAME:      [[CONTAINER:%[^,]+]] :
 // CHECK:         [[CONTAINER_COPY:%[^,]+]] = copy_value [[CONTAINER]]
 // CHECK:         [[SETTER:%[^,]+]] = class_method [[CONTAINER_COPY]]
-// CHECK:         [[REGISTER_4:%[^,]+]] = apply [[SETTER]]([[VALUE]], [[CONTAINER_COPY]])
+// CHECK:         apply [[SETTER]]([[VALUE]], [[CONTAINER_COPY]])
 // CHECK:         destroy_value [[CONTAINER_COPY]]
 // CHECK-LABEL: } // end sil function '$s20opaque_values_silgen16FormClassKeyPathyyF1QL_C1qSivpADTk'
 @_silgen_name("FormClassKeyPath")

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -782,3 +782,20 @@ func intIntoAnyHashableVar() {
 func intIntoAnyHashableLet() {
   let anyHashable: AnyHashable = 0
 }
+
+// CHECK-LABEL: sil {{.*}}[ossa] @consumeExprOfOwnedAddrOnlyValue : {{.*}} {
+// CHECK:       bb0([[T:%[^,]+]] :
+// CHECK:         [[T_LIFETIME:%[^,]+]] = begin_borrow [[T]]
+// CHECK:         [[T_COPY:%[^,]+]] = copy_value [[T_LIFETIME]]
+// CHECK:         [[T_MOVE:%[^,]+]] = move_value [allows_diagnostics] [[T_COPY]]
+// CHECK:         [[SINK:%[^,]+]] = function_ref @sink
+// CHECK:         apply [[SINK]]<T>([[T_MOVE]])
+// CHECK:         end_borrow [[T_LIFETIME]]
+// CHECK:         destroy_value [[T]]
+// CHECK-LABEL: } // end sil function 'consumeExprOfOwnedAddrOnlyValue'
+@_silgen_name("consumeExprOfOwnedAddrOnlyValue")
+func consumeExprOfOwnedAddrOnlyValue<T>(_ t: __owned T) {
+  sink(consume t)
+}
+@_silgen_name("sink")
+func sink<T>(_ t: consuming T) {}


### PR DESCRIPTION
Check whether a value is "effectively loadable" by checking in addition to whether its loadable also whether the module is address-lowered.  

This raises the question: would it be useful to have an isEffectivelyLoadable helper that should be used almost everywhere or indeed whether isLoadable should check address-lowered-ness and a secondary rarely used API would return whether the type is loadable after address-lowering.  A question not answered in this PR.
