### PR TITLE
[embedded] Add support for (non-generic) classes in embedded Swift

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -89,6 +89,10 @@ inline bool isEmbedded(CanType t) {
   return t->getASTContext().LangOpts.hasFeature(Feature::Embedded);
 }
 
+inline bool isMetadataAllowedInEmbedded(CanType t) {
+  return isa<ClassType>(t);
+}
+
 inline bool isEmbedded(Decl *d) {
   return d->getASTContext().LangOpts.hasFeature(Feature::Embedded);
 }
@@ -840,7 +844,7 @@ public:
   static LinkEntity forTypeMetadata(CanType concreteType,
                                     TypeMetadataAddress addr) {
     assert(!isObjCImplementation(concreteType));
-    assert(!isEmbedded(concreteType));
+    assert(!isEmbedded(concreteType) || isMetadataAllowedInEmbedded(concreteType));
     LinkEntity entity;
     entity.setForType(Kind::TypeMetadata, concreteType);
     entity.Data |= LINKENTITY_SET_FIELD(MetadataAddress, unsigned(addr));

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -99,6 +99,13 @@ public:
     addClassMembers(Target, Target);
   }
 
+  void embeddedLayout() {
+    asImpl().noteAddressPoint();
+    asImpl().addSuperclass();
+    asImpl().addDestructorFunction();
+    addEmbeddedClassMembers(Target);
+  }
+
   /// Notes the beginning of the field offset vector for a particular ancestor
   /// of a generic-layout class.
   void noteStartOfFieldOffsets(ClassDecl *whichClass) {}
@@ -180,6 +187,21 @@ private:
     if (IGM.hasResilientMetadata(theClass, ResilienceExpansion::Maximal,
                                  rootClass))
       return;
+
+    // Add vtable entries.
+    asImpl().addVTableEntries(theClass);
+  }
+
+  /// Add fields associated with the given class and its bases.
+  void addEmbeddedClassMembers(ClassDecl *theClass) {
+    // Visit the superclass first.
+    if (auto *superclassDecl = theClass->getSuperclassDecl()) {
+      addEmbeddedClassMembers(superclassDecl);
+    }
+
+    // Note that we have to emit a global variable storing the metadata
+    // start offset, or access remaining fields relative to one.
+    asImpl().noteStartOfImmediateMembers(theClass);
 
     // Add vtable entries.
     asImpl().addVTableEntries(theClass);

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -68,6 +68,14 @@ public:
     static_assert(MetadataAdjustmentIndex::Class == 3,
                   "Adjustment index must be synchronized with this layout");
 
+    if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+      asImpl().noteAddressPoint();
+      asImpl().addSuperclass();
+      asImpl().addDestructorFunction();
+      addEmbeddedClassMembers(Target);
+      return;
+    }
+
     // Pointer to layout string
     asImpl().addLayoutStringPointer();
 
@@ -97,13 +105,6 @@ public:
 
     // Class members.
     addClassMembers(Target, Target);
-  }
-
-  void embeddedLayout() {
-    asImpl().noteAddressPoint();
-    asImpl().addSuperclass();
-    asImpl().addDestructorFunction();
-    addEmbeddedClassMembers(Target);
   }
 
   /// Notes the beginning of the field offset vector for a particular ancestor

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1078,6 +1078,8 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
   if (!D->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
     emitClassMetadata(*this, D, fragileLayout, resilientLayout);
     emitFieldDescriptor(D);
+  } else {
+    emitEmbeddedClassMetadata(*this, D, fragileLayout);
   }
 
   IRGen.addClassForEagerInitialization(D);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4970,6 +4970,11 @@ llvm::GlobalValue *IRGenModule::defineTypeMetadata(
                 : LinkEntity::forTypeMetadata(
                       concreteType, TypeMetadataAddress::FullMetadata));
 
