### PR TITLE
build: fix the build of the toolchain

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -269,7 +269,8 @@ function(add_pure_swift_host_tool name)
 
   # Option handling
   set(options)
-  set(single_parameter_options)
+  set(single_parameter_options
+    SWIFT_COMPONENT)
   set(multiple_parameter_options
         DEPENDENCIES
         SWIFT_DEPENDENCIES)
@@ -341,6 +342,18 @@ function(add_pure_swift_host_tool name)
       COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/${name}.swiftmodule"
       COMMAND_EXPAND_LISTS
       COMMENT "Update mtime of executable outputs workaround")
-  # Export this target.
-  set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
+
+  if(NOT APSHT_SWIFT_COMPONENT STREQUAL no_component)
+    add_dependencies(${APSHT_SWIFT_COMPONENT} ${name})
+    swift_install_in_component(TARGETS ${name}
+      COMPONENT ${APSHT_SWIFT_COMPONENT}
+      RUNTIME DESTINATION bin)
+    swift_is_installing_component(${APSHT_SWIFT_COMPONENT} is_installing)
+  endif()
+
+  if(NOT is_installing)
+    set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
+  else()
+    set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
+  endif()
 endfunction()

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -16,6 +16,8 @@ if (SWIFT_SWIFT_PARSER)
     DEPENDENCIES
       swiftDemangling
       $<TARGET_OBJECTS:_swiftCSwiftPluginServer>
+    SWIFT_COMPONENT
+      compiler
     SWIFT_DEPENDENCIES
       SwiftSyntax::SwiftSyntaxMacros
       SwiftSyntax::SwiftSyntaxMacroExpansion
@@ -24,10 +26,5 @@ if (SWIFT_SWIFT_PARSER)
   )
   target_include_directories(swift-plugin-server PRIVATE
     Sources/CSwiftPluginServer/include
-  )
-  swift_install_in_component(TARGETS swift-plugin-server
-    RUNTIME
-      DESTINATION bin
-      COMPONENT compiler
   )
 endif()


### PR DESCRIPTION
This wires up the new macro properly into the build machinery to ensure that the `distribution` target properly builds and installs the dependencies.  This fixes the missing `swift-plugin-server` on Windows.
