### PR TITLE
Remove CPU requirement from test/SILOptimizer/character_literals.swift

### DIFF
--- a/test/SILOptimizer/character_literals.swift
+++ b/test/SILOptimizer/character_literals.swift
@@ -1,12 +1,9 @@
 // RUN: %target-swift-frontend -parse-as-library -O -emit-ir  %s | %FileCheck %s
-// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib,CPU=arm64
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: swift_in_compiler
 
 // This is an end-to-end test to ensure that the optimizer generates
 // a simple literal for character literals.
-
-// Please note: this test targets "core2" to ensure consistent output
-// on all x86 host processors.
 
 // We generate this as an LLVM constant global directly, no runtime heap
 // allocation. Match that.


### PR DESCRIPTION
Since LLVM doesn't support targeting core2, presumably we don't need to worry about older targets anymore.
