### PR TITLE
Serialization: Refine safety checks for extensions/protocols

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3289,9 +3289,10 @@ public:
 
       // We can mark the extension unsafe only if it has no public
       // conformances.
-      auto protocols = ext->getLocalProtocols(
-                                        ConformanceLookupKind::OnlyExplicit);
-      if (!protocols.empty())
+      auto protocols = ext->getLocalProtocols(ConformanceLookupKind::All);
+      bool hasSafeConformances = std::any_of(protocols.begin(), protocols.end(),
+                                             isDeserializationSafe);
+      if (hasSafeConformances)
         return true;
 
       // Truly empty extensions are safe, it may happen in swiftinterfaces.
@@ -3300,9 +3301,6 @@ public:
 
       return false;
     }
-
-    if (isa<ProtocolDecl>(decl))
-      return true;
 
     auto value = cast<ValueDecl>(decl);
 

--- a/test/Serialization/Safety/indirect-conformance.swift
+++ b/test/Serialization/Safety/indirect-conformance.swift
@@ -12,8 +12,8 @@
 
 // RUN: cat %t/Lib.swiftinterface | %FileCheck %t/Lib.swift
 
-public protocol PublicProtocol : AnyObject {}
-// CHECK: public protocol PublicProtocol : AnyObject
+public protocol PublicProtocol {}
+// CHECK: public protocol PublicProtocol
 
 protocol InternalProtocol: PublicProtocol {}
 // CHECK-NOT: InternalProtocol
@@ -21,8 +21,12 @@ protocol InternalProtocol: PublicProtocol {}
 public class IndirectConformant {
     public init() {}
 }
+
 extension IndirectConformant: InternalProtocol {}
 // CHECK: extension Lib.IndirectConformant : Lib.PublicProtocol {}
+
+extension String: InternalProtocol {}
+// CHECK: extension Swift.String : Lib.PublicProtocol {}
 
 //--- Client.swift
 
@@ -43,10 +47,8 @@ import Lib
 
 func requireConformanceToPublicProtocol(_ a: PublicProtocol) {}
 requireConformanceToPublicProtocol(IndirectConformant())
+requireConformanceToPublicProtocol("string")
 
-/// Deserialization safety should keep the original chain. We're mostly
-/// documenting the current safety implementation details here, if we can get
-/// without deserializing 'InternalProtocol' it would be even better.
 // CHECK: Deserialized: 'IndirectConformant'
 // CHECK: Deserialized: 'PublicProtocol'
-// CHECK: Deserialized: 'InternalProtocol'
+// CHECK-NOT: Deserialized: 'InternalProtocol'

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -34,12 +34,12 @@
 public protocol PublicProto {}
 // SAFETY-PRIVATE: Serialization safety, safe: 'PublicProto'
 internal protocol InternalProto {}
-// SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
-// NO-SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalProto'
+// NO-SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalProto'
 private protocol PrivateProto {}
-// SAFETY-PRIVATE: Serialization safety, safe: 'PrivateProto'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'PrivateProto'
 fileprivate protocol FileprivateProto {}
-// SAFETY-PRIVATE: Serialization safety, safe: 'FileprivateProto'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'FileprivateProto'
 
 internal struct InternalStruct : PublicProto {
 // SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalStruct'

--- a/test/Serialization/Safety/unsafe-extensions.swift
+++ b/test/Serialization/Safety/unsafe-extensions.swift
@@ -47,8 +47,8 @@ extension ExtendedPublic : PublicProto {
 
 /// Internal
 internal protocol InternalProto {}
-// SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
-// NO-SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalProto'
+// NO-SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalProto'
 internal struct ExtendedInternal {}
 // SAFETY-INTERNAL: Serialization safety, unsafe: 'ExtendedInternal'
 // NO-SAFETY-INTERNAL: Serialization safety, safe: 'ExtendedInternal'
@@ -63,7 +63,7 @@ extension ExtendedInternal : InternalProto {}
 
 /// Private
 private protocol PrivateProto {}
-// SAFETY-PRIVATE: Serialization safety, safe: 'PrivateProto'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'PrivateProto'
 private struct ExtendedPrivate {}
 // SAFETY-PRIVATE: Serialization safety, unsafe: 'ExtendedPrivate'
 extension ExtendedPrivate {
@@ -75,7 +75,7 @@ extension ExtendedPrivate : PrivateProto {}
 
 /// Fileprivate
 private protocol FileprivateProto {}
-// SAFETY-PRIVATE: Serialization safety, safe: 'FileprivateProto'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'FileprivateProto'
 private struct ExtendedFileprivate {}
 // SAFETY-PRIVATE: Serialization safety, unsafe: 'ExtendedFileprivate'
 extension ExtendedFileprivate {
@@ -87,14 +87,14 @@ extension ExtendedFileprivate : FileprivateProto {}
 
 /// Back to public
 extension ExtendedPublic : InternalProto {
-// SAFETY-INTERNAL: Serialization safety, safe: 'extension ExtendedPublic'
-// NO-SAFETY-INTERNAL: Serialization safety, safe: 'extension ExtendedPublic'
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'extension ExtendedPublic'
+// NO-SAFETY-INTERNAL: Serialization safety, unsafe: 'extension ExtendedPublic'
 }
 extension ExtendedPublic : PrivateProto {
-// SAFETY-PRIVATE: Serialization safety, safe: 'extension ExtendedPublic'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPublic'
 }
 extension ExtendedPublic : FileprivateProto {
-// SAFETY-PRIVATE: Serialization safety, safe: 'extension ExtendedPublic'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPublic'
 }
 
 extension ExtendedPublic {


### PR DESCRIPTION
In https://github.com/apple/swift/pull/65267 deserialization safety was made more conservative, allowing deserialization of any protocol and deserialization of any extension declaring an explicit conformance to any protocol. We can refine this to only allow deserialization of safe protocols and deserialization of extensions declaring conformances to safe protocols. Importantly, though, we must look up all conformances declared by the extension, not just the explicit ones.

Resolves rdar://114673761
