### PR TITLE
[Test] Require asserts for some experimental-feature tests.

### DIFF
--- a/test/IRGen/tuple_conformances.swift
+++ b/test/IRGen/tuple_conformances.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend -emit-ir -parse-stdlib -primary-file %s -enable-experimental-feature TupleConformances -parse-as-library | %FileCheck %s
 
+// -enable-experimental-feature requires an asserts build
+// REQUIRES: asserts
+
 import Swift
 
 protocol P {

--- a/test/Interpreter/lazy/deferred_syntax_errors.swift
+++ b/test/Interpreter/lazy/deferred_syntax_errors.swift
@@ -1,6 +1,9 @@
 // REQUIRES: OS=macosx
 // RUN: %target-jit-run %s -enable-experimental-feature LazyImmediate | %FileCheck %s
 
+// -enable-experimental-feature requires an asserts build
+// REQUIRES: asserts
+
 // Tests that parsing of function bodies is deferred
 // to runtime when the interpreter is invoked using
 // experimental lazy compilation. Syntax errors in

--- a/test/Interpreter/lazy/deferred_type_errors.swift
+++ b/test/Interpreter/lazy/deferred_type_errors.swift
@@ -1,6 +1,9 @@
 // REQUIRES: OS=macosx
 // RUN: %target-jit-run %s -enable-experimental-feature LazyImmediate | %FileCheck %s
 
+// -enable-experimental-feature requires an asserts build
+// REQUIRES: asserts
+
 // Tests that type checking of function bodies is
 // deferred to runtime when the interpreter is invoked
 // using experimental lazy compilation. Type errors in

--- a/test/Interpreter/lazy/globals.swift
+++ b/test/Interpreter/lazy/globals.swift
@@ -1,6 +1,9 @@
 // REQUIRES: OS=macosx
 // RUN: %target-jit-run %s -enable-experimental-feature LazyImmediate | %FileCheck %s
 
+// -enable-experimental-feature requires an asserts build
+// REQUIRES: asserts
+
 // Tests that piecewise compilation works with global variables
 
 let x = 1

--- a/test/Interpreter/lazy/linkage_promotion.swift
+++ b/test/Interpreter/lazy/linkage_promotion.swift
@@ -2,6 +2,9 @@
 // REQUIRES: swift_interpreter
 // RUN: %target-jit-run %s -enable-experimental-feature LazyImmediate | %FileCheck %s
 
+// -enable-experimental-feature requires an asserts build
+// REQUIRES: asserts
+
 // Tests that the linkage of private symbols is
 // promoted to hidden external, allowing
 // single-function compilation of non-public symbols.


### PR DESCRIPTION
For LazyImmediate and TupleConformances.
