### PR TITLE
Remove Sendable conformances from conforming types to AsyncIteratorProtocol

### DIFF
--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -137,8 +137,5 @@ extension AsyncCompactMapSequence: @unchecked Sendable
         Base.Element: Sendable, 
         ElementOfResult: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncCompactMapSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable, 
-        ElementOfResult: Sendable { }
+@available(*, unavailable)
+extension AsyncCompactMapSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -141,7 +141,5 @@ extension AsyncDropFirstSequence: Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncDropFirstSequence.Iterator: Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncDropFirstSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -134,7 +134,5 @@ extension AsyncDropWhileSequence: @unchecked Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncDropWhileSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncDropWhileSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -120,7 +120,6 @@ extension AsyncFilterSequence: @unchecked Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncFilterSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncFilterSequence.Iterator: Sendable { }
+

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -163,10 +163,5 @@ extension AsyncFlatMapSequence: @unchecked Sendable
         SegmentOfResult: Sendable, 
         SegmentOfResult.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncFlatMapSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable, 
-        SegmentOfResult: Sendable, 
-        SegmentOfResult.Element: Sendable, 
-        SegmentOfResult.AsyncIterator: Sendable { }
+@available(*, unavailable)
+extension AsyncFlatMapSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -125,8 +125,5 @@ extension AsyncMapSequence: @unchecked Sendable
         Base.Element: Sendable, 
         Transformed: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncMapSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable, 
-        Transformed: Sendable { }
+@available(*, unavailable)
+extension AsyncMapSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -115,7 +115,5 @@ extension AsyncPrefixSequence: Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncPrefixSequence.Iterator: Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncPrefixSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -127,7 +127,5 @@ extension AsyncPrefixWhileSequence: @unchecked Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncPrefixWhileSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncPrefixWhileSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -451,6 +451,9 @@ extension AsyncStream {
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream: @unchecked Sendable where Element: Sendable { }
+
+@available(*, unavailable)
+extension AsyncStream.Iterator: Sendable { }
 #else
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -158,7 +158,5 @@ extension AsyncThrowingCompactMapSequence: @unchecked Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncThrowingCompactMapSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncThrowingCompactMapSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -161,7 +161,5 @@ extension AsyncThrowingDropWhileSequence: @unchecked Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncThrowingDropWhileSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncThrowingDropWhileSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -143,7 +143,5 @@ extension AsyncThrowingFilterSequence: @unchecked Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncThrowingFilterSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncThrowingFilterSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -178,10 +178,5 @@ extension AsyncThrowingFlatMapSequence: @unchecked Sendable
         SegmentOfResult: Sendable, 
         SegmentOfResult.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncThrowingFlatMapSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable, 
-        SegmentOfResult: Sendable, 
-        SegmentOfResult.Element: Sendable, 
-        SegmentOfResult.AsyncIterator: Sendable { }
+@available(*, unavailable)
+extension AsyncThrowingFlatMapSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -148,8 +148,5 @@ extension AsyncThrowingMapSequence: @unchecked Sendable
         Base.Element: Sendable, 
         Transformed: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncThrowingMapSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable, 
-        Transformed: Sendable { }
+@available(*, unavailable)
+extension AsyncThrowingMapSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -146,7 +146,5 @@ extension AsyncThrowingPrefixWhileSequence: @unchecked Sendable
   where Base: Sendable, 
         Base.Element: Sendable { }
 
-@available(SwiftStdlib 5.1, *)
-extension AsyncThrowingPrefixWhileSequence.Iterator: @unchecked Sendable 
-  where Base.AsyncIterator: Sendable, 
-        Base.Element: Sendable { }
+@available(*, unavailable)
+extension AsyncThrowingPrefixWhileSequence.Iterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -498,6 +498,9 @@ extension AsyncThrowingStream {
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream: @unchecked Sendable where Element: Sendable { }
+
+@available(*, unavailable)
+extension AsyncThrowingStream.Iterator: Sendable { }
 #else
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -1148,6 +1148,12 @@ extension ThrowingTaskGroup: AsyncSequence {
   }
 }
 
+@available(*, unavailable)
+extension TaskGroup.Iterator: Sendable { }
+
+@available(*, unavailable)
+extension ThrowingTaskGroup.Iterator: Sendable { }
+
 // ==== -----------------------------------------------------------------------
 // MARK: Runtime functions
 


### PR DESCRIPTION
Sending iterations across concurrency domains leaves a number of really gnarly potentials for races. This walks the conformances of all AsyncIteratorProtocol types to forbid conformance to Sendable.

Note: this is not ABI breaking, but it may be API breaking. So this is a provisional experiment.

Without this change folks could potentially take iterators from AsyncSequence types and pass those for use in two tasks:
```
let iterator = someSeq.makeAsyncIterator()
Task {
  var iter_copy_a = iterator
  while let item = await iter_copy_a.next() {
  }
}
Task {
  var iter_copy_b = iterator
  while let item = await iter_copy_a.next() {
  }
}
```

This will violate the base presumptions of the iteration being exclusive mutations. At best it will drop values, and at worst this can result (depending on the base AsyncSequence) in crashes.