### PR TITLE
Sema: Set type on pattern in synthesized enum equatable/hashable conformance

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -946,6 +946,7 @@ CaseStmt *DerivedConformance::unavailableEnumElementCaseStmt(
         TypeExpr::createImplicit(enumType, C), SourceLoc(), DeclNameLoc(),
         DeclNameRef(elt->getBaseIdentifier()), elt, nullptr, /*DC*/ parentDC);
     eltPattern->setImplicit();
+    eltPattern->setType(enumType);
     return eltPattern;
   };
 

--- a/test/Interpreter/enum_equatable_hashable_correctness.swift
+++ b/test/Interpreter/enum_equatable_hashable_correctness.swift
@@ -32,6 +32,11 @@ enum HasUnavailableCases: Hashable {
   case unavailablePayload(UnavailableStruct)
 }
 
+enum AllUnavailableCases: Hashable {
+  @available(*, unavailable)
+  case nope
+}
+
 var EnumSynthesisTests = TestSuite("EnumSynthesis")
 
 EnumSynthesisTests.test("BasicEquatability/Hashability") {


### PR DESCRIPTION
Fixes a regression caused by https://github.com/apple/swift/pull/67636 in which the patterns for case statements generated to match unavailable enum elements were missing a type. The missing type caused a crash during SILGen if the unavailable element case was the first one in the swtich statement.

Resolves rdar://113761850
