### PR TITLE
[5.9] [Runtime] Add a function to check type creation

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1007,6 +1007,18 @@ SWIFT_RUNTIME_STDLIB_SPI
 void _swift_registerConcurrencyStandardTypeDescriptors(
     const ConcurrencyStandardTypeDescriptors *descriptors);
 
+/// Check if the given generic arguments are valid inputs for the generic type
+/// context and if so call the metadata access function and return the metadata.
+///
+/// Note: This expects the caller to heap allocate all pack pointers within the
+/// generic arguments via 'swift_allocateMetadataPack'.
+SWIFT_RUNTIME_STDLIB_SPI
+SWIFT_CC(swift)
+const Metadata *_swift_instantiateCheckedGenericMetadata(
+    const TypeContextDescriptor *context,
+    const void * const *genericArgs,
+    size_t genericArgsSize);
+
 #pragma clang diagnostic pop
 
 } // end namespace swift

--- a/test/Runtime/check_create_type.swift
+++ b/test/Runtime/check_create_type.swift
@@ -1,0 +1,129 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// REQUIRES: executable_test
+
+// UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+
+let testSuite = TestSuite("CheckedCreateType")
+
+struct Variadic<each T> {
+  struct Nested<U, each V: Equatable> {}
+}
+
+@_silgen_name("swift_allocateMetadataPack")
+func allocateMetadataPack(
+  _ packPointer: UnsafeRawPointer,
+  _ packCount: UInt
+) -> UnsafeRawPointer
+
+@_silgen_name("_swift_instantiateCheckedGenericMetadata")
+func _instantiateCheckedGenericMetadata(
+  _ descriptor: UnsafeRawPointer,
+  _ genericArgs: UnsafeRawPointer,
+  _ genericArgsSize: UInt
+) -> Any.Type?
+
+func metaPointer(_ x: Any.Type) -> UnsafeRawPointer {
+  unsafeBitCast(x, to: UnsafeRawPointer.self)
+}
+
+testSuite.test("_swift_checkedCreateType non-variadic") {
+  let dictMeta = unsafeBitCast(
+    [Int: Int].self as Any.Type,
+    to: UnsafeRawPointer.self
+  )
+  let dictDesc = dictMeta.load(
+    fromByteOffset: MemoryLayout<Int>.size,
+    as: UnsafeRawPointer.self
+  )
+
+  let dictGenericArgs: [Any.Type] = [String.self, Double.self]
+
+  dictGenericArgs.withUnsafeBufferPointer {
+    let newDict = _instantiateCheckedGenericMetadata(
+      dictDesc,
+      UnsafeRawPointer($0.baseAddress!),
+      UInt($0.count)
+    )
+
+    expectTrue(newDict == [String: Double].self)
+  }
+}
+
+testSuite.test("_swift_checkedCreateType variadic") {
+  let variMeta = unsafeBitCast(
+    Variadic< >.self as Any.Type,
+    to: UnsafeRawPointer.self
+  )
+  let variDesc = variMeta.load(
+    fromByteOffset: MemoryLayout<Int>.size,
+    as: UnsafeRawPointer.self
+  )
+
+  let variPack: [Any.Type] = [Int.self, Int8.self, UInt8.self]
+
+  variPack.withUnsafeBufferPointer { pack in
+    let packPointer = allocateMetadataPack(
+      UnsafeRawPointer(pack.baseAddress!),
+      UInt(pack.count)
+    )
+    let genericArgs = [packPointer]
+
+    genericArgs.withUnsafeBufferPointer { genericArgs in
+      let newVari = _instantiateCheckedGenericMetadata(
+        variDesc,
+        UnsafeRawPointer(genericArgs.baseAddress!),
+        UInt(genericArgs.count)
+      )
+
+      expectTrue(newVari == Variadic<Int, Int8, UInt8>.self)
+    }
+  }
+}
+
+testSuite.test("_swift_checkedCreateType variadic nested with requirements") {
+  let nestedMeta = unsafeBitCast(
+    Variadic< >.Nested<()>.self as Any.Type,
+    to: UnsafeRawPointer.self
+  )
+  let nestedDesc = nestedMeta.load(
+    fromByteOffset: MemoryLayout<Int>.size,
+    as: UnsafeRawPointer.self
+  )
+
+  let variPack: [Any.Type] = [String.self, [Int].self, UInt64.self]
+
+  let nestedPack: [Any.Type] = [Int.self, Substring.self, Bool.self]
+
+  nestedPack.withUnsafeBufferPointer { nestedPack in
+    variPack.withUnsafeBufferPointer { variPack in
+      let nestedGenericArgs = [
+        allocateMetadataPack(
+          UnsafeRawPointer(variPack.baseAddress!),
+          UInt(variPack.count)
+        ),
+        metaPointer(Int16.self),
+        allocateMetadataPack(
+          UnsafeRawPointer(nestedPack.baseAddress!),
+          UInt(nestedPack.count)
+        )
+      ]
+
+      nestedGenericArgs.withUnsafeBufferPointer { nestedGenericArgs in
+
+        let newNested = _instantiateCheckedGenericMetadata(
+          nestedDesc,
+          UnsafeRawPointer(nestedGenericArgs.baseAddress!),
+          UInt(nestedGenericArgs.count)
+        )
+
+        expectTrue(newNested == Variadic<String, [Int], UInt64>.Nested<Int16, Int, Substring, Bool>.self)
+      }
+    }
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68359

* Explanation:
In some situations it is needed to dynamically instantiate new variations of a generic type given a flat list of the desired generic arguments. With the introduction of parameter packs, performing this operation is nigh impossible without the runtime's help. Add a new SPI that does the right thing for us and checks that the given generic arguments are suitable for the passed type and instantiate that variation for us.

* Scope:
Currently none as this is a new function that isn't being exercised anywhere.

* Main Branch PR: https://github.com/apple/swift/pull/68359

* Risk: Low

* Reviewed By: @mikeash 

* Testing: Added test-cases to the suite.

Resolves: rdar://112163811