### PR TITLE
RequirementMachine: Add missing entry to Symbol::Kinds

### DIFF
--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -30,6 +30,7 @@ const StringRef Symbol::Kinds[] = {
   "assocty",
   "generic",
   "name",
+  "shape",
   "layout",
   "super",
   "concrete"

--- a/test/Generics/analyze_requirement_machine.swift
+++ b/test/Generics/analyze_requirement_machine.swift
@@ -1,0 +1,3 @@
+// RUN: %target-typecheck-verify-swift -analyze-requirement-machine
+
+public func f<T: FixedWidthInteger>(_: T) {}


### PR DESCRIPTION
When we added same-shape requirements, we broke -analyze-requirement-machine, which outputs some histograms. Add a regression test to make sure this code path doesn't bitrot.