### PR TITLE
[IRGen] Only use value witness getEnumTag function for "normal" enums

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -905,6 +905,9 @@ static llvm::Constant *getEnumTagFunction(IRGenModule &IGM,
   if (!typeLayoutEntry->layoutString(IGM, genericSig) &&
       !isRuntimeInstatiatedLayoutString(IGM, typeLayoutEntry)) {
     return nullptr;
+  } else if (typeLayoutEntry->copyDestroyKind(IGM) !=
+             EnumTypeLayoutEntry::CopyDestroyStrategy::Normal) {
+    return nullptr;
   } else if (typeLayoutEntry->isSingleton()) {
     return IGM.getSingletonEnumGetEnumTagFn();
   } else if (!typeLayoutEntry->isFixedSize(IGM)) {
@@ -938,6 +941,9 @@ getDestructiveInjectEnumTagFunction(IRGenModule &IGM,
                                     GenericSignature genericSig) {
   if ((!typeLayoutEntry->layoutString(IGM, genericSig) &&
        !isRuntimeInstatiatedLayoutString(IGM, typeLayoutEntry))) {
+    return nullptr;
+  } else if (typeLayoutEntry->copyDestroyKind(IGM) !=
+             EnumTypeLayoutEntry::CopyDestroyStrategy::Normal) {
     return nullptr;
   } else if (typeLayoutEntry->isSingleton()) {
     return IGM.getSingletonEnumDestructiveInjectEnumTagFn();

--- a/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types_resilient.swift
@@ -25,6 +25,11 @@ public enum ResilientSinglePayloadEnumGeneric<T> {
     case nonEmpty(T)
 }
 
+public enum ResilientSinglePayloadEnumIndirect {
+    case empty
+    indirect case nonEmpty(AnyObject)
+}
+
 public enum ResilientMultiPayloadEnumGeneric<T> {
     case empty0
     case empty1
@@ -53,6 +58,14 @@ public enum ResilientSinglePayloadEnumSimple {
 
 public enum ResilientSingletonEnum {
     case nonEmpty(AnyObject)
+}
+
+public func getResilientSinglePayloadEnumIndirectEmpty() -> ResilientSinglePayloadEnumIndirect {
+    return .empty
+}
+
+public func getResilientSinglePayloadEnumIndirectNonEmpty(_ x: AnyObject) -> ResilientSinglePayloadEnumIndirect {
+    return .nonEmpty(x)
 }
 
 public func getResilientSinglePayloadEnumGenericEmpty0<T>(_ t: T.Type) -> ResilientSinglePayloadEnumGeneric<T> {

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -842,6 +842,26 @@ func testResilientSinglePayloadEnumSimpleTag() {
 
 testResilientSinglePayloadEnumSimpleTag()
 
+func testResilientSinglePayloadEnumIndirectTag() {
+    let x = switch getResilientSinglePayloadEnumIndirectNonEmpty(SimpleClass(x: 23)) {
+    case .nonEmpty: 0
+    case .empty: 1
+    }
+
+    // CHECK: Enum case: 0
+    print("Enum case: \(x)")
+
+    let y = switch getResilientSinglePayloadEnumIndirectEmpty() {
+    case .nonEmpty: 0
+    case .empty: 1
+    }
+
+    // CHECK: Enum case: 1
+    print("Enum case: \(y)")
+}
+
+testResilientSinglePayloadEnumIndirectTag()
+
 func testResilientSinglePayloadEnumComplexTag() {
     let x = switch getResilientSinglePayloadEnumComplexEmpty0() {
     case .nonEmpty: 0


### PR DESCRIPTION
rdar://115013153

For special enum cases, e.g. effectively optional references, the layout string will be the same as the payload, because we don't have to check for the particular case. For those cases we have to use the regular witnesses, which should be shared among all those cases.
