### PR TITLE
[Sema] Report uses of `package import` without defining a package name

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1916,6 +1916,10 @@ WARNING(access_control_non_objc_open_member,none,
 ERROR(access_control_requires_package_name, none,
       "%0 has a package access level but no -package-name was specified: %1",
       (Identifier, StringRef))
+ERROR(access_control_requires_package_name_import, none,
+      "package import can only be used from a module with a package name; "
+      "set it with the compiler flag -package-name",
+      ())
 ERROR(invalid_decl_attribute,none,
       "'%0' attribute cannot be applied to this declaration", (DeclAttribute))
 ERROR(attr_invalid_on_decl_kind,none,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1979,6 +1979,14 @@ public:
                      target->getModuleFilename());
     }
 
+    // Report use of package import when no package name is set.
+    if (ID->getAccessLevel() == AccessLevel::Package &&
+        getASTContext().LangOpts.PackageName.empty()) {
+      auto &diags = ID->getASTContext().Diags;
+      diags.diagnose(ID->getLoc(),
+                     diag::access_control_requires_package_name_import);
+    }
+
     // Report the public import of a private module.
     if (ID->getASTContext().LangOpts.LibraryLevel == LibraryLevel::API) {
       auto importer = ID->getModuleContext();

--- a/test/Sema/access-level-and-non-resilient-import.swift
+++ b/test/Sema/access-level-and-non-resilient-import.swift
@@ -17,18 +17,22 @@
 /// A resilient client will error on public imports.
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
 // RUN:   -enable-library-evolution -swift-version 5 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name pkg
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
 // RUN:   -enable-library-evolution -swift-version 6 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name pkg
 
 /// A non-resilient client doesn't complain.
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
 // RUN:   -swift-version 5 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -package-name pkg
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
 // RUN:   -swift-version 6 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -package-name pkg
 
 //--- DefaultLib.swift
 //--- PublicLib.swift

--- a/test/Sema/access-level-import-diag-priority.swift
+++ b/test/Sema/access-level-import-diag-priority.swift
@@ -12,9 +12,11 @@
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name pkg
 // RUN: %target-swift-frontend -typecheck %t/LocalVsImportClient.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name pkg
 
 //--- PublicLib.swift
 public struct PublicImportType {}

--- a/test/Sema/access-level-import-flag-check.swift
+++ b/test/Sema/access-level-import-flag-check.swift
@@ -9,9 +9,11 @@
 // RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t
 
 /// Check flag requirement, without and with the flag.
-// RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t -verify
+// RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t -verify \
+// RUN:   -package-name package
 // RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -package-name package
 // REQUIRES: asserts
 
 //--- PublicLib.swift

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -21,7 +21,8 @@
 public struct LibType {}
 
 // RUN: %target-swift-frontend -typecheck %t/OneFile_AllExplicit.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name package
 //--- OneFile_AllExplicit.swift
 public import Lib
 package import Lib
@@ -30,7 +31,8 @@ fileprivate import Lib
 private import Lib
 
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_AllExplicit_File?.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name package
 //--- ManyFiles_AllExplicit_FileA.swift
 public import Lib
 //--- ManyFiles_AllExplicit_FileB.swift

--- a/test/Sema/access-level-import-inlinable.swift
+++ b/test/Sema/access-level-import-inlinable.swift
@@ -18,7 +18,8 @@
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -enable-library-evolution -swift-version 5 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name package
 
 //--- PublicLib.swift
 public protocol PublicImportProto {

--- a/test/Sema/access-level-import-parsing.swift
+++ b/test/Sema/access-level-import-parsing.swift
@@ -11,7 +11,8 @@
 
 /// Check that all access levels are accepted, except for 'open'.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name package
 
 //--- PublicLib.swift
 //--- PackageLib.swift

--- a/test/Sema/package-import-no-package-name.swift
+++ b/test/Sema/package-import-no-package-name.swift
@@ -1,0 +1,17 @@
+/// Report uses of package import without a package.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -package-name pkg
+
+//--- PackageLib.swift
+public struct PackageImportType {}
+
+//--- Client.swift
+package import PackageLib // expected-error {{package import can only be used from a module with a package name; set it with the compiler flag -package-name}}

--- a/test/Serialization/access-level-import-dependencies.swift
+++ b/test/Serialization/access-level-import-dependencies.swift
@@ -49,6 +49,7 @@ private import HiddenDep
 import PublicDep
 
 // RUN: %target-swift-frontend -typecheck %t/ClientOfNonPublic.swift -I %t \
+// RUN:   -package-name pkg \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=HIDDEN-DEP %s
 // HIDDEN-DEP-NOT: loaded module 'HiddenDep'
 //--- ClientOfNonPublic.swift
@@ -61,6 +62,7 @@ import PrivateDep
 // RUN: %target-swift-frontend -emit-module %t/PublicDep.swift -o %t -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 // RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t -I %t \
+// RUN:   -package-name MyPackage \
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 // RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport
@@ -110,6 +112,7 @@ import PrivateDep
 // RUN: %target-swift-frontend -typecheck %t/TestableClientOfPublic.swift -I %t \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
 // RUN: %target-swift-frontend -typecheck %t/TestableClientOfNonPublic.swift -I %t \
+// RUN:   -package-name pkg \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
 
 /// In the case of a testable of a module reexporting another Swift module,
@@ -132,6 +135,7 @@ import PrivateDep
 /// Fail if the transitive dependency is missing.
 // RUN: rm %t/HiddenDep.swiftmodule
 // RUN: %target-swift-frontend -typecheck %t/TestableClientOfNonPublic.swift -I %t \
+// RUN:   -package-name pkg \
 // RUN:   -verify -show-diagnostics-after-fatal
 
 /// In a multi-file scenario, we try and fail to load the transitive dependency


### PR DESCRIPTION
Marking an import with `package` doesn't make sense outside of a package/group of modules. Report it as an error when it's used from a module without a package-name.