### PR TITLE
[AST] ASTScope: Cache previously looked up parent module

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -155,6 +155,10 @@ private:
 
   mutable llvm::Optional<CharSourceRange> cachedCharSourceRange;
 
+  /// Stores the result of a lazy lookup for a parent module performed via
+  /// \c getParentModule.
+  NullablePtr<ModuleDecl> ParentModule;
+
 #pragma mark - constructor / destructor
 public:
   ASTScopeImpl(){};
@@ -222,6 +226,8 @@ public:
   virtual NullablePtr<MacroExpansionDecl> getFreestandingMacro() const {
     return nullptr;
   }
+
+  ModuleDecl *getParentModule();
 
 #pragma mark - debugging and printing
 

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -182,6 +182,17 @@ const SourceFile *ASTScopeImpl::getSourceFile() const {
   return getParent().get()->getSourceFile();
 }
 
+ModuleDecl *ASTScopeImpl::getParentModule() {
+  if (ParentModule)
+    return ParentModule.get();
+
+  auto *SF = getSourceFile();
+  auto *module = SF->getParentModule();
+  ParentModule = module;
+
+  return module;
+}
+
 const SourceFile *ASTSourceFileScope::getSourceFile() const { return SF; }
 
 ASTContext &ASTSourceFileScope::getASTContext() const {

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -91,7 +91,7 @@ static SourceLoc translateLocForReplacedRange(SourceManager &sourceMgr,
 NullablePtr<ASTScopeImpl>
 ASTScopeImpl::findChildContaining(SourceLoc loc,
                                   SourceManager &sourceMgr) const {
-  auto *moduleDecl = this->getSourceFile()->getParentModule();
+  auto *moduleDecl = const_cast<ASTScopeImpl *>(this)->getParentModule();
   auto *locSourceFile = moduleDecl->getSourceFileContainingLocation(loc);
 
   // Use binary search to find the child that contains this location.

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1487,7 +1487,6 @@ mixin-preset=
     mixin_osx_package,use_os_runtime
 
 [preset: mixin_buildbot_osx_package,no_test]
-skip-test-swift
 skip-test-swiftpm
 skip-test-swift-driver
 skip-test-llbuild


### PR DESCRIPTION
Add a method that looks up and stores parent module declaration, 
this is very intended to alleviate cost of pointer chasing happening 
in `findChildContaining`.

Resolves: rdar://114667496


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
