### PR TITLE
ASTGen: add a workaround for CSC conformance visibility

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -186,7 +186,11 @@ enum ASTGenMacroDiagnostic: DiagnosticMessage, FixItMessage {
   var message: String {
     switch self {
     case .thrownError(let error):
-      return String(describing: error)
+      if let err = error as? PluginError {
+        return err.description
+      } else {
+        return String(describing: error)
+      }
 
     case .oldStyleExternalMacro:
       return "external macro definitions are now written using #externalMacro"


### PR DESCRIPTION
A thrown error is stored as `any Error` which does not conform to `CustomStringConvertible`.  When we perform the conversion via the `String(describing:)` initialiser, for some reason the runtime does not find the conformance and the error is not translated properly. Explicitly casting to `PluginError` resolves the missing conformance and fixes a test failure.