### PR TITLE
[5.9][SILGen] InitAccessors: Materialize default argument if it's required by init/setter

### DIFF
--- a/test/SILOptimizer/init_accessors_with_indirect_newValue.swift
+++ b/test/SILOptimizer/init_accessors_with_indirect_newValue.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend -primary-file %s -Onone -emit-sil \
+// RUN:   -enable-library-evolution \
+// RUN:   -Xllvm -sil-print-after=definite-init \
+// RUN:   -o /dev/null -module-name init_accessors 2>&1 | %FileCheck %s
+
+public class Test {
+  public enum State: Equatable {
+  case start
+  case failed(any Swift.Error)
+  case completed
+
+    public static func == (lhs: Self, rhs: Self) -> Bool { false }
+  }
+
+  private var _state: State = .start {
+    didSet { }
+  }
+
+  public private(set) var state: State = .start {
+    @storageRestrictions(initializes: _state)
+    init {
+      _state = newValue
+    }
+
+    get { _state }
+    set { _state = newValue }
+  }
+
+  // CHECK-LABEL: sil [ossa] @$s14init_accessors4TestCACycfc : $@convention(method) (@owned Test) -> @owned Test
+  //
+  // CHECK: [[DEFAULT_VALUE_INIT:%.*]] = function_ref @$s14init_accessors4TestC5stateAC5StateOvpfi : $@convention(thin) () -> @out Test.State
+  // CHECK-NEXT: [[DEFAULT_VALUE_SLOT:%.*]] = alloc_stack $Test.State
+  // CHECK-NEXT: {{.*}} = apply [[DEFAULT_VALUE_INIT]]([[DEFAULT_VALUE_SLOT]]) : $@convention(thin) () -> @out Test.State
+  // CHECK-NEXT: [[DEFAULT_VALUE:%.*]] = load [take] [[DEFAULT_VALUE_SLOT]] : $*Test.State
+  // CHECK: [[NEW_VALUE:%.*]] = alloc_stack $Test.State
+  // CHECK-NEXT: store [[DEFAULT_VALUE]] to [init] [[NEW_VALUE]] : $*Test.State
+  // CHECK: assign_or_init [init] self %0 : $Test, value [[NEW_VALUE]] : $*Test.State, init {{.*}} : $@convention(thin) (@in Test.State) -> @out Test.State, set {{.*}} : $@callee_guaranteed (@in Test.State) -> ()
+  //
+  // CHECK: [[START_STATE:%.*]] = enum $Test.State, #Test.State.start!enumelt
+  // CHECK-NEXT: [[NEW_VALUE:%.*]] = alloc_stack $Test.State
+  // CHECK-NEXT: store [[START_STATE]] to [trivial] [[NEW_VALUE]] : $*Test.State
+  // CHECK: assign_or_init [set] self %0 : $Test, value [[NEW_VALUE]] : $*Test.State, init {{.*}} : $@convention(thin) (@in Test.State) -> @out Test.State, set {{.*}} : $@callee_guaranteed (@in Test.State) -> ()
+  public init() {
+    state = .start
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68178

---

- Explanation:

  We do this in `GetterSetterComponent` but overlooked it for default initialization expressions. 
  If init/setter require `newValue` to be passed indirectly we have to make sure to materialize it 
  before handing to `assign_or_init` instruction.

- Scope: init accessor properties with default values that are required to be passed indirectly.

- Main Branch PR: https://github.com/apple/swift/pull/68178

- Resolves: rdar://114350227

- Risk: Low

- Reviewed By: @jckarter 

- Testing: Added test-cases to the suite.

Resolves: rdar://114350227
(cherry picked from commit e96f9e5b33a60949bdd68df65144513f1946ce92)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
