### PR TITLE
Include variant in AdjointValue.h

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/AdjointValue.h
+++ b/include/swift/SILOptimizer/Differentiation/AdjointValue.h
@@ -25,6 +25,8 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Debug.h"
 
+#include <variant>
+
 namespace swift {
 namespace autodiff {
 


### PR DESCRIPTION
d971f125d966 added a usage of std::variant and std::holds_alternative to SILOptimizer/Differentiation/AdjointValue.h, but did not include variant directly. This caused issues while building on Linux.

Failing run: https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch-RA-linux-ubuntu-18_04/3239/

```
/home/build-user/swift/include/swift/SILOptimizer/Differentiation/AdjointValue.h:234:8: error: no template named 'variant' in namespace 'std'
  std::variant<unsigned int, VarDecl *> inner;
  ~~~~~^
/home/build-user/swift/include/swift/SILOptimizer/Differentiation/AdjointValue.h:218:17: error: no member named 'holds_alternative' in namespace 'std'
    return std::holds_alternative<unsigned int>(inner);
           ~~~~~^
/home/build-user/swift/include/swift/SILOptimizer/Differentiation/AdjointValue.h:218:44: error: expected '(' for function-style cast or type construction
    return std::holds_alternative<unsigned int>(inner);
                                  ~~~~~~~~ ^
/home/build-user/swift/include/swift/SILOptimizer/Differentiation/AdjointValue.h:234:41: warning: private field 'inner' is not used [-Wunused-private-field]
  std::variant<unsigned int, VarDecl *> inner;
                                        ^
```
