### PR TITLE
Fix a fatal error not-terminating issue in Windows

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -471,3 +471,18 @@ void swift::swift_abortDisabledUnicodeSupport() {
                     "Unicode normalization data is disabled on this platform");
 
 }
+
+#if defined(_WIN32)
+// On Windows, exceptions may be swallowed in some cases and the
+// process may not terminate as expected on crashes. For example,
+// illegal instructions used by llvm.trap. Disable the exception
+// swallowing so that the error handling works as expected.
+__attribute__((__constructor__))
+static void ConfigureExceptionPolicy() {
+  BOOL Suppress = FALSE;
+  SetUserObjectInformationA(GetCurrentProcess(),
+                            UOI_TIMERPROC_EXCEPTION_SUPPRESSION,
+                            &Suppress, sizeof(Suppress));
+}
+
+#endif

--- a/test/stdlib/WinExceptionSuppression.swift
+++ b/test/stdlib/WinExceptionSuppression.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -module-name=main %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: not %target-run %t/a.out 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: OS=windows-msvc
+
+// Check that a fatal error terminates the process and it appears only once.
+// CHECK: Fatal error
+// CHECK-NOT: Fatal error
+
+import WinSDK
+
+private var timerID: UINT_PTR = 1
+let doWork: TIMERPROC = { (_: HWND?, _: UINT, _: UINT_PTR, _: DWORD) in
+    fatalError("oops")
+    timerID = SetTimer(nil, timerID, UInt32(0), doWork)
+}
+var msg: MSG = .init()
+timerID = SetTimer(nil, timerID, UInt32(0), doWork)
+while (GetMessageA(&msg, nil, 0, 0)) {
+  TranslateMessage(&msg);
+  DispatchMessageA(&msg);
+}


### PR DESCRIPTION
Instead of llvm.trap because it may not terminate the process and may leave the process state in limbo. For example, llvm.trap is turned into the ud2 instruction on X86 which can cause an infinite sigill on Windows.
