### PR TITLE
[5.9] [Macros] Ensure that we find operators in any macro-expanded context.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1327,6 +1327,13 @@ static bool contextMayExpandOperator(
   else
     return false;
 
+  // If the context declaration itself is within a macro expansion, it may
+  // have an operator.
+  if (auto sourceFile = dc->getParentSourceFile()) {
+    if (sourceFile->getFulfilledMacroRole())
+      return true;
+  }
+
   ASTContext &ctx = dc->getASTContext();
   auto potentialExpansions = evaluateOrDefault(
       ctx.evaluator, PotentialMacroExpansionsInContextRequest{decl},

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1623,6 +1623,28 @@ public struct DefineStructWithUnqualifiedLookupMacro: DeclarationMacro {
   }
 }
 
+public struct DefineComparableTypeMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["""
+    struct ComparableType: Comparable {
+      static func <(lhs: ComparableType, rhs: ComparableType) -> Bool {
+        return false
+      }
+
+      enum Inner: String, Comparable {
+        case hello = "hello"
+        static func <(lhs: ComparableType.Inner, rhs: ComparableType.Inner) -> Bool {
+          return lhs.rawValue < rhs.rawValue
+        }
+      }
+    }
+    """]
+  }
+}
+
 public struct AddMemberWithFixIt: MemberMacro {
   public static func expansion<
     Declaration: DeclGroupSyntax, Context: MacroExpansionContext

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -566,3 +566,11 @@ struct DeprecatedStructWrapper {
   #deprecatedStringifyAsDeclMacro(1 + 1)
 }
 #endif
+
+
+@freestanding(declaration, names: named(ComparableType))
+macro DefineComparableType() = #externalMacro(module: "MacroDefinition", type: "DefineComparableTypeMacro")
+
+struct HasNestedType {
+  #DefineComparableType
+}


### PR DESCRIPTION
In any nominal declaration or extension thereof that is produced by a macro expansion, make sure we perform qualified name lookup when resolving operators so that we're guaranteed to find the macro-introduced operators. Otherwise, expanding a macro that defines a new type with conformances involving operators doesn't work.

Fixes rdar://114257019, cherry-picked from https://github.com/apple/swift/pull/68085