### PR TITLE
[cxx-interop] Provide similar support for std::u32string as std::string and std::u16string.

### DIFF
--- a/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
+++ b/stdlib/public/Cxx/cxxshim/libcxxstdlibshim.h
@@ -6,3 +6,6 @@ typedef std::hash<std::string> __swift_interopHashOfString;
 
 /// Used for std::u16string conformance to Swift.Hashable
 typedef std::hash<std::u16string> __swift_interopHashOfU16String;
+
+/// Used for std::u32string conformance to Swift.Hashable
+typedef std::hash<std::u32string> __swift_interopHashOfU32String;

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -84,6 +84,26 @@ StdStringOverlayTestSuite.test("std::u16string operators") {
   expectTrue(s1 == "something123literal")
 }
 
+StdStringOverlayTestSuite.test("std::u32string operators") {
+  var s1 = std.u32string("something")
+  let s2 = std.u32string("123")
+  let sum = s1 + s2
+  expectEqual(sum, std.u32string("something123"))
+
+  expectFalse(s1 == s2)
+  let s3 = std.u32string("something123")
+  expectFalse(s1 == s3)
+  expectFalse(s2 == s3)
+
+  s1 += s2
+  expectTrue(s1 == std.u32string("something123"))
+  expectTrue(s1 == s3)
+
+  // Make sure the operators work together with ExpressibleByStringLiteral conformance.
+  s1 += "literal"
+  expectTrue(s1 == "something123literal")
+}
+
 StdStringOverlayTestSuite.test("std::string::append") {
   var s1 = std.string("0123")
   let s2 = std.string("abc")
@@ -96,6 +116,13 @@ StdStringOverlayTestSuite.test("std::u16string::append") {
   let s2 = std.u16string("abc")
   s1.append(s2)
   expectEqual(s1, std.u16string("0123abc"))
+}
+
+StdStringOverlayTestSuite.test("std::u32string::append") {
+  var s1 = std.u32string("0123")
+  let s2 = std.u32string("abc")
+  s1.append(s2)
+  expectEqual(s1, std.u32string("0123abc"))
 }
 
 StdStringOverlayTestSuite.test("std::string as Hashable") {
@@ -140,6 +167,27 @@ StdStringOverlayTestSuite.test("std::u16string as Hashable") {
   expectNotEqual(h2, h3)
 }
 
+StdStringOverlayTestSuite.test("std::u32string as Hashable") {
+  let s0 = std.u32string()
+  let h0 = s0.hashValue
+
+  let s1 = std.u32string("something")
+  let h1 = s1.hashValue
+
+  let s2 = std.u32string("something123")
+  let h2 = s2.hashValue
+
+  let s3 = std.u32string("something")
+  let h3 = s3.hashValue
+
+  expectEqual(h1, h3)
+  expectNotEqual(h0, h1)
+  expectNotEqual(h0, h2)
+  expectNotEqual(h0, h3)
+  expectNotEqual(h1, h2)
+  expectNotEqual(h2, h3)
+}
+
 StdStringOverlayTestSuite.test("std::u16string <=> Swift.String") {
   let cxx1 = std.u16string()
   let swift1 = String(cxx1)
@@ -165,6 +213,36 @@ StdStringOverlayTestSuite.test("std::u16string <=> Swift.String") {
   expectEqual(swift5, "emoji_🤖")
 
   let cxx6 = std.u16string("xyz\0abc")
+  expectEqual(cxx6.size(), 7)
+  let swift6 = String(cxx6)
+  expectEqual(swift6, "xyz\0abc")
+}
+
+StdStringOverlayTestSuite.test("std::u32string <=> Swift.String") {
+  let cxx1 = std.u32string()
+  let swift1 = String(cxx1)
+  expectEqual(swift1, "")
+
+  let cxx2 = std.u32string("something123")
+  expectEqual(cxx2.size(), 12)
+  let swift2 = String(cxx2)
+  expectEqual(swift2, "something123")
+
+  let cxx3: std.u32string = "literal"
+  expectEqual(cxx3.size(), 7)
+
+  let cxx4: std.u32string = "тест"
+  expectEqual(cxx4.size(), 4)
+  let swift4 = String(cxx4)
+  expectEqual(swift4, "тест")
+
+  // Emojis are represented by more than one CWideChar.
+  let cxx5: std.u32string = "emoji_🤖"
+  expectEqual(cxx5.size(), 7)
+  let swift5 = String(cxx5)
+  expectEqual(swift5, "emoji_🤖")
+
+  let cxx6 = std.u32string("xyz\0abc")
   expectEqual(cxx6.size(), 7)
   let swift6 = String(cxx6)
   expectEqual(swift6, "xyz\0abc")
@@ -198,6 +276,23 @@ StdStringOverlayTestSuite.test("std::u16string as Swift.CustomDebugStringConvert
     cxx3.push_back(scalar)
   }
   expectEqual(cxx3.debugDescription, "std.u16string(a�c)")
+}
+
+StdStringOverlayTestSuite.test("std::u32string as Swift.CustomDebugStringConvertible") {
+  let cxx1 = std.u32string()
+  expectEqual(cxx1.debugDescription, "std.u32string()")
+
+  let cxx2 = std.u32string("something123")
+  expectEqual(cxx2.debugDescription, "std.u32string(something123)")
+
+  // Since std::u32string does not support pushing back UInt32 directly, we utilize UInt16 instead.
+  let scalars: [UInt16] = [97, 55296, 99]
+  var cxx3_16 = std.u16string()
+  for scalar: UInt16 in scalars {
+    cxx3_16.push_back(scalar)
+  }
+  let cxx3 = std.u32string(String(cxx3_16))
+  expectEqual(cxx3.debugDescription, "std.u32string(a�c)")
 }
 
 StdStringOverlayTestSuite.test("std::string as Swift.Sequence") {
@@ -247,6 +342,32 @@ StdStringOverlayTestSuite.test("std::u16string as Swift.CustomStringConvertible"
     cxx3.push_back(scalar)
   }
   expectEqual(cxx3.description, "a�c")
+}
+
+StdStringOverlayTestSuite.test("std::u32string as Swift.CustomStringConvertible") {
+  let cxx1 = std.u32string()
+  expectEqual(cxx1.description, "")
+
+  let cxx2 = std.u32string("something123")
+  expectEqual(cxx2.description, "something123")
+
+  // Since std::u32string does not support pushing back UInt32 directly, we utilize UInt16 instead.
+  let scalars: [UInt16] = [97, 55296, 99]
+  var cxx3_16 = std.u16string()
+  for scalar: UInt16 in scalars {
+    cxx3_16.push_back(scalar)
+  }
+  let cxx3 = std.u32string(String(cxx3_16))
+  expectEqual(cxx3.description, "a�c")
+
+  // For `push_back`
+  let scalars2: [Unicode.Scalar] = [0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x2C, 0x20, 0x4E16, 0x754C]
+    .compactMap { Unicode.Scalar($0) }
+  var cxx4 = std.u32string()
+  for scalar: Unicode.Scalar in scalars2 {
+    cxx4.push_back(scalar)
+  }
+  expectEqual(cxx4.description, "Hello, 世界")
 }
 
 StdStringOverlayTestSuite.test("std::string from C string") {


### PR DESCRIPTION

<!-- What's in this pull request? -->
Provide similar support for std::u32string as std::string and std::u16string.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #68211

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
