### PR TITLE
Sema: Improve diagnostics logic for references to imported decl behind a restrictive import

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2783,6 +2783,16 @@ public:
                         bool forConformance = false,
                         bool allowUsableFromInline = false) const;
 
+  using ImportAccessLevel = llvm::Optional<AttributedImport<ImportedModule>>;
+
+  /// Returns the import that may restrict the access to this decl
+  /// from \p useDC.
+  ///
+  /// If this decl and \p useDC are from the same module it returns
+  /// \c llvm::None. If there are many imports, it returns the most
+  /// permissive one.
+  ImportAccessLevel getImportAccessFrom(const DeclContext *useDC) const;
+
   /// Returns whether this declaration should be treated as \c open from
   /// \p useDC. This is very similar to #getFormalAccess, but takes
   /// \c \@testable into account.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2332,12 +2332,12 @@ ERROR(access_level_conflict_with_exported,none,
       (DeclAttribute, DeclAttribute))
 NOTE(module_imported_here,none,
      "module %0 imported as '%select{private|fileprivate|internal|package|%ERROR|%ERROR}1' here",
-     (Identifier, AccessLevel))
+     (const ModuleDecl*, AccessLevel))
 NOTE(decl_import_via_here,none,
      "%kind0 imported as "
      "'%select{private|fileprivate|internal|package|%ERROR|%ERROR}1' "
      "from %2 here",
-     (const ValueDecl *, AccessLevel, Identifier))
+     (const ValueDecl *, AccessLevel, const ModuleDecl*))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4326,6 +4326,16 @@ bool ValueDecl::isAccessibleFrom(const DeclContext *useDC,
                      [&]() { return getFormalAccess(); });
 }
 
+ImportAccessLevel ValueDecl::getImportAccessFrom(const DeclContext *useDC) const {
+  ModuleDecl *Mod = getModuleContext();
+  if (useDC && useDC->getParentModule() != Mod) {
+    if (auto useSF = useDC->getParentSourceFile()) {
+      return useSF->getImportAccessLevel(Mod);
+    }
+  }
+  return llvm::None;
+}
+
 bool AbstractStorageDecl::isSetterAccessibleFrom(const DeclContext *DC,
                                                  bool forConformance) const {
   assert(isSettable(DC));

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4062,6 +4062,16 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
     resultDC = resultDC->getParent();
   }
 
+  auto localImportRestriction = VD->getImportAccessFrom(useDC);
+  if (localImportRestriction.has_value()) {
+    AccessLevel importAccessLevel =
+      localImportRestriction.value().accessLevel;
+    if (access > importAccessLevel) {
+      access = std::min(access, importAccessLevel);
+      resultDC = useDC->getParentSourceFile();
+    }
+  }
+
   switch (access) {
   case AccessLevel::Private:
   case AccessLevel::FilePrivate:

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3155,6 +3155,7 @@ bool SourceFile::hasTestableOrPrivateImport(
   case AccessLevel::Internal:
   case AccessLevel::Package:
   case AccessLevel::Public:
+  case AccessLevel::Open:
     // internal/public access only needs an import marked as @_private. The
     // filename does not need to match (and we don't serialize it for such
     // decls).
@@ -3173,8 +3174,6 @@ bool SourceFile::hasTestableOrPrivateImport(
                    desc.options.contains(ImportFlags::PrivateImport);
           }
         });
-  case AccessLevel::Open:
-    return true;
   case AccessLevel::FilePrivate:
   case AccessLevel::Private:
     // Fallthrough.

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -192,7 +192,6 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     return;
 
   AccessScope problematicAccessScope = AccessScope::getPublic();
