### PR TITLE
Rework ASTDumper

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1118,6 +1118,9 @@ public:
 #include "swift/AST/TokenKinds.def"
   };
 
+  static StringRef
+  getLiteralKindPlainName(ObjectLiteralExpr::LiteralKind kind);
+
 private:
   ArgumentList *ArgList;
   SourceLoc PoundLoc;

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -203,8 +203,6 @@ enum class ReadImplKind {
 };
 enum { NumReadImplKindBits = 4 };
 
-StringRef getReadImplKindName(ReadImplKind kind);
-
 /// How are simple write accesses implemented?
 enum class WriteImplKind {
   /// It's immutable.
@@ -231,8 +229,6 @@ enum class WriteImplKind {
 };
 enum { NumWriteImplKindBits = 4 };
 
-StringRef getWriteImplKindName(WriteImplKind kind);
-
 /// How are read-write accesses implemented?
 enum class ReadWriteImplKind {
   /// It's immutable.
@@ -257,8 +253,6 @@ enum class ReadWriteImplKind {
   InheritedWithDidSet,
 };
 enum { NumReadWriteImplKindBits = 4 };
-
-StringRef getReadWriteImplKindName(ReadWriteImplKind kind);
 
 class StorageImplInfo {
   using IntType = uint16_t;

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -189,6 +189,7 @@ public:
   void print(raw_ostream &OS, const PrintOptions &Opts = PrintOptions()) const;
   void print(ASTPrinter &Printer, const PrintOptions &Opts) const;
   SWIFT_DEBUG_DUMP;
+  void dump(raw_ostream &OS, unsigned indent = 0) const;
 };
 
 /// A TypeRepr for a type with a syntax error.  Can be used both as a

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -133,8 +133,7 @@ static void printSourceRange(raw_ostream &OS, const SourceRange R,
           /*PrintText=*/false);
 }
 
-static StringRef
-getSILFunctionTypeRepresentationString(SILFunctionType::Representation value) {
+static StringRef getDumpString(SILFunctionType::Representation value) {
   switch (value) {
   case SILFunctionType::Representation::Thick: return "thick";
   case SILFunctionType::Representation::Block: return "block";
@@ -151,7 +150,7 @@ getSILFunctionTypeRepresentationString(SILFunctionType::Representation value) {
   llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
 }
 
-StringRef swift::getReadImplKindName(ReadImplKind kind) {
+static StringRef getDumpString(ReadImplKind kind) {
   switch (kind) {
   case ReadImplKind::Stored:
     return "stored";
@@ -167,7 +166,7 @@ StringRef swift::getReadImplKindName(ReadImplKind kind) {
   llvm_unreachable("bad kind");
 }
 
-StringRef swift::getWriteImplKindName(WriteImplKind kind) {
+static StringRef getDumpString(WriteImplKind kind) {
   switch (kind) {
   case WriteImplKind::Immutable:
     return "immutable";
@@ -187,7 +186,7 @@ StringRef swift::getWriteImplKindName(WriteImplKind kind) {
   llvm_unreachable("bad kind");
 }
 
-StringRef swift::getReadWriteImplKindName(ReadWriteImplKind kind) {
+static StringRef getDumpString(ReadWriteImplKind kind) {
   switch (kind) {
   case ReadWriteImplKind::Immutable:
     return "immutable";
@@ -207,7 +206,7 @@ StringRef swift::getReadWriteImplKindName(ReadWriteImplKind kind) {
   llvm_unreachable("bad kind");
 }
 
-static StringRef getImportKindString(ImportKind value) {
+static StringRef getDumpString(ImportKind value) {
   switch (value) {
   case ImportKind::Module: return "module";
   case ImportKind::Type: return "type";
@@ -222,8 +221,7 @@ static StringRef getImportKindString(ImportKind value) {
   llvm_unreachable("Unhandled ImportKind in switch.");
 }
 
-static StringRef
-getForeignErrorConventionKindString(ForeignErrorConvention::Kind value) {
+static StringRef getDumpString(ForeignErrorConvention::Kind value) {
   switch (value) {
   case ForeignErrorConvention::ZeroResult: return "ZeroResult";
   case ForeignErrorConvention::NonZeroResult: return "NonZeroResult";
@@ -234,7 +232,7 @@ getForeignErrorConventionKindString(ForeignErrorConvention::Kind value) {
 
   llvm_unreachable("Unhandled ForeignErrorConvention in switch.");
 }
-static StringRef getDefaultArgumentKindString(DefaultArgumentKind value) {
+static StringRef getDumpString(DefaultArgumentKind value) {
   switch (value) {
     case DefaultArgumentKind::None: return "none";
 #define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
@@ -250,8 +248,7 @@ static StringRef getDefaultArgumentKindString(DefaultArgumentKind value) {
 
   llvm_unreachable("Unhandled DefaultArgumentKind in switch.");
 }
-static StringRef
-getObjCSelectorExprKindString(ObjCSelectorExpr::ObjCSelectorKind value) {
+static StringRef getDumpString(ObjCSelectorExpr::ObjCSelectorKind value) {
   switch (value) {
     case ObjCSelectorExpr::Method: return "method";
     case ObjCSelectorExpr::Getter: return "getter";
@@ -260,7 +257,7 @@ getObjCSelectorExprKindString(ObjCSelectorExpr::ObjCSelectorKind value) {
 
   llvm_unreachable("Unhandled ObjCSelectorExpr in switch.");
 }
-static StringRef getAccessSemanticsString(AccessSemantics value) {
+static StringRef getDumpString(AccessSemantics value) {
   switch (value) {
     case AccessSemantics::Ordinary: return "ordinary";
     case AccessSemantics::DirectToStorage: return "direct_to_storage";
@@ -270,7 +267,7 @@ static StringRef getAccessSemanticsString(AccessSemantics value) {
 
   llvm_unreachable("Unhandled AccessSemantics in switch.");
 }
-static StringRef getMetatypeRepresentationString(MetatypeRepresentation value) {
+static StringRef getDumpString(MetatypeRepresentation value) {
   switch (value) {
     case MetatypeRepresentation::Thin: return "thin";
     case MetatypeRepresentation::Thick: return "thick";
@@ -279,8 +276,7 @@ static StringRef getMetatypeRepresentationString(MetatypeRepresentation value) {
 
   llvm_unreachable("Unhandled MetatypeRepresentation in switch.");
 }
-static StringRef
-getStringLiteralExprEncodingString(StringLiteralExpr::Encoding value) {
+static StringRef getDumpString(StringLiteralExpr::Encoding value) {
   switch (value) {
     case StringLiteralExpr::UTF8: return "utf8";
     case StringLiteralExpr::OneUnicodeScalar: return "unicodeScalar";
@@ -288,7 +284,7 @@ getStringLiteralExprEncodingString(StringLiteralExpr::Encoding value) {
 
   llvm_unreachable("Unhandled StringLiteral in switch.");
 }
-static StringRef getCtorInitializerKindString(CtorInitializerKind value) {
+static StringRef getDumpString(CtorInitializerKind value) {
   switch (value) {
     case CtorInitializerKind::Designated: return "designated";
     case CtorInitializerKind::Convenience: return "convenience";
@@ -298,7 +294,7 @@ static StringRef getCtorInitializerKindString(CtorInitializerKind value) {
 
   llvm_unreachable("Unhandled CtorInitializerKind in switch.");
 }
-static StringRef getAssociativityString(Associativity value) {
+static StringRef getDumpString(Associativity value) {
   switch (value) {
     case Associativity::None: return "none";
     case Associativity::Left: return "left";
@@ -586,7 +582,7 @@ namespace {
         OS << " exported";
 
       if (ID->getImportKind() != ImportKind::Module)
-        OS << " kind=" << getImportKindString(ID->getImportKind());
+        OS << " kind=" << getDumpString(ID->getImportKind());
 
       OS << " '";
       // Check if module aliasing was used for the given imported module; for
@@ -835,17 +831,17 @@ namespace {
         auto impl = D->getImplInfo();
         PrintWithColorRAII(OS, DeclModifierColor)
           << " readImpl="
-          << getReadImplKindName(impl.getReadImpl());
+          << getDumpString(impl.getReadImpl());
         if (!impl.supportsMutation()) {
           PrintWithColorRAII(OS, DeclModifierColor)
             << " immutable";
         } else {
           PrintWithColorRAII(OS, DeclModifierColor)
             << " writeImpl="
-            << getWriteImplKindName(impl.getWriteImpl());
+            << getDumpString(impl.getWriteImpl());
           PrintWithColorRAII(OS, DeclModifierColor)
             << " readWriteImpl="
-            << getReadWriteImplKindName(impl.getReadWriteImpl());
+            << getDumpString(impl.getReadWriteImpl());
         }
       }
     }
@@ -966,7 +962,7 @@ namespace {
 
       if (auto fec = D->getForeignErrorConvention()) {
         OS << " foreign_error=";
-        OS << getForeignErrorConventionKindString(fec->getKind());
+        OS << getDumpString(fec->getKind());
         bool wantResultType = (
           fec->getKind() == ForeignErrorConvention::ZeroResult ||
           fec->getKind() == ForeignErrorConvention::NonZeroResult);
@@ -1032,7 +1028,7 @@ namespace {
 
       if (P->getDefaultArgumentKind() != DefaultArgumentKind::None) {
         printField("default_arg",
-                   getDefaultArgumentKindString(P->getDefaultArgumentKind()));
+                   getDumpString(P->getDefaultArgumentKind()));
       }
 
       if (P->hasDefaultExpr() &&
@@ -1147,7 +1143,7 @@ namespace {
       if (CD->isRequired())
         PrintWithColorRAII(OS, DeclModifierColor) << " required";
       PrintWithColorRAII(OS, DeclModifierColor) << " "
-        << getCtorInitializerKindString(CD->getInitKind());
+        << getDumpString(CD->getInitKind());
       if (CD->isFailable())
         PrintWithColorRAII(OS, DeclModifierColor) << " failable="
           << (CD->isImplicitlyUnwrappedOptional()
@@ -1228,7 +1224,7 @@ namespace {
 
       OS.indent(Indent+2);
       OS << "associativity "
-         << getAssociativityString(PGD->getAssociativity()) << "\n";
+         << getDumpString(PGD->getAssociativity()) << "\n";
 
       OS.indent(Indent+2);
       OS << "assignment " << (PGD->isAssignment() ? "true" : "false");
@@ -2007,7 +2003,7 @@ public:
   void visitStringLiteralExpr(StringLiteralExpr *E) {
     printCommon(E, "string_literal_expr");
     PrintWithColorRAII(OS, LiteralValueColor) << " encoding="
-      << getStringLiteralExprEncodingString(E->getEncoding())
+      << getDumpString(E->getEncoding())
       << " value=" << QuotedString(E->getValue())
       << " builtin_initializer=";
     E->getBuiltinInitializer().dump(
@@ -2047,7 +2043,7 @@ public:
 
     if (E->isString()) {
       OS << " encoding="
-         << getStringLiteralExprEncodingString(E->getStringEncoding());
+         << getDumpString(E->getStringEncoding());
     }
     OS << " builtin_initializer=";
     E->getBuiltinInitializer().dump(OS);
@@ -2085,7 +2081,7 @@ public:
     printDeclRef(E->getDeclRef());
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)
       PrintWithColorRAII(OS, AccessLevelColor)
-        << " " << getAccessSemanticsString(E->getAccessSemantics());
+        << " " << getDumpString(E->getAccessSemantics());
     PrintWithColorRAII(OS, ExprModifierColor)
       << " function_ref=" << getFunctionRefKindStr(E->getFunctionRefKind());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
@@ -2155,7 +2151,7 @@ public:
     printDeclRef(E->getMember());
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)
       PrintWithColorRAII(OS, AccessLevelColor)
-        << " " << getAccessSemanticsString(E->getAccessSemantics());
+        << " " << getDumpString(E->getAccessSemantics());
     if (E->isSuper())
       OS << " super";
 
@@ -2267,7 +2263,7 @@ public:
     printCommon(E, "subscript_expr");
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)
       PrintWithColorRAII(OS, AccessLevelColor)
-        << " " << getAccessSemanticsString(E->getAccessSemantics());
+        << " " << getDumpString(E->getAccessSemantics());
     if (E->isSuper())
       OS << " super";
     if (E->hasDecl()) {
@@ -2897,7 +2893,7 @@ public:
   }
   void visitObjCSelectorExpr(ObjCSelectorExpr *E) {
     printCommon(E, "objc_selector_expr");
-    OS << " kind=" << getObjCSelectorExprKindString(E->getSelectorKind());
+    OS << " kind=" << getDumpString(E->getSelectorKind());
     PrintWithColorRAII(OS, DeclColor) << " decl=";
     printDeclRef(E->getMethod());
     OS << '\n';
@@ -3989,7 +3985,7 @@ namespace {
     void visitMetatypeType(MetatypeType *T, StringRef label) {
       printCommon(label, "metatype_type");
       if (T->hasRepresentation())
-        OS << " " << getMetatypeRepresentationString(T->getRepresentation());
+        OS << " " << getDumpString(T->getRepresentation());
       printRec(T->getInstanceType());
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
@@ -3998,7 +3994,7 @@ namespace {
                                       StringRef label) {
       printCommon(label, "existential_metatype_type");
       if (T->hasRepresentation())
-        OS << " " << getMetatypeRepresentationString(T->getRepresentation());
+        OS << " " << getDumpString(T->getRepresentation());
       printRec(T->getInstanceType());
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
@@ -4123,7 +4119,7 @@ namespace {
 
         if (representation != SILFunctionType::Representation::Thick) {
           printField("representation",
-                     getSILFunctionTypeRepresentationString(representation));
+                     getDumpString(representation));
         }
         printFlag(!T->isNoEscape(), "escaping");
         printFlag(T->isSendable(), "Sendable");

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -458,16 +458,6 @@ namespace {
     void printRec(const Pattern *P, StringRef label = "");
     void printRec(Type ty, StringRef label = "");
 
-    template <typename NodeTy>
-    void printRecLabeled(NodeTy *Node, StringRef label) {
-      OS << '\n';
-      Indent += 2;
-      printHead(label, ASTNodeColor);
-      printRec(Node);
-      printFoot();
-      Indent -= 2;
-    }
-
     raw_ostream &printHead(StringRef Name, TerminalColor Color,
                            StringRef Label = "") {
       OS.indent(Indent);
@@ -852,7 +842,7 @@ namespace {
     }
 
     void visitSourceFile(const SourceFile &SF) {
-     printHead("source_file", ASTNodeColor);
+      printHead("source_file", ASTNodeColor);
       PrintWithColorRAII(OS, LocationColor) << " \"" << SF.getFilename() << '\"';
 
       if (auto items = SF.getCachedTopLevelItems()) {
@@ -972,7 +962,7 @@ namespace {
       }
 
       if (auto init = PD->getStructuralDefaultExpr()) {
-        printRecLabeled(init, "expression");
+        printRec(init, "expression");
       }
 
       printFoot();
@@ -1030,16 +1020,10 @@ namespace {
       for (auto idx : range(PBD->getNumPatternEntries())) {
         printRec(PBD->getPattern(idx));
         if (PBD->getOriginalInit(idx)) {
-          OS << '\n';
-          OS.indent(Indent + 2);
-          OS << "Original init:";
-          printRec(PBD->getOriginalInit(idx));
+          printRec(PBD->getOriginalInit(idx), "original_init");
         }
         if (PBD->getInit(idx)) {
-          OS << '\n';
-          OS.indent(Indent + 2);
-          OS << "Processed init:";
-          printRec(PBD->getInit(idx));
+          printRec(PBD->getInit(idx), "processed_init");
         }
       }
       printFoot();
@@ -1132,16 +1116,9 @@ namespace {
 
       if (auto FD = dyn_cast<FuncDecl>(D)) {
         if (FD->getResultTypeRepr()) {
-          OS << '\n';
-          Indent += 2;
-          printHead("result", DeclColor);
-          printRec(FD->getResultTypeRepr());
-          printFoot();
+          printRec(FD->getResultTypeRepr(), "result");
           if (auto opaque = FD->getOpaqueResultTypeDecl()) {
-            OS << '\n';
-            printHead("opaque_result_decl", DeclColor) << '\n';
-            printRec(opaque);
-            printFoot();
+            printRec(opaque, "opaque_result_decl");
           }
           Indent -= 2;
         }
@@ -1693,12 +1670,7 @@ public:
     printCommon(S, "for_each_stmt", label);
     printRec(S->getPattern());
     if (S->getWhere()) {
-      OS << '\n';
-      Indent += 2;
-      printHead("where", ASTNodeColor);
-      printRec(S->getWhere());
-      printFoot();
-      Indent -= 2;
+      printRec(S->getWhere(), "where");
     }
     printRec(S->getParsedSequence());
     if (S->getIteratorVar()) {
@@ -1882,7 +1854,7 @@ public:
       return;
     }
     
-    printRecLabeled(semanticExpr, "semantic_expr");
+    printRec(semanticExpr, "semantic_expr");
   }
 
   void visitErrorExpr(ErrorExpr *E, StringRef label) {
@@ -2336,10 +2308,10 @@ public:
     printCommon(E, "collection_upcast_expr", label);
     printRec(E->getSubExpr());
     if (auto keyConversion = E->getKeyConversion()) {
-      printRecLabeled(keyConversion.Conversion, "key_conversion");
+      printRec(keyConversion.Conversion, "key_conversion");
     }
     if (auto valueConversion = E->getValueConversion()) {
-      printRecLabeled(valueConversion.Conversion, "value_conversion");
+      printRec(valueConversion.Conversion, "value_conversion");
     }
     printFoot();
   }
@@ -2883,14 +2855,14 @@ public:
     Indent -= 2;
 
     if (auto stringLiteral = E->getObjCStringLiteralExpr()) {
-      printRecLabeled(stringLiteral, "objc_string_literal");
+      printRec(stringLiteral, "objc_string_literal");
     }
     if (!E->isObjC()) {
       if (auto root = E->getParsedRoot()) {
-        printRecLabeled(root, "parsed_root");
+        printRec(root, "parsed_root");
       }
       if (auto path = E->getParsedPath()) {
-        printRecLabeled(path, "parsed_path");
+        printRec(path, "parsed_path");
       }
     }
     printFoot();
@@ -2926,11 +2898,11 @@ public:
     printCommon(E, "type_join_expr", label);
 
     if (auto *var = E->getVar()) {
-      printRecLabeled(var, "var");
+      printRec(var, "var");
     }
 
     if (auto *SVE = E->getSingleValueStmtExpr()) {
-      printRecLabeled(SVE, "single_value_stmt_expr");
+      printRec(SVE, "single_value_stmt_expr");
     }
 
     for (auto *member : E->getElements()) {
@@ -2950,7 +2922,7 @@ public:
       printArgumentList(E->getArgs());
     }
     if (auto rewritten = E->getRewritten()) {
-      printRecLabeled(rewritten, "rewritten");
+      printRec(rewritten, "rewritten");
     }
     printFoot();
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -512,7 +512,7 @@ public:
 
       printRec(arg.getExpr());
       printFoot();
-    }, "");
+    });
   }
 
   void printRec(const ArgumentList *argList, StringRef label = "") {
@@ -586,7 +586,7 @@ public:
       SmallPtrSet<const ProtocolConformance *, 4> Dumped;
       dumpSubstitutionMapRec(map, OS, SubstitutionMap::DumpStyle::Full,
                              Indent, Dumped);
-    }, "");
+    });
   }
 
   void printRec(ProtocolConformanceRef conf, StringRef label = "") {
@@ -618,6 +618,13 @@ public:
                                 TerminalColor color = FieldLabelColor) {
     printFieldRaw([&](raw_ostream &OS) { OS << '\'' << value << '\''; }, name,
                    color);
+  }
+
+
+  // Print a field with a value.
+  template<typename Fn>
+  void printFlagRaw(Fn body, TerminalColor color = FieldLabelColor) {
+    printFieldRaw(body, "", color);
   }
 
   // Print a single flag.
@@ -994,11 +1001,11 @@ public:
       printFlag(attrs.hasAttribute<ObjCAttr>(), "@objc");
       printFlag(attrs.hasAttribute<DynamicAttr>(), "dynamic");
       if (auto *attr = attrs.getAttribute<DynamicReplacementAttr>()) {
-        printFieldRaw([&](raw_ostream &OS) {
+        printFlagRaw([&](raw_ostream &OS) {
           OS << "@_dynamicReplacement(for: \"";
           OS << attr->getReplacedFunctionName();
           OS << "\")";
-        }, "");
+        });
       }
       auto lifetimeString = getDumpString(VD->getLifetimeAnnotation());
       if (!lifetimeString.empty())
@@ -1214,9 +1221,9 @@ public:
     void printCommonAFD(AbstractFunctionDecl *D, const char *Type, StringRef Label) {
       printCommon(D, Type, Label, FuncColor);
       if (!D->getCaptureInfo().isTrivial()) {
-        printFieldRaw([&](raw_ostream &OS) {
+        printFlagRaw([&](raw_ostream &OS) {
           D->getCaptureInfo().print(OS);
-        }, "");
+        });
       }
 
       printFlag(D->getAttrs().hasAttribute<NonisolatedAttr>(), "nonisolated",
@@ -1250,7 +1257,7 @@ public:
           if (auto errorParamIndex = fac->completionHandlerErrorParamIndex())
             printField(*errorParamIndex, "error_param");
           printFoot();
-        }, "");
+        });
       }
 
       if (auto fec = D->getForeignErrorConvention()) {
@@ -1269,7 +1276,7 @@ public:
           if (wantResultType)
             printField(fec->getResultType(), "resulttype");
           printFoot();
-        }, "");
+        });
       }
 
       if (D->hasSingleExpressionBody()) {
@@ -1335,7 +1342,7 @@ public:
 
     void visitIfConfigDecl(IfConfigDecl *ICD, StringRef label) {
       printCommon(ICD, "if_config_decl", label);
-      printRecRange(ICD->getClauses(), &ICD->getASTContext(), "");
+      printRecRange(ICD->getClauses(), &ICD->getASTContext(), "clauses");
       printFoot();
     }
 
@@ -1360,7 +1367,7 @@ public:
           for (auto &rel : rels)
             printFlag(rel.Name.str());
           printFoot();
-        }, "");
+        });
       };
       printRelationsRec(PGD->getHigherThan(), "higherThan");
       printRelationsRec(PGD->getLowerThan(), "lowerThan");
@@ -1773,7 +1780,7 @@ public:
         }
 
         printFoot();
-      }, "");
+      });
     }
 
     printRec(S->getBody());
@@ -1805,16 +1812,9 @@ public:
 
   void visitDoCatchStmt(DoCatchStmt *S, StringRef label) {
     printCommon(S, "do_catch_stmt", label);
-    printRec(S->getBody());
-    visitCatches(S->getCatches());
+    printRec(S->getBody(), "body");
+    printRecRange(S->getCatches(), Ctx, "catch_stmts");
     printFoot();
-  }
-  void visitCatches(ArrayRef<CaseStmt *> clauses) {
-    for (auto clause : clauses) {
-      printRecRaw([&](StringRef label) {
-        visitCaseStmt(clause, label);
-      }, "");
-    }
   }
 };
 
@@ -2049,7 +2049,7 @@ public:
           printHead("candidate_decl", DeclModifierColor, label);
           printNameRaw([&](raw_ostream &OS) { D->dumpRef(OS); });
           printFoot();
-        }, "");
+        });
       }
     }
 
@@ -2158,7 +2158,7 @@ public:
         printRecRaw([&](StringRef label) {
           printHead("<tuple element default value>", ExprColor);
           printFoot();
-        }, "");
+        });
       }
     }
 
@@ -2852,11 +2852,11 @@ public:
             printRec(args);
           }
           printFoot();
-        }, "");
+        });
       }
 
       printFoot();
-    }, "");
+    });
 
     if (auto stringLiteral = E->getObjCStringLiteralExpr()) {
       printRec(stringLiteral, "objc_string_literal");
@@ -3208,7 +3208,7 @@ public:
 
         printRec(Field.getFieldType());
         printFoot();
-      }, "");
+      });
     }
 
     printRecRange(T->getGenericArguments(), "generic_arguments");
@@ -3749,7 +3749,7 @@ namespace {
             printField(elt.getName().str(), "name");
           printRec(elt.getType());
           printFoot();
-        }, "");
+        });
       }
 
       printFoot();
