### PR TITLE
Removing code for 'initializes' and 'accesses' attributes old syntax

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -345,12 +345,6 @@ SIMPLE_DECL_ATTR(_marker, Marker,
 SIMPLE_DECL_ATTR(reasync, AtReasync,
   OnProtocol | ConcurrencyOnly | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   110)
-DECL_ATTR(initializes, Initializes,
-  OnAccessor | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIBreakingToRemove,
-  111)
-DECL_ATTR(accesses, Accesses,
-  OnAccessor | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIBreakingToRemove,
-  113)
 SIMPLE_DECL_ATTR(_unsafeInheritExecutor, UnsafeInheritExecutor,
   OnFunc | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove,
   114)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1555,68 +1555,6 @@ public:
   }
 };
 
-class InitializesAttr final
-    : public DeclAttribute,
-      private llvm::TrailingObjects<InitializesAttr, Identifier> {
-  friend TrailingObjects;
-
-  size_t numProperties;
-
-  InitializesAttr(SourceLoc atLoc, SourceRange range,
-                  ArrayRef<Identifier> properties);
-
-public:
-  static InitializesAttr *create(ASTContext &ctx,
-                                 SourceLoc atLoc, SourceRange range,
-                                 ArrayRef<Identifier> properties);
-
-  size_t numTrailingObjects(OverloadToken<Identifier>) const {
-    return numProperties;
-  }
-
-  unsigned getNumProperties() const { return numProperties; }
-
-  ArrayRef<Identifier> getProperties() const {
-    return {getTrailingObjects<Identifier>(), numProperties};
-  }
-
-  ArrayRef<VarDecl *> getPropertyDecls(AccessorDecl *attachedTo) const;
-
-  static bool classof(const DeclAttribute *DA) {
-    return DA->getKind() == DAK_Initializes;
-  }
-};
-
-class AccessesAttr final
-    : public DeclAttribute,
-      private llvm::TrailingObjects<AccessesAttr, Identifier> {
-  friend TrailingObjects;
-
-  size_t numProperties;
-
-  AccessesAttr(SourceLoc atLoc, SourceRange range,
-               ArrayRef<Identifier> properties);
-
-public:
-  static AccessesAttr *create(ASTContext &ctx,
-                              SourceLoc atLoc, SourceRange range,
-                              ArrayRef<Identifier> properties);
-
-  size_t numTrailingObjects(OverloadToken<Identifier>) const {
-    return numProperties;
-  }
-
-  ArrayRef<Identifier> getProperties() const {
-    return {getTrailingObjects<Identifier>(), numProperties};
-  }
-
-  ArrayRef<VarDecl *> getPropertyDecls(AccessorDecl *attachedTo) const;
-
-  static bool classof(const DeclAttribute *DA) {
-    return DA->getKind() == DAK_Accesses;
-  }
-};
-
 class StorageRestrictionsAttr final
     : public DeclAttribute,
       private llvm::TrailingObjects<StorageRestrictionsAttr, Identifier> {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7397,12 +7397,6 @@ ERROR(init_accessor_can_refer_only_to_properties,none,
       " to stored properties",
       (DescriptiveDeclKind, DeclNameRef))
 
-ERROR(init_accessor_initializes_attribute_on_other_declaration,none,
-      "initializes(...) attribute could only be used with init accessors",
-      ())
-ERROR(init_accessor_accesses_attribute_on_other_declaration,none,
-      "accesses(...) attribute could only be used with init accessors",
-      ())
 ERROR(storage_restrictions_attribute_not_on_init_accessor,none,
       "@storageRestrictions attribute could only be used with init accessors",
       ())

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1274,10 +1274,6 @@ public:
                                        AccessorKind currentKind,
                                        SourceLoc const& currentLoc);
 