-  ImportAccessLevel problematicImport = llvm::None;
 
   if (type) {
     llvm::Optional<AccessScope> typeAccessScope =
@@ -263,8 +262,16 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
   const TypeRepr *complainRepr = TypeAccessScopeDiagnoser::findTypeWithScope(
       typeRepr, problematicAccessScope, useDC, checkUsableFromInline);
 
+  ImportAccessLevel complainImport = llvm::None;
+  if (complainRepr) {
+    const ValueDecl *VD =
+      static_cast<const IdentTypeRepr*>(complainRepr)->getBoundDecl();
+    assert(VD && "findTypeWithScope should return bound TypeReprs only");
+    complainImport = VD->getImportAccessFrom(useDC);
+  }
+
   diagnose(problematicAccessScope, complainRepr, downgradeToWarning,
-           problematicImport);
+           complainImport);
 }
 
 /// Checks if the access scope of the type described by \p TL is valid for the

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -330,11 +330,11 @@ static void noteLimitingImport(ASTContext &ctx,
                        diag::decl_import_via_here,
                        VD,
                        limitImport->accessLevel,
-                       limitImport->module.importedModule->getName());
+                       limitImport->module.importedModule);
   } else {
-   ctx.Diags.diagnose(limitImport->accessLevelLoc, diag::module_imported_here,
-                      limitImport->module.importedModule->getName(),
-                      limitImport->accessLevel);
+    ctx.Diags.diagnose(limitImport->accessLevelLoc, diag::module_imported_here,
+                       limitImport->module.importedModule,
+                       limitImport->accessLevel);
   }
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3430,8 +3430,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
         // non-resilient modules.
         llvm::Optional<AccessScope> underlyingTypeScope =
             TypeAccessScopeChecker::getAccessScope(type, DC,
-                                                   /*usableFromInline*/ false)
-                .Scope;
+                                                   /*usableFromInline*/ false);
         assert(underlyingTypeScope.has_value() &&
                "the type is already invalid and we shouldn't have gotten here");
 

--- a/test/Sema/access-level-import-diag-priority.swift
+++ b/test/Sema/access-level-import-diag-priority.swift
@@ -1,7 +1,7 @@
 /// Report the most restricted types when many types are problematic.
 
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
+// RUN: split-file --leading-lines %s %t
 
 /// Build the libraries.
 // RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t
@@ -37,11 +37,11 @@ public struct PrivateImportType {}
 public import PublicLib
 package import PackageLib // expected-note {{struct 'PackageImportType' imported as 'package' from 'PackageLib' here}}
 internal import InternalLib // expected-note {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
-fileprivate import FileprivateLib // expected-note 2 {{struct 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
-private import PrivateLib // expected-note 2 {{struct 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
+fileprivate import FileprivateLib // expected-note 3 {{struct 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
+private import PrivateLib // expected-note 1 {{struct 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
 
 /// Simple ordering
-public func publicFuncUsesPrivate(_ a: PublicImportType, b: PackageImportType, c: InternalImportType, d: FileprivateImportType, e: PrivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a private type}}
+public func publicFuncUsesPrivate(_ a: PublicImportType, b: PackageImportType, c: InternalImportType, d: FileprivateImportType, e: PrivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}
     var _: PrivateImportType
 }
 public func publicFuncUsesFileprivate(_ a: PublicImportType, b: PackageImportType, c: InternalImportType, d: FileprivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}

--- a/test/Sema/access-level-import-exportability.swift
+++ b/test/Sema/access-level-import-exportability.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
+// RUN: split-file --leading-lines %s %t
 
 /// Build the libraries.
 // RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t \
@@ -129,7 +129,7 @@ public func PublicFuncUsesInternal(_: InternalImportType) { // expected-error {{
     var _: InternalImportType
 }
 
-public class PublicSubclassFilepriovate : FileprivateImportClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
+public class PublicSubclassFileprivate : FileprivateImportClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
 
 /// More complete test.
 //--- CompletenessClient.swift
