### PR TITLE
Don't inline non-ossa function into an ossa function in mandatory inlining

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -123,10 +123,17 @@ private func shouldInline(apply: FullApplySite, callee: Function, alreadyInlined
   if callee.isTransparent {
     return true
   }
+
+  if apply.parentFunction.hasOwnership && !callee.hasOwnership {
+    // Cannot inline a non-ossa function into an ossa function
+    return false
+  }
+
   if apply is BeginApplyInst {
     // Avoid co-routines because they might allocate (their context).
     return true
   }
+
   if apply.parentFunction.isGlobalInitOnceFunction && callee.inlineStrategy == .always {
     // Some arithmetic operations, like integer conversions, are not transparent but `inline(__always)`.
     // Force inlining them in global initializers so that it's possible to statically initialize the global.


### PR DESCRIPTION
Update the inliner with this check.
Inlining non-ossa into ossa can causes unexpected consequences.

Fixes rdar://114466605

