### PR TITLE
[AST] Make an availability helper to better determine when a feature is available

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -990,6 +990,13 @@ public:
   /// target triple.
   bool supportsVersionedAvailability() const;
 
+  /// Check's if our current availability context is contained within the given
+  /// feature's availability context. Prefer using this over the isContainedIn
+  /// function on availability context because this also checks if 1. we're
+  /// compiling the standard library (who has access to everything) and 2. if
+  /// we've disabled availability checking.
+  bool isAvailabilityAvailable(AvailabilityContext featureAvailability) const;
+
   //===--------------------------------------------------------------------===//
   // Diagnostics Helper functions
   //===--------------------------------------------------------------------===//

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -1031,6 +1031,11 @@ public:
   /// \returns true if this module is the "swift" standard library module.
   bool isStdlibModule() const;
 
+  /// Returns true if this module is any of the standard modules part of the
+  /// Swift toolchain. This includes "Swift", "_Concurrency",
+  /// "_StringProcessing", etc.
+  bool isSomeStdlibModule() const;
+
   /// \returns true if this module has standard substitutions for mangling.
   bool hasStandardSubstitutions() const;
 

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -32,6 +32,12 @@ constexpr static const StringLiteral SWIFT_DISTRIBUTED_NAME = "Distributed";
 constexpr static const StringLiteral SWIFT_STRING_PROCESSING_NAME = "_StringProcessing";
 /// The name of the Backtracing module, which supports that extension.
 constexpr static const StringLiteral SWIFT_BACKTRACING_NAME = "_Backtracing";
+/// The name of the _RegexParser module.
+constexpr static const StringLiteral SWIFT_REGEX_PARSER_NAME = "_RegexParser";
+/// The name of the RegexBuilder module.
+constexpr static const StringLiteral SWIFT_REGEX_BUILDER_NAME = "RegexBuilder";
+/// The name of the Observation module.
+constexpr static const StringLiteral SWIFT_OBSERVATION_NAME = "Observation";
 /// The name of the SwiftShims module, which contains private stdlib decls.
 constexpr static const StringLiteral SWIFT_SHIMS_NAME = "SwiftShims";
 /// The name of the CxxShim module, which contains a cxx casting utility.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -787,6 +787,22 @@ bool ASTContext::supportsVersionedAvailability() const {
   return minimumAvailableOSVersionForTriple(LangOpts.Target).has_value();
 }
 
+bool ASTContext::isAvailabilityAvailable(
+                                AvailabilityContext featureAvailability) const {
+  // Any of the modules that are part of the Swift toolchain always have access
+  // to the latest and greatest.
+  if (MainModule->isSomeStdlibModule()) {
+    return true;
+  }
+
+  if (LangOpts.DisableAvailabilityChecking) {
+    return true;
+  }
+
+  return AvailabilityContext::forDeploymentTarget(*const_cast<ASTContext *>(this))
+      .isContainedIn(featureAvailability);
+}
+
 // FIXME: Rename abstractSyntaxDeclForAvailableAttribute since it's useful
 // for more attributes than `@available`.
 const Decl *

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2425,6 +2425,19 @@ bool ModuleDecl::isStdlibModule() const {
   return !getParent() && getName() == getASTContext().StdlibModuleName;
 }
 
