### PR TITLE
[IRGen] Some fixes for raw layout types and noncopyable types in the stdlib

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3081,7 +3081,8 @@ static void emitInitializeRawLayout(IRGenFunction &IGF, SILType likeType,
   auto initRawAvail = IGF.IGM.Context.getInitRawStructMetadataAvailability();
 
   if (!IGF.IGM.Context.LangOpts.DisableAvailabilityChecking &&
-      !deploymentAvailability.isContainedIn(initRawAvail)) {
+      !deploymentAvailability.isContainedIn(initRawAvail) &&
+      !IGF.IGM.getSwiftModule()->isStdlibModule()) {
     emitInitializeRawLayoutOld(IGF, likeType, count, T, metadata, collector);
     return;
   }

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -279,11 +279,28 @@ getTypeRefByFunction(IRGenModule &IGM,
           llvm::Instruction *br = nullptr;
           llvm::BasicBlock *supportedBB = nullptr;
           if (useForwardCompatibility) {
-            auto runtimeSupportsNoncopyableTypesSymbol
-              = IGM.Module.getOrInsertGlobal("swift_runtimeSupportsNoncopyableTypes",
-                                             IGM.Int8Ty);
-            cast<llvm::GlobalVariable>(runtimeSupportsNoncopyableTypesSymbol)
-              ->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
+            llvm::Value *runtimeSupportsNoncopyableTypesSymbol = nullptr;
+
+            // This is weird. When building the stdlib, we don't have access to
+            // the swift_runtimeSupportsNoncopyableTypes symbol in the Swift.o,
+            // so we'll emit an adrp + ldr to resolve the GOT address. However,
+            // this symbol is defined as an abolsute in the runtime object files
+            // to address 0x0 right now and ld doesn't quite understand how to
+            // fixup this GOT address when merging the runtime and stdlib. Just
+            // unconditionally fail the branch.
+            //
+            // Note: When the value of this symbol changes, this MUST be
+            // updated.
+            if (IGM.getSwiftModule()->isStdlibModule()) {
+              runtimeSupportsNoncopyableTypesSymbol
+                  = llvm::ConstantInt::get(IGM.Int8Ty, 0);
+            } else {
+              runtimeSupportsNoncopyableTypesSymbol
+                  = IGM.Module.getOrInsertGlobal(
+                      "swift_runtimeSupportsNoncopyableTypes", IGM.Int8Ty);
+              cast<llvm::GlobalVariable>(runtimeSupportsNoncopyableTypesSymbol)
+                  ->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
+            }
               
             auto runtimeSupportsNoncopyableTypes
               = IGF.Builder.CreateIsNotNull(runtimeSupportsNoncopyableTypesSymbol,

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -990,6 +990,29 @@ namespace {
         return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
       }
 
+      auto decl = T.getASTType()->getStructOrBoundGenericStruct();
+      auto rawLayout = decl->getAttrs().getAttribute<RawLayoutAttr>();
+
+      // If we have a raw layout struct who is fixed size, it means the
+      // layout of the struct is fully concrete.
+      if (rawLayout) {
+        auto likeType = rawLayout->getResolvedLikeType(decl)->getCanonicalType();
+        SILType loweredLikeType = IGM.getLoweredType(likeType);
+
+        // The given struct type T that we're building is fully concrete, but
+        // our like type is still in terms of the potential archetype of the
+        // type.
+        auto subs = T.getASTType()->getContextSubstitutionMap(
+          IGM.getSwiftModule(), decl);
+
+        loweredLikeType = loweredLikeType.subst(IGM.getSILModule(), subs);
+
+        // Array like raw layouts are still handled correctly even though the
+        // type layout entry is only that of the like type.
+        return IGM.getTypeInfo(loweredLikeType)
+            .buildTypeLayoutEntry(IGM, loweredLikeType, useStructLayouts);
+      }
+
       std::vector<TypeLayoutEntry *> fields;
       for (auto &field : getFields()) {
         auto fieldTy = field.getType(IGM, T);
@@ -1082,13 +1105,6 @@ namespace {
         return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
       }
 
-      std::vector<TypeLayoutEntry *> fields;
-      for (auto &field : getFields()) {
-        auto fieldTy = field.getType(IGM, T);
-        fields.push_back(
-            field.getTypeInfo().buildTypeLayoutEntry(IGM, fieldTy, useStructLayouts));
-      }
-
       auto decl = T.getASTType()->getStructOrBoundGenericStruct();
       auto rawLayout = decl->getAttrs().getAttribute<RawLayoutAttr>();
 
@@ -1096,13 +1112,8 @@ namespace {
       // layout of the struct is dependent on the archetype of the thing it's
       // like.
       if (rawLayout) {
-        SILType loweredLikeType;
-
-        if (auto likeType = rawLayout->getResolvedScalarLikeType(decl)) {
-          loweredLikeType = IGM.getLoweredType(*likeType);
-        } else if (auto likeArray = rawLayout->getResolvedArrayLikeTypeAndCount(decl)) {
-          loweredLikeType = IGM.getLoweredType(likeArray->first);
-        }
+        auto likeType = rawLayout->getResolvedLikeType(decl)->getCanonicalType();
+        SILType loweredLikeType = IGM.getLoweredType(likeType);
 
         // The given struct type T that we're building may be in a generic
         // environment that is different than that which was built our
@@ -1113,10 +1124,18 @@ namespace {
 
         loweredLikeType = loweredLikeType.subst(IGM.getSILModule(), subs);
 
-        return IGM.getTypeInfo(loweredLikeType).buildTypeLayoutEntry(IGM,
-          loweredLikeType, useStructLayouts);
+        // Array like raw layouts are still handled correctly even though the
+        // type layout entry is only that of the like type.
+        return IGM.getTypeInfo(loweredLikeType)
+            .buildTypeLayoutEntry(IGM, loweredLikeType, useStructLayouts);
       }
 
+      std::vector<TypeLayoutEntry *> fields;
+      for (auto &field : getFields()) {
+        auto fieldTy = field.getType(IGM, T);
+        fields.push_back(
+            field.getTypeInfo().buildTypeLayoutEntry(IGM, fieldTy, useStructLayouts));
+      }
       assert(!fields.empty() &&
              "Empty structs should not be NonFixedStructTypeInfo");
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -996,6 +996,12 @@ namespace {
       // If we have a raw layout struct who is fixed size, it means the
       // layout of the struct is fully concrete.
       if (rawLayout) {
+        // Defer to this fixed type info for type layout if the raw layout
+        // specifies size and alignment.
+        if (rawLayout->getSizeAndAlignment()) {
+          return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+        }
+
         auto likeType = rawLayout->getResolvedLikeType(decl)->getCanonicalType();
         SILType loweredLikeType = IGM.getLoweredType(likeType);
 
@@ -1112,6 +1118,10 @@ namespace {
       // layout of the struct is dependent on the archetype of the thing it's
       // like.
       if (rawLayout) {
+        // Note: We don't have to handle the size and alignment case here for
+        // raw layout because those are always fixed, so only dependent layouts
+        // will be non-fixed.
+
         auto likeType = rawLayout->getResolvedLikeType(decl)->getCanonicalType();
         SILType loweredLikeType = IGM.getLoweredType(likeType);
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -85,6 +85,9 @@ using namespace metadataimpl;
 // types, so we explicitly define this symbol to be zero for now. Binaries
 // weak-import this symbol so they will resolve it to a zero address on older
 // runtimes as well.
+//
+// Note: If this symbol's value ever gets updated, the corresponding condition
+// handled by IRGen MUST be updated in tandem.
 __asm__("  .globl _swift_runtimeSupportsNoncopyableTypes\n");
 __asm__(".set _swift_runtimeSupportsNoncopyableTypes, 0\n");
 #endif

--- a/test/IRGen/Inputs/raw_layout_multifile_b.swift
+++ b/test/IRGen/Inputs/raw_layout_multifile_b.swift
@@ -6,6 +6,13 @@ extension Foo where T == Int32 {
 
 public func foo(_: borrowing Foo<Int32>) {}
 
+@_rawLayout(size: 4, alignment: 4)
+public struct Int32Fake: ~Copyable {
+  var address: UnsafeMutablePointer<Int32> {
+    .init(Builtin.unprotectedAddressOfBorrow(self))
+  }
+}
+
 @_rawLayout(like: T)
 public struct UnsafeCell<T>: ~Copyable {
   var address: UnsafeMutablePointer<T> {

--- a/test/IRGen/Inputs/raw_layout_multifile_b.swift
+++ b/test/IRGen/Inputs/raw_layout_multifile_b.swift
@@ -1,5 +1,21 @@
+import Builtin
+
 extension Foo where T == Int32 {
 
 }
 
 public func foo(_: borrowing Foo<Int32>) {}
+
+@_rawLayout(like: T)
+public struct UnsafeCell<T>: ~Copyable {
+  var address: UnsafeMutablePointer<T> {
+    .init(Builtin.unprotectedAddressOfBorrow(self))
+  }
+}
+
+@_rawLayout(likeArrayOf: T, count: 3)
+public struct SmallVectorOf3<T>: ~Copyable {
+  var address: UnsafeMutablePointer<T> {
+    .init(Builtin.unprotectedAddressOfBorrow(self))
+  }
+}

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -98,6 +98,16 @@ struct PaddedCell<T>: ~Copyable {}
 @_rawLayout(likeArrayOf: T, count: 8)
 struct SmallVectorBuf<T>: ~Copyable {}
 
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}14SmallVectorOf3VWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 0
+// stride
+// CHECK-SAME:  , {{i64|i32}} 0
+// flags: alignment 0, incomplete
+// CHECK-SAME:  , <i32 0x400000>
+@_rawLayout(likeArrayOf: T, count: 3)
+struct SmallVectorOf3<T>: ~Copyable {}
+
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}8UsesCellVWV" = {{.*}} %swift.vwtable
 // size
 // CHECK-SAME:  , {{i64|i32}} 8
@@ -108,6 +118,28 @@ struct SmallVectorBuf<T>: ~Copyable {}
 struct UsesCell: ~Copyable {
     let someCondition: Bool
     let specialInt: Cell<Int32>
+}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}13BufferOf3BoolVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 3
+// stride
+// CHECK-SAME:  , {{i64|i32}} 3
+// flags: alignment 0, noncopyable
+// CHECK-SAME:  , <i32 0x800000>
+struct BufferOf3Bool: ~Copyable {
+    let buffer: SmallVectorOf3<Bool>
+}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}9BadBufferVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 48
+// stride
+// CHECK-SAME:  , {{i64|i32}} 48
+// flags: alignment 7, noncopyable, is not inline
+// CHECK-SAME:  , <i32 0x820007>
+struct BadBuffer: ~Copyable {
+    let buffer: SmallVectorOf3<Int64?>
 }
 
 // Dependent layout metadata initialization:

--- a/test/IRGen/raw_layout_multifile.swift
+++ b/test/IRGen/raw_layout_multifile.swift
@@ -5,6 +5,17 @@
 @_rawLayout(like: Int32)
 public struct Foo<T>: ~Copyable {}
 
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}5MyIntVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 4
+// stride
+// CHECK-SAME:  , {{i64|i32}} 4
+// flags: alignment 3, noncopyable
+// CHECK-SAME:  , <i32 0x800003>
+struct MyInt: ~Copyable {
+  let x: Int32Fake
+}
+
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}9BadBufferVWV" = {{.*}} %swift.vwtable
 // size
 // CHECK-SAME:  , {{i64|i32}} 48
@@ -37,4 +48,10 @@ public func something() -> Int64 {
 public func something2() -> Int64? {
   let buf = BadBuffer()
   return buf.buf.address[1]
+}
+
+// Force emission of MyInt's descriptor to be lazy...
+public func something3() -> Int32 {
+  let x = MyInt(x: Int32Fake())
+  return x.x.address.pointee
 }

--- a/test/IRGen/raw_layout_multifile.swift
+++ b/test/IRGen/raw_layout_multifile.swift
@@ -1,7 +1,40 @@
-// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir -primary-file %s %S/Inputs/raw_layout_multifile_b.swift
-// RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir %s -primary-file %S/Inputs/raw_layout_multifile_b.swift
-
-import Swift
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/chex.py < %s > %t/raw_layout_multifile.swift
+// RUN: %target-swift-frontend -enable-experimental-feature BuiltinModule -enable-experimental-feature RawLayout -emit-ir -O -disable-availability-checking %s %S/Inputs/raw_layout_multifile_b.swift | %FileCheck %t/raw_layout_multifile.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 @_rawLayout(like: Int32)
 public struct Foo<T>: ~Copyable {}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}9BadBufferVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 48
+// stride
+// CHECK-SAME:  , {{i64|i32}} 48
+// flags: alignment 7, noncopyable, is not inline
+// CHECK-SAME:  , <i32 0x820007>
+struct BadBuffer: ~Copyable {
+  let buf = SmallVectorOf3<Int64?>()
+}
+
+// CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}5WeirdVWV" = {{.*}} %swift.vwtable
+// size
+// CHECK-SAME:  , {{i64|i32}} 8
+// stride
+// CHECK-SAME:  , {{i64|i32}} 8
+// flags: alignment 7, noncopyable
+// CHECK-SAME:  , <i32 0x800007>
+struct Weird: ~Copyable {
+  let value = UnsafeCell<Int64>()
+}
+
+// Force emission of Weird's descriptor to be lazy...
+public func something() -> Int64 {
+  let x = Weird()
+  return x.value.address.pointee
+}
+
+// Force emission of BadBuffer's descriptor to be lazy...
+public func something2() -> Int64? {
+  let buf = BadBuffer()
+  return buf.buf.address[1]
+}


### PR DESCRIPTION
When a type's metadata is emitted lazily, those paths in the compiler specifically ask for the type layout entry of the type info. For fixed raw layout types, we weren't handling this case and so the compiler would crash when say we need to lazily emit metadata. 

This also fixes the stdlib's issue of not being able to define noncopyable types because of a linker bug with referencing `swift_runtimeSupportsNoncopyableTypes`. Just unconditionally fail it for the stdlib.