### PR TITLE
Improve ad-hoc remoteCall and remoteCallVoid matching; independent of order

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -529,7 +529,8 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   auto *ActParam = std::find_if_not(
       genericParams->begin(), genericParams->end(),
       [this, &C, &module](GenericTypeParamDecl *param) {
-        return module->lookupConformance(
+        return module
+            ->lookupConformance(
                 mapTypeIntoContext(param->getDeclaredInterfaceType()),
                 C.getProtocol(KnownProtocolKind::DistributedActor))
             .isInvalid();
@@ -539,10 +540,12 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   auto *ErrParam = std::find_if_not(
       genericParams->begin(), genericParams->end(),
       [this, &C, &module, ActParam](GenericTypeParamDecl *param) {
-        return param == *ActParam || module->lookupConformance(
-                mapTypeIntoContext(param->getDeclaredInterfaceType()),
-                C.getProtocol(KnownProtocolKind::Error))
-            .isInvalid();
+        return param == *ActParam ||
+               module
+                   ->lookupConformance(
+                       mapTypeIntoContext(param->getDeclaredInterfaceType()),
+                       C.getProtocol(KnownProtocolKind::Error))
+                   .isInvalid();
       });
   if (!ErrParam) {
     return false;
@@ -553,11 +556,11 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   // no requirements to check on `Res`
   GenericTypeParamDecl *ResParam = nullptr;
   if (!isVoidReturn) {
-    if (auto **foundResParm = std::find_if(
-        genericParams->begin(), genericParams->end(),
-        [ErrParam, ActParam](GenericTypeParamDecl *param) {
-      return param != *ErrParam && param != *ActParam;
-    })) {
+    if (auto **foundResParm =
+            std::find_if(genericParams->begin(), genericParams->end(),
+                         [ErrParam, ActParam](GenericTypeParamDecl *param) {
+                           return param != *ErrParam && param != *ActParam;
+                         })) {
       ResParam = *foundResParm;
     } else {
       return false;
@@ -582,38 +585,40 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   // same_type: Act.ID FakeActorSystem.ActorID // LAST one
 
   // --- Check requirement: conforms_to: Act DistributedActor
-//  auto actorReq = requirements[0];
+  //  auto actorReq = requirements[0];
   auto distActorTy = C.getProtocol(KnownProtocolKind::DistributedActor)
                        ->getInterfaceType()
                        ->getMetatypeInstanceType();
 
-  auto foundActorRequirement = std::find_if(requirements.begin(), requirements.end(), [distActorTy](Requirement req) {
-    if (req.getKind() != RequirementKind::Conformance) {
-      return false;
-    }
-    if (!req.getSecondType()->isEqual(distActorTy)) {
-      return false;
-    }
-    return true;
-  });
+  auto foundActorRequirement = std::find_if(
+      requirements.begin(), requirements.end(), [distActorTy](Requirement req) {
+        if (req.getKind() != RequirementKind::Conformance) {
+          return false;
+        }
+        if (!req.getSecondType()->isEqual(distActorTy)) {
+          return false;
+        }
+        return true;
+      });
   if (!foundActorRequirement) {
     return false;
   }
 
   // --- Check requirement: conforms_to: Err Error
-//  auto errorReq = requirements[1];
+  //  auto errorReq = requirements[1];
   auto errorTy = C.getProtocol(KnownProtocolKind::Error)
                      ->getInterfaceType()
                      ->getMetatypeInstanceType();
-  auto foundErrorRequirement = std::find_if(requirements.begin(), requirements.end(), [errorTy](Requirement req) {
-    if (req.getKind() != RequirementKind::Conformance) {
-      return false;
-    }
-    if (!req.getSecondType()->isEqual(errorTy)) {
-      return false;
-    }
-    return true;
-  });
+  auto foundErrorRequirement = std::find_if(
+      requirements.begin(), requirements.end(), [errorTy](Requirement req) {
+        if (req.getKind() != RequirementKind::Conformance) {
+          return false;
+        }
+        if (!req.getSecondType()->isEqual(errorTy)) {
+          return false;
+        }
+        return true;
+      });
   if (!foundErrorRequirement) {
     return false;
   }
@@ -626,8 +631,8 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   } else if (ResParam) {
     assert(ResParam && "Non void function, yet no Res generic parameter found");
     auto resultType = func->mapTypeIntoContext(func->getResultInterfaceType())
-        ->getMetatypeInstanceType()
-        ->getDesugaredType();
+                          ->getMetatypeInstanceType()
+                          ->getDesugaredType();
     auto resultParamType = func->mapTypeIntoContext(
         ResParam->getInterfaceType()->getMetatypeInstanceType());
     // The result of the function must be the `Res` generic argument.
@@ -635,8 +640,9 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
       return false;
     }
 
-    for (auto requirementProto: requirementProtos) {
-      auto conformance = module->lookupConformance(resultType, requirementProto);
+    for (auto requirementProto : requirementProtos) {
+      auto conformance =
+          module->lookupConformance(resultType, requirementProto);
       if (conformance.isInvalid()) {
         return false;
       }

--- a/test/Distributed/distributed_actor_system_adhoc_requirement_different_spelling.swift
+++ b/test/Distributed/distributed_actor_system_adhoc_requirement_different_spelling.swift
@@ -1,0 +1,489 @@
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+struct SomeError: DistributedActorSystem {
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
+
+  func resignID(_ id: ActorID) {
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
+
+  public func remoteCall<Act, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: (some Error).Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
+
+//  public func remoteCallVoid<Act, Err>(
+  public func remoteCallVoid<Act>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: (some Error).Type
+//    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+//    Err: Error,
+    Act.ID == ActorID {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
+}
+
+// some DistributedActor is incorrect since we have additional requirements on it, so don't allow that.
+struct SomeDASomeError: DistributedActorSystem {
+  // expected-error@-1{{struct 'SomeDASomeError' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+
+  // expected-error@-4{{struct 'SomeDASomeError' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
+
+  func resignID(_ id: ActorID) {
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
+
+  public func remoteCall<Res>(
+    on actor: some DistributedActor,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: (some Error).Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where
+//    Act: DistributedActor,
+//    Act.ID == ActorID,
+    Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
+
+  public func remoteCallVoid(
+    on actor: some DistributedActor,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: (some Error).Type
+//    throwing: Err.Type
+  ) async throws
+//    where
+//    Act: DistributedActor,
+//    Err: Error,
+//    Act.ID == ActorID
+  {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
+}
+
+// Wrong by trying to express all requirements as the same generic type
+struct CantBeAllTheSame: DistributedActorSystem {
+  // expected-error@-1{{struct 'CantBeAllTheSame' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+
+  // expected-error@-4{{struct 'CantBeAllTheSame' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
+
+  func resignID(_ id: ActorID) {
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
+
+  public func remoteCall<X>(
+    on actor: some DistributedActor,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: X.Type,
+    returning: X.Type
+  ) async throws -> X
+    where
+    X: DistributedActor,
+    X.ID == ActorID,
+    X: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
+
+  public func remoteCallVoid<X>(
+    on actor: some DistributedActor,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: X.Type
+  ) async throws
+    where
+    X: DistributedActor,
+    X.ID == ActorID,
+    X: Error
+  {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
+}
+
+// ==== ------------------------------------------------------------------------
+
+public struct ActorAddress: Sendable, Hashable, Codable {
+  let address: String
+  init(parse address: String) {
+    self.address = address
+  }
+}
+
+public protocol SomeProtocol: Sendable {}
+
+struct FakeInvocationEncoder: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+struct AnyInvocationEncoder: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = Any
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+struct LargeSerializationReqFakeInvocationEncoder: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = Codable & SomeProtocol
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+public struct PublicFakeInvocationEncoder: DistributedTargetInvocationEncoder {
+  public typealias SerializationRequirement = Codable
+
+  public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  public mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  public mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  public mutating func doneRecording() throws {}
+}
+
+struct FakeInvocationEncoder_missing_recordArgument: DistributedTargetInvocationEncoder {
+  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  // MISSING: mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+struct FakeInvocationEncoder_missing_recordArgument2: DistributedTargetInvocationEncoder {
+  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument2' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Argument: SomeProtocol>(_ argument: Argument) throws {} // BAD
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+struct FakeInvocationEncoder_missing_recordReturnType: DistributedTargetInvocationEncoder {
+  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordReturnType' is missing witness for protocol requirement 'recordReturnType'}}
+  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordReturnType' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  // MISSING: mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+struct FakeInvocationEncoder_missing_recordErrorType: DistributedTargetInvocationEncoder {
+  //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordErrorType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  // MISSING: mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+struct FakeInvocationEncoder_recordArgument_wrongType: DistributedTargetInvocationEncoder {
+  //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_wrongType' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: String, other: Argument) throws {} // BAD
+  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument.Type) throws {} // BAD
+  mutating func recordArgument<Argument: SerializationRequirement>(badName: Argument) throws {} // BAD
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+struct FakeInvocationEncoder_recordArgument_missingMutating: DistributedTargetInvocationEncoder {
+  //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_missingMutating' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+struct FakeInvocationEncoder_recordResultType_wrongType: DistributedTargetInvocationEncoder {
+  //expected-error@-1{{struct 'FakeInvocationEncoder_recordResultType_wrongType' is missing witness for protocol requirement 'recordReturnType'}}
+  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordReturnType' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(s: String, _ resultType: R.Type) throws {} // BAD
+  mutating func recordReturnType<R: SomeProtocol>(_ resultType: R.Type) throws {} // BAD
+  mutating func recordReturnType<R: SerializationRequirement>(badName: R.Type) throws {} // BAD
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+
+struct FakeInvocationEncoder_recordErrorType_wrongType: DistributedTargetInvocationEncoder {
+  //expected-error@-1{{type 'FakeInvocationEncoder_recordErrorType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
+  typealias SerializationRequirement = Codable
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(BadName type: E.Type) throws {} // BAD
+  mutating func recordErrorType<E: SerializationRequirement>(_ type: E.Type) throws {} // BAD
+  //expected-note@-1{{candidate has non-matching type '<E> (E.Type) throws -> ()'}}
+  mutating func doneRecording() throws {}
+}
+
+class FakeInvocationDecoder: DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Codable
+
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
+}
+
+class AnyInvocationDecoder: DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Any
+
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
+}
+
+class LargeSerializationReqFakeInvocationDecoder : DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Codable & SomeProtocol
+
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
+}
+
+public final class PublicFakeInvocationDecoder : DistributedTargetInvocationDecoder {
+  public typealias SerializationRequirement = Codable
+
+  public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  public func decodeReturnType() throws -> Any.Type? { nil }
+  public func decodeErrorType() throws -> Any.Type? { nil }
+}
+
+public final class PublicFakeInvocationDecoder_badNotPublic: DistributedTargetInvocationDecoder {
+  public typealias SerializationRequirement = Codable
+
+  public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  // expected-error@-1{{method 'decodeNextArgument()' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedTargetInvocationDecoder'}}
+  func decodeReturnType() throws -> Any.Type? { nil }
+  // expected-error@-1{{method 'decodeReturnType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
+  // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
+  func decodeErrorType() throws -> Any.Type? { nil }
+  // expected-error@-1{{method 'decodeErrorType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
+  // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
+}
+
+final class PublicFakeInvocationDecoder_badBadProtoRequirement: DistributedTargetInvocationDecoder {
+  // expected-error@-1{{class 'PublicFakeInvocationDecoder_badBadProtoRequirement' is missing witness for protocol requirement 'decodeNextArgument'}}
+  // expected-note@-2{{protocol 'DistributedTargetInvocationDecoder' requires function 'decodeNextArgument' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SomeProtocol>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
+}
+
+public struct FakeResultHandler: DistributedTargetInvocationResultHandler {
+  public typealias SerializationRequirement = Codable
+
+  public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  public func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+  public func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
+}
+
+struct AnyResultHandler: DistributedTargetInvocationResultHandler {
+  typealias SerializationRequirement = Any
+
+  func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+  func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
+}
+struct LargeSerializationReqFakeInvocationResultHandler: DistributedTargetInvocationResultHandler {
+  typealias SerializationRequirement = Codable & SomeProtocol
+
+  func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+  func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
+}
+
+struct BadResultHandler_missingOnReturn: DistributedTargetInvocationResultHandler {
+  // expected-error@-1{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
+  // expected-note@-2{{protocol 'DistributedTargetInvocationResultHandler' requires function 'onReturn' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  // func onReturn<Res: SerializationRequirement>(value: Res) async throws {} // MISSING
+  func onReturnVoid() async throws {}
+  func onThrow<Err: Error>(error: Err) async throws {}
+}
+
+struct BadResultHandler_missingRequirement: DistributedTargetInvocationResultHandler {
+  // expected-error@-1{{struct 'BadResultHandler_missingRequirement' is missing witness for protocol requirement 'onReturn'}}
+  // expected-note@-2{{protocol 'DistributedTargetInvocationResultHandler' requires function 'onReturn' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  func onReturn<Success>(value: Success) async throws {} // MISSING : Codable
+  func onReturnVoid() async throws {}
+  func onThrow<Err: Error>(error: Err) async throws {}
+}
+
+struct BadResultHandler_mutatingButShouldNotBe: DistributedTargetInvocationResultHandler {
+  // expected-error@-1{{struct 'BadResultHandler_mutatingButShouldNotBe' is missing witness for protocol requirement 'onReturn'}}
+  // expected-note@-2{{protocol 'DistributedTargetInvocationResultHandler' requires function 'onReturn' with signature:}}
+  typealias SerializationRequirement = Codable
+
+  mutating func onReturn<Success: Codable>(value: Success) async throws {} // WRONG: can't be mutating
+  func onReturnVoid() async throws {}
+  func onThrow<Err: Error>(error: Err) async throws {}
+}
+
+public struct PublicFakeResultHandler: DistributedTargetInvocationResultHandler {
+  public typealias SerializationRequirement = Codable
+
+  public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  public func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+  public func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
+}
+

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -38,6 +38,7 @@ struct MissingRemoteCall: DistributedActorSystem {
   }
 
   func makeInvocationEncoder() -> InvocationEncoder {
+    .init()
   }
 }
 


### PR DESCRIPTION
Resolves rdar://102126743

Resolves https://github.com/apple/swift/issues/61999

The ad-hoc method finding was a bit naive by checking for only the specific `<Act, Err, Res>` form, however people can write those generics in any order. And even as `some Error` which surprises the naive detection logic which assume error generic requirement at index `1`.

This changes it to be more "find things that match" rather than be position oriented.