### PR TITLE
[stdlib] Set PYTHONIOENCODING when building the stdlib

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -801,6 +801,7 @@ function(_compile_swift_files
     set(swift_compiler_tool "${SWIFT_SOURCE_DIR}/utils/check-incremental" "${swift_compiler_tool}")
   endif()
 
+  set(custom_env "PYTHONIOENCODING=UTF8")
   if(SWIFTFILE_IS_STDLIB OR
      # Linux "hosttools" build require builder's runtime before building the runtime.
      (BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS" AND SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD|FREEBSD")
@@ -811,13 +812,13 @@ function(_compile_swift_files
       # to pick up the stdlib from the previous bootstrapping stage, because the
       # stdlib in the current stage is not built yet.
       if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
-        set(set_environment_args "${CMAKE_COMMAND}" "-E" "env" "DYLD_LIBRARY_PATH=${bs_lib_dir}")
+        list(APPEND custom_env "DYLD_LIBRARY_PATH=${bs_lib_dir}")
       elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD|FREEBSD")
-        set(set_environment_args "${CMAKE_COMMAND}" "-E" "env" "LD_LIBRARY_PATH=${bs_lib_dir}")
+        list(APPEND custom_env "LD_LIBRARY_PATH=${bs_lib_dir}")
       endif()
     endif()
-
   endif()
+  set(set_environment_args "${CMAKE_COMMAND}" "-E" "env" "${custom_env}")
 
   if (SWIFT_REPORT_STATISTICS)
     list(GET dirs_to_create 0 first_obj_dir)

--- a/test/ScanDependencies/unicode_filename.swift
+++ b/test/ScanDependencies/unicode_filename.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -scan-dependencies %/s %/S/Inputs/unicode_filёnamё.swift -o %t/deps.json
 
 // Check the contents of the JSON output
-// RUN: env PYTHONIOENCODING=UTF-8 %validate-json < %t/deps.json
+// RUN: %validate-json < %t/deps.json
 // RUN: %FileCheck %s < %t/deps.json
 
 public func bar() {

--- a/validation-test/Python/line-directive.swift
+++ b/validation-test/Python/line-directive.swift
@@ -1,4 +1,8 @@
-// REQUIRES: rdar92613094
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
 // RUN: %{python} %utils/line-directive
-// RUN: %{python} %utils/line-directive -- %{python} -c "print('你好')"
+// RUN: %{python} %utils/line-directive -- %{python} %t/unicode.py
+
+//--- unicode.py
+print('你好')


### PR DESCRIPTION
Ubuntu 18.04 seems to be defaulting to 'ascii', causing an error when using line-directive combined with the utf-8 diagnostic output used when early swift syntax is enabled.

Also fix up a validation-test while I'm here.