### PR TITLE
MemoryLifetimeVerifier: relax the check for trivial enums a bit

### DIFF
--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -151,8 +151,6 @@ public:
 
 bool MemoryLifetimeVerifier::isEnumTrivialAt(int locIdx,
                                              SILInstruction *atInst) {
-  const Location *rootLoc = locations.getRootLocation(locIdx);
-  SILBasicBlock *rootBlock = rootLoc->representativeValue->getParentBlock();
   SILBasicBlock *startBlock = atInst->getParent();
   
   // Start at atInst an walk up the control flow.
@@ -164,12 +162,9 @@ bool MemoryLifetimeVerifier::isEnumTrivialAt(int locIdx,
       // Stop at trivial stores to the enum.
       continue;
     }
-    if (block == rootBlock) {
-      // We reached the block where the memory location is defined. So we cannot
-      // prove that the enum contains a non-payload case.
+    if (block == function->getEntryBlock()) {
       return false;
     }
-    assert(block != function->getEntryBlock());
     for (SILBasicBlock *pred : block->getPredecessorBlocks()) {
       // Stop walking to the predecessor if block is a non-payload successor
       // of a switch_enum/switch_enum_addr.

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -30,6 +30,12 @@ struct Mixed {
   var i: Int
 }
 
+enum KlassOrBool {
+  case value(T)
+  case bool(Bool)
+}
+
+
 sil [ossa] @test_struct : $@convention(thin) (@in Outer) -> @owned T {
 bb0(%0 : $*Outer):
   %1 = struct_element_addr %0 : $*Outer, #Outer.y
@@ -725,3 +731,35 @@ bb0(%0: $*Inner):
   %r = tuple ()
   return %r : $()
 }
+
+sil [ossa] @test : $@convention(thin) (@guaranteed KlassOrBool) -> () {
+bb0(%0 : @guaranteed $KlassOrBool):
+  %1 = alloc_stack $KlassOrBool                   
+  %2 = copy_value %0 : $KlassOrBool               
+  store %2 to [init] %1 : $*KlassOrBool           
+  %4 = load_borrow %1 : $*KlassOrBool             
+  switch_enum %4 : $KlassOrBool, case #KlassOrBool.bool!enumelt: bb1, case #KlassOrBool.value!enumelt: bb2 
+
+bb1(%6 : $Bool):                                  
+  end_borrow %4 : $KlassOrBool                    
+  %8 = alloc_stack $KlassOrBool                   
+  %9 = load [copy] %1 : $*KlassOrBool             
+  store %9 to [init] %8 : $*KlassOrBool           
+  %11 = load_borrow %8 : $*KlassOrBool            
+  %12 = unchecked_enum_data %11 : $KlassOrBool, #KlassOrBool.bool!enumelt
+  end_borrow %11 : $KlassOrBool                   
+  dealloc_stack %8 : $*KlassOrBool                
+  br bb3                                          
+
+bb2(%16 : @guaranteed $T):                    
+  end_borrow %4 : $KlassOrBool                    
+  %18 = load [take] %1 : $*KlassOrBool            
+  destroy_value %18 : $KlassOrBool                
+  br bb3                                          
+
+bb3:                                              
+  dealloc_stack %1 : $*KlassOrBool                
+  %22 = tuple ()                                  
+  return %22 : $()                                
+} 
+


### PR DESCRIPTION
Trivial enum cases in a memory location don't need to be destroyed. Don't require that the store to such a memory location is statically known as a trivial enum case. Instead just require that it's below a switch_enum successor for a trivial case.

Fixes a false alarm.

rdar://114274714
