### PR TITLE
[OpaqueValues] Consume addr-only vars as loadable.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6189,7 +6189,7 @@ RValue RValueEmitter::visitConsumeExpr(ConsumeExpr *E, SGFContext C) {
     }
     optTemp->finishInitialization(SGF);
 
-    if (subType.isLoadable(SGF.F)) {
+    if (subType.isLoadable(SGF.F) || !SGF.useLoweredAddresses()) {
       ManagedValue value = SGF.B.createLoadTake(E, optTemp->getManagedAddress());
       if (value.getType().isTrivial(SGF.F))
         return RValue(SGF, {value}, subType.getASTType());


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/68064 which didn't handle LoadExprs.
