### PR TITLE
[ConstraintSystem] Look through specialization while simplifying cons…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5724,6 +5724,13 @@ void constraints::simplifyLocator(ASTNode &anchor,
     }
 
     case ConstraintLocator::ConstructorMember:
+      // Look through specialization first, because it doesn't play a
+      // functional role here.
+      if (auto *USE = getAsExpr<UnresolvedSpecializeExpr>(anchor)) {
+        anchor = USE->getSubExpr();
+        range = anchor.getSourceRange();
+      }
+
       // - This is really an implicit 'init' MemberRef, so point at the base,
       //   i.e. the TypeExpr.
       // - For re-declarations we'd get an overloaded reference

--- a/test/Constraints/ambiguous_specialized_name_diagnostics.swift
+++ b/test/Constraints/ambiguous_specialized_name_diagnostics.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend -emit-module %t/src/A.swift \
+// RUN:   -module-name A -swift-version 5 -enable-library-evolution \
+// RUN:   -emit-module-path %t/A.swiftmodule
+
+// RUN: %target-swift-frontend -emit-module %t/src/B.swift \
+// RUN:   -I %t -module-name B -swift-version 5 -enable-library-evolution \
+// RUN:   -emit-module-path %t/B.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck %t/src/main.swift \
+// RUN:   -module-name main -I %t -verify
+
+// https://github.com/apple/swift/issues/67799
+
+//--- A.swift
+public final class S<T> {
+  public init(t: T) {
+  }
+
+  public func test() {}
+  public static func staticFn() {}
+}
+
+//--- B.swift
+public final class S<T> {
+  public init(t: T) {
+  }
+
+  public func test() {}
+  public static func staticFn() {}
+}
+
+//--- main.swift
+import A
+import B
+
+func test() {
+  _ = S<Int>(t: 42) // expected-error {{ambiguous use of 'init(t:)'}}
+
+  S<Int>(t: 42).test() // expected-error {{ambiguous use of 'init(t:)'}}
+
+  // FIXME(diagnostics): This should produce ambiguity diagnostic too
+  S<Int>.staticFn()
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+}


### PR DESCRIPTION
…tructor locator

If type is explicitly specialized i.e. `A<Int>` in certain cases its `TypeExpr` 
or `OverloadedDeclRefExpr` (if type name is ambiguous) would be wrapped 
in `UnresolvedSpecializeExpr` which has to be looked through when simplifying
`constructor member` so the anchor could point to the underlying type reference.

Resolves: https://github.com/apple/swift/issues/67799
Resolves: rdar://113577294

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
