### PR TITLE
SwiftCompilerSources: force the `-static` flag

### DIFF
--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -29,6 +29,7 @@ private extension Target {
         swiftSettings: [
           .interoperabilityMode(.Cxx),
           .unsafeFlags([
+            "-static",
             "-Xcc", "-I../include",
             "-Xcc", "-I../../llvm-project/llvm/include",
             "-Xcc", "-I../../llvm-project/clang/include",


### PR DESCRIPTION
These libraries are built statically for static linking.  SPM currently does not support libraries, and this will ensure that we properly build the library target for consumption into the compiler.