### PR TITLE
NFC: Expand -experimental-lazy-typecheck test coverage

### DIFF
--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -22,7 +22,7 @@ func internalFunc() -> DoesNotExist { // expected-error {{cannot find type 'Does
 }
 
 @inlinable func inlinableFunc() -> Int {
-  return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+  return 1
 }
 
 private func privateFunc() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}

--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -61,11 +61,23 @@ protocol InternalProto {
 public struct PublicStruct {
   // FIXME: Test properties
 
+  public init(x: Int) {
+    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+  }
+
   public func publicMethod() -> Int {
     return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
   }
 
+  public static func publicStaticMethod() {
+    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+  }
+
   func internalMethod() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+    return 1
+  }
+
+  static func internalStaticMethod() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
     return 1
   }
 }
@@ -76,6 +88,32 @@ struct InternalStruct: DoesNotExist { // expected-error {{cannot find type 'Does
   func f(_ x: DoesNotExist) {} // expected-error {{cannot find type 'DoesNotExist' in scope}}
 }
 
+public class PublicClass {
+  // FIXME: Test properties
+
+  public init(x: Int) {
+    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+  }
+
+  // FIXME: TBDGen causes this constructor to be type checked
+//  init(_ x: DoesNotExist) {}
+
+  public func publicMethod() -> Int {
+    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+  }
+
+  public class func publicClassMethod() {
+    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+  }
+
+  // FIXME: TBDGen causes these methods to be type checked
+//  func internalMethod() -> DoesNotExist {}
+//  class func internalClassMethod() -> DoesNotExist {}
+}
+
+class InternalClass: DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  init(x: DoesNotExist) {} // expected-error {{cannot find type 'DoesNotExist' in scope}}
+}
 // FIXME: Test enums
 // FIXME: Test conformances
 // FIXME: Test global vars

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -20,6 +20,14 @@ func testGlobalFunctions() {
   }
 }
 
-func testPublicStruct(_ s: PublicStruct) {
+func testPublicStruct() {
+  var s = PublicStruct(x: 1)
   _ = s.publicMethod()
+  PublicStruct.publicStaticMethod()
+}
+
+func testPublicClass() {
+  let c = PublicClass(x: 2)
+  _ = c.publicMethod()
+  PublicClass.publicClassMethod()
 }

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -1,0 +1,25 @@
+// This source file contains an example client of all the public declarations
+// exposed by the library implemented in lazy_typecheck.swift.
+
+import lazy_typecheck
+
+struct ConformsToPublicProto: PublicProto {
+  func req() -> Int { return 1 }
+}
+
+func testGlobalFunctions() {
+  _ = publicFunc()
+  _ = publicFuncWithDefaultArg()
+  #if TEST_PACKAGE
+  _ = packageFunc()
+  #endif
+  constrainedGenericPublicFunction(ConformsToPublicProto())
+  if #available(SwiftStdlib 5.1, *) {
+    _ = publicFuncWithOpaqueReturnType()
+    _ = publicAEICFuncWithOpaqueReturnType()
+  }
+}
+
+func testPublicStruct(_ s: PublicStruct) {
+  _ = s.publicMethod()
+}

--- a/test/ModuleInterface/lazy-typecheck.swift
+++ b/test/ModuleInterface/lazy-typecheck.swift
@@ -3,12 +3,15 @@
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-module-interface-path %t/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
 // RUN: %FileCheck %s < %t/lazy_typecheck.swiftinterface
 
+// RUN: rm -rf %t/*.swiftmodule
+// RUN: %target-swift-frontend -package-name Package -typecheck %S/../Inputs/lazy_typecheck_client.swift -I %t
+
 // CHECK: import Swift
 
 // CHECK:       public func publicFunc() -> Swift.Int
 // CHECK:       publicFuncWithDefaultArg(_ x: Swift.Int = 1) -> Swift.Int
 // CHECK:       @inlinable internal func inlinableFunc() -> Swift.Int {
-// CHECK-NEXT:    return true // expected-error {{[{][{]}}cannot convert return expression of type 'Bool' to return type 'Int'{{[}][}]}}
+// CHECK-NEXT:    return 1
 // CHECK-NEXT:  }
 // CHECK:       public func constrainedGenericPublicFunction<T>(_ t: T) where T : lazy_typecheck.PublicProto
 // CHECK:       @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/test/ModuleInterface/lazy-typecheck.swift
+++ b/test/ModuleInterface/lazy-typecheck.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-module-interface-path %t/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
 // RUN: %FileCheck %s < %t/lazy_typecheck.swiftinterface
 
 // RUN: rm -rf %t/*.swiftmodule
@@ -31,5 +31,14 @@
 // CHECK:       }
 
 // CHECK:       public struct PublicStruct {
+// CHECK:         public init(x: Swift.Int)
 // CHECK:         public func publicMethod() -> Swift.Int
+// CHECK:         public static func publicStaticMethod()
+// CHECK:       }
+
+// CHECK:       public class PublicClass {
+// CHECK:         public init(x: Swift.Int)
+// CHECK:         public func publicMethod() -> Swift.Int
+// CHECK:         public class func publicClassMethod()
+// CHECK:         deinit
 // CHECK:       }

--- a/test/Serialization/serialize-external-decls-only-lazy-typecheck.swift
+++ b/test/Serialization/serialize-external-decls-only-lazy-typecheck.swift
@@ -1,25 +1,5 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -enable-library-evolution -parse-as-library -package-name Package -typecheck -verify
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path %t/lazy_typecheck.swiftmodule -enable-library-evolution -parse-as-library -package-name Package -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
-// RUN: %target-swift-frontend -package-name Package -typecheck %s -I %t
 
