### PR TITLE
Fix inaccurate error on inout in wrong parameter type 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3685,6 +3685,9 @@ ERROR(attr_not_on_variadic_parameters,none,
       "'%0' must not be used on variadic parameters", (StringRef))
 ERROR(attr_not_on_subscript_parameters,none,
       "'%0' must not be used on subscript parameters", (StringRef))
+ERROR(attr_not_on_enum_case_parameters,none,
+      "'%0' must not be used on enum case parameters", (StringRef))
+
 ERROR(attr_not_on_stored_properties,none,
       "'%0' must not be used on stored properties", (DeclAttribute))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3681,13 +3681,10 @@ ERROR(dynamic_self_default_arg,none,
 
 ERROR(attr_only_one_decl_kind,none,
       "%0 may only be used on '%1' declarations", (DeclAttribute,StringRef))
+ERROR(attr_only_valid_on_func_or_init_params,none,
+      "'%0' may only be used on function or initializer parameters", (StringRef))
 ERROR(attr_not_on_variadic_parameters,none,
       "'%0' must not be used on variadic parameters", (StringRef))
-ERROR(attr_not_on_subscript_parameters,none,
-      "'%0' must not be used on subscript parameters", (StringRef))
-ERROR(attr_not_on_enum_case_parameters,none,
-      "'%0' must not be used on enum case parameters", (StringRef))
-
 ERROR(attr_not_on_stored_properties,none,
       "'%0' must not be used on stored properties", (DeclAttribute))
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4294,26 +4294,21 @@ TypeResolver::resolveOwnershipTypeRepr(OwnershipTypeRepr *repr,
       options.hasBase(TypeResolverContext::SubscriptDecl) ||
       options.hasBase(TypeResolverContext::EnumElementDecl)) {
 
-    auto diagID = diag::attr_only_on_parameters;
-    bool removeRepr = true;
-    if (options.hasBase(TypeResolverContext::SubscriptDecl)) {
-      diagID = diag::attr_not_on_subscript_parameters;
+    decltype(diag::attr_only_on_parameters) diagID;
+    if (options.hasBase(TypeResolverContext::SubscriptDecl) ||
+        options.hasBase(TypeResolverContext::EnumElementDecl)) {
+      diagID = diag::attr_only_valid_on_func_or_init_params;
     } else if (options.is(TypeResolverContext::VariadicFunctionInput)) {
       diagID = diag::attr_not_on_variadic_parameters;
-    } else if (options.hasBase(TypeResolverContext::EnumElementDecl)) {
-      diagID = diag::attr_not_on_enum_case_parameters;
     } else {
       diagID = diag::attr_only_on_parameters;
-      removeRepr = false;
     }
+
     StringRef name;
     if (ownershipRepr) {
       name = ownershipRepr->getSpecifierSpelling();
     }
-    auto diag = diagnoseInvalid(repr, repr->getSpecifierLoc(), diagID, name);
-    if (removeRepr)
-      diag.fixItRemove(repr->getLoc());
-
+    diagnoseInvalid(repr, repr->getSpecifierLoc(), diagID, name);
     return ErrorType::get(getASTContext());
   }
 

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -36,7 +36,7 @@ actor TestActor {
   var value2: Int = 1 // expected-note 4{{property declared here}}
   var points: [Point] = [] // expected-note {{property declared here}}
 
-  subscript(x : inout Int) -> Int { // expected-error {{'inout' must not be used on subscript parameters}}
+  subscript(x : inout Int) -> Int { // expected-error {{'inout' may only be used on function or initializer parameters}}
     x += 1
     return x
   }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -646,8 +646,8 @@ func f(a : FooClass, b : LetStructMembers) {
 class MutableSubscripts {
   var x : Int = 0
 
-  subscript(x: inout Int) -> () { x += 1 } // expected-error {{'inout' must not be used on subscript parameters}}
-  subscript<T>(x: inout T) -> () { // expected-error {{'inout' must not be used on subscript parameters}}
+  subscript(x: inout Int) -> () { x += 1 } // expected-error {{'inout' may only be used on function or initializer parameters}}
+  subscript<T>(x: inout T) -> () { // expected-error {{'inout' may only be used on function or initializer parameters}}
     fatalError()
   }
 

--- a/test/attr/attr_inout.swift
+++ b/test/attr/attr_inout.swift
@@ -7,7 +7,7 @@ func h(_ : inout Int) -> (inout Int) -> (inout Int) -> Int { }
 func ff(x: (inout Int, inout Float)) { } //  expected-error 2{{'inout' may only be used on parameters}}
 
 enum inout_carrier {
-  case carry(inout Int) // expected-error {{'inout' may only be used on parameters}}
+  case carry(inout Int) // expected-error {{'inout' may only be used on function or initializer parameters}}
 }
 
 func deprecated(inout x: Int) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -324,8 +324,8 @@ func useSynthesizedMember() {
 
 // Non-materializable argument type
 enum Lens<T> {
-  case foo(inout T) // expected-error {{'inout' may only be used on parameters}}
-  case bar(inout T, Int) // expected-error {{'inout' may only be used on parameters}}
+  case foo(inout T) // expected-error {{'inout' may only be used on function or initializer parameters}}
+  case bar(inout T, Int) // expected-error {{'inout' may only be used on function or initializer parameters}}
 
   case baz((inout T) -> ()) // ok
   case quux((inout T, inout T) -> ()) // ok

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -464,15 +464,15 @@ do {
 
 struct InOutSubscripts {
   subscript(x1: inout Int) -> Int { return 0 }
-  // expected-error@-1 {{'inout' must not be used on subscript parameters}}
+  // expected-error@-1 {{'inout' may only be used on function or initializer parameters}}
 
   subscript(x2: inout Int, y2: inout Int) -> Int { return 0 }
-  // expected-error@-1 2{{'inout' must not be used on subscript parameters}}
+  // expected-error@-1 2{{'inout' may only be used on function or initializer parameters}}
 
   subscript(x3: (inout Int) -> ()) -> Int { return 0 } // ok
   subscript(x4: (inout Int, inout Int) -> ()) -> Int { return 0 } // ok
 
   subscript(inout x5: Int) -> Int { return 0 }
   // expected-error@-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}
-  // expected-error@-2 {{'inout' must not be used on subscript parameters}}
+  // expected-error@-2 {{'inout' may only be used on function or initializer parameters}}
 }

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -205,3 +205,10 @@ func rdar94888357() {
 
   let _ = S<String, String>("") // expected-error {{generic type 'S' specialized with too many type parameters (got 2, but expected 1)}}
 }
+
+// https://github.com/apple/swift/issues/68417
+enum E {
+  subscript(x: inout Int) -> Bool { true } // expected-error {{'inout' must not be used on subscript parameters}} {{16-22=}}
+  case c(x: inout Int) // expected-error {{'inout' must not be used on enum case parameters}} {{13-19=}}
+  func d(x: inout Int ...) // expected-error {{'inout' must not be used on variadic parameters}} {{13-19=}}
+}

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -208,7 +208,17 @@ func rdar94888357() {
 
 // https://github.com/apple/swift/issues/68417
 enum E {
-  subscript(x: inout Int) -> Bool { true } // expected-error {{'inout' must not be used on subscript parameters}} {{16-22=}}
-  case c(x: inout Int) // expected-error {{'inout' must not be used on enum case parameters}} {{13-19=}}
-  func d(x: inout Int ...) // expected-error {{'inout' must not be used on variadic parameters}} {{13-19=}}
+  subscript(x: inout Int) -> Bool { true } // expected-error {{'inout' may only be used on function or initializer parameters}}
+  case c(x: inout Int) // expected-error {{'inout' may only be used on function or initializer parameters}}
+  func d(x: inout Int ...) {} // expected-error {{'inout' must not be used on variadic parameters}}
+  func e(x: inout Int) {} // ok
+  init(x: inout Int) {} // ok
+}
+
+do {
+  struct Test {
+    init(_: inout Int...) {} // expected-error {{'inout' must not be used on variadic parameters}}
+    func test(_: inout String...) {} // expected-error {{'inout' must not be used on variadic parameters}}
+    subscript(_: inout Double...) -> Bool { true } // expected-error {{'inout' may only be used on function or initializer parameters}}
+  }
 }


### PR DESCRIPTION
This PR improves error description on misusage of `inout` in parameter types that cannot be used with `inout` .

This also adds a fixit to remove the `inout` attribute. 

Resolves #68417