### PR TITLE
Update SILOptimizer/character_literals.swift for arm64

### DIFF
--- a/test/SILOptimizer/character_literals.swift
+++ b/test/SILOptimizer/character_literals.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -parse-as-library -O -target-cpu core2 -emit-ir  %s | %FileCheck %s
-// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib,CPU=x86_64
+// RUN: %target-swift-frontend -parse-as-library -O -emit-ir  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib,CPU=arm64
 // REQUIRES: swift_in_compiler
 
 // This is an end-to-end test to ensure that the optimizer generates


### PR DESCRIPTION
This very old test used out-dated target flags as a temporary workaround. The test only needs to pass on the most widespread target as a sanity check.