### PR TITLE
[AST] ASTScope: Pass parent module to all search methods

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -298,15 +298,18 @@ private:
 
 protected:
   /// Not const because may reexpand some scopes.
-  ASTScopeImpl *findInnermostEnclosingScope(SourceLoc,
+  ASTScopeImpl *findInnermostEnclosingScope(ModuleDecl *,
+                                            SourceLoc,
                                             NullablePtr<raw_ostream>);
-  ASTScopeImpl *findInnermostEnclosingScopeImpl(SourceLoc,
+  ASTScopeImpl *findInnermostEnclosingScopeImpl(ModuleDecl *,
+                                                SourceLoc,
                                                 NullablePtr<raw_ostream>,
                                                 SourceManager &,
                                                 ScopeCreator &);
 
 private:
-  NullablePtr<ASTScopeImpl> findChildContaining(SourceLoc loc,
+  NullablePtr<ASTScopeImpl> findChildContaining(ModuleDecl *,
+                                                SourceLoc loc,
                                                 SourceManager &sourceMgr) const;
 
 #pragma mark - - lookup- per scope

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -251,7 +251,8 @@ void ASTSourceFileScope::expandFunctionBody(AbstractFunctionDecl *AFD) {
   auto sr = AFD->getOriginalBodySourceRange();
   if (sr.isInvalid())
     return;
-  ASTScopeImpl *bodyScope = findInnermostEnclosingScope(sr.Start, nullptr);
+  ASTScopeImpl *bodyScope =
+      findInnermostEnclosingScope(AFD->getParentModule(), sr.Start, nullptr);
   if (!bodyScope->getWasExpanded())
     bodyScope->expandAndBeCurrent(*scopeCreator);
 }

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -54,7 +54,8 @@ void ASTScopeImpl::dumpOneScopeMapLocation(
 
   llvm::errs() << "***Scope at " << lineColumn.first << ":" << lineColumn.second
                << "***\n";
-  auto *locScope = findInnermostEnclosingScope(loc, &llvm::errs());
+  auto *parentModule = getSourceFile()->getParentModule();
+  auto *locScope = findInnermostEnclosingScope(parentModule, loc, &llvm::errs());
   locScope->print(llvm::errs(), 0, false, false);
 
   namelookup::ASTScopeDeclGatherer gatherer;


### PR DESCRIPTION
Addresses recently discovered performance regression.
`findChildContaining` has to handle macros and for that
it needs a parent module, looking it up every time is expensive
because it involves walking up back to a source file scope.

Resolves: rdar://114667408
Resolves: rdar://114667496

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
