### PR TITLE
[SE-0407] [Macros] Provide member macros with information about "missing" conformances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 _**Note:** This is in reverse chronological order, so newer entries are added to the top._
 
+## Swift 5.9.2
+
+* [SE-0407][]:
+
+  Member macros can specify a list of protocols via the `conformances` argument to the macro role. The macro implementation will be provided with those protocols that are listed but have not already been implemented by the type to which the member macro is attached, in the same manner as extension macros.
+
+   ```swift
+   @attached(member, conformances: Decodable, Encodable, names: named(init(from:), encode(to:)))
+@attached(extension, conformances: Decodable, Encodable, names: named(init(from:), encode(to:)))
+macro Codable() = #externalMacro(module: "MyMacros", type: "CodableMacro")
+   ```
+
 ## Swift 5.9
 
 * [SE-0382][], [SE-0389][], [SE-0394][], [SE-0397][]:
@@ -9830,6 +9842,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 [SE-0389]: https://github.com/apple/swift-evolution/blob/main/proposals/0389-attached-macros.md
 [SE-0394]: https://github.com/apple/swift-evolution/blob/main/proposals/0394-swiftpm-expression-macros.md
 [SE-0397]: https://github.com/apple/swift-evolution/blob/main/proposals/0397-freestanding-declaration-macros.md
