### PR TITLE
[test] Require asserts for pullback_generation_nested_addelement_adjoints.swift

### DIFF
--- a/test/AutoDiff/SILOptimizer/pullback_generation_nested_addelement_adjoints.swift
+++ b/test/AutoDiff/SILOptimizer/pullback_generation_nested_addelement_adjoints.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend -emit-sil -verify -Xllvm --sil-print-after=differentiation -Xllvm --debug-only=differentiation %s 2>&1 | %FileCheck %s
 
+// Needed for '--debug-only'
+// REQUIRES: asserts
+
 import _Differentiation
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
It looks like `--debug-only` requires an asserts build