### PR TITLE
[5.9] [Test] Reenabled xfail'd test.

### DIFF
--- a/test/attr/attr_originally_definedin_backward_compatibility.swift
+++ b/test/attr/attr_originally_definedin_backward_compatibility.swift
@@ -1,8 +1,6 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=ios
 // UNSUPPORTED: DARWIN_SIMULATOR=ios
-// rdar://problem/64298096
-// XFAIL: OS=ios && CPU=arm64
 // rdar://problem/65399527
 // XFAIL: OS=ios && CPU=armv7s
 //


### PR DESCRIPTION
*5.9 cherry-pick of https://github.com/apple/swift/pull/68176*

- Explanation: Remove an XFAIL for a test that's now passing on that configuration
- Scope: Test-only change
- Issue: rdar://65399527
- Risk: None
- Testing: Added tests to test suite
- Reviewer: Nate Chandler