### PR TITLE
Split a test for windows aarch64 and have it pass

### DIFF
--- a/test/ClangImporter/availability_returns_twice-msvc-aarch64.swift
+++ b/test/ClangImporter/availability_returns_twice-msvc-aarch64.swift
@@ -1,0 +1,17 @@
+// RUN: not %target-swift-frontend -typecheck -verify %s 2>&1 | %FileCheck %s
+// REQUIRES: OS=windows-msvc && CPU=aarch64
+
+import vcruntime
+typealias JumpBuffer = _JBTYPE
+
+func test_unavailable_returns_twice_function() {
+  var x: JumpBuffer
+  _ = _setjmp(&x)
+}
+
+// CHECK: availability_returns_twice-msvc-aarch64.swift:{{[0-9]+}}:{{[0-9]+}}: error: unexpected error produced: cannot find type '_JBTYPE' in scope
+// CHECK-NEXT: typealias JumpBuffer = _JBTYPE
+// CHECK-NEXT:  ^
+// CHECK-NEXT: setjmp.h:{{[0-9]+}}:{{[0-9]+}}: note: diagnostic produced elsewhere: macro '_JBTYPE' unavailable: structure not supported
+// CHECK-NEXT:   #define _JBTYPE unsigned __int64
+

--- a/test/ClangImporter/availability_returns_twice-msvc-x86_64.swift
+++ b/test/ClangImporter/availability_returns_twice-msvc-x86_64.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// REQUIRES: OS=windows-msvc
+// REQUIRES: OS=windows-msvc && CPU=x86_64
 
 import vcruntime
 typealias JumpBuffer = _JBTYPE


### PR DESCRIPTION
The test availability_returns_twice-msvc.swift leads to a different compile error for windows aarch64 because _JBTYPE is a macro as opposed to a typedef and the swift compiler doesn't parse the macro. Split the test and handle the results respectively.