@@ -3932,7 +3932,7 @@ namespace {
             printRec(param.getPlainType());
 
             printFoot();
-          }, "");
+          });
         }
         printFoot();
       }, label);
@@ -3948,7 +3948,7 @@ namespace {
             info.dump(OS, clangCtx);
           });
           printFoot();
-        }, "");
+        });
       }
     }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -822,7 +822,8 @@ namespace {
         return;
 
       printFieldRaw([&](raw_ostream &OS) {
-        L.print(OS, Ctx->SourceMgr);
+        escaping_ostream escOS(OS);
+        L.print(escOS, Ctx->SourceMgr);
       }, label, LocationColor);
     }
 
@@ -832,7 +833,8 @@ namespace {
         return;
 
       printFieldRaw([&](raw_ostream &OS) {
-        R.print(OS, Ctx->SourceMgr, /*PrintText=*/false);
+        escaping_ostream escOS(OS);
+        R.print(escOS, Ctx->SourceMgr, /*PrintText=*/false);
       }, "range", RangeColor);
     }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1222,12 +1222,17 @@ StringRef ObjectLiteralExpr::getLiteralKindRawName() const {
   llvm_unreachable("unspecified literal");
 }
 
-StringRef ObjectLiteralExpr::getLiteralKindPlainName() const {
-  switch (getLiteralKind()) {
+StringRef ObjectLiteralExpr::
+getLiteralKindPlainName(ObjectLiteralExpr::LiteralKind kind) {
+  switch (kind) {
 #define POUND_OBJECT_LITERAL(Name, Desc, Proto) case Name: return Desc;
 #include "swift/AST/TokenKinds.def"    
   }
   llvm_unreachable("unspecified literal");
+}
+
+StringRef ObjectLiteralExpr::getLiteralKindPlainName() const {
+  return ObjectLiteralExpr::getLiteralKindPlainName(getLiteralKind());
 }
 
 ConstructorDecl *OtherConstructorDeclRefExpr::getDecl() const {

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -3,36 +3,36 @@
 // expected-warning @+1 {{'@differentiable' has been renamed to '@differentiable(reverse)'}} {{23-23=(reverse)}}
 let a: @differentiable (Float) -> Float // okay
 // CHECK: (pattern_named "a"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
 let b: @differentiable(reverse) (Float) -> Float // okay
 // CHECK: (pattern_named "b"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
 let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
 // CHECK: (pattern_named "c"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 // CHECK-NEXT:  (type_function
 // CHECK-NEXT:    (type_tuple
-// CHECK-NEXT:      (type_ident id='Float' bind=<none>)
-// CHECK-NEXT:      (type_attributed attrs=@noDerivative
-// CHECK-NEXT:        (type_ident id='Float' bind=<none>))
-// CHECK-NEXT:    (type_ident id='Float' bind=<none>))))
+// CHECK-NEXT:      (type_ident id="Float" unbound)
+// CHECK-NEXT:      (type_attributed attrs="@noDerivative "
+// CHECK-NEXT:        (type_ident id="Float" unbound))
+// CHECK-NEXT:    (type_ident id="Float" unbound))))
 
 let d: @differentiable(reverse) (Float) throws -> Float // okay
 // CHECK: (pattern_named "d"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
 let e: @differentiable(reverse) (Float) throws -> Float // okay
 // CHECK: (pattern_named "e"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
 // Generic type test.
 struct A<T> {
   func foo() {
     let local: @differentiable(reverse) (T) -> T // okay
     // CHECK: (pattern_named "local"
-    // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+    // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
   }
 }
 
@@ -50,28 +50,28 @@ struct B {
   struct linear {}
   let propertyB1: @differentiable(reverse) (linear) -> Float // okay
   // CHECK: (pattern_named "propertyB1"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   let propertyB2: @differentiable(reverse) (linear) -> linear // okay
   // CHECK: (pattern_named "propertyB2"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   let propertyB3: @differentiable(reverse) (linear, linear) -> linear // okay
   // CHECK: (pattern_named "propertyB3"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   let propertyB4: @differentiable(reverse) (linear, Float) -> linear // okay
   // CHECK: (pattern_named "propertyB4"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   let propertyB5: @differentiable(reverse) (Float, linear) -> linear // okay
   // CHECK: (pattern_named "propertyB5"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   let propertyB6: @differentiable(reverse) (linear, linear, Float, linear)
     -> Float // okay
   // CHECK: (pattern_named "propertyB6"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   // expected-error @+1 {{expected ')' in '@differentiable' attribute}}
   let propertyB7: @differentiable(reverse (linear) -> Float
@@ -82,20 +82,20 @@ struct C {
   typealias reverse = (C) -> C
   let propertyC1: @differentiable(reverse) (reverse) -> Float // okay
   // CHECK: (pattern_named "propertyC1"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   let propertyC2: @differentiable(reverse) (reverse) -> reverse // okay
   // CHECK: (pattern_named "propertyC2"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   let propertyC3: @differentiable(reverse) reverse // okay
   // CHECK: (pattern_named "propertyC3"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) "
 
   let propertyC4: reverse // okay
   // CHECK: (pattern_named "propertyC4"
 
   let propertyC6: @differentiable(reverse) @convention(c) reverse // okay
   // CHECK: (pattern_named "propertyC6"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs="@differentiable(reverse) @convention(c) "
 }

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -2,15 +2,15 @@
 
 // expected-warning @+1 {{'@differentiable' has been renamed to '@differentiable(reverse)'}} {{23-23=(reverse)}}
 let a: @differentiable (Float) -> Float // okay
-// CHECK: (pattern_named 'a'
+// CHECK: (pattern_named "a"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
 let b: @differentiable(reverse) (Float) -> Float // okay
-// CHECK: (pattern_named 'b'
+// CHECK: (pattern_named "b"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
 let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
-// CHECK: (pattern_named 'c'
+// CHECK: (pattern_named "c"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 // CHECK-NEXT:  (type_function
 // CHECK-NEXT:    (type_tuple
@@ -20,18 +20,18 @@ let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
 // CHECK-NEXT:    (type_ident id='Float' bind=<none>))))
 
 let d: @differentiable(reverse) (Float) throws -> Float // okay
-// CHECK: (pattern_named 'd'
+// CHECK: (pattern_named "d"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
 let e: @differentiable(reverse) (Float) throws -> Float // okay
-// CHECK: (pattern_named 'e'
+// CHECK: (pattern_named "e"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
 // Generic type test.
 struct A<T> {
   func foo() {
     let local: @differentiable(reverse) (T) -> T // okay
-    // CHECK: (pattern_named 'local'
+    // CHECK: (pattern_named "local"
     // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
   }
 }
@@ -49,28 +49,28 @@ let d: @differentiable(notValidArg) (Float) -> Float
 struct B {
   struct linear {}
   let propertyB1: @differentiable(reverse) (linear) -> Float // okay
-  // CHECK: (pattern_named 'propertyB1'
+  // CHECK: (pattern_named "propertyB1"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB2: @differentiable(reverse) (linear) -> linear // okay
-  // CHECK: (pattern_named 'propertyB2'
+  // CHECK: (pattern_named "propertyB2"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB3: @differentiable(reverse) (linear, linear) -> linear // okay
-  // CHECK: (pattern_named 'propertyB3'
+  // CHECK: (pattern_named "propertyB3"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB4: @differentiable(reverse) (linear, Float) -> linear // okay
-  // CHECK: (pattern_named 'propertyB4'
+  // CHECK: (pattern_named "propertyB4"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB5: @differentiable(reverse) (Float, linear) -> linear // okay
-  // CHECK: (pattern_named 'propertyB5'
+  // CHECK: (pattern_named "propertyB5"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB6: @differentiable(reverse) (linear, linear, Float, linear)
     -> Float // okay
-  // CHECK: (pattern_named 'propertyB6'
+  // CHECK: (pattern_named "propertyB6"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   // expected-error @+1 {{expected ')' in '@differentiable' attribute}}
@@ -81,21 +81,21 @@ struct B {
 struct C {
   typealias reverse = (C) -> C
   let propertyC1: @differentiable(reverse) (reverse) -> Float // okay
-  // CHECK: (pattern_named 'propertyC1'
+  // CHECK: (pattern_named "propertyC1"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyC2: @differentiable(reverse) (reverse) -> reverse // okay
-  // CHECK: (pattern_named 'propertyC2'
+  // CHECK: (pattern_named "propertyC2"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyC3: @differentiable(reverse) reverse // okay
-  // CHECK: (pattern_named 'propertyC3'
+  // CHECK: (pattern_named "propertyC3"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyC4: reverse // okay
-  // CHECK: (pattern_named 'propertyC4'
+  // CHECK: (pattern_named "propertyC4"
 
   let propertyC6: @differentiable(reverse) @convention(c) reverse // okay
-  // CHECK: (pattern_named 'propertyC6'
+  // CHECK: (pattern_named "propertyC6"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 }

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -14,10 +14,10 @@ let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 // CHECK-NEXT:  (type_function
 // CHECK-NEXT:    (type_tuple
-// CHECK-NEXT:      (type_ident id='Float' bind=none)
+// CHECK-NEXT:      (type_ident id='Float' bind=<none>)
 // CHECK-NEXT:      (type_attributed attrs=@noDerivative
-// CHECK-NEXT:        (type_ident id='Float' bind=none))
-// CHECK-NEXT:    (type_ident id='Float' bind=none))))
+// CHECK-NEXT:        (type_ident id='Float' bind=<none>))
+// CHECK-NEXT:    (type_ident id='Float' bind=<none>))))
 
 let d: @differentiable(reverse) (Float) throws -> Float // okay
 // CHECK: (pattern_named 'd'

--- a/test/Concurrency/async_main_resolution.swift
+++ b/test/Concurrency/async_main_resolution.swift
@@ -62,13 +62,13 @@ extension MainProtocol {
 @main struct MyMain : AsyncMainProtocol {}
 #endif
 
-// CHECK-IS-SYNC-LABEL: "MyMain" interface type='MyMain.Type'
-// CHECK-IS-SYNC: (func_decl implicit "$main()" interface type='(MyMain.Type) -> () -> ()'
-// CHECK-IS-SYNC:       (declref_expr implicit type='(MyMain.Type) -> () -> ()'
+// CHECK-IS-SYNC-LABEL: "MyMain" interface type="MyMain.Type"
+// CHECK-IS-SYNC: (func_decl implicit "$main()" interface type="(MyMain.Type) -> () -> ()"
+// CHECK-IS-SYNC:       (declref_expr implicit type="(MyMain.Type) -> () -> ()"
 
-// CHECK-IS-ASYNC-LABEL: "MyMain" interface type='MyMain.Type'
-// CHECK-IS-ASYNC: (func_decl implicit "$main()" interface type='(MyMain.Type) -> () async -> ()'
-// CHECK-IS-ASYNC:       (declref_expr implicit type='(MyMain.Type) -> () async -> ()'
+// CHECK-IS-ASYNC-LABEL: "MyMain" interface type="MyMain.Type"
+// CHECK-IS-ASYNC: (func_decl implicit "$main()" interface type="(MyMain.Type) -> () async -> ()"
+// CHECK-IS-ASYNC:       (declref_expr implicit type="(MyMain.Type) -> () async -> ()"
 
 // CHECK-IS-ERROR1: error: 'MyMain' is annotated with @main and must provide a main static function of type {{\(\) -> Void or \(\) throws -> Void|\(\) -> Void, \(\) throws -> Void, \(\) async -> Void, or \(\) async throws -> Void}}
 // CHECK-IS-ERROR2: error: ambiguous use of 'main'

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -18,32 +18,32 @@ extension MyActor {
   func testClosureIsolation() async {
     // CHECK: acceptClosure
     // CHECK: closure_expr
-    // CHECK: actor-isolated
+    // CHECK: actor_isolated
     acceptClosure { self.syncMethod() }
 
     // CHECK: acceptSendableClosure
     // CHECK: closure_expr
-    // CHECK-NOT: actor-isolated
+    // CHECK-NOT: actor_isolated
     acceptSendableClosure { print(self) }
 
     // CHECK: acceptAsyncClosure
     // CHECK: closure_expr
-    // CHECK-SAME: actor-isolated=closure_isolation.(file).MyActor extension.testClosureIsolation().self
+    // CHECK-SAME: actor_isolated=closure_isolation.(file).MyActor extension.testClosureIsolation().self
     acceptAsyncClosure { await method() }
 
     // CHECK: acceptAsyncClosure
     // CHECK: closure_expr
-    // CHECK-NOT: actor-isolated
+    // CHECK-NOT: actor_isolated
     acceptAsyncClosure { () async in print() }
 
     // CHECK: acceptEscapingAsyncClosure
     // CHECK: closure_expr
-    // CHECK: actor-isolated
+    // CHECK: actor_isolated
     acceptEscapingAsyncClosure { self.syncMethod() }
 
     // CHECK: acceptEscapingAsyncClosure
     // CHECK: closure_expr
-    // CHECK: actor-isolated
+    // CHECK: actor_isolated
     acceptEscapingAsyncClosure { () async in print(self) }
   }
 }
@@ -63,21 +63,21 @@ func someAsyncFunc() async { }
 @SomeGlobalActor func someGlobalActorFunc() async {
   // CHECK: acceptAsyncClosure
   // CHECK: closure_expr
-  // CHECK-SAME: global-actor-isolated=SomeGlobalActor
+  // CHECK-SAME: global_actor_isolated=SomeGlobalActor
   acceptAsyncClosure { await someAsyncFunc() }
 
   // CHECK: acceptAsyncClosure
   // CHECK: closure_expr
-  // CHECK-SAME: global-actor-isolated=SomeGlobalActor
+  // CHECK-SAME: global_actor_isolated=SomeGlobalActor
   acceptAsyncClosure { () async in print("hello") }
 
   // CHECK: acceptEscapingAsyncClosure
   // CHECK: closure_expr
-  // CHECK: actor-isolated
+  // CHECK: actor_isolated
   acceptEscapingAsyncClosure { await someAsyncFunc() }
 
   // CHECK: acceptEscapingAsyncClosure
   // CHECK: closure_expr
-  // CHECK: actor-isolated
+  // CHECK: actor_isolated
   acceptEscapingAsyncClosure { () async in print("hello") }
 }

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -28,7 +28,7 @@ extension MyActor {
 
     // CHECK: acceptAsyncClosure
     // CHECK: closure_expr
-    // CHECK-SAME: actor_isolated=closure_isolation.(file).MyActor extension.testClosureIsolation().self
+    // CHECK-SAME: actor_isolated="closure_isolation.(file).MyActor extension.testClosureIsolation().self@
     acceptAsyncClosure { await method() }
 
     // CHECK: acceptAsyncClosure
@@ -63,12 +63,12 @@ func someAsyncFunc() async { }
 @SomeGlobalActor func someGlobalActorFunc() async {
   // CHECK: acceptAsyncClosure
   // CHECK: closure_expr
-  // CHECK-SAME: global_actor_isolated=SomeGlobalActor
+  // CHECK-SAME: global_actor_isolated="SomeGlobalActor"
   acceptAsyncClosure { await someAsyncFunc() }
 
   // CHECK: acceptAsyncClosure
   // CHECK: closure_expr
-  // CHECK-SAME: global_actor_isolated=SomeGlobalActor
+  // CHECK-SAME: global_actor_isolated="SomeGlobalActor"
   acceptAsyncClosure { () async in print("hello") }
 
   // CHECK: acceptEscapingAsyncClosure

--- a/test/Concurrency/where_clause_main_resolution.swift
+++ b/test/Concurrency/where_clause_main_resolution.swift
@@ -22,22 +22,22 @@ protocol App {
 // CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}}
 // CHECK-NOT: where
 // CHECK-NEXT: (func_decl range={{\[}}[[SOURCE_FILE]]:[[DEFAULT_ASYNCHRONOUS_MAIN_LINE:[0-9]+]]:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} "main()"
-// CHECK-SAME: interface type='<Self where Self : App> (Self.Type) -> () async -> ()'
+// CHECK-SAME: interface type="<Self where Self : App> (Self.Type) -> () async -> ()"
 
 extension App where Configuration == Config1 {
-// CHECK-CONFIG1: (func_decl implicit "$main()" interface type='(MainType.Type) -> () -> ()'
+// CHECK-CONFIG1: (func_decl implicit "$main()" interface type="(MainType.Type) -> () -> ()"
 // CHECK-CONFIG1: [[SOURCE_FILE]]:[[# @LINE+1 ]]
     static func main() { }
 }
 
 extension App where Configuration == Config2 {
-// CHECK-CONFIG2: (func_decl implicit "$main()" interface type='(MainType.Type) -> () async -> ()'
+// CHECK-CONFIG2: (func_decl implicit "$main()" interface type="(MainType.Type) -> () async -> ()"
 // CHECK-CONFIG2: [[SOURCE_FILE]]:[[# @LINE+1 ]]
     static func main() async { }
 }
 
 extension App where Configuration == Config3 {
-// CHECK-CONFIG3-ASYNC: (func_decl implicit "$main()" interface type='(MainType.Type) -> () async -> ()'
+// CHECK-CONFIG3-ASYNC: (func_decl implicit "$main()" interface type="(MainType.Type) -> () async -> ()"
 // CHECK-CONFIG3-ASYNC: [[SOURCE_FILE]]:[[DEFAULT_ASYNCHRONOUS_MAIN_LINE]]
 }
 

--- a/test/Concurrency/where_clause_main_resolution.swift
+++ b/test/Concurrency/where_clause_main_resolution.swift
@@ -16,9 +16,9 @@ protocol App {
 
 // Load in the source file name and grab line numbers for default main funcs
 // CHECK: (source_file "[[SOURCE_FILE:[^"]+]]"
-// CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} App where
-// CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} App where
-// CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} App where
+// CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} "App" where
+// CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} "App" where
+// CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} "App" where
 // CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}}
 // CHECK-NOT: where
 // CHECK-NEXT: (func_decl range={{\[}}[[SOURCE_FILE]]:[[DEFAULT_ASYNCHRONOUS_MAIN_LINE:[0-9]+]]:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} "main()"

--- a/test/Constraints/init_literal_via_coercion.swift
+++ b/test/Constraints/init_literal_via_coercion.swift
@@ -5,15 +5,15 @@
 // `0 as <#Type#>` should get literal bound early via equality constraint.
 
 // CHECK: ---Constraint solving at [{{.*}}:12:1 - line:12:13]---
-// CHECK: (integer_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
+// CHECK: (integer_literal_expr type="[[LITERAL_VAR:\$T[0-9]+]]" {{.*}}
 // CHECK: Type Variables:
 // CHECK: [[LITERAL_VAR]] as UInt32 {{.*}}
 // CHECK-NOT: disjunction (remembered) \[\[locator@{{.*}} [Coerce@{{.*}}\]\]]:
 _ = UInt32(0)
 
 // CHECK: ---Constraint solving at [{{.*}}22:1 - line:22:13]---
-// CHECK: (coerce_expr implicit type='[[CAST_TYPE:\$T[0-9]+]]' {{.*}}
-// CHECK-NEXT: (nil_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
+// CHECK: (coerce_expr implicit type="[[CAST_TYPE:\$T[0-9]+]]" {{.*}}
+// CHECK-NEXT: (nil_literal_expr type="[[LITERAL_VAR:\$T[0-9]+]]" {{.*}}
 // CHECK: Type Variables:
 // CHECK: [[LITERAL_VAR]] as Int? {{.*}}
 // CHECK: disjunction (remembered) {{.*}}

--- a/test/Constraints/invalid_decl_ref.swift
+++ b/test/Constraints/invalid_decl_ref.swift
@@ -4,6 +4,6 @@
 
 import Foundation
 
-// CHECK: declref_expr type='module<SomeModule>'
-// CHECK-NEXT: type_expr type='Data.Type'
+// CHECK: declref_expr type="module<SomeModule>"
+// CHECK-NEXT: type_expr type="Data.Type"
 let type = SomeModule.Data.self

--- a/test/Constraints/issue-58019.swift
+++ b/test/Constraints/issue-58019.swift
@@ -3,9 +3,9 @@
 // https://github.com/apple/swift/issues/58019
 
 func fetch() {
-  // CHECK: open_existential_expr implicit type='Void'
-  // CHECK: opaque_value_expr implicit type='any MyError'
-  // CHECK-NOT: type='SryMap<$T{{.*}}>.Failure'
+  // CHECK: open_existential_expr implicit type="Void"
+  // CHECK: opaque_value_expr implicit type="any MyError"
+  // CHECK-NOT: type="SryMap<$T{{.*}}>.Failure"
   sryMap { return "" }
   .napError{ $0.abc() }
 }

--- a/test/Constraints/issue-60806.swift
+++ b/test/Constraints/issue-60806.swift
@@ -18,8 +18,8 @@ enum NonBarBaz {
 
 let _: Foo<Bar> = Foo<Bar> { (a: Bar) -> Void in
   switch a {
-  // CHECK: (pattern_is type='any Bar' cast_kind=value_cast cast_to=Baz
-  // CHECK-NEXT: (pattern_enum_element type='Baz' element=Baz.someCase
+  // CHECK: (pattern_is type="any Bar" cast_kind=value_cast cast_to="Baz"
+  // CHECK-NEXT: (pattern_enum_element type="Baz" element="Baz.someCase"
   case let .someCase(value) as Baz:
     print(value)
   // expected-warning@-1 {{cast from 'any Bar' to unrelated type 'NonBarBaz' always fails}}

--- a/test/Constraints/issue-60806.swift
+++ b/test/Constraints/issue-60806.swift
@@ -18,8 +18,8 @@ enum NonBarBaz {
 
 let _: Foo<Bar> = Foo<Bar> { (a: Bar) -> Void in
   switch a {
-  // CHECK: (pattern_is type='any Bar' value_cast Baz
-  // CHECK-NEXT: (pattern_enum_element type='Baz' Baz.someCase
+  // CHECK: (pattern_is type='any Bar' cast_kind=value_cast cast_to=Baz
+  // CHECK-NEXT: (pattern_enum_element type='Baz' element=Baz.someCase
   case let .someCase(value) as Baz:
     print(value)
   // expected-warning@-1 {{cast from 'any Bar' to unrelated type 'NonBarBaz' always fails}}

--- a/test/Constraints/nil-coalescing-favoring.swift
+++ b/test/Constraints/nil-coalescing-favoring.swift
@@ -6,9 +6,9 @@ struct B {
 
 struct A {
   init(_ other: B) {}
-  // CHECK: constructor_decl{{.*}}interface type='(A.Type) -> (B?) -> A'
+  // CHECK: constructor_decl{{.*}}interface type="(A.Type) -> (B?) -> A"
   init(_ other: B?) {
-    // CHECK: dot_syntax_call_expr type='(B) -> A'
+    // CHECK: dot_syntax_call_expr type="(B) -> A"
     self.init(other ?? ._none)
   }
 }

--- a/test/Constraints/result_builder_conjunction_selection.swift
+++ b/test/Constraints/result_builder_conjunction_selection.swift
@@ -63,12 +63,12 @@ do {
   // CHECK: ---Initial constraints for the given expression---
   // CHECK: (attempting type variable {{.*}} := () -> {{.*}}
   // CHECK: (attempting conjunction element pattern binding element @ 0 :
-  // CHECK-NEXT: (pattern_named 'x')
+  // CHECK-NEXT: (pattern_named "x")
   // CHECK: (attempting conjunction element syntactic element
   // CHECK-NEXT: (call_expr {{.*}}
   // CHECK: (attempting type variable {{.*}} := (Bool) -> {{.*}}
   // CHECK: (attempting conjunction element pattern binding element @ 0
-  // CHECK: (pattern_named implicit '$__builder{{.*}}')
+  // CHECK: (pattern_named implicit "$__builder{{.*}}")
   // CHECK: (applying conjunction result to outer context
   // CHECK: (attempting type variable {{.*}} := (Int?) -> {{.*}}
   // CHECK: (attempting disjunction choice {{.*}} bound to decl {{.*}}.Int.init(_:)

--- a/test/Constraints/result_builder_conjunction_selection.swift
+++ b/test/Constraints/result_builder_conjunction_selection.swift
@@ -32,7 +32,7 @@ do {
   func test<T, U>(_: T, @Builder _: () -> some P<U>) {}
 
   // CHECK: ---Initial constraints for the given expression---
-  // CHECK: (integer_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
+  // CHECK: (integer_literal_expr type="[[LITERAL_VAR:\$T[0-9]+]]" {{.*}}
   // CHECK: (attempting type variable binding [[CLOSURE:\$T[0-9]+]] := () -> {{.*}}
   // CHECK-NOT: (attempting type variable binding [[LITERAL_VAR]] := {{.*}}
   // CHECK: (attempting conjunction element pattern binding element @ 0
@@ -48,7 +48,7 @@ do {
   func test<T, U>(_: T, @Builder _: (T) -> some P<U>) {}
 
   // CHECK: ---Initial constraints for the given expression---
-  // CHECK: (integer_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
+  // CHECK: (integer_literal_expr type="[[LITERAL_VAR:\$T[0-9]+]]" {{.*}}
   // CHECK: (attempting type variable binding [[LITERAL_VAR]] := Int
   // CHECK: (attempting conjunction element pattern binding element @ 0
   test(42) { v in

--- a/test/Constraints/result_builder_generic_infer.swift
+++ b/test/Constraints/result_builder_generic_infer.swift
@@ -22,34 +22,34 @@ struct ProtocolSubstitution: P {
   typealias A = Int
 
   // CHECK: var_decl{{.*}}x1
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> Int))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> Int')
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> ProtocolSubstitution))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> ProtocolSubstitution')
   var x2: [S] { S() }
 }
 
 // CHECK: struct_decl{{.*}}ArchetypeSubstitution
 struct ArchetypeSubstitution<A>: P {
   // CHECK: var_decl{{.*}}x1
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> A))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> A')
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> ArchetypeSubstitution<A>))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> ArchetypeSubstitution<A>')
   var x2: [S] { S() }
 }
 
 // CHECK-LABEL: struct_decl{{.*}}ExplicitGenericAttribute
 struct ExplicitGenericAttribute<T: P> {
   // CHECK: var_decl{{.*}}x1
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> T))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> T')
   @Builder<T>
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> T.A))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> T.A')
   @Builder<T.A>
   var x2: [S] { S() }
 }
@@ -61,10 +61,10 @@ extension ConcreteTypeSubstitution: P where Value == Int {
   typealias A = Value
 
   // CHECK: var_decl{{.*}}x1
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> Int))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> Int')
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> ConcreteTypeSubstitution<Int>))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> ConcreteTypeSubstitution<Int>')
   var x2: [S] { S() }
 }

--- a/test/Constraints/result_builder_switch_with_vars.swift
+++ b/test/Constraints/result_builder_switch_with_vars.swift
@@ -49,8 +49,8 @@ func tuplify<T>(@TupleBuilder body: (E) throws -> T) rethrows {
 tuplify {
   switch $0 {
   // CHECK: (case_body_variables
-  // CHECK-NEXT: (var_decl implicit {{.*}} "a" interface type='String' let readImpl=stored immutable)
-  // CHECK-NEXT: (var_decl implicit {{.*}} "b" interface type='Int' let readImpl=stored immutable)
+  // CHECK-NEXT: (var_decl implicit {{.*}} "a" interface type="String" let readImpl=stored immutable)
+  // CHECK-NEXT: (var_decl implicit {{.*}} "b" interface type="Int" let readImpl=stored immutable)
   case let .test(a, b):
     a
     b
@@ -58,8 +58,8 @@ tuplify {
 
   switch $0 {
     // CHECK: (case_body_variables
-    // CHECK-NEXT: (var_decl implicit {{.*}} "a" interface type='String' let readImpl=stored immutable)
-    // CHECK-NEXT: (var_decl implicit {{.*}} "b" interface type='Int' let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "a" interface type="String" let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "b" interface type="Int" let readImpl=stored immutable)
   case .test(let a, let b):
     a
     b
@@ -67,21 +67,21 @@ tuplify {
 
   switch $0 {
     // CHECK: (case_body_variables
-    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type='(a: String, b: Int)' let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type="(a: String, b: Int)" let readImpl=stored immutable)
   case let .test((value)):
     value.a
   }
 
   switch $0 {
     // CHECK: (case_body_variables
-    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type='(a: String, b: Int)' let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type="(a: String, b: Int)" let readImpl=stored immutable)
   case let .test(value):
     value.a
   }
 
   switch $0 {
     // CHECK: (case_body_variables
-    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type='(a: String, b: Int)' let readImpl=stored immutable)
+    // CHECK-NEXT: (var_decl implicit {{.*}} "value" interface type="(a: String, b: Int)" let readImpl=stored immutable)
   case .test(let value):
     value.a
   }

--- a/test/DWARFImporter/basic.swift
+++ b/test/DWARFImporter/basic.swift
@@ -23,10 +23,10 @@ import ObjCModule
 
 let pureSwift = Int32(42)
 // FAIL-NOT:  var_decl
-// CHECK:     var_decl "pureSwift" {{.*}} type='Int32'
-// SWIFTONLY: var_decl "pureSwift" {{.*}} type='Int32' 
+// CHECK:     var_decl "pureSwift" {{.*}} type="Int32"
+// SWIFTONLY: var_decl "pureSwift" {{.*}} type="Int32" 
 
 let point = Point(x: 1, y: 2)
-// CHECK:     var_decl "point" {{.*}} type='Point'
+// CHECK:     var_decl "point" {{.*}} type="Point"
 // SWIFTONLY-NOT: var_decl "point"
 

--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -37,9 +37,9 @@ distributed actor DefaultWorker {
 // Check that we create the "remote reference" executor:
 // CHECK: (return_stmt implicit
 // CHECK:   (call_expr implicit type="UnownedSerialExecutor" nothrow
-// CHECK:     (declref_expr implicit type="(DefaultWorker) -> UnownedSerialExecutor" decl="Distributed.(file).buildDefaultDistributedRemoteActorExecutor [with (substitution_map generic_signature=<Act where Act : DistributedActor> (substitution Act -> DefaultWorker))]"
+// CHECK:     (declref_expr implicit type="(DefaultWorker) -> UnownedSerialExecutor" decl="Distributed.(file).buildDefaultDistributedRemoteActorExecutor [with (substitution_map generic_signature='<Act where Act : DistributedActor>' 'Act -> DefaultWorker')]"
 
 // Check the default executor synthesis for local actor otherwise:
 // CHECK: (return_stmt implicit
 // CHECK:   (call_expr implicit type="Builtin.Executor" nothrow
-// CHECK:     (declref_expr implicit type="(DefaultWorker) -> Builtin.Executor" decl="Builtin.(file).buildDefaultActorExecutorRef [with (substitution_map generic_signature=<T where T : AnyObject> (substitution T -> DefaultWorker))]" function_ref=unapplied)
+// CHECK:     (declref_expr implicit type="(DefaultWorker) -> Builtin.Executor" decl="Builtin.(file).buildDefaultActorExecutorRef [with (substitution_map generic_signature='<T where T : AnyObject>' 'T -> DefaultWorker')]" function_ref=unapplied)

--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -25,21 +25,21 @@ distributed actor DefaultWorker {
 }
 
 // Check DefaultWorker, the DefaultActor version of the synthesis:
-// CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type='DefaultWorker.Type' access=internal non_resilient distributed actor
+// CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type="DefaultWorker.Type" access=internal non_resilient distributed actor
 // The unowned executor property:
-// CHECK:    (var_decl implicit "unownedExecutor" interface type='UnownedSerialExecutor' access=internal final readImpl=getter immutable
+// CHECK:    (var_decl implicit "unownedExecutor" interface type="UnownedSerialExecutor" access=internal final readImpl=getter immutable
 
 // We guard the rest of the body; we only return a default executor if the actor is local:
 // CHECK:       (guard_stmt implicit
-// CHECK:         (call_expr implicit type='Bool' nothrow
-// CHECK:           (declref_expr implicit type='@_NO_EXTINFO (AnyObject) -> Bool' decl=Distributed.(file).__isLocalActor function_ref=unapplied)
+// CHECK:         (call_expr implicit type="Bool" nothrow
+// CHECK:           (declref_expr implicit type="@_NO_EXTINFO (AnyObject) -> Bool" decl="Distributed.(file).__isLocalActor" function_ref=unapplied)
 
 // Check that we create the "remote reference" executor:
 // CHECK: (return_stmt implicit
-// CHECK:   (call_expr implicit type='UnownedSerialExecutor' nothrow
-// CHECK:     (declref_expr implicit type='(DefaultWorker) -> UnownedSerialExecutor' decl=Distributed.(file).buildDefaultDistributedRemoteActorExecutor [with (substitution_map generic_signature=<Act where Act : DistributedActor> (substitution Act -> DefaultWorker))]
+// CHECK:   (call_expr implicit type="UnownedSerialExecutor" nothrow
+// CHECK:     (declref_expr implicit type="(DefaultWorker) -> UnownedSerialExecutor" decl="Distributed.(file).buildDefaultDistributedRemoteActorExecutor [with (substitution_map generic_signature=<Act where Act : DistributedActor> (substitution Act -> DefaultWorker))]"
 
 // Check the default executor synthesis for local actor otherwise:
 // CHECK: (return_stmt implicit
-// CHECK:   (call_expr implicit type='Builtin.Executor' nothrow
-// CHECK:     (declref_expr implicit type='(DefaultWorker) -> Builtin.Executor' decl=Builtin.(file).buildDefaultActorExecutorRef [with (substitution_map generic_signature=<T where T : AnyObject> (substitution T -> DefaultWorker))] function_ref=unapplied)
+// CHECK:   (call_expr implicit type="Builtin.Executor" nothrow
+// CHECK:     (declref_expr implicit type="(DefaultWorker) -> Builtin.Executor" decl="Builtin.(file).buildDefaultActorExecutorRef [with (substitution_map generic_signature=<T where T : AnyObject> (substitution T -> DefaultWorker))]" function_ref=unapplied)

--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -25,7 +25,7 @@ distributed actor DefaultWorker {
 }
 
 // Check DefaultWorker, the DefaultActor version of the synthesis:
-// CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type='DefaultWorker.Type' access=internal non-resilient actor
+// CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type='DefaultWorker.Type' access=internal non_resilient distributed actor
 // The unowned executor property:
 // CHECK:    (var_decl implicit "unownedExecutor" interface type='UnownedSerialExecutor' access=internal final readImpl=getter immutable
 

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -32,9 +32,9 @@ protocol P3 {
 }
 
 // CHECK-LABEL: StructDecl name=Basic
-// CHECK: (normal_conformance type=Basic protocol=P1
-// CHECK-NEXT: (assoc_type req=A type=Int)
-// CHECK-NEXT: (value req=f() witness=main.(file).Basic.f()@{{.*}}))
+// CHECK: (normal_conformance type="Basic" protocol="P1"
+// CHECK-NEXT: (assoc_type req="A" type="Int")
+// CHECK-NEXT: (value req="f()" witness="main.(file).Basic.f()@{{.*}}"))
 struct Basic: P1 {
     typealias A = Int
     func f() -> Int { fatalError() }
@@ -43,11 +43,11 @@ struct Basic: P1 {
 // Recursive conformances should have finite output.
 
 // CHECK-LABEL: StructDecl name=Recur
-// CHECK-NEXT: (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=Recur)
-// CHECK-NEXT:   (assoc_type req=B type=Recur)
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above))
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
+// CHECK-NEXT: (normal_conformance type="Recur" protocol="P2"
+// CHECK-NEXT:   (assoc_type req="A" type="Recur")
+// CHECK-NEXT:   (assoc_type req="B" type="Recur")
+// CHECK-NEXT:   (normal_conformance type="Recur" protocol="P2" <details printed above>)
+// CHECK-NEXT:   (normal_conformance type="Recur" protocol="P2" <details printed above>))
 struct Recur: P2 {
     typealias A = Recur
     typealias B = Recur
@@ -56,15 +56,15 @@ struct Recur: P2 {
 // The full information about a conformance doesn't need to be printed twice.
 
 // CHECK-LABEL: StructDecl name=NonRecur
-// CHECK-NEXT: (normal_conformance type=NonRecur protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=Recur)
-// CHECK-NEXT:   (assoc_type req=B type=Recur)
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:     (assoc_type req=A type=Recur)
-// CHECK-NEXT:     (assoc_type req=B type=Recur)
-// CHECK-NEXT:     (normal_conformance type=Recur protocol=P2 (details printed above))
-// CHECK-NEXT:     (normal_conformance type=Recur protocol=P2 (details printed above)))
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
+// CHECK-NEXT: (normal_conformance type="NonRecur" protocol="P2"
+// CHECK-NEXT:   (assoc_type req="A" type="Recur")
+// CHECK-NEXT:   (assoc_type req="B" type="Recur")
+// CHECK-NEXT:   (normal_conformance type="Recur" protocol="P2"
+// CHECK-NEXT:     (assoc_type req="A" type="Recur")
+// CHECK-NEXT:     (assoc_type req="B" type="Recur")
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>)
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:   (normal_conformance type="Recur" protocol="P2" <details printed above>))
 struct NonRecur: P2 {
     typealias A = Recur
     typealias B = Recur
@@ -77,9 +77,9 @@ struct NonRecur: P2 {
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic
 struct Generic<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic
-// CHECK-NEXT: (normal_conformance type=Generic<T> protocol=P1
-// CHECK-NEXT:   (assoc_type req=A type=T)
-// CHECK-NEXT:   (value req=f() witness=main.(file).Generic extension.f()@{{.*}})
+// CHECK-NEXT: (normal_conformance type="Generic<T>" protocol="P1"
+// CHECK-NEXT:   (assoc_type req="A" type="T")
+// CHECK-NEXT:   (value req="f()" witness="main.(file).Generic extension.f()@{{.*}}")
 // CHECK-NEXT:   conforms_to: T P1)
 extension Generic: P1 where T: P1 {
     typealias A = T
@@ -94,11 +94,11 @@ extension Generic: P1 where T: P1 {
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Super
 class Super<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Super
-// CHECK-NEXT: (normal_conformance type=Super<T, U> protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=T)
-// CHECK-NEXT:   (assoc_type req=B type=T)
-// CHECK-NEXT:   (abstract_conformance protocol=P2)
-// CHECK-NEXT:   (abstract_conformance protocol=P2)
+// CHECK-NEXT: (normal_conformance type="Super<T, U>" protocol="P2"
+// CHECK-NEXT:   (assoc_type req="A" type="T")
+// CHECK-NEXT:   (assoc_type req="B" type="T")
+// CHECK-NEXT:   (abstract_conformance protocol="P2")
+// CHECK-NEXT:   (abstract_conformance protocol="P2")
 // CHECK-NEXT:   conforms_to: T P2
 // CHECK-NEXT:   conforms_to: U P2)
 extension Super: P2 where T: P2, U: P2 {
@@ -108,29 +108,29 @@ extension Super: P2 where T: P2, U: P2 {
 
 // Inherited/specialized conformances.
 // CHECK-LABEL: ClassDecl name=Sub
-// CHECK-NEXT: (inherited_conformance type=Sub protocol=P2
-// CHECK-NEXT:   (specialized_conformance type=Super<NonRecur, Recur> protocol=P2
-// CHECK-NEXT:      (substitution_map generic_signature=<T, U where T : P2, U : P2>
-// CHECK-NEXT:         (substitution T -> NonRecur)
-// CHECK-NEXT:         (substitution U -> Recur)
-// CHECK-NEXT:         (conformance type=T
-// CHECK-NEXT:            (normal_conformance type=NonRecur protocol=P2
-// CHECK-NEXT:              (assoc_type req=A type=Recur)
-// CHECK-NEXT:              (assoc_type req=B type=Recur)
-// CHECK-NEXT:              (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:                (assoc_type req=A type=Recur)
-// CHECK-NEXT:                (assoc_type req=B type=Recur)
-// CHECK-NEXT:                (normal_conformance type=Recur protocol=P2 (details printed above))
-// CHECK-NEXT:                (normal_conformance type=Recur protocol=P2 (details printed above)))
-// CHECK-NEXT:              (normal_conformance type=Recur protocol=P2 (details printed above))))
-// CHECK-NEXT:         (conformance type=U
-// CHECK-NEXT:            (normal_conformance type=Recur protocol=P2 (details printed above))))
-// CHECK-NEXT:     (conditional requirements unable to be computed)
-// CHECK-NEXT:     (normal_conformance type=Super<T, U> protocol=P2
-// CHECK-NEXT:       (assoc_type req=A type=T)
-// CHECK-NEXT:       (assoc_type req=B type=T)
-// CHECK-NEXT:       (abstract_conformance protocol=P2)
-// CHECK-NEXT:       (abstract_conformance protocol=P2)
+// CHECK-NEXT: (inherited_conformance type="Sub" protocol="P2"
+// CHECK-NEXT:   (specialized_conformance type="Super<NonRecur, Recur>" protocol="P2"
+// CHECK-NEXT:      (substitution_map generic_signature="<T, U where T : P2, U : P2>"
+// CHECK-NEXT:         (substitution "T -> NonRecur")
+// CHECK-NEXT:         (substitution "U -> Recur")
+// CHECK-NEXT:         (conformance type="T"
+// CHECK-NEXT:            (normal_conformance type="NonRecur" protocol="P2"
+// CHECK-NEXT:              (assoc_type req="A" type="Recur")
+// CHECK-NEXT:              (assoc_type req="B" type="Recur")
+// CHECK-NEXT:              (normal_conformance type="Recur" protocol="P2"
+// CHECK-NEXT:                (assoc_type req="A" type="Recur")
+// CHECK-NEXT:                (assoc_type req="B" type="Recur")
+// CHECK-NEXT:                (normal_conformance type="Recur" protocol="P2" <details printed above>)
+// CHECK-NEXT:                (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:              (normal_conformance type="Recur" protocol="P2" <details printed above>)))
+// CHECK-NEXT:         (conformance type="U"
+// CHECK-NEXT:            (normal_conformance type="Recur" protocol="P2" <details printed above>)))
+// CHECK-NEXT:     (<conditional requirements unable to be computed>)
+// CHECK-NEXT:     (normal_conformance type="Super<T, U>" protocol="P2"
+// CHECK-NEXT:       (assoc_type req="A" type="T")
+// CHECK-NEXT:       (assoc_type req="B" type="T")
+// CHECK-NEXT:       (abstract_conformance protocol="P2")
+// CHECK-NEXT:       (abstract_conformance protocol="P2")
 // CHECK-NEXT:       conforms_to: T P2
 // CHECK-NEXT:       conforms_to: U P2)))
 class Sub: Super<NonRecur, Recur> {}
@@ -139,24 +139,24 @@ class Sub: Super<NonRecur, Recur> {}
 // should work through SubstitutionMaps.
 
 // CHECK-LABEL: StructDecl name=RecurGeneric
-// CHECK-NEXT: (normal_conformance type=RecurGeneric<T> protocol=P3
-// CHECK-NEXT:   (assoc_type req=A type=RecurGeneric<T>)
-// CHECK-NEXT:   (normal_conformance type=RecurGeneric<T> protocol=P3 (details printed above)))
+// CHECK-NEXT: (normal_conformance type="RecurGeneric<T>" protocol="P3"
+// CHECK-NEXT:   (assoc_type req="A" type="RecurGeneric<T>")
+// CHECK-NEXT:   (normal_conformance type="RecurGeneric<T>" protocol="P3" <details printed above>))
 struct RecurGeneric<T: P3>: P3 {
     typealias A = RecurGeneric<T>
 }
 
 // CHECK-LABEL: StructDecl name=Specialize
-// CHECK-NEXT: (normal_conformance type=Specialize protocol=P3
-// CHECK-NEXT:   (assoc_type req=A type=RecurGeneric<Specialize>)
-// CHECK-NEXT:   (specialized_conformance type=Specialize.A protocol=P3
-// CHECK-NEXT:     (substitution_map generic_signature=<T where T : P3>
-// CHECK-NEXT:       (substitution T -> Specialize)
-// CHECK-NEXT:       (conformance type=T
-// CHECK-NEXT:         (normal_conformance type=Specialize protocol=P3 (details printed above))))
-// CHECK-NEXT:     (normal_conformance type=RecurGeneric<T> protocol=P3
-// CHECK-NEXT:       (assoc_type req=A type=RecurGeneric<T>)
-// CHECK-NEXT:       (normal_conformance type=RecurGeneric<T> protocol=P3 (details printed above)))))
+// CHECK-NEXT: (normal_conformance type="Specialize" protocol="P3"
+// CHECK-NEXT:   (assoc_type req="A" type="RecurGeneric<Specialize>")
+// CHECK-NEXT:   (specialized_conformance type="Specialize.A" protocol="P3"
+// CHECK-NEXT:     (substitution_map generic_signature="<T where T : P3>"
+// CHECK-NEXT:       (substitution "T -> Specialize")
+// CHECK-NEXT:       (conformance type="T"
+// CHECK-NEXT:         (normal_conformance type="Specialize" protocol="P3" <details printed above>)))
+// CHECK-NEXT:     (normal_conformance type="RecurGeneric<T>" protocol="P3"
+// CHECK-NEXT:       (assoc_type req="A" type="RecurGeneric<T>")
+// CHECK-NEXT:       (normal_conformance type="RecurGeneric<T>" protocol="P3" <details printed above>))))
 struct Specialize: P3 {
     typealias A = RecurGeneric<Specialize>
 }

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -80,7 +80,7 @@ struct Generic<T> {}
 // CHECK-NEXT: (normal_conformance type="Generic<T>" protocol="P1"
 // CHECK-NEXT:   (assoc_type req="A" type="T")
 // CHECK-NEXT:   (value req="f()" witness="main.(file).Generic extension.f()@{{.*}}")
-// CHECK-NEXT:   conforms_to: T P1)
+// CHECK-NEXT:   (requirement "T" conforms_to "P1")
 extension Generic: P1 where T: P1 {
     typealias A = T
     func f() -> T { fatalError() }
@@ -99,8 +99,8 @@ class Super<T, U> {}
 // CHECK-NEXT:   (assoc_type req="B" type="T")
 // CHECK-NEXT:   (abstract_conformance protocol="P2")
 // CHECK-NEXT:   (abstract_conformance protocol="P2")
-// CHECK-NEXT:   conforms_to: T P2
-// CHECK-NEXT:   conforms_to: U P2)
+// CHECK-NEXT:   (requirement "T" conforms_to "P2")
+// CHECK-NEXT:   (requirement "U" conforms_to "P2"))
 extension Super: P2 where T: P2, U: P2 {
     typealias A = T
     typealias B = T
@@ -131,8 +131,8 @@ extension Super: P2 where T: P2, U: P2 {
 // CHECK-NEXT:       (assoc_type req="B" type="T")
 // CHECK-NEXT:       (abstract_conformance protocol="P2")
 // CHECK-NEXT:       (abstract_conformance protocol="P2")
-// CHECK-NEXT:       conforms_to: T P2
-// CHECK-NEXT:       conforms_to: U P2)))
+// CHECK-NEXT:       (requirement "T" conforms_to "P2")
+// CHECK-NEXT:       (requirement "U" conforms_to "P2"))))
 class Sub: Super<NonRecur, Recur> {}
 
 // Specialization of a recursive conformance should be okay: recursion detection

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -99,8 +99,8 @@ enum MyEnum {
 // CHECK-NEXT:      (sequence_expr type='<null>'
 // CHECK-NEXT:        (discard_assignment_expr type='<null>')
 // CHECK-NEXT:        (assign_expr type='<null>'
-// CHECK-NEXT:          (**NULL EXPRESSION**)
-// CHECK-NEXT:          (**NULL EXPRESSION**))
+// CHECK-NEXT:          (<null expr>)
+// CHECK-NEXT:          (<null expr>))
 // CHECK-NEXT:        (closure_expr type='<null>' discriminator={{[0-9]+}}
 // CHECK-NEXT:          (parameter_list range=[{{.+}}]
 // CHECK-NEXT:            (parameter "v"))

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -114,7 +114,7 @@ struct SelfParam {
   // CHECK-NEXT:    (parameter "self")
   // CHECK-NEXT:    (parameter_list range=[{{.+}}])
   // CHECK-NEXT:    (result=type_optional
-  // CHECK-NEXT:      (type_ident id='SelfParam' bind=none))
+  // CHECK-NEXT:      (type_ident id='SelfParam' bind=<none>))
   static func createOptional() -> SelfParam? {
 
     // CHECK-LABEL: (call_expr type='<null>'
@@ -127,7 +127,7 @@ struct SelfParam {
 // CHECK-LABEL: (func_decl range=[{{.+}}] "dumpMemberTypeRepr()"
 // CHECK-NEXT:    (parameter_list range=[{{.+}}])
 // CHECK-NEXT:    (result=type_member
-// CHECK-NEXT:      (type_ident id='Array' bind=none)
-// CHECK-NEXT:        (type_ident id='Bool' bind=none)
-// CHECK-NEXT:      (type_ident id='Element' bind=none))
+// CHECK-NEXT:      (type_ident id='Array' bind=<none>
+// CHECK-NEXT:        (type_ident id='Bool' bind=<none>))
+// CHECK-NEXT:      (type_ident id='Element' bind=<none>))
 func dumpMemberTypeRepr() -> Array<Bool>.Element { true }

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -6,10 +6,10 @@
 func foo(_ n: Int) -> Int {
   // CHECK:   (brace_stmt
   // CHECK:     (return_stmt
-  // CHECK:       (integer_literal_expr type='<null>' value=42 {{.*}})))
+  // CHECK:       (integer_literal_expr type="<null>" value="42" {{.*}})))
   // CHECK-AST: (brace_stmt
   // CHECK-AST:   (return_stmt
-  // CHECK-AST:     (integer_literal_expr type='{{[^']+}}' {{.*}} value=42 {{.*}})
+  // CHECK-AST:     (integer_literal_expr type="{{[^"]+}}" {{.*}} value="42" {{.*}})
     return 42
 }
 
@@ -18,13 +18,13 @@ func foo(_ n: Int) -> Int {
 // CHECK-AST-LABEL: (func_decl{{.*}}"bar()"
 func bar() {
   // CHECK: (brace_stmt
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type="{{[^"]+}}" name="foo"
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type="{{[^"]+}}" name="foo"
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type="{{[^"]+}}" name="foo"
   // CHECK-AST: (brace_stmt
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
+  // CHECK-AST-NEXT:   (declref_expr type="{{[^"]+}}" {{.*}} decl="main.(file).foo@
+  // CHECK-AST-NEXT:   (declref_expr type="{{[^"]+}}" {{.*}} decl="main.(file).foo@
+  // CHECK-AST-NEXT:   (declref_expr type="{{[^"]+}}" {{.*}} decl="main.(file).foo@
   foo foo foo
 }
 
@@ -38,7 +38,7 @@ enum TrailingSemi {
   case A,B;
 
   // CHECK-LABEL: (subscript_decl{{.*}}trailing_semi
-  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' get for="subscript(_:)"
+  // CHECK-NOT:   (func_decl{{.*}}trailing_semi <anonymous @ 0x{{[0-9a-f]+}}> get for="subscript(_:)"
   // CHECK:       (accessor_decl{{.*}} <anonymous @ 0x{{[0-9a-f]+}}> get for="subscript(_:)"
   subscript(x: Int) -> Int {
     // CHECK-LABEL: (pattern_binding_decl{{.*}}trailing_semi
@@ -55,26 +55,26 @@ enum TrailingSemi {
 };
 
 // The substitution map for a declref should be relatively unobtrusive.
-// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
+// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" "<T : Hashable>" interface type="<T where T : Hashable> (T) -> ()" access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
-// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
+// CHECK-AST:         (processed_init=declref_expr type="(Int) -> ()" location={{.*}} range={{.*}} decl="main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))]" function_ref=unapplied))
 let _: (Int) -> () = generic
 
 // Closures should be marked as escaping or not.
 func escaping(_: @escaping (Int) -> Int) {}
 escaping({ $0 })
-// CHECK-AST:        (declref_expr type='(@escaping (Int) -> Int) -> ()'
+// CHECK-AST:        (declref_expr type="(@escaping (Int) -> Int) -> ()"
 // CHECK-AST-NEXT:        (argument_list
 // CHECK-AST-NEXT:          (argument
-// CHECK-AST-NEXT:            (closure_expr type='(Int) -> Int' {{.*}} discriminator=0 escaping single_expression
+// CHECK-AST-NEXT:            (closure_expr type="(Int) -> Int" {{.*}} discriminator=0 escaping single_expression
 
 func nonescaping(_: (Int) -> Int) {}
 nonescaping({ $0 })
-// CHECK-AST:        (declref_expr type='((Int) -> Int) -> ()'
+// CHECK-AST:        (declref_expr type="((Int) -> Int) -> ()"
 // CHECK-AST-NEXT:        (argument_list
 // CHECK-AST-NEXT:          (argument
-// CHECK-AST-NEXT:            (closure_expr type='(Int) -> Int' {{.*}} discriminator=1 single_expression
+// CHECK-AST-NEXT:            (closure_expr type="(Int) -> Int" {{.*}} discriminator=1 single_expression
 
 // CHECK-LABEL: (struct_decl range=[{{.+}}] "MyStruct")
 struct MyStruct {}
@@ -85,23 +85,23 @@ enum MyEnum {
     // CHECK-LABEL: (enum_case_decl range=[{{.+}}]
     // CHECK-NEXT:    (enum_element_decl range=[{{.+}}]  "foo(x:)"
     // CHECK-NEXT:      (parameter_list range=[{{.+}}]
-    // CHECK-NEXT:         (parameter "x" apiName=x)))
+    // CHECK-NEXT:         (parameter "x" apiName="x")))
     // CHECK-NEXT:     (enum_element_decl range=[{{.+}}] "bar"))
     // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "foo(x:)"
     // CHECK-NEXT:    (parameter_list range=[{{.+}}]
-    // CHECK-NEXT:      (parameter "x" apiName=x)))
+    // CHECK-NEXT:      (parameter "x" apiName="x")))
     // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "bar"))
     case foo(x: MyStruct), bar
 }
 
 // CHECK-LABEL: (top_level_code_decl range=[{{.+}}]
 // CHECK-NEXT:    (brace_stmt implicit range=[{{.+}}]
-// CHECK-NEXT:      (sequence_expr type='<null>'
-// CHECK-NEXT:        (discard_assignment_expr type='<null>')
-// CHECK-NEXT:        (assign_expr type='<null>'
+// CHECK-NEXT:      (sequence_expr type="<null>"
+// CHECK-NEXT:        (discard_assignment_expr type="<null>")
+// CHECK-NEXT:        (assign_expr type="<null>"
 // CHECK-NEXT:          (<null expr>)
 // CHECK-NEXT:          (<null expr>))
-// CHECK-NEXT:        (closure_expr type='<null>' discriminator={{[0-9]+}}
+// CHECK-NEXT:        (closure_expr type="<null>" discriminator={{[0-9]+}}
 // CHECK-NEXT:          (parameter_list range=[{{.+}}]
 // CHECK-NEXT:            (parameter "v"))
 // CHECK-NEXT:          (brace_stmt range=[{{.+}}])))))
@@ -114,11 +114,11 @@ struct SelfParam {
   // CHECK-NEXT:    (parameter "self")
   // CHECK-NEXT:    (parameter_list range=[{{.+}}])
   // CHECK-NEXT:    (result=type_optional
-  // CHECK-NEXT:      (type_ident id='SelfParam' bind=<none>))
+  // CHECK-NEXT:      (type_ident id="SelfParam" unbound))
   static func createOptional() -> SelfParam? {
 
-    // CHECK-LABEL: (call_expr type='<null>'
-    // CHECK-NEXT:    (unresolved_decl_ref_expr type='<null>' name=SelfParam function_ref=unapplied)
+    // CHECK-LABEL: (call_expr type="<null>"
+    // CHECK-NEXT:    (unresolved_decl_ref_expr type="<null>" name="SelfParam" function_ref=unapplied)
     // CHECK-NEXT:    (argument_list)
     SelfParam()
   }
@@ -127,7 +127,7 @@ struct SelfParam {
 // CHECK-LABEL: (func_decl range=[{{.+}}] "dumpMemberTypeRepr()"
 // CHECK-NEXT:    (parameter_list range=[{{.+}}])
 // CHECK-NEXT:    (result=type_member
-// CHECK-NEXT:      (type_ident id='Array' bind=<none>
-// CHECK-NEXT:        (type_ident id='Bool' bind=<none>))
-// CHECK-NEXT:      (type_ident id='Element' bind=<none>))
+// CHECK-NEXT:      (type_ident id="Array" unbound
+// CHECK-NEXT:        (type_ident id="Bool" unbound))
+// CHECK-NEXT:      (type_ident id="Element" unbound))
 func dumpMemberTypeRepr() -> Array<Bool>.Element { true }

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -38,8 +38,8 @@ enum TrailingSemi {
   case A,B;
 
   // CHECK-LABEL: (subscript_decl{{.*}}trailing_semi
-  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' get for=subscript(_:)
-  // CHECK:       (accessor_decl{{.*}}'anonname={{.*}}' get for=subscript(_:)
+  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' get for="subscript(_:)"
+  // CHECK:       (accessor_decl{{.*}} <anonymous @ 0x{{[0-9a-f]+}}> get for="subscript(_:)"
   subscript(x: Int) -> Int {
     // CHECK-LABEL: (pattern_binding_decl{{.*}}trailing_semi
     // CHECK-NOT:   (var_decl{{.*}}trailing_semi "y"

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -58,7 +58,7 @@ enum TrailingSemi {
 // CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
-// CHECK-AST:         (declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
+// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
 let _: (Int) -> () = generic
 
 // Closures should be marked as escaping or not.
@@ -113,9 +113,8 @@ struct SelfParam {
   // CHECK-LABEL: (func_decl range=[{{.+}}] "createOptional()" type
   // CHECK-NEXT:    (parameter "self")
   // CHECK-NEXT:    (parameter_list range=[{{.+}}])
-  // CHECK-NEXT:    (result
-  // CHECK-NEXT:      (type_optional
-  // CHECK-NEXT:        (type_ident id='SelfParam' bind=none)))
+  // CHECK-NEXT:    (result=type_optional
+  // CHECK-NEXT:      (type_ident id='SelfParam' bind=none))
   static func createOptional() -> SelfParam? {
 
     // CHECK-LABEL: (call_expr type='<null>'
@@ -127,9 +126,8 @@ struct SelfParam {
 
 // CHECK-LABEL: (func_decl range=[{{.+}}] "dumpMemberTypeRepr()"
 // CHECK-NEXT:    (parameter_list range=[{{.+}}])
-// CHECK-NEXT:    (result
-// CHECK-NEXT:      (type_member
-// CHECK-NEXT:        (type_ident id='Array' bind=none)
-// CHECK-NEXT:          (type_ident id='Bool' bind=none)
-// CHECK-NEXT:        (type_ident id='Element' bind=none)))
+// CHECK-NEXT:    (result=type_member
+// CHECK-NEXT:      (type_ident id='Array' bind=none)
+// CHECK-NEXT:        (type_ident id='Bool' bind=none)
+// CHECK-NEXT:      (type_ident id='Element' bind=none))
 func dumpMemberTypeRepr() -> Array<Bool>.Element { true }

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -58,7 +58,7 @@ enum TrailingSemi {
 // CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" "<T : Hashable>" interface type="<T where T : Hashable> (T) -> ()" access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
-// CHECK-AST:         (processed_init=declref_expr type="(Int) -> ()" location={{.*}} range={{.*}} decl="main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))]" function_ref=unapplied))
+// CHECK-AST:         (processed_init=declref_expr type="(Int) -> ()" location={{.*}} range={{.*}} decl="main.(file).generic@{{.*}} [with (substitution_map generic_signature='<T where T : Hashable>' 'T -> Int')]" function_ref=unapplied))
 let _: (Int) -> () = generic
 
 // Closures should be marked as escaping or not.

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -38,8 +38,8 @@ enum TrailingSemi {
   case A,B;
 
   // CHECK-LABEL: (subscript_decl{{.*}}trailing_semi
-  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' get_for=subscript(_:)
-  // CHECK:       (accessor_decl{{.*}}'anonname={{.*}}' get_for=subscript(_:)
+  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' get for=subscript(_:)
+  // CHECK:       (accessor_decl{{.*}}'anonname={{.*}}' get for=subscript(_:)
   subscript(x: Int) -> Int {
     // CHECK-LABEL: (pattern_binding_decl{{.*}}trailing_semi
     // CHECK-NOT:   (var_decl{{.*}}trailing_semi "y"

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -67,14 +67,14 @@ escaping({ $0 })
 // CHECK-AST:        (declref_expr type='(@escaping (Int) -> Int) -> ()'
 // CHECK-AST-NEXT:        (argument_list
 // CHECK-AST-NEXT:          (argument
-// CHECK-AST-NEXT:            (closure_expr type='(Int) -> Int' {{.*}} discriminator=0 escaping single-expression
+// CHECK-AST-NEXT:            (closure_expr type='(Int) -> Int' {{.*}} discriminator=0 escaping single_expression
 
 func nonescaping(_: (Int) -> Int) {}
 nonescaping({ $0 })
 // CHECK-AST:        (declref_expr type='((Int) -> Int) -> ()'
 // CHECK-AST-NEXT:        (argument_list
 // CHECK-AST-NEXT:          (argument
-// CHECK-AST-NEXT:            (closure_expr type='(Int) -> Int' {{.*}} discriminator=1 single-expression
+// CHECK-AST-NEXT:            (closure_expr type='(Int) -> Int' {{.*}} discriminator=1 single_expression
 
 // CHECK-LABEL: (struct_decl range=[{{.+}}] "MyStruct")
 struct MyStruct {}

--- a/test/Frontend/module-alias-dump-ast.swift
+++ b/test/Frontend/module-alias-dump-ast.swift
@@ -13,12 +13,12 @@
 // RUN: %target-swift-frontend -dump-ast %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/result-ast.output
 
 // RUN: %FileCheck %s -input-file %t/result-ast.output -check-prefix CHECK-AST
-// CHECK-AST-NOT: bind=XLogging
+// CHECK-AST-NOT: bind="XLogging"
 // CHECK-AST-NOT: module<XLogging>
-// CHECK-AST-NOT: decl=XLogging
-// CHECK-AST: type_ident id='XLogging' bind=AppleLogging
+// CHECK-AST-NOT: decl="XLogging"
+// CHECK-AST: type_ident id="XLogging" bind="AppleLogging"
 // CHECK-AST: module<AppleLogging>
-// CHECK-AST: decl=AppleLogging
+// CHECK-AST: decl="AppleLogging"
 
 // BEGIN FileLogging.swift
 public struct Logger {

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -19,7 +19,7 @@ func takes_P5<X: P5>(_: X) {}
 
 struct Free<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Free
-// CHECK-NEXT: (normal_conformance type=Free<T> protocol=P2
+// CHECK-NEXT: (normal_conformance type="Free<T>" protocol="P2"
 // CHECK-NEXT:   conforms_to: T P1)
 extension Free: P2 where T: P1 {} 
 // expected-note@-1 {{requirement from conditional conformance of 'Free<U>' to 'P2'}} 
@@ -34,7 +34,7 @@ func free_bad<U>(_: U) {
 struct Constrained<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
-// CHECK-NEXT: (normal_conformance type=Constrained<T> protocol=P2
+// CHECK-NEXT: (normal_conformance type="Constrained<T>" protocol="P2"
 // CHECK-NEXT:   conforms_to: T P3)
 extension Constrained: P2 where T: P3 {} // expected-note {{requirement from conditional conformance of 'Constrained<U>' to 'P2'}}
 func constrained_good<U: P1 & P3>(_: U) {
@@ -47,21 +47,21 @@ func constrained_bad<U: P1>(_: U) {
 struct RedundantSame<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame
-// CHECK-NEXT: (normal_conformance type=RedundantSame<T> protocol=P2)
+// CHECK-NEXT: (normal_conformance type="RedundantSame<T>" protocol="P2")
 extension RedundantSame: P2 where T: P1 {}
 // expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
 
 struct RedundantSuper<T: P4> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
-// CHECK-NEXT: (normal_conformance type=RedundantSuper<T> protocol=P2)
+// CHECK-NEXT: (normal_conformance type="RedundantSuper<T>" protocol="P2")
 extension RedundantSuper: P2 where T: P1 {}
 // expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
 
 struct OverlappingSub<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
-// CHECK-NEXT: (normal_conformance type=OverlappingSub<T> protocol=P2
+// CHECK-NEXT: (normal_conformance type="OverlappingSub<T>" protocol="P2"
 // CHECK-NEXT:   conforms_to: T P4)
 extension OverlappingSub: P2 where T: P4 {} // expected-note {{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
 // expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
@@ -76,7 +76,7 @@ func overlapping_sub_bad<U: P1>(_: U) {
 struct SameType<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
-// CHECK-NEXT: (normal_conformance type=SameType<T> protocol=P2
+// CHECK-NEXT: (normal_conformance type="SameType<T>" protocol="P2"
 // CHECK-NEXT:   same_type: T Int)
 extension SameType: P2 where T == Int {}
 // expected-note@-1 {{requirement from conditional conformance of 'SameType<U>' to 'P2'}}
@@ -93,7 +93,7 @@ func same_type_bad<U>(_: U) {
 struct SameTypeGeneric<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
-// CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, U> protocol=P2
+// CHECK-NEXT: (normal_conformance type="SameTypeGeneric<T, U>" protocol="P2"
 // CHECK-NEXT:   same_type: T U)
 extension SameTypeGeneric: P2 where T == U {}
 // expected-note@-1 {{requirement from conditional conformance of 'SameTypeGeneric<U, Int>' to 'P2'}}
@@ -119,7 +119,7 @@ func same_type_bad<U, V>(_: U, _: V) {
 struct Infer<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
-// CHECK-NEXT: (normal_conformance type=Infer<T, U> protocol=P2
+// CHECK-NEXT: (normal_conformance type="Infer<T, U>" protocol="P2"
 // CHECK-NEXT:   same_type: T Constrained<U>
 // CHECK-NEXT:   conforms_to:  U P1)
 extension Infer: P2 where T == Constrained<U> {}
@@ -138,7 +138,7 @@ func infer_bad<U: P1, V>(_: U, _: V) {
 struct InferRedundant<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
-// CHECK-NEXT: (normal_conformance type=InferRedundant<T, U> protocol=P2
+// CHECK-NEXT: (normal_conformance type="InferRedundant<T, U>" protocol="P2"
 // CHECK-NEXT:   same_type: T Constrained<U>)
 extension InferRedundant: P2 where T == Constrained<U> {}
 func infer_redundant_good<U: P1>(_: U) {
@@ -159,7 +159,7 @@ class C3: C2 {}
 struct ClassFree<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
-// CHECK-NEXT: (normal_conformance type=ClassFree<T> protocol=P2
+// CHECK-NEXT: (normal_conformance type="ClassFree<T>" protocol="P2"
 // CHECK-NEXT:   superclass: T C1)
 extension ClassFree: P2 where T: C1 {} // expected-note {{requirement from conditional conformance of 'ClassFree<U>' to 'P2'}}
 func class_free_good<U: C1>(_: U) {
@@ -173,7 +173,7 @@ func class_free_bad<U>(_: U) {
 struct ClassMoreSpecific<T: C1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
-// CHECK-NEXT: (normal_conformance type=ClassMoreSpecific<T> protocol=P2
+// CHECK-NEXT: (normal_conformance type="ClassMoreSpecific<T>" protocol="P2"
 // CHECK-NEXT:   superclass: T C3)
 extension ClassMoreSpecific: P2 where T: C3 {} // expected-note {{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
 // expected-warning@-1 {{redundant superclass constraint 'T' : 'C1'}}
@@ -189,7 +189,7 @@ func class_more_specific_bad<U: C1>(_: U) {
 struct ClassLessSpecific<T: C3> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
-// CHECK-NEXT: (normal_conformance type=ClassLessSpecific<T> protocol=P2)
+// CHECK-NEXT: (normal_conformance type="ClassLessSpecific<T>" protocol="P2")
 extension ClassLessSpecific: P2 where T: C1 {}
 // expected-warning@-1 {{redundant superclass constraint 'T' : 'C1'}}
 
@@ -213,13 +213,13 @@ func subclass_bad() {
 struct InheritEqual<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
-// CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P2
+// CHECK-NEXT:  (normal_conformance type="InheritEqual<T>" protocol="P2"
 // CHECK-NEXT:    conforms_to: T P1)
 extension InheritEqual: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
-// CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P5
-// CHECK-NEXT:    (normal_conformance type=InheritEqual<T> protocol=P2
+// CHECK-NEXT:  (normal_conformance type="InheritEqual<T>" protocol="P5"
+// CHECK-NEXT:    (normal_conformance type="InheritEqual<T>" protocol="P2"
 // CHECK-NEXT:      conforms_to: T P1)
 // CHECK-NEXT:    conforms_to: T P1)
 extension InheritEqual: P5 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P5'}}
@@ -245,13 +245,13 @@ extension InheritLess: P5 {}
 struct InheritMore<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
-// CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P2
+// CHECK-NEXT:  (normal_conformance type="InheritMore<T>" protocol="P2"
 // CHECK-NEXT:    conforms_to: T P1)
 extension InheritMore: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritMore<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
-// CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P5
-// CHECK-NEXT:    (normal_conformance type=InheritMore<T> protocol=P2
+// CHECK-NEXT:  (normal_conformance type="InheritMore<T>" protocol="P5"
+// CHECK-NEXT:    (normal_conformance type="InheritMore<T>" protocol="P2"
 // CHECK-NEXT:      conforms_to: T P1)
 // CHECK-NEXT:    conforms_to: T P4)
 extension InheritMore: P5 where T: P4 {} // expected-note 2 {{requirement from conditional conformance of 'InheritMore<U>' to 'P5'}}
@@ -334,7 +334,7 @@ extension TwoDisjointConformances: P2 where T == String {}
 struct RedundancyOrderDependenceGood<T: P1, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
-// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceGood<T, U> protocol=P2
+// CHECK-NEXT: (normal_conformance type="RedundancyOrderDependenceGood<T, U>" protocol="P2"
 // CHECK-NEXT:   same_type: T U)
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 // expected-warning@-1 {{redundant conformance constraint 'U' : 'P1'}}
@@ -342,7 +342,7 @@ extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
-// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, U> protocol=P2
+// CHECK-NEXT: (normal_conformance type="RedundancyOrderDependenceBad<T, U>" protocol="P2"
 // CHECK-NEXT:   conforms_to: T P1
 // CHECK-NEXT:   same_type: T U)
 extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -20,7 +20,7 @@ func takes_P5<X: P5>(_: X) {}
 struct Free<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Free
 // CHECK-NEXT: (normal_conformance type="Free<T>" protocol="P2"
-// CHECK-NEXT:   conforms_to: T P1)
+// CHECK-NEXT:   (requirement "T" conforms_to "P1"))
 extension Free: P2 where T: P1 {} 
 // expected-note@-1 {{requirement from conditional conformance of 'Free<U>' to 'P2'}} 
 // expected-note@-2 {{requirement from conditional conformance of 'Free<T>' to 'P2'}}
@@ -35,7 +35,7 @@ struct Constrained<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
 // CHECK-NEXT: (normal_conformance type="Constrained<T>" protocol="P2"
-// CHECK-NEXT:   conforms_to: T P3)
+// CHECK-NEXT:   (requirement "T" conforms_to "P3"))
 extension Constrained: P2 where T: P3 {} // expected-note {{requirement from conditional conformance of 'Constrained<U>' to 'P2'}}
 func constrained_good<U: P1 & P3>(_: U) {
     takes_P2(Constrained<U>())
@@ -62,7 +62,7 @@ struct OverlappingSub<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
 // CHECK-NEXT: (normal_conformance type="OverlappingSub<T>" protocol="P2"
-// CHECK-NEXT:   conforms_to: T P4)
+// CHECK-NEXT:   (requirement "T" conforms_to "P4"))
 extension OverlappingSub: P2 where T: P4 {} // expected-note {{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
 // expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
 func overlapping_sub_good<U: P4>(_: U) {
@@ -77,7 +77,7 @@ struct SameType<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
 // CHECK-NEXT: (normal_conformance type="SameType<T>" protocol="P2"
-// CHECK-NEXT:   same_type: T Int)
+// CHECK-NEXT:   (requirement "T" same_type "Int"))
 extension SameType: P2 where T == Int {}
 // expected-note@-1 {{requirement from conditional conformance of 'SameType<U>' to 'P2'}}
 // expected-note@-2 {{requirement from conditional conformance of 'SameType<Float>' to 'P2'}}
@@ -94,7 +94,7 @@ struct SameTypeGeneric<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
 // CHECK-NEXT: (normal_conformance type="SameTypeGeneric<T, U>" protocol="P2"
-// CHECK-NEXT:   same_type: T U)
+// CHECK-NEXT:   (requirement "T" same_type "U"))
 extension SameTypeGeneric: P2 where T == U {}
 // expected-note@-1 {{requirement from conditional conformance of 'SameTypeGeneric<U, Int>' to 'P2'}}
 // expected-note@-2 {{requirement from conditional conformance of 'SameTypeGeneric<Int, Float>' to 'P2'}}
@@ -120,8 +120,8 @@ struct Infer<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
 // CHECK-NEXT: (normal_conformance type="Infer<T, U>" protocol="P2"
-// CHECK-NEXT:   same_type: T Constrained<U>
-// CHECK-NEXT:   conforms_to:  U P1)
+// CHECK-NEXT:   (requirement "T" same_type "Constrained<U>")
+// CHECK-NEXT:   (requirement "U" conforms_to "P1"))
 extension Infer: P2 where T == Constrained<U> {}
 // expected-note@-1 2 {{requirement from conditional conformance of 'Infer<Constrained<U>, V>' to 'P2'}}
 func infer_good<U: P1>(_: U) {
@@ -139,7 +139,7 @@ struct InferRedundant<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
 // CHECK-NEXT: (normal_conformance type="InferRedundant<T, U>" protocol="P2"
-// CHECK-NEXT:   same_type: T Constrained<U>)
+// CHECK-NEXT:   (requirement "T" same_type "Constrained<U>"))
 extension InferRedundant: P2 where T == Constrained<U> {}
 func infer_redundant_good<U: P1>(_: U) {
     takes_P2(InferRedundant<Constrained<U>, U>())
@@ -160,7 +160,7 @@ struct ClassFree<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
 // CHECK-NEXT: (normal_conformance type="ClassFree<T>" protocol="P2"
-// CHECK-NEXT:   superclass: T C1)
+// CHECK-NEXT:   (requirement "T" subclass_of "C1"))
 extension ClassFree: P2 where T: C1 {} // expected-note {{requirement from conditional conformance of 'ClassFree<U>' to 'P2'}}
 func class_free_good<U: C1>(_: U) {
     takes_P2(ClassFree<U>())
@@ -174,7 +174,7 @@ struct ClassMoreSpecific<T: C1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
 // CHECK-NEXT: (normal_conformance type="ClassMoreSpecific<T>" protocol="P2"
-// CHECK-NEXT:   superclass: T C3)
+// CHECK-NEXT:   (requirement "T" subclass_of "C3"))
 extension ClassMoreSpecific: P2 where T: C3 {} // expected-note {{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
 // expected-warning@-1 {{redundant superclass constraint 'T' : 'C1'}}
 func class_more_specific_good<U: C3>(_: U) {
@@ -214,14 +214,14 @@ struct InheritEqual<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-NEXT:  (normal_conformance type="InheritEqual<T>" protocol="P2"
-// CHECK-NEXT:    conforms_to: T P1)
+// CHECK-NEXT:    (requirement "T" conforms_to "P1"))
 extension InheritEqual: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-NEXT:  (normal_conformance type="InheritEqual<T>" protocol="P5"
 // CHECK-NEXT:    (normal_conformance type="InheritEqual<T>" protocol="P2"
-// CHECK-NEXT:      conforms_to: T P1)
-// CHECK-NEXT:    conforms_to: T P1)
+// CHECK-NEXT:      (requirement "T" conforms_to "P1"))
+// CHECK-NEXT:    (requirement "T" conforms_to "P1"))
 extension InheritEqual: P5 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P5'}}
 func inheritequal_good<U: P1>(_: U) {
   takes_P2(InheritEqual<U>())
@@ -246,14 +246,14 @@ struct InheritMore<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-NEXT:  (normal_conformance type="InheritMore<T>" protocol="P2"
-// CHECK-NEXT:    conforms_to: T P1)
+// CHECK-NEXT:    (requirement "T" conforms_to "P1"))
 extension InheritMore: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritMore<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-NEXT:  (normal_conformance type="InheritMore<T>" protocol="P5"
 // CHECK-NEXT:    (normal_conformance type="InheritMore<T>" protocol="P2"
-// CHECK-NEXT:      conforms_to: T P1)
-// CHECK-NEXT:    conforms_to: T P4)
+// CHECK-NEXT:      (requirement "T" conforms_to "P1"))
+// CHECK-NEXT:    (requirement "T" conforms_to "P4"))
 extension InheritMore: P5 where T: P4 {} // expected-note 2 {{requirement from conditional conformance of 'InheritMore<U>' to 'P5'}}
 func inheritequal_good_good<U: P4>(_: U) {
   takes_P2(InheritMore<U>())
@@ -335,7 +335,7 @@ struct RedundancyOrderDependenceGood<T: P1, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
 // CHECK-NEXT: (normal_conformance type="RedundancyOrderDependenceGood<T, U>" protocol="P2"
-// CHECK-NEXT:   same_type: T U)
+// CHECK-NEXT:   (requirement "T" same_type "U"))
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 // expected-warning@-1 {{redundant conformance constraint 'U' : 'P1'}}
 
@@ -343,8 +343,8 @@ struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
 // CHECK-NEXT: (normal_conformance type="RedundancyOrderDependenceBad<T, U>" protocol="P2"
-// CHECK-NEXT:   conforms_to: T P1
-// CHECK-NEXT:   same_type: T U)
+// CHECK-NEXT:   (requirement "T" conforms_to "P1")
+// CHECK-NEXT:   (requirement "T" same_type "U"))
 extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
 
 // Checking of conditional requirements for existential conversions.

--- a/test/Generics/minimal_conformances_compare_concrete.swift
+++ b/test/Generics/minimal_conformances_compare_concrete.swift
@@ -14,9 +14,9 @@ struct G<X> {}
 // CHECK-NEXT: Generic signature: <X where X == Derived>
 extension G where X : Base, X : P, X == Derived {}
 
-// RULE: + superclass: τ_0_0 Base
-// RULE: + conforms_to: τ_0_0 P
-// RULE: + same_type: τ_0_0 Derived
+// RULE: + (requirement "\xCF\x84_0_0" subclass_of "Base")
+// RULE: + (requirement "\xCF\x84_0_0" conforms_to "P")
+// RULE: + (requirement "\xCF\x84_0_0" same_type "Derived")
 
 // RULE: Rewrite system: {
 // RULE-NEXT: - [P].[P] => [P] [permanent]

--- a/test/ImportResolution/import-resolution-overload.swift
+++ b/test/ImportResolution/import-resolution-overload.swift
@@ -60,7 +60,7 @@ extension HasFooSub {
 func testHasFooSub(_ hfs: HasFooSub) -> Int {
   // CHECK: return_stmt
   // CHECK-NOT: func_decl
-  // CHECK: member_ref_expr{{.*}}decl=overload_vars.(file).HasFoo.foo
+  // CHECK: member_ref_expr{{.*}}decl="overload_vars.(file).HasFoo.foo
   return hfs.foo
 }
 
@@ -72,7 +72,7 @@ extension HasBar {
 func testHasBar(_ hb: HasBar) -> Int {
   // CHECK: return_stmt
   // CHECK-NOT: func_decl
-  // CHECK: member_ref_expr{{.*}}decl=overload_vars.(file).HasBar.bar
+  // CHECK: member_ref_expr{{.*}}decl="overload_vars.(file).HasBar.bar
   return hb.bar
 }
 

--- a/test/Parse/raw_string.swift
+++ b/test/Parse/raw_string.swift
@@ -71,14 +71,13 @@ _ = ##"""
 // ===---------- False Multiline Delimiters --------===
 
 /// Source code contains zero-width character in this format: `#"[U+200B]"[U+200B]"#`
-/// The check contains zero-width character in this format: `"[U+200B]\"[U+200B]"`
 /// If this check fails after you implement `diagnoseZeroWidthMatchAndAdvance`,
 /// then you may need to tweak how to test for single-line string literals that
 /// resemble a multiline delimiter in `advanceIfMultilineDelimiter` so that it
 /// passes again.
 /// See https://github.com/apple/swift/issues/51192.
 _ = #"​"​"#
-// CHECK: "​\"​"
+// CHECK: "\xE2\x80\x8B\"\xE2\x80\x8B"
 
 _ = #""""#
 // CHECK: "\"\""

--- a/test/Parse/source_locs.swift
+++ b/test/Parse/source_locs.swift
@@ -7,5 +7,5 @@ func string_interpolation() {
 
 // RUN: not %target-swift-frontend -dump-ast %/s | %FileCheck %s
 // CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc=SOURCE_DIR/test/Parse/source_locs.swift:4:12 {{.*}}
-// CHECK: (editor_placeholder_expr type='()' {{.*}} trailing_angle_bracket_loc=SOURCE_DIR/test/Parse/source_locs.swift:5:9
+// CHECK: (editor_placeholder_expr type="()" {{.*}} trailing_angle_bracket_loc=SOURCE_DIR/test/Parse/source_locs.swift:5:9
 

--- a/test/SILOptimizer/inline_generics.sil
+++ b/test/SILOptimizer/inline_generics.sil
@@ -147,9 +147,9 @@ sil_vtable MyNumber {}
 // substituting we need to pick up the normal_conformance.
 
 // CHECK-LABEL: sil @test_inlining : $@convention(objc_method) (@owned MyNumber) -> () {
-// CHECK-NOT: Generic specialization information for call-site dootherstuff <MyNumber & SomeProto> conformances <(abstract_conformance protocol=OtherProto)>
+// CHECK-NOT: Generic specialization information for call-site dootherstuff <MyNumber & SomeProto> conformances <(abstract_conformance protocol="OtherProto")>
 // CHECK: Generic specialization information
-// CHECK: (normal_conformance type=MyObject protocol=OtherProto)
+// CHECK: (normal_conformance type="MyObject" protocol="OtherProto")
 // CHECK: end sil function 'test_inlining'
 
 sil @test_inlining : $@convention(objc_method) (@owned MyNumber) -> () {

--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -670,8 +670,8 @@ sil @callee2 : $@convention(thin) <τ_0_0 where τ_0_0 : SubscriptionViewControl
 // CHECK:   [[T5:%.*]] = function_ref @callee2 : $@convention(thin) <τ_0_0 where τ_0_0 : SubscriptionViewControllerDelegate> (@in τ_0_0, @thick SubscriptionViewControllerBuilder.Type) -> @owned SubscriptionViewControllerBuilder
 // CHECK:   [[T6:%.*]] = alloc_stack $@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122", any ResourceKitProtocol) Self
 // CHECK:   copy_addr [[T4]] to [init] [[T6]] : $*@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122", any ResourceKitProtocol) Self
-// CHECK: Generic specialization information for call-site callee2 <any ResourceKitProtocol> conformances <(inherited_conformance type=any ResourceKitProtocol protocol=SubscriptionViewControllerDelegate
-// CHECK:  (normal_conformance type=MyObject protocol=SubscriptionViewControllerDelegate))>:
+// CHECK: Generic specialization information for call-site callee2 <any ResourceKitProtocol> conformances <(inherited_conformance type="any ResourceKitProtocol" protocol="SubscriptionViewControllerDelegate"
+// CHECK:  (normal_conformance type="MyObject" protocol="SubscriptionViewControllerDelegate"))>:
 // CHECK:   apply [[T5]]<@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122", any ResourceKitProtocol) Self>([[T6]], [[T1]])
 
 sil @test_opend_archetype_concrete_conformance_substitution : $@convention(method) (@guaranteed ResourceKitProtocol, @guaranteed ViewController) -> () {

--- a/test/Sema/dynamic_self_implicit_conversions.swift
+++ b/test/Sema/dynamic_self_implicit_conversions.swift
@@ -19,32 +19,32 @@ class A {
 
 class B: A {
   func test() -> Self {
-    // CHECK: covariant_return_conversion_expr implicit type='Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_return_conversion_expr implicit type="Self" location={{.*}}.swift:[[@LINE+1]]
     _ = super.method()
-    // CHECK: covariant_function_conversion_expr implicit type='() -> Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_function_conversion_expr implicit type="() -> Self" location={{.*}}.swift:[[@LINE+1]]
     _ = super.method
-    // CHECK: covariant_return_conversion_expr implicit type='Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_return_conversion_expr implicit type="Self" location={{.*}}.swift:[[@LINE+1]]
     _ = super.property
-    // CHECK: covariant_return_conversion_expr implicit type='Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_return_conversion_expr implicit type="Self" location={{.*}}.swift:[[@LINE+1]]
     _ = super[]
 
     return super.property
   }
 
   static func testStatic() -> Self {
-    // CHECK: covariant_return_conversion_expr implicit type='Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_return_conversion_expr implicit type="Self" location={{.*}}.swift:[[@LINE+1]]
     _ = super.staticMethod()
-    // CHECK: covariant_function_conversion_expr implicit type='() -> Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_function_conversion_expr implicit type="() -> Self" location={{.*}}.swift:[[@LINE+1]]
     _ = super.staticMethod
     // CHECK-NOT: function_conversion_expr {{.*}} location={{.*}}.swift:[[@LINE+3]]
     // CHECK-NOT: covariant_function_conversion_expr {{.*}} location={{.*}}.swift:[[@LINE+2]]
-    // CHECK: covariant_return_conversion_expr implicit type='Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_return_conversion_expr implicit type="Self" location={{.*}}.swift:[[@LINE+1]]
     _ = self.method
-    // CHECK: covariant_return_conversion_expr implicit type='Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_return_conversion_expr implicit type="Self" location={{.*}}.swift:[[@LINE+1]]
     _ = self.init()
-    // CHECK: covariant_return_conversion_expr implicit type='Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_return_conversion_expr implicit type="Self" location={{.*}}.swift:[[@LINE+1]]
     _ = super.staticProperty
-    // CHECK: covariant_return_conversion_expr implicit type='Self' location={{.*}}.swift:[[@LINE+1]]
+    // CHECK: covariant_return_conversion_expr implicit type="Self" location={{.*}}.swift:[[@LINE+1]]
     _ = super[]
 
     return super.staticProperty
@@ -53,8 +53,8 @@ class B: A {
 
 func testOnExistential(arg: P & A) {
   // FIXME: This could be a single conversion.
-  // CHECK: function_conversion_expr implicit type='() -> any A & P' location={{.*}}.swift:[[@LINE+2]]
-  // CHECK-NEXT: covariant_function_conversion_expr implicit type='() -> any A & P' location={{.*}}.swift:[[@LINE+1]]
+  // CHECK: function_conversion_expr implicit type="() -> any A & P" location={{.*}}.swift:[[@LINE+2]]
+  // CHECK-NEXT: covariant_function_conversion_expr implicit type="() -> any A & P" location={{.*}}.swift:[[@LINE+1]]
   _ = arg.method
 }
 

--- a/test/Sema/property_wrappers.swift
+++ b/test/Sema/property_wrappers.swift
@@ -17,11 +17,11 @@ struct WrapperWithClosureArg<Value> {
 // rdar://problem/59685601
 // CHECK-LABEL: R_59685601
 struct R_59685601 {
-  // CHECK:      argument_list implicit labels=wrappedValue:reset:
-  // CHECK-NEXT:   argument label=wrappedValue
-  // CHECK-NEXT:     property_wrapper_value_placeholder_expr implicit type='String'
-  // CHECK-NEXT:     opaque_value_expr implicit type='String'
-  // CHECK-NEXT:     string_literal_expr type='String'
+  // CHECK:      argument_list implicit labels="wrappedValue:reset:"
+  // CHECK-NEXT:   argument label="wrappedValue"
+  // CHECK-NEXT:     property_wrapper_value_placeholder_expr implicit type="String"
+  // CHECK-NEXT:     opaque_value_expr implicit type="String"
+  // CHECK-NEXT:     string_literal_expr type="String"
   @WrapperWithClosureArg(reset: { value, transaction in
     transaction.state = 10
   })
@@ -37,13 +37,13 @@ struct Wrapper<Value> {
 struct TestInitSubscript {
   enum Color: CaseIterable { case pink }
 
-  // CHECK:      argument_list labels=wrappedValue:
-  // CHECK-NEXT:   argument label=wrappedValue
-  // CHECK-NEXT:     subscript_expr type='TestInitSubscript.Color'
+  // CHECK:      argument_list labels="wrappedValue:"
+  // CHECK-NEXT:   argument label="wrappedValue"
+  // CHECK-NEXT:     subscript_expr type="TestInitSubscript.Color"
   // CHECK:            argument_list implicit
   // CHECK-NEXT:         argument
-  // CHECK-NOT:            property_wrapper_value_placeholder_expr implicit type='Int'
-  // CHECK:                integer_literal_expr type='Int'
+  // CHECK-NOT:            property_wrapper_value_placeholder_expr implicit type="Int"
+  // CHECK:                integer_literal_expr type="Int"
   @Wrapper(wrappedValue: Color.allCases[0])
   var color: Color
 }
@@ -68,19 +68,19 @@ public class W_58201<Value> {
 
 // CHECK-LABEL: struct_decl{{.*}}S1_58201
 struct S1_58201 {
-  // CHECK:      argument_list implicit labels=wrappedValue:
-  // CHECK-NEXT:   argument label=wrappedValue
-  // CHECK-NEXT:     autoclosure_expr implicit type='() -> Bool?' discriminator=0 captures=(<opaque_value> ) escaping
-  // CHECK:            autoclosure_expr implicit type='() -> Bool?' discriminator=1 escaping
+  // CHECK:      argument_list implicit labels="wrappedValue:"
+  // CHECK-NEXT:   argument label="wrappedValue"
+  // CHECK-NEXT:     autoclosure_expr implicit type="() -> Bool?" discriminator=0 captures=(<opaque_value> ) escaping
+  // CHECK:            autoclosure_expr implicit type="() -> Bool?" discriminator=1 escaping
   @W_58201 var a: Bool?
 }
 
 // CHECK-LABEL: struct_decl{{.*}}S2_58201
 struct S2_58201 {
-  // CHECK:      argument_list implicit labels=wrappedValue:
-  // CHECK-NEXT:   argument label=wrappedValue
-  // CHECK-NEXT:     autoclosure_expr implicit type='() -> Bool' location={{.*}}.swift:[[@LINE+2]]:26 range=[{{.+}}] discriminator=0 captures=(<opaque_value> ) escaping
-  // CHECK:            autoclosure_expr implicit type='() -> Bool' location={{.*}}.swift:[[@LINE+1]]:26 range=[{{.+}}] discriminator=1 escaping
+  // CHECK:      argument_list implicit labels="wrappedValue:"
+  // CHECK-NEXT:   argument label="wrappedValue"
+  // CHECK-NEXT:     autoclosure_expr implicit type="() -> Bool" location={{.*}}.swift:[[@LINE+2]]:26 range=[{{.+}}] discriminator=0 captures=(<opaque_value> ) escaping
+  // CHECK:            autoclosure_expr implicit type="() -> Bool" location={{.*}}.swift:[[@LINE+1]]:26 range=[{{.+}}] discriminator=1 escaping
   @W_58201 var b: Bool = false
 }
 

--- a/test/Sema/type_eraser.swift
+++ b/test/Sema/type_eraser.swift
@@ -40,7 +40,7 @@ func testNoDynamic() -> some P {
 // CHECK-LABEL: testNoOpaque
 dynamic func testNoOpaque() -> P {
   // CHECK: erasure_expr implicit type="any P"
-  // CHECK-NEXT: normal_conformance type=ConcreteP protocol=P
+  // CHECK-NEXT: normal_conformance type="ConcreteP" protocol="P"
   // CHECK-NEXT: call_expr type="ConcreteP"
   ConcreteP()
 }

--- a/test/Sema/type_eraser.swift
+++ b/test/Sema/type_eraser.swift
@@ -11,45 +11,45 @@ struct ConcreteP: P, Hashable {}
 
 // CHECK-LABEL: testBasic
 dynamic func testBasic() -> some P {
-  // CHECK:      underlying_to_opaque_expr{{.*}}'some P'
-  // CHECK-NEXT:   call_expr implicit type='AnyP'
-  // CHECK:          argument_list implicit labels=erasing:
-  // CHECK-NEXT:       argument label=erasing
-  // CHECK-NEXT:         call_expr type='ConcreteP'
+  // CHECK:      underlying_to_opaque_expr{{.*}}"some P"
+  // CHECK-NEXT:   call_expr implicit type="AnyP"
+  // CHECK:          argument_list implicit labels="erasing:"
+  // CHECK-NEXT:       argument label="erasing"
+  // CHECK-NEXT:         call_expr type="ConcreteP"
   ConcreteP()
 }
 
 // CHECK-LABEL: testTypeAlias
 typealias AliasForP = P
 dynamic func testTypeAlias() -> some AliasForP {
-  // CHECK:      underlying_to_opaque_expr{{.*}}'some P'
-  // CHECK-NEXT:   call_expr implicit type='AnyP'
-  // CHECK:          argument_list implicit labels=erasing:
-  // CHECK-NEXT:       argument label=erasing
-  // CHECK-NEXT:         call_expr type='ConcreteP'
+  // CHECK:      underlying_to_opaque_expr{{.*}}"some P"
+  // CHECK-NEXT:   call_expr implicit type="AnyP"
+  // CHECK:          argument_list implicit labels="erasing:"
+  // CHECK-NEXT:       argument label="erasing"
+  // CHECK-NEXT:         call_expr type="ConcreteP"
   ConcreteP()
 }
 
 // CHECK-LABEL: testNoDynamic
 func testNoDynamic() -> some P {
-  // CHECK: underlying_to_opaque_expr{{.*}}'some P'
-  // CHECK-NEXT: call_expr type='ConcreteP'
+  // CHECK: underlying_to_opaque_expr{{.*}}"some P"
+  // CHECK-NEXT: call_expr type="ConcreteP"
   ConcreteP()
 }
 
 // CHECK-LABEL: testNoOpaque
 dynamic func testNoOpaque() -> P {
-  // CHECK: erasure_expr implicit type='any P'
+  // CHECK: erasure_expr implicit type="any P"
   // CHECK-NEXT: normal_conformance type=ConcreteP protocol=P
-  // CHECK-NEXT: call_expr type='ConcreteP'
+  // CHECK-NEXT: call_expr type="ConcreteP"
   ConcreteP()
 }
 
 // CHECK-LABEL: testComposition
 typealias Composition = P & Hashable
 dynamic func testComposition() -> some Composition {
-  // CHECK: underlying_to_opaque_expr{{.*}}'some Hashable & P'
-  // CHECK-NEXT: call_expr type='ConcreteP'
+  // CHECK: underlying_to_opaque_expr{{.*}}"some Hashable & P"
+  // CHECK-NEXT: call_expr type="ConcreteP"
   ConcreteP()
 }
 
@@ -66,11 +66,11 @@ class TestResultBuilder {
   // CHECK-LABEL: testTransformFnBody
   @Builder dynamic var testTransformFnBody: some P {
     // CHECK:      return_stmt
-    // CHECK-NEXT:   underlying_to_opaque_expr implicit type='some P'
-    // CHECK-NEXT:     call_expr implicit type='AnyP'
-    // CHECK:            argument_list implicit labels=erasing:
-    // CHECK-NEXT:         argument label=erasing
-    // CHECK:                declref_expr implicit type='@lvalue ConcreteP'
+    // CHECK-NEXT:   underlying_to_opaque_expr implicit type="some P"
+    // CHECK-NEXT:     call_expr implicit type="AnyP"
+    // CHECK:            argument_list implicit labels="erasing:"
+    // CHECK-NEXT:         argument label="erasing"
+    // CHECK:                declref_expr implicit type="@lvalue ConcreteP"
     ConcreteP()
   }
 
@@ -79,14 +79,14 @@ class TestResultBuilder {
 
   // CHECK-LABEL: testClosureBuilder
   dynamic var testClosureBuilder: some P {
-    // CHECK:      underlying_to_opaque_expr implicit type='some P'
-    // CHECK-NEXT:   call_expr implicit type='AnyP'
-    // CHECK:          argument_list implicit labels=erasing:
-    // CHECK-NEXT:       argument label=erasing
-    // CHECK:              closure_expr type='() -> ConcreteP'
+    // CHECK:      underlying_to_opaque_expr implicit type="some P"
+    // CHECK-NEXT:   call_expr implicit type="AnyP"
+    // CHECK:          argument_list implicit labels="erasing:"
+    // CHECK-NEXT:       argument label="erasing"
+    // CHECK:              closure_expr type="() -> ConcreteP"
     takesBuilder {
       // CHECK: return_stmt
-      // CHECK-NEXT: call_expr implicit type='ConcreteP'
+      // CHECK-NEXT: call_expr implicit type="ConcreteP"
       ConcreteP()
     }
   }
@@ -95,11 +95,11 @@ class TestResultBuilder {
 // CHECK-LABEL: class_decl{{.*}}DynamicReplacement
 class DynamicReplacement {
   dynamic func testDynamicReplaceable() -> some P {
-    // CHECK:      underlying_to_opaque_expr implicit type='some P'
-    // CHECK-NEXT:   call_expr implicit type='AnyP'
-    // CHECK:          argument_list implicit labels=erasing:
-    // CHECK-NEXT:       argument label=erasing
-    // CHECK-NEXT:         call_expr type='ConcreteP'
+    // CHECK:      underlying_to_opaque_expr implicit type="some P"
+    // CHECK-NEXT:   call_expr implicit type="AnyP"
+    // CHECK:          argument_list implicit labels="erasing:"
+    // CHECK-NEXT:       argument label="erasing"
+    // CHECK-NEXT:         call_expr type="ConcreteP"
     ConcreteP()
   }
 }
@@ -111,11 +111,11 @@ extension DynamicReplacement {
   func testDynamicReplacement() -> some P {
     print("not single expr return")
     // CHECK:      return_stmt
-    // CHECK-NEXT:   underlying_to_opaque_expr implicit type='some P'
-    // CHECK-NEXT:     call_expr implicit type='AnyP'
-    // CHECK:            argument_list implicit labels=erasing:
-    // CHECK-NEXT:         argument label=erasing
-    // CHECK-NEXT:           call_expr type='ConcreteP'
+    // CHECK-NEXT:   underlying_to_opaque_expr implicit type="some P"
+    // CHECK-NEXT:     call_expr implicit type="AnyP"
+    // CHECK:            argument_list implicit labels="erasing:"
+    // CHECK-NEXT:         argument label="erasing"
+    // CHECK-NEXT:           call_expr type="ConcreteP"
     return ConcreteP()
   }
 }

--- a/test/Sema/type_eraser_experimental_flag.swift
+++ b/test/Sema/type_eraser_experimental_flag.swift
@@ -11,7 +11,7 @@ struct ConcreteP: P, Hashable {}
 
 // CHECK-LABEL: testTypeErased
 func testTypeErased() -> some P {
-  // CHECK: underlying_to_opaque_expr{{.*}}'some P'
-  // CHECK-NEXT: call_expr implicit type='AnyP'
+  // CHECK: underlying_to_opaque_expr{{.*}}"some P"
+  // CHECK-NEXT: call_expr implicit type="AnyP"
   ConcreteP()
 }

--- a/test/attr/ApplicationMain/attr_main_throws.swift
+++ b/test/attr/ApplicationMain/attr_main_throws.swift
@@ -7,10 +7,10 @@ struct MyBase {
   }
 }
 
-// CHECK-AST: (func_decl implicit "$main()" interface type='(MyBase.Type) -> () throws -> ()' access=internal type
+// CHECK-AST: (func_decl implicit "$main()" interface type="(MyBase.Type) -> () throws -> ()" access=internal type
 // CHECK-AST-NEXT:  (parameter "self")
 // CHECK-AST-NEXT:  (parameter_list)
 // CHECK-AST-NEXT:  (brace_stmt implicit
 // CHECK-AST-NEXT:    (return_stmt implicit
 // CHECK-AST-NEXT:      (try_expr implicit
-// CHECK-AST-NEXT:        (call_expr implicit type='()'
+// CHECK-AST-NEXT:        (call_expr implicit type="()"

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -7,21 +7,21 @@
 // Public types with @frozen are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non-resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non-resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non_resilient
 @frozen public struct Point {
   let x, y: Int
 }
 
-// RESILIENCE-ON: struct_decl{{.*}}"FixedPoint" interface type='FixedPoint.Type' access=public non-resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"FixedPoint" interface type='FixedPoint.Type' access=public non-resilient
+// RESILIENCE-ON: struct_decl{{.*}}"FixedPoint" interface type='FixedPoint.Type' access=public non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"FixedPoint" interface type='FixedPoint.Type' access=public non_resilient
 @_fixed_layout public struct FixedPoint {
   // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   let x, y: Int
 }
 
-// RESILIENCE-ON: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
-// RESILIENCE-OFF: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
+// RESILIENCE-ON: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non_resilient
+// RESILIENCE-OFF: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non_resilient
 @frozen public enum ChooseYourOwnAdventure {
   case JumpIntoRabbitHole
   case EatMushroom
@@ -32,22 +32,22 @@
 //
 
 // RESILIENCE-ON: struct_decl{{.*}}"Size" interface type='Size.Type' access=public resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Size" interface type='Size.Type' access=public non-resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Size" interface type='Size.Type' access=public non_resilient
 public struct Size {
   let w, h: Int
 }
 
-// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineStruct" interface type='UsableFromInlineStruct.Type' access=internal non-resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineStruct" interface type='UsableFromInlineStruct.Type' access=internal non-resilient
+// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineStruct" interface type='UsableFromInlineStruct.Type' access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineStruct" interface type='UsableFromInlineStruct.Type' access=internal non_resilient
 @frozen @usableFromInline struct UsableFromInlineStruct {}
 
-// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type='UsableFromInlineFixedStruct.Type' access=internal non-resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type='UsableFromInlineFixedStruct.Type' access=internal non-resilient
+// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type='UsableFromInlineFixedStruct.Type' access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type='UsableFromInlineFixedStruct.Type' access=internal non_resilient
 @_fixed_layout @usableFromInline struct UsableFromInlineFixedStruct {}
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
 
 // RESILIENCE-ON: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public resilient
-// RESILIENCE-OFF: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public non-resilient
+// RESILIENCE-OFF: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public non_resilient
 public enum TaxCredit {
   case EarnedIncome
   case MortgageDeduction
@@ -57,8 +57,8 @@ public enum TaxCredit {
 // Internal types are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl{{.*}}"Rectangle" interface type='Rectangle.Type' access=internal non-resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Rectangle" interface type='Rectangle.Type' access=internal non-resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Rectangle" interface type='Rectangle.Type' access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Rectangle" interface type='Rectangle.Type' access=internal non_resilient
 struct Rectangle {
   let topLeft: Point
   let bottomRight: Size

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -7,21 +7,21 @@
 // Public types with @frozen are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Point" interface type="Point.Type" access=public non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Point" interface type="Point.Type" access=public non_resilient
 @frozen public struct Point {
   let x, y: Int
 }
 
-// RESILIENCE-ON: struct_decl{{.*}}"FixedPoint" interface type='FixedPoint.Type' access=public non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"FixedPoint" interface type='FixedPoint.Type' access=public non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"FixedPoint" interface type="FixedPoint.Type" access=public non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"FixedPoint" interface type="FixedPoint.Type" access=public non_resilient
 @_fixed_layout public struct FixedPoint {
   // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   let x, y: Int
 }
 
-// RESILIENCE-ON: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non_resilient
-// RESILIENCE-OFF: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non_resilient
+// RESILIENCE-ON: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type="ChooseYourOwnAdventure.Type" access=public non_resilient
+// RESILIENCE-OFF: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type="ChooseYourOwnAdventure.Type" access=public non_resilient
 @frozen public enum ChooseYourOwnAdventure {
   case JumpIntoRabbitHole
   case EatMushroom
@@ -31,23 +31,23 @@
 // Public types are resilient when -enable-library-evolution is on
 //
 
-// RESILIENCE-ON: struct_decl{{.*}}"Size" interface type='Size.Type' access=public resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Size" interface type='Size.Type' access=public non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Size" interface type="Size.Type" access=public resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Size" interface type="Size.Type" access=public non_resilient
 public struct Size {
   let w, h: Int
 }
 
-// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineStruct" interface type='UsableFromInlineStruct.Type' access=internal non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineStruct" interface type='UsableFromInlineStruct.Type' access=internal non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineStruct" interface type="UsableFromInlineStruct.Type" access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineStruct" interface type="UsableFromInlineStruct.Type" access=internal non_resilient
 @frozen @usableFromInline struct UsableFromInlineStruct {}
 
-// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type='UsableFromInlineFixedStruct.Type' access=internal non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type='UsableFromInlineFixedStruct.Type' access=internal non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type="UsableFromInlineFixedStruct.Type" access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type="UsableFromInlineFixedStruct.Type" access=internal non_resilient
 @_fixed_layout @usableFromInline struct UsableFromInlineFixedStruct {}
 // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
 
-// RESILIENCE-ON: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public resilient
-// RESILIENCE-OFF: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public non_resilient
+// RESILIENCE-ON: enum_decl{{.*}}"TaxCredit" interface type="TaxCredit.Type" access=public resilient
+// RESILIENCE-OFF: enum_decl{{.*}}"TaxCredit" interface type="TaxCredit.Type" access=public non_resilient
 public enum TaxCredit {
   case EarnedIncome
   case MortgageDeduction
@@ -57,8 +57,8 @@ public enum TaxCredit {
 // Internal types are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl{{.*}}"Rectangle" interface type='Rectangle.Type' access=internal non_resilient
-// RESILIENCE-OFF: struct_decl{{.*}}"Rectangle" interface type='Rectangle.Type' access=internal non_resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Rectangle" interface type="Rectangle.Type" access=internal non_resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Rectangle" interface type="Rectangle.Type" access=internal non_resilient
 struct Rectangle {
   let topLeft: Point
   let bottomRight: Size

--- a/test/attr/attr_native_dynamic.swift
+++ b/test/attr/attr_native_dynamic.swift
@@ -2,19 +2,19 @@
 
 struct Strukt {
   // CHECK: (struct_decl {{.*}} "Strukt"
-  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
+  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type="Int" access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="dynamicStorageOnlyVar"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="dynamicStorageOnlyVar"
   // CHECK: (accessor_decl {{.*}} access=internal _modify for="dynamicStorageOnlyVar"
   dynamic var dynamicStorageOnlyVar : Int = 0
 
-  // CHECK: (var_decl {{.*}} "computedVar" interface type='Int' access=internal dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar" interface type="Int" access=internal dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar"
   dynamic var computedVar : Int {
     return 0
   }
 
-  // CHECK: (var_decl {{.*}} "computedVar2" interface type='Int' access=internal dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar2" interface type="Int" access=internal dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar2"
   dynamic var computedVar2 : Int {
     get {
@@ -22,7 +22,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type="Int" access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterSetter"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarGetterSetter"
   // CHECK: (accessor_decl {{.*}} access=internal _modify for="computedVarGetterSetter"
@@ -34,7 +34,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type="Int" access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterModify"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarGetterModify"
   // CHECK: (accessor_decl {{.*}} access=internal set for="computedVarGetterModify"
@@ -46,7 +46,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadSet"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarReadSet"
   // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadSet"
@@ -58,7 +58,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadModify"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarReadModify"
   // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadModify"
@@ -70,7 +70,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "storedWithObserver" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
+  // CHECK: (var_decl {{.*}} "storedWithObserver" interface type="Int" access=internal dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
   // CHECK: (accessor_decl {{.*}}access=private dynamic didSet for="storedWithObserver"
   // CHECK: (accessor_decl {{.*}}access=internal dynamic get for="storedWithObserver"
   // CHECK: (accessor_decl {{.*}}access=internal set for="storedWithObserver"
@@ -136,19 +136,19 @@ struct Strukt {
 
 class Klass {
   // CHECK: (class_decl {{.*}} "Klass"
-  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
+  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type="Int" access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="dynamicStorageOnlyVar"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="dynamicStorageOnlyVar"
   // CHECK: (accessor_decl {{.*}} access=internal _modify for="dynamicStorageOnlyVar"
   dynamic var dynamicStorageOnlyVar : Int = 0
 
-  // CHECK: (var_decl {{.*}} "computedVar" interface type='Int' access=internal dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar" interface type="Int" access=internal dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar"
   dynamic var computedVar : Int {
     return 0
   }
 
-  // CHECK: (var_decl {{.*}} "computedVar2" interface type='Int' access=internal dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar2" interface type="Int" access=internal dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar2"
   dynamic var computedVar2 : Int {
     get {
@@ -156,7 +156,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type="Int" access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterSetter"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarGetterSetter"
   // CHECK: (accessor_decl {{.*}} access=internal _modify for="computedVarGetterSetter"
@@ -168,7 +168,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type="Int" access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterModify"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarGetterModify"
   // CHECK: (accessor_decl {{.*}} access=internal set for="computedVarGetterModify"
@@ -180,7 +180,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadSet"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarReadSet"
   // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadSet"
@@ -192,7 +192,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type="Int" access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadModify"
   // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarReadModify"
   // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadModify"
@@ -285,12 +285,12 @@ class Klass {
 class SubKlass : Klass {
 
   // CHECK: (class_decl {{.*}} "SubKlass"
-  // CHECK: (func_decl {{.*}} "aMethod(arg:)" interface type='(SubKlass) -> (Int) -> Int' access=internal {{.*}} dynamic
+  // CHECK: (func_decl {{.*}} "aMethod(arg:)" interface type="(SubKlass) -> (Int) -> Int" access=internal {{.*}} dynamic
   override dynamic func aMethod(arg: Int) -> Int {
    return 23
   }
 
-  // CHECK: (func_decl {{.*}} "anotherMethod()" interface type='(SubKlass) -> () -> Int' access=internal {{.*}} dynamic
+  // CHECK: (func_decl {{.*}} "anotherMethod()" interface type="(SubKlass) -> () -> Int" access=internal {{.*}} dynamic
   override dynamic func anotherMethod() -> Int {
    return 23
   }

--- a/test/attr/attr_native_dynamic.swift
+++ b/test/attr/attr_native_dynamic.swift
@@ -3,19 +3,19 @@
 struct Strukt {
   // CHECK: (struct_decl {{.*}} "Strukt"
   // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="dynamicStorageOnlyVar"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="dynamicStorageOnlyVar"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="dynamicStorageOnlyVar"
   dynamic var dynamicStorageOnlyVar : Int = 0
 
   // CHECK: (var_decl {{.*}} "computedVar" interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar"
   dynamic var computedVar : Int {
     return 0
   }
 
   // CHECK: (var_decl {{.*}} "computedVar2" interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVar2
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar2"
   dynamic var computedVar2 : Int {
     get {
       return 0
@@ -23,9 +23,9 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterSetter"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarGetterSetter"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="computedVarGetterSetter"
   dynamic var computedVarGetterSetter : Int {
     get {
       return 0
@@ -35,9 +35,9 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal set for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterModify"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarGetterModify"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="computedVarGetterModify"
   dynamic var computedVarGetterModify : Int {
     get {
       return 0
@@ -47,10 +47,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal get for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadSet"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarReadSet"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadSet"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="computedVarReadSet"
   dynamic var computedVarReadSet : Int {
     _read {
     }
@@ -59,10 +59,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal get for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal set for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadModify"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarReadModify"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadModify"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="computedVarReadModify"
   dynamic var computedVarReadModify : Int {
     _read {
     }
@@ -71,10 +71,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "storedWithObserver" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
-  // CHECK: (accessor_decl {{.*}}access=private dynamic didSet for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal dynamic get for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal set for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal _modify for=storedWithObserver
+  // CHECK: (accessor_decl {{.*}}access=private dynamic didSet for="storedWithObserver"
+  // CHECK: (accessor_decl {{.*}}access=internal dynamic get for="storedWithObserver"
+  // CHECK: (accessor_decl {{.*}}access=internal set for="storedWithObserver"
+  // CHECK: (accessor_decl {{.*}}access=internal _modify for="storedWithObserver"
   dynamic var storedWithObserver : Int {
     didSet {
     }
@@ -86,9 +86,9 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="subscript(_:)"
   dynamic subscript(_ index: Int) -> Int {
     get {
       return 1
@@ -98,9 +98,9 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="subscript(_:)"
   dynamic subscript(_ index: Float) -> Int {
     get {
       return 1
@@ -110,10 +110,10 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="subscript(_:)"
   dynamic subscript(_ index: Double) -> Int {
     _read {
     }
@@ -122,10 +122,10 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="subscript(_:)"
   dynamic subscript(_ index: Strukt) -> Int {
     _read {
     }
@@ -137,19 +137,19 @@ struct Strukt {
 class Klass {
   // CHECK: (class_decl {{.*}} "Klass"
   // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="dynamicStorageOnlyVar"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="dynamicStorageOnlyVar"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="dynamicStorageOnlyVar"
   dynamic var dynamicStorageOnlyVar : Int = 0
 
   // CHECK: (var_decl {{.*}} "computedVar" interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar"
   dynamic var computedVar : Int {
     return 0
   }
 
   // CHECK: (var_decl {{.*}} "computedVar2" interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVar2
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVar2"
   dynamic var computedVar2 : Int {
     get {
       return 0
@@ -157,9 +157,9 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterSetter"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarGetterSetter"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="computedVarGetterSetter"
   dynamic var computedVarGetterSetter : Int {
     get {
       return 0
@@ -169,9 +169,9 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal set for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="computedVarGetterModify"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarGetterModify"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="computedVarGetterModify"
   dynamic var computedVarGetterModify : Int {
     get {
       return 0
@@ -181,10 +181,10 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal get for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadSet"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="computedVarReadSet"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadSet"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="computedVarReadSet"
   dynamic var computedVarReadSet : Int {
     _read {
     }
@@ -193,10 +193,10 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal get for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal set for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="computedVarReadModify"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="computedVarReadModify"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="computedVarReadModify"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="computedVarReadModify"
   dynamic var computedVarReadModify : Int {
     _read {
     }
@@ -214,10 +214,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="subscript(_:)"
   dynamic subscript(_ index: Int) -> Int {
     unsafeAddress {
       fatalError()
@@ -228,10 +228,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="subscript(_:)"
   dynamic subscript(_ index: Float) -> Int {
     get {
       return 1
@@ -242,11 +242,11 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="subscript(_:)"
   dynamic subscript(_ index: Double) -> Int {
     _read {
     }
@@ -256,10 +256,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for="subscript(_:)"
   dynamic subscript(_ index: Int8) -> Int {
     unsafeAddress {
       fatalError()
@@ -269,10 +269,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal get for="subscript(_:)"
+  // CHECK: (accessor_decl {{.*}} access=internal set for="subscript(_:)"
   dynamic subscript(_ index: Int16) -> Int {
     unsafeAddress {
       fatalError()

--- a/test/attr/attr_native_dynamic.swift
+++ b/test/attr/attr_native_dynamic.swift
@@ -3,19 +3,19 @@
 struct Strukt {
   // CHECK: (struct_decl {{.*}} "Strukt"
   // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=dynamicStorageOnlyVar
   dynamic var dynamicStorageOnlyVar : Int = 0
 
   // CHECK: (var_decl {{.*}} "computedVar" interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVar
   dynamic var computedVar : Int {
     return 0
   }
 
   // CHECK: (var_decl {{.*}} "computedVar2" interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVar2
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVar2
   dynamic var computedVar2 : Int {
     get {
       return 0
@@ -23,9 +23,9 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=computedVarGetterSetter
   dynamic var computedVarGetterSetter : Int {
     get {
       return 0
@@ -35,9 +35,9 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} access=internal set for=computedVarGetterModify
   dynamic var computedVarGetterModify : Int {
     get {
       return 0
@@ -47,10 +47,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal get for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=computedVarReadSet
   dynamic var computedVarReadSet : Int {
     _read {
     }
@@ -59,10 +59,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal get for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal set for=computedVarReadModify
   dynamic var computedVarReadModify : Int {
     _read {
     }
@@ -71,10 +71,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "storedWithObserver" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
-  // CHECK: (accessor_decl {{.*}}access=private dynamic didSet_for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal dynamic get_for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal set_for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal _modify_for=storedWithObserver
+  // CHECK: (accessor_decl {{.*}}access=private dynamic didSet for=storedWithObserver
+  // CHECK: (accessor_decl {{.*}}access=internal dynamic get for=storedWithObserver
+  // CHECK: (accessor_decl {{.*}}access=internal set for=storedWithObserver
+  // CHECK: (accessor_decl {{.*}}access=internal _modify for=storedWithObserver
   dynamic var storedWithObserver : Int {
     didSet {
     }
@@ -86,9 +86,9 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
   dynamic subscript(_ index: Int) -> Int {
     get {
       return 1
@@ -98,9 +98,9 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
   dynamic subscript(_ index: Float) -> Int {
     get {
       return 1
@@ -110,10 +110,10 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
   dynamic subscript(_ index: Double) -> Int {
     _read {
     }
@@ -122,10 +122,10 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
   dynamic subscript(_ index: Strukt) -> Int {
     _read {
     }
@@ -137,19 +137,19 @@ struct Strukt {
 class Klass {
   // CHECK: (class_decl {{.*}} "Klass"
   // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=dynamicStorageOnlyVar
   dynamic var dynamicStorageOnlyVar : Int = 0
 
   // CHECK: (var_decl {{.*}} "computedVar" interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVar
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVar
   dynamic var computedVar : Int {
     return 0
   }
 
   // CHECK: (var_decl {{.*}} "computedVar2" interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVar2
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVar2
   dynamic var computedVar2 : Int {
     get {
       return 0
@@ -157,9 +157,9 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterSetter" interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=computedVarGetterSetter
   dynamic var computedVarGetterSetter : Int {
     get {
       return 0
@@ -169,9 +169,9 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterModify" interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} access=internal set for=computedVarGetterModify
   dynamic var computedVarGetterModify : Int {
     get {
       return 0
@@ -181,10 +181,10 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadSet" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal get for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=computedVarReadSet
   dynamic var computedVarReadSet : Int {
     _read {
     }
@@ -193,10 +193,10 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadModify" interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal get for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} access=internal set for=computedVarReadModify
   dynamic var computedVarReadModify : Int {
     _read {
     }
@@ -214,10 +214,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
   dynamic subscript(_ index: Int) -> Int {
     unsafeAddress {
       fatalError()
@@ -228,10 +228,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
   dynamic subscript(_ index: Float) -> Int {
     get {
       return 1
@@ -242,11 +242,11 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
   dynamic subscript(_ index: Double) -> Int {
     _read {
     }
@@ -256,10 +256,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic set for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal _modify for=subscript(_:)
   dynamic subscript(_ index: Int8) -> Int {
     unsafeAddress {
       fatalError()
@@ -269,10 +269,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal get for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} access=internal set for=subscript(_:)
   dynamic subscript(_ index: Int16) -> Int {
     unsafeAddress {
       fatalError()

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2320,12 +2320,12 @@ class ClassThrows1 {
 class ImplicitClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
   // CHECK-DUMP-LABEL: func_decl{{.*}}"methodReturnsVoid()"
-  // CHECK-DUMP: (foreign_error_convention kind=ZeroResult unowned param=0 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
+  // CHECK-DUMP: (foreign_error_convention kind=ZeroResult unowned param=0 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>" resulttype="ObjCBool")
   func methodReturnsVoid() throws { }
 
   // CHECK: @objc func methodReturnsObjCClass() throws -> Class_ObjC1
   // CHECK-DUMP-LABEL: func_decl{{.*}}"methodReturnsObjCClass()" 
-  // CHECK-DUMP: (foreign_error_convention kind=NilResult unowned param=0 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>)
+  // CHECK-DUMP: (foreign_error_convention kind=NilResult unowned param=0 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>")
   func methodReturnsObjCClass() throws -> Class_ObjC1 {
     return Class_ObjC1()
   }
@@ -2341,12 +2341,12 @@ class ImplicitClassThrows1 {
 
   // CHECK: @objc func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int)
   // CHECK-DUMP-LABEL: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"
-  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=1 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=1 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>" resulttype="ObjCBool")
   func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int) throws { }
 
   // CHECK: @objc init(degrees: Double) throws
   // CHECK-DUMP-LABEL: constructor_decl{{.*}}"init(degrees:)"
-  // CHECK-DUMP:  (foreign_error_convention kind=NilResult unowned param=1 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>)
+  // CHECK-DUMP:  (foreign_error_convention kind=NilResult unowned param=1 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>")
   init(degrees: Double) throws { }
 
   // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
@@ -2374,7 +2374,7 @@ class ImplicitClassThrows1 {
 class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
   // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping ((Int) -> Int), fn3: @escaping ((Int) -> Int))
   // CHECK-DUMP-LABEL: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"
-  // CHECK-DUMP: (foreign_error_convention kind=ZeroResult unowned param=1 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
+  // CHECK-DUMP: (foreign_error_convention kind=ZeroResult unowned param=1 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>" resulttype="ObjCBool")
   override func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: (@escaping (Int) -> Int), fn3: (@escaping (Int) -> Int)) throws { }
 }
 
@@ -2424,23 +2424,23 @@ class ThrowsObjCName {
   func method7(x: Int) throws { }
 
   // CHECK-DUMP-LABEL: func_decl{{.*}}"method8(_:fn1:fn2:)"
-  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=2 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=2 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>" resulttype="ObjCBool")
   @objc(method8:fn1:error:fn2:) // access-note-move{{ThrowsObjCName.method8(_:fn1:fn2:)}}
   func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
   // CHECK-DUMP-LABEL: func_decl{{.*}}"method9(_:fn1:fn2:)"
-  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=0 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=0 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>" resulttype="ObjCBool")
   @objc(method9AndReturnError:s:fn1:fn2:) // access-note-move{{ThrowsObjCName.method9(_:fn1:fn2:)}}
   func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
 class SubclassThrowsObjCName : ThrowsObjCName {
   // CHECK-DUMP-LABEL: func_decl{{.*}}"method8(_:fn1:fn2:)"
-  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=2 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=2 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>" resulttype="ObjCBool")
   override func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
   // CHECK-DUMP-LABEL: func_decl{{.*}}"method9(_:fn1:fn2:)"
-  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=0 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=0 paramtype="Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>" resulttype="ObjCBool")
   override func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2319,11 +2319,13 @@ class ClassThrows1 {
 @objc // access-note-move{{ImplicitClassThrows1}}
 class ImplicitClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
-  // CHECK-DUMP: func_decl{{.*}}"methodReturnsVoid()"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP-LABEL: func_decl{{.*}}"methodReturnsVoid()"
+  // CHECK-DUMP: (foreign_error_convention kind=ZeroResult unowned param=0 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
   func methodReturnsVoid() throws { }
 
   // CHECK: @objc func methodReturnsObjCClass() throws -> Class_ObjC1
-  // CHECK-DUMP: func_decl{{.*}}"methodReturnsObjCClass()" {{.*}}foreign_error=NilResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
+  // CHECK-DUMP-LABEL: func_decl{{.*}}"methodReturnsObjCClass()" 
+  // CHECK-DUMP: (foreign_error_convention kind=NilResult unowned param=0 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>)
   func methodReturnsObjCClass() throws -> Class_ObjC1 {
     return Class_ObjC1()
   }
@@ -2338,11 +2340,13 @@ class ImplicitClassThrows1 {
   func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil }
 
   // CHECK: @objc func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int)
-  // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP-LABEL: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=1 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
   func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int) throws { }
 
   // CHECK: @objc init(degrees: Double) throws
-  // CHECK-DUMP: constructor_decl{{.*}}"init(degrees:)"{{.*}}foreign_error=NilResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
+  // CHECK-DUMP-LABEL: constructor_decl{{.*}}"init(degrees:)"
+  // CHECK-DUMP:  (foreign_error_convention kind=NilResult unowned param=1 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>)
   init(degrees: Double) throws { }
 
   // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
@@ -2369,7 +2373,8 @@ class ImplicitClassThrows1 {
 @objc // access-note-move{{SubclassImplicitClassThrows1}}
 class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
   // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping ((Int) -> Int), fn3: @escaping ((Int) -> Int))
-  // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP-LABEL: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"
+  // CHECK-DUMP: (foreign_error_convention kind=ZeroResult unowned param=1 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
   override func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: (@escaping (Int) -> Int), fn3: (@escaping (Int) -> Int)) throws { }
 }
 
@@ -2418,20 +2423,24 @@ class ThrowsObjCName {
   @objc(method7) // bad-access-note-move{{ThrowsObjCName.method7(x:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
   func method7(x: Int) throws { }
 
-  // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP-LABEL: func_decl{{.*}}"method8(_:fn1:fn2:)"
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=2 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
   @objc(method8:fn1:error:fn2:) // access-note-move{{ThrowsObjCName.method8(_:fn1:fn2:)}}
   func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
-  // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP-LABEL: func_decl{{.*}}"method9(_:fn1:fn2:)"
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=0 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
   @objc(method9AndReturnError:s:fn1:fn2:) // access-note-move{{ThrowsObjCName.method9(_:fn1:fn2:)}}
   func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
 class SubclassThrowsObjCName : ThrowsObjCName {
-  // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP-LABEL: func_decl{{.*}}"method8(_:fn1:fn2:)"
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=2 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
   override func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
-  // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP-LABEL: func_decl{{.*}}"method9(_:fn1:fn2:)"
+  // CHECK-DUMP:  (foreign_error_convention kind=ZeroResult unowned param=0 paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> resulttype=ObjCBool)
   override func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -10,12 +10,12 @@ import Foundation
 class MyClass {
   // CHECK: @objc func doBigJobClass() async -> Int
   // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobClass{{.*}}
-  // CHECK-DUMP: (foreign_async_convention completion_handler_type=@convention(block) (Int) -> () completion_handler_param=0)
+  // CHECK-DUMP: (foreign_async_convention completion_handler_type="@convention(block) (Int) -> ()" completion_handler_param=0)
   @objc func doBigJobClass() async -> Int { return 0 }
 
   // CHECK: @objc func doBigJobOrFailClass(_: Int) async throws -> (AnyObject, Int)
   // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobOrFailClass{{.*}}
-  // CHECK-DUMP: (foreign_async_convention completion_handler_type=@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> () completion_handler_param=1 error_param=2)
+  // CHECK-DUMP: (foreign_async_convention completion_handler_type="@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> ()" completion_handler_param=1 error_param=2)
   @objc func doBigJobOrFailClass(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
 
   @objc func takeAnAsync(_ fn: () async -> Int) { } // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
@@ -31,12 +31,12 @@ class MyClass {
 actor MyActor {
   // CHECK: @objc func doBigJobActor() async -> Int
   // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobActor{{.*}}
-  // CHECK-DUMP: (foreign_async_convention completion_handler_type=@convention(block) (Int) -> () completion_handler_param=0)
+  // CHECK-DUMP: (foreign_async_convention completion_handler_type="@convention(block) (Int) -> ()" completion_handler_param=0)
   @objc func doBigJobActor() async -> Int { return 0 }
 
   // CHECK: @objc func doBigJobOrFailActor(_: Int) async throws -> (AnyObject, Int)
   // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobOrFailActor{{.*}}
-  // CHECK-DUMP: (foreign_async_convention completion_handler_type=@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> () completion_handler_param=1 error_param=2)
+  // CHECK-DUMP: (foreign_async_convention completion_handler_type="@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> ()" completion_handler_param=1 error_param=2)
   @objc func doBigJobOrFailActor(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
   // expected-warning@-1{{non-sendable type '(AnyObject, Int)' returned by actor-isolated '@objc' instance method 'doBigJobOrFailActor' cannot cross actor boundary}}
 

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -8,13 +8,15 @@ import Foundation
 
 // CHECK: class MyClass
 class MyClass {
-  // CHECK: @objc func doBigJob() async -> Int
-  // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}foreign_async=@convention(block) (Int) -> (),completion_handler_param=0
-  @objc func doBigJob() async -> Int { return 0 }
+  // CHECK: @objc func doBigJobClass() async -> Int
+  // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobClass{{.*}}
+  // CHECK-DUMP: (foreign_async_convention completion_handler_type=@convention(block) (Int) -> () completion_handler_param=0)
+  @objc func doBigJobClass() async -> Int { return 0 }
 
-  // CHECK: @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int)
-  // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}foreign_async=@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> (),completion_handler_param=1,error_param=2
-  @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
+  // CHECK: @objc func doBigJobOrFailClass(_: Int) async throws -> (AnyObject, Int)
+  // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobOrFailClass{{.*}}
+  // CHECK-DUMP: (foreign_async_convention completion_handler_type=@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> () completion_handler_param=1 error_param=2)
+  @objc func doBigJobOrFailClass(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
 
   @objc func takeAnAsync(_ fn: () async -> Int) { } // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-1{{'async' function types cannot be represented in Objective-C}}
@@ -27,14 +29,16 @@ class MyClass {
 
 // CHECK: actor MyActor
 actor MyActor {
-  // CHECK: @objc func doBigJob() async -> Int
-  // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}foreign_async=@convention(block) (Int) -> (),completion_handler_param=0
-  @objc func doBigJob() async -> Int { return 0 }
+  // CHECK: @objc func doBigJobActor() async -> Int
+  // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobActor{{.*}}
+  // CHECK-DUMP: (foreign_async_convention completion_handler_type=@convention(block) (Int) -> () completion_handler_param=0)
+  @objc func doBigJobActor() async -> Int { return 0 }
 
-  // CHECK: @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int)
-  // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}foreign_async=@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> (),completion_handler_param=1,error_param=2
-  @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
-  // expected-warning@-1{{non-sendable type '(AnyObject, Int)' returned by actor-isolated '@objc' instance method 'doBigJobOrFail' cannot cross actor boundary}}
+  // CHECK: @objc func doBigJobOrFailActor(_: Int) async throws -> (AnyObject, Int)
+  // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobOrFailActor{{.*}}
+  // CHECK-DUMP: (foreign_async_convention completion_handler_type=@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> () completion_handler_param=1 error_param=2)
+  @objc func doBigJobOrFailActor(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
+  // expected-warning@-1{{non-sendable type '(AnyObject, Int)' returned by actor-isolated '@objc' instance method 'doBigJobOrFailActor' cannot cross actor boundary}}
 
   // Actor-isolated entities cannot be exposed to Objective-C.
   @objc func synchronousBad() { } // expected-error{{actor-isolated instance method 'synchronousBad()' cannot be @objc}}

--- a/test/decl/protocol/associated_type_overrides.swift
+++ b/test/decl/protocol/associated_type_overrides.swift
@@ -5,7 +5,7 @@ protocol P1 {
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P2"
-// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P1))
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden="P1"))
 protocol P2 : P1 {
   associatedtype A
 }
@@ -15,13 +15,13 @@ protocol P3 {
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P4"
-// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P2, P3))
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden="P2, P3"))
 protocol P4 : P2, P3 {
   associatedtype A
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P5"
-// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P4))
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden="P4"))
 protocol P5 : P4, P2 {
   associatedtype A
 }

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -17,7 +17,7 @@ protocol P0 {
 // CHECK: protocol{{.*}}"P1"
 protocol P1: P0 {
   // CHECK: associated_type_decl
-  // CHECK-SAME: overridden=P0
+  // CHECK-SAME: overridden="P0"
   associatedtype A
 
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : P1{{.*}}override={{.*}}P0.foo
@@ -25,7 +25,7 @@ protocol P1: P0 {
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-SAME: override=override.(file).P0.prop
+  // CHECK-SAME: override="override.(file).P0.prop
   var prop: A { get }
 }
 
@@ -42,7 +42,7 @@ protocol P2 {
 protocol P3: P1, P2 {
   // CHECK: associated_type_decl
   // CHECK-SAME: "A"
-  // CHECK-SAME: override=override.(file).P1.A
+  // CHECK-SAME: override="override.(file).P1.A
   // CHECK-SAME: override.(file).P2.A
   associatedtype A
 
@@ -51,7 +51,7 @@ protocol P3: P1, P2 {
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-SAME: override=override.(file).P2.prop
+  // CHECK-SAME: override="override.(file).P2.prop
   // CHECK-SAME: override.(file).P1.prop
   var prop: A { get }
 }
@@ -79,7 +79,7 @@ protocol P5: P0 where Self.A == Int {
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-SAME: override=override.(file).P0.prop
+  // CHECK-SAME: override="override.(file).P0.prop
   var prop: Int { get }
 }
 
@@ -91,7 +91,7 @@ protocol P6: P0 {
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-SAME: override=override.(file).P0.prop
+  // CHECK-SAME: override="override.(file).P0.prop
   override var prop: A { get }
 }
 

--- a/test/decl/protocol/req/existentials_covariant_erasure.swift
+++ b/test/decl/protocol/req/existentials_covariant_erasure.swift
@@ -34,11 +34,11 @@ do {
     let x5 = pc.lotsOfSelfFunc
     let x6 = pc.lotsOfSelfProp
 
-    // CHECK: (pattern_named type='((any P) -> Void, ((any P)?) -> Void, ([any P]) -> Void, ([Array<any P>?]) -> Void) -> [String : () -> any P]' 'x1')
-    // CHECK: (pattern_named type='((any P) -> Void, ((any P)?) -> Void, ([any P]) -> Void, ([Array<any P>?]) -> Void) -> [String : () -> any P]' 'x2')
-    // CHECK: (pattern_named type='((any P & Q) -> Void, ((any P & Q)?) -> Void, ([any P & Q]) -> Void, ([Array<any P & Q>?]) -> Void) -> [String : () -> any P & Q]' 'x3')
-    // CHECK: (pattern_named type='((any P & Q) -> Void, ((any P & Q)?) -> Void, ([any P & Q]) -> Void, ([Array<any P & Q>?]) -> Void) -> [String : () -> any P & Q]' 'x4')
-    // CHECK: (pattern_named type='((any C & P) -> Void, ((any C & P)?) -> Void, ([any C & P]) -> Void, ([Array<any C & P>?]) -> Void) -> [String : () -> any C & P]' 'x5')
-    // CHECK: (pattern_named type='((any C & P) -> Void, ((any C & P)?) -> Void, ([any C & P]) -> Void, ([Array<any C & P>?]) -> Void) -> [String : () -> any C & P]' 'x6')
+    // CHECK: (pattern_named type='((any P) -> Void, ((any P)?) -> Void, ([any P]) -> Void, ([Array<any P>?]) -> Void) -> [String : () -> any P]' "x1")
+    // CHECK: (pattern_named type='((any P) -> Void, ((any P)?) -> Void, ([any P]) -> Void, ([Array<any P>?]) -> Void) -> [String : () -> any P]' "x2")
+    // CHECK: (pattern_named type='((any P & Q) -> Void, ((any P & Q)?) -> Void, ([any P & Q]) -> Void, ([Array<any P & Q>?]) -> Void) -> [String : () -> any P & Q]' "x3")
+    // CHECK: (pattern_named type='((any P & Q) -> Void, ((any P & Q)?) -> Void, ([any P & Q]) -> Void, ([Array<any P & Q>?]) -> Void) -> [String : () -> any P & Q]' "x4")
+    // CHECK: (pattern_named type='((any C & P) -> Void, ((any C & P)?) -> Void, ([any C & P]) -> Void, ([Array<any C & P>?]) -> Void) -> [String : () -> any C & P]' "x5")
+    // CHECK: (pattern_named type='((any C & P) -> Void, ((any C & P)?) -> Void, ([any C & P]) -> Void, ([Array<any C & P>?]) -> Void) -> [String : () -> any C & P]' "x6")
   }
 }

--- a/test/decl/protocol/req/existentials_covariant_erasure.swift
+++ b/test/decl/protocol/req/existentials_covariant_erasure.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -dump-ast %s | %FileCheck %s
 
-// Test that covariant 'Self' references get erased to the existential base type
+// Test that covariant "Self" references get erased to the existential base type
 // when operating on existential values.
 
 class C {}
@@ -34,11 +34,11 @@ do {
     let x5 = pc.lotsOfSelfFunc
     let x6 = pc.lotsOfSelfProp
 
-    // CHECK: (pattern_named type='((any P) -> Void, ((any P)?) -> Void, ([any P]) -> Void, ([Array<any P>?]) -> Void) -> [String : () -> any P]' "x1")
-    // CHECK: (pattern_named type='((any P) -> Void, ((any P)?) -> Void, ([any P]) -> Void, ([Array<any P>?]) -> Void) -> [String : () -> any P]' "x2")
-    // CHECK: (pattern_named type='((any P & Q) -> Void, ((any P & Q)?) -> Void, ([any P & Q]) -> Void, ([Array<any P & Q>?]) -> Void) -> [String : () -> any P & Q]' "x3")
-    // CHECK: (pattern_named type='((any P & Q) -> Void, ((any P & Q)?) -> Void, ([any P & Q]) -> Void, ([Array<any P & Q>?]) -> Void) -> [String : () -> any P & Q]' "x4")
-    // CHECK: (pattern_named type='((any C & P) -> Void, ((any C & P)?) -> Void, ([any C & P]) -> Void, ([Array<any C & P>?]) -> Void) -> [String : () -> any C & P]' "x5")
-    // CHECK: (pattern_named type='((any C & P) -> Void, ((any C & P)?) -> Void, ([any C & P]) -> Void, ([Array<any C & P>?]) -> Void) -> [String : () -> any C & P]' "x6")
+    // CHECK: (pattern_named type="((any P) -> Void, ((any P)?) -> Void, ([any P]) -> Void, ([Array<any P>?]) -> Void) -> [String : () -> any P]" "x1")
+    // CHECK: (pattern_named type="((any P) -> Void, ((any P)?) -> Void, ([any P]) -> Void, ([Array<any P>?]) -> Void) -> [String : () -> any P]" "x2")
+    // CHECK: (pattern_named type="((any P & Q) -> Void, ((any P & Q)?) -> Void, ([any P & Q]) -> Void, ([Array<any P & Q>?]) -> Void) -> [String : () -> any P & Q]" "x3")
+    // CHECK: (pattern_named type="((any P & Q) -> Void, ((any P & Q)?) -> Void, ([any P & Q]) -> Void, ([Array<any P & Q>?]) -> Void) -> [String : () -> any P & Q]" "x4")
+    // CHECK: (pattern_named type="((any C & P) -> Void, ((any C & P)?) -> Void, ([any C & P]) -> Void, ([Array<any C & P>?]) -> Void) -> [String : () -> any C & P]" "x5")
+    // CHECK: (pattern_named type="((any C & P) -> Void, ((any C & P)?) -> Void, ([any C & P]) -> Void, ([Array<any C & P>?]) -> Void) -> [String : () -> any C & P]" "x6")
   }
 }

--- a/test/decl/var/property_wrappers_synthesis.swift
+++ b/test/decl/var/property_wrappers_synthesis.swift
@@ -26,8 +26,8 @@ struct UseWrapper<T: DefaultInit> {
   var wrapped = T()
 
   // CHECK: pattern_binding_decl implicit
-  // CHECK-NEXT: pattern_typed implicit type='Wrapper<T>'
-  // CHECK-NEXT: pattern_named implicit type='Wrapper<T>' "_wrapped"
+  // CHECK-NEXT: pattern_typed implicit type="Wrapper<T>"
+  // CHECK-NEXT: pattern_named implicit type="Wrapper<T>" "_wrapped"
   // CHECK: constructor_ref_call_expr
   // CHECK-NEXT: declref_expr{{.*}}Wrapper.init(wrappedValue:)
   init() { }
@@ -82,9 +82,9 @@ class MyObservedType {
   @Observable var observedProperty = 17
 
   // CHECK: accessor_decl{{.*}}get for="observedProperty"
-  // CHECK:   subscript_expr implicit type='@lvalue Int' decl={{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)
+  // CHECK:   subscript_expr implicit type="@lvalue Int" decl="{{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)@
 
   // CHECK: accessor_decl{{.*}}set for="observedProperty"
-  // CHECK:   subscript_expr implicit type='@lvalue Int' decl={{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)
+  // CHECK:   subscript_expr implicit type="@lvalue Int" decl="{{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)@
 }
 

--- a/test/decl/var/property_wrappers_synthesis.swift
+++ b/test/decl/var/property_wrappers_synthesis.swift
@@ -13,13 +13,13 @@ protocol DefaultInit {
 struct UseWrapper<T: DefaultInit> {
   // CHECK: var_decl{{.*}}"wrapped"
 
-  // CHECK: accessor_decl{{.*}}get for=wrapped
+  // CHECK: accessor_decl{{.*}}get for="wrapped"
   // CHECK: member_ref_expr{{.*}}UseWrapper._wrapped
 
-  // CHECK: accessor_decl{{.*}}set for=wrapped
+  // CHECK: accessor_decl{{.*}}set for="wrapped"
   // CHECK: member_ref_expr{{.*}}UseWrapper._wrapped
 
-  // CHECK: accessor_decl{{.*}}_modify for=wrapped
+  // CHECK: accessor_decl{{.*}}_modify for="wrapped"
   // CHECK: yield_stmt
   // CHECK: member_ref_expr{{.*}}Wrapper.wrappedValue
   @Wrapper
@@ -27,7 +27,7 @@ struct UseWrapper<T: DefaultInit> {
 
   // CHECK: pattern_binding_decl implicit
   // CHECK-NEXT: pattern_typed implicit type='Wrapper<T>'
-  // CHECK-NEXT: pattern_named implicit type='Wrapper<T>' '_wrapped'
+  // CHECK-NEXT: pattern_named implicit type='Wrapper<T>' "_wrapped"
   // CHECK: constructor_ref_call_expr
   // CHECK-NEXT: declref_expr{{.*}}Wrapper.init(wrappedValue:)
   init() { }
@@ -36,7 +36,7 @@ struct UseWrapper<T: DefaultInit> {
 struct UseWillSetDidSet {
   // CHECK: var_decl{{.*}}"z"
 
-  // CHECK: accessor_decl{{.*}}set for=z
+  // CHECK: accessor_decl{{.*}}set for="z"
   // CHECK: member_ref_expr{{.*}}UseWillSetDidSet._z
   @Wrapper
   var z: Int {
@@ -81,10 +81,10 @@ struct Observable<Value> {
 class MyObservedType {
   @Observable var observedProperty = 17
 
-  // CHECK: accessor_decl{{.*}}get for=observedProperty
+  // CHECK: accessor_decl{{.*}}get for="observedProperty"
   // CHECK:   subscript_expr implicit type='@lvalue Int' decl={{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)
 
-  // CHECK: accessor_decl{{.*}}set for=observedProperty
+  // CHECK: accessor_decl{{.*}}set for="observedProperty"
   // CHECK:   subscript_expr implicit type='@lvalue Int' decl={{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)
 }
 

--- a/test/decl/var/property_wrappers_synthesis.swift
+++ b/test/decl/var/property_wrappers_synthesis.swift
@@ -13,13 +13,13 @@ protocol DefaultInit {
 struct UseWrapper<T: DefaultInit> {
   // CHECK: var_decl{{.*}}"wrapped"
 
-  // CHECK: accessor_decl{{.*}}get_for=wrapped
+  // CHECK: accessor_decl{{.*}}get for=wrapped
   // CHECK: member_ref_expr{{.*}}UseWrapper._wrapped
 
-  // CHECK: accessor_decl{{.*}}set_for=wrapped
+  // CHECK: accessor_decl{{.*}}set for=wrapped
   // CHECK: member_ref_expr{{.*}}UseWrapper._wrapped
 
-  // CHECK: accessor_decl{{.*}}_modify_for=wrapped
+  // CHECK: accessor_decl{{.*}}_modify for=wrapped
   // CHECK: yield_stmt
   // CHECK: member_ref_expr{{.*}}Wrapper.wrappedValue
   @Wrapper
@@ -36,7 +36,7 @@ struct UseWrapper<T: DefaultInit> {
 struct UseWillSetDidSet {
   // CHECK: var_decl{{.*}}"z"
 
-  // CHECK: accessor_decl{{.*}}set_for=z
+  // CHECK: accessor_decl{{.*}}set for=z
   // CHECK: member_ref_expr{{.*}}UseWillSetDidSet._z
   @Wrapper
   var z: Int {
@@ -81,10 +81,10 @@ struct Observable<Value> {
 class MyObservedType {
   @Observable var observedProperty = 17
 
-  // CHECK: accessor_decl{{.*}}get_for=observedProperty
+  // CHECK: accessor_decl{{.*}}get for=observedProperty
   // CHECK:   subscript_expr implicit type='@lvalue Int' decl={{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)
 
-  // CHECK: accessor_decl{{.*}}set_for=observedProperty
+  // CHECK: accessor_decl{{.*}}set for=observedProperty
   // CHECK:   subscript_expr implicit type='@lvalue Int' decl={{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)
 }
 

--- a/test/expr/capture/dynamic_self.swift
+++ b/test/expr/capture/dynamic_self.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
-// CHECK: func_decl{{.*}}"clone()" interface type='(Android) -> () -> Self'
+// CHECK: func_decl{{.*}}"clone()" interface type="(Android) -> () -> Self"
 
 class Android {
   func clone() -> Self {
-    // CHECK: closure_expr type='() -> Self' {{.*}} discriminator=0 captures=(<dynamic_self> self<direct>)
+    // CHECK: closure_expr type="() -> Self" {{.*}} discriminator=0 captures=(<dynamic_self> self<direct>)
     let fn = { return self }
     return fn()
   }

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -2,33 +2,33 @@
 
 func doSomething<T>(_ t: T) {}
 
-// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" <T> interface type='<T> (t: T, x: AnyObject) -> ()'
+// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" "<T>" interface type="<T> (t: T, x: AnyObject) -> ()"
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=0 captures=(<generic> t<direct>) escaping single_expression
+  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=0 captures=(<generic> t<direct>) escaping single_expression
   _ = { doSomething(t) }
 
   // Special case -- closure does not capture outer generic parameters
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=1 captures=(x<direct>) escaping single_expression
+  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=1 captures=(x<direct>) escaping single_expression
   _ = { doSomething(x) }
 
   // Special case -- closure captures outer generic parameter, but it does not
   // appear as the type of any expression
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=2 captures=(<generic> x<direct>)
+  // CHECK: closure_expr type="() -> ()" {{.*}} discriminator=2 captures=(<generic> x<direct>)
   _ = { if x is T {} }
 
   // Nested generic functions always capture outer generic parameters, even if
   // they're not mentioned in the function body
-  // CHECK: func_decl{{.*}}"innerGeneric(u:)" <U> interface type='<T, U> (u: U) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"innerGeneric(u:)" "<U>" interface type="<T, U> (u: U) -> ()" {{.*}} captures=(<generic> )
   func innerGeneric<U>(u: U) {}
 
   // Make sure we look through typealiases
   typealias TT = (a: T, b: T)
 
-  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface type='<T> (tt: TT) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface type="<T> (tt: TT) -> ()" {{.*}} captures=(<generic> )
   func localFunction(tt: TT) {}
 
-  // CHECK: closure_expr type='(TT) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: closure_expr type="(TT) -> ()" {{.*}} captures=(<generic> )
   let _: (TT) -> () = { _ in }
 }

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -6,11 +6,11 @@ func doSomething<T>(_ t: T) {}
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=0 captures=(<generic> t<direct>) escaping  single-expression
+  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=0 captures=(<generic> t<direct>) escaping single_expression
   _ = { doSomething(t) }
 
   // Special case -- closure does not capture outer generic parameters
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=1 captures=(x<direct>) escaping single-expression
+  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=1 captures=(x<direct>) escaping single_expression
   _ = { doSomething(x) }
 
   // Special case -- closure captures outer generic parameter, but it does not

--- a/test/expr/capture/local_lazy.swift
+++ b/test/expr/capture/local_lazy.swift
@@ -5,7 +5,7 @@ struct S {
   func foo() -> Int {
     // Make sure the decl context for the autoclosure passed to ?? is deep
     // enough that it can 'see' the capture of $0 from the outer closure.
-    // CHECK-LABEL: (lazy_initializer_expr
+    // CHECK-LABEL: (original_init=lazy_initializer_expr
     // CHECK: (closure_expr
     // CHECK: location={{.*}}local_lazy.swift:[[@LINE+3]]
     // CHECK: (autoclosure_expr implicit
@@ -17,7 +17,7 @@ struct S {
 
 extension S {
   func bar() -> Int {
-    // CHECK-LABEL: (lazy_initializer_expr
+    // CHECK-LABEL: (original_init=lazy_initializer_expr
     // CHECK: (closure_expr
     // CHECK: location={{.*}}local_lazy.swift:[[@LINE+3]]
     // CHECK: (autoclosure_expr implicit

--- a/test/expr/capture/nested.swift
+++ b/test/expr/capture/nested.swift
@@ -2,9 +2,9 @@
 
 // CHECK: func_decl{{.*}}"foo2(_:)"
 func foo2(_ x: Int) -> (Int) -> (Int) -> Int {
-  // CHECK: closure_expr type='(Int) -> (Int) -> Int' {{.*}} discriminator=0 captures=(x)
+  // CHECK: closure_expr type="(Int) -> (Int) -> Int" {{.*}} discriminator=0 captures=(x)
   return {(bar: Int) -> (Int) -> Int in
-    // CHECK: closure_expr type='(Int) -> Int' {{.*}} discriminator=0 captures=(x<direct>, bar<direct>)
+    // CHECK: closure_expr type="(Int) -> Int" {{.*}} discriminator=0 captures=(x<direct>, bar<direct>)
     return {(bas: Int) -> Int in
       return x + bar + bas
     }

--- a/test/expr/capture/top-level-guard.swift
+++ b/test/expr/capture/top-level-guard.swift
@@ -15,7 +15,7 @@ guard let x = Optional(0) else { fatalError() }
 // CHECK: (top_level_code_decl
 _ = 0 // intervening code
 
-// CHECK-LABEL: (func_decl{{.*}}"function()" interface type='() -> ()' access=internal captures=(x<direct>)
+// CHECK-LABEL: (func_decl{{.*}}"function()" interface type="() -> ()" access=internal captures=(x<direct>)
 func function() {
   _ = x
 }
@@ -39,7 +39,7 @@ let closureCapture: () -> Void = { [x] in
 }
 
 // CHECK-LABEL: (defer_stmt
-// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface type='() -> ()' access=fileprivate captures=(x<direct><noescape>)
+// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface type="() -> ()" access=fileprivate captures=(x<direct><noescape>)
 defer {
   _ = x
 }

--- a/test/expr/capture/top-level-guard.swift
+++ b/test/expr/capture/top-level-guard.swift
@@ -20,7 +20,7 @@ func function() {
   _ = x
 }
 
-// CHECK-LABEL: (closure_expr
+// CHECK-LABEL: (processed_init=closure_expr
 // CHECK: location={{.*}}top-level-guard.swift:[[@LINE+3]]
 // CHECK: captures=(x<direct>)
 // CHECK: (var_decl{{.*}}"closure"
@@ -28,7 +28,7 @@ let closure: () -> Void = {
   _ = x
 }
 
-// CHECK-LABEL: (capture_list
+// CHECK-LABEL: (processed_init=capture_list
 // CHECK: location={{.*}}top-level-guard.swift:[[@LINE+5]]
 // CHECK: (closure_expr
 // CHECK: location={{.*}}top-level-guard.swift:[[@LINE+3]]

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -51,7 +51,7 @@ func testDowncastOptionalObjectConditional(obj: AnyObject?!) -> [String]?? {
   // CHECK-NEXT: (optional_evaluation_expr implicit type='[String]?'
   // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='[String]'
-  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} writtenType='[String]?'
+  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} written_type='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject?'
   // CHECK-NEXT: (declref_expr type='AnyObject??'

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -35,26 +35,26 @@ func testDowncastNSArrayToArray(nsarray: NSArray) {
 
 // CHECK-LABEL: testDowncastOptionalObject
 func testDowncastOptionalObject(obj: AnyObject?!) -> [String]? {
-  // CHECK: (optional_evaluation_expr implicit type='[String]?'
-  // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
-  // CHECK: (forced_checked_cast_expr type='[String]'{{.*value_cast}}
-  // CHECK: (bind_optional_expr implicit type='AnyObject'
-  // CHECK-NEXT: (force_value_expr implicit type='AnyObject?'
-  // CHECK-NEXT: (declref_expr type='AnyObject??' 
+  // CHECK: (optional_evaluation_expr implicit type="[String]?"
+  // CHECK-NEXT: (inject_into_optional implicit type="[String]?"
+  // CHECK: (forced_checked_cast_expr type="[String]"{{.*value_cast}}
+  // CHECK: (bind_optional_expr implicit type="AnyObject"
+  // CHECK-NEXT: (force_value_expr implicit type="AnyObject?"
+  // CHECK-NEXT: (declref_expr type="AnyObject??" 
   return obj as! [String]?
 }
 
 // CHECK-LABEL: testDowncastOptionalObjectConditional
 func testDowncastOptionalObjectConditional(obj: AnyObject?!) -> [String]?? {
-  // CHECK: (optional_evaluation_expr implicit type='[String]??'
-  // CHECK-NEXT: (inject_into_optional implicit type='[String]??'
-  // CHECK-NEXT: (optional_evaluation_expr implicit type='[String]?'
-  // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
-  // CHECK-NEXT: (bind_optional_expr implicit type='[String]'
-  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} written_type='[String]?'
-  // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject'
-  // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject?'
-  // CHECK-NEXT: (declref_expr type='AnyObject??'
+  // CHECK: (optional_evaluation_expr implicit type="[String]??"
+  // CHECK-NEXT: (inject_into_optional implicit type="[String]??"
+  // CHECK-NEXT: (optional_evaluation_expr implicit type="[String]?"
+  // CHECK-NEXT: (inject_into_optional implicit type="[String]?"
+  // CHECK-NEXT: (bind_optional_expr implicit type="[String]"
+  // CHECK-NEXT: (conditional_checked_cast_expr type="[String]?" {{.*value_cast}} written_type="[String]?"
+  // CHECK-NEXT: (bind_optional_expr implicit type="AnyObject"
+  // CHECK-NEXT: (bind_optional_expr implicit type="AnyObject?"
+  // CHECK-NEXT: (declref_expr type="AnyObject??"
   return obj as? [String]?
 }
 

--- a/test/expr/delayed-ident/optional_overload.swift
+++ b/test/expr/delayed-ident/optional_overload.swift
@@ -40,11 +40,11 @@ let _: S1? = .init(S1())
 let _: S1? = .init(overloaded: ())
 // If members exist on Optional and Wrapped, always choose the one on optional
 // CHECK: declref_expr {{.*}} location={{.*}}optional_overload.swift:40
-// CHECK-SAME: decl=optional_overload.(file).Optional extension.init(overloaded:)
+// CHECK-SAME: decl="optional_overload.(file).Optional extension.init(overloaded:)@
 let _: S1? = .member_overload
 // Should choose the overload from Optional even if the Wrapped overload would otherwise have a better score
 // CHECK: member_ref_expr {{.*}} location={{.*}}optional_overload.swift:44
-// CHECK-SAME: decl=optional_overload.(file).Optional extension.member_overload
+// CHECK-SAME: decl="optional_overload.(file).Optional extension.member_overload@
 let _: S1? = .init(failable: ())
 let _: S1? = .member3()
 let _: S1? = .member4

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -14,10 +14,10 @@ struct TakesArray<T> {
 // CHECK-LABEL: func_decl{{.*}}"arrayUpcast(_:_:)"
 // CHECK: assign_expr
 // CHECK-NOT: collection_upcast_expr
-// CHECK: array_expr type='[(X) -> Void]'
-// CHECK: function_conversion_expr implicit type='(X) -> Void'
+// CHECK: array_expr type="[(X) -> Void]"
+// CHECK: function_conversion_expr implicit type="(X) -> Void"
 // CHECK-NEXT: {{declref_expr.*x1}}
-// CHECK-NEXT: function_conversion_expr implicit type='(X) -> Void'
+// CHECK-NEXT: function_conversion_expr implicit type="(X) -> Void"
 // CHECK-NEXT: {{declref_expr.*x2}}
 func arrayUpcast(_ x1: @escaping (P) -> Void, _ x2: @escaping (P) -> Void) {
   _ = TakesArray<X>([x1, x2])
@@ -30,9 +30,9 @@ struct TakesDictionary<T> {
 // CHECK-LABEL: func_decl{{.*}}"dictionaryUpcast(_:_:)"
 // CHECK: assign_expr
 // CHECK-NOT: collection_upcast_expr
-// CHECK: paren_expr type='([Int : (X) -> Void])'
+// CHECK: paren_expr type="([Int : (X) -> Void])"
 // CHECK-NOT: collection_upcast_expr
-// CHECK: (dictionary_expr type='[Int : (X) -> Void]'
+// CHECK: (dictionary_expr type="[Int : (X) -> Void]"
 func dictionaryUpcast(_ x1: @escaping (P) -> Void, _ x2: @escaping (P) -> Void) {
   _ = TakesDictionary<X>(([1: x1, 2: x2]))
 }


### PR DESCRIPTION
This PR refactors the ASTDumper to make it more structured, less mistake-prone, and more amenable to future changes. For example:

```cpp
  // Before:
  void visitUnresolvedDotExpr(UnresolvedDotExpr *E) {
    printCommon(E, "unresolved_dot_expr")
      << " field '" << E->getName() << "'";
    PrintWithColorRAII(OS, ExprModifierColor)
      << " function_ref=" << getFunctionRefKindStr(E->getFunctionRefKind());
    if (E->getBase()) {
      OS << '\n';
      printRec(E->getBase());
    }
    PrintWithColorRAII(OS, ParenthesisColor) << ')';
  }

  // After:
  void visitUnresolvedDotExpr(UnresolvedDotExpr *E, StringRef label) {
    printCommon(E, "unresolved_dot_expr", label);

    printFieldQuoted(E->getName(), "field");
    printField(E->getFunctionRefKind(), "function_ref", ExprModifierColor);

    if (E->getBase()) {
      printRec(E->getBase());
    }

    printFoot();
  }
```

* Values are printed through calls to base class methods, rather than direct access to the underlying `raw_ostream`.
    * These methods tend to reduce the chances of bugs like missing/extra spaces or newlines, too much/too little indentation, etc.
    * More values are quoted, and unprintable/non-ASCII characters in quoted values are escaped before printing.
* Infrastructure to label child nodes now exists.
    * Some weird breaks from the normal "style", like `PatternBindingDecl`'s original and processed initializers, have been brought into line.
* Some types that previously used ad-hoc dumping functions, like conformances and substitution maps, are now structured similarly to the dumper classes.
* I've fixed the odd dumping bug along the way. For example, distributed actors were only marked `actor`, not `distributed actor`.

This PR doesn't change the overall style of AST dumps; they're still pseudo-S-expressions. But the logic that implements this style is now isolated into a relatively small base class, making it feasible to introduce e.g. JSON dumping in the future.
