### PR TITLE
Frontend: Introduce `-experimental-serialize-external-decls-only` option

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -802,6 +802,10 @@ namespace swift {
 
     /// Defer typechecking of declarations to their use at runtime
     bool DeferToRuntime = false;
+
+    /// Allow request evalutation to perform type checking lazily, instead of
+    /// eagerly typechecking source files after parsing.
+    bool EnableLazyTypecheck = false;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -155,7 +155,6 @@ public:
     NoneAction,        ///< No specific action
     Parse,             ///< Parse only
     ResolveImports,    ///< Parse and resolve imports only
-    LazyTypecheck,     ///< Parse and then do minimal type-checking for outputs
     Typecheck,         ///< Parse and type-check only
     DumpParse,         ///< Parse only and dump AST
     DumpInterfaceHash, ///< Parse and dump the interface token hash.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -267,7 +267,6 @@ public:
   /// \see ModuleDecl::arePrivateImportsEnabled
   bool EnablePrivateImports = false;
 
-
   /// Indicates whether we add implicit dynamic.
   ///
   /// \see ModuleDecl::isImplicitDynamicEnabled
@@ -321,6 +320,10 @@ public:
   /// Should we serialize the hashes of dependencies (vs. the modification
   /// times) when compiling a module interface?
   bool SerializeModuleInterfaceDependencyHashes = false;
+
+  /// Should we only serialize decls that may be referenced externally in the
+  /// binary module?
+  bool SerializeExternalDeclsOnly = false;
 
   /// Should we warn if an imported module needed to be rebuilt from a
   /// module interface file?

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -406,6 +406,9 @@ def debug_forbid_typecheck_prefix : Separate<["-"], "debug-forbid-typecheck-pref
   HelpText<"Triggers llvm fatal_error if typechecker tries to typecheck a decl "
            "with the provided prefix name">;
 
+def experimental_lazy_typecheck : Flag<["-"], "experimental-lazy-typecheck">,
+  HelpText<"Type-check lazily as needed to produce requested outputs">;
+
 def debug_emit_invalid_swiftinterface_syntax : Flag<["-"], "debug-emit-invalid-swiftinterface-syntax">,
   HelpText<"Write an invalid declaration into swiftinterface files">;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -166,6 +166,10 @@ def serialize_debugging_options : Flag<["-"], "serialize-debugging-options">,
 def serialized_path_obfuscate : Separate<["-"], "serialized-path-obfuscate">,
     HelpText<"Remap source paths in debug info">, MetaVarName<"<prefix=replacement>">;
 
+def experimental_serialize_external_decls_only
+  : Flag<["-"], "experimental-serialize-external-decls-only">,
+  HelpText<"Only serialize decls that should be exposed to clients">;
+
 def empty_abi_descriptor : Flag<["-"], "empty-abi-descriptor">,
   HelpText<"Avoid printing actual module content into ABI descriptor file">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1164,9 +1164,6 @@ def resolve_imports : Flag<["-"], "resolve-imports">,
 def typecheck : Flag<["-"], "typecheck">,
   HelpText<"Parse and type-check input file(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
-def experimental_lazy_typecheck : Flag<["-"], "experimental-lazy-typecheck">,
-  HelpText<"Parse input file(s), then type-check lazily as needed to produce requested outputs">, ModeOpt,
-  Flags<[FrontendOption, NoInteractiveOption, HelpHidden, DoesNotAffectIncrementalBuild]>;
 def dump_parse : Flag<["-"], "dump-parse">,
   HelpText<"Parse input file(s) and dump AST(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -156,6 +156,7 @@ namespace swift {
     bool StaticLibrary = false;
     bool HermeticSealAtLink = false;
     bool IsOSSA = false;
+    bool SerializeExternalDeclsOnly = false;
   };
 
 } // end namespace swift

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -552,8 +552,6 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::Parse;
   if (Opt.matches(OPT_resolve_imports))
     return FrontendOptions::ActionType::ResolveImports;
-  if (Opt.matches(OPT_experimental_lazy_typecheck))
-    return FrontendOptions::ActionType::LazyTypecheck;
   if (Opt.matches(OPT_typecheck))
     return FrontendOptions::ActionType::Typecheck;
   if (Opt.matches(OPT_dump_parse))

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -318,6 +318,8 @@ bool ArgsToFrontendOptionsConverter::convert(
         A->getOption().matches(OPT_serialize_debugging_options);
   }
 
