### PR TITLE
Build the fragile swiftCxx statically on all platforms

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -487,8 +487,15 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
       this->addLinkLibrary(LinkLibrary("stdc++", LibraryKind::Library));
 
     // Do not try to link Cxx with itself.
-    if (!getSwiftModule()->getName().is("Cxx"))
-      this->addLinkLibrary(LinkLibrary("swiftCxx", LibraryKind::Library));
+    if (!getSwiftModule()->getName().is("Cxx")) {
+      bool isStatic = false;
+      if (const auto *M = Context.getModuleByName("Cxx"))
+        isStatic = M->isStaticLibrary();
+      this->addLinkLibrary(LinkLibrary(target.isOSWindows() && isStatic
+                                          ? "libswiftCxx"
+                                          : "swiftCxx",
+                                       LibraryKind::Library));
+    }
 
     // Do not try to link CxxStdlib with the C++ standard library, Cxx or
     // itself.

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -1,17 +1,12 @@
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../cmake/modules)
 include(StdlibOptions)
 
-set(SWIFT_CXX_LIBRARY_KIND STATIC)
-if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
-  set(SWIFT_CXX_LIBRARY_KIND SHARED)
-endif()
-
 set(SWIFT_CXX_DEPS symlink_clang_headers)
 if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   list(APPEND SWIFT_CXX_DEPS copy-legacy-layouts)
 endif()
 
-add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY IS_FRAGILE
+add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY IS_FRAGILE
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
     CxxPair.swift

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -6,7 +6,7 @@ if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   list(APPEND SWIFT_CXX_DEPS copy-legacy-layouts)
 endif()
 
-add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY IS_FRAGILE
+add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
     CxxPair.swift

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -11,7 +11,7 @@ if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   list(APPEND SWIFT_CXX_DEPS copy-legacy-layouts)
 endif()
 
-add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
+add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY IS_FRAGILE
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
     CxxPair.swift

--- a/test/Interop/Cxx/class/constructors-copy-irgen-macosx.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-macosx.swift
@@ -1,6 +1,6 @@
 // Target-specific tests for C++ copy constructor code generation.
 
-// RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info -Xcc -fignore-exceptions | %FileCheck %s -check-prefix=ITANIUM_X64
+// RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.13 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info -Xcc -fignore-exceptions | %FileCheck %s -check-prefix=ITANIUM_X64
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64

--- a/test/Interop/Cxx/class/constructors-irgen-macosx.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-macosx.swift
@@ -1,6 +1,6 @@
 // Target-specific tests for C++ constructor call code generation.
 
-// RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info -Xcc -fignore-exceptions | %FileCheck %s -check-prefix=ITANIUM_X64
+// RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.13 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info -Xcc -fignore-exceptions | %FileCheck %s -check-prefix=ITANIUM_X64
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64

--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -28,7 +28,7 @@ for module_file in os.listdir(sdk_overlay_dir):
         continue
     # Skip the C++ standard library overlay because it's not yet shipped
     # in any released SDK.
-    if module_name == "CxxStdlib":
+    if module_name in ("Cxx", "CxxStdlib"):
         continue
     # TODO(TF-1229): Fix the "_Differentiation" module.
     if module_name == "_Differentiation":


### PR DESCRIPTION
Mark the Cxx module as fragile and build it statically on all platforms.  C++ Interop is an upcoming feature and has not yet declared ABI stability and so is always meant to be statically linked.