### PR TITLE
[Dependency Scanning] Avoid adding a cross-import-overlay dependency when  scanning the cross-import overlay module itself.

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -690,7 +690,6 @@ public:
     std::string ImportedModuleName = module.front().Item.str().str();
     auto submodulePath = module.getSubmodulePath();
     if (submodulePath.size() > 0 && !submodulePath[0].Item.empty()) {
-      assert(submodulePath.size() == 1 && "Unsupported Clang submodule import");
       auto submoduleComponent = submodulePath[0];
       // Special case: a submodule named "Foo.Private" can be moved to a top-level
       // module named "Foo_Private". ClangImporter has special support for this.

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -673,7 +673,8 @@ static void discoverCrossImportOverlayDependencies(
                     // secondary module, and add the overlay names to the
                     // dependencies list.
                     for (auto overlayName : overlayMap[Id.first]) {
-                      if (std::find_if(allDependencies.begin(),
+                      if (overlayName.str() != mainModuleName &&
+                          std::find_if(allDependencies.begin(),
                                        allDependencies.end(),
                                        [&](ModuleDependencyID Id) {
                                          return Id.first == overlayName.str();

--- a/test/ScanDependencies/no_cross_import_module_for_self.swift
+++ b/test/ScanDependencies/no_cross_import_module_for_self.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/CHeaders/ExtraCModules -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -module-name _cross_import_E
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// Ordinarily, importing `E` and `SubE` triggers a cross-import of `_cross_import_E`, but not here, because we are building `_cross_import_E` Swift module itself.
+import EWrapper
+import SubEWrapper
+
+// CHECK:   "swift": "_cross_import_E"
+// CHECK:  "directDependencies": [
+// CHECK-DAG:   "swift": "EWrapper"
+// CHECK-DAG:   "swift": "SubEWrapper"
+// CHECK-DAG:   "swift": "Swift"
+// CHECK-DAG:   "swift": "SwiftOnoneSupport"
+// CHECK-DAG:   "swift": "_Concurrency"
+// CHECK-DAG:   "swift": "_StringProcessing"
+// CHECK-DAG:   "clang": "_SwiftConcurrencyShims"
+// CHECK-NOT:   "swift": "_cross_import_E"
+// CHECK: ]
+
+


### PR DESCRIPTION
Otherwise, we will have the cross-import overlay module depending on...itself.

Resolves rdar://114265603