-import lazy_typecheck
-
-struct ConformsToPublicProto: PublicProto {
-  func req() -> Int { return 1 }
-}
-
-func testGlobalFunctions() {
-  _ = publicFunc()
-  _ = publicFuncWithDefaultArg()
-  _ = packageFunc()
-  constrainedGenericPublicFunction(ConformsToPublicProto())
-  if #available(SwiftStdlib 5.1, *) {
-    _ = publicFuncWithOpaqueReturnType()
-    _ = publicAEICFuncWithOpaqueReturnType()
-  }
-}
-
-func testPublicStruct(_ s: PublicStruct) {
-  _ = s.publicMethod()
-}
+// RUN: %target-swift-frontend -package-name Package -typecheck %S/../Inputs/lazy_typecheck_client.swift -D TEST_PACKAGE -I %t

--- a/test/TBD/lazy-typecheck.swift
+++ b/test/TBD/lazy-typecheck.swift
@@ -17,13 +17,23 @@ compatibility-version: 0
 swift-abi-version: 7
 exports:
   - targets:         [ arm64-macos ]
-    symbols:         [ '_$s14lazy_typecheck10publicFuncSiyF', '_$s14lazy_typecheck11PublicProtoMp',
-                        '_$s14lazy_typecheck11PublicProtoP3reqSiyFTj', '_$s14lazy_typecheck11PublicProtoP3reqSiyFTq',
-                        '_$s14lazy_typecheck11PublicProtoTL', '_$s14lazy_typecheck11packageFuncSiyF',
-                        '_$s14lazy_typecheck12PublicStructV12publicMethodSiyF', '_$s14lazy_typecheck12PublicStructVMa',
-                        '_$s14lazy_typecheck12PublicStructVMn', '_$s14lazy_typecheck12PublicStructVN',
-                        '_$s14lazy_typecheck13inlinableFuncSiyF', '_$s14lazy_typecheck24publicFuncWithDefaultArgyS2iF',
-                        '_$s14lazy_typecheck30publicFuncWithOpaqueReturnTypeQryF',
-                        '_$s14lazy_typecheck30publicFuncWithOpaqueReturnTypeQryFQOMQ',
-                        '_$s14lazy_typecheck32constrainedGenericPublicFunctionyyxAA0E5ProtoRzlF' ]
+    symbols:         [ '_$s14lazy_typecheck10publicFuncSiyF', '_$s14lazy_typecheck11PublicClassC06publicD6MethodyyFZTj',
+                       '_$s14lazy_typecheck11PublicClassC06publicD6MethodyyFZTq',
+                       '_$s14lazy_typecheck11PublicClassC12publicMethodSiyFTj', '_$s14lazy_typecheck11PublicClassC12publicMethodSiyFTq',
+                       '_$s14lazy_typecheck11PublicClassC1xACSi_tcfC', '_$s14lazy_typecheck11PublicClassC1xACSi_tcfCTj',
+                       '_$s14lazy_typecheck11PublicClassC1xACSi_tcfCTq', '_$s14lazy_typecheck11PublicClassC1xACSi_tcfc',
+                       '_$s14lazy_typecheck11PublicClassCMa', '_$s14lazy_typecheck11PublicClassCMm',
+                       '_$s14lazy_typecheck11PublicClassCMn', '_$s14lazy_typecheck11PublicClassCMo',
+                       '_$s14lazy_typecheck11PublicClassCMu', '_$s14lazy_typecheck11PublicClassCN',
+                       '_$s14lazy_typecheck11PublicClassCfD', '_$s14lazy_typecheck11PublicClassCfd',
+                       '_$s14lazy_typecheck11PublicProtoMp', '_$s14lazy_typecheck11PublicProtoP3reqSiyFTj',
+                       '_$s14lazy_typecheck11PublicProtoP3reqSiyFTq', '_$s14lazy_typecheck11PublicProtoTL',
+                       '_$s14lazy_typecheck11packageFuncSiyF', '_$s14lazy_typecheck12PublicStructV12publicMethodSiyF',
+                       '_$s14lazy_typecheck12PublicStructV18publicStaticMethodyyFZ',
+                       '_$s14lazy_typecheck12PublicStructV1xACSi_tcfC', '_$s14lazy_typecheck12PublicStructVMa',
+                       '_$s14lazy_typecheck12PublicStructVMn', '_$s14lazy_typecheck12PublicStructVN',
+                       '_$s14lazy_typecheck13inlinableFuncSiyF', '_$s14lazy_typecheck24publicFuncWithDefaultArgyS2iF',
+                       '_$s14lazy_typecheck30publicFuncWithOpaqueReturnTypeQryF',
+                       '_$s14lazy_typecheck30publicFuncWithOpaqueReturnTypeQryFQOMQ',
+                       '_$s14lazy_typecheck32constrainedGenericPublicFunctionyyxAA0E5ProtoRzlF' ]
 ...


### PR DESCRIPTION
- Refactor the client of the `lazy_typecheck` module into a shared input file. This allows the `ModuleInterface` test for `-experimental-lazy-typecheck ` to attempt to build a client against the emitted `.swiftinterface` which will help us ensure the emitted interface is correct.
- Add classes and constructors to the APIs vended by the `lazy_typecheck` module.