### PR TITLE
[rebranch] Use enableIncrementalProcessing again

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -734,9 +734,6 @@ importer::getNormalInvocationArguments(
       }
     }
   }
-
-  invocationArgStrs.push_back("-Xclang");
-  invocationArgStrs.push_back("-fincremental-extensions");
 }
 
 static void
@@ -1355,6 +1352,7 @@ ClangImporter::create(ASTContext &ctx,
     return nullptr; // there was an error related to the compiler arguments.
 
   clang::Preprocessor &clangPP = instance.getPreprocessor();
+  clangPP.enableIncrementalProcessing();
 
   // Setup Preprocessor callbacks before initialing the parser to make sure
   // we catch implicit includes.


### PR DESCRIPTION
The `incremental-extensions` is used for incremental parsing in the REPL (which also changes how parsing runs). We only want "incremental processing" in so far as it doesn't teardown the lexer or run the end of translation unit action. This was joined into `incremental-extensions`, but is now split apart again.

Resolves rdar://113406310.