### PR TITLE
5.9: [MoveChecker] Complete lifetimes before checking.

### DIFF
--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -388,8 +388,9 @@ bool OwnershipUseVisitor<Impl>::visitGuaranteedUse(Operand *use) {
   case OperandOwnership::ForwardingUnowned:
   case OperandOwnership::UnownedInstantaneousUse:
   case OperandOwnership::BitwiseEscape:
-  case OperandOwnership::EndBorrow:
     return handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding);
+  case OperandOwnership::EndBorrow:
+    return handleUsePoint(use, UseLifetimeConstraint::LifetimeEnding);
 
   case OperandOwnership::Reborrow:
     if (!asImpl().handleOuterReborrow(use))

--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -283,11 +283,18 @@ bool OwnershipUseVisitor<Impl>::visitInnerBorrowScopeEnd(Operand *borrowEnd) {
   case OperandOwnership::EndBorrow:
     return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);
 
-  case OperandOwnership::Reborrow:
+  case OperandOwnership::Reborrow: {
     if (!asImpl().handleInnerReborrow(borrowEnd))
       return false;
 
     return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);
+  }
+  case OperandOwnership::DestroyingConsume: {
+    // partial_apply [on_stack] can introduce borrowing operand and can have destroy_value consumes.
+    auto *pai = dyn_cast<PartialApplyInst>(borrowEnd->get());
+    assert(pai && pai->isOnStack());
+    return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);
+  }
 
   default:
     llvm_unreachable("expected borrow scope end");

--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -290,9 +290,14 @@ bool OwnershipUseVisitor<Impl>::visitInnerBorrowScopeEnd(Operand *borrowEnd) {
     return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);
   }
   case OperandOwnership::DestroyingConsume: {
-    // partial_apply [on_stack] can introduce borrowing operand and can have destroy_value consumes.
+    // partial_apply [on_stack] can introduce borrowing operand and can have
+    // destroy_value consumes.
     auto *pai = dyn_cast<PartialApplyInst>(borrowEnd->get());
-    assert(pai && pai->isOnStack());
+    // TODO: When we have ForwardingInstruction abstraction, walk the use-def
+    // chain to ensure we have a partial_apply [on_stack] def.
+    assert(pai && pai->isOnStack() ||
+           OwnershipForwardingMixin::get(
+               cast<SingleValueInstruction>(borrowEnd->get())));
     return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);
   }
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -477,6 +477,9 @@ struct BorrowingOperand {
   /// valid BorrowedValue instance.
   BorrowedValue getBorrowIntroducingUserResult();
 
+  /// Return the borrowing operand's value.
+  SILValue getScopeIntroducingUserResult();
+
   /// Compute the implicit uses that this borrowing operand "injects" into the
   /// set of its operands uses.
   ///

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1261,6 +1261,11 @@ public:
   ///
   /// \p inst is an OwnershipForwardingMixin
   static bool isAddressOnly(SILInstruction *inst);
+
+  // Call \p visitor on all forwarded results of the current forwarding
+  // operation.
+  static bool visitForwardedValues(SILInstruction *inst,
+                                   function_ref<bool(SILValue)> visitor);
 };
 
 /// A single value inst that forwards a static ownership from its first operand.

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -129,7 +129,7 @@ static bool endLifetimeAtUnreachableBlocks(SILValue value,
       changed = true;
     }
     for (auto *successor : block->getSuccessorBlocks()) {
-      deadEndBlocks.push(successor);
+      deadEndBlocks.pushIfNotVisited(successor);
     }
   }
   return changed;

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -140,8 +140,10 @@ struct InteriorLivenessVisitor :
   /// Handles begin_borrow, load_borrow, store_borrow, begin_apply.
   bool handleInnerBorrow(BorrowingOperand borrowingOperand) {
     if (handleInnerScopeCallback) {
-      handleInnerScopeCallback(
-        borrowingOperand.getBorrowIntroducingUserResult().value);
+      auto value = borrowingOperand.getScopeIntroducingUserResult();
+      if (value) {
+        handleInnerScopeCallback(value);
+      }
     }
     return true;
   }

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -751,6 +751,30 @@ BorrowedValue BorrowingOperand::getBorrowIntroducingUserResult() {
   llvm_unreachable("covered switch");
 }
 
