### PR TITLE
[Macros/C bridging] Replace use of `free` for Swift-allocated pointer

### DIFF
--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -17,6 +17,8 @@ using namespace swift;
 
 namespace {
 struct BridgedDiagnosticImpl {
+  typedef llvm::MallocAllocator Allocator;
+
   InFlightDiagnostic inFlight;
   std::vector<StringRef> textBlobs;
 
@@ -31,8 +33,10 @@ struct BridgedDiagnosticImpl {
 
   ~BridgedDiagnosticImpl() {
     inFlight.flush();
+
+    Allocator allocator;
     for (auto text : textBlobs) {
-      free((void *)text.data());
+      allocator.Deallocate(text.data(), text.size());
     }
   }
 };
@@ -100,8 +104,8 @@ BridgedDiagnostic Diagnostic_create(BridgedDiagnosticEngine cDiags,
                                     BridgedSourceLoc cLoc,
                                     BridgedString cText) {
   StringRef origText = convertString(cText);
-  llvm::MallocAllocator mallocAlloc;
-  StringRef text = origText.copy(mallocAlloc);
+  BridgedDiagnosticImpl::Allocator alloc;
+  StringRef text = origText.copy(alloc);
 
   SourceLoc loc = convertSourceLoc(cLoc);
 
@@ -148,8 +152,8 @@ void Diagnostic_fixItReplace(BridgedDiagnostic cDiag,
   SourceLoc endLoc = convertSourceLoc(cEndLoc);
 
   StringRef origReplaceText = convertString(cReplaceText);
-  llvm::MallocAllocator mallocAlloc;
-  StringRef replaceText = origReplaceText.copy(mallocAlloc);
+  BridgedDiagnosticImpl::Allocator alloc;
+  StringRef replaceText = origReplaceText.copy(alloc);
 
   BridgedDiagnosticImpl *diag = convertDiagnostic(cDiag);
   diag->textBlobs.push_back(replaceText);

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -170,6 +170,11 @@ func allocateUTF8String(
   }
 }
 
+@_cdecl("swift_ASTGen_freeString")
+public func freeString(pointer: UnsafePointer<UInt8>?) {
+  pointer?.deallocate()
+}
+
 /// Diagnostics produced here.
 enum ASTGenMacroDiagnostic: DiagnosticMessage, FixItMessage {
   case thrownError(Error)
@@ -411,6 +416,14 @@ func checkMacroDefinition(
     )
     return -1
   }
+}
+
+@_cdecl("swift_ASTGen_freeExpansionReplacements")
+public func freeExpansionReplacements(
+  pointer: UnsafeMutablePointer<Int>?,
+  numReplacements: Int
+) {
+  UnsafeMutableBufferPointer(start: pointer, count: numReplacements).deallocate()
 }
 
 // Make an expansion result for '@_cdecl' function caller.


### PR DESCRIPTION
We cannot depend on Swift's unsafe pointers using `malloc` under the hood, so don't use `free` on them. Instead, expose entry points from Swift to C++ to free any Swift-allocated data structures that need to be deallocated from C++.
