### PR TITLE
[cxx-interop] Update an inheritance test

### DIFF
--- a/test/Interop/Cxx/class/inheritance/Inputs/sub-types.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/sub-types.h
@@ -1,8 +1,3 @@
-template <class From, class To>
-To __swift_interopStaticCast(From from) {
-  return static_cast<To>(from);
-}
-
 struct Base {
   enum class EnumClass : char { eca = 2, ecb = 3, ecc = 4 };
   enum Enum { ea, eb, ec };


### PR DESCRIPTION
`__swift_interopStaticCast` is now defined in the CxxShim module. Clients do not need to redefine it manually.