### PR TITLE
Magical vanishing tuple conformances

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -299,23 +299,23 @@ public:
   /// be satisfied.
   ArrayRef<Requirement> getConditionalRequirements() const;
 
-  /// Substitute the conforming type and produce a ProtocolConformance that
+  /// Substitute the conforming type and produce a ProtocolConformanceRef that
   /// applies to the substituted type.
-  ProtocolConformance *subst(SubstitutionMap subMap,
-                             SubstOptions options = llvm::None) const;
+  ProtocolConformanceRef subst(SubstitutionMap subMap,
+                               SubstOptions options = llvm::None) const;
 
-  /// Substitute the conforming type and produce a ProtocolConformance that
+  /// Substitute the conforming type and produce a ProtocolConformanceRef that
   /// applies to the substituted type.
-  ProtocolConformance *subst(TypeSubstitutionFn subs,
-                             LookupConformanceFn conformances,
-                             SubstOptions options = llvm::None) const;
+  ProtocolConformanceRef subst(TypeSubstitutionFn subs,
+                               LookupConformanceFn conformances,
+                               SubstOptions options = llvm::None) const;
 
-  /// Substitute the conforming type and produce a ProtocolConformance that
+  /// Substitute the conforming type and produce a ProtocolConformanceRef that
   /// applies to the substituted type.
   ///
   /// This function should generally not be used outside of the substitution
   /// subsystem.
