### PR TITLE
Fix Cyrillic `с` in `bug_report.md`: Replace with Latin `c` in `contributors`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ etc., please report it to https://feedbackassistant.apple.com instead.
 Explain how to reproduce the problem (in steps if seen fit) and include either
 an inline test case (preferred) or a project that reproduces it. Consider
 reducing the sample to the smallest amount of code possible — a smaller test
-case is easier to reason about and more appealing to сontributors.
+case is easier to reason about and more appealing to contributors.
 -->
 
 **Expected behavior**


### PR DESCRIPTION

<!-- What's in this pull request? -->
**Overview**
The `bug_report.md` file contained a subtle issue where the variable name contributors was actually spelled with a Cyrillic `с` instead of a Latin `c`.

**Changes**
Replaced Cyrillic `с` with Latin `c` in the contributors variable name within `bug_report.md`.


<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
