### PR TITLE
[embedded] Fix compiler crash in getRuntimeEffect when processing ExistentialMetatypeInst

### DIFF
--- a/test/embedded/anyobject-error-no-stdlib.swift
+++ b/test/embedded/anyobject-error-no-stdlib.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-emit-ir -parse-stdlib %s -enable-experimental-feature Embedded -verify
+
+public enum Never {}
+
+@_silgen_name("abort")
+func abort() -> Never
+
+@_semantics("typechecker.type(of:)")
+public func type<T, Metatype>(of value: T) -> Metatype { abort() }
+
+public typealias AnyObject = Builtin.AnyObject
+
+precedencegroup AssignmentPrecedence { assignment: true }
+
+public func foo(_ x: AnyObject) {
+  _ = type(of: x) // expected-error {{existential can cause metadata allocation or locks}}
+  // expected-note@-1 {{called from here}}
+}


### PR DESCRIPTION
Fixes the following crash (showcased by the added testcase):
```
1.	Swift version 5.9-dev (LLVM 104f7296fe3d75d, Swift df4f824b02947ca)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for main)
4.	While running pass #93 SILModuleTransform "PerformanceDiagnostics".
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x00000001095d2038 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
1  swift-frontend           0x00000001095d145c llvm::sys::RunSignalHandlers() + 112
2  swift-frontend           0x00000001095d2678 SignalHandler(int) + 304
3  libsystem_platform.dylib 0x00000001a516ea24 _sigtramp + 56
4  swift-frontend           0x00000001056f9384 swift::getRuntimeEffect(swift::SILInstruction*, swift::SILType&) + 1228
5  swift-frontend           0x00000001056f9384 swift::getRuntimeEffect(swift::SILInstruction*, swift::SILType&) + 1228
6  swift-frontend           0x00000001051bd6cc (anonymous namespace)::PerformanceDiagnostics::visitInst(swift::SILInstruction*, swift::PerformanceConstraints, (anonymous namespace)::PerformanceDiagnostics::LocWithParent*) + 60
7  swift-frontend           0x00000001051bcf64 (anonymous namespace)::PerformanceDiagnosticsPass::run() + 916
8  swift-frontend           0x00000001051ff774 swift::SILPassManager::runModulePass(unsigned int) + 800
9  swift-frontend           0x0000000105201894 swift::SILPassManager::execute() + 624
10 swift-frontend           0x00000001051fc9b0 swift::SILPassManager::executePassPipelinePlan(swift::SILPassPipelinePlan const&) + 72
11 swift-frontend           0x00000001051fc94c swift::ExecuteSILPipelineRequest::evaluate(swift::Evaluator&, swift::SILPipelineExecutionDescriptor) const + 52
```
