### PR TITLE
build: adjust the build to support non-Apple environments

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -573,6 +573,9 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
     else()
       message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${ASRLF_BOOTSTRAPPING_MODE}'")
     endif()
+  else()
+    target_link_directories(${target} PRIVATE
+      ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH})
   endif()
 
   if(SWIFT_SWIFT_PARSER)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,6 +46,12 @@ if (SWIFT_SWIFT_PARSER)
        "${CMAKE_SHARED_LIBRARY_SUFFIX}"
        OUTPUT_VARIABLE SWIFT_SYNTAX_SHARED_LIBRARIES)
 
+  list(TRANSFORM SWIFT_SYNTAX_MODULES PREPEND "${CMAKE_IMPORT_LIBRARY_PREFIX}"
+    OUTPUT_VARIABLE SWIFT_SYNTAX_IMPORT_LIBRARIES)
+  list(TRANSFORM SWIFT_SYNTAX_IMPORT_LIBRARIES APPEND
+    "${CMAKE_IMPORT_LIBRARY_SUFFIX}" OUTPUT_VARIABLE
+    SWIFT_SYNTAX_IMPORT_LIBRARIES)
+
   # Interface library to collect swiftinterfaces and swiftmodules from
   # SwiftSyntax
   add_library(swiftSyntaxLibraries INTERFACE)
@@ -64,26 +70,46 @@ if (SWIFT_SWIFT_PARSER)
       )
     endif()
 
-    add_custom_command(
-      OUTPUT "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${sharedlib}"
-      DEPENDS "${SWIFT_SYNTAX_LIBRARIES_BUILD_DIR}/${sharedlib}"
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SWIFT_SYNTAX_LIBRARIES_BUILD_DIR}/${sharedlib} ${SWIFT_HOST_LIBRARIES_DEST_DIR}/${sharedlib}
-      ${add_origin_rpath}
-    )
-
-    add_custom_target(copy_swiftSyntaxLibrary_${sharedlib}
-      DEPENDS "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${sharedlib}"
-      COMMENT "Copying ${sharedlib}"
-    )
-
-    swift_install_in_component(
-      PROGRAMS "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${sharedlib}"
-      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
-      COMPONENT compiler
-    )
+    if(CMAKE_SYSTEM_NAME MATCHES Windows)
+      add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${sharedlib}
+                         DEPENDS "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/bin/${sharedlib}"
+                         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/bin/${sharedlib} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${sharedlib})
+      add_custom_target(copy_swiftSyntaxLibrary_${sharedlib}
+                        DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${sharedlib}
+                        COMMENT "copying ${sharedlib}")
+      swift_install_in_component(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${sharedlib}
+                                 DESTINATION bin
+                                 COMPONENT compiler)
+    else()
+      add_custom_command(OUTPUT "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${sharedlib}"
+                         DEPENDS "${SWIFT_SYNTAX_LIBRARIES_BUILD_DIR}/${sharedlib}"
+                         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SWIFT_SYNTAX_LIBRARIES_BUILD_DIR}/${sharedlib} ${SWIFT_HOST_LIBRARIES_DEST_DIR}/${sharedlib}
+                         ${add_origin_rpath})
+      add_custom_target(copy_swiftSyntaxLibrary_${sharedlib}
+                        DEPENDS "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${sharedlib}"
+                        COMMENT "Copying ${sharedlib}")
+      swift_install_in_component(PROGRAMS "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${sharedlib}"
+                                 DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
+                                 COMPONENT compiler)
+    endif()
 
     add_dependencies(swiftSyntaxLibraries copy_swiftSyntaxLibrary_${sharedlib})
   endforeach()
+
+  if(CMAKE_SYSTEM_NAME MATCHES Windows)
+    foreach(implib ${SWIFT_SYNTAX_IMPORT_LIBRARIES})
+      add_custom_command(OUTPUT ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib/swift/windows/${implib}
+        DEPENDS ${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host/${implib}
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host/${implib} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib/swift/windows/${implib})
+      add_custom_target(copy_swiftSyntaxLibrary_${implib}
+        DEPENDS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib/swift/windows/${implib}
+        COMMENT "Copying ${implib}")
+      swift_install_in_component(PROGRAMS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib/swift/windows/${implib}
+        DESTINATION lib
+        COMPONENT compiler)
+      add_dependencies(swiftSyntaxLibraries copy_swiftSyntaxLibrary_${implib})
+    endforeach()
+  endif()
 
   # Copy all of the Swift modules from earlyswiftsyntax so they can be found
   # in the same relative place within the build directory as in the final

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -161,6 +161,9 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
       # Add rpath to the host Swift libraries.
       file(RELATIVE_PATH relative_hostlib_path "${path}" "${SWIFTLIB_DIR}/host")
       list(APPEND RPATH_LIST "$ORIGIN/${relative_hostlib_path}")
+    else()
+      target_link_directories(${target} PRIVATE
+        ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH})
     endif()
 
     # For the "end step" of bootstrapping configurations on Darwin, need to be

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -5,6 +5,8 @@
 # parser is built in.
 function(add_swift_parser_link_libraries target)
   if(SWIFT_SWIFT_PARSER)
+    target_link_directories(${target} PRIVATE
+      ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH})
     target_link_libraries(${target}
                           PRIVATE swiftCore)
 


### PR DESCRIPTION
Account for import libraries and the associated layout difference on
platforms (e.g. DLLs are placed in `bin`).  This is required to enable
building the macro path on Windows.