### PR TITLE
[embedded] Lay the groundwork for embedded Swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -30,12 +30,13 @@ let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-
   (moduleContext: ModulePassContext) in
 
   var worklist = FunctionWorklist()
-  worklist.addAllPerformanceAnnotatedFunctions(of: moduleContext)
-  worklist.addAllAnnotatedGlobalInitOnceFunctions(of: moduleContext)
   // For embedded Swift, optimize all the functions (there cannot be any
   // generics, type metadata, etc.)
   if moduleContext.options.enableEmbeddedSwift {
     worklist.addAllNonGenericFunctions(of: moduleContext)
+  } else {
+    worklist.addAllPerformanceAnnotatedFunctions(of: moduleContext)
+    worklist.addAllAnnotatedGlobalInitOnceFunctions(of: moduleContext)
   }
 
   optimizeFunctionsTopDown(using: &worklist, moduleContext)

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -300,6 +300,15 @@ fileprivate struct FunctionWorklist {
   }
 
   mutating func addAllPerformanceAnnotatedFunctions(of moduleContext: ModulePassContext) {
+    // For embedded Swift, optimize all the functions (there cannot be any
+    // generics, type metadata, etc.)
+    if moduleContext.options.enableEmbeddedSwift {
+      for f in moduleContext.functions {
+        pushIfNotVisited(f)
+      }
+      return
+    }
+
     for f in moduleContext.functions where f.performanceConstraints != .none {
       pushIfNotVisited(f)
     }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
@@ -28,6 +28,10 @@ struct Options {
     _bridged.enableSimplificationFor(inst.bridged)
   }
 
+  var enableEmbeddedSwift: Bool {
+    _bridged.enableEmbeddedSwift()
+  }
+
   enum AssertConfiguration {
     case enabled
     case disabled

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -137,6 +137,8 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
   /// It's called from a `[global_init]` function via a `builtin "once"`.
   public var isGlobalInitOnceFunction: Bool { bridged.isGlobalInitOnceFunction() }
 
+  public var isGenericFunction: Bool { bridged.isGenericFunction() }
+
   /// Kinds of effect attributes which can be defined for a Swift function.
   public enum EffectAttribute {
     /// No effect attribute is specified.

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -554,5 +554,8 @@ ERROR(layout_string_instantiation_without_layout_strings,none,
       "-enable-layout-string-value-witnesses-instantiation can not be enabled "
       "without -enable-layout-string-value-witnesses.", ())
 
+ERROR(evolution_with_embedded,none,
+      "Library evolution cannot be enabled with embedded Swift.", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -232,6 +232,9 @@ EXPERIMENTAL_FEATURE(ThenStatements, false)
 /// Enable the `@_rawLayout` attribute.
 EXPERIMENTAL_FEATURE(RawLayout, true)
 
+/// Enables the "embedded" swift mode (no runtime).
+EXPERIMENTAL_FEATURE(Embedded, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -85,6 +85,18 @@ enum class TypeMetadataAddress {
   FullMetadata,
 };
 
+inline bool isEmbedded(CanType t) {
+  return t->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+}
+
+inline bool isEmbedded(Decl *d) {
+  return d->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+}
+
+inline bool isEmbedded(const ProtocolConformance *c) {
+  return c->getType()->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+}
+
 /// A link entity is some sort of named declaration, combined with all
 /// the information necessary to distinguish specific implementations
 /// of the declaration from each other.
@@ -828,6 +840,7 @@ public:
   static LinkEntity forTypeMetadata(CanType concreteType,
                                     TypeMetadataAddress addr) {
     assert(!isObjCImplementation(concreteType));
+    assert(!isEmbedded(concreteType));
     LinkEntity entity;
     entity.setForType(Kind::TypeMetadata, concreteType);
     entity.Data |= LINKENTITY_SET_FIELD(MetadataAddress, unsigned(addr));
@@ -835,6 +848,7 @@ public:
   }
 
   static LinkEntity forTypeMetadataPattern(NominalTypeDecl *decl) {
+    assert(!isEmbedded(decl));
     LinkEntity entity;
     entity.setForDecl(Kind::TypeMetadataPattern, decl);
     return entity;
@@ -891,6 +905,7 @@ public:
 
   static LinkEntity forNominalTypeDescriptor(NominalTypeDecl *decl) {
     assert(!isObjCImplementation(decl));
+    assert(!isEmbedded(decl));
     LinkEntity entity;
     entity.setForDecl(Kind::NominalTypeDescriptor, decl);
     return entity;
@@ -898,18 +913,21 @@ public:
 
   static LinkEntity forNominalTypeDescriptorRecord(NominalTypeDecl *decl) {
     assert(!isObjCImplementation(decl));
+    assert(!isEmbedded(decl));
     LinkEntity entity;
     entity.setForDecl(Kind::NominalTypeDescriptorRecord, decl);
     return entity;
   }
 
   static LinkEntity forOpaqueTypeDescriptor(OpaqueTypeDecl *decl) {
+    assert(!isEmbedded(decl));
     LinkEntity entity;
     entity.setForDecl(Kind::OpaqueTypeDescriptor, decl);
     return entity;
   }
 
   static LinkEntity forOpaqueTypeDescriptorRecord(OpaqueTypeDecl *decl) {
+    assert(!isEmbedded(decl));
     LinkEntity entity;
     entity.setForDecl(Kind::OpaqueTypeDescriptorRecord, decl);
     return entity;
@@ -990,6 +1008,7 @@ public:
   }
 
   static LinkEntity forValueWitness(CanType concreteType, ValueWitness witness) {
+    assert(!isEmbedded(concreteType));
     LinkEntity entity;
     entity.Pointer = concreteType.getPointer();
     entity.Data = LINKENTITY_SET_FIELD(Kind, unsigned(Kind::ValueWitness))
@@ -998,6 +1017,7 @@ public:
   }
 
   static LinkEntity forValueWitnessTable(CanType type) {
+    assert(!isEmbedded(type));
     LinkEntity entity;
     entity.setForType(Kind::ValueWitnessTable, type);
     return entity;
@@ -1027,6 +1047,7 @@ public:
   }
 
   static LinkEntity forProtocolWitnessTable(const RootProtocolConformance *C) {
+    assert(!isEmbedded(C));
     LinkEntity entity;
     entity.setForProtocolConformance(Kind::ProtocolWitnessTable, C);
     return entity;
@@ -1034,6 +1055,7 @@ public:
 
   static LinkEntity
   forProtocolWitnessTablePattern(const ProtocolConformance *C) {
+    assert(!isEmbedded(C));
     LinkEntity entity;
     entity.setForProtocolConformance(Kind::ProtocolWitnessTablePattern, C);
     return entity;

--- a/include/swift/SIL/RuntimeEffect.h
+++ b/include/swift/SIL/RuntimeEffect.h
@@ -52,6 +52,9 @@ enum class RuntimeEffect : unsigned {
   /// The runtime function calls ObjectiveC methods.
   ObjectiveC          = 0x40,
   
+  /// Witness methods, boxing, unboxing, itializting, etc.
+  Existential         = 0x80,
+  
   /// Not modelled currently.
   Concurrency         = 0x0,
 

--- a/include/swift/SIL/RuntimeEffect.h
+++ b/include/swift/SIL/RuntimeEffect.h
@@ -52,7 +52,7 @@ enum class RuntimeEffect : unsigned {
   /// The runtime function calls ObjectiveC methods.
   ObjectiveC          = 0x40,
   
-  /// Witness methods, boxing, unboxing, itializting, etc.
+  /// Witness methods, boxing, unboxing, initializing, etc.
   Existential         = 0x80,
   
   /// Not modelled currently.

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -260,6 +260,10 @@ struct BridgedFunction {
     return getFunction()->isGlobalInitOnceFunction();
   }
 
+  bool isGenericFunction() const {
+    return getFunction()->getGenericSignature().isNull();
+  }
+
   bool hasSemanticsAttr(llvm::StringRef attrName) const {
     return getFunction()->hasSemanticsAttr(attrName);
   }

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -494,6 +494,11 @@ struct BridgedPassContext {
     return mod->getOptions().EnableStackProtection;
   }
 
+  bool enableEmbeddedSwift() const {
+    swift::SILModule *mod = invocation->getPassManager()->getModule();
+    return mod->getASTContext().LangOpts.hasFeature(swift::Feature::Embedded);
+  }
+
   bool enableMoveInoutStackProtection() const {
     swift::SILModule *mod = invocation->getPassManager()->getModule();
     return mod->getOptions().EnableMoveInoutStackProtection;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3148,6 +3148,10 @@ static bool usesFeatureBuiltinStackAlloc(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureEmbedded(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureBuiltinUnprotectedStackAlloc(Decl *decl) {
   return false;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1316,6 +1316,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
   Opts.BypassResilienceChecks |= Args.hasArg(OPT_bypass_resilience);
 
+  if (FrontendOpts.EnableLibraryEvolution && Opts.hasFeature(Feature::Embedded)) {
+    Diags.diagnose(SourceLoc(), diag::evolution_with_embedded);
+    HadError = true;
+  }
+
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1075,8 +1075,10 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
   assert(!IRGen.hasLazyMetadata(D));
 
   // Emit the class metadata.
-  emitClassMetadata(*this, D, fragileLayout, resilientLayout);
-  emitFieldDescriptor(D);
+  if (!D->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    emitClassMetadata(*this, D, fragileLayout, resilientLayout);
+    emitFieldDescriptor(D);
+  }
 
   IRGen.addClassForEagerInitialization(D);
   IRGen.addBackDeployedObjCActorInitialization(D);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1412,14 +1412,14 @@ deleteAndReenqueueForEmissionValuesDependentOnCanonicalPrespecializedMetadataRec
 void IRGenerator::emitLazyDefinitions() {
   if (SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
     // In embedded Swift, the compiler cannot emit any metadata, etc.
-    assert(LazyTypeMetadata.empty() &&
-           LazySpecializedTypeMetadataRecords.empty() &&
-           LazyTypeContextDescriptors.empty() &&
-           LazyOpaqueTypeDescriptors.empty() &&
-           LazyFunctionDefinitions.empty() &&
-           LazyCanonicalSpecializedMetadataAccessors.empty() &&
-           LazyMetadataAccessors.empty() &&
-           LazyWitnessTables.empty());
+    LazyTypeMetadata.clear();
+    LazySpecializedTypeMetadataRecords.clear();
+    LazyTypeContextDescriptors.clear();
+    LazyOpaqueTypeDescriptors.clear();
+    LazyFunctionDefinitions.clear();
+    LazyCanonicalSpecializedMetadataAccessors.clear();
+    LazyMetadataAccessors.clear();
+    LazyWitnessTables.clear();
   }
 
   while (!LazyTypeMetadata.empty() ||

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -7158,7 +7158,8 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
 }
 
 void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
-  if (!IRGen.hasLazyMetadata(theEnum)) {
+  if (!IRGen.hasLazyMetadata(theEnum) &&
+      !theEnum->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
     emitEnumMetadata(*this, theEnum);
     emitFieldDescriptor(theEnum);
   }

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1780,6 +1780,11 @@ static void forEachProtocolWitnessTable(
   assert(protocols.size() == witnessConformances.size() &&
          "mismatched protocol conformances");
 
+  // Don't emit witness tables in embedded Swift.
+  if (srcType->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    return;
+  }
+
   for (unsigned i = 0, e = protocols.size(); i < e; ++i) {
     assert(protocols[i] == witnessConformances[i].getRequirement());
     auto table = emitWitnessTableRef(IGF, srcType, srcMetadataCache,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2568,6 +2568,10 @@ static void eraseExistingTypeContextDescriptor(IRGenModule &IGM,
 void irgen::emitLazyTypeContextDescriptor(IRGenModule &IGM,
                                           NominalTypeDecl *type,
                                           RequireMetadata_t requireMetadata) {
+  if (type->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    return;
+  }
+
   eraseExistingTypeContextDescriptor(IGM, type);
 
   bool hasLayoutString = false;
@@ -6465,6 +6469,10 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
 /// that the ObjC runtime uses for uniquing.
 void IRGenModule::emitProtocolDecl(ProtocolDecl *protocol) {
   PrettyStackTraceDecl stackTraceRAII("emitting metadata for", protocol);
+
+  if (protocol->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    return;
+  }
 
   // Marker protocols are never emitted.
   if (protocol->isMarkerProtocol())

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2394,6 +2394,10 @@ static void addWTableTypeMetadata(IRGenModule &IGM,
 }
 
 void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
+  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+    return;
+  }
+
   // Don't emit a witness table if it is a declaration.
   if (wt->isDeclaration())
     return;
@@ -3353,6 +3357,8 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
                                         CanType srcType,
                                         llvm::Value **srcMetadataCache,
                                         ProtocolConformanceRef conformance) {
+  assert(!srcType->getASTContext().LangOpts.hasFeature(Feature::Embedded));
+
   auto proto = conformance.getRequirement();
   assert(Lowering::TypeConverter::protocolRequiresWitnessTable(proto)
          && "protocol does not have witness tables?!");

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1597,7 +1597,8 @@ const TypeInfo *irgen::getPhysicalStructFieldTypeInfo(IRGenModule &IGM,
 }
 
 void IRGenModule::emitStructDecl(StructDecl *st) {
-  if (!IRGen.hasLazyMetadata(st)) {
+  if (!IRGen.hasLazyMetadata(st) &&
+      !st->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
     emitStructMetadata(*this, st);
     emitFieldDescriptor(st);
   }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3303,6 +3303,8 @@ llvm::Value *IRGenFunction::emitTypeMetadataRef(CanType type) {
 MetadataResponse
 IRGenFunction::emitTypeMetadataRef(CanType type,
                                    DynamicMetadataRequest request) {
+  assert(!type->getASTContext().LangOpts.hasFeature(Feature::Embedded));
+
   type = IGM.getRuntimeReifiedType(type);
   // Look through any opaque types we're allowed to.
   type = IGM.substOpaqueTypesWithUnderlyingTypes(type);

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -601,6 +601,9 @@ public:
     if (canSkipNominal(NTD))
       return;
 
+    if (NTD->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+      return;
+
     auto declaredType = NTD->getDeclaredType()->getCanonicalType();
 
     if (!NTD->getObjCImplementationDecl()) {

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -354,17 +354,8 @@ bool PerformanceDiagnostics::visitInst(SILInstruction *inst,
   RuntimeEffect impact = getRuntimeEffect(inst, impactType);
   LocWithParent loc(inst->getLoc().getSourceLoc(), parentLoc);
 
-  if (isa<WitnessMethodInst>(inst) ||
-      isa<InitExistentialAddrInst>(inst) ||
-      isa<InitExistentialValueInst>(inst) ||
-      isa<InitExistentialRefInst>(inst) ||
-      isa<OpenExistentialValueInst>(inst) ||
-      isa<OpenExistentialRefInst>(inst) ||
-      isa<OpenExistentialAddrInst>(inst) ||
-      isa<OpenExistentialBoxInst>(inst) ||
-      isa<OpenExistentialBoxValueInst>(inst) ||
-      isa<InitExistentialMetatypeInst>(inst) ||
-      isa<OpenExistentialMetatypeInst>(inst)) {
+  if (module.getASTContext().LangOpts.hasFeature(Feature::Embedded) &&
+      impact & RuntimeEffect::Existential) {
     PrettyStackTracePerformanceDiagnostics stackTrace("existential", inst);
     diagnose(loc, diag::performance_metadata, "existential");
     return true;

--- a/test/embedded/basic-errors-no-stdlib.swift
+++ b/test/embedded/basic-errors-no-stdlib.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend -emit-ir %s -parse-stdlib -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
+
+public protocol Player {}
+struct Concrete: Player {}
+
+// CHECK: error: existential can cause metadata allocation or locks
+public func test() -> any Player {
+  Concrete()
+}

--- a/test/embedded/basic-irgen-no-stdlib.swift
+++ b/test/embedded/basic-irgen-no-stdlib.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s
+
+struct Bool {}
+
+protocol Player {
+  func play()
+  var canPlay: Bool { get }
+}
+
+struct Concrete : Player {
+  func play() { }
+  var canPlay: Bool { Bool() }
+}
+
+func start(p: some Player) {
+  p.play()
+}
+
+public func main() {
+  start(p: Concrete())
+}
+
+// CHECK-LABEL: declare hidden swiftcc void @"$s4main8ConcreteVACycfC"()
+
+// CHECK-LABEL: declare hidden swiftcc void @"$s4main5start1pyx_tAA6PlayerRzlFAA8ConcreteV_Tg5"()
+
+// CHECK-LABEL: define swiftcc void @"$s4mainAAyyF"()
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    call swiftcc void @"$s4main8ConcreteVACycfC"()
+// CHECK-NEXT:    call swiftcc void @"$s4main5start1pyx_tAA6PlayerRzlFAA8ConcreteV_Tg5"()
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }

--- a/test/embedded/basic-irgen-no-stdlib.swift
+++ b/test/embedded/basic-irgen-no-stdlib.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s
 
+// TODO: investigate why windows is generating more metadata.
+// XFAIL: OS=windows-msvc
+
 struct Bool {}
 
 protocol Player {

--- a/test/embedded/basic-irgen-no-stdlib.swift
+++ b/test/embedded/basic-irgen-no-stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s
 
 struct Bool {}
 
@@ -24,7 +24,7 @@ public func main() {
 
 // CHECK-LABEL: declare hidden swiftcc void @"$s4main5start1pyx_tAA6PlayerRzlFAA8ConcreteV_Tg5"()
 
-// CHECK-LABEL: define swiftcc void @"$s4mainAAyyF"()
+// CHECK-LABEL: define protected swiftcc void @"$s4mainAAyyF"()
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    call swiftcc void @"$s4main8ConcreteVACycfC"()
 // CHECK-NEXT:    call swiftcc void @"$s4main5start1pyx_tAA6PlayerRzlFAA8ConcreteV_Tg5"()

--- a/test/embedded/evolution-with-embedded-diag.swift
+++ b/test/embedded/evolution-with-embedded-diag.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend -emit-ir %s -enable-library-evolution -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -emit-ir %s -enable-resilience -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
+
+// CHECK: error: Library evolution cannot be enabled with embedded Swift.


### PR DESCRIPTION
This PR adds an experimental feature: Embedded (swift). It starts implementing the feature by during on mandatory optimizations (specialization, devirtualization, inlining, etc.) for all functions and applying mandatory performance diagnostics. It also adds a number of asserts to IRGen to ensure we don't emit anything that we shouldn't. 

Next steps will be serializing all functions in all modules when embedded Swift is enabled. We will probably need some more IRGen work along the way (and maybe some more optimizations/fixes). Then we can move on to the standard library. 

See Kuba's forum post https://forums.swift.org/t/embedded-swift/67057