### PR TITLE
[5.10][build-script] Install 'earlyswiftsyntax' if 'install-swift' is off

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -73,10 +73,10 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
         pass
 
     def should_install(self, host_target):
-        # The artifacts are copied to build directory of 'swift' and are
-        # installed as a part of 'swift' product.
-        return False
+        # When '--install-swift' is enabled, earlyswiftsyntax libraries are installed
+        # from 'swift' product.
+        return (self.should_build(host_target) and self.args.install_swiftsyntax and
+                "--install-swift" not in self.args.build_script_impl_args)
 
     def install(self, host_target):
-        # No-op.
-        pass
+        self.install_with_cmake(["install"], self.host_install_destdir(host_target))


### PR DESCRIPTION
Cherry-pick #68462 into `release/5.10`

* **Explanation**: Some build scenarios (e.g. lldb) want swift-syntax libraries be installed, but don't want to install "swift" compiler products. Install `earlyswiftsyntax` products independently when `--install-swiftsyntax` is specified but `--install-swift` is NOT specified.
* **Scope**: Build system
* **Risk**: Low, this doesn't affect majority of build presets.
* **Testing**: Passes current test suite
* **Isssues**: TBA
* **Reviewer**: Ben Barham (@bnbarham)