### PR TITLE
(More) Declaration checker support for tuple conformances

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5178,13 +5178,11 @@ public:
 /// and conformances for tuple types.
 ///
 /// - The declared interface type is the special TheTupleType singleton.
-/// - The generic parameter list has one pack generic parameter, <Elements...>
-/// - The generic signature has no requirements, <Elements...>
+/// - The generic parameter list has one pack generic parameter, <each Element>
+/// - The generic signature has no requirements, <each Element>
 /// - The self interface type is the tuple type containing a single pack
-///   expansion, (Elements...).
+///   expansion, (repeat each Element).
 class BuiltinTupleDecl final : public NominalTypeDecl {
-  TupleType *TupleSelfType = nullptr;
-
 public:
   BuiltinTupleDecl(Identifier Name, DeclContext *Parent);
 
@@ -5192,7 +5190,7 @@ public:
     return SourceRange();
   }
 
-  TupleType *getTupleSelfType() const;
+  TupleType *getTupleSelfType(const ExtensionDecl *owner) const;
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2733,10 +2733,23 @@ NOTE(ambiguous_witnesses_wrong_name,none,
 NOTE(no_witnesses_type,none,
      "protocol requires nested type %0; add nested type %0 for conformance",
      (const AssociatedTypeDecl *))
-NOTE(default_associated_type_req_fail,none,
+NOTE(no_witnesses_type_tuple,none,
+     "protocol requires nested type %0; add type alias %0 with underlying type %1 "
+     "for conformance",
+     (const AssociatedTypeDecl *, Type))
+NOTE(default_associated_type_unsatisfied_conformance,none,
      "default type %0 for associated type %1 (from protocol %2) "
-     "does not %select{inherit from|conform to}4 %3",
-     (Type, const AssociatedTypeDecl *, Type, Type, bool))
+     "does not conform to %3",
+     (Type, const AssociatedTypeDecl *, Type, Type))
+NOTE(default_associated_type_unsatisfied_superclass,none,
+     "default type %0 for associated type %1 (from protocol %2) "
+     "does not inherit from %3",
+     (Type, const AssociatedTypeDecl *, Type, Type))
+NOTE(default_associated_type_tuple,none,
+     "default type %0 for associated type %1 (from protocol %2) "
+     "is unsuitable for tuple conformance; the associated type requirement "
+     "must be fulfilled by a type alias with underlying type %3",
+     (Type, const AssociatedTypeDecl *, Type, Type))
 ERROR(associated_type_access,none,
       "associated type in "
       "%select{a private|a fileprivate|an internal|a package|a public|%error}0 protocol "
@@ -2764,10 +2777,19 @@ WARNING(associated_type_not_usable_from_inline_warn,none,
 NOTE(bad_associated_type_deduction,none,
      "unable to infer associated type %0 for protocol %1",
      (const AssociatedTypeDecl *, const ProtocolDecl *))
-NOTE(associated_type_deduction_witness_failed,none,
+NOTE(associated_type_deduction_unsatisfied_conformance,none,
      "candidate would match and infer %0 = %1 if %1 "
-     "%select{inherited from|conformed to}3 %2",
-     (const AssociatedTypeDecl *, Type, Type, bool))
+     "conformed to %2",
+     (const AssociatedTypeDecl *, Type, Type))
+NOTE(associated_type_deduction_unsatisfied_superclass,none,
+     "candidate would match and infer %0 = %1 if %1 "
+     "inherited from %2",
+     (const AssociatedTypeDecl *, Type, Type))
+NOTE(associated_type_deduction_tuple,none,
+     "cannot infer %0 = %1 in tuple conformance because "
+     "the associated type requirement must be fulfilled by a type alias with "
+     "underlying type %2",
+     (const AssociatedTypeDecl *, Type, Type))
 NOTE(associated_type_witness_conform_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
      "is not a nominal type and so can't conform to %2",
@@ -2858,9 +2880,17 @@ NOTE(protocol_witness_enum_case_payload, none,
 
 NOTE(protocol_witness_type,none,
      "possibly intended match", ())
-NOTE(protocol_witness_nonconform_type,none,
+NOTE(protocol_type_witness_unsatisfied_conformance,none,
      "possibly intended match %0 does not "
-     "%select{inherit from|conform to}2 %1", (Type, Type, bool))
+     "conform to %1", (Type, Type))
+NOTE(protocol_type_witness_unsatisfied_superclass,none,
+     "possibly intended match %0 does not "
+     "inherit from %1", (Type, Type))
+NOTE(protocol_type_witness_tuple,none,
+     "possibly intended match %0 is unsuitable for tuple conformance; "
+     "the associated type requirement must be fulfilled by a type alias "
+     "with underlying type %1",
+     (Type, Type))
 
 NOTE(protocol_witness_circularity,none,
      "candidate references itself", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2363,7 +2363,8 @@ ERROR(tuple_extension_extra_requirement,none,
       (Type, unsigned, Type))
 ERROR(tuple_extension_missing_requirement,none,
       "tuple extension must require that %0 conforms to %1", (Type, Type))
-
+ERROR(tuple_extension_nested_type,none,
+      "type %0 cannot be nested in tuple extension", (const NominalTypeDecl *))
 ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
 ERROR(extension_placeholder,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2355,6 +2355,15 @@ ERROR(experimental_tuple_extension,none,
       ())
 ERROR(tuple_extension_wrong_type,none,
       "tuple extension must be written as extension of %0", (Type))
+ERROR(tuple_extension_one_conformance,none,
+      "tuple extension must declare conformance to exactly one protocol", ())
+ERROR(tuple_extension_extra_requirement,none,
+      "tuple extension cannot require that %0 "
+      "%select{conforms to|subclasses|is the same type as|%error|%error}1 %2",
+      (Type, unsigned, Type))
+ERROR(tuple_extension_missing_requirement,none,
+      "tuple extension must require that %0 conforms to %1", (Type, Type))
+
 ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
 ERROR(extension_placeholder,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2353,6 +2353,8 @@ ERROR(extension_access_with_conformances,none,
 ERROR(experimental_tuple_extension,none,
       "tuple extensions are experimental",
       ())
+ERROR(tuple_extension_wrong_type,none,
+      "tuple extension must be written as extension of %0", (Type))
 ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
 ERROR(extension_placeholder,none,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7861,27 +7861,24 @@ Type DeclContext::getSelfTypeInContext() const {
   return mapTypeIntoContext(getSelfInterfaceType());
 }
 
-TupleType *BuiltinTupleDecl::getTupleSelfType() const {
-  if (TupleSelfType)
-    return TupleSelfType;
-
+TupleType *BuiltinTupleDecl::getTupleSelfType(const ExtensionDecl *owner) const {
   auto &ctx = getASTContext();
 
-  // Get the generic parameter type 'Elements'.
-  auto paramType = getGenericParams()->getParams()[0]
-      ->getDeclaredInterfaceType();
+  // Get the generic parameter type 'each T'.
+  auto *genericParams = owner->getGenericParams();
+  assert(genericParams != nullptr);
+  assert(genericParams->getParams().size() == 1);
+  assert(genericParams->getOuterParameters() == nullptr);
+  auto paramType = genericParams->getParams()[0]->getDeclaredInterfaceType();
 
-  // Build the pack expansion type 'Elements...'.
+  // Build the pack expansion type 'repeat each T'.
   Type packExpansionType = PackExpansionType::get(paramType, paramType);
 
-  // Build the one-element tuple type '(Elements...)'.
+  // Build the one-element tuple type '(repeat each T)'.
   SmallVector<TupleTypeElt, 1> elts;
   elts.push_back(packExpansionType);
 
-  const_cast<BuiltinTupleDecl *>(this)->TupleSelfType =
-      TupleType::get(elts, ctx);
-
-  return TupleSelfType;
+  return TupleType::get(elts, ctx);
 }
 
 /// Retrieve the interface type of 'self' for the given context.
@@ -7890,7 +7887,7 @@ Type DeclContext::getSelfInterfaceType() const {
 
   if (auto *nominalDecl = getSelfNominalTypeDecl()) {
     if (auto *builtinTupleDecl = dyn_cast<BuiltinTupleDecl>(nominalDecl))
-      return builtinTupleDecl->getTupleSelfType();
+      return builtinTupleDecl->getTupleSelfType(cast<ExtensionDecl>(this));
 
     if (isa<ProtocolDecl>(nominalDecl)) {
       auto *genericParams = nominalDecl->getGenericParams();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7865,7 +7865,13 @@ TupleType *BuiltinTupleDecl::getTupleSelfType(const ExtensionDecl *owner) const 
   auto &ctx = getASTContext();
 
   // Get the generic parameter type 'each T'.
-  auto *genericParams = owner->getGenericParams();
+  GenericParamList *genericParams;
+  if (owner != nullptr) {
+    genericParams = owner->getGenericParams();
+  } else {
+    genericParams = getGenericParams();
+  }
+
   assert(genericParams != nullptr);
   assert(genericParams->getParams().size() == 1);
   assert(genericParams->getOuterParameters() == nullptr);
@@ -7887,7 +7893,7 @@ Type DeclContext::getSelfInterfaceType() const {
 
   if (auto *nominalDecl = getSelfNominalTypeDecl()) {
     if (auto *builtinTupleDecl = dyn_cast<BuiltinTupleDecl>(nominalDecl))
-      return builtinTupleDecl->getTupleSelfType(cast<ExtensionDecl>(this));
+      return builtinTupleDecl->getTupleSelfType(dyn_cast<ExtensionDecl>(this));
 
     if (isa<ProtocolDecl>(nominalDecl)) {
       auto *genericParams = nominalDecl->getGenericParams();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1071,12 +1071,19 @@ directReferencesForTypeRepr(Evaluator &evaluator, ASTContext &ctx,
 /// the given type.
 static DirectlyReferencedTypeDecls directReferencesForType(Type type);
 
+enum class ResolveToNominalFlags : uint8_t {
+  AllowTupleType = 0x1
+};
+
+using ResolveToNominalOptions = OptionSet<ResolveToNominalFlags>;
+
 /// Given a set of type declarations, find all of the nominal type declarations
 /// that they reference, looking through typealiases as appropriate.
 static TinyPtrVector<NominalTypeDecl *>
 resolveTypeDeclsToNominal(Evaluator &evaluator,
                           ASTContext &ctx,
                           ArrayRef<TypeDecl *> typeDecls,
+                          ResolveToNominalOptions options,
                           SmallVectorImpl<ModuleDecl *> &modulesFound,
                           bool &anyObject);
 
@@ -1130,6 +1137,7 @@ SelfBounds SelfBoundsFromWhereClauseRequest::evaluate(
 
     SmallVector<ModuleDecl *, 2> modulesFound;
     auto rhsNominals = resolveTypeDeclsToNominal(evaluator, ctx, rhsDecls,
+                                                 ResolveToNominalOptions(),
                                                  modulesFound,
                                                  result.anyObject);
     result.decls.insert(result.decls.end(),
@@ -1168,7 +1176,8 @@ SelfBounds SelfBoundsFromGenericSignatureRequest::evaluate(
     auto rhsDecls = directReferencesForType(req.getSecondType());
     SmallVector<ModuleDecl *, 2> modulesFound;
     auto rhsNominals = resolveTypeDeclsToNominal(
-        evaluator, ctx, rhsDecls, modulesFound, result.anyObject);
+        evaluator, ctx, rhsDecls, ResolveToNominalOptions(),
+        modulesFound, result.anyObject);
     result.decls.insert(result.decls.end(), rhsNominals.begin(),
                         rhsNominals.end());
   }
@@ -2651,6 +2660,7 @@ static TinyPtrVector<NominalTypeDecl *>
 resolveTypeDeclsToNominal(Evaluator &evaluator,
                           ASTContext &ctx,
                           ArrayRef<TypeDecl *> typeDecls,
+                          ResolveToNominalOptions options,
                           SmallVectorImpl<ModuleDecl *> &modulesFound,
                           bool &anyObject,
                           llvm::SmallPtrSetImpl<TypeAliasDecl *> &typealiases) {
@@ -2664,6 +2674,14 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
   for (auto typeDecl : typeDecls) {
     // Nominal type declarations get copied directly.
     if (auto nominalDecl = dyn_cast<NominalTypeDecl>(typeDecl)) {
+      // ... unless it's the special Builtin.TheTupleType that we return
+      // when resolving a TupleTypeRepr, and the caller isn't asking for
+      // that.
+      if (!options.contains(ResolveToNominalFlags::AllowTupleType) &&
+          isa<BuiltinTupleDecl>(nominalDecl)) {
+        continue;
+      }
+
       addNominalDecl(nominalDecl);
       continue;
     }
@@ -2680,7 +2698,7 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
 
       auto underlyingNominalReferences
         = resolveTypeDeclsToNominal(evaluator, ctx, underlyingTypeReferences,
-                                    modulesFound, anyObject, typealiases);
+                                    options, modulesFound, anyObject, typealiases);
       std::for_each(underlyingNominalReferences.begin(),
                     underlyingNominalReferences.end(),
                     addNominalDecl);
@@ -2731,11 +2749,12 @@ static TinyPtrVector<NominalTypeDecl *>
 resolveTypeDeclsToNominal(Evaluator &evaluator,
                           ASTContext &ctx,
                           ArrayRef<TypeDecl *> typeDecls,
+                          ResolveToNominalOptions options,
                           SmallVectorImpl<ModuleDecl *> &modulesFound,
                           bool &anyObject) {
   llvm::SmallPtrSet<TypeAliasDecl *, 4> typealiases;
-  return resolveTypeDeclsToNominal(evaluator, ctx, typeDecls, modulesFound,
-                                   anyObject, typealiases);
+  return resolveTypeDeclsToNominal(evaluator, ctx, typeDecls, options,
+                                   modulesFound, anyObject, typealiases);
 }
 
 /// Perform unqualified name lookup for types at the given location.
@@ -2839,8 +2858,9 @@ directReferencesForQualifiedTypeLookup(Evaluator &evaluator,
     SmallVector<ModuleDecl *, 2> moduleDecls;
     bool anyObject = false;
     auto nominalTypeDecls =
-      resolveTypeDeclsToNominal(ctx.evaluator, ctx, baseTypes, moduleDecls,
-                                anyObject);
+      resolveTypeDeclsToNominal(ctx.evaluator, ctx, baseTypes,
+                                ResolveToNominalOptions(),
+                                moduleDecls, anyObject);
 
     dc->lookupQualified(nominalTypeDecls, name, loc, options, members);
 
@@ -2956,6 +2976,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
       return directReferencesForTypeRepr(evaluator, ctx,
                                          tupleRepr->getElementType(0), dc,
                                          allowUsableFromInline);
+    } else {
+      return { 1, ctx.getBuiltinTupleDecl() };
     }
     return { };
   }
@@ -3018,6 +3040,9 @@ static DirectlyReferencedTypeDecls directReferencesForType(Type type) {
   // If there is a generic declaration, return it.
   if (auto genericDecl = type->getAnyGeneric())
     return { 1, genericDecl };
+
+  if (dyn_cast<TupleType>(type.getPointer()))
+    return { 1, type->getASTContext().getBuiltinTupleDecl() };
 
   if (type->isExistentialType()) {
     DirectlyReferencedTypeDecls result;
@@ -3122,7 +3147,8 @@ SuperclassDeclRequest::evaluate(Evaluator &evaluator,
     bool anyObject = false;
     auto inheritedNominalTypes
       = resolveTypeDeclsToNominal(evaluator, Ctx,
-                                  inheritedTypes, modulesFound, anyObject);
+                                  inheritedTypes, ResolveToNominalOptions(),
+                                  modulesFound, anyObject);
 
     // Look for a class declaration.
     ClassDecl *superclass = nullptr;
@@ -3191,9 +3217,10 @@ NominalTypeDecl *
 ExtendedNominalRequest::evaluate(Evaluator &evaluator,
                                  ExtensionDecl *ext) const {
   auto typeRepr = ext->getExtendedTypeRepr();
-  if (!typeRepr)
+  if (!typeRepr) {
     // We must've seen 'extension { ... }' during parsing.
     return nullptr;
+  }
 
   ASTContext &ctx = ext->getASTContext();
   DirectlyReferencedTypeDecls referenced =
@@ -3204,8 +3231,9 @@ ExtendedNominalRequest::evaluate(Evaluator &evaluator,
   SmallVector<ModuleDecl *, 2> modulesFound;
   bool anyObject = false;
   auto nominalTypes
-    = resolveTypeDeclsToNominal(evaluator, ctx, referenced, modulesFound,
-                                anyObject);
+    = resolveTypeDeclsToNominal(evaluator, ctx, referenced,
+                                ResolveToNominalFlags::AllowTupleType,
+                                modulesFound, anyObject);
 
   // If there is more than 1 element, we will emit a warning or an error
   // elsewhere, so don't handle that case here.
@@ -3518,6 +3546,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
   SmallVector<ModuleDecl *, 2> modulesFound;
   bool anyObject = false;
   auto nominals = resolveTypeDeclsToNominal(evaluator, ctx, decls,
+                                            ResolveToNominalOptions(),
                                             modulesFound, anyObject);
   if (nominals.size() == 1 && !isa<ProtocolDecl>(nominals.front()))
     return nominals.front();
@@ -3535,6 +3564,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
             identTypeRepr->getNameRef(), identTypeRepr->getLoc(), dc,
             LookupOuterResults::Included);
         nominals = resolveTypeDeclsToNominal(evaluator, ctx, decls,
+                                             ResolveToNominalOptions(),
                                              modulesFound, anyObject);
         if (nominals.size() == 1 && !isa<ProtocolDecl>(nominals.front())) {
           auto nominal = nominals.front();
@@ -3584,8 +3614,9 @@ void swift::getDirectlyInheritedNominalTypeDecls(
   // Resolve those type declarations to nominal type declarations.
   SmallVector<ModuleDecl *, 2> modulesFound;
   auto nominalTypes
-    = resolveTypeDeclsToNominal(ctx.evaluator, ctx, referenced, modulesFound,
-                                anyObject);
+    = resolveTypeDeclsToNominal(ctx.evaluator, ctx, referenced,
+                                ResolveToNominalOptions(),
+                                modulesFound, anyObject);
 
   // Dig out the source location
   // FIXME: This is a hack. We need cooperation from
@@ -3772,8 +3803,9 @@ ProtocolDecl *ImplementsAttrProtocolRequest::evaluate(
   SmallVector<ModuleDecl *, 2> modulesFound;
   bool anyObject = false;
   auto nominalTypes
-    = resolveTypeDeclsToNominal(evaluator, ctx, referenced, modulesFound,
-                                anyObject);
+    = resolveTypeDeclsToNominal(evaluator, ctx, referenced,
+                                ResolveToNominalOptions(),
+                                modulesFound, anyObject);
 
   if (nominalTypes.empty())
     return nullptr;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2938,28 +2938,12 @@ bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias,
   // If neither is generic at this level, we have a pass-through typealias.
   if (!typealias->isGeneric()) return true;
 
-  if (isa<BuiltinTupleDecl>(nominal) &&
-      typealias->getUnderlyingType()->isEqual(
+  if (typealias->getUnderlyingType()->isEqual(
         nominal->getSelfInterfaceType())) {
     return true;
   }
 
-  auto boundGenericType = typealias->getUnderlyingType()
-      ->getAs<BoundGenericType>();
-  if (!boundGenericType) return false;
-
-  // If our arguments line up with our innermost generic parameters, it's
-  // a passthrough typealias.
-  auto innermostGenericParams = typealiasSig.getInnermostGenericParams();
-  auto boundArgs = boundGenericType->getGenericArgs();
-  if (boundArgs.size() != innermostGenericParams.size())
-    return false;
-
-  return std::equal(boundArgs.begin(), boundArgs.end(),
-                    innermostGenericParams.begin(),
-                    [](Type arg, GenericTypeParamType *gp) {
-                      return arg->isEqual(gp);
-                    });
+  return false;
 }
 
 Type

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2938,6 +2938,12 @@ bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias,
   // If neither is generic at this level, we have a pass-through typealias.
   if (!typealias->isGeneric()) return true;
 
+  if (isa<BuiltinTupleDecl>(nominal) &&
+      typealias->getUnderlyingType()->isEqual(
+        nominal->getSelfInterfaceType())) {
+    return true;
+  }
+
   auto boundGenericType = typealias->getUnderlyingType()
       ->getAs<BoundGenericType>();
   if (!boundGenericType) return false;
@@ -2995,8 +3001,9 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
                    : extendedNominal->getDeclaredType();
       }
 
-      if (underlyingType->is<TupleType>())
-        extendedType = underlyingType;
+      if (underlyingType->is<TupleType>()) {
+        return extendedType;
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3493,9 +3493,17 @@ public:
     auto *nominal = ED->getExtendedNominal();
 
     // Diagnose experimental tuple extensions.
-    if (nominal && isa<BuiltinTupleDecl>(nominal) &&
-        !getASTContext().LangOpts.hasFeature(Feature::TupleConformances)) {
-      ED->diagnose(diag::experimental_tuple_extension);
+    if (nominal && isa<BuiltinTupleDecl>(nominal)) {
+      if (!getASTContext().LangOpts.hasFeature(Feature::TupleConformances)) {
+        ED->diagnose(diag::experimental_tuple_extension);
+      }
+
+      if (extType->is<TupleType>()) {
+        auto selfType = ED->getSelfInterfaceType();
+        if (!extType->isEqual(selfType)) {
+          ED->diagnose(diag::tuple_extension_wrong_type, selfType);
+        }
+      }
     }
 
     if (nominal == nullptr) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1901,13 +1901,12 @@ void MultiConformanceChecker::checkAllConformances() {
 static void diagnoseConformanceImpliedByConditionalConformance(
     DiagnosticEngine &Diags, NormalProtocolConformance *conformance,
     NormalProtocolConformance *implyingConf, bool issueFixit) {
-  Type T = conformance->getType();
   auto proto = conformance->getProtocol();
   Type protoType = proto->getDeclaredInterfaceType();
   auto implyingProto = implyingConf->getProtocol()->getDeclaredInterfaceType();
   auto loc = implyingConf->getLoc();
   Diags.diagnose(loc, diag::conditional_conformances_cannot_imply_conformances,
-                 T, implyingProto, protoType);
+                 conformance->getType(), implyingProto, protoType);
 
   if (!issueFixit)
     return;
@@ -1949,11 +1948,7 @@ static void diagnoseConformanceImpliedByConditionalConformance(
     llvm::raw_svector_ostream prefixStream(prefix);
     llvm::raw_svector_ostream suffixStream(suffix);
 
-    ValueDecl *decl = T->getAnyNominal();
-    if (!decl)
-      decl = T->getAnyGeneric();
-
-    prefixStream << "extension " << decl->getName() << ": " << protoType << " ";
+    prefixStream << "extension " << ext->getExtendedType() << ": " << protoType << " ";
     suffixStream << " {\n"
                  << indent << extraIndent << "<#witnesses#>\n"
                  << indent << "}\n\n"

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -89,7 +89,11 @@ public:
 
     /// Type witness does not satisfy a layout requirement on
     /// the associated type.
-    Layout
+    Layout,
+
+    /// Type witness of a tuple conformance does not have the form
+    /// (repeat (each Element).A).
+    Tuple
   } kind;
 
 private:
@@ -121,6 +125,10 @@ public:
 
   static CheckTypeWitnessResult forLayout(Type reqt) {
     return CheckTypeWitnessResult(Layout, reqt);
+  }
+
+  static CheckTypeWitnessResult forTuple(Type reqt) {
+    return CheckTypeWitnessResult(Tuple, reqt);
   }
 
   Kind getKind() const { return kind; }

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -72,23 +72,61 @@ struct TypeWitnessConflict {
 ///
 /// This class evaluates true if an error occurred.
 class CheckTypeWitnessResult {
-  Type Requirement;
+public:
+  enum Kind {
+    Success,
+
+    /// Type witness contains an error type.
+    Error,
+
+    /// Type witness does not satisfy a conformance requirement on
+    /// the associated type.
+    Conformance,
+
+    /// Type witness does not satisfy a superclass requirement on
+    /// the associated type.
+    Superclass,
+
+    /// Type witness does not satisfy a layout requirement on
+    /// the associated type.
+    Layout
+  } kind;
+
+private:
+  Type reqt;
+
+  CheckTypeWitnessResult() : kind(Success) {}
+
+  CheckTypeWitnessResult(Kind kind, Type reqt)
+    : kind(kind), reqt(reqt) {}
 
 public:
-  CheckTypeWitnessResult() { }
-  CheckTypeWitnessResult(Type reqt) : Requirement(reqt) {}
+  static CheckTypeWitnessResult forSuccess() {
+    return CheckTypeWitnessResult(Success, Type());
+  }
 
-  Type getRequirement() const { return Requirement; }
-  bool isConformanceRequirement() const {
-    return Requirement->isExistentialType();
+  static CheckTypeWitnessResult forError() {
+    return CheckTypeWitnessResult(Error, Type());
   }
-  bool isSuperclassRequirement() const {
-    return !isConformanceRequirement();
+
+  static CheckTypeWitnessResult forConformance(ProtocolDecl *proto) {
+    auto reqt = proto->getDeclaredInterfaceType();
+    return CheckTypeWitnessResult(Conformance, reqt);
   }
-  bool isError() const {
-    return Requirement->is<ErrorType>();
+
+  static CheckTypeWitnessResult forSuperclass(Type reqt) {
+    assert(reqt->getClassOrBoundGenericClass());
+    return CheckTypeWitnessResult(Superclass, reqt);
   }
-  explicit operator bool() const { return !Requirement.isNull(); }
+
+  static CheckTypeWitnessResult forLayout(Type reqt) {
+    return CheckTypeWitnessResult(Layout, reqt);
+  }
+
+  Kind getKind() const { return kind; }
+  Type getRequirement() const { return reqt; }
+
+  explicit operator bool() const { return kind != Success; }
 };
 
 /// Check whether the given type witness can be used for the given
@@ -1057,7 +1095,7 @@ class AssociatedTypeInference {
   /// Information about a failed, defaulted associated type.
   const AssociatedTypeDecl *failedDefaultedAssocType = nullptr;
   Type failedDefaultedWitness;
-  CheckTypeWitnessResult failedDefaultedResult;
+  CheckTypeWitnessResult failedDefaultedResult = CheckTypeWitnessResult::forSuccess();
 
   /// Information about a failed, derived associated type.
   AssociatedTypeDecl *failedDerivedAssocType = nullptr;

--- a/test/CAS/educational-notes.swift
+++ b/test/CAS/educational-notes.swift
@@ -13,10 +13,11 @@ let x = 1 +
 // NO-COLOR-NOT: {{-+$}}
 
 // A diagnostic with an educational note using supported markdown features
-extension (Int, Int) {}
-// CHECK:{{.*}}[0m[0;1;31merror: [0m[1mnon-nominal type '(Int, Int)' cannot be extended
-// CHECK-NEXT:[0mextension (Int, Int) {}
-// CHECK-NEXT:[0;1;32m^         ~~~~~~~~~~
+typealias Crap = () -> ()
+extension Crap {}
+// CHECK:{{.*}}[0m[0;1;31merror: [0m[1mnon-nominal type 'Crap' (aka '() -> ()') cannot be extended
+// CHECK-NEXT:[0mextension Crap {}
+// CHECK-NEXT:[0;1;32m^         ~~~~
 // CHECK-NEXT:[0m[0m[1mNominal Types[0m
 // CHECK-NEXT:--------------
 // CHECK-EMPTY:
@@ -42,9 +43,9 @@ extension (Int, Int) {}
 // CHECK-NEXT:[0m[1mHeader 1[0m
 // CHECK-NEXT:[0m[1mHeader 3[0m
 
-// NO-COLOR:{{.*}}error: non-nominal type '(Int, Int)' cannot be extended
-// NO-COLOR-NEXT:extension (Int, Int) {}
-// NO-COLOR-NEXT:^         ~~~~~~~~~~
+// NO-COLOR:{{.*}}error: non-nominal type 'Crap' (aka '() -> ()') cannot be extended
+// NO-COLOR-NEXT:extension Crap {}
+// NO-COLOR-NEXT:^         ~~~~
 // NO-COLOR-NEXT:Nominal Types
 // NO-COLOR-NEXT:--------------
 // NO-COLOR-EMPTY:
@@ -72,15 +73,15 @@ extension (Int, Int) {}
 
 // CHECK-DESCRIPTIVE: educational-notes.swift
 // CHECK-DESCRIPTIVE-NEXT:  | // A diagnostic with an educational note
-// CHECK-DESCRIPTIVE-NEXT:  | extension (Int, Int) {}
+// CHECK-DESCRIPTIVE-NEXT:  | extension Crap {}
 // CHECK-DESCRIPTIVE-NEXT:  | ^ error: expected expression after operator
 // CHECK-DESCRIPTIVE-NEXT:  |
 
 // CHECK-DESCRIPTIVE: educational-notes.swift
 // CHECK-DESCRIPTIVE-NEXT:  | // A diagnostic with an educational note
-// CHECK-DESCRIPTIVE-NEXT:  | extension (Int, Int) {}
-// CHECK-DESCRIPTIVE-NEXT:  |           ~~~~~~~~~~
-// CHECK-DESCRIPTIVE-NEXT:  | ^ error: non-nominal type '(Int, Int)' cannot be extended
+// CHECK-DESCRIPTIVE-NEXT:  | extension Crap {}
+// CHECK-DESCRIPTIVE-NEXT:  |           ~~~~
+// CHECK-DESCRIPTIVE-NEXT:  | ^ error: non-nominal type 'Crap' (aka '() -> ()') cannot be extended
 // CHECK-DESCRIPTIVE-NEXT:  |
 // CHECK-DESCRIPTIVE-NEXT: Nominal Types
 // CHECK-DESCRIPTIVE-NEXT: -------------

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -3,18 +3,44 @@
 // Because of -enable-experimental-feature TupleConformances
 // REQUIRES: asserts
 
+extension () {
+  // expected-error@-1 {{tuple extension must be written as extension of '(repeat each Element)'}}
+  // expected-error@-2 {{tuple extension must declare conformance to exactly one protocol}}
+}
+
+typealias Tuple<each Element> = (repeat each Element)
+
+protocol Q {}
+
+class C {}
+
+extension Tuple: Q where repeat each Element: Collection, repeat (each Element).Element == (each Element).Index, repeat (each Element).Indices: AnyObject, repeat (each Element).SubSequence: C {}
+// expected-error@-1 {{tuple extension must require that 'each Element' conforms to 'Q'}}
+// expected-error@-2 {{tuple extension cannot require that 'each Element' conforms to 'Collection'}}
+// expected-error@-3 {{tuple extension cannot require that '(each Element).Element' is the same type as '(each Element).Index'}}
+// expected-error@-4 {{tuple extension cannot require that '(each Element).Indices' conforms to 'AnyObject'}}
+// expected-error@-5 {{tuple extension cannot require that '(each Element).SubSequence' subclasses 'C'}}
+
+protocol Base1 {}
+protocol Derived1: Base1 {}
+
+extension Tuple: Derived1 where repeat each Element: Derived1 {}
+// expected-error@-1 {{conditional conformance of type '(repeat each Element)' to protocol 'Derived1' does not imply conformance to inherited protocol 'Base1'}} // FIXME: crappy error
+// expected-note@-2 {{did you mean to explicitly state the conformance like 'extension (repeat each Element): Base1 where ...'?}}
+// expected-error@-3 {{tuple extension must declare conformance to exactly one protocol}}
+
+protocol Base2 {}
+protocol Derived2: Base2 {}
+
+extension Tuple: Derived2 {}
+// expected-error@-1 {{tuple extension must declare conformance to exactly one protocol}} // FIXME: crappy error
+
 protocol P {
   associatedtype A
   associatedtype B
 
   func f()
 }
-
-extension () {}
-// expected-error@-1 {{tuple extension must be written as extension of '(repeat each Element)'}}
-// FIXME: Inaccurate
-
-typealias Tuple<each Element> = (repeat each Element)
 
 extension Tuple: P where repeat each Element: P {
   typealias A = (repeat (each Element).A)

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -68,7 +68,7 @@ protocol P {
 
 extension Tuple: P where repeat each Element: P {
   typealias A = (repeat (each Element).A)
-  typealias B = Float
+  typealias B = (repeat (each Element).B)
   func f() {}
 }
 
@@ -85,7 +85,7 @@ func same<T>(_: T, _: T) {}
 
 func useConformance() {
   same(returnsPA((1, 2, 3)), (Int, Int, Int).self)
-  same(returnsPB((1, 2, 3)), Float.self)
+  same(returnsPB((1, 2, 3)), (String, String, String).self)
 
   (1, 2, 3).f()
 }

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -11,6 +11,11 @@ extension () {
   // expected-error@-1 {{type 'Nested' cannot be nested in tuple extension}}
 }
 
+typealias BadTuple<each Horse> = (repeat each Horse, Int)
+extension BadTuple {}
+// expected-error@-1 {{tuple extension must be written as extension of '(repeat each Horse)'}}
+// expected-error@-2 {{tuple extension must declare conformance to exactly one protocol}}
+
 typealias Tuple<each Element> = (repeat each Element)
 
 protocol Q {}
@@ -28,8 +33,8 @@ protocol Base1 {}
 protocol Derived1: Base1 {}
 
 extension Tuple: Derived1 where repeat each Element: Derived1 {}
-// expected-error@-1 {{conditional conformance of type '(repeat each Element)' to protocol 'Derived1' does not imply conformance to inherited protocol 'Base1'}} // FIXME: crappy error
-// expected-note@-2 {{did you mean to explicitly state the conformance like 'extension (repeat each Element): Base1 where ...'?}}
+// expected-error@-1 {{conditional conformance of type '(repeat each Element)' to protocol 'Derived1' does not imply conformance to inherited protocol 'Base1'}}
+// expected-note@-2 {{did you mean to explicitly state the conformance like 'extension Tuple: Base1 where ...'?}}
 // expected-error@-3 {{tuple extension must declare conformance to exactly one protocol}}
 
 protocol Base2 {}
@@ -37,6 +42,22 @@ protocol Derived2: Base2 {}
 
 extension Tuple: Derived2 {}
 // expected-error@-1 {{tuple extension must declare conformance to exactly one protocol}} // FIXME: crappy error
+
+////
+
+protocol P2 {}
+
+typealias FancyTuple1<each Cat: P2> = (repeat each Cat)
+extension FancyTuple1: P2 {}
+
+protocol P3 {}
+
+typealias FancyTuple2<each Cat: C> = (repeat each Cat)
+extension FancyTuple2: P3 {}
+// expected-error@-1 {{tuple extension cannot require that 'each Cat' subclasses 'C'}}
+// expected-error@-2 {{tuple extension must require that 'each Cat' conforms to 'P3'}}
+
+////
 
 protocol P {
   associatedtype A

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -1,8 +1,7 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature TupleConformances -parse-stdlib
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TupleConformances
 
+// Because of -enable-experimental-feature TupleConformances
 // REQUIRES: asserts
-
-import Swift
 
 protocol P {
   associatedtype A
@@ -11,8 +10,14 @@ protocol P {
   func f()
 }
 
-extension Builtin.TheTupleType: P where repeat each Elements: P {
-  typealias A = (repeat (each Elements).A)
+extension () {}
+// expected-error@-1 {{tuple extension must be written as extension of '(repeat each Element)'}}
+// FIXME: Inaccurate
+
+typealias Tuple<each Element> = (repeat each Element)
+
+extension Tuple: P where repeat each Element: P {
+  typealias A = (repeat (each Element).A)
   typealias B = Float
   func f() {}
 }
@@ -37,7 +42,7 @@ func useConformance() {
 
 ////
 
-extension Builtin.TheTupleType: Equatable where repeat each Elements: Equatable {
+extension Tuple: Equatable where repeat each Element: Equatable {
   // FIXME: Hack
   @_disfavoredOverload
   public static func ==(lhs: Self, rhs: Self) -> Bool {
@@ -51,7 +56,7 @@ extension Builtin.TheTupleType: Equatable where repeat each Elements: Equatable 
   }
 }
 
-extension Builtin.TheTupleType: Hashable where repeat each Elements: Hashable {
+extension Tuple: Hashable where repeat each Element: Hashable {
   public func hash(into hasher: inout Hasher) {
     repeat (each self).hash(into: &hasher)
   }

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -6,6 +6,9 @@
 extension () {
   // expected-error@-1 {{tuple extension must be written as extension of '(repeat each Element)'}}
   // expected-error@-2 {{tuple extension must declare conformance to exactly one protocol}}
+
+  struct Nested {}
+  // expected-error@-1 {{type 'Nested' cannot be nested in tuple extension}}
 }
 
 typealias Tuple<each Element> = (repeat each Element)

--- a/test/IRGen/tuple_conformances.swift
+++ b/test/IRGen/tuple_conformances.swift
@@ -1,9 +1,7 @@
-// RUN: %target-swift-frontend -emit-ir -parse-stdlib -primary-file %s -enable-experimental-feature TupleConformances -parse-as-library | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -enable-experimental-feature TupleConformances -parse-as-library | %FileCheck %s
 
 // -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts
-
-import Swift
 
 protocol P {
   func defaultRequirement()
@@ -14,7 +12,9 @@ extension P {
   func defaultRequirement() {}
 }
 
-extension Builtin.TheTupleType: P where repeat each Elements: P {
+typealias Tuple<each Element> = (repeat each Element)
+
+extension Tuple: P where repeat each Element: P {
   static func staticRequirement() {}
 }
 

--- a/test/SourceKit/Sema/educational_note_diags.swift
+++ b/test/SourceKit/Sema/educational_note_diags.swift
@@ -1,4 +1,5 @@
-extension (Int, Int) {}
+typealias Crap = () -> ()
+extension Crap {}
 
 // RUN: %sourcekitd-test -req=sema %s -- %s | %FileCheck %s -check-prefix=NO_OVERRIDE
 

--- a/test/attr/ApplicationMain/attr_main_tuple_extension.swift
+++ b/test/attr/ApplicationMain/attr_main_tuple_extension.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %s
 
 @main
-extension (Int, String) { // expected-error {{non-nominal type '(Int, String)' cannot be extended}}
+extension Int.Type { // expected-error {{cannot extend a metatype 'Int.Type'}}
   static func main() {
   }
 }

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -87,11 +87,6 @@ protocol P1 {}
 
 protocol P2 {}
 
-extension () {} // expected-error {{non-nominal type '()' cannot be extended}} {{educational-notes=nominal-types}}
-
-typealias TupleAlias = (x: Int, y: Int)
-extension TupleAlias {} // expected-error{{non-nominal type 'TupleAlias' (aka '(x: Int, y: Int)') cannot be extended}} {{educational-notes=nominal-types}}
-
 // Test property accessors in extended types
 class C {}
 extension C {

--- a/test/decl/protocol/req/associated_type_tuple.swift
+++ b/test/decl/protocol/req/associated_type_tuple.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TupleConformances
+
+typealias Tuple<each T> = (repeat each T)
+
+protocol P1 {
+  associatedtype A // expected-note {{protocol requires nested type 'A'; add type alias 'A' with underlying type '(repeat (each T).A)' for conformance}}
+}
+
+extension Tuple: P1 where repeat each T: P1 {} // expected-error {{type '(repeat each T)' does not conform to protocol 'P1'}}
+
+protocol P2 {
+  associatedtype A = Int // expected-note {{default type 'Int' for associated type 'A' (from protocol 'P2') is unsuitable for tuple conformance; the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).A)'}}
+}
+
+extension Tuple: P2 where repeat each T: P2 {} // expected-error {{type '(repeat each T)' does not conform to protocol 'P2'}}
+
+protocol P3 {
+  associatedtype A // expected-note {{unable to infer associated type 'A' for protocol 'P3'}}
+  func f() -> A
+}
+
+extension Tuple: P3 where repeat each T: P3 { // expected-error {{type '(repeat each T)' does not conform to protocol 'P3'}}
+  func f() -> Int {} // expected-note {{cannot infer 'A' = 'Int' in tuple conformance because the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).A)'}}
+}

--- a/test/diagnostics/educational-notes.swift
+++ b/test/diagnostics/educational-notes.swift
@@ -10,10 +10,11 @@ let x = 1 +
 // NO-COLOR-NOT: {{-+$}}
 
 // A diagnostic with an educational note using supported markdown features
-extension (Int, Int) {}
-// CHECK:{{.*}}[0m[0;1;31merror: [0m[1mnon-nominal type '(Int, Int)' cannot be extended
-// CHECK-NEXT:[0mextension (Int, Int) {}
-// CHECK-NEXT:[0;1;32m^         ~~~~~~~~~~
+typealias Crap = () -> ()
+extension Crap {}
+// CHECK:{{.*}}[0m[0;1;31merror: [0m[1mnon-nominal type 'Crap' (aka '() -> ()') cannot be extended
+// CHECK-NEXT:[0mextension Crap {}
+// CHECK-NEXT:[0;1;32m^         ~~~~
 // CHECK-NEXT:[0m[0m[1mNominal Types[0m
 // CHECK-NEXT:--------------
 // CHECK-EMPTY:
@@ -39,9 +40,9 @@ extension (Int, Int) {}
 // CHECK-NEXT:[0m[1mHeader 1[0m
 // CHECK-NEXT:[0m[1mHeader 3[0m
 
-// NO-COLOR:{{.*}}error: non-nominal type '(Int, Int)' cannot be extended
-// NO-COLOR-NEXT:extension (Int, Int) {}
-// NO-COLOR-NEXT:^         ~~~~~~~~~~
+// NO-COLOR:{{.*}}error: non-nominal type 'Crap' (aka '() -> ()') cannot be extended
+// NO-COLOR-NEXT:extension Crap {}
+// NO-COLOR-NEXT:^         ~~~~
 // NO-COLOR-NEXT:Nominal Types
 // NO-COLOR-NEXT:--------------
 // NO-COLOR-EMPTY:
@@ -69,15 +70,15 @@ extension (Int, Int) {}
 
 // CHECK-DESCRIPTIVE: educational-notes.swift
 // CHECK-DESCRIPTIVE-NEXT:  | // A diagnostic with an educational note
-// CHECK-DESCRIPTIVE-NEXT:  | extension (Int, Int) {}
+// CHECK-DESCRIPTIVE-NEXT:  | extension Crap {}
 // CHECK-DESCRIPTIVE-NEXT:  | ^ error: expected expression after operator
 // CHECK-DESCRIPTIVE-NEXT:  |
 
 // CHECK-DESCRIPTIVE: educational-notes.swift
 // CHECK-DESCRIPTIVE-NEXT:  | // A diagnostic with an educational note
-// CHECK-DESCRIPTIVE-NEXT:  | extension (Int, Int) {}
-// CHECK-DESCRIPTIVE-NEXT:  |           ~~~~~~~~~~
-// CHECK-DESCRIPTIVE-NEXT:  | ^ error: non-nominal type '(Int, Int)' cannot be extended
+// CHECK-DESCRIPTIVE-NEXT:  | extension Crap {}
+// CHECK-DESCRIPTIVE-NEXT:  |           ~~~~
+// CHECK-DESCRIPTIVE-NEXT:  | ^ error: non-nominal type 'Crap' (aka '() -> ()') cannot be extended
 // CHECK-DESCRIPTIVE-NEXT:  |
 // CHECK-DESCRIPTIVE-NEXT: Nominal Types
 // CHECK-DESCRIPTIVE-NEXT: -------------

--- a/test/diagnostics/verifier.swift
+++ b/test/diagnostics/verifier.swift
@@ -33,13 +33,14 @@ func b() {
 // CHECK: unexpected warning produced: initialization of immutable value 'c' was never used
 // CHECK-WARNINGS-AS-ERRORS: unexpected error produced: initialization of immutable value 'c' was never used
 
-extension (Int, Int) {} // expected-error {{non-nominal type '(Int, Int)' cannot be extended}} {{educational-notes=foo-bar-baz}}
+typealias Crap = () -> ()
+extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') cannot be extended}} {{educational-notes=foo-bar-baz}}
 // CHECK: error: expected educational note(s) not seen; actual educational note(s): {{[{][{]}}educational-notes=nominal-types{{[}][}]}}
 
-extension (Bool, Int) {} // expected-error {{non-nominal type '(Bool, Int)' cannot be extended}} {{educational-notes=nominal-types}} {{educational-notes=nominal-types}}
+extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') cannot be extended}} {{educational-notes=nominal-types}} {{educational-notes=nominal-types}}
 // CHECK: error: each verified diagnostic may only have one {{[{][{]}}educational-notes=<#notes#>{{[}][}]}} declaration
 
-extension (Bool, Bool) {} // expected-error {{non-nominal type '(Bool, Bool)' cannot be extended}} {{educational-notes=nominal-types,foo-bar-baz}}
+extension Crap {} // expected-error {{non-nominal type 'Crap' (aka '() -> ()') cannot be extended}} {{educational-notes=nominal-types,foo-bar-baz}}
 // CHECK: error: expected educational note(s) not seen; actual educational note(s): {{[{][{]}}educational-notes=nominal-types{{[}][}]}}
 
 // Verify the serialized diags have the right magic at the top.


### PR DESCRIPTION
This PR implements a new syntax that doesn't require -parse-stdlib, suggested by @hborla. The nice thing is that we want it to just work anyway, even if/when a new syntax is added:

```swift
typealias MyTuple<each Horse> = (repeat each Horse)
extension MyTuple: P where repeat each Horse: P {...}
```

Or with requirement inference:
```swift
typealias MyTuple<each Horse: P> = (repeat each Horse)
extension MyTuple: P {...}
```

This PR also implements enforcement of various semantic restrictions:

- Extended type must be `(repeat each T)` where `T` is the type parameter pack of the alias.

- A tuple extension must define a conformance to exactly one protocol `P`, this conformance must be conditional, and there must be exactly one conditional requirement that is a pack conformance requirement of `T` to `P`. You cannot have `extension Tuple: P where repeat each T: Q`, because if T is replaced with a single scalar type `X`, we get `X: P where X: Q`, which is false in general unless P inherits from Q.

- An associated type `A` must be witnessed by `(repeat (each T).A)` in the conformance; that is, we require that `(repeat each T).A == (repeat (each T).A)`. This restriction is required for a similar reason, for coherence with the one-element vanishing substitution.

The above is not enough to ensure coherence. We also need to statically and dynamically unwrap one-element tuple conformances, and prevent devirtualization of certain calls. This will happen in a subsequent PR.