### PR TITLE
[Macros] Add a frontend flag `-Rmacro-loading` to remark on macro resolution

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1120,6 +1120,12 @@ REMARK(module_loaded,none,
        "; source: '%2', loaded: '%3'",
        (Identifier, unsigned, StringRef, StringRef))
 
+REMARK(macro_loaded,none,
+       "loaded macro implementation module %0 from "
+       "%select{shared library '%2'|executable '%2'|"
+       "compiler plugin server '%2' with shared library '%3'}1",
+       (Identifier, unsigned, StringRef, StringRef))
+
 REMARK(transitive_dependency_behavior,none,
        "%1 has %select{a required|an optional|an ignored}2 "
        "transitive dependency on '%0'",

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -246,6 +246,9 @@ namespace swift {
     /// Emit remarks about contextual inconsistencies in loaded modules.
     bool EnableModuleRecoveryRemarks = false;
 
+     /// Emit a remark after loading a macro implementation.
+    bool EnableMacroLoadingRemarks = false;
+
     /// Emit a remark when indexing a system module.
     bool EnableIndexingSystemModuleRemarks = false;
     

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -389,6 +389,10 @@ def remark_module_recovery : Flag<["-"], "Rmodule-recovery">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit remarks about contextual inconsistencies in loaded modules">;
 
+def remark_macro_loading : Flag<["-"], "Rmacro-loading">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit remarks about loaded macro implementations">;
+
 def remark_indexing_system_module : Flag<["-"], "Rindexing-system-module">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit a remark when indexing a system module">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1016,7 +1016,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
   Opts.EnableModuleRecoveryRemarks = Args.hasArg(OPT_remark_module_recovery);
-
+  Opts.EnableMacroLoadingRemarks = Args.hasArg(OPT_remark_macro_loading);
   Opts.EnableIndexingSystemModuleRemarks = Args.hasArg(OPT_remark_indexing_system_module);
 
   Opts.EnableSkipExplicitInterfaceModuleBuildRemarks = Args.hasArg(OPT_remark_skip_explicit_interface_build);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -359,12 +359,23 @@ CompilerPluginLoadRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
   if (!entry.executablePath.empty()) {
     if (LoadedExecutablePlugin *executablePlugin =
             loader.loadExecutablePlugin(entry.executablePath)) {
+      if (ctx->LangOpts.EnableMacroLoadingRemarks) {
+        unsigned tag = entry.libraryPath.empty() ? 1 : 2;
+        ctx->Diags.diagnose(SourceLoc(), diag::macro_loaded, moduleName, tag,
+                            entry.executablePath, entry.libraryPath);
+      }
+
       return initializeExecutablePlugin(*ctx, executablePlugin,
                                         entry.libraryPath, moduleName);
     }
   } else if (!entry.libraryPath.empty()) {
     if (LoadedLibraryPlugin *libraryPlugin =
             loader.loadLibraryPlugin(entry.libraryPath)) {
+      if (ctx->LangOpts.EnableMacroLoadingRemarks) {
+        ctx->Diags.diagnose(SourceLoc(), diag::macro_loaded, moduleName, 0,
+                            entry.libraryPath, StringRef());
+      }
+
       return libraryPlugin;
     }
   }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -12,7 +12,7 @@
 
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -I %t -DIMPORT_MACRO_LIBRARY
 
-// RUN: not %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics > %t/macro-printing.txt
+// RUN: not %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics -Rmacro-loading > %t/macro-printing.txt
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK-DIAGS %s
 
 // RUN: %FileCheck %s  --check-prefix CHECK-MACRO-PRINTED < %t/macro-printing.txt
@@ -33,6 +33,8 @@
 // RUN: %FileCheck -check-prefix=CHECK-MODULE-TRACE %s < %t/loaded_module_trace.trace.json
 
 // CHECK-MODULE-TRACE: {{libMacroDefinition.dylib|libMacroDefinition.so|MacroDefinition.dll}}
+
+// CHECK-DIAGS: loaded macro implementation module 'MacroDefinition' from shared library
 
 #if IMPORT_MACRO_LIBRARY
 import freestanding_macro_library

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -21,6 +21,19 @@
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
 
+// RUN: not %swift-target-frontend \
+// RUN:   -typecheck \
+// RUN:   -swift-version 5 \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -Rmacro-loading \
+// RUN:   -module-name MyApp \
+// RUN:   %t/test.swift \
+// RUN:   2>&1 | tee %t/macro-loading.txt
+
+// RUN: %FileCheck -check-prefix=DIAGS %s < %t/macro-loading.txt
+
+// DIAGS: loaded macro implementation module 'TestPlugin' from executable
+
 // CHECK: ->(plugin:[[#PID:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION:]]}}}
 // CHECK: <-(plugin:[[#PID]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
 // CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"testString","typeName":"TestStringMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":5,"offset":301},"source":"#testString(123)"}}}

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -25,11 +25,25 @@
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 -enable-experimental-feature Macros \
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
+// RUN:   -Rmacro-loading -verify-ignore-unknown \
 // RUN:   -module-name MyApp \
 // RUN:   %s \
 // RUN:   2>&1 | tee %t/macro-expansions.txt
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
+
+// RUN: not %swift-target-frontend \
+// RUN:   -typecheck \
+// RUN:   -swift-version 5 \
+// RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
+// RUN:   -Rmacro-loading \
+// RUN:   -module-name MyApp \
+// RUN:   %s \
+// RUN:   2>&1 | tee %t/macro-loading.txt
+
+// RUN: %FileCheck -check-prefix=CHECK-DIAGS %s < %t/macro-loading.txt
+
+// CHECK-DIAGS: loaded macro implementation module 'MacroDefinition' from compiler plugin server
 
 // CHECK: ->(plugin:[[#PID1:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION:]]}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"getCapabilityResult":{"capability":{"features":["load-plugin-library"],"protocolVersion":[[#PROTOCOL_VERSION]]}}}


### PR DESCRIPTION
Macro implementations can come from various locations associated with different search paths. Add a frontend flag `-Rmacro-loading` to emit a remark when each macro implementation module is resolved, providing the kind of macro (shared library, executable, shared library loaded via the plugin server) and appropriate paths. This allows one to tell from the build load which macros are used.

Addresses rdar://110780311.
