### PR TITLE
[AutoDiff] re-enable rdar71319547 generated-decls-shall-not-be-resilient

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/rdar71319547-generated-decls-shall-not-be-resilient.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar71319547-generated-decls-shall-not-be-resilient.swift
@@ -4,8 +4,6 @@
 
 // rdar://71319547
 
-// REQUIRES: rdar76127287
-
 import _Differentiation
 
 // Assertion failed: (mainPullbackStruct->getType() == pbStructLoweredType), function run, file swift/lib/SILOptimizer/Differentiation/PullbackCloner.cpp, line 1899.

--- a/test/AutoDiff/compiler_crashers_fixed/rdar71319547-generated-decls-shall-not-be-resilient.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar71319547-generated-decls-shall-not-be-resilient.swift
@@ -6,27 +6,11 @@
 
 import _Differentiation
 
-// Assertion failed: (mainPullbackStruct->getType() == pbStructLoweredType), function run, file swift/lib/SILOptimizer/Differentiation/PullbackCloner.cpp, line 1899.
-// Stack dump:
-// 1.	Swift version 5.3-dev (LLVM 618cb952e0f199a, Swift d74c261f098665c)
-// 2.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for main.main)
-// 3.	While running pass #17 SILModuleTransform "Differentiation".
-// 4.	While processing // differentiability witness for foo(_:)
-// sil_differentiability_witness [serialized] [reverse] [parameters 0] [results 0] @$s4main3fooyS2fF : $@convention(thin) (Float) -> Float {
-// }
 @differentiable(reverse, wrt: x)
 public func i_have_a_pullback_struct(_ x: Float) -> Float {
   return x
 }
 
-// Assertion failed: (v->getType().isObject()), function operator(), file swift/lib/SIL/Utils/ValueUtils.cpp, line 22.
-// Stack dump:
-// 1.	Swift version 5.3-dev (LLVM 618cb952e0f199a, Swift d74c261f098665c)
-// 2.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for main.main)
-// 3.	While running pass #24 SILModuleTransform "Differentiation".
-// 4.	While processing // differentiability witness for i_have_a_branching_trace_enum(_:)
-// sil_differentiability_witness [serialized] [reverse] [parameters 0] [results 0] @$s4main29i_have_a_branching_trace_enumyS2fF : $@convention(thin) (Float) -> Float {
-// }
 @differentiable(reverse, wrt: x)
 public func i_have_a_branching_trace_enum(_ x: Float) -> Float {
   if true {

--- a/test/AutoDiff/compiler_crashers_fixed/rdar71319547-generated-decls-shall-not-be-resilient.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar71319547-generated-decls-shall-not-be-resilient.swift
@@ -6,11 +6,27 @@
 
 import _Differentiation
 
+// Assertion failed: (mainPullbackStruct->getType() == pbStructLoweredType), function run, file swift/lib/SILOptimizer/Differentiation/PullbackCloner.cpp, line 1899.
+// Stack dump:
+// 1.	Swift version 5.3-dev (LLVM 618cb952e0f199a, Swift d74c261f098665c)
+// 2.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for main.main)
+// 3.	While running pass #17 SILModuleTransform "Differentiation".
+// 4.	While processing // differentiability witness for foo(_:)
+// sil_differentiability_witness [serialized] [reverse] [parameters 0] [results 0] @$s4main3fooyS2fF : $@convention(thin) (Float) -> Float {
+// }
 @differentiable(reverse, wrt: x)
 public func i_have_a_pullback_struct(_ x: Float) -> Float {
   return x
 }
 
+// Assertion failed: (v->getType().isObject()), function operator(), file swift/lib/SIL/Utils/ValueUtils.cpp, line 22.
+// Stack dump:
+// 1.	Swift version 5.3-dev (LLVM 618cb952e0f199a, Swift d74c261f098665c)
+// 2.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for main.main)
+// 3.	While running pass #24 SILModuleTransform "Differentiation".
+// 4.	While processing // differentiability witness for i_have_a_branching_trace_enum(_:)
+// sil_differentiability_witness [serialized] [reverse] [parameters 0] [results 0] @$s4main29i_have_a_branching_trace_enumyS2fF : $@convention(thin) (Float) -> Float {
+// }
 @differentiable(reverse, wrt: x)
 public func i_have_a_branching_trace_enum(_ x: Float) -> Float {
   if true {


### PR DESCRIPTION
This PR re-enables AutoDiff test which caused the compiler to crash, but the underlying feature has been fixed.
It was disabled in this PR:
https://github.com/apple/swift/commit/4c1d4a04ce2f84b1c501476600ee1f5adadccc14