### PR TITLE
🍒[cxx-interop] Look up `NSNotificationName` in C++ language mode properly

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -555,7 +555,9 @@ clang::TypedefNameDecl *importer::findSwiftNewtype(const clang::NamedDecl *decl,
     clang::LookupResult lookupResult(clangSema, notificationName,
                                      clang::SourceLocation(),
                                      clang::Sema::LookupOrdinaryName);
-    if (!clangSema.LookupName(lookupResult, clangSema.TUScope))
+    if (!clangSema.LookupQualifiedName(
+            lookupResult,
+            /*LookupCtx*/ clangSema.getASTContext().getTranslationUnitDecl()))
       return nullptr;
     auto nsDecl = lookupResult.getAsSingle<clang::TypedefNameDecl>();
     if (!nsDecl)

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -17,7 +17,7 @@ module NSOptionsMangling {
   header "NSOptionsMangling.h"
 }
 
-module NSNofiticationBridging {
+module NSNotificationBridging {
   header "nsnotification-bridging.h"
   requires objc
   requires cplusplus

--- a/test/Interop/Cxx/objc-correctness/Inputs/nsnotification-bridging.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/nsnotification-bridging.h
@@ -1,3 +1,4 @@
 #import <Foundation/Foundation.h>
 
 extern NSString * const SpaceShipNotification;
+extern "C" NSString * const CExternNotification;

--- a/test/Interop/Cxx/objc-correctness/nsnotification-bridging-ide-test.swift
+++ b/test/Interop/Cxx/objc-correctness/nsnotification-bridging-ide-test.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=NSNofiticationBridging -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=NSNotificationBridging -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Interop/Cxx/objc-correctness/nsnotification-bridging-ide-test.swift
+++ b/test/Interop/Cxx/objc-correctness/nsnotification-bridging-ide-test.swift
@@ -5,3 +5,4 @@
 // CHECK: import Foundation
 
 // CHECK: let SpaceShipNotification: String
+// CHECK: let CExternNotification: String

--- a/test/Interop/Cxx/objc-correctness/nsnotification-typechecker.swift
+++ b/test/Interop/Cxx/objc-correctness/nsnotification-typechecker.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-objc-interop -enable-experimental-cxx-interop
+// REQUIRES: objc_interop
+
+import Foundation
+import NSNotificationBridging
+
+func test(_ n: NSNotification.Name) {}
+
+test(NSNotification.Name.SpaceShip)
+test(NSNotification.Name.CExtern)


### PR DESCRIPTION
This change makes sure that `NSNotification.Name.NEVPNStatusDidChange` is imported correctly when C++ interop is enabled.

`importer::findSwiftNewtype` is called while writing Clang modules, at a point when the translation-unit scope does not exist (`clangSema.TUScope` is `nullptr`).

That prevents the Clang lookup from discovering `NSNotificationName` declaration.

Instead of trying to pass a translation-unit scope to Clang, let's use qualified name lookup which does not require a scope.

Original PR: https://github.com/apple/swift/pull/68217

rdar://112199372