### PR TITLE
Disable StringAPI test on OS stdlib

### DIFF
--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -2,6 +2,11 @@
 // REQUIRES: executable_test
 // REQUIRES: reflection
 
+// These tests verify fixes in >5.9 Swift, and will
+// fail if run against earlier standard library versions.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 //
 // Tests for the non-Foundation API of String
 //


### PR DESCRIPTION
These tests verify fixes in the stdlib post-5.9, which means that they fail when tested on older versions of the stdlib.

Fixes rdar://114581543