### PR TITLE
[5.9][CodeSynthesis] Make sure that init synthesis expands macros

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1997,3 +1997,24 @@ public struct NestedMagicLiteralMacro: ExpressionMacro {
       """
   }
 }
+
+public struct InitWithProjectedValueWrapperMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      private var _value: Wrapper
+      var _$value: Wrapper {
+        @storageRestrictions(initializes: _value)
+        init {
+          self._value = newValue
+        }
+        get { _value }
+      }
+      """
+    ]
+  }
+}

--- a/test/Macros/init_accessor.swift
+++ b/test/Macros/init_accessor.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: swift_swift_parser, executable_test
+
+@attached(peer, names: named(_value), named(_$value))
+macro Wrapped() = #externalMacro(module: "MacroDefinition",
+                                 type: "InitWithProjectedValueWrapperMacro")
+
+@propertyWrapper
+struct Wrapper {
+  var wrappedValue: Int {
+    1
+  }
+  var projectedValue: Wrapper {
+    self
+  }
+}
+
+struct Test {
+  @Wrapped
+  var value: Int { 1 }
+}
+
+let test = Test(_$value: Wrapper())
+print(test.value)
+// CHECK: 1


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/67721

--- 

- Explanation:

Previously both `AreAllStoredPropertiesDefaultInitableRequest` and `HasMemberwiseInitRequest` 
checked only "current" properties of the type but macro expansions can add new stored and/or 
init accessor properties that affect this logic so we need to make sure that macro expansions 
happen and new properties are accounted for.

Note that the original idea was to use `getStoredProperties()` but that runs into multiple circularity
issues related to lazy properties.

- Scope: Macro expansions with init accessor properties.

- Main Branch PR: https://github.com/apple/swift/pull/67721

- Resolves: rdar://112153201

- Risk: Low

- Reviewed By: @hborla 

- Testing: Added test-cases to the suite.

Resolves: rdar://112153201

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
