### PR TITLE
[Concurrency] Don't allow nonisolated initializers to introduce data races via superclass property observers.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -68,10 +68,10 @@ public:
     /// For example, a mutable stored property or synchronous function within
     /// the actor is isolated to the instance of that actor.
     ActorInstance,
-    /// The declaration is explicitly specified to be independent of any actor,
+    /// The declaration is explicitly specified to be not isolated to any actor,
     /// meaning that it can be used from any actor but is also unable to
     /// refer to the isolated state of any given actor.
-    Independent,
+    Nonisolated,
     /// The declaration is isolated to a global actor. It can refer to other
     /// entities with the same global actor.
     GlobalActor,
@@ -104,8 +104,8 @@ public:
     return ActorIsolation(Unspecified, nullptr);
   }
 
-  static ActorIsolation forIndependent() {
-    return ActorIsolation(Independent, nullptr);
+  static ActorIsolation forNonisolated() {
+    return ActorIsolation(Nonisolated, nullptr);
   }
 
   static ActorIsolation forActorInstanceSelf(NominalTypeDecl *actor) {
@@ -128,7 +128,7 @@ public:
 
   bool isUnspecified() const { return kind == Unspecified; }
   
-  bool isIndependent() const { return kind == Independent; }
+  bool isNonisolated() const { return kind == Nonisolated; }
 
   /// Retrieve the parameter to which actor-instance isolation applies.
   ///
@@ -146,7 +146,7 @@ public:
       return true;
 
     case Unspecified:
-    case Independent:
+    case Nonisolated:
       return false;
     }
   }
