### PR TITLE
[Swift bridging] Consistently use correctly-defined Swift(U)Int for bridging

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -25,17 +25,14 @@
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 SWIFT_BEGIN_ASSUME_NONNULL
 
-typedef long SwiftInt;
-typedef unsigned long SwiftUInt;
-
 typedef struct {
   const unsigned char *_Nullable data;
-  long length;
+  SwiftInt length;
 } BridgedString;
 
 typedef struct {
   const void *_Nullable data;
-  long numElements;
+  SwiftInt numElements;
 } BridgedArrayRef;
 
 typedef struct BridgedASTContext {
@@ -70,7 +67,7 @@ typedef struct {
   BridgedSourceLoc TrailingCommaLoc;
 } BridgedTupleTypeElement;
 
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedRequirementReprKind : long {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedRequirementReprKind : SwiftInt {
   /// A type bound T : P, where T is a type that depends on a generic
   /// parameter and P is some type that should bound T, either as a concrete
   /// supertype or a protocol to which T must conform.
@@ -97,7 +94,7 @@ typedef struct {
 } BridgedRequirementRepr;
 
 /// Diagnostic severity when reporting diagnostics.
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticSeverity : long {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticSeverity : SwiftInt {
   BridgedFatalError,
   BridgedError,
   BridgedWarning,
@@ -113,7 +110,7 @@ typedef struct BridgedDiagnosticEngine {
   void *raw;
 } BridgedDiagnosticEngine;
 
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : long {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : SwiftInt {
   /// An expanded macro.
   BridgedExpandedMacro = 0,
   /// An external macro, spelled with either the old spelling (Module.Type)
@@ -124,7 +121,7 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : long {
 } BridgedMacroDefinitionKind;
 
 /// Bridged parameter specifiers
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : long {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : SwiftInt {
   BridgedAttributedTypeSpecifierInOut,
   BridgedAttributedTypeSpecifierBorrowing,
   BridgedAttributedTypeSpecifierConsuming,
@@ -135,7 +132,7 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : long
 } BridgedAttributedTypeSpecifier;
 
 // Bridged type attribute kinds, which mirror TypeAttrKind exactly.
-typedef enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : long {
+typedef enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : SwiftInt {
   BridgedTypeAttrKind_autoclosure,
   BridgedTypeAttrKind_convention,
   BridgedTypeAttrKind_noescape,
@@ -187,7 +184,7 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : long {
   BridgedTypeAttrKind_Count
 } BridgedTypeAttrKind;
 
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) ASTNodeKind : long {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) ASTNodeKind : SwiftInt {
   ASTNodeKindExpr,
   ASTNodeKindStmt,
   ASTNodeKindDecl
@@ -307,7 +304,7 @@ void *IfStmt_create(BridgedASTContext cContext, BridgedSourceLoc cIfLoc,
 void *BraceStmt_create(BridgedASTContext cContext, BridgedSourceLoc cLBLoc,
                        BridgedArrayRef elements, BridgedSourceLoc cRBLoc);
 
-BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, long len);
+BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, SwiftInt len);
 
 void *ParamDecl_create(BridgedASTContext cContext, BridgedSourceLoc cLoc,
                        BridgedSourceLoc cArgLoc, BridgedIdentifier argName,
@@ -357,7 +354,7 @@ void *GenericTypeParamDecl_create(BridgedASTContext cContext,
                                   BridgedDeclContext cDeclContext,
                                   BridgedIdentifier name,
                                   BridgedSourceLoc cNameLoc,
-                                  BridgedSourceLoc cEachLoc, long index,
+                                  BridgedSourceLoc cEachLoc, SwiftInt index,
                                   _Bool isParameterPack);
 void GenericTypeParamDecl_setInheritedType(BridgedASTContext cContext,
                                            void *Param, void *ty);

--- a/include/swift/Basic/CBasicBridging.h
+++ b/include/swift/Basic/CBasicBridging.h
@@ -55,6 +55,7 @@ typedef __UINT64_TYPE__ __swiftc_uint64_t;
 #else
 typedef unsigned __INT64_TYPE__ __swiftc_uint64_t;
 #endif
+#endif
 
 typedef __INT32_TYPE__ __swiftc_int32_t;
 #ifdef __UINT32_TYPE__
@@ -81,7 +82,6 @@ typedef __swiftc_uint32_t SwiftUInt;
 #else
 typedef __swiftc_intn_t(__INTPTR_WIDTH__) SwiftInt;
 typedef __swiftc_uintn_t(__INTPTR_WIDTH__) SwiftUInt;
-#endif
 #endif
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS

--- a/include/swift/Basic/CBasicBridging.h
+++ b/include/swift/Basic/CBasicBridging.h
@@ -64,12 +64,12 @@ typedef unsigned __INT32_TYPE__ __swiftc_uint32_t;
 #define __swiftc_uintn_t(n) __swiftc_join3(__swiftc_uint, n, _t)
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#if defined(_WIN32)
-typedef __swiftc_int32_t SwiftInt;
-typedef __swiftc_uint32_t SwiftUInt;
-#elif defined(_WIN64)
+#if defined(_WIN64)
 typedef __swiftc_int64_t SwiftInt;
 typedef __swiftc_uint64_t SwiftUInt;
+#elif defined(_WIN32)
+typedef __swiftc_int32_t SwiftInt;
+typedef __swiftc_uint32_t SwiftUInt;
 #else
 #error unknown windows pointer width
 #endif

--- a/include/swift/Basic/CBasicBridging.h
+++ b/include/swift/Basic/CBasicBridging.h
@@ -38,9 +38,12 @@ FeatureName,
 
 SWIFT_BEGIN_ASSUME_NONNULL
 
+typedef long SwiftInt;
+typedef unsigned long SwiftUInt;
+
 typedef struct BridgedData {
   const char *_Nullable baseAddress;
-  unsigned long size;
+  SwiftUInt size;
 } BridgedData;
 
 void BridgedData_free(BridgedData data);

--- a/include/swift/Basic/CBasicBridging.h
+++ b/include/swift/Basic/CBasicBridging.h
@@ -35,7 +35,12 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__)
+#if defined(_MSC_VER) && !defined(__clang__)
+typedef __int64 __swiftc_int64_t;
+typedef unsigned __int64 __swiftc_uint64_t;
+typedef int __swiftc_int32_t;
+typedef unsigned int __swiftc_uint32_t;
+#elif !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__)
 #include <stdint.h>
 typedef int64_t __swiftc_int64_t;
 typedef uint64_t __swiftc_uint64_t;

--- a/include/swift/Basic/CBasicBridging.h
+++ b/include/swift/Basic/CBasicBridging.h
@@ -55,13 +55,13 @@ typedef __UINT64_TYPE__ __swiftc_uint64_t;
 #else
 typedef unsigned __INT64_TYPE__ __swiftc_uint64_t;
 #endif
-#endif
 
 typedef __INT32_TYPE__ __swiftc_int32_t;
 #ifdef __UINT32_TYPE__
 typedef __UINT32_TYPE__ __swiftc_uint32_t;
 #else
 typedef unsigned __INT32_TYPE__ __swiftc_uint32_t;
+#endif
 #endif
 
 #define __swiftc_join3(a,b,c) a ## b ## c

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -204,7 +204,7 @@ void *ImportDecl_create(BridgedASTContext cContext,
                             std::move(importPath).get());
 }
 
-BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, long len) {
+BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, SwiftInt len) {
   SourceLoc loc = convertSourceLoc(cLoc).getAdvancedLoc(len);
   return {loc.getOpaquePointerValue()};
 }
@@ -764,7 +764,7 @@ void *GenericTypeParamDecl_create(BridgedASTContext cContext,
                                   BridgedDeclContext cDeclContext,
                                   BridgedIdentifier name,
                                   BridgedSourceLoc cNameLoc,
-                                  BridgedSourceLoc cEachLoc, long index,
+                                  BridgedSourceLoc cEachLoc, SwiftInt index,
                                   bool isParameterPack) {
   return GenericTypeParamDecl::createParsed(
       convertDeclContext(cDeclContext), convertIdentifier(name),
@@ -881,6 +881,6 @@ bool Plugin_waitForNextMessage(PluginHandle handle, BridgedData *out) {
   auto size = message.size();
   auto outPtr = malloc(size);
   memcpy(outPtr, message.data(), size);
-  *out = BridgedData{(const char *)outPtr, (unsigned long)size};
+  *out = BridgedData{(const char *)outPtr, (SwiftUInt)size};
   return false;
 }

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -1,4 +1,5 @@
 import CASTBridging
+import CBasicBridging
 import SwiftParser
 
 // Needed to use SyntaxTransformVisitor's visit method.
@@ -8,7 +9,7 @@ import SwiftSyntax
 extension Array {
   public func withBridgedArrayRef<T>(_ c: (BridgedArrayRef) -> T) -> T {
     withUnsafeBytes { buf in
-      c(BridgedArrayRef(data: buf.baseAddress!, numElements: count))
+      c(BridgedArrayRef(data: buf.baseAddress!, numElements: SwiftInt(count)))
     }
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -1,4 +1,5 @@
 import CASTBridging
+import CBasicBridging
 import SwiftParser
 
 // Needed to use SyntaxTransformVisitor's visit method.
@@ -37,7 +38,7 @@ extension ASTGenVisitor {
 
     return .decl(
       GenericTypeParamDecl_create(
-        self.ctx, self.declContext, name, nameLoc, eachLoc, genericParameterIndex,
+        self.ctx, self.declContext, name, nameLoc, eachLoc, SwiftInt(genericParameterIndex),
         eachLoc.raw != nil))
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -281,7 +281,7 @@ func checkMacroDefinition(
       if module == "Builtin" {
         switch type {
         case "ExternalMacro":
-          return BridgedMacroDefinitionKind.builtinExternalMacro.rawValue
+          return Int(BridgedMacroDefinitionKind.builtinExternalMacro.rawValue)
 
         default:
           // Warn about the unknown builtin.
@@ -326,7 +326,7 @@ func checkMacroDefinition(
           ]
         )
       )
-      return BridgedMacroDefinitionKind.externalMacro.rawValue
+      return Int(BridgedMacroDefinitionKind.externalMacro.rawValue)
 
     case let .expansion(expansionSyntax, replacements: _)
         where expansionSyntax.macroName.text == "externalMacro":
@@ -365,7 +365,7 @@ func checkMacroDefinition(
       // Form the "ModuleName.TypeName" result string.
       (externalMacroPointer.pointee, externalMacroLength.pointee) =
         allocateUTF8String("\(module).\(type)", nullTerminated: true)
-      return BridgedMacroDefinitionKind.externalMacro.rawValue
+      return Int(BridgedMacroDefinitionKind.externalMacro.rawValue)
 
     case let .expansion(expansionSyntax, replacements: replacements):
       // Provide the expansion syntax.
@@ -376,7 +376,7 @@ func checkMacroDefinition(
 
       // If there are no replacements, we're done.
       if replacements.isEmpty {
-        return BridgedMacroDefinitionKind.expandedMacro.rawValue
+        return Int(BridgedMacroDefinitionKind.expandedMacro.rawValue)
       }
 
       // The replacements are triples: (startOffset, endOffset, parameter index).
@@ -391,7 +391,7 @@ func checkMacroDefinition(
 
       replacementsPtr.pointee = replacementBuffer.baseAddress
       numReplacementsPtr.pointee = replacements.count
-      return BridgedMacroDefinitionKind.expandedMacro.rawValue
+      return Int(BridgedMacroDefinitionKind.expandedMacro.rawValue)
     }
   } catch let errDiags as DiagnosticsError {
     let srcMgr = SourceManager(cxxDiagnosticEngine: diagEnginePtr)

--- a/lib/ASTGen/Sources/ASTGen/Misc.swift
+++ b/lib/ASTGen/Sources/ASTGen/Misc.swift
@@ -1,4 +1,5 @@
 import CASTBridging
+import CBasicBridging
 import SwiftParser
 
 // Needed to use SyntaxTransformVisitor's visit method.
@@ -65,7 +66,7 @@ extension BridgedSourceLoc {
   ) {
     if let start = buffer.baseAddress,
       position.utf8Offset >= 0 && position.utf8Offset < buffer.count {
-      self = SourceLoc_advanced(BridgedSourceLoc(raw: start), position.utf8Offset)
+      self = SourceLoc_advanced(BridgedSourceLoc(raw: start), SwiftInt(position.utf8Offset))
     } else {
       self = nil
     }
@@ -75,7 +76,7 @@ extension BridgedSourceLoc {
 extension String {
   mutating func withBridgedString<R>(_ body: (BridgedString) throws -> R) rethrows -> R {
     try withUTF8 { buffer in
-      try body(BridgedString(data: buffer.baseAddress, length: buffer.count))
+      try body(BridgedString(data: buffer.baseAddress, length: SwiftInt(buffer.count)))
     }
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -121,7 +121,7 @@ struct CompilerPlugin {
 
   private func sendMessage(_ message: HostToPluginMessage) throws {
     let hadError = try LLVMJSON.encoding(message) { (data) -> Bool in
-      return Plugin_sendMessage(opaqueHandle, BridgedData(baseAddress: data.baseAddress, size: UInt(data.count)))
+      return Plugin_sendMessage(opaqueHandle, BridgedData(baseAddress: data.baseAddress, size: SwiftUInt(data.count)))
     }
     if hadError {
       throw PluginError.failedToSendMessage
@@ -339,7 +339,7 @@ class PluginDiagnosticsEngine {
     guard let bufferBaseAddress = exportedSourceFile.pointee.buffer.baseAddress else {
       return nil
     }
-    return SourceLoc_advanced(BridgedSourceLoc(raw: bufferBaseAddress), offset)
+    return SourceLoc_advanced(BridgedSourceLoc(raw: bufferBaseAddress), SwiftInt(offset))
   }
 
   /// C++ source location from a position value from a plugin.

--- a/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
+++ b/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
@@ -41,7 +41,7 @@ public struct LLVMJSON {
 
   /// Decode a JSON data to a Swift value.
   public static func decode<T: Decodable>(_ type: T.Type, from json: UnsafeBufferPointer<Int8>) throws -> T {
-    let data = BridgedData(baseAddress: json.baseAddress, size: UInt(json.count))
+    let data = BridgedData(baseAddress: json.baseAddress, size: SwiftUInt(json.count))
     let valuePtr = JSON_deserializedValue(data)
     defer { JSON_value_delete(valuePtr) }
 

--- a/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
@@ -71,12 +71,12 @@ typedef unsigned __INT8_TYPE__ __swift_uint8_t;
 #define __swift_uintn_t(n) __swift_join3(__swift_uint, n, _t)
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#if defined(_WIN32)
-typedef __swift_int32_t __swift_intptr_t;
-typedef __swift_uint32_t __swift_uintptr_t;
-#elif defined(_WIN64)
+#if defined(_WIN64)
 typedef __swift_int64_t __swift_intptr_t;
 typedef __swift_uint64_t __swift_uintptr_t;
+#elif defined(_WIN32)
+typedef __swift_int32_t __swift_intptr_t;
+typedef __swift_uint32_t __swift_uintptr_t;
 #else
 #error unknown windows pointer width
 #endif


### PR DESCRIPTION
The `SwiftInt` and `SwiftUInt` types in the compiler provide `C` equivalents to Swift's `Int` and `UInt`. Consistently use these types in the C/Swift bridging layer, to avoid painful truncations and data-size mismatches.

This is harder than it should be. The canonical C types are `ptrdiff_t` and `size_t`, but we're in the depths of the compiler we can't include the C library headers that provide them because they introduce cyclic module dependencies. Sigh.

SwiftShims has some logic to compute these types. However, SwiftShims is part of the Swift runtime, not the compiler, so those headers cannot be included here. So, we clone the logic and simplify it somewhat for our use case.

This fixes truncation issues on Windows, where the uses of `unsigned long` and `long` for Swift(U)Int are incorrect.