### PR TITLE
SimplifyBranch: don't leave an empty block after merging two basic blocks

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBranch.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBranch.swift
@@ -70,8 +70,10 @@ private extension BranchInst {
       }
       parentBB.moveAllInstructions(toBeginOf: targetBB, context)
       parentBB.moveAllArguments(to: targetBB, context)
+      context.erase(block: parentBB)
     } else {
       targetBB.moveAllInstructions(toEndOf: parentBB, context)
+      context.erase(block: targetBB)
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -71,6 +71,10 @@ extension MutatingContext {
     erase(instruction: inst)
   }
 
+  func erase(block: BasicBlock) {
+    _bridged.eraseBlock(block.bridged)
+  }
+
   func tryOptimizeApplyOfPartialApply(closure: PartialApplyInst) -> Bool {
     if _bridged.tryOptimizeApplyOfPartialApply(closure.bridged) {
       notifyInstructionsChanged()
@@ -225,10 +229,6 @@ struct FunctionPassContext : MutatingContext {
       let nameStr = llvm.StringRef(nameBuffer.baseAddress, nameBuffer.count)
       return _bridged.lookupStdlibFunction(nameStr).function
     }
-  }
-
-  func erase(block: BasicBlock) {
-    _bridged.eraseBlock(block.bridged)
   }
 
   func modifyEffects(in function: Function, _ body: (inout FunctionEffects) -> ()) {

--- a/test/SILOptimizer/simplify_branch_crash.sil
+++ b/test/SILOptimizer/simplify_branch_crash.sil
@@ -1,0 +1,28 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-opt-pass-count=1.1 -simplification -simplify-instruction=br | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+// Check that branch simplification doesn't leave empty blocks.
+// -sil-opt-pass-count=1.1  prevents dead block elimination which would hide the problem.
+
+
+
+// CHECK-LABEL: sil @dont_leave_empty_blocks
+// CHECK:       bb0(%0 : $Builtin.Int64):
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    return %0
+// CHECK:       } // end sil function 'dont_leave_empty_blocks'
+sil @dont_leave_empty_blocks : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%0 : $Builtin.Int64):
+  br bb1
+
+bb1:
+  br bb2
+
+bb2:
+  return %0 : $Builtin.Int64
+}


### PR DESCRIPTION
Although empty blocks are cleaned up at the end of every Simplification pass, it's not legal SIL to have empty blocks and subsequent simplification passes may crash because of this.

rdar://115169880
