### PR TITLE
Remove realpath in lit site config to fix Driver/working-directory.swift test failure

### DIFF
--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -13,6 +13,7 @@
 import os
 import platform
 import sys
+import lit.util
 
 config.cmake = "@CMAKE_COMMAND@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
@@ -172,6 +173,6 @@ if '@SWIFT_SWIFT_PARSER@' == 'TRUE':
 
 # Let the main config do the real work.
 if config.test_exec_root is None:
-    config.test_exec_root = os.path.dirname(os.path.realpath(__file__))
+    config.test_exec_root = os.path.dirname(lit.util.abs_path_preserve_drive(__file__))
 lit_config.load_config(
     config, os.path.join(config.swift_src_root, "test", "lit.cfg"))


### PR DESCRIPTION
Remove a remaining usage of `os.path.realpath` that breaks the `Driver/working-directory.swift` test on Windows.

swiftc was getting passed `"-working-directory" "C:/Users/tristan/Dev/SwiftToolchain/b/1/tools/swift/test-windows-x86_64/Driver/Output/working-directory.swift.tmp"` causing a mismatch in `// OUTPUT_FILE_MAP_2: BUILD_DIR{{.*}}main-modified.o` when `"BUILD_DIR=S:/b/1/tools/swift"`

```
$ "s:\\b\\1\\bin\\swiftc.exe" "-toolchain-stdlib-rpath" "-module-cache-path" "S:\b\1\swift-test-results\x86_64-unknown-windows-msvc\clang-module-cache" "-swift-version" "4" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0" "-Xfrontend" "-define-availability" "-Xfrontend" "SwiftStdlib 5.10:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" "-driver-print-jobs" "-working-directory" "C:/Users/tristan/Dev/SwiftToolchain/b/1/tools/swift/test-windows-x86_64/Driver/Output/working-directory.swift.tmp" "-c" "main.swift" "-output-file-map" "ofmo2.json"
$ "C:\Users\tristan\AppData\Local\Programs\Python\Python39\python.exe" "S:\SourceCache\swift\utils\PathSanitizingFileCheck" "--allow-unused-prefixes" "--sanitize" "BUILD_DIR=S:/b/1/tools/swift" "--sanitize" "SOURCE_DIR=S:/SourceCache/swift" "--use-filecheck" "s:\b\1\bin\filecheck.exe" "--enable-windows-compatibility" "S:\SourceCache\swift\test\Driver\working-directory.swift" "-check-prefix=OUTPUT_FILE_MAP_2" "--enable-yaml-compatibility"
# command stderr:
S:\SourceCache\swift\test\Driver\working-directory.swift:66:23: error: OUTPUT_FILE_MAP_2: expected string not found in input
// OUTPUT_FILE_MAP_2: BUILD_DIR{{.*}}main-modified.o
                      ^
<stdin>:1:1: note: scanning from here
"s:\\b\\1\\bin\\swiftc.exe" -frontend -c -primary-file "C:/Users/tristan/Dev/SwiftToolchain/b/1/tools/swift/test-windows-x86_64/Driver/Output/working-directory.swift.tmp\\main.swift" -target x86_64-unknown-windows-msvc -disable-objc-interop -module-cache-path "S:\\b\\1\\swift-test-results\\x86_64-unknown-windows-msvc\\clang-module-cache" -swift-version 4 -define-availability "SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" -define-availability "SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2" -define-availability "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0" -define-availability "SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4" -define-availability "SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0" -define-availability "SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5" -define-availability "SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0" -define-availability "SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4" -define-availability "SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0" -define-availability "SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4" -define-availability "SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0" -define-availability "SwiftStdlib 5.10:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" -Xcc -working-directory -Xcc C:/Users/tristan/Dev/SwiftToolchain/b/1/tools/swift/test-windows-x86_64/Driver/Output/working-directory.swift.tmp -plugin-path "s:\\b\\1\\lib\\swift\\host\\plugins" -plugin-path "s:\\b\\1\\local\\lib\\swift\\host\\plugins" -autolink-library oldnames -autolink-library msvcrt -Xcc -D_MT -Xcc -D_DLL -module-name main -o "C:/Users/tristan/Dev/SwiftToolchain/b/1/tools/swift/test-windows-x86_64/Driver/Output/working-directory.swift.tmp\\main-modified.o"
```