### PR TITLE
[cxx-interop] Introduce APINotes file for C++ stdlib

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3226,8 +3226,6 @@ namespace {
           // instead of checking if they come from the `std` module.
           if (!d->getDeclName().isIdentifier())
             return false;
-          if (d->getName() == "abs" || d->getName() == "div")
-            return true;
           if (Impl.SwiftContext.LangOpts.Target.isOSDarwin())
             return d->getName() == "strstr" || d->getName() == "sin" ||
                    d->getName() == "cos" || d->getName() == "exit";

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -1,3 +1,22 @@
+#
+# API Notes for the C++ Standard Library
+#
+set(output_dir "${SWIFTLIB_DIR}/apinotes")
+add_custom_target(CxxStdlib-apinotes
+    COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${output_dir}"
+    COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/std.apinotes" "${output_dir}"
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/std.apinotes
+    COMMENT "Copying CxxStdlib API Notes to ${output_dir}")
+
+swift_install_in_component(FILES std.apinotes
+    DESTINATION "lib/swift/apinotes"
+    COMPONENT compiler)
+
+set_property(TARGET CxxStdlib-apinotes PROPERTY FOLDER "Miscellaneous")
+add_dependencies(sdk-overlay CxxStdlib-apinotes)
+add_dependencies(compiler CxxStdlib-apinotes)
+
+
 # Swift compiler currently assumes that the Darwin overlay is a dependency of
 # CxxStdlib, and fails to build CxxStdlib if Darwin.swiftmodule in build dir
 # is built with a different (older) version of the compiler. To workaround this,
@@ -34,4 +53,4 @@ add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_O
     TARGET_SDKS ALL_APPLE_PLATFORMS LINUX WINDOWS
     INSTALL_IN_COMPONENT compiler
     INSTALL_WITH_SHARED
-    DEPENDS libstdcxx-modulemap libcxxshim_modulemap)
+    DEPENDS libstdcxx-modulemap libcxxshim_modulemap CxxStdlib-apinotes)

--- a/stdlib/public/Cxx/std/std.apinotes
+++ b/stdlib/public/Cxx/std/std.apinotes
@@ -1,0 +1,8 @@
+Name: std
+Functions:
+- Name: abs
+  Availability: nonswift
+  AvailabilityMsg: Use the C standard library function
+- Name: div
+  Availability: nonswift
+  AvailabilityMsg: Use the C standard library function


### PR DESCRIPTION
This adds an `std.apinotes` file that is installed into `lib/swift/apinotes` along with existing Darwin apinotes. This new file is installed on all platforms. It replaces a few special cases in the compiler for `cmath` and `cstring` functions.

This does not require the upcoming APINotes support for namespaces, however, this does require https://github.com/apple/llvm-project/pull/7309.

rdar://107572302