### PR TITLE
Create CaseConvertible

### DIFF
--- a/stdlib/public/core/CaseConvertible.swift
+++ b/stdlib/public/core/CaseConvertible.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public protocol CaseConvertible {
+    
+    associatedtype RawValue
+    
+    var rawValue: RawValue { get }
+
+}
+
+extension CaseConvertible where RawValue: BinaryInteger {
+    
+    public func asFloat() -> Float { Float(rawValue) }
+    public func asDouble() -> Double { Double(rawValue) }
+    public func asInt() -> Float { Int(rawValue) }
+    
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

I often find the need to quickly convert from an enum case whose RawValue is an Int or String to a series of different Numeric types. This protocol is directly intended to do that auto-magically for any enumeration whose base RawValue is either a StringLiteral or Numeric.

Example of such a case
```swift
enum Example: Int {
  case one = 1
  case two = 2
  case three = 3
}

let myFloat = Float(Example.three.rawValue)
let myFloat = Example.three.asFloat()

func doSomething(example: Example) {
  let float = example.asFloat()
  // additional code here
}
```

Extensions to this protocol could be made in CoreGraphics allowing consumers to quickly access constant values where needed in any CG Numeric or any numeric value converted to that unique type.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
