### PR TITLE
tests: replace shell with python for portability

### DIFF
--- a/test/ClangImporter/pch-bridging-header-deps-fine.swift
+++ b/test/ClangImporter/pch-bridging-header-deps-fine.swift
@@ -1,30 +1,26 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: rm -f %t.*
-//
+
 // Generate a bridging PCH, use it in a swift file, and check that the swift file's .swiftdeps
 // mention the .h the PCH was generated from, and any .h files included in it.
-//
+
 // RUN: %target-swift-frontend -emit-pch -o %t.pch %/S/Inputs/chained-unit-test-bridging-header-to-pch.h
 // RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -primary-file %s -import-objc-header %t.pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.d
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS --enable-yaml-compatibility %s < %t-processed.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 --enable-yaml-compatibility %s < %t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.persistent.d -emit-reference-dependencies-path %t.persistent.swiftdeps -primary-file %s -import-objc-header %/S/Inputs/chained-unit-test-bridging-header-to-pch.h -pch-output-dir %t/pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.persistent.d
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.persistent.swiftdeps %t-processed.persistent.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.persistent.swiftdeps > %t-processed.persistent.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS  --enable-yaml-compatibility %s < %t-processed.persistent.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 --enable-yaml-compatibility %s < %t-processed.persistent.swiftdeps
 
 print(app_function(1))
 
-// CHECK-DEPS: pch-bridging-header-deps-fine.o : {{.*}}SOURCE_DIR{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}app-bridging-header-to-pch.h {{.*}}SOURCE_DIR{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}chained-unit-test-bridging-header-to-pch.h
+// CHECK-DEPS: pch-bridging-header-deps-fine.o : {{.*}}{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}app-bridging-header-to-pch.h {{.*}}{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}chained-unit-test-bridging-header-to-pch.h
 
-// CHECK-SWIFTDEPS: externalDepend {{.*}} 'SOURCE_DIR{{/|\\\\}}test{{/|\\\\}}ClangImporter{{/|\\\\}}Inputs{{/|\\\\}}app-bridging-header-to-pch.h'
-// CHECK-SWIFTDEPS: externalDepend {{.*}} 'SOURCE_DIR{{/|\\\\}}test{{/|\\\\}}ClangImporter{{/|\\\\}}Inputs{{/|\\\\}}chained-unit-test-bridging-header-to-pch.h'
+// CHECK-SWIFTDEPS: externalDepend {{.*}} '{{.*}}{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}app-bridging-header-to-pch.h'
+// CHECK-SWIFTDEPS: externalDepend {{.*}} '{{.*}}{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}chained-unit-test-bridging-header-to-pch.h'
 
 // CHECK-SWIFTDEPS2-NOT: {{.*}}.pch

--- a/test/Frontend/dependencies-fine.swift
+++ b/test/Frontend/dependencies-fine.swift
@@ -1,17 +1,13 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-dependencies-path - -resolve-imports "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC %s
 // RUN: %target-swift-frontend -emit-reference-dependencies-path - -typecheck -primary-file "%S/../Inputs/empty file.swift" > %t.swiftdeps
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-BASIC-YAML %s <%t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
 // RUN: %FileCheck -check-prefix=CHECK-BASIC %s < %t.d
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-BASIC-YAML %s < %t-processed.swiftdeps
 
 // CHECK-BASIC-LABEL: - :
@@ -20,7 +16,7 @@
 // CHECK-BASIC-NOT: {{ }}:{{ }}
 
 // CHECK-BASIC-YAML-NOT: externalDepend {{.*}}empty
-// CHECK-BASIC-YAML: externalDepend {{.*}} '{{.*}}Swift.swiftmodule{{(/.+[.]swiftmodule)?}}'
+// CHECK-BASIC-YAML: externalDepend {{.*}} '{{.*}}Swift.swiftmodule{{/|\\}}{{(.+[.]swiftmodule)?}}'
 
 
 // RUN: %target-swift-frontend -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck "%S/../Inputs/empty file.swift" 2>&1 | %FileCheck -check-prefix=NO-PRIMARY-FILE %s
@@ -48,7 +44,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file %s
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-IMPORT-YAML %s <%t-processed.swiftdeps
 
 // CHECK-IMPORT-LABEL: - :
@@ -87,14 +83,14 @@
 // CHECK-IMPORT-TRACK-SYSTEM-NOT: {{[^\\]}}:
 
 // CHECK-IMPORT-YAML-NOT: externalDepend {{.*}}dependencies-fine.swift
-// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\}}Swift.swiftmodule{{(/.+[.]swiftmodule)?}}'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\}}Swift.swiftmodule{{/|\\}}{{(.+[.]swiftmodule)?}}'
 // CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies/$$$$$.h'
-// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies{{/|\\\\}}UserClangModule.h'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies{{/|\\}}UserClangModule.h'
 // CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies/extra-header.h'
-// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies{{/|\\\\}}module.modulemap'
-// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\\\}}ObjectiveC.swift'
-// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\\\}}Foundation.swift'
-// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\\\}}CoreGraphics.swift'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}Inputs/dependencies{{/|\\}}module.modulemap'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\}}ObjectiveC.swift'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\}}Foundation.swift'
+// CHECK-IMPORT-YAML-DAG: externalDepend {{.*}} '{{.*}}{{/|\\}}CoreGraphics.swift'
 
 // CHECK-ERROR-YAML: # Dependencies are unknown because a compilation error occurred.
 

--- a/test/Frontend/dependencies-preservation-fine.swift
+++ b/test/Frontend/dependencies-preservation-fine.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // This test verifies that copies of dependency files are preserved after a
 // compilation. For example, if the first compilation produces 'foo.swiftdeps',
 // a second compilation should move 'foo.swiftdeps' to 'foo.swiftdeps~', then
@@ -11,7 +7,7 @@
 
 // First, produce the dependency files and verify their contents.
 // RUN: %target-swift-frontend -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file "%S/../Inputs/empty file.swift"
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK %s < %t-processed.swiftdeps
 
 // CHECK-NOT: topLevel{{.*}}EmptyStruct{{.*}}true
@@ -22,7 +18,7 @@
 // file.
 // RUN: %target-swift-frontend -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file %S/../Inputs/global_resilience.swift
 // RUN: %FileCheck -check-prefix=CHECK %s < %t.swiftdeps~
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-OVERWRITTEN %s < %t-processed.swiftdeps
 
 // CHECK-OVERWRITTEN:topLevel{{.*}}EmptyStruct{{.*}}true

--- a/test/Incremental/Dependencies/function-fine.swift
+++ b/test/Incremental/Dependencies/function-fine.swift
@@ -1,13 +1,9 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 private func testParamType(_: InterestingType) {}

--- a/test/Incremental/Dependencies/function-return-type-fine.swift
+++ b/test/Incremental/Dependencies/function-return-type-fine.swift
@@ -1,13 +1,9 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 private func testReturnType() -> InterestingType { fatalError() }

--- a/test/Incremental/Dependencies/protocol-conformer-ext-fine.swift
+++ b/test/Incremental/Dependencies/protocol-conformer-ext-fine.swift
@@ -1,13 +1,9 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 private struct Test {}

--- a/test/Incremental/Dependencies/protocol-conformer-fine.swift
+++ b/test/Incremental/Dependencies/protocol-conformer-fine.swift
@@ -1,13 +1,9 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 private struct Test : InterestingProto {}

--- a/test/Incremental/Dependencies/reference-dependencies-dynamic-lookup-fine.swift
+++ b/test/Incremental/Dependencies/reference-dependencies-dynamic-lookup-fine.swift
@@ -1,15 +1,11 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
 
 // Check that the output is deterministic.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t-2.swiftdeps %t-2-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t-2.swiftdeps > %t-2-processed.swiftdeps
 // RUN: diff %t-processed.swiftdeps %t-2-processed.swiftdeps
 
 // RUN: %FileCheck %s < %t-processed.swiftdeps

--- a/test/Incremental/Dependencies/reference-dependencies-fine.swift
+++ b/test/Incremental/Dependencies/reference-dependencies-fine.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 
@@ -10,8 +6,8 @@
 // RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/../Inputs/reference-dependencies-helper.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
 
 // Merge each entry onto one line and sort to overcome order differences
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t-2.swiftdeps %t-2-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t-2.swiftdeps > %t-2-processed.swiftdeps
 // RUN: diff %t-processed.swiftdeps %t-2-processed.swiftdeps
 
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t-processed.swiftdeps

--- a/test/Incremental/Dependencies/reference-dependencies-members-fine.swift
+++ b/test/Incremental/Dependencies/reference-dependencies-members-fine.swift
@@ -1,15 +1,11 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 
 // RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/../Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t.swiftdeps
 
 // RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %S/../Inputs/reference-dependencies-members-helper.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t-2.swiftdeps %t-2-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t-2.swiftdeps > %t-2-processed.swiftdeps
 
 // RUN: diff %t-processed.swiftdeps %t-2-processed.swiftdeps
 

