### PR TITLE
[5.10] Ensure module tracing is off when checking `disable-implicit*`…

### DIFF
--- a/cmake/modules/SwiftImplicitImport.cmake
+++ b/cmake/modules/SwiftImplicitImport.cmake
@@ -3,6 +3,8 @@ function(swift_supports_implicit_module module_name out_var)
   file(WRITE "${CMAKE_BINARY_DIR}/tmp/empty-check-${module_name}.swift" "")
   execute_process(
     COMMAND
+      ${CMAKE_COMMAND}
+      -E env --unset=SWIFT_LOADED_MODULE_TRACE_FILE
       "${CMAKE_Swift_COMPILER}"
       -Xfrontend -disable-implicit-${module_name}-module-import
       -Xfrontend -parse-stdlib


### PR DESCRIPTION
In some internal configurations we set the
`SWIFT_LOADED_MODULE_TRACE_FILE` environment variable when running the build of the compiler -- as a result, this causes `-parse` to always fails, preventing to detect properly if we can use `disable-implicit*` flags.

(cherry picked from commit ec49873c5ee3b29ceb0b9fe3c6485af927ddc6fa)

**Explanation:** explicitly unset `SWIFT_LOADED_MODULE_TRACE_FILE` when detecting if the Swift compiler supporst `disable-implicit*` flags -- this is to prevent the `-parse` invocation we use for such detection to fail unconditionally
**Radar:** rdar://115338219
**Scope:** build logic used to detect if the compiler supports `disable-implicit*`
**Risk:** low
* we manipulate the environment variables only during this detection, preventing side effects to the rest of the configuration and thebuild
* `SWIFT_LOADED_MODULE_TRACE_FILE` is mostly used in internal configuration, and should not affect opensource

**Testing:** run a local Darwin build setting `SWIFT_LOADED_MODULE_TRACE_FILE` manually, checked that the `disable-implicit` flags are correctly used during builds of the compiler
**Reviewed by:**