### PR TITLE
[embedded] Add basics of module serialization, importing and validation in embedded Swift.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -663,7 +663,7 @@ protected:
     HasAnyUnavailableDuringLoweringValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -706,6 +706,9 @@ protected:
 
     /// Whether this module was built with -experimental-hermetic-seal-at-link.
     HasHermeticSealAtLink : 1,
+
+    /// Whether this module was built with embedded Swift.
+    IsEmbeddedSwiftModule : 1,
 
     /// Whether this module has been compiled with comprehensive checking for
     /// concurrency, e.g., Sendable checking.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -872,6 +872,12 @@ ERROR(need_hermetic_seal_to_import_module,none,
       "module %0 was built with -experimental-hermetic-seal-at-link, but "
       "current compilation does not have -experimental-hermetic-seal-at-link",
       (Identifier))
+ERROR(cannot_import_embedded_module,none,
+      "module %0 cannot be imported because it was built with embedded Swift",
+      (Identifier))
+ERROR(cannot_import_non_embedded_module,none,
+      "module %0 cannot be imported in embedded Swift mode",
+      (Identifier))
 ERROR(need_cxx_interop_to_import_module,none,
       "module %0 was built with C++ interoperability enabled, but "
       "current compilation does not enable C++ interoperability",

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -656,6 +656,14 @@ public:
     Bits.ModuleDecl.HasHermeticSealAtLink = enabled;
   }
 
