### PR TITLE
[embedded] Initial support for generic classes in embedded Swift

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -358,6 +358,8 @@ ERROR(bad_attr_on_non_const_global,none,
       "global variable must be a compile-time constant to use %0 attribute", (StringRef))
 ERROR(global_must_be_compile_time_const,none,
       "global variable must be a compile-time constant", ())
+ERROR(non_final_generic_class_function,none,
+      "classes cannot have non-final generic fuctions in embedded Swift", ())
 NOTE(performance_called_from,none,
       "called from here", ())
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -90,7 +90,7 @@ inline bool isEmbedded(CanType t) {
 }
 
 inline bool isMetadataAllowedInEmbedded(CanType t) {
-  return isa<ClassType>(t);
+  return isa<ClassType>(t) || isa<BoundGenericClassType>(t);
 }
 
 inline bool isEmbedded(Decl *d) {

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -243,6 +243,9 @@ private:
   /// Lookup table for SIL vtables from class decls.
   llvm::DenseMap<const ClassDecl *, SILVTable *> VTableMap;
 
+  /// Lookup table for specialized SIL vtables from types.
+  llvm::DenseMap<SILType, SILVTable *> SpecializedVTableMap;
+
   /// The list of SILVTables in the module.
   std::vector<SILVTable*> vtables;
 
@@ -826,6 +829,9 @@ public:
 
   /// Look up the VTable mapped to the given ClassDecl. Returns null on failure.
   SILVTable *lookUpVTable(const ClassDecl *C, bool deserializeLazily = true);
+
+  /// Look up a specialized VTable
+  SILVTable *lookUpSpecializedVTable(SILType classTy);
 
   /// Attempt to lookup the function corresponding to \p Member in the class
   /// hierarchy of \p Class.

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -247,6 +247,8 @@ SWIFT_FUNCTION_PASS(DeadStoreElimination, "dead-store-elimination",
      "Dead Store Elimination")
 PASS(GenericSpecializer, "generic-specializer",
      "Generic Function Specialization on Static Types")
+PASS(VTableSpecializer, "vtable-specializer",
+     "Generic Specialization on VTables")
 PASS(ExistentialSpecializer, "existential-specializer",
      "Existential Specializer")
 PASS(SILSkippingChecker, "check-sil-skipping",

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -63,6 +63,9 @@ protected:
     : super(IGM), Target(target),
       VTable(IGM.getSILModule().lookUpVTable(target, /*deserialize*/ false)) {}
 
+  ClassMetadataVisitor(IRGenModule &IGM, ClassDecl *target, SILVTable *vtable)
+    : super(IGM), Target(target), VTable(vtable) {}
+
 public:
   void layout() {
     static_assert(MetadataAdjustmentIndex::Class == 3,

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1079,7 +1079,9 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
     emitClassMetadata(*this, D, fragileLayout, resilientLayout);
     emitFieldDescriptor(D);
   } else {
-    emitEmbeddedClassMetadata(*this, D, fragileLayout);
+    if (!D->isGenericContext()) {
+      emitEmbeddedClassMetadata(*this, D, fragileLayout);
+    }
   }
 
   IRGen.addClassForEagerInitialization(D);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1239,7 +1239,7 @@ void IRGenModule::emitGlobalLists() {
 // Eagerly emit functions that are externally visible. Functions that are
 // dynamic replacements must also be eagerly emitted.
 static bool isLazilyEmittedFunction(SILFunction &f, SILModule &m) {
-  // Embedded Swift only emits specialized function, so don't emit genreic
+  // Embedded Swift only emits specialized function, so don't emit generic
   // functions, even if they're externally visible.
   if (f.getASTContext().LangOpts.hasFeature(Feature::Embedded) &&
       f.getLoweredFunctionType()->getSubstGenericSignature()) {
@@ -1412,13 +1412,19 @@ deleteAndReenqueueForEmissionValuesDependentOnCanonicalPrespecializedMetadataRec
 void IRGenerator::emitLazyDefinitions() {
   if (SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
     // In embedded Swift, the compiler cannot emit any metadata, etc.
-    LazyTypeMetadata.clear();
-    LazySpecializedTypeMetadataRecords.clear();
-    LazyTypeContextDescriptors.clear();
-    LazyOpaqueTypeDescriptors.clear();
-    LazyCanonicalSpecializedMetadataAccessors.clear();
-    LazyMetadataAccessors.clear();
-    LazyWitnessTables.clear();
+    assert(LazyTypeMetadata.empty());
+    assert(LazySpecializedTypeMetadataRecords.empty());
+    assert(LazyTypeContextDescriptors.empty());
+    assert(LazyOpaqueTypeDescriptors.empty());
+    assert(LazyFieldDescriptors.empty());
+    // LazyFunctionDefinitions are allowed, but they must not be generic
+    for (SILFunction *f : LazyFunctionDefinitions) {
+      assert(!f->getLoweredFunctionType()->getSubstGenericSignature());
+    }
+    assert(LazyWitnessTables.empty());
+    assert(LazyCanonicalSpecializedMetadataAccessors.empty());
+    assert(LazyMetadataAccessors.empty());
+    // LazySpecializedClassMetadata is allowed
   }
 
   while (!LazyTypeMetadata.empty() ||
@@ -1493,9 +1499,8 @@ void IRGenerator::emitLazyDefinitions() {
     while (!LazyFunctionDefinitions.empty()) {
       SILFunction *f = LazyFunctionDefinitions.pop_back_val();
       CurrentIGMPtr IGM = getGenModule(f);
-      // XXX TODO
-      //assert(!f->isPossiblyUsedExternally()
-      //       && "function with externally-visible linkage emitted lazily?");
+      assert(!f->isPossiblyUsedExternally()
+             && "function with externally-visible linkage emitted lazily?");
       IGM->emitSILFunction(f);
     }
 
@@ -1536,6 +1541,10 @@ void IRGenerator::addLazyFunction(SILFunction *f) {
   // Add it to the queue if it hasn't already been put there.
   if (!LazilyEmittedFunctions.insert(f).second)
     return;
+    
+  if (SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    assert(!f->getLoweredFunctionType()->getSubstGenericSignature());
+  }
 
   assert(!FinishedEmittingLazyDefinitions);
   LazyFunctionDefinitions.push_back(f);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5123,9 +5123,12 @@ IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
   // trigger lazy emission of the metadata.
   if (NominalTypeDecl *nominal = concreteType->getAnyNominal()) {
     IRGen.noteUseOfTypeMetadata(nominal);
-    if (auto *classDecl = dyn_cast<ClassDecl>(nominal)) {
-      if (classDecl->isGenericContext()) {
-        IRGen.noteUseOfSpecializedClassMetadata(concreteType);
+
+    if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+      if (auto *classDecl = dyn_cast<ClassDecl>(nominal)) {
+        if (classDecl->isGenericContext()) {
+          IRGen.noteUseOfSpecializedClassMetadata(concreteType);
+        }
       }
     }
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5006,7 +5006,6 @@ void irgen::emitEmbeddedClassMetadata(IRGenModule &IGM, ClassDecl *classDecl,
                                             fragileLayout);
   metadataBuilder.layout();
   bool canBeConstant = metadataBuilder.canBeConstant();
-  metadataBuilder.createMetadataAccessFunction();
 
   CanType declaredType = classDecl->getDeclaredType()->getCanonicalType();
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3772,6 +3772,14 @@ namespace {
         FieldLayout(fieldLayout),
         MetadataLayout(IGM.getClassMetadataLayout(theClass)) {}
 
+    ClassMetadataBuilderBase(IRGenModule &IGM, ClassDecl *theClass,
+                             ConstantStructBuilder &builder,
+                             const ClassLayout &fieldLayout,
+                             SILVTable *vtable)
+      : super(IGM, theClass, vtable), B(builder),
+        FieldLayout(fieldLayout),
+        MetadataLayout(IGM.getClassMetadataLayout(theClass)) {}
+
   public:
     const ClassLayout &getFieldLayout() const { return FieldLayout; }
 
@@ -4208,6 +4216,12 @@ namespace {
                               ConstantStructBuilder &builder,
                               const ClassLayout &fieldLayout)
       : super(IGM, theClass, builder, fieldLayout) {}
+
+    FixedClassMetadataBuilder(IRGenModule &IGM, ClassDecl *theClass,
+                              ConstantStructBuilder &builder,
+                              const ClassLayout &fieldLayout,
+                              SILVTable *vtable)
+      : super(IGM, theClass, builder, fieldLayout, vtable) {}
 
     void addFieldOffset(VarDecl *var) {
       if (asImpl().getFieldLayout().hasObjCImplementation())
@@ -4999,6 +5013,37 @@ void irgen::emitEmbeddedClassMetadata(IRGenModule &IGM, ClassDecl *classDecl,
   StringRef section{};
   bool isPattern = false;
   auto var = IGM.defineTypeMetadata(declaredType, isPattern, canBeConstant,
+                                    init.finishAndCreateFuture(), section);
+  (void)var;
+}
+
+void irgen::emitLazySpecializedClassMetadata(IRGenModule &IGM,
+                                             CanType classTy) {
+  auto &context = classTy->getNominalOrBoundGenericNominal()->getASTContext();
+  PrettyStackTraceType stackTraceRAII(
+    context, "emitting lazy specialized class metadata for", classTy);
+
+  SILType classType = SILType::getPrimitiveObjectType(classTy);
+  auto &classTI = IGM.getTypeInfo(classType).as<ClassTypeInfo>();
+  
+  auto &fragileLayout =
+    classTI.getClassLayout(IGM, classType, /*forBackwardDeployment=*/true);
+
+  ClassDecl *classDecl = classType.getClassOrBoundGenericClass();
+
+  ConstantInitBuilder initBuilder(IGM);
+  auto init = initBuilder.beginStruct();
+  init.setPacked(true);
+
+  SILVTable *vtable = IGM.getSILModule().lookUpSpecializedVTable(classType);
+  assert(vtable);
+
+  FixedClassMetadataBuilder builder(IGM, classDecl, init, fragileLayout, vtable);
+  builder.layout();
+  bool canBeConstant = builder.canBeConstant();
+
+  StringRef section{};
+  auto var = IGM.defineTypeMetadata(classTy, false, canBeConstant,
                                     init.finishAndCreateFuture(), section);
   (void)var;
 }

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -83,6 +83,8 @@ namespace irgen {
   /// Emit the type metadata accessor for a type for which it might be used.
   void emitLazyMetadataAccessor(IRGenModule &IGM, NominalTypeDecl *type);
 
+  void emitLazySpecializedClassMetadata(IRGenModule &IGM, CanType classType);
+
   void emitLazyCanonicalSpecializedMetadataAccessor(IRGenModule &IGM,
                                                     CanType theType);
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -327,6 +327,10 @@ private:
   /// The queue of lazy witness tables to emit.
   llvm::SmallVector<SILWitnessTable *, 4> LazyWitnessTables;
 
+  llvm::SmallVector<CanType, 4> LazySpecializedClassMetadata;
+
+  llvm::SmallPtrSet<TypeBase *, 4> LazilyEmittedSpecializedClassMetadata;
+
   llvm::SmallVector<ClassDecl *, 4> ClassesForEagerInitialization;
 
   llvm::SmallVector<ClassDecl *, 4> ObjCActorsNeedingSuperclassSwizzle;
@@ -471,6 +475,8 @@ public:
       LazyMetadataAccessors.insert(decl);
     }
   }
+
+  void noteUseOfSpecializedClassMetadata(CanType classType);
 
   void noteUseOfTypeMetadata(NominalTypeDecl *type) {
     noteUseOfTypeGlobals(type, true, RequireMetadata);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2361,6 +2361,10 @@ void IRGenModule::emitSILFunction(SILFunction *f) {
   if (f->isExternalDeclaration())
     return;
 
+  if (Context.LangOpts.hasFeature(Feature::Embedded) &&
+      f->getLoweredFunctionType()->isPolymorphic())
+    return;
+
   // Do not emit bodies of public_external functions.
   if (hasPublicVisibility(f->getLinkage()) && f->isAvailableExternally())
     return;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -736,6 +736,13 @@ static MetadataResponse emitNominalMetadataRef(IRGenFunction &IGF,
   if (auto cache = IGF.tryGetLocalTypeMetadata(theType, request))
     return cache;
 
+  if (IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+    MetadataResponse response = emitNominalPrespecializedGenericMetadataRef(
+        IGF, theDecl, theType, request, CanonicalSpecializedMetadata);
+    IGF.setScopedLocalTypeMetadata(theType, response);
+    return response;
+  }
+
   // Grab the substitutions.
   GenericArguments genericArgs;
   genericArgs.collect(IGF, theType);
@@ -3322,7 +3329,8 @@ IRGenFunction::emitTypeMetadataRef(CanType type,
   
   if (type->hasArchetype() ||
       !shouldTypeMetadataAccessUseAccessor(IGM, type) ||
-      isa<PackType>(type)) {
+      isa<PackType>(type) ||
+      type->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
     return emitDirectTypeMetadataRef(*this, type, request);
   }
 
@@ -3911,6 +3919,11 @@ llvm::Value *irgen::emitClassHeapMetadataRef(IRGenFunction &IGF, CanType type,
         result = IGF.Builder.CreateBitCast(result, IGF.IGM.TypeMetadataPtrTy);
       return result;
     }
+  }
+
+  if (IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+    llvm::Constant *result = IGF.IGM.getAddrOfTypeMetadata(type);
+    return result;
   }
 
   llvm::Value *result = IGF.emitTypeMetadataRef(type, request).getMetadata();

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -546,6 +546,15 @@ SILMoveOnlyDeinit *SILModule::lookUpMoveOnlyDeinit(const NominalTypeDecl *C,
   return tbl;
 }
 
+SILVTable *SILModule::lookUpSpecializedVTable(SILType classTy) {
+  // First try to look up R from the lookup table.
+  auto R = SpecializedVTableMap.find(classTy);
+  if (R != SpecializedVTableMap.end())
+    return R->second;
+
+  return nullptr;
+}
+
 SerializedSILLoader *SILModule::getSILLoader() {
   // If the SILLoader is null, create it.
   if (!SILLoader)

--- a/lib/SIL/IR/SILVTable.cpp
+++ b/lib/SIL/IR/SILVTable.cpp
@@ -42,9 +42,10 @@ SILVTable *SILVTable::create(SILModule &M, ClassDecl *Class, SILType classType,
   auto buf = M.allocate(size, alignof(SILVTable));
   SILVTable *vt = ::new (buf) SILVTable(Class, classType, Serialized, Entries);
   M.vtables.push_back(vt);
-  M.VTableMap[Class] = vt;
   if (vt->isSpecialized())
     M.SpecializedVTableMap[classType] = vt;
+  else
+    M.VTableMap[Class] = vt;
   // Update the Module's cache with new vtable + vtable entries:
   for (const Entry &entry : Entries) {
     M.VTableEntryCache.insert({{vt, entry.getMethod()}, entry});

--- a/lib/SIL/IR/SILVTable.cpp
+++ b/lib/SIL/IR/SILVTable.cpp
@@ -23,14 +23,28 @@
 
 using namespace swift;
 
+void SILVTableEntry::setImplementation(SILFunction *f) {
+  getImplementation()->decrementRefCount();
+  ImplAndKind.setPointer(f);
+  f->incrementRefCount();
+}
+
 SILVTable *SILVTable::create(SILModule &M, ClassDecl *Class,
+                              IsSerialized_t Serialized,
+                              ArrayRef<Entry> Entries) {
+  return create(M, Class, SILType(), Serialized, Entries);
+}
+
+SILVTable *SILVTable::create(SILModule &M, ClassDecl *Class, SILType classType,
                              IsSerialized_t Serialized,
                              ArrayRef<Entry> Entries) {
   auto size = totalSizeToAlloc<Entry>(Entries.size());
   auto buf = M.allocate(size, alignof(SILVTable));
-  SILVTable *vt = ::new (buf) SILVTable(Class, Serialized, Entries);
+  SILVTable *vt = ::new (buf) SILVTable(Class, classType, Serialized, Entries);
   M.vtables.push_back(vt);
   M.VTableMap[Class] = vt;
+  if (vt->isSpecialized())
+    M.SpecializedVTableMap[classType] = vt;
   // Update the Module's cache with new vtable + vtable entries:
   for (const Entry &entry : Entries) {
     M.VTableEntryCache.insert({{vt, entry.getMethod()}, entry});
@@ -60,9 +74,9 @@ void SILVTable::updateVTableCache(const Entry &entry) {
   M.VTableEntryCache[{this, entry.getMethod()}] = entry;
 }
 
-SILVTable::SILVTable(ClassDecl *c, IsSerialized_t serialized,
+SILVTable::SILVTable(ClassDecl *c, SILType classType, IsSerialized_t serialized,
                      ArrayRef<Entry> entries)
-  : Class(c), Serialized(serialized), NumEntries(entries.size()) {
+  : Class(c), classType(classType), Serialized(serialized), NumEntries(entries.size()) {
   std::uninitialized_copy(entries.begin(), entries.end(),
                           getTrailingObjects<Entry>());
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7106,7 +7106,7 @@ void SILModule::verify(SILPassManager *passManager,
   llvm::DenseSet<ClassDecl*> vtableClasses;
   unsigned EntriesSZ = 0;
   for (const auto &vt : getVTables()) {
-    if (!vtableClasses.insert(vt->getClass()).second) {
+    if (!vt->isSpecialized() && !vtableClasses.insert(vt->getClass()).second) {
       llvm::errs() << "Vtable redefined: " << vt->getClass()->getName() << "!\n";
       assert(false && "triggering standard assertion failure routine");
     }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6923,7 +6923,8 @@ void SILVTable::verify(const SILModule &M) const {
       entry.getMethod().print(os);
     }
 
-    if (M.getStage() != SILStage::Lowered) {
+    if (M.getStage() != SILStage::Lowered &&
+        !M.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
       SILVerifier(*entry.getImplementation(), /*passManager=*/nullptr,
                                               /*SingleFunction=*/true,
                                               /*checkLinearLifetime=*/ false)

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -234,6 +234,9 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // occur before IRGen.
   P.addMoveOnlyTypeEliminator();
 
+  // For embedded Swift: Specialize generic class vtables.
+  P.addVTableSpecializer();
+
   P.addMandatoryPerformanceOptimizations();
   P.addOnoneSimplification();
   P.addInitializeStaticGlobals();
@@ -1006,9 +1009,6 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
 
   // For embedded Swift: CMO is used to serialize libraries.
   P.addCrossModuleOptimization();
-
-  // For embedded Swift: Specialize generic class vtables.
-  P.addVTableSpecializer();
 
   // First serialize the SIL if we are asked to.
   P.startPipeline("Serialization");

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -1007,6 +1007,9 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   // For embedded Swift: CMO is used to serialize libraries.
   P.addCrossModuleOptimization();
 
+  // For embedded Swift: Specialize generic class vtables.
+  P.addVTableSpecializer();
+
   // First serialize the SIL if we are asked to.
   P.startPipeline("Serialization");
   P.addSerializeSILPass();

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -37,4 +37,5 @@ target_sources(swiftSILOptimizer PRIVATE
   SpeculativeDevirtualizer.cpp
   StringOptimization.cpp
   TempLValueOpt.cpp
-  TempRValueElimination.cpp)
+  TempRValueElimination.cpp
+  VTableSpecializer.cpp)

--- a/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
@@ -1,0 +1,240 @@
+//===--- VTableSpecializer.cpp - Specialization of vtables ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Specialize vtables of generic classes for embedded Swift.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-vtable-specializer"
+
+#include "llvm/ADT/SmallVector.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/SIL/OptimizationRemark.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
+#include "swift/SILOptimizer/Utils/ConstantFolding.h"
+#include "swift/SILOptimizer/Utils/Devirtualize.h"
+#include "swift/SILOptimizer/Utils/Generics.h"
+#include "swift/SILOptimizer/Utils/InstructionDeleter.h"
+#include "swift/SILOptimizer/Utils/SILInliner.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+#include "swift/SILOptimizer/Utils/StackNesting.h"
+
+using namespace swift;
+
+namespace {
+
+class VTableSpecializer : public SILModuleTransform {
+  bool specializeVTables(SILModule &module);
+  bool specializeVTableFor(AllocRefInst *allocRef, SILModule &module);
+  SILFunction *specializeVTableMethod(SILFunction *origMethod,
+                                      SubstitutionMap subs, SILModule &module);
+  bool specializeClassMethodInst(ClassMethodInst *cm);
+
+  /// The entry point to the transformation.
+  void run() override {
+    SILModule &module = *getModule();
+
+    if (!module.getASTContext().LangOpts.hasFeature(Feature::Embedded)) return;
+
+    LLVM_DEBUG(llvm::dbgs() << "***** VTableSpecializer\n");
+
+    if (specializeVTables(module)) invalidateFunctionTables();
+  }
+};
+
+}  // end anonymous namespace
+
+bool VTableSpecializer::specializeVTables(SILModule &module) {
+  bool changed = false;
+  for (SILFunction &func : module) {
+    if (func.getLoweredFunctionType()->isPolymorphic()) continue;
+
+    for (SILBasicBlock &block : func) {
+      for (SILInstruction &inst : block) {
+        if (auto *allocRef = dyn_cast<AllocRefInst>(&inst)) {
+          changed |= specializeVTableFor(allocRef, module);
+          continue;
+        }
+        if (auto *cm = dyn_cast<ClassMethodInst>(&inst)) {
+          changed |= specializeClassMethodInst(cm);
+          continue;
+        }
+      }
+    }
+  }
+
+  for (SILVTable *vtable : module.getVTables()) {
+    if (vtable->getClass()->isGenericContext()) continue;
+
+    for (SILVTableEntry &entry : vtable->getMutableEntries()) {
+      SILFunction *method = entry.getImplementation();
+      if (!method->getLoweredFunctionType()->isPolymorphic()) continue;
+
+      if (entry.getKind() != SILVTableEntry::Kind::Inherited) {
+        vtable->dump();
+        entry.getMethod().dump();
+      }
+      assert(entry.getKind() == SILVTableEntry::Kind::Inherited);
+      Decl *classOfMethod =
+          entry.getMethod().getDecl()->getDeclContext()->getAsDecl();
+      SILType classTy = vtable->getClassType();
+      while (classTy.getClassOrBoundGenericClass() != classOfMethod) {
+        classTy = classTy.getSuperclass();
+      }
+      auto *classDecl = cast<ClassDecl>(classOfMethod);
+      SubstitutionMap subs = classTy.getASTType()->getContextSubstitutionMap(
+          classDecl->getParentModule(), classDecl);
+
+      SILFunction *specializedMethod =
+          specializeVTableMethod(method, subs, module);
+      entry.setImplementation(specializedMethod);
+      vtable->updateVTableCache(entry);
+    }
+  }
+
+  return changed;
+}
+
+bool VTableSpecializer::specializeVTableFor(AllocRefInst *allocRef,
+                                            SILModule &module) {
+  SILType classTy = allocRef->getType();
+  CanType astType = classTy.getASTType();
+  BoundGenericClassType *genClassTy = dyn_cast<BoundGenericClassType>(astType);
+  if (!genClassTy) return false;
+
+  if (module.lookUpSpecializedVTable(classTy)) return false;
+
+  LLVM_DEBUG(llvm::dbgs() << "specializeVTableFor "
+                          << genClassTy->getDecl()->getName() << '\n');
+
+  ClassDecl *classDecl = genClassTy->getDecl();
+  SILVTable *origVtable = module.lookUpVTable(classDecl);
+  if (!origVtable) {
+    llvm::errs() << "No vtable available for "
+                 << genClassTy->getDecl()->getName() << '\n';
+    llvm::report_fatal_error("no vtable");
+  }
+
+  SubstitutionMap subs = astType->getContextSubstitutionMap(
+      classDecl->getParentModule(), classDecl);
+
+  llvm::SmallVector<SILVTableEntry, 8> newEntries;
+
+  for (const SILVTableEntry &entry : origVtable->getEntries()) {
+    SILFunction *origMethod = entry.getImplementation();
+    SILFunction *specializedMethod =
+        specializeVTableMethod(origMethod, subs, module);
+    newEntries.push_back(SILVTableEntry(entry.getMethod(), specializedMethod,
+                                        entry.getKind(),
+                                        entry.isNonOverridden()));
+  }
+
+  SILVTable::create(module, classDecl, classTy, IsNotSerialized, newEntries);
+  return true;
+}
+
+SILFunction *VTableSpecializer::specializeVTableMethod(SILFunction *origMethod,
+                                                       SubstitutionMap subs,
+                                                       SILModule &module) {
+  LLVM_DEBUG(llvm::dbgs() << "specializeVTableMethod " << origMethod->getName()
+                          << '\n');
+
+  if (!origMethod->getLoweredFunctionType()->isPolymorphic()) return origMethod;
+
+  LLVM_DEBUG(llvm::dbgs() << "specializeVTableMethod " << origMethod->getName()
+                          << '\n');
+
+  ReabstractionInfo ReInfo(module.getSwiftModule(), module.isWholeModule(),
+                           ApplySite(), origMethod, subs, IsNotSerialized,
+                           /*ConvertIndirectToDirect=*/true,
+                           /*dropMetatypeArgs=*/false);
+
+  if (!ReInfo.canBeSpecialized()) {
+    llvm::errs() << "Cannot specialize vtable method " << origMethod->getName()
+                 << '\n';
+    llvm::report_fatal_error("cannot specialize vtable method");
+  }
+
+  SILOptFunctionBuilder FunctionBuilder(*this);
+
+  GenericFuncSpecializer FuncSpecializer(FunctionBuilder, origMethod, subs,
+                                         ReInfo, /*isMandatory=*/true);
+  SILFunction *SpecializedF = FuncSpecializer.lookupSpecialization();
+  if (!SpecializedF) SpecializedF = FuncSpecializer.tryCreateSpecialization();
+  if (!SpecializedF || SpecializedF->getLoweredFunctionType()->hasError()) {
+    llvm::errs()
+        << "Cannot specialize vtable method " << origMethod->getName() << '\n'
+        << "Generic class methods are not supported in embedded mode\n";
+    llvm::report_fatal_error("cannot specialize vtable method");
+  }
+
+  // Link after specializing to pull in everything referenced from another
+  // module in case some referenced functions have non-public linkage.
+  module.linkFunction(SpecializedF, SILModule::LinkingMode::LinkAll);
+
+  SpecializedF->setLinkage(SILLinkage::Public);
+  SpecializedF->setSerialized(IsNotSerialized);
+
+  return SpecializedF;
+}
+
+bool VTableSpecializer::specializeClassMethodInst(ClassMethodInst *cm) {
+  SILValue instance = cm->getOperand();
+  SILType classTy = instance->getType();
+  CanType astType = classTy.getASTType();
+  BoundGenericClassType *genClassTy = dyn_cast<BoundGenericClassType>(astType);
+  if (!genClassTy) return false;
+
+  ClassDecl *classDecl = genClassTy->getDecl();
+  SubstitutionMap subs = astType->getContextSubstitutionMap(
+      classDecl->getParentModule(), classDecl);
+
+  SILType funcTy = cm->getType();
+
+  SILFunction *f = cm->getFunction();
+  SILModule &m = f->getModule();
+  SILType substitutedType =
+      funcTy.substGenericArgs(m, subs, TypeExpansionContext::minimal());
+
+  ReabstractionInfo reInfo(substitutedType.getAs<SILFunctionType>(), m);
+  reInfo.createSubstitutedAndSpecializedTypes();
+  CanSILFunctionType finalFuncTy = reInfo.getSpecializedType();
+  SILType finalSILTy = SILType::getPrimitiveObjectType(finalFuncTy);
+
+  SILBuilder builder(cm);
+  auto *newCM = builder.createClassMethod(cm->getLoc(), cm->getOperand(),
+                                          cm->getMember(), finalSILTy);
+
+  while (!cm->use_empty()) {
+    Operand *use = *cm->use_begin();
+    SILInstruction *user = use->getUser();
+    ApplySite AI = ApplySite::isa(user);
+    if (AI && AI.getCalleeOperand() == use) {
+      replaceWithSpecializedCallee(AI, newCM, reInfo);
+      AI.getInstruction()->eraseFromParent();
+      continue;
+    }
+    llvm::errs() << "unsupported use of class method "
+                 << newCM->getMember().getDecl()->getName() << " in function "
+                 << newCM->getFunction()->getName() << '\n';
+    llvm::report_fatal_error("unsupported class method");
+  }
+
+  return true;
+}
+
+SILTransform *swift::createVTableSpecializer() {
+  return new VTableSpecializer();
+}

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -256,60 +256,6 @@ public:
   }
 };
 
-class TypeReplacements {
-private:
-  llvm::Optional<SILType> resultType;
-  llvm::MapVector<unsigned, CanType> indirectResultTypes;
-  llvm::MapVector<unsigned, CanType> paramTypeReplacements;
-  llvm::MapVector<unsigned, CanType> yieldTypeReplacements;
-
-public:
-  llvm::Optional<SILType> getResultType() const { return resultType; }
-
-  void setResultType(SILType type) { resultType = type; }
-
-  bool hasResultType() const { return resultType.has_value(); }
-
-  const llvm::MapVector<unsigned, CanType> &getIndirectResultTypes() const {
-    return indirectResultTypes;
-  }
-
-  void addIndirectResultType(unsigned index, CanType type) {
-    indirectResultTypes.insert(std::make_pair(index, type));
-  }
-
-  bool hasIndirectResultTypes() const { return !indirectResultTypes.empty(); }
-
-  const llvm::MapVector<unsigned, CanType> &getParamTypeReplacements() const {
-    return paramTypeReplacements;
-  }
-
-  void addParameterTypeReplacement(unsigned index, CanType type) {
-    paramTypeReplacements.insert(std::make_pair(index, type));
-  }
-
-  bool hasParamTypeReplacements() const {
-    return !paramTypeReplacements.empty();
-  }
-
-  const llvm::MapVector<unsigned, CanType> &getYieldTypeReplacements() const {
-    return yieldTypeReplacements;
-  }
-
-  void addYieldTypeReplacement(unsigned index, CanType type) {
-    yieldTypeReplacements.insert(std::make_pair(index, type));
-  }
-
-  bool hasYieldTypeReplacements() const {
-    return !yieldTypeReplacements.empty();
-  }
-
-  bool hasTypeReplacements() const {
-    return hasResultType() || hasParamTypeReplacements() ||
-           hasIndirectResultTypes() || hasYieldTypeReplacements();
-  }
-};
-
 class SpecializedFunction {
 private:
   SILFunction *fn;
@@ -2362,10 +2308,10 @@ cleanupCallArguments(SILBuilder &builder, SILLocation loc,
 
 /// Create a new apply based on an old one, but with a different
 /// function being applied.
-static ApplySite
-replaceWithSpecializedCallee(ApplySite applySite, SILValue callee,
+ApplySite
+swift::replaceWithSpecializedCallee(ApplySite applySite, SILValue callee,
                              const ReabstractionInfo &reInfo,
-                             const TypeReplacements &typeReplacements = {}) {
+                             const TypeReplacements &typeReplacements) {
   SILBuilderWithScope builder(applySite.getInstruction());
   SILLocation loc = applySite.getLoc();
   SmallVector<SILValue, 4> arguments;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2807,6 +2807,9 @@ void SILSerializer::writeSILVTable(const SILVTable &vt) {
       vt.getClass()->getEffectiveAccess() < swift::AccessLevel::Public)
     return;
 
+  if (vt.isSpecialized())
+    return;
+
   // Use the mangled name of the class as a key to distinguish between classes
   // which have the same name (but are in different contexts).
   Mangle::ASTMangler mangler;

--- a/test/embedded/basic-modules-no-stdlib.swift
+++ b/test/embedded/basic-modules-no-stdlib.swift
@@ -4,8 +4,7 @@
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -swift-version 5 -emit-ir     -I %t                      %t/Main.swift     -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s
 
-// TODO: investigate why windows is generating more metadata.
-// XFAIL: OS=windows-msvc
+// REQUIRES: swift_in_compiler
 
 // BEGIN MyModule.swift
 

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s --check-prefix CHECK-SIL
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s --check-prefix CHECK-IR
 
 precedencegroup AssignmentPrecedence { assignment: true }
 
@@ -18,17 +19,46 @@ public func bar(t: T2) -> MyClass<T2> {
   return MyClass<T2>(t: t)
 }
 
-// CHECK: @"$s4main7MyClassCyAA2T2VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfDAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
-// CHECK: @"$s4main7MyClassCyAA2T1VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfDAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvgAA2T1V_Tg5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvsAA2T1V_Tg5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvMAA2T1V_Tg5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tgm5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassCfDAA2T1V_Tg5 {{.*}}{
 
-// CHECK: define {{.*}}void @"$s4main7MyClassC1txvgAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK: define {{.*}}void @"$s4main7MyClassC1txvsAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK: define {{.*}}ptr @"$s4main2T1VWOd"(ptr %0, ptr %1)
-// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tgm5"()
-// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tgm5"(i1 %0)
-// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T2V_Tg5"(i1 %0, ptr swiftself %1)
-// CHECK: define {{.*}}void @"$s4main7MyClassCfDAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK: define {{.*}}ptr @"$s4main3foo1tAA7MyClassCyAA2T1VGAG_tF"()
-// CHECK: define {{.*}}ptr @"$s4main3bar1tAA7MyClassCyAA2T2VGAG_tF"(i1 %0)
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvgAA2T2V_Tg5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvsAA2T2V_Tg5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1txvMAA2T2V_Tg5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tgm5 {{.*}}{
+// CHECK-SIL-DAG: sil {{.*}}@$s4main7MyClassCfDAA2T2V_Tg5 {{.*}}{
+
+// CHECK-SIL: sil_vtable MyClass {
+// CHECK-SIL:   #MyClass.t!getter: <T> (MyClass<T>) -> () -> T : @$s4main7MyClassC1txvgAA2T1V_Tg5 // specialized MyClass.t.getter
+// CHECK-SIL:   #MyClass.t!setter: <T> (MyClass<T>) -> (T) -> () : @$s4main7MyClassC1txvsAA2T1V_Tg5 // specialized MyClass.t.setter
+// CHECK-SIL:   #MyClass.t!modify: <T> (MyClass<T>) -> () -> () : @$s4main7MyClassC1txvMAA2T1V_Tg5  // specialized MyClass.t.modify
+// CHECK-SIL:   #MyClass.init!allocator: <T> (MyClass<T>.Type) -> (T) -> MyClass<T> : @$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5  // specialized MyClass.__allocating_init(t:)
+// CHECK-SIL:   #MyClass.deinit!deallocator: @$s4main7MyClassCfDAA2T1V_Tg5  // specialized MyClass.__deallocating_deinit
+// CHECK-SIL: }
+
+// CHECK-SIL: sil_vtable MyClass {
+// CHECK-SIL:   #MyClass.t!getter: <T> (MyClass<T>) -> () -> T : @$s4main7MyClassC1txvgAA2T2V_Tg5 // specialized MyClass.t.getter
+// CHECK-SIL:   #MyClass.t!setter: <T> (MyClass<T>) -> (T) -> () : @$s4main7MyClassC1txvsAA2T2V_Tg5 // specialized MyClass.t.setter
+// CHECK-SIL:   #MyClass.t!modify: <T> (MyClass<T>) -> () -> () : @$s4main7MyClassC1txvMAA2T2V_Tg5  // specialized MyClass.t.modify
+// CHECK-SIL:   #MyClass.init!allocator: <T> (MyClass<T>.Type) -> (T) -> MyClass<T> : @$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tg5  // specialized MyClass.__allocating_init(t:)
+// CHECK-SIL:   #MyClass.deinit!deallocator: @$s4main7MyClassCfDAA2T2V_Tg5  // specialized MyClass.__deallocating_deinit
+// CHECK-SIL: }
+
+
+// CHECK-IR: @"$s4main7MyClassCyAA2T2VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfDAA2T2V_Tg5", ptr @"$s4main7MyClassC1txvgAA2T2V_Tg5", ptr @"$s4main7MyClassC1txvsAA2T2V_Tg5", ptr @"$s4main7MyClassC1txvMAA2T2V_Tg5", ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tg5" }>
+// CHECK-IR: @"$s4main7MyClassCyAA2T1VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfDAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
+
+// CHECK-IR: define {{.*}}void @"$s4main7MyClassC1txvgAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR: define {{.*}}void @"$s4main7MyClassC1txvsAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR: define {{.*}}ptr @"$s4main2T1VWOd"(ptr %0, ptr %1)
+// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tgm5"()
+// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tgm5"(i1 %0)
+// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T2V_Tg5"(i1 %0, ptr swiftself %1)
+// CHECK-IR: define {{.*}}void @"$s4main7MyClassCfDAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR: define {{.*}}ptr @"$s4main3foo1tAA7MyClassCyAA2T1VGAG_tF"()
+// CHECK-IR: define {{.*}}ptr @"$s4main3bar1tAA7MyClassCyAA2T2VGAG_tF"(i1 %0)

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s --check-prefix CHECK-IR
 
+// REQUIRES: swift_in_compiler
+
 precedencegroup AssignmentPrecedence { assignment: true }
 
 public struct T1 {}
@@ -51,14 +53,17 @@ public func bar(t: T2) -> MyClass<T2> {
 // CHECK-IR: @"$s4main7MyClassCyAA2T2VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfDAA2T2V_Tg5", ptr @"$s4main7MyClassC1txvgAA2T2V_Tg5", ptr @"$s4main7MyClassC1txvsAA2T2V_Tg5", ptr @"$s4main7MyClassC1txvMAA2T2V_Tg5", ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tg5" }>
 // CHECK-IR: @"$s4main7MyClassCyAA2T1VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfDAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
 
-// CHECK-IR: define {{.*}}void @"$s4main7MyClassC1txvgAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK-IR: define {{.*}}void @"$s4main7MyClassC1txvsAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK-IR: define {{.*}}ptr @"$s4main2T1VWOd"(ptr %0, ptr %1)
-// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tgm5"()
-// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tgm5"(i1 %0)
-// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK-IR: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T2V_Tg5"(i1 %0, ptr swiftself %1)
-// CHECK-IR: define {{.*}}void @"$s4main7MyClassCfDAA2T1V_Tg5"(ptr swiftself %0)
-// CHECK-IR: define {{.*}}ptr @"$s4main3foo1tAA7MyClassCyAA2T1VGAG_tF"()
-// CHECK-IR: define {{.*}}ptr @"$s4main3bar1tAA7MyClassCyAA2T2VGAG_tF"(i1 %0)
+// CHECK-IR-DAG: define {{.*}}void @"$s4main7MyClassC1txvgAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR-DAG: define {{.*}}i1 @"$s4main7MyClassC1txvgAA2T2V_Tg5"(ptr swiftself %0)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tg5"(i1 %0, ptr swiftself %1)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tgm5"()
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tgm5"(i1 %0)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T2V_Tg5"(i1 %0, ptr swiftself %1)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassCfdAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main7MyClassCfdAA2T2V_Tg5"(ptr swiftself %0)
+// CHECK-IR-DAG: define {{.*}}void @"$s4main7MyClassCfDAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK-IR-DAG: define {{.*}}void @"$s4main7MyClassCfDAA2T2V_Tg5"(ptr swiftself %0)
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main3foo1tAA7MyClassCyAA2T1VGAG_tF"()
+// CHECK-IR-DAG: define {{.*}}ptr @"$s4main3bar1tAA7MyClassCyAA2T2VGAG_tF"(i1 %0)

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none | %FileCheck %s
+
+precedencegroup AssignmentPrecedence { assignment: true }
+
+public struct T1 {}
+public struct T2 { var x: Builtin.Int1 }
+
+public class MyClass<T> {
+  var t: T
+  init(t: T) { self.t = t }
+}
+
+public func foo(t: T1) -> MyClass<T1> {
+  return MyClass<T1>(t: t)
+}
+
+public func bar(t: T2) -> MyClass<T2> {
+  return MyClass<T2>(t: t)
+}
+
+// CHECK: @"$s4main7MyClassCyAA2T2VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfDAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
+// CHECK: @"$s4main7MyClassCyAA2T1VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfDAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$s4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
+
+// CHECK: define {{.*}}void @"$s4main7MyClassC1txvgAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK: define {{.*}}void @"$s4main7MyClassC1txvsAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK: define {{.*}}ptr @"$s4main2T1VWOd"(ptr %0, ptr %1)
+// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tgm5"()
+// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T2V_Tgm5"(i1 %0)
+// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK: define {{.*}}ptr @"$s4main7MyClassC1tACyxGx_tcfcAA2T2V_Tg5"(i1 %0, ptr swiftself %1)
+// CHECK: define {{.*}}void @"$s4main7MyClassCfDAA2T1V_Tg5"(ptr swiftself %0)
+// CHECK: define {{.*}}ptr @"$s4main3foo1tAA7MyClassCyAA2T1VGAG_tF"()
+// CHECK: define {{.*}}ptr @"$s4main3bar1tAA7MyClassCyAA2T2VGAG_tF"(i1 %0)

--- a/test/embedded/classes-methods-no-stdlib.swift
+++ b/test/embedded/classes-methods-no-stdlib.swift
@@ -25,7 +25,6 @@ public func test(x: MyClass) {
   // CHECK: call swiftcc void @"$s4main7MyClassC3baryyF"
 
   let y = MySubClass()
-  // CHECK: call swiftcc %swift.metadata_response @"$s4main10MySubClassCMa"
   // CHECK: call swiftcc ptr @"$s4main10MySubClassCACycfC"
 
   y.foo() // does not go through the vtable

--- a/test/embedded/classes-no-stdlib.swift
+++ b/test/embedded/classes-no-stdlib.swift
@@ -7,7 +7,6 @@ public class MyClass {}
 // CHECK-DAG: define {{.*}}void @"$s4main7MyClassCfD"
 // CHECK-DAG: define {{.*}}ptr @"$s4main7MyClassCACycfC"
 // CHECK-DAG: define {{.*}}ptr @"$s4main7MyClassCACycfc"
-// CHECK-DAG: define {{.*}}%swift.metadata_response @"$s4main7MyClassCMa"
 
 public func foo() -> MyClass {
   return MyClass()
@@ -21,7 +20,6 @@ public class MySubClass: MyClass {}
 // CHECK-DAG: define {{.*}}ptr @"$s4main10MySubClassCACycfc"
 // CHECK-DAG: define {{.*}}ptr @"$s4main10MySubClassCfd"
 // CHECK-DAG: define {{.*}}void @"$s4main10MySubClassCfD"
-// CHECK-DAG: define {{.*}}%swift.metadata_response @"$s4main10MySubClassCMa"
 
 public func bar() -> MyClass {
   return MySubClass()

--- a/test/embedded/classes-non-final-method-no-stdlib.swift
+++ b/test/embedded/classes-non-final-method-no-stdlib.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-emit-ir -verify %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none
+
+public class MyClass {
+  func foo<T>(t: T) { } // expected-error {{classes cannot have non-final generic fuctions in embedded Swift}}
+  func bar() { }
+}


### PR DESCRIPTION
- VTableSpecializer, a new pass that synthesizes a new vtable per each observed concrete type used
- Don't use full type metadata refs in embedded Swift
- Lazily emit specialized class metadata (LazySpecializedClassMetadata) in IRGen
- Don't emit regular class metadata for a class decl if it's generic (only emit the specialized metadata)
- Does not (yet?) support downcasts (`as?`) of class instances