### PR TITLE
[Distributed] Add fixits for distributed system adhoc requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5348,9 +5348,9 @@ ERROR(broken_distributed_actor_requirement,none,
 ERROR(distributed_actor_system_conformance_missing_adhoc_requirement,none,
       "%kind0 is missing witness for protocol requirement %1",
       (const ValueDecl *, DeclName))
-NOTE(note_distributed_actor_system_conformance_missing_adhoc_requirement,none,
-      "protocol %0 requires function %1 with signature:\n%2",
-     (DeclName, DeclName, StringRef))
+//NOTE(note_distributed_actor_system_conformance_missing_adhoc_requirement,none,
+//      "protocol %0 requires function %1 with signature:\n%2",
+//     (DeclName, DeclName, StringRef))
 
 ERROR(override_implicit_unowned_executor,none,
       "cannot override an actor's 'unownedExecutor' property that wasn't "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5348,9 +5348,6 @@ ERROR(broken_distributed_actor_requirement,none,
 ERROR(distributed_actor_system_conformance_missing_adhoc_requirement,none,
       "%kind0 is missing witness for protocol requirement %1",
       (const ValueDecl *, DeclName))
-//NOTE(note_distributed_actor_system_conformance_missing_adhoc_requirement,none,
-//      "protocol %0 requires function %1 with signature:\n%2",
-//     (DeclName, DeclName, StringRef))
 
 ERROR(override_implicit_unowned_executor,none,
       "cannot override an actor's 'unownedExecutor' property that wasn't "

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/TypeVisitor.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/Basic/Defer.h"
+#include "swift/AST/ASTPrinter.h"
 
 using namespace swift;
 
@@ -222,6 +223,69 @@ static bool checkAdHocRequirementAccessControl(
       return true;
 }
 
+static bool diagnoseMissingAdHocProtocolRequirement(ASTContext &C, Identifier identifier, NominalTypeDecl *decl) {
+  assert(decl);
+  auto FixitLocation = decl->getBraces().Start;
+
+  // Prepare the indent (same as `printRequirementStub`)
+  StringRef ExtraIndent;
+  StringRef CurrentIndent =
+      Lexer::getIndentationForLine(C.SourceMgr, decl->getStartLoc(), &ExtraIndent);
+
+  llvm::SmallString<128> Text;
+  llvm::raw_svector_ostream OS(Text);
+  ExtraIndentStreamPrinter Printer(OS, CurrentIndent);
+
+  Printer << (decl->getFormalAccess() == AccessLevel::Public ? "public " : "");
+
+  if (identifier == C.Id_remoteCall) {
+    Printer << "func remoteCall<Act, Err, Res>("
+               "on actor: Act, "
+               "target: RemoteCallTarget, "
+               "invocation: inout InvocationEncoder, "
+               "throwing: Err.Type, "
+               "returning: Res.Type) "
+               "async throws -> Res "
+               "where Act: DistributedActor, "
+               "Act.ID == ActorID, "
+               "Err: Error, "
+               "Res: SerializationRequirement";
+  } else if (identifier == C.Id_remoteCallVoid) {
+    Printer << "func remoteCallVoid<Act, Err>("
+               "on actor: Act, "
+               "target: RemoteCallTarget, "
+               "invocation: inout InvocationEncoder, "
+               "throwing: Err.Type"
+               ") async throws "
+               "where Act: DistributedActor, "
+               "Act.ID == ActorID, "
+               "Err: Error";
+  } else if (identifier == C.Id_recordArgument) {
+    Printer << "mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws";
+  } else if (identifier == C.Id_recordReturnType) {
+    Printer << "mutating func recordReturnType<Res: SerializationRequirement>(_ resultType: Res.Type) throws";
+  } else if (identifier == C.Id_decodeNextArgument) {
+    Printer << "mutating func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument";
+  } else if (identifier == C.Id_onReturn) {
+    Printer << "func onReturn<Success: SerializationRequirement>(value: Success) async throws";
+  } else {
+    llvm_unreachable("Unknown identifier for diagnosing ad-hoc missing requirement.");
+  }
+
+  /// Print the "{ <#code#> }" placeholder body
+  Printer << " {\n";
+  Printer << ExtraIndent << getCodePlaceholder();
+  Printer << "\n}\n";
+
+  decl->diagnose(
+      diag::distributed_actor_system_conformance_missing_adhoc_requirement,
+      decl, identifier);
+  decl->diagnose(diag::missing_witnesses_general)
+      .fixItInsertAfter(FixitLocation, Text.str());
+
+  return true;
+}
+
 bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
     ASTContext &C,
     ProtocolDecl *Proto,
@@ -238,53 +302,21 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
     auto remoteCallDecl =
         C.getRemoteCallOnDistributedActorSystem(decl, /*isVoidReturn=*/false);
     if (!remoteCallDecl && diagnose) {
-      auto identifier = C.Id_remoteCall;
-      decl->diagnose(
-          diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl, identifier);
-      decl->diagnose(
-          diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
-          Proto->getName(), identifier,
-          "func remoteCall<Act, Err, Res>(\n"
-          "    on actor: Act,\n"
-          "    target: RemoteCallTarget,\n"
-          "    invocation: inout InvocationEncoder,\n"
-          "    throwing: Err.Type,\n"
-          "    returning: Res.Type\n"
-          ") async throws -> Res\n"
-          "  where Act: DistributedActor,\n"
-          "        Act.ID == ActorID,\n"
-          "        Err: Error,\n"
-          "        Res: SerializationRequirement\n");
+      anyMissingAdHocRequirements = diagnoseMissingAdHocProtocolRequirement(C, C.Id_remoteCall, decl);
+    }
+    if (checkAdHocRequirementAccessControl(decl, Proto, remoteCallDecl)) {
       anyMissingAdHocRequirements = true;
     }
-    if (checkAdHocRequirementAccessControl(decl, Proto, remoteCallDecl))
-      anyMissingAdHocRequirements = true;
 
     // - remoteCallVoid
     auto remoteCallVoidDecl =
         C.getRemoteCallOnDistributedActorSystem(decl, /*isVoidReturn=*/true);
     if (!remoteCallVoidDecl && diagnose) {
-      auto identifier = C.Id_remoteCallVoid;
-      decl->diagnose(
-          diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl, identifier);
-      decl->diagnose(
-          diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
-          Proto->getName(), identifier,
-          "func remoteCallVoid<Act, Err>(\n"
-          "    on actor: Act,\n"
-          "    target: RemoteCallTarget,\n"
-          "    invocation: inout InvocationEncoder,\n"
-          "    throwing: Err.Type\n"
-          ") async throws\n"
-          "  where Act: DistributedActor,\n"
-          "        Act.ID == ActorID,\n"
-          "        Err: Error\n");
+      anyMissingAdHocRequirements = diagnoseMissingAdHocProtocolRequirement(C, C.Id_remoteCallVoid, decl);
+    }
+    if (checkAdHocRequirementAccessControl(decl, Proto, remoteCallVoidDecl)) {
       anyMissingAdHocRequirements = true;
     }
-    if (checkAdHocRequirementAccessControl(decl, Proto, remoteCallVoidDecl))
-      anyMissingAdHocRequirements = true;
 
     return anyMissingAdHocRequirements;
   }
@@ -295,32 +327,20 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
     // - recordArgument
     auto recordArgumentDecl = C.getRecordArgumentOnDistributedInvocationEncoder(decl);
     if (!recordArgumentDecl) {
-      auto identifier = C.Id_recordArgument;
-      decl->diagnose(
-          diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl, identifier);
-      decl->diagnose(diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
-                     Proto->getName(), identifier,
-                     "mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws\n");
+      anyMissingAdHocRequirements = diagnoseMissingAdHocProtocolRequirement(C, C.Id_recordArgument, decl);
+    }
+    if (checkAdHocRequirementAccessControl(decl, Proto, recordArgumentDecl)) {
       anyMissingAdHocRequirements = true;
     }
-    if (checkAdHocRequirementAccessControl(decl, Proto, recordArgumentDecl))
-      anyMissingAdHocRequirements = true;
 
     // - recordReturnType
     auto recordReturnTypeDecl = C.getRecordReturnTypeOnDistributedInvocationEncoder(decl);
     if (!recordReturnTypeDecl) {
-      auto identifier = C.Id_recordReturnType;
-      decl->diagnose(
-          diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl, identifier);
-      decl->diagnose(diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
-                     Proto->getName(), identifier,
-                     "mutating func recordReturnType<Res: SerializationRequirement>(_ resultType: Res.Type) throws\n");
+      anyMissingAdHocRequirements = diagnoseMissingAdHocProtocolRequirement(C, C.Id_recordReturnType, decl);
+    }
+    if (checkAdHocRequirementAccessControl(decl, Proto, recordReturnTypeDecl)) {
       anyMissingAdHocRequirements = true;
     }
-    if (checkAdHocRequirementAccessControl(decl, Proto, recordReturnTypeDecl))
-      anyMissingAdHocRequirements = true;
 
     return anyMissingAdHocRequirements;
   }
@@ -331,17 +351,11 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
     // - decodeNextArgument
     auto decodeNextArgumentDecl = C.getDecodeNextArgumentOnDistributedInvocationDecoder(decl);
     if (!decodeNextArgumentDecl) {
-      auto identifier = C.Id_decodeNextArgument;
-      decl->diagnose(
-          diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl, identifier);
-      decl->diagnose(diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
-                     Proto->getName(), identifier,
-                     "mutating func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument\n");
+      anyMissingAdHocRequirements = diagnoseMissingAdHocProtocolRequirement(C, C.Id_decodeNextArgument, decl);
+    }
+    if (checkAdHocRequirementAccessControl(decl, Proto, decodeNextArgumentDecl)) {
       anyMissingAdHocRequirements = true;
     }
-    if (checkAdHocRequirementAccessControl(decl, Proto, decodeNextArgumentDecl))
-      anyMissingAdHocRequirements = true;
 
     return anyMissingAdHocRequirements;
   }
@@ -352,19 +366,11 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
     // - onReturn
     auto onReturnDecl = C.getOnReturnOnDistributedTargetInvocationResultHandler(decl);
     if (!onReturnDecl) {
-      auto identifier = C.Id_onReturn;
-      decl->diagnose(
-          diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl, identifier);
-      decl->diagnose(
-          diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
-          Proto->getName(), identifier,
-          "func onReturn<Success: SerializationRequirement>(value: "
-          "Success) async throws\n");
+      anyMissingAdHocRequirements = diagnoseMissingAdHocProtocolRequirement(C, C.Id_onReturn, decl);
+    }
+    if (checkAdHocRequirementAccessControl(decl, Proto, onReturnDecl)) {
       anyMissingAdHocRequirements = true;
     }
-    if (checkAdHocRequirementAccessControl(decl, Proto, onReturnDecl))
-      anyMissingAdHocRequirements = true;
 
     return anyMissingAdHocRequirements;
   }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -211,7 +211,6 @@ static bool checkAdHocRequirementAccessControl(
     return true;
 
   // === check access control
-  // TODO(distributed): this is for ad-hoc requirements and is likely too naive
   if (func->getEffectiveAccess() == decl->getEffectiveAccess()) {
     return false;
   }
@@ -236,6 +235,8 @@ static bool diagnoseMissingAdHocProtocolRequirement(ASTContext &C, Identifier id
   llvm::raw_svector_ostream OS(Text);
   ExtraIndentStreamPrinter Printer(OS, CurrentIndent);
 
+  Printer.printNewline();
+  Printer.printIndent();
   Printer << (decl->getFormalAccess() == AccessLevel::Public ? "public " : "");
 
   if (identifier == C.Id_remoteCall) {
@@ -275,7 +276,9 @@ static bool diagnoseMissingAdHocProtocolRequirement(ASTContext &C, Identifier id
   /// Print the "{ <#code#> }" placeholder body
   Printer << " {\n";
   Printer << ExtraIndent << getCodePlaceholder();
-  Printer << "\n}\n";
+  Printer.printNewline();
+  Printer.printIndent();
+  Printer << "}\n";
 
   decl->diagnose(
       diag::distributed_actor_system_conformance_missing_adhoc_requirement,

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_fixits.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_fixits.swift
@@ -8,10 +8,10 @@ import Distributed
 
 struct MissingRemoteCall: DistributedActorSystem {
   // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{add stubs for conformance}}{{51-51=func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
+  // expected-note@-2{{add stubs for conformance}}{{51-51=\nfunc remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
 
   // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}{{51-51=func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+  // expected-note@-5{{add stubs for conformance}}{{51-51=\nfunc remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -43,10 +43,10 @@ struct MissingRemoteCall: DistributedActorSystem {
 
 public struct PublicMissingRemoteCall: DistributedActorSystem {
   // expected-error@-1{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{add stubs for conformance}}{{64-64=public func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
+  // expected-note@-2{{add stubs for conformance}}{{64-64=\npublic func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
 
   // expected-error@-4{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{add stubs for conformance}}{{64-64=public func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+  // expected-note@-5{{add stubs for conformance}}{{64-64=\npublic func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
 
 
   public typealias ActorID = ActorAddress

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_fixits.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_fixits.swift
@@ -1,0 +1,148 @@
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+struct MissingRemoteCall: DistributedActorSystem {
+  // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{add stubs for conformance}}{{51-51=func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
+
+  // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{add stubs for conformance}}{{51-51=func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
+
+  func resignID(_ id: ActorID) {
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
+}
+
+public struct PublicMissingRemoteCall: DistributedActorSystem {
+  // expected-error@-1{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{add stubs for conformance}}{{64-64=public func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
+
+  // expected-error@-4{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{add stubs for conformance}}{{64-64=public func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+
+
+  public typealias ActorID = ActorAddress
+  public typealias InvocationDecoder = FakeInvocationDecoder
+  public typealias InvocationEncoder = FakeInvocationEncoder
+  public typealias SerializationRequirement = Codable
+  public typealias ResultHandler = FakeResultHandler
+
+  public func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  public func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
+
+  public func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
+
+  public func resignID(_ id: ActorID) {
+  }
+
+  public func makeInvocationEncoder() -> InvocationEncoder {
+  }
+}
+
+// ==== ------------------------------------------------------------------------
+
+public struct ActorAddress: Sendable, Hashable, Codable {
+  let address: String
+
+  init(parse address: String) {
+    self.address = address
+  }
+}
+
+public protocol SomeProtocol: Sendable {
+}
+
+public struct FakeInvocationEncoder: DistributedTargetInvocationEncoder {
+  public typealias SerializationRequirement = Codable
+
+  public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {
+  }
+
+  public mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {
+  }
+
+  public mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {
+  }
+
+  public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {
+  }
+
+  public mutating func doneRecording() throws {
+  }
+}
+
+public class FakeInvocationDecoder: DistributedTargetInvocationDecoder {
+  public typealias SerializationRequirement = Codable
+
+  public func decodeGenericSubstitutions() throws -> [Any.Type] {
+    []
+  }
+
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument {
+    fatalError()
+  }
+
+  public func decodeReturnType() throws -> Any.Type? {
+    nil
+  }
+
+  public func decodeErrorType() throws -> Any.Type? {
+    nil
+  }
+}
+
+public struct FakeResultHandler: DistributedTargetInvocationResultHandler {
+  public typealias SerializationRequirement = Codable
+
+  public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+
+  public func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+
+  public func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
+}
+
+

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -8,10 +8,10 @@ import Distributed
 
 struct MissingRemoteCall: DistributedActorSystem {
   // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
 
   // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-note@-5{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -43,10 +43,10 @@ struct MissingRemoteCall: DistributedActorSystem {
 
 struct RemoteCallMutating: DistributedActorSystem {
   // expected-error@-1{{struct 'RemoteCallMutating' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
 
   // expected-error@-4{{struct 'RemoteCallMutating' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-note@-5{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -104,10 +104,10 @@ struct RemoteCallMutating: DistributedActorSystem {
 
 struct MissingRemoteCall_missingInout_on_encoder: DistributedActorSystem {
   // expected-error@-1{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
 
   // expected-error@-4{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-note@-5{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -221,10 +221,10 @@ struct MissingRemoteCall_missing_makeInvocationEncoder: DistributedActorSystem {
 
 struct Error_wrongReturn: DistributedActorSystem {
   // expected-error@-1{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
 
   // expected-error@-4{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-note@-5{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -296,10 +296,10 @@ struct Error_wrongReturn: DistributedActorSystem {
 
 struct BadRemoteCall_param: DistributedActorSystem {
   // expected-error@-1{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
 
   // expected-error@-4{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-note@-5{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = FakeInvocationDecoder
@@ -406,7 +406,7 @@ public struct BadRemoteCall_notPublic: DistributedActorSystem {
 
 public struct BadRemoteCall_badResultConformance: DistributedActorSystem {
   // expected-error@-1{{struct 'BadRemoteCall_badResultConformance' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
 
   public typealias ActorID = ActorAddress
   public typealias InvocationDecoder = PublicFakeInvocationDecoder
@@ -513,7 +513,7 @@ struct BadRemoteCall_largeSerializationRequirement: DistributedActorSystem {
 
 struct BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition: DistributedActorSystem {
   // expected-error@-1{{struct 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
 
   typealias ActorID = ActorAddress
   typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
@@ -669,7 +669,7 @@ public struct PublicFakeInvocationEncoder: DistributedTargetInvocationEncoder {
 
 struct FakeInvocationEncoder_missing_recordArgument: DistributedTargetInvocationEncoder {
   //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument' is missing witness for protocol requirement 'recordArgument'}}
-  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  //expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -681,7 +681,7 @@ struct FakeInvocationEncoder_missing_recordArgument: DistributedTargetInvocation
 
 struct FakeInvocationEncoder_missing_recordArgument2: DistributedTargetInvocationEncoder {
   //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument2' is missing witness for protocol requirement 'recordArgument'}}
-  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  //expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -693,7 +693,7 @@ struct FakeInvocationEncoder_missing_recordArgument2: DistributedTargetInvocatio
 
 struct FakeInvocationEncoder_missing_recordReturnType: DistributedTargetInvocationEncoder {
   //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordReturnType' is missing witness for protocol requirement 'recordReturnType'}}
-  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordReturnType' with signature:}}
+  //expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -716,7 +716,7 @@ struct FakeInvocationEncoder_missing_recordErrorType: DistributedTargetInvocatio
 
 struct FakeInvocationEncoder_recordArgument_wrongType: DistributedTargetInvocationEncoder {
   //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_wrongType' is missing witness for protocol requirement 'recordArgument'}}
-  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  //expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -729,7 +729,7 @@ struct FakeInvocationEncoder_recordArgument_wrongType: DistributedTargetInvocati
 }
 struct FakeInvocationEncoder_recordArgument_missingMutating: DistributedTargetInvocationEncoder {
   //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_missingMutating' is missing witness for protocol requirement 'recordArgument'}}
-  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  //expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -741,7 +741,7 @@ struct FakeInvocationEncoder_recordArgument_missingMutating: DistributedTargetIn
 
 struct FakeInvocationEncoder_recordResultType_wrongType: DistributedTargetInvocationEncoder {
   //expected-error@-1{{struct 'FakeInvocationEncoder_recordResultType_wrongType' is missing witness for protocol requirement 'recordReturnType'}}
-  //expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordReturnType' with signature:}}
+  //expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -818,7 +818,7 @@ public final class PublicFakeInvocationDecoder_badNotPublic: DistributedTargetIn
 
 final class PublicFakeInvocationDecoder_badBadProtoRequirement: DistributedTargetInvocationDecoder {
   // expected-error@-1{{class 'PublicFakeInvocationDecoder_badBadProtoRequirement' is missing witness for protocol requirement 'decodeNextArgument'}}
-  // expected-note@-2{{protocol 'DistributedTargetInvocationDecoder' requires function 'decodeNextArgument' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
@@ -870,7 +870,7 @@ struct LargeSerializationReqFakeInvocationResultHandler: DistributedTargetInvoca
 
 struct BadResultHandler_missingOnReturn: DistributedTargetInvocationResultHandler {
   // expected-error@-1{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
-  // expected-note@-2{{protocol 'DistributedTargetInvocationResultHandler' requires function 'onReturn' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}{{84-84=func onReturn<Success: SerializationRequirement>(value: Success) async throws {\n    <#code#>\n\}\n}}
   typealias SerializationRequirement = Codable
 
   // func onReturn<Res: SerializationRequirement>(value: Res) async throws {} // MISSING
@@ -880,7 +880,7 @@ struct BadResultHandler_missingOnReturn: DistributedTargetInvocationResultHandle
 
 struct BadResultHandler_missingRequirement: DistributedTargetInvocationResultHandler {
   // expected-error@-1{{struct 'BadResultHandler_missingRequirement' is missing witness for protocol requirement 'onReturn'}}
-  // expected-note@-2{{protocol 'DistributedTargetInvocationResultHandler' requires function 'onReturn' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   func onReturn<Success>(value: Success) async throws {} // MISSING : Codable
@@ -890,7 +890,7 @@ struct BadResultHandler_missingRequirement: DistributedTargetInvocationResultHan
 
 struct BadResultHandler_mutatingButShouldNotBe: DistributedTargetInvocationResultHandler {
   // expected-error@-1{{struct 'BadResultHandler_mutatingButShouldNotBe' is missing witness for protocol requirement 'onReturn'}}
-  // expected-note@-2{{protocol 'DistributedTargetInvocationResultHandler' requires function 'onReturn' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = Codable
 
   mutating func onReturn<Success: Codable>(value: Success) async throws {} // WRONG: can't be mutating

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -870,7 +870,7 @@ struct LargeSerializationReqFakeInvocationResultHandler: DistributedTargetInvoca
 
 struct BadResultHandler_missingOnReturn: DistributedTargetInvocationResultHandler {
   // expected-error@-1{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
-  // expected-note@-2{{add stubs for conformance}}{{84-84=func onReturn<Success: SerializationRequirement>(value: Success) async throws {\n    <#code#>\n\}\n}}
+  // expected-note@-2{{add stubs for conformance}}{{84-84=\nfunc onReturn<Success: SerializationRequirement>(value: Success) async throws {\n    <#code#>\n\}\n}}
   typealias SerializationRequirement = Codable
 
   // func onReturn<Res: SerializationRequirement>(value: Res) async throws {} // MISSING

--- a/test/Distributed/distributed_imcomplete_system_dont_crash.swift
+++ b/test/Distributed/distributed_imcomplete_system_dont_crash.swift
@@ -7,9 +7,9 @@ import Distributed
 
 public final class CompletelyHollowActorSystem: DistributedActorSystem {
   // expected-error@-1{{type 'CompletelyHollowActorSystem' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-note@-2{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
   // expected-error@-3{{class 'CompletelyHollowActorSystem' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-4{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-4{{add stubs for conformance}}
   // expected-error@-5{{class 'CompletelyHollowActorSystem' is missing witness for protocol requirement 'remoteCallVoid'}}
 
   public typealias ActorID = String
@@ -42,6 +42,6 @@ public final class CompletelyHollowActorSystem_NotEvenTypes: DistributedActorSys
   // expected-error@-1{{type 'CompletelyHollowActorSystem_NotEvenTypes' does not conform to protocol 'DistributedActorSystem'}}
   // expected-error@-2{{class 'CompletelyHollowActorSystem_NotEvenTypes' is missing witness for protocol requirement 'remoteCallVoid'}}
   // expected-error@-3{{class 'CompletelyHollowActorSystem_NotEvenTypes' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-4{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
-  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid' with signature:}}
+  // expected-note@-4{{add stubs for conformance}}
+  // expected-note@-5{{add stubs for conformance}}
 }

--- a/test/Distributed/distributed_serializationRequirement_must_be_protocol.swift
+++ b/test/Distributed/distributed_serializationRequirement_must_be_protocol.swift
@@ -16,9 +16,9 @@ final class SomeEnum: Sendable {}
 final class System: DistributedActorSystem {
   // ignore those since they all fail with the SerializationRequirement being invalid:
   // expected-error@-2{{type 'System' does not conform to protocol 'DistributedActorSystem'}}
-  // expected-note@-3{{protocol 'DistributedActorSystem' requires function 'remoteCallVoid'}}
+  // expected-note@-3{{add stubs for conformance}}
   // expected-error@-4{{class 'System' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-5{{protocol 'DistributedActorSystem' requires function 'remoteCall' with signature:}}
+  // expected-note@-5{{add stubs for conformance}}
   // expected-error@-6{{class 'System' is missing witness for protocol requirement 'remoteCallVoid'}}
   typealias ActorID = String
   typealias InvocationEncoder = ClassInvocationEncoder
@@ -82,9 +82,9 @@ final class System: DistributedActorSystem {
 
 struct ClassInvocationEncoder: DistributedTargetInvocationEncoder {
   // expected-error@-1{{struct 'ClassInvocationEncoder' is missing witness for protocol requirement 'recordArgument'}}
-  // expected-note@-2{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordArgument' with signature:}}
+  // expected-note@-2{{add stubs for conformance}}
   // expected-error@-3{{struct 'ClassInvocationEncoder' is missing witness for protocol requirement 'recordReturnType'}}
-  // expected-note@-4{{protocol 'DistributedTargetInvocationEncoder' requires function 'recordReturnType' with signature:}}
+  // expected-note@-4{{add stubs for conformance}}
   typealias SerializationRequirement = SomeClazz
 
   public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -97,7 +97,7 @@ struct ClassInvocationEncoder: DistributedTargetInvocationEncoder {
 
 final class ClassInvocationDecoder: DistributedTargetInvocationDecoder {
   // expected-error@-1{{class 'ClassInvocationDecoder' is missing witness for protocol requirement 'decodeNextArgument'}}
-  // expected-note@-2{{protocol 'DistributedTargetInvocationDecoder' requires function 'decodeNextArgument'}}
+  // expected-note@-2{{add stubs for conformance}}
   typealias SerializationRequirement = SomeClazz
 
   public func decodeGenericSubstitutions() throws -> [Any.Type] {


### PR DESCRIPTION
We only printed text of what the methods should be, rather than emitting a fixit for the ad-hoc requirements the actor system is cursed/blessed with 👻

Instead, we now offer a proper fixit such that adopting `DistributedActorSystem` will be as simple as normal types: clicking the fixit button.

Before merging I want to test drive this in Xcode to see the diagnostics really work and feel the same as normal ones.

rdar://114185115

