### PR TITLE
Driver: virtualise the plugin path handling

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -340,7 +340,10 @@ public:
   void addLinkRuntimeLib(const llvm::opt::ArgList &Args,
                          llvm::opt::ArgStringList &Arguments,
                          StringRef LibName) const;
-    
+
+  virtual void addPluginArguments(const llvm::opt::ArgList &Args,
+                                  llvm::opt::ArgStringList &Arguments) const {}
+
   /// Validates arguments passed to the toolchain.
   ///
   /// An override point for platform-specific subclasses to customize the

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -24,6 +24,7 @@
 #include "swift/Driver/Compilation.h"
 #include "swift/Driver/Driver.h"
 #include "swift/Driver/Job.h"
+#include "swift/IDETool/CompilerInvocation.h"
 #include "swift/Option/Options.h"
 #include "clang/Basic/DarwinSDKInfo.h"
 #include "clang/Basic/Version.h"
@@ -121,6 +122,31 @@ std::string toolchains::Darwin::sanitizerRuntimeLibName(StringRef Sanitizer,
           getDarwinLibraryNameSuffixForTriple(this->getTriple()) +
           (shared ? "_dynamic.dylib" : ".a"))
       .str();
+}
+
+void
+toolchains::Darwin::addPluginArguments(const ArgList &Args,
+                                       ArgStringList &Arguments) const {
+  SmallString<64> pluginPath;
+  auto programPath = getDriver().getSwiftProgramPath();
+  CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
+      programPath, /*shared=*/true, pluginPath);
+
+  auto defaultPluginPath = pluginPath;
+  llvm::sys::path::append(defaultPluginPath, "host", "plugins");
+
+  // Default plugin path.
+  Arguments.push_back("-plugin-path");
+  Arguments.push_back(Args.MakeArgString(defaultPluginPath));
+
+  // Local plugin path.
+  llvm::sys::path::remove_filename(pluginPath); // Remove "swift"
+  llvm::sys::path::remove_filename(pluginPath); // Remove "lib"
+  llvm::sys::path::append(pluginPath, "local", "lib");
+  llvm::sys::path::append(pluginPath, "swift");
+  llvm::sys::path::append(pluginPath, "host", "plugins");
+  Arguments.push_back("-plugin-path");
+  Arguments.push_back(Args.MakeArgString(pluginPath));
 }
 
 static void addLinkRuntimeLibRPath(const ArgList &Args,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -372,30 +372,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   // options.
   inputArgs.AddAllArgs(arguments, options::OPT_plugin_search_Group);
   addPlatformSpecificPluginFrontendArgs(OI, output, inputArgs, arguments);
-  
-  // Toolchain-relative plugin paths
-  {
-    SmallString<64> pluginPath;
-    auto programPath = getDriver().getSwiftProgramPath();
-    CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
-        programPath, /*shared=*/true, pluginPath);
 
-    auto defaultPluginPath = pluginPath;
-    llvm::sys::path::append(defaultPluginPath, "host", "plugins");
-
-    // Default plugin path.
-    arguments.push_back("-plugin-path");
-    arguments.push_back(inputArgs.MakeArgString(defaultPluginPath));
-
-    // Local plugin path.
-    llvm::sys::path::remove_filename(pluginPath); // Remove "swift"
-    llvm::sys::path::remove_filename(pluginPath); // Remove "lib"
-    llvm::sys::path::append(pluginPath, "local", "lib");
-    llvm::sys::path::append(pluginPath, "swift");
-    llvm::sys::path::append(pluginPath, "host", "plugins");
-    arguments.push_back("-plugin-path");
-    arguments.push_back(inputArgs.MakeArgString(pluginPath));
-  }
+  addPluginArguments(inputArgs, arguments);
 
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -65,7 +65,10 @@ protected:
                                      const JobContext &context) const override;
   InvocationInfo constructInvocation(const StaticLinkJobAction &job,
                                      const JobContext &context) const override;
-    
+
+  void addPluginArguments(const llvm::opt::ArgList &Args,
+                          llvm::opt::ArgStringList &Arguments) const override;
+
   void validateArguments(DiagnosticEngine &diags,
                          const llvm::opt::ArgList &args,
                          StringRef defaultTarget) const override;
@@ -113,8 +116,12 @@ protected:
 public:
   Windows(const Driver &D, const llvm::Triple &Triple) : ToolChain(D, Triple) {}
   ~Windows() = default;
+
   std::string sanitizerRuntimeLibName(StringRef Sanitizer,
                                       bool shared = true) const override;
