### PR TITLE
Concurrency: avoid elaborated types (NFC)

### DIFF
--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -108,12 +108,12 @@
 
 OVERRIDE_ACTOR(task_enqueue, void,
                SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-               swift::, (class Job *job, ExecutorRef executor),
+               swift::, (Job *job, ExecutorRef executor),
                (job, executor))
 
 OVERRIDE_ACTOR(job_run, void,
                SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-               swift::, (class Job *job, ExecutorRef executor),
+               swift::, (Job *job, ExecutorRef executor),
                (job, executor))
 
 OVERRIDE_ACTOR(task_getCurrentExecutor, ExecutorRef,


### PR DESCRIPTION
The current type elaboration does not match the elaborated type as defined.  This causes a warning.  Prefer to use the unelaborated type to avoid having to synchronise the declaration and definition.