### PR TITLE
Add test to make sure we don't crash on missing ActorSystem typealias

### DIFF
--- a/test/Distributed/distributed_actor_system_missing_type_dontCrash.swift
+++ b/test/Distributed/distributed_actor_system_missing_type_dontCrash.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+// rdar://90886302 This test would crash if not typealias ActorSystem was declared for an actor
+distributed actor Fish {
+  // expected-error@-1{{distributed actor 'Fish' does not declare ActorSystem it can be used with.}}
+  // expected-error@-2{{distributed actor 'Fish' does not declare ActorSystem it can be used with.}}
+  // expected-note@-3{{you can provide a module-wide default actor system by declaring:\ntypealias DefaultDistributedActorSystem = <#ConcreteActorSystem#>}}
+
+  distributed func tell(_ text: String, by: Fish) {
+    // What would the fish say, if it could talk?
+  }
+}


### PR DESCRIPTION
We actually don't crash here but diagnose properly as expected, but doesn't hurt to have an explicit test for this.

Refs rdar://90886302