### PR TITLE
Ensure module tracing is off when checking `disable-implicit*` flags

### DIFF
--- a/cmake/modules/SwiftImplicitImport.cmake
+++ b/cmake/modules/SwiftImplicitImport.cmake
@@ -3,6 +3,8 @@ function(swift_supports_implicit_module module_name out_var)
   file(WRITE "${CMAKE_BINARY_DIR}/tmp/empty-check-${module_name}.swift" "")
   execute_process(
     COMMAND
+      ${CMAKE_COMMAND}
+      -E env --unset=SWIFT_LOADED_MODULE_TRACE_FILE
       "${CMAKE_Swift_COMPILER}"
       -Xfrontend -disable-implicit-${module_name}-module-import
       -Xfrontend -parse-stdlib


### PR DESCRIPTION
In some internal configurations we set the
`SWIFT_LOADED_MODULE_TRACE_FILE` environment variable when running the build of the compiler -- as a result, this causes `-parse` to always fails, preventing to detect properly if we can use `disable-implicit*` flags.

Addresses rdar://115338219