### PR TITLE
test: introduce a new `%swift-plugin-dir` macro

### DIFF
--- a/test/IDE/complete_optionset.swift
+++ b/test/IDE/complete_optionset.swift
@@ -1,6 +1,7 @@
-// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -plugin-path %swift-host-lib-dir/plugins
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -plugin-path %swift-plugin-dir
+
+// REQUIRES: swift_swift_parser
 
 @OptionSet<UInt8>
 struct ShippingOptions {

--- a/test/Macros/macro_expand_other.swift
+++ b/test/Macros/macro_expand_other.swift
@@ -4,12 +4,13 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
 
 // Diagnostics testing
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
 
 // Execution testing
-// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
+// RUN: %target-build-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
+
 // REQUIRES: swift_swift_parser, executable_test
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")

--- a/test/Macros/option_set.swift
+++ b/test/Macros/option_set.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_swift_parser, executable_test
 
-// RUN: %target-run-simple-swift(-Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins -emit-tbd -emit-tbd-path %t.tbd)
+// RUN: %target-run-simple-swift(-Xfrontend -plugin-path -Xfrontend %swift-plugin-dir -emit-tbd -emit-tbd-path %t.tbd)
 
 import Swift
 

--- a/test/ModuleInterface/Observable.swift
+++ b/test/ModuleInterface/Observable.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -plugin-path %swift-host-lib-dir/plugins -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -plugin-path %swift-plugin-dir -disable-availability-checking
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library -disable-availability-checking
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -531,7 +531,14 @@ shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 
-config.swift_host_lib_dir = make_path(config.swift_lib_dir, 'swift', 'host')
+if kIsWindows:
+    config.swift_plugin_dir = config.swift_bin_dir
+    # FIXME: this is a workaround for the collsion between the build toolchain
+    # and the current build, this should be `make_path(config.swift_lib_dir, 'swift')`
+    config.swift_build_lib_dir = make_path(config.swift_lib_dir, 'swift', 'host')
+else:
+    config.swift_plugin_dir = make_path(config.swift_lib_dir, 'swift', 'host', 'plugins')
+    config.swift_build_lib_dir = make_path(config.swift_lib_dir, 'swift', 'host')
 
 if platform.system() == 'Darwin':
     config.swift_driver = (
@@ -541,8 +548,14 @@ if platform.system() == 'Darwin':
         "env SDKROOT=%s %r -toolchain-stdlib-rpath -Xlinker -rpath -Xlinker /usr/lib/swift %s %s %s"
         % (shell_quote(config.host_sdkroot), config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
     config.host_build_swift = (
-        "%s -sdk %s -target %s -no-toolchain-stdlib-rpath -I %s -L %s"
-        % (config.swiftc_driver, config.host_sdkroot, config.host_triple, config.swift_host_lib_dir, config.swift_host_lib_dir))
+        "%s -sdk %s -target %s -no-toolchain-stdlib-rpath -I %s -L %s" % (
+            config.swiftc_driver,
+            config.host_sdkroot,
+            config.host_triple,
+            config.swift_build_lib_dir,
+            config.swift_build_lib_dir
+        )
+    )
 else:
     config.swift_driver = (
         "%r %s %s %s"
@@ -555,7 +568,7 @@ else:
             '' if kIsWindows else '-toolchain-stdlib-rpath',
             mcp_opt,
             config.swift_test_options,
-            config.swift_driver_test_options
+            config.swift_driver_test_options,
         )
     )
     # Parse the host triple.
@@ -566,8 +579,8 @@ else:
             config.swiftc_driver,
             config.host_triple,
             '' if kIsWindows else '-no-toolchain-stdlib-rpath',
-            config.swift_host_lib_dir,
-            config.swift_host_lib_dir,
+            config.swift_build_lib_dir,
+            config.swift_build_lib_dir,
             '' if kIsWindows else '-Xlinker -rpath -Xlinker {}'.format(toolchain_lib_dir)
         )
     )
@@ -576,7 +589,7 @@ config.substitutions.append( ('%llvm_obj_root', config.llvm_obj_root) )
 config.substitutions.append( ('%swift-bin-dir', config.swift_bin_dir) )
 config.substitutions.append( ('%swift-lib-dir', config.swift_lib_dir) )
 config.substitutions.append( ('%swift-share-dir', config.swift_share_dir) )
-config.substitutions.append( ('%swift-host-lib-dir', config.swift_host_lib_dir))
+config.substitutions.append( ('%swift-plugin-dir', config.swift_plugin_dir) )
 config.substitutions.append( ('%llvm_src_root', config.llvm_src_root) )
 config.substitutions.append( ('%swift_obj_root', config.swift_obj_root) )
 config.substitutions.append( ('%swift_src_root', config.swift_src_root) )
@@ -2662,9 +2675,9 @@ config.substitutions.append(('%hmaptool', os.path.join(config.llvm_src_root, '..
 if hasattr(config, 'target_library_path_var'):
   host_library_env = (
           "/usr/bin/env " +
-          construct_library_path_env([config.swift_host_lib_dir]))
+          construct_library_path_env([make_path(config.swift_lib_dir, 'swift', 'host')]))
 else:
-  host_library_env = "env"
+  host_library_env = ""
 
 config.substitutions.append(('%host-library-env', host_library_env))
 

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -1,9 +1,9 @@
 // REQUIRES: swift_swift_parser, executable_test
 
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-plugin-dir)
 
 // Run this test via the swift-plugin-server
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -external-plugin-path -Xfrontend %swift-host-lib-dir/plugins#%swift-plugin-server)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -external-plugin-path -Xfrontend %swift-plugin-dir#%swift-plugin-server)
 
 // REQUIRES: observation
 // REQUIRES: concurrency

--- a/test/stdlib/Observation/ObservableAvailabilityCycle.swift
+++ b/test/stdlib/Observation/ObservableAvailabilityCycle.swift
@@ -1,8 +1,8 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend -typecheck -parse-as-library -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server -primary-file %s %S/Inputs/ObservableClass.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -external-plugin-path %swift-plugin-dir#%swift-plugin-server -primary-file %s %S/Inputs/ObservableClass.swift
 
-// RUN: %target-swift-frontend -typecheck -parse-as-library -external-plugin-path %swift-host-lib-dir/plugins#%swift-plugin-server %s -primary-file %S/Inputs/ObservableClass.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -external-plugin-path %swift-plugin-dir#%swift-plugin-server %s -primary-file %S/Inputs/ObservableClass.swift
 
 // REQUIRES: observation
 // REQUIRES: concurrency

--- a/test/stdlib/Observation/ObservableDiagnostics.swift
+++ b/test/stdlib/Observation/ObservableDiagnostics.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -plugin-path %swift-host-lib-dir/plugins
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -plugin-path %swift-plugin-dir
 
 // REQUIRES: observation
 // REQUIRES: concurrency

--- a/test/stdlib/Observation/ObservableDidSetWillSet.swift
+++ b/test/stdlib/Observation/ObservableDidSetWillSet.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_swift_parser, executable_test
 
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins) | %FileCheck %s
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -Xfrontend -plugin-path -Xfrontend %swift-plugin-dir) | %FileCheck %s
 
 // REQUIRES: observation
 // REQUIRES: concurrency


### PR DESCRIPTION
Use this to define the macro location rather than the "host" dir (which is actually for the build and not the host).  Furthermore, on Windows, the build dir is /usr/lib/swift as the host content is in the SDK.

This prepares the tests for Windows.