### PR TITLE
[5.9] Ban the use of accessor macros on bindings with multiple variables in a single binding

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7236,6 +7236,9 @@ ERROR(macro_expand_circular_reference_unnamed, none,
 NOTE(macro_expand_circular_reference_unnamed_through, none,
      "circular reference expanding %0 macros", (StringRef))
 
+ERROR(accessor_macro_not_single_var, none,
+      "accessor macro %0 can only apply to a single variable", (DeclName))
+
 //------------------------------------------------------------------------------
 // MARK: Noncopyable Types Diagnostics
 //------------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1399,6 +1399,15 @@ bool swift::accessorMacroIntroducesInitAccessor(
 llvm::Optional<unsigned> swift::expandAccessors(AbstractStorageDecl *storage,
                                                 CustomAttr *attr,
                                                 MacroDecl *macro) {
+  if (auto var = dyn_cast<VarDecl>(storage)) {
+    // Check that the variable is part of a single-variable pattern.
+    auto binding = var->getParentPatternBinding();
+    if (binding && binding->getSingleVar() != var) {
+      var->diagnose(diag::accessor_macro_not_single_var, macro->getName());
+      return llvm::None;
+    }
+  }
+
   // Evaluate the macro.
   auto macroSourceFile =
       ::evaluateAttachedMacro(macro, storage, attr,

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -155,3 +155,11 @@ struct HasStoredTests {
   // expected-note@-3 2{{'z' declared here}}
 #endif
 }
+
+
+#if TEST_DIAGNOSTICS
+struct MultipleVars {
+  @AddWillSet var (x, y): (Int, Int) = (0, 0)
+  // expected-error@-1 2{{accessor macro 'AddWillSet()' can only apply to a single variable}}
+}
+#endif


### PR DESCRIPTION
As with property wrappers, we can't properly desugar the application of accessor macros to bindings with multiple variables. Prohibit them up front.

Fixes rdar://112783811, cherry-picked from https://github.com/apple/swift/pull/68087