+bool ModuleDecl::isSomeStdlibModule() const {
+  return !getParent && (
+    getName() == getASTContext().StdlibModuleName ||
+    getName() == getASTContext().Id_Concurrency ||
+    getName().str() == SWIFT_ONONE_SUPPORT ||
+    getName().str() == SWIFT_DISTRIBUTED_NAME ||
+    getName().str() == SWIFT_REGEX_PARSER_NAME ||
+    getName().str() == SWIFT_STRING_PROCESSING_NAME ||
+    getName().str() == SWIFT_REGEX_BUILDER_NAME ||
+    getName().str() == SWIFT_BACKTRACING_NAME ||
+    getName().str() == SWIFT_OBSERVATION_NAME);
+}
+
 bool ModuleDecl::hasStandardSubstitutions() const {
   return !getParent() &&
       (getName() == getASTContext().StdlibModuleName ||

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -461,7 +461,7 @@ getAddressOfOpaqueTypeDescriptor(IRGenFunction &IGF,
 MetadataResponse irgen::emitOpaqueTypeMetadataRef(IRGenFunction &IGF,
                                           CanOpaqueTypeArchetypeType archetype,
                                           DynamicMetadataRequest request) {
-  bool signedDescriptor = IGF.IGM.getAvailabilityContext().isContainedIn(
+  bool signedDescriptor = IGF.IGM.Context.isAvailabilityAvailable(
     IGF.IGM.Context.getSignedDescriptorAvailability());
 
   auto accessorFn = signedDescriptor ?
@@ -504,7 +504,7 @@ MetadataResponse irgen::emitOpaqueTypeMetadataRef(IRGenFunction &IGF,
 llvm::Value *irgen::emitOpaqueTypeWitnessTableRef(IRGenFunction &IGF,
                                           CanOpaqueTypeArchetypeType archetype,
                                           ProtocolDecl *protocol) {
-  bool signedDescriptor = IGF.IGM.getAvailabilityContext().isContainedIn(
+  bool signedDescriptor = IGF.IGM.Context.isAvailabilityAvailable(
     IGF.IGM.Context.getSignedDescriptorAvailability());
 
   auto accessorFn = signedDescriptor ?

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2745,9 +2745,7 @@ llvm::Constant *irgen::emitObjCProtocolData(IRGenModule &IGM,
   // The linker on older deployment targets does not gracefully handle the
   // situation when both an objective c object and a swift object define the
   // protocol under the same symbol name.
-  auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(IGM.Context);
-  bool canUseClangEmission = deploymentAvailability.isContainedIn(
+  bool canUseClangEmission = IGM.Context.isAvailabilityAvailable(
     IGM.Context.getSwift58Availability());
 
   if (llvm::Triple(IGM.Module.getTargetTriple()).isOSDarwin() &&
@@ -2930,9 +2928,7 @@ IRGenModule::getClassMetadataStrategy(const ClassDecl *theClass) {
 
     // If the Objective-C runtime is new enough, we can just use the update
     // pattern unconditionally.
-    auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(Context);
-    if (deploymentAvailability.isContainedIn(
+    if (Context.isAvailabilityAvailable(
           Context.getObjCMetadataUpdateCallbackAvailability()))
       return ClassMetadataStrategy::Update;
 

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -236,9 +236,7 @@ llvm::Value *irgen::emitBuiltinStartAsyncLet(IRGenFunction &IGF,
   // space, so that we don't run into that bug. We leave a note on the
   // declaration so that coroutine splitting can pad out the final context
   // size after splitting.
-  auto deploymentAvailability
-    = AvailabilityContext::forDeploymentTarget(IGF.IGM.Context);
-  if (!deploymentAvailability.isContainedIn(
+  if (!IGF.IGM.Context.isAvailabilityAvailable(
                                    IGF.IGM.Context.getSwift57Availability()))
   {
     auto taskAsyncFunctionPointer

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1285,8 +1285,7 @@ FunctionPointer IRGenModule::getFixedClassInitializationFn() {
   if (ObjCInterop) {
     // In new enough ObjC runtimes, objc_opt_self provides a direct fast path
     // to realize a class.
-    if (getAvailabilityContext()
-         .isContainedIn(Context.getSwift51Availability())) {
+    if (Context.isAvailabilityAvailable(Context.getSwift51Availability())) {
       fn = getObjCOptSelfFunctionPointer();
     }
     // Otherwise, the Swift runtime always provides a `get
@@ -1367,7 +1366,7 @@ llvm::Value *IRGenFunction::emitLoadRefcountedPtr(Address addr,
 llvm::Value *IRGenFunction::
 emitIsUniqueCall(llvm::Value *value, ReferenceCounting style, SourceLoc loc, bool isNonNull) {
   FunctionPointer fn;
-  bool nonObjC = !IGM.getAvailabilityContext().isContainedIn(
+  bool nonObjC = !IGM.Context.isAvailabilityAvailable(
       IGM.Context.getObjCIsUniquelyReferencedAvailability());
   switch (style) {
   case ReferenceCounting::Native: {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3072,12 +3072,9 @@ static void emitInitializeRawLayout(IRGenFunction &IGF, SILType likeType,
   // If our deployment target doesn't contain the new swift_initRawStructMetadata,
   // emit a call to the swift_initStructMetadata tricking it into thinking
   // we have a single field.
-  auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(IGF.IGM.Context);
   auto initRawAvail = IGF.IGM.Context.getInitRawStructMetadataAvailability();
 
-  if (!IGF.IGM.Context.LangOpts.DisableAvailabilityChecking &&
-      !deploymentAvailability.isContainedIn(initRawAvail)) {
+  if (!IGF.IGM.Context.isAvailabilityAvailable(initRawAvail)) {
     emitInitializeRawLayoutOld(IGF, likeType, count, T, metadata, collector);
     return;
   }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1537,10 +1537,7 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
   // Whether the Objective-C runtime is guaranteed to invoke the class
   // metadata update callback when realizing a Swift class referenced from
   // Objective-C.
-  auto deploymentAvailability =
-    AvailabilityContext::forDeploymentTarget(IGM.Context);
-  bool supportsObjCMetadataUpdateCallback =
-    deploymentAvailability.isContainedIn(
+  bool supportsObjCMetadataUpdateCallback = IGM.Context.isAvailabilityAvailable(
         IGM.Context.getObjCMetadataUpdateCallbackAvailability());
 
   // If our deployment target allows us to rely on the metadata update

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -775,17 +775,9 @@ namespace RuntimeConstants {
     return RuntimeAvailability::AlwaysAvailable;
   }
 
-  bool
-  isDeploymentAvailabilityContainedIn(ASTContext &Context,
-                                      AvailabilityContext featureAvailability) {
-    auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(Context);
-    return deploymentAvailability.isContainedIn(featureAvailability);
-  }
-
   RuntimeAvailability OpaqueTypeAvailability(ASTContext &Context) {
     auto featureAvailability = Context.getOpaqueTypeAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -795,7 +787,7 @@ namespace RuntimeConstants {
   GetTypesInAbstractMetadataStateAvailability(ASTContext &context) {
     auto featureAvailability =
         context.getTypesInAbstractMetadataStateAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -803,7 +795,7 @@ namespace RuntimeConstants {
 
   RuntimeAvailability DynamicReplacementAvailability(ASTContext &Context) {
     auto featureAvailability = Context.getSwift51Availability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::AvailableByCompatibilityLibrary;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -813,7 +805,7 @@ namespace RuntimeConstants {
   CompareTypeContextDescriptorsAvailability(ASTContext &Context) {
     auto featureAvailability =
         Context.getCompareTypeContextDescriptorsAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -823,7 +815,7 @@ namespace RuntimeConstants {
   CompareProtocolConformanceDescriptorsAvailability(ASTContext &Context) {
     auto featureAvailability =
         Context.getCompareProtocolConformanceDescriptorsAvailability();
-    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -833,7 +825,7 @@ namespace RuntimeConstants {
   GetCanonicalSpecializedMetadataAvailability(ASTContext &context) {
     auto featureAvailability =
         context.getIntermodulePrespecializedGenericMetadataAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -843,7 +835,7 @@ namespace RuntimeConstants {
   GetCanonicalPrespecializedGenericMetadataAvailability(ASTContext &context) {
     auto featureAvailability =
         context.getPrespecializedGenericMetadataAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -851,7 +843,7 @@ namespace RuntimeConstants {
 
   RuntimeAvailability ConcurrencyAvailability(ASTContext &context) {
     auto featureAvailability = context.getConcurrencyAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -860,7 +852,7 @@ namespace RuntimeConstants {
   RuntimeAvailability ConcurrencyDiscardingTaskGroupAvailability(ASTContext &context) {
     auto featureAvailability =
         context.getConcurrencyDiscardingTaskGroupAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -868,7 +860,7 @@ namespace RuntimeConstants {
 
   RuntimeAvailability DifferentiationAvailability(ASTContext &context) {
     auto featureAvailability = context.getDifferentiationAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -877,7 +869,7 @@ namespace RuntimeConstants {
   RuntimeAvailability
   MultiPayloadEnumTagSinglePayloadAvailability(ASTContext &context) {
     auto featureAvailability = context.getMultiPayloadEnumTagSinglePayload();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -887,7 +879,7 @@ namespace RuntimeConstants {
   ObjCIsUniquelyReferencedAvailability(ASTContext &context) {
     auto featureAvailability =
         context.getObjCIsUniquelyReferencedAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -896,7 +888,7 @@ namespace RuntimeConstants {
   RuntimeAvailability SignedConformsToProtocolAvailability(ASTContext &context) {
     auto featureAvailability =
         context.getSignedConformsToProtocolAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -905,7 +897,7 @@ namespace RuntimeConstants {
   RuntimeAvailability SignedDescriptorAvailability(ASTContext &context) {
     auto featureAvailability =
         context.getSignedDescriptorAvailability();
-    if (!isDeploymentAvailabilityContainedIn(context, featureAvailability)) {
+    if (!Context.isAvailabilityAvailable(featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }
     return RuntimeAvailability::AlwaysAvailable;
@@ -1324,8 +1316,7 @@ void IRGenerator::addBackDeployedObjCActorInitialization(ClassDecl *ClassDecl) {
 
   // If we are not back-deploying concurrency, there's nothing to do.
   ASTContext &ctx = ClassDecl->getASTContext();
-  auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(ctx);
-  if (deploymentAvailability.isContainedIn(ctx.getConcurrencyAvailability()))
+  if (ctx.isAvailabilityAvailable(ctx.getConcurrencyAvailability()))
     return;
 
   ObjCActorsNeedingSuperclassSwizzle.push_back(ClassDecl);
@@ -1920,10 +1911,8 @@ bool IRGenModule::shouldPrespecializeGenericMetadata() {
     return IRGen.Opts.PrespecializeGenericMetadata;
   }
   auto &context = getSwiftModule()->getASTContext();
-  auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(context);
   return IRGen.Opts.PrespecializeGenericMetadata &&
-         deploymentAvailability.isContainedIn(
+         context.isAvailabilityAvailable(
              context.getPrespecializedGenericMetadataAvailability()) &&
          canPrespecializeTarget;
 }
@@ -1944,7 +1933,7 @@ bool IRGenModule::canMakeStaticObjectsReadOnly() {
   if (!Triple.isOSDarwin())
     return false;
 
-  return getAvailabilityContext().isContainedIn(
+  return Context.isAvailabilityAvailable(
           Context.getImmortalRefCountSymbolsAvailability());
 #endif
 }
@@ -2061,9 +2050,7 @@ void IRGenModule::emitSwiftAsyncExtendedFrameInfoWeakRef() {
 
 bool IRGenModule::isConcurrencyAvailable() {
   auto &ctx = getSwiftModule()->getASTContext();
-  auto deploymentAvailability =
-    AvailabilityContext::forDeploymentTarget(ctx);
-  return deploymentAvailability.isContainedIn(ctx.getConcurrencyAvailability());
+  return ctx.isAvailabilityAvailable(ctx.getConcurrencyAvailability());
 }
 
 /// Pretend the other files that drivers/build systems expect exist by

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1313,9 +1313,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
         .isWeakImported(module);
   case Kind::KnownAsyncFunctionPointer:
     auto &context = module->getASTContext();
-    auto deploymentAvailability =
-        AvailabilityContext::forDeploymentTarget(context);
-    return !deploymentAvailability.isContainedIn(
+    return !context.isAvailabilityAvailable(
         context.getConcurrencyAvailability());
   }
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3022,9 +3022,7 @@ static bool canIssueIncompleteMetadataRequests(IRGenModule &IGM) {
   // We can only answer blocking complete metadata requests with the <=5.1
   // runtime ABI entry points.
   auto &context = IGM.getSwiftModule()->getASTContext();
-  auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(context);
-  return deploymentAvailability.isContainedIn(
+  return context.isAvailabilityAvailable(
       context.getTypesInAbstractMetadataStateAvailability());
 }
 
@@ -3176,7 +3174,7 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
     stringAddr = subIGF.Builder.CreateIntToPtr(stringAddr, IGM.Int8PtrTy);
 
     llvm::CallInst *call;
-    bool signedDescriptor = IGM.getAvailabilityContext().isContainedIn(
+    bool signedDescriptor = IGM.Context.isAvailabilityAvailable(
       IGM.Context.getSignedDescriptorAvailability());
     if (request.isStaticallyAbstract()) {
       call = signedDescriptor ?

--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -189,10 +189,9 @@ bool SILGenModule::requiresBackDeploymentThunk(ValueDecl *decl,
   // Use of a back deployment thunk is unnecessary if the deployment target is
   // high enough that the ABI implementation of the back deployed declaration is
   // guaranteed to be available.
-  auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(ctx);
   auto declAvailability =
       AvailabilityContext(VersionRange::allGTE(*backDeployBeforeVersion));
-  if (deploymentAvailability.isContainedIn(declAvailability))
+  if (ctx.isAvailabilityAvailable(declAvailability))
     return false;
 
   return true;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1735,8 +1735,7 @@ shouldReplaceCallByContiguousArrayStorageAnyObject(SILFunction &F,
 
   // On SwiftStdlib 5.7 we can replace the call.
   auto &ctxt = storageMetaTy->getASTContext();
-  auto deployment = AvailabilityContext::forDeploymentTarget(ctxt);
-  if (!deployment.isContainedIn(ctxt.getSwift57Availability()))
+  if (!ctx.isAvailabilityAvailable(ctxt.getSwift57Availability()))
     return llvm::None;
 
   auto genericArgs = boundGenericTy->getGenericArgs();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2596,8 +2596,7 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
   }
 
   if (!mainFunction) {
-    const bool hasAsyncSupport =
-        AvailabilityContext::forDeploymentTarget(context).isContainedIn(
+    const bool hasAsyncSupport = context.isAvailabilityAvailable(
             context.getBackDeployedConcurrencyAvailability());
     context.Diags.diagnose(attr->getLocation(),
                            diag::attr_MainType_without_main,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6264,10 +6264,7 @@ static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl) {
   // If the class does not have a custom @objc name and the deployment target
   // supports the objc_getClass() hook, the workaround is unnecessary.
   ASTContext &ctx = classDecl->getASTContext();
-  auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(ctx);
-  if (deploymentAvailability.isContainedIn(
-        ctx.getObjCGetClassHookAvailability()) &&
+  if (ctx.isAvailabilityAvailable(ctx.getObjCGetClassHookAvailability()) &&
       !hasExplicitObjCName(classDecl))
     return;
 


### PR DESCRIPTION
A lot of times when we're generating code in IRGen we just check that the current deployment target is contained in the feature's availability. This is fine, except for two cases 1. we've explicitly disabled availability via `-disable-availability-checking` and 2. we're building the standard library. The standard library, for a number of unfortunate reasons, does not share the deployment target of the latest and greatest. Instead, it is many versions behind and a consequence of this is that new runtime features, for example `swift_getTypeByMangledNameInContext2` which now take ptrauth signed function arguments or `swift_initRawStructMetadata`, are not being utilized within any of the standard library modules. Make a helper function that checks if we're compiling any of these standard modules or if we've disabled availability and fall back to asking our deployment target if it has the feature availability and use it mostly everywhere we do these sort of queries.