### PR TITLE
🍒[cxx-interop][SwiftToCxx] Emit foreign reference types with `*` in the generated Clang header

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2504,7 +2504,7 @@ private:
   void visitClassType(ClassType *CT,
                       llvm::Optional<OptionalTypeKind> optionalKind) {
     const ClassDecl *CD = CT->getClassOrBoundGenericClass();
-    assert(CD->isObjC());
+    assert(CD->isObjC() || CD->isForeignReferenceType());
     auto clangDecl = dyn_cast_or_null<clang::NamedDecl>(CD->getClangDecl());
     if (clangDecl) {
       // Hack for <os/object.h> types, which use classes in Swift but
@@ -2512,7 +2512,8 @@ private:
       StringRef osObjectName = maybeGetOSObjectBaseName(clangDecl);
       if (!osObjectName.empty()) {
         os << osObjectName << "_t";
-      } else if (isa<clang::ObjCInterfaceDecl>(clangDecl)) {
+      } else if (isa<clang::ObjCInterfaceDecl>(clangDecl) ||
+                 CD->isForeignReferenceType()) {
         os << clangDecl->getName() << " *";
       } else {
         maybePrintTagKeyword(CD);

--- a/test/Interop/CxxToSwiftToObjcxx/Inputs/bridge-cxx-types-to-objcxx.h
+++ b/test/Interop/CxxToSwiftToObjcxx/Inputs/bridge-cxx-types-to-objcxx.h
@@ -1,0 +1,3 @@
+class __attribute__((swift_attr("import_reference"),
+                     swift_attr("retain:immortal"),
+                     swift_attr("release:immortal"))) X {};

--- a/test/Interop/CxxToSwiftToObjcxx/Inputs/module.modulemap
+++ b/test/Interop/CxxToSwiftToObjcxx/Inputs/module.modulemap
@@ -1,0 +1,5 @@
+module MyCxxModule {
+    header "bridge-cxx-types-to-objcxx.h"
+    export *
+    requires cplusplus
+}

--- a/test/Interop/CxxToSwiftToObjcxx/bridge-cxx-types-to-objcxx.swift
+++ b/test/Interop/CxxToSwiftToObjcxx/bridge-cxx-types-to-objcxx.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -I %S/Inputs -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -target arm64-apple-macosx13.3
+// RUN: %FileCheck %s < %t/UseCxxTy.h
+
+// REQUIRES: OS=macosx
+
+import Foundation
+import MyCxxModule
+
+@objc class C: NSObject {
+  @objc var x: X? = nil
+}
+
+// CHECK: @property (nonatomic) X * _Nullable x;

--- a/test/Interop/CxxToSwiftToObjcxx/lit.local.cfg
+++ b/test/Interop/CxxToSwiftToObjcxx/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = ['.swift', '.cpp', '.mm']


### PR DESCRIPTION
C++ foreign reference types are imported to Swift as classes, not structs. When generating a Clang header that represents a Swift struct holding a C++ FRT as a field, we need to print the FRT as a pointer.

This was previously hitting an assertion in debug builds of the compiler: `assert(CD->isObjC())`.

Original PR: https://github.com/apple/swift/pull/68237

rdar://114711899
(cherry picked from commit c45753dca2253e924a86d00b6117ee21ca41722c)