+
+  void addPluginArguments(const llvm::opt::ArgList &Args,
+                          llvm::opt::ArgStringList &Arguments) const override;
 };
 
 class LLVM_LIBRARY_VISIBILITY WebAssembly : public ToolChain {
@@ -168,6 +175,9 @@ public:
   ~GenericUnix() = default;
   std::string sanitizerRuntimeLibName(StringRef Sanitizer,
                                       bool shared = true) const override;
+
+  void addPluginArguments(const llvm::opt::ArgList &Args,
+                          llvm::opt::ArgStringList &Arguments) const override;
 };
 
 class LLVM_LIBRARY_VISIBILITY Android : public GenericUnix {

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -21,6 +21,7 @@
 #include "swift/Driver/Compilation.h"
 #include "swift/Driver/Driver.h"
 #include "swift/Driver/Job.h"
+#include "swift/IDETool/CompilerInvocation.h"
 #include "swift/Option/Options.h"
 #include "swift/Option/SanitizerOptions.h"
 #include "clang/Basic/Version.h"
@@ -45,6 +46,31 @@ toolchains::GenericUnix::sanitizerRuntimeLibName(StringRef Sanitizer,
           this->getTriple().getArchName() +
           (this->getTriple().isAndroid() ? "-android" : "") + ".a")
       .str();
+}
+
+void
+toolchains::GenericUnix::addPluginArguments(const ArgList &Args,
+                                            ArgStringList &Arguments) const {
+  SmallString<64> pluginPath;
+  auto programPath = getDriver().getSwiftProgramPath();
+  CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
+      programPath, /*shared=*/true, pluginPath);
+
+  auto defaultPluginPath = pluginPath;
+  llvm::sys::path::append(defaultPluginPath, "host", "plugins");
+
+  // Default plugin path.
+  Arguments.push_back("-plugin-path");
+  Arguments.push_back(Args.MakeArgString(defaultPluginPath));
+
+  // Local plugin path.
+  llvm::sys::path::remove_filename(pluginPath); // Remove "swift"
+  llvm::sys::path::remove_filename(pluginPath); // Remove "lib"
+  llvm::sys::path::append(pluginPath, "local", "lib");
+  llvm::sys::path::append(pluginPath, "swift");
+  llvm::sys::path::append(pluginPath, "host", "plugins");
+  Arguments.push_back("-plugin-path");
+  Arguments.push_back(Args.MakeArgString(pluginPath));
 }
 
 ToolChain::InvocationInfo

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -44,6 +44,17 @@ std::string toolchains::Windows::sanitizerRuntimeLibName(StringRef Sanitizer,
       .str();
 }
 
+void
+toolchains::Windows::addPluginArguments(const ArgList &Args,
+                                        ArgStringList &Arguments) const {
+  SmallString<261> LibraryPath = StringRef(getDriver().getSwiftProgramPath());
+  llvm::sys::path::remove_filename(LibraryPath); // Remove `swift`
+
+  // Default plugin path.
+  Arguments.push_back("-plugin-path");
+  Arguments.push_back(Args.MakeArgString(LibraryPath));
+}
+
 ToolChain::InvocationInfo
 toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
                                          const JobContext &context) const {

--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -10,18 +10,21 @@ def get_target_os():
     return run_os
 
 if get_target_os() in ['windows-msvc']:
-  config.substitutions.insert(
-    0,
-    (
-      '%swift-build-cxx-plugin',
-      '%clang -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin'
+    config.substitutions.insert(0, ('%target-abi', 'WIN'))
+    config.substitutions.insert(
+        0,
+        (
+            '%swift-build-cxx-plugin',
+            '%clang -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin'
+        )
     )
-  )
 else:
-  config.substitutions.insert(
-    0,
-    (
-      '%swift-build-cxx-plugin',
-      '%clang -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin -Xlinker -rpath -Xlinker %swift-lib-dir'
+    # FIXME(compnerd) do all the targets we currently support use SysV ABI?
+    config.substitutions.insert(0, ('%target-abi', 'SYSV'))
+    config.substitutions.insert(
+        0,
+        (
+            '%swift-build-cxx-plugin',
+            '%clang -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin -Xlinker -rpath -Xlinker %swift-lib-dir'
+        )
     )
-  )

--- a/test/Macros/serialize_plugin_search_paths.swift
+++ b/test/Macros/serialize_plugin_search_paths.swift
@@ -16,5 +16,5 @@
 // CHECK:     -external-plugin-path {{.*}}plugins#{{.*}}swift-plugin-server
 // CHECK:     -load-plugin-library {{.*}}MacroDefinition.{{dylib|so|dll}}
 // CHECK:     -load-plugin-executable {{.*}}mock-plugin#TestPlugin
-// CHECK:     -plugin-path {{.*}}plugins
-// CHECK:     -plugin-path {{.*}}plugins
+// CHECK-SYSV:-plugin-path {{.*}}plugins
+// CHECK-SYSV:-plugin-path {{.*}}plugins


### PR DESCRIPTION
The plugin layouts are different across platforms.  Move this into a virtual method and allow replacement.  On Windows, the plugins are placed into the `bin` directory as the DLLs should always be co-located to ensure that the proper DLLs are found (there is no concept of RPATH).