### PR TITLE
SourceKit: handle Windows paths for request options

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -427,7 +427,7 @@ static bool setSyntacticMacroExpansions(sourcekitd_object_t req,
   SmallVector<sourcekitd_object_t, 4> expansions;
   for (std::string &opt : opts.RequestOptions) {
     SmallVector<StringRef, 3> args;
-    StringRef(opt).split(args, ":");
+    StringRef(opt).split(args, ":", /*maxSplits=*/2);
     unsigned line, column;
 
     if (args.size() != 3 || args[0].getAsInteger(10, line) ||


### PR DESCRIPTION
Windows paths involve a `:`.  Ideally, we would just use `;` as the separator rather than `:`, but for now special case a single character entry as a drive letter.