### PR TITLE
SILGen: Use the right abstraction pattern when loading 'async let' result [5.9]

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -7015,11 +7015,10 @@ ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,
   assert(visitor.varAddr && "didn't find var in pattern?");
   
   // Load and reabstract the value if needed.
-  auto genericSig = F.getLoweredFunctionType()->getInvocationGenericSignature();
-  auto substVarTy = var->getType()->getReducedType(genericSig);
-  auto substAbstraction = AbstractionPattern(genericSig, substVarTy);
-  return emitLoad(loc, visitor.varAddr, substAbstraction, substVarTy,
-                  getTypeLowering(substAbstraction, substVarTy),
+  auto substVarTy = var->getType()->getCanonicalType();
+  return emitLoad(loc, visitor.varAddr,
+                  AbstractionPattern::getOpaque(), substVarTy,
+                  getTypeLowering(substVarTy),
                   SGFContext(), IsNotTake);
 }
 

--- a/test/SILGen/async_let_reabstraction.swift
+++ b/test/SILGen/async_let_reabstraction.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking
+// REQUIRES: concurrency
+
+public func callee() async -> (() -> ()) {
+    fatalError()
+}
+
+public func caller() async {
+  async let future = callee()
+  let result = await future
+  result()
+}


### PR DESCRIPTION
* Description: Declaring an 'async let' binding with a function type would crash SILGen because of disagreement about the abstraction pattern to use for the payload.

* Origination: Probably there forever.

* Radar: rdar://114823719.

* Risk: Very low. Should be a no-op unless the payload type is a function, which is the case that used to crash.

* Reviewed by: @jckarter 

* main PR: https://github.com/apple/swift/pull/68399