### PR TITLE
[Test] Require swift_interpreter in a couple tests.

### DIFF
--- a/test/Interpreter/lazy/deferred_syntax_errors.swift
+++ b/test/Interpreter/lazy/deferred_syntax_errors.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// REQUIRES: swift_interpreter
 // RUN: %target-jit-run %s -enable-experimental-feature LazyImmediate | %FileCheck %s
 
 // -enable-experimental-feature requires an asserts build

--- a/test/Interpreter/lazy/deferred_type_errors.swift
+++ b/test/Interpreter/lazy/deferred_type_errors.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// REQUIRES: swift_interpreter
 // RUN: %target-jit-run %s -enable-experimental-feature LazyImmediate | %FileCheck %s
 
 // -enable-experimental-feature requires an asserts build

--- a/test/Interpreter/lazy/globals.swift
+++ b/test/Interpreter/lazy/globals.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// REQUIRES: swift_interpreter
 // RUN: %target-jit-run %s -enable-experimental-feature LazyImmediate | %FileCheck %s
 
 // -enable-experimental-feature requires an asserts build


### PR DESCRIPTION
Tests that use %target-jit-run require swift_interpreter.
