### PR TITLE
Replace generic `basic_string` overloads of `StableHasher::combine` with concrete ones.

### DIFF
--- a/include/swift/Basic/StableHasher.h
+++ b/include/swift/Basic/StableHasher.h
@@ -173,7 +173,11 @@ public:
     return combine_many(arg.first, arg.second);
   }
 
-  template <typename T> void combine(const std::basic_string<T> &arg) {
+  void combine(const std::basic_string<char> &arg) {
+    return combine_range(arg.begin(), arg.end());
+  }
+
+  void combine(const std::basic_string<wchar_t> &arg) {
     return combine_range(arg.begin(), arg.end());
   }
 


### PR DESCRIPTION
The generic `char_traits` implementation was deprecated and has since been removed from libc++ (https://reviews.llvm.org/D157058). When building with a libc++ that has it removed, the generic `basic_string<T>` overloads cause errors during template substitution.
