### PR TITLE
5.9.0: [stdlib] Delete bad @_effects(readonly) annotation

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -821,7 +821,6 @@ extension Dictionary: ExpressibleByDictionaryLiteral {
   /// - Parameter elements: The key-value pairs that will make up the new
   ///   dictionary. Each key in `elements` must be unique.
   @inlinable
-  @_effects(readonly)
   @_semantics("optimize.sil.specialize.generic.size.never")
   public init(dictionaryLiteral elements: (Key, Value)...) {
     let native = _NativeDictionary<Key, Value>(capacity: elements.count)

--- a/validation-test/SILOptimizer/rdar114699006.swift
+++ b/validation-test/SILOptimizer/rdar114699006.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend \
+// RUN:     -primary-file %s   \
+// RUN:     -module-name main  \
+// RUN:     -O                 \
+// RUN:     -g                 \
+// RUN:     -target x86_64-apple-macos10.13 \
+// RUN:     -emit-ir           \
+// RUN:     -o /dev/null       \
+// RUN:     -Xllvm -sil-print-function='$s4main1CCACycfc' \
+// RUN:     2>&1 | %FileCheck %s
+
+// This test expects the stdlib to be in its properly optimized form.
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+// No need to run this test that has a hard-coded target of macos10.13 on other
+// platforms.
+// REQUIRES: OS=macosx
+
+// Verify that after RetainSinking runs, the retain of the __EmptyArrayStorage
+// is _above_ the call to $sSD17dictionaryLiteralSDyxq_Gx_q_td_tcfCSS_SSTg5
+// which consumes the reference.
+// rdar://114699006
+
+// CHECK-LABEL: *** SIL function after {{.*}} RetainSinking (retain-sinking)
+// CHECK-LABEL: sil {{.*}}@$s4main1CCACycfc : {{.*}} {
+// CHECK:         [[REF:%[^,]+]] = raw_pointer_to_ref {{%[^,]+}} : $Builtin.RawPointer to $__EmptyArrayStorage
+// CHECK:         [[BRIDGE_OBJECT:%[^,]+]] = unchecked_ref_cast [[REF]] : $__EmptyArrayStorage to $Builtin.BridgeObject
+// CHECK:         [[BRIDGE_STORAGE:%[^,]+]] = struct $_BridgeStorage<__ContiguousArrayStorageBase> ([[BRIDGE_OBJECT]] :
+// CHECK:         [[ARRAY_BUFFER:%[^,]+]] = struct $_ArrayBuffer<(String, String)> ([[BRIDGE_STORAGE]] :
+// CHECK:         [[ARRAY:%[^,]+]] = struct $Array<(String, String)> ([[ARRAY_BUFFER]] :
+// CHECK:         [[DICTIONARY_INIT:%[^,]+]] = function_ref @$sSD17dictionaryLiteralSDyxq_Gx_q_td_tcfCSS_SSTg5
+// CHECK-NEXT:    strong_retain [[REF]] : $__EmptyArrayStorage
+// CHECK-NEXT:    apply [[DICTIONARY_INIT]]([[ARRAY]], {{.*}})
+// CHECK-LABEL: } // end sil function '$s4main1CCACycfc'
+
+class C {
+    var d: [String : String] = [:]
+}


### PR DESCRIPTION
**Description:** Programs built with release/5.9 crash when back-deploying to before 10.15 if they use an empty dictionary literal.

Since 2014, `Dictionary.init(dictionaryLiteral:)` has been annotated `@_effects(readonly)`.  Among other things, that annotation means the function must not release any values.  At the time, the default convention for `init`s was that they "borrowed" the values passed to them--they could not release them.  Subsequently, that default convention changed so that `init`s instead "_consumed_" the values passed to them--starting then, the `init`s released the values if they were not consumed by some other mechanism (storing them, calling some other function which consumed them, etc.).  From that time on, this annotation has been incorrect.

In release/5.9, this incorrectness was exposed as a runtime crash.  In particular, given a program involving a class with a field of dictionary type which is initialized to be the empty dictionary, building that program with release/5.9 and running that program on pre-10.15 will result in a runtime crash.

Here's what's happening: the empty dictionary literal `[:]` is turned into a call `Dictionary.init(dictionaryLiteral: [])`.  The empty array is passed to `Dictionary.init` which consumes it.  Because `Dictionary.init` does not store (or otherwise consume) the empty array, it releases it.  Because `Dictionary.init` consumes its argument, when compiling the function containing the call to it (i.e. containing `[:]`), the compiler retains the empty array `[]` that's passed to it.  Now, to decrease unnecessary ARC traffic, the compiler sinks retains and hoists releases so that they can be eliminated altogether.  When the compiler sinks the retain of `[]`, it is allowed to move it past the call to `Dictionary.init` because the call is explicitly annotated `@_effects(readonly)` which means that it can't release the empty array.  Because `Dictionary.init` actually releases its argument `[]`, the call to retain is a use-after-free.

The crashes only occur on older macOSes because more recently (since 2019) empty collection singletons like the empty array have been made immortal.
**Risk:** Very low.  The fix is to delete an annotation from a stdlib function.  The annotation only communicates (false) information about optimization opportunities to the compiler.
**Scope:** Very narrow.  Deletes a single line of code from a stdlib function.
**Reward:** High.  Fixes runtime crashes for many programs built with release/5.9 compilers when running on old macOSes.
**Origin:** Primeval.
**Original PR:** https://github.com/apple/swift/pull/68223
**Reviewed By:** Andrew Trick ( @atrick )
**Testing:** Added a test demonstrating that retain of `[]` is not sunk to below the call to `Dictionary.init`.  Verified that runtime crash doesn't occur with fix applied.
**Resolves:** rdar://114699006