+SILValue BorrowingOperand::getScopeIntroducingUserResult() {
+  switch (kind) {
+  case BorrowingOperandKind::Invalid:
+  case BorrowingOperandKind::Yield:
+  case BorrowingOperandKind::Apply:
+  case BorrowingOperandKind::TryApply:
+    return SILValue();
+
+  case BorrowingOperandKind::BeginAsyncLet:
+  case BorrowingOperandKind::PartialApplyStack:
+  case BorrowingOperandKind::BeginBorrow:
+    return cast<SingleValueInstruction>(op->getUser());
+
+  case BorrowingOperandKind::BeginApply:
+    return cast<BeginApplyInst>(op->getUser())->getTokenResult();
+
+  case BorrowingOperandKind::Branch: {
+    PhiOperand phiOp(op);
+    return phiOp.getValue();
+  }
+  }
+  llvm_unreachable("covered switch");
+}
+
 void BorrowingOperand::getImplicitUses(
     SmallVectorImpl<Operand *> &foundUses) const {
   // FIXME: this visitScopeEndingUses should never return false once dead

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -171,7 +171,7 @@ bb10:
 sil @foo : $@convention(thin) (@guaranteed C) -> ()
 
 // Ensure no assert fires while handling lifetime end of partial_apply
-sil [ossa] @testPartialApplyStack : $@convention(thin) (@guaranteed C) -> () {
+sil [ossa] @testPartialApplyStack1 : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   test_specification "ossa-lifetime-completion @instruction[0]"
   %8 = copy_value %0 : $C
@@ -192,5 +192,23 @@ bb3:
   destroy_value %8 : $C
   %180 = tuple ()
   return %180 : $()
+}
+
+// Ensure no assert fires while handling lifetime end of partial_apply
+sil [ossa] @testPartialApplyStack2 : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "ossa-lifetime-completion @instruction[1]"
+  %2 = alloc_stack $C
+  %3 = copy_value %0 : $C
+  %4 = begin_borrow %3 : $C
+  %5 = function_ref @foo : $@convention(thin) (@guaranteed C) -> ()
+  %6 = partial_apply [callee_guaranteed] [on_stack] %5(%4) : $@convention(thin) (@guaranteed C) -> ()
+  %7 = mark_dependence %6 : $@noescape @callee_guaranteed () -> () on %2 : $*C
+  destroy_value %7 : $@noescape @callee_guaranteed () -> ()
+  end_borrow %4 : $C
+  destroy_value %3 : $C
+  dealloc_stack %2 : $*C
+  %12 = tuple ()
+  return %12 : $()
 }
 

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -102,6 +102,31 @@ bb3:
   return %r : $()
 }
 
+sil @use_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+
+sil [ossa] @argTest : $@convention(method) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  test_specification "ossa-lifetime-completion @argument"
+  debug_value %0 : $C
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb4
+
+bb2:
+  br bb3
+
+bb3:
+  %3 = function_ref @use_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %0 : $C
+  %r = tuple ()
+  return %r : $()
+
+bb4:
+  unreachable
+}
+
 // Ensure no assert fires while inserting dead end blocks to the worklist
 sil [ossa] @testLexicalLifetimeCompletion : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
@@ -141,5 +166,31 @@ bb9:
 
 bb10:
   br bb8
+}
+
+sil @foo : $@convention(thin) (@guaranteed C) -> ()
+
+// Ensure no assert fires while handling lifetime end of partial_apply
+sil [ossa] @testPartialApplyStack : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "ossa-lifetime-completion @instruction[0]"
+  %8 = copy_value %0 : $C
+  %9 = begin_borrow %8 : $C
+  %80 = function_ref @foo : $@convention(thin) (@guaranteed C) -> ()
+  %81 = partial_apply [callee_guaranteed] [on_stack] %80(%9) : $@convention(thin) (@guaranteed C) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %81 : $@noescape @callee_guaranteed () -> ()
+  br bb3
+
+bb2:
+  unreachable
+
+bb3:
+  end_borrow %9 : $C
+  destroy_value %8 : $C
+  %180 = tuple ()
+  return %180 : $()
 }
 

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -102,3 +102,44 @@ bb3:
   return %r : $()
 }
 
+// Ensure no assert fires while inserting dead end blocks to the worklist
+sil [ossa] @testLexicalLifetimeCompletion : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  test_specification "ossa-lifetime-completion @argument"
+  debug_value %0 : $C, let, name "newElements", argno 1
+  cond_br undef, bb1, bb2
+
+bb1:
+  cond_br undef, bb3, bb4
+
+bb2:
+  cond_br undef, bb9, bb10
+
+bb3:
+  br bb8
+
+bb4:
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb7
+
+bb6:
+  br bb7
+
+bb7:
+  unreachable
+
+bb8:
+  %77 = apply undef(%0) : $@convention(method) (@guaranteed C) -> ()
+  destroy_value %0 : $C
+  %79 = tuple ()
+  return %79 : $()
+
+bb9:
+  br bb8
+
+bb10:
+  br bb8
+}
+

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -6,6 +6,11 @@ import Builtin
 
 class C {}
 
