### PR TITLE
[Sema] Improves diagnostic when passing an argument as property of an optional class instance (#57437)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -330,7 +330,7 @@ ERROR(cannot_convert_initializer_value_nil,none,
       "'nil' cannot initialize specified type %0", (Type))
 
 ERROR(cannot_convert_to_return_type,none,
-      "cannot convert return expression of type %0 to return type %1",
+      "return expressions for types %0 and %1 are not interconvertible",
       (Type,Type))
 ERROR(cannot_convert_to_return_type_protocol,none,
       "return expression of type %0 does not conform to %1", (Type,Type))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6534,6 +6534,15 @@ bool ConstraintSystem::repairFailures(
     // diagnostics.
     if (flags.contains(TMF_MatchingGenericArguments))
       break;
+    
+    if (!path.empty()) {
+      if (path.back().is<LocatorPathElt::ApplyArgToParam>())
+        conversionsOrFixes.push_back(AllowArgumentMismatch::create(
+            *this, lhs, rhs, getConstraintLocator(anchor, path)));
+      else if (path.back().is<LocatorPathElt::ContextualType>())
+        conversionsOrFixes.push_back(IgnoreContextualType::create(
+            *this, lhs, rhs, getConstraintLocator(anchor, path)));
+    }
 
     Type fromType;
     Type toType;

--- a/test/Constraints/parameterized_existentials.swift
+++ b/test/Constraints/parameterized_existentials.swift
@@ -15,7 +15,7 @@ func f2(x: any P<Int>) -> any P {
 
 func f3(x: any P<Int>) -> any P<String> {
   // FIXME: Misleading diagnostic
-  return x // expected-error {{cannot convert return expression of type 'String' to return type 'Int'}}
+  return x // expected-error {{return expressions for types 'String' and 'Int' are not interconvertible}}
 }
 
 struct G<T> {}
@@ -24,19 +24,19 @@ struct G<T> {}
 // expected-note@-3 {{arguments to generic parameter 'T' ('any P<Int>' and 'any P<String>') are expected to be equal}}
 
 func g1(x: G<any P>) -> G<any P<Int>> {
-  return x // expected-error {{cannot convert return expression of type 'G<any P>' to return type 'G<any P<Int>>'}}
+  return x // expected-error {{return expressions for types 'G<any P>' and 'G<any P<Int>>' are not interconvertible}}
 }
 
 func g2(x: G<any P<Int>>) -> G<any P> {
-  return x // expected-error {{cannot convert return expression of type 'G<any P<Int>>' to return type 'G<any P>'}}
+  return x // expected-error {{return expressions for types 'G<any P<Int>>' and 'G<any P>' are not interconvertible}}
 }
 
 func g3(x: G<any P<Int>>) -> G<any P<String>> {
-  return x // expected-error {{cannot convert return expression of type 'G<any P<Int>>' to return type 'G<any P<String>>'}}
+  return x // expected-error {{return expressions for types 'G<any P<Int>>' and 'G<any P<String>>' are not interconvertible}}
 }
 
 func h1(x: (any P)?) -> (any P<Int>)? {
-  return x // expected-error {{cannot convert return expression of type '(any P)?' to return type '(any P<Int>)?'}}
+  return x // expected-error {{return expressions for types 'any P' and 'any P<Int>' are not interconvertible}}
 }
 
 func h2(x: (any P<Int>)?) -> (any P)? {
@@ -44,5 +44,6 @@ func h2(x: (any P<Int>)?) -> (any P)? {
 }
 
 func h3(x: (any P<Int>)?) -> (any P<String>)? {
-  return x // expected-error {{cannot convert return expression of type '(any P<Int>)?' to return type '(any P<String>)?'}}
+  return x // expected-error {{return expressions for types 'any P<Int>' and 'any P<String>' are not interconvertible}
+  // expected-note@-1 {{arguments to generic parameter 'T' ('any P<Int>' and 'any P<String>') are expected to be equal}}
 }


### PR DESCRIPTION
Resolves #57437

As described in the issue, “Type of expression is ambiguous” error is thrown when passing an argument as property of an optional class instance, which further broken down into an `argument` or `contextual` type.