### PR TITLE
AST: Refactor representation of inherited types

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -35,6 +35,7 @@
 #include "swift/AST/RequirementSignature.h"
 #include "swift/AST/StorageImpl.h"
 #include "swift/AST/TypeAlignments.h"
+#include "swift/AST/TypeResolutionStage.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/ArrayRefView.h"
@@ -1572,7 +1573,11 @@ public:
   /// given index.
   TypeRepr *getTypeRepr(unsigned i) const { return Entries[i].getTypeRepr(); }
 
-  /// Returns the array of inherited type entries.
+  /// Returns the `Type` for the entry of the inheritance clause at the given
+  /// index, resolved at the given stage, or `Type()` if resolution fails.
+  Type getResolvedType(unsigned i, TypeResolutionStage stage =
+                                       TypeResolutionStage::Interface) const;
+
   /// Returns the underlying array of inherited type entries.
   ///
   /// NOTE: The `Type` associated with an entry may not be resolved yet.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1565,10 +1565,6 @@ public:
   size_t size() const { return Entries.size(); }
   IntRange<size_t> const getIndices() { return indices(Entries); }
 
-  // FIXME: Remove these in favor of more targeted conveniences
-  const InheritedEntry &front() const { return Entries.front(); }
-  const InheritedEntry &back() const { return Entries.back(); }
-
   /// Returns the `TypeRepr *` for the entry of the inheritance clause at the
   /// given index.
   TypeRepr *getTypeRepr(unsigned i) const { return Entries[i].getTypeRepr(); }
@@ -1589,12 +1585,12 @@ public:
   const InheritedEntry &getEntry(unsigned i) const { return Entries[i]; }
 
   /// Returns the source location of the beginning of the inheritance clause.
