### PR TITLE
More progress towards variadic-tuple argument reabstraction

### DIFF
--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -90,6 +90,7 @@ class ManagedValue {
   }
 
 public:
+  /// Constructs an invalid ManagedValue.
   ManagedValue() = default;
 
   /// Sometimes SILGen wants to represent an owned value or owned address
@@ -249,6 +250,10 @@ public:
   /// being represented by this ManagedValue.
   static ManagedValue forInContext() {
     return ManagedValue(SILValue(), true, CleanupHandle::invalid());
+  }
+
+  bool isValid() const {
+    return valueAndFlag.getInt() || valueAndFlag.getPointer();
   }
 
   bool isLValue() const {

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -486,6 +486,20 @@ ManagedValue SILGenBuilder::createLoadTake(SILLocation loc, ManagedValue v,
   return SGF.emitManagedRValueWithCleanup(result, lowering);
 }
 
+ManagedValue SILGenBuilder::createLoadTrivial(SILLocation loc,
+                                              ManagedValue addr) {
+#ifndef NDEBUG
+  auto &lowering = SGF.getTypeLowering(addr.getType());
+  assert(lowering.isTrivial());
+  assert((!lowering.isAddressOnly() || !SGF.silConv.useLoweredAddresses()) &&
+         "cannot load an unloadable type");
+  assert(!addr.hasCleanup());
+#endif
+  auto value = createLoad(loc, addr.getValue(),
+                          LoadOwnershipQualifier::Trivial);
+  return ManagedValue::forObjectRValueWithoutOwnership(value);
+}
+
 ManagedValue SILGenBuilder::createLoadCopy(SILLocation loc, ManagedValue v) {
   auto &lowering = SGF.getTypeLowering(v.getType());
   return createLoadCopy(loc, v, lowering);

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -267,6 +267,8 @@ public:
   ManagedValue createLoadCopy(SILLocation loc, ManagedValue addr,
                               const TypeLowering &lowering);
 
+  ManagedValue createLoadTrivial(SILLocation loc, ManagedValue addr);
+
   /// Create a SILArgument for an input parameter. Asserts if used to create a
   /// function argument for an out parameter.
   ManagedValue createInputFunctionArgument(

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2515,6 +2515,13 @@ public:
                                              CanPackType formalPackType,
                                              unsigned componentIndex);
 
+  /// Enter a cleanup to destroy the preceding components of a pack,
+  /// leading up to (but not including) a particular component index.
+  CleanupHandle
+  enterDestroyPrecedingPackComponentsCleanup(SILValue addr,
+                                             CanPackType formalPackType,
+                                             unsigned componentIndex);
+
   /// Enter a cleanup to destroy the preceding values in a pack-expansion
   /// component of a tuple.
   ///
@@ -2766,7 +2773,8 @@ public:
   void emitDestroyPack(SILLocation loc,
                        SILValue packAddr,
                        CanPackType formalPackType,
-                       unsigned firstComponentIndex = 0);
+                       unsigned beginIndex,
+                       unsigned endIndex);
 
   /// Emit instructions to destroy a suffix of a tuple value.
   ///

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -1826,12 +1826,12 @@ private:
                              AbstractionPattern outerOrigType,
                              CanType outerSubstType,
                              ManagedValue outer,
-                             SILParameterInfo result) {
-    auto resultTy = SGF.getSILType(result, InnerTypesFuncTy);
+                             SILParameterInfo innerParam) {
+    auto innerTy = SGF.getSILType(innerParam, InnerTypesFuncTy);
 
     return processSingle(innerOrigType, innerSubstType,
                          outerOrigType, outerSubstType,
-                         outer, resultTy, result.getConvention());
+                         outer, innerTy, innerParam.getConvention());
   }
 
   ManagedValue processSingle(AbstractionPattern innerOrigType,
@@ -1839,47 +1839,47 @@ private:
                              AbstractionPattern outerOrigType,
                              CanType outerSubstType,
                              ManagedValue outer,
-                             SILType resultTy,
-                             ParameterConvention resultConvention) {
+                             SILType innerTy,
+                             ParameterConvention innerConvention) {
     // Easy case: we want to pass exactly this value.
-    if (outer.getType() == resultTy) {
-      if (isConsumedParameter(resultConvention) && !outer.isPlusOne(SGF)) {
+    if (outer.getType() == innerTy) {
+      if (isConsumedParameter(innerConvention) && !outer.isPlusOne(SGF)) {
         outer = outer.copyUnmanaged(SGF, Loc);
       }
 
       return outer;
     }
 
-    switch (resultConvention) {
+    switch (innerConvention) {
     // Direct translation is relatively easy.
     case ParameterConvention::Direct_Owned:
     case ParameterConvention::Direct_Unowned:
       return processIntoOwned(innerOrigType, innerSubstType,
                               outerOrigType, outerSubstType,
-                              outer, resultTy);
+                              outer, innerTy);
     case ParameterConvention::Direct_Guaranteed:
       return processIntoGuaranteed(innerOrigType, innerSubstType,
                                    outerOrigType, outerSubstType,
-                                   outer, resultTy);
+                                   outer, innerTy);
     case ParameterConvention::Indirect_In: {
       if (SGF.silConv.useLoweredAddresses()) {
         return processIndirect(innerOrigType, innerSubstType,
                                outerOrigType, outerSubstType,
-                               outer, resultTy);
+                               outer, innerTy);
       }
       return processIntoOwned(innerOrigType, innerSubstType,
                               outerOrigType, outerSubstType,
-                              outer, resultTy);
+                              outer, innerTy);
     }
     case ParameterConvention::Indirect_In_Guaranteed: {
       if (SGF.silConv.useLoweredAddresses()) {
         return processIndirect(innerOrigType, innerSubstType,
                                outerOrigType, outerSubstType,
-                               outer, resultTy);
+                               outer, innerTy);
       }
       return processIntoGuaranteed(innerOrigType, innerSubstType,
                                    outerOrigType, outerSubstType,
-                                   outer, resultTy);
+                                   outer, innerTy);
     }
     case ParameterConvention::Pack_Guaranteed:
     case ParameterConvention::Pack_Owned:

