### PR TITLE
stdlib: mark the modules as `extern_c`

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-module ucrt [system] {
+module ucrt [system] [extern_c] {
   module C {
     module complex {
       /* disallow the header in C++ mode as it forwards to `ccomplex`.  */
@@ -161,7 +161,7 @@ module ucrt [system] {
   }
 }
 
-module corecrt [system] {
+module corecrt [system] [extern_c] {
   use vcruntime
 
   header "corecrt.h"

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -84,7 +84,7 @@ module _visualc_intrinsics [system] [extern_c] {
   }
 }
 
-module SAL [system] {
+module SAL [system] [extern_c] {
   header "sal.h"
   export *
 
@@ -94,7 +94,7 @@ module SAL [system] {
   }
 }
 
-module vcruntime [system] {
+module vcruntime [system] [extern_c] {
   use SAL
   export SAL
 
@@ -111,7 +111,7 @@ module vcruntime [system] {
   }
 }
 
-module std_config [system] {
+module std_config [system] [extern_c] {
   header "crtdefs.h"
   header "crtversion.h"
   export *

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-module WinSDK [system] {
+module WinSDK [system] [extern_c] {
   module WinSock2 {
     header "WinSock2.h"
     header "WS2tcpip.h"
@@ -166,74 +166,6 @@ module WinSDK [system] {
 
       link "ComDlg32.Lib"
     }
-  }
-
-  explicit module DirectX {
-    module Direct3D11 {
-      header "d3d11.h"
-      header "d3d11_1.h"
-      header "d3d11_2.h"
-      header "d3d11_3.h"
-      header "d3d11_4.h"
-      export *
-
-      link "d3d11.lib"
-      link "dxgi.lib"
-    }
-
-    module Direct3D12 {
-      header "d3d12.h"
-      export *
-
-      link "d3d12.lib"
-      link "dxgi.lib"
-    }
-
-    // FIXME(compnerd) DXGI is part of the Direct3D interfaces currently; we
-    // should split it out, but because it is part of the D3D11 interfaces, this
-    // separate module is meant to augment the uncovered portions only.
-    module _DXGI {
-      header "../shared/dxgi1_6.h"
-      header "dxgidebug.h"
-      export *
-
-      link "dxgi.lib"
-    }
-
-    module D3DCompiler {
-      header "d3dcompiler.h"
-      export *
-
-      link "d3dcompiler.lib"
-    }
-
-    module XAudio29 {
-      header "xaudio2.h"
-      header "xaudio2fx.h"
-      export *
-
-      link "xaudio2.lib"
-
-      requires cplusplus
-    }
-
-    // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was
-    // part of Vista.
-    module XInput14 {
-      header "Xinput.h"
-      export *
-
-      link "xinput.lib"
-    }
-    
-    module DirectInput8 {
-      header "dinput.h"
-      export *
-
-      link "dinput.lib"
-    }
-
-    link "dxguid.lib"
   }
 
   // FIXME(compnerd) this is a hack for the HWND typedef for DbgHelp
@@ -495,6 +427,7 @@ module WinSDK [system] {
   }
 
   module WinNT {
+    requires core.path
     header "winnt.h"
     export *
   }
@@ -527,11 +460,11 @@ module WinSDK [system] {
 
     link "AdvAPI32.Lib"
   }
-  
+
   module WinUSB {
     header "winusb.h"
     export *
-    
+
     link "winusb.lib"
   }
 
@@ -546,3 +479,70 @@ module WinSDK [system] {
   }
 }
 
+module DirectX [system] {
+  module Direct3D11 {
+    header "d3d11.h"
+    header "d3d11_1.h"
+    header "d3d11_2.h"
+    header "d3d11_3.h"
+    header "d3d11_4.h"
+    export *
+
+    link "d3d11.lib"
+    link "dxgi.lib"
+  }
+
+  module Direct3D12 {
+    header "d3d12.h"
+    export *
+
+    link "d3d12.lib"
+    link "dxgi.lib"
+  }
+
+  // FIXME(compnerd) DXGI is part of the Direct3D interfaces currently; we
+  // should split it out, but because it is part of the D3D11 interfaces, this
+  // separate module is meant to augment the uncovered portions only.
+  module _DXGI {
+    header "../shared/dxgi1_6.h"
+    header "dxgidebug.h"
+    export *
+
+    link "dxgi.lib"
+  }
+
+  module D3DCompiler {
+    header "d3dcompiler.h"
+    export *
+
+    link "d3dcompiler.lib"
+  }
+
+  module XAudio29 {
+    header "xaudio2.h"
+    header "xaudio2fx.h"
+    export *
+
+    link "xaudio2.lib"
+
+    requires cplusplus
+  }
+
+  // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was
+  // part of Vista.
+  module XInput14 {
+    header "Xinput.h"
+    export *
+
+    link "xinput.lib"
+  }
+
+  module DirectInput8 {
+    header "dinput.h"
+    export *
+
+    link "dinput.lib"
+  }
+
+  link "dxguid.lib"
+}


### PR DESCRIPTION
This is now important due to the use of C++ interop.  The C++ interop will re-construct the modules in the C++ context changing the type definitions and causing a mismatch due to the re-contextualisation of the types.