+  Opts.SerializeExternalDeclsOnly |=
+      Args.hasArg(OPT_experimental_serialize_external_decls_only);
   Opts.DebugPrefixSerializedDebuggingOptions |=
       Args.hasArg(OPT_prefix_serialized_debugging_options);
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1423,6 +1423,8 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
 
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);
 
+  Opts.EnableLazyTypecheck |= Args.hasArg(OPT_experimental_lazy_typecheck);
+
   return HadError;
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1395,6 +1395,11 @@ bool CompilerInstance::performParseAndResolveImportsOnly() {
 void CompilerInstance::performSema() {
   performParseAndResolveImportsOnly();
 
+  // Skip eager type checking. Instead, let later stages of compilation drive
+  // type checking as needed through request evaluation.
+  if (getASTContext().TypeCheckerOpts.EnableLazyTypecheck)
+    return;
+
   FrontendStatsTracer tracer(getStatsReporter(), "perform-sema");
 
   forEachFileToTypeCheck([&](SourceFile &SF) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -225,6 +225,9 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
 
   serializationOpts.IsOSSA = getSILOptions().EnableOSSAModules;
 
+  serializationOpts.SerializeExternalDeclsOnly =
+      opts.SerializeExternalDeclsOnly;
+
   return serializationOpts;
 }
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -33,7 +33,6 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -105,7 +104,6 @@ bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
   case ActionType::PrintFeature:
     return false;
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
@@ -151,7 +149,6 @@ bool FrontendOptions::doesActionRequireInputs(ActionType action) {
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
@@ -194,7 +191,6 @@ bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
@@ -234,7 +230,6 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::ScanDependencies:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
@@ -295,7 +290,6 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
 
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::TypecheckModuleFromInterface:
   case ActionType::DumpParse:
@@ -383,7 +377,6 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::PrintFeature:
     return false;
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -410,7 +403,6 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -453,7 +445,6 @@ bool FrontendOptions::canActionEmitModuleSummary(ActionType action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -515,7 +506,6 @@ bool FrontendOptions::canActionEmitClangHeader(ActionType action) {
   case ActionType::PrintVersion:
   case ActionType::PrintFeature:
     return false;
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -557,7 +547,6 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::PrintFeature:
     return false;
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -587,7 +576,6 @@ bool FrontendOptions::canActionEmitModuleSemanticInfo(ActionType action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -631,7 +619,6 @@ bool FrontendOptions::canActionEmitConstValues(ActionType action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -673,7 +660,6 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -741,7 +727,6 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::PrintFeature:
     return false;
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -762,7 +747,6 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   switch (action) {
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -821,7 +805,6 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
 
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -851,7 +834,6 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
   case ActionType::ResolveImports:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -903,7 +885,6 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::DumpTypeInfo:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
-  case ActionType::LazyTypecheck:
   case ActionType::Typecheck:
   case ActionType::ResolveImports:
   case ActionType::MergeModules:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1359,9 +1359,6 @@ static bool performAction(CompilerInstance &Instance,
     return performParseOnly(*Instance.getMainModule());
   case FrontendOptions::ActionType::ResolveImports:
     return Instance.performParseAndResolveImportsOnly();
-  case FrontendOptions::ActionType::LazyTypecheck:
-    // For now, this action is just an alias of ResolveImports.
-    return Instance.performParseAndResolveImportsOnly();
   case FrontendOptions::ActionType::Typecheck:
     return withSemanticAnalysis(Instance, observer,
                                 [](CompilerInstance &Instance) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3258,6 +3258,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     }
   }
 
+public:
   /// Determine if \p decl is safe to deserialize when it's public
   /// or otherwise needed by the client in normal builds, this should usually
   /// correspond to logic in type-checking ensuring these safe decls don't
@@ -3336,6 +3337,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     return false;
   }
 
+private:
   /// Write a \c DeserializationSafetyLayout record only when \p decl is unsafe
   /// to deserialize.
   ///
@@ -3505,6 +3507,9 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
     SmallVector<DeclID, 16> memberIDs;
     for (auto member : members) {
+      if (S.shouldSkipDecl(member))
+        continue;
+
       if (!shouldSerializeMember(member))
         continue;
 
@@ -4885,6 +4890,14 @@ static bool canSkipWhenInvalid(const Decl *D) {
     if (!isa<ClassDecl>(D->getDeclContext()))
       return true;
   }
+  return false;
+}
+
+bool Serializer::shouldSkipDecl(const Decl *D) const {
+  if (Options.SerializeExternalDeclsOnly &&
+      !DeclSerializer::isDeserializationSafe(D))
+    return true;
+
   return false;
 }
 
@@ -6358,6 +6371,9 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
         continue;
       }
 
+      if (shouldSkipDecl(D))
+        continue;
+
       if (auto VD = dyn_cast<ValueDecl>(D)) {
         if (!VD->hasName())
           continue;
@@ -6406,6 +6422,8 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
     nextFile->getOpaqueReturnTypeDecls(opaqueReturnTypeDecls);
 
     for (auto TD : localTypeDecls) {
+      if (shouldSkipDecl(TD))
+        continue;
 
       // FIXME: We should delay parsing function bodies so these type decls
       //        don't even get added to the file.
@@ -6436,6 +6454,9 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
     }
 
     for (auto OTD : opaqueReturnTypeDecls) {
+      if (shouldSkipDecl(OTD))
+        continue;
+
       // FIXME: We should delay parsing function bodies so these type decls
       //        don't even get added to the file.
       if (OTD->getDeclContext()->getInnermostSkippedFunctionContext())

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -332,6 +332,9 @@ private:
   /// Check if a decl is cross-referenced.
   bool isDeclXRef(const Decl *D) const;
 
+  /// Check if a decl should be skipped during serialization.
+  bool shouldSkipDecl(const Decl *D) const;
+
   /// Writes a reference to a decl in another module.
   void writeCrossReference(const DeclContext *DC, uint32_t pathLen = 1);
 

--- a/test/Driver/emit-interface.swift
+++ b/test/Driver/emit-interface.swift
@@ -26,9 +26,3 @@
 // CHECK-FILELIST: swift{{(-frontend|c)?(\.exe)?"?}} -frontend
 // CHECK-FILELIST-SAME: -supplementary-output-file-map
 // CHECK-FILELIST-NOT: emit-interface.swift{{ }}
-
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -experimental-lazy-typecheck %s -emit-module-interface -o %t/foo 2>&1 | %FileCheck -check-prefix=CHECK-LAZY-TYPECHECK %s
-
-// CHECK-LAZY-TYPECHECK: swift{{(-frontend|c)?(\.exe)?"?}} -frontend
-// CHECK-LAZY-TYPECHECK-SAME: -experimental-lazy-typecheck
-// CHECK-LAZY-TYPECHECK-SAME: emit-interface.swift

--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -71,7 +71,8 @@ public struct PublicStruct {
 }
 
 struct InternalStruct: DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
-  var x: DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  // FIXME: TBD emission causes this property to be typechecked
+//  var x: DoesNotExist
 
   func f(_ x: DoesNotExist) {} // expected-error {{cannot find type 'DoesNotExist' in scope}}
 }

--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -1,0 +1,81 @@
+// This source file contains intentional type checking errors that should be
+// avoided when compiling with -experimental-lazy-typecheck and emitting module
+// outputs since all the errors occur in regions of the AST that do not
+// need to be type checked in order to emit a module or module interface.
+
+// MARK: - Global functions
+
+public func publicFunc() -> Int {
+  return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+}
+
+public func publicFuncWithDefaultArg(_ x: Int = 1) -> Int {
+  return doesNotExist() // expected-error {{cannot find 'doesNotExist' in scope}}
+}
+
+package func packageFunc() -> Int {
+  return false // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+}
+
+func internalFunc() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  return 1
+}
+
+@inlinable func inlinableFunc() -> Int {
+  return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+}
+
+private func privateFunc() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  return 1
+}
+
+public func constrainedGenericPublicFunction<T>(_ t: T) where T: PublicProto {
+  doesNotExist() // expected-error {{cannot find 'doesNotExist' in scope}}
+}
+
+@available(SwiftStdlib 5.1, *)
+public func publicFuncWithOpaqueReturnType() -> some PublicProto { // expected-note {{opaque return type declared here}}
+  return 1 // expected-error {{return type of global function 'publicFuncWithOpaqueReturnType()' requires that 'Int' conform to 'PublicProto'}}
+}
+
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient public func publicAEICFuncWithOpaqueReturnType() -> some Any {
+  if #available(macOS 20, *) {
+    return 3
+  } else {
+    return "hi"
+  }
+}
+
+// MARK: - Nominal types
+
+public protocol PublicProto {
+  func req() -> Int
+}
+
+protocol InternalProto {
+  // FIXME: Serialization causes typechecking of protocols regardless of access level
+//  func req() -> DoesNotExist
+}
+
+public struct PublicStruct {
+  // FIXME: Test properties
+
+  public func publicMethod() -> Int {
+    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+  }
+
+  func internalMethod() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+    return 1
+  }
+}
+
+struct InternalStruct: DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  var x: DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
+
+  func f(_ x: DoesNotExist) {} // expected-error {{cannot find type 'DoesNotExist' in scope}}
+}
+
+// FIXME: Test enums
+// FIXME: Test conformances
+// FIXME: Test global vars

--- a/test/ModuleInterface/lazy-typecheck.swift
+++ b/test/ModuleInterface/lazy-typecheck.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-module-interface-path %t/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
+// RUN: %FileCheck %s < %t/lazy_typecheck.swiftinterface
+
+// CHECK: import Swift
+
+// CHECK:       public func publicFunc() -> Swift.Int
+// CHECK:       publicFuncWithDefaultArg(_ x: Swift.Int = 1) -> Swift.Int
+// CHECK:       @inlinable internal func inlinableFunc() -> Swift.Int {
+// CHECK-NEXT:    return true // expected-error {{[{][{]}}cannot convert return expression of type 'Bool' to return type 'Int'{{[}][}]}}
+// CHECK-NEXT:  }
+// CHECK:       public func constrainedGenericPublicFunction<T>(_ t: T) where T : lazy_typecheck.PublicProto
+// CHECK:       @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+// CHECK-NEXT:  public func publicFuncWithOpaqueReturnType() -> some lazy_typecheck.PublicProto
+
+// CHECK:       @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+// CHECK-NEXT:  @_alwaysEmitIntoClient public func publicAEICFuncWithOpaqueReturnType() -> some Any {
+// CHECK-NEXT:    if #available(macOS 20, *) {
+// CHECK-NEXT:      return 3
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      return "hi"
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// CHECK:       public protocol PublicProto {
+// CHECK:         func req() -> Swift.Int
+// CHECK:       }
+
+// CHECK:       public struct PublicStruct {
+// CHECK:         public func publicMethod() -> Swift.Int
+// CHECK:       }

--- a/test/ModuleInterface/resolve-imports.swift
+++ b/test/ModuleInterface/resolve-imports.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -resolve-imports %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
-// RUN: %target-swift-frontend -experimental-lazy-typecheck %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
-// RUN: %FileCheck %s < %t/main.swiftinterface
+// RUN: %target-swift-frontend -swift-version 5 -parse-as-library -enable-library-evolution -module-name resolve_imports -resolve-imports %s -emit-module-interface-path %t/resolve_imports.swiftinterface
+// RUN: %FileCheck %s < %t/resolve_imports.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/resolve_imports.swiftinterface)
 
 // CHECK: import Swift
 
@@ -21,6 +21,3 @@ public class C {}
 // CHECK: public class C {
 // CHECK: deinit
 // CHECK: }
-
-// Globals
-public var year = 2023

--- a/test/Sema/lazy-typecheck.swift
+++ b/test/Sema/lazy-typecheck.swift
@@ -1,0 +1,7 @@
+// RUN: not %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -experimental-lazy-typecheck
+
+// With lazy typechecking enabled and no compiler outputs specified, no errors
+// should be emitted for this semantically invalid code.
+
+var x: DoesNotExist

--- a/test/Serialization/serialize-external-decls-only-lazy-typecheck.swift
+++ b/test/Serialization/serialize-external-decls-only-lazy-typecheck.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -enable-library-evolution -parse-as-library -package-name Package -typecheck -verify
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path %t/lazy_typecheck.swiftmodule -enable-library-evolution -parse-as-library -package-name Package -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
+// RUN: %target-swift-frontend -package-name Package -typecheck %s -I %t
+
+import lazy_typecheck
+
+struct ConformsToPublicProto: PublicProto {
+  func req() -> Int { return 1 }
+}
+
+func testGlobalFunctions() {
+  _ = publicFunc()
+  _ = publicFuncWithDefaultArg()
+  _ = packageFunc()
+  constrainedGenericPublicFunction(ConformsToPublicProto())
+  if #available(SwiftStdlib 5.1, *) {
+    _ = publicFuncWithOpaqueReturnType()
+    _ = publicAEICFuncWithOpaqueReturnType()
+  }
+}
+
+func testPublicStruct(_ s: PublicStruct) {
+  _ = s.publicMethod()
+}

--- a/test/TBD/lazy-typecheck.swift
+++ b/test/TBD/lazy-typecheck.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -target arm64-apple-macosx10.13 -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
+// RUN: %llvm-readtapi %t/lazy_typecheck.tbd %t/expected.tbd
+
+// REQUIRES: OS=macosx
+
+//--- expected.tbd
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ arm64-macos ]
+flags:           [ not_app_extension_safe ]
+install-name:    ''
+current-version: 0
+compatibility-version: 0
+swift-abi-version: 7
+exports:
+  - targets:         [ arm64-macos ]
+    symbols:         [ '_$s14lazy_typecheck10publicFuncSiyF', '_$s14lazy_typecheck11PublicProtoMp',
+                        '_$s14lazy_typecheck11PublicProtoP3reqSiyFTj', '_$s14lazy_typecheck11PublicProtoP3reqSiyFTq',
+                        '_$s14lazy_typecheck11PublicProtoTL', '_$s14lazy_typecheck11packageFuncSiyF',
+                        '_$s14lazy_typecheck12PublicStructV12publicMethodSiyF', '_$s14lazy_typecheck12PublicStructVMa',
+                        '_$s14lazy_typecheck12PublicStructVMn', '_$s14lazy_typecheck12PublicStructVN',
+                        '_$s14lazy_typecheck13inlinableFuncSiyF', '_$s14lazy_typecheck24publicFuncWithDefaultArgyS2iF',
+                        '_$s14lazy_typecheck30publicFuncWithOpaqueReturnTypeQryF',
+                        '_$s14lazy_typecheck30publicFuncWithOpaqueReturnTypeQryFQOMQ',
+                        '_$s14lazy_typecheck32constrainedGenericPublicFunctionyyxAA0E5ProtoRzlF' ]
+...

--- a/test/TBD/resolve_imports.swift
+++ b/test/TBD/resolve_imports.swift
@@ -1,8 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -resolve-imports -emit-tbd -emit-tbd-path %t/resolve_imports.tbd %s -disable-availability-checking
-// RUN: %target-swift-frontend -experimental-lazy-typecheck -emit-tbd -emit-tbd-path %t/lazy_typecheck.tbd %s -disable-availability-checking
 // RUN: %FileCheck %s < %t/resolve_imports.tbd
-// RUN: %FileCheck %s < %t/lazy_typecheck.tbd
 
 // REQUIRES: OS=macosx 
 
@@ -30,16 +28,16 @@ extension PrivateProto {
 public struct S: PrivateProto {}
 
 // CHECK: symbols: [
-// CHECK: '_$s14lazy_typecheck1CCMa',
-// CHECK: '_$s14lazy_typecheck1CCMm',
-// CHECK: '_$s14lazy_typecheck1CCMn',
-// CHECK: '_$s14lazy_typecheck1CCN',
-// CHECK: '_$s14lazy_typecheck1CCfD',
-// CHECK: '_$s14lazy_typecheck1CCfd',
-// CHECK: '_$s14lazy_typecheck1SVMa',
-// CHECK: '_$s14lazy_typecheck1SVMn',
-// CHECK: '_$s14lazy_typecheck1SVN',
-// CHECK: '_$s14lazy_typecheck1SVSQAAMc',
-// CHECK: '_$s14lazy_typecheck1SVSQAASQ2eeoiySbx_xtFZTW',
+// CHECK: '_$s15resolve_imports1CCMa',
+// CHECK: '_$s15resolve_imports1CCMm',
+// CHECK: '_$s15resolve_imports1CCMn',
+// CHECK: '_$s15resolve_imports1CCN',
+// CHECK: '_$s15resolve_imports1CCfD',
+// CHECK: '_$s15resolve_imports1CCfd',
+// CHECK: '_$s15resolve_imports1SVMa',
+// CHECK: '_$s15resolve_imports1SVMn',
+// CHECK: '_$s15resolve_imports1SVN',
+// CHECK: '_$s15resolve_imports1SVSQAAMc',
+// CHECK: '_$s15resolve_imports1SVSQAASQ2eeoiySbx_xtFZTW',
 // CHECK: _main
 // CHECK: ]


### PR DESCRIPTION
This option is designed to be used in conjunction with `-experimental-lazy-typecheck` and `-experimental-skip-all-function-bodies` when emitting a resilient module. The emitted binary module should contain only the decls needed by clients and should contain roughly the same contents as it would if the corresponding swiftinterface were emitted instead and then built.
    
This functionality is a work in progress. Some parts of the AST may still get typechecked unnecessarily. Additionally, serialization does not trigger the appropriate typechecking requests for some ASTs and then fails due to missing types.

Resolves rdar://114230586