### PR TITLE
[SILGen] InitAccessors: Make sure that `assign_or_init` always directly references self

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1852,7 +1852,20 @@ void SILGenFunction::emitAssignOrInit(SILLocation loc, ManagedValue selfValue,
     setterFRef = SILUndef::get(initFRef->getType(), F);
   }
 
-  B.createAssignOrInit(loc, field, selfValue.getValue(),
+  auto isValueSelf = !selfValue.getType().getASTType()->mayHaveSuperclass();
+  // If we are emitting `assign_or_init` instruction for a value
+  // type, we need to make sure that "self" is always a l-value
+  // reference to "rootself" because `nonmutating set` loads "self"
+  // and referencing `selfValue` in such case is incorrect because
+  // it's a copy which is going to be skipped by DI.
+  auto selfRef = selfValue;
+  if (isValueSelf && !selfRef.isLValue()) {
+    auto *ctor = cast<ConstructorDecl>(FunctionDC->getAsDecl());
+    selfRef = maybeEmitValueOfLocalVarDecl(ctor->getImplicitSelfDecl(),
+                                           AccessKind::ReadWrite);
+  }
+
+  B.createAssignOrInit(loc, field, selfRef.getValue(),
                        newValue.forward(*this), initFRef, setterFRef,
                        AssignOrInitInst::Unknown);
 }

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -658,16 +658,16 @@ bool LifetimeChecker::shouldEmitError(const SILInstruction *Inst) {
       }))
     return false;
 
-  // Ignore loads used only by an assign_by_wrapper setter. This
-  // is safe to ignore because assign_by_wrapper will only be
-  // re-written to use the setter if the value is fully initialized.
+  // Ignore loads used only by an assign_by_wrapper or assign_or_init setter.
+  // This is safe to ignore because assign_by_wrapper/assign_or_init will
+  // only be re-written to use the setter if the value is fully initialized.
   if (auto *load = dyn_cast<SingleValueInstruction>(Inst)) {
     if (auto Op = load->getSingleUse()) {
       if (auto PAI = dyn_cast<PartialApplyInst>(Op->getUser())) {
-        if (std::find_if(PAI->use_begin(), PAI->use_end(),
-                         [](auto PAIUse) {
-                           return isa<AssignByWrapperInst>(PAIUse->getUser());
-                         }) != PAI->use_end()) {
+        if (std::find_if(PAI->use_begin(), PAI->use_end(), [](auto PAIUse) {
+              return isa<AssignByWrapperInst>(PAIUse->getUser()) ||
+                     isa<AssignOrInitInst>(PAIUse->getUser());
+            }) != PAI->use_end()) {
           return false;
         }
       }

--- a/test/Interpreter/init_accessors.swift
+++ b/test/Interpreter/init_accessors.swift
@@ -847,3 +847,77 @@ do {
 // CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional(""))
 // CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional("Hello"))
 // CHECK-NEXT: TestMixedDefaultInitalizable(a: nil, b: Optional(""))
+
+do {
+  struct TestNonMutatingSetDefault {
+    var _count: Int
+
+    var count: Int = 42 {
+      @storageRestrictions(initializes: _count)
+      init {
+        _count = newValue
+      }
+
+      get { _count }
+      nonmutating set {}
+    }
+  }
+
+  struct TestNonMutatingSetNoDefault {
+    var _count: Int
+
+    var count: Int {
+      @storageRestrictions(initializes: _count)
+      init {
+        print("init accessor is called: \(newValue)")
+        _count = newValue
+      }
+
+      get { _count }
+
+      nonmutating set {
+        print("nonmutating set called: \(newValue)")
+      }
+    }
+
+    init(value: Int) {
+      self.count = value
+      self.count = value + 1
+    }
+  }
+
+  struct TestNonMutatingSetCustom {
+    var _count: Int
+
+    var count: Int = 42 {
+      @storageRestrictions(initializes: _count)
+      init {
+        print("init accessor is called: \(newValue)")
+        _count = newValue
+      }
+
+      get { _count }
+
+      nonmutating set {
+        print("nonmutating set called: \(newValue)")
+      }
+    }
+
+    init(custom: Int) {
+      count = custom
+    }
+  }
+
+  print("test-nonmutating-set-1: \(TestNonMutatingSetDefault())")
+  print("test-nonmutating-set-2: \(TestNonMutatingSetDefault(count: 0))")
+  print("test-nonmutating-set-3: \(TestNonMutatingSetNoDefault(value: -1))")
+  print("test-nonmutating-set-4: \(TestNonMutatingSetCustom(custom: 0))")
+}
+// CHECK: test-nonmutating-set-1: TestNonMutatingSetDefault(_count: 42)
+// CHECK-NEXT: test-nonmutating-set-2: TestNonMutatingSetDefault(_count: 0)
+// CHECK-NEXT: init accessor is called: -1
+// CHECK-NEXT: nonmutating set called: 0
+// CHECK-NEXT: test-nonmutating-set-3: TestNonMutatingSetNoDefault(_count: -1)
+// CHECK-NEXT: init accessor is called: 42
+// CHECK-NEXT: nonmutating set called: 0
+// CHECK-NEXT: test-nonmutating-set-4: TestNonMutatingSetCustom(_count: 42)


### PR DESCRIPTION
`nonmutating set` gets a copy of "self" in `GetterSetterComponent`
which is expected for partial application of the setter but doesn't
work for "self" reference that `assign_or_init` instruction needs
to emit references to stored properties during lowering. We need to
make sure that "self" is always a reference to rootself of the
constructor before passing it to `assign_or_init`.

Resolves: https://github.com/apple/swift/issues/67827
Resolves: rdar://114433261

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
