### PR TITLE
[donotmerge] Draft implementation for pointer conversion restrictions

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -516,6 +516,10 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(actor, Actor,
   DeclModifier | OnClass | ConcurrencyOnly | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   102)
 
+SIMPLE_DECL_ATTR(_forwardedToC, ForwardedToC,
+  OnParam | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove,
+  147)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6510,6 +6510,10 @@ public:
   /// Attempt to apply an implicit `@_nonEphemeral` attribute to this parameter.
   void setNonEphemeralIfPossible();
 
+  /// Does this parameter allow the implicit conversion from native Swift types
+  /// like Array or String to any of the UnsafePointer types?
+  bool isForwardedToC() const;
+
   /// Remove the type of this varargs element designator, without the array
   /// type wrapping it.  A parameter like "Int..." will have formal parameter
   /// type of "[Int]" and this returns "Int".

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3789,9 +3789,9 @@ ERROR(optional_compilerinitialized,none,
 ERROR(instancemember_compilerinitialized,none,
       "'@_compilerInitialized' can only be applied to a non-static class or actor member", ())
 
-// @_nonEphemeral attribute
-ERROR(non_ephemeral_non_pointer_type,none,
-      "@_nonEphemeral attribute only applies to pointer types", ())
+// @_nonEphemeral and @forwardedToC attribute
+ERROR(attr_non_pointer_type,none,
+      "@%0 attribute only applies to pointer types", (StringRef))
 
 // NSManaged attribute
 ERROR(attr_NSManaged_not_instance_member,none,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3796,6 +3796,7 @@ namespace {
       printFlag(paramFlags.isAutoClosure(), "autoclosure");
       printFlag(paramFlags.isNonEphemeral(), "nonEphemeral");
       printFlag(paramFlags.isCompileTimeConst(), "compileTimeConst");
+      printFlag(paramFlags.isForwardedToC(), "forwardedToC");
       printFlag(getDumpString(paramFlags.getValueOwnership()));
     }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8098,6 +8098,10 @@ void ParamDecl::setNonEphemeralIfPossible() {
   }
 }
 
+bool ParamDecl::isForwardedToC() const {
+  return getAttrs().hasAttribute<ForwardedToCAttr>();
+}
+
 Type ParamDecl::getVarargBaseTy(Type VarArgT) {
   TypeBase *T = VarArgT.getPointer();
   if (auto *AT = dyn_cast<VariadicSequenceType>(T))
@@ -8128,7 +8132,7 @@ AnyFunctionType::Param ParamDecl::toFunctionParam(Type type) const {
   auto flags = ParameterTypeFlags::fromParameterType(
       type, isVariadic(), isAutoClosure(), isNonEphemeral(),
       getSpecifier(), isIsolated(), /*isNoDerivative*/ false,
-      isCompileTimeConst());
+      isCompileTimeConst(), isForwardedToC());
   return AnyFunctionType::Param(type, label, flags, internalLabel);
 }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2470,6 +2470,11 @@ static ParamDecl *getParameterInfo(ClangImporter::Implementation *impl,
                               ? ParamSpecifier::InOut
                               : ParamSpecifier::Default);
   paramInfo->setInterfaceType(swiftParamTy);
+
+  if (swiftParamTy->getAnyPointerElementType()) {
+    paramInfo->getAttrs().add(new (paramInfo->getASTContext()) ForwardedToCAttr(/*isImplicit*/ true));
+  }
+
   impl->recordImplicitUnwrapForDecl(paramInfo, isParamTypeImplicitlyUnwrapped);
 
   return paramInfo;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7607,6 +7607,14 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       PointerTypeKind pointerKind;
       if (Type pointeeTy =
               unwrappedType2->getAnyPointerElementType(pointerKind)) {
+        bool isForwardedToC = false;
+        if (isArgumentOfImportedDecl(locator)) {
+          isForwardedToC = true;
+        } else if (locator.endsWith<LocatorPathElt::ApplyArgToParam>()) {
+          auto arg2Param = locator.last()
+                           ->castTo<LocatorPathElt::ApplyArgToParam>();
+          isForwardedToC = arg2Param.getParameterFlags().isForwardedToC();
+        }
         switch (pointerKind) {
         case PTK_UnsafeRawPointer:
         case PTK_UnsafeMutableRawPointer:
@@ -7632,7 +7640,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
               // Only try an inout-to-pointer conversion if we know it's not
               // an array being converted to a raw pointer type. Such
               // conversions can only use array-to-pointer.
-              if (!baseIsArray || !isRawPointerKind(pointerKind)) {
+              if (isForwardedToC &&
+                  (!baseIsArray || !isRawPointerKind(pointerKind))) {
                 conversionsOrFixes.push_back(
                     ConversionRestrictionKind::InoutToPointer);
 
@@ -7692,9 +7701,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
             if (pointerKind == PTK_UnsafePointer
                 || pointerKind == PTK_UnsafeRawPointer) {
               if (!isAutoClosureArgument) {
+
                 if (type1->isArrayType()) {
-                  conversionsOrFixes.push_back(
+                  if (isForwardedToC) {
+                    conversionsOrFixes.push_back(
                       ConversionRestrictionKind::ArrayToPointer);
+                  }
 
                   // If regular array-to-pointer conversion doesn't work,
                   // let's try C pointer conversion that has special semantics
@@ -7708,7 +7720,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                 // The pointer can be converted from a string, if the element
                 // type is compatible.
                 auto &ctx = getASTContext();
-                if (type1->isString()) {
+                if (type1->isString() && isForwardedToC) {
                   auto baseTy = getFixedTypeRecursive(pointeeTy, false);
 
                   if (baseTy->isTypeVariableOrMember() ||
@@ -7769,8 +7781,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           // PTK_AutoreleasingUnsafeMutablePointer can be converted from an
           // inout reference to a scalar.
           if (!isAutoClosureArgument && type1->is<InOutType>()) {
-            conversionsOrFixes.push_back(
-                                     ConversionRestrictionKind::InoutToPointer);
+            if (!isForwardedToC) {
+              conversionsOrFixes.push_back(
+                  ConversionRestrictionKind::InoutToPointer);
+            }
           }
           break;
         }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -346,6 +346,8 @@ public:
   void visitMacroRoleAttr(MacroRoleAttr *attr);
   
   void visitRawLayoutAttr(RawLayoutAttr *attr);
+
+  void visitForwardedToCAttr(ForwardedToCAttr *attr);
 };
 
 } // end anonymous namespace
@@ -4152,7 +4154,7 @@ void AttributeChecker::visitNonEphemeralAttr(NonEphemeralAttr *attr) {
     return;
   }
 
-  diagnose(attr->getLocation(), diag::non_ephemeral_non_pointer_type);
+  diagnose(attr->getLocation(), diag::attr_non_pointer_type, attr->getAttrName());
   attr->setInvalid();
 }
 
@@ -7042,6 +7044,25 @@ void AttributeChecker::visitRawLayoutAttr(RawLayoutAttr *attr) {
   
   // The storage is not directly referenceable by stored properties.
   sd->setHasUnreferenceableStorage(true);
+}
+
+void AttributeChecker::visitForwardedToCAttr(ForwardedToCAttr *attr) {
+  auto *param = cast<ParamDecl>(D);
+  auto type = param->getInterfaceType()->lookThroughSingleOptionalType();
+
+  // Can only be applied to Unsafe[...]Pointer types
+  if (type->getAnyPointerElementType())
+    return;
+
+  // ... or the protocol Self type.
+  auto *outerDC = param->getDeclContext()->getParent();
+  if (outerDC->getSelfProtocolDecl() &&
+      type->isEqual(outerDC->getSelfInterfaceType())) {
+    return;
+  }
+
+  diagnose(attr->getLocation(), diag::attr_non_pointer_type, attr->getAttrName());
+  attr->setInvalid();
 }
 
 namespace {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1552,6 +1552,7 @@ namespace  {
     UNINTERESTING_ATTR(PrivateImport)
     UNINTERESTING_ATTR(MainType)
     UNINTERESTING_ATTR(Preconcurrency)
+    UNINTERESTING_ATTR(ForwardedToC)
 
     // Differentiation-related attributes.
     UNINTERESTING_ATTR(Differentiable)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3506,7 +3506,7 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
 
     auto paramFlags = ParameterTypeFlags::fromParameterType(
         ty, variadic, autoclosure, /*isNonEphemeral*/ false, ownership,
-        isolated, noDerivative, compileTimeConst);
+        isolated, noDerivative, compileTimeConst, /*forwardedToC*/ false);
     elements.emplace_back(ty, argumentLabel, paramFlags, parameterName);
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6533,13 +6533,13 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
     IdentifierID internalLabelID;
     TypeID typeID;
     bool isVariadic, isAutoClosure, isNonEphemeral, isIsolated,
-        isCompileTimeConst;
+        isCompileTimeConst, isForwardedToC;
     bool isNoDerivative;
     unsigned rawOwnership;
     decls_block::FunctionParamLayout::readRecord(
         scratch, labelID, internalLabelID, typeID, isVariadic, isAutoClosure,
         isNonEphemeral, rawOwnership, isIsolated, isNoDerivative,
-        isCompileTimeConst);
+        isCompileTimeConst, isForwardedToC);
 
     auto ownership = getActualParamDeclSpecifier(
       (serialization::ParamDeclSpecifier)rawOwnership);
@@ -6554,7 +6554,7 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
                         ParameterTypeFlags(isVariadic, isAutoClosure,
                                            isNonEphemeral, *ownership,
                                            isIsolated, isNoDerivative,
-                                           isCompileTimeConst),
+                                           isCompileTimeConst, isForwardedToC),
                         MF.getIdentifier(internalLabelID));
   }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 807; // keypath accessor
+const uint16_t SWIFTMODULE_VERSION_MINOR = 808; // isForwardedToC
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1209,7 +1209,8 @@ namespace decls_block {
     ParamDeclSpecifierField, // inout, shared or owned?
     BCFixed<1>,          // isolated
     BCFixed<1>,          // noDerivative?
-    BCFixed<1>           // compileTimeConst
+    BCFixed<1>,          // compileTimeConst
+    BCFixed<1>           // forwarded to C?
   >;
 
   TYPE_LAYOUT(MetatypeTypeLayout,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5318,7 +5318,7 @@ public:
           S.addTypeRef(param.getPlainType()), paramFlags.isVariadic(),
           paramFlags.isAutoClosure(), paramFlags.isNonEphemeral(), rawOwnership,
           paramFlags.isIsolated(), paramFlags.isNoDerivative(),
-          paramFlags.isCompileTimeConst());
+          paramFlags.isCompileTimeConst(), paramFlags.isForwardedToC());
     }
   }
 

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -28,8 +28,7 @@ func _blackHolePtr<T>(_ x: UnsafePointer<T>) {
 }
 
 public func _blackHole<T>(_ x: T) {
-  var x = x
-  _blackHolePtr(&x)
+  withUnsafePointer(to: x, _blackHolePtr)
 }
 
 @inline(never)

--- a/stdlib/private/SwiftPrivate/AtomicInt.swift.gyb
+++ b/stdlib/private/SwiftPrivate/AtomicInt.swift.gyb
@@ -49,10 +49,11 @@ public final class _stdlib_AtomicInt {
 
   public func compareExchange(expected: inout Int, desired: Int) -> Bool {
     var expectedVar = expected
-    let result = _swift_stdlib_atomicCompareExchangeStrongInt(
-      object: _valuePtr,
-      expected: &expectedVar,
-      desired: desired)
+    let result = withUnsafeMutablePointer(to: &expectedVar) {
+      _swift_stdlib_atomicCompareExchangeStrongInt(
+        object: _valuePtr, expected: $0, desired: desired
+      )
+    }
     expected = expectedVar
     return result
   }

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -191,33 +191,33 @@ typealias _stdlib_posix_spawn_file_actions_t = posix_spawn_file_actions_t?
 
 @_silgen_name("_stdlib_posix_spawn_file_actions_init")
 internal func _stdlib_posix_spawn_file_actions_init(
-  _ file_actions: UnsafeMutablePointer<_stdlib_posix_spawn_file_actions_t>
+  @_forwardedToC _ file_actions: UnsafeMutablePointer<_stdlib_posix_spawn_file_actions_t>
 ) -> CInt
 
 @_silgen_name("_stdlib_posix_spawn_file_actions_destroy")
 internal func _stdlib_posix_spawn_file_actions_destroy(
-  _ file_actions: UnsafeMutablePointer<_stdlib_posix_spawn_file_actions_t>
+  @_forwardedToC _ file_actions: UnsafeMutablePointer<_stdlib_posix_spawn_file_actions_t>
 ) -> CInt
 
 @_silgen_name("_stdlib_posix_spawn_file_actions_addclose")
 internal func _stdlib_posix_spawn_file_actions_addclose(
-  _ file_actions: UnsafeMutablePointer<_stdlib_posix_spawn_file_actions_t>,
+  @_forwardedToC _ file_actions: UnsafeMutablePointer<_stdlib_posix_spawn_file_actions_t>,
   _ filedes: CInt) -> CInt
 
 @_silgen_name("_stdlib_posix_spawn_file_actions_adddup2")
 internal func _stdlib_posix_spawn_file_actions_adddup2(
-  _ file_actions: UnsafeMutablePointer<_stdlib_posix_spawn_file_actions_t>,
+  @_forwardedToC _ file_actions: UnsafeMutablePointer<_stdlib_posix_spawn_file_actions_t>,
   _ filedes: CInt,
   _ newfiledes: CInt) -> CInt
 
 @_silgen_name("_stdlib_posix_spawn")
 internal func _stdlib_posix_spawn(
-  _ pid: UnsafeMutablePointer<pid_t>?,
-  _ file: UnsafePointer<Int8>,
-  _ file_actions: UnsafePointer<_stdlib_posix_spawn_file_actions_t>?,
-  _ attrp: UnsafePointer<posix_spawnattr_t>?,
-  _ argv: UnsafePointer<UnsafeMutablePointer<Int8>?>,
-  _ envp: UnsafePointer<UnsafeMutablePointer<Int8>?>?) -> CInt
+  @_forwardedToC _ pid: UnsafeMutablePointer<pid_t>?,
+  @_forwardedToC _ file: UnsafePointer<Int8>,
+  @_forwardedToC _ file_actions: UnsafePointer<_stdlib_posix_spawn_file_actions_t>?,
+  @_forwardedToC _ attrp: UnsafePointer<posix_spawnattr_t>?,
+  @_forwardedToC _ argv: UnsafePointer<UnsafeMutablePointer<Int8>?>,
+  @_forwardedToC _ envp: UnsafePointer<UnsafeMutablePointer<Int8>?>?) -> CInt
 #endif
 
 /// Calls POSIX `pipe()`.

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -89,8 +89,10 @@ public struct _stdlib_fd_set {
 }
 
 public func _stdlib_select(
-  _ readfds: inout _stdlib_fd_set, _ writefds: inout _stdlib_fd_set,
-  _ errorfds: inout _stdlib_fd_set, _ timeout: UnsafeMutablePointer<timeval>?
+  _ readfds: inout _stdlib_fd_set,
+  _ writefds: inout _stdlib_fd_set,
+  _ errorfds: inout _stdlib_fd_set,
+  @_forwardedToC _ timeout: UnsafeMutablePointer<timeval>?
 ) -> CInt {
   return readfds._data.withUnsafeMutableBufferPointer {
     (readfds) in

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -242,7 +242,9 @@ internal struct ReflectionInfo : Sequence {
   }
 }
 
-internal func sendBytes<T>(from address: UnsafePointer<T>, count: Int) {
+internal func sendBytes<T>(
+  @_forwardedToC from address: UnsafePointer<T>, count: Int
+) {
   var source = UnsafeRawPointer(address)
   var bytesLeft = count
   debugLog("BEGIN \(#function)"); defer { debugLog("END \(#function)") }

--- a/stdlib/public/Backtracing/CoreSymbolication.swift
+++ b/stdlib/public/Backtracing/CoreSymbolication.swift
@@ -203,15 +203,16 @@ private func fromCFString(_ cf: CFString) -> String {
                   as: UTF8.self)
   } else {
     var byteLen = CFIndex(0)
-
-    _ = CFStringGetBytes(cf,
-                         CFRangeMake(0, length),
-                         CFStringBuiltInEncodings.UTF8.rawValue,
-                         0,
-                         false,
-                         nil,
-                         0,
-                         &byteLen)
+    withUnsafeMutablePointer(to: &byteLen) {
+      _ = CFStringGetBytes(cf,
+                           CFRangeMake(0, length),
+                           CFStringBuiltInEncodings.UTF8.rawValue,
+                           0,
+                           false,
+                           nil,
+                           0,
+                           $0)
+    }
 
     let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: byteLen)
     defer {

--- a/stdlib/public/Backtracing/CoreSymbolication.swift
+++ b/stdlib/public/Backtracing/CoreSymbolication.swift
@@ -168,7 +168,7 @@ internal func CFStringGetBytes(_ s: CFString,
                                _ isExternalRepresentation: Bool,
                                _ buffer: UnsafeMutableRawPointer?,
                                _ maxBufLen: CFIndex,
-                               _ usedBufLen: UnsafeMutablePointer<CFIndex>?)
+                               @forwardedToC _ usedBufLen: UnsafeMutablePointer<CFIndex>?)
   -> CFIndex {
   return Sym.CFStringGetBytes(s, range, encoding, lossByte,
                               isExternalRepresentation, buffer, maxBufLen,

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -14,7 +14,7 @@ import Swift
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_continuation_logFailedCheck")
-internal func logFailedCheck(_ message: UnsafeRawPointer)
+internal func logFailedCheck(@_forwardedToC _ message: UnsafeRawPointer)
 
 /// Implementation class that holds the `UnsafeContinuation` instance for
 /// a `CheckedContinuation`.

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -103,13 +103,13 @@ enum _ClockID: Int32 {
 @available(SwiftStdlib 5.7, *)
 @_silgen_name("swift_get_time")
 internal func _getTime(
-  seconds: UnsafeMutablePointer<Int64>,
-  nanoseconds: UnsafeMutablePointer<Int64>,
+  @_forwardedToC seconds: UnsafeMutablePointer<Int64>,
+  @_forwardedToC nanoseconds: UnsafeMutablePointer<Int64>,
   clock: CInt)
 
 @available(SwiftStdlib 5.7, *)
 @_silgen_name("swift_get_clock_res")
 internal func _getClockRes(
-  seconds: UnsafeMutablePointer<Int64>,
-  nanoseconds: UnsafeMutablePointer<Int64>,
+  @_forwardedToC seconds: UnsafeMutablePointer<Int64>,
+  @_forwardedToC nanoseconds: UnsafeMutablePointer<Int64>,
   clock: CInt)

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -672,7 +672,8 @@ public struct RemoteCallTarget: CustomStringConvertible, Hashable {
 @_silgen_name("swift_distributed_execute_target")
 func _executeDistributedTarget<D: DistributedTargetInvocationDecoder>(
   on actor: AnyObject, // DistributedActor
-  _ targetName: UnsafePointer<UInt8>, _ targetNameLength: UInt,
+  @_forwardedToC _ targetName: UnsafePointer<UInt8>,
+  _ targetNameLength: UInt,
   argumentDecoder: inout D,
   argumentTypes: Builtin.RawPointer,
   resultBuffer: Builtin.RawPointer,

--- a/stdlib/public/core/AtomicInt.swift.gyb
+++ b/stdlib/public/core/AtomicInt.swift.gyb
@@ -51,10 +51,13 @@ public final class _stdlib_AtomicInt {
 
   public func compareExchange(expected: inout Int, desired: Int) -> Bool {
     var expectedVar = expected
-    let result = _swift_stdlib_atomicCompareExchangeStrongInt(
-      object: _valuePtr,
-      expected: &expectedVar,
-      desired: desired)
+    let result = withUnsafeMutablePointer(to: &expectedVar) {
+      _swift_stdlib_atomicCompareExchangeStrongInt(
+        object: _valuePtr,
+        expected: $0,
+        desired: desired
+      )
+    }
     expected = expectedVar
     return result
   }

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -15,8 +15,9 @@ import SwiftShims
 #if SWIFT_STDLIB_HAS_COMMANDLINE
 
 @_silgen_name("_swift_stdlib_getUnsafeArgvArgc")
-internal func _swift_stdlib_getUnsafeArgvArgc(_: UnsafeMutablePointer<Int32>)
-  -> UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
+internal func _swift_stdlib_getUnsafeArgvArgc(
+  @_forwardedToC _: UnsafeMutablePointer<Int32>
+) -> UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
 
 /// Command-line arguments for the current process.
 @frozen // namespace

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -362,10 +362,11 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     for bucket in native.hashTable {
       let key = _key(at: bucket, bridgedKeys: bridgedKeys)
       let value = _value(at: bucket, bridgedValues: bridgedValues)
-      block(
-        Unmanaged.passUnretained(key),
-        Unmanaged.passUnretained(value),
-        &stop)
+      withUnsafeMutablePointer(to: &stop) {
+        block(
+          Unmanaged.passUnretained(key), Unmanaged.passUnretained(value), $0
+        )
+      }
       if stop != 0 { return }
     }
   }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2764,7 +2764,13 @@ internal func _resolveKeyPathGenericArgReference(
     // Unaligned load of the offset.
     let pointerReference = reference + 1
     var offset: Int32 = 0
-    _memcpy(dest: &offset, src: pointerReference, size: 4)
+    withUnsafeMutablePointer(to: &offset) {
+      _memcpy(
+        dest: $0,
+        src: pointerReference,
+        size: numericCast(MemoryLayout<Int32>.size)
+      )
+    }
 
     let accessorPtrRaw = _resolveCompactFunctionPointer(pointerReference, offset)
     let accessorPtrSigned =

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -289,7 +289,10 @@ public func _forEachField(
         return false
       }
     } else {
-      if !body("", offset, childType, kind) {
+      let result = withUnsafePointer(to: CChar.zero) {
+        !body($0, offset, childType, kind)
+      }
+      if result {
         return false
       }
     }
@@ -373,7 +376,10 @@ public func _forEachFieldWithKeyPath<Root>(
         return false
       }
     } else {
-      if !body("", partialKeyPath) {
+      let result = withUnsafePointer(to: CChar.zero) {
+        !body($0, partialKeyPath)
+      }
+      if result {
         return false
       }
     }

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -36,7 +36,7 @@ internal func _getRecursiveChildCount(_: Any.Type) -> Int
 internal func _getChildMetadata(
   _: Any.Type,
   index: Int,
-  fieldMetadata: UnsafeMutablePointer<_FieldReflectionMetadata>
+  @_forwardedToC fieldMetadata: UnsafeMutablePointer<_FieldReflectionMetadata>
 ) -> Any.Type
 
 @_silgen_name("swift_reflectionMirror_recursiveChildOffset")
@@ -52,8 +52,8 @@ internal func _getChild<T>(
   of: T,
   type: Any.Type,
   index: Int,
-  outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
-  outFreeFunc: UnsafeMutablePointer<NameFreeFunc?>
+  @_forwardedToC outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
+  @_forwardedToC outFreeFunc: UnsafeMutablePointer<NameFreeFunc?>
 ) -> Any
 
 // Returns 'c' (class), 'e' (enum), 's' (struct), 't' (tuple), or '\0' (none)

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -628,7 +628,9 @@ extension String {
         into: { arg.append($0) })
       arg.append(TargetEncoding.CodeUnit(0))
       _internalInvariant(!repaired)
-      return try body(arg)
+      return try arg.withUnsafeBufferPointer {
+        try body($0.baseAddress._unsafelyUnwrappedUnchecked)
+      }
     }
   }
 }

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -45,13 +45,15 @@ internal typealias _CocoaString = AnyObject
   func _fastCharacterContents() -> UnsafePointer<UInt16>?
 
   @objc(getBytes:maxLength:usedLength:encoding:options:range:remainingRange:)
-  func getBytes(_ buffer: UnsafeMutableRawPointer?,
-   maxLength maxBufferCount: Int,
-  usedLength usedBufferCount: UnsafeMutablePointer<Int>?,
+  func getBytes(
+    _ buffer: UnsafeMutableRawPointer?,
+    maxLength maxBufferCount: Int,
+    @_forwardedToC usedLength usedBufferCount: UnsafeMutablePointer<Int>?,
     encoding: UInt,
-     options: UInt,
-       range: _SwiftNSRange,
-       remaining leftover: UnsafeMutablePointer<_SwiftNSRange>?) -> Int8
+    options: UInt,
+    range: _SwiftNSRange,
+    @_forwardedToC remaining leftover: UnsafeMutablePointer<_SwiftNSRange>?
+  ) -> Int8
 
   @objc(compare:options:range:locale:)
   func compare(_ string: _CocoaString,

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -587,7 +587,9 @@ Generate a backtrace for the parent process.
   static func backtraceFormatter() -> BacktraceFormatter {
     var terminalSize = winsize(ws_row: 24, ws_col: 80,
                                ws_xpixel: 1024, ws_ypixel: 768)
-    _ = ioctl(0, CUnsignedLong(TIOCGWINSZ), &terminalSize)
+    withUnsafeMutablePointer(to: &terminalSize) {
+      _ = ioctl(0, CUnsignedLong(TIOCGWINSZ), $0)
+    }
 
     return BacktraceFormatter(formattingOptions
                               .theme(theme)


### PR DESCRIPTION
Partial implementation for the "constrain pointer conversions" [pitch](https://gist.github.com/glessard/ba1468bdc09d51ce5253cd7043ad3a78).

Allows pointer conversions only for C functions or pointer parameters to Swift functions that have the `@_forwardedToC` attribute.

To do:
- fix the many tests that are broken by this
- validate that `@_forwardedToC` parameters are indeed forwarded to C
- enable only when an experimental feature flag is set
- decide whether https://github.com/apple/swift/issues/68332 is a bug, and adjust accordingly