### PR TITLE
[5.10 🍒][Dependency Scanning] Attempt to lookup optional transitive dependencies of binary module dependencies #68498

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -116,8 +116,10 @@ public:
 
   ModuleDependencyInfoStorageBase(ModuleDependencyKind dependencyKind,
                                   const std::vector<std::string> &moduleImports,
+                                  const std::vector<std::string> &optionalModuleImports,
                                   StringRef moduleCacheKey = "")
       : dependencyKind(dependencyKind), moduleImports(moduleImports),
+        optionalModuleImports(optionalModuleImports),
         moduleCacheKey(moduleCacheKey.str()), resolved(false), finalized(false)  {}
 
   virtual ModuleDependencyInfoStorageBase *clone() const = 0;
@@ -296,11 +298,12 @@ public:
                                      const std::string &moduleDocPath,
                                      const std::string &sourceInfoPath,
                                      const std::vector<std::string> &moduleImports,
+                                     const std::vector<std::string> &optionalModuleImports,
                                      const std::vector<std::string> &headerImports,
                                      const bool isFramework,
                                      const std::string &moduleCacheKey)
       : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftBinary,
-                                        moduleImports, moduleCacheKey),
+                                        moduleImports, optionalModuleImports, moduleCacheKey),
         compiledModulePath(compiledModulePath), moduleDocPath(moduleDocPath),
         sourceInfoPath(sourceInfoPath), preCompiledBridgingHeaderPaths(headerImports),
         isFramework(isFramework) {}
@@ -471,12 +474,14 @@ public:
       const std::string &moduleDocPath,
       const std::string &sourceInfoPath,
       const std::vector<std::string> &moduleImports,
+      const std::vector<std::string> &optionalModuleImports,
       const std::vector<std::string> &headerImports,
       bool isFramework, const std::string &moduleCacheKey) {
     return ModuleDependencyInfo(
         std::make_unique<SwiftBinaryModuleDependencyStorage>(
           compiledModulePath, moduleDocPath, sourceInfoPath,
-          moduleImports, headerImports, isFramework, moduleCacheKey));
+          moduleImports, optionalModuleImports,
+          headerImports, isFramework, moduleCacheKey));
   }
 
   /// Describe the main Swift module.

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -39,7 +39,7 @@ using llvm::BCVBR;
 
 /// Every .moddepcache file begins with these 4 bytes, for easy identification.
 const unsigned char MODULE_DEPENDENCY_CACHE_FORMAT_SIGNATURE[] = {'I', 'M', 'D','C'};
-const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 4;
+const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 5; // optionalModuleImports
 /// Increment this on every change.
 const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 1;
 
@@ -124,6 +124,7 @@ using ModuleInfoLayout =
                    IdentifierIDField,            // moduleName
                    ContextHashIDField,           // contextHash
                    ImportArrayIDField,           // moduleImports
+                   ImportArrayIDField,           // optionalModuleImports
                    DependencyIDArrayIDField      // resolvedDirectModuleDependencies
                    >;
 

--- a/test/ScanDependencies/optional_deps_of_binary_testable_imports.swift
+++ b/test/ScanDependencies/optional_deps_of_binary_testable_imports.swift
@@ -7,8 +7,8 @@
 
 @testable import Foo
 
-// Step 1: build swift interface and swift module side by side, make them testable
-// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name -I %S/Inputs/CHeaders -I %S/Inputs/Swift -enable-testing
+// Step 1: build a binary swift module for `Foo`, make it testable
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -I %S/Inputs/CHeaders -I %S/Inputs/Swift -enable-testing
 
 // Step 2: scan dependencies
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -sdk %t -prebuilt-module-cache-path %t/clang-module-cache -I %S/Inputs/CHeaders -I %S/Inputs/Swift

--- a/test/ScanDependencies/required_deps_of_testable_imports.swift
+++ b/test/ScanDependencies/required_deps_of_testable_imports.swift
@@ -10,7 +10,7 @@
 // Step 1: build swift interface and swift module side by side, make them testable
 // RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name -I %S/Inputs/CHeaders -I %S/Inputs/Swift -enable-testing -enable-experimental-feature AccessLevelOnImport
 
-// Step 3: scan dependencies
+// Step 2: scan dependencies
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -sdk %t -prebuilt-module-cache-path %t/clang-module-cache -I %S/Inputs/CHeaders -I %S/Inputs/Swift
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 


### PR DESCRIPTION
5.10 Cherry-pick of https://github.com/apple/swift/pull/68498
---------------------------------------------
Instead of simply pretending they do not exist, do a best-effort lookup.
