### PR TITLE
Disable stdlib tests under the OS stdlib

### DIFF
--- a/test/stdlib/ForEachField.swift
+++ b/test/stdlib/ForEachField.swift
@@ -15,6 +15,10 @@
 // REQUIRES: executable_test
 // REQUIRES: reflection
 
+// Only run these tests with a just-built stdlib.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 @_spi(Reflection) import Swift
 import StdlibUnittest
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -8,6 +8,10 @@
 // XFAIL: interpret
 // UNSUPPORTED: freestanding
 
+// Only run these tests with a just-built stdlib.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 // With a non-optimized stdlib the test takes very long.
 // REQUIRES: optimized_stdlib
 


### PR DESCRIPTION
These two tests verify recent fixes, so they fail when run against older versions of the stdlib.

Fixes rdar://114565585.