### PR TITLE
[MoveChecker] Complete lifetimes before checking.

### DIFF
--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -321,6 +321,10 @@ public:
   /// Return true if the forwarded value is address-only either before or after
   /// forwarding.
   bool isAddressOnly() const;
+
+  // Call \p visitor on all forwarded results of the current forwarding
+  // operation.
+  bool visitForwardedValues(function_ref<bool(SILValue)> visitor);
 };
 } // end namespace swift
 

--- a/lib/SIL/Utils/InstWrappers.cpp
+++ b/lib/SIL/Utils/InstWrappers.cpp
@@ -70,3 +70,28 @@ bool ForwardingOperation::isAddressOnly() const {
   return forwardingInst->getOperand(0)->getType().isAddressOnly(
       *forwardingInst->getFunction());
 }
+
+bool ForwardingOperation::visitForwardedValues(
+    function_ref<bool(SILValue)> visitor) {
+  if (auto *svi = dyn_cast<SingleValueInstruction>(forwardingInst)) {
+    return visitor(svi);
+  }
+  if (auto *mvri = dyn_cast<MultipleValueInstruction>(forwardingInst)) {
+    return llvm::all_of(mvri->getResults(), [&](SILValue value) {
+      if (value->getOwnershipKind() == OwnershipKind::None)
+        return true;
+      return visitor(value);
+    });
+  }
+  auto *ti = cast<TermInst>(forwardingInst);
+  assert(ti->mayHaveTerminatorResult());
+  return llvm::all_of(ti->getSuccessorBlocks(), [&](SILBasicBlock *succBlock) {
+    // If we do not have any arguments, then continue.
+    if (succBlock->args_empty())
+      return true;
+
+    auto args = succBlock->getSILPhiArguments();
+    assert(args.size() == 1 && "Transforming terminator with multiple args?!");
+    return visitor(args[0]);
+  });
+}

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -30,6 +30,7 @@
 #include "swift/SIL/FieldSensitivePrunedLiveness.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/OSSALifetimeCompletion.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILArgument.h"
@@ -86,6 +87,7 @@ struct MoveOnlyChecker {
   }
 
   void checkObjects();
+  void completeObjectLifetimes(ArrayRef<MarkUnresolvedNonCopyableValueInst *>);
   void checkAddresses();
 };
 
@@ -110,8 +112,73 @@ void MoveOnlyChecker::checkObjects() {
     return;
   }
 
+  completeObjectLifetimes(moveIntroducersToProcess.getArrayRef());
+
   MoveOnlyObjectChecker checker{diagnosticEmitter, domTree, poa, allocator};
   madeChange |= checker.check(moveIntroducersToProcess);
+}
+
+void MoveOnlyChecker::completeObjectLifetimes(
+    ArrayRef<MarkUnresolvedNonCopyableValueInst *> insts) {
+// TODO: Delete once OSSALifetimeCompletion is run as part of SILGenCleanup.
+  OSSALifetimeCompletion completion(fn, domTree);
+
+  // Collect all values derived from each mark_unresolved_non_copyable_value
+  // instruction via ownership instructions and phis.
+  ValueWorklist transitiveValues(fn);
+  for (auto *inst : insts) {
+    transitiveValues.push(inst);
+  }
+  while (auto value = transitiveValues.pop()) {
+    for (auto *use : value->getUses()) {
+      auto *user = use->getUser();
+      switch (user->getKind()) {
+      case SILInstructionKind::BeginBorrowInst:
+      case SILInstructionKind::CopyValueInst:
+      case SILInstructionKind::MoveValueInst:
+        transitiveValues.pushIfNotVisited(cast<SingleValueInstruction>(user));
+        break;
+      case SILInstructionKind::BranchInst: {
+        PhiOperand po(use);
+        transitiveValues.pushIfNotVisited(po.getValue());
+        break;
+      }
+      default: {
+        auto forward = ForwardingOperation(user);
+        if (!forward)
+          continue;
+        forward.visitForwardedValues([&transitiveValues](auto forwarded) {
+          transitiveValues.pushIfNotVisited(forwarded);
+          return true;
+        });
+        break;
+      }
+      }
+    }
+  }
+  // Complete the lifetime of each collected value.  This is a subset of the
+  // work that SILGenCleanup will do.
+  for (auto *block : poa->get(fn)->getPostOrder()) {
+    for (SILInstruction &inst : reverse(*block)) {
+      for (auto result : inst.getResults()) {
+        if (!transitiveValues.isVisited(result))
+          continue;
+        if (completion.completeOSSALifetime(result) ==
+            LifetimeCompletion::WasCompleted) {
+          madeChange = true;
+        }
+      }
+    }
+    for (SILArgument *arg : block->getArguments()) {
+      assert(!arg->isReborrow() && "reborrows not legal at this SIL stage");
+      if (!transitiveValues.isVisited(arg))
+        continue;
+      if (completion.completeOSSALifetime(arg) ==
+          LifetimeCompletion::WasCompleted) {
+        madeChange = true;
+      }
+    }
+  }
 }
 
 void MoveOnlyChecker::checkAddresses() {

--- a/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
+++ b/lib/SILOptimizer/Mandatory/SILGenCleanup.cpp
@@ -124,6 +124,7 @@ bool SILGenCleanup::completeOSSALifetimes(SILFunction *function) {
       }
     }
     for (SILArgument *arg : block->getArguments()) {
+      assert(!arg->isReborrow() && "reborrows not legal at this SIL stage");
       if (completion.completeOSSALifetime(arg) ==
           LifetimeCompletion::WasCompleted) {
         changed = true;

--- a/validation-test/SILOptimizer/gh68328.swift
+++ b/validation-test/SILOptimizer/gh68328.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/bin 
+// RUN: %target-run %t/bin 2> %t/out.txt || true
+// RUN: %FileCheck %s < %t/out.txt
+
+struct Example: ~Copyable {
+    private var failureString: String { "Goodbye." }
+    deinit { fatalError("FATAL ERROR: \(failureString)") }
+}
+
+func doit() {
+  let e = Example()
+  // CHECK: FATAL ERROR: Goodbye.
+}
+
+doit()


### PR DESCRIPTION
Before move-checking values, complete the lifetimes of all the values derived from them via copy, borrow, move, and phi.

Collect all such values and their derived transitive values and then complete the lifetimes of each, visiting the instructions which produce them in post-order.

Once OSSALifetimeCompletion runs as part of SILGenCleanup, this code can be deleted.
