### PR TITLE
[Test] Mark three tests unsupported on use_os_stdlib.

### DIFF
--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -10,6 +10,8 @@
 
 // REQUIRES: executable_test
 
+// Requires runtime functions added in Swift 5.9.
+// UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
 import Swift

--- a/test/Interpreter/layout_string_witnesses_objc.swift
+++ b/test/Interpreter/layout_string_witnesses_objc.swift
@@ -11,6 +11,9 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// Requires runtime functions added in Swift 5.9.
+// UNSUPPORTED: use_os_stdlib
+
 import Swift
 import layout_string_witnesses_types
 import ObjCClasses

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -12,6 +12,8 @@
 
 // REQUIRES: executable_test
 
+// Requires runtime functions added in Swift 5.9.
+// UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
 import Swift


### PR DESCRIPTION
These tests require an OS with Swift 5.9, and that can't be expressed as a REQUIRES: line.

rdar://114564735
