### PR TITLE
SILOptimizer: Make some analysis caches lazy

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
@@ -27,15 +27,10 @@ class ClassDecl;
 class ClassHierarchyAnalysis : public SILAnalysis {
 public:
   typedef SmallVector<ClassDecl *, 8> ClassList;
-  typedef SmallPtrSet<ClassDecl *, 32> ClassSet;
-  typedef SmallVector<NominalTypeDecl *, 8> NominalTypeList;
-  typedef llvm::DenseMap<ProtocolDecl *, NominalTypeList>
-      ProtocolImplementations;
+  typedef llvm::DenseMap<ClassDecl *, ClassList> ClassListMap;
 
   ClassHierarchyAnalysis(SILModule *Mod)
-      : SILAnalysis(SILAnalysisKind::ClassHierarchy), M(Mod) {
-    init();
-  }
+      : SILAnalysis(SILAnalysisKind::ClassHierarchy), M(Mod) {}
 
   ~ClassHierarchyAnalysis();
 
@@ -65,7 +60,8 @@ public:
   /// Returns a list of the known direct subclasses of a class \p C in
   /// the current module.
   const ClassList &getDirectSubClasses(ClassDecl *C) {
-    return DirectSubclassesCache[C];
+    populateDirectSubclassesCacheIfNecessary();
+    return (*DirectSubclassesCache)[C];
   }
 
   /// Returns a list of the known indirect subclasses of a class \p C in
@@ -81,7 +77,8 @@ public:
 
   /// Returns true if the class is inherited by another class in this module.
   bool hasKnownDirectSubclasses(ClassDecl *C) {
-    return DirectSubclassesCache.count(C);
+    populateDirectSubclassesCacheIfNecessary();
+    return DirectSubclassesCache->count(C);
   }
 
   /// Returns true if the class is indirectly inherited by another class
@@ -92,18 +89,19 @@ public:
   }
 
 private:
-  /// Compute inheritance properties.
-  void init();
   void getIndirectSubClasses(ClassDecl *Base,
                              ClassList &IndirectSubs);
   /// The module
   SILModule *M;
 
   /// A cache that maps a class to all of its known direct subclasses.
-  llvm::DenseMap<ClassDecl*, ClassList> DirectSubclassesCache;
+  llvm::Optional<ClassListMap> DirectSubclassesCache;
 
   /// A cache that maps a class to all of its known indirect subclasses.
-  llvm::DenseMap<ClassDecl*, ClassList> IndirectSubclassesCache;
+  ClassListMap IndirectSubclassesCache;
+
+  /// Populates `DirectSubclassesCache` if necessary.
+  void populateDirectSubclassesCacheIfNecessary();
 };
 
 }

--- a/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
@@ -39,9 +39,7 @@ public:
       SoleConformingTypeMap;
 
   ProtocolConformanceAnalysis(SILModule *Mod)
-      : SILAnalysis(SILAnalysisKind::ProtocolConformance), M(Mod) {
-    init();
-  }
+      : SILAnalysis(SILAnalysisKind::ProtocolConformance), M(Mod) {}
 
   ~ProtocolConformanceAnalysis();
 
@@ -66,14 +64,15 @@ public:
   virtual void invalidateFunctionTables() override {}
 
   /// Get the nominal types that implement a protocol.
