### PR TITLE
[Test] Have rdar81421394.swift import Foundation.

### DIFF
--- a/validation-test/SILGen/rdar81421394.swift
+++ b/validation-test/SILGen/rdar81421394.swift
@@ -10,6 +10,8 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+import Foundation
+
 protocol RangeFinder {
     var range: NSRange { get set }
 }


### PR DESCRIPTION
This test occasionally fails due apparently not loading libswiftFoundation. The test relies on a bridging header to import the Foundation module, which seems iffy. Explicitly import Foundation instead.

rdar://114590327