+[SE-0407]: https://github.com/apple/swift-evolution/blob/main/proposals/0407-member-macro-conformances.md
 [#64927]: <https://github.com/apple/swift/issues/64927>
 [#42697]: <https://github.com/apple/swift/issues/42697>
 [#42728]: <https://github.com/apple/swift/issues/42728>

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8621,6 +8621,7 @@ public:
   /// be added if this macro does not contain an extension role.
   void getIntroducedConformances(
       NominalTypeDecl *attachedTo,
+      MacroRole role,
       SmallVectorImpl<ProtocolDecl *> &conformances) const;
 
   /// Returns a DeclName that represents arbitrary names.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3337,10 +3337,10 @@ public:
   void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
-/// Returns the resolved constraint types that an extension macro
-/// adds conformances to.
-class ResolveExtensionMacroConformances
-    : public SimpleRequest<ResolveExtensionMacroConformances,
+/// Returns the resolved constraint types that a macro references conformances
+/// to.
+class ResolveMacroConformances
+    : public SimpleRequest<ResolveMacroConformances,
                            ArrayRef<Type>(const MacroRoleAttr *, const Decl *),
                            RequestFlags::Cached> {
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -360,7 +360,7 @@ SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
 SWIFT_REQUEST(TypeChecker, ResolveMacroRequest,
               ConcreteDeclRef(UnresolvedMacroReference, const Decl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, ResolveExtensionMacroConformances,
+SWIFT_REQUEST(TypeChecker, ResolveMacroConformances,
               ArrayRef<Type>(const MacroRoleAttr *, const Decl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeEraserTypeRequest,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1387,7 +1387,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     // Print conformances, if present.
     auto conformances = evaluateOrDefault(
         D->getASTContext().evaluator,
-        ResolveExtensionMacroConformances{Attr, D},
+        ResolveMacroConformances{Attr, D},
         {});
     if (!conformances.empty()) {
       Printer << ", conformances: ";

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -503,7 +503,8 @@ void ConformanceLookupTable::addMacroGeneratedProtocols(
       MacroRole::Extension,
       [&](CustomAttr *attr, MacroDecl *macro) {
         SmallVector<ProtocolDecl *, 2> conformances;
-        macro->getIntroducedConformances(nominal, conformances);
+        macro->getIntroducedConformances(
+            nominal, MacroRole::Extension, conformances);
 
         for (auto *protocol : conformances) {
           addProtocol(protocol, attr->getLocation(), source);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10826,15 +10826,16 @@ void MacroDecl::getIntroducedNames(MacroRole role, ValueDecl *attachedTo,
 
 void MacroDecl::getIntroducedConformances(
     NominalTypeDecl *attachedTo,
+    MacroRole role,
     SmallVectorImpl<ProtocolDecl *> &conformances) const {
-  auto *attr = getMacroRoleAttr(MacroRole::Extension);
+  auto *attr = getMacroRoleAttr(role);
   if (!attr)
     return;
 
   auto &ctx = getASTContext();
   auto constraintTypes = evaluateOrDefault(
       ctx.evaluator,
-      ResolveExtensionMacroConformances{attr, this},
+      ResolveMacroConformances{attr, this},
       {});
 
   for (auto constraint : constraintTypes) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7151,7 +7151,7 @@ void AttributeChecker::visitMacroRoleAttr(MacroRoleAttr *attr) {
 
   (void)evaluateOrDefault(
       Ctx.evaluator,
-      ResolveExtensionMacroConformances{attr, D},
+      ResolveMacroConformances{attr, D},
       {});
 }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2018,3 +2018,53 @@ public struct InitWithProjectedValueWrapperMacro: PeerMacro {
     ]
   }
 }
+
+public struct RequiredDefaultInitMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    if protocols.isEmpty {
+      return []
+    }
+
+    let decl: DeclSyntax =
+      """
+      extension \(type.trimmed): DefaultInit {
+      }
+
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
+extension RequiredDefaultInitMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    fatalError("old swift-syntax")
+  }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let decl: DeclSyntax
+    if declaration.is(ClassDeclSyntax.self) && protocols.isEmpty {
+      decl = "required init() { }"
+    } else {
+      decl = "init() { }"
+    }
+    return [ decl ]
+  }
+}

--- a/test/Macros/macro_expand_member_with_conformances.swift
+++ b/test/Macros/macro_expand_member_with_conformances.swift
@@ -1,0 +1,22 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ExtensionMacros -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5 -I %t
+protocol DefaultInit {
+  init()
+}
+
+@attached(extension, conformances: DefaultInit)
+@attached(member, conformances: DefaultInit, names: named(init()))
+macro DefaultInit() = #externalMacro(module: "MacroDefinition", type: "RequiredDefaultInitMacro")
+
+@DefaultInit
+class C { }
+
+@DefaultInit
+class D: C { }
+
+@DefaultInit
+struct E { }


### PR DESCRIPTION
Provide member macros with similar information about conformances to what extension macros receive, allowing member macros to document which conformances they care about (e.g., Decodable) and then receiving the list of conformances that aren't already available for the type in question. For example, a macro such as

    @attached(member, conformances: Decodable, Encodable, names: named(init(from:), encode(to:)))
    macro Codable() = ...

Expanded on a type that is not already Decodable/Encodable would be provided with Decodable and Encodable (via the new `missingConformancesTo:` argument to the macro implementation) when the type itself does not conform to those types.

Member macros still cannot produce conformances, so this is likely to be used in conjunction with extension macros most of the time. The extension macro declares the conformance, and can also declare any members that shouldn't be part of the primary type definition---such as initializers that shouldn't suppress the memberwise initializer. On the other hand, the member macro will need to define any members that must be in the primary definition, such as required initializers, members that must be overridable by subclasses, and stored properties.

Codable synthesis is an example that benefits from member macros with conformances, because for classes it wants to introduce a required initializer for decoding and an overridable encode operation, and these must be members of the nominal type itself. Specifically, the `Codable` macro above is likely to have two attached member roles:

    @attached(member, conformances: Decodable, Encodable, names: named(init(from:), encode(to:)))
    @attached(extension, conformances: Decodable, Encodable, names: named(init(from:), encode(to:)))
    macro Codable() = ...

where the "extension" role is responsible for defining the conformance (always), and the "member" creates the appropriate members for classes (`init` vs. `required init`).

Tracked by rdar://112532829. Cherry-picked from https://github.com/apple/swift/pull/67758