-  ArrayRef<NominalTypeDecl *> getConformances(const ProtocolDecl *P) const {
-    auto ConformsListIt = ProtocolConformanceCache.find(P);
-    return ConformsListIt != ProtocolConformanceCache.end()
+  ArrayRef<NominalTypeDecl *> getConformances(const ProtocolDecl *P) {
+    populateConformanceCacheIfNecessary();
+    auto ConformsListIt = ProtocolConformanceCache->find(P);
+    return ConformsListIt != ProtocolConformanceCache->end()
                ? ArrayRef<NominalTypeDecl *>(ConformsListIt->second.begin(),
                                              ConformsListIt->second.end())
                : ArrayRef<NominalTypeDecl *>();
   }
-  
+
   /// Traverse ProtocolConformanceMapCache recursively to determine sole
   /// conforming concrete type. 
   NominalTypeDecl *findSoleConformingType(ProtocolDecl *Protocol);
@@ -83,17 +82,17 @@ public:
   bool getSoleConformingType(ProtocolDecl *Protocol, ClassHierarchyAnalysis *CHA, CanType &ConcreteType);
 
 private:
-  /// Compute inheritance properties.
-  void init();
-
   /// The module.
   SILModule *M;
 
   /// A cache that maps a protocol to its conformances.
-  ProtocolConformanceMap ProtocolConformanceCache;
+  llvm::Optional<ProtocolConformanceMap> ProtocolConformanceCache;
 
   /// A cache that holds SoleConformingType for protocols.
   SoleConformingTypeMap SoleConformingTypeCache;
+
+  /// Populates `ProtocolConformanceCache` if necessary.
+  void populateConformanceCacheIfNecessary();
 };
 
 } // namespace swift

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -67,7 +67,8 @@ static std::string identifierForContext(const DeclContext *DC) {
 
   const auto *ext = cast<ExtensionDecl>(DC);
   auto fp = ext->getBodyFingerprint().value_or(Fingerprint::ZERO());
-  auto typeStr = Mangler.mangleTypeAsContextUSR(ext->getExtendedNominal());
+  const auto *nominal = ext->getExtendedNominal();
+  auto typeStr = nominal ? Mangler.mangleTypeAsContextUSR(nominal) : "";
   return (typeStr + "@" + fp.getRawValue()).str();
 }
 

--- a/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
@@ -19,7 +19,13 @@
 
 using namespace swift;
 
-void ClassHierarchyAnalysis::init() {
+// FIXME: This could be implemented as a request.
+void ClassHierarchyAnalysis::populateDirectSubclassesCacheIfNecessary() {
+  if (DirectSubclassesCache.has_value())
+    return;
+
+  DirectSubclassesCache.emplace();
+
   auto module = M->getSwiftModule();
 
   // For each class declaration in our V-table list:
@@ -42,7 +48,7 @@ void ClassHierarchyAnalysis::init() {
       // Find the superclass's list of direct subclasses.  If it's non-empty,
       // we've previously walked up to the class, so there's no reason to keep
       // walking from this point.
-      auto &list = DirectSubclassesCache[super];
+      auto &list = (*DirectSubclassesCache)[super];
       bool shouldVisitSuper = list.empty();
 
       // Check whether C is already in the list, which can happen

--- a/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
@@ -70,7 +70,12 @@ public:
 };
 } // end anonymous namespace
 
-void ProtocolConformanceAnalysis::init() {
+// FIXME: This could be implemented as a request.
+void ProtocolConformanceAnalysis::populateConformanceCacheIfNecessary() {
+  if (ProtocolConformanceCache.has_value())
+    return;
+
+  ProtocolConformanceCache.emplace();
 
   // We only do this in Whole-Module compilation mode.
   if (!M->isWholeModule())
@@ -84,7 +89,7 @@ void ProtocolConformanceAnalysis::init() {
 
   /// This operation is quadratic and should only be performed
   /// in whole module compilation!
-  NominalTypeWalker Walker(ProtocolConformanceCache);
+  NominalTypeWalker Walker(*ProtocolConformanceCache);
   for (auto *D : Decls) {
     D->walk(Walker);
   }


### PR DESCRIPTION
When serializing modules with `-experimental-skip-all-function-bodies`, the `ClassHierarchyAnalysis` and `ProtocolConformanceAnalysis` analyses were eagerly populating caches that would go unused since there is no optimization to do when there are no SIL function bodies. With `-experimental-lazy-typecheck`, this work would also trigger unnecessary typechecking requests. NFC.