### PR TITLE
[Demangling] Avoid UB call to memcpy().

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -206,7 +206,8 @@ public:
     if (Growth < Capacity * 2)
       Growth = Capacity * 2;
     T *NewObjects = Allocate<T>(Capacity + Growth);
-    memcpy(NewObjects, Objects, OldAllocSize);
+    if (OldAllocSize)
+      memcpy(NewObjects, Objects, OldAllocSize);
     Objects = NewObjects;
     Capacity += Growth;
   }


### PR DESCRIPTION
When appending to an empty `CharVector`, we were inadvertently relying on `memcpy(NewObjects, NULL, 0)` being a no-op, whereas in practice the C standard says it's UB because of the `NULL` pointer.

Fix by only calling `memcpy()` if we actually have bytes to copy.

rdar://114447171