--- a/test/Incremental/Dependencies/struct-member-fine.swift
+++ b/test/Incremental/Dependencies/struct-member-fine.swift
@@ -1,13 +1,9 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 private struct Wrapper {

--- a/test/Incremental/Dependencies/subscript-fine.swift
+++ b/test/Incremental/Dependencies/subscript-fine.swift
@@ -1,13 +1,9 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 struct Wrapper {

--- a/test/Incremental/Dependencies/typealias-fine.swift
+++ b/test/Incremental/Dependencies/typealias-fine.swift
@@ -1,13 +1,9 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DNEW -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-NEW
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 
 private struct Wrapper {

--- a/test/Incremental/Dependencies/var-fine.swift
+++ b/test/Incremental/Dependencies/var-fine.swift
@@ -1,10 +1,6 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %target-swift-frontend -emit-silgen -primary-file %s %S/Inputs/InterestingType.swift -DOLD -emit-reference-dependencies-path %t.swiftdeps -module-name main | %FileCheck %s -check-prefix=CHECK-OLD
 
-// RUN: %S/../../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t.swiftdeps %t-processed.swiftdeps
+// RUN: %{python} %S/../../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t.swiftdeps > %t-processed.swiftdeps
 
 // RUN: %FileCheck -check-prefix=CHECK-DEPS %s < %t-processed.swiftdeps
 

--- a/test/Inputs/process_fine_grained_swiftdeps.py
+++ b/test/Inputs/process_fine_grained_swiftdeps.py
@@ -1,6 +1,4 @@
 
-import os
-import re
 import subprocess
 import sys
 
@@ -9,27 +7,30 @@ import sys
 # <kind> <aspect> <context> <name> <isProvides>
 # Also sort for consistency, since the node order can vary.
 
-output = subprocess.run([
+output = subprocess.run(
+    [
         sys.argv[1],
         "--to-yaml",
         "--input-filename={}".format(sys.argv[2]),
-        "--output-filename=-"
-    ], stdout=subprocess.PIPE)
+        "--output-filename=-",
+    ],
+    stdout=subprocess.PIPE,
+)
 entries = []
-k = a = c = n = s = p = ''
-for line in output.stdout.decode('utf-8').split('\n'):
-    if 'kind:' in line:
+k = a = c = n = s = p = ""
+for line in output.stdout.decode("utf-8").split("\n"):
+    if "kind:" in line:
         k = line.split()[1]
-    if 'aspect:' in line:
+    if "aspect:" in line:
         a = line.split()[1]
-    if 'context:' in line:
+    if "context:" in line:
         c = line.split()[1]
-    if 'name:' in line:
+    if "name:" in line:
         n = ' '.join(line.split()[1:])
-    if 'sequenceNumber:' in line:
+    if "sequenceNumber:" in line:
         s = line.split()[1]
-    if 'isProvides:' in line:
+    if "isProvides:" in line:
         p = line.split()[1]
         entries.append(' '.join([k, a, c, n, p]))
 entries.sort()
-print('\n'.join(entries))
+print("\n".join(entries))

--- a/test/Inputs/process_fine_grained_swiftdeps.py
+++ b/test/Inputs/process_fine_grained_swiftdeps.py
@@ -1,0 +1,30 @@
+
+import os
+import re
+import subprocess
+import sys
+
+output = subprocess.run([
+        sys.argv[1],
+        "--to-yaml",
+        "--input-filename={}".format(sys.argv[2]),
+        "--output-filename=-"
+    ], stdout=subprocess.PIPE)
+entries = []
+k = a = c = n = s = p = ''
+for line in output.stdout.decode('utf-8').split('\n'):
+    if 'kind:' in line:
+        k = line.split()[1]
+    if 'aspect:' in line:
+        a = line.split()[1]
+    if 'context:' in line:
+        c = line.split()[1]
+    if 'name:' in line:
+        n = ' '.join(line.split()[1:])
+    if 'sequenceNumber:' in line:
+        s = line.split()[1]
+    if 'isProvides:' in line:
+        p = line.split()[1]
+        entries.append(' '.join([k, a, c, n, p]))
+entries.sort()
+print('\n'.join(entries))

--- a/test/Inputs/process_fine_grained_swiftdeps.py
+++ b/test/Inputs/process_fine_grained_swiftdeps.py
@@ -4,6 +4,11 @@ import re
 import subprocess
 import sys
 
+# Fine-grained swiftdeps files use multiple lines for each graph node.
+# Compress such a file so that each entry is one line of the form:
+# <kind> <aspect> <context> <name> <isProvides>
+# Also sort for consistency, since the node order can vary.
+
 output = subprocess.run([
         sys.argv[1],
         "--to-yaml",

--- a/test/Inputs/process_fine_grained_swiftdeps.sh
+++ b/test/Inputs/process_fine_grained_swiftdeps.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-# Fine-grained swiftdeps files use multiple lines for each graph node.
-# Compress such a file so that each entry is one line of the form:
-# <kind> <aspect> <context> <name> <isProvides>
-# Also sort for consistency, since the node order can vary.
-
-${1} --to-yaml --input-filename=${2} --output-filename=${3}.tmp
-
-awk '/kind:/ {k = $2}; /aspect:/ {a = $2}; /context:/ {c = $2}; /name/ {n = $2}; /sequenceNumber/ {s = $2}; /isProvides:/ {print k, a, c, n, $2}' < ${3}.tmp | sort > ${3}

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -34,7 +34,7 @@
 // RUN:   -primary-file %t/src/macro_library.swift \
 // RUN:   -emit-reference-dependencies-path %t/macro_library.swiftdeps \
 // RUN:   -emit-dependencies-path %t/macro_library.d
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/macro_library.swiftdeps %t/macro_library.swiftdeps.processed
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t/macro_library.swiftdeps > %t/macro_library.swiftdeps.processed
 // RUN: %FileCheck --check-prefix WITH_PLUGIN %s < %t/macro_library.swiftdeps.processed
 
 //#-- Without macro (no -D USE_MACRO)
@@ -46,7 +46,7 @@
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -emit-reference-dependencies-path %t/without_macro.swiftdeps \
 // RUN:   -emit-dependencies-path %t/without_macro.d
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/without_macro.swiftdeps %t/without_macro.swiftdeps.processed
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t/without_macro.swiftdeps > %t/without_macro.swiftdeps.processed
 // RUN: %FileCheck --check-prefix WITHOUT_PLUGIN %s < %t/without_macro.swiftdeps.processed
 
 //#-- With macro - primary (-D USE_MACRO)
@@ -59,7 +59,7 @@
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -emit-reference-dependencies-path %t/with_macro_primary.swiftdeps \
 // RUN:   -emit-dependencies-path %t/with_macro_primary.d
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/with_macro_primary.swiftdeps %t/with_macro_primary.swiftdeps.processed
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t/with_macro_primary.swiftdeps > %t/with_macro_primary.swiftdeps.processed
 // RUN: %FileCheck --check-prefix WITH_PLUGIN %s < %t/with_macro_primary.swiftdeps.processed
 
 //#-- With macro - non-primary (-D USE_MACRO)
@@ -72,11 +72,11 @@
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -emit-reference-dependencies-path %t/with_macro_nonprimary.swiftdeps \
 // RUN:   -emit-dependencies-path %t/with_macro_nonprimary.d
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps.sh %swift-dependency-tool %t/with_macro_nonprimary.swiftdeps %t/with_macro_nonprimary.swiftdeps.processed
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t/with_macro_nonprimary.swiftdeps > %t/with_macro_nonprimary.swiftdeps.processed
 // RUN: %FileCheck --check-prefix WITHOUT_PLUGIN %s < %t/with_macro_nonprimary.swiftdeps.processed
 
-// WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}mock-plugin' false
-// WITH_PLUGIN: externalDepend interface '' 'BUILD_DIR{{.*}}libMacroDefinition.{{(dylib|so|dll)}}' false
+// WITH_PLUGIN: externalDepend interface '' '{{.*}}mock-plugin' false
+// WITH_PLUGIN: externalDepend interface '' '{{.*}}MacroDefinition.{{(dylib|so|dll)}}' false
 
 // WITHOUT_PLUGIN-NOT:  MacroDefinition
 // WITHOUT_PLUGIN-NOT:  mock-plugin


### PR DESCRIPTION
Replace the process_fine_grained_swiftdeps.sh with a python equivalent (which also preserves the horrendous handling of YAML and even "faithfully" replicates the horrible global variables).  This enables a number of tests on Windows although the instigating macro test is not yet enabled due to the need for further tweaks to the tests.