### PR TITLE
[embedded] Add an interim attr to mark declarations as unavailable in embedded Swift

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1316,9 +1316,13 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
   Opts.BypassResilienceChecks |= Args.hasArg(OPT_bypass_resilience);
 
-  if (FrontendOpts.EnableLibraryEvolution && Opts.hasFeature(Feature::Embedded)) {
-    Diags.diagnose(SourceLoc(), diag::evolution_with_embedded);
-    HadError = true;
+  if (Opts.hasFeature(Feature::Embedded)) {
+    Opts.UnavailableDeclOptimizationMode = UnavailableDeclOptimization::Complete;
+
+    if (FrontendOpts.EnableLibraryEvolution) {
+      Diags.diagnose(SourceLoc(), diag::evolution_with_embedded);
+      HadError = true;
+    }
   }
 
   if (auto A = Args.getLastArg(OPT_checked_async_objc_bridging)) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -345,12 +345,14 @@ static bool isInsideCompatibleUnavailableDeclaration(
     return false;
   }
 
-  // Refuse calling unavailable functions from unavailable code,
-  // but allow the use of types.
+  // Unless in embedded Swift mode, refuse calling unavailable functions from
+  // unavailable code, but allow the use of types.
   PlatformKind platform = attr->Platform;
-  if (platform == PlatformKind::none && !isa<TypeDecl>(D) &&
-      !isa<ExtensionDecl>(D)) {
-    return false;
+  if (!D->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    if (platform == PlatformKind::none && !isa<TypeDecl>(D) &&
+        !isa<ExtensionDecl>(D)) {
+      return false;
+    }
   }
 
   return (*referencedPlatform == platform ||

--- a/test/embedded/availability-code-removal.swift
+++ b/test/embedded/availability-code-removal.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib -enable-experimental-feature Embedded
+
+public protocol Player {}
+struct Concrete: Player {}
+
+@_unavailableInEmbedded
+public func test() -> any Player {
+  Concrete() // no error because we're in unavailable-in-embedded context
+}

--- a/test/embedded/availability-code-removal.swift
+++ b/test/embedded/availability-code-removal.swift
@@ -1,4 +1,14 @@
-// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib -enable-experimental-feature Embedded
+// This test is checking that usage of an existential (which is normally
+// disallowed in embedded Swift and flagged in IRGen) is left undiagnosed
+// because the context is @_unavailableInEmbedded.
+//
+// The breakdown of that is
+// - (1) @_unavailableInEmbedded makes the declaration unavailable,
+// - (2) unavailable function bodies is removed in embedded Swift,
+// - (3) the test() function is not reported by the existential checker.
+
+// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib | %FileCheck %s --check-prefix CHECK-A
+// RUN: %target-swift-frontend -emit-ir %s -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s --check-prefix CHECK-B
 
 public protocol Player {}
 struct Concrete: Player {}
@@ -7,3 +17,6 @@ struct Concrete: Player {}
 public func test() -> any Player {
   Concrete() // no error because we're in unavailable-in-embedded context
 }
+
+// CHECK-A: $s4main4testAA6Player_pyF
+// CHECK-B-NOT: $s4main4testAA6Player_pyF

--- a/test/embedded/availability.swift
+++ b/test/embedded/availability.swift
@@ -1,0 +1,22 @@
+// Building with regular Swift should succeed
+// RUN: %target-swift-emit-ir %s -parse-stdlib
+
+// Building with embedded Swift should produce unavailability errors
+// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-experimental-feature Embedded
+
+@_unavailableInEmbedded
+public func embedded() { }
+public func regular() {
+	embedded() // expected-error {{'embedded()' is unavailable: unavailable in embedded Swift}}
+	// expected-note@-3 {{'embedded()' has been explicitly marked unavailable here}}
+}
+
+@_unavailableInEmbedded
+public func unused() { } // no error
+
+@_unavailableInEmbedded
+public func called_from_unavailable() { }
+@_unavailableInEmbedded
+public func also_embedded() { 
+	called_from_unavailable() // no error
+}


### PR DESCRIPTION
Implemented as custom parsing logic instead of a proper attribute because we want it to be rewritten at parse time (into nothing in regular Swift mode, and into unconditional unavailable attr in embedded Swift mode), no serialization, printing, etc.

This is supposed to be temporary, and only used in the stdlib to unblock progress on annotating the stdlib.