### PR TITLE
[CMake] Fix several issues that caused unnecessary rebuild

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -1001,7 +1001,9 @@ function(_compile_swift_files
     if(SWIFTFILE_STATIC)
       set(command_copy_interface_file)
       if(interface_file)
-        set(command_copy_interface_file COMMAND "${CMAKE_COMMAND}" "-E" "copy" ${interface_file} ${interface_file_static})
+        set(command_copy_interface_file
+          COMMAND "${CMAKE_COMMAND}" "-E" "copy" ${interface_file} ${interface_file_static}
+          COMMAND "${CMAKE_COMMAND}" "-E" "copy" ${private_interface_file} ${private_interface_file_static})
       endif()
       add_custom_command_target(
         module_dependency_target_static

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -921,7 +921,10 @@ function(_compile_swift_files
   string(REPLACE ";" "'\n'" source_files_quoted "${source_files}")
   string(SHA1 file_name "'${source_files_quoted}'")
   set(file_path "${CMAKE_CURRENT_BINARY_DIR}/${file_name}.txt")
-  file(GENERATE OUTPUT "${file_path}" CONTENT "'${source_files_quoted}'")
+  file(WRITE "${file_path}.tmp" "'${source_files_quoted}'")
+  add_custom_command(
+    OUTPUT "${file_path}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${file_path}.tmp" "${file_path}")
 
   # If this platform/architecture combo supports backward deployment to old
   # Objective-C runtimes, we need to copy a YAML file with legacy type layout

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -921,7 +921,7 @@ function(_compile_swift_files
   string(REPLACE ";" "'\n'" source_files_quoted "${source_files}")
   string(SHA1 file_name "'${source_files_quoted}'")
   set(file_path "${CMAKE_CURRENT_BINARY_DIR}/${file_name}.txt")
-  file(WRITE "${file_path}" "'${source_files_quoted}'")
+  file(GENERATE OUTPUT "${file_path}" CONTENT "'${source_files_quoted}'")
 
   # If this platform/architecture combo supports backward deployment to old
   # Objective-C runtimes, we need to copy a YAML file with legacy type layout

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -2,11 +2,13 @@
 # API Notes for the C++ Standard Library
 #
 set(output_dir "${SWIFTLIB_DIR}/apinotes")
-add_custom_target(CxxStdlib-apinotes
+add_custom_command_target(unused_var
+    CUSTOM_TARGET_NAME CxxStdlib-apinotes
     COMMAND ${CMAKE_COMMAND} "-E" "make_directory" "${output_dir}"
     COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_SOURCE_DIR}/std.apinotes" "${output_dir}"
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/std.apinotes
-    COMMENT "Copying CxxStdlib API Notes to ${output_dir}")
+    COMMENT "Copying CxxStdlib API Notes to ${output_dir}"
+    OUTPUT "${output_dir}/std.apinotes"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/std.apinotes")
 
 swift_install_in_component(FILES std.apinotes
     DESTINATION "lib/swift/apinotes"


### PR DESCRIPTION
`build-script --reconfigure` should be "no work to do" unless anything has changed.

* [cxx-interop] Use add_custom_command_target for copying std.apinotes
`COMMAND` for `add_custom_target` are ["always considered out of date"](https://cmake.org/cmake/help/latest/command/add_custom_target.html) and executed every time. Because of that, targets depends on that were always marked "dirty". Use `add_custom_command_target` instead.
* [stdlib]  Copy '.private.swiftinteface' to swift_static
`.private.swiftinterface` should be a part of the module. And it's declared as `OUTPUT` file list, but they were never created. Because of that the target was always rebuilt.
* [stdlib] Update source file list only if different
Write source file list using `file(GENERATE` so that they are updated only if thier content is changed. Otherwise stdlib modules are rebuild every time cmake configuration happens.