### PR TITLE
test: sink `-no-toolchain-stdlib-rpath` into lit

### DIFF
--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -1,7 +1,7 @@
 // REQUIRES: swift_swift_parser, executable_test
 
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
 
 // Diagnostics testing
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS

--- a/test/Macros/macro_expand_other.swift
+++ b/test/Macros/macro_expand_other.swift
@@ -1,7 +1,7 @@
 // Expanding macros that are defined in terms of other macros.
 
 // RUN: %empty-directory(%t)
-// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
 
 // Diagnostics testing
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS

--- a/test/Macros/macro_plugin_broken.swift
+++ b/test/Macros/macro_plugin_broken.swift
@@ -6,8 +6,7 @@
 // RUN: %host-build-swift \
 // RUN:   -swift-version 5 -o %t/broken-plugin \
 // RUN:   -module-name=TestPlugin \
-// RUN:   %t/broken_plugin.swift \
-// RUN:   -g -no-toolchain-stdlib-rpath -swift-version 5
+// RUN:   %t/broken_plugin.swift
 
 // RUN: not %swift-target-frontend \
 // RUN:   -typecheck \

--- a/test/Macros/macro_plugin_searchorder.swift
+++ b/test/Macros/macro_plugin_searchorder.swift
@@ -18,8 +18,7 @@
 // RUN:   -emit-library -o %t/lib/plugins/%target-library-name(MacroDefinition) \
 // RUN:   -module-name MacroDefinition \
 // RUN:   -D PLUGIN_PATH \
-// RUN:   %t/src/MacroDefinition.swift \
-// RUN:   -g -no-toolchain-stdlib-rpath
+// RUN:   %t/src/MacroDefinition.swift
 
 //#-- For -load-plugin-library
 // RUN: %host-build-swift \
@@ -27,8 +26,7 @@
 // RUN:   -emit-library -o %t/lib/tmp/%target-library-name(MacroDefinition) \
 // RUN:   -module-name MacroDefinition \
 // RUN:   -D LOAD_PLUGIN_LIBRARY \
-// RUN:   %t/src/MacroDefinition.swift \
-// RUN:   -g -no-toolchain-stdlib-rpath
+// RUN:   %t/src/MacroDefinition.swift
 
 //#-- For -external-plugin-path
 // RUN: %host-build-swift \
@@ -36,8 +34,7 @@
 // RUN:   -emit-library -o %t/external/%target-library-name(MacroDefinition) \
 // RUN:   -module-name MacroDefinition \
 // RUN:   -D EXTERNAL_PLUGIN_PATH \
-// RUN:   %t/src/MacroDefinition.swift \
-// RUN:   -g -no-toolchain-stdlib-rpath
+// RUN:   %t/src/MacroDefinition.swift
 
 //#-- For -load-plugin-executable
 // RUN: %clang \

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -12,8 +12,7 @@
 // RUN:   -swift-version 5 \
 // RUN:   -emit-library -o %t/plugin/%target-library-name(MacroDefinition) \
 // RUN:   -module-name MacroDefinition \
