### PR TITLE
swift-plugin-server: default to C++17

### DIFF
--- a/tools/swift-plugin-server/Package.swift
+++ b/tools/swift-plugin-server/Package.swift
@@ -34,6 +34,6 @@ let package = Package(
         "CSwiftPluginServer"
       ]
     ),
-    
-  ]
+  ],
+  cxxLanguageStandard: .cxx17
 )


### PR DESCRIPTION
This is required to build on Windows and for C++ interop.