### PR TITLE
Serialization: Tagged compilers should rebuild modules from swiftinterface under the resource-dir

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -820,15 +820,21 @@ class ModuleInterfaceLoaderImpl {
           return std::make_error_code(std::errc::not_supported);
         } else if (isInResourceDir(adjacentMod) &&
                    loadMode == ModuleLoadingMode::PreferSerialized &&
+                   !version::isCurrentCompilerTagged() &&
                    rebuildInfo.getOrInsertCandidateModule(adjacentMod).serializationStatus !=
                      serialization::Status::SDKMismatch) {
           // Special-case here: If we're loading a .swiftmodule from the resource
           // dir adjacent to the compiler, defer to the serialized loader instead
-          // of falling back. This is mainly to support development of Swift,
+          // of falling back. This is to support local development of Swift,
           // where one might change the module format version but forget to
           // recompile the standard library. If that happens, don't fall back
-          // and silently recompile the standard library -- instead, error like
-          // we used to.
+          // and silently recompile the standard library, raise an error
+          // instead.
+          //
+          // This logic is disabled for tagged compilers, so distributed
+          // compilers should ignore this restriction and rebuild all modules
+          // from a swiftinterface when required.
+          //
           // Still accept modules built with a different SDK, allowing the use
           // of one toolchain against a different SDK.
           LLVM_DEBUG(llvm::dbgs() << "Found out-of-date module in the "


### PR DESCRIPTION
There is some special logic for loading modules from under the resource-dir. In this case, if there's a swiftmodule next to the swiftinterface we refuse to rebuild the module from the swiftinterface. It was designed to catch misconfigurations, either locally if we forget to rebuild the stdlib from source or at deployement.

It has been causing issues recently with LLDB and other tools. Let's keep this behavior only for the local scenario by limiting it to untagged compilers. Leaving tagged/distributed compilers to rebuild more modules from the swiftinterface. This restriction aligns with the strict compiler tag check for swiftmodule compatibility which is applied by tagged compilers only.