### PR TITLE
Fix IRGenModule::getMaximalTypeExpansionContext to use the proper associated context

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2017,7 +2017,7 @@ const llvm::StringRef IRGenerator::getClangDataLayoutString() {
 }
 
 TypeExpansionContext IRGenModule::getMaximalTypeExpansionContext() const {
-  return TypeExpansionContext::maximal(getSwiftModule(),
+  return TypeExpansionContext::maximal(getSILModule().getAssociatedContext(),
                                        getSILModule().isWholeModule());
 }
 

--- a/test/IRGen/Inputs/opaque_result_type_private_2.swift
+++ b/test/IRGen/Inputs/opaque_result_type_private_2.swift
@@ -1,0 +1,11 @@
+public protocol P {
+  associatedtype A : P
+  func d() -> Self.A
+}
+
+public struct B<Content: P> {
+  public var a: Content.A
+  init(_ v: Content) {
+    a = v.d()
+  }
+}

--- a/test/IRGen/opaque_result_type_private.swift
+++ b/test/IRGen/opaque_result_type_private.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -disable-availability-checking -c -primary-file %s %S/Inputs/opaque_result_type_private_2.swift
+
+// This test used to crash during IRGen.
+
+private struct C : P {
+  var x = 1
+  func d() -> some P {
+    return self
+  }
+}
+
+public func test() {
+    var x = B(C())
+    print(x)
+}


### PR DESCRIPTION
In a per file compilation mode we want to use the file context -- which is stored in the AssociatedContext -- rather than defaulting to the current Swift Module context.

rdar://114344533