@@ -207,7 +207,7 @@ fileprivate func FileprivateFuncUsesInternal(_: InternalImportType) {
 fileprivate func FileprivateFuncUsesFileprivate(_: FileprivateImportType) {
     var _: FileprivateImportType
 }
-fileprivate func FileprivateFuncUsesPrivate(_: PrivateImportType) { // expected-error {{function cannot be declared fileprivate because its parameter uses a private type}}
+fileprivate func FileprivateFuncUsesPrivate(_: PrivateImportType) {
     var _: PrivateImportType
 }
 
@@ -291,7 +291,7 @@ fileprivate func FileprivateFuncReturnUsesInternal() -> InternalImportType {
 fileprivate func FileprivateFuncReturnUsesFileprivate() -> FileprivateImportType {
     fatalError()
 }
-fileprivate func FileprivateFuncReturnUsesPrivate() -> PrivateImportType { // expected-error {{function cannot be declared fileprivate because its result uses a private type}}
+fileprivate func FileprivateFuncReturnUsesPrivate() -> PrivateImportType {
     fatalError()
 }
 
@@ -415,7 +415,7 @@ fileprivate struct FileprivateSubscriptUsesFileprivate {
     }
 }
 fileprivate struct FileprivateSubscriptUsesPrivate {
-    fileprivate subscript(index: PrivateImportType) -> PrivateImportType { // expected-error {{subscript cannot be declared fileprivate because its index uses a private type}}
+    fileprivate subscript(index: PrivateImportType) -> PrivateImportType {
         fatalError()
     }
 }
@@ -462,7 +462,7 @@ public protocol PublicProtoRefinesPrivate: PrivateImportProto {} // expected-err
 public class PublicSubclassPublic : PublicImportClass {}
 public class PublicSubclassPackage : PackageImportClass {} // expected-error {{class cannot be declared public because its superclass is package}}
 public class PublicSubclassInternal : InternalImportClass {} // expected-error {{class cannot be declared public because its superclass is internal}}
-public class PublicSubclassFilepriovate : FileprivateImportClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
+public class PublicSubclassFileprivate : FileprivateImportClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
 public class PublicSubclassPrivate : PrivateImportClass {} // expected-error {{class cannot be declared public because its superclass is private}}
 
 
@@ -481,7 +481,7 @@ package protocol PackageProtoRefinesPrivate: PrivateImportProto {} // expected-e
 package class PackageSubclassPublic : PublicImportClass {}
 package class PackageSubclassPackage : PackageImportClass {}
 package class PackageSubclassInternal : InternalImportClass {} // expected-error {{class cannot be declared package because its superclass is internal}}
-package class PackageSubclassFilepriovate : FileprivateImportClass {} // expected-error {{class cannot be declared package because its superclass is fileprivate}}
+package class PackageSubclassFileprivate : FileprivateImportClass {} // expected-error {{class cannot be declared package because its superclass is fileprivate}}
 package class PackageSubclassPrivate : PrivateImportClass {} // expected-error {{class cannot be declared package because its superclass is private}}
 
 
@@ -500,7 +500,7 @@ internal protocol InternalProtoRefinesPrivate: PrivateImportProto {} // expected
 internal class InternalSubclassPublic : PublicImportClass {}
 internal class InternalSubclassPackage : PackageImportClass {}
 internal class InternalSubclassInternal : InternalImportClass {}
-internal class InternalSubclassFilepriovate : FileprivateImportClass {} // expected-error {{class cannot be declared internal because its superclass is fileprivate}}
+internal class InternalSubclassFileprivate : FileprivateImportClass {} // expected-error {{class cannot be declared internal because its superclass is fileprivate}}
 internal class InternalSubclassPrivate : PrivateImportClass {} // expected-error {{class cannot be declared internal because its superclass is private}}
 
 
@@ -508,19 +508,19 @@ fileprivate protocol FileprivateProtoUsesPublic: PublicImportProto where T == Pu
 fileprivate protocol FileprivateProtoWherePackage: PublicImportProto where T == PackageImportType {}
 fileprivate protocol FileprivateProtoWhereInternal: PublicImportProto where T == InternalImportType {}
 fileprivate protocol FileprivateProtoWhereFileprivate: PublicImportProto where T == FileprivateImportType {}
-fileprivate protocol FileprivateProtoWherePrivate: PublicImportProto where T == PrivateImportType {} // expected-error {{fileprivate protocol's 'where' clause cannot use a private struct}}
+fileprivate protocol FileprivateProtoWherePrivate: PublicImportProto where T == PrivateImportType {}
 
 fileprivate protocol FileprivateProtoRefinesPublic: PublicImportProto {}
 fileprivate protocol FileprivateProtoRefinesPackage: PackageImportProto {}
 fileprivate protocol FileprivateProtoRefinesInternal: InternalImportProto {}
 fileprivate protocol FileprivateProtoRefinesFileprivate: FileprivateImportProto {}
-fileprivate protocol FileprivateProtoRefinesPrivate: PrivateImportProto {} // expected-error {{fileprivate protocol cannot refine a private protocol}}
+fileprivate protocol FileprivateProtoRefinesPrivate: PrivateImportProto {}
 
 fileprivate class FileprivateSubclassPublic : PublicImportClass {}
 fileprivate class FileprivateSubclassPackage : PackageImportClass {}
 fileprivate class FileprivateSubclassInternal : InternalImportClass {}
-fileprivate class FileprivateSubclassFilepriovate : FileprivateImportClass {}
-fileprivate class FileprivateSubclassPrivate : PrivateImportClass {} // expected-error {{class cannot be declared fileprivate because its superclass is private}}
+fileprivate class FileprivateSubclassFileprivate : FileprivateImportClass {}
+fileprivate class FileprivateSubclassPrivate : PrivateImportClass {}
 
 
 private protocol PrivateProtoUsesPublic: PublicImportProto where T == PublicImportType {}
@@ -538,7 +538,7 @@ private protocol PrivateProtoRefinesPrivate: PrivateImportProto {}
 private class PrivateSubclassPublic : PublicImportClass {}
 private class PrivateSubclassPackage : PackageImportClass {}
 private class PrivateSubclassInternal : InternalImportClass {}
-private class PrivateSubclassFilepriovate : FileprivateImportClass {}
+private class PrivateSubclassFileprivate : FileprivateImportClass {}
 private class PrivateSubclassPrivate : PrivateImportClass {}
 
 public struct PublicTypeAliasUses {
@@ -570,7 +570,7 @@ fileprivate struct FileprivateTypeAliasUses {
     fileprivate typealias TAPackage = PackageImportProto
     fileprivate typealias TAInternal = InternalImportProto
     fileprivate typealias TAFileprivate = FileprivateImportProto
-    fileprivate typealias TAPrivate = PrivateImportProto // expected-error {{type alias cannot be declared fileprivate because its underlying type uses a private type}}
+    fileprivate typealias TAPrivate = PrivateImportProto
 }
 
 private struct PrivateTypeAliasUses {
@@ -629,13 +629,13 @@ fileprivate protocol FileprivateProtocol {
     associatedtype ATDefaultInternal = InternalImportProto
     associatedtype ATDefaultFileprivate = FileprivateImportProto
     // Accocciated type have a minimum formal access level at internal.
-    associatedtype ATDefaultPrivate = PrivateImportProto // expected-error {{associated type in an internal protocol uses a private type in its default definition}}
+    associatedtype ATDefaultPrivate = PrivateImportProto
 
     associatedtype ATRequirePublic: PublicImportProto
     associatedtype ATRequirePackage: PackageImportProto
     associatedtype ATRequireInternal: InternalImportProto
     associatedtype ATRequireFileprivate: FileprivateImportProto
-    associatedtype ATRequirePrivate: PrivateImportProto // expected-error {{associated type in an internal protocol uses a private type in its requirement}}
+    associatedtype ATRequirePrivate: PrivateImportProto
 }
 
 private protocol PrivateProtocol {
@@ -732,7 +732,7 @@ fileprivate struct FileprivateVars {
     fileprivate var b: PackageImportType
     fileprivate var c: InternalImportType
     fileprivate var d: FileprivateImportType
-    fileprivate var e: PrivateImportType // expected-error {{property cannot be declared fileprivate because its type uses a private type}}
+    fileprivate var e: PrivateImportType
 
     @PublicLibWrapper
     fileprivate var f: PublicImportType
@@ -743,13 +743,13 @@ fileprivate struct FileprivateVars {
     @FileprivateLibWrapper
     fileprivate var i: PublicImportType
     @PrivateLibWrapper
-    fileprivate var j: PublicImportType // expected-error {{property cannot be declared fileprivate because its property wrapper type uses a private type}}
+    fileprivate var j: PublicImportType
 
     fileprivate var k = PublicImportType()
     fileprivate var l = PackageImportType()
     fileprivate var m = InternalImportType()
     fileprivate var n = FileprivateImportType()
-    fileprivate var o = PrivateImportType() // expected-error {{property cannot be declared fileprivate because its type 'PrivateImportType' uses a private type}}
+    fileprivate var o = PrivateImportType()
 }
 
 private struct PrivateVars {
@@ -799,7 +799,7 @@ fileprivate struct FileprivateGenericUsesPublic<A: PublicImportProto> {}
 fileprivate struct FileprivateGenericUsesPackage<A: PackageImportProto> {}
 fileprivate struct FileprivateGenericUsesInternal<A: InternalImportProto> {}
 fileprivate struct FileprivateGenericUsesFileprivate<A: FileprivateImportProto> {}
-fileprivate struct FileprivateGenericUsesPrivate<A: PrivateImportProto> {} // expected-error {{generic struct cannot be declared fileprivate because its generic parameter uses a private type}}
+fileprivate struct FileprivateGenericUsesPrivate<A: PrivateImportProto> {}
 
 private struct PrivateGenericUsesPublic<A: PublicImportProto> {}
 private struct PrivateGenericUsesPackage<A: PackageImportProto> {}

--- a/test/Sema/access-level-import-exportability.swift
+++ b/test/Sema/access-level-import-exportability.swift
@@ -319,7 +319,8 @@ public struct PublicSubscriptUsesPublic {
     }
 }
 public struct PublicSubscriptUsesPackage {
-    public subscript(index: PackageImportType) -> PackageImportType { // expected-error {{subscript cannot be declared public because its index uses a package type}}
+    public subscript(index: PackageImportType) -> PackageImportType { // expected-error {{subscript cannot be declared public because its element type uses a package type}}
+    // This error should be on the `index` like the other ones.
         fatalError()
     }
 }

--- a/test/Sema/access-level-import-inlinable.swift
+++ b/test/Sema/access-level-import-inlinable.swift
@@ -1,19 +1,20 @@
-// Test use of decls restricted by an import access-level in inlinable code.
+// Test use of decls restricted by an import access-level in inlinable code
+// and frozen structs.
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
 /// Build the libraries.
 // RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t \
-// RUN:   -enable-library-evolution
+// RUN:   -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t \
-// RUN:   -enable-library-evolution
+// RUN:   -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t \
-// RUN:   -enable-library-evolution
+// RUN:   -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t \
-// RUN:   -enable-library-evolution
+// RUN:   -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t \
-// RUN:   -enable-library-evolution
+// RUN:   -swift-version 5 -enable-library-evolution
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
@@ -52,6 +53,8 @@ public struct InternalImportType {
 }
 public func InternalFunc() {}
 
+@frozen public struct InternalImportFrozenType {}
+
 //--- FileprivateLib.swift
 public protocol FileprivateImportProto {
     associatedtype T
@@ -74,12 +77,13 @@ public struct PrivateImportType {
 public import PublicLib
 
 package import PackageLib
-// expected-note@-1 2 {{struct 'PackageImportType' imported as 'package' from 'PackageLib' here}}
+// expected-note@-1 4 {{struct 'PackageImportType' imported as 'package' from 'PackageLib' here}}
 
 internal import InternalLib
-// expected-note@-1 6 {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
+// expected-note@-1 9 {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
 // expected-note@-2 4 {{protocol 'InternalImportProto' imported as 'internal' from 'InternalLib' here}}
 // expected-note@-3 2 {{global function 'InternalFunc()' imported as 'internal' from 'InternalLib' here}}
+// expected-note@-4 2 {{struct 'InternalImportFrozenType' imported as 'internal' from 'InternalLib' here}}
 
 fileprivate import FileprivateLib
 // expected-note@-1 2 {{generic struct 'FileprivateImportWrapper' imported as 'fileprivate' from 'FileprivateLib' here}}
@@ -87,7 +91,7 @@ fileprivate import FileprivateLib
 // expected-note@-3 2 {{protocol 'FileprivateImportProto' imported as 'fileprivate' from 'FileprivateLib' here}}
 
 private import PrivateLib
-// expected-note@-1 4 {{struct 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
+// expected-note@-1 10 {{struct 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
  // expected-note@-2 2 {{initializer 'init()' imported as 'private' from 'PrivateLib' here}}
 
 public struct GenericType<T, U> {}
@@ -170,4 +174,88 @@ public struct GenericType<T, U> {}
   let _: GenericType<PublicImportType, PublicImportType>
   let _: GenericType<InternalImportType, PrivateImportType> // expected-error {{struct 'InternalImportType' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
   // expected-error @-1 {{struct 'PrivateImportType' is private and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+}
+
+@frozen public struct BadFields1 {
+  private var field: PrivateImportType // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@_fixed_layout public struct FixedBadFields1 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field: PrivateImportType // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@frozen public struct BadFields2 {
+  private var field: PrivateImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@_fixed_layout public struct FixedBadFields2 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field: PrivateImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@frozen public struct BadFields3 {
+  internal var field: PackageImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@_fixed_layout public struct FixedBadFields3 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  internal var field: PackageImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@frozen @usableFromInline struct BadFields4 {
+  internal var field: InternalImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@_fixed_layout @usableFromInline struct FixedBadFields4 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  internal var field: InternalImportType? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@frozen public struct BadFields5 {
+  private var field: PrivateImportType? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+    didSet {}
+  }
+}
+
+@_fixed_layout public struct FixedBadFields5 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field: PrivateImportType? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+    didSet {}
+  }
+}
+
+@frozen public struct BadFields6 {
+  private var field: InternalImportFrozenType? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+    didSet {}
+  }
+}
+
+@_fixed_layout public struct FixedBadFields6 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field: InternalImportFrozenType? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+    didSet {}
+  }
+}
+
+// expected-error@+1 {{the result of a '@usableFromInline' function must be '@usableFromInline' or public}}
+@usableFromInline func notReallyUsableFromInline() -> InternalImportType? { return nil }
+@frozen public struct BadFields7 {
+  private var field = notReallyUsableFromInline() // expected-error {{type referenced from a stored property with inferred type 'InternalImportType?' in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@_fixed_layout public struct FrozenBadFields7 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field = notReallyUsableFromInline() // expected-error {{type referenced from a stored property with inferred type 'InternalImportType?' in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@frozen public struct OKFields {
+  internal static var staticProp: InternalImportType?
+  private var computed: PrivateImportType? { return nil }
+}
+
+@_fixed_layout public struct FixedOKFields {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  internal static var staticProp: InternalImportType?
+  private var computed: PrivateImportType? { return nil }
 }

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -641,7 +641,7 @@ public struct Subscripts {
   package subscript (x: PrivateStruct, y: String) -> String { return "" } // expected-error {{subscript cannot be declared package because its index uses a private type}}
   package subscript (x: String, y: PrivateStruct) -> String { return "" } // expected-error {{subscript cannot be declared package because its index uses a private type}}
   package subscript (x: InternalStruct, y: FilePrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{subscript cannot be declared package because its index uses a fileprivate type}}
-  package subscript (x: FilePrivateStruct, y: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript cannot be declared package because its element type uses a private type}}
+  package subscript (x: FilePrivateStruct, y: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{subscript cannot be declared package because its index uses a fileprivate type}}
   package subscript (x: String, y: String) -> InternalStruct { return InternalStruct() } // expected-error {{subscript cannot be declared package because its element type uses an internal type}}
 }
 
@@ -654,12 +654,12 @@ public struct Methods {
   public func c(a: InternalStruct, b: PrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared public because its parameter uses a private type}}
   public func d(a: PrivateStruct, b: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{method cannot be declared public because its parameter uses a private type}}
   public func e(a: Int, b: Int) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared public because its result uses an internal type}}
-  public func f(a: Int, b: PackageStruct) -> PackageStruct { return PackageStruct() } // expected-error {{method cannot be declared public because its parameter uses a package type}}
+  public func f(a: Int, b: PackageStruct) -> PackageStruct { return PackageStruct() } // expected-error {{method cannot be declared public because its result uses a package type}}
 
   package func x(x: PrivateStruct, y: String) -> String { return "" } // expected-error {{method cannot be declared package because its parameter uses a private type}}
   package func y(x: String, y: PrivateStruct) -> String { return "" } // expected-error {{method cannot be declared package because its parameter uses a private type}}
   package func z(x: InternalStruct, y: FilePrivateStruct) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared package because its parameter uses a fileprivate type}}
-  package func w(x: FilePrivateStruct, y: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{method cannot be declared package because its result uses a private type}}
+  package func w(x: FilePrivateStruct, y: InternalStruct) -> PrivateStruct { return PrivateStruct() } // expected-error {{method cannot be declared package because its parameter uses a fileprivate type}}
   package func v(x: String, y: String) -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared package because its result uses an internal type}}
   package func q() -> InternalStruct { return InternalStruct() } // expected-error {{method cannot be declared package because its result uses an internal type}}
 }
