### PR TITLE
[stdlib] Add @discardableResult to Set.insert’s AnyHashable overload

### DIFF
--- a/stdlib/public/core/SetAnyHashableExtensions.swift
+++ b/stdlib/public/core/SetAnyHashableExtensions.swift
@@ -16,6 +16,7 @@
 
 extension Set where Element == AnyHashable {
   @inlinable
+  @discardableResult
   public mutating func insert<ConcreteElement: Hashable>(
     _ newMember: __owned ConcreteElement
   ) -> (inserted: Bool, memberAfterInsert: ConcreteElement) {


### PR DESCRIPTION
Unlike the core Set.insert, this utility declaration wasn’t declared `@discardableResult`.

rdar://114008680
