### PR TITLE
Cache additional TypeRefBuilder operations

### DIFF
--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -424,6 +424,18 @@ private:
   /// Cache for field info lookups.
   std::unordered_map<std::string, RemoteRef<FieldDescriptor>> FieldTypeInfoCache;
 
+  /// Cache for normalized reflection name lookups.
+  std::unordered_map<uint64_t /* remote address */, llvm::Optional<std::string>>
+      NormalizedReflectionNameCache;
+
+  /// Cache for built-in type descriptor lookups.
+  std::unordered_map<std::string /* normalized name */,
+                     RemoteRef<BuiltinTypeDescriptor>>
+      BuiltInTypeDescriptorCache;
+
+  /// The index of the last ReflectionInfo cached by BuiltInTypeDescriptorCache.
+  uint32_t NormalizedReflectionNameCacheLastReflectionInfoCache = 0;
+
   std::vector<std::unique_ptr<const GenericSignatureRef>> SignatureRefPool;
 
   TypeConverter TC;


### PR DESCRIPTION
Speed up Remote Mirror significantly by caching two additional calculations in TypeRefBuilder.

These changes shouldn't significantly impact the memory footprint of Remote Mirror. Testing against a large process which used plenty of Swift, I saw `BuiltInTypeDescriptorCache` contain only about 4000 entries, and `NormalizedReflectionNameCache` only cache 3 MB of strings.

Resolves rdar://111248508