### PR TITLE
[se-0405] Implement API additions

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -518,7 +518,7 @@ extension String {
   ///   - encoding: A conformer to `Unicode.Encoding` to be used
   ///               to decode `codeUnits`.
   @inlinable
-  @available(SwiftStdlib 5.10, *)
+  @available(SwiftStdlib 5.11, *)
   public init?<Encoding: Unicode.Encoding>(
     validating codeUnits: some Sequence<Encoding.CodeUnit>,
     as encoding: Encoding.Type
@@ -578,7 +578,7 @@ extension String {
   ///   - encoding: A conformer to `Unicode.Encoding` that can decode
   ///               `codeUnits` as `UInt8`
   @inlinable
-  @available(SwiftStdlib 5.10, *)
+  @available(SwiftStdlib 5.11, *)
   public init?<Encoding>(
     validating codeUnits: some Sequence<Int8>,
     as encoding: Encoding.Type

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -505,12 +505,12 @@ extension String {
   ///
   ///     let validUTF8: [UInt8] = [67, 97, 0, 102, 195, 169]
   ///     let valid = String(validating: validUTF8, as: UTF8.self)
-  ///     print(valid)
-  ///     // Prints "Optional("Café")"
+  ///     print(valid ?? "nil")
+  ///     // Prints "Café"
   ///
   ///     let invalidUTF16: [UInt16] = [0x41, 0x42, 0xd801]
   ///     let invalid = String(validating: invalidUTF16, as: UTF16.self)
-  ///     print(invalid)
+  ///     print(invalid ?? "nil")
   ///     // Prints "nil"
   ///
   /// - Parameters:
@@ -567,12 +567,12 @@ extension String {
   ///
   ///     let validUTF8: [Int8] = [67, 97, 0, 102, -61, -87]
   ///     let valid = String(validating: validUTF8, as: UTF8.self)
-  ///     print(valid)
-  ///     // Prints "Optional("Café")"
+  ///     print(valid ?? "nil")
+  ///     // Prints "Café"
   ///
   ///     let invalidASCII: [Int8] = [67, 97, -5]
   ///     let invalid = String(validating: invalidASCII, as: Unicode.ASCII.self)
-  ///     print(invalid)
+  ///     print(invalid ?? "nil")
   ///     // Prints "nil"
   ///
   /// - Parameters:

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -523,12 +523,14 @@ extension String {
     validating codeUnits: some Sequence<Encoding.CodeUnit>,
     as encoding: Encoding.Type
   ) {
-    let newString: String?? = codeUnits.withContiguousStorageIfAvailable {
+    let contiguousResult = codeUnits.withContiguousStorageIfAvailable {
       String._validate($0, as: Encoding.self)
     }
-    if let newString {
-      guard let newString else { return nil }
-      self = newString
+    if let validationResult = contiguousResult {
+      guard let validatedString = validationResult else {
+        return nil
+      }
+      self = validatedString
       return
     }
 
@@ -583,14 +585,16 @@ extension String {
     validating codeUnits: some Sequence<Int8>,
     as encoding: Encoding.Type
   ) where Encoding: Unicode.Encoding, Encoding.CodeUnit == UInt8 {
-    let newString: String?? = codeUnits.withContiguousStorageIfAvailable {
+    let contiguousResult = codeUnits.withContiguousStorageIfAvailable {
       $0.withMemoryRebound(to: UInt8.self) {
         String._validate($0, as: Encoding.self)
       }
     }
-    if let newString {
-      guard let newString else { return nil }
-      self = newString
+    if let validationResult = contiguousResult {
+      guard let validatedString = validationResult else {
+        return nil
+      }
+      self = validatedString
       return
     }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -493,6 +493,114 @@ extension String {
     self = String._fromNonContiguousUnsafeBitcastUTF8Repairing(codeUnits).0
   }
 
+  /// Creates a new `String` by copying and validating the sequence of
+  /// code units passed in, according to the specified encoding.
+  ///
+  /// This initializer does not try to repair ill-formed code unit sequences.
+  /// If any are found, the result of the initializer is `nil`.
+  ///
+  /// The following example calls this initializer with the contents of two
+  /// different arrays---first with a well-formed UTF-8 code unit sequence and
+  /// then with an ill-formed UTF-16 code unit sequence.
+  ///
+  ///     let validUTF8: [UInt8] = [67, 97, 0, 102, 195, 169]
+  ///     let valid = String(validating: validUTF8, as: UTF8.self)
+  ///     print(valid)
+  ///     // Prints "Optional("Café")"
+  ///
+  ///     let invalidUTF16: [UInt16] = [0x41, 0x42, 0xd801]
+  ///     let invalid = String(validating: invalidUTF16, as: UTF16.self)
+  ///     print(invalid)
+  ///     // Prints "nil"
+  ///
+  /// - Parameters:
+  ///   - codeUnits: A sequence of code units that encode a `String`
+  ///   - encoding: A conformer to `Unicode.Encoding` to be used
+  ///               to decode `codeUnits`.
+  @inlinable
+  @available(SwiftStdlib 5.10, *)
+  public init?<Encoding: Unicode.Encoding>(
+    validating codeUnits: some Sequence<Encoding.CodeUnit>,
+    as encoding: Encoding.Type
+  ) {
+    let newString: String?? = codeUnits.withContiguousStorageIfAvailable {
+      String._validate($0, as: Encoding.self)
+    }
+    if let newString {
+      guard let newString else { return nil }
+      self = newString
+      return
+    }
+
+    // slow-path
+    var transcoded: [UTF8.CodeUnit] = []
+    transcoded.reserveCapacity(codeUnits.underestimatedCount)
+    var isASCII = true
+    let error = transcode(
+      codeUnits.makeIterator(),
+      from: Encoding.self,
+      to: UTF8.self,
+      stoppingOnError: true,
+      into: {
+        uint8 in
+        transcoded.append(uint8)
+        if isASCII && (uint8 & 0x80) == 0x80 { isASCII = false }
+      }
+    )
+    if error { return nil }
+    self = transcoded.withUnsafeBufferPointer{
+      String._uncheckedFromUTF8($0, asciiPreScanResult: isASCII)
+    }
+  }
+
+  /// Creates a new `String` by copying and validating the sequence of
+  /// `Int8` passed in, according to the specified encoding.
+  ///
+  /// This initializer does not try to repair ill-formed code unit sequences.
+  /// If any are found, the result of the initializer is `nil`.
+  ///
+  /// The following example calls this initializer with the contents of two
+  /// different arrays---first with a well-formed UTF-8 code unit sequence and
+  /// then with an ill-formed ASCII code unit sequence.
+  ///
+  ///     let validUTF8: [Int8] = [67, 97, 0, 102, -61, -87]
+  ///     let valid = String(validating: validUTF8, as: UTF8.self)
+  ///     print(valid)
+  ///     // Prints "Optional("Café")"
+  ///
+  ///     let invalidASCII: [Int8] = [67, 97, -5]
+  ///     let invalid = String(validating: invalidASCII, as: Unicode.ASCII.self)
+  ///     print(invalid)
+  ///     // Prints "nil"
+  ///
+  /// - Parameters:
+  ///   - codeUnits: A sequence of code units that encode a `String`
+  ///   - encoding: A conformer to `Unicode.Encoding` that can decode
+  ///               `codeUnits` as `UInt8`
+  @inlinable
+  @available(SwiftStdlib 5.10, *)
+  public init?<Encoding>(
+    validating codeUnits: some Sequence<Int8>,
+    as encoding: Encoding.Type
+  ) where Encoding: Unicode.Encoding, Encoding.CodeUnit == UInt8 {
+    let newString: String?? = codeUnits.withContiguousStorageIfAvailable {
+      $0.withMemoryRebound(to: UInt8.self) {
+        String._validate($0, as: Encoding.self)
+      }
+    }
+    if let newString {
+      guard let newString else { return nil }
+      self = newString
+      return
+    }
+
+    // slow-path
+    let uint8s = codeUnits.lazy.map(UInt8.init(bitPattern:))
+    let string = String(validating: uint8s, as: Encoding.self)
+    guard let string else { return nil }
+    self = string
+  }
+
   /// Creates a new string with the specified capacity in UTF-8 code units, and
   /// then calls the given closure with a buffer covering the string's
   /// uninitialized memory.

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -493,7 +493,7 @@ extension String {
     self = String._fromNonContiguousUnsafeBitcastUTF8Repairing(codeUnits).0
   }
 
-  /// Creates a new `String` by copying and validating the sequence of
+  /// Creates a new string by copying and validating the sequence of
   /// code units passed in, according to the specified encoding.
   ///
   /// This initializer does not try to repair ill-formed code unit sequences.
@@ -553,8 +553,8 @@ extension String {
     }
   }
 
-  /// Creates a new `String` by copying and validating the sequence of
-  /// `Int8` passed in, according to the specified encoding.
+  /// Creates a new string by copying and validating the sequence of
+  /// code units passed in, according to the specified encoding.
   ///
   /// This initializer does not try to repair ill-formed code unit sequences.
   /// If any are found, the result of the initializer is `nil`.
@@ -596,9 +596,7 @@ extension String {
 
     // slow-path
     let uint8s = codeUnits.lazy.map(UInt8.init(bitPattern:))
-    let string = String(validating: uint8s, as: Encoding.self)
-    guard let string else { return nil }
-    self = string
+    self.init(validating: uint8s, as: Encoding.self)
   }
 
   /// Creates a new string with the specified capacity in UTF-8 code units, and

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -352,7 +352,7 @@ extension String {
         break
       case .error:
         // validation error: clean up and return nil
-        buffer.prefix(through: written).deinitialize()
+        buffer.prefix(upTo: written).deinitialize()
         buffer.deallocate()
         return nil
       case .emptyInput:

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -339,7 +339,7 @@ extension String {
           let copy: UnsafeMutableBufferPointer<UInt8>
           copy = UnsafeMutableBufferPointer.allocate(capacity: newCapacity)
           let copied = copy.moveInitialize(
-            fromContentsOf: buffer.prefix(through: written)
+            fromContentsOf: buffer.prefix(upTo: written)
           )
           buffer.deallocate()
           buffer = copy

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -305,20 +305,15 @@ extension String {
     _ input: UnsafeBufferPointer<Encoding.CodeUnit>,
     as encoding: Encoding.Type
   ) -> String? {
-  fast: // fast-path
     if encoding.CodeUnit.self == UInt8.self {
       let bytes = _identityCast(input, to: UnsafeBufferPointer<UInt8>.self)
-      let isASCII: Bool
       if encoding.self == UTF8.self {
         guard case .success(let info) = validateUTF8(bytes) else { return nil }
-        isASCII = info.isASCII
+        return String._uncheckedFromUTF8(bytes, asciiPreScanResult: info.isASCII)
       } else if encoding.self == Unicode.ASCII.self {
         guard _allASCII(bytes) else { return nil }
-        isASCII = true
-      } else {
-        break fast
+        return String._uncheckedFromASCII(bytes)
       }
-      return String._uncheckedFromUTF8(bytes, asciiPreScanResult: isASCII)
     }
 
     // slow-path

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -300,7 +300,7 @@ extension String {
   }
 
   @usableFromInline
-  @available(SwiftStdlib 5.10, *)
+  @available(SwiftStdlib 5.11, *)
   internal static func _validate<Encoding: Unicode.Encoding>(
     _ input: UnsafeBufferPointer<Encoding.CodeUnit>,
     as encoding: Encoding.Type

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -298,4 +298,53 @@ extension String {
       String._uncheckedFromUTF8($0)
     }
   }
+
+  @usableFromInline
+  @available(SwiftStdlib 5.10, *)
+  internal static func _validate<Encoding: Unicode.Encoding>(
+    _ input: UnsafeBufferPointer<Encoding.CodeUnit>,
+    as encoding: Encoding.Type
+  ) -> String? {
+  fast: // fast-path
+    if encoding.CodeUnit.self == UInt8.self {
+      let bytes = _identityCast(input, to: UnsafeBufferPointer<UInt8>.self)
+      let isASCII: Bool
+      if encoding.self == UTF8.self {
+        guard case .success(let info) = validateUTF8(bytes) else { return nil }
+        isASCII = info.isASCII
+      } else if encoding.self == Unicode.ASCII.self {
+        guard _allASCII(bytes) else { return nil }
+        isASCII = true
+      } else {
+        break fast
+      }
+      return String._uncheckedFromUTF8(bytes, asciiPreScanResult: isASCII)
+    }
+
+    // slow-path
+    // this multiplier is a worst-case estimate
+    let multiplier = if encoding.self == UTF16.self { 3 } else { 4 }
+    return withUnsafeTemporaryAllocation(
+      of: UInt8.self, capacity: input.count * multiplier
+    ) {
+      output -> String? in
+      var isASCII = true
+      var index = output.startIndex
+      let error = transcode(
+        input.makeIterator(),
+        from: encoding.self,
+        to: UTF8.self,
+        stoppingOnError: true,
+        into: {
+          uint8 in
+          output[index] = uint8
+          output.formIndex(after: &index)
+          if isASCII && (uint8 & 0x80) == 0x80 { isASCII = false }
+        }
+      )
+      if error { return nil }
+      let bytes = UnsafeBufferPointer(start: output.baseAddress, count: index)
+      return String._uncheckedFromUTF8(bytes, asciiPreScanResult: isASCII)
+    }
+  }
 }

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -681,6 +681,8 @@ final internal class __SharedStringStorage
 
   internal var _breadcrumbs: _StringBreadcrumbs? = nil
 
+  internal var immortal = false
+
   internal var count: Int { _countAndFlags.count }
 
   internal init(
@@ -689,6 +691,7 @@ final internal class __SharedStringStorage
   ) {
     self._owner = nil
     self.start = ptr
+    self.immortal = true
 #if _pointerBitWidth(_64)
     self._countAndFlags = countAndFlags
 #elseif _pointerBitWidth(_32)
@@ -707,6 +710,32 @@ final internal class __SharedStringStorage
   final internal var asString: String {
     @_effects(readonly) @inline(__always) get {
       return String(_StringGuts(self))
+    }
+  }
+
+  internal init(
+    _mortal ptr: UnsafePointer<UInt8>,
+    countAndFlags: _StringObject.CountAndFlags
+  ) {
+    // ptr *must* be the start of an allocation
+    self._owner = nil
+    self.start = ptr
+    self.immortal = false
+#if _pointerBitWidth(_64)
+    self._countAndFlags = countAndFlags
+#elseif _pointerBitWidth(_32)
+    self._count = countAndFlags.count
+    self._countFlags = countAndFlags.flags
+#else
+#error("Unknown platform")
+#endif
+    super.init()
+    self._invariantCheck()
+  }
+
+  deinit {
+    if (_owner == nil) && !immortal {
+      start.deallocate()
     }
   }
 }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -45,6 +45,15 @@ Added: _$ss19_getWeakRetainCountySuyXlF
 // Swift._getUnownedRetainCount(Swift.AnyObject) -> Swift.UInt
 Added: _$ss22_getUnownedRetainCountySuyXlF
 
+// Swift.String.init<A, B where A: Swift._UnicodeEncoding, B: Swift.Sequence, A.CodeUnit == B.Element>(validating: B, as: A.Type) -> Swift.String?
+Added: _$sSS10validating2asSSSgq__xmtcs16_UnicodeEncodingRzSTR_7ElementQy_8CodeUnitRtzr0_lufC
+
+// Swift.String.init<A, B where A: Swift._UnicodeEncoding, B: Swift.Sequence, A.CodeUnit == Swift.UInt8, B.Element == Swift.Int8>(validating: B, as: A.Type) -> Swift.String?
+Added: _$sSS10validating2asSSSgq__xmtcs16_UnicodeEncodingRzSTR_s5UInt8V8CodeUnitRtzs4Int8V7ElementRt_r0_lufC
+
+// static Swift.String._validate<A where A: Swift._UnicodeEncoding>(_: Swift.UnsafeBufferPointer<A.CodeUnit>, as: A.Type) -> Swift.String?
+Added: _$sSS9_validate_2asSSSgSRy8CodeUnitQzG_xmts16_UnicodeEncodingRzlFZ
+
 // class __StaticArrayStorage
 Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfC
 Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTj

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -45,6 +45,15 @@ Added: _$ss19_getWeakRetainCountySuyXlF
 // Swift._getUnownedRetainCount(Swift.AnyObject) -> Swift.UInt
 Added: _$ss22_getUnownedRetainCountySuyXlF
 
+// Swift.String.init<A, B where A: Swift._UnicodeEncoding, B: Swift.Sequence, A.CodeUnit == B.Element>(validating: B, as: A.Type) -> Swift.String?
+Added: _$sSS10validating2asSSSgq__xmtcs16_UnicodeEncodingRzSTR_7ElementQy_8CodeUnitRtzr0_lufC
+
+// Swift.String.init<A, B where A: Swift._UnicodeEncoding, B: Swift.Sequence, A.CodeUnit == Swift.UInt8, B.Element == Swift.Int8>(validating: B, as: A.Type) -> Swift.String?
+Added: _$sSS10validating2asSSSgq__xmtcs16_UnicodeEncodingRzSTR_s5UInt8V8CodeUnitRtzs4Int8V7ElementRt_r0_lufC
+
+// static Swift.String._validate<A where A: Swift._UnicodeEncoding>(_: Swift.UnsafeBufferPointer<A.CodeUnit>, as: A.Type) -> Swift.String?
+Added: _$sSS9_validate_2asSSSgSRy8CodeUnitQzG_xmts16_UnicodeEncodingRzlFZ
+
 // class __StaticArrayStorage
 Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfC
 Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTj

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -143,3 +143,148 @@ if #available(SwiftStdlib 5.3, *) {
     expectEqual(str1, str6)
   }
 }
+
+let s1 = "Long string containing the characters é, ß, 🦆, and 👨‍👧‍👦."
+let s2 = "Long ascii string with no accented characters (obviously)."
+
+StringCreateTests.test("Validating.utf8")
+.skip(.custom(
+  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
+  reason: "Requires Swift 5.10's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 5.10, *) else { return }
+  
+  let i1 = Array(s1.utf8)
+  let i2 = Array(s2.utf8)
+  let i3 = {
+    var modified = i1
+    let index = modified.lastIndex(of: 240)
+    expectNotNil(index)
+    index.map { modified[$0] = 0 }
+    return modified
+  }()
+
+  var actual: String?
+  for simpleString in SimpleString.allCases {
+    let expected = simpleString.rawValue
+    actual = String(validating: expected.utf8, as: Unicode.UTF8.self)
+    expectEqual(actual, expected)
+  }
+
+  expectEqual(String(validating: i1, as: UTF8.self), s1)
+  expectEqual(String(validating: i2, as: UTF8.self), s2)
+  expectNil(String(validating: i3, as: UTF8.self))
+
+  expectEqual(String(validating: AnyCollection(i1), as: UTF8.self), s1)
+  expectEqual(String(validating: AnyCollection(i2), as: UTF8.self), s2)
+  expectNil(String(validating: AnyCollection(i3), as: UTF8.self))
+}
+
+StringCreateTests.test("Validating.utf8.from.int8")
+.skip(.custom(
+  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
+  reason: "Requires Swift 5.10's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 5.10, *) else { return }
+
+  let i1 = s1.utf8.map(Int8.init(bitPattern:))
+  let i2 = s2.utf8.map(Int8.init(bitPattern:))
+  let i3 = {
+    var modified = i1
+    let index = modified.lastIndex(of: Int8(bitPattern: 240))
+    expectNotNil(index)
+    index.map { modified[$0] = 0 }
+    return modified
+  }()
+
+  expectEqual(String(validating: i1, as: UTF8.self), s1)
+  expectEqual(String(validating: i2, as: UTF8.self), s2)
+  expectNil(String(validating: i3, as: UTF8.self))
+
+  expectEqual(String(validating: AnyCollection(i1), as: UTF8.self), s1)
+  expectEqual(String(validating: AnyCollection(i2), as: UTF8.self), s2)
+  expectNil(String(validating: AnyCollection(i3), as: UTF8.self))
+}
+
+StringCreateTests.test("Validating.ascii")
+.skip(.custom(
+  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
+  reason: "Requires Swift 5.10's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 5.10, *) else { return }
+
+  let i1 = Array(s1.utf8)
+  let i2 = Array(s2.utf8)
+
+  expectNil(String(validating: i1, as: Unicode.ASCII.self))
+  expectEqual(String(validating: i2, as: Unicode.ASCII.self), s2)
+
+  expectNil(String(validating: AnyCollection(i1), as: Unicode.ASCII.self))
+  expectEqual(String(validating: AnySequence(i2), as: Unicode.ASCII.self), s2)
+
+  let i3 = i1.map(Int8.init(bitPattern:))
+  let i4 = i2.map(Int8.init(bitPattern:))
+
+  expectNil(String(validating: i3, as: Unicode.ASCII.self))
+  expectEqual(String(validating: i4, as: Unicode.ASCII.self), s2)
+
+  expectNil(String(validating: AnyCollection(i3), as: Unicode.ASCII.self))
+  expectEqual(String(validating: AnySequence(i4), as: Unicode.ASCII.self), s2)
+}
+
+StringCreateTests.test("Validating.utf16")
+.skip(.custom(
+  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
+  reason: "Requires Swift 5.10's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 5.10, *) else { return }
+
+  let i1 = Array(s1.utf16)
+  let i2 = Array(s2.utf16)
+  let i3 = {
+    var modified = i1
+    let index = modified.lastIndex(of: 32)
+    expectNotNil(index)
+    index.map { modified[$0] = 0xd801 }
+    return modified
+  }()
+
+  expectEqual(String(validating: i1, as: UTF16.self), s1)
+  expectEqual(String(validating: i2, as: UTF16.self), s2)
+  expectNil(String(validating: i3, as: UTF16.self))
+
+  expectEqual(String(validating: AnySequence(i1), as: UTF16.self), s1)
+  expectEqual(String(validating: AnySequence(i2), as: UTF16.self), s2)
+  expectNil(String(validating: AnyCollection(i3), as: UTF16.self))
+}
+
+StringCreateTests.test("Validating.utf32")
+.skip(.custom(
+  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
+  reason: "Requires Swift 5.10's standard library"
+))
+.code {
+  guard #available(SwiftStdlib 5.10, *) else { return }
+
+  let i1 = s1.unicodeScalars.map(\.value)
+  let i2 = s2.unicodeScalars.map(\.value)
+  let i3 = {
+    var modified = i1
+    let index = modified.lastIndex(of: .init(bitPattern: 32))
+    expectNotNil(index)
+    index.map { modified[$0] = .max }
+    return modified
+  }()
+
+  expectEqual(String(validating: i1, as: UTF32.self), s1)
+  expectEqual(String(validating: i2, as: UTF32.self), s2)
+  expectNil(String(validating: i3, as: UTF32.self))
+
+  expectEqual(String(validating: AnySequence(i1), as: UTF32.self), s1)
+  expectEqual(String(validating: AnySequence(i2), as: UTF32.self), s2)
+  expectNil(String(validating: AnyCollection(i3), as: UTF32.self))
+}

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -149,12 +149,12 @@ let s2 = "Long ascii string with no accented characters (obviously)."
 
 StringCreateTests.test("Validating.utf8")
 .skip(.custom(
-  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
-  reason: "Requires Swift 5.10's standard library"
+  { if #available(SwiftStdlib 5.11, *) { false } else { true } },
+  reason: "Requires Swift 5.11's standard library"
 ))
 .code {
-  guard #available(SwiftStdlib 5.10, *) else { return }
-  
+  guard #available(SwiftStdlib 5.11, *) else { return }
+
   let i1 = Array(s1.utf8)
   let i2 = Array(s2.utf8)
   let i3 = {
@@ -183,11 +183,11 @@ StringCreateTests.test("Validating.utf8")
 
 StringCreateTests.test("Validating.utf8.from.int8")
 .skip(.custom(
-  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
-  reason: "Requires Swift 5.10's standard library"
+  { if #available(SwiftStdlib 5.11, *) { false } else { true } },
+  reason: "Requires Swift 5.11's standard library"
 ))
 .code {
-  guard #available(SwiftStdlib 5.10, *) else { return }
+  guard #available(SwiftStdlib 5.11, *) else { return }
 
   let i1 = s1.utf8.map(Int8.init(bitPattern:))
   let i2 = s2.utf8.map(Int8.init(bitPattern:))
@@ -210,11 +210,11 @@ StringCreateTests.test("Validating.utf8.from.int8")
 
 StringCreateTests.test("Validating.ascii")
 .skip(.custom(
-  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
-  reason: "Requires Swift 5.10's standard library"
+  { if #available(SwiftStdlib 5.11, *) { false } else { true } },
+  reason: "Requires Swift 5.11's standard library"
 ))
 .code {
-  guard #available(SwiftStdlib 5.10, *) else { return }
+  guard #available(SwiftStdlib 5.11, *) else { return }
 
   let i1 = Array(s1.utf8)
   let i2 = Array(s2.utf8)
@@ -237,11 +237,11 @@ StringCreateTests.test("Validating.ascii")
 
 StringCreateTests.test("Validating.utf16")
 .skip(.custom(
-  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
-  reason: "Requires Swift 5.10's standard library"
+  { if #available(SwiftStdlib 5.11, *) { false } else { true } },
+  reason: "Requires Swift 5.11's standard library"
 ))
 .code {
-  guard #available(SwiftStdlib 5.10, *) else { return }
+  guard #available(SwiftStdlib 5.11, *) else { return }
 
   let i1 = Array(s1.utf16)
   let i2 = Array(s2.utf16)
@@ -264,11 +264,11 @@ StringCreateTests.test("Validating.utf16")
 
 StringCreateTests.test("Validating.utf32")
 .skip(.custom(
-  { if #available(SwiftStdlib 5.10, *) { false } else { true } },
-  reason: "Requires Swift 5.10's standard library"
+  { if #available(SwiftStdlib 5.11, *) { false } else { true } },
+  reason: "Requires Swift 5.11's standard library"
 ))
 .code {
-  guard #available(SwiftStdlib 5.10, *) else { return }
+  guard #available(SwiftStdlib 5.11, *) else { return }
 
   let i1 = s1.unicodeScalars.map(\.value)
   let i2 = s2.unicodeScalars.map(\.value)

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -279,12 +279,16 @@ StringCreateTests.test("Validating.utf32")
     index.map { modified[$0] = .max }
     return modified
   }()
+  let s4 = SimpleString.emoji.rawValue
+  let i4 = s4.unicodeScalars.map(\.value)
 
   expectEqual(String(validating: i1, as: UTF32.self), s1)
   expectEqual(String(validating: i2, as: UTF32.self), s2)
   expectNil(String(validating: i3, as: UTF32.self))
+  expectEqual(String(validating: i4, as: UTF32.self), s4)
 
   expectEqual(String(validating: AnySequence(i1), as: UTF32.self), s1)
   expectEqual(String(validating: AnySequence(i2), as: UTF32.self), s2)
   expectNil(String(validating: AnyCollection(i3), as: UTF32.self))
+  expectEqual(String(validating: AnySequence(i4), as: UTF32.self), s4)
 }


### PR DESCRIPTION
API additions (and tests) from [SE-0405](https://github.com/apple/swift-evolution/blob/main/proposals/0405-string-validating-initializers.md), namely:
```
String.init?<Encoding>(
    validating codeUnits: some Sequence<Encoding.CodeUnit>,
    as encoding: Encoding.Type
  ) where Encoding: Unicode.Encoding

String.init?<Encoding>(
    validating codeUnits: some Sequence<Int8>,
    as encoding: Encoding.Type
  ) where Encoding: Unicode.Encoding, Encoding.CodeUnit == UInt8
```
The API renaming is in https://github.com/apple/swift/pull/68423.

rdar://114999766