### PR TITLE
[CodeCompletion] Migrate completions after `return` and `yield` to solver-based

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1555,7 +1555,8 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
   case CompletionKind::ForEachSequence:
   case CompletionKind::PostfixExprBeginning:
   case CompletionKind::StmtOrExpr: 
-  case CompletionKind::ReturnStmtExpr: {
+  case CompletionKind::ReturnStmtExpr:
+  case CompletionKind::YieldStmtExpr: {
     assert(CurDeclContext);
 
     bool AddUnresolvedMemberCompletions =
@@ -1728,6 +1729,7 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
   case CompletionKind::PostfixExprParen:
   case CompletionKind::PostfixExpr:
   case CompletionKind::ReturnStmtExpr:
+  case CompletionKind::YieldStmtExpr:
     llvm_unreachable("should be already handled");
     return;
 
@@ -1973,19 +1975,6 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
         Lookup.getPostfixKeywordCompletions(resultTy, analyzedExpr);
       }
     }
-    break;
-  }
-
-  case CompletionKind::YieldStmtExpr: {
-    SourceLoc Loc = P.Context.SourceMgr.getIDEInspectionTargetLoc();
-    if (auto FD = dyn_cast<AccessorDecl>(CurDeclContext)) {
-      if (FD->isCoroutine()) {
-        // TODO: handle multi-value yields.
-        Lookup.setExpectedTypes(FD->getStorage()->getValueInterfaceType(),
-                                /*isImplicitSingleExpressionReturn*/ false);
-      }
-    }
-    Lookup.getValueCompletionsInDeclContext(Loc);
     break;
   }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -890,6 +890,25 @@ static void addObserverKeywords(CodeCompletionResultSink &Sink) {
   addKeyword(Sink, "didSet", CodeCompletionKeywordKind::None);
 }
 
+static void addKeywordsAfterReturn(CodeCompletionResultSink &Sink, DeclContext *DC) {
+  // `return nil` is not actually represented as a `ReturnExpr` in the AST but
+  // gets translated to a `FailStmt`. We thus can't produce the 'nil' completion
+  // using the solver-based implementation. Add the result manually.
+  if (auto ctor = dyn_cast_or_null<ConstructorDecl>(DC->getAsDecl())) {
+    if (ctor->isFailable()) {
+      CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Literal,
+                                          SemanticContextKind::None);
+      Builder.setLiteralKind(CodeCompletionLiteralKind::NilLiteral);
+      Builder.addKeyword("nil");
+      Builder.addTypeAnnotation(ctor->getResultInterfaceType(), {});
+      Builder.setResultTypes(ctor->getResultInterfaceType());
+      ExpectedTypeContext TypeContext;
+      TypeContext.setPossibleTypes({ctor->getResultInterfaceType()});
+      Builder.setTypeContext(TypeContext, DC);
+    }
+  }
+}
+
 void swift::ide::addExprKeywords(CodeCompletionResultSink &Sink,
                                  DeclContext *DC) {
   // Expression is invalid at top-level of non-script files.
@@ -1026,6 +1045,8 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
 
     LLVM_FALLTHROUGH;
   case CompletionKind::ReturnStmtExpr:
+    addKeywordsAfterReturn(Sink, CurDeclContext);
+    LLVM_FALLTHROUGH;
   case CompletionKind::YieldStmtExpr:
   case CompletionKind::ForEachSequence:
     addSuperKeyword(Sink, CurDeclContext);
@@ -1533,7 +1554,8 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
   case CompletionKind::CaseStmtBeginning:
   case CompletionKind::ForEachSequence:
   case CompletionKind::PostfixExprBeginning:
-  case CompletionKind::StmtOrExpr: {
+  case CompletionKind::StmtOrExpr: 
+  case CompletionKind::ReturnStmtExpr: {
     assert(CurDeclContext);
 
     bool AddUnresolvedMemberCompletions =
@@ -1705,6 +1727,7 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
   case CompletionKind::CaseStmtBeginning:
   case CompletionKind::PostfixExprParen:
   case CompletionKind::PostfixExpr:
+  case CompletionKind::ReturnStmtExpr:
     llvm_unreachable("should be already handled");
     return;
 
@@ -1950,16 +1973,6 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
         Lookup.getPostfixKeywordCompletions(resultTy, analyzedExpr);
       }
     }
-    break;
-  }
-
-  case CompletionKind::ReturnStmtExpr : {
-    SourceLoc Loc = P.Context.SourceMgr.getIDEInspectionTargetLoc();
-    SmallVector<Type, 2> possibleReturnTypes;
-    collectPossibleReturnTypesFromContext(CurDeclContext, possibleReturnTypes);
-    Lookup.setExpectedTypes(possibleReturnTypes,
-                            /*isImplicitSingleExpressionReturn*/ false);
-    Lookup.getValueCompletionsInDeclContext(Loc);
     break;
   }
 

