### PR TITLE
[Build] Support building Compatibility libraries from a separate repository.

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -711,6 +711,8 @@ def create_argument_parser():
            help='run sourcekit-lsp tests under all sanitizers')
     option('--install-swiftsyntax', toggle_true('install_swiftsyntax'),
            help='install SwiftSyntax')
+    option('--install-swift-compatibility-libs', toggle_true('install_swift_compatibility_libs'),
+           help='install swift-compatibility-libs')
     option('--swiftsyntax-verify-generated-files',
            toggle_true('swiftsyntax_verify_generated_files'),
            help='set to verify that the generated files in the source tree ' +
@@ -747,6 +749,9 @@ def create_argument_parser():
            toggle_true('build_swift_inspect'),
            help='build SwiftInspect using swiftpm against the just built '
                 'toolchain')
+    option(['--swift-compatibility-libs'],
+           toggle_true('build_swift_compatibility_libraries'),
+           help='build swift-compatibility-libs')
     option(['--build-minimal-stdlib'], toggle_true('build_minimalstdlib'),
            help='build the \'minimal\' freestanding stdlib variant into a '
                 'separate build directory ')

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -648,6 +648,8 @@ class BuildScriptInvocation(object):
                             is_enabled=self.args.build_sourcekitlsp)
         builder.add_product(products.Benchmarks,
                             is_enabled=self.args.build_toolchainbenchmarks)
+        builder.add_product(products.SwiftCompatibilityLibs,
+                            is_enabled=self.args.build_swift_compatibility_libraries)
         builder.add_product(products.SwiftInspect,
                             is_enabled=self.args.build_swift_inspect)
         builder.add_product(products.TSanLibDispatch,

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -30,6 +30,7 @@ from .playgroundsupport import PlaygroundSupport
 from .skstresstester import SKStressTester
 from .sourcekitlsp import SourceKitLSP
 from .swift import Swift
+from .swiftcompatibilitylibs import SwiftCompatibilityLibs
 from .swiftdocc import SwiftDocC
 from .swiftdoccrender import SwiftDocCRender
 from .swiftdriver import SwiftDriver
@@ -58,6 +59,7 @@ __all__ = [
     'Ninja',
     'PlaygroundSupport',
     'Swift',
+    'SwiftCompatibilityLibs',
     'SwiftFormat',
     'SwiftInspect',
     'SwiftPM',

--- a/utils/swift_build_support/swift_build_support/products/swiftcompatibilitylibs.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftcompatibilitylibs.py
@@ -1,0 +1,55 @@
+# swift_build_support/products/swiftcompatibilitylibs.py --------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from . import cmake_product
+
+
+# Build against the current installed toolchain.
+class SwiftCompatibilityLibs(cmake_product.CMakeProduct):
+    @classmethod
+    def product_source_name(cls):
+        return "swift-compatibility-libs"
+
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    @classmethod
+    def is_before_build_script_impl_product(cls):
+        return False
+
+    def should_build(self, host_target):
+        return True
+
+    def build(self, host_target):
+        build_variant = 'RelWithDebInfo'
+        self.build_with_cmake(["all"], build_variant, [], prefer_just_built_toolchain=True)
+
+    def should_test(self, host_target):
+        return False
+
+    def test(self, host_target):
+        """Just run a single instance of the command for both .debug and
+           .release.
+        """
+        pass
+
+    def should_install(self, host_target):
+        return self.args.install_swift_compatibility_libs
+
+    def install(self, host_target):
+        install_destdir = self.host_install_destdir(host_target)
+        self.install_with_cmake(["install"], install_destdir + self.args.install_prefix)
+
+    @classmethod
+    def get_dependencies(cls):
+        return []


### PR DESCRIPTION
`--swift-compatibility-libs` will build from an adjacent swift-compatibility-libs repository.