+  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+    entity = LinkEntity::forTypeMetadata(concreteType,
+                                         TypeMetadataAddress::AddressPoint);
+  }
+
   auto DbgTy = DebugTypeInfo::getGlobalMetadata(
       MetatypeType::get(concreteType),
       entity.getDefaultDeclarationType(*this)->getPointerTo(), Size(0),
@@ -4991,6 +4996,10 @@ llvm::GlobalValue *IRGenModule::defineTypeMetadata(
 
   LinkInfo link = LinkInfo::get(*this, entity, ForDefinition);
   markGlobalAsUsedBasedOnLinkage(*this, link, var);
+  
+  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+    return var;
+  }
 
   /// For concrete metadata, we want to use the initializer on the
   /// "full metadata", and define the "direct" address point as an alias.

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -59,6 +59,11 @@ namespace irgen {
                          const ClassLayout &fragileLayout,
                          const ClassLayout &resilientLayout);
 
+  /// Emit "embedded Swift" class metadata (a simple vtable) for the given class
+  /// declaration.
+  void emitEmbeddedClassMetadata(IRGenModule &IGM, ClassDecl *theClass,
+                                 const ClassLayout &fragileLayout);
+
   /// Emit the constant initializer of the type metadata candidate for
   /// the given foreign class declaration.
   llvm::Constant *emitForeignTypeMetadataInitializer(IRGenModule &IGM,

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3303,7 +3303,8 @@ llvm::Value *IRGenFunction::emitTypeMetadataRef(CanType type) {
 MetadataResponse
 IRGenFunction::emitTypeMetadataRef(CanType type,
                                    DynamicMetadataRequest request) {
-  if (type->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+  if (type->getASTContext().LangOpts.hasFeature(Feature::Embedded) &&
+      !isMetadataAllowedInEmbedded(type)) {
     llvm::errs() << "Metadata pointer requested in embedded Swift for type "
                  << type << "\n";
     assert(0 && "metadata used in embedded mode");

--- a/test/embedded/classes-methods-no-stdlib.swift
+++ b/test/embedded/classes-methods-no-stdlib.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s
+
+public class MyClass {
+  func foo() { }
+  func bar() { }
+}
+
+public class MySubClass: MyClass {
+  override func foo() { }
+}
+
+// CHECK: @"$s4main7MyClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfD", ptr @"$s4main7MyClassC3fooyyF", ptr @"$s4main7MyClassC3baryyF", ptr @"$s4main7MyClassCACycfC" }>
+// CHECK: @"$s4main10MySubClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr }> <{ ptr @"$s4main7MyClassCN", ptr @"$s4main10MySubClassCfD", ptr @"$s4main10MySubClassC3fooyyF", ptr @"$s4main7MyClassC3baryyF", ptr @"$s4main10MySubClassCACycfC" }>
+
+// CHECK: define {{.*}}void @"$s4main4test1xyAA7MyClassC_tF"(ptr %0)
+public func test(x: MyClass) {
+
+  x.foo() // goes through the vtable
+  // CHECK: %1 = load ptr, ptr %0
+  // CHECK: %2 = getelementptr inbounds ptr, ptr %1, i64 2
+  // CHECK: %3 = load ptr, ptr %2
+  // CHECK: call swiftcc void %3(ptr swiftself %0)
+
+  x.bar() // does not go through the vtable
+  // CHECK: call swiftcc void @"$s4main7MyClassC3baryyF"
+
+  let y = MySubClass()
+  // CHECK: call swiftcc %swift.metadata_response @"$s4main10MySubClassCMa"
+  // CHECK: call swiftcc ptr @"$s4main10MySubClassCACycfC"
+
+  y.foo() // does not go through the vtable
+  // CHECK: call swiftcc void @"$s4main10MySubClassC3fooyyF"
+
+  y.bar() // does not go through the vtable
+  // CHECK: call swiftcc void @"$s4main7MyClassC3baryyF"
+
+}

--- a/test/embedded/classes-no-stdlib.swift
+++ b/test/embedded/classes-no-stdlib.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s
+
+// TODO: investigate why windows is generating more metadata.
+// XFAIL: OS=windows-msvc
+
+public class MyClass {}
+
+// CHECK-DAG: @"$s4main7MyClassCN" = {{.*}}<{ ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfD", ptr @"$s4main7MyClassCACycfC" }>
+// CHECK-DAG: define {{.*}}ptr @"$s4main7MyClassCfd"
+// CHECK-DAG: define {{.*}}void @"$s4main7MyClassCfD"
+// CHECK-DAG: define {{.*}}ptr @"$s4main7MyClassCACycfC"
+// CHECK-DAG: define {{.*}}ptr @"$s4main7MyClassCACycfc"
+// CHECK-DAG: define {{.*}}%swift.metadata_response @"$s4main7MyClassCMa"
+
+public func foo() -> MyClass {
+  return MyClass()
+}
+// CHECK-DAG: define {{.*}}ptr @"$s4main3fooAA7MyClassCyF"
+
+public class MySubClass: MyClass {}
+
+// CHECK-DAG: @"$s4main10MySubClassCN" = {{.*}}<{ ptr, ptr, ptr }> <{ ptr @"$s4main7MyClassCN", ptr @"$s4main10MySubClassCfD", ptr @"$s4main10MySubClassCACycfC" }>
+// CHECK-DAG: define {{.*}}ptr @"$s4main10MySubClassCACycfC"
+// CHECK-DAG: define {{.*}}ptr @"$s4main10MySubClassCACycfc"
+// CHECK-DAG: define {{.*}}ptr @"$s4main10MySubClassCfd"
+// CHECK-DAG: define {{.*}}void @"$s4main10MySubClassCfD"
+// CHECK-DAG: define {{.*}}%swift.metadata_response @"$s4main10MySubClassCMa"
+
+public func bar() -> MyClass {
+  return MySubClass()
+}
+// CHECK-DAG: define {{.*}}ptr @"$s4main3barAA7MyClassCyF"

--- a/test/embedded/classes-no-stdlib.swift
+++ b/test/embedded/classes-no-stdlib.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s
 
-// TODO: investigate why windows is generating more metadata.
-// XFAIL: OS=windows-msvc
-
 public class MyClass {}
 
 // CHECK-DAG: @"$s4main7MyClassCN" = {{.*}}<{ ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfD", ptr @"$s4main7MyClassCACycfC" }>


### PR DESCRIPTION
Add support for (non-generic) classes in embedded Swift

- In embedded Swift, classes get a simplified metadata: Basically just a vtable + destructor + superclass pointer.
- Only non-resilient (intended as permanent restriction), non-generic classes (for now) supported.
- Relax the check that prohibits metadata emission and usage to allow classes.
