### PR TITLE
[Presets] Disable early* on more Linux presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1149,6 +1149,10 @@ reconfigure
 # in Linux CI bots
 relocate-xdg-cache-home-under-build-subdir
 
+# Temporarily disable early swift driver/syntax builds so that linux images
+# can use the swift release images as a base.
+skip-early-swift-driver
+skip-early-swiftsyntax
 
 [preset: buildbot_incremental_linux]
 mixin-preset=
@@ -2906,3 +2910,8 @@ skip-test-cmark
 skip-test-swift
 skip-build-benchmarks
 skip-test-foundation
+
+# Temporarily disable early swift driver/syntax builds so that linux images
+# can use the swift release images as a base.
+skip-early-swift-driver
+skip-early-swiftsyntax


### PR DESCRIPTION
We don't handle building early swift-syntax on Linux yet. Disable it on more failing presets.