### PR TITLE
5.9: [InstructionDeleter] Don't delete-as dead instructions which produce owned move-only values.

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -302,6 +302,22 @@ struct PrintTypeLowering : UnitTest {
   }
 };
 
+// Arguments:
+// - instruction: the instruction to delete
+// Dumps:
+// - the function
+struct DeleterDeleteIfDeadTest : UnitTest {
+  DeleterDeleteIfDeadTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto *inst = arguments.takeInstruction();
+    InstructionDeleter deleter;
+    llvm::dbgs() << "Deleting-if-dead " << *inst;
+    auto deleted = deleter.deleteIfDead(inst);
+    llvm::dbgs() << "deleteIfDead returned " << deleted << "\n";
+    getFunction()->dump();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // MARK: OSSA Lifetime Unit Tests
 //===----------------------------------------------------------------------===//
@@ -975,6 +991,7 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     ADD_UNIT_TEST_SUBCLASS("function-get-self-argument-index", FunctionGetSelfArgumentIndex)
     ADD_UNIT_TEST_SUBCLASS("has-pointer-escape", OwnershipUtilsHasPointerEscape)
     ADD_UNIT_TEST_SUBCLASS("print-type-lowering", PrintTypeLowering)
+    ADD_UNIT_TEST_SUBCLASS("deleter-delete-if-dead", DeleterDeleteIfDeadTest)
     ADD_UNIT_TEST_SUBCLASS("interior-liveness", InteriorLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("is-deinit-barrier", IsDeinitBarrierTest)
     ADD_UNIT_TEST_SUBCLASS("is-lexical", IsLexicalTest)

--- a/test/SILOptimizer/instruction_deleter.sil
+++ b/test/SILOptimizer/instruction_deleter.sil
@@ -1,0 +1,30 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+struct MOS : ~Copyable {}
+
+sil @getMOS : $() -> (@owned MOS)
+sil @barrier : $() -> ()
+
+// CHECK-LABEL: begin running test {{.*}} on dontDeleteDeadMoveOnlyValue
+// CHECK:       Deleting-if-dead {{.*}} move_value
+// CHECK:       deleteIfDead returned 0
+// CHECK-LABEL: sil [ossa] @dontDeleteDeadMoveOnlyValue : {{.*}} {
+// CHECK:         [[GET:%[^,]+]] = function_ref @getMOS
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         [[MOS:%[^,]+]] = apply [[GET]]()
+// CHECK:         [[MOV:%[^,]+]] = move_value [[MOS]]
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[MOV]]
+// CHECK-LABEL: } // end sil function 'dontDeleteDeadMoveOnlyValue'
+// CHECK-LABEL: end running test {{.*}} on dontDeleteDeadMoveOnlyValue
+sil [ossa] @dontDeleteDeadMoveOnlyValue : $() -> () {
+  %get = function_ref @getMOS : $@convention(thin) () -> (@owned MOS)
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  %mos = apply %get() : $@convention(thin) () -> (@owned MOS)
+  test_specification "deleter-delete-if-dead @instruction"
+  %mov = move_value %mos : $MOS
+  apply %barrier() : $@convention(thin) () -> ()
+  destroy_value %mov : $MOS
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
**Description:** Many passes use the InstructionDeleter, requesting that it try to delete an instruction if its dead.  The deleter has a number of checks to determine what counts as "dead".  

Among those checks is an early exit, affirming that an instruction which satisfies a few other conditions is indeed dead if it satisfies `getSingleValueCopyOrCast`.  At least one instruction (`move_value`) satisfying that predicate may produce an owned move-only value.  Such an instruction must not be deleted as dead.  

Here, an additional condition is added prior to considering the `getSingleValueCopyOrCast` predicate; namely, whether the instruction produces an owned move-only value.  If it does, the deleter determines that the instruction is not dead and does not delete it.
**Risk:** Low.  
**Scope:** Narrow.  The change only affects move-only values.
**Original PR:** https://github.com/apple/swift/pull/68108
**Reviewed By:** Andrew Trick ( @atrick )
**Testing:** Added a test.
**Resolves:** rdar://114351349
