### PR TITLE
[IRGen][interop] do not add 'nocapture' to not bitwise takable types

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -266,7 +266,10 @@ static void addIndirectValueParameterAttributes(IRGenModule &IGM,
   llvm::AttrBuilder b(IGM.getLLVMContext());
   // Value parameter pointers can't alias or be captured.
   b.addAttribute(llvm::Attribute::NoAlias);
-  b.addAttribute(llvm::Attribute::NoCapture);
+  // Bitwise takable value types are guaranteed not to capture
+  // a pointer into itself.
+  if (ti.isBitwiseTakable(ResilienceExpansion::Maximal))
+    b.addAttribute(llvm::Attribute::NoCapture);
   // The parameter must reference dereferenceable memory of the type.
   addDereferenceableAttributeToBuilder(IGM, b, ti);
 
@@ -278,9 +281,11 @@ static void addPackParameterAttributes(IRGenModule &IGM,
                                        llvm::AttributeList &attrs,
                                        unsigned argIndex) {
   llvm::AttrBuilder b(IGM.getLLVMContext());
-  // Pack parameter pointers can't alias or be captured.
+  // Pack parameter pointers can't alias.
+  // Note: they are not marked `nocapture` as one
+  // pack parameter could be a value type (e.g. a C++ type)
+  // that captures its own pointer in itself.
   b.addAttribute(llvm::Attribute::NoAlias);
-  b.addAttribute(llvm::Attribute::NoCapture);
   // TODO: we could mark this dereferenceable when the pack has fixed
   // components.
   // TODO: add an alignment attribute
@@ -301,8 +306,10 @@ static void addInoutParameterAttributes(IRGenModule &IGM, SILType paramSILType,
     // attribute if it's a pointer being passed inout.
     b.addAttribute(llvm::Attribute::NoAlias);
   }
-  // Aliasing inouts can't be captured without doing unsafe stuff.
-  b.addAttribute(llvm::Attribute::NoCapture);
+  // Bitwise takable value types are guaranteed not to capture
+  // a pointer into itself.
+  if (ti.isBitwiseTakable(ResilienceExpansion::Maximal))
+    b.addAttribute(llvm::Attribute::NoCapture);
   // The inout must reference dereferenceable memory of the type.
   addDereferenceableAttributeToBuilder(IGM, b, ti);
 
@@ -341,10 +348,14 @@ llvm::CallingConv::ID irgen::expandCallingConv(IRGenModule &IGM,
 static void addIndirectResultAttributes(IRGenModule &IGM,
                                         llvm::AttributeList &attrs,
                                         unsigned paramIndex, bool allowSRet,
-                                        llvm::Type *storageType) {
+                                        llvm::Type *storageType,
+                                        const TypeInfo &typeInfo) {
   llvm::AttrBuilder b(IGM.getLLVMContext());
   b.addAttribute(llvm::Attribute::NoAlias);
-  b.addAttribute(llvm::Attribute::NoCapture);
+  // Bitwise takable value types are guaranteed not to capture
+  // a pointer into itself.
+  if (typeInfo.isBitwiseTakable(ResilienceExpansion::Maximal))
+    b.addAttribute(llvm::Attribute::NoCapture);
   if (allowSRet) {
     assert(storageType);
     b.addStructRetAttr(storageType);
@@ -509,7 +520,7 @@ llvm::Type *SignatureExpansion::addIndirectResult() {
   const TypeInfo &resultTI = IGM.getTypeInfo(resultType);
   auto storageTy = resultTI.getStorageType();
   addIndirectResultAttributes(IGM, Attrs, ParamIRTypes.size(), claimSRet(),
-                              storageTy);
+                              storageTy, resultTI);
   addPointerParameter(storageTy);
   return IGM.VoidTy;
 }
@@ -568,11 +579,12 @@ void SignatureExpansion::expandIndirectResults() {
     auto useSRet = claimSRet();
     // We need to use opaque types or non fixed size storage types because llvm
     // does type based analysis based on the type of sret arguments.
-    if (useSRet && !isa<FixedTypeInfo>(IGM.getTypeInfo(indirectResultType))) {
+    const TypeInfo &typeInfo = IGM.getTypeInfo(indirectResultType);
+    if (useSRet && !isa<FixedTypeInfo>(typeInfo)) {
       storageTy = IGM.OpaqueTy;
     }
     addIndirectResultAttributes(IGM, Attrs, ParamIRTypes.size(), useSRet,
-                                storageTy);
+                                storageTy, typeInfo);
     addPointerParameter(storageTy);
   }
 }
@@ -1459,7 +1471,7 @@ void SignatureExpansion::expandExternalSignatureTypes() {
             param, IGM.getMaximalTypeExpansionContext());
         auto &paramTI = cast<FixedTypeInfo>(IGM.getTypeInfo(paramTy));
         addIndirectResultAttributes(IGM, Attrs, getCurParamIndex(), claimSRet(),
-                                    paramTI.getStorageType());
+                                    paramTI.getStorageType(), paramTI);
         break;
       }
       }

--- a/test/AutoDiff/IRGen/runtime.swift
+++ b/test/AutoDiff/IRGen/runtime.swift
@@ -12,7 +12,7 @@ func test_context_builtins_with_type<T>(t: T) {
   UnsafeMutableRawPointer(newBuffer).storeBytes(of: t, as: T.self)
 }
 
