### PR TITLE
[ConstraintSystem] Remove all stack allocation from `Solution`

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1459,11 +1459,11 @@ public:
 
   /// The list of fixes that need to be applied to the initial expression
   /// to make the solution work.
-  llvm::SmallVector<ConstraintFix *, 4> Fixes;
+  std::vector<ConstraintFix *> Fixes;
 
   /// For locators associated with call expressions, the trailing closure
   /// matching rule and parameter bindings that were applied.
-  llvm::SmallMapVector<ConstraintLocator *, MatchCallArgumentResult, 4>
+  llvm::MapVector<ConstraintLocator *, MatchCallArgumentResult>
       argumentMatchingChoices;
 
   /// The set of disjunction choices used to arrive at this solution,
@@ -1486,14 +1486,14 @@ public:
       PackExpansionEnvironments;
 
   /// The pack expansion environment that can open a given pack element.
-  llvm::SmallMapVector<PackElementExpr *, PackExpansionExpr *, 2>
+  llvm::MapVector<PackElementExpr *, PackExpansionExpr *>
       PackEnvironments;
 
   /// The locators of \c Defaultable constraints whose defaults were used.
-  llvm::SmallPtrSet<ConstraintLocator *, 2> DefaultedConstraints;
+  llvm::DenseSet<ConstraintLocator *> DefaultedConstraints;
 
   /// Implicit value conversions applied for a given locator.
-  SmallVector<std::pair<ConstraintLocator *, ConversionRestrictionKind>, 2>
+  std::vector<std::pair<ConstraintLocator *, ConversionRestrictionKind>>
       ImplicitValueConversions;
 
   /// The node -> type mappings introduced by this solution.
@@ -1518,19 +1518,19 @@ public:
 
   /// Maps case label items to information tracked about them as they are
   /// being solved.
-  llvm::SmallMapVector<const CaseLabelItem *, CaseLabelItemInfo, 4>
+  llvm::MapVector<const CaseLabelItem *, CaseLabelItemInfo>
       caseLabelItems;
 
   /// A map of expressions to the ExprPatterns that they are being solved as
   /// a part of.
-  llvm::SmallMapVector<Expr *, ExprPattern *, 2> exprPatterns;
+  llvm::MapVector<Expr *, ExprPattern *> exprPatterns;
 
   /// The set of parameters that have been inferred to be 'isolated'.
-  llvm::SmallVector<ParamDecl *, 2> isolatedParams;
+  std::vector<ParamDecl *> isolatedParams;
 
   /// The set of closures that have been inferred to be "isolated by
   /// preconcurrency".
-  llvm::SmallVector<const ClosureExpr *, 2> preconcurrencyClosures;
+  std::vector<const ClosureExpr *> preconcurrencyClosures;
 
   /// The set of functions that have been transformed by a result builder.
   llvm::MapVector<AnyFunctionRef, AppliedBuilderTransform>

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -131,7 +131,10 @@ Solution ConstraintSystem::finalize() {
   if (solverState && solverState->PartialSolutionScope) {
     firstFixIndex = solverState->PartialSolutionScope->numFixes;
   }
-  solution.Fixes.append(Fixes.begin() + firstFixIndex, Fixes.end());
+
+  for (const auto &fix :
+       llvm::make_range(Fixes.begin() + firstFixIndex, Fixes.end()))
+    solution.Fixes.push_back(fix);
 
   // Remember all the disjunction choices we made.
   for (auto &choice : DisjunctionChoices) {
@@ -199,11 +202,18 @@ Solution ConstraintSystem::finalize() {
   }
 
   solution.targets = targets;
-  solution.caseLabelItems = caseLabelItems;
-  solution.exprPatterns = exprPatterns;
-  solution.isolatedParams.append(isolatedParams.begin(), isolatedParams.end());
-  solution.preconcurrencyClosures.append(preconcurrencyClosures.begin(),
-                                         preconcurrencyClosures.end());
+
+  for (const auto &item : caseLabelItems)
+    solution.caseLabelItems.insert(item);
+
+  for (const auto &pattern : exprPatterns)
+    solution.exprPatterns.insert(pattern);
+
+  for (const auto &param : isolatedParams)
+    solution.isolatedParams.push_back(param);
+
+  for (const auto &closure : preconcurrencyClosures)
+    solution.preconcurrencyClosures.push_back(closure);
 
   for (const auto &transformed : resultBuilderTransformed) {
     solution.resultBuilderTransformed.insert(transformed);
@@ -231,7 +241,8 @@ Solution ConstraintSystem::finalize() {
     solution.PackExpansionEnvironments.insert(env);
   }
 
-  solution.PackEnvironments = PackEnvironments;
+  for (const auto &packEnv : PackEnvironments)
+    solution.PackEnvironments.insert(packEnv);
 
   return solution;
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4186,13 +4186,35 @@ Type Solution::simplifyTypeForCodeCompletion(Type Ty) const {
   return Ty->getRValueType();
 }
 
+template <typename T>
+static inline size_t size_in_bytes(const T &x) {
+  return (x.size() * (sizeof(typename T::key_type) + sizeof(unsigned))) +
+         (x.size() * (sizeof(typename T::value_type)));
+}
+
 size_t Solution::getTotalMemory() const {
   return sizeof(*this) + typeBindings.getMemorySize() +
          overloadChoices.getMemorySize() +
          ConstraintRestrictions.getMemorySize() +
-         llvm::capacity_in_bytes(Fixes) + DisjunctionChoices.getMemorySize() +
+         (Fixes.size() * sizeof(void *)) + DisjunctionChoices.getMemorySize() +
          OpenedTypes.getMemorySize() + OpenedExistentialTypes.getMemorySize() +
+         OpenedPackExpansionTypes.getMemorySize() +
+         PackExpansionEnvironments.getMemorySize() +
+         size_in_bytes(PackEnvironments) +
          (DefaultedConstraints.size() * sizeof(void *)) +
+         ImplicitCallAsFunctionRoots.getMemorySize() +
+         nodeTypes.getMemorySize() +
+         keyPathComponentTypes.getMemorySize() +
+         size_in_bytes(KeyPaths) +
+         (contextualTypes.size() * sizeof(ASTNode))  +
+         size_in_bytes(targets) +
+         size_in_bytes(caseLabelItems) +
+         size_in_bytes(exprPatterns) +
+         (isolatedParams.size() * sizeof(void *)) +
+         (preconcurrencyClosures.size() * sizeof(void *)) +
+         size_in_bytes(resultBuilderTransformed) +
+         size_in_bytes(appliedPropertyWrappers) +
+         size_in_bytes(argumentLists) +
          ImplicitCallAsFunctionRoots.getMemorySize();
 }
 


### PR DESCRIPTION
An experiment to see how much memory we were spending on empty collections for each partial solution.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