-  ProtocolConformance *subst(InFlightSubstitution &IFS) const;
+  ProtocolConformanceRef subst(InFlightSubstitution &IFS) const;
 
   SWIFT_DEBUG_DUMP;
   void dump(llvm::raw_ostream &out, unsigned indent = 0) const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2731,6 +2731,13 @@ ASTContext::getSpecializedConformance(Type type,
   if (auto result = specializedConformances.FindNodeOrInsertPos(id, insertPos))
     return result;
 
+  // Vanishing tuple conformances must be handled by the caller.
+  if (isa<BuiltinTupleDecl>(generic->getDeclContext()->getSelfNominalTypeDecl())) {
+    assert(type->is<TupleType>() && "Vanishing tuple substitution is not "
+           "here. Did you mean to use ProtocolConformanceRef::subst() "
+           "instead?");
+  }
+
   // Build a new specialized conformance.
   auto result
     = new (*this, arena) SpecializedProtocolConformance(type, generic,

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -87,7 +87,7 @@ ProtocolConformanceRef::subst(Type origType, InFlightSubstitution &IFS) const {
     return *this;
 
   if (isConcrete())
-    return ProtocolConformanceRef(getConcrete()->subst(IFS));
+    return getConcrete()->subst(IFS);
   if (isPack())
     return getPack()->subst(IFS);
 
@@ -126,7 +126,7 @@ ProtocolConformanceRef::subst(Type origType, InFlightSubstitution &IFS) const {
 
 ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() const {
   if (isConcrete()) {
-    auto *concrete = getConcrete()->subst(
+    return getConcrete()->subst(
         [](SubstitutableType *type) -> Type {
           if (auto *archetypeType = type->getAs<ArchetypeType>())
             return archetypeType->getInterfaceType();
@@ -134,7 +134,6 @@ ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() cons
         },
         MakeAbstractConformanceForGenericType(),
         SubstFlags::PreservePackExpansionLevel);
-    return ProtocolConformanceRef(concrete);
   } else if (isPack()) {
     return getPack()->subst(
         [](SubstitutableType *type) -> Type {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4765,8 +4765,9 @@ case TypeKind::Id:
     if (!anyChanged)
       return *this;
 
-    // If the transform would yield a singleton tuple, and we didn't
-    // start with one, flatten to produce the element type.
+    // Handle vanishing tuples -- If the transform would yield a singleton
+    // tuple, and we didn't start with one, flatten to produce the
+    // element type.
     if (elements.size() == 1 &&
         !elements[0].getType()->is<PackExpansionType>() &&
         !(tuple->getNumElements() == 1 &&

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1190,7 +1190,7 @@ getWitnessTableLazyAccessFunction(IRGenModule &IGM,
 static const ProtocolConformance *
 mapConformanceIntoContext(const RootProtocolConformance *conf) {
   if (auto *genericEnv = conf->getDeclContext()->getGenericEnvironmentOfContext())
-    return conf->subst(genericEnv->getForwardingSubstitutionMap());
+    return conf->subst(genericEnv->getForwardingSubstitutionMap()).getConcrete();
   return conf;
 }
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -1146,6 +1146,15 @@ static bool canDevirtualizeWitnessMethod(ApplySite applySite, bool isMandatory) 
 
   auto *wmi = cast<WitnessMethodInst>(applySite.getCallee());
 
+  // Handle vanishing tuples: don't devirtualize a call to a tuple conformance
+  // if the lookup type can possibly be unwrapped after substitution.
+  if (auto tupleType = dyn_cast<TupleType>(wmi->getLookupType())) {
+    if (tupleType->containsPackExpansionType() &&
+        tupleType->getNumScalarElements() <= 1) {
+      return false;
+    }
+  }
+
   std::tie(f, wt) = applySite.getModule().lookUpFunctionInWitnessTable(
       wmi->getConformance(), wmi->getMember(), SILModule::LinkingMode::LinkAll);
 

--- a/test/SILOptimizer/tuple-conformances.swift
+++ b/test/SILOptimizer/tuple-conformances.swift
@@ -22,9 +22,20 @@ public func transparentCallee<T: P>(t: T.Type) {
   t.protocolMethod()
 }
 
+// Make sure we don't devirtualize the call when we inline transparentCallee()
+// into transparentCaller(), because we might unwrap the tuple conformance
+// later.
+
+// CHECK-LABEL: sil [transparent] @$s4main17transparentCaller5tupleyxxQp_tm_tRvzAA1PRzlF : $@convention(thin) <each T where repeat each T : P> (@thin (repeat each T).Type) -> () {
 @_transparent public func transparentCaller<each T: P>(tuple: (repeat each T).Type) {
   callee(t: tuple)
+
+// CHECK: [[FN:%.*]] = witness_method $(repeat each T), #P.protocolMethod : <Self where Self : P> (Self.Type) -> () -> () : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+// CHECK: apply [[FN:%.*]]<(repeat each T)>({{.*}})
+
   transparentCallee(t: tuple)
+
+// FIXME: This one is wrong in the AST
   tuple.protocolMethod()
 }
 
@@ -39,10 +50,13 @@ public func caller() {
 // CHECK: [[FN:%.*]] = function_ref @$s4main6callee1tyxm_tAA1PRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
 // CHECK: apply [[FN]]<Int>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
 
-// FIXME: These should call Int.protocolMethod()!
+// Make sure the witness method call in transparentCallee() was devirtualized to Int.protocolMethod().
+
+// CHECK: [[FN:%.*]] = function_ref @$sSi4mainE14protocolMethodyyFZ : $@convention(method) (@thin Int.Type) -> () // user: %6
+// CHECK: apply [[FN]]({{.*}}) : $@convention(method) (@thin Int.Type) -> ()
+
+// FIXME: This is the `tuple.protocolMethod()` in transparentCaller(). It should
+// also refer to Int.protocolMethod()!
 
 // CHECK: [[FN:%.*]] = function_ref @$sBT4mainRvzAA1PRzlE14protocolMethodyyFZ : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()
-// CHECK: apply [[FN]]<Pack{Int}>(%4) : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()
-
-// CHECK: [[FN:%.*]] = function_ref @$sBT4mainRvzAA1PRzlE14protocolMethodyyFZ : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()
-// CHECK: apply [[FN]]<Pack{Int}>(%0) : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()
+// CHECK: apply [[FN]]<Pack{Int}>({{.*}}) : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()

--- a/test/SILOptimizer/tuple-conformances.swift
+++ b/test/SILOptimizer/tuple-conformances.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend -emit-sil %s -enable-experimental-feature TupleConformances | %FileCheck %s
+
+public typealias Tuple<each T> = (repeat each T)
+
+public protocol P {
+  static func protocolMethod()
+}
+
+extension Tuple: P where repeat each T: P {
+  public static func protocolMethod() {}
+}
+
+extension Int: P {
+  public static func protocolMethod() {}
+}
+
+public func callee<T: P>(t: T.Type) {
+}
+
+@_transparent
+public func transparentCallee<T: P>(t: T.Type) {
+  t.protocolMethod()
+}
+
+@_transparent public func transparentCaller<each T: P>(tuple: (repeat each T).Type) {
+  callee(t: tuple)
+  transparentCallee(t: tuple)
+  tuple.protocolMethod()
+}
+
+// Inlining transparentCaller() into caller() exercises the code path to unwrap
+// a one-element tuple conformance.
+
+public func caller() {
+  transparentCaller(tuple: Int.self)
+}
+
+// CHECK-LABEL: sil @$s4main6calleryyF : $@convention(thin) () -> () {
+// CHECK: [[FN:%.*]] = function_ref @$s4main6callee1tyxm_tAA1PRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+// CHECK: apply [[FN]]<Int>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+
+// FIXME: These should call Int.protocolMethod()!
+
+// CHECK: [[FN:%.*]] = function_ref @$sBT4mainRvzAA1PRzlE14protocolMethodyyFZ : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()
+// CHECK: apply [[FN]]<Pack{Int}>(%4) : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()
+
+// CHECK: [[FN:%.*]] = function_ref @$sBT4mainRvzAA1PRzlE14protocolMethodyyFZ : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()
+// CHECK: apply [[FN]]<Pack{Int}>(%0) : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@thin (repeat each τ_0_0).Type) -> ()


### PR DESCRIPTION
This handles AST substitution and devirtualization. We still need to do the same unwrapping operation dynamically in IRGen, and also fix name lookup in the solver.