### PR TITLE
AST: Revert inherited type request in ConformanceLookupTable

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -228,8 +228,7 @@ void ConformanceLookupTable::inheritConformances(ClassDecl *classDecl,
 
     auto inheritedTypes = classDecl->getInherited();
     for (unsigned i : inheritedTypes.getIndices()) {
-      if (auto inheritedType = inheritedTypes.getResolvedType(i)) {
-
+      if (auto inheritedType = inheritedTypes.getEntry(i).getType()) {
         if (inheritedType->getClassOrBoundGenericClass()) {
           superclassLoc = inheritedTypes.getEntry(i).getSourceRange().Start;
           return superclassLoc;

--- a/test/Generics/rdar115314044.swift
+++ b/test/Generics/rdar115314044.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+
+public protocol P {}
+
+public protocol Q {
+  associatedtype A: P
+  func f(_: A)
+}
+
+open class Parent<C: P>: Q {
+  public func f(_: C) {}
+}
+
+final class Child: Parent<Child.Nested> {
+  struct Nested: P {}
+}


### PR DESCRIPTION
One of the request triggers added to `ConformanceLookupTable` in https://github.com/apple/swift/pull/68384 can cause circular request evaluation. Revert the request trigger since it doesn't appear to be necessary for the test cases introduced in that PR.

Resolves rdar://115314044
