### PR TITLE
ASTGen: account for alternate path separators

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -43,7 +43,13 @@ extension String {
   /// Retrieve the base name of a string that represents a path, removing the
   /// directory.
   var basename: String {
-    guard let lastSlash = lastIndex(where: { ["/", "\\"].contains($0) }) else {
+    guard let lastSlash = lastIndex(where: {
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(Android) || os(Linux)
+        ["/"].contains($0)
+#else
+        ["/", "\\"].contains($0)
+#endif
+    }) else {
       return self
     }
 

--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -43,7 +43,7 @@ extension String {
   /// Retrieve the base name of a string that represents a path, removing the
   /// directory.
   var basename: String {
-    guard let lastSlash = lastIndex(of: "/") else {
+    guard let lastSlash = lastIndex(where: { ["/", "\\"].contains($0) }) else {
       return self
     }
 


### PR DESCRIPTION
Windows supports `\` and `/` as path separators.  Account for both in computing the basename.  This repairs a few test failures on Windows.