### PR TITLE
[Runtime] Add a function to check type creation

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1046,6 +1046,16 @@ void swift_initRawStructMetadata(StructMetadata *self,
                                  const TypeLayout *likeType,
                                  int32_t count);
 
+/// Check if the given generic arguments are valid inputs for the generic type
+/// context and if so call the access function to return 
+SWIFT_RUNTIME_STDLIB_SPI
+SWIFT_CC(swift)
+const Metadata *_swift_checkedCreateType(const TypeContextDescriptor *context,
+                                         const void * const *genericArgs,
+                                         size_t genericArgsSize,
+                                         const int32_t *packCounts,
+                                         size_t packCountsSize);
+
 #pragma clang diagnostic pop
 
 } // end namespace swift

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1047,14 +1047,16 @@ void swift_initRawStructMetadata(StructMetadata *self,
                                  int32_t count);
 
 /// Check if the given generic arguments are valid inputs for the generic type
-/// context and if so call the access function to return 
+/// context and if so call the metadata access function and return the metadata.
+///
+/// Note: This expects the caller to heap allocate all pack pointers within the
+/// generic arguments via 'swift_allocateMetadataPack'.
 SWIFT_RUNTIME_STDLIB_SPI
 SWIFT_CC(swift)
-const Metadata *_swift_checkedCreateType(const TypeContextDescriptor *context,
-                                         const void * const *genericArgs,
-                                         size_t genericArgsSize,
-                                         const int32_t *packCounts,
-                                         size_t packCountsSize);
+const Metadata *_swift_instantiateCheckedGenericMetadata(
+    const TypeContextDescriptor *context,
+    const void * const *genericArgs,
+    size_t genericArgsSize);
 
 #pragma clang diagnostic pop
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2832,11 +2832,10 @@ swift_getOpaqueTypeConformance(const void * const *arguments,
 
 SWIFT_RUNTIME_STDLIB_SPI
 SWIFT_CC(swift)
-const Metadata *swift::_swift_checkedCreateType(const TypeContextDescriptor *context,
-                                                const void * const *genericArgs,
-                                                size_t genericArgsSize,
-                                                const int32_t *packCounts,
-                                                size_t packCountsSize) {
+const Metadata *swift::_swift_instantiateCheckedGenericMetadata(
+    const TypeContextDescriptor *context,
+    const void * const *genericArgs,
+    size_t genericArgsSize) {
   context = swift_auth_data_non_address(
       context, SpecialPointerAuthDiscriminators::ContextDescriptor);
 
@@ -2844,33 +2843,14 @@ const Metadata *swift::_swift_checkedCreateType(const TypeContextDescriptor *con
     return nullptr;
   }
 
-  if (packCounts && genericArgsSize != packCountsSize) {
-    return nullptr;
-  }
-
-  llvm::SmallVector<MetadataOrPack, 8> fixedGenericArgs;
-
-  // Heap allocate all of the potential stack allocated pack pointers
-  for (size_t i = 0; i != genericArgsSize; i += 1) {
-    // Use -1 to indicate that this is not a pack pointer and instead just
-    // metadata. If we were not passed a packCount array, treat all elements as
-    // if they were just metadata.
-    if ((packCounts && packCounts[i] == -1) || !packCounts) {
-      fixedGenericArgs.push_back(MetadataOrPack(genericArgs[i]));
-      continue;
-    }
-
-    auto packPointer = swift_allocateMetadataPack(
-      reinterpret_cast<const Metadata *const *>(genericArgs[i]), packCounts[i]);
-    fixedGenericArgs.push_back(MetadataOrPack(packPointer));
-  }
-
   DemanglerForRuntimeTypeResolution<StackAllocatedDemangler<2048>> demangler;
 
+  llvm::ArrayRef<MetadataOrPack> genericArgsRef(
+      reinterpret_cast<const MetadataOrPack *>(genericArgs), genericArgsSize);
   llvm::SmallVector<unsigned, 8> genericParamCounts;
   llvm::SmallVector<const void *, 8> allGenericArgs;
 
-  auto result = _gatherGenericParameters(context, fixedGenericArgs,
+  auto result = _gatherGenericParameters(context, genericArgsRef,
                                          /* parent */ nullptr,
                                          genericParamCounts, allGenericArgs,
                                          demangler);

--- a/test/Runtime/check_create_type.swift
+++ b/test/Runtime/check_create_type.swift
@@ -1,0 +1,128 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// REQUIRES: executable_test
+
+// UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+
+let testSuite = TestSuite("CheckedCreateType")
+
+struct Variadic<each T> {
+  struct Nested<U, each V: Equatable> {}
+}
+
+@_silgen_name("_swift_checkedCreateType")
+func _checkedCreateType(
+  _ descriptor: UnsafeRawPointer,
+  _ genericArgs: UnsafeRawPointer,
+  _ genericArgsSize: UInt,
+  _ packCounts: UnsafeRawPointer?,
+  _ packCountsSize: UInt
+) -> Any.Type?
+
+func metaPointer(_ x: Any.Type) -> UnsafeRawPointer {
+  unsafeBitCast(x, to: UnsafeRawPointer.self)
+}
+
+testSuite.test("_swift_checkedCreateType non-variadic") {
+  let dictMeta = unsafeBitCast(
+    [Int: Int].self as Any.Type,
+    to: UnsafeRawPointer.self
+  )
+  let dictDesc = dictMeta.load(
+    fromByteOffset: MemoryLayout<Int>.size,
+    as: UnsafeRawPointer.self
+  )
+
+  let dictGenericArgs: [Any.Type] = [String.self, Double.self]
+
+  dictGenericArgs.withUnsafeBufferPointer {
+    let newDict = _checkedCreateType(
+      dictDesc,
+      UnsafeRawPointer($0.baseAddress!),
+      UInt($0.count),
+      nil,
+      0
+    )
+
+    expectTrue(newDict == [String: Double].self)
+  }
+}
+
+testSuite.test("_swift_checkedCreateType variadic") {
+  let variMeta = unsafeBitCast(
+    Variadic< >.self as Any.Type,
+    to: UnsafeRawPointer.self
+  )
+  let variDesc = variMeta.load(
+    fromByteOffset: MemoryLayout<Int>.size,
+    as: UnsafeRawPointer.self
+  )
+
+  let variPack: [Any.Type] = [Int.self, Int8.self, UInt8.self]
+  let variPackCounts: [Int32] = [3]
+
+  variPack.withUnsafeBufferPointer { pack in
+    let genericArgs = [UnsafeRawPointer(pack.baseAddress!)]
+
+    genericArgs.withUnsafeBufferPointer { genericArgs in
+      variPackCounts.withUnsafeBufferPointer { packCounts in
+        let newVari = _checkedCreateType(
+          variDesc,
+          UnsafeRawPointer(genericArgs.baseAddress!),
+          UInt(genericArgs.count),
+          UnsafeRawPointer(packCounts.baseAddress!),
+          UInt(packCounts.count)
+        )
+
+        expectTrue(newVari == Variadic<Int, Int8, UInt8>.self)
+      }
+    }
+  }
+}
+
+testSuite.test("_swift_checkedCreateType variadic nested with requirements") {
+  let nestedMeta = unsafeBitCast(
+    Variadic< >.Nested<()>.self as Any.Type,
+    to: UnsafeRawPointer.self
+  )
+  let nestedDesc = nestedMeta.load(
+    fromByteOffset: MemoryLayout<Int>.size,
+    as: UnsafeRawPointer.self
+  )
+
+  let variPack: [Any.Type] = [String.self, [Int].self, UInt64.self]
+
+  let nestedPack: [Any.Type] = [Int.self, Substring.self, Bool.self]
+
+  nestedPack.withUnsafeBufferPointer { nestedPack in
+    variPack.withUnsafeBufferPointer { variPack in
+      let nestedGenericArgs = [
+        UnsafeRawPointer(variPack.baseAddress!),
+        metaPointer(Int16.self),
+        UnsafeRawPointer(nestedPack.baseAddress!)
+      ]
+
+      nestedGenericArgs.withUnsafeBufferPointer { nestedGenericArgs in
+        // 3 for each T, -1 for U, and 3 for each V
+        let nestedPackCounts: [Int32] = [3, -1, 3]
+
+        nestedPackCounts.withUnsafeBufferPointer { nestedPackCounts in
+          let newNested = _checkedCreateType(
+            nestedDesc,
+            UnsafeRawPointer(nestedGenericArgs.baseAddress!),
+            UInt(nestedGenericArgs.count),
+            UnsafeRawPointer(nestedPackCounts.baseAddress!),
+            UInt(nestedPackCounts.count)
+          )
+
+          expectTrue(newNested == Variadic<String, [Int], UInt64>.Nested<Int16, Int, Substring, Bool>.self)
+        }
+      }
+    }
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
This adds a new SPI that takes a list of generic arguments and checks if said generic arguments are suitable to use as the generic arguments for the given type. If they are, gather all the extra arguments needed and fix up all of the pack pointers to call the metadata access function with these fixed up generic arguments.