### PR TITLE
[CSSimplify] Rework detection of missing/extraneous arguments in closure

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1229,3 +1229,23 @@ func closureWithCaseArchetype<T>(_: T.Type) {
     }
   }
 }
+
+// rdar://112426330 - invalid diagnostic when closure argument is omitted
+do {
+  func test<T>(_: T, _: (T) -> Void) {}
+
+  test(42) { // expected-error {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{13-13= _ in}}
+    print("")
+  }
+
+  func context(_: (Int) -> Void) {}
+  func context(_: () -> Void) {}
+
+  context {
+    test(42) { // expected-error {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{15-15= _ in}}
+      print("")
+    }
+  }
+
+
+}


### PR DESCRIPTION
Checking type variables is no longer necessary because constraint 
system now stores types of all closures it encountered, this makes
detection logic more reliable as well.

Resolves: rdar://112426330

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