@@ -721,7 +721,7 @@ public protocol AssocTypes {
   associatedtype PrivatePackageConformer: PrivateProto = PackageStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
 
   associatedtype PrivatePrivateDefaultConformer: PrivateProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
-  associatedtype PackagePackageDefaultConformer: PackageProto = PackageStruct // expected-error {{associated type in a public protocol uses a package type in its requirement}}
+  associatedtype PackagePackageDefaultConformer: PackageProto = PackageStruct // expected-error {{associated type in a public protocol uses a package type in its default definition}}
 
   associatedtype PublicPublicDefaultConformer: PublicProto = PublicStruct
 }


### PR DESCRIPTION
The use of access-level keywords on imports restrict where these dependencies can be used, e.g. a type imported as internal can only be used in internal or lower decls. This PR centralizes and moves the logic applying these restrictions deeper in the access-scope logic instead of separately tracking the import access-level. Also simplify how we find the import with the restriction to point at it with a note.

This change fixes an edge case with the previous system that forbade the use of of a type from a `private import` in a `fileprivate` decl. This should be allowed as the scope of a private import is at the file level, similarly to `file private`.

There is some unintended changes to diagnostics details. In the case where multiple types referenced by a decl are problematic, we try to diagnose only to the most problematic one. This prioritization order changed in some cases and I plan on investigating it further.