### PR TITLE
SILGen: Use the right abstraction pattern when loading 'async let' result

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -7023,11 +7023,10 @@ ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,
   assert(visitor.varAddr && "didn't find var in pattern?");
   
   // Load and reabstract the value if needed.
-  auto genericSig = F.getLoweredFunctionType()->getInvocationGenericSignature();
   auto substVarTy = var->getTypeInContext()->getCanonicalType();
-  auto substAbstraction = AbstractionPattern(genericSig, substVarTy);
-  return emitLoad(loc, visitor.varAddr, substAbstraction, substVarTy,
-                  getTypeLowering(substAbstraction, substVarTy),
+  return emitLoad(loc, visitor.varAddr,
+                  AbstractionPattern::getOpaque(), substVarTy,
+                  getTypeLowering(substVarTy),
                   SGFContext(), IsNotTake);
 }
 

--- a/test/SILGen/async_let_reabstraction.swift
+++ b/test/SILGen/async_let_reabstraction.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking
+// REQUIRES: concurrency
+
+public func callee() async -> (() -> ()) {
+    fatalError()
+}
+
+public func caller() async {
+  async let future = callee()
+  let result = await future
+  result()
+}


### PR DESCRIPTION
The payload is stored maximally-abstracted, so make sure we respect that to avoid a crash when the 'async let' binding has a function type.

Fixes rdar://114823719.