### PR TITLE
Sema: leak rather than corrupt memory

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -155,9 +155,7 @@ func allocateUTF8String(
   var string = string
   return string.withUTF8 { utf8 in
     let capacity = utf8.count + (nullTerminated ? 1 : 0)
-    let ptr = UnsafeMutablePointer<UInt8>.allocate(
-      capacity: capacity
-    )
+    let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
     if let baseAddress = utf8.baseAddress {
       ptr.initialize(from: baseAddress, count: utf8.count)
     }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -196,10 +196,12 @@ MacroDefinition MacroDefinitionRequest::evaluate(
       &externalMacroNameLength, &replacements, &numReplacements);
 
   // Clean up after the call.
+  /*
   SWIFT_DEFER {
     free(externalMacroNamePtr);
     free(replacements);
   };
+  */
 
   if (checkResult < 0 && ctx.CompletionCallback) {
     // If the macro failed to check and we are in code completion mode, pretend

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1067,7 +1067,7 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
         {evaluatedSourceAddress, (size_t)evaluatedSourceLength},
         adjustMacroExpansionBufferName(*discriminator));
-    free((void *)evaluatedSourceAddress);
+    /* free((void *)evaluatedSourceAddress); */
     break;
 #else
     ctx.Diags.diagnose(loc, diag::macro_unsupported);
@@ -1345,7 +1345,7 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
         {evaluatedSourceAddress, (size_t)evaluatedSourceLength},
         adjustMacroExpansionBufferName(*discriminator));
-    free((void *)evaluatedSourceAddress);
+    /* free((void *)evaluatedSourceAddress); */
     break;
 #else
     attachedTo->diagnose(diag::macro_unsupported);


### PR DESCRIPTION
`UnsafeMutableBufferPointer.allocate` does not guarantee usage of `malloc` (and in fact guarantees the opposite due to alignment assumptions).  The memory allocated by that must be released by `UnsafeMutableBufferPointer.deallocate` only as that is guaranteed to correctly call the deallocation routine.  Leak memory rather than corrupting memory.