### PR TITLE
test: adjust the definition of `BUILD_DIR` and `SOURCE_DIR`

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2681,8 +2681,8 @@ run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitiz
         # we provide we use realpath here. Because PathSanitizingFileCheck only
         # understands sanitize patterns with forward slashes, and realpath normalizes
         # the slashes, we have to replace them back to forward slashes.
-        shell_quote(lit.util.abs_path_preserve_drive(swift_obj_root).replace("\\", "/")),
-        shell_quote(lit.util.abs_path_preserve_drive(config.swift_src_root).replace("\\", "/")),
+        shell_quote(abs_path_preserve_drive(swift_obj_root).replace("\\", "/")),
+        shell_quote(abs_path_preserve_drive(config.swift_src_root).replace("\\", "/")),
         shell_quote(config.filecheck),
         '--enable-windows-compatibility' if kIsWindows else '')
 


### PR DESCRIPTION
Use the new `abs_path_preserve_drive` function to prevent the expansion of substituted paths in these paths.