### PR TITLE
[Diagnostics] Require explicit releasenone.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -102,6 +102,14 @@ ERROR(exclusivity_access_required_unknown_decl_moveonly,none,
 NOTE(exclusivity_conflicting_access,none,
      "conflicting access is here", ())
 
+WARNING(error_attr_effects_consume_requires_explicit_releasenone_self,none,
+      "annotation implies no releases, but consumes self", ())
+WARNING(error_attr_effects_consume_requires_explicit_releasenone,none,
+      "annotation implies no releases, but consumes parameter %0", (DeclName))
+NOTE(note_attr_effects_consume_requires_explicit_releasenone,none,
+     "parameter %0 defined here", (DeclName))
+NOTE(fixit_attr_effects_consume_requires_explicit_releasenone,none,"add explicit @_effects(releasenone) if this is intended", ())
+
 ERROR(unsupported_c_function_pointer_conversion,none,
       "C function pointer signature %0 is not compatible with expected type %1",
       (Type, Type))

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -13,9 +13,10 @@
 #include "swift/SIL/SILFunctionBuilder.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Availability.h"
-#include "swift/AST/DiagnosticsParse.h"
-#include "swift/AST/DistributedDecl.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticsParse.h"
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/DistributedDecl.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/SemanticAttrs.h"
 
@@ -60,6 +61,8 @@ void SILFunctionBuilder::addFunctionAttributes(
   if (auto *A = Attrs.getAttribute(DAK_EmitAssemblyVisionRemarks))
     F->addSemanticsAttr(semantics::FORCE_EMIT_OPT_REMARK_PREFIX);
 
+  auto *attributedFuncDecl = constant.getAbstractFunctionDecl();
+
   // Propagate @_specialize.
   for (auto *A : Attrs.getAttributes<SpecializeAttr>()) {
     auto *SA = cast<SpecializeAttr>(A);
@@ -103,21 +106,74 @@ void SILFunctionBuilder::addFunctionAttributes(
     }
   }
 
+  EffectsAttr const *writeNoneEffect = nullptr;
+  EffectsAttr const *releaseNoneEffect = nullptr;
   llvm::SmallVector<const EffectsAttr *, 8> customEffects;
   if (constant) {
     for (auto *attr : Attrs.getAttributes<EffectsAttr>()) {
       auto *effectsAttr = cast<EffectsAttr>(attr);
-      if (effectsAttr->getKind() == EffectsKind::Custom) {
+      switch (effectsAttr->getKind()) {
+      case EffectsKind::Custom:
         customEffects.push_back(effectsAttr);
-      } else {
-        if (F->getEffectsKind() != EffectsKind::Unspecified &&
-            F->getEffectsKind() != effectsAttr->getKind()) {
-          mod.getASTContext().Diags.diagnose(effectsAttr->getLocation(),
-              diag::warning_in_effects_attribute, "mismatching function effects");
-        } else {
-          F->setEffectsKind(effectsAttr->getKind());
-        }
+        // Proceed to the next attribute, don't set the effects kind based on
+        // this attribute.
+        continue;
+      case EffectsKind::ReadNone:
+      case EffectsKind::ReadOnly:
+        writeNoneEffect = effectsAttr;
+        break;
+      case EffectsKind::ReleaseNone:
+        releaseNoneEffect = effectsAttr;
+        break;
+      default:
+        break;
       }
+      if (effectsAttr->getKind() == EffectsKind::Custom)
+        continue;
+      if (F->getEffectsKind() != EffectsKind::Unspecified) {
+        // If multiple known effects are specified, the most restrictive one
+        // is used.
+        F->setEffectsKind(
+            std::min(effectsAttr->getKind(), F->getEffectsKind()));
+      } else {
+        F->setEffectsKind(effectsAttr->getKind());
+      }
+    }
+  }
+
+  if (writeNoneEffect && !releaseNoneEffect) {
+    auto constantType = mod.Types.getConstantFunctionType(
+        TypeExpansionContext::minimal(), constant);
+    SILFunctionConventions fnConv(constantType, mod);
+
+    auto selfIndex = fnConv.getSILArgIndexOfSelf();
+    for (auto index : indices(fnConv.getParameters())) {
+      auto param = fnConv.getParameters()[index];
+      if (!param.isConsumed())
+        continue;
+      if (index == selfIndex) {
+        mod.getASTContext().Diags.diagnose(
+            writeNoneEffect->getLocation(),
+            diag::
+                error_attr_effects_consume_requires_explicit_releasenone_self);
+      } else {
+        auto *pd = attributedFuncDecl->getParameters()->get(index);
+        mod.getASTContext().Diags.diagnose(
+            writeNoneEffect->getLocation(),
+            diag::error_attr_effects_consume_requires_explicit_releasenone,
+            pd->getName());
+        mod.getASTContext().Diags.diagnose(
+            pd->getNameLoc(),
+            diag::note_attr_effects_consume_requires_explicit_releasenone,
+            pd->getName());
+      }
+      mod.getASTContext()
+          .Diags
+          .diagnose(
+              writeNoneEffect->getLocation(),
+              diag::fixit_attr_effects_consume_requires_explicit_releasenone)
+          .fixItInsertAfter(writeNoneEffect->getRange().End,
+                            " @_effects(releasenone)");
     }
   }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -715,11 +715,11 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
 
   // Note: Do not provide any SILLocation. You can set it afterwards.
   SILGenFunctionBuilder builder(*this);
-  auto &IGM = *this;
+  auto &SGM = *this;
   auto *F = builder.getOrCreateFunction(
       getBestLocation(constant), constant, forDefinition,
-      [&IGM](SILLocation loc, SILDeclRef constant) -> SILFunction * {
-        return IGM.getFunction(constant, NotForDefinition);
+      [&SGM](SILLocation loc, SILDeclRef constant) -> SILFunction * {
+        return SGM.getFunction(constant, NotForDefinition);
       });
 
   assert(F && "SILFunction should have been defined");

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -68,7 +68,7 @@ func _deallocateUninitializedArray<Element>(
 #if !INTERNAL_CHECKS_ENABLED
 @_alwaysEmitIntoClient
 @_semantics("array.finalize_intrinsic")
-@_effects(readnone)
+@_effects(readnone) @_effects(releasenone)
 @_effects(escaping array.value** => return.value**)
 @_effects(escaping array.value**.class*.value** => return.value**.class*.value**)
 public // COMPILER_INTRINSIC

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -345,7 +345,7 @@ extension _SmallString {
 extension _SmallString {
   // Resiliently create from a tagged cocoa string
   //
-  @_effects(readonly) // @opaque
+  @_effects(readonly) @_effects(releasenone) // @opaque
   @usableFromInline // testable
   internal init?(taggedCocoa cocoa: AnyObject) {
     self.init()
@@ -367,7 +367,7 @@ extension _SmallString {
     self._invariantCheck()
   }
   
-  @_effects(readonly) // @opaque
+  @_effects(readonly) @_effects(releasenone) // @opaque
   internal init?(taggedASCIICocoa cocoa: AnyObject) {
     self.init()
     var success = true

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -230,7 +230,7 @@ extension String {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  @_effects(readonly)
+  @_effects(readonly) @_effects(releasenone)
   public init(stringInterpolation: DefaultStringInterpolation) {
     self = stringInterpolation.make()
   }
@@ -254,7 +254,7 @@ extension Substring {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  @_effects(readonly)
+  @_effects(readonly) @_effects(releasenone)
   public init(stringInterpolation: DefaultStringInterpolation) {
     self.init(stringInterpolation.make())
   }

--- a/test/SIL/diagnose_effects.swift
+++ b/test/SIL/diagnose_effects.swift
@@ -1,0 +1,120 @@
+// RUN: %target-swift-emit-silgen %s -o /dev/null -verify
+
+class C {}
+struct S {
+
+  var c: C
+
+////////////////////////////////////////////////////////////////////////////////
+// Implicitly consuming argument.                                             //
+////////////////////////////////////////////////////////////////////////////////
+
+  @_effects(readnone) 
+  // expected-warning@-1{{annotation implies no releases, but consumes parameter 'c'}} 
+  // expected-note@-2{{add explicit @_effects(releasenone) if this is intended}}
+  // expected-note@+1{{parameter 'c' defined here}}
+  init(readnone c: C) { self.c = c }
+
+  @_effects(readnone) 
+  // expected-warning@-1{{annotation implies no releases, but consumes parameter 'readnone_noargumentlabel'}} 
+  // expected-note@-2{{add explicit @_effects(releasenone) if this is intended}}
+  // expected-note@+1{{parameter 'readnone_noargumentlabel' defined here}}
+  init(readnone_noargumentlabel: C) { self.c = readnone_noargumentlabel }
+  
+  @_effects(readnone) @_effects(releasenone) // ok
+  init(readnone_releasenone c: C) { self.c = c }
+  
+  @_effects(releasenone) @_effects(readnone) // ok
+  init(releasenone_readnone c: C) { self.c = c }
+
+  @_effects(readonly)
+  // expected-warning@-1{{annotation implies no releases, but consumes parameter 'c'}} 
+  // expected-note@-2{{add explicit @_effects(releasenone) if this is intended}}
+  // expected-note@+1{{parameter 'c' defined here}}
+  init(readonly c: C) { self.c = c }
+
+  @_effects(readonly) @_effects(releasenone) // ok
+  init(readonly_releasenone c: C) { self.c = c }
+
+  @_effects(releasenone) @_effects(readonly) // ok
+  init(releasenone_readonly c: C) { self.c = c }
+
+  @_effects(releasenone) // ok
+  init(releasenone c: C) { self.c = c }
+
+////////////////////////////////////////////////////////////////////////////////
+// Explicitly consuming argument.                                             //
+////////////////////////////////////////////////////////////////////////////////
+
+  @_effects(readnone)
+  // expected-warning@-1{{annotation implies no releases, but consumes parameter 'c'}} 
+  // expected-note@-2{{add explicit @_effects(releasenone) if this is intended}}
+  // expected-note@+1{{parameter 'c' defined here}}
+  mutating func readnoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(readnone) @_effects(releasenone) // ok
+  mutating func readnone_releasenoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(releasenone) @_effects(readnone) // ok
+  mutating func releasenone_readnoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(readonly)
+  // expected-warning@-1{{annotation implies no releases, but consumes parameter 'c'}} 
+  // expected-note@-2{{add explicit @_effects(releasenone) if this is intended}}
+  // expected-note@+1{{parameter 'c' defined here}}
+  mutating func readonlyConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(readonly) @_effects(releasenone) // ok
+  mutating func reasonly_releasenoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(releasenone) @_effects(readonly) // ok
+  mutating func releasenone_reasonlyConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(releasenone) // ok
+  mutating func releasenoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+////////////////////////////////////////////////////////////////////////////////
+// Explicitly consuming self.                                                 //
+////////////////////////////////////////////////////////////////////////////////
+
+  @_effects(readnone)
+  // expected-warning@-1{{annotation implies no releases, but consumes self}} 
+  // expected-note@-2{{add explicit @_effects(releasenone) if this is intended}}
+  __consuming func readnoneConsumeSelf() {}
+
+  @_effects(readnone) @_effects(releasenone) // ok
+  __consuming func readnone_releasenoneConsumeSelf() {}
+
+  @_effects(releasenone) @_effects(readnone) // ok
+  __consuming func readnone_readnoneConsumeSelf() {}
+
+  @_effects(readonly)
+  // expected-warning@-1{{annotation implies no releases, but consumes self}} 
+  // expected-note@-2{{add explicit @_effects(releasenone) if this is intended}}
+  __consuming func readonlyConsumeSelf() {}
+
+  @_effects(readonly) @_effects(releasenone) // ok
+  __consuming func readonly_releasenoneConsumeSelf() {}
+
+   @_effects(releasenone) @_effects(readonly) // ok
+  __consuming func releasenone_readonlyConsumeSelf() {}
+
+  @_effects(releasenone) // ok
+  __consuming func releasenoneConsumeSelf() {}
+
+}
+


### PR DESCRIPTION
Functions which which consume their arguments will release them on any branches where the arguments are unused.  Users of `@_effects(readnone)` and `@_effects(readonly)` may not consider this when annotating their functions.  Require that functions annotated thus are also annotated @_effects(releasenone).

In order to support this, adjust SILFunctionBuilder to allow distinct non-custom effects and to interpret such "conflicting" guarantees to provide the strongest guarantee.  For example, annotating a function both `@_effects(readnone)` and `@_effects(releasenone)` is equivalent to only annotating it `@_effects(readnone)`.

