### PR TITLE
[swift-syntax] Don’t pass `--filecheck-exec` to swift-syntax’s build script

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -116,13 +116,7 @@ class SwiftSyntax(product.Product):
         llvm_build_dir = os.path.realpath(llvm_build_dir)
 
         self.run_swiftsyntax_build_script(target=host_target,
-                                          command='test',
-                                          additional_params=[
-                                              '--filecheck-exec',
-                                              os.path.join(llvm_build_dir,
-                                                           'bin',
-                                                           'FileCheck')
-                                          ])
+                                          command='test')
 
     def should_install(self, host_target):
         return self.args.install_swiftsyntax


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/2160

---

swift-syntax no longer has lit tests, so the `--filecheck-exec` parameter isn’t needed anymore.