-// CHECK-LABEL: define{{.*}}@test_context_builtins_with_type(ptr noalias nocapture %0, ptr %T)
+// CHECK-LABEL: define{{.*}}@test_context_builtins_with_type(ptr noalias %0, ptr %T)
 // CHECK: entry:
 // CHECK:   [[CTX:%.*]] = call swiftcc ptr @swift_autoDiffCreateLinearMapContextWithType(ptr %T)
 // CHECK:   call swiftcc ptr @swift_autoDiffProjectTopLevelSubcontext(ptr [[CTX]])

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -44,7 +44,7 @@ public class C<R> {
 
   // SIL-LABEL: // C.f<A>(_:)
   // IR-LABEL: define {{.*}} @"$s1A1CC1fyyqd__lF"
-  // IR-SAME: nocapture %[[ARG_0:.*]], {{.*}} %[[ARG_S:.*]],
+  // IR-SAME: %[[ARG_0:.*]], {{.*}} %[[ARG_S:.*]],
 #sourceLocation(file: "f.swift", line: 1)
   public func f<S>(_ s: S) {
     // SIL: debug_value %0 : $*S, let, name "s", argno 1, expr op_deref, {{.*}} scope [[F]]

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -218,7 +218,7 @@ public func copyableVarArgTest(_ k: inout Klass) {
     k.doSomething()
 }
 
-// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo20addressOnlyValueTestyyxAA1PRzlF"(ptr noalias nocapture %0, ptr %T, ptr %T.P)
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo20addressOnlyValueTestyyxAA1PRzlF"(ptr noalias %0, ptr %T, ptr %T.P)
 // CHECK: @llvm.dbg.addr(metadata ptr %{{.*}}, metadata ![[K_ADDR_LET_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
 // CHECK-NEXT: br
 // CHECK: @llvm.dbg.value(metadata ptr undef, metadata ![[K_ADDR_LET_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
@@ -308,7 +308,7 @@ public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
     m.doSomething()
 }
 
-// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18addressOnlyVarTestyyxAA1PRzlF"(ptr noalias nocapture %0, ptr %T, ptr %T.P)
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18addressOnlyVarTestyyxAA1PRzlF"(ptr noalias %0, ptr %T, ptr %T.P)
 // CHECK: @llvm.dbg.addr(metadata ptr %{{.*}}, metadata ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
 // CHECK-NEXT: br
 // CHECK: @llvm.dbg.value(metadata ptr undef, metadata ![[K_ADDRONLY_VAR_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]

--- a/test/DebugInfo/struct_resilience.swift
+++ b/test/DebugInfo/struct_resilience.swift
@@ -11,8 +11,8 @@
 //
 import resilient_struct
 
-// CHECK-LABEL: define{{.*}} swiftcc void @"$s17struct_resilience9takesSizeyy010resilient_A00D0VF"(ptr noalias nocapture %0)
-// CHECK-LLDB-LABEL: define{{.*}} swiftcc void @"$s17struct_resilience9takesSizeyy010resilient_A00D0VF"(ptr noalias nocapture dereferenceable({{8|16}}) %0)
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s17struct_resilience9takesSizeyy010resilient_A00D0VF"(ptr noalias %0)
+// CHECK-LLDB-LABEL: define{{.*}} swiftcc void @"$s17struct_resilience9takesSizeyy010resilient_A00D0VF"(ptr noalias dereferenceable({{8|16}}) %0)
 public func takesSize(_ s: Size) {}
 
 

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -94,7 +94,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(ptr swiftasync %0, ptr nocapture %1, ptr %2, ptr %3, {{.*}}, ptr [[ACTOR:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(ptr swiftasync %0, ptr %1, ptr %2, ptr %3, {{.*}}, ptr [[ACTOR:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Read the current offset and cast an element to `Int`
 
@@ -116,7 +116,7 @@ public distributed actor MyOtherActor {
 // CHECK: missing-witness1:
 // CHECK-NEXT: call void @llvm.trap()
 // CHECK-NEXT: unreachable
-// CHECK: call swiftcc void @"$s27FakeDistributedActorSystems0A17InvocationDecoderC18decodeNextArgumentxyKSeRzSERzlF"(ptr noalias nocapture sret(%swift.opaque) [[ARG_0_VALUE_BUF]], ptr %arg_type, ptr [[ENCODABLE_WITNESS]], ptr [[DECODABLE_WITNESS]], ptr swiftself [[DECODER]], ptr noalias nocapture swifterror dereferenceable(8) %swifterror)
+// CHECK: call swiftcc void @"$s27FakeDistributedActorSystems0A17InvocationDecoderC18decodeNextArgumentxyKSeRzSERzlF"(ptr noalias sret(%swift.opaque) [[ARG_0_VALUE_BUF]], ptr %arg_type, ptr [[ENCODABLE_WITNESS]], ptr [[DECODABLE_WITNESS]], ptr swiftself [[DECODER]], ptr noalias nocapture swifterror dereferenceable(8) %swifterror)
 
 // CHECK: store ptr null, ptr %swifterror
 // CHECK-NEXT: %._value = getelementptr inbounds %TSi, ptr [[ARG_0_VALUE_BUF]], i32 0, i32 0
@@ -192,7 +192,7 @@ public distributed actor MyOtherActor {
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTE"
 
 /// !!! in `simple3` interesting bits are: argument value extraction (because string is exploded into N arguments) and call to distributed thunk
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(ptr swiftasync %0, ptr nocapture [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(ptr swiftasync %0, ptr [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 
 // CHECK: [[ARG_SIZE:%.*]] = and i64 {{.*}}, -16
@@ -232,7 +232,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(ptr swiftasync %0, ptr nocapture [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(ptr swiftasync %0, ptr [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Let's check that the call doesn't have any arguments and returns nothing.
 
@@ -272,7 +272,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTE"
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(ptr swiftasync {{.*}}, ptr nocapture [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(ptr swiftasync {{.*}}, ptr [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// First, let's check that all of the different argument types here are loaded correctly.
 
@@ -319,7 +319,7 @@ public distributed actor MyOtherActor {
 
 /// ---> Accessor for `genericArgs`
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(ptr swiftasync %0, ptr  nocapture [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUF:%.*]], ptr [[GENERIC_SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(ptr swiftasync %0, ptr  [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUF:%.*]], ptr [[GENERIC_SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr [[ACTOR:%.*]], ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// ---> Load `T`
 
@@ -368,7 +368,7 @@ public distributed actor MyOtherActor {
 
 /// Let's check that there is argument decoding since parameter list is empty
 
-// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(ptr swiftasync {{.*}}, ptr nocapture [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr {{.*}}, ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(ptr swiftasync {{.*}}, ptr [[ARG_DECODER:%.*]], ptr [[ARG_TYPES:%.*]], ptr [[RESULT_BUFF:%.*]], ptr [[SUBS:%.*]], ptr [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], ptr {{.*}}, ptr [[DECODER_TYPE:%.*]], ptr [[DECODER_PROTOCOL_WITNESS:%.*]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: {{.*}} = alloca ptr
 // CHECK-NEXT: %swifterror = alloca swifterror ptr

--- a/test/IRGen/TestABIInaccessible.swift
+++ b/test/IRGen/TestABIInaccessible.swift
@@ -8,7 +8,7 @@ public struct AnotherType<T> {
 }
 
 // Don't pass the metadata of Private<T> to AnotherType<T>'s outlined destroy.
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s4main4copyyAA11AnotherTypeVyxGAElF"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s4main4copyyAA11AnotherTypeVyxGAElF"(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T)
 // CHECK:  [[MD:%.*]] = call swiftcc %swift.metadata_response @"$s4main11AnotherTypeVMa"(i{{.*}} 0, ptr %T)
 // CHECK:  [[MD1:%.*]] = extractvalue %swift.metadata_response [[MD]], 0
 // CHECK:  [[MD2:%.*]] = call swiftcc %swift.metadata_response @"$s4main6PublicVMa"(i{{.*}} 0, ptr %T)

--- a/test/IRGen/archetype_resilience.sil
+++ b/test/IRGen/archetype_resilience.sil
@@ -16,7 +16,7 @@ public enum EnumWithClassArchetypeAndDynamicSize<T : AnyObject> {
   case B(Size)
 }
 
-// CHECK-LABEL: define swiftcc void @copyDynamicMultiEnum(ptr %"EnumWithClassArchetypeAndDynamicSize<T>", ptr %U, ptr noalias nocapture swiftself %0)
+// CHECK-LABEL: define swiftcc void @copyDynamicMultiEnum(ptr %"EnumWithClassArchetypeAndDynamicSize<T>", ptr %U, ptr noalias swiftself %0)
 // CHECK: call ptr @"$s20archetype_resilience36EnumWithClassArchetypeAndDynamicSizeOyxGRlzCr0_lWOc"(ptr %0, ptr {{.*}}, ptr %"EnumWithClassArchetypeAndDynamicSize<T>")
 // CHECK: ret void
 sil [ossa] @copyDynamicMultiEnum : $@convention(method) <T, U where T: AnyObject> (@in_guaranteed EnumWithClassArchetypeAndDynamicSize<T>) -> () {

--- a/test/IRGen/argument_attrs.sil
+++ b/test/IRGen/argument_attrs.sil
@@ -4,49 +4,49 @@ import Builtin
 
 struct Huge { var x, y, z, w, a, b, c, d, e, f: Builtin.Int32 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def(ptr nocapture dereferenceable(4) %0, ptr noalias nocapture dereferenceable(4) %1, ptr noalias nocapture dereferenceable(4) %2, ptr noalias nocapture dereferenceable(40) %3, ptr noalias nocapture %4, ptr noalias nocapture %5, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def(ptr nocapture dereferenceable(4) %0, ptr noalias nocapture dereferenceable(4) %1, ptr noalias nocapture dereferenceable(4) %2, ptr noalias nocapture dereferenceable(40) %3, ptr noalias %4, ptr noalias nocapture %5, ptr %T)
 sil @arguments_in_def : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> () {
 entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
-  // CHECK: call swiftcc void @arguments_in_decl(ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias nocapture {{%.*}}, ptr noalias nocapture {{%.*}}, ptr %T)
+  // CHECK: call swiftcc void @arguments_in_decl(ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias nocapture {{%.*}}, ptr %T)
   %f = function_ref @arguments_in_decl : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
   %x = apply %f<T>(%1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
-  // CHECK: call swiftcc void @arguments_in_def(ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias nocapture {{%.*}}, ptr noalias nocapture {{%.*}}, ptr %T)
+  // CHECK: call swiftcc void @arguments_in_def(ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias nocapture {{%.*}}, ptr %T)
   %g = function_ref @arguments_in_def : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
   %y = apply %g<T>(%1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
   return undef : $()
 }
 
-// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl(ptr nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(40), ptr noalias nocapture, ptr noalias nocapture, ptr)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl(ptr nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(40), ptr noalias, ptr noalias nocapture, ptr)
 sil @arguments_in_decl : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_out(ptr noalias nocapture sret({{.*}}) %0, ptr nocapture dereferenceable(4) %1, ptr noalias nocapture dereferenceable(4) %2, ptr noalias nocapture dereferenceable(4) %3, ptr noalias nocapture dereferenceable(40) %4, ptr noalias nocapture %5, ptr noalias nocapture %6, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_out(ptr noalias nocapture sret({{.*}}) %0, ptr nocapture dereferenceable(4) %1, ptr noalias nocapture dereferenceable(4) %2, ptr noalias nocapture dereferenceable(4) %3, ptr noalias nocapture dereferenceable(40) %4, ptr noalias %5, ptr noalias nocapture %6, ptr %T)
 sil @arguments_in_def_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32 {
 entry(%0 : $*Builtin.Int32, %1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
-  // CHECK: call swiftcc void @arguments_in_decl_out(ptr noalias nocapture sret({{.*}}) {{%.*}}, ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias nocapture {{%.*}}, ptr noalias nocapture {{%.*}}, ptr {{%.*}})
+  // CHECK: call swiftcc void @arguments_in_decl_out(ptr noalias nocapture sret({{.*}}) {{%.*}}, ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias nocapture {{%.*}}, ptr {{%.*}})
   %f = function_ref @arguments_in_decl_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
   %x = apply %f<T>(%0, %1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
-  // CHECK: call swiftcc void @arguments_in_def_out(ptr noalias nocapture sret({{.*}}) {{%.*}}, ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias nocapture {{%.*}}, ptr noalias nocapture {{%.*}}, ptr {{%.*}})
+  // CHECK: call swiftcc void @arguments_in_def_out(ptr noalias nocapture sret({{.*}}) {{%.*}}, ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias nocapture {{%.*}}, ptr {{%.*}})
   %g = function_ref @arguments_in_def_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
   %y = apply %g<T>(%0, %1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
   return undef : $()
 }
 
-// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_out(ptr noalias nocapture sret({{.*}}), ptr nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(40), ptr noalias nocapture, ptr noalias nocapture, ptr)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_out(ptr noalias nocapture sret({{.*}}), ptr nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(40), ptr noalias, ptr noalias nocapture, ptr)
 sil @arguments_in_decl_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_huge_ret(ptr noalias nocapture sret({{.*}}) %0, ptr nocapture dereferenceable(4) %1, ptr noalias nocapture dereferenceable(4) %2, ptr noalias nocapture dereferenceable(4) %3, ptr noalias nocapture dereferenceable(40) %4, ptr noalias nocapture %5, ptr noalias nocapture %6, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_huge_ret(ptr noalias nocapture sret({{.*}}V) %0, ptr nocapture dereferenceable(4) %1, ptr noalias nocapture dereferenceable(4) %2, ptr noalias nocapture dereferenceable(4) %3, ptr noalias nocapture dereferenceable(40) %4, ptr noalias %5, ptr noalias nocapture %6, ptr %T)
 sil @arguments_in_def_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge {
 entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
   %f = function_ref @arguments_in_decl_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
-  // CHECK: call swiftcc void @arguments_in_decl_huge_ret(ptr noalias nocapture sret({{.*}}) {{%.*}}, ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias nocapture {{%.*}}, ptr noalias nocapture {{%.*}}, ptr {{%.*}})
+  // CHECK: call swiftcc void @arguments_in_decl_huge_ret(ptr noalias nocapture sret({{.*}}) {{%.*}}, ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias nocapture {{%.*}}, ptr {{%.*}})
   %x = apply %f<T>(%1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
-  // CHECK: call swiftcc void @arguments_in_def_huge_ret(ptr noalias nocapture sret({{.*}}) {{%.*}}, ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias nocapture {{%.*}}, ptr noalias nocapture {{%.*}}, ptr {{%.*}})
+  // CHECK: call swiftcc void @arguments_in_def_huge_ret(ptr noalias nocapture sret({{.*}}) {{%.*}}, ptr nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(4) {{%.*}}, ptr noalias nocapture dereferenceable(40) {{%.*}}, ptr noalias {{%.*}}, ptr noalias nocapture {{%.*}}, ptr {{%.*}})
   %g = function_ref @arguments_in_def_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
   %y = apply %g<T>(%1, %2, %3, %4, %5, %6) : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
   return %y : $Huge
 }
 
-// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_huge_ret(ptr noalias nocapture sret({{.*}}), ptr nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(40), ptr noalias nocapture, ptr noalias nocapture, ptr)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_huge_ret(ptr noalias nocapture sret({{.*}}), ptr nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(4), ptr noalias nocapture dereferenceable(40), ptr noalias, ptr noalias nocapture, ptr)
 sil @arguments_in_decl_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
 
 

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -30,7 +30,7 @@ struct Owl<T : Runcible, U> {
 class Pussycat<T : Runcible, U> {
   init() {} 
 
-  // CHECK: define hidden swiftcc void @"$s16associated_types8PussycatC3eat{{[_0-9a-zA-Z]*}}F"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr noalias nocapture %2, ptr swiftself %3)
+  // CHECK: define hidden swiftcc void @"$s16associated_types8PussycatC3eat{{[_0-9a-zA-Z]*}}F"(ptr noalias %0, ptr noalias %1, ptr noalias %2, ptr swiftself %3)
   func eat(_ what: T.RuncerType.Runcee, and: T.RuncerType, with: T) { }
 }
 
@@ -71,7 +71,7 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
   U.RuncerType.Runcee.accelerate()
 }
 
-// CHECK: define hidden swiftcc void @"$s16associated_types16testFastRuncible_1uyx_q_tAA0E0RzAA0dE0R_10RuncerTypeQy_AFRtzr0_lF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr %T, ptr %U, ptr %T.Runcible, ptr %U.FastRuncible) {{.*}} {
+// CHECK: define hidden swiftcc void @"$s16associated_types16testFastRuncible_1uyx_q_tAA0E0RzAA0dE0R_10RuncerTypeQy_AFRtzr0_lF"(ptr noalias %0, ptr noalias %1, ptr %T, ptr %U, ptr %T.Runcible, ptr %U.FastRuncible) {{.*}} {
 //   1. Get the type metadata for U.RuncerType.Runcee.
 //     1a. Get the type metadata for U.RuncerType.
 //         Note that we actually look things up in T, which is going to prove unfortunate.

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -141,7 +141,7 @@ bb0:
 
 
 // CHECK-LABEL: define{{.*}} swiftcc void @testRunInline(
-// CHECK-SAME:      ptr noalias nocapture sret(%swift.opaque) [[RESULT:%[^,]+]],
+// CHECK-SAME:      ptr noalias sret(%swift.opaque) [[RESULT:%[^,]+]],
 // CHECK-SAME:      ptr [[CLOSURE:%[^,]+]],
 // CHECK-SAME:      ptr [[CLOSURE_CONTEXT:%[^,]+]],
 // CHECK-SAME:      ptr [[FUTURE_RESULT_TYPE:%[^,]+]])

--- a/test/IRGen/async/class_resilience.swift
+++ b/test/IRGen/async/class_resilience.swift
@@ -41,7 +41,7 @@ open class MyBaseClass<T> {
 // CHECK-LABEL: @"$s16class_resilience9MyDerivedCMn" = hidden constant
 // CHECK-SAME: ptr @"$s16class_resilience9MyDerivedC4waitSiyYaF010resilient_A09BaseClassCADxyYaFTVTu"
 
-// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience14callsAwaitableyx010resilient_A09BaseClassCyxGYalF"(ptr noalias nocapture %0, ptr swiftasync %1{{.*}})
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience14callsAwaitableyx010resilient_A09BaseClassCyxGYalF"(ptr noalias %0, ptr swiftasync %1{{.*}})
 // CHECK-DIRECT: ptr @"$s15resilient_class9BaseClassC4waitxyYaFTjTu"
 // CHECK-INDIRECT: [[LOAD:%[0-9]+]] = load ptr, ptr inttoptr (i64 and (i64 add (i64 ptrtoint (ptr @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1), i64 -2) to ptr), align {{4|8}}
 // CHECK-INDIRECT-NEXT: select i1 icmp eq (i64 and (i64 add (i64 ptrtoint (ptr @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1), i64 1), i64 0),
@@ -52,7 +52,7 @@ public func callsAwaitable<T>(_ c: BaseClass<T>) async -> T {
   return await c.wait()
 }
 
-// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience11MyBaseClassC4waitxyYaFTj"(ptr noalias nocapture %0, ptr swiftasync %1, ptr swiftself %2) {{#([0-9]+)}} {
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience11MyBaseClassC4waitxyYaFTj"(ptr noalias %0, ptr swiftasync %1, ptr swiftself %2) {{#([0-9]+)}} {
 
 class MyDerived : BaseClass<Int> {
   override func wait() async -> Int {

--- a/test/IRGen/async/protocol_resilience.swift
+++ b/test/IRGen/async/protocol_resilience.swift
@@ -26,7 +26,7 @@ public protocol MyAwaitable {
 // CHECK-LABEL: @"$s19protocol_resilience19ConformsToAwaitableVyxG010resilient_A00E0AAMc" = hidden constant
 // CHECK-SAME: ptr @"$s19protocol_resilience19ConformsToAwaitableVyxG010resilient_A00E0AaeFP4wait6ResultQzyYaFTWTu"
 
-// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience14callsAwaitabley6ResultQzxYa010resilient_A00D0RzlF"(ptr noalias nocapture %0, ptr swiftasync %1, ptr noalias nocapture %2, ptr %T, ptr %T.Awaitable)
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience14callsAwaitabley6ResultQzxYa010resilient_A00D0RzlF"(ptr noalias %0, ptr swiftasync %1, ptr noalias %2, ptr %T, ptr %T.Awaitable)
 // CHECK-DIRECT: ptr @"$s18resilient_protocol9AwaitableP4wait6ResultQzyYaFTjTu"
 // CHECK-INDIRECT: [[LOAD:%[0-9]+]] = load ptr, ptr inttoptr (i64 and (i64 add (i64 ptrtoint (ptr @"\01__imp_$s18resilient_protocol9AwaitableP4wait6ResultQzyYaFTjTu" to i64), i64 1), i64 -2) to ptr), align {{4|8}}
 // CHECK-INDIRECT: select i1 icmp eq (i64 and (i64 add (i64 ptrtoint (ptr @"\01__imp_$s18resilient_protocol9AwaitableP4wait6ResultQzyYaFTjTu" to i64), i64 1), i64 1), i64 0),
@@ -37,7 +37,7 @@ public func callsAwaitable<T : Awaitable>(_ t: T) async -> T.Result {
   return await t.wait()
 }
 
-// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience11MyAwaitableP4wait6ResultQzyYaFTj"(ptr noalias nocapture %0, ptr swiftasync %1, ptr noalias nocapture swiftself %2, ptr %3, ptr %4)
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience11MyAwaitableP4wait6ResultQzyYaFTj"(ptr noalias %0, ptr swiftasync %1, ptr noalias swiftself %2, ptr %3, ptr %4)
 
 struct ConformsToAwaitable<T> : Awaitable {
   var value: T

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -66,7 +66,7 @@ public func f3_uses_f2() {
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases10f3_uses_f2yyF"()
-// CHECK: call swiftcc void @"$s22big_types_corner_cases9BigStructVACycfC"(ptr noalias nocapture sret({{.*}}) 
+// CHECK: call swiftcc void @"$s22big_types_corner_cases9BigStructVACycfC"(ptr noalias nocapture sret({{.*}})
 // CHECK: call swiftcc { ptr, ptr } @"$s22big_types_corner_cases13f2_returns_f1AA9BigStructVADcyF"()
 // CHECK: call swiftcc void {{.*}}(ptr noalias nocapture sret({{.*}}) {{.*}}, ptr noalias nocapture dereferenceable({{.*}}) {{.*}}, ptr swiftself {{.*}})
 // CHECK: ret void
@@ -96,7 +96,7 @@ public class BigClass {
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s22big_types_corner_cases8BigClassC03useE6Struct0aH0yAA0eH0V_tF"(ptr noalias nocapture dereferenceable({{.*}}) %0, ptr swiftself %1)
-// CHECK: call swiftcc void {{.*}}(ptr noalias nocapture dereferenceable({{.*}}) %0, ptr swiftself 
+// CHECK: call swiftcc void {{.*}}(ptr noalias nocapture dereferenceable({{.*}}) %0, ptr swiftself
 // CHECK: ret void
 
 public struct MyStruct {
@@ -178,8 +178,8 @@ public struct MUseStruct {
   internal let callInternalLet: () -> BigStruct?
 }
 
-// CHECK-LABEL-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18stringAndSubstringSS_s0G0VtyF"(ptr noalias nocapture sret({{.*}}) %0) #0 {
-// CHECK-LABEL-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18stringAndSubstringSS_s0G0VtyF"(ptr noalias nocapture sret({{.*}}) %0) #0 {
+// CHECK-LABEL-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18stringAndSubstringSS_s0G0VtyF"(ptr noalias sret({{.*}}) %0) #0 {
+// CHECK-LABEL-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases18stringAndSubstringSS_s0G0VtyF"(ptr noalias sret({{.*}}) %0) #0 {
 // CHECK: alloca %TSs
 // CHECK: alloca %TSs
 // CHECK: ret void
@@ -202,7 +202,7 @@ public func testGetFunc() {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s22big_types_corner_cases7TestBigC4testyyF"(ptr swiftself %0)
 // CHECK: [[CALL1:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSayy22big_types_corner_cases9BigStructVcSgGMD"
 // CHECK: [[CALL2:%.*]] = call ptr @"$sSayy22big_types_corner_cases9BigStructVcSgGSayxGSlsWl
-// CHECK:  call swiftcc void @"$sSlsE10firstIndex5where0B0QzSgSb7ElementQzKXE_tKF"(ptr noalias nocapture sret({{.*}}) %{{[0-9]+}}, ptr @"$s22big_types_corner_cases7TestBig{{.*}}", ptr null, ptr %{{[0-9]+}}, ptr [[CALL2]]
+// CHECK:  call swiftcc void @"$sSlsE10firstIndex5where0B0QzSgSb7ElementQzKXE_tKF"(ptr noalias sret({{.*}}) %{{[0-9]+}}, ptr @"$s22big_types_corner_cases7TestBig{{.*}}", ptr null, ptr %{{[0-9]+}}, ptr [[CALL2]]
 class TestBig {
     typealias Handler = (BigStruct) -> Void
 
@@ -286,8 +286,8 @@ public protocol QueryHandler: ProtoQueryHandler {
 
 public extension QueryHandler {
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_15queryyqd___tAA0E0Rd__lF"(ptr noalias nocapture %0, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %1)
-// CHECK: call swiftcc void {{.*}}(ptr noalias nocapture {{.*}}, ptr swiftself {{.*}})
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_15queryyqd___tAA0E0Rd__lF"(ptr noalias %0, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %1)
+// CHECK: call swiftcc void {{.*}}(ptr noalias {{.*}}, ptr swiftself {{.*}})
 // CHECK: ret void
     func forceHandle_1<Q: Query>(query: Q) -> Void {
         guard let body = handle_1 as? (Q) -> Void else {
@@ -296,9 +296,9 @@ public extension QueryHandler {
         body(query)
     }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_25query8ReturnedQyd___AA9BigStructVSgtqd___tAA0E0Rd__lF"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr noalias nocapture %2, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_25query8ReturnedQyd___AA9BigStructVSgtqd___tAA0E0Rd__lF"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias %1, ptr noalias %2, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias swiftself %3)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
-// CHECK: call swiftcc void {{.*}}(ptr noalias nocapture sret({{.*}}) [[ALLOC]], ptr noalias nocapture {{.*}}, ptr noalias nocapture {{.*}}, ptr swiftself {{.*}})
+// CHECK: call swiftcc void {{.*}}(ptr noalias nocapture sret({{.*}}) [[ALLOC]], ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}})
 // CHECK: ret void
     func forceHandle_2<Q: Query>(query: Q) -> (Q.Returned, BigStruct?) {
         guard let body = handle_2 as? (Q) -> (Q.Returned, BigStruct?) else {
@@ -307,12 +307,12 @@ public extension QueryHandler {
         return body(query)
     }
 
-// CHECK-LABEL-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_35query8ReturnedQyd___SbAA9BigStructVcSgtqd___tAA0E0Rd__lF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %2)
-// CHECK-64: {{.*}} = call swiftcc { i64, i64 } {{.*}}(ptr noalias nocapture {{.*}}, ptr noalias nocapture {{.*}}, ptr swiftself {{.*}})
+// CHECK-LABEL-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_35query8ReturnedQyd___SbAA9BigStructVcSgtqd___tAA0E0Rd__lF"(ptr noalias %0, ptr noalias nocapture %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %2)
+// CHECK-64: {{.*}} = call swiftcc { i64, i64 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}})
 // CHECK-64: ret { i64, i64 }
 
-// CHECK-LABEL-32: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32} @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_35query8ReturnedQyd___SbAA9BigStructVcSgtqd___tAA0E0Rd__lF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %2)
-// CHECK-32: {{.*}} = call swiftcc { i32, i32 } {{.*}}(ptr noalias nocapture {{.*}}, ptr noalias nocapture {{.*}}, ptr swiftself {{.*}})
+// CHECK-LABEL-32: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32} @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_35query8ReturnedQyd___SbAA9BigStructVcSgtqd___tAA0E0Rd__lF"(ptr noalias %0, ptr noalias nocapture %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %2)
+// CHECK-32: {{.*}} = call swiftcc { i32, i32 } {{.*}}(ptr noalias {{.*}}, ptr noalias nocapture {{.*}}, ptr swiftself {{.*}})
 // CHECK-32: ret { i32, i32 }
     func forceHandle_3<Q: Query>(query: Q) -> (Q.Returned, Filter?) {
         guard let body = handle_3 as? (Q) -> (Q.Returned, Filter?) else {
@@ -321,12 +321,12 @@ public extension QueryHandler {
         return body(query)
     }
 
-// CHECK-LABEL-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %2, ptr swifterror %3)
-// CHECK-64: {{.*}} = call swiftcc { i64, i64 } {{.*}}(ptr noalias nocapture {{.*}}, ptr noalias nocapture {{.*}}, ptr swiftself {{.*}}, ptr noalias nocapture swifterror {{.*}})
+// CHECK-LABEL-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias nocapture %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %2, ptr swifterror %3)
+// CHECK-64: {{.*}} = call swiftcc { i64, i64 } {{.*}}(ptr noalias {{.*}}, ptr noalias {{.*}}, ptr swiftself {{.*}}, ptr noalias nocapture swifterror {{.*}})
 // CHECK-64: ret { i64, i64 }
 
-// CHECK-LABEL-32: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32} @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %2, ptr swifterror %3)
-// CHECK-32: {{.*}} = call swiftcc { i32, i32 } {{.*}}(ptr noalias nocapture {{.*}}, ptr noalias nocapture {{.*}}, ptr swiftself {{.*}}, ptr noalias nocapture {{.*}})
+// CHECK-LABEL-32: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32} @"$s22big_types_corner_cases12QueryHandlerPAAE13forceHandle_45query8ReturnedQyd___SbAA9BigStructVcSgtqd___tKAA0E0Rd__lF"(ptr noalias %0, ptr noalias nocapture %1, ptr{{.*}}, ptr{{.*}}, ptr {{.*}}.QueryHandler, ptr {{.*}}.Query, ptr noalias nocapture swiftself %2, ptr swifterror %3)
+// CHECK-32: {{.*}} = call swiftcc { i32, i32 } {{.*}}(ptr noalias {{.*}}, ptr noalias nocapture {{.*}}, ptr swiftself {{.*}}, ptr noalias nocapture {{.*}})
 // CHECK-32: ret { i32, i32 }
     func forceHandle_4<Q: Query>(query: Q) throws -> (Q.Returned, Filter?) {
         guard let body = handle_4 as? (Q) throws -> (Q.Returned, Filter?) else {

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -18,7 +18,7 @@ entry(%e : $Error):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @alloc_boxed_existential(ptr noalias nocapture %0, ptr %T, ptr %T.Error)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @alloc_boxed_existential(ptr noalias %0, ptr %T, ptr %T.Error)
 sil @alloc_boxed_existential : $@convention(thin) <T: Error> (@in T) -> @owned Error {
 entry(%x : $*T):
   // CHECK: [[BOX_PAIR:%.*]] = call swiftcc { ptr, ptr } @swift_allocError(ptr %T, ptr %T.Error, ptr null, i1 false)

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -449,7 +449,7 @@ func destroyNonPODArray(_ array: Builtin.RawPointer, count: Builtin.Word) {
   Builtin.destroyArray(C.self, array, count)
 }
 
-// CHECK-LABEL: define hidden {{.*}}void @"$s8builtins15destroyGenArray_5count_yBp_BwxtlF"(ptr %0, i64 %1, ptr noalias nocapture %2, ptr %T)
+// CHECK-LABEL: define hidden {{.*}}void @"$s8builtins15destroyGenArray_5count_yBp_BwxtlF"(ptr %0, i64 %1, ptr noalias %2, ptr %T)
 // CHECK-NOT:   loop:
 // CHECK:         call void @swift_arrayDestroy
 func destroyGenArray<T>(_ array: Builtin.RawPointer, count: Builtin.Word, _: T) {
@@ -527,7 +527,7 @@ func copyNonPODArray(_ dest: Builtin.RawPointer, src: Builtin.RawPointer, count:
   Builtin.assignTakeArray(W.self, dest, src, count)
 }
 
-// CHECK-LABEL: define hidden {{.*}}void @"$s8builtins12copyGenArray{{[_0-9a-zA-Z]*}}F"(ptr %0, ptr %1, i64 %2, ptr noalias nocapture %3, ptr %T)
+// CHECK-LABEL: define hidden {{.*}}void @"$s8builtins12copyGenArray{{[_0-9a-zA-Z]*}}F"(ptr %0, ptr %1, i64 %2, ptr noalias %3, ptr %T)
 // CHECK-NOT:   loop:
 // CHECK:        call void @swift_arrayInitWithCopy
 // CHECK-NOT:   loop:

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -113,7 +113,7 @@ func call_class_bounded_archetype(_ x: ConcreteClass) -> ConcreteClass {
   // CHECK: ret ptr [[OUT_ORIG]]
 }
 
-// CHECK: define hidden swiftcc void @"$s22class_bounded_generics04not_a1_B10_archetype{{[_0-9a-zA-Z]*}}F"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T, ptr %T.NotClassBound)
+// CHECK: define hidden swiftcc void @"$s22class_bounded_generics04not_a1_B10_archetype{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T, ptr %T.NotClassBound)
 func not_class_bounded_archetype<T : NotClassBound>(_ x: T) -> T {
   return x
 }

--- a/test/IRGen/class_resilience_thunks.swift
+++ b/test/IRGen/class_resilience_thunks.swift
@@ -6,10 +6,10 @@
 
 import resilient_class_thunks
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s23class_resilience_thunks21testDispatchThunkBase1b1ty010resilient_a1_C00G0CyxG_xtlF"(ptr %0, ptr noalias nocapture %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s23class_resilience_thunks21testDispatchThunkBase1b1ty010resilient_a1_C00G0CyxG_xtlF"(ptr %0, ptr noalias %1)
 public func testDispatchThunkBase<T>(b: Base<T>, t: T) {
 
-  // CHECK: call swiftcc void @"$s22resilient_class_thunks4BaseC6takesTyyxFTj"(ptr noalias nocapture {{%.*}}, ptr swiftself %0)
+  // CHECK: call swiftcc void @"$s22resilient_class_thunks4BaseC6takesTyyxFTj"(ptr noalias {{%.*}}, ptr swiftself %0)
   b.takesT(t)
 
   // CHECK: call swiftcc void @"$s22resilient_class_thunks4BaseC8takesIntyySiFTj"([[INT]] 0, ptr swiftself %0)
@@ -24,7 +24,7 @@ public func testDispatchThunkBase<T>(b: Base<T>, t: T) {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s23class_resilience_thunks24testDispatchThunkDerived1dy010resilient_a1_C00G0C_tF"(ptr %0)
 public func testDispatchThunkDerived(d: Derived) {
 
-  // CHECK: call swiftcc void @"$s22resilient_class_thunks4BaseC6takesTyyxFTj"(ptr noalias nocapture {{%.*}}, ptr swiftself {{%.*}})
+  // CHECK: call swiftcc void @"$s22resilient_class_thunks4BaseC6takesTyyxFTj"(ptr noalias {{%.*}}, ptr swiftself {{%.*}})
   d.takesT(0)
 
   // CHECK: call swiftcc void @"$s22resilient_class_thunks7DerivedC8takesIntyySiSgFTj"([[INT]] 0, i8 1, ptr swiftself %0)

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -31,7 +31,7 @@ func b<T : Ordinable>(seq seq: T) -> (Int) -> Int {
 // CHECK: }
 
 // -- Closure entry point
-// CHECK: define internal swiftcc i64 @"$s7closure1b3seqS2icx_tAA9OrdinableRzlFS2icfU_"(i64 %0, ptr noalias nocapture %1, ptr %T, ptr %T.Ordinable) {{.*}} {
+// CHECK: define internal swiftcc i64 @"$s7closure1b3seqS2icx_tAA9OrdinableRzlFS2icfU_"(i64 %0, ptr noalias %1, ptr %T, ptr %T.Ordinable) {{.*}} {
 
 // -- partial_apply stub
 // CHECK: define internal swiftcc i64 @"$s7closure1b3seqS2icx_tAA9OrdinableRzlFS2icfU_TA"(i64 %0, ptr swiftself %1) {{.*}} {
@@ -40,12 +40,12 @@ func b<T : Ordinable>(seq seq: T) -> (Int) -> Int {
 // CHECK:   [[TYPE:%.*]] = load ptr, ptr [[BINDINGSADDR]], align 8
 // CHECK:   [[WITNESSADDR:%.*]] = getelementptr inbounds ptr, ptr [[BINDINGSADDR]], i32 1
 // CHECK:   [[WITNESS:%.*]] = load ptr, ptr [[WITNESSADDR]], align 8
-// CHECK:   [[RES:%.*]] = tail call swiftcc i64 @"$s7closure1b3seqS2icx_tAA9OrdinableRzlFS2icfU_"(i64 %0, ptr noalias nocapture {{.*}}, ptr [[TYPE]], ptr [[WITNESS]])
+// CHECK:   [[RES:%.*]] = tail call swiftcc i64 @"$s7closure1b3seqS2icx_tAA9OrdinableRzlFS2icfU_"(i64 %0, ptr noalias {{.*}}, ptr [[TYPE]], ptr [[WITNESS]])
 // CHECK:   ret i64 [[RES]]
 // CHECK: }
 
 // -- <rdar://problem/14443343> Boxing of tuples with generic elements
-// CHECK: define hidden swiftcc { ptr, ptr } @"$s7closure14captures_tuple1xx_q_tycx_q_t_tr0_lF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr %T, ptr %U)
+// CHECK: define hidden swiftcc { ptr, ptr } @"$s7closure14captures_tuple1xx_q_tycx_q_t_tr0_lF"(ptr noalias %0, ptr noalias %1, ptr %T, ptr %U)
 func captures_tuple<T, U>(x x: (T, U)) -> () -> (T, U) {
   // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata2(i64 0, ptr %T, ptr %U, ptr null, ptr null)
   // CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0

--- a/test/IRGen/conformance_resilience.swift
+++ b/test/IRGen/conformance_resilience.swift
@@ -5,24 +5,24 @@
 
 import resilient_protocol
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @"$s22conformance_resilience14useConformanceyyx18resilient_protocol22OtherResilientProtocolRzlF"(ptr noalias nocapture %0, ptr %T, ptr %T.OtherResilientProtocol)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @"$s22conformance_resilience14useConformanceyyx18resilient_protocol22OtherResilientProtocolRzlF"(ptr noalias %0, ptr %T, ptr %T.OtherResilientProtocol)
 public func useConformance<T : OtherResilientProtocol>(_: T) {}
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22conformance_resilience14getConformanceyy18resilient_protocol7WrapperVyxGlF"(ptr noalias nocapture %0, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22conformance_resilience14getConformanceyy18resilient_protocol7WrapperVyxGlF"(ptr noalias %0, ptr %T)
 public func getConformance<T>(_ w: Wrapper<T>) {
   // CHECK: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s18resilient_protocol7WrapperVMa"([[INT]] 0, ptr %T)
   // CHECK: [[META:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
   // CHECK: [[WTABLE:%.*]] = call ptr @swift_getWitnessTable(ptr @"$s18resilient_protocol7WrapperVyxGAA22OtherResilientProtocolAAMc", ptr [[META]], ptr undef)
-  // CHECK: call swiftcc void @"$s22conformance_resilience14useConformanceyyx18resilient_protocol22OtherResilientProtocolRzlF"(ptr noalias nocapture %0, ptr [[META]], ptr [[WTABLE]])
+  // CHECK: call swiftcc void @"$s22conformance_resilience14useConformanceyyx18resilient_protocol22OtherResilientProtocolRzlF"(ptr noalias %0, ptr [[META]], ptr [[WTABLE]])
   // CHECK: ret void
   useConformance(w)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22conformance_resilience14getConformanceyy18resilient_protocol15ConcreteWrapperVF"(ptr noalias nocapture %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22conformance_resilience14getConformanceyy18resilient_protocol15ConcreteWrapperVF"(ptr noalias %0)
 public func getConformance(_ w: ConcreteWrapper) {
   // CHECK: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s18resilient_protocol15ConcreteWrapperVMa"([[INT]] 0)
   // CHECK: [[META:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
-  // CHECK: call swiftcc void @"$s22conformance_resilience14useConformanceyyx18resilient_protocol22OtherResilientProtocolRzlF"(ptr noalias nocapture %0, ptr [[META]], ptr @"$s18resilient_protocol15ConcreteWrapperVAA22OtherResilientProtocolAAWP")
+  // CHECK: call swiftcc void @"$s22conformance_resilience14useConformanceyyx18resilient_protocol22OtherResilientProtocolRzlF"(ptr noalias %0, ptr [[META]], ptr @"$s18resilient_protocol15ConcreteWrapperVAA22OtherResilientProtocolAAWP")
   // CHECK: ret void
   useConformance(w)
 }

--- a/test/IRGen/dynamic_self_cast.swift
+++ b/test/IRGen/dynamic_self_cast.swift
@@ -12,7 +12,7 @@ public class SelfCasts {
     return s as! Self
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc ptr @"$s17dynamic_self_cast9SelfCastsC09genericToD0yACXDxlFZ"(ptr noalias nocapture %0, ptr %T, ptr swiftself %1)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc ptr @"$s17dynamic_self_cast9SelfCastsC09genericToD0yACXDxlFZ"(ptr noalias %0, ptr %T, ptr swiftself %1)
   // CHECK: call zeroext i1 @swift_dynamicCast(ptr {{%.*}}, ptr {{%.*}}, ptr %T, ptr %1, {{.*}})
   // CHECK: ret
   public static func genericToSelf<T>(_ s: T) -> Self {
@@ -26,7 +26,7 @@ public class SelfCasts {
     return s as! Self
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s17dynamic_self_cast9SelfCastsC011genericFromD0xylFZ"(ptr noalias nocapture sret({{.*}}) %0, ptr %T, ptr swiftself %1)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s17dynamic_self_cast9SelfCastsC011genericFromD0xylFZ"(ptr noalias sret({{.*}}) %0, ptr %T, ptr swiftself %1)
   // CHECK: call zeroext i1 @swift_dynamicCast(ptr {{%.*}}, ptr {{%.*}}, ptr %1, ptr %T, {{.*}})
   // CHECK: ret
   public static func genericFromSelf<T>() -> T {
@@ -49,7 +49,7 @@ public class SelfCasts {
     return s as? Self
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC09genericToD11ConditionalyACXDSgxlFZ"(ptr noalias nocapture %0, ptr %T, ptr swiftself %1)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC09genericToD11ConditionalyACXDSgxlFZ"(ptr noalias %0, ptr %T, ptr swiftself %1)
   // CHECK: call zeroext i1 @swift_dynamicCast(ptr {{%.*}}, ptr {{%.*}}, ptr %T, ptr %1, {{.*}})
   // CHECK: ret
   public static func genericToSelfConditional<T>(_ s: T) -> Self? {
@@ -63,7 +63,7 @@ public class SelfCasts {
     return s as? Self
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s17dynamic_self_cast9SelfCastsC011genericFromD11ConditionalxSgylFZ"(ptr noalias nocapture sret({{.*}}) %0, ptr %T, ptr swiftself %1)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s17dynamic_self_cast9SelfCastsC011genericFromD11ConditionalxSgylFZ"(ptr noalias sret({{.*}}) %0, ptr %T, ptr swiftself %1)
   // CHECK: call zeroext i1 @swift_dynamicCast(ptr {{%.*}}, ptr {{%.*}}, ptr %1, ptr %T, {{.*}})
   // CHECK: ret
   public static func genericFromSelfConditional<T>() -> T? {

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -198,7 +198,7 @@ enum DynamicSingleton<T> {
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(i64 %0, i64 %1) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(ptr noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(ptr noalias dereferenceable(16) %0) {{.*}} {
 sil @singleton_switch : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
@@ -217,7 +217,7 @@ dest:
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(i64 %0, i64 %1) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(ptr noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(ptr noalias dereferenceable(16) %0) {{.*}} {
 sil @singleton_switch_arg : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
@@ -259,7 +259,7 @@ dest:
 // CHECK-64:   [[B:%.*]] = insertvalue { i64, i64 } [[A]], i64 %1, 1
 // CHECK-64:   ret { i64, i64 } [[B]]
 // CHECK-64: }
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject(ptr noalias nocapture sret({{.*}}) %0, i64 %1, i64 %2) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject(ptr noalias sret({{.*}}) %0, i64 %1, i64 %2) {{.*}} {
 // CHECK-32: entry:
 // CHECK-32:  [[GEP1:%.*]] = getelementptr inbounds <{ i64, i64 }>, ptr %0, i32 0, i32 0
 // CHECK-32:                 store i64 %1, ptr [[GEP1]]
@@ -752,7 +752,7 @@ enum AggregateSinglePayload2 {
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_unpack_2([[WORD]] %0, [[WORD]] %1, [[WORD]] %2, [[WORD]] %3) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(ptr noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(ptr noalias dereferenceable(16) %0) {{.*}} {
 sil @aggregate_single_payload_unpack_2 : $@convention(thin) (AggregateSinglePayload2) -> () {
 entry(%u : $AggregateSinglePayload2):
   switch_enum %u : $AggregateSinglePayload2, case #AggregateSinglePayload2.x!enumelt: x_dest, default default_dest
@@ -783,7 +783,7 @@ end:
 // CHECK-64:  %9 = insertvalue { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } %8, [[WORD]] %3, 3
 // CHECK-64:  ret { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } %9
 
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_2_inject(ptr noalias nocapture sret({{.*}}) %0, i32 %1, i32 %2, i32 %3, i32 %4) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_2_inject(ptr noalias sret({{.*}}) %0, i32 %1, i32 %2, i32 %3, i32 %4) {{.*}} {
 // CHECK-32:  [[TRUNC:%.*]] = trunc i32 %1 to i21
 // CHECK-32:  [[ZEXT:%.*]] = zext i21 [[TRUNC]] to i32
 // CHECK-32:  [[GEP:%.*]] = getelementptr inbounds {{.*}} %0, i32 0, i32 0
@@ -1217,7 +1217,7 @@ enum DynamicSinglePayload<T> {
   case w
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_switch(ptr noalias nocapture %0, ptr %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_switch(ptr noalias %0, ptr %T) {{.*}} {
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds ptr, ptr %T, i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load ptr, ptr [[TMP2]]
 // CHECK:   [[ENUMADDR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 6
@@ -1245,7 +1245,7 @@ end:
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T) {{.*}} {
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds ptr, ptr %T, i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load ptr, ptr [[TMP2]]
 // CHECK:   [[ENUMADDR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 7
@@ -1258,7 +1258,7 @@ entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(ptr noalias nocapture sret({{.*}}) %0, ptr %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(ptr noalias sret({{.*}}) %0, ptr %T) {{.*}} {
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds ptr, ptr %T, i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load ptr, ptr [[TMP2]]
 // CHECK:   [[ENUMADDR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 7
@@ -2345,7 +2345,7 @@ enum MultiPayloadAddressOnlySpareBits {
   case Y(AddressOnlySpareBitsPayload)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_spare_bits(ptr noalias nocapture dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_spare_bits(ptr noalias dereferenceable({{.*}}) %0)
 sil @multi_payload_address_only_spare_bits : $@convention(thin) (@in MultiPayloadAddressOnlySpareBits) -> () {
 entry(%m : $*MultiPayloadAddressOnlySpareBits):
   destroy_addr %m : $*MultiPayloadAddressOnlySpareBits
@@ -2374,7 +2374,7 @@ typealias AllConcreteTestEnums = (
 
 sil_global @x : $AllConcreteTestEnums
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_singleton_switch_indirect(ptr noalias nocapture %0, ptr %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_singleton_switch_indirect(ptr noalias %0, ptr %T) {{.*}} {
 // CHECK:   ret void
 // CHECK: }
 sil @dynamic_singleton_switch_indirect : $<T> (@in DynamicSingleton<T>) -> () {
@@ -2480,7 +2480,7 @@ struct StructWithWeakVar {
 weak var delegate: delegateProtocol?
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(ptr noalias nocapture dereferenceable({{.*}}) %0)
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(ptr noalias dereferenceable({{.*}}) %0)
 sil @weak_optional : $@convention(thin) (@in StructWithWeakVar?) -> () {
 entry(%x : $*StructWithWeakVar?):
   // CHECK-64:      icmp eq [[WORD]] {{%.*}}, 0

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -256,7 +256,7 @@ entry:
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_inject
-// CHECK:         (ptr noalias nocapture sret({{.*}}) %0, ptr %T)
+// CHECK:         (ptr noalias sret({{.*}}) %0, ptr %T)
 sil @dynamic_inject : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int64> {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
   // CHECK: call void @swift_storeEnumTagMultiPayload(ptr {{%.*}}, ptr [[TYPE:%.*]], i32 0)
@@ -272,7 +272,7 @@ entry(%e : $*EitherOr<T, Builtin.Int64>):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_project
-// CHECK:         (ptr noalias nocapture sret({{.*}}) %0, ptr %T)
+// CHECK:         (ptr noalias sret({{.*}}) %0, ptr %T)
 sil @dynamic_project : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int64> {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
   %l = unchecked_take_enum_data_addr %e : $*EitherOr<T, Builtin.Int64>, #EitherOr.Left!enumelt
@@ -282,7 +282,7 @@ entry(%e : $*EitherOr<T, Builtin.Int64>):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_switch
-// CHECK:         (ptr noalias nocapture sret({{.*}}) %0, ptr %T)
+// CHECK:         (ptr noalias sret({{.*}}) %0, ptr %T)
 sil @dynamic_switch : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int64> {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
   // CHECK: [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
@@ -323,7 +323,7 @@ next(%x : $Builtin.Int8):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_value_semantics
-// CHECK:         (ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T)
+// CHECK:         (ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T)
 sil @dynamic_value_semantics : $@convention(thin) <T> (@in EitherOr<T, Builtin.Int64>) -> @out EitherOr<T, Builtin.Int64> {
 entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
@@ -361,7 +361,7 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_value_semantics2
-// CHECK:         (ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T)
+// CHECK:         (ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T)
 sil @dynamic_value_semantics2 : $@convention(thin) <T> (@in EitherOr<T, C>) -> @out EitherOr<T, C> {
 entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -202,7 +202,7 @@ enum DynamicSingleton<T> {
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(i64 %0, i64 %1) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(ptr noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(ptr noalias dereferenceable(16) %0) {{.*}} {
 sil @singleton_switch : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
@@ -221,7 +221,7 @@ dest:
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(i64 %0, i64 %1) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(ptr noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(ptr noalias dereferenceable(16) %0) {{.*}} {
 sil @singleton_switch_arg : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
@@ -263,7 +263,7 @@ dest:
 // CHECK-64:   [[B:%.*]] = insertvalue { i64, i64 } [[A]], i64 %1, 1
 // CHECK-64:   ret { i64, i64 } [[B]]
 // CHECK-64: }
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject(ptr noalias nocapture sret({{.*}}) %0, i64 %1, i64 %2) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject(ptr noalias sret({{.*}}) %0, i64 %1, i64 %2) {{.*}} {
 // CHECK-32: entry:
 // CHECK-32:  [[GEP1:%.*]] = getelementptr inbounds <{ i64, i64 }>, ptr %0, i32 0, i32 0
 // CHECK-32:                 store i64 %1, ptr [[GEP1]]
@@ -756,7 +756,7 @@ enum AggregateSinglePayload2 {
 }
 
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_unpack_2([[WORD]] %0, [[WORD]] %1, [[WORD]] %2, [[WORD]] %3) {{.*}} {
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(ptr noalias nocapture dereferenceable(16) %0) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(ptr noalias dereferenceable(16) %0) {{.*}} {
 sil @aggregate_single_payload_unpack_2 : $@convention(thin) (AggregateSinglePayload2) -> () {
 entry(%u : $AggregateSinglePayload2):
   switch_enum %u : $AggregateSinglePayload2, case #AggregateSinglePayload2.x!enumelt: x_dest, default default_dest
@@ -787,7 +787,7 @@ end:
 // CHECK-64:  %9 = insertvalue { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } %8, [[WORD]] %3, 3
 // CHECK-64:  ret { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } %9
 
-// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_2_inject(ptr noalias nocapture sret({{.*}}) %0, i32 %1, i32 %2, i32 %3, i32 %4) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_2_inject(ptr noalias sret({{.*}}) %0, i32 %1, i32 %2, i32 %3, i32 %4) {{.*}} {
 // CHECK-32:  [[TRUNC:%.*]] = trunc i32 %1 to i21
 // CHECK-32:  [[ZEXT:%.*]] = zext i21 [[TRUNC]] to i32
 // CHECK-32:  [[GEP:%.*]] = getelementptr inbounds {{.*}} %0, i32 0, i32 0
@@ -1221,7 +1221,7 @@ enum DynamicSinglePayload<T> {
   case w
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_switch(ptr noalias nocapture %0, ptr %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_switch(ptr noalias %0, ptr %T) {{.*}} {
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds ptr, ptr %T, i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load ptr, ptr [[TMP2]]
 // CHECK:   [[ENUMADDR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 6
@@ -1249,7 +1249,7 @@ end:
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T) {{.*}} {
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds ptr, ptr %T, i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load ptr, ptr [[TMP2]]
 // CHECK:   [[ENUMADDR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 7
@@ -1262,7 +1262,7 @@ entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(ptr noalias nocapture sret({{.*}}) %0, ptr %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(ptr noalias sret({{.*}}) %0, ptr %T) {{.*}} {
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds ptr, ptr %T, i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load ptr, ptr [[TMP2]]
 // CHECK:   [[ENUMADDR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 7
@@ -2349,7 +2349,7 @@ enum MultiPayloadAddressOnlySpareBits {
   case Y(AddressOnlySpareBitsPayload)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_spare_bits(ptr noalias nocapture dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_spare_bits(ptr noalias dereferenceable({{.*}}) %0)
 sil @multi_payload_address_only_spare_bits : $@convention(thin) (@in MultiPayloadAddressOnlySpareBits) -> () {
 entry(%m : $*MultiPayloadAddressOnlySpareBits):
   destroy_addr %m : $*MultiPayloadAddressOnlySpareBits
@@ -2378,7 +2378,7 @@ typealias AllConcreteTestEnums = (
 
 sil_global @x : $AllConcreteTestEnums
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_singleton_switch_indirect(ptr noalias nocapture %0, ptr %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_singleton_switch_indirect(ptr noalias %0, ptr %T) {{.*}} {
 // CHECK:   ret void
 // CHECK: }
 sil @dynamic_singleton_switch_indirect : $<T> (@in DynamicSingleton<T>) -> () {
@@ -2484,7 +2484,7 @@ struct StructWithWeakVar {
 weak var delegate: delegateProtocol?
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(ptr noalias nocapture dereferenceable({{.*}}) %0)
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(ptr noalias dereferenceable({{.*}}) %0)
 sil @weak_optional : $@convention(thin) (@in StructWithWeakVar?) -> () {
 entry(%x : $*StructWithWeakVar?):
   // CHECK-64:      icmp eq [[WORD]] {{%.*}}, 0

--- a/test/IRGen/enum_objc.sil
+++ b/test/IRGen/enum_objc.sil
@@ -109,7 +109,7 @@ struct StructWithWeakVar {
 weak var delegate: delegateProtocol?
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(ptr noalias nocapture dereferenceable({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(ptr noalias dereferenceable({{.*}}) %0)
 sil @weak_optional : $@convention(thin) (@in StructWithWeakVar?) -> () {
 entry(%x : $*StructWithWeakVar?):
   // CHECK:      icmp eq [[WORD:i32|i64]] {{%.*}}, 0

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -72,7 +72,7 @@ enum InternalEither {
   case Right(ReferenceFast)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15enum_resilience25functionWithResilientEnumy010resilient_A06MediumOAEF"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15enum_resilience25functionWithResilientEnumy010resilient_A06MediumOAEF"(ptr noalias sret({{.*}}) %0, ptr noalias %1)
 public func functionWithResilientEnum(_ m: Medium) -> Medium {
 
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s14resilient_enum6MediumOMa"([[INT]] 0)
@@ -90,7 +90,7 @@ public func functionWithResilientEnum(_ m: Medium) -> Medium {
   return m
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15enum_resilience33functionWithIndirectResilientEnumy010resilient_A00E8ApproachOAEF"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15enum_resilience33functionWithIndirectResilientEnumy010resilient_A00E8ApproachOAEF"(ptr noalias sret({{.*}}) %0, ptr noalias %1)
 public func functionWithIndirectResilientEnum(_ ia: IndirectApproach) -> IndirectApproach {
 
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s14resilient_enum16IndirectApproachOMa"([[INT]] 0)
@@ -172,7 +172,7 @@ public func constructResilientEnumPayload(_ s: Size) -> Medium {
   return Medium.Postcard(s)
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i32|i64}} @"$s15enum_resilience19resilientSwitchTestySi0c1_A06MediumOF"(ptr noalias nocapture %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i32|i64}} @"$s15enum_resilience19resilientSwitchTestySi0c1_A06MediumOF"(ptr noalias %0)
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s14resilient_enum6MediumOMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[VWT_ADDR:%.*]] = getelementptr inbounds ptr, ptr [[METADATA]], [[INT]] -1
@@ -250,7 +250,7 @@ public func resilientEnumPartialApply(_ f: (Medium) -> Int) {
 // CHECK:     ret void
 }
 
-// CHECK-LABEL: define internal swiftcc void @"$s14resilient_enum6MediumOSiIgnd_ACSiIegnr_TRTA"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr swiftself %2)
+// CHECK-LABEL: define internal swiftcc void @"$s14resilient_enum6MediumOSiIgnd_ACSiIegnr_TRTA"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias %1, ptr swiftself %2)
 
 
 // Enums with resilient payloads from a different resilience domain
@@ -296,7 +296,7 @@ public func getResilientEnumType() -> Any.Type {
 // from metadata -- make sure we can do that
 extension ResilientMultiPayloadGenericEnum {
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s14resilient_enum32ResilientMultiPayloadGenericEnumO0B11_resilienceE16getTypeParameterxmyF"(ptr %"ResilientMultiPayloadGenericEnum<T>", ptr noalias nocapture swiftself %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s14resilient_enum32ResilientMultiPayloadGenericEnumO0B11_resilienceE16getTypeParameterxmyF"(ptr %"ResilientMultiPayloadGenericEnum<T>", ptr noalias swiftself %0)
 // CHECK: [[T_ADDR:%.*]] = getelementptr inbounds ptr, ptr %"ResilientMultiPayloadGenericEnum<T>", [[INT]] 2
 // CHECK-NEXT: [[T:%.*]] = load ptr, ptr [[T_ADDR]]
   public func getTypeParameter() -> T.Type {
@@ -304,7 +304,7 @@ extension ResilientMultiPayloadGenericEnum {
   }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15enum_resilience39constructExhaustiveWithResilientMembers010resilient_A011SimpleShapeOyF"(ptr noalias nocapture sret({{.*}}) %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15enum_resilience39constructExhaustiveWithResilientMembers010resilient_A011SimpleShapeOyF"(ptr noalias sret({{.*}}) %0)
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct4SizeVMa"([[INT]] 0)
 // CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT: [[WITNESSTABLE_ADDR:%[0-9]+]] = getelementptr inbounds ptr, ptr [[METADATA]], {{(i64|i32)}} -1

--- a/test/IRGen/error_self_conformance.sil
+++ b/test/IRGen/error_self_conformance.sil
@@ -8,7 +8,7 @@ sil @take_any_error : $@convention(thin) <T: Error> (@in T) -> ()
 sil @test : $@convention(thin) (@in Error) -> () {
 entry(%0 : $*Error):
   // CHECK: [[ERROR_METADATA:%.*]] = call {{.*}}@"$ss5Error_pMD"
-  // CHECK-NEXT: call swiftcc void @take_any_error(ptr noalias nocapture %0, ptr [[ERROR_METADATA]], ptr @"$ss5ErrorWS")
+  // CHECK-NEXT: call swiftcc void @take_any_error(ptr noalias %0, ptr [[ERROR_METADATA]], ptr @"$ss5ErrorWS")
   // CHECK-NEXT: ret void
   %take = function_ref @take_any_error : $@convention(thin) <T: Error> (@in T) -> ()
   apply %take<Error>(%0) : $@convention(thin) <T: Error> (@in T) -> ()

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -47,7 +47,7 @@ entry(%s : $CP):
   return %z : $CP
 }
 
-// CHECK-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @class_existential_weak(ptr noalias nocapture sret({{.*}}) %0, i64 %1, i64 %2)
+// CHECK-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @class_existential_weak(ptr noalias sret({{.*}}) %0, i64 %1, i64 %2)
 sil @class_existential_weak : $@convention(thin) (@owned CP?) -> @out @sil_weak CP? {
 entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[V:%.*]] = alloca { %swift.weak, ptr }

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -97,7 +97,7 @@ entry(%s : $CP):
   return %z : $CP
 }
 
-// CHECK-DAG: define{{( protected)?}} swiftcc void @class_existential_weak(ptr noalias nocapture sret({{.*}}) %0, i64 %1, i64 %2)
+// CHECK-DAG: define{{( protected)?}} swiftcc void @class_existential_weak(ptr noalias sret({{.*}}) %0, i64 %1, i64 %2)
 sil @class_existential_weak : $@convention(thin) (@owned CP?) -> @out @sil_weak CP? {
 entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[V:%.*]] = alloca { %swift.weak, ptr }

--- a/test/IRGen/frozen_protocols.swift
+++ b/test/IRGen/frozen_protocols.swift
@@ -39,10 +39,10 @@ public struct ConformsToFrozenProtocol : FrozenProtocol {
 // Requirements in @_fixed_layout protocols are called by direct witness
 // table lookup
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s16frozen_protocols23callOtherProtocolMethodyyx18resilient_protocol0d6FrozenE0RzlF"(ptr noalias nocapture %0, ptr %T, ptr %T.OtherFrozenProtocol)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s16frozen_protocols23callOtherProtocolMethodyyx18resilient_protocol0d6FrozenE0RzlF"(ptr noalias %0, ptr %T, ptr %T.OtherFrozenProtocol)
 // CHECK: [[ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.OtherFrozenProtocol, i32 1
 // CHECK: [[FN:%.*]] = load ptr, ptr [[ADDR]]
-// CHECK: call swiftcc void [[FN]](ptr noalias nocapture swiftself %0, ptr %T, ptr %T.OtherFrozenProtocol)
+// CHECK: call swiftcc void [[FN]](ptr noalias swiftself %0, ptr %T, ptr %T.OtherFrozenProtocol)
 // CHECK: ret void
 
 // @_fixed_layout protocols still emit method dispatch thunks though, which

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -33,7 +33,7 @@ import gizmo
 // CHECK:   @_PROTOCOL__TtP13generic_casts10ObjCProto1_
 // CHECK: }
 
-// CHECK: define hidden swiftcc i64 @"$s13generic_casts8allToIntySixlF"(ptr noalias nocapture %0, ptr %T)
+// CHECK: define hidden swiftcc i64 @"$s13generic_casts8allToIntySixlF"(ptr noalias %0, ptr %T)
 func allToInt<T>(_ x: T) -> Int {
   return x as! Int
   // CHECK: [[INT_TEMP:%.*]] = alloca %TSi,
@@ -49,7 +49,7 @@ func allToInt<T>(_ x: T) -> Int {
   // CHECK: ret i64 [[INT_RESULT]]
 }
 
-// CHECK: define hidden swiftcc void @"$s13generic_casts8intToAllyxSilF"(ptr noalias nocapture sret({{.*}}) %0, i64 %1, ptr %T) {{.*}} {
+// CHECK: define hidden swiftcc void @"$s13generic_casts8intToAllyxSilF"(ptr noalias sret({{.*}}) %0, i64 %1, ptr %T) {{.*}} {
 func intToAll<T>(_ x: Int) -> T {
   // CHECK: [[INT_TEMP:%.*]] = alloca %TSi,
   // CHECK: [[T0:%.*]] = getelementptr inbounds %TSi, ptr [[INT_TEMP]], i32 0, i32 0
@@ -91,7 +91,7 @@ func protoCast(_ x: ObjCClass) -> ObjCProto1 & NSRuncing {
 
 // <rdar://problem/15313840>
 // Class existential to opaque archetype cast
-// CHECK: define hidden swiftcc void @"$s13generic_casts33classExistentialToOpaqueArchetypeyxAA10ObjCProto1_plF"(ptr noalias nocapture sret({{.*}}) %0, ptr %1, ptr %T)
+// CHECK: define hidden swiftcc void @"$s13generic_casts33classExistentialToOpaqueArchetypeyxAA10ObjCProto1_plF"(ptr noalias sret({{.*}}) %0, ptr %1, ptr %T)
 func classExistentialToOpaqueArchetype<T>(_ x: ObjCProto1) -> T {
   var x = x
   // CHECK: [[X:%.*]] = alloca %T13generic_casts10ObjCProto1P

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -23,7 +23,7 @@ public func type<T, Metatype>(of value: T) -> Metatype {
   never()
 }
 
-// CHECK: define hidden swiftcc ptr [[GENERIC_TYPEOF:@"\$s17generic_metatypes0A6TypeofyxmxlF"]](ptr noalias nocapture %0, ptr [[TYPE:%.*]])
+// CHECK: define hidden swiftcc ptr [[GENERIC_TYPEOF:@"\$s17generic_metatypes0A6TypeofyxmxlF"]](ptr noalias %0, ptr [[TYPE:%.*]])
 func genericTypeof<T>(_ x: T) -> T.Type {
   // CHECK: [[METATYPE:%.*]] = call ptr @swift_getDynamicType(ptr {{.*}}, ptr [[TYPE]], i1 false)
   // CHECK: ret ptr [[METATYPE]]
@@ -37,10 +37,10 @@ class Bar {}
 func remapToSubstitutedMetatypes(_ x: Foo, y: Bar)
   -> (Foo.Type, Bar.Type)
 {
-  // CHECK: call swiftcc ptr [[GENERIC_TYPEOF]](ptr noalias nocapture undef, ptr {{.*}} @"$s17generic_metatypes3FooVMf", {{.*}})
+  // CHECK: call swiftcc ptr [[GENERIC_TYPEOF]](ptr noalias undef, ptr {{.*}} @"$s17generic_metatypes3FooVMf", {{.*}})
   // CHECK: [[BAR_REQUEST:%.*]] = call {{.*}}@"$s17generic_metatypes3BarCMa"
   // CHECK: [[BAR:%.*]] = extractvalue {{.*}} [[BAR_REQUEST]]
-  // CHECK: [[BAR_META:%.*]] = call swiftcc ptr [[GENERIC_TYPEOF]](ptr noalias nocapture {{%.*}}, ptr [[BAR]])
+  // CHECK: [[BAR_META:%.*]] = call swiftcc ptr [[GENERIC_TYPEOF]](ptr noalias {{%.*}}, ptr [[BAR]])
   // CHECK: ret ptr [[BAR_META]]
   return (genericTypeof(x), genericTypeof(y))
 }

--- a/test/IRGen/generic_metatypes_future.swift
+++ b/test/IRGen/generic_metatypes_future.swift
@@ -24,7 +24,7 @@ public func type<T, Metatype>(of value: T) -> Metatype {
   never()
 }
 
-// CHECK: define hidden swiftcc ptr [[GENERIC_TYPEOF:@"\$s17generic_metatypes0A6TypeofyxmxlF"]](ptr noalias nocapture %0, ptr [[TYPE:%.*]])
+// CHECK: define hidden swiftcc ptr [[GENERIC_TYPEOF:@"\$s17generic_metatypes0A6TypeofyxmxlF"]](ptr noalias %0, ptr [[TYPE:%.*]])
 func genericTypeof<T>(_ x: T) -> T.Type {
   // CHECK: [[METATYPE:%.*]] = call ptr @swift_getDynamicType(ptr {{.*}}, ptr [[TYPE]], i1 false)
   // CHECK: ret ptr [[METATYPE]]
@@ -38,10 +38,10 @@ class Bar {}
 func remapToSubstitutedMetatypes(_ x: Foo, y: Bar)
   -> (Foo.Type, Bar.Type)
 {
-  // CHECK: call swiftcc ptr [[GENERIC_TYPEOF]](ptr noalias nocapture undef, ptr {{.*}} @"$s17generic_metatypes3FooVMf", {{.*}})
+  // CHECK: call swiftcc ptr [[GENERIC_TYPEOF]](ptr noalias undef, ptr {{.*}} @"$s17generic_metatypes3FooVMf", {{.*}})
   // CHECK: [[BAR_REQUEST:%.*]] = call {{.*}}@"$s17generic_metatypes3BarCMa"
   // CHECK: [[BAR:%.*]] = extractvalue {{.*}} [[BAR_REQUEST]]
-  // CHECK: [[BAR_META:%.*]] = call swiftcc ptr [[GENERIC_TYPEOF]](ptr noalias nocapture {{%.*}}, ptr [[BAR]])
+  // CHECK: [[BAR_META:%.*]] = call swiftcc ptr [[GENERIC_TYPEOF]](ptr noalias {{%.*}}, ptr [[BAR]])
   // CHECK: ret ptr [[BAR_META]]
   return (genericTypeof(x), genericTypeof(y))
 }

--- a/test/IRGen/generic_ternary.swift
+++ b/test/IRGen/generic_ternary.swift
@@ -4,7 +4,7 @@
 
 // <rdar://problem/13793646>
 struct OptionalStreamAdaptor<T : IteratorProtocol> {
-  // CHECK: define hidden swiftcc void @"$s15generic_ternary21OptionalStreamAdaptorV4next{{[_0-9a-zA-Z]*}}F"(ptr noalias nocapture sret({{.*}}) %0, ptr %"OptionalStreamAdaptor<T>", ptr nocapture swiftself dereferenceable({{.*}}) %1)
+  // CHECK: define hidden swiftcc void @"$s15generic_ternary21OptionalStreamAdaptorV4next{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) %0, ptr %"OptionalStreamAdaptor<T>", ptr nocapture swiftself dereferenceable({{.*}}) %1)
   mutating
   func next() -> Optional<T.Element> {
     return x[0].next()

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -10,7 +10,7 @@
 // CHECK-DAG: %swift.tuple_element_type = type { ptr, i32 }
 
 func dup<T>(_ x: T) -> (T, T) { var x = x; return (x,x) }
-// CHECK:    define hidden swiftcc void @"$s14generic_tuples3dupyx_xtxlF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr noalias nocapture %2, ptr %T)
+// CHECK:    define hidden swiftcc void @"$s14generic_tuples3dupyx_xtxlF"(ptr noalias %0, ptr noalias %1, ptr noalias %2, ptr %T)
 // CHECK:    entry:
 //   Allocate a local variable for 'x'.
 // CHECK: [[VWT_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T, i64 -1
@@ -62,22 +62,22 @@ func callDupC(_ c: C) { _ = dupC(c) }
 // CHECK-NEXT: call void @swift_release(ptr [[LEFT]])
 // CHECK-NEXT: ret void
 
-// CHECK: define hidden swiftcc i64 @"$s14generic_tuples4lumpySi_xxtxlF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr noalias nocapture %2, ptr %T)
+// CHECK: define hidden swiftcc i64 @"$s14generic_tuples4lumpySi_xxtxlF"(ptr noalias %0, ptr noalias %1, ptr noalias %2, ptr %T)
 func lump<T>(_ x: T) -> (Int, T, T) { return (0,x,x) }
-// CHECK: define hidden swiftcc { i64, i64 } @"$s14generic_tuples5lump2ySi_SixtxlF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr %T)
+// CHECK: define hidden swiftcc { i64, i64 } @"$s14generic_tuples5lump2ySi_SixtxlF"(ptr noalias %0, ptr noalias %1, ptr %T)
 func lump2<T>(_ x: T) -> (Int, Int, T) { return (0,0,x) }
-// CHECK: define hidden swiftcc void @"$s14generic_tuples5lump3yx_xxtxlF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr noalias nocapture %2, ptr noalias nocapture %3, ptr %T)
+// CHECK: define hidden swiftcc void @"$s14generic_tuples5lump3yx_xxtxlF"(ptr noalias %0, ptr noalias %1, ptr noalias %2, ptr noalias %3, ptr %T)
 func lump3<T>(_ x: T) -> (T, T, T) { return (x,x,x) }
-// CHECK: define hidden swiftcc i64 @"$s14generic_tuples5lump4yx_SixtxlF"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr noalias nocapture %2, ptr %T)
+// CHECK: define hidden swiftcc i64 @"$s14generic_tuples5lump4yx_SixtxlF"(ptr noalias %0, ptr noalias %1, ptr noalias %2, ptr %T)
 func lump4<T>(_ x: T) -> (T, Int, T) { return (x,0,x) }
 
-// CHECK: define hidden swiftcc i64 @"$s14generic_tuples6unlumpyS2i_xxt_tlF"(i64 %0, ptr noalias nocapture %1, ptr noalias nocapture %2, ptr %T)
+// CHECK: define hidden swiftcc i64 @"$s14generic_tuples6unlumpyS2i_xxt_tlF"(i64 %0, ptr noalias %1, ptr noalias %2, ptr %T)
 func unlump<T>(_ x: (Int, T, T)) -> Int { return x.0 }
-// CHECK: define hidden swiftcc void @"$s14generic_tuples7unlump1yxSi_xxt_tlF"(ptr noalias nocapture sret({{.*}}) %0, i64 %1, ptr noalias nocapture %2, ptr noalias nocapture %3, ptr %T)
+// CHECK: define hidden swiftcc void @"$s14generic_tuples7unlump1yxSi_xxt_tlF"(ptr noalias sret({{.*}}) %0, i64 %1, ptr noalias %2, ptr noalias %3, ptr %T)
 func unlump1<T>(_ x: (Int, T, T)) -> T { return x.1 }
-// CHECK: define hidden swiftcc void @"$s14generic_tuples7unlump2yxx_Sixt_tlF"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, i64 %2, ptr noalias nocapture %3, ptr %T)
+// CHECK: define hidden swiftcc void @"$s14generic_tuples7unlump2yxx_Sixt_tlF"(ptr noalias sret({{.*}}) %0, ptr noalias %1, i64 %2, ptr noalias %3, ptr %T)
 func unlump2<T>(_ x: (T, Int, T)) -> T { return x.0 }
-// CHECK: define hidden swiftcc i64 @"$s14generic_tuples7unlump3ySix_Sixt_tlF"(ptr noalias nocapture %0, i64 %1, ptr noalias nocapture %2, ptr %T)
+// CHECK: define hidden swiftcc i64 @"$s14generic_tuples7unlump3ySix_Sixt_tlF"(ptr noalias %0, i64 %1, ptr noalias %2, ptr %T)
 func unlump3<T>(_ x: (T, Int, T)) -> Int { return x.1 }
 
 

--- a/test/IRGen/indexing.sil
+++ b/test/IRGen/indexing.sil
@@ -38,7 +38,7 @@ entry(%p : $*(), %i: $Builtin.Word):
   return undef : $()
 }
 
-// CHECK:      define{{( protected)?}} {{.*}}void @dynamic_size(ptr noalias nocapture %0, i64 %1, ptr %T) {{.*}} {
+// CHECK:      define{{( protected)?}} {{.*}}void @dynamic_size(ptr noalias %0, i64 %1, ptr %T) {{.*}} {
 // CHECK:   [[T1:%.*]] = getelementptr inbounds ptr, ptr %T, i64 -1
 // CHECK-NEXT:   [[VWT:%T.valueWitnesses]] = load ptr, ptr [[T1]], align 8
 // CHECK:        [[STRIDE_ADDR:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[VWT]], i32 0, i32 9

--- a/test/IRGen/infinite_archetype.swift
+++ b/test/IRGen/infinite_archetype.swift
@@ -6,5 +6,5 @@ protocol Fooable {
   associatedtype Foo
 }
 
-// CHECK: define hidden swiftcc void @"$s18infinite_archetype3foo{{[_0-9a-zA-Z]*}}F"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T, ptr %T.Fooable)
+// CHECK: define hidden swiftcc void @"$s18infinite_archetype3foo{{[_0-9a-zA-Z]*}}F"(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T, ptr %T.Fooable)
 func foo<T: Fooable>(x: T) -> T where T == T.Foo { return x }

--- a/test/IRGen/lifetime.sil
+++ b/test/IRGen/lifetime.sil
@@ -14,7 +14,7 @@ bb0(%x : $*T):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @generic(ptr noalias nocapture %0, ptr %T) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @generic(ptr noalias %0, ptr %T) {{.*}} {
 //   Allocate it.
 // CHECK:      [[VWT_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T, {{(i32|i64)}} -1
 // CHECK-NEXT: [[VWT:%.*]] = load ptr, ptr [[VWT_ADDR]]
@@ -51,7 +51,7 @@ bb0(%x : $*T):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @generic_with_reuse(ptr noalias nocapture %0, ptr %T) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @generic_with_reuse(ptr noalias %0, ptr %T) {{.*}} {
 //   Allocate it.
 // CHECK:      [[VWT_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T, {{(i32|i64)}} -1
 // CHECK-NEXT: [[VWT:%.*]] = load ptr, ptr [[VWT_ADDR]]

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -54,7 +54,7 @@ public func markerInDictionary() -> Any {
 }
 
 // Note: no witness tables
-// CHECK: swiftcc void @"$s15marker_protocol7genericyyxAA1PRzlF"(ptr noalias nocapture %0, ptr %T)
+// CHECK: swiftcc void @"$s15marker_protocol7genericyyxAA1PRzlF"(ptr noalias %0, ptr %T)
 public func generic<T: P>(_: T) { }
 
 public struct GenericType<T: Hashable & P> { }

--- a/test/IRGen/non_fixed_return.swift
+++ b/test/IRGen/non_fixed_return.swift
@@ -55,14 +55,14 @@ func create<T>(_ t: T) -> C<T> {
 // We use opaque storage types because LLVM performs type based analysis based
 // on the sret storage type which goes wrong with non fixed types.
 
-// CHECK-LABEL: define hidden swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(ptr noalias nocapture sret(%swift.opaque) %0
+// CHECK-LABEL: define hidden swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(ptr noalias sret(%swift.opaque) %0
 
-// CHECK-LABEL: define hidden swiftcc void @"$s16non_fixed_return6createyAA1CVyxGxlF"(ptr noalias nocapture sret(%swift.opaque) %0, ptr noalias nocapture %1, ptr %T)
-// CHECK:  call swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(ptr noalias nocapture sret(%swift.opaque) %0
+// CHECK-LABEL: define hidden swiftcc void @"$s16non_fixed_return6createyAA1CVyxGxlF"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr %T)
+// CHECK:  call swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(ptr noalias sret(%swift.opaque) %0
 // CHECK:  ret void
 
 // Make sure we don't loose the stores for the optional UInt32? in optimize mode.
-// OPT-LABEL: define hidden swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(ptr noalias nocapture sret(%swift.opaque) %0
+// OPT-LABEL: define hidden swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(ptr noalias sret(%swift.opaque) %0
 // OPT:  store i32 0, ptr [[BASE:%[0-9]+]]
 // OPT:  [[ADDR2:%.*]] = getelementptr inbounds %Ts6UInt32VSg, ptr [[BASE]], i64 0, i32 1
 // OPT:  store i1 true, ptr [[ADDR2]]

--- a/test/IRGen/objc_enum_multi_file.swift
+++ b/test/IRGen/objc_enum_multi_file.swift
@@ -34,7 +34,7 @@ func useFoo(_ x: Foo) -> Int32 {
   }
 
   // CHECK: [[DEFAULT]]:
-  // CHECK: call swiftcc void @"$ss32_diagnoseUnexpectedEnumCaseValue{{.+}}"(ptr @"$s{{.+}}3FooON", ptr noalias nocapture %{{.+}}, ptr @"$ss5Int32VN")
+  // CHECK: call swiftcc void @"$ss32_diagnoseUnexpectedEnumCaseValue{{.+}}"(ptr @"$s{{.+}}3FooON", ptr noalias %{{.+}}, ptr @"$ss5Int32VN")
   // CHECK-NEXT: unreachable
 
   // CHECK: [[FINAL]]:
@@ -68,7 +68,7 @@ func useBar(_ x: Bar) -> Int32 {
   }
 
   // CHECK: [[DEFAULT]]:
-  // CHECK: call swiftcc void @"$ss32_diagnoseUnexpectedEnumCaseValue{{.+}}"(ptr @"$s{{.+}}3BarON", ptr noalias nocapture %{{.+}}, ptr @"$ss5Int32VN")
+  // CHECK: call swiftcc void @"$ss32_diagnoseUnexpectedEnumCaseValue{{.+}}"(ptr @"$s{{.+}}3BarON", ptr noalias %{{.+}}, ptr @"$ss5Int32VN")
   // CHECK-NEXT: unreachable
 
   // CHECK: [[FINAL]]:

--- a/test/IRGen/opaque_values_irgen.sil
+++ b/test/IRGen/opaque_values_irgen.sil
@@ -4,7 +4,7 @@ import Builtin
 
 sil_stage raw
 
-// CHECK: define hidden swiftcc void @f010_irgen_identity(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T)
+// CHECK: define hidden swiftcc void @f010_irgen_identity(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T)
 // CHECK: entry:
 // CHECK-NOT: call
 // CHECK-NOT: call

--- a/test/IRGen/open_boxed_existential.sil
+++ b/test/IRGen/open_boxed_existential.sil
@@ -14,7 +14,7 @@ entry(%b : $Error):
   // CHECK: [[WITNESS:%.*]] = load {{.*}} [[OUT_WITNESS]]
   %o = open_existential_box %b : $Error to $*@opened("01234567-89AB-CDEF-0123-000000000000", Error) Self
   %m = witness_method $@opened("01234567-89AB-CDEF-0123-000000000000", Error) Self, #Error._code!getter, %o : $*@opened("01234567-89AB-CDEF-0123-000000000000", Error) Self : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
-  // CHECK: [[RESULT:%.*]] =  call swiftcc [[INT:i[0-9]+]] @"$ss5ErrorP5_codeSivgTj"(ptr noalias nocapture swiftself [[ADDR]], ptr [[TYPE]], ptr [[WITNESS]])
+  // CHECK: [[RESULT:%.*]] =  call swiftcc [[INT:i[0-9]+]] @"$ss5ErrorP5_codeSivgTj"(ptr noalias swiftself [[ADDR]], ptr [[TYPE]], ptr [[WITNESS]])
   %c = apply %m<@opened("01234567-89AB-CDEF-0123-000000000000", Error) Self>(%o) : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
   // CHECK: ret [[INT]] [[RESULT]]
   return %c : $Int

--- a/test/IRGen/outlined_copy_addr.swift
+++ b/test/IRGen/outlined_copy_addr.swift
@@ -18,7 +18,7 @@ public struct StructWithBaseStruct<T: BaseProt> {
     var elem2: BaseStruct<Element>
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s11outcopyaddr010StructWithbc4BaseB0V4elemAA0bcdB0VyxGvg"(ptr noalias nocapture sret({{.*}}) %0, ptr %"StructWithStructWithBaseStruct<T>", ptr noalias nocapture swiftself %1)
+// CHECK-LABEL: define hidden swiftcc void @"$s11outcopyaddr010StructWithbc4BaseB0V4elemAA0bcdB0VyxGvg"(ptr noalias sret({{.*}}) %0, ptr %"StructWithStructWithBaseStruct<T>", ptr noalias swiftself %1)
 // CHECK: call ptr @"$s11outcopyaddr014StructWithBaseB0VyxGAA9ChildProtRzlWOc"
 public struct StructWithStructWithBaseStruct<T: ChildProt> {
     public typealias Element = T
@@ -36,7 +36,7 @@ struct OtherInternal<T> {
 struct MyPrivate<T: P> {
   var otherHelper: OtherInternal<T>? = nil
 
-  // CHECK-LABEL: define hidden swiftcc {{i32|i64}} @"$s11outcopyaddr9MyPrivateVyACyxGxcfC"(ptr noalias nocapture %0, ptr %T, ptr %T.P) {{.*}} {
+  // CHECK-LABEL: define hidden swiftcc {{i32|i64}} @"$s11outcopyaddr9MyPrivateVyACyxGxcfC"(ptr noalias %0, ptr %T, ptr %T.P) {{.*}} {
   // CHECK: call ptr @"$s11outcopyaddr9MyPrivateVyxGAA1PRzlWOh"(ptr {{%.*}})
   // CHECK: ret
   init(_: T) { }

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -272,7 +272,7 @@ bb0(%x : $*SwiftClassPair):
 
 sil public_external @captured_fixed_and_dependent_params : $@convention(thin) <A> (@guaranteed SwiftClass, @in A, Int) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_non_fixed_layout(ptr %0, ptr noalias nocapture %1, i64 %2, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_indirect_non_fixed_layout(ptr %0, ptr noalias %1, i64 %2, ptr %T)
 // -- Round the base offset for the T field up to T's alignment.
 // CHECK:         [[T_VWTABLE_ADDR:%.*]] = getelementptr {{.*}} %T, [[WORD:i[0-9]+]] -1
 // CHECK:         [[T_VWTABLE:%.*]] = load {{.*}} [[T_VWTABLE_ADDR]]
@@ -340,8 +340,8 @@ bb0(%x : $*T):
   return %p : $@callee_owned () -> @out T
 }
 
-// CHECK-LABEL: define internal swiftcc void @"$s28captured_dependent_out_paramTA"(ptr noalias nocapture sret({{.*}}) %0, ptr swiftself %1) {{.*}} {
-// CHECK:         call swiftcc void @captured_dependent_out_param(ptr noalias nocapture sret({{.*}})
+// CHECK-LABEL: define internal swiftcc void @"$s28captured_dependent_out_paramTA"(ptr noalias sret({{.*}}) %0, ptr swiftself %1) {{.*}} {
+// CHECK:         call swiftcc void @captured_dependent_out_param(ptr noalias sret({{.*}})
 
 sil @partial_apply_dynamic_with_out_param : $@convention(thin) <T> (Int32, @owned @callee_owned (Int32) -> @out T) -> @callee_owned () -> @out T {
 bb0(%x : $Int32, %f : $@callee_owned (Int32) -> @out T):
@@ -352,7 +352,7 @@ bb0(%x : $Int32, %f : $@callee_owned (Int32) -> @out T):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @partial_apply_dynamic_with_out_param
 // CHECK:         insertvalue {{.*}} [[FORWARDER:@"\$sTA[A-Za-z0-9_]*"]]
 // CHECK:       define internal swiftcc void [[FORWARDER]]
-// CHECK:         call swiftcc void {{%.*}}(ptr noalias nocapture sret({{.*}})
+// CHECK:         call swiftcc void {{%.*}}(ptr noalias sret({{.*}})
 
 class Base {
 }
@@ -501,7 +501,7 @@ sil public_external @generic_indirect_return2 : $@convention(thin) <T> (Int) -> 
 // CHECK: ret { ptr, ptr } [[R2]]
 
 // CHECK-LABEL: define internal swiftcc void @"$s24generic_indirect_return2TA"(ptr noalias nocapture sret({{.*}}) %0, ptr swiftself %1)
-// CHECK: call swiftcc void @generic_indirect_return2(ptr noalias nocapture sret({{.*}}) %0,
+// CHECK: call swiftcc void @generic_indirect_return2(ptr noalias sret({{.*}}) %0,
 // CHECK:  ret void
 sil @partial_apply_generic_indirect_return2 : $@convention(thin) (Int) -> @callee_owned () -> @owned GenericEnum2<Int> {
   bb0(%0 : $Int):
@@ -670,7 +670,7 @@ bb0(%x : $*SwiftClassPair):
 sil public_external @closure : $@convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> ()
 
 // Make sure that we use the heap header size (16) for the initial offset.
-// CHECK-LABEL: define{{.*}} swiftcc void @test_initial_offset(ptr noalias nocapture %0, ptr %1)
+// CHECK-LABEL: define{{.*}} swiftcc void @test_initial_offset(ptr noalias %0, ptr %1)
 // CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct12ResilientIntVMa"
 // CHECK:   [[MD:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:   [[VWT_PTR:%.*]] = getelementptr inbounds ptr, ptr [[MD]], i64 -1
@@ -702,7 +702,7 @@ struct SomeType : Proto2 {
 
 sil @foo : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
 
-// CHECK-64-LABEL: define{{.*}} swiftcc void @empty_followed_by_non_fixed(ptr noalias nocapture %0)
+// CHECK-64-LABEL: define{{.*}} swiftcc void @empty_followed_by_non_fixed(ptr noalias %0)
 // CHECK-64:  [[FLAGS:%.*]] = load i32, ptr
 // CHECK-64:  [[FLAGS2:%.*]] = zext i32 [[FLAGS]] to i64
 // CHECK-64:  [[ALIGNMASK:%.*]] = and i64 [[FLAGS2]], 255

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -77,7 +77,7 @@ sil hidden_external @takingQ : $@convention(thin) <τ_0_0 where  τ_0_0 : Q> (@o
 sil hidden_external @takingQAndEmpty : $@convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>, EmptyType) -> ()
 sil hidden_external @takingEmptyAndQ : $@convention(thin) <τ_0_0 where  τ_0_0 : Q> (EmptyType, @owned WeakBox<τ_0_0>) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @bind_polymorphic_param_from_context(ptr noalias nocapture %0, ptr %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @bind_polymorphic_param_from_context(ptr noalias %0, ptr %"\CF\84_0_1")
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s23partial_apply_forwarder12BaseProducerVMa"([[INT]] 255, ptr %"\CF\84_0_1")
 // CHECK:   [[BPTYPE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -104,7 +104,7 @@ bb0(%0 : $*τ_0_1):
   return %9 : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @bind_polymorphic_param_from_context_2(ptr noalias nocapture %0, ptr %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @bind_polymorphic_param_from_context_2(ptr noalias %0, ptr %"\CF\84_0_1")
 // CHECK:   [[OBJ:%.*]] = call {{.*}} @swift_allocObject
 // CHECK:   [[REF:%.*]] = call {{.*}} @swift_allocObject
 // CHECK:   [[CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"$s15takingQAndEmptyTA{{(\.ptrauth)?}}", ptr undef }, ptr [[REF]], 1
@@ -117,7 +117,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
   return %9 : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @bind_polymorphic_param_from_context_3(ptr noalias nocapture %0, ptr %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @bind_polymorphic_param_from_context_3(ptr noalias %0, ptr %"\CF\84_0_1")
 // CHECK:   [[OBJ:%.*]] = call {{.*}} @swift_allocObject
 // CHECK:   [[REF:%.*]] = call {{.*}} @swift_allocObject
 // CHECK:   [[CLOSURE:%.*]] = insertvalue { ptr, ptr } { ptr @"$s15takingEmptyAndQTA{{(\.ptrauth)?}}", ptr undef }, ptr [[REF]], 1
@@ -131,7 +131,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
   return %9 : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @bind_polymorphic_param_from_forwarder_parameter(ptr noalias nocapture %0, ptr %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @bind_polymorphic_param_from_forwarder_parameter(ptr noalias %0, ptr %"\CF\84_0_1")
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s23partial_apply_forwarder12BaseProducerVMa"([[INT]] 255, ptr %"\CF\84_0_1")
 // CHECK:   [[BPTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -160,7 +160,7 @@ struct S {
 
 sil hidden_external @takingQAndS : $@convention(thin) <τ_0_0 where  τ_0_0 : Q> (S, @owned WeakBox<τ_0_0>) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{.*}} @bind_polymorphic_param_from_context_with_layout(ptr noalias nocapture %0, i64 %1, ptr %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{.*}} @bind_polymorphic_param_from_context_with_layout(ptr noalias %0, i64 %1, ptr %"\CF\84_0_1")
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s23partial_apply_forwarder12BaseProducerVMa"([[INT]] 255, ptr %"\CF\84_0_1")
 // CHECK:   [[BPTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0

--- a/test/IRGen/partial_apply_generic.swift
+++ b/test/IRGen/partial_apply_generic.swift
@@ -38,7 +38,7 @@ var x = seq ~> split
 //
 
 // CHECK-LABEL: define internal swiftcc { ptr, ptr } @"$s21partial_apply_generic5split{{[_0-9a-zA-Z]*}}FTA"(ptr noalias nocapture %0, ptr swiftself %1)
-// CHECK:         tail call swiftcc { ptr, ptr } @"$s21partial_apply_generic5split{{[_0-9a-zA-Z]*}}F"(ptr noalias nocapture %0,
+// CHECK:         tail call swiftcc { ptr, ptr } @"$s21partial_apply_generic5split{{[_0-9a-zA-Z]*}}F"(ptr noalias %0,
 
 struct HugeStruct { var a, b, c, d: Int }
 struct S {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
@@ -109,7 +109,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
@@ -101,7 +101,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAFySSGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
@@ -100,7 +100,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA9Argument1ACLLCySiGAGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_con_double.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_con_double.swift
@@ -114,7 +114,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_subclass_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_subclass_arg.swift
@@ -112,7 +112,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subclass_arg-2nd_anc_gen-1st-arg_con_int.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subclass_arg-2nd_anc_gen-1st-arg_con_int.swift
@@ -112,7 +112,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
@@ -110,7 +110,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -77,7 +77,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CySiGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_class.swift
@@ -36,11 +36,11 @@ func consume<T>(_ t: T) {
 //      CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
 // CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCyAA3BoxACLLCGMD"
 //      CHECK:   {{%[0-9]+}} = call swiftcc ptr @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr swiftself [[METADATA]]
 // CHECK-SAME:   )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_function.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_function.swift
@@ -26,11 +26,11 @@ func consume<T>(_ t: T) {
 //      CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
 // CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCySSSicGMD"
 //      CHECK:   {{%[0-9]+}} = call swiftcc ptr @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr swiftself [[METADATA]]
 // CHECK-SAME:   )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
@@ -92,7 +92,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA3BoxACLLCySiGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
@@ -101,7 +101,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}},
+// CHECK-SAME:     ptr noalias {{%[0-9]+}},
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
@@ -117,7 +117,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CyAA6EitherACLLOySiGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
@@ -88,7 +88,7 @@ func consume<T>(_ t: T) {
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4:[0-9A-Z_]+]]CyAA4LeftACLLVySiGGMb"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_tuple.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_tuple.swift
@@ -26,11 +26,11 @@ func consume<T>(_ t: T) {
 //      CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
 // CHECK-SAME:     @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]LLCySi_SStGMD"
 //      CHECK:   {{%[0-9]+}} = call swiftcc ptr @"$s4main5Value[[UNIQUE_ID_1]]LLC5firstADyxGx_tcfC"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr swiftself [[METADATA]]
 // CHECK-SAME:   )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[METADATA]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/class-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -25,7 +25,7 @@ func consume<T>(_ t: T) {
 // CHECK: entry:
 // CHECK:   [[METADATA_RESPONSE:%[0-9]+]] = call swiftcc %swift.metadata_response @"$s4main9NamespaceCA2A4ZangCRszlE19ExtensionNonGenericCyAE_GMa"([[INT]] 0)
 // CHECK:   [[METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%.*}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%.*}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( Namespace<Zang>.ExtensionNonGeneric() )

--- a/test/IRGen/prespecialized-metadata/enum-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -31,7 +31,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main5Value[[UNIQUE_ID_1]]OySiGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -38,7 +38,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main9NamespaceC5ValueOySi_GMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-1distinct_use.swift
@@ -37,7 +37,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main5ValueOySiGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
@@ -31,7 +31,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main5ValueOyS2i10TestModule1PAAyHCg_GMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_resilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_resilient-1distinct_use.swift
@@ -33,7 +33,7 @@ func consume<T>(_ t: T) {
 // CHECK:      [[DEMANGLED_TYPE:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
 // CHECK-SAME:     $s4main5ValueOyS2i10TestModule1PAAyHCg_GMD
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr [[DEMANGLED_TYPE]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-public-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-public-1distinct_use.swift
@@ -37,7 +37,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main5ValueOySiGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_generic_use.swift
@@ -35,7 +35,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main5OuterOyAA5InnerVySiGGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1distinct_use.swift
@@ -47,7 +47,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   $s4main5ValueOySiGMf
 // CHECK-SAME: )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -35,7 +35,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main9NamespaceC5ValueOySS_SiGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -35,7 +35,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main9NamespaceO5ValueOySS_SiGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -35,7 +35,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main9NamespaceV5ValueOySS_SiGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-2argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-2argument-1distinct_use.swift
@@ -50,7 +50,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueOyS2iGMf{{[^,]}}

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-3argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-3argument-1distinct_use.swift
@@ -52,7 +52,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueOyS3iGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-4argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-4argument-1distinct_use.swift
@@ -54,7 +54,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueOyS4iGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-5argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-5argument-1distinct_use.swift
@@ -52,7 +52,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:   ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueOyS5iGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-frozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-frozen.swift
@@ -37,7 +37,7 @@ enum Value<First> {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueOy10TestModule7IntegerVGMf

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
@@ -25,7 +25,7 @@ enum Value<First> {
 // CHECK:      [[DEMANGLED_TYPE:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(
 // CHECK-SAME:   $s4main5ValueOy10TestModule7IntegerVGMD
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr [[DEMANGLED_TYPE]]
 // CHECK-SAME: )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-payload_size.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-payload_size.swift
@@ -49,7 +49,7 @@ func consume<T>(_ t: T) {
 
 //      CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 //      CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main5ValueOySiGMf

--- a/test/IRGen/prespecialized-metadata/enum-outmodule-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/enum-outmodule-1argument-1distinct_use-struct-inmodule.swift
@@ -54,7 +54,7 @@ struct TheArgument {
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 //      CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -34,7 +34,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]VySiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-0argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-0argument-within-class-1argument-1distinct_use.swift
@@ -37,7 +37,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main9NamespaceC5ValueVySi_GMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-0argument.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-0argument.swift
@@ -17,7 +17,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     <{ 
 // CHECK-SAME:       ptr, 

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1conformance-1distinct_use.swift
@@ -40,7 +40,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
@@ -24,8 +24,8 @@ func consume<T>(_ t: T) {
 //       themselves generic (Outer<Inner<Int>>, here), a direct reference to
 //       the prespecialized metadata should be emitted here.
 // CHECK: call swiftcc void @"$s4main5OuterV5firstACyxGx_tcfC"(
-// CHECK-SAME:   ptr noalias nocapture sret({{.*}}) %{{[0-9]+}},
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias sret({{.*}}) %{{[0-9]+}},
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5InnerVySiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_use.swift
@@ -34,7 +34,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2conformance-1distinct_use.swift
@@ -44,7 +44,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-2distinct_use.swift
@@ -51,7 +51,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf
@@ -60,7 +60,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySdGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3conformance-1distinct_use.swift
@@ -48,7 +48,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-3distinct_use.swift
@@ -62,7 +62,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf
@@ -71,7 +71,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySdGMf
@@ -80,7 +80,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySSGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4conformance-1distinct_use.swift
@@ -52,7 +52,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-4distinct_use.swift
@@ -74,7 +74,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf
@@ -83,7 +83,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySdGMf
@@ -92,7 +92,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySSGMf
@@ -101,7 +101,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:    call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVys5UInt8VGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5conformance-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5conformance-1distinct_use.swift
@@ -56,7 +56,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-5distinct_use.swift
@@ -110,7 +110,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf
@@ -119,7 +119,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySdGMf
@@ -128,7 +128,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySSGMf
@@ -137,7 +137,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVys5UInt8VGMf
@@ -146,7 +146,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVys4Int8VGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-clang_node-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-clang_node-1distinct_use.swift
@@ -28,7 +28,7 @@ struct Value<T> {
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[TYPE:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s4main5ValueVySo12NSDictionaryCGMD")
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture {{%.*}}, 
+// CHECK-SAME:   ptr noalias {{%.*}}, 
 // CHECK-SAME:   ptr [[TYPE]])
 // CHECK: }
 func doit() {

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-class-1argument-1distinct_use.swift
@@ -38,7 +38,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main9NamespaceC5ValueVySS_SiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-enum-1argument-1distinct_use.swift
@@ -38,7 +38,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main9NamespaceO5ValueVySS_SiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-1argument-1distinct_use.swift
@@ -38,7 +38,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main9NamespaceV5ValueVySS_SiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-within-struct-2argument-constrained_extension-equal_arguments-1distinct_use.swift
@@ -45,7 +45,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:     ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:     ptr getelementptr inbounds (
 // CHECK-SAME:       %swift.full_type, 
 // CHECK-SAME:       $s4main9NamespaceVAAq_RszrlE5ValueVyS2i_SSGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-1distinct_use.swift
@@ -43,7 +43,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVyS2iGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-2distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-2distinct_use.swift
@@ -69,7 +69,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVyS2iGMf
@@ -78,7 +78,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySdSiGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-3distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-3distinct_use.swift
@@ -95,7 +95,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVyS2iGMf
@@ -104,7 +104,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySdSiGMf
@@ -113,7 +113,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySSSdGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-4distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-4distinct_use.swift
@@ -121,7 +121,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVyS2iGMf
@@ -130,7 +130,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySdSiGMf
@@ -139,7 +139,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySSSdGMf
@@ -148,7 +148,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVys5UInt8VSSGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-5distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-5distinct_use.swift
@@ -203,7 +203,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVyS2iGMf
@@ -212,7 +212,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySdSiGMf
@@ -221,7 +221,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySSSdGMf
@@ -230,7 +230,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVys5UInt8VSSGMf
@@ -239,7 +239,7 @@ func consume<T>(_ t: T) {
 // CHECK-SAME:   )
 // CHECK-SAME: )
 // CHECK:      call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVys4Int8Vs5UInt8VGMf

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-within-class-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-2argument-within-class-1argument-1distinct_use.swift
@@ -46,7 +46,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main9NamespaceC5ValueVySS_SiSdGMf

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-inmodule.swift
@@ -61,7 +61,7 @@ struct TheArgument {
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 //      CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-othermodule.swift
@@ -55,7 +55,7 @@ import Argument
 // CHECK-SAME:     $s7Generic11OneArgumentVy0C07IntegerVGMJ
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-samemodule.swift
@@ -51,7 +51,7 @@ import Argument
 // CHECK-SAME:     $s8Argument03OneA0VyAA7IntegerVGMJ
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_inmodule.swift
@@ -55,7 +55,7 @@ import Argument
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_othermodule.swift
@@ -51,7 +51,7 @@ import Argument
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_samemodule.swift
@@ -49,7 +49,7 @@ import Argument
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_inmodule.swift
@@ -60,7 +60,7 @@ struct AnotherArgument {
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 //      CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_othermodule.swift
@@ -53,7 +53,7 @@ import Argument
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_samemodule.swift
@@ -56,7 +56,7 @@ import Argument
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-inmodule.swift
@@ -59,7 +59,7 @@ struct TheArgument {
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 //      CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
@@ -54,7 +54,7 @@ import Argument
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
@@ -52,7 +52,7 @@ import Generic
 // CHECK-SAME:   )
 // CHECK-NEXT:   [[CANONICALIZED_METADATA:%[0-9]+]] = extractvalue %swift.metadata_response [[CANONICALIZED_METADATA_RESPONSE]], 0
 // CHECK-NEXT:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:     ptr noalias nocapture {{%[0-9]+}}, 
+// CHECK-SAME:     ptr noalias {{%[0-9]+}}, 
 // CHECK-SAME:     ptr [[CANONICALIZED_METADATA]]
 // CHECK-SAME:   )
 // CHECK: }

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-resilient-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-resilient-othermodule.swift
@@ -21,7 +21,7 @@ import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s7Generic11OneArgumentVy0C07IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%[0-9]+}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%[0-9]+}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-resilient-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-resilient-samemodule.swift
@@ -19,7 +19,7 @@ import Generic
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s7Generic11OneArgumentVyAA7IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%[0-9]+}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%[0-9]+}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-inmodule.swift
@@ -23,7 +23,7 @@ struct TheArgument {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s7Generic11OneArgumentVy4main03TheC0VGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%[0-9]+}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%[0-9]+}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( OneArgument(TheArgument(value: 13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
@@ -21,7 +21,7 @@ import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s7Generic11OneArgumentVy0C07IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%[0-9]+}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%[0-9]+}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
@@ -19,7 +19,7 @@ import Generic
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s7Generic11OneArgumentVyAA7IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%[0-9]+}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%[0-9]+}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-othermodule.swift
@@ -21,7 +21,7 @@ import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s7Generic11OneArgumentVy0C07IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%[0-9]+}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%[0-9]+}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-resilient-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-resilient-othermodule.swift
@@ -21,7 +21,7 @@ import Argument
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s7Generic11OneArgumentVy0C07IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%[0-9]+}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%[0-9]+}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-resilient-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-resilient-samemodule.swift
@@ -19,7 +19,7 @@ import Generic
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s7Generic11OneArgumentVyAA7IntegerVGMD")
-// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias nocapture {{%[0-9]+}}, ptr [[METADATA]])
+// CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(ptr noalias {{%[0-9]+}}, ptr [[METADATA]])
 // CHECK: }
 func doit() {
   consume( OneArgument(Integer(13)) )

--- a/test/IRGen/prespecialized-metadata/struct-public-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-public-inmodule-1argument-1distinct_use.swift
@@ -35,7 +35,7 @@ func consume<T>(_ t: T) {
 
 // CHECK: define hidden swiftcc void @"$s4main4doityyF"() #{{[0-9]+}} {
 // CHECK:   call swiftcc void @"$s4main7consumeyyxlF"(
-// CHECK-SAME:   ptr noalias nocapture %{{[0-9]+}}, 
+// CHECK-SAME:   ptr noalias %{{[0-9]+}}, 
 // CHECK-SAME:   ptr getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     $s4main5ValueVySiGMf

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -136,7 +136,7 @@ protocol InternalProtocol {
 
 // CHECK-SAME: }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultC(ptr noalias nocapture swiftself %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultC(ptr noalias swiftself %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 sil @defaultC : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> () {
 bb0(%0 : $*Self):
@@ -147,7 +147,7 @@ bb0(%0 : $*Self):
   return %result : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultD(ptr noalias nocapture swiftself %0, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultD(ptr noalias swiftself %0, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @defaultD : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> () {
@@ -156,7 +156,7 @@ bb0(%0 : $*Self):
   // Make sure we can emit direct references to other default implementations
   // CHECK-NEXT: %[[SELF:.*]] = alloca ptr
   // CHECK-NEXT: store ptr %Self, ptr %[[SELF]]
-  // CHECK-NEXT: call swiftcc void @defaultC(ptr noalias nocapture swiftself %0, ptr %Self, ptr %SelfWitnessTable)
+  // CHECK-NEXT: call swiftcc void @defaultC(ptr noalias swiftself %0, ptr %Self, ptr %SelfWitnessTable)
   %fn1 = function_ref @defaultC : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
   %ignore1 = apply %fn1<Self>(%0) : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 
@@ -165,7 +165,7 @@ bb0(%0 : $*Self):
 
   // CHECK-NEXT: [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 5
   // CHECK-NEXT: [[WITNESS_FN:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
-  // CHECK: call swiftcc void [[WITNESS_FN]](ptr noalias nocapture swiftself %0, ptr %Self, ptr %SelfWitnessTable)
+  // CHECK: call swiftcc void [[WITNESS_FN]](ptr noalias swiftself %0, ptr %Self, ptr %SelfWitnessTable)
   %fn2 = witness_method $Self, #ResilientProtocol.defaultC : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
   %ignore2 = apply %fn2<Self>(%0) : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 
@@ -271,7 +271,7 @@ bb0(%0 : $*ConformingStruct):
   // Make sure we can emit direct references to default implementations with a
   // concrete Self type.
 
-  // CHECK-NEXT: call swiftcc void @defaultC(ptr noalias nocapture swiftself %0, ptr %Self, ptr %SelfWitnessTable)
+  // CHECK-NEXT: call swiftcc void @defaultC(ptr noalias swiftself %0, ptr %Self, ptr %SelfWitnessTable)
   %fn1 = function_ref @defaultC : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
   %ignore1 = apply %fn1<ConformingStruct>(%0) : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 
@@ -317,7 +317,7 @@ sil_witness_table ConformingStruct : ResilientProtocol module protocol_resilienc
 // Make sure resilient conformances are accessed with an accessor function
 //
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomething(ptr noalias nocapture %0, ptr %T, ptr %T.OtherResilientProtocol)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomething(ptr noalias %0, ptr %T, ptr %T.OtherResilientProtocol)
 sil @doSomething : $@convention(thin) <T : OtherResilientProtocol> (@in T) -> () {
 bb0(%0 : $*T):
   %result = tuple ()
@@ -330,7 +330,7 @@ bb0(%0 : $*ResilientConformingType):
 
   // CHECK-NEXT: entry:
   // CHECK-NEXT: [[WTABLE:%.*]] = call ptr @"$s19protocol_resilience23ResilientConformingTypeVAC010resilient_A005OtherC8ProtocolAAWl"()
-  // CHECK-NEXT: call swiftcc void @doSomething(ptr noalias nocapture %0, ptr getelementptr inbounds ({{.*}} @"$s19protocol_resilience23ResilientConformingTypeVMf", i32 0, i32 2), ptr [[WTABLE]])
+  // CHECK-NEXT: call swiftcc void @doSomething(ptr noalias %0, ptr getelementptr inbounds ({{.*}} @"$s19protocol_resilience23ResilientConformingTypeVMf", i32 0, i32 2), ptr [[WTABLE]])
 
   %fn = function_ref @doSomething : $@convention(thin) <T : OtherResilientProtocol> (@in T) -> ()
   %ignore = apply %fn<ResilientConformingType>(%0) : $@convention(thin) <T : OtherResilientProtocol> (@in T) -> ()
@@ -374,7 +374,7 @@ sil_witness_table AnotherConformingStruct : RefinesOtherResilientProtocol module
 sil_witness_table hidden AnotherConformingStruct: OtherResilientProtocol module protocol_resilience {
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomethingRefined(ptr noalias nocapture %0, ptr %T, ptr %T.RefinesOtherResilientProtocol)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomethingRefined(ptr noalias %0, ptr %T, ptr %T.RefinesOtherResilientProtocol)
 sil @doSomethingRefined : $@convention(thin) <T : RefinesOtherResilientProtocol> (@in T) -> () {
 bb0(%0 : $*T):
   %result = tuple ()
@@ -387,7 +387,7 @@ bb0(%0 : $*AnotherConformingStruct):
 
   // CHECK-NEXT: entry:
   // CHECK-NEXT: [[WTABLE:%.*]] = call ptr @"$s19protocol_resilience23AnotherConformingStructVAcA29RefinesOtherResilientProtocolAAWl"()
-  // CHECK-NEXT: call swiftcc void @doSomethingRefined(ptr noalias nocapture %0, ptr getelementptr inbounds ({{.*}} @"$s19protocol_resilience23AnotherConformingStructVMf", i32 0, i32 2), ptr [[WTABLE]])
+  // CHECK-NEXT: call swiftcc void @doSomethingRefined(ptr noalias %0, ptr getelementptr inbounds ({{.*}} @"$s19protocol_resilience23AnotherConformingStructVMf", i32 0, i32 2), ptr [[WTABLE]])
 
   %fn = function_ref @doSomethingRefined : $@convention(thin) <T : RefinesOtherResilientProtocol> (@in T) -> ()
   %ignore = apply %fn<AnotherConformingStruct>(%0) : $@convention(thin) <T : RefinesOtherResilientProtocol> (@in T) -> ()
@@ -417,7 +417,7 @@ sil_witness_table ConformsWithResilientAssoc : HasResilientAssoc module protocol
   associated_type T: ResilientConformingType
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomethingAssoc(ptr noalias nocapture %0, ptr %T, ptr %T.HasResilientAssoc)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomethingAssoc(ptr noalias %0, ptr %T, ptr %T.HasResilientAssoc)
 sil @doSomethingAssoc : $@convention(thin) <T : HasResilientAssoc> (@in T) -> () {
 bb0(%0 : $*T):
   %result = tuple ()
@@ -430,7 +430,7 @@ bb0(%0 : $*ConformsWithResilientAssoc):
 
   // CHECK-NEXT: entry:
   // CHECK-NEXT: [[WTABLE:%.*]] = call ptr @"$s19protocol_resilience26ConformsWithResilientAssocVAcA03HaseF0AAWl
-  // CHECK-NEXT: call swiftcc void @doSomethingAssoc(ptr noalias nocapture %0, ptr getelementptr inbounds ({{.*}} @"$s19protocol_resilience26ConformsWithResilientAssocVMf", i32 0, i32 2), ptr [[WTABLE]])
+  // CHECK-NEXT: call swiftcc void @doSomethingAssoc(ptr noalias %0, ptr getelementptr inbounds ({{.*}} @"$s19protocol_resilience26ConformsWithResilientAssocVMf", i32 0, i32 2), ptr [[WTABLE]])
 
   %fn = function_ref @doSomethingAssoc : $@convention(thin) <T : HasResilientAssoc> (@in T) -> ()
   %ignore = apply %fn<ConformsWithResilientAssoc>(%0) : $@convention(thin) <T : HasResilientAssoc> (@in T) -> ()

--- a/test/IRGen/protocol_resilience_thunks.swift
+++ b/test/IRGen/protocol_resilience_thunks.swift
@@ -16,8 +16,8 @@ import resilient_protocol
 // CHECK-LABEL: @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTq" ={{( dllexport)?}}{{( protected)?}} alias %swift.protocol_requirement, getelementptr inbounds (<{{.*}}>, ptr @"$s26protocol_resilience_thunks19MyResilientProtocolMp", i32 0, i32 12)
 // CHECK-LABEL: @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvMTq" ={{( dllexport)?}}{{( protected)?}} alias %swift.protocol_requirement, getelementptr inbounds (<{{.*}}>, ptr @"$s26protocol_resilience_thunks19MyResilientProtocolMp", i32 0, i32 13)
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks26callResilientWitnessMethodyyx010resilient_A00E12BaseProtocolRzlF"(ptr noalias nocapture %0, ptr %T, ptr %T.ResilientBaseProtocol)
-// CHECK: call swiftcc {{.*}} @"$s18resilient_protocol21ResilientBaseProtocolP11requirementSiyFTj"(ptr noalias nocapture swiftself %0, ptr %T, ptr %T.ResilientBaseProtocol)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks26callResilientWitnessMethodyyx010resilient_A00E12BaseProtocolRzlF"(ptr noalias %0, ptr %T, ptr %T.ResilientBaseProtocol)
+// CHECK: call swiftcc {{.*}} @"$s18resilient_protocol21ResilientBaseProtocolP11requirementSiyFTj"(ptr noalias swiftself %0, ptr %T, ptr %T.ResilientBaseProtocol)
 // CHECK: ret void
 public func callResilientWitnessMethod<T : ResilientBaseProtocol>(_ value: T) {
   _ = value.requirement()
@@ -36,66 +36,66 @@ public protocol MyResilientProtocol {
   var property: Bool { get set }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP11returnsVoid1xySb_tFTj"(i1 %0, ptr noalias nocapture swiftself %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP11returnsVoid1xySb_tFTj"(i1 %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_GEP:%.*]] = getelementptr inbounds ptr, ptr %3, i32 1
 // CHECK:      [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_GEP]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_GEP]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: call swiftcc void [[WITNESS]](i1 %0, ptr noalias nocapture swiftself %1, ptr %2, ptr %3)
+// CHECK-NEXT: call swiftcc void [[WITNESS]](i1 %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$s26protocol_resilience_thunks19MyResilientProtocolP11returnsBoolSbyFTj"(ptr noalias nocapture swiftself %0, ptr %1, ptr %2)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$s26protocol_resilience_thunks19MyResilientProtocolP11returnsBoolSbyFTj"(ptr noalias swiftself %0, ptr %1, ptr %2)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %2, i32 2
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 [[WITNESS]](ptr noalias nocapture swiftself %0, ptr %1, ptr %2)
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 [[WITNESS]](ptr noalias swiftself %0, ptr %1, ptr %2)
 // CHECK-NEXT: ret i1 [[RESULT]]
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP10returnsAnyypyFTj"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture swiftself %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP10returnsAnyypyFTj"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3, i32 3
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture swiftself %1, ptr %2, ptr %3)
+// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias nocapture sret({{.*}}) %0, ptr noalias swiftself %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP12throwingFuncyyKFTj"(ptr noalias nocapture swiftself %0, ptr{{( noalias nocapture( swifterror)? dereferenceable\(.\))?}} %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP12throwingFuncyyKFTj"(ptr noalias swiftself %0, ptr{{( noalias nocapture( swifterror)? dereferenceable\(.\))?}} %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3, i32 4
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias nocapture swiftself %0, ptr{{( noalias nocapture( swifterror)? dereferenceable\(.\))?}} %1, ptr %2, ptr %3)
+// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias swiftself %0, ptr{{( noalias nocapture( swifterror)? dereferenceable\(.\))?}} %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP11genericFuncyqd__qd__lFTj"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %2, ptr noalias nocapture swiftself %3, ptr %4, ptr %5)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP11genericFuncyqd__qd__lFTj"(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %2, ptr noalias swiftself %3, ptr %4, ptr %5)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %5, i32 5
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %2, ptr noalias nocapture swiftself %3, ptr %4, ptr %5)
+// CHECK-NEXT: call swiftcc void [[WITNESS]](ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %2, ptr noalias swiftself %3, ptr %4, ptr %5)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvgTj"(ptr noalias nocapture swiftself %0, ptr %1, ptr %2)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvgTj"(ptr noalias swiftself %0, ptr %1, ptr %2)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %2, i32 6
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 [[WITNESS]](ptr noalias nocapture swiftself %0, ptr %1, ptr %2)
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 [[WITNESS]](ptr noalias swiftself %0, ptr %1, ptr %2)
 // CHECK-NEXT: ret i1 [[RESULT]]
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTj"(i1 %0, ptr nocapture swiftself %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTj"(i1 %0, ptr swiftself %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3, i32 7
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: call swiftcc void [[WITNESS]](i1 %0, ptr nocapture swiftself %1, ptr %2, ptr %3)
+// CHECK-NEXT: call swiftcc void [[WITNESS]](i1 %0, ptr swiftself %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvMTj"(ptr noalias dereferenceable({{16|32}}) %0, ptr nocapture swiftself %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @"$s26protocol_resilience_thunks19MyResilientProtocolP8propertySbvMTj"(ptr noalias dereferenceable({{16|32}}) %0, ptr swiftself %1, ptr %2, ptr %3)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3, i32 8
 // CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr [[WITNESS_ADDR]] to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
-// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc { ptr, ptr } [[WITNESS]](ptr noalias dereferenceable({{16|32}}) %0, ptr nocapture swiftself %1, ptr %2, ptr %3)
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc { ptr, ptr } [[WITNESS]](ptr noalias dereferenceable({{16|32}}) %0, ptr swiftself %1, ptr %2, ptr %3)
 // CHECK-NEXT: ret { ptr, ptr } [[RESULT]]

--- a/test/IRGen/relative_protocol_witness_table.swift
+++ b/test/IRGen/relative_protocol_witness_table.swift
@@ -200,7 +200,7 @@ func instantiate_conditional_conformance_2nd<T>(_ t : T)  where T: Sub, T.S == T
 
 // Simple witness entry access.
 
-// CHECK: define{{.*}} swiftcc void @"$s1A14requireWitnessyyxAA8FuncOnlyRzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[PWT:%.*]])
+// CHECK: define{{.*}} swiftcc void @"$s1A14requireWitnessyyxAA8FuncOnlyRzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[PWT:%.*]])
 // CHECK:[[ENTRY:.*]]:
 // CHECK:  [[T4:%.*]] = call ptr @"__swift_relative_protocol_witness_table_access_1_$s1A8FuncOnlyP1ayyFTq"(ptr [[PWT]])
 // CHECK:  call{{.*}} swiftcc void [[T4]]
@@ -232,7 +232,7 @@ func instantiate_conditional_conformance_2nd<T>(_ t : T)  where T: Sub, T.S == T
 
 // Parent witness entry access.
 
-// CHECK: define hidden swiftcc void @"$s1A15requireWitness2yyxAA9InheritedRzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[T_INHERITED:%.*]])
+// CHECK: define hidden swiftcc void @"$s1A15requireWitness2yyxAA9InheritedRzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[T_INHERITED:%.*]])
 // CHECK: [[T_FUNCONLY:%.*]] = call ptr @__swift_relative_protocol_witness_table_parent_1(ptr [[T_INHERITED]])
 // CHECK: call ptr @"__swift_relative_protocol_witness_table_access_1_$s1A8FuncOnlyP1ayyFTq"(ptr [[T_FUNCONLY]])
 

--- a/test/IRGen/signature_conformances_multifile.swift
+++ b/test/IRGen/signature_conformances_multifile.swift
@@ -8,7 +8,7 @@ func passQ() {
   // CHECK: call swiftcc void @"$s32signature_conformances_multifile12AlsoConformsVACyxGycfC"(ptr @"$sSiN")
   // CHECK: %0 = call {{.*}} @"$s32signature_conformances_multifile12AlsoConformsVySiGMD"
   // CHECK: %1 = call ptr @"$s32signature_conformances_multifile12AlsoConformsVySiGACyxGAA1QAAWl"()
-  // CHECK: call swiftcc void @"$s32signature_conformances_multifile6takesQyyxAA1QRzlF"(ptr noalias nocapture undef, ptr %0, ptr %1)
+  // CHECK: call swiftcc void @"$s32signature_conformances_multifile6takesQyyxAA1QRzlF"(ptr noalias undef, ptr %0, ptr %1)
   takesQ(AlsoConforms<Int>())
 
   // CHECK: ret void
@@ -19,7 +19,7 @@ func passP() {
   // CHECK: call swiftcc void @"$s32signature_conformances_multifile8ConformsVACyxq_GycfC"(ptr @"$sSiN", ptr @"$sSSN")
   // CHECK: %0 = call {{.*}} @"$s32signature_conformances_multifile8ConformsVySiSSGMD"
   // CHECK: %1 = call ptr @"$s32signature_conformances_multifile8ConformsVySiSSGACyxq_GAA1PAAWl"()
-  // CHECK: call swiftcc void @"$s32signature_conformances_multifile6takesPyyxAA1PRzlF"(ptr noalias nocapture undef, ptr %0, ptr %1)
+  // CHECK: call swiftcc void @"$s32signature_conformances_multifile6takesPyyxAA1PRzlF"(ptr noalias undef, ptr %0, ptr %1)
   takesP(Conforms<Int, String>())
 
   // CHECK: ret void

--- a/test/IRGen/signature_conformances_multifile_future.swift
+++ b/test/IRGen/signature_conformances_multifile_future.swift
@@ -14,7 +14,7 @@ func passQ() {
   // CHECK: [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s39signature_conformances_multifile_future12AlsoConformsVySiGMD")
   // CHECK: [[WITNESS_TABLE:%[0-9]+]] = call ptr @"$s39signature_conformances_multifile_future12AlsoConformsVySiGACyxGAA1QAAWl"()
   // CHECK: call swiftcc void @"$s39signature_conformances_multifile_future6takesQyyxAA1QRzlF"(
-  // CHECK-SAME:   ptr noalias nocapture undef, 
+  // CHECK-SAME:   ptr noalias undef, 
   // CHECK-SAME:   ptr [[METADATA]], 
   // CHECK-SAME:   ptr [[WITNESS_TABLE]]
   // CHECK-SAME: )
@@ -29,7 +29,7 @@ func passP() {
   // CHECK: [[METADATA:%[0-9]+]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s39signature_conformances_multifile_future8ConformsVySiSSGMD")
   // CHECK: [[WITNESS_TABLE:%[0-9]+]] = call ptr @"$s39signature_conformances_multifile_future8ConformsVySiSSGACyxq_GAA1PAAWl"()
   // CHECK: call swiftcc void @"$s39signature_conformances_multifile_future6takesPyyxAA1PRzlF"(
-  // CHECK-SAME:   ptr noalias nocapture undef, 
+  // CHECK-SAME:   ptr noalias undef, 
   // CHECK-SAME:   ptr [[METADATA]], 
   // CHECK-SAME:   ptr [[WITNESS_TABLE]]
   // CHECK-SAME: )

--- a/test/IRGen/sil_generic_witness_methods.swift
+++ b/test/IRGen/sil_generic_witness_methods.swift
@@ -13,7 +13,7 @@ protocol P {
 
 struct S {}
 
-// CHECK-LABEL: define hidden swiftcc void @"$s27sil_generic_witness_methods05call_D0{{[_0-9a-zA-Z]*}}F"(ptr noalias nocapture %0, ptr noalias nocapture %1, ptr %T, ptr %U, ptr %T.P)
+// CHECK-LABEL: define hidden swiftcc void @"$s27sil_generic_witness_methods05call_D0{{[_0-9a-zA-Z]*}}F"(ptr noalias %0, ptr noalias %1, ptr %T, ptr %U, ptr %T.P)
 func call_methods<T: P, U>(_ x: T, y: S, z: U) {
   // CHECK: [[STATIC_METHOD_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.P, i32 2
   // CHECK: [[STATIC_METHOD_PTR:%.*]] = load ptr, ptr [[STATIC_METHOD_ADDR]], align 8
@@ -22,15 +22,15 @@ func call_methods<T: P, U>(_ x: T, y: S, z: U) {
 
   // CHECK: [[CONCRETE_METHOD_PTR_GEP:%.*]] = getelementptr inbounds ptr, ptr %T.P, i32 1
   // CHECK: [[CONCRETE_METHOD_PTR:%.*]] = load ptr, ptr [[CONCRETE_METHOD_PTR_GEP]]
-  // CHECK: call swiftcc void [[CONCRETE_METHOD_PTR]](ptr noalias nocapture swiftself {{%.*}}, ptr %T, ptr %T.P)
+  // CHECK: call swiftcc void [[CONCRETE_METHOD_PTR]](ptr noalias swiftself {{%.*}}, ptr %T, ptr %T.P)
   x.concrete_method()
   // CHECK: [[GENERIC_METHOD_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.P, i32 3
   // CHECK: [[GENERIC_METHOD_PTR:%.*]] = load ptr, ptr [[GENERIC_METHOD_ADDR]], align 8
-  // CHECK: call swiftcc void [[GENERIC_METHOD_PTR]](ptr noalias nocapture {{.*}}, ptr {{.*}} @"$s27sil_generic_witness_methods1SVMf", {{.*}} ptr noalias nocapture swiftself {{.*}}, ptr %T, ptr %T.P)
+  // CHECK: call swiftcc void [[GENERIC_METHOD_PTR]](ptr noalias {{.*}}, ptr {{.*}} @"$s27sil_generic_witness_methods1SVMf", {{.*}} ptr noalias swiftself {{.*}}, ptr %T, ptr %T.P)
   x.generic_method(y)
   // CHECK: [[GENERIC_METHOD_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.P, i32 3
   // CHECK: [[GENERIC_METHOD_PTR:%.*]] = load ptr, ptr [[GENERIC_METHOD_ADDR]], align 8
-  // CHECK: call swiftcc void [[GENERIC_METHOD_PTR]](ptr noalias nocapture {{.*}}, ptr %U, ptr noalias nocapture swiftself {{.*}}, ptr %T, ptr %T.P)
+  // CHECK: call swiftcc void [[GENERIC_METHOD_PTR]](ptr noalias {{.*}}, ptr %U, ptr noalias swiftself {{.*}}, ptr %T, ptr %T.P)
   x.generic_method(z)
 }
 
@@ -42,7 +42,7 @@ func call_existential_methods(_ x: P, y: S) {
   // CHECK: [[WTABLE:%.*]] = load ptr, ptr [[WTABLE_ADDR]], align 8
   // CHECK: [[CONCRETE_METHOD_PTR_GEP:%.*]] = getelementptr inbounds ptr, ptr [[WTABLE]], i32 1
   // CHECK: [[CONCRETE_METHOD_PTR:%.*]] = load ptr, ptr [[CONCRETE_METHOD_PTR_GEP]], align 8
-  // CHECK: call swiftcc void [[CONCRETE_METHOD_PTR]](ptr noalias nocapture swiftself {{%.*}}, ptr [[METADATA]], ptr [[WTABLE]])
+  // CHECK: call swiftcc void [[CONCRETE_METHOD_PTR]](ptr noalias swiftself {{%.*}}, ptr [[METADATA]], ptr [[WTABLE]])
   x.concrete_method()
 
   // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds %T27sil_generic_witness_methods1PP, ptr [[X]], i32 0, i32 1
@@ -51,6 +51,6 @@ func call_existential_methods(_ x: P, y: S) {
   // CHECK: [[WTABLE:%.*]] = load ptr, ptr [[WTABLE_ADDR]], align 8
   // CHECK: [[GENERIC_METHOD_ADDR:%.*]] = getelementptr inbounds ptr, ptr [[WTABLE]], i32 3
   // CHECK: [[GENERIC_METHOD_PTR:%.*]] = load ptr, ptr [[GENERIC_METHOD_ADDR]], align 8
-  // CHECK: call swiftcc void [[GENERIC_METHOD_PTR]](ptr noalias nocapture {{.*}}, ptr {{.*}} @"$s27sil_generic_witness_methods1SVMf", {{.*}} ptr noalias nocapture swiftself {{%.*}}, ptr [[METADATA]], ptr [[WTABLE]])
+  // CHECK: call swiftcc void [[GENERIC_METHOD_PTR]](ptr noalias {{.*}}, ptr {{.*}} @"$s27sil_generic_witness_methods1SVMf", {{.*}} ptr noalias swiftself {{%.*}}, ptr [[METADATA]], ptr [[WTABLE]])
   x.generic_method(y)
 }

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -87,14 +87,14 @@ entry(%x : $@thick Bar<T, U, V>.Type):
 
 // TODO: %Self Type arg is redundant for class method witness
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @concrete_type_generic_method_witness(ptr noalias nocapture %0, ptr %Z, ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @concrete_type_generic_method_witness(ptr noalias %0, ptr %Z, ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 sil @concrete_type_generic_method_witness : $@convention(witness_method: P) <Z> (@in Z, @in Foo) -> @thick Foo.Type {
 entry(%z : $*Z, %x : $*Foo):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @generic_type_generic_method_witness(ptr noalias nocapture %0, ptr %Z, ptr noalias nocapture swiftself dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @generic_type_generic_method_witness(ptr noalias %0, ptr %Z, ptr noalias nocapture swiftself dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
 sil @generic_type_generic_method_witness : $@convention(witness_method: P) <T, U, V, Z> (@in Z, @in Bar<T, U, V>) -> @thick Bar<T, U, V>.Type {
 entry(%z : $*Z, %x : $*Bar<T, U, V>):
   %t = metatype $@thick T.Type
@@ -105,14 +105,14 @@ entry(%z : $*Z, %x : $*Bar<T, U, V>):
   return %m : $@thick Bar<T, U, V>.Type
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @concrete_type_generic_static_method_witness(ptr noalias nocapture %0, ptr %Z, ptr swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @concrete_type_generic_static_method_witness(ptr noalias %0, ptr %Z, ptr swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 sil @concrete_type_generic_static_method_witness : $@convention(witness_method: P) <Z> (@in Z, @thick Foo.Type) -> @thick Foo.Type {
 entry(%z : $*Z, %x : $@thick Foo.Type):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @generic_type_generic_static_method_witness(ptr noalias nocapture %0, ptr %Z, ptr swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @generic_type_generic_static_method_witness(ptr noalias %0, ptr %Z, ptr swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 sil @generic_type_generic_static_method_witness : $@convention(witness_method: P) <T, U, V, Z> (@in Z, @thick Bar<T, U, V>.Type) -> @thick Bar<T, U, V>.Type {
 entry(%z : $*Z, %x : $@thick Bar<T, U, V>.Type):
   %t = metatype $@thick T.Type

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -14,7 +14,7 @@ import resilient_enum
 // Resilient structs from outside our resilience domain are manipulated via
 // value witnesses
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience30functionWithResilientTypesSize_1f010resilient_A00G0VAFn_A2FnXEtF"(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %2, ptr %3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience30functionWithResilientTypesSize_1f010resilient_A00G0VAFn_A2FnXEtF"(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %2, ptr %3)
 
 public func functionWithResilientTypesSize(_ s: __owned Size, f: (__owned Size) -> Size) -> Size {
 // CHECK: entry:
@@ -31,7 +31,7 @@ public func functionWithResilientTypesSize(_ s: __owned Size, f: (__owned Size) 
 // CHECK: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_PTR]]
 // CHECK: [[STRUCT_LOC:%.*]] = call ptr [[WITNESS]](ptr noalias [[ALLOCA]], ptr noalias %1, ptr [[METADATA]])
 
-// CHECK: call swiftcc void %2(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture [[ALLOCA]], ptr swiftself %3)
+// CHECK: call swiftcc void %2(ptr noalias sret({{.*}}) %0, ptr noalias [[ALLOCA]], ptr swiftself %3)
 
 // CHECK: [[WITNESS_PTR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 1
 // CHECK: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_PTR]]
@@ -51,7 +51,7 @@ public func functionWithResilientTypesSize(_ s: __owned Size, f: (__owned Size) 
 // Make sure we use a type metadata accessor function, and load indirect
 // field offsets from it.
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience35functionWithResilientTypesRectangleyy010resilient_A00G0VF"(ptr noalias nocapture %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience35functionWithResilientTypesRectangleyy010resilient_A00G0VF"(ptr noalias %0)
 public func functionWithResilientTypesRectangle(_ r: Rectangle) {
 // CHECK: entry:
 // CHECK:      [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct9RectangleVMa"([[INT]] 0)
@@ -168,7 +168,7 @@ public func partialApplyOfResilientMethod(r: ResilientStructWithMethod) {
 
 // Type is address-only in SIL, and resilient in IRGen
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience29partialApplyOfResilientMethod1sy010resilient_A04SizeV_tF"(ptr noalias nocapture %0)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience29partialApplyOfResilientMethod1sy010resilient_A04SizeV_tF"(ptr noalias %0)
 public func partialApplyOfResilientMethod(s: Size) {
   _ = s.method
 }
@@ -179,7 +179,7 @@ public func resilientAny(s : ResilientWeakRef) {
   wantsAny(s)
 }
 
-// CHECK-LABEL: define{{.*}} swiftcc void @"$s17struct_resilience12resilientAny1sy0c1_A016ResilientWeakRefV_tF"(ptr noalias nocapture %0)
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s17struct_resilience12resilientAny1sy0c1_A016ResilientWeakRefV_tF"(ptr noalias %0)
 // CHECK: entry:
 // CHECK: [[ANY:%.*]] = alloca %Any
 // CHECK: [[META:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct16ResilientWeakRefVMa"([[INT]] 0)

--- a/test/IRGen/synthesized_conformance.swift
+++ b/test/IRGen/synthesized_conformance.swift
@@ -34,10 +34,10 @@ func doEquality<T: Equatable>(_: T) {}
 // CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s23synthesized_conformance8equalityyyF"()
 public func equality() {
     // CHECK: [[Struct_Equatable:%.*]] = call ptr @"$s23synthesized_conformance6StructVySiGACyxGSQAASQRzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance10doEqualityyyxSQRzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[Struct_Equatable]])
+    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance10doEqualityyyxSQRzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[Struct_Equatable]])
     doEquality(Struct(x: 1))
     // CHECK: [[Enum_Equatable:%.*]] = call ptr @"$s23synthesized_conformance4EnumOySiGACyxGSQAASQRzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance10doEqualityyyxSQRzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[Enum_Equatable]])
+    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance10doEqualityyyxSQRzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[Enum_Equatable]])
     doEquality(Enum.a(1))
 }
 
@@ -45,15 +45,15 @@ func doEncodable<T: Encodable>(_: T) {}
 // CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s23synthesized_conformance9encodableyyF"()
 public func encodable() {
     // CHECK: [[Struct_Encodable:%.*]] = call ptr @"$s23synthesized_conformance6StructVySiGACyxGSEAASeRzSERzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance11doEncodableyyxSERzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[Struct_Encodable]])
+    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance11doEncodableyyxSERzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[Struct_Encodable]])
     doEncodable(Struct(x: 1))
     // CHECK: [[Enum_Encodable:%.*]] = call ptr @"$s23synthesized_conformance4EnumOySiGACyxGSEAASeRzSERzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance11doEncodableyyxSERzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[Enum_Encodable]])
+    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance11doEncodableyyxSERzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[Enum_Encodable]])
     doEncodable(Enum.a(1))
     // CHECK: [[Final_Encodable:%.*]] = call ptr @"$s23synthesized_conformance5FinalCySiGACyxGSEAASERzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance11doEncodableyyxSERzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[Final_Encodable]])
+    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance11doEncodableyyxSERzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[Final_Encodable]])
     doEncodable(Final(x: 1))
     // CHECK: [[Nonfinal_Encodable:%.*]] = call ptr @"$s23synthesized_conformance8NonfinalCySiGACyxGSEAASERzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance11doEncodableyyxSERzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[Nonfinal_Encodable]])
+    // CHECK-NEXT: call swiftcc void @"$s23synthesized_conformance11doEncodableyyxSERzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[Nonfinal_Encodable]])
     doEncodable(Nonfinal(x: 1))
 }

--- a/test/IRGen/synthesized_conformance_future.swift
+++ b/test/IRGen/synthesized_conformance_future.swift
@@ -39,10 +39,10 @@ func doEquality<T: Equatable>(_: T) {}
 // CHECK-LABEL: define{{( dllexport| protected)?}} swiftcc void @"$s30synthesized_conformance_future8equalityyyF"()
 public func equality() {
     // CHECK: [[TMP:%.*]] = alloca %TSi
-    // CHECK: call swiftcc void @"$s30synthesized_conformance_future6StructV1xACyxGx_tcfC"(ptr noalias nocapture {{[^,]*}}, ptr noalias nocapture [[TMP]], ptr @"$sSiN")
+    // CHECK: call swiftcc void @"$s30synthesized_conformance_future6StructV1xACyxGx_tcfC"(ptr noalias {{[^,]*}}, ptr noalias [[TMP]], ptr @"$sSiN")
     // CHECK: [[Struct_Equatable:%.*]] = call ptr @"$s30synthesized_conformance_future6StructVySiGACyxGSQAASQRzlWl"()
     // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future10doEqualityyyxSQRzlF"(
-    // CHECK-SAME:   ptr noalias nocapture {{[^,]*}},
+    // CHECK-SAME:   ptr noalias {{[^,]*}},
     // CHECK-SAME:   ptr getelementptr inbounds (
     // CHECK-SAME:     %swift.full_type,
     // CHECK-SAME:     ptr @"$s30synthesized_conformance_future6StructVySiGMf", 
@@ -54,7 +54,7 @@ public func equality() {
     doEquality(Struct(x: 1))
     // CHECK: [[Enum_Equatable:%.*]] = call ptr @"$s30synthesized_conformance_future4EnumOySiGACyxGSQAASQRzlWl"()
     // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future10doEqualityyyxSQRzlF"(
-    // CHECK-SAME:   ptr noalias nocapture {{%[^,]+}}, 
+    // CHECK-SAME:   ptr noalias {{%[^,]+}}, 
     // CHECK-SAME:   ptr getelementptr inbounds (
     // CHECK-SAME:     %swift.full_type,
     // CHECK-SAME:     ptr @"$s30synthesized_conformance_future4EnumOySiGMf",
@@ -71,7 +71,7 @@ func doEncodable<T: Encodable>(_: T) {}
 public func encodable() {
     // CHECK: [[Struct_Encodable:%.*]] = call ptr @"$s30synthesized_conformance_future6StructVySiGACyxGSEAASeRzSERzlWl"()
     // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(
-    // CHECK-SAME:   ptr noalias nocapture {{[^,]*}}, 
+    // CHECK-SAME:   ptr noalias {{[^,]*}}, 
     // CHECK-SAME:   ptr getelementptr inbounds (
     // CHECK-SAME:     %swift.full_type,
     // CHECK-SAME:     ptr @"$s30synthesized_conformance_future6StructVySiGMf", 
@@ -83,7 +83,7 @@ public func encodable() {
     doEncodable(Struct(x: 1))
     // CHECK: [[Enum_Encodable:%.*]] = call ptr @"$s30synthesized_conformance_future4EnumOySiGACyxGSEAASeRzSERzlWl"()
     // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(
-    // CHECK-SAME:   ptr noalias nocapture {{[^,]*}},
+    // CHECK-SAME:   ptr noalias {{[^,]*}},
     // CHECK-SAME:   ptr getelementptr inbounds (
     // CHECK-SAME:     %swift.full_type,
     // CHECK-SAME:     ptr @"$s30synthesized_conformance_future4EnumOySiGMf"
@@ -94,9 +94,9 @@ public func encodable() {
     // CHECK-SAME: )
     doEncodable(Enum.a(1))
     // CHECK: [[Final_Encodable:%.*]] = call ptr @"$s30synthesized_conformance_future5FinalCySiGACyxGSEAASERzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[Final_Encodable]])
+    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[Final_Encodable]])
     doEncodable(Final(x: 1))
     // CHECK: [[Nonfinal_Encodable:%.*]] = call ptr @"$s30synthesized_conformance_future8NonfinalCySiGACyxGSEAASERzlWl"()
-    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(ptr noalias nocapture {{%.*}}, ptr {{%.*}}, ptr [[Nonfinal_Encodable]])
+    // CHECK-NEXT: call swiftcc void @"$s30synthesized_conformance_future11doEncodableyyxSERzlF"(ptr noalias {{%.*}}, ptr {{%.*}}, ptr [[Nonfinal_Encodable]])
     doEncodable(Nonfinal(x: 1))
 }

--- a/test/IRGen/unmanaged_objc_throw_func.swift
+++ b/test/IRGen/unmanaged_objc_throw_func.swift
@@ -51,7 +51,7 @@ import Foundation
 // CHECK: [[L6]]:                                     ; preds = %[[L5]]
 // CHECK-NEXT: %[[T9:.+]] = phi ptr [ %[[T8]], %[[L5]] ]
 // CHECK-NEXT: %[[T10:.+]] = call swiftcc ptr @"$s10Foundation22_convertErrorToNSErrorySo0E0Cs0C0_pF"(ptr %[[T6]]) #{{[0-9]+}}
-// CHECK: call swiftcc void @"$sSA7pointeexvs"(ptr noalias nocapture %{{.+}}, ptr %[[T9]], ptr %{{.+}}) #{{[0-9]+}}
+// CHECK: call swiftcc void @"$sSA7pointeexvs"(ptr noalias %{{.+}}, ptr %[[T9]], ptr %{{.+}}) #{{[0-9]+}}
 // CHECK: call void @swift_errorRelease(ptr %[[T6]]) #{{[0-9]+}}
 // CHECK-NEXT: br label %[[L7:.+]]
 

--- a/test/IRGen/variadic_generic_captures.swift
+++ b/test/IRGen/variadic_generic_captures.swift
@@ -6,7 +6,7 @@ public func has_metadata_pack<each T>(t: repeat each T) -> () -> () {
   return { _ = (repeat each T).self }
 }
 
-// CHECK-LABEL: define{{( protected)?}}{{( dllexport)?}} swiftcc { ptr, ptr } @"$s25variadic_generic_captures17has_metadata_pack1tyycxxQp_tRvzlF"(ptr noalias nocapture %0, i{{32|64}} %1, ptr %"each T") #0 {
+// CHECK-LABEL: define{{( protected)?}}{{( dllexport)?}} swiftcc { ptr, ptr } @"$s25variadic_generic_captures17has_metadata_pack1tyycxxQp_tRvzlF"(ptr noalias %0, i{{32|64}} %1, ptr %"each T") #0 {
 // CHECK: [[CONTEXT0:%.*]] = call noalias ptr @swift_allocObject(
 
 // CHECK: [[GENERIC_ARGS_ADDR:%.*]] = getelementptr inbounds {{.*}} [[CONTEXT0]], i32 0, i32 {{(1|2)}}
@@ -34,7 +34,7 @@ public func has_metadata_pack_noescape<each T>(t: repeat each T) {
   takesNoEscape { _ = (repeat each T).self }
 }
 
-// CHECK-LABEL: define{{( protected)?}}{{( dllexport)?}} swiftcc void @"$s25variadic_generic_captures26has_metadata_pack_noescape1tyxxQp_tRvzlF"(ptr noalias nocapture %0, i{{32|64}} %1, ptr %"each T") #0 {
+// CHECK-LABEL: define{{( protected)?}}{{( dllexport)?}} swiftcc void @"$s25variadic_generic_captures26has_metadata_pack_noescape1tyxxQp_tRvzlF"(ptr noalias %0, i{{32|64}} %1, ptr %"each T") #0 {
 // CHECK: [[CONTEXT0:%.*]] = alloca i8, [[INT]]
 
 // CHECK: [[GENERIC_ARGS:%.*]] = getelementptr inbounds {{.*}} [[CONTEXT0]], i32 0, i32 {{(1|2)}}

--- a/test/IRGen/variadic_generic_fulfillment.swift
+++ b/test/IRGen/variadic_generic_fulfillment.swift
@@ -10,7 +10,7 @@ public struct GG<each T> {
   }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s28variadic_generic_fulfillment2GGV7doStuff5inputyxxQp_tF"(ptr noalias nocapture %0, ptr %"GG<repeat each T>", ptr noalias nocapture swiftself %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s28variadic_generic_fulfillment2GGV7doStuff5inputyxxQp_tF"(ptr noalias %0, ptr %"GG<repeat each T>", ptr noalias swiftself %1)
 // CHECK: [[T_PTR:%.*]] = getelementptr inbounds ptr, ptr %"GG<repeat each T>"
 // CHECK: [[T:%.*]] = load ptr, ptr [[T_PTR]]
 

--- a/test/IRGen/variadic_generic_functions.swift
+++ b/test/IRGen/variadic_generic_functions.swift
@@ -2,17 +2,17 @@
 
 // REQUIRES: PTRSIZE=64
 
-// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f11tyxxQp_tRvzlF"(ptr noalias nocapture %0, i64 %1, ptr %"each T")
+// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f11tyxxQp_tRvzlF"(ptr noalias %0, i64 %1, ptr %"each T")
 func f1<each T>(t: repeat each T) {}
 
-// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f21t1uyxxQp_q_q_QptRvzRv_r0_lF"(ptr noalias nocapture %0, ptr noalias nocapture %1, i64 %2, i64 %3, ptr %"each T", ptr %"each U")
+// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f21t1uyxxQp_q_q_QptRvzRv_r0_lF"(ptr noalias %0, ptr noalias %1, i64 %2, i64 %3, ptr %"each T", ptr %"each U")
 func f2<each T, each U>(t: repeat each T, u: repeat each U) {}
 
-// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f31t1uyxxQp_q_xQptRvzRv_q_Rhzr0_lF"(ptr noalias nocapture %0, ptr noalias nocapture %1, i64 %2, ptr %"each T", ptr %"each U")
+// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f31t1uyxxQp_q_xQptRvzRv_q_Rhzr0_lF"(ptr noalias %0, ptr noalias %1, i64 %2, ptr %"each T", ptr %"each U")
 func f3<each T, each U>(t: repeat each T, u: repeat each U) where (repeat (each T, each U)): Any {}
 
 protocol P {}
 
-// CHECK-LABEL: define {{.*}}void @f4(ptr noalias nocapture %0, i64 %1, ptr %"each T", ptr %"each T.P")
+// CHECK-LABEL: define {{.*}}void @f4(ptr noalias %0, i64 %1, ptr %"each T", ptr %"each T.P")
 @_silgen_name("f4")
 func f4<each T : P>(t: repeat each T) {}

--- a/test/IRGen/variadic_generics.sil
+++ b/test/IRGen/variadic_generics.sil
@@ -141,14 +141,14 @@ entry(%addr : $*T):
 }
 
 // CHECK-LABEL: define {{.*}}@test_tuple_pack_element_addr_1(
-// CHECK-SAME:        ptr nocapture [[TUPLE_ADDR:%[^,]+]], i{{(64|32)}} [[INDEX:%[^,]+]]
+// CHECK-SAME:        ptr [[TUPLE_ADDR:%[^,]+]], i{{(64|32)}} [[INDEX:%[^,]+]]
 // CHECK:         [[ELT_TYPE:%.*]] = phi ptr [
 // CHECK:         [[RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata
 // CHECK:         [[UNCAST_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
 // CHECK:         [[OFFSET_PTR:%[^,]+]] = getelementptr inbounds %swift.tuple_type, ptr [[UNCAST_METADATA]], i{{(64|32)}} 0, i32 3, i{{(64|32)}} [[INDEX]]
 // CHECK:         [[OFFSET:%[^,]+]] = load i32, ptr [[OFFSET_PTR]], align
 // CHECK:         [[UNCAST_ELEMENT_ADDR:%[^,]+]] = getelementptr inbounds i8, ptr [[TUPLE_ADDR]], i32 [[OFFSET]]
-// CHECK:         call swiftcc void @borrow(ptr noalias nocapture [[UNCAST_ELEMENT_ADDR]], ptr [[ELT_TYPE]])
+// CHECK:         call swiftcc void @borrow(ptr noalias [[UNCAST_ELEMENT_ADDR]], ptr [[ELT_TYPE]])
 sil @test_tuple_pack_element_addr_1 :  $<T, U> (@inout (String, T, U, Int), Builtin.Word) -> () {
 bb0(%tuple : $*(String, T, U, Int), %i : $Builtin.Word):
   %index = dynamic_pack_index %i of $Pack{Float, T, U, Float}

--- a/test/IRGen/variadic_vanishing_tuple.swift
+++ b/test/IRGen/variadic_vanishing_tuple.swift
@@ -6,7 +6,7 @@ public func makeTuple<each T>(_ t: repeat each T) {
   takesMetatype((repeat each T).self)
 }
 
-// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc void @"$s24variadic_vanishing_tuple9makeTupleyyxxQpRvzlF"(ptr noalias nocapture %0, {{i32|i64}} %1, ptr %"each T")
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc void @"$s24variadic_vanishing_tuple9makeTupleyyxxQpRvzlF"(ptr noalias %0, {{i32|i64}} %1, ptr %"each T")
 // CHECK:   [[CMP:%.*]] = icmp eq [[INT]] %1, 1
 // CHECK:   br i1 [[CMP]], label %vanishing-tuple, label %actual-tuple
 

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -36,7 +36,7 @@ bb0(%0 : $*A, %1 : $Optional<C>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store(ptr nocapture dereferenceable({{.*}}) %0, i64 %1) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store(ptr dereferenceable({{.*}}) %0, i64 %1) {{.*}} {
 // CHECK:      [[X:%.*]] = getelementptr inbounds [[A:%T4weak1AV]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = call ptr @swift_weakLoadStrong(ptr [[X]])
 // CHECK-NEXT: %3 = ptrtoint  ptr %2 to i64
@@ -59,7 +59,7 @@ bb0(%0 : $*B, %1 : $Optional<P>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store_proto(ptr nocapture dereferenceable({{.*}}) %0, i64 %1, i64 %2)
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store_proto(ptr dereferenceable({{.*}}) %0, i64 %1, i64 %2)
 // CHECK:      [[X:%.*]] = getelementptr inbounds [[B:%T4weak1BV]], ptr %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK:%swift.weak]], ptr }, ptr [[X]], i32 0, i32 0
 // CHECK-NEXT: [[T1:%.*]] = call ptr @swift_unknownObjectWeakLoadStrong(ptr [[T0]])

--- a/test/IRGen/weak_class_protocol.sil
+++ b/test/IRGen/weak_class_protocol.sil
@@ -6,7 +6,7 @@ import Swift
 
 protocol Foo: class { }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @store_weak(ptr noalias nocapture sret({{.*}}) %0, i64 %1, i64 %2) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @store_weak(ptr noalias sret({{.*}}) %0, i64 %1, i64 %2) {{.*}} {
 // CHECK:       entry:
 // CHECK-objc:    [[INSTANCE:%.*]] = inttoptr i64 %1 to ptr
 // CHECK-native:  [[INSTANCE:%.*]] = inttoptr i64 %1 to ptr

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -110,8 +110,8 @@ public func useConditionallyAvailableMethod(s: ConditionallyAvailableStruct) {
   s.conditionallyAvailableMethod()
 }
 
-// CHECK-OLD-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper28ConditionallyAvailableStructV013conditionallyF6MethodyyF"(ptr noalias nocapture swiftself)
-// CHECK-NEW-LABEL: declare swiftcc void @"$s31weak_import_availability_helper28ConditionallyAvailableStructV013conditionallyF6MethodyyF"(ptr noalias nocapture swiftself)
+// CHECK-OLD-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper28ConditionallyAvailableStructV013conditionallyF6MethodyyF"(ptr noalias swiftself)
+// CHECK-NEW-LABEL: declare swiftcc void @"$s31weak_import_availability_helper28ConditionallyAvailableStructV013conditionallyF6MethodyyF"(ptr noalias swiftself)
 
 @available(macOS, unavailable)
 public func useUnavailableStruct() {
@@ -125,4 +125,4 @@ public func useUnavailableMethod(s: UnvailableStruct) {
   s.unavailableMethod()
 }
 
-// CHECK-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper16UnvailableStructV17unavailableMethodyyF"(ptr noalias nocapture swiftself)
+// CHECK-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper16UnvailableStructV17unavailableMethodyyF"(ptr noalias swiftself)

--- a/test/IRGen/weak_import_native.swift
+++ b/test/IRGen/weak_import_native.swift
@@ -10,7 +10,7 @@ import weak_import_native_helper
 // CHECK-DAG: @"$s25weak_import_native_helper23ProtocolWithWeakMembersP1TAC_AA05OtherE0Tn" = extern_weak global %swift.protocol_requirement
 // CHECK-DAG: @"$s1T25weak_import_native_helper23ProtocolWithWeakMembersPTl" = extern_weak global %swift.protocol_requirement
 // CHECK-DAG: @"$s25weak_import_native_helper23ProtocolWithWeakMembersP1fyyFTq" = extern_weak global %swift.method_descriptor
-// CHECK-DAG: declare extern_weak swiftcc void @"$s25weak_import_native_helper23ProtocolWithWeakMembersPAAE1fyyF"(ptr, ptr, ptr noalias nocapture swiftself)
+// CHECK-DAG: declare extern_weak swiftcc void @"$s25weak_import_native_helper23ProtocolWithWeakMembersPAAE1fyyF"(ptr, ptr, ptr noalias swiftself)
 struct ConformsToProtocolWithWeakMembers : ProtocolWithWeakMembers {}
 
 func testTopLevel() {

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -9,7 +9,7 @@ protocol DefCon {
 }
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defcon(ptr noalias nocapture sret({{.*}}) %0, ptr %1, ptr %T, ptr %T.DefCon) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defcon(ptr noalias sret({{.*}}) %0, ptr %1, ptr %T, ptr %T.DefCon) {{.*}} {
 sil @defcon : $@convention(thin) <T: DefCon> (@thick T.Type) -> @out T {
 entry(%0: $*T, %1: $@thick T.Type):
 
@@ -60,7 +60,7 @@ struct SyncUp<Deliverable> : Synergy {
   }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testGenericWitnessMethod(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testGenericWitnessMethod(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T)
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s14witness_method6SyncUpVMa"([[INT]] 255, ptr %T)
 // CHECK:   [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -69,7 +69,7 @@ struct SyncUp<Deliverable> : Synergy {
 // CHECK:   [[WITNESS_FN:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @swift_checkMetadataState([[INT]] 0, ptr [[METADATA]])
 // CHECK:   [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK:   call swiftcc void [[WITNESS_FN]](ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture swiftself %1, ptr [[METADATA]], ptr [[WTABLE]])
+// CHECK:   call swiftcc void [[WITNESS_FN]](ptr noalias sret({{.*}}) %0, ptr noalias swiftself %1, ptr [[METADATA]], ptr [[WTABLE]])
 // CHECK:   ret void
 
 sil @testGenericWitnessMethod : $@convention(thin) <T> (@in SyncUp<T>) -> @out T {
@@ -87,11 +87,11 @@ protocol Strategy {
   func disrupt() -> GrowthHack
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testArchetypeWitnessMethod(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture %1, ptr %T, ptr %T.Strategy)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testArchetypeWitnessMethod(ptr noalias sret({{.*}}) %0, ptr noalias %1, ptr %T, ptr %T.Strategy)
 // CHECK: entry:
 // CHECK:   [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.Strategy, i32 3
 // CHECK:   [[WITNESS_FN:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
-// CHECK:   call swiftcc void [[WITNESS_FN]](ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture swiftself %1, ptr %T, ptr %T.Strategy)
+// CHECK:   call swiftcc void [[WITNESS_FN]](ptr noalias sret({{.*}}) %0, ptr noalias swiftself %1, ptr %T, ptr %T.Strategy)
 // CHECK:   ret void
 
 sil @testArchetypeWitnessMethod : $@convention(thin) <T : Strategy> (@in T) -> @out T.GrowthHack {
@@ -121,7 +121,7 @@ entry(%self : $*T):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testClassArchetypeWitnessMethod(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture dereferenceable({{4|8}}) %1, ptr %T, ptr %CoverSheet)
 // CHECK: entry:
 // CHECK:  [[WITNESS_FN:%.*]] = load ptr, ptr getelementptr inbounds (ptr, ptr @"$s14witness_method9TPSReportCyxGAA8StrategyAAWP", i32 3)
-// CHECK: call swiftcc void [[WITNESS_FN]](ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture swiftself %1, ptr %T, ptr @"$s14witness_method9TPSReportCyxGAA8StrategyAAWP")
+// CHECK: call swiftcc void [[WITNESS_FN]](ptr noalias sret({{.*}}) %0, ptr noalias swiftself %1, ptr %T, ptr @"$s14witness_method9TPSReportCyxGAA8StrategyAAWP")
 // CHECK: ret void
 
 sil @testClassArchetypeWitnessMethod : $@convention(thin) <T><CoverSheet where T : TPSReport<CoverSheet>> (@in_guaranteed T) -> (@out T.GrowthHack) {

--- a/test/IRGen/witness_table_objc_associated_type.swift
+++ b/test/IRGen/witness_table_objc_associated_type.swift
@@ -33,7 +33,7 @@ struct SO: C {
 // CHECK:         ptr {{.*}}@"$s34witness_table_objc_associated_type2SOVAA1CA2aDP3fooyyFTW{{(\.ptrauth)?}}"
 // CHECK:       ]
 
-// CHECK-LABEL: define hidden swiftcc void @"$s34witness_table_objc_associated_type0A25OffsetAfterAssociatedTypeyyxAA1BRzlF"(ptr noalias nocapture %0, ptr %T, ptr %T.B)
+// CHECK-LABEL: define hidden swiftcc void @"$s34witness_table_objc_associated_type0A25OffsetAfterAssociatedTypeyyxAA1BRzlF"(ptr noalias %0, ptr %T, ptr %T.B)
 func witnessOffsetAfterAssociatedType<T: B>(_ x: T) {
   // CHECK:         [[FOO_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.B, i32 3
   // CHECK:         [[FOO:%.*]] = load {{.*}} [[FOO_ADDR]]
@@ -41,7 +41,7 @@ func witnessOffsetAfterAssociatedType<T: B>(_ x: T) {
   x.foo()
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s34witness_table_objc_associated_type0A29OffsetAfterAssociatedTypeObjCyyxAA1CRzlF"(ptr noalias nocapture %0, ptr %T, ptr %T.C) {{.*}} {
+// CHECK-LABEL: define hidden swiftcc void @"$s34witness_table_objc_associated_type0A29OffsetAfterAssociatedTypeObjCyyxAA1CRzlF"(ptr noalias %0, ptr %T, ptr %T.C) {{.*}} {
 func witnessOffsetAfterAssociatedTypeObjC<T: C>(_ x: T) {
   // CHECK:         [[FOO_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.C, i32 2
   // CHECK:         [[FOO:%.*]] = load {{.*}} [[FOO_ADDR]]

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -30,13 +30,13 @@ extension Single: P1 where A: P2 {
 
 // witness method for Single.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2_i8star:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
 // CHECK-NEXT:    [[A_PTR:%.*]] = getelementptr inbounds ptr, ptr %Self, i64 2
 // CHECK-NEXT:    [[A:%.*]] = load ptr, ptr [[A_PTR]], align 8
-// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(ptr noalias nocapture %0, ptr [[A]], ptr %"\CF\84_1_0", ptr [[A_P2_i8star]], ptr %"\CF\84_1_0.P3")
+// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(ptr noalias %0, ptr [[A]], ptr %"\CF\84_1_0", ptr [[A_P2_i8star]], ptr %"\CF\84_1_0.P3")
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
@@ -208,7 +208,7 @@ extension Double: P1 where B: P2, C: P3 {
 
 // witness method for Double.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP7genericyyqd__AaGRd__lFTW"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP7genericyyqd__AaGRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
@@ -223,7 +223,7 @@ extension Double: P1 where B: P2, C: P3 {
 // CHECK-NEXT:    [[C_PTR:%.*]] = getelementptr inbounds ptr, ptr %Self, i64 3
 // CHECK-NEXT:    [[C:%.*]] = load ptr, ptr [[C_PTR]], align 8
 
-// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVA2A2P2RzAA2P3R_rlE7genericyyqd__AaERd__lF"(ptr noalias nocapture %0, ptr [[B]], ptr [[C]], ptr %"\CF\84_1_0", ptr [[B_P2_i8star]], ptr [[C_P3_i8star]], ptr %"\CF\84_1_0.P3")
+// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVA2A2P2RzAA2P3R_rlE7genericyyqd__AaERd__lF"(ptr noalias %0, ptr [[B]], ptr [[C]], ptr %"\CF\84_1_0", ptr [[B_P2_i8star]], ptr [[C_P3_i8star]], ptr %"\CF\84_1_0.P3")
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_basic_conformances_future.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances_future.swift
@@ -30,13 +30,13 @@ extension Single: P1 where A: P2 {
 
 // witness method for Single.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2_i8star:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
 // CHECK-NEXT:    [[A_PTR:%.*]] = getelementptr inbounds ptr, ptr %Self, i64 2
 // CHECK-NEXT:    [[A:%.*]] = load ptr, ptr [[A_PTR]], align 8
-// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(ptr noalias nocapture %0, ptr [[A]], ptr %"\CF\84_1_0", ptr [[A_P2_i8star]], ptr %"\CF\84_1_0.P3")
+// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances6SingleVA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(ptr noalias %0, ptr [[A]], ptr %"\CF\84_1_0", ptr [[A_P2_i8star]], ptr %"\CF\84_1_0.P3")
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
@@ -187,7 +187,7 @@ extension Double: P1 where B: P2, C: P3 {
 
 // witness method for Double.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP7genericyyqd__AaGRd__lFTW"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlAaEP7genericyyqd__AaGRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
@@ -202,7 +202,7 @@ extension Double: P1 where B: P2, C: P3 {
 // CHECK-NEXT:    [[C_PTR:%.*]] = getelementptr inbounds ptr, ptr %Self, i64 3
 // CHECK-NEXT:    [[C:%.*]] = load ptr, ptr [[C_PTR]], align 8
 
-// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVA2A2P2RzAA2P3R_rlE7genericyyqd__AaERd__lF"(ptr noalias nocapture %0, ptr [[B]], ptr [[C]], ptr %"\CF\84_1_0", ptr [[B_P2_i8star]], ptr [[C_P3_i8star]], ptr %"\CF\84_1_0.P3")
+// CHECK-NEXT:    call swiftcc void @"$s42conditional_conformance_basic_conformances6DoubleVA2A2P2RzAA2P3R_rlE7genericyyqd__AaERd__lF"(ptr noalias %0, ptr [[B]], ptr [[C]], ptr %"\CF\84_1_0", ptr [[B_P2_i8star]], ptr [[C_P3_i8star]], ptr %"\CF\84_1_0.P3")
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_subclass.swift
+++ b/test/Inputs/conditional_conformance_subclass.swift
@@ -27,12 +27,12 @@ extension Base: P1 where A: P2 {
 
 // witness method for Base.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
 // CHECK-NEXT:    [[SELF:%.]] = load ptr, ptr %1, align 8
-// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass4BaseCA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr [[A_P2]], ptr %"\CF\84_1_0.P3", ptr swiftself [[SELF]])
+// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass4BaseCA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(ptr noalias %0, ptr %"\CF\84_1_0", ptr [[A_P2]], ptr %"\CF\84_1_0.P3", ptr swiftself [[SELF]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_subclass_future.swift
+++ b/test/Inputs/conditional_conformance_subclass_future.swift
@@ -27,12 +27,12 @@ extension Base: P1 where A: P2 {
 
 // witness method for Base.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlAaEP7genericyyqd__AA2P3Rd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself dereferenceable(8) %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[A_P2:%.*]] = load ptr, ptr [[A_P2_PTR]], align 8
 // CHECK-NEXT:    [[SELF:%.]] = load ptr, ptr %1, align 8
-// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass4BaseCA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr [[A_P2]], ptr %"\CF\84_1_0.P3", ptr swiftself [[SELF]])
+// CHECK-NEXT:    call swiftcc void @"$s32conditional_conformance_subclass4BaseCA2A2P2RzlE7genericyyqd__AA2P3Rd__lF"(ptr noalias %0, ptr %"\CF\84_1_0", ptr [[A_P2]], ptr %"\CF\84_1_0.P3", ptr swiftself [[SELF]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_with_assoc.swift
+++ b/test/Inputs/conditional_conformance_with_assoc.swift
@@ -67,7 +67,7 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 
 // witness method for Double.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP7genericyyqd__AaFRd__lFTW"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP7genericyyqd__AaFRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[C_P3:%.*]] = load ptr, ptr [[C_P3_PTR]], align 8
@@ -87,7 +87,7 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %Self, i64 4
 // CHECK-NEXT:    %"\CF\84_0_0.P2" = load ptr, ptr [[B_P2_PTR]], align 8
 
-// CHECK-NEXT:    call swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVA2A2P3R_AA2P23AT2RpzAadF_AfaEP3AT3RPzrlE7genericyyqd__AaDRd__lF"(ptr noalias nocapture %0, ptr %"\CF\84_0_0", ptr %"\CF\84_0_1", ptr %"\CF\84_1_0", ptr %"\CF\84_0_0.P2", ptr [[C_P3]], ptr %"\CF\84_1_0.P3", ptr [[B_AT2_P2]], ptr [[B_AT2_AT2_AT3_P3]])
+// CHECK-NEXT:    call swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVA2A2P3R_AA2P23AT2RpzAadF_AfaEP3AT3RPzrlE7genericyyqd__AaDRd__lF"(ptr noalias %0, ptr %"\CF\84_0_0", ptr %"\CF\84_0_1", ptr %"\CF\84_1_0", ptr %"\CF\84_0_0.P2", ptr [[C_P3]], ptr %"\CF\84_1_0.P3", ptr [[B_AT2_P2]], ptr [[B_AT2_AT2_AT3_P3]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_with_assoc_future.swift
+++ b/test/Inputs/conditional_conformance_with_assoc_future.swift
@@ -67,7 +67,7 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 
 // witness method for Double.generic
 
-// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP7genericyyqd__AaFRd__lFTW"(ptr noalias nocapture %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
+// CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlAaEP7genericyyqd__AaFRd__lFTW"(ptr noalias %0, ptr %"\CF\84_1_0", ptr %"\CF\84_1_0.P3", ptr noalias nocapture swiftself %1, ptr %Self, ptr %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds ptr, ptr %SelfWitnessTable, i32 -1
 // CHECK-NEXT:    [[C_P3:%.*]] = load ptr, ptr [[C_P3_PTR]], align 8
@@ -87,7 +87,7 @@ extension Double: P1 where B.AT2: P2, C: P3, B.AT2.AT2.AT3: P3 {
 // CHECK-NEXT:    [[B_P2_PTR:%.*]] = getelementptr inbounds ptr, ptr %Self, i64 4
 // CHECK-NEXT:    %"\CF\84_0_0.P2" = load ptr, ptr [[B_P2_PTR]], align 8
 
-// CHECK-NEXT:    call swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVA2A2P3R_AA2P23AT2RpzAadF_AfaEP3AT3RPzrlE7genericyyqd__AaDRd__lF"(ptr noalias nocapture %0, ptr %"\CF\84_0_0", ptr %"\CF\84_0_1", ptr %"\CF\84_1_0", ptr %"\CF\84_0_0.P2", ptr [[C_P3]], ptr %"\CF\84_1_0.P3", ptr [[B_AT2_P2]], ptr [[B_AT2_AT2_AT3_P3]])
+// CHECK-NEXT:    call swiftcc void @"$s34conditional_conformance_with_assoc6DoubleVA2A2P3R_AA2P23AT2RpzAadF_AfaEP3AT3RPzrlE7genericyyqd__AaDRd__lF"(ptr noalias %0, ptr %"\CF\84_0_0", ptr %"\CF\84_0_1", ptr %"\CF\84_1_0", ptr %"\CF\84_0_0.P2", ptr [[C_P3]], ptr %"\CF\84_1_0.P3", ptr [[B_AT2_P2]], ptr [[B_AT2_AT2_AT3_P3]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 

--- a/test/Interop/Cxx/class/constructors-irgen-macosx.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-macosx.swift
@@ -9,7 +9,7 @@ import Constructors
 import TypeClassification
 
 public func createHasVirtualBase() -> HasVirtualBase {
-  // ITANIUM_X64: define swiftcc void @"$s7MySwift20createHasVirtualBaseSo0deF0VyF"(ptr noalias nocapture sret({{.*}}) %0)
+  // ITANIUM_X64: define swiftcc void @"$s7MySwift20createHasVirtualBaseSo0deF0VyF"(ptr noalias sret({{.*}}) %0)
   // ITANIUM_X64-NOT: define
   // ITANIUM_X64: call void @_ZN14HasVirtualBaseC1E7ArgType(ptr %{{[0-9]+}}, i32 %{{[0-9]+}})
   return HasVirtualBase(ArgType())

--- a/test/Interop/Cxx/class/constructors-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-windows.swift
@@ -9,7 +9,7 @@ import Constructors
 import TypeClassification
 
 public func createHasVirtualBase() -> HasVirtualBase {
-  // MICROSOFT_X64: define dllexport swiftcc void @"$s7MySwift20createHasVirtualBaseSo0{{bcD0VyF|deF0VyF}}"(ptr noalias nocapture sret({{.*}}) %0)
+  // MICROSOFT_X64: define dllexport swiftcc void @"$s7MySwift20createHasVirtualBaseSo0{{bcD0VyF|deF0VyF}}"(ptr noalias sret({{.*}}) %0)
   // MICROSOFT_X64-NOT: define
   // Note `this` return type and implicit "most derived" argument.
   // MICROSOFT_X64: call ptr @"??0HasVirtualBase@@QEAA@UArgType@@@Z"(ptr %{{[0-9]+}}, i32 %{{[0-9]+}}, i32 1)

--- a/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
@@ -62,7 +62,7 @@ public func testStructWithCopyConstructorAndSubobjectCopyConstructorAndValue()
   return obj.member.value == 42
 }
 
-// CHECK-LABEL: define {{.*}}i1 @"$s4main4test3objSbSo33StructWithCopyConstructorAndValueV_tF"(ptr noalias nocapture dereferenceable(4) %0)
+// CHECK-LABEL: define {{.*}}i1 @"$s4main4test3objSbSo33StructWithCopyConstructorAndValueV_tF"(ptr noalias dereferenceable(4) %0)
 // CHECK: [[VAL:%.*]] = getelementptr inbounds %TSo33StructWithCopyConstructorAndValueV, ptr %0, i32 0, i32 0
 // CHECK: [[VAL_VAL:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[VAL]], i32 0, i32 0
 // CHECK: [[LHS:%.*]] = load i32, ptr [[VAL_VAL]]
@@ -72,7 +72,7 @@ public func test(obj: StructWithCopyConstructorAndValue) -> Bool {
   return obj.value == 42
 }
 
-// CHECK-LABEL: define {{.*}}i1 @"$s4main4test3objSbSo42StructWithSubobjectCopyConstructorAndValueV_tF"(ptr noalias nocapture dereferenceable(4) %0)
+// CHECK-LABEL: define {{.*}}i1 @"$s4main4test3objSbSo42StructWithSubobjectCopyConstructorAndValueV_tF"(ptr noalias dereferenceable(4) %0)
 // CHECK: [[TMP:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
 // CHECK: [[MEMBER:%.*]] = getelementptr inbounds %TSo42StructWithSubobjectCopyConstructorAndValueV, ptr %0, i32 0, i32 0
 // CHECK: [[VAL:%.*]] = getelementptr inbounds %TSo33StructWithCopyConstructorAndValueV, ptr [[TMP]], i32 0, i32 0
@@ -84,7 +84,7 @@ public func test(obj: StructWithSubobjectCopyConstructorAndValue) -> Bool {
   return obj.member.value == 42
 }
 
-// CHECK-LABEL: define {{.*}}i1 @"$s4main4test3objSbSo037StructWithCopyConstructorAndSubobjectfgH5ValueV_tF"(ptr noalias nocapture dereferenceable(4) %0)
+// CHECK-LABEL: define {{.*}}i1 @"$s4main4test3objSbSo037StructWithCopyConstructorAndSubobjectfgH5ValueV_tF"(ptr noalias dereferenceable(4) %0)
 // CHECK:[[TEMP:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
 // CHECK:[[VAL:%.*]] = getelementptr inbounds %TSo33StructWithCopyConstructorAndValueV, ptr [[TEMP]], i32 0, i32 0
 // CHECK:[[VAL_VAL:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[VAL]], i32 0, i32 0

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -716,7 +716,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial does not call the 'destroy' value witness,
 // because it is known that the object is Trivial, i.e. contains no references.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5"(ptr noalias nocapture sret(%swift.opaque) %0, ptr noalias nocapture %1, ptr nocapture %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr %2, ptr %S
 // CHECK-IRGEN-NEXT: entry:
 // CHECK-IRGEN:   %3 = getelementptr inbounds ptr, ptr %S, i{{.*}} -1
 // CHECK-IRGEN-NEXT:   %S.valueWitnesses = load ptr, ptr %3

--- a/test/SILOptimizer/eager_specialize_ossa.sil
+++ b/test/SILOptimizer/eager_specialize_ossa.sil
@@ -904,7 +904,7 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 
 // Check that a specialization for _Trivial does not call the 'destroy' value witness,
 // because it is known that the object is Trivial, i.e. contains no references.
-// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5"(ptr noalias nocapture sret(%swift.opaque) %0, ptr noalias nocapture %1, ptr nocapture %2, ptr %S
+// CHECK-IRGEN-LABEL: define linkonce_odr hidden swiftcc void @"$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, ptr %2, ptr %S
 // CHECK-IRGEN-NEXT: entry:
 // CHECK-IRGEN:   %3 = getelementptr inbounds ptr, ptr %S, i{{.*}} -1
 // CHECK-IRGEN-NEXT:   %S.valueWitnesses = load ptr, ptr %3


### PR DESCRIPTION
The use of 'nocapture' for parameters and return values is incorrect for C++ types, as they can actually capture a pointer into its own value (e.g. std::string in libstdc++)

rdar://115062687
