### PR TITLE
Add driver options to swift to enable MCCAS

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -491,6 +491,15 @@ public:
   /// The calling convention used to perform non-swift calls.
   llvm::CallingConv::ID PlatformCCallingConvention;
 
+  /// Use CAS based object format as the output.
+  bool UseCASBackend;
+
+  /// The output mode for the CAS Backend.
+  llvm::CASBackendMode CASObjMode;
+
+  /// Emit a .casid file next to the object file if CAS Backend is used.
+  bool EmitCASIDFile;
+
   IRGenOptions()
       : DWARFVersion(2),
         OutputKind(IRGenOutputKind::LLVMAssemblyAfterOptimization),
@@ -502,9 +511,9 @@ public:
         DebugInfoFormat(IRGenDebugInfoFormat::None),
         DisableClangModuleSkeletonCUs(false), UseJIT(false),
         DisableLLVMOptzns(false), DisableSwiftSpecificLLVMOptzns(false),
-        Playground(false),
-        EmitStackPromotionChecks(false), UseSingleModuleLLVMEmission(false),
-        FunctionSections(false), PrintInlineTree(false), AlwaysCompile(false),
+        Playground(false), EmitStackPromotionChecks(false),
+        UseSingleModuleLLVMEmission(false), FunctionSections(false),
+        PrintInlineTree(false), AlwaysCompile(false),
         EmbedMode(IRGenEmbedMode::None), LLVMLTOKind(IRGenLLVMLTOKind::None),
         SwiftAsyncFramePointer(SwiftAsyncFramePointerKind::Auto),
         HasValueNamesSetting(false), ValueNames(false),
@@ -526,13 +535,12 @@ public:
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
         InternalizeAtLink(false), InternalizeSymbols(false),
         EmitGenericRODatas(false), NoPreallocatedInstantiationCaches(false),
-        DisableReadonlyStaticObjects(false),
-        CollocatedMetadataFunctions(false),
-        ColocateTypeDescriptors(true),
-        UseRelativeProtocolWitnessTables(false), CmdArgs(),
-        SanitizeCoverage(llvm::SanitizerCoverageOptions()),
+        DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
+        ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
+        CmdArgs(), SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All),
-        PlatformCCallingConvention(llvm::CallingConv::C) {
+        PlatformCCallingConvention(llvm::CallingConv::C), UseCASBackend(false),
+        CASObjMode(llvm::CASBackendMode::Native) {
 #ifndef NDEBUG
     DisableRoundTripDebugTypes = false;
 #else

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -164,6 +164,10 @@ public:
     return LangOpts.Target.str();
   }
 
+  bool requiresCAS() const {
+    return FrontendOpts.EnableCaching || FrontendOpts.UseCASBackend;
+  }
+
   void setClangModuleCachePath(StringRef Path) {
     ClangImporterOpts.ModuleCachePath = Path.str();
   }

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -14,14 +14,15 @@
 #define SWIFT_FRONTEND_FRONTENDOPTIONS_H
 
 #include "swift/Basic/FileTypes.h"
-#include "swift/Basic/Version.h"
 #include "swift/Basic/PathRemapper.h"
+#include "swift/Basic/Version.h"
 #include "swift/Frontend/FrontendInputsAndOutputs.h"
 #include "swift/Frontend/InputFile.h"
+#include "clang/CAS/CASOptions.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringMap.h"
-#include "clang/CAS/CASOptions.h"
+#include "llvm/MC/MCTargetOptions.h"
 
 #include <set>
 #include <string>
@@ -148,6 +149,15 @@ public:
 
   /// CacheKey for input file.
   std::string InputFileKey;
+
+  /// Enable using the LLVM MCCAS backend for object file output.
+  bool UseCASBackend = false;
+
+  /// The output mode for the CAS Backend.
+  llvm::CASBackendMode CASObjMode;
+
+  /// Emit a .casid file next to the object file if CAS Backend is used.
+  bool EmitCASIDFile = false;
 
   /// Number of retry opening an input file if the previous opening returns
   /// bad file descriptor error.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1866,6 +1866,19 @@ def external_plugin_path : Separate<["-"], "external-plugin-path">, Group<plugin
   Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Add directory to the plugin search path with a plugin server executable">,
   MetaVarName<"<path>#<plugin-server-path>">;
+  
+def cas_backend: Flag<["-"], "cas-backend">,
+  Flags<[FrontendOption, NoDriverOption]>,
+  HelpText<"Enable using CASBackend for object file output">;
+
+def cas_backend_mode: Joined<["-"], "cas-backend-mode=">,
+  Flags<[FrontendOption, NoDriverOption]>,
+  HelpText<"CASBackendMode for output kind">,
+  MetaVarName<"native|casid|verify">;
+
+def cas_emit_casid_file: Flag<["-"], "cas-emit-casid-file">,
+  Flags<[FrontendOption, NoDriverOption]>,
+  HelpText<"Emit .casid file next to object file when CAS Backend is enabled">;
 
 def load_plugin_library:
   Separate<["-"], "load-plugin-library">, Group<plugin_search_Group>,

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -263,7 +263,8 @@ namespace swift {
                            const IRGenOptions &opts,
                            UnifiedStatsReporter *stats, DiagnosticEngine &diags,
                            llvm::raw_pwrite_stream &out,
-                           llvm::sys::Mutex *diagMutex = nullptr);
+                           llvm::sys::Mutex *diagMutex = nullptr,
+                           llvm::raw_pwrite_stream *casid = nullptr);
 
   /// Wrap a serialized module inside a swift AST section in an object file.
   void createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -382,6 +382,17 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.BlocklistConfigFilePaths.push_back(A);
   }
 
