### PR TITLE
Disable stdlib/Duration.swift tests on old OSes.

### DIFF
--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -5,6 +5,11 @@
 // provided by the 32-bit LLVM. See `dividingFullWidth` in IntegerTypes.swift.gyb
 // UNSUPPORTED: PTRSIZE=32
 
+// These test a codepath that was fixed in the Swift 5.9 stdlib, so it will
+// fail if run against earlier standard library versions.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import StdlibUnittest
 
 var suite = TestSuite("StringIndexTests")


### PR DESCRIPTION
These tests exercise a code path that has a known bug on older OS versions (fixed with Swift 5.9), so disable it for testing in those environments.

Fixes rdar://114571157
