### PR TITLE
Introduce `do` expressions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1256,6 +1256,9 @@ ERROR(single_value_stmt_must_be_unlabeled,none,
 ERROR(if_expr_must_be_syntactically_exhaustive,none,
       "'if' must have an unconditional 'else' to be used as expression",
       ())
+ERROR(do_catch_expr_must_be_syntactically_exhaustive,none,
+      "'do catch' must have an unconditional 'catch' to be used as expression",
+      ())
 ERROR(single_value_stmt_branch_empty,none,
       "expected expression in branch of '%0' expression",
       (StmtKind))
@@ -1269,8 +1272,8 @@ ERROR(cannot_jump_in_single_value_stmt,none,
 ERROR(effect_marker_on_single_value_stmt,none,
       "'%0' may not be used on '%1' expression", (StringRef, StmtKind))
 ERROR(out_of_place_then_stmt,none,
-      "'then' may only appear as the last statement in an 'if' or 'switch' "
-      "expression", ())
+      "'then' may only appear as the last statement in an 'if', 'switch', or "
+      "'do' expression", ())
 
 ERROR(did_not_call_function_value,none,
       "function value was used as a property; add () to call it",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6075,7 +6075,7 @@ public:
 class SingleValueStmtExpr : public Expr {
 public:
   enum class Kind {
-    If, Switch
+    If, Switch, Do, DoCatch
   };
 
 private:

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1417,6 +1417,9 @@ public:
     return {getTrailingObjects<CaseStmt *>(), Bits.DoCatchStmt.NumCatches};
   }
 
+  /// Retrieve the complete set of branches for this do-catch statement.
+  ArrayRef<Stmt *> getBranches(SmallVectorImpl<Stmt *> &scratch) const;
+
   /// Does this statement contain a syntactically exhaustive catch
   /// clause?
   ///

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -144,7 +144,6 @@ public:
 
   /// Whether the statement can produce a single value, and as such may be
   /// treated as an expression.
-  IsSingleValueStmtResult mayProduceSingleValue(Evaluator &eval) const;
   IsSingleValueStmtResult mayProduceSingleValue(ASTContext &ctx) const;
 
   /// isImplicit - Determines whether this statement was implicitly-generated,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3947,6 +3947,10 @@ public:
     /// The statement is an 'if' statement without an unconditional 'else'.
     NonExhaustiveIf,
 
+    /// The statement is a 'do catch' statement without an unconditional
+    /// 'catch'.
+    NonExhaustiveDoCatch,
+
     /// There is no branch that produces a resulting value.
     NoResult,
 
@@ -4002,6 +4006,9 @@ public:
   }
   static IsSingleValueStmtResult nonExhaustiveIf() {
     return IsSingleValueStmtResult(Kind::NonExhaustiveIf);
+  }
+  static IsSingleValueStmtResult nonExhaustiveDoCatch() {
+    return IsSingleValueStmtResult(Kind::NonExhaustiveDoCatch);
   }
   static IsSingleValueStmtResult noResult() {
     return IsSingleValueStmtResult(Kind::NoResult);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4039,9 +4039,12 @@ public:
 };
 
 /// Computes whether a given statement can be treated as a SingleValueStmtExpr.
+///
+// TODO: We ought to consider storing a reference to the ASTContext on the
+// evaluator.
 class IsSingleValueStmtRequest
     : public SimpleRequest<IsSingleValueStmtRequest,
-                           IsSingleValueStmtResult(const Stmt *),
+                           IsSingleValueStmtResult(const Stmt *, ASTContext *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -4049,8 +4052,8 @@ public:
 private:
   friend SimpleRequest;
 
-  IsSingleValueStmtResult
-  evaluate(Evaluator &evaluator, const Stmt *stmt) const;
+  IsSingleValueStmtResult evaluate(Evaluator &evaluator, const Stmt *stmt,
+                                   ASTContext *ctx) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -448,7 +448,7 @@ SWIFT_REQUEST(TypeChecker, PreCheckReturnStmtRequest,
               Stmt *(ReturnStmt *, DeclContext *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsSingleValueStmtRequest,
-              IsSingleValueStmtResult(const Stmt *),
+              IsSingleValueStmtResult(const Stmt *, ASTContext *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, MacroDefinitionRequest,
               MacroDefinition(MacroDecl *),

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -232,6 +232,9 @@ EXPERIMENTAL_FEATURE(PlaygroundExtendedCallbacks, true)
 /// Enable 'then' statements.
 EXPERIMENTAL_FEATURE(ThenStatements, false)
 
+/// Enable 'do' expressions.
+EXPERIMENTAL_FEATURE(DoExpressions, false)
+
 /// Enable the `@_rawLayout` attribute.
 EXPERIMENTAL_FEATURE(RawLayout, true)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3563,6 +3563,10 @@ static bool usesFeatureThenStatements(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureDoExpressions(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureNewCxxMethodSafetyHeuristics(Decl *decl) {
   return decl->hasClangNode();
 }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1227,6 +1227,7 @@ public:
         break;
       case Kind::UnterminatedBranches:
       case Kind::NonExhaustiveIf:
+      case Kind::NonExhaustiveDoCatch:
       case Kind::UnhandledStmt:
       case Kind::CircularReference:
       case Kind::HasLabel:

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -333,13 +333,9 @@ Stmt *BraceStmt::getSingleActiveStatement() const {
   return getSingleActiveElement().dyn_cast<Stmt *>();
 }
 
-IsSingleValueStmtResult Stmt::mayProduceSingleValue(Evaluator &eval) const {
-  return evaluateOrDefault(eval, IsSingleValueStmtRequest{this},
-                           IsSingleValueStmtResult::circularReference());
-}
-
 IsSingleValueStmtResult Stmt::mayProduceSingleValue(ASTContext &ctx) const {
-  return mayProduceSingleValue(ctx.evaluator);
+  return evaluateOrDefault(ctx.evaluator, IsSingleValueStmtRequest{this, &ctx},
+                           IsSingleValueStmtResult::circularReference());
 }
 
 SourceLoc ReturnStmt::getStartLoc() const {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -859,6 +859,15 @@ SwitchStmt::getBranches(SmallVectorImpl<Stmt *> &scratch) const {
   return scratch;
 }
 
+ArrayRef<Stmt *>
+DoCatchStmt::getBranches(SmallVectorImpl<Stmt *> &scratch) const {
+  assert(scratch.empty());
+  scratch.push_back(getBody());
+  for (auto *CS : getCatches())
+    scratch.push_back(CS->getBody());
+  return scratch;
+}
+
 // See swift/Basic/Statistic.h for declaration: this enables tracing Stmts, is
 // defined here to avoid too much layering violation / circular linkage
 // dependency.

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -37,6 +37,7 @@ extension Parser.ExperimentalFeatures {
     }
     mapFeature(.ThenStatements, to: .thenStatements)
     mapFeature(.TypedThrows, to: .typedThrows)
+    mapFeature(.DoExpressions, to: .doExpressions)
   }
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -592,11 +592,13 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   // First check to see if we have the start of a regex literal `/.../`.
   tryLexRegexLiteral(/*forUnappliedOperator*/ false);
 
-  // Try parse an 'if' or 'switch' as an expression. Note we do this here in
-  // parseExprUnary as we don't allow postfix syntax to hang off such
+  // Try parse 'if', 'switch', and 'do' as expressions. Note we do this here
+  // in parseExprUnary as we don't allow postfix syntax to hang off such
   // expressions to avoid ambiguities such as postfix '.member', which can
   // currently be parsed as a static dot member for a result builder.
-  if (Tok.isAny(tok::kw_if, tok::kw_switch)) {
+  if (Tok.isAny(tok::kw_if, tok::kw_switch) ||
+      (Tok.is(tok::kw_do) &&
+       Context.LangOpts.hasFeature(Feature::DoExpressions))) {
     auto Result = parseStmt();
     Expr *E = nullptr;
     if (Result.isNonNull()) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3947,6 +3947,11 @@ private:
                        diag::if_expr_must_be_syntactically_exhaustive);
         break;
       }
+      case IsSingleValueStmtResult::Kind::NonExhaustiveDoCatch: {
+        Diags.diagnose(S->getStartLoc(),
+                       diag::do_catch_expr_must_be_syntactically_exhaustive);
+        break;
+      }
       case IsSingleValueStmtResult::Kind::HasLabel: {
         // FIXME: We should offer a fix-it to remove (currently we don't track
         // the colon SourceLoc).

--- a/test/SILGen/do_expr.swift
+++ b/test/SILGen/do_expr.swift
@@ -1,0 +1,185 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature ThenStatements -enable-experimental-feature DoExpressions %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -enable-experimental-feature ThenStatements -enable-experimental-feature DoExpressions %s
+
+// Required for experimental features
+// REQUIRES: asserts
+
+@discardableResult
+func throwsError(_ x: Int = 0) throws -> Int { 0 }
+
+struct Err: Error {}
+
+func test1() -> Int {
+  do { 5 }
+}
+// CHECK-LABEL: sil hidden [ossa] @$s7do_expr5test1SiyF : $@convention(thin) () -> Int
+// CHECK:       [[RESULT:%[0-9]+]] = alloc_stack $Int
+// CHECK:       store {{%[0-9]+}} to [trivial] [[RESULT]] : $*Int
+// CHECK-NEXT:  [[RET:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK-NEXT:  dealloc_stack [[RESULT]] : $*Int
+// CHECK-NEXT:  return [[RET]] : $Int
+
+func test2() -> Int {
+  return do { 5 }
+}
+
+func test3() -> Int {
+  let x = do { 5 }
+  return x
+}
+
+func test4() -> Int {
+  do { then 5 }
+}
+
+func test5() -> Int {
+  let x = do { (); then 5 }
+  return x
+}
+
+func test6() -> Int {
+  let x = do {
+    let y = 0
+    try throwsError()
+    then y
+  } catch {
+    7
+  }
+  return x
+}
+// CHECK-LABEL: sil hidden [ossa] @$s7do_expr5test6SiyF : $@convention(thin) () -> Int
+// CHECK:       [[RESULT:%[0-9]+]] = alloc_stack $Int
+// CHECK:       [[Y_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 0
+// CHECK:       [[Y:%[0-9]+]] = apply {{%[0-9]+}}([[Y_LIT]], {{%[0-9]+}})
+// CHECK:       [[THROWS_ERR_FN:%[0-9]+]] = function_ref @$s7do_expr11throwsErroryS2iKF : $@convention(thin) (Int) -> (Int, @error any Error)
+// CHECK:       try_apply [[THROWS_ERR_FN]]({{%[0-9]+}}) : $@convention(thin) (Int) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_NORMAL]]
+// CHECK-NEXT:  store [[Y]] to [trivial] [[RESULT]] : $*Int
+// CHECK-NEXT:  br [[BB_EXIT:bb[0-9]+]]
+//
+// CHECK:       [[BB_EXIT]]
+// CHECK:       [[RET:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       dealloc_stack [[RESULT]] : $*Int
+// CHECK:       return [[RET]] : $Int
+//
+// CHECK:       [[BB_ERR]]
+// CHECK:       [[SEVEN_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 7
+// CHECK:       [[SEVEN:%[0-9]+]] = apply {{%[0-9]+}}([[SEVEN_LIT]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK:       store [[SEVEN]] to [trivial] [[RESULT]] : $*Int
+// CHECK:       br [[BB_EXIT]]
+
+func test7() throws -> Int {
+  let x = do {
+    let y = 0
+    then try throwsError(y)
+  } catch _ where .random() {
+    then try throwsError()
+  } catch {
+    7
+  }
+  return x
+}
+// CHECK-LABEL: sil hidden [ossa] @$s7do_expr5test7SiyKF : $@convention(thin) () -> (Int, @error any Error)
+// CHECK:       [[RESULT:%[0-9]+]] = alloc_stack $Int
+// CHECK:       [[Y_LIT:%[0-9]]] = integer_literal $Builtin.IntLiteral, 0
+// CHECK:       [[Y:%[0-9]+]] = apply {{%[0-9]+}}([[Y_LIT]], {{%[0-9]+}})
+// CHECK:       [[THROWS_ERR_FN:%[0-9]]] = function_ref @$s7do_expr11throwsErroryS2iKF : $@convention(thin) (Int) -> (Int, @error any Error)
+// CHECK:       try_apply [[THROWS_ERR_FN]]([[Y]]) : $@convention(thin) (Int) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_NORMAL]]([[I:%[0-9]+]] : $Int)
+// CHECK-NEXT:  store [[I]] to [trivial] [[RESULT]] : $*Int
+// CHECK-NEXT:  br [[BB_EXIT:bb[0-9]+]]
+//
+// CHECK:       [[BB_EXIT]]
+// CHECK:       [[RET:%[0-9]+]] = load [trivial] [[RESULT]] : $*Int
+// CHECK:       dealloc_stack [[RESULT]] : $*Int
+// CHECK:       return [[RET]] : $Int
+//
+// CHECK:       [[BB_ERR]]
+// CHECK:       function_ref @$sSb6randomSbyFZ : $@convention(method) (@thin Bool.Type) -> Bool
+// CHECK:       cond_br {{%[0-9]+}}, [[BB_FIRST_CATCH:bb[0-9]+]], [[BB_SECOND_CATCH:bb[0-9]+]]
+//
+// CHECK:       [[BB_FIRST_CATCH]]
+// CHECK:       [[THROWS_ERR_FN:%[0-9]+]] = function_ref @$s7do_expr11throwsErroryS2iKF : $@convention(thin) (Int) -> (Int, @error any Error)
+// CHECK:       try_apply [[THROWS_ERR_FN]]({{%[0-9]+}}) : $@convention(thin) (Int) -> (Int, @error any Error), normal [[BB_NORMAL2:bb[0-9]+]], error [[BB_ERR2:bb[0-9]+]]
+//
+// CHECK:       [[BB_NORMAL2]]([[I:%[0-9]+]] : $Int):
+// CHECK-NEXT:  store [[I]] to [trivial] [[RESULT]] : $*Int
+// CHECK:       br [[BB_EXIT:bb[0-9]+]]
+//
+// CHECK:       [[BB_SECOND_CATCH]]
+// CHECK:       [[SEVEN_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 7
+// CHECK:       [[SEVEN:%[0-9]+]] = apply {{%[0-9]+}}([[SEVEN_LIT]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK:       store [[SEVEN]] to [trivial] [[RESULT]] : $*Int
+// CHECK:       br [[BB_EXIT]]
+//
+// CHECK:       [[BB_ERR2]]([[ERR:%[0-9]+]] : @owned $any Error)
+// CHECK:       dealloc_stack [[RESULT]] : $*Int
+// CHECK:       throw [[ERR]] : $any Error
+
+func test8() throws -> Int {
+  var x = 0
+  x = do {
+    let y = 0
+    then try throwsError(y)
+  } catch _ where .random() {
+    then try throwsError()
+  } catch {
+    8
+  }
+  return x
+}
+
+func test9() throws -> Int {
+  let fn = {
+    do {
+      let y = 0
+      then try throwsError(y)
+    } catch _ where .random() {
+      then try throwsError()
+    } catch {
+      8
+    }
+  }
+  return try fn()
+}
+
+func test10() -> Int {
+  do { 5 } as Int
+}
+
+func testExhaustive1() -> Error {
+  // We can syntactically determine that 'let x' is a non-refutable pattern.
+  let err = do {
+    try throwsError()
+    then Err() as Error
+  } catch let x {
+    x
+  }
+  return err
+}
+
+func testExhaustive2() -> Error {
+  do {
+    try throwsError()
+    then Err() as Error
+  } catch let x {
+    x
+  }
+}
+
+func throwAndReturnError() throws -> Error { fatalError() }
+
+func testExhaustive3() -> Error {
+  do {
+    try throwAndReturnError()
+  } catch let x {
+    x
+  }
+}
+
+func testExhaustive4() {
+  // We can syntactically determine that '_' is a non-refutable pattern.
+  let _ = do { try throwsError() } catch _ { 0 }
+}

--- a/test/SILGen/do_expr_address_only_tuple_return_value_context.swift
+++ b/test/SILGen/do_expr_address_only_tuple_return_value_context.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-emit-silgen -verify -enable-experimental-feature DoExpressions %s
+
+// Required for experimental features
+// REQUIRES: asserts
+
+struct BigNontrivialThing {
+  var x: Any
+  var y: Any
+}
+
+func throwBNT() throws -> BigNontrivialThing? { fatalError() }
+func nothrowBNT() -> BigNontrivialThing? { fatalError() }
+func throwStr() throws -> String { fatalError() }
+func nothrowStr() -> String { fatalError() }
+
+func foo() throws -> (BigNontrivialThing?, String) {
+  do {
+    (nothrowBNT(), try throwStr())
+  } catch _ where .random() {
+    (try throwBNT(), nothrowStr())
+  } catch _ where .random() {
+    (try throwBNT(), try throwStr())
+  } catch {
+    (nothrowBNT(), nothrowStr())
+  }
+}

--- a/test/expr/unary/do_expr.swift
+++ b/test/expr/unary/do_expr.swift
@@ -1,0 +1,658 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature ThenStatements -enable-experimental-feature DoExpressions
+
+// Required for experimental features
+// REQUIRES: asserts
+
+@discardableResult
+func throwsError() throws -> Int { 0 }
+
+struct Err: Error {}
+
+func test1() -> Int {
+  return do { 5 }
+}
+
+func test2() -> Int {
+  return do { try throwsError() } catch { 0 }
+}
+
+func test3() -> Int {
+  return
+  do { 5 }
+  // expected-warning@-1 {{expression following 'return' is treated as an argument of the 'return'}}
+  // expected-note@-2 {{indent the expression to silence this warning}}
+}
+
+func test4() -> Int {
+  return
+    do { 5 }
+}
+
+func test5() -> Int {
+  return
+  do { try throwsError() } catch { 0 }
+  // expected-warning@-1 {{expression following 'return' is treated as an argument of the 'return'}}
+  // expected-note@-2 {{indent the expression to silence this warning}}
+}
+
+func test6() -> Int {
+  return
+    do { try throwsError() } catch { 0 }
+}
+
+func test7() -> Int {
+  do { 5 }
+}
+
+func test8() -> Int {
+  do { try throwsError() } catch { 0 }
+}
+
+func test9() -> Int {
+  do { 5 } as Int
+}
+
+func test10() -> Int {
+  do { try throwsError() } catch { 0 } as Int
+}
+
+func test11() -> Int {
+  let x = do { 5 }
+  return x
+}
+
+func test12() -> Int {
+  let x = do { try throwsError() } catch { 0 }
+  return x
+}
+
+func test13() -> Int {
+  let fn = { do { 5 } }
+  return fn()
+}
+
+func test14() -> Int {
+  let fn = { do { try throwsError() } catch { 0 } }
+  return fn()
+}
+
+func testEmpty1() {
+  let _ = do {} // expected-error {{expected expression in branch of 'do' expression}}
+}
+
+func testEmpty2() -> Int {
+  // Fine, treated as a statement.
+  do {}
+}
+
+func testEmpty3() -> Int {
+  let _ = do { try throwsError() } catch {}
+  // expected-error@-1 {{expected expression in branch of 'do-catch' expression}}
+}
+
+func testEmpty4() -> Int {
+  // Fine, treated as a statement.
+  do { try throwsError() } catch {}
+}
+
+func testNonExhaustive1() throws -> Int {
+  let _ = do { try throwsError() } catch is Err { 0 }
+  // expected-error@-1 {{'do catch' must have an unconditional 'catch' to be used as expression}}
+}
+
+func testNonExhaustive2() throws -> Int {
+  // Non-exhaustive, so statement.
+  do { try throwsError() } catch is Err { 0 }
+  // expected-warning@-1 {{integer literal is unused}}
+}
+
+func testReturn1() -> Int {
+  let _ = do {
+    try throwsError()
+  } catch {
+    if .random() {
+      return 0 // expected-error {{cannot 'return' in 'do-catch' when used as expression}}
+    }
+    then 0
+  }
+}
+
+func testReturn2() -> Int {
+  // The return means this must be a statement.
+  do {
+    try throwsError()
+  } catch {
+    if .random() {
+      return 0
+    }
+    then 0 // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
+  }
+}
+
+// MARK: Effect specifiers
+
+func tryDo1() -> Int {
+  try do { 0 }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+}
+
+func tryDo2() -> Int {
+  let x = try do { 0 }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  return x
+}
+
+func tryDo3() -> Int {
+  return try do { 0 }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+}
+
+func tryDo4() throws -> Int {
+  return try do { 0 }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+}
+
+func tryDo5() throws -> Int {
+  return try do { tryDo4() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+}
+
+func tryDo6() throws -> Int {
+  try do { tryDo4() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+}
+
+func tryDo7() throws -> Int {
+  let x = try do { tryDo4() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+  return x
+}
+
+func tryDo8() throws -> Int {
+  return try do { try tryDo4() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+}
+
+func tryDo9() throws -> Int {
+  try do { try tryDo4() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+}
+
+func tryDo10() throws -> Int {
+  let x = try do { try tryDo4() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  return x
+}
+
+func tryDo11() throws -> Int {
+  let x = try do { try tryDo4() } catch { tryDo4() }
+  // expected-error@-1 {{'try' may not be used on 'do-catch' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+  return x
+}
+
+func tryDo12() throws -> Int {
+  let x = try do { tryDo4() } catch { tryDo4() }
+  // expected-error@-1 {{'try' may not be used on 'do-catch' expression}}
+  // expected-error@-2 2{{call can throw but is not marked with 'try'}}
+  // expected-note@-3 2{{did you mean to use 'try'?}}
+  // expected-note@-4 2{{did you mean to handle error as optional value?}}
+  // expected-note@-5 2{{did you mean to disable error propagation?}}
+  return x
+}
+
+func tryDo13() throws -> Int {
+  let x = try do { // expected-error {{'try' may not be used on 'do-catch' expression}}
+    tryDo4() // expected-warning {{result of call to 'tryDo4()' is unused}}
+    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-note@-2 {{did you mean to use 'try'?}}
+    // expected-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-note@-4 {{did you mean to disable error propagation?}}
+
+    _ = tryDo4()
+    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-note@-2 {{did you mean to use 'try'?}}
+    // expected-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-note@-4 {{did you mean to disable error propagation?}}
+
+    _ = try tryDo4() // Okay.
+
+    // Okay.
+    do {
+      _ = try tryDo4()
+    } catch {}
+
+    print("hello")
+    throw Err()
+  } catch _ where .random() {
+    0
+  } catch {
+    throw error
+  }
+  return x
+}
+
+func throwsBool() throws -> Bool { true }
+
+func tryDo14() throws -> Int {
+  try do { try tryDo4() } catch _ where throwsBool() { 0 } catch { 1 }
+  // expected-error@-1 {{'try' may not be used on 'do-catch' expression}}
+  // expected-error@-2 {{call can throw, but errors cannot be thrown out of a catch guard expression}}
+}
+
+func tryDo15() throws -> Int {
+  try do { try tryDo4() } catch _ where try throwsBool() { 1 } catch { 1 }
+  // expected-error@-1 {{'try' may not be used on 'do-catch' expression}}
+  // expected-error@-2 {{call can throw, but errors cannot be thrown out of a catch guard expression}}
+}
+
+func tryDo16() throws -> Int {
+  do { try tryDo4() } catch _ where throwsBool() { 0 } catch { 1 }
+  // expected-error@-1 {{call can throw, but errors cannot be thrown out of a catch guard expression}}
+}
+
+func tryDo17() throws -> Int {
+  do { tryDo4() } catch { 1 }
+  // expected-error@-1 {{call can throw but is not marked with 'try'}}
+  // expected-note@-2 {{did you mean to use 'try'?}}
+  // expected-note@-3 {{did you mean to handle error as optional value?}}
+  // expected-note@-4 {{did you mean to disable error propagation?}}
+}
+
+func tryDo18() {
+  // Make sure we don't warn here.
+  do {
+    let _ = do { try tryDo4() }
+  } catch {}
+}
+
+func tryDo19() {
+  // Make sure we don't warn here.
+  do {
+    let _ = do { throw Err() }
+  } catch {}
+}
+
+func tryDo19() throws -> Int {
+  let x = do { try tryDo4() } catch { throw Err() }
+  return x
+}
+
+func tryDo20() throws -> Int {
+  do { try tryDo4() } catch { throw Err() }
+}
+
+func tryDo21(_ fn: () throws -> Int) rethrows -> Int {
+  let x = do { try fn() }
+  return x
+}
+
+func tryDo22(_ fn: () throws -> Int) rethrows -> Int {
+  do { try fn() }
+}
+
+func tryDo23(_ fn: () throws -> Int) rethrows -> Int {
+  // Fine, we can only end up in the 'catch' if we rethrow in the first place.
+  let x = do { try fn() } catch { throw Err() }
+  return x
+}
+
+func tryDo23_2(_ fn: () throws -> Int) rethrows -> Int {
+  let x = do { try tryDo4() } catch _ where .random() { try fn() } catch { throw Err() }
+  // expected-error@-1 {{a function declared 'rethrows' may only throw if its parameter does}}
+  return x
+}
+
+func tryDo24(_ fn: () throws -> Int) rethrows -> Int {
+  // Fine, we can only end up in the 'catch' if we rethrow in the first place.
+  let x = do { try fn() } catch { try tryDo4() }
+  return x
+}
+
+func tryDo24_2(_ fn: () throws -> Int) rethrows -> Int {
+  let x = do { try tryDo4() } catch _ where .random() { try fn() } catch { try tryDo4() }
+  // expected-error@-1 {{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
+  return x
+}
+
+func tryDo25(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = do { try fn() } catch { try tryDo4() }
+    return x
+  } catch {
+    return 0
+  }
+}
+
+func tryDo26(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = do { try fn() } catch { throw Err() }
+    return x
+  } catch {
+    return 0
+  }
+}
+
+func tryDo27(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = do { try fn() } catch { try tryDo4() }
+    return x
+  } catch {
+    throw error  // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func tryDo28(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = do { try fn() } catch { throw Err() }
+    return x
+  } catch {
+    throw error  // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func tryDo29(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = do { try fn() }
+    return x
+  } catch {
+    throw error // Okay.
+  }
+}
+
+func tryDo30(_ fn: () throws -> Int) rethrows -> Int {
+  // FIXME: This ought to work (https://github.com/apple/swift/issues/68824)
+  do {
+    let x = do { try fn() } catch { throw error }
+    return x
+  } catch {
+    throw error // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func awaitDo1() async -> Int {
+  await do { 0 }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+}
+
+func awaitDo2() async -> Int {
+  let x = await do { 0 }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  return x
+}
+
+func awaitDo3() -> Int { // expected-note {{add 'async' to function 'awaitDo3()' to make it asynchronous}}
+  return await do { 0 }
+  // expected-error@-1 {{'await' in a function that does not support concurrency}}
+}
+
+func awaitDo4() async -> Int {
+  return await do { 0 }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+}
+
+func awaitDo5() async -> Int {
+  return await do { awaitDo4() }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+}
+
+func awaitDo6() async -> Int {
+  await do { awaitDo4() }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+}
+
+func awaitDo7() async -> Int {
+  let x = await do { awaitDo4() }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+  return x
+}
+
+func awaitDo8() async -> Int {
+  return await do { await awaitDo4() }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+}
+
+func awaitDo9() async -> Int {
+  await do { await awaitDo4() }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+}
+
+func awaitDo10() async -> Int {
+  let x = await do { await awaitDo4() }
+  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  return x
+}
+
+func awaitDo11() async -> Int {
+  let x = await do { try await tryAwaitDo1() } catch { awaitDo4() }
+  // expected-error@-1 {{'await' may not be used on 'do-catch' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+  return x
+}
+
+func awaitDo12() async -> Int {
+  let x = await do { try tryAwaitDo1() } catch { awaitDo4() }
+  // expected-error@-1 {{'await' may not be used on 'do-catch' expression}}
+  // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 2{{call is 'async'}}
+  return x
+}
+
+func awaitDo13() async throws -> Int {
+  let x = await do { // expected-error {{'await' may not be used on 'do-catch' expression}}
+    awaitDo4() // expected-warning {{result of call to 'awaitDo4()' is unused}}
+    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-note@-2 {{call is 'async'}}
+
+    _ = awaitDo4()
+    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-note@-2 {{call is 'async'}}
+
+    _ = await awaitDo4() // Okay.
+
+    // Okay.
+    let _ = {
+      _ = await awaitDo4()
+    }
+
+    print("hello")
+    throw Err()
+  } catch _ where .random() {
+    0
+  } catch {
+    throw error
+  }
+  return x
+}
+
+func asyncBool() async -> Bool { true }
+
+func awaitDo14() async -> Int {
+  await do { try tryDo4() } catch _ where asyncBool() { 0 } catch { 1 }
+  // expected-error@-1 {{'await' may not be used on 'do-catch' expression}}
+  // expected-error@-2 {{'async' call cannot occur in a catch guard expression}}
+}
+
+func awaitDo15() async -> Int {
+  await do { try tryDo4() } catch _ where await asyncBool() { 0 } catch { 1 }
+  // expected-error@-1 {{'await' may not be used on 'do-catch' expression}}
+  // expected-error@-2 {{'async' call cannot occur in a catch guard expression}}
+}
+
+func awaitDo16() async -> Int {
+  do { try tryDo4() } catch _ where asyncBool() { 0 } catch { 1 }
+  // expected-error@-1 {{'async' call cannot occur in a catch guard expression}}
+}
+
+func awaitDo17() async -> Int {
+  do { awaitDo4() }
+  // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-2 {{call is 'async'}}
+}
+
+func awaitDo18() {
+  let _ = {
+    let _ = do { await awaitDo4() }
+  }
+}
+
+func awaitDo19() async -> Int {
+  let x = do { await awaitDo4() }
+  return x
+}
+
+func awaitDo20() async -> Int {
+  do { await awaitDo4() }
+}
+
+func tryAwaitDo1() async throws -> Int {
+  try await do { 0 }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+}
+
+func tryAwaitDo2() async throws -> Int {
+  try await do { 0 } as Int
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+}
+
+func tryAwaitDo3() async throws -> Int {
+  try await do { tryAwaitDo2() } as Int
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-note@-4 {{did you mean to use 'try'?}}
+  // expected-note@-5 {{did you mean to handle error as optional value?}}
+  // expected-note@-6 {{did you mean to disable error propagation?}}
+  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-8 {{call is 'async'}}
+}
+
+func tryAwaitDo4() async throws -> Int {
+  try await do { try tryAwaitDo2() } as Int
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-4 {{call is 'async'}}
+}
+
+func tryAwaitDo5() async throws -> Int {
+  try await do { await tryAwaitDo2() } as Int
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-note@-4 {{did you mean to use 'try'?}}
+  // expected-note@-5 {{did you mean to handle error as optional value?}}
+  // expected-note@-6 {{did you mean to disable error propagation?}}
+}
+
+func tryAwaitDo6() async throws -> Int {
+  try await do { try await tryAwaitDo2() } as Int
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+}
+
+func tryAwaitDo7() async throws -> Int {
+  try await do { tryAwaitDo2() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-note@-4 {{did you mean to use 'try'?}}
+  // expected-note@-5 {{did you mean to handle error as optional value?}}
+  // expected-note@-6 {{did you mean to disable error propagation?}}
+  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-8 {{call is 'async'}}
+}
+
+func tryAwaitDo8() async throws -> Int {
+  try await do { try tryAwaitDo2() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-4 {{call is 'async'}}
+}
+
+func tryAwaitDo9() async throws -> Int {
+  try await do { await tryAwaitDo2() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-note@-4 {{did you mean to use 'try'?}}
+  // expected-note@-5 {{did you mean to handle error as optional value?}}
+  // expected-note@-6 {{did you mean to disable error propagation?}}
+}
+
+func tryAwaitDo10() async throws -> Int {
+  try await do { try await tryAwaitDo2() }
+  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+}
+
+func tryAwaitDo11(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = do { try await fn() } catch { try await tryAwaitDo4() }
+    return x
+  } catch {
+    return 0
+  }
+}
+
+func tryAwaitDo12(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = do { try await fn() } catch { throw Err() }
+    return x
+  } catch {
+    return 0
+  }
+}
+
+func tryAwaitDo13(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = do { try await fn() } catch { try await tryAwaitDo4() }
+    return x
+  } catch {
+    throw error  // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func tryAwaitDo14(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = do { try await fn() } catch { throw Err() }
+    return x
+  } catch {
+    throw error  // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func tryAwaitDo15(_ fn: () async throws -> Int) async rethrows -> Int {
+  // FIXME: This ought to work (https://github.com/apple/swift/issues/68824)
+  do {
+    let x = do { try await fn() } catch { throw error }
+    return x
+  } catch {
+    throw error // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}

--- a/test/expr/unary/do_expr_disabled.swift
+++ b/test/expr/unary/do_expr_disabled.swift
@@ -1,0 +1,94 @@
+// RUN: %target-typecheck-verify-swift
+
+// Currently disabled by default.
+
+func throwsError() throws -> Int { 0 }
+
+func test1() -> Int {
+  return do { 5 }
+  // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+  // expected-error@-2 {{non-void function should return a value}}
+  // expected-warning@-3 {{integer literal is unused}}
+}
+
+func test2() -> Int {
+  return do { try throwsError() } catch { 0 }
+  // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+  // expected-error@-2 {{non-void function should return a value}}
+  // expected-warning@-3 {{integer literal is unused}}
+  // expected-warning@-4 {{result of call to 'throwsError()' is unused}}
+}
+
+func test3() -> Int {
+  return
+  do { 5 }
+  // expected-error@-2 {{non-void function should return a value}}
+  // expected-warning@-2 {{integer literal is unused}}
+}
+
+func test4() -> Int {
+  return
+  do { try throwsError() } catch { 0 }
+  // expected-error@-2 {{non-void function should return a value}}
+  // expected-warning@-2 {{integer literal is unused}}
+  // expected-warning@-3 {{result of call to 'throwsError()' is unused}}
+}
+
+func test5() -> Int {
+  do { 5 } // expected-warning {{integer literal is unused}}
+}
+
+func test6() -> Int {
+  do { try throwsError() } catch { 0 }
+  // expected-warning@-1 {{integer literal is unused}}
+  // expected-warning@-2 {{result of call to 'throwsError()' is unused}}
+}
+
+func test7() -> Int {
+  do { 5 } as Int
+  // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+  // expected-warning@-2 {{integer literal is unused}}
+  // expected-error@-3 {{expected expression}}
+}
+
+func test8() -> Int {
+  do { try throwsError() } catch { 0 } as Int
+  // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+  // expected-warning@-2 {{integer literal is unused}}
+  // expected-error@-3 {{expected expression}}
+  // expected-warning@-4 {{result of call to 'throwsError()' is unused}}
+}
+
+func test9() -> Int {
+  let x = do { 5 }
+  // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+  // expected-error@-2 {{expected initial value after '='}}
+  // expected-warning@-3 {{integer literal is unused}}
+
+  return x
+}
+
+func test10() -> Int {
+  let x = do { try throwsError() } catch { 0 }
+  // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+  // expected-error@-2 {{expected initial value after '='}}
+  // expected-warning@-3 {{integer literal is unused}}
+  // expected-warning@-4 {{result of call to 'throwsError()' is unused}}
+
+  return x
+}
+
+func test11() -> Int {
+  let fn = { do { 5 } }
+  // expected-warning@-1 {{integer literal is unused}}
+
+  return fn() // expected-error {{cannot convert return expression of type '()' to return type 'Int'}}
+}
+
+func test12() -> Int {
+  let fn = { do { try throwsError() } catch { 0 } }
+  // expected-warning@-1 {{integer literal is unused}}
+  // expected-warning@-2 {{result of call to 'throwsError()' is unused}}
+
+  return fn() // expected-error {{cannot convert return expression of type '()' to return type 'Int'}}
+}

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -933,6 +933,7 @@ func continue1() -> Int {
 func return1() -> Int {
   // Make sure we always reject a return.
   let i = if .random() {
+    ()
     do {
       for _ in [0] {
         while true {
@@ -1502,6 +1503,11 @@ struct SomeEraserP: EraserP {}
 // rdar://113435870 - Make sure we allow an implicit init(erasing:) call.
 dynamic func testDynamicOpaqueErase() -> some EraserP {
   if .random() { SomeEraserP() } else { SomeEraserP() }
+}
+
+struct NonExhaustiveProperty {
+  let i = if .random() { 0 }
+  // expected-error@-1 {{'if' must have an unconditional 'else' to be used as expression}}
 }
 
 // MARK: Out of place if exprs

--- a/test/stmt/then_stmt.swift
+++ b/test/stmt/then_stmt.swift
@@ -10,23 +10,23 @@ func then(_: Int = 0, x: Int = 0, fn: () -> Void = {}) {}
 
 func testThenStmt(_ x: Int) {
   // These are statements
-  then x // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
-  then ()  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
-  then (1)  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
-  then (1, 2)  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
-  then ""  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then x // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
+  then ()  // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
+  then (1)  // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
+  then (1, 2)  // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
+  then ""  // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
   then []
-  // expected-error@-1 {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  // expected-error@-1 {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
   // expected-error@-2 {{empty collection literal requires an explicit type}}
-  then [0]  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then [0]  // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
 
   then if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  // expected-error@-1 {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
   // expected-error@-2 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
-  then -1 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
-  then ~1 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
-  then /abc/ // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+  then -1 // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
+  then ~1 // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
+  then /abc/ // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
 
   let x: Int = if .random() {
     then .zero
@@ -69,22 +69,22 @@ struct S {
 
   mutating func testThenAsMember() -> Int {
     do {
-      then  // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+      then  // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
     } // expected-error {{expected expression after 'then'}}
-    then // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    then // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
     0 // expected-warning {{expression following 'then' is treated as an argument of the 'then'}}
     // expected-note@-1 {{indent the expression to silence this warning}}
 
     // Indented is okay.
-    then // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    then // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
       0
 
     then;
-    // expected-error@-1 {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    // expected-error@-1 {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
     // expected-error@-2 {{expected expression after 'then'}}
 
     then . foo
-    // expected-error@-1 {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    // expected-error@-1 {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
     // expected-error@-2 {{reference to member 'foo' cannot be resolved without a contextual type}}
 
     // These are expressions.
@@ -131,14 +131,14 @@ struct S {
 func testOutOfPlace() -> Int {
   if .random() {
     guard .random() else {
-      then 0 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+      then 0 // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
     }
     if .random() {
-      then 0 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+      then 0 // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
     } else {
-      then 1 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+      then 1 // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
     }
-    then 0 // expected-error {{'then' may only appear as the last statement in an 'if' or 'switch' expression}}
+    then 0 // expected-error {{'then' may only appear as the last statement in an 'if', 'switch', or 'do' expression}}
     then 0
   } else {
     then 1


### PR DESCRIPTION
Allow `do` and `do catch` statements to be treated as expressions if they either have single expression branches, or have terminating `then` statements, following the same rules as `if`/`switch` expressions. This is currently gated behind an experimental feature flag pending evolution discussion.