### PR TITLE
tests: add missing `env`

### DIFF
--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -11,7 +11,7 @@
 // RUN:  -o %t/mock-plugin \
 // RUN:  %t/plugin.c
 
-// RUN: SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -11,7 +11,7 @@
 // RUN:  -o %t/mock-plugin \
 // RUN:  %t/plugin.c
 
-// RUN: SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 -enable-experimental-feature Macros \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \


### PR DESCRIPTION
The `env` is required to set the environment variable as executing with environment variables is a SysV Shell thing and is not generally portable.  This is required to support Windows.