-  ParserStatus parseInitAccessorEffects(ParsedAccessors &accessors,
-                                        AccessorKind currentKind,
-                                        DeclAttributes &Attributes);
-
   /// Parse accessors provided as a separate list, for use in macro
   /// expansions.
   void parseTopLevelAccessors(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9567,10 +9567,6 @@ ArrayRef<VarDecl *> AccessorDecl::getInitializedProperties() const {
   if (auto *SR = getAttrs().getAttribute<StorageRestrictionsAttr>())
     return SR->getInitializesProperties(const_cast<AccessorDecl *>(this));
 
-  // Fallback to old effect style declaration.
-  if (auto *initAttr = getAttrs().getAttribute<InitializesAttr>())
-    return initAttr->getPropertyDecls(const_cast<AccessorDecl *>(this));
-
   return {};
 }
 
@@ -9579,10 +9575,6 @@ ArrayRef<VarDecl *> AccessorDecl::getAccessedProperties() const {
 
   if (auto *SR = getAttrs().getAttribute<StorageRestrictionsAttr>())
     return SR->getAccessesProperties(const_cast<AccessorDecl *>(this));
-
-  // Fallback to old effect style declaration.
-  if (auto *accessAttr = getAttrs().getAttribute<AccessesAttr>())
-    return accessAttr->getPropertyDecls(const_cast<AccessorDecl *>(this));
 
   return {};
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3523,14 +3523,6 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
     }
 
-  case DAK_Initializes: {
-    llvm_unreachable("InitializesAttr not yet implemented");
-  }
-
-  case DAK_Accesses: {
-    llvm_unreachable("AccessesAttr not yet implemented");
-  }
-
   case DAK_StorageRestrictions: {
     ParserResult<StorageRestrictionsAttr> Attr =
         parseStorageRestrictionsAttribute(AtLoc, Loc);
@@ -7446,71 +7438,6 @@ ParserStatus Parser::parseGetEffectSpecifier(ParsedAccessors &accessors,
   return Status;
 }
 
-template <typename EffectAttr>
-static ParserStatus parseInitAccessorEffect(Parser &P,
-                                            DeclAttributes &attributes,
-                                            StringRef attrName) {
-  ParserStatus status;
-
-  if (P.Tok.isContextualKeyword(attrName)) {
-    auto effectLoc = P.consumeToken();
-    if (!P.Tok.is(tok::l_paren)) {
-      P.diagnose(P.Tok.getLoc(), diag::attr_expected_lparen,
-                 attrName, true);
-      status.setIsParseError();
-      return status;
-    }
-
-    // Consume '('
-    P.consumeToken();
-
-    bool hasNextProperty = false;
-    // Consume the identifier list
-    SmallVector<Identifier, 4> properties;
-    do {
-      Identifier propertyName;
-      SourceLoc propertyNameLoc;
-      if (P.parseIdentifier(propertyName, propertyNameLoc,
-                            diag::init_accessor_expected_name,
-                            /*diagnoseDollarPrefix=*/true)) {
-        status.setIsParseError();
-        return status;
-      }
-
-      properties.push_back(propertyName);
-
-      // Parse the comma, if the list continues.
-      hasNextProperty = P.consumeIf(tok::comma);
-    } while (hasNextProperty);
-
-    if (!P.Tok.is(tok::r_paren)) {
-      P.diagnose(P.Tok.getLoc(), diag::attr_expected_rparen,
-                 attrName, true);
-      status.setIsParseError();
-      return status;
-    }
-
-    // Consume ')'
-    SourceLoc rParenLoc = P.consumeToken();
-
-    auto *attr = EffectAttr::create(P.Context, SourceLoc(),
-                                    SourceRange(effectLoc, rParenLoc),
-                                    properties);
-    attributes.add(attr);
-  }
-
-  return status;
-}
-
-ParserStatus Parser::parseInitAccessorEffects(ParsedAccessors &accessors,
-                                              AccessorKind currentKind,
-                                              DeclAttributes &attrs) {
-  ParserStatus status;
-  status |= parseInitAccessorEffect<InitializesAttr>(*this, attrs, "initializes");
-  status |= parseInitAccessorEffect<AccessesAttr>(*this, attrs, "accesses");
-  return status;
-}
-
 bool Parser::parseAccessorAfterIntroducer(
     SourceLoc Loc, AccessorKind Kind, ParsedAccessors &accessors,
     bool &hasEffectfulGet, ParameterList *Indices, bool &parsingLimitedSyntax,
@@ -7525,7 +7452,6 @@ bool Parser::parseAccessorAfterIntroducer(
   SourceLoc throwsLoc;
   Status |= parseGetEffectSpecifier(accessors, asyncLoc, throwsLoc,
                                     hasEffectfulGet, Kind, Loc);
-  Status |= parseInitAccessorEffects(accessors, Kind, Attributes);
 
   // Set up a function declaration.
   auto accessor =

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1577,8 +1577,6 @@ namespace  {
     UNINTERESTING_ATTR(ObjCMembers)
     UNINTERESTING_ATTR(ObjCRuntimeName)
     UNINTERESTING_ATTR(RestatedObjCConformance)
-    UNINTERESTING_ATTR(Initializes)
-    UNINTERESTING_ATTR(Accesses)
     UNINTERESTING_ATTR(StorageRestrictions)
     UNINTERESTING_ATTR(Implements)
     UNINTERESTING_ATTR(StaticInitializeObjCMetadata)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5584,36 +5584,6 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
-      case decls_block::Initializes_DECL_ATTR: {
-        ArrayRef<uint64_t> rawPropertyIDs;
-        serialization::decls_block::InitializesDeclAttrLayout::
-            readRecord(scratch, rawPropertyIDs);
-
-        SmallVector<Identifier, 4> properties;
-        for (auto rawID : rawPropertyIDs) {
-          properties.push_back(MF.getIdentifier(rawID));
-        }
-
-        Attr = InitializesAttr::create(ctx, SourceLoc(), SourceRange(),
-                                       properties);
-        break;
-      }
-
-      case decls_block::Accesses_DECL_ATTR: {
-        ArrayRef<uint64_t> rawPropertyIDs;
-        serialization::decls_block::AccessesDeclAttrLayout::
-            readRecord(scratch, rawPropertyIDs);
-
-        SmallVector<Identifier, 4> properties;
-        for (auto rawID : rawPropertyIDs) {
-          properties.push_back(MF.getIdentifier(rawID));
-        }
-
-        Attr = AccessesAttr::create(ctx, SourceLoc(), SourceRange(),
-                                    properties);
-        break;
-      }
-
       case decls_block::StorageRestrictions_DECL_ATTR: {
         unsigned numInitializesProperties;
         ArrayRef<uint64_t> rawPropertyIDs;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 802; // added tuple_pack_extract
+const uint16_t SWIFTMODULE_VERSION_MINOR = 803; // removed initializes and accesses attributes
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2232,16 +2232,6 @@ namespace decls_block {
       BCVBR<4>, // # of type erased parameters
       BCArray<IdentifierIDField> // target function pieces, spi groups, type erased params
       >;
-
-  using InitializesDeclAttrLayout = BCRecordLayout<
-      Initializes_DECL_ATTR,
-      BCArray<IdentifierIDField> // initialized properties
-  >;
-
-  using AccessesDeclAttrLayout = BCRecordLayout<
-      Accesses_DECL_ATTR,
-      BCArray<IdentifierIDField> // initialized properties
-  >;
 
   using StorageRestrictionsDeclAttrLayout = BCRecordLayout<
       StorageRestrictions_DECL_ATTR,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2923,34 +2923,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Initializes: {
-      auto abbrCode = S.DeclTypeAbbrCodes[InitializesDeclAttrLayout::Code];
-      auto attr = cast<InitializesAttr>(DA);
-
-      SmallVector<IdentifierID, 4> properties;
-      for (auto identifier : attr->getProperties()) {
-        properties.push_back(S.addDeclBaseNameRef(identifier));
-      }
-
-      InitializesDeclAttrLayout::emitRecord(
-          S.Out, S.ScratchRecord, abbrCode, properties);
-      return;
-    }
-
-    case DAK_Accesses: {
-      auto abbrCode = S.DeclTypeAbbrCodes[AccessesDeclAttrLayout::Code];
-      auto attr = cast<InitializesAttr>(DA);
-
-      SmallVector<IdentifierID, 4> properties;
-      for (auto identifier : attr->getProperties()) {
-        properties.push_back(S.addDeclBaseNameRef(identifier));
-      }
-
-      AccessesDeclAttrLayout::emitRecord(
-          S.Out, S.ScratchRecord, abbrCode, properties);
-      return;
-    }
-
     case DAK_StorageRestrictions: {
       auto abbrCode = S.DeclTypeAbbrCodes[StorageRestrictionsDeclAttrLayout::Code];
       auto attr = cast<StorageRestrictionsAttr>(DA);


### PR DESCRIPTION
<!-- What's in this pull request? -->
The initializes and accesses attributes are old syntax for what now is `storageRestriction`. So this removes the C++ parser code, serialization, type checking diagnostics and attributes definitions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
