### PR TITLE
Frontend: introduce a new `swift_upcoming` search path entry

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -238,7 +238,26 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
       llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
     }
     RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+
+    // Allow a fallback lookup for ABI-unstable features that are part of
+    // preview features.
+    LibPath = SearchPathOpts.getSDKPath();
+    llvm::sys::path::append(LibPath, "usr", "lib", "swift_upcoming");
+    if (!Triple.isOSDarwin()) {
+      // Use the non-architecture suffixed form with directory-layout
+      // swiftmodules.
+      llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
+      RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+
+      // Compatibility with older releases - use the architecture suffixed form
+      // for pre-directory-layout multi-architecture layout.  Note that some
+      // platforms (e.g. Windows) will use this even with directory layout in
+      // older releases.
+      llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
+    }
+    RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
   }
+
   SearchPathOpts.setRuntimeLibraryImportPaths(RuntimeLibraryImportPaths);
 }
 


### PR DESCRIPTION
This adds `/usr/lib/swift_upcoming` to the default search path that follows `/usr/lib/swift` to allow us to have a staging ground for upcoming features.  Given that upcoming features may be ABI unstable, they are statically linked.  The default behaviour of isolating static and dynamic libraries into `/usr/lib/swift` and `/usr/lib/swift_static` and switching that based upon `-static-stdlib` is important to preserve as the linkage is encoded into the swift module and impacts the code generation on some platforms.  This allows us to include a default search path that may link statically irrespective of how the remainder of the standard library is linked.