### PR TITLE
[CSBindings] Delay default binding production until inference is exhausted

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2052,7 +2052,7 @@ bool TypeVarBindingProducer::computeNext() {
     }
   }
 
-  if (NumTries == 0) {
+  if (newBindings.empty()) {
     // Add defaultable constraints (if any).
     for (auto *constraint : DelayedDefaults) {
       if (constraint->getKind() == ConstraintKind::FallbackType) {
@@ -2065,6 +2065,9 @@ bool TypeVarBindingProducer::computeNext() {
 
       addNewBinding(getDefaultBinding(constraint));
     }
+
+    // Drop all of the default since we have converted them into bindings.
+    DelayedDefaults.clear();
   }
 
   if (newBindings.empty())


### PR DESCRIPTION
Previously, default bindings (from Defaultable and FallbackType constraints)
where added to the set right after the first attempt, but that is incorrect because
binding producer should exhaust the chain of superclasses and other "inferred"
bindings first or risk producing subpar solutions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
