### PR TITLE
test: mark a job incompatible with Swift parser

### DIFF
--- a/test/Driver/windows-link-job.swift
+++ b/test/Driver/windows-link-job.swift
@@ -6,5 +6,6 @@
 // swift-frontend cannot be copied to another location with bootstrapping because
 // it will not find the libswiftCore library with its relative RPATH.
 // UNSUPPORTED: swift_in_compiler
+// UNSUPPORTED: swift_swift_parser
 
 // CHECK: {{^}}clang


### PR DESCRIPTION
Due to the fact that we do not statically link the toolchain, we cannot currently support this test.  Mark it as unavailable currently with the early syntax parser enabled.