### PR TITLE
[Diagnostics] Improving diagnostics for function type coerce with different number of args

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2761,6 +2761,17 @@ bool ContextualFailure::diagnoseAsNote() {
     }
   }
 
+  // Note that mentions candidate type number of parameters diff.
+  auto fromFnType = getFromType()->getAs<FunctionType>();
+  auto toFnType = getToType()->getAs<FunctionType>();
+  if (fromFnType && toFnType &&
+      fromFnType->getNumParams() > toFnType->getNumParams()) {
+    emitDiagnosticAt(decl, diag::candidate_with_extraneous_args, fromFnType,
+                     fromFnType->getNumParams(), toFnType,
+                     toFnType->getNumParams());
+    return true;
+  }
+
   emitDiagnosticAt(decl, diag::found_candidate_type, getFromType());
   return true;
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3431,10 +3431,10 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       // let i: Int = 0
       // (fn as (Int, Int) -> Void)(i, i)
       //
-      // Since we are not in a function argument application, so simply record
+      // Since we are not in a function argument application, simply record
       // a function type mismatch instead of an argument fix.
-      // Except for when a closure is a subexpr because missing and extraneous
-      // arg fix can properly handle closure diagnostic.
+      // Except for when a closure is a subexpr because closure expr parameters
+      // syntax can be added or removed by missing/extraneous arguments fix.
       if (loc->isForCoercion() && !isExpr<ClosureExpr>(anchor)) {
         auto *fix = ContextualMismatch::create(*this, func1, func2, loc);
         if (recordFix(fix))

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -163,3 +163,28 @@ let _: Int = any as Int // expected-error {{'Any' is not convertible to 'Int'}}
 // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{18-20=as!}}
 let _: Int? = any as Int // expected-error {{'Any' is not convertible to 'Int'}}
 // expected-note@-1 {{did you mean to use 'as?' to conditionally downcast?}} {{19-21=as?}}
+
+// https://github.com/apple/swift/issues/63926
+
+do {
+  func fn(_: Int) {} // expected-note {{found candidate with type '(Int) -> ()'}}
+  // expected-note@-1 {{candidate '(Int) -> ()' has 1 parameter, but context '() -> Void' has 0}}
+  func fn(_: Bool) {} // expected-note {{found candidate with type '(Bool) -> ()'}}
+  // expected-note@-1 {{candidate '(Bool) -> ()' has 1 parameter, but context '() -> Void' has 0}}
+
+  func fn_1(_: Bool) {} 
+
+  let i = 0
+  // Missing parameters.
+  (fn as (Int, Int) -> Void)(i, i) // expected-error {{cannot convert value of type '(Int) -> ()' to type '(Int, Int) -> Void' in coercion}}
+  (fn as (Bool, Bool) -> Void)(i, i) // expected-error {{cannot convert value of type '(Bool) -> ()' to type '(Bool, Bool) -> Void' in coercion}}
+  // expected-error@-1 2{{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+  (fn as (Int, Bool) -> Void)(i, i) // expected-error {{cannot convert value of type '(Int) -> ()' to type '(Int, Bool) -> Void' in coercion}}
+  // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+  (fn as (String) -> Void)(i) // expected-error {{no exact matches in reference to local function 'fn'}}
+  // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+
+  // Extraneous parameters.
+  (fn as () -> Void)() // expected-error {{no exact matches in reference to local function 'fn'}}
+  (fn_1 as () -> Void)() // expected-error {{cannot convert value of type '(Bool) -> ()' to type '() -> Void' in coercion}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

For a function match failure on the number of args, record a contextual failure to diagnose as a type mismatch since is not a function application. Except for closures because missing/extraneous argument fix can handle closure mismatch and provide fix-its to closure expr arguments.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/63926

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