+public enum FakeOptional<T> {
+  case none
+  case some(T)
+}
+
 // CHECK-LABEL: begin running test 1 of 1 on eagerConsumneOwnedArg: ossa-lifetime-completion with: @argument
 // CHECK-LABEL: OSSA lifetime completion: %0 = argument of bb0 : $C
 // CHECK: sil [ossa] @eagerConsumneOwnedArg : $@convention(thin) (@owned C) -> () {
@@ -45,3 +50,55 @@ bb3:
   %r = tuple ()
   return %r : $()
 }
+
+// CHECK-LABEL: sil [ossa] @borrowTest : $@convention(method) (@owned C) -> () {
+// CHECK: bb1:
+// CHECK-NEXT: end_borrow
+// CHECK-NEXT: br bb3
+// CHECK-LABEL: } // end sil function 'borrowTest'
+sil [ossa] @borrowTest : $@convention(method) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  test_specification "ossa-lifetime-completion @instruction[0]"
+  %borrow = begin_borrow %0 : $C
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_borrow %borrow : $C
+  br bb3
+
+bb2:
+  end_borrow %borrow : $C
+  br bb3
+
+bb3:
+  destroy_value %0 : $C
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @enumTest : $@convention(method) (@guaranteed FakeOptional<C>) -> () {
+// CHECK: bb2
+// CHECK: destroy_value
+// CHECK: br bb3
+// CHECK-LABEL: } // end sil function 'enumTest'
+sil [ossa] @enumTest : $@convention(method) (@guaranteed FakeOptional<C>) -> () {
+bb0(%0 : @guaranteed $FakeOptional<C>):
+  test_specification "ossa-lifetime-completion @instruction[0]"
+  %copy = copy_value %0 : $FakeOptional<C>
+  %borrow = begin_borrow %copy : $FakeOptional<C>
+  switch_enum %borrow : $FakeOptional<C>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%some : @guaranteed $C):
+  end_borrow %borrow : $FakeOptional<C>
+  destroy_value %copy : $FakeOptional<C>
+  br bb3
+
+bb2:
+  end_borrow %borrow : $FakeOptional<C>
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/validation-test/SILOptimizer/gh68328.swift
+++ b/validation-test/SILOptimizer/gh68328.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/bin
+// RUN: %target-codesign %t/bin
+// RUN: %target-run %t/bin 2> %t/out.txt || true
+// RUN: %FileCheck %s < %t/out.txt
+
+// REQUIRES: executable_test
+
+struct Example: ~Copyable {
+    private var failureString: String { "Goodbye." }
+    deinit { fatalError("FATAL ERROR: \(failureString)") }
+}
+
+func doit() {
+  let e = Example()
+  // CHECK: FATAL ERROR: Goodbye.
+}
+
+doit()


### PR DESCRIPTION
**Description:** Fix wrong move-only diagnostic in no-return functions.

The move-checker for objects relies on a utility (`CanonicalizeOSSALifetime`) to eliminate spurious copies.  That utility is permitted to bail out in the face of SIL it doesn't understand.  In particular, the utility bails out if lifetimes are not complete; such lifetimes occur in no-return functions.  The checker, however, just issues a diagnostic `Usage of a noncopyable type that compiler can't verify. This is a compiler bug.` in the face of that bail out.

Since the move-checker relies on the utility not bailing out, the fix is for the move-checker to transform the SIL before using the utility--specifically, to complete OSSA lifetimes via `OSSALifetimeCompletion`.  This must be done for each value which will be checked and values derived from it via ownership and forwarding operations.

This is the first use of `OSSALifetimeCompletion` on release/5.9.  The utility is, however, already in use on main in TempRValueElimination and Mem2Reg.  As a result, several fixes from main need to be picked up on release/5.9.

**Risk:** Low.  This only affects functions with move-only values, but the fix is to use the `OSSALifetimeCompletion` utility on release/5.9 for the first time.

**Scope:** Narrow. Only functions with move-only values are affected.

**Original PR:** https://github.com/apple/swift/pull/68342

**Reviewed By:** Meghana Gupta ( @meg-gupta )

**Testing:** Added test.

**Resolves:** rdar://115185992