### PR TITLE
5.9: [CopyPropagation] Only delete if canonicalized.

### DIFF
--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -600,7 +600,9 @@ void CopyPropagation::run() {
   // Canonicalize all owned defs.
   while (!defWorklist.ownedValues.empty()) {
     SILValue def = defWorklist.ownedValues.pop_back_val();
-    canonicalizer.canonicalizeValueLifetime(def);
+    auto canonicalized = canonicalizer.canonicalizeValueLifetime(def);
+    if (!canonicalized)
+      continue;
     // Copies of borrowed values may be dead.
     if (auto *inst = def->getDefiningInstruction())
       deleter.trackIfDead(inst);

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -16,6 +16,10 @@ class C {
   var a: Builtin.Int64
 }
 
+struct MOS : ~Copyable {
+  deinit {}
+}
+
 sil [ossa] @dummy : $@convention(thin) () -> ()
 sil [ossa] @barrier : $@convention(thin) () -> ()
 sil [ossa] @getOwnedC : $@convention(thin) () -> (@owned C)
@@ -25,6 +29,7 @@ sil [ossa] @takeOwnedCTwice : $@convention(thin) (@owned C, @owned C) -> ()
 sil [ossa] @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
 sil [ossa] @borrowB : $@convention(thin) (@guaranteed B) -> ()
 sil [ossa] @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+sil [ossa] @getMOS : $() -> (@owned MOS)
 
 // -O hoists the destroy
 //
@@ -988,4 +993,24 @@ bb0:
   dealloc_stack %14 : $*Optional<@callee_guaranteed () -> ()>
   %99 = tuple ()
   return %99 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dontShortenDeadMoveOnlyLifetime : {{.*}} {
+// CHECK:         [[GET:%[^,]+]] = function_ref @getMOS
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         [[MOS:%[^,]+]] = apply [[GET]]()
+// CHECK:         [[MOV:%[^,]+]] = move_value [lexical] [[MOS]]
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[MOV]]
+// CHECK-LABEL: } // end sil function 'dontShortenDeadMoveOnlyLifetime'
+sil [ossa] @dontShortenDeadMoveOnlyLifetime : $@convention(thin) () -> () {
+  %get = function_ref @getMOS : $@convention(thin) () -> (@owned MOS)
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  %mos = apply %get() : $@convention(thin) () -> (@owned MOS)
+  // Note: This must be lexical so that it doesn't get eliminated as redundant.
+  %mov = move_value [lexical] %mos : $MOS
+  apply %barrier() : $@convention(thin) () -> ()
+  destroy_value %mov : $MOS
+  %retval = tuple ()
+  return %retval : $()
 }


### PR DESCRIPTION
**Description:** During CopyPropagation, while canonicalizing the lifetimes of owned values, the CanonicalizeOSSALifetime utility is used on each value of interest.  If the utility can't canonicalize, it returns false.  Previously, the return code was ignored and the pass tried to delete-if-dead the original value.  Here the pass is fixed to take no further action on that value if the utility returns false; in particular, it does not try to delete it.
**Risk:** Very low.  The fix is just to check a return code and move on to processing the next value if appropriate.
**Scope:** Narrow.  The change only affects move-only values.
**Original PR:** https://github.com/apple/swift/pull/68090
**Reviewed By:** Meghana Gupta ( @meg-gupta ), Andrew Trick ( @atrick )
**Testing:** Added a test.
**Resolves:** rdar://114323803
