### PR TITLE
Address truncation in types

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -25,17 +25,17 @@
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 SWIFT_BEGIN_ASSUME_NONNULL
 
-typedef long SwiftInt;
-typedef unsigned long SwiftUInt;
+typedef long long SwiftInt;
+typedef unsigned long long SwiftUInt;
 
 typedef struct {
   const unsigned char *_Nullable data;
-  long length;
+  size_t length;
 } BridgedString;
 
 typedef struct {
   const void *_Nullable data;
-  long numElements;
+  size_t numElements;
 } BridgedArrayRef;
 
 typedef struct BridgedASTContext {
@@ -113,7 +113,7 @@ typedef struct BridgedDiagnosticEngine {
   void *raw;
 } BridgedDiagnosticEngine;
 
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : long {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : size_t {
   /// An expanded macro.
   BridgedExpandedMacro = 0,
   /// An external macro, spelled with either the old spelling (Module.Type)
@@ -307,7 +307,7 @@ void *IfStmt_create(BridgedASTContext cContext, BridgedSourceLoc cIfLoc,
 void *BraceStmt_create(BridgedASTContext cContext, BridgedSourceLoc cLBLoc,
                        BridgedArrayRef elements, BridgedSourceLoc cRBLoc);
 
-BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, long len);
+BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, size_t len);
 
 void *ParamDecl_create(BridgedASTContext cContext, BridgedSourceLoc cLoc,
                        BridgedSourceLoc cArgLoc, BridgedIdentifier argName,
@@ -357,7 +357,7 @@ void *GenericTypeParamDecl_create(BridgedASTContext cContext,
                                   BridgedDeclContext cDeclContext,
                                   BridgedIdentifier name,
                                   BridgedSourceLoc cNameLoc,
-                                  BridgedSourceLoc cEachLoc, long index,
+                                  BridgedSourceLoc cEachLoc, size_t index,
                                   _Bool isParameterPack);
 void GenericTypeParamDecl_setInheritedType(BridgedASTContext cContext,
                                            void *Param, void *ty);

--- a/include/swift/Basic/CBasicBridging.h
+++ b/include/swift/Basic/CBasicBridging.h
@@ -40,7 +40,7 @@ SWIFT_BEGIN_ASSUME_NONNULL
 
 typedef struct BridgedData {
   const char *_Nullable baseAddress;
-  unsigned long size;
+  size_t size;
 } BridgedData;
 
 void BridgedData_free(BridgedData data);

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -204,7 +204,7 @@ void *ImportDecl_create(BridgedASTContext cContext,
                             std::move(importPath).get());
 }
 
-BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, long len) {
+BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, size_t len) {
   SourceLoc loc = convertSourceLoc(cLoc).getAdvancedLoc(len);
   return {loc.getOpaquePointerValue()};
 }
@@ -764,7 +764,7 @@ void *GenericTypeParamDecl_create(BridgedASTContext cContext,
                                   BridgedDeclContext cDeclContext,
                                   BridgedIdentifier name,
                                   BridgedSourceLoc cNameLoc,
-                                  BridgedSourceLoc cEachLoc, long index,
+                                  BridgedSourceLoc cEachLoc, size_t index,
                                   bool isParameterPack) {
   return GenericTypeParamDecl::createParsed(
       convertDeclContext(cDeclContext), convertIdentifier(name),


### PR DESCRIPTION
We were truncating the parameter by using an incorrect parameter type in various locations.  Adjust the types to account for 64-bit platforms which use LLP64.