### PR TITLE
swift_build_support: fix `shell.run` bytes printing

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -242,7 +242,7 @@ def run(*args, **kwargs):
         _echo_command(dry_run, *args, env=env, prompt="{0}+ ".format(prefix))
         if output:
             for line in output.splitlines():
-                print("{0}{1}".format(prefix, line))
+                print("{0}{1}".format(prefix, line.decode('utf-8')))
         sys.stdout.flush()
         sys.stderr.flush()
     if lock:

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -242,7 +242,7 @@ def run(*args, **kwargs):
         _echo_command(dry_run, *args, env=env, prompt="{0}+ ".format(prefix))
         if output:
             for line in output.splitlines():
-                print("{0}{1}".format(prefix, line.decode('utf-8')))
+                print("{0}{1}".format(prefix, line.decode('utf-8', errors='replace')))
         sys.stdout.flush()
         sys.stderr.flush()
     if lock:


### PR DESCRIPTION
`output.splitlines()` returns a value of `bytes` type, not `str`, which leads to `b` prefixed to it when printing.

This led to broken output when running `update-checkout`. Before:

```
[swiftpm]                               b"Already on 'main'"
```

After:

```
[swiftpm]                               Already on 'main'
```
