### PR TITLE
Fixes for layout strings enum support

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -2408,7 +2408,6 @@ bool EnumTypeLayoutEntry::refCountString(IRGenModule &IGM,
 
     auto *accessor = createMetatypeAccessorFunction(IGM, ty, genericSig);
     B.addFixedEnumRefCount(accessor);
-    B.addSkip(fixedSize(IGM)->getValue());
     return true;
   }
   }


### PR DESCRIPTION
The fixes are all around enum support. Some tag comparisons and pointer masking were incorrect and led to crashes.

rdar://114575149