--- a/lib/SILGen/TupleGenerators.h
+++ b/lib/SILGen/TupleGenerators.h
@@ -225,6 +225,11 @@ public:
     return formalPackType;
   }
 
+  SILType getPackComponentType() const {
+    assert(isOrigPackExpansion());
+    return packValue.getType().getPackElementType(getPackComponentIndex());
+  }
+
   /// Given that we just processed an input, advance to the next,
   /// if there is on.
   ///
@@ -261,6 +266,17 @@ public:
   /// be used for *inner* types.  If the pack is an input you've
   /// received, you should call projectPackComponent.
   ManagedValue createPackComponentTemporary(SILGenFunction &SGF, SILLocation loc);
+
+  /// Set the current pack component.  Do not call this multiple times
+  /// for the same component.
+  ///
+  /// You should only call this when the pack not yet initialized,
+  /// which generally means when it corresponds to an output you're
+  /// generating.  In the reabstraction code, this means it should only
+  /// be used for *inner* types.  If the pack is an input you've
+  /// received, you should call projectPackComponent.
+  void setPackComponent(SILGenFunction &SGF, SILLocation loc,
+                        ManagedValue elt);
 };
 
 /// A generator for visiting the addresses of the elements of

--- a/test/SILGen/variadic-generic-reabstract-tuple-result.swift
+++ b/test/SILGen/variadic-generic-reabstract-tuple-result.swift
@@ -140,10 +140,10 @@ func test8() {
 // CHECK-LABEL: sil shared {{.*}} @$sSS_Sit_QSiIegk_SSSiIegod_TR :
 // CHECK:         [[PACK:%.*]] = alloc_pack $Pack{(String, Int)}
 // CHECK-NEXT:    [[TUPLE_TEMP:%.*]] = alloc_stack $(String, Int)
-// CHECK-NEXT:    [[TUPLE_INDEX:%.*]] = scalar_pack_index 0 of $Pack{(String, Int)}
-// CHECK-NEXT:    pack_element_set [[TUPLE_TEMP]] : $*(String, Int) into [[TUPLE_INDEX]] of [[PACK]] : $*Pack{(String, Int)}
 // CHECK-NEXT:    [[STRING_ADDR:%.*]] = tuple_element_addr [[TUPLE_TEMP]] : $*(String, Int), 0
 // CHECK-NEXT:    [[INT_ADDR:%.*]] = tuple_element_addr [[TUPLE_TEMP]] : $*(String, Int), 1
+// CHECK-NEXT:    [[TUPLE_INDEX:%.*]] = scalar_pack_index 0 of $Pack{(String, Int)}
+// CHECK-NEXT:    pack_element_set [[TUPLE_TEMP]] : $*(String, Int) into [[TUPLE_INDEX]] of [[PACK]] : $*Pack{(String, Int)}
 // CHECK-NEXT:    apply %0([[PACK]])
 // CHECK-NEXT:    [[STRING:%.*]] = load [take] [[STRING_ADDR]] : $*String
 // CHECK-NEXT:    [[INT:%.*]] = load [trivial] [[INT_ADDR]] : $*Int
@@ -206,17 +206,18 @@ func test10<each T>() -> Use<repeat each T> {
 // CHECK-LABEL: sil {{.*}} @$s4main6test10AA3UseVyxxQp_QPGyRvzlF :
 // CHECK:         function_ref @$sSS_xxQpSit_QSiIegk_SSxxQp_QSiSiIegokd_RvzlTR : $@convention(thin) <each τ_0_0> (@guaranteed @callee_guaranteed () -> @pack_out Pack{(String, repeat each τ_0_0, Int)}) -> (@owned String, @pack_out Pack{repeat each τ_0_0}, Int)
 // CHECK-LABEL: sil shared {{.*}} @$sSS_xxQpSit_QSiIegk_SSxxQp_QSiSiIegokd_RvzlTR :
-//   Set up the inner pack argument with a tuple temporary.
+//   Create a tuple temporary.
 // CHECK:         [[PACK:%.*]] = alloc_pack $Pack{(String, repeat each T, Int)}
 // CHECK-NEXT:    [[TUPLE_TEMP:%.*]] = alloc_stack $(String, repeat each T, Int)
-// CHECK-NEXT:    [[TUPLE_INDEX:%.*]] = scalar_pack_index 0 of $Pack{(String, repeat each T, Int)}
-// CHECK-NEXT:    pack_element_set [[TUPLE_TEMP]] : $*(String, repeat each T, Int) into [[TUPLE_INDEX]] of [[PACK]] : $*Pack{(String, repeat each T, Int)}
 //   Project out the tuple elements for the non-expansion elements;
 //   we'll use these after the call.
 // CHECK-NEXT:    [[STRING_INDEX:%.*]] = scalar_pack_index 0 of $Pack{String, repeat each T, Int}
 // CHECK-NEXT:    [[STRING_ADDR:%.*]] = tuple_pack_element_addr [[STRING_INDEX]] of [[TUPLE_TEMP]] : $*(String, repeat each T, Int) as $*String
 // CHECK-NEXT:    [[INT_INDEX:%.*]] = scalar_pack_index 2 of $Pack{String, repeat each T, Int}
 // CHECK-NEXT:    [[INT_ADDR:%.*]] = tuple_pack_element_addr [[INT_INDEX]] of [[TUPLE_TEMP]] : $*(String, repeat each T, Int) as $*Int
+//   Write the tuple temporary's address into the inner argument pack.
+// CHECK-NEXT:    [[TUPLE_INDEX:%.*]] = scalar_pack_index 0 of $Pack{(String, repeat each T, Int)}
+// CHECK-NEXT:    pack_element_set [[TUPLE_TEMP]] : $*(String, repeat each T, Int) into [[TUPLE_INDEX]] of [[PACK]] : $*Pack{(String, repeat each T, Int)}
 //   Call the reabstracted function.
 // CHECK-NEXT:    apply %1([[PACK]])
 //   Load the first component of the tuple (the string).


### PR DESCRIPTION
Still trying to build common code paths between the result and argument translators.  Most of the new work here involves allowing for inner emission to generate values that have meaningful cleanups that need to be tracked, which isn't a problem for result translation because result translation is mostly the pre-call pass, which simply forwards indirect slots.