-// RUN:   %S/Inputs/syntax_macro_definitions.swift \
-// RUN:   -g -no-toolchain-stdlib-rpath
+// RUN:   %S/Inputs/syntax_macro_definitions.swift
 
 //#-- Prepare the macro executable plugin.
 // RUN: %clang \

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -541,23 +541,48 @@ if platform.system() == 'Darwin':
         "env SDKROOT=%s %r -toolchain-stdlib-rpath -Xlinker -rpath -Xlinker /usr/lib/swift %s %s %s"
         % (shell_quote(config.host_sdkroot), config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
     config.host_build_swift = (
-        "%s -sdk %s -target %s -I %s -L %s"
+        "%s -sdk %s -target %s -no-toolchain-stdlib-rpath -I %s -L %s"
         % (config.swiftc_driver, config.host_sdkroot, config.host_triple, config.swift_host_lib_dir, config.swift_host_lib_dir))
 else:
     config.swift_driver = (
         "%r %s %s %s"
         % (config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
+
     if kIsWindows:
         config.swift_driver += " -libc " + config.swift_stdlib_msvc_runtime
+
     config.swiftc_driver = (
-        "%r -toolchain-stdlib-rpath %s %s %s"
-        % (config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
+        "%r -g %s %s %s %s" % (
+            config.swiftc,
+            '' if kIsWindows else '-no-toolchain-stdlib-rpath',
+            mcp_opt,
+            config.swift_test_options,
+            config.swift_driver_test_options
+        )
+    )
+
     # Parse the host triple.
     (host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
     toolchain_lib_dir = make_path(config.swift_lib_dir, 'swift', host_os)
-    config.host_build_swift = (
-        "%s -target %s -I %s -L %s -Xlinker -rpath -Xlinker %s"
-        % (config.swiftc_driver, config.host_triple, config.swift_host_lib_dir, config.swift_host_lib_dir, toolchain_lib_dir))
+    if kIsWindows:
+        config.host_build_swift = (
+            "%s -target %s -I %s -L %s" % (
+                config.swiftc_driver,
+                config.host_triple,
+                config.swift_host_lib_dir,
+                config.swift_host_lib_dir,
+            )
+        )
+    else:
+        config.host_build_swift = (
+            "%s -target %s -g -no-toolchain-stdlib-rpath -I %s -L %s -Xlinker -rpath -Xlinker %s" % (
+                config.swiftc_driver,
+                config.host_triple,
+                config.swift_host_lib_dir,
+                config.swift_host_lib_dir,
+                toolchain_lib_dir
+            )
+        )
 
 config.substitutions.append( ('%llvm_obj_root', config.llvm_obj_root) )
 config.substitutions.append( ('%swift-bin-dir', config.swift_bin_dir) )

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -547,42 +547,30 @@ else:
     config.swift_driver = (
         "%r %s %s %s"
         % (config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options))
-
     if kIsWindows:
         config.swift_driver += " -libc " + config.swift_stdlib_msvc_runtime
-
     config.swiftc_driver = (
-        "%r -g %s %s %s %s" % (
+        "%r %s %s %s %s" % (
             config.swiftc,
-            '' if kIsWindows else '-no-toolchain-stdlib-rpath',
+            '' if kIsWindows else '-toolchain-stdlib-rpath',
             mcp_opt,
             config.swift_test_options,
             config.swift_driver_test_options
         )
     )
-
     # Parse the host triple.
     (host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
     toolchain_lib_dir = make_path(config.swift_lib_dir, 'swift', host_os)
-    if kIsWindows:
-        config.host_build_swift = (
-            "%s -target %s -I %s -L %s" % (
-                config.swiftc_driver,
-                config.host_triple,
-                config.swift_host_lib_dir,
-                config.swift_host_lib_dir,
-            )
+    config.host_build_swift = (
+        "%s -target %s -g %s -I %s -L %s %s" % (
+            config.swiftc_driver,
+            config.host_triple,
+            '' if kIsWindows else '-no-toolchain-stdlib-rpath',
+            config.swift_host_lib_dir,
+            config.swift_host_lib_dir,
+            '' if kIsWindows else '-Xlinker -rpath -Xlinker {}'.format(toolchain_lib_dir)
         )
-    else:
-        config.host_build_swift = (
-            "%s -target %s -g -no-toolchain-stdlib-rpath -I %s -L %s -Xlinker -rpath -Xlinker %s" % (
-                config.swiftc_driver,
-                config.host_triple,
-                config.swift_host_lib_dir,
-                config.swift_host_lib_dir,
-                toolchain_lib_dir
-            )
-        )
+    )
 
 config.substitutions.append( ('%llvm_obj_root', config.llvm_obj_root) )
 config.substitutions.append( ('%swift-bin-dir', config.swift_bin_dir) )


### PR DESCRIPTION
This is a platform specific option and should be handled by lit patterns rather than encoded into the tests.
