### PR TITLE
Cxx: build Cxx module statically on all platforms

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -488,8 +488,15 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
       this->addLinkLibrary(LinkLibrary("stdc++", LibraryKind::Library));
 
     // Do not try to link Cxx with itself.
-    if (!getSwiftModule()->getName().is("Cxx"))
-      this->addLinkLibrary(LinkLibrary("swiftCxx", LibraryKind::Library));
+    if (!getSwiftModule()->getName().is("Cxx")) {
+      bool isStatic = false;
+      if (const auto *M = Context.getModuleByName("Cxx"))
+        isStatic = M->isStaticLibrary();
+      this->addLinkLibrary(LinkLibrary(target.isOSWindows() && isStatic
+                                          ? "libswiftCxx"
+                                          : "swiftCxx",
+                                       LibraryKind::Library));
+    }
 
     // Do not try to link CxxStdlib with the C++ standard library, Cxx or
     // itself.

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -1,17 +1,12 @@
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake/modules)
 include(StdlibOptions)
 
-set(SWIFT_CXX_LIBRARY_KIND STATIC)
-if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
-  set(SWIFT_CXX_LIBRARY_KIND SHARED)
-endif()
-
 set(SWIFT_CXX_DEPS symlink_clang_headers)
 if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   list(APPEND SWIFT_CXX_DEPS copy-legacy-layouts)
 endif()
 
-add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY IS_FRAGILE
+add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY IS_FRAGILE
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
     CxxPair.swift


### PR DESCRIPTION
This adjusts Cxx to be built statically on all platforms including Windows.  The static library support is sufficient to support this module linking statically on Windows.