### PR TITLE
[CMake][SourceKit] Add RPATH to 'lib/swift/host'

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -116,6 +116,11 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
 
     endif() # HAS_SWIFT_MODULES AND ASKD_BOOTSTRAPPING_MODE
 
+    if(SWIFT_SWIFT_PARSER)
+      # Add rpath to the host Swift libraries.
+      file(RELATIVE_PATH relative_hostlib_path "${path}" "${SWIFTLIB_DIR}/host")
+      list(APPEND RPATH_LIST "@loader_path/${relative_hostlib_path}")
+    endif()
   elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD" AND HAS_SWIFT_MODULES AND ASKD_BOOTSTRAPPING_MODE)
     set(swiftrt "swiftImageRegistrationObject${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
     if(ASKD_BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|CROSSCOMPILE")


### PR DESCRIPTION
RPATH to 'lib/swift/host' was missing in Darwin platform.

Failure caused by https://github.com/apple/swift/pull/68082.
Before #68082 in macOS environment, sourcekitd-test had RPATH to `lib/swift/host`, but `sourcekitdInProc` didn't. It worked because `.dylib` inherits executable's RPATH. #68082 changed so `sourcekit-test` doesn't have RPATH to `swiftCore` and lib/swift/host because that executable itself didn't depend on it. But since `sourcekitdInProc` didn't have correct RPATH, it failed. Solution here is that `sourcekitdInProc` have the correct RPATH.

rdar://114700107