### PR TITLE
[send-not-sendable] Eliminate relative includes and add a file header.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -447,6 +447,10 @@ public:
     return const_cast<Expr *>(this)->getValueProvidingExpr();
   }
 
+  /// Find the original type of a value, looking through various implicit
+  /// conversions.
+  Type findOriginalType() const;
+
   /// If this is a reference to an operator written as a member of a type (or
   /// extension thereof), return the underlying operator reference.
   DeclRefExpr *getMemberOperatorRef();

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -873,6 +873,9 @@ public:
 
   bool isMarkedAsImmortal() const;
 
+  ProtocolConformanceRef conformsToProtocol(SILFunction *fn,
+                                            ProtocolDecl *protocol) const;
+
   //
   // Accessors for types used in SIL instructions:
   //

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2789,3 +2789,28 @@ FrontendStatsTracer::getTraceFormatter<const Expr *>() {
   return &TF;
 }
 
+Type Expr::findOriginalType() const {
+  auto *expr = this;
+  do {
+    expr = expr->getSemanticsProvidingExpr();
+
+    if (auto inout = dyn_cast<InOutExpr>(expr)) {
+      expr = inout->getSubExpr();
+      continue;
+    }
+
+    if (auto ice = dyn_cast<ImplicitConversionExpr>(expr)) {
+      expr = ice->getSubExpr();
+      continue;
+    }
+
+    if (auto open = dyn_cast<OpenExistentialExpr>(expr)) {
+      expr = open->getSubExpr();
+      continue;
+    }
+
+    break;
+  } while (true);
+
+  return expr->getType()->getRValueType();
+}

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1211,3 +1211,8 @@ SILType SILType::removingMoveOnlyWrapperToBoxedType(const SILFunction *fn) {
                                     boxTy->getSubstitutions());
   return SILType::getPrimitiveObjectType(newBoxType);
 }
+
+ProtocolConformanceRef
+SILType::conformsToProtocol(SILFunction *fn, ProtocolDecl *protocol) const {
+  return fn->getParentModule()->conformsToProtocol(getASTType(), protocol);
+}

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1837,33 +1837,6 @@ static void noteGlobalActorOnContext(DeclContext *dc, Type globalActor) {
   }
 }
 
-/// Find the original type of a value, looking through various implicit
-/// conversions.
-Type swift::findOriginalValueType(Expr *expr) {
-  do {
-    expr = expr->getSemanticsProvidingExpr();
-
-    if (auto inout = dyn_cast<InOutExpr>(expr)) {
-      expr = inout->getSubExpr();
-      continue;
-    }
-
-    if (auto ice = dyn_cast<ImplicitConversionExpr>(expr)) {
-      expr = ice->getSubExpr();
-      continue;
-    }
-
-    if (auto open = dyn_cast<OpenExistentialExpr>(expr)) {
-      expr = open->getSubExpr();
-      continue;
-    }
-
-    break;
-  } while (true);
-
-  return expr->getType()->getRValueType();
-}
-
 bool swift::diagnoseApplyArgSendability(ApplyExpr *apply, const DeclContext *declContext) {
   auto isolationCrossing = apply->getIsolationCrossing();
   if (!isolationCrossing.has_value())
@@ -1904,7 +1877,7 @@ bool swift::diagnoseApplyArgSendability(ApplyExpr *apply, const DeclContext *dec
       // Determine the type of the argument, ignoring any implicit
       // conversions that could have stripped sendability.
       if (Expr *argExpr = arg.getExpr()) {
-          argType = findOriginalValueType(argExpr);
+          argType = argExpr->findOriginalType();
       }
     }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -362,10 +362,6 @@ struct SendableCheckContext {
   bool isExplicitSendableConformance() const;
 };
 
-/// Find the original type of a value, looking through various implicit
-/// conversions.
-Type findOriginalValueType(Expr *expr);
-
 /// Diagnose any non-Sendable types that occur within the given type, using
 /// the given diagnostic.
 ///


### PR DESCRIPTION
Specifically, the two routines we were importing relatively were:

1. TypeChecker::conformsToProtocol. I moved this onto a helper routine on SILType.

2. swift::findOriginalValueType(Expr *). This routine just looks through various implicit conversions to find the original underlying type. I moved it to a helper method on Expr.

Just some cleanups.