### PR TITLE
[Test] Reenabled xfail'd test.

### DIFF
--- a/test/attr/attr_originally_definedin_backward_compatibility.swift
+++ b/test/attr/attr_originally_definedin_backward_compatibility.swift
@@ -1,8 +1,6 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=ios
 // UNSUPPORTED: DARWIN_SIMULATOR=ios
-// rdar://problem/64298096
-// XFAIL: OS=ios && CPU=arm64
 // rdar://problem/65399527
 // XFAIL: OS=ios && CPU=armv7s
 //


### PR DESCRIPTION
The test `test/attr/attr_originally_definedin_backward_compatibility.swift` is passing now on the XFAIL'd configuration.