-  SourceLoc getSourceRangeStart() const {
+  SourceLoc getStartLoc() const {
     return getEntries().front().getSourceRange().Start;
   }
 
   /// Returns the source location of the end of the inheritance clause.
-  SourceLoc getSourceRangeEnd() const {
+  SourceLoc getEndLoc() const {
     return getEntries().back().getSourceRange().End;
   }
 };

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -620,17 +620,6 @@ SelfBounds getSelfBoundsFromWhereClause(
 /// given protocol or protocol extension.
 SelfBounds getSelfBoundsFromGenericSignature(const ExtensionDecl *extDecl);
 
-/// Retrieve the TypeLoc at the given \c index from among the set of
-/// type declarations that are directly "inherited" by the given declaration.
-inline const TypeLoc &getInheritedTypeLocAtIndex(
-    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
-    unsigned index) {
-  if (auto typeDecl = decl.dyn_cast<const TypeDecl *>())
-    return typeDecl->getInherited()[index];
-
-  return decl.get<const ExtensionDecl *>()->getInherited()[index];
-}
-
 namespace namelookup {
 
 /// Searches through statements and patterns for local variable declarations.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -96,6 +96,8 @@ private:
            llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
            unsigned index, TypeResolutionStage stage) const;
 
+  const TypeLoc &getTypeLoc() const;
+
 public:
   // Source location
   SourceLoc getNearestLoc() const;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -569,11 +569,11 @@ namespace {
         PrintWithColorRAII(OS, DeclModifierColor) << " trailing_semi";
     }
 
-    void printInherited(ArrayRef<InheritedEntry> Inherited) {
+    void printInherited(InheritedTypes Inherited) {
       if (Inherited.empty())
         return;
       OS << " inherits: ";
-      interleave(Inherited,
+      interleave(Inherited.getEntries(),
                  [&](InheritedEntry Super) { Super.getType().print(OS); },
                  [&] { OS << ", "; });
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2954,8 +2954,8 @@ static bool usesFeatureRethrowsProtocol(
     return false;
 
   // Check an inheritance clause for a marker protocol.
-  auto checkInherited = [&](ArrayRef<InheritedEntry> inherited) -> bool {
-    for (const auto &inheritedEntry : inherited) {
+  auto checkInherited = [&](InheritedTypes inherited) -> bool {
+    for (const auto &inheritedEntry : inherited.getEntries()) {
       if (auto inheritedType = inheritedEntry.getType()) {
         if (inheritedType->isExistentialType()) {
           auto layout = inheritedType->getExistentialLayout();
@@ -7681,15 +7681,10 @@ void
 swift::getInheritedForPrinting(
     const Decl *decl, const PrintOptions &options,
     llvm::SmallVectorImpl<InheritedEntry> &Results) {
-  ArrayRef<InheritedEntry> inherited;
-  if (auto td = dyn_cast<TypeDecl>(decl)) {
-    inherited = td->getInherited();
-  } else if (auto ed = dyn_cast<ExtensionDecl>(decl)) {
-    inherited = ed->getInherited();
-  }
+  InheritedTypes inherited = InheritedTypes(decl);
 
   // Collect explicit inherited types.
-  for (auto entry: inherited) {
+  for (auto entry : inherited.getEntries()) {
     if (auto ty = entry.getType()) {
       bool foundUnprintable = ty.findIf([&](Type subTy) {
         if (auto aliasTy = dyn_cast<TypeAliasType>(subTy.getPointer()))
@@ -7831,7 +7826,7 @@ void GenericParamList::print(ASTPrinter &Printer,
         if (!P->getInherited().empty()) {
           Printer << " : ";
 
-          auto loc = P->getInherited()[0];
+          auto loc = P->getInherited().getEntry(0);
           if (willUseTypeReprPrinting(loc, nullptr, PO)) {
             loc.getTypeRepr()->print(Printer, PO);
           } else {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -164,8 +164,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (auto *typeRepr = ED->getExtendedTypeRepr())
       if (doIt(typeRepr))
         return true;
-    for (auto &Inherit : ED->getInherited()) {
-      if (auto *const TyR = Inherit.getTypeRepr())
+    auto inheritedTypes = ED->getInherited();
+    for (auto i : inheritedTypes.getIndices()) {
+      if (auto *const TyR = inheritedTypes.getTypeRepr(i))
         if (doIt(TyR))
           return true;
     }
@@ -276,7 +277,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitGenericTypeParamDecl(GenericTypeParamDecl *GTPD) {
-    for (const auto &Inherit: GTPD->getInherited()) {
+    for (const auto &Inherit : GTPD->getInherited().getEntries()) {
       if (auto *const TyR = Inherit.getTypeRepr())
         if (doIt(TyR))
           return true;
@@ -285,7 +286,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitAssociatedTypeDecl(AssociatedTypeDecl *ATD) {
-    for (const auto &Inherit: ATD->getInherited()) {
+    for (const auto &Inherit : ATD->getInherited().getEntries()) {
       if (auto *const TyR = Inherit.getTypeRepr())
         if (doIt(TyR))
           return true;
@@ -310,9 +311,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
 
     bool WalkGenerics = visitGenericParamListIfNeeded(NTD);
 
-    for (const auto &Inherit : NTD->getInherited()) {
-      if (auto *const TyR = Inherit.getTypeRepr())
-        if (doIt(Inherit.getTypeRepr()))
+    auto inheritedTypes = NTD->getInherited();
+    for (auto i : inheritedTypes.getIndices()) {
+      if (auto *const TyR = inheritedTypes.getTypeRepr(i))
+        if (doIt(TyR))
           return true;
     }
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -226,7 +226,7 @@ void ConformanceLookupTable::inheritConformances(ClassDecl *classDecl,
     if (superclassLoc.isValid())
       return superclassLoc;
 
-    for (const auto &inherited : classDecl->getInherited()) {
+    for (const auto &inherited : classDecl->getInherited().getEntries()) {
       if (auto inheritedType = inherited.getType()) {
         if (inheritedType->getClassOrBoundGenericClass()) {
           superclassLoc = inherited.getSourceRange().Start;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1527,6 +1527,38 @@ InheritedEntry::InheritedEntry(const TypeLoc &typeLoc)
     isUnchecked = typeRepr->findUncheckedAttrLoc().isValid();
 }
 
+InheritedTypes::InheritedTypes(
+    llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl)
+    : Decl(decl) {
+  if (auto *typeDecl = decl.dyn_cast<const TypeDecl *>()) {
+    Entries = typeDecl->Inherited;
+  } else {
+    Entries = decl.get<const ExtensionDecl *>()->Inherited;
+  }
+}
+
+InheritedTypes::InheritedTypes(const class Decl *decl) {
+  if (auto typeDecl = dyn_cast<TypeDecl>(decl)) {
+    Decl = typeDecl;
+    Entries = typeDecl->Inherited;
+  } else if (auto extensionDecl = dyn_cast<ExtensionDecl>(decl)) {
+    Decl = extensionDecl;
+    Entries = extensionDecl->Inherited;
+  } else {
+    Decl = nullptr;
+    Entries = ArrayRef<InheritedEntry>();
+  }
+}
+
+InheritedTypes::InheritedTypes(const TypeDecl *typeDecl) : Decl(typeDecl) {
+  Entries = typeDecl->Inherited;
+}
+
+InheritedTypes::InheritedTypes(const ExtensionDecl *extensionDecl)
+    : Decl(extensionDecl) {
+  Entries = extensionDecl->Inherited;
+}
+
 ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
                              TypeRepr *extendedType,
                              ArrayRef<InheritedEntry> inherited,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1559,6 +1559,15 @@ InheritedTypes::InheritedTypes(const ExtensionDecl *extensionDecl)
   Entries = extensionDecl->Inherited;
 }
 
+Type InheritedTypes::getResolvedType(unsigned i,
+                                     TypeResolutionStage stage) const {
+  ASTContext &ctx = Decl.is<const ExtensionDecl *>()
+                        ? Decl.get<const ExtensionDecl *>()->getASTContext()
+                        : Decl.get<const TypeDecl *>()->getASTContext();
+  return evaluateOrDefault(ctx.evaluator, InheritedTypeRequest{Decl, i, stage},
+                           Type());
+}
+
 ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
                              TypeRepr *extendedType,
                              ArrayRef<InheritedEntry> inherited,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5223,7 +5223,7 @@ SourceRange GenericTypeParamDecl::getSourceRange() const {
     startLoc = eachLoc;
 
   if (!getInherited().empty())
-    endLoc = getInherited().back().getSourceRange().End;
+    endLoc = getInherited().getEndLoc();
 
   return {startLoc, endLoc};
 }
@@ -5261,7 +5261,7 @@ SourceRange AssociatedTypeDecl::getSourceRange() const {
   } else if (auto defaultDefinition = getDefaultDefinitionTypeRepr()) {
     endLoc = defaultDefinition->getEndLoc();
   } else if (!getInherited().empty()) {
-    endLoc = getInherited().back().getSourceRange().End;
+    endLoc = getInherited().getEndLoc();
   } else {
     endLoc = getNameLoc();
   }

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -40,9 +40,8 @@ namespace swift {
 
 SourceLoc InheritedDeclsReferencedRequest::getNearestLoc() const {
   const auto &storage = getStorage();
-  auto &typeLoc = getInheritedTypeLocAtIndex(std::get<0>(storage),
-                                             std::get<1>(storage));
-  return typeLoc.getLoc();
+  auto inheritedTypes = InheritedTypes(std::get<0>(storage));
+  return inheritedTypes.getEntry(std::get<1>(storage)).getLoc();
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -956,7 +956,7 @@ TypeAliasRequirementsRequest::evaluate(Evaluator &evaluator,
       return { ", ", trailing->getRequirements().back().getSourceRange().End };
 
     // Inheritance clause.
-    return { " where ", proto->getInherited().back().getSourceRange().End };
+    return { " where ", proto->getInherited().getEndLoc() };
   };
 
   // Retrieve the set of requirements that a given associated type declaration

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -729,17 +729,14 @@ void swift::rewriting::realizeInheritedRequirements(
     TypeDecl *decl, Type type, bool shouldInferRequirements,
     SmallVectorImpl<StructuralRequirement> &result,
     SmallVectorImpl<RequirementError> &errors) {
-  auto &ctx = decl->getASTContext();
   auto inheritedTypes = decl->getInherited();
   auto *dc = decl->getInnermostDeclContext();
   auto *moduleForInference = dc->getParentModule();
 
-  for (unsigned index : inheritedTypes.getIndices()) {
-    Type inheritedType
-      = evaluateOrDefault(ctx.evaluator,
-                          InheritedTypeRequest{decl, index,
-                          TypeResolutionStage::Structural},
-                          Type());
+  for (auto index : inheritedTypes.getIndices()) {
+    Type inheritedType =
+        inheritedTypes.getResolvedType(index, TypeResolutionStage::Structural);
+
     if (!inheritedType) continue;
 
     // Ignore trivially circular protocol refinement (protocol P : P)

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -103,11 +103,14 @@ void swift::simple_display(llvm::raw_ostream &out, const TypeLoc source) {
 // Inherited type computation.
 //----------------------------------------------------------------------------//
 
-SourceLoc InheritedTypeRequest::getNearestLoc() const {
+const TypeLoc &InheritedTypeRequest::getTypeLoc() const {
   const auto &storage = getStorage();
-  auto &typeLoc = getInheritedTypeLocAtIndex(std::get<0>(storage),
-                                             std::get<1>(storage));
-  return typeLoc.getLoc();
+  auto inheritedTypes = InheritedTypes(std::get<0>(storage));
+  return inheritedTypes.getEntry(std::get<1>(storage));
+}
+
+SourceLoc InheritedTypeRequest::getNearestLoc() const {
+  return getTypeLoc().getLoc();
 }
 
 bool InheritedTypeRequest::isCached() const {
@@ -115,9 +118,7 @@ bool InheritedTypeRequest::isCached() const {
 }
 
 llvm::Optional<Type> InheritedTypeRequest::getCachedResult() const {
-  const auto &storage = getStorage();
-  auto &typeLoc = getInheritedTypeLocAtIndex(std::get<0>(storage),
-                                             std::get<1>(storage));
+  auto &typeLoc = getTypeLoc();
   if (typeLoc.wasValidated())
     return typeLoc.getType();
 
@@ -125,10 +126,7 @@ llvm::Optional<Type> InheritedTypeRequest::getCachedResult() const {
 }
 
 void InheritedTypeRequest::cacheResult(Type value) const {
-  const auto &storage = getStorage();
-  auto &typeLoc = getInheritedTypeLocAtIndex(std::get<0>(storage),
-                                             std::get<1>(storage));
-  const_cast<TypeLoc &>(typeLoc).setType(value);
+  const_cast<TypeLoc &>(getTypeLoc()).setType(value);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -343,7 +343,7 @@ bool ide::printExtensionUSR(const ExtensionDecl *ED, raw_ostream &OS) {
   }
   OS << getUSRSpacePrefix() << "e:";
   printValueDeclUSR(nominal, OS);
-  for (auto Inherit : ED->getInherited()) {
+  for (auto Inherit : ED->getInherited().getEntries()) {
     if (auto T = Inherit.getType()) {
       if (T->getAnyNominal())
         return printValueDeclUSR(T->getAnyNominal(), OS);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8621,7 +8621,7 @@ GenericSignature ClangImporter::Implementation::buildGenericSignature(
   SmallVector<Requirement, 2> requirements;
   for (auto param : *genericParams) {
     Type paramType = param->getDeclaredInterfaceType();
-    for (const auto &inherited : param->getInherited()) {
+    for (const auto &inherited : param->getInherited().getEntries()) {
       Type inheritedType = inherited.getType();
       if (inheritedType->isAnyObject()) {
         requirements.push_back(

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -479,11 +479,11 @@ class InheritedProtocolCollector {
   /// If \p skipExtra is true then avoid recording any extra protocols to
   /// print, such as synthesized conformances or conformances to non-public
   /// protocols.
-  void recordProtocols(ArrayRef<InheritedEntry> directlyInherited,
-                       const Decl *D, bool skipExtra = false) {
+  void recordProtocols(InheritedTypes directlyInherited, const Decl *D,
+                       bool skipExtra = false) {
     llvm::Optional<AvailableAttrList> availableAttrs;
 
-    for (InheritedEntry inherited : directlyInherited) {
+    for (InheritedEntry inherited : directlyInherited.getEntries()) {
       Type inheritedTy = inherited.getType();
       if (!inheritedTy || !inheritedTy->isExistentialType())
         continue;
@@ -526,7 +526,7 @@ class InheritedProtocolCollector {
   /// For each type directly inherited by \p extension, record any protocols
   /// that we would have printed in ConditionalConformanceProtocols.
   void recordConditionalConformances(const ExtensionDecl *extension) {
-    for (TypeLoc inherited : extension->getInherited()) {
+    for (TypeLoc inherited : extension->getInherited().getEntries()) {
       Type inheritedTy = inherited.getType();
       if (!inheritedTy || !inheritedTy->isExistentialType())
         continue;
@@ -551,7 +551,7 @@ public:
   ///
   /// \sa recordProtocols
   static void collectProtocols(PerTypeMap &map, const Decl *D) {
-    ArrayRef<InheritedEntry> directlyInherited;
+    InheritedTypes directlyInherited = InheritedTypes(D);
     const NominalTypeDecl *nominal;
     const IterableDeclContext *memberContext;
 
@@ -565,7 +565,6 @@ public:
       return true;
     };
     if ((nominal = dyn_cast<NominalTypeDecl>(D))) {
-      directlyInherited = nominal->getInherited();
       memberContext = nominal;
 
     } else if (auto *extension = dyn_cast<ExtensionDecl>(D)) {
@@ -573,7 +572,6 @@ public:
         return;
       }
       nominal = extension->getExtendedNominal();
-      directlyInherited = extension->getInherited();
       memberContext = extension;
     } else {
       return;

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2059,8 +2059,7 @@ private:
   }
 
   llvm::Optional<IndentContext>
-  getIndentContextFromInherits(ArrayRef<InheritedEntry> Inherits,
-                               SourceLoc ContextLoc) {
+  getIndentContextFromInherits(InheritedTypes Inherits, SourceLoc ContextLoc) {
     if (Inherits.empty())
       return llvm::None;
 
@@ -2074,7 +2073,7 @@ private:
     assert(ColonLoc.has_value() && "inherits list without leading colon?");
 
     ListAligner Aligner(SM, TargetLocation, ContextLoc, ColonLoc->getLoc());
-    for (auto TL: Inherits)
+    for (auto TL : Inherits.getEntries())
       Aligner.updateAlignment(TL.getSourceRange(), TL.getTypeRepr());
     return Aligner.getContextAndSetAlignment(CtxOverride);
   }

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2063,7 +2063,7 @@ private:
     if (Inherits.empty())
       return llvm::None;
 
-    SourceLoc StartLoc = Inherits.front().getSourceRange().Start;
+    SourceLoc StartLoc = Inherits.getStartLoc();
     if (StartLoc.isInvalid())
       return llvm::None;
 

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -917,7 +917,7 @@ ASTWalker::PreWalkAction ModelASTWalker::walkToDeclPre(Decl *D) {
     SourceLoc NREnd = NRStart.getAdvancedLoc(NTD->getName().getLength());
     SN.NameRange = CharSourceRange(SM, NRStart, NREnd);
 
-    for (const TypeLoc &TL : NTD->getInherited()) {
+    for (const TypeLoc &TL : NTD->getInherited().getEntries()) {
       CharSourceRange TR = charSourceRangeFromSourceRange(SM,
                                                           TL.getSourceRange());
       SN.InheritedTypeRanges.push_back(TR);
@@ -937,7 +937,7 @@ ASTWalker::PreWalkAction ModelASTWalker::walkToDeclPre(Decl *D) {
       NSR = repr->getSourceRange();
     SN.NameRange = charSourceRangeFromSourceRange(SM, NSR);
 
-    for (const TypeLoc &TL : ED->getInherited()) {
+    for (const TypeLoc &TL : ED->getInherited().getEntries()) {
       CharSourceRange TR = charSourceRangeFromSourceRange(SM,
                                                           TL.getSourceRange());
       SN.InheritedTypeRanges.push_back(TR);
@@ -1116,7 +1116,7 @@ ASTWalker::PreWalkAction ModelASTWalker::walkToDeclPre(Decl *D) {
                                               GenericParamD->getSourceRange());
     SN.NameRange = CharSourceRange(GenericParamD->getNameLoc(),
                                    GenericParamD->getName().getLength());
-    for (const TypeLoc &TL : GenericParamD->getInherited()) {
+    for (const TypeLoc &TL : GenericParamD->getInherited().getEntries()) {
       CharSourceRange TR = charSourceRangeFromSourceRange(SM,
                                                           TL.getSourceRange());
       SN.InheritedTypeRanges.push_back(TR);

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -974,8 +974,7 @@ private:
   /// \param Loc The location of the reference, otherwise the location of the TypeLoc is used.
   bool reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related,
                             bool isImplicit=false, SourceLoc Loc={});
-  bool reportInheritedTypeRefs(
-      ArrayRef<InheritedEntry> Inherited, Decl *Inheritee);
+  bool reportInheritedTypeRefs(InheritedTypes Inherited, Decl *Inheritee);
 
   bool reportPseudoGetterDecl(VarDecl *D) {
     return reportPseudoAccessor(D, AccessorKind::Get, /*IsRef=*/false,
@@ -1073,7 +1072,7 @@ private:
         if (shouldIndex(VD, /*IsRef=*/false))
           return true;
 
-    for (auto Inherit : D->getInherited())
+    for (auto Inherit : D->getInherited().getEntries())
       if (auto T = Inherit.getType())
         if (T->getAnyNominal() &&
             shouldIndex(T->getAnyNominal(), /*IsRef=*/false))
@@ -1384,8 +1383,9 @@ bool IndexSwiftASTWalker::reportRelatedRef(ValueDecl *D, SourceLoc Loc, bool isI
   return !Cancelled;
 }
 
-bool IndexSwiftASTWalker::reportInheritedTypeRefs(ArrayRef<InheritedEntry> Inherited, Decl *Inheritee) {
-  for (auto Base : Inherited) {
+bool IndexSwiftASTWalker::reportInheritedTypeRefs(InheritedTypes Inherited,
+                                                  Decl *Inheritee) {
+  for (auto Base : Inherited.getEntries()) {
     if (!reportRelatedTypeRef(Base, (SymbolRoleSet) SymbolRole::RelationBaseOf, Inheritee))
       return false;
   }

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -3539,7 +3539,7 @@ public:
   AddEquatableContext(NominalTypeDecl *Decl)
       : DC(Decl), Adopter(Decl->getDeclaredType()),
         StartLoc(Decl->getBraces().Start),
-        ProtocolsLocations(Decl->getInherited()),
+        ProtocolsLocations(Decl->getInherited().getEntries()),
         Protocols(getAllProtocols(Decl)),
         ProtInsertStartLoc(Decl->getNameLoc()),
         StoredProperties(Decl->getStoredProperties()),
@@ -3548,7 +3548,7 @@ public:
   AddEquatableContext(ExtensionDecl *Decl)
       : DC(Decl), Adopter(Decl->getExtendedType()),
         StartLoc(Decl->getBraces().Start),
-        ProtocolsLocations(Decl->getInherited()),
+        ProtocolsLocations(Decl->getInherited().getEntries()),
         Protocols(getAllProtocols(Decl->getExtendedNominal())),
         ProtInsertStartLoc(Decl->getExtendedTypeRepr()->getEndLoc()),
         StoredProperties(Decl->getExtendedNominal()->getStoredProperties()),

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3400,10 +3400,8 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
       emitDiagnostic(diag::assign_protocol_conformance_fix_it, constraint,
                      nominal->getDescriptiveKind(), fromType);
   if (!nominal->getInherited().empty()) {
-    auto lastInherited = nominal->getInherited().back().getLoc();
-    auto lastInheritedEndLoc =
-        Lexer::getLocForEndOfToken(getASTContext().SourceMgr, lastInherited);
-    conformanceDiag.fixItInsert(lastInheritedEndLoc, ", " + protoString);
+    auto lastInheritedEndLoc = nominal->getInherited().getEndLoc();
+    conformanceDiag.fixItInsertAfter(lastInheritedEndLoc, ", " + protoString);
   } else {
     auto nameEndLoc = Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
                                                  nominal->getNameLoc());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3399,7 +3399,7 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   auto conformanceDiag =
       emitDiagnostic(diag::assign_protocol_conformance_fix_it, constraint,
                      nominal->getDescriptiveKind(), fromType);
-  if (nominal->getInherited().size() > 0) {
+  if (!nominal->getInherited().empty()) {
     auto lastInherited = nominal->getInherited().back().getLoc();
     auto lastInheritedEndLoc =
         Lexer::getLocForEndOfToken(getASTContext().SourceMgr, lastInherited);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -338,7 +338,7 @@ static bool canSynthesizeCodingKey(DerivedConformance &derived) {
     }
   }
 
-  auto inherited = enumDecl->getInherited();
+  auto inherited = enumDecl->getInherited().getEntries();
   if (!inherited.empty() && inherited.front().wasValidated() &&
       inherited.front().isError())
     return false;

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -336,7 +336,7 @@ void DerivedConformance::tryDiagnoseFailedComparableDerivation(
   if (auto enumDecl = dyn_cast<EnumDecl>(nominal)) {
     if (enumDecl->hasRawType() && !enumDecl->getRawType()->is<ErrorType>()) {
       auto rawType = enumDecl->getRawType();
-      auto rawTypeLoc = enumDecl->getInherited()[0].getSourceRange().Start;
+      auto rawTypeLoc = enumDecl->getInherited().front().getSourceRange().Start;
       ctx.Diags.diagnose(rawTypeLoc,
                          diag::comparable_synthesis_raw_value_not_allowed,
                          rawType, nominal->getDeclaredInterfaceType(),

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -336,7 +336,7 @@ void DerivedConformance::tryDiagnoseFailedComparableDerivation(
   if (auto enumDecl = dyn_cast<EnumDecl>(nominal)) {
     if (enumDecl->hasRawType() && !enumDecl->getRawType()->is<ErrorType>()) {
       auto rawType = enumDecl->getRawType();
-      auto rawTypeLoc = enumDecl->getInherited().front().getSourceRange().Start;
+      auto rawTypeLoc = enumDecl->getInherited().getStartLoc();
       ctx.Diags.diagnose(rawTypeLoc,
                          diag::comparable_synthesis_raw_value_not_allowed,
                          rawType, nominal->getDeclaredInterfaceType(),

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -460,7 +460,7 @@ bool DerivedConformance::canDeriveRawRepresentable(DeclContext *DC,
 
   rawType = DC->mapTypeIntoContext(rawType);
 
-  auto inherited = enumDecl->getInherited();
+  auto inherited = enumDecl->getInherited().getEntries();
   if (!inherited.empty() && inherited.front().wasValidated() &&
       inherited.front().isError())
     return false;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -918,12 +918,9 @@ public:
     DescriptiveDeclKind declKind = DescriptiveDeclKind::Protocol;
 
     // FIXME: Hack to ensure that we've computed the types involved here.
-    ASTContext &ctx = proto->getASTContext();
-    for (unsigned i : proto->getInherited().getIndices()) {
-      (void)evaluateOrDefault(ctx.evaluator,
-                              InheritedTypeRequest{
-                                proto, i, TypeResolutionStage::Interface},
-                              Type());
+    auto inheritedTypes = proto->getInherited();
+    for (auto i : inheritedTypes.getIndices()) {
+      (void)inheritedTypes.getResolvedType(i);
     }
 
     auto declKindForType = [](Type type) -> DescriptiveDeclKind {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -629,7 +629,7 @@ static void addSendableFixIt(
     diag.fixItInsert(fixItLoc,
                      unchecked ? ": @unchecked Sendable" : ": Sendable");
   } else {
-    auto fixItLoc = nominal->getInherited().back().getLoc();
+    auto fixItLoc = nominal->getInherited().getEndLoc();
     diag.fixItInsertAfter(fixItLoc,
                           unchecked ? ", @unchecked Sendable" : ", Sendable");
   }
@@ -644,7 +644,7 @@ static void addSendableFixIt(const GenericTypeParamDecl *genericArgument,
     diag.fixItInsertAfter(fixItLoc,
                           unchecked ? ": @unchecked Sendable" : ": Sendable");
   } else {
-    auto fixItLoc = genericArgument->getInherited().back().getLoc();
+    auto fixItLoc = genericArgument->getInherited().getEndLoc();
     diag.fixItInsertAfter(fixItLoc,
                           unchecked ? ", @unchecked Sendable" : ", Sendable");
   }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1319,8 +1319,9 @@ static llvm::Optional<ObjCReason> shouldMarkClassAsObjC(const ClassDecl *CD) {
              .limitBehavior(behavior);
          } else if (CD->getSuperclass().isNull()) {
            CD->diagnose(diag::invalid_objc_swift_root_class_insert_nsobject)
-             .fixItInsert(CD->getInherited().front().getLoc(), "NSObject, ")
-             .limitBehavior(behavior);
+               .fixItInsert(CD->getInherited().getEntry(0).getLoc(),
+                            "NSObject, ")
+               .limitBehavior(behavior);
          }
       }
 
@@ -1594,7 +1595,7 @@ static bool isEnumObjC(EnumDecl *enumDecl) {
   if (!isCIntegerType(rawType)) {
     SourceRange errorRange;
     if (!enumDecl->getInherited().empty())
-      errorRange = enumDecl->getInherited().front().getSourceRange();
+      errorRange = enumDecl->getInherited().getEntry(0).getSourceRange();
     enumDecl->diagnose(diag::objc_enum_raw_type_not_integer, rawType)
       .highlight(errorRange);
     return false;

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2892,7 +2892,7 @@ public:
 
     // Conformances are declared exclusively in the interface, so diagnose any
     // in the implementation right away.
-    for (auto &inherited : ext->getInherited()) {
+    for (auto &inherited : ext->getInherited().getEntries()) {
       bool isImportedProtocol = false;
       if (auto protoNominal = inherited.getType()->getAnyNominal())
         isImportedProtocol = protoNominal->hasClangNode();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2728,14 +2728,14 @@ public:
       // The raw type must be one of the blessed literal convertible types.
       if (!computeAutomaticEnumValueKind(ED)) {
         if (!rawTy->is<ErrorType>()) {
-          DE.diagnose(ED->getInherited().front().getSourceRange().Start,
+          DE.diagnose(ED->getInherited().getStartLoc(),
                       diag::raw_type_not_literal_convertible, rawTy);
         }
       }
       
       // We need at least one case to have a raw value.
       if (ED->getAllElements().empty()) {
-        DE.diagnose(ED->getInherited().front().getSourceRange().Start,
+        DE.diagnose(ED->getInherited().getStartLoc(),
                     diag::empty_enum_raw_type);
       }
     }
@@ -3467,7 +3467,7 @@ public:
     if (EED->hasAssociatedValues()) {
       if (auto rawTy = ED->getRawType()) {
         EED->diagnose(diag::enum_with_raw_type_case_with_argument);
-        DE.diagnose(ED->getInherited().front().getSourceRange().Start,
+        DE.diagnose(ED->getInherited().getStartLoc(),
                     diag::enum_raw_type_here, rawTy);
         EED->setInvalid();
       }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -92,14 +92,12 @@ static Type containsParameterizedProtocolType(Type inheritedTy) {
 /// file.
 static void checkInheritanceClause(
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> declUnion) {
-  ArrayRef<InheritedEntry> inheritedClause;
+  auto inheritedClause = InheritedTypes(declUnion).getEntries();
   const ExtensionDecl *ext = nullptr;
   const TypeDecl *typeDecl = nullptr;
   const Decl *decl;
   if ((ext = declUnion.dyn_cast<const ExtensionDecl *>())) {
     decl = ext;
-
-    inheritedClause = ext->getInherited();
 
     // Protocol extensions cannot have inheritance clauses.
     if (auto proto = ext->getExtendedProtocolDecl()) {
@@ -114,7 +112,6 @@ static void checkInheritanceClause(
   } else {
     typeDecl = declUnion.get<const TypeDecl *>();
     decl = typeDecl;
-    inheritedClause = typeDecl->getInherited();
   }
 
   // Can this declaration's inheritance clause contain a class or
@@ -2968,7 +2965,7 @@ public:
           return;
 
         // go over the all types directly conformed-to by the extension
-        for (auto entry : extension->getInherited()) {
+        for (auto entry : extension->getInherited().getEntries()) {
           diagnoseIncompatibleWithMoveOnlyType(extension->getLoc(), nomDecl,
                                                entry.getType());
         }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -155,10 +155,8 @@ void swift::diagnoseDistributedFunctionInNonDistributedActorProtocol(
   } else {
     // Similar to how Sendable FitIts do this, we insert at the end of
     // the inherited types.
-    ASTContext &ctx = proto->getASTContext();
-    SourceLoc fixItLoc = proto->getInherited().back().getSourceRange().End;
-    fixItLoc = Lexer::getLocForEndOfToken(ctx.SourceMgr, fixItLoc);
-    diag.fixItInsert(fixItLoc, ", DistributedActor");
+    SourceLoc fixItLoc = proto->getInherited().getEndLoc();
+    diag.fixItInsertAfter(fixItLoc, ", DistributedActor");
   }
 }
 
@@ -173,10 +171,8 @@ void swift::addCodableFixIt(
     SourceLoc fixItLoc = nominal->getBraces().Start;
     diag.fixItInsert(fixItLoc, ": Codable");
   } else {
-    ASTContext &ctx = nominal->getASTContext();
-    SourceLoc fixItLoc = nominal->getInherited().back().getSourceRange().End;
-    fixItLoc = Lexer::getLocForEndOfToken(ctx.SourceMgr, fixItLoc);
-    diag.fixItInsert(fixItLoc, ", Codable");
+    SourceLoc fixItLoc = nominal->getInherited().getEndLoc();
+    diag.fixItInsertAfter(fixItLoc, ", Codable");
   }
 }
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1678,7 +1678,8 @@ swift::expandExtensions(CustomAttr *attr, MacroDecl *macro,
 
     // Extension macros can only add conformances that are documented by
     // the `@attached(extension)` attribute.
-    for (auto inherited : extension->getInherited()) {
+    auto inheritedTypes = extension->getInherited();
+    for (auto i : inheritedTypes.getIndices()) {
       auto constraint =
           TypeResolution::forInterface(
               extension->getDeclContext(),
@@ -1686,7 +1687,7 @@ swift::expandExtensions(CustomAttr *attr, MacroDecl *macro,
               /*unboundTyOpener*/ nullptr,
               /*placeholderHandler*/ nullptr,
               /*packElementOpener*/ nullptr)
-          .resolveType(inherited.getTypeRepr());
+          .resolveType(inheritedTypes.getTypeRepr(i));
 
       // Already diagnosed or will be diagnosed later.
       if (constraint->is<ErrorType>() || !constraint->isConstraintType())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5592,13 +5592,9 @@ void swift::diagnoseConformanceFailure(Type T,
       if (!classDecl)
         return;
 
-      auto inheritedClause = classDecl->getInherited().getEntries();
-      for (unsigned i : indices(inheritedClause)) {
-        auto &inherited = inheritedClause[i];
-
-        // Find the inherited type.
-        InheritedTypeRequest request{classDecl, i, TypeResolutionStage::Interface};
-        Type inheritedTy = evaluateOrDefault(ctx.evaluator, request, Type());
+      auto inheritedTypes = classDecl->getInherited();
+      for (auto i : inheritedTypes.getIndices()) {
+        Type inheritedTy = inheritedTypes.getResolvedType(i);
 
         // If it's a class, we cannot suggest a different class to inherit
         // from.
@@ -5608,7 +5604,8 @@ void swift::diagnoseConformanceFailure(Type T,
         // Is it the NSObject protocol?
         if (auto protoTy = inheritedTy->getAs<ProtocolType>()) {
           if (isNSObjectProtocol(protoTy->getDecl())) {
-            diag.fixItReplace(inherited.getSourceRange(), "NSObject");
+            diag.fixItReplace(inheritedTypes.getEntry(i).getSourceRange(),
+                              "NSObject");
             return;
           }
         }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5562,15 +5562,15 @@ void swift::diagnoseConformanceFailure(Type T,
 
       auto rawType = enumDecl->getRawType();
 
-      diags.diagnose(enumDecl->getInherited().front().getSourceRange().Start,
-                     diag::enum_raw_type_nonconforming_and_nonsynthable,
-                     T, rawType);
+      diags.diagnose(enumDecl->getInherited().getStartLoc(),
+                     diag::enum_raw_type_nonconforming_and_nonsynthable, T,
+                     rawType);
 
       // If the reason is that the raw type does not conform to
       // Equatable, say so.
       if (!TypeChecker::conformsToKnownProtocol(
               rawType, KnownProtocolKind::Equatable, DC->getParentModule())) {
-        SourceLoc loc = enumDecl->getInherited().front().getSourceRange().Start;
+        SourceLoc loc = enumDecl->getInherited().getStartLoc();
         diags.diagnose(loc, diag::enum_raw_type_not_equatable, rawType);
         return;
       }
@@ -6635,9 +6635,8 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
           DerivedConformance::derivesProtocolConformance(dc, enumDecl,
                                                          diag.Protocol) &&
           enumDecl->hasRawType() &&
-          enumDecl->getInherited().front().getSourceRange().isValid()) {
-        auto inheritedLoc =
-            enumDecl->getInherited().front().getSourceRange().Start;
+          enumDecl->getInherited().getStartLoc().isValid()) {
+        auto inheritedLoc = enumDecl->getInherited().getStartLoc();
         Context.Diags.diagnose(
             inheritedLoc, diag::enum_declares_rawrep_with_raw_type,
             dc->getDeclaredInterfaceType(), enumDecl->getRawType());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5562,7 +5562,7 @@ void swift::diagnoseConformanceFailure(Type T,
 
       auto rawType = enumDecl->getRawType();
 
-      diags.diagnose(enumDecl->getInherited()[0].getSourceRange().Start,
+      diags.diagnose(enumDecl->getInherited().front().getSourceRange().Start,
                      diag::enum_raw_type_nonconforming_and_nonsynthable,
                      T, rawType);
 
@@ -5570,7 +5570,7 @@ void swift::diagnoseConformanceFailure(Type T,
       // Equatable, say so.
       if (!TypeChecker::conformsToKnownProtocol(
               rawType, KnownProtocolKind::Equatable, DC->getParentModule())) {
-        SourceLoc loc = enumDecl->getInherited()[0].getSourceRange().Start;
+        SourceLoc loc = enumDecl->getInherited().front().getSourceRange().Start;
         diags.diagnose(loc, diag::enum_raw_type_not_equatable, rawType);
         return;
       }
@@ -5592,7 +5592,7 @@ void swift::diagnoseConformanceFailure(Type T,
       if (!classDecl)
         return;
 
-      auto inheritedClause = classDecl->getInherited();
+      auto inheritedClause = classDecl->getInherited().getEntries();
       for (unsigned i : indices(inheritedClause)) {
         auto &inherited = inheritedClause[i];
 
@@ -6638,8 +6638,9 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
           DerivedConformance::derivesProtocolConformance(dc, enumDecl,
                                                          diag.Protocol) &&
           enumDecl->hasRawType() &&
-          enumDecl->getInherited()[0].getSourceRange().isValid()) {
-        auto inheritedLoc = enumDecl->getInherited()[0].getSourceRange().Start;
+          enumDecl->getInherited().front().getSourceRange().isValid()) {
+        auto inheritedLoc =
+            enumDecl->getInherited().front().getSourceRange().Start;
         Context.Diags.diagnose(
             inheritedLoc, diag::enum_declares_rawrep_with_raw_type,
             dc->getDeclaredInterfaceType(), enumDecl->getRawType());

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -71,7 +71,7 @@ Type InheritedTypeRequest::evaluate(
     break;
   }
 
-  const TypeLoc &typeLoc = getInheritedTypeLocAtIndex(decl, index);
+  const TypeLoc &typeLoc = InheritedTypes(decl).getEntry(index);
 
   Type inheritedType;
   if (typeLoc.getTypeRepr())
@@ -103,7 +103,7 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
       return Type();
   }
 
-  for (unsigned int idx : indices(nominalDecl->getInherited())) {
+  for (unsigned int idx : nominalDecl->getInherited().getIndices()) {
     auto result = evaluator(InheritedTypeRequest{nominalDecl, idx, stage});
 
     if (auto err = result.takeError()) {
@@ -140,7 +140,7 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
 
 Type EnumRawTypeRequest::evaluate(Evaluator &evaluator,
                                   EnumDecl *enumDecl) const {
-  for (unsigned int idx : indices(enumDecl->getInherited())) {
+  for (unsigned int idx : enumDecl->getInherited().getIndices()) {
     auto inheritedTypeResult = evaluator(
         InheritedTypeRequest{enumDecl, idx, TypeResolutionStage::Interface});
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3801,9 +3801,9 @@ public:
   /// Add all of the inherited entries to the result vector.
   ///
   /// \returns the number of entries added.
-  size_t addInherited(ArrayRef<InheritedEntry> inheritedEntries,
+  size_t addInherited(InheritedTypes inheritedEntries,
                       SmallVectorImpl<TypeID> &result) {
-    for (const auto &inherited : inheritedEntries) {
+    for (const auto &inherited : inheritedEntries.getEntries()) {
       assert(!inherited.getType() || !inherited.getType()->hasArchetype());
       TypeID typeRef = S.addTypeRef(inherited.getType());
 
@@ -4218,7 +4218,7 @@ public:
         proto->getInherited(), inheritedAndDependencyTypes);
 
     // Separately collect inherited protocol types as dependencies.
-    for (auto element : proto->getInherited()) {
+    for (auto element : proto->getInherited().getEntries()) {
       auto elementType = element.getType();
       assert(!elementType || !elementType->hasArchetype());
       if (elementType &&

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -861,7 +861,7 @@ AccessLevel Symbol::getEffectiveAccessLevel(const ExtensionDecl *ED) {
   }
 
   AccessLevel maxInheritedAL = AccessLevel::Private;
-  for (auto Inherited : ED->getInherited()) {
+  for (auto Inherited : ED->getInherited().getEntries()) {
     if (const auto Type = Inherited.getType()) {
       if (const auto *Proto = dyn_cast_or_null<ProtocolDecl>(
               Type->getAnyNominal())) {

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -389,7 +389,7 @@ void
 SymbolGraph::recordInheritanceRelationships(Symbol S) {
   const auto VD = S.getLocalSymbolDecl();
   if (const auto *NTD = dyn_cast<NominalTypeDecl>(VD)) {
-    for (const auto &InheritanceLoc : NTD->getInherited()) {
+    for (const auto &InheritanceLoc : NTD->getInherited().getEntries()) {
       auto Ty = InheritanceLoc.getType();
       if (!Ty) {
         continue;

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -623,7 +623,7 @@ static void reportRelated(ASTContext &Ctx, const Decl *D,
         passExtends(TD, Consumer);
     }
 
-    passInherits(ED->getInherited(), Consumer);
+    passInherits(ED->getInherited().getEntries(), Consumer);
 
   } else if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
 
@@ -631,7 +631,7 @@ static void reportRelated(ASTContext &Ctx, const Decl *D,
       // If underlying type exists, report the inheritance and conformance of the
       // underlying type.
       if (auto NM = Ty->getAnyNominal()) {
-        passInherits(NM->getInherited(), Consumer);
+        passInherits(NM->getInherited().getEntries(), Consumer);
         passConforms(NM->getSatisfiedProtocolRequirements(/*Sorted=*/true),
                      Consumer);
         return;


### PR DESCRIPTION
Replace the `InheritedEntry` array returned by `getInherited()` on both `ExtensionDecl` and `TypeDecl` with the `InheritedTypes` wrapper. This wrapper provides shared conveniences to make working with abstract inheritance clauses less awkward. The refactor will make it simpler to perform type resolution on the types in inheritance clauses, which will be important for fixing bugs related to emitting `.swiftinterface` and `.tbd` outputs in lazy typechecking mode.

NFC.