### PR TITLE
Add time-tests to lit-args for toolchain bot preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1396,6 +1396,8 @@ stress-test
 
 lldb-test-swift-only
 
+lit-args=-v --time-tests
+
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s
 


### PR DESCRIPTION
The test times have increased significantly (~2hrs) from Swift 5.8, adding `--time-test` to understand which test are impacted. 

main -> [Total Duration: 28911.67 seconds (8h 1m 51s)](https://ci.swift.org/job/oss-swift-package-macos/2158/)

- `49.2%             	 14213.16              	 macosx-x86_64-swift-test`
- check-swift-all-macosx-x86_64 - Testing Time: 3686.73s
- check-swift-all-iphonesimulator-x86_64 - Testing Time: 3469.71s
- check-swift-all-appletvsimulator-x86_64 - Testing Time: 3440.48s
- check-swift-all-watchsimulator-x86_64 - Testing Time: 3454.80s

swift 5.9 -> [Total Duration: 29337.78 seconds (8h 8m 57s)](https://ci.swift.org/view/Swift%205.9/job/oss-swift-5.9-package-macos/365/console)

- `48.0%             	 14088.03              	 macosx-x86_64-swift-test`
- check-swift-all-macosx-x86_64 - Testing Time: 3763.61s
- check-swift-all-iphonesimulator-x86_64 - Testing Time: 3352.74s
- check-swift-all-appletvsimulator-x86_64 - Testing Time: 3410.95s
- check-swift-all-watchsimulator-x86_64 - Testing Time: 3416.26s

swift 5.8 -> [Total Duration: 19097.89 seconds (5h 18m 17s)](https://ci.swift.org/view/Swift%205.8/job/oss-swift-5.8-package-macos/124/console)

- `34.1%             	 6518.98               	 macosx-x86_64-swift-test`
- check-swift-all-macosx-x86_64 - Testing Time: 1617.60s
- check-swift-all-iphonesimulator-x86_64 - Testing Time: 1518.86s
- check-swift-all-appletvsimulator-x86_64 - Testing Time: 1520.41s
- check-swift-all-watchsimulator-x86_6 - Testing Time: 1512.11s