@@ -195,7 +195,7 @@ public:
       return false;
 
     switch (lhs.getKind()) {
-    case Independent:
+    case Nonisolated:
     case Unspecified:
       return true;
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3778,8 +3778,8 @@ public:
 class ClosureActorIsolation {
 public:
   enum Kind {
-    /// The closure is independent of any actor.
-    Independent,
+    /// The closure is not isolated to any actor.
+    Nonisolated,
 
     /// The closure is tied to the actor instance described by the given
     /// \c VarDecl*, which is the (captured) `self` of an actor.
@@ -3810,7 +3810,7 @@ public:
   ClosureActorIsolation(bool preconcurrency = false)
       : storage(nullptr, preconcurrency) { }
 
-  static ClosureActorIsolation forIndependent(bool preconcurrency) {
+  static ClosureActorIsolation forNonisolated(bool preconcurrency) {
     return ClosureActorIsolation(preconcurrency);
   }
 
@@ -3827,7 +3827,7 @@ public:
   /// Determine the kind of isolation.
   Kind getKind() const {
     if (storage.getPointer().isNull())
-      return Kind::Independent;
+      return Kind::Nonisolated;
 
     if (storage.getPointer().is<VarDecl *>())
       return Kind::ActorInstance;
@@ -3837,7 +3837,7 @@ public:
 
   /// Whether the closure is isolated at all.
   explicit operator bool() const {
-    return getKind() != Kind::Independent;
+    return getKind() != Kind::Nonisolated;
   }
 
   /// Whether the closure is isolated at all.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2593,7 +2593,7 @@ public:
       << " discriminator=" << E->getRawDiscriminator();
 
     switch (auto isolation = E->getActorIsolation()) {
-    case ClosureActorIsolation::Independent:
+    case ClosureActorIsolation::Nonisolated:
       break;
 
     case ClosureActorIsolation::ActorInstance:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2313,7 +2313,7 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
             break;
 
           case ActorIsolation::ActorInstance:
-          case ActorIsolation::Independent:
+          case ActorIsolation::Nonisolated:
           case ActorIsolation::GlobalActor:
             return true;
         }
@@ -10166,7 +10166,7 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
 
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
       switch (auto isolation = closure->getActorIsolation()) {
-      case ClosureActorIsolation::Independent:
+      case ClosureActorIsolation::Nonisolated:
       case ClosureActorIsolation::GlobalActor:
         return false;
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -920,7 +920,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
       break;
     }
 
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::Unspecified:
       Out << "nonisolated";
       break;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1875,8 +1875,8 @@ RebindSelfInConstructorExpr::getCalledConstructor(bool &isChainToSuper) const {
 
 ActorIsolation ClosureActorIsolation::getActorIsolation() const {
   switch (getKind()) {
-  case ClosureActorIsolation::Independent:
-    return ActorIsolation::forIndependent().withPreconcurrency(
+  case ClosureActorIsolation::Nonisolated:
+    return ActorIsolation::forNonisolated().withPreconcurrency(
         preconcurrency());
 
   case ClosureActorIsolation::GlobalActor: {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1607,7 +1607,7 @@ SourceLoc MacroDefinitionRequest::getNearestLoc() const {
 bool ActorIsolation::requiresSubstitution() const {
   switch (kind) {
   case ActorInstance:
-  case Independent:
+  case Nonisolated:
   case Unspecified:
     return false;
 
@@ -1621,7 +1621,7 @@ bool ActorIsolation::requiresSubstitution() const {
 ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   switch (kind) {
   case ActorInstance:
-  case Independent:
+  case Nonisolated:
   case Unspecified:
     return *this;
 
@@ -1645,8 +1645,8 @@ void swift::simple_display(
       out << "actor " << state.getActor()->getName();
       break;
 
-    case ActorIsolation::Independent:
-      out << "actor-independent";
+    case ActorIsolation::Nonisolated:
+      out << "nonisolated";
       break;
 
     case ActorIsolation::Unspecified:

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -788,7 +788,7 @@ void CompletionLookup::analyzeActorIsolation(
     break;
   }
   case ActorIsolation::Unspecified:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
     return;
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5514,7 +5514,7 @@ RValue SILGenFunction::emitApply(
       break;
 
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
       llvm_unreachable("Not isolated");
       break;
     }

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -595,7 +595,7 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
       return true;
 
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
       return false;

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1280,7 +1280,7 @@ void SILGenFunction::emitProlog(
           // the instance properties of the class.
           return false;
 
-        case ActorIsolation::Independent:
+        case ActorIsolation::Nonisolated:
         case ActorIsolation::Unspecified:
           return false;
         }
@@ -1331,7 +1331,7 @@ void SILGenFunction::emitProlog(
     auto actorIsolation = getActorIsolation(funcDecl);
     switch (actorIsolation.getKind()) {
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
       break;
 
     case ActorIsolation::ActorInstance: {
@@ -1382,7 +1382,7 @@ void SILGenFunction::emitProlog(
     bool wantExecutor = F.isAsync() || wantDataRaceChecks;
     auto actorIsolation = closureExpr->getActorIsolation();
     switch (actorIsolation.getKind()) {
-    case ClosureActorIsolation::Independent:
+    case ClosureActorIsolation::Nonisolated:
       break;
 
     case ClosureActorIsolation::ActorInstance: {
@@ -1569,7 +1569,7 @@ SILGenFunction::emitExecutor(SILLocation loc, ActorIsolation isolation,
                              llvm::Optional<ManagedValue> maybeSelf) {
   switch (isolation.getKind()) {
   case ActorIsolation::Unspecified:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
     return llvm::None;
 
   case ActorIsolation::ActorInstance: {
@@ -1595,9 +1595,9 @@ void SILGenFunction::emitHopToActorValue(SILLocation loc, ManagedValue actor) {
       getActorIsolationOfContext(FunctionDC, [](AbstractClosureExpr *CE) {
         return CE->getActorIsolation();
       });
-  if (isolation != ActorIsolation::Independent
+  if (isolation != ActorIsolation::Nonisolated
       && isolation != ActorIsolation::Unspecified) {
-    // TODO: Explicit hop with no hop-back should only be allowed in independent
+    // TODO: Explicit hop with no hop-back should only be allowed in nonisolated
     // async functions. But it needs work for any closure passed to
     // Task.detached, which currently has unspecified isolation.
     llvm::report_fatal_error(

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1027,7 +1027,7 @@ void LifetimeChecker::injectActorHops() {
     break;
 
   case ActorIsolation::Unspecified:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
   case ActorIsolation::GlobalActorUnsafe:
   case ActorIsolation::GlobalActor:
     return;

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -481,7 +481,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD, ObjCReason Reason) {
     // in the generated header.
     return false;
 
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
   case ActorIsolation::Unspecified:
     return false;
   }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -97,7 +97,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
 
   case ActorIsolation::GlobalActor:
   case ActorIsolation::GlobalActorUnsafe:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
   case ActorIsolation::Unspecified:
     break;
   }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1497,3 +1497,31 @@ extension MyActor {
     }
   }
 }
+
+@MainActor
+class SuperWithNonisolatedInit {
+  static func isolatedToMainActor() {}
+
+  // expected-note@+1 2 {{mutation of this property is only permitted within the actor}}
+  var x: Int = 0 {
+    didSet {
+      SuperWithNonisolatedInit.isolatedToMainActor()
+    }
+  }
+
+  nonisolated init() {}
+}
+
+class OverridesNonsiolatedInit: SuperWithNonisolatedInit {
+  override nonisolated init() {
+    super.init()
+
+    // expected-error@+1 {{main actor-isolated property 'x' can not be mutated from a non-isolated context}}
+    super.x = 10
+  }
+
+  nonisolated func f() {
+    // expected-error@+1 {{main actor-isolated property 'x' can not be mutated from a non-isolated context}}
+    super.x = 10
+  }
+}


### PR DESCRIPTION
Fixes an issue where a nonisolated initializer of a subclass could invoke global-actor-isolated properties in the superclass:

```swift
@MainActor
func mainFn() { ... }

@MainActor
class Parent {
  var x: Int = 0 {
    didSet { mainFn() }
  }

  nonisolated init() {}
}

class Child: Parent {
  override nonisolated init() {
    super.init()
    super.x = 10 // this should be an error!
  }
}
```

The first commit of this change also renames `Independent` to `Nonisolated` throughout the actor isolation checker.

Resolves rdar://86550653