### PR TITLE
[NFC][Concurrency] Add a few test cases for isolated parameters.

### DIFF
--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -319,3 +319,17 @@ func isolatedClosures() {
     a.f()
   }
 }
+
+// Test case for https://github.com/apple/swift/issues/62568
+func execute<ActorType: Actor>(
+  on isolatedActor: isolated ActorType,
+  task: @escaping @Sendable (isolated ActorType) -> Void)
+{
+  // Compiler correctly allows this task to execute synchronously.
+  task(isolatedActor)
+  // Start a task that inherits the current execution context (i.e. that of the isolatedActor)
+  Task {
+    // 'await' is not not necessary because 'task' is synchronous.
+    task(isolatedActor)
+  }
+}

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -333,3 +333,18 @@ func execute<ActorType: Actor>(
     task(isolatedActor)
   }
 }
+
+actor ProtectsDictionary {
+  var dictionary: [String: String] = ["A": "B"]
+}
+
+func getValues(
+  forKeys keys: [String],
+  from actor: isolated ProtectsDictionary
+) -> [String?] {
+  // A non-escaping, synchronous closure cannot cross isolation
+  // boundaries; it should be isolated to 'actor'.
+  keys.map { key in
+    actor.dictionary[key]
+  }
+}


### PR DESCRIPTION
Adds a few test cases for isolated parameter issues that are now fixed on `main`:
* Inheriting actor context within a function that uses an isolated parameter.
* A non-escaping, synchronous closure used within a function with an isolated parameter.

Resolves https://github.com/apple/swift/issues/62568, rdar://90849047