### PR TITLE
TBDGen: Don't skip extensions on clang types

### DIFF
--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/Basic/Defer.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/SILLinkage.h"
 #include "swift/SIL/SILModule.h"
@@ -372,7 +373,9 @@ class SILSymbolVisitorImpl : public ASTVisitor<SILSymbolVisitorImpl> {
     if (!Ctx.getOpts().PublicSymbolsOnly)
       return false;
 
-    if (NTD->hasClangNode())
+    // Don't skip nominals from clang modules; they have PublicNonUnique
+    // linkage.
+    if (isa<ClangModuleUnit>(NTD->getDeclContext()->getModuleScopeContext()))
       return false;
 
     return getDeclLinkage(NTD) != FormalLinkage::PublicUnique;

--- a/test/TBD/Inputs/custom-error.h
+++ b/test/TBD/Inputs/custom-error.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+extern NSString *const CustomErrorDomain;
+
+// typedef NS_ERROR_ENUM(CustomErrorDomain, CustomErrorCode) { ... }
+typedef enum CustomErrorCode : long CustomErrorCode;
+enum __attribute__((ns_error_domain(CustomErrorDomain))) CustomErrorCode : long {
+  CustomErrorA,
+};

--- a/test/TBD/Inputs/module.modulemap
+++ b/test/TBD/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module CustomError {
+  header "custom-error.h"
+}

--- a/test/TBD/custom_objc_error.swift
+++ b/test/TBD/custom_objc_error.swift
@@ -1,0 +1,14 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -I %S/Inputs/ -disable-objc-attr-requires-foundation-module -emit-tbd -emit-tbd-path %t/test.tbd
+
+import Foundation
+@_exported import CustomError
+
+extension CustomError : CustomStringConvertible {
+  public var description: String {
+    let nsError = self as NSError
+    return nsError.description
+  }
+}


### PR DESCRIPTION
Fixes a regression introduced with https://github.com/apple/swift/pull/68216. Some nominal types belonging to clang modules don't have a clang node in the AST, so make sure we match the logic used when computing IR linkage to determine whether a nominal type is a clang type.

Resolves rdar://115308770