+  if (Arg *A = Args.getLastArg(OPT_cas_backend_mode)) {
+    Opts.CASObjMode = llvm::StringSwitch<llvm::CASBackendMode>(A->getValue())
+                          .Case("native", llvm::CASBackendMode::Native)
+                          .Case("casid", llvm::CASBackendMode::CASID)
+                          .Case("verify", llvm::CASBackendMode::Verify)
+                          .Default(llvm::CASBackendMode::Native);
+  }
+
+  Opts.UseCASBackend = Args.hasArg(OPT_cas_backend);
+  Opts.EmitCASIDFile = Args.hasArg(OPT_cas_emit_casid_file);
+
   return false;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -266,6 +266,10 @@ setIRGenOutputOptsFromFrontendOptions(IRGenOptions &IRGenOpts,
     }
   }(FrontendOpts.RequestedAction);
 
+  IRGenOpts.UseCASBackend = FrontendOpts.UseCASBackend;
+  IRGenOpts.CASObjMode = FrontendOpts.CASObjMode;
+  IRGenOpts.EmitCASIDFile = FrontendOpts.EmitCASIDFile;
+
   // If we're in JIT mode, set the requisite flags.
   if (FrontendOpts.RequestedAction == FrontendOptions::ActionType::Immediate) {
     IRGenOpts.UseJIT = true;
@@ -1457,8 +1461,7 @@ static bool ValidateModulesOnceOptions(const ClangImporterOptions &Opts,
   return false;
 }
 
-static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
-                                   ArgList &Args,
+static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
                                    DiagnosticEngine &Diags,
                                    StringRef workingDirectory,
                                    const LangOptions &LangOpts,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -414,7 +414,7 @@ void CompilerInstance::setupDependencyTrackerIfNeeded() {
 
 bool CompilerInstance::setupCASIfNeeded(ArrayRef<const char *> Args) {
   const auto &Opts = getInvocation().getFrontendOptions();
-  if (!Opts.EnableCaching)
+  if (!getInvocation().requiresCAS())
     return false;
 
   auto MaybeDB= Opts.CASOpts.getOrCreateDatabases();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1674,6 +1674,7 @@ static bool generateCode(CompilerInstance &Instance, StringRef OutputFilename,
   std::unique_ptr<llvm::TargetMachine> TargetMachine =
       createTargetMachine(opts, Instance.getASTContext());
 
+  TargetMachine->Options.MCOptions.CAS = Instance.getSharedCASInstance();
   // Free up some compiler resources now that we have an IRModule.
   freeASTContextIfPossible(Instance);
 

--- a/test/CAS/mccas.swift
+++ b/test/CAS/mccas.swift
@@ -1,0 +1,26 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -c %s -g -cas-backend -cas-backend-mode=verify -cas-path %t/cas -o %t/test-verify.o
+// RUN: %llvm-dwarfdump %t/test-verify.o | %FileCheck %s --check-prefix=VERIFY-FILE
+// VERIFY-FILE: .debug_info
+
+// RUN: %target-swift-frontend -c %s -g -cas-backend -cas-backend-mode=native -cas-path %t/cas -o %t/test-native.o
+// RUN: %llvm-dwarfdump %t/test-native.o | %FileCheck %s --check-prefix=NATIVE-FILE
+// NATIVE-FILE: .debug_info
+
+// RUN: %target-swift-frontend -c %s -g -cas-backend -cas-backend-mode=casid -cas-path %t/cas -o %t/test-casid.id
+// RUN: cat %t/test-casid.id | %FileCheck %s --check-prefix=CASID-FILE
+// CASID-FILE: llvmcas://{{.*}}
+
+// RUN: %target-swift-frontend -c %s -g -cas-backend -cas-emit-casid-file -cas-backend-mode=verify -cas-path %t/cas -o %t/test-verify-emit.o
+// RUN: cat %t/test-verify-emit.o.casid | %FileCheck %s --check-prefix=VERIFY-EMIT
+// VERIFY-EMIT: llvmcas://{{.*}}
+
+// RUN: %target-swift-frontend -c %s -g -cas-backend -cas-emit-casid-file -cas-backend-mode=native -cas-path %t/cas -o %t/test-native-emit.o
+// RUN: cat %t/test-native-emit.o.casid | %FileCheck %s --check-prefix=NATIVE-EMIT
+// NATIVE-EMIT: llvmcas://{{.*}}
+
+// RUN: %target-swift-frontend -c %s -g -cas-backend -cas-emit-casid-file -cas-backend-mode=casid -cas-path %t/cas -o %t/test.id
+// RUN: not cat %t/test.id.casid
+
+func testFunc() {}


### PR DESCRIPTION
To enable MCCAS, the following driver options have been added

-cas-backend: Enable MCCAS backend in swift, the option -cache-compile-job must also be used.

-cas-backend-mode=native: Set the CAS Backend mode to emit an object file after materializing it from the CAS.

-cas-backend-mode=casid: Emit a file with the CASID for the CAS that was created.

-cas-backend-mode=verify: Verify that the object file created is identical to the object file materialized from the CAS.

-cas-emit-casid-file: Emit a .casid file next to the object file when CAS Backend is enabled.

This commit reverts 0e8554bb15408da6f0619176b6f84eadf88ab983, which reverted 3c949028e8363463c5520aab1ea49c24f5103b6c

Apologies for that, the test mccas.swift should have been guarded correctly, I think this should fix it