--- a/lib/IDE/ExprCompletion.cpp
+++ b/lib/IDE/ExprCompletion.cpp
@@ -77,12 +77,7 @@ void ExprTypeCheckCompletionCallback::sawSolutionImpl(
     const constraints::Solution &S) {
   auto &CS = S.getConstraintSystem();
 
-  Type ExpectedTy;
-  if (auto ContextualType = S.getContextualType(CompletionExpr)) {
-    ExpectedTy = ContextualType;
-  } else {
-    ExpectedTy = getTypeForCompletion(S, CompletionExpr);
-  }
+  Type ExpectedTy = getTypeForCompletion(S, CompletionExpr);
 
   bool ImplicitReturn = isImplicitSingleExpressionReturn(CS, CompletionExpr);
 

--- a/lib/IDE/ExprCompletion.cpp
+++ b/lib/IDE/ExprCompletion.cpp
@@ -77,7 +77,12 @@ void ExprTypeCheckCompletionCallback::sawSolutionImpl(
     const constraints::Solution &S) {
   auto &CS = S.getConstraintSystem();
 
-  Type ExpectedTy = getTypeForCompletion(S, CompletionExpr);
+  Type ExpectedTy;
+  if (auto ContextualType = CS.getContextualType(CompletionExpr, /*forConstraint=*/false)) {
+    ExpectedTy = ContextualType;
+  } else {
+    ExpectedTy = getTypeForCompletion(S, CompletionExpr);
+  }
 
   bool ImplicitReturn = isImplicitSingleExpressionReturn(CS, CompletionExpr);
 

--- a/lib/IDE/ExprCompletion.cpp
+++ b/lib/IDE/ExprCompletion.cpp
@@ -78,7 +78,7 @@ void ExprTypeCheckCompletionCallback::sawSolutionImpl(
   auto &CS = S.getConstraintSystem();
 
   Type ExpectedTy;
-  if (auto ContextualType = CS.getContextualType(CompletionExpr, /*forConstraint=*/false)) {
+  if (auto ContextualType = S.getContextualType(CompletionExpr)) {
     ExpectedTy = ContextualType;
   } else {
     ExpectedTy = getTypeForCompletion(S, CompletionExpr);

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -176,10 +176,13 @@ void PostfixCompletionCallback::sawSolutionImpl(
     return;
 
   auto *Locator = CS.getConstraintLocator(SemanticExpr);
-  Type ExpectedTy = getTypeForCompletion(S, CompletionExpr);
+  Type ExpectedTy;
   Expr *ParentExpr = CS.getParentExpr(CompletionExpr);
-  if (!ParentExpr && !ExpectedTy)
-    ExpectedTy = CS.getContextualType(CompletionExpr, /*forConstraint=*/false);
+  if (auto ContextualType = CS.getContextualType(CompletionExpr, /*forConstraint=*/false)) {
+    ExpectedTy = ContextualType;
+  } else {
+    ExpectedTy = getTypeForCompletion(S, CompletionExpr);
+  }
 
   auto *CalleeLocator = S.getCalleeLocator(Locator);
   ValueDecl *ReferencedDecl = nullptr;

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -176,12 +176,7 @@ void PostfixCompletionCallback::sawSolutionImpl(
     return;
 
   auto *Locator = CS.getConstraintLocator(SemanticExpr);
-  Type ExpectedTy;
-  if (auto ContextualType = S.getContextualType(CompletionExpr)) {
-    ExpectedTy = ContextualType;
-  } else {
-    ExpectedTy = getTypeForCompletion(S, CompletionExpr);
-  }
+  Type ExpectedTy = getTypeForCompletion(S, CompletionExpr);
   Expr *ParentExpr = CS.getParentExpr(CompletionExpr);
 
   auto *CalleeLocator = S.getCalleeLocator(Locator);

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -177,12 +177,12 @@ void PostfixCompletionCallback::sawSolutionImpl(
 
   auto *Locator = CS.getConstraintLocator(SemanticExpr);
   Type ExpectedTy;
-  Expr *ParentExpr = CS.getParentExpr(CompletionExpr);
-  if (auto ContextualType = CS.getContextualType(CompletionExpr, /*forConstraint=*/false)) {
+  if (auto ContextualType = S.getContextualType(CompletionExpr)) {
     ExpectedTy = ContextualType;
   } else {
     ExpectedTy = getTypeForCompletion(S, CompletionExpr);
   }
+  Expr *ParentExpr = CS.getParentExpr(CompletionExpr);
 
   auto *CalleeLocator = S.getCalleeLocator(Locator);
   ValueDecl *ReferencedDecl = nullptr;

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -47,6 +47,10 @@ void TypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
 
 Type swift::ide::getTypeForCompletion(const constraints::Solution &S,
                                       ASTNode Node) {
+  if (auto ContextualType = S.getContextualType(Node)) {
+    return ContextualType;
+  }
+
   if (!S.hasType(Node)) {
     assert(false && "Expression wasn't type checked?");
     return nullptr;
@@ -59,9 +63,6 @@ Type swift::ide::getTypeForCompletion(const constraints::Solution &S,
   } else {
     Result = S.getResolvedType(Node);
   }
-
-  if (!Result || Result->is<UnresolvedType>())
-    Result = S.getContextualType(Node);
 
   if (Result && Result->is<UnresolvedType>()) {
     Result = Type();

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -880,9 +880,10 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
     }
 
     auto expr = parseExpr(diag::expected_expr_yield);
-    if (expr.hasCodeCompletion())
-      return makeParserCodeCompletionResult<Stmt>();
-    if (expr.isParseErrorOrHasCompletion()) {
+    if (expr.hasCodeCompletion() && expr.isNonNull()) {
+      status |= expr;
+      yields.push_back(expr.get());
+    } else if (expr.isParseErrorOrHasCompletion()) {
       auto endLoc = (Tok.getLoc() == beginLoc ? beginLoc : PreviousLoc);
       yields.push_back(
         new (Context) ErrorExpr(SourceRange(beginLoc, endLoc)));

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -312,8 +312,8 @@ class DependentTypeInClosure<Data: DataType> {
 func testDependentTypeInClosure() {
   let _: DependentTypeInClosure = .#^DEPENDENT_IN_CLOSURE_3^#
 // DEPENDENT_IN_CLOSURE_3: Begin completions, 2 items
-// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#(arg): DataType#}, {#fn: (Data.Content) -> Void##(Data.Content) -> Void#})[#DependentTypeInClosure<DataType>#];
-// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#arg: DataType#}, {#fn: () -> Data.Content##() -> Data.Content#})[#DependentTypeInClosure<DataType>#];
+// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal: init({#(arg): DataType#}, {#fn: (DataType.Content) -> Void##(DataType.Content) -> Void#})[#DependentTypeInClosure<DataType>#];
+// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal: init({#arg: DataType#}, {#fn: () -> DataType.Content##() -> DataType.Content#})[#DependentTypeInClosure<DataType>#];
 
   let _ = DependentTypeInClosure(#^DEPENDENT_IN_CLOSURE_1^#)
 // DEPENDENT_IN_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#(arg): DataType#}, {#fn: (_) -> Void##(_) -> Void#}[')'][#DependentTypeInClosure<DataType>#];

--- a/test/IDE/complete_yield.swift
+++ b/test/IDE/complete_yield.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+struct YieldVariables {
+  var stringValue: String
+
+  var property: String {
+    _read {
+      yield #^IN_READ^#
+      // IN_READ-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: stringValue[#String#]; name=stringValue
+    }
+    _modify {
+      var localString = ""
+      yield #^IN_MODIFY^#
+      // IN_MODIFY-DAG: Decl[InstanceVar]/CurrNominal:      stringValue[#String#]; name=stringValue
+      // IN_MODIFY-DAG: Decl[LocalVar]/Local:               localString[#String#]; name=localString
+    }
+  }
+
+  var otherProperty: String {
+    _modify {
+      var localString = ""
+      yield &#^IN_MODIFY_WITH_REF^#
+      // FIXME: We should probably be returning a convertible type relation here.
+      // IN_MODIFY_WITH_REF: Decl[LocalVar]/Local:               localString[#String#]; name=localString
+      // IN_MODIFY_WITH_REF: Decl[InstanceVar]/CurrNominal:      stringValue[#String#]; name=stringValue
+    }
+  }
+}
+


### PR DESCRIPTION
This was pretty straightforward. Completions after `return` needed special handling for `return nil` in failable constructors because `return nil` is represented as a `FailStmt` in the type checker and thus we didn’t get completions for `nil` here by default.

We didn’t have any tests for completion after `yield`. I added a couple. The results aren’t amazing (I didn’t look into whether we could include some results or add more type relations) but probably better than before and since this is an experimental language feature, I think it’s not too important.