### PR TITLE
[5.9][Stdlib] Fix bridgedStorage lifetime in SwiftNativeNSArray._destroyBridgedStorage.

### DIFF
--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -367,9 +367,11 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
 
   internal func _destroyBridgedStorage(_ hb: __BridgingBufferStorage?) {
     if let bridgedStorage = hb {
-      let buffer = _BridgingBuffer(bridgedStorage)
-      let count = buffer.count
-      buffer.baseAddress.deinitialize(count: count)
+      withExtendedLifetime(bridgedStorage) {
+        let buffer = _BridgingBuffer(bridgedStorage)
+        let count = buffer.count
+        buffer.baseAddress.deinitialize(count: count)
+      }
     }
   }
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/68403 to `release/5.9`.

Extend the lifetime of bridgedStorage until after the contents are deinitialized. When two threads race in withUnsafeBufferOfObjects, the loser uses _destroyBridgedStorage to destroy its candidate buffer, and we need to extend the lifetime of that buffer since the parameter is the only extant reference to it.

rdar://99565140