### PR TITLE
[cxx-interop][SwiftToCxx] Print `operator` keyword when mapping Swift operator to C++

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -156,6 +156,8 @@ isVisibleToObjC(const ValueDecl *VD, AccessLevel minRequiredAccess,
 StringRef
 swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
                                       CustomNamesOnly_t customNamesOnly) {
+  ASTContext& ctx = VD->getASTContext();
+
   if (const auto *Expose = VD->getAttrs().getAttribute<ExposeAttr>()) {
     if (!Expose->Name.empty())
       return Expose->Name;
@@ -166,6 +168,11 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
 
   if (isa<ConstructorDecl>(VD))
     return "init";
+
+  if (VD->isOperator()) {
+    std::string name = ("operator" + VD->getBaseIdentifier().str()).str();
+    return ctx.getIdentifier(name).str();
+  }
 
   if (auto *mod = dyn_cast<ModuleDecl>(VD)) {
     if (mod->isStdlibModule())
@@ -188,7 +195,7 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
         os << char(std::toupper(paramNameStr[0]));
         os << paramNameStr.drop_front(1);
       }
-      auto r = VD->getASTContext().getIdentifier(os.str());
+      auto r = ctx.getIdentifier(os.str());
       return r.str();
     }
 

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Operators -clang-header-expose-decls=all-public -emit-clang-header-path %t/operators.h
+// RUN: %FileCheck %s < %t/operators.h
+
+// TODO: %check-interop-cxx-header-in-clang(%t/operators.h)
+// unfortunately the header still triggers an error:
+//   error: no member named '_impl_IntBox' in namespace 'Operators::_impl'
+
+// CHECK-LABEL: namespace Operators SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Operators") {
+
+// CHECK-LABEL: namespace _impl {
+
+// CHECK: SWIFT_EXTERN bool $s9Operators2eeoiySbAA6IntBoxV_ADtF(struct swift_interop_passStub_Operators_uint32_t_0_4 lhs, struct swift_interop_passStub_Operators_uint32_t_0_4 rhs) SWIFT_NOEXCEPT SWIFT_CALL; // ==(_:_:)
+
+// CHECK: }
+
+public struct IntBox { var x: CInt }
+
+public func -(lhs: IntBox, rhs: IntBox) -> CInt {
+  return lhs.x - rhs.x
+}
+
+// CHECK: SWIFT_INLINE_THUNK int operator-(const IntBox& lhs, const IntBox& rhs) noexcept SWIFT_SYMBOL("s:9Operators1soiys5Int32VAA6IntBoxV_AFtF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK:   return _impl::$s9Operators1soiys5Int32VAA6IntBoxV_AFtF(_impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(lhs)), _impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(rhs)));
+// CHECK: }
+
+public func ==(lhs: IntBox, rhs: IntBox) -> Bool {
+  return lhs.x == rhs.x
+}
+
+// CHECK: SWIFT_INLINE_THUNK bool operator==(const IntBox& lhs, const IntBox& rhs) noexcept SWIFT_SYMBOL("s:9Operators2eeoiySbAA6IntBoxV_ADtF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK:   return _impl::$s9Operators2eeoiySbAA6IntBoxV_ADtF(_impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(lhs)), _impl::swift_interop_passDirect_Operators_uint32_t_0_4(_impl::_impl_IntBox::getOpaquePointer(rhs)));
+// CHECK: }


### PR DESCRIPTION
Previously we emitted this:
```
SWIFT_INLINE_THUNK bool ==(const IntBox& lhs, const IntBox& rhs)
```
which is not valid in C++.

Now we'll emit this:
```
SWIFT_INLINE_THUNK bool operator==(const IntBox& lhs, const IntBox& rhs)
```

rdar://114772296