### PR TITLE
[Concurrency] Fix an issue with Sendable checking for function references.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1002,7 +1002,7 @@ bool swift::diagnoseNonSendableTypesInReference(
     Expr *base, ConcreteDeclRef declRef,
     const DeclContext *fromDC, SourceLoc refLoc,
     SendableCheckReason refKind, llvm::Optional<ActorIsolation> knownIsolation,
-    FunctionCheckKind funcCheckKind, SourceLoc diagnoseLoc) {
+    FunctionCheckOptions funcCheckOptions, SourceLoc diagnoseLoc) {
   // Retrieve the actor isolation to use in diagnostics.
   auto getActorIsolation = [&] {
     if (knownIsolation)
@@ -1025,7 +1025,7 @@ bool swift::diagnoseNonSendableTypesInReference(
   // For functions, check the parameter and result types.
   SubstitutionMap subs = declRef.getSubstitutions();
   if (auto function = dyn_cast<AbstractFunctionDecl>(declRef.getDecl())) {
-    if (funcCheckKind != FunctionCheckKind::Results) {
+    if (funcCheckOptions.contains(FunctionCheckKind::Params)) {
       // only check params if funcCheckKind specifies so
       for (auto param : *function->getParameters()) {
         Type paramType = param->getInterfaceType().subst(subs);
@@ -1039,7 +1039,7 @@ bool swift::diagnoseNonSendableTypesInReference(
 
     // Check the result type of a function.
     if (auto func = dyn_cast<FuncDecl>(function)) {
-      if (funcCheckKind != FunctionCheckKind::Params) {
+      if (funcCheckOptions.contains(FunctionCheckKind::Results)) {
         // only check results if funcCheckKind specifies so
         Type resultType = func->getResultInterfaceType().subst(subs);
         if (diagnoseNonSendableTypes(
@@ -1069,7 +1069,7 @@ bool swift::diagnoseNonSendableTypesInReference(
 
   if (auto subscript = dyn_cast<SubscriptDecl>(declRef.getDecl())) {
     for (auto param : *subscript->getIndices()) {
-      if (funcCheckKind != FunctionCheckKind::Results) {
+      if (funcCheckOptions.contains(FunctionCheckKind::Params)) {
         // Check params of this subscript override for sendability
         Type paramType = param->getInterfaceType().subst(subs);
         if (diagnoseNonSendableTypes(
@@ -1080,7 +1080,7 @@ bool swift::diagnoseNonSendableTypesInReference(
       }
     }
 
-    if (funcCheckKind != FunctionCheckKind::Results) {
+    if (funcCheckOptions.contains(FunctionCheckKind::Results)) {
       // Check the element type of a subscript.
       Type resultType = subscript->getElementInterfaceType().subst(subs);
       if (diagnoseNonSendableTypes(
@@ -3176,7 +3176,12 @@ namespace {
         return diagnoseNonSendableTypesInReference(
                    base, declRef, getDeclContext(), loc,
                    SendableCheckReason::ExitingActor,
-                   result.isolation);
+                   result.isolation,
+                   // Function reference sendability can only cross isolation
+                   // boundaries when they're passed as an argument or called,
+                   // and their Sendability depends only on captures; do not
+                   // check the parameter or result types here.
+                   FunctionCheckOptions());
 
       case ActorReferenceResult::EntersActor:
         // Handle all of the checking below.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -246,16 +246,17 @@ public:
   operator Kind() const { return kind; }
 };
 
-/// Specifies whether checks applied to function types should
-/// apply to their params, results, or both
+/// Individual options used with \c FunctionCheckOptions
 enum class FunctionCheckKind {
-  /// Check params and results
-  ParamsResults,
-  /// Check params only
-  Params,
-  /// Check results only
-  Results,
+  /// Check params
+  Params = 1 << 0,
+  /// Check results
+  Results = 1 << 1,
 };
+
+/// Specifies whether checks applied to function types should apply to
+/// their parameters, their results, both, or neither.
+using FunctionCheckOptions = OptionSet<FunctionCheckKind>;
 
 /// Diagnose the presence of any non-sendable types when referencing a
 /// given declaration from a particular declaration context.
@@ -280,7 +281,7 @@ enum class FunctionCheckKind {
 /// \param refKind Describes what kind of reference is being made, which is
 /// used to tailor the diagnostic.
 ///
-/// \param funcCheckKind Describes whether function types in this reference
+/// \param funcCheckOptions Describes whether function types in this reference
 /// should be checked for sendability of their results, params, or both
 ///
 /// \param diagnoseLoc Provides an alternative source location to `refLoc`
@@ -293,7 +294,10 @@ bool diagnoseNonSendableTypesInReference(
     const DeclContext *fromDC, SourceLoc refLoc,
     SendableCheckReason refKind,
     llvm::Optional<ActorIsolation> knownIsolation = llvm::None,
-    FunctionCheckKind funcCheckKind = FunctionCheckKind::ParamsResults,
+    FunctionCheckOptions funcCheckOptions =
+        (FunctionCheckOptions() |
+         FunctionCheckKind::Params |
+         FunctionCheckKind::Results),
     SourceLoc diagnoseLoc = SourceLoc());
 
 /// Produce a diagnostic for a missing conformance to Sendable.

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -249,7 +249,7 @@ func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> 
 final class NonSendable {
   // expected-note @-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   // SendNonSendable emits 3 fewer errors here.
-  // expected-targeted-and-complete-note @-3 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  // expected-targeted-and-complete-note @-3 4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   var value = ""
 
   @MainActor
@@ -283,4 +283,16 @@ func testNonSendableBaseArg() async {
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
+}
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+func callNonisolatedAsyncClosure(
+  ns: NonSendable,
+  g: (NonSendable) async -> Void
+) async {
+  // FIXME: This should also produce a diagnostic with SendNonSendable, because
+  // the 'ns' parameter should be merged into the MainActor's region.
+  await g(ns)
+  // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -249,7 +249,7 @@ func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> 
 final class NonSendable {
   // expected-note @-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   // SendNonSendable emits 3 fewer errors here.
-  // expected-targeted-and-complete-note @-3 4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  // expected-targeted-and-complete-note @-3 5 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   var value = ""
 
   @MainActor
@@ -286,13 +286,22 @@ func testNonSendableBaseArg() async {
 }
 
 @available(SwiftStdlib 5.1, *)
+@Sendable
+func globalSendable(_ ns: NonSendable) async {}
+
+@available(SwiftStdlib 5.1, *)
 @MainActor
 func callNonisolatedAsyncClosure(
   ns: NonSendable,
   g: (NonSendable) async -> Void
 ) async {
-  // FIXME: This should also produce a diagnostic with SendNonSendable, because
-  // the 'ns' parameter should be merged into the MainActor's region.
+  // FIXME: Both cases below should also produce a diagnostic with SendNonSendable,
+  // because the 'ns' parameter should be merged into the MainActor's region.
+
   await g(ns)
+  // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
+
+  let f: (NonSendable) async -> () = globalSendable // okay
+  await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
 }


### PR DESCRIPTION
* Add a test case for passing a non-Sendable argument to a nonisolated closure in an actor-isolated context. This previously did not produce a diagnostic, but now does on main.
*  Don't check parameter and result types of function references for Sendability. Sendability of function references depends only on captures, and applies when the function itself is passed across isolation boundaries. Parameter and result values can only cross isolation boundaries when the function is called, so they shouldn't be checked when checking a reference for Sendable violations.

Resolves rdar://104129168