### PR TITLE
[Sema] Some more cleanup now that we migrated all of code completion to solver-based

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -74,9 +74,8 @@ class SyntacticElementTarget;
 // so they could be made friends of ConstraintSystem.
 namespace TypeChecker {
 
-llvm::Optional<BraceStmt *> applyResultBuilderBodyTransform(
-    FuncDecl *func, Type builderType,
-    bool ClosuresInResultBuilderDontParticipateInInference);
+llvm::Optional<BraceStmt *> applyResultBuilderBodyTransform(FuncDecl *func,
+                                                            Type builderType);
 
 llvm::Optional<constraints::SyntacticElementTarget>
 typeCheckExpression(constraints::SyntacticElementTarget &target,
@@ -1815,12 +1814,6 @@ enum class ConstraintSystemFlags {
 
   /// Disable macro expansions.
   DisableMacroExpansions = 0x100,
-
-  /// Non solver-based code completion expects that closures inside result
-  /// builders don't participate in inference.
-  /// Once all code completion kinds are migrated to solver-based we should be
-  /// able to remove this flag.
-  ClosuresInResultBuildersDontParticipateInInference = 0x200,
 };
 
 /// Options that affect the constraint system as a whole.
@@ -2877,9 +2870,8 @@ private:
 
   // FIXME: Perhaps these belong on ConstraintSystem itself.
   friend llvm::Optional<BraceStmt *>
-  swift::TypeChecker::applyResultBuilderBodyTransform(
-      FuncDecl *func, Type builderType,
-      bool ClosuresInResultBuilderDontParticipateInInference);
+  swift::TypeChecker::applyResultBuilderBodyTransform(FuncDecl *func,
+                                                      Type builderType);
 
   friend llvm::Optional<SyntacticElementTarget>
   swift::TypeChecker::typeCheckExpression(

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -912,9 +912,8 @@ private:
 
 } // end anonymous namespace
 
-llvm::Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
-    FuncDecl *func, Type builderType,
-    bool ClosuresInResultBuilderDontParticipateInInference) {
+llvm::Optional<BraceStmt *>
+TypeChecker::applyResultBuilderBodyTransform(FuncDecl *func, Type builderType) {
   // Pre-check the body: pre-check any expressions in it and look
   // for return statements.
   //
@@ -970,10 +969,6 @@ llvm::Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
   }
 
   ConstraintSystemOptions options = ConstraintSystemFlags::AllowFixes;
-  if (ClosuresInResultBuilderDontParticipateInInference) {
-    options |= ConstraintSystemFlags::
-        ClosuresInResultBuildersDontParticipateInInference;
-  }
   auto resultInterfaceTy = func->getResultInterfaceType();
   auto resultContextType = func->mapTypeIntoContext(resultInterfaceTy);
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1008,7 +1008,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // problems with restating requirements in protocols.
     identical = false;
 
-    if (cs.Context.CompletionCallback) {
+    if (cs.isForCodeCompletion()) {
       // Don't rank based on overload choices of function calls that contain the
       // code completion token.
       ASTNode anchor = simplifyLocatorToAnchor(overload.locator);

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -945,7 +945,7 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
 
       if (Solutions.size() == 1) {
         auto score = Solutions.front().getFixedScore();
-        if (score.Data[SK_Fix] > 0 && !CS.getASTContext().CompletionCallback)
+        if (score.Data[SK_Fix] > 0 && !CS.isForCodeCompletion())
           Producer.markExhausted();
       }
     } else if (Solutions.size() != 1) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7320,15 +7320,7 @@ bool ConstraintSystem::participatesInInference(ClosureExpr *closure) const {
   if (closure->hasEmptyBody())
     return false;
 
-  // If body is nested in a parent that has a function builder applied,
-  // let's prevent inference until result builders.
-  if (Options.contains(
-          ConstraintSystemFlags::
-              ClosuresInResultBuildersDontParticipateInInference)) {
-    return !isInResultBuilderContext(closure);
-  } else {
-    return true;
-  }
+  return true;
 }
 
 TypeVarBindingProducer::TypeVarBindingProducer(BindingSet &bindings)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7311,9 +7311,6 @@ bool ConstraintSystem::participatesInInference(ClosureExpr *closure) const {
   if (getAppliedResultBuilderTransform(closure))
     return true;
 
-  if (closure->hasSingleExpressionBody())
-    return true;
-
   if (Options.contains(ConstraintSystemFlags::LeaveClosureBodyUnchecked))
     return false;
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2629,31 +2629,14 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
     }
   }
 
-  // The enclosing closure might be a single expression closure or a function
-  // builder closure. In such cases, the body elements are type checked with
-  // the closure itself. So we need to try type checking the enclosing closure
-  // signature first unless it has already been type checked.
+  // If the context is a closure, type check the entire surrounding closure.
+  // Conjunction constraints ensure that statements unrelated to the one that
+  // contains the code completion token are not type checked.
   if (auto CE = dyn_cast<ClosureExpr>(DC)) {
     if (CE->getBodyState() == ClosureExpr::BodyState::Parsed) {
       swift::typeCheckASTNodeAtLoc(
           TypeCheckASTNodeAtLocContext::declContext(CE->getParent()),
           CE->getLoc());
-      // We need the actor isolation of the closure to be set so that we can
-      // annotate results that are on the same global actor.
-      // Since we are evaluating TypeCheckASTNodeAtLocRequest for every closure
-      // from outermost to innermost, we don't want to call checkActorIsolation,
-      // because that would cause actor isolation to be checked multiple times
-      // for nested closures. Instead, call determineClosureActorIsolation
-      // directly and set the closure's actor isolation manually. We can
-      // guarantee of that the actor isolation of enclosing closures have their
-      // isolation checked before nested ones are being checked by the way
-      // TypeCheckASTNodeAtLocRequest is called multiple times, as described
-      // above.
-      auto ActorIsolation = determineClosureActorIsolation(
-          CE, __Expr_getType, __AbstractClosureExpr_getActorIsolation);
-      CE->setActorIsolation(ActorIsolation);
-      // Type checking the parent closure also type checked this node.
-      // Nothing to do anymore.
       return false;
     }
   }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2605,11 +2605,8 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
   if (auto *func = dyn_cast<FuncDecl>(DC)) {
     if (Type builderType = getResultBuilderType(func)) {
       if (func->getBody()) {
-        auto optBody = TypeChecker::applyResultBuilderBodyTransform(
-            func, builderType,
-            /*ClosuresInResultBuilderDontParticipateInInference=*/
-            ctx.CompletionCallback == nullptr &&
-                ctx.SolutionCallback == nullptr);
+        auto optBody =
+            TypeChecker::applyResultBuilderBodyTransform(func, builderType);
         if ((ctx.CompletionCallback && ctx.CompletionCallback->gotCallback()) ||
             (ctx.SolutionCallback && ctx.SolutionCallback->gotCallback())) {
           // We already informed the completion callback of solutions found by

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -459,9 +459,8 @@ void typeCheckASTNode(ASTNode &node, DeclContext *DC,
 /// e.g., because of a \c return statement. Otherwise, returns either the
 /// fully type-checked body of the function (on success) or a \c nullptr
 /// value if an error occurred while type checking the transformed body.
-llvm::Optional<BraceStmt *> applyResultBuilderBodyTransform(
-    FuncDecl *func, Type builderType,
-    bool ClosuresInResultBuilderDontParticipateInInference = false);
+llvm::Optional<BraceStmt *> applyResultBuilderBodyTransform(FuncDecl *func,
+                                                            Type builderType);
 
 /// Find the return statements within the body of the given function.
 std::vector<ReturnStmt *> findReturnStatements(AnyFunctionRef fn);


### PR DESCRIPTION
- Delete the `ClosuresInResultBuilderDontParticipateInInference` flag from the constraint system
- Don’t set actor isolation in `TypeCheckASTNodeAtLocRequest`
- Check `cs.isForCodeCompletion()` instead of checking for presence of `CompletionCallback`