### PR TITLE
[Build] Skip early-* on non-darwin hosts

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -890,10 +890,6 @@ installable-package=%(installable_package)s
 # in Linux CI bots
 relocate-xdg-cache-home-under-build-subdir
 
-# Temporarily disable early swift driver/syntax builds so that linux images
-# can use the swift release images as a base.
-skip-early-swift-driver
-skip-early-swiftsyntax
 
 [preset: buildbot_linux_base]
 mixin-preset=
@@ -1149,10 +1145,6 @@ reconfigure
 # in Linux CI bots
 relocate-xdg-cache-home-under-build-subdir
 
-# Temporarily disable early swift driver/syntax builds so that linux images
-# can use the swift release images as a base.
-skip-early-swift-driver
-skip-early-swiftsyntax
 
 [preset: buildbot_incremental_linux]
 mixin-preset=

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
@@ -11,6 +11,7 @@
 # ----------------------------------------------------------------------------
 
 import os
+import sys
 
 from . import earlyswiftsyntax
 from . import product
@@ -42,6 +43,11 @@ class EarlySwiftDriver(product.Product):
         return True
 
     def should_build(self, host_target):
+        # Temporarily disable for non-darwin since this build never works
+        # outside of that case currently.
+        if sys.platform != 'darwin':
+            return False
+
         if self.is_cross_compile_target(host_target):
             return False
 

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -10,6 +10,8 @@
 #
 # ----------------------------------------------------------------------------
 
+import sys
+
 from . import cmake_product
 from .. import toolchain
 
@@ -32,6 +34,11 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
         return True
 
     def should_build(self, host_target):
+        # Temporarily disable for non-darwin since this build never works
+        # outside of that case currently.
+        if sys.platform != 'darwin':
+            return False
+
         if self.args.build_early_swiftsyntax:
             if toolchain.host_toolchain().find_tool("swift") is None:
                 warn_msg = 'Host toolchain could not locate a '\

--- a/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
+++ b/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
@@ -2,7 +2,7 @@
 # RUN: mkdir -p %t
 # RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --infer --swiftpm --cmake %cmake 2>&1 | %FileCheck %s
 
-# REQUIRES: standalone_build
+# REQUIRES: standalone_build, OS=macosx
 
 # Just make sure we compute the build graph/emit output.
 #

--- a/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
@@ -1,4 +1,4 @@
-# REQUIRES: standalone_build
+# REQUIRES: standalone_build, OS=macosx
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t

--- a/validation-test/BuildSystem/test_early_swift_driver_and_test.test
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_test.test
@@ -1,4 +1,4 @@
-# REQUIRES: standalone_build
+# REQUIRES: standalone_build, OS=macosx
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t


### PR DESCRIPTION
These builds do not work outside of darwin currently. Rather than adding the skip to all the necessary build presets, just disable in the product instead.