### PR TITLE
Unleashing the Potential of Observation

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -58,11 +58,14 @@ public struct ObservableMacro {
   static func withMutationFunction(_ observableType: TokenSyntax) -> DeclSyntax {
     return 
       """
-      internal nonisolated func withMutation<Member, MutationResult>(
-      keyPath: KeyPath<\(observableType), Member>,
-      _ mutation: () throws -> MutationResult
-      ) rethrows -> MutationResult {
-      try \(raw: registrarVariableName).withMutation(of: self, keyPath: keyPath, mutation)
+      internal nonisolated func withMutation<Member>(
+      keyPath: KeyPath<\(observableType) , Member>,
+      storageKeyPath: ReferenceWritableKeyPath<\(observableType) , Member>,
+      newValue: Member
+      ) {
+      \(raw: registrarVariableName).withMutation(of: self, keyPath: keyPath) {
+      self[keyPath: storageKeyPath] = newValue
+      }
       }
       """
   }
@@ -321,9 +324,7 @@ public struct ObservationTrackedMacro: AccessorMacro {
     let setAccessor: AccessorDeclSyntax =
       """
       set {
-      withMutation(keyPath: \\.\(identifier)) {
-      _\(identifier) = newValue
-      }
+      withMutation(keyPath: \\.\(identifier), storageKeyPath: \\._\(identifier), newValue: newValue)
       }
       """
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Description
By modifying Observable.withMutation to KeyPath for value modification, it allows developers to extend the withMutation to support more functionality, such as support for Equatable, Hashable, Identifiable and so on.

## Discussion:
https://forums.swift.org/t/observation-with-equatable/66855/6

## API Changes:
No public APIs have changed

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
