### PR TITLE
[ConstraintSystem] Simplify checking optionality of key path components

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1479,10 +1479,10 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
     } else {
       emitDiagnostic(diag::invalid_optional_inferred_keypath_root, baseType,
                      Member, unwrappedBaseType);
-      emitDiagnostic(diag::optional_key_path_root_base_chain, Member)
-          .fixItInsert(sourceRange.End, "?.");
-      emitDiagnostic(diag::optional_key_path_root_base_unwrap, Member)
-          .fixItInsert(sourceRange.End, "!.");
+//      emitDiagnostic(diag::optional_key_path_root_base_chain, Member)
+//          .fixItInsert(sourceRange.End, "?.");
+//      emitDiagnostic(diag::optional_key_path_root_base_unwrap, Member)
+//          .fixItInsert(sourceRange.End, "!.");
     }
   } else {
     // Check whether or not the base of this optional unwrap is implicit self

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12230,10 +12230,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
             auto *componentLoc =
                 getConstraintLocator(locator->getAnchor(), path.drop_back());
 
-            if (hasFixFor(componentLoc, FixKind::DefineMemberBasedOnUse) ||
-                hasFixFor(componentLoc, FixKind::UnwrapOptionalBase) ||
-                hasFixFor(componentLoc,
-                          FixKind::UnwrapOptionalBaseWithOptionalResult))
+            if (hasFixFor(componentLoc, FixKind::DefineMemberBasedOnUse))
               return true;
           }
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -967,6 +967,7 @@ func testMemberAccessOnOptionalKeyPathComponent() {
   _ = \S1a.b_opt?.c.d
   // expected-error@-1 {{value of optional type 'S1c?' must be unwrapped to refer to member 'd' of wrapped base type 'S1c'}}
   // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}} {{20-20=?}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
 
   _ = \S1a.b.c.d
   // expected-error@-1 {{value of optional type 'S1c?' must be unwrapped to refer to member 'd' of wrapped base type 'S1c'}}
@@ -1067,8 +1068,10 @@ func f_56996() {
 // https://github.com/apple/swift/issues/55805
 // Key-path missing optional crashes compiler: Inactive constraints left over?
 func f_55805() {
-  let _: KeyPath<String?, Int?> = \.utf8.count // expected-error {{value of optional type 'String.UTF8View?' must be unwrapped to refer to member 'count' of wrapped base type 'String.UTF8View'}}
-  // expected-note@-1 {{chain the optional using '?' to access member 'count' only for non-'nil' base values}}
+  let _: KeyPath<String?, Int?> = \.utf8.count // expected-error {{key path value type 'Int' cannot be converted to contextual type 'Int?'}}
+  // expected-error@-1 {{key path root inferred as optional type 'String?' must be unwrapped to refer to member 'utf8' of unwrapped type 'String'}}
+  // expected-note@-2 {{chain the optional using '?.' to access unwrapped type member 'utf8'}}
+  // expected-note@-3 {{unwrap the optional using '!.' to access unwrapped type member 'utf8'}}
 }
 
 // rdar://74711236 - crash due to incorrect member access in key path


### PR DESCRIPTION
To check member optionality, the constraint solver creates a disjunction that compares an optional of the member type with its non optional type:

```
(considering: $T5[.d: value] == $T6 @ locator@0x13700dd50 [KeyPath@/Users/amritpankaur/test.swift:1120:5 → key path component #3]
        (added constraint: disjunction @ locator@0x13700dd50 [KeyPath@/Users/amritpankaur/test.swift:1120:5 → key path component #3]:
          >             $T6 bind $T11 [fix: unwrap optional base of member lookup] @ locator@0x13700dd50 [KeyPath@/... → key path component #3]
          >             $T11? bind $T6 [fix: unwrap optional base of member lookup] @ locator@0x13700dd50 [KeyPath@/... → key path component #3])
         (overload set choice binding $T11 := Int)
))
```

These changes remove this disjunction step for key path components and delays member type resolution until there is an available contextual type. Key path components will only record a single fix:
```
(considering: $T5[.d: value] == $T6 @ locator@0x13180f150 [KeyPath@/... → key path component #3]
    (attempting fix [fix: unwrap optional base of member lookup] @ locator@0x13180f150 [KeyPath@/... → key path component #3])
      (overload set choice binding $T6 := Int)
```
