### PR TITLE
AST: leak memory rather than corrupt memory

### DIFF
--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -31,9 +31,10 @@ struct BridgedDiagnosticImpl {
 
   ~BridgedDiagnosticImpl() {
     inFlight.flush();
-    for (auto text : textBlobs) {
-      free((void *)text.data());
-    }
+    /*
+    for (auto &text : textBlobs)
+      BridgedDiagnosticImpl::Allocator.Deallocate(&text);
+    */
   }
 };
 } // namespace


### PR DESCRIPTION
`llvm::MallocAllocator` uses `operator new`, not `malloc`.  This memory may not be `free`'ed but must be `delete`d.  However, this is also not guaranteed.  Instead, we should have a global bump allocator or a global `llvm::MallocAllocator` that uses `Allocate` and `Deallocate` to manage this memory.