### PR TITLE
🌲 Disabling failing Linux tests for rebranch visibility

### DIFF
--- a/test/DebugInfo/BridgingHeaderPCH.swift
+++ b/test/DebugInfo/BridgingHeaderPCH.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar114728459
+
 // RUN: %target-swift-frontend \
 // RUN:   -emit-pch %S/Inputs/InlineBridgingHeader.h -o %t.pch 
 // RUN: %target-swift-frontend \

--- a/test/DebugInfo/ClangModuleBreadcrumbs.swift
+++ b/test/DebugInfo/ClangModuleBreadcrumbs.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar114728459
+
 // RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs \
 // RUN:   -Xcc -DFOO="foo" -Xcc -UBAR -o - | %FileCheck %s
 //

--- a/test/Frontend/dependencies-fine.swift
+++ b/test/Frontend/dependencies-fine.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar114207865
+
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-dependencies-path - -resolve-imports "%S/../Inputs/empty file.swift" | %FileCheck -check-prefix=CHECK-BASIC %s


### PR DESCRIPTION
Disabling on rebranch:
 - Frontend/dependencies-fine.swift
 - DebugInfo/BridgingHeaderPCH.swift
 - DebugInfo/ClangModuleBreadcrumbs.swift

Trying to see where the rest of the toolchain build stands on Linux.