+  /// Returns true if this module was built with embedded Swift
+  bool isEmbeddedSwiftModule() const {
+    return Bits.ModuleDecl.IsEmbeddedSwiftModule;
+  }
+  void setIsEmbeddedSwiftModule(bool enabled = true) {
+    Bits.ModuleDecl.IsEmbeddedSwiftModule = enabled;
+  }
+
   /// Returns true if this module was built with C++ interoperability enabled.
   bool hasCxxInteroperability() const {
     return Bits.ModuleDecl.HasCxxInteroperability;

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -155,6 +155,7 @@ namespace swift {
     bool DisableCrossModuleIncrementalInfo = false;
     bool StaticLibrary = false;
     bool HermeticSealAtLink = false;
+    bool EmbeddedSwiftModule = false;
     bool IsOSSA = false;
     bool SerializeExternalDeclsOnly = false;
   };

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -128,6 +128,7 @@ class ExtendedValidationInfo {
     unsigned IsSIB : 1;
     unsigned IsStaticLibrary : 1;
     unsigned HasHermeticSealAtLink : 1;
+    unsigned IsEmbeddedSwiftModule : 1;
     unsigned IsTestable : 1;
     unsigned ResilienceStrategy : 2;
     unsigned IsImplicitDynamicEnabled : 1;
@@ -180,6 +181,10 @@ public:
   bool hasHermeticSealAtLink() const { return Bits.HasHermeticSealAtLink; }
   void setHasHermeticSealAtLink(bool val) {
     Bits.HasHermeticSealAtLink = val;
+  }
+  bool isEmbeddedSwiftModule() const { return Bits.IsEmbeddedSwiftModule; }
+  void setIsEmbeddedSwiftModule(bool val) {
+    Bits.IsEmbeddedSwiftModule = val;
   }
   bool isTestable() const { return Bits.IsTestable; }
   void setIsTestable(bool val) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -718,6 +718,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   Bits.ModuleDecl.IsMainModule = 0;
   Bits.ModuleDecl.HasIncrementalInfo = 0;
   Bits.ModuleDecl.HasHermeticSealAtLink = 0;
+  Bits.ModuleDecl.IsEmbeddedSwiftModule = 0;
   Bits.ModuleDecl.IsConcurrencyChecked = 0;
   Bits.ModuleDecl.ObjCNameLookupCachePopulated = 0;
   Bits.ModuleDecl.HasCxxInteroperability = 0;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -223,6 +223,9 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
 
   serializationOpts.HermeticSealAtLink = opts.HermeticSealAtLink;
 
+  serializationOpts.EmbeddedSwiftModule =
+      LangOpts.hasFeature(Feature::Embedded);
+
   serializationOpts.IsOSSA = getSILOptions().EnableOSSAModules;
 
   serializationOpts.SerializeExternalDeclsOnly =

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1557,6 +1557,11 @@ static bool validateTBDIfNeeded(const CompilerInvocation &Invocation,
       return false;
     }
 
+    // Embedded Swift does not support TBD.
+    if (Invocation.getLangOptions().hasFeature(Feature::Embedded)) {
+      return false;
+    }
+
     // Cross-module optimization does not support TBD.
     if (Invocation.getSILOptions().CMOMode == CrossModuleOptimizationMode::Aggressive) {
       return false;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -536,7 +536,7 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
   // libraries. This may however cause the library to get pulled in in
   // situations where it isn't useful, such as for dylibs, though this is
   // harmless aside from code size.
-  if (!IRGen.Opts.UseJIT) {
+  if (!IRGen.Opts.UseJIT && !Context.LangOpts.hasFeature(Feature::Embedded)) {
     auto addBackDeployLib = [&](llvm::VersionTuple version,
                                 StringRef libraryName, bool forceLoad) {
       llvm::Optional<llvm::VersionTuple> compatibilityVersion;
@@ -1416,7 +1416,6 @@ void IRGenerator::emitLazyDefinitions() {
     LazySpecializedTypeMetadataRecords.clear();
     LazyTypeContextDescriptors.clear();
     LazyOpaqueTypeDescriptors.clear();
-    LazyFunctionDefinitions.clear();
     LazyCanonicalSpecializedMetadataAccessors.clear();
     LazyMetadataAccessors.clear();
     LazyWitnessTables.clear();

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3303,7 +3303,11 @@ llvm::Value *IRGenFunction::emitTypeMetadataRef(CanType type) {
 MetadataResponse
 IRGenFunction::emitTypeMetadataRef(CanType type,
                                    DynamicMetadataRequest request) {
-  assert(!type->getASTContext().LangOpts.hasFeature(Feature::Embedded));
+  if (type->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    llvm::errs() << "Metadata pointer requested in embedded Swift for type "
+                 << type << "\n";
+    assert(0 && "metadata used in embedded mode");
+  }
 
   type = IGM.getRuntimeReifiedType(type);
   // Look through any opaque types we're allowed to.

--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -120,7 +120,8 @@ void SILLinkerVisitor::maybeAddFunctionToWorklist(SILFunction *F,
     return;
   }
 
-  // In the performance pipeline, we deserialize all reachable functions.
+  // In the performance pipeline or embedded mode, we deserialize all reachable
+  // functions.
   if (isLinkAll())
     return deserializeAndPushToWorklist(F);
 
@@ -433,6 +434,11 @@ void SILLinkerVisitor::process() {
       // Remove The Serialized state (if any)
       //  This allows for more optimizations
       Fn->setSerialized(IsSerialized_t::IsNotSerialized);
+    }
+
+    // TODO: This should probably be done as a separate SIL pass ("internalize")
+    if (Fn->getModule().getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+      Fn->setLinkage(stripExternalFromLinkage(Fn->getLinkage()));
     }
 
     LLVM_DEBUG(llvm::dbgs() << "Process imports in function: "

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -142,7 +142,10 @@ private:
 
   /// Is the current mode link all? Link all implies we should try and link
   /// everything, not just transparent/shared functions.
-  bool isLinkAll() const { return Mode == LinkingMode::LinkAll; }
+  bool isLinkAll() const {
+    return Mode == LinkingMode::LinkAll ||
+           Mod.getASTContext().LangOpts.hasFeature(Feature::Embedded);
+  }
 
   void linkInVTable(ClassDecl *D);
 

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -898,6 +898,10 @@ void SILModule::performOnceForPrespecializedImportedExtensions(
   if (prespecializedFunctionDeclsImported)
     return;
 
+  // No prespecitalizations in embedded Swift
+  if (getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return;
+
   SmallVector<ModuleDecl *, 8> importedModules;
   // Add the Swift module.
   if (!isStdlibModule()) {

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -1004,6 +1004,9 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   // inlinable functions from imported ones.
   P.addOnonePrespecializations();
 
+  // For embedded Swift: CMO is used to serialize libraries.
+  P.addCrossModuleOptimization();
+
   // First serialize the SIL if we are asked to.
   P.startPipeline("Serialization");
   P.addSerializeSILPass();

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -621,6 +621,11 @@ public:
     return Core->Bits.HasHermeticSealAtLink;
   }
 
+  /// Whether this module was built using embedded Swift.
+  bool isEmbeddedSwiftModule() const {
+    return Core->Bits.IsEmbeddedSwiftModule;
+  }
+
   /// Whether this module was built with C++ interoperability enabled.
   bool hasCxxInteroperability() const {
     return Core->Bits.HasCxxInteroperability;

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -158,6 +158,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::HAS_HERMETIC_SEAL_AT_LINK:
       extendedInfo.setHasHermeticSealAtLink(true);
       break;
+    case options_block::IS_EMBEDDED_SWIFT_MODULE:
+      extendedInfo.setIsEmbeddedSwiftModule(true);
+      break;
     case options_block::IS_TESTABLE:
       extendedInfo.setIsTestable(true);
       break;
@@ -1405,6 +1408,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.IsSIB = extInfo.isSIB();
       Bits.IsStaticLibrary = extInfo.isStaticLibrary();
       Bits.HasHermeticSealAtLink = extInfo.hasHermeticSealAtLink();
+      Bits.IsEmbeddedSwiftModule = extInfo.isEmbeddedSwiftModule();
       Bits.IsTestable = extInfo.isTestable();
       Bits.ResilienceStrategy = unsigned(extInfo.getResilienceStrategy());
       Bits.IsImplicitDynamicEnabled = extInfo.isImplicitDynamicEnabled();

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -367,6 +367,9 @@ private:
     /// Whether this module was built with -experimental-hermetic-seal-at-link.
     unsigned HasHermeticSealAtLink : 1;
 
+    /// Whether this module was built with embedded Swift.
+    unsigned IsEmbeddedSwiftModule : 1;
+
     /// Whether this module file is compiled with '-enable-testing'.
     unsigned IsTestable : 1;
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 803; // removed initializes and accesses attributes
+const uint16_t SWIFTMODULE_VERSION_MINOR = 804; // embedded swift modules
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -885,6 +885,7 @@ namespace options_block {
     IS_SIB,
     IS_STATIC_LIBRARY,
     HAS_HERMETIC_SEAL_AT_LINK,
+    IS_EMBEDDED_SWIFT_MODULE,
     IS_TESTABLE,
     RESILIENCE_STRATEGY,
     ARE_PRIVATE_IMPORTS_ENABLED,
@@ -926,6 +927,10 @@ namespace options_block {
 
   using HasHermeticSealAtLinkLayout = BCRecordLayout<
     HAS_HERMETIC_SEAL_AT_LINK
+  >;
+
+  using IsEmbeddedSwiftModuleLayout = BCRecordLayout<
+    IS_EMBEDDED_SWIFT_MODULE
   >;
 
   using IsTestableLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1038,6 +1038,11 @@ void Serializer::writeHeader() {
         HasHermeticSealAtLink.emit(ScratchRecord);
       }
 
+      if (Options.EmbeddedSwiftModule) {
+        options_block::IsEmbeddedSwiftModuleLayout IsEmbeddedSwiftModule(Out);
+        IsEmbeddedSwiftModule.emit(ScratchRecord);
+      }
+
       if (M->isTestingEnabled()) {
         options_block::IsTestableLayout IsTestable(Out);
         IsTestable.emit(ScratchRecord);

--- a/test/embedded/basic-irgen-no-stdlib.swift
+++ b/test/embedded/basic-irgen-no-stdlib.swift
@@ -23,11 +23,11 @@ public func main() {
   start(p: Concrete())
 }
 
-// CHECK-LABEL: declare hidden swiftcc void @"$s4main8ConcreteVACycfC"()
+// CHECK-LABEL: define {{.*}}void @"$s4main8ConcreteVACycfC"()
 
-// CHECK-LABEL: declare hidden swiftcc void @"$s4main5start1pyx_tAA6PlayerRzlFAA8ConcreteV_Tg5"()
+// CHECK-LABEL: define {{.*}}void @"$s4main5start1pyx_tAA6PlayerRzlFAA8ConcreteV_Tg5"()
 
-// CHECK-LABEL: define protected swiftcc void @"$s4mainAAyyF"()
+// CHECK-LABEL: define {{.*}}void @"$s4mainAAyyF"()
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    call swiftcc void @"$s4main8ConcreteVACycfC"()
 // CHECK-NEXT:    call swiftcc void @"$s4main5start1pyx_tAA6PlayerRzlFAA8ConcreteV_Tg5"()

--- a/test/embedded/basic-modules-no-stdlib.swift
+++ b/test/embedded/basic-modules-no-stdlib.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -swift-version 5 -emit-ir     -I %t                      %t/Main.swift     -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s
+
+// TODO: investigate why windows is generating more metadata.
+// XFAIL: OS=windows-msvc
+
+// BEGIN MyModule.swift
+
+public struct Bool {}
+
+public protocol Player {
+  func play()
+  var canPlay: Bool { get }
+}
+
+public struct Concrete : Player {
+  public init() { }
+  public func play() { }
+  public var canPlay: Bool { Bool() }
+}
+
+public func start(p: some Player) {
+  p.play()
+}
+
+public func moduleMain() {
+  start(p: Concrete())
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+public func main() {
+  moduleMain()
+}
+
+// CHECK: define {{.*}}@main{{.*}} {
+// CHECK: define {{.*}}void @"$s4Main4mainyyF"{{.*}} {
+// CHECK: define {{.*}}void @"$s8MyModule10moduleMainyyF"{{.*}} {
+// CHECK: define {{.*}}void @"$s8MyModule8ConcreteVACycfC"{{.*}} {
+// CHECK: define {{.*}}void @"$s8MyModule5start1pyx_tAA6PlayerRzlFAA8ConcreteV_Tg5"{{.*}} {
+// CHECK: define {{.*}}void @"$s8MyModule8ConcreteV4playyyF"{{.*}} {

--- a/test/embedded/basic-modules-validation-no-stdlib.swift
+++ b/test/embedded/basic-modules-validation-no-stdlib.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// both modules are embedded - ok
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -parse-stdlib -enable-experimental-feature Embedded
+
+// MyModule is not embedded - error
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib
+// RUN: not %target-swift-frontend -emit-ir -I %t %t/Main.swift -parse-stdlib -enable-experimental-feature Embedded 2>&1 | %FileCheck %s --check-prefix CHECK-A
+
+// main module is not embedded - error
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -enable-experimental-feature Embedded
+// RUN: not %target-swift-frontend -emit-ir -I %t %t/Main.swift -parse-stdlib 2>&1 | %FileCheck %s --check-prefix CHECK-B
+
+// BEGIN MyModule.swift
+
+public func foo() { }
+
+// BEGIN Main.swift
+
+import MyModule
+
+public func main() {
+  foo()
+}
+
+// CHECK-A: error: module 'MyModule' cannot be imported in embedded Swift mode
+// CHECK-B: error: module 'MyModule' cannot be imported because it was built with embedded Swift

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -7,7 +7,8 @@
 
 // CHECK: ---
 // CHECK: name:            Non-Diagnostic Mandatory Optimizations
-// CHECK: passes:          [ "for-each-loop-unroll", "mandatory-arc-opts", "onone-prespecializer" ]
+// CHECK: passes:          [ "for-each-loop-unroll", "mandatory-arc-opts", "onone-prespecializer",
+// CHECK-NEXT:               "cmo" ]
 // CHECK: ---
 // CHECK: name:            Serialization
 // CHECK: passes:          [ "serialize-sil", "sil-moved-async-var-dbginfo-propagator",


### PR DESCRIPTION
This PR adds basics of module serialization, importing and validation in embedded Swift, as described in the Embedded Swift vision document: https://github.com/kubamracek/swift-evolution/blob/embedded-swift/visions/embedded-swift.md

This builds on top of https://github.com/apple/swift/pull/68244 -- only the last commit is relevant in this PR.

Rough breakdown of the changes:
- Add a flag to the serialized module (IsEmbeddedSwiftModule)
- Check on import that the mode matches (don't allow importing non-embedded module in embedded mode and vice versa)
- Drop TBD support, it's not expected to work in embedded Swift for now
- Drop auto-linking backdeploy libraries, it's not expected to backdeploy embedded Swift for now
- Drop prespecializations, not expected to work in embedded Swift for now
- Use CMO to serialize everything when emitting an embedded Swift module
- Change SILLinker to deserialize/import everything when importing an embedded Swift module
- Add an IR test for importing modules
- Add a deserialization validation test
