### PR TITLE
[docs][concurrency] Document more explicitly closure lifetime of a Task init

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -76,6 +76,43 @@ import Swift
 /// like the reason for cancellation.
 /// This reflects the fact that a task can be canceled for many reasons,
 /// and additional reasons can accrue during the cancellation process.
+///
+/// ### Task closure lifetime
+/// Tasks initialized with a closure, representing the code that will be executed by this task.
+///
+/// Once this code has ran to completion, and the task therefore has completed, resulting in either
+/// a failure or result value, this closure is eagerly released.
+///
+/// Keeping the `Task` object retained, will not indefinitely keep the closure retained.
+/// This means that tasks rarely need to capture values as `weak`, since when they complete
+/// any references they hold are released (as the closure is released).
+///
+/// For example, in this example, it is not necessary to capture the actor as weak,
+/// because as the task completes it'll let go of the actor reference, breaking the
+/// reference cycle between the Task and the actor holding it.
+///
+/// ```
+/// struct Work: Sendable {}
+///
+/// actor Worker {
+///     var work: Task<Work, Never>?
+///
+///     deinit {
+///
+///         print("deinit")
+///     }
+///
+///     func start() {
+///         work = Task {
+///             return Work()
+///         }
+///     }
+/// }
+///
+/// await Actor().start()
+/// // no references to Actor other than inside the Task
+/// // as the Task completes; the closure is destroyed releasing the actor.
+/// ```
 @available(SwiftStdlib 5.1, *)
 @frozen
 public struct Task<Success: Sendable, Failure: Error>: Sendable {

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -83,9 +83,10 @@ import Swift
 /// Once this code has ran to completion, and the task therefore has completed, resulting in either
 /// a failure or result value, this closure is eagerly released.
 ///
-/// Keeping the `Task` object retained, will not indefinitely keep the closure retained.
-/// This means that tasks rarely need to capture values as `weak`, since when they complete
-/// any references they hold are released (as the closure is released).
+/// Retaining a task object doesn't indefinitely retain the closure,
+/// because any references that a task holds are released
+/// after the task completes.
+/// Consequently, tasks rarely need to capture weak references to values.
 ///
 /// For example, in this example, it is not necessary to capture the actor as weak,
 /// because as the task completes it'll let go of the actor reference, breaking the

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -80,7 +80,7 @@ import Swift
 /// ### Task closure lifetime
 /// Tasks initialized with a closure, representing the code that will be executed by this task.
 ///
-/// Once this code has ran to completion, and the task therefore has completed, resulting in either
+/// After this code has run to completion, the task has completed, resulting in either
 /// a failure or result value, this closure is eagerly released.
 ///
 /// Retaining a task object doesn't indefinitely retain the closure,

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -78,7 +78,7 @@ import Swift
 /// and additional reasons can accrue during the cancellation process.
 ///
 /// ### Task closure lifetime
-/// Tasks initialized with a closure, representing the code that will be executed by this task.
+/// A task is initialized with a closure. containing the code that the task executes.
 ///
 /// After this code has run to completion, the task has completed, resulting in either
 /// a failure or result value, this closure is eagerly released.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -95,16 +95,18 @@ import Swift
 /// struct Work: Sendable {}
 ///
 /// actor Worker {
-///     var work: Task<Work, Never>?
+///     var work: Task<Void, Never>?
+///     var result: Work?
 ///
 ///     deinit {
-///
 ///         print("deinit")
 ///     }
 ///
 ///     func start() {
 ///         work = Task {
-///             return Work()
+///             try? await Task.sleep(for: .seconds(3))
+///             self.work = Work() // we captured self
+///             // but as the task completes, this reference is released
 ///         }
 ///     }
 /// }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -78,7 +78,7 @@ import Swift
 /// and additional reasons can accrue during the cancellation process.
 ///
 /// ### Task closure lifetime
-/// A task is initialized with a closure. containing the code that the task executes.
+/// Tasks are initialized by passing a closure containing the code that will be executed by a given task.
 ///
 /// After this code has run to completion, the task has completed, resulting in either
 /// a failure or result value, this closure is eagerly released.
@@ -88,7 +88,7 @@ import Swift
 /// after the task completes.
 /// Consequently, tasks rarely need to capture weak references to values.
 ///
-/// For example, in this example, it is not necessary to capture the actor as weak,
+/// For example, in the following snippet of code it is not necessary to capture the actor as `weak`,
 /// because as the task completes it'll let go of the actor reference, breaking the
 /// reference cycle between the Task and the actor holding it.
 ///
@@ -100,21 +100,42 @@ import Swift
 ///     var result: Work?
 ///
 ///     deinit {
-///         print("deinit")
+///         assert(work != nil)
+///         // even though the task is still retained,
+///         // once it completes it no longer causes a reference cycle with the actor
+///
+///         print("deinit actor")
 ///     }
 ///
 ///     func start() {
 ///         work = Task {
+///             print("start task work")
 ///             try? await Task.sleep(for: .seconds(3))
-///             self.work = Work() // we captured self
+///             self.result = Work() // we captured self
+///             print("completed task work")
 ///             // but as the task completes, this reference is released
 ///         }
+///         // we keep a strong reference to the task
 ///     }
 /// }
+/// ```
 ///
+/// And using it like this:
+///
+/// ```
 /// await Actor().start()
-/// // no references to Actor other than inside the Task
-/// // as the Task completes; the closure is destroyed releasing the actor.
+/// ```
+///
+/// Note that there is nothing, other than the Task's use of `self` retaining the actor,
+/// And that the start method immediately returns, without waiting for the unstructured `Task` to finish.
+/// So once the task completes and its the closure is destroyed, the strong reference to the "self" of the actor is also released allowing the actor to deinitialize as expected.
+///
+/// Therefore, the above call will consistently result in the following output:
+///
+/// ```
+/// start task work
+/// completed task work
+/// deinit actor
 /// ```
 @available(SwiftStdlib 5.1, *)
 @frozen


### PR DESCRIPTION
Docs improvement explaining that we actively destory the Task closure -- because devs are not entirely sure about this and sometimes reach to weak captures more than they need to.

resolves rdar://112653483

resolves https://github.com/apple/swift/issues/67452