### PR TITLE
TBDGen: Skip visiting nominal types with non-public linkage

### DIFF
--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -71,8 +71,7 @@ public struct PublicStruct {
 }
 
 struct InternalStruct: DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
-  // FIXME: TBD emission causes this property to be typechecked
-//  var x: DoesNotExist
+  var x: DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
 
   func f(_ x: DoesNotExist) {} // expected-error {{cannot find type 'DoesNotExist' in scope}}
 }


### PR DESCRIPTION
As a performance optimization, `SILSymbolVisitor` can skip doing any work for nominal types that have non-public linkage when the `PublicSymbolsOnly` option is enabled. This makes `.tbd` emission trigger fewer unnecessary type checking requests when `-experimenal-lazy-typecheck` is specified.

Resolves rdar://114704791
