### PR TITLE
test: introduce a helper for building mock plugins

### DIFF
--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -1,3 +1,27 @@
 # '-enable-experimental-feature Macros' requires an asserts build.
 if 'asserts' not in config.available_features:
     config.unsupported = True
+
+config.subsitutions = list(config.substitutions)
+
+def get_target_os():
+    import re
+    (run_cpu, run_vendor, run_os, run_version) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
+    return run_os
+
+if get_target_os() in ['windows-msvc']:
+  config.substitutions.insert(
+    0,
+    (
+      '%swift-build-cxx-plugin',
+      '%clang -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin'
+    )
+  )
+else:
+  config.substitutions.insert(
+    0,
+    (
+      '%swift-build-cxx-plugin',
+      '%clang -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin -Xlinker -rpath -Xlinker %swift-lib-dir'
+    )
+  )

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -3,13 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %clang \
-// RUN:  -isysroot %host_sdk \
-// RUN:  -I %swift_src_root/include \
-// RUN:  -L %swift-lib-dir -l_swiftMockPlugin \
-// RUN:  -Wl,-rpath,%swift-lib-dir \
-// RUN:  -o %t/mock-plugin \
-// RUN:  %t/plugin.c
+// RUN: %swift-build-cxx-plugin -o %t/mock-plugin %t/plugin.c
 
 // RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
 // RUN:   -typecheck -verify \

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -3,13 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %clang \
-// RUN:  -isysroot %host_sdk \
-// RUN:  -I %swift_src_root/include \
-// RUN:  -L %swift-lib-dir -l_swiftMockPlugin \
-// RUN:  -Wl,-rpath,%swift-lib-dir \
-// RUN:  -o %t/mock-plugin \
-// RUN:  %t/plugin.c
+// RUN: %swift-build-cxx-plugin -o %t/mock-plugin %t/plugin.c
 
 // RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
 // RUN:   -typecheck -verify \

--- a/test/Macros/macro_plugin_searchorder.swift
+++ b/test/Macros/macro_plugin_searchorder.swift
@@ -40,13 +40,7 @@
 // RUN:   -g -no-toolchain-stdlib-rpath
 
 //#-- For -load-plugin-executable
-// RUN: %clang \
-// RUN:  -isysroot %host_sdk \
-// RUN:  -I %swift_src_root/include \
-// RUN:  -L %swift-lib-dir -l_swiftMockPlugin \
-// RUN:  -Wl,-rpath,%swift-lib-dir \
-// RUN:  -o %t/libexec/MacroDefinitionPlugin \
-// RUN:  %t/src/MacroDefinition.c
+// RUN: %swift-build-cxx-plugin -o %t/libexec/MacroDefinitionPlugin %t/src/MacroDefinition.c
 
 //#-- Expect -load-plugin-library
 // RUN: %target-build-swift %t/src/test.swift \

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -16,13 +16,7 @@
 // RUN:   -g -no-toolchain-stdlib-rpath
 
 //#-- Prepare the macro executable plugin.
-// RUN: %clang \
-// RUN:  -isysroot %host_sdk \
-// RUN:  -I %swift_src_root/include \
-// RUN:  -L %swift-lib-dir -l_swiftMockPlugin \
-// RUN:  -Wl,-rpath,%swift-lib-dir \
-// RUN:  -o %t/mock-plugin \
-// RUN:  %t/src/plugin.c
+// RUN: %swift-build-cxx-plugin -o %t/mock-plugin %t/src/plugin.c
 
 //#-- Prepare the macro library.
 // RUN: %target-swift-frontend \


### PR DESCRIPTION
Introduce a helper for mock plugins as `-rpath` is not a portable construct.  This allows running more of the macro tests on Windows.