### PR TITLE
Avoid realpath drive resolution to fix symlink-related test failures on Windows

### DIFF
--- a/include/swift/Basic/SymbolicLinks.h
+++ b/include/swift/Basic/SymbolicLinks.h
@@ -14,20 +14,15 @@
 #define SWIFT_BASIC_SYMBOLICLINKS_H
 
 #include "swift/Basic/LLVM.h"
-#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/VirtualFileSystem.h"
+#include <string>
 
 namespace swift {
 
 /// Tries to resolve symbolic links in a given path, but preserves
 /// substitute drives on Windows to avoid MAX_PATH issues.
 /// On failure, returns the original path.
-llvm::SmallString<128> resolveSymbolicLinks(llvm::StringRef InputPath);
-
-/// Tries to resolve symbolic links in a given path, but preserves
-/// substitute drives on Windows to avoid MAX_PATH issues.
-/// On failure, returns the original path.
-llvm::SmallString<128> resolveSymbolicLinks(llvm::StringRef InputPath,
+std::string resolveSymbolicLinks(llvm::StringRef InputPath,
     llvm::vfs::FileSystem *FileSystem);
 
 } // namespace swift

--- a/include/swift/Basic/SymbolicLinks.h
+++ b/include/swift/Basic/SymbolicLinks.h
@@ -14,8 +14,10 @@
 #define SWIFT_BASIC_SYMBOLICLINKS_H
 
 #include "swift/Basic/LLVM.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <string>
+#include <optional>
 
 namespace swift {
 
@@ -23,7 +25,8 @@ namespace swift {
 /// substitute drives on Windows to avoid MAX_PATH issues.
 /// On failure, returns the original path.
 std::string resolveSymbolicLinks(llvm::StringRef InputPath,
-    llvm::vfs::FileSystem *FileSystem);
+    llvm::vfs::FileSystem *FileSystem,
+    std::optional<llvm::sys::path::Style> Style = std::nullopt);
 
 } // namespace swift
 

--- a/include/swift/Basic/SymbolicLinks.h
+++ b/include/swift/Basic/SymbolicLinks.h
@@ -1,0 +1,35 @@
+//===--- SymbolicLinks.h ----------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_SYMBOLICLINKS_H
+#define SWIFT_BASIC_SYMBOLICLINKS_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/VirtualFileSystem.h"
+
+namespace swift {
+
+/// Tries to resolve symbolic links in a given path, but preserves
+/// substitute drives on Windows to avoid MAX_PATH issues.
+/// On failure, returns the original path.
+llvm::SmallString<128> resolveSymbolicLinks(llvm::StringRef InputPath);
+
+/// Tries to resolve symbolic links in a given path, but preserves
+/// substitute drives on Windows to avoid MAX_PATH issues.
+/// On failure, returns the original path.
+llvm::SmallString<128> resolveSymbolicLinks(llvm::StringRef InputPath,
+    llvm::vfs::FileSystem *FileSystem);
+
+} // namespace swift
+
+#endif // SWIFT_BASIC_BLOTSETVECTOR_H

--- a/include/swift/Basic/SymbolicLinks.h
+++ b/include/swift/Basic/SymbolicLinks.h
@@ -14,6 +14,7 @@
 #define SWIFT_BASIC_SYMBOLICLINKS_H
 
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <string>
@@ -23,10 +24,13 @@ namespace swift {
 
 /// Tries to resolve symbolic links in a given path, but preserves
 /// substitute drives on Windows to avoid MAX_PATH issues.
-/// On failure, returns the original path.
+/// \param InputPath The path to be resolved.
+/// \param FileSystem The FileSystem for resolving the path.
+/// \param Style An optional path style to honor in the return value.
+/// \returns The resolved path, or the original path on failure. 
 std::string resolveSymbolicLinks(llvm::StringRef InputPath,
-    llvm::vfs::FileSystem *FileSystem,
-    std::optional<llvm::sys::path::Style> Style = std::nullopt);
+    llvm::vfs::FileSystem &FileSystem,
+    llvm::Optional<llvm::sys::path::Style> Style = llvm::None);
 
 } // namespace swift
 

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -72,6 +72,7 @@ add_swift_host_library(swiftBasic STATIC
   StableHasher.cpp
   Statistic.cpp
   StringExtras.cpp
+  SymbolicLinks.cpp
   TargetInfo.cpp
   TaskQueue.cpp
   ThreadSafeRefCounted.cpp

--- a/lib/Basic/SymbolicLinks.cpp
+++ b/lib/Basic/SymbolicLinks.cpp
@@ -18,10 +18,10 @@ using namespace llvm;
 
 static std::error_code resolveSymbolicLinks(
     StringRef InputPath,
-    llvm::vfs::FileSystem *FileSystem,
+    llvm::vfs::FileSystem &FileSystem,
     SmallVectorImpl<char> &Result) {
 
-  if (auto ErrorCode = FileSystem->getRealPath(InputPath, Result)) {
+  if (auto ErrorCode = FileSystem.getRealPath(InputPath, Result)) {
     return ErrorCode;
   }
 
@@ -31,7 +31,7 @@ static std::error_code resolveSymbolicLinks(
 
   // For Windows paths, make sure we didn't resolve across drives.
   SmallString<128> AbsPathBuf = InputPath;
-  if (auto ErrorCode = FileSystem->makeAbsolute(AbsPathBuf)) {
+  if (auto ErrorCode = FileSystem.makeAbsolute(AbsPathBuf)) {
     // We can't guarantee that the real path preserves the drive
     return ErrorCode;
   }
@@ -52,8 +52,8 @@ static std::error_code resolveSymbolicLinks(
 
 std::string swift::resolveSymbolicLinks(
   StringRef InputPath,
-  llvm::vfs::FileSystem *FileSystem,
-  std::optional<llvm::sys::path::Style> Style) {
+  llvm::vfs::FileSystem &FileSystem,
+  llvm::Optional<llvm::sys::path::Style> Style) {
 
   llvm::SmallString<128> OutputPathBuf;
   if (::resolveSymbolicLinks(InputPath, FileSystem, OutputPathBuf)) {

--- a/lib/Basic/SymbolicLinks.cpp
+++ b/lib/Basic/SymbolicLinks.cpp
@@ -1,0 +1,79 @@
+//===--- SymbolicLinks.cpp - Utility functions for resolving symlinks -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/SymbolicLinks.h"
+#include "llvm/Support/Path.h"
+
+using namespace llvm;
+
+SmallString<128> swift::resolveSymbolicLinks(StringRef FilePath) {
+  SmallString<128> RealPathBuf;
+  if (llvm::sys::fs::real_path(FilePath, RealPathBuf)) {
+    return FilePath;
+  }
+
+  if (!is_style_windows(llvm::sys::path::Style::native)) {
+    return RealPathBuf;
+  }
+
+  // For Windows paths, only use the real path if it doesn't resolve
+  // a substitute drive, as those are used to avoid MAX_PATH issues.
+  SmallString<128> AbsPathBuf = FilePath;
+  if (llvm::sys::fs::make_absolute(AbsPathBuf)) {
+    return FilePath;
+  }
+
+  if (llvm::sys::path::root_name(RealPathBuf) ==
+      llvm::sys::path::root_name(AbsPathBuf)) {
+    return RealPathBuf;
+  }
+
+  // Fallback to using the absolute path.
+  // Simplifying /../ is semantically valid on Windows even in the
+  // presence of symbolic links.
+  llvm::sys::path::remove_dots(AbsPathBuf, /*remove_dot_dot=*/ true);
+  return AbsPathBuf;
+}
+
+// Resolves symbolic links in a given file path, stopping short
+// of resolving across substitute drives on Windows since
+// those are used to avoid running into MAX_PATH issues.
+llvm::SmallString<128> swift::resolveSymbolicLinks(
+  StringRef InputPath,
+  llvm::vfs::FileSystem *FileSystem) {
+
+  llvm::SmallString<128> RealPathBuf;
+  if (FileSystem->getRealPath(InputPath, RealPathBuf)) {
+    return InputPath;
+  }
+
+  if (!is_style_windows(llvm::sys::path::Style::native)) {
+    return RealPathBuf;
+  }
+
+  // For Windows paths, make sure we didn't resolve across drives.
+  SmallString<128> AbsPathBuf = InputPath;
+  if (FileSystem->makeAbsolute(AbsPathBuf)) {
+    return InputPath;
+  }
+
+  if (llvm::sys::path::root_name(RealPathBuf) ==
+      llvm::sys::path::root_name(AbsPathBuf)) {
+    return RealPathBuf;
+  }
+
+  // Fallback to using the absolute path.
+  // Simplifying /../ is semantically valid on Windows even in the
+  // presence of symbolic links.
+  llvm::sys::path::remove_dots(AbsPathBuf, /*remove_dot_dot=*/ true);
+  return AbsPathBuf;
+}

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -84,7 +84,7 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
     std::string &Error) {
   assert(FileSystem);
 
-  llvm::SmallString<128> PrimaryFile = resolveSymbolicLinks(
+  std::string PrimaryFile = resolveSymbolicLinks(
       UnresolvedPrimaryFile, FileSystem.get());
 
   unsigned primaryCount = 0;
@@ -92,8 +92,8 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
   // clang's FileManager ?
   FrontendInputsAndOutputs replacementInputsAndOutputs;
   for (const InputFile &input : inputsAndOutputs.getAllInputs()) {
-    auto newFilename = resolveSymbolicLinks(
-        input.getFileName(), FileSystem.get());
+    llvm::SmallString<128> newFilename = StringRef(resolveSymbolicLinks(
+        input.getFileName(), FileSystem.get()));
     llvm::sys::path::native(newFilename);
     bool newIsPrimary = input.isPrimary() ||
                         (!PrimaryFile.empty() && PrimaryFile == newFilename);

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -79,23 +79,22 @@ static std::string adjustClangTriple(StringRef TripleStr) {
 }
 
 static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
-    FrontendInputsAndOutputs &inputsAndOutputs, StringRef UnresolvedPrimaryFile,
+    FrontendInputsAndOutputs &inputsAndOutputs,
+    StringRef UnresolvedPrimaryFile,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) {
   assert(FileSystem);
 
   std::string PrimaryFile = resolveSymbolicLinks(
-      UnresolvedPrimaryFile, FileSystem.get());
+      UnresolvedPrimaryFile, *FileSystem);
 
   unsigned primaryCount = 0;
   // FIXME: The frontend should be dealing with symlinks, maybe similar to
   // clang's FileManager ?
   FrontendInputsAndOutputs replacementInputsAndOutputs;
   for (const InputFile &input : inputsAndOutputs.getAllInputs()) {
-    std::string newFilename = resolveSymbolicLinks(
-        input.getFileName(),
-        FileSystem.get(),
-        llvm::sys::path::Style::native);
+    std::string newFilename = resolveSymbolicLinks(input.getFileName(),
+        *FileSystem, llvm::sys::path::Style::native);
     bool newIsPrimary = input.isPrimary() ||
                         (!PrimaryFile.empty() && PrimaryFile == newFilename);
     if (newIsPrimary) {

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -92,9 +92,10 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
   // clang's FileManager ?
   FrontendInputsAndOutputs replacementInputsAndOutputs;
   for (const InputFile &input : inputsAndOutputs.getAllInputs()) {
-    llvm::SmallString<128> newFilename = StringRef(resolveSymbolicLinks(
-        input.getFileName(), FileSystem.get()));
-    llvm::sys::path::native(newFilename);
+    std::string newFilename = resolveSymbolicLinks(
+        input.getFileName(),
+        FileSystem.get(),
+        llvm::sys::path::Style::native);
     bool newIsPrimary = input.isPrimary() ||
                         (!PrimaryFile.empty() && PrimaryFile == newFilename);
     if (newIsPrimary) {
@@ -103,7 +104,7 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
     assert(primaryCount < 2 && "cannot handle multiple primaries");
 
     replacementInputsAndOutputs.addInput(
-        InputFile(newFilename.str(), newIsPrimary, input.getBuffer()));
+        InputFile(newFilename, newIsPrimary, input.getBuffer()));
   }
 
   if (PrimaryFile.empty() || primaryCount == 1) {

--- a/test/SourceKit/CursorInfo/cursor_symlink.swift
+++ b/test/SourceKit/CursorInfo/cursor_symlink.swift
@@ -1,3 +1,6 @@
+// We can't resolve symlinks on a substituted drive without risking MAX_PATH issues
+// REQUIRES: !windows_substituted_drive
+
 // RUN: %empty-directory(%t.dir)
 // RUN: echo "let foo = 0" > %t.dir/real.swift
 // RUN: %{python} %S/../../Inputs/symlink.py %t.dir/real.swift %t.dir/linked.swift

--- a/test/SourceKit/CursorInfo/cursor_symlink.swift
+++ b/test/SourceKit/CursorInfo/cursor_symlink.swift
@@ -1,11 +1,11 @@
-// We can't resolve symlinks on a substituted drive without risking MAX_PATH issues
-// REQUIRES: !windows_substituted_drive
-
 // RUN: %empty-directory(%t.dir)
 // RUN: echo "let foo = 0" > %t.dir/real.swift
 // RUN: %{python} %S/../../Inputs/symlink.py %t.dir/real.swift %t.dir/linked.swift
 // RUN: %sourcekitd-test -req=cursor -pos=1:5 %t.dir/linked.swift -- %t.dir/real.swift | %FileCheck %s
 // RUN: %sourcekitd-test -req=cursor -pos=1:5 %t.dir/real.swift -- %t.dir/linked.swift | %FileCheck %s
+
+// We can't resolve symlinks on a substituted drive without risking MAX_PATH issues
+// REQUIRES: !windows_substituted_drive
 
 // CHECK: source.lang.swift.decl.var.global (1:5-1:8)
 // CHECK: foo

--- a/test/SourceKit/Indexing/indexstore_multifile.swift
+++ b/test/SourceKit/Indexing/indexstore_multifile.swift
@@ -1,5 +1,4 @@
 // RUN: %empty-directory(%t)
-// RUN: echo TTTTTT %t
 // RUN: %sourcekitd-test -req=index-to-store %s -index-store-path %t/idx -index-unit-output-path %t/indexstore_multifile.o -- -c -module-name indexstoremodule -o args_output_path.o %s %S/Inputs/indexstore_multifile_other.swift
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck  --dump-input=always --dump-input-filter=all %s
 

--- a/test/SourceKit/Indexing/indexstore_multifile.swift
+++ b/test/SourceKit/Indexing/indexstore_multifile.swift
@@ -1,4 +1,5 @@
 // RUN: %empty-directory(%t)
+// RUN: echo TTTTTT %t
 // RUN: %sourcekitd-test -req=index-to-store %s -index-store-path %t/idx -index-unit-output-path %t/indexstore_multifile.o -- -c -module-name indexstoremodule -o args_output_path.o %s %S/Inputs/indexstore_multifile_other.swift
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck  --dump-input=always --dump-input-filter=all %s
 

--- a/test/SourceKit/Sema/sema_symlink.swift
+++ b/test/SourceKit/Sema/sema_symlink.swift
@@ -1,3 +1,6 @@
+// We can't resolve symlinks on a substituted drive without risking MAX_PATH issues
+// REQUIRES: !windows_substituted_drive
+
 // RUN: %empty-directory(%t.dir)
 // RUN: echo "let foo: Int = goo" > %t.dir/real.swift
 // RUN: %{python} %S/../../Inputs/symlink.py %t.dir/real.swift %t.dir/linked.swift

--- a/test/SourceKit/Sema/sema_symlink.swift
+++ b/test/SourceKit/Sema/sema_symlink.swift
@@ -1,6 +1,3 @@
-// We can't resolve symlinks on a substituted drive without risking MAX_PATH issues
-// REQUIRES: !windows_substituted_drive
-
 // RUN: %empty-directory(%t.dir)
 // RUN: echo "let foo: Int = goo" > %t.dir/real.swift
 // RUN: %{python} %S/../../Inputs/symlink.py %t.dir/real.swift %t.dir/linked.swift
@@ -8,3 +5,6 @@
 // RUN: %diff -u %s.response %t.link.response
 // RUN: %sourcekitd-test -req=sema %t.dir/real.swift -- %t.dir/linked.swift | %sed_clean > %t.real.response
 // RUN: %diff -u %s.response %t.real.response
+
+// We can't resolve symlinks on a substituted drive without risking MAX_PATH issues
+// REQUIRES: !windows_substituted_drive

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -1,6 +1,13 @@
 import os
+import platform
 import shlex
 
+# NOTE: this mirrors the kIsWindows from lit.lit.TestRunner in LLVM
+kIsWindows = platform.system() == 'Windows'
+if kIsWindows:
+    from pathlib import Path
+    if Path(__file__).resolve().drive != Path(__file__).drive:
+        config.available_features.add('windows_substituted_drive')
 
 if 'sourcekit' not in config.available_features:
     config.unsupported = True

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -2,7 +2,7 @@ import os
 import platform
 import shlex
 
-# NOTE: this mirrors the kIsWindows from lit.lit.TestRunner in LLVM
+# NOTE: this mirrors the kIsWindows from the parent lit.cfg
 kIsWindows = platform.system() == 'Windows'
 if kIsWindows:
     from pathlib import Path

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -5,8 +5,17 @@ import shlex
 # NOTE: this mirrors the kIsWindows from the parent lit.cfg
 kIsWindows = platform.system() == 'Windows'
 if kIsWindows:
-    from pathlib import Path
-    if Path(__file__).resolve().drive != Path(__file__).drive:
+    # Detect if we are on a substituted drive
+    # We can't rely on os.path.realpath because older Python versions implement it as abspath
+    # So get the list of substitute drives from subst.exe
+    import subprocess
+    subst_path = os.path.join(os.environ["SystemRoot"], "system32", "subst.exe")
+    subst_stdout = subprocess.run([subst_path], capture_output=True).stdout
+    subst_lines_bytes = subst_stdout.splitlines()
+    
+    # Encoding doesn't matter, the drive is one letter and a colon
+    current_drive_bytes = os.path.splitdrive(__file__)[0].encode("utf-8")
+    if any(line_bytes.startswith(current_drive_bytes) for line_bytes in subst_lines_bytes):
         config.available_features.add('windows_substituted_drive')
 
 if 'sourcekit' not in config.available_features:

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -12,10 +12,14 @@ if kIsWindows:
     subst_path = os.path.join(os.environ["SystemRoot"], "system32", "subst.exe")
     subst_stdout = subprocess.run([subst_path], capture_output=True).stdout
     subst_lines_bytes = subst_stdout.splitlines()
+
+    def is_on_subst_drive(path):
+        # Encoding doesn't matter, the drive is one letter and a colon
+        drive_bytes = os.path.splitdrive(path)[0].encode("utf-8")
+        return any(line_bytes.startswith(current_drive_bytes) for line_bytes in subst_lines_bytes)
     
-    # Encoding doesn't matter, the drive is one letter and a colon
-    current_drive_bytes = os.path.splitdrive(__file__)[0].encode("utf-8")
-    if any(line_bytes.startswith(current_drive_bytes) for line_bytes in subst_lines_bytes):
+    current_drive_bytes = os.path.splitdrive(config.test_exec_root)[0].encode("utf-8")
+    if is_on_subst_drive(config.test_source_root) or is_on_subst_drive(config.test_exec_root):
         config.available_features.add('windows_substituted_drive')
 
 if 'sourcekit' not in config.available_features:

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -13,6 +13,7 @@
 import os
 import platform
 import sys
+import lit.util
 
 config.cmake = "@CMAKE_COMMAND@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
@@ -172,6 +173,6 @@ if '@SWIFT_SWIFT_PARSER@' == 'TRUE':
 
 # Let the main config do the real work.
 if config.test_exec_root is None:
-    config.test_exec_root = os.path.dirname(os.path.realpath(__file__))
+    config.test_exec_root = os.path.dirname(lit.util.abs_path_preserve_drive(__file__))
 lit_config.load_config(
     config, os.path.join(config.swift_src_root, "test", "lit.cfg"))

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -844,7 +844,8 @@ FileContent SwiftASTManager::Implementation::getFileContent(
     StringRef UnresolvedPath, bool IsPrimary,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) const {
-  auto FilePath = resolveSymbolicLinks(UnresolvedPath);
+  std::string FilePath = resolveSymbolicLinks(UnresolvedPath,
+      FileSystem.get());
   if (auto EditorDoc = EditorDocs->findByPath(FilePath, /*IsRealpath=*/true))
     return getFileContentFromSnap(EditorDoc->getLatestSnapshot(), IsPrimary,
                                   FilePath);

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -846,7 +846,7 @@ FileContent SwiftASTManager::Implementation::getFileContent(
     std::string &Error) const {
   std::string FilePath = resolveSymbolicLinks(UnresolvedPath,
       FileSystem.get());
-  if (auto EditorDoc = EditorDocs->findByPath(FilePath, /*IsRealpath=*/true))
+  if (auto EditorDoc = EditorDocs->findByPath(FilePath))
     return getFileContentFromSnap(EditorDoc->getLatestSnapshot(), IsPrimary,
                                   FilePath);
 
@@ -865,7 +865,7 @@ BufferStamp SwiftASTManager::Implementation::getBufferStamp(
   assert(FileSystem);
 
   if (CheckEditorDocs) {
-    if (auto EditorDoc = EditorDocs->findByPath(FilePath)) {
+    if (auto EditorDoc = EditorDocs->findByPath(FilePath, FileSystem.get())) {
       return EditorDoc->getLatestSnapshot()->getStamp();
     }
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -22,6 +22,7 @@
 
 #include "swift/AST/PluginLoader.h"
 #include "swift/Basic/Cache.h"
+#include "swift/Basic/SymbolicLinks.h"
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -843,7 +844,7 @@ FileContent SwiftASTManager::Implementation::getFileContent(
     StringRef UnresolvedPath, bool IsPrimary,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) const {
-  std::string FilePath = SwiftLangSupport::resolvePathSymlinks(UnresolvedPath);
+  auto FilePath = resolveSymbolicLinks(UnresolvedPath);
   if (auto EditorDoc = EditorDocs->findByPath(FilePath, /*IsRealpath=*/true))
     return getFileContentFromSnap(EditorDoc->getLatestSnapshot(), IsPrimary,
                                   FilePath);

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -844,8 +844,7 @@ FileContent SwiftASTManager::Implementation::getFileContent(
     StringRef UnresolvedPath, bool IsPrimary,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) const {
-  std::string FilePath = resolveSymbolicLinks(UnresolvedPath,
-      FileSystem.get());
+  std::string FilePath = resolveSymbolicLinks(UnresolvedPath, *FileSystem);
   if (auto EditorDoc = EditorDocs->findByPath(FilePath))
     return getFileContentFromSnap(EditorDoc->getLatestSnapshot(), IsPrimary,
                                   FilePath);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -304,13 +304,13 @@ SwiftEditorDocumentFileMap::getByUnresolvedName(StringRef FilePath) {
 }
 
 SwiftEditorDocumentRef
-SwiftEditorDocumentFileMap::findByPath(StringRef FilePath, bool IsRealpath) {
+SwiftEditorDocumentFileMap::findByPath(StringRef FilePath,
+    llvm::vfs::FileSystem *FileSystem) {
   SwiftEditorDocumentRef EditorDoc;
 
   std::string Scratch;
-  if (!IsRealpath) {
-    Scratch = resolveSymbolicLinks(FilePath,
-        llvm::vfs::getRealFileSystem().get());
+  if (FileSystem) {
+    Scratch = resolveSymbolicLinks(FilePath, FileSystem);
     FilePath = Scratch;
   }
   Queue.dispatchSync([&]{

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/SILOptions.h"
 #include "swift/AST/USRGeneration.h"
+#include "swift/Basic/SymbolicLinks.h"
 #include "swift/Config.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/CodeCompletionCache.h"
@@ -972,13 +973,6 @@ void SwiftLangSupport::printMemberDeclDescription(const swift::ValueDecl *VD,
   }
 }
 
-std::string SwiftLangSupport::resolvePathSymlinks(StringRef FilePath) {
-  std::string InputPath = FilePath.str();
-  llvm::SmallString<256> output;
-  if (llvm::sys::fs::real_path(InputPath, output))
-    return InputPath;
-  return std::string(output.str());
-}
 
 void SwiftLangSupport::getStatistics(StatisticsReceiver receiver) {
   std::vector<Statistic *> stats = {
@@ -1040,10 +1034,8 @@ void SwiftLangSupport::performWithParamsToCompletionLikeOperation(
   // Resolve symlinks for the input file; we resolve them for the input files
   // in the arguments as well.
   // FIXME: We need the Swift equivalent of Clang's FileEntry.
-  llvm::SmallString<128> bufferIdentifier;
-  if (auto err = FileSystem->getRealPath(
-          UnresolvedInputFile->getBufferIdentifier(), bufferIdentifier))
-    bufferIdentifier = UnresolvedInputFile->getBufferIdentifier();
+  auto bufferIdentifier = resolveSymbolicLinks(
+      UnresolvedInputFile->getBufferIdentifier());
 
   // Create a buffer for code completion. This contains '\0' at 'Offset'
   // position of 'UnresolvedInputFile' buffer.

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -1034,8 +1034,8 @@ void SwiftLangSupport::performWithParamsToCompletionLikeOperation(
   // Resolve symlinks for the input file; we resolve them for the input files
   // in the arguments as well.
   // FIXME: We need the Swift equivalent of Clang's FileEntry.
-  auto bufferIdentifier = resolveSymbolicLinks(
-      UnresolvedInputFile->getBufferIdentifier());
+  std::string bufferIdentifier = resolveSymbolicLinks(
+      UnresolvedInputFile->getBufferIdentifier(), FileSystem.get());
 
   // Create a buffer for code completion. This contains '\0' at 'Offset'
   // position of 'UnresolvedInputFile' buffer.

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -1035,7 +1035,7 @@ void SwiftLangSupport::performWithParamsToCompletionLikeOperation(
   // in the arguments as well.
   // FIXME: We need the Swift equivalent of Clang's FileEntry.
   std::string bufferIdentifier = resolveSymbolicLinks(
-      UnresolvedInputFile->getBufferIdentifier(), FileSystem.get());
+      UnresolvedInputFile->getBufferIdentifier(), *FileSystem);
 
   // Create a buffer for code completion. This contains '\0' at 'Offset'
   // position of 'UnresolvedInputFile' buffer.

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -147,11 +147,11 @@ public:
                    SwiftEditorDocumentRef &EditorDoc);
   /// Looks up the document only by the path name that was given initially.
   SwiftEditorDocumentRef getByUnresolvedName(StringRef FilePath);
-  /// Looks up the document by resolving symlinks in the paths.
-  /// If \p IsRealpath is \c true, then \p FilePath must already be
-  /// canonicalized to a realpath.
-  SwiftEditorDocumentRef findByPath(StringRef FilePath,
-                                    bool IsRealpath = false);
+  /// Looks up the document, resolving symlinks in paths if a filesystem
+  /// is provided, and otherwise assuming prior canonicalization.
+  SwiftEditorDocumentRef
+  findByPath(StringRef FilePath,
+             llvm::vfs::FileSystem *FileSystem = nullptr);
   SwiftEditorDocumentRef remove(StringRef FilePath);
 };
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -516,10 +516,6 @@ public:
   printMemberDeclDescription(const swift::ValueDecl *VD, swift::Type baseTy,
                              bool usePlaceholder, llvm::raw_ostream &OS);
 
-  /// Tries to resolve the path to the real file-system path. If it fails it
-  /// returns the original path;
-  static std::string resolvePathSymlinks(StringRef FilePath);
-
   /// The result returned from \c performWithParamsToCompletionLikeOperation.
   struct CompletionLikeOperationParams {
     swift::CompilerInvocation &Invocation;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -143,15 +143,19 @@ class SwiftEditorDocumentFileMap {
 
 public:
   bool getOrUpdate(StringRef FilePath,
+                   llvm::vfs::FileSystem &FileSystem,
                    SwiftLangSupport &LangSupport,
                    SwiftEditorDocumentRef &EditorDoc);
+
   /// Looks up the document only by the path name that was given initially.
   SwiftEditorDocumentRef getByUnresolvedName(StringRef FilePath);
+
   /// Looks up the document, resolving symlinks in paths if a filesystem
-  /// is provided, and otherwise assuming prior canonicalization.
+  /// is provided, and otherwise assumes prior canonicalization.
   SwiftEditorDocumentRef
   findByPath(StringRef FilePath,
              llvm::vfs::FileSystem *FileSystem = nullptr);
+
   SwiftEditorDocumentRef remove(StringRef FilePath);
 };
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1495,8 +1495,7 @@ public:
     // blocked waiting on the AST to be fully typechecked.
 
     ImmutableTextSnapshotRef InputSnap;
-    if (auto EditorDoc = Lang.getEditorDocuments()->findByPath(
-            PrimaryFilePath))
+    if (auto EditorDoc = Lang.getEditorDocuments()->findByPath(PrimaryFilePath))
       InputSnap = EditorDoc->getLatestSnapshot();
     if (!InputSnap)
       return false;
@@ -1556,7 +1555,7 @@ static SourceFile *retrieveInputFile(StringRef inputBufferName,
     if (haveRealPath)
       return nullptr;
     std::string realPath = resolveSymbolicLinks(inputBufferName,
-        &CI.getFileSystem());
+        CI.getFileSystem());
     return retrieveInputFile(realPath, CI, /*haveRealPath=*/true);
   }
 
@@ -2120,7 +2119,7 @@ void SwiftLangSupport::getCursorInfo(
   if (InputBufferName.empty() && Length == 0) {
     std::string InputFileError;
     std::string RealInputFilePath = resolveSymbolicLinks(PrimaryFilePath,
-        fileSystem.get());
+        *fileSystem);
     InputBuffer =
         std::shared_ptr<llvm::MemoryBuffer>(getASTManager()->getMemoryBuffer(
             RealInputFilePath, fileSystem, InputFileError));

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1556,7 +1556,8 @@ static SourceFile *retrieveInputFile(StringRef inputBufferName,
     // done that)
     if (haveRealPath)
       return nullptr;
-    auto realPath = resolveSymbolicLinks(inputBufferName);
+    std::string realPath = resolveSymbolicLinks(inputBufferName,
+        llvm::vfs::getRealFileSystem().get());
     return retrieveInputFile(realPath, CI, /*haveRealPath=*/true);
   }
 
@@ -2119,7 +2120,8 @@ void SwiftLangSupport::getCursorInfo(
   std::shared_ptr<llvm::MemoryBuffer> InputBuffer;
   if (InputBufferName.empty() && Length == 0) {
     std::string InputFileError;
-    auto RealInputFilePath = resolveSymbolicLinks(PrimaryFilePath);
+    std::string RealInputFilePath = resolveSymbolicLinks(PrimaryFilePath,
+        fileSystem.get());
     InputBuffer =
         std::shared_ptr<llvm::MemoryBuffer>(getASTManager()->getMemoryBuffer(
             RealInputFilePath, fileSystem, InputFileError));

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -641,8 +641,7 @@ mapOffsetToNewerSnapshot(unsigned Offset,
 static void mapLocToLatestSnapshot(
     SwiftLangSupport &Lang, LocationInfo &Location,
     ArrayRef<ImmutableTextSnapshotRef> PreviousASTSnaps) {
-  auto EditorDoc = Lang.getEditorDocuments()->findByPath(Location.Filename,
-                                                         /*IsRealpath=*/true);
+  auto EditorDoc = Lang.getEditorDocuments()->findByPath(Location.Filename);
   if (!EditorDoc)
     return;
 
@@ -1497,7 +1496,7 @@ public:
 
     ImmutableTextSnapshotRef InputSnap;
     if (auto EditorDoc = Lang.getEditorDocuments()->findByPath(
-            PrimaryFilePath, /*IsRealpath=*/true))
+            PrimaryFilePath))
       InputSnap = EditorDoc->getLatestSnapshot();
     if (!InputSnap)
       return false;
@@ -1557,7 +1556,7 @@ static SourceFile *retrieveInputFile(StringRef inputBufferName,
     if (haveRealPath)
       return nullptr;
     std::string realPath = resolveSymbolicLinks(inputBufferName,
-        llvm::vfs::getRealFileSystem().get());
+        &CI.getFileSystem());
     return retrieveInputFile(realPath, CI, /*haveRealPath=*/true);
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/Basic/SymbolicLinks.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/CodeCompletion.h"
@@ -1555,8 +1556,7 @@ static SourceFile *retrieveInputFile(StringRef inputBufferName,
     // done that)
     if (haveRealPath)
       return nullptr;
-    std::string realPath =
-        SwiftLangSupport::resolvePathSymlinks(inputBufferName);
+    auto realPath = resolveSymbolicLinks(inputBufferName);
     return retrieveInputFile(realPath, CI, /*haveRealPath=*/true);
   }
 
@@ -2119,8 +2119,7 @@ void SwiftLangSupport::getCursorInfo(
   std::shared_ptr<llvm::MemoryBuffer> InputBuffer;
   if (InputBufferName.empty() && Length == 0) {
     std::string InputFileError;
-    llvm::SmallString<128> RealInputFilePath;
-    fileSystem->getRealPath(PrimaryFilePath, RealInputFilePath);
+    auto RealInputFilePath = resolveSymbolicLinks(PrimaryFilePath);
     InputBuffer =
         std::shared_ptr<llvm::MemoryBuffer>(getASTManager()->getMemoryBuffer(
             RealInputFilePath, fileSystem, InputFileError));

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_sourcekit_executable(sourcekitd-test
 )
 target_link_libraries(sourcekitd-test PRIVATE
   SourceKitSupport
+  swiftBasic
   clangRewrite
   clangLex
   clangBasic)

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -2082,7 +2082,8 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
                                       return ResponseSymbolInfo::read(Entry);
                                     });
 
-  std::string Filename = swift::resolveSymbolicLinks(FilenameIn.str()).str().str();
+  std::string Filename = swift::resolveSymbolicLinks(FilenameIn.str(),
+      llvm::vfs::getRealFileSystem().get());
 
   SymbolInfo.print(OS, Filename, VFSFiles);
   OS << "ACTIONS BEGIN\n";

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -14,6 +14,7 @@
 
 #include "SourceKit/Support/Concurrency.h"
 #include "TestOptions.h"
+#include "swift/Basic/SymbolicLinks.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -2081,10 +2082,7 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
                                       return ResponseSymbolInfo::read(Entry);
                                     });
 
-  std::string Filename = FilenameIn.str();
-  llvm::SmallString<256> output;
-  if (!llvm::sys::fs::real_path(Filename, output))
-    Filename = std::string(output.str());
+  std::string Filename = swift::resolveSymbolicLinks(FilenameIn.str()).str().str();
 
   SymbolInfo.print(OS, Filename, VFSFiles);
   OS << "ACTIONS BEGIN\n";

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -2083,7 +2083,7 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
                                     });
 
   std::string Filename = swift::resolveSymbolicLinks(FilenameIn.str(),
-      llvm::vfs::getRealFileSystem().get());
+      *llvm::vfs::getRealFileSystem());
 
   SymbolInfo.print(OS, Filename, VFSFiles);
   OS << "ACTIONS BEGIN\n";


### PR DESCRIPTION
Fixes the `SourceKit/Indexing/indexstore_multifile.swift` test and several others (mostly in sourcekit) which would perform `realpath` path substitution and expand substitute paths on Windows, resulting in failing string comparisons. This is the swift repo counterpart of https://reviews.llvm.org/D154130 , where we eliminated the use of realpath resolution in `lit.py` since this prevented us from using substitute drives on Windows to avoid running into `MAX_PATH` issues. The new symbolic link resolution logic attempts to use `real_path` on Windows, but will fall back to `make_absolute` if that would change the drive on which the path is based. Some symbolic link tests must thus be skipped because we will not honor the symlink resolution if the source tree is on a substitute drive.