### PR TITLE
[embedded] Build an initial embedded Swift standard library

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3107,6 +3107,7 @@ bool CompilerInvocation::parseArgs(
   setBridgingHeaderFromFrontendOptions(ClangImporterOpts, FrontendOpts);
   if (LangOpts.hasFeature(Feature::Embedded)) {
     IRGenOpts.InternalizeAtLink = true;
+    IRGenOpts.DisableLegacyTypeInfo = true;
   }
 
   return false;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1327,6 +1327,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Diags.diagnose(SourceLoc(), diag::evolution_with_embedded);
       HadError = true;
     }
+
+    if (FrontendOpts.InputsAndOutputs.hasPrimaryInputs()) {
+      Diags.diagnose(SourceLoc(), diag::wmo_with_embedded);
+      HadError = true;
+    }
   }
 
   if (auto A = Args.getLastArg(OPT_checked_async_objc_bridging)) {
@@ -1342,15 +1347,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                      A->getAsString(Args), A->getValue());
       HadError = true;
     }
-  }
-
-  // Is this the correct way to query for WMO?
-  bool isWMO =
-    Args.hasArg(OPT_wmo) ||
-    Args.hasArg(OPT_whole_module_optimization);
-  if (!isWMO && Opts.hasFeature(Feature::Embedded)) {
-    Diags.diagnose(SourceLoc(), diag::wmo_with_embedded);
-    HadError = true;
   }
 
   return HadError || UnsupportedOS || UnsupportedArch;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1042,6 +1042,8 @@ bool CompilerInvocation::shouldImportSwiftONoneSupport() const {
     return false;
   if (getSILOptions().shouldOptimize())
     return false;
+  if (LangOpts.hasFeature(Feature::Embedded))
+    return false;
 
   // If we are not executing an action that has a dependency on
   // SwiftOnoneSupport, don't load it.

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -679,6 +679,9 @@ endfunction()
 # STATIC
 #   Build a static library.
 #
+# ONLY_SWIFTMODULE
+#   Do not build either static or shared, build just the .swiftmodule.
+#
 # SDK sdk
 #   SDK to build for.
 #
@@ -744,6 +747,7 @@ function(add_swift_target_library_single target name)
         OBJECT_LIBRARY
         SHARED
         STATIC
+        ONLY_SWIFTMODULE
         NO_LINK_NAME
         INSTALL_WITH_SHARED
         IS_FRAGILE)
@@ -760,6 +764,7 @@ function(add_swift_target_library_single target name)
         MACCATALYST_BUILD_FLAVOR
         BACK_DEPLOYMENT_LIBRARY
         ENABLE_LTO
+        MODULE_DIR
         BOOTSTRAPPING)
   set(SWIFTLIB_SINGLE_multiple_parameter_options
         C_COMPILE_FLAGS
@@ -814,7 +819,8 @@ function(add_swift_target_library_single target name)
 
   if(NOT SWIFTLIB_SINGLE_SHARED AND
      NOT SWIFTLIB_SINGLE_STATIC AND
-     NOT SWIFTLIB_SINGLE_OBJECT_LIBRARY)
+     NOT SWIFTLIB_SINGLE_OBJECT_LIBRARY AND
+     NOT SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
     message(FATAL_ERROR
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
   endif()
@@ -878,6 +884,8 @@ function(add_swift_target_library_single target name)
     set(libkind SHARED)
   elseif(SWIFTLIB_SINGLE_STATIC)
     set(libkind STATIC)
+  elseif(SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
+    set(libkind NONE)
   else()
     message(FATAL_ERROR
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
@@ -953,11 +961,13 @@ function(add_swift_target_library_single target name)
       SDK ${SWIFTLIB_SINGLE_SDK}
       ARCHITECTURE ${SWIFTLIB_SINGLE_ARCHITECTURE}
       MODULE_NAME ${module_name}
+      MODULE_DIR ${SWIFTLIB_SINGLE_MODULE_DIR}
       COMPILE_FLAGS ${SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS}
       ${SWIFTLIB_SINGLE_IS_STDLIB_keyword}
       ${SWIFTLIB_SINGLE_IS_STDLIB_CORE_keyword}
       ${SWIFTLIB_SINGLE_IS_SDK_OVERLAY_keyword}
       ${SWIFTLIB_SINGLE_IS_FRAGILE_keyword}
+      ${SWIFTLIB_SINGLE_ONLY_SWIFTMODULE_keyword}
       ${embed_bitcode_arg}
       ${SWIFTLIB_SINGLE_STATIC_keyword}
       ${SWIFTLIB_SINGLE_NO_LINK_NAME_keyword}
@@ -1033,6 +1043,12 @@ function(add_swift_target_library_single target name)
   if(libkind STREQUAL "SHARED")
     list(APPEND INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS
          ${SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS_SHARED_ONLY})
+  endif()
+
+  if (SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
+    add_custom_target("${target}"
+      DEPENDS "${swift_module_dependency_target}")
+    return()
   endif()
 
   add_library("${target}" ${libkind}

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -13,6 +13,7 @@
 /// A value that has a custom representation in `AnyHashable`.
 ///
 /// `Self` should also conform to `Hashable`.
+@_unavailableInEmbedded
 public protocol _HasCustomAnyHashableRepresentation {
   /// Returns a custom representation of `self` as `AnyHashable`.
   /// If returns nil, the default representation is used.
@@ -38,6 +39,7 @@ public protocol _HasCustomAnyHashableRepresentation {
 }
 
 @usableFromInline
+@_unavailableInEmbedded
 internal protocol _AnyHashableBox {
   var _canonicalBox: _AnyHashableBox { get }
 
@@ -56,12 +58,14 @@ internal protocol _AnyHashableBox {
   func _downCastConditional<T>(into result: UnsafeMutablePointer<T>) -> Bool
 }
 
+@_unavailableInEmbedded
 extension _AnyHashableBox {
   var _canonicalBox: _AnyHashableBox {
     return self
   }
 }
 
+@_unavailableInEmbedded
 internal struct _ConcreteHashableBox<Base: Hashable>: _AnyHashableBox {
   internal var _baseHashable: Base
 
@@ -135,6 +139,7 @@ internal struct _ConcreteHashableBox<Base: Hashable>: _AnyHashableBox {
 /// compatible hashes, as the hash encoding that it uses may change between any
 /// two releases of the standard library.
 @frozen
+@_unavailableInEmbedded
 public struct AnyHashable {
   internal var _box: _AnyHashableBox
 
@@ -146,6 +151,7 @@ public struct AnyHashable {
   ///
   /// - Parameter base: A hashable value to wrap.
   @_specialize(where H == String)
+  @_unavailableInEmbedded
   public init<H: Hashable>(_ base: H) {
     if H.self == String.self {
       self.init(_box: _ConcreteHashableBox(base))
@@ -206,6 +212,7 @@ public struct AnyHashable {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyHashable: Equatable {
   /// Returns a Boolean value indicating whether two type-erased hashable
   /// instances wrap the same value.
@@ -234,6 +241,7 @@ extension AnyHashable: Equatable {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyHashable: Hashable {
   public var hashValue: Int {
     return _box._canonicalBox._hashValue
@@ -248,12 +256,14 @@ extension AnyHashable: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyHashable: CustomStringConvertible {
   public var description: String {
     return String(describing: base)
   }
 }
 
+@_unavailableInEmbedded
 extension AnyHashable: CustomDebugStringConvertible {
   public var debugDescription: String {
     return "AnyHashable(" + String(reflecting: base) + ")"
@@ -270,10 +280,12 @@ extension AnyHashable: CustomReflectable {
 }
 #endif
 
+@_unavailableInEmbedded
 @available(SwiftStdlib 5.5, *)
 extension AnyHashable: _HasCustomAnyHashableRepresentation {
 }
 
+@_unavailableInEmbedded
 extension AnyHashable {
   @_alwaysEmitIntoClient
   public __consuming func _toCustomAnyHashable() -> AnyHashable? {
@@ -288,6 +300,7 @@ extension AnyHashable {
 /// conformance, if it exists.
 /// Called by AnyHashableSupport.cpp.
 @_silgen_name("_swift_makeAnyHashableUsingDefaultRepresentation")
+@_unavailableInEmbedded
 internal func _makeAnyHashableUsingDefaultRepresentation<H: Hashable>(
   of value: H,
   storingResultInto result: UnsafeMutablePointer<AnyHashable>
@@ -297,12 +310,14 @@ internal func _makeAnyHashableUsingDefaultRepresentation<H: Hashable>(
 
 /// Provided by AnyHashable.cpp.
 @_silgen_name("_swift_makeAnyHashableUpcastingToHashableBaseType")
+@_unavailableInEmbedded
 internal func _makeAnyHashableUpcastingToHashableBaseType<H: Hashable>(
   _ value: H,
   storingResultInto result: UnsafeMutablePointer<AnyHashable>
 )
 
 @inlinable
+@_unavailableInEmbedded
 public // COMPILER_INTRINSIC
 func _convertToAnyHashable<H: Hashable>(_ value: H) -> AnyHashable {
   return AnyHashable(value)
@@ -310,6 +325,7 @@ func _convertToAnyHashable<H: Hashable>(_ value: H) -> AnyHashable {
 
 /// Called by the casting machinery.
 @_silgen_name("_swift_convertToAnyHashableIndirect")
+@_unavailableInEmbedded
 internal func _convertToAnyHashableIndirect<H: Hashable>(
   _ value: H,
   _ target: UnsafeMutablePointer<AnyHashable>
@@ -319,6 +335,7 @@ internal func _convertToAnyHashableIndirect<H: Hashable>(
 
 /// Called by the casting machinery.
 @_silgen_name("_swift_anyHashableDownCastConditionalIndirect")
+@_unavailableInEmbedded
 internal func _anyHashableDownCastConditionalIndirect<T>(
   _ value: UnsafePointer<AnyHashable>,
   _ target: UnsafeMutablePointer<T>

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -476,17 +476,11 @@ extension Array: _ArrayProtocol {
     return _getCapacity()
   }
 
-  /// An object that guarantees the lifetime of this array's elements.
   #if $Embedded
-  public // @testable
-  var _owner: Builtin.NativeObject? {
-    @inlinable // FIXME(inline-always)
-    @inline(__always)
-    get {
-      return _buffer.owner      
-    }
-  }
-  #else
+  public typealias AnyObject = Builtin.NativeObject
+  #endif
+
+  /// An object that guarantees the lifetime of this array's elements.
   @inlinable
   public // @testable
   var _owner: AnyObject? {
@@ -496,7 +490,6 @@ extension Array: _ArrayProtocol {
       return _buffer.owner      
     }
   }
-  #endif
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
@@ -1492,7 +1485,6 @@ extension Array: CustomStringConvertible, CustomDebugStringConvertible {
 }
 
 extension Array {
-  #if !$Embedded
   @usableFromInline @_transparent
   @_unavailableInEmbedded
   internal func _cPointerArgs() -> (AnyObject?, UnsafeRawPointer?) {
@@ -1503,18 +1495,6 @@ extension Array {
     let n = ContiguousArray(self._buffer)._buffer
     return (n.owner, UnsafeRawPointer(n.firstElementAddress))
   }
-  #else
-  @usableFromInline @_transparent
-  @_unavailableInEmbedded
-  internal func _cPointerArgs() -> (Builtin.NativeObject?, UnsafeRawPointer?) {
-    let p = _baseAddressIfContiguous
-    if _fastPath(p != nil || isEmpty) {
-      return (_owner, UnsafeRawPointer(p))
-    }
-    let n = ContiguousArray(self._buffer)._buffer
-    return (n.owner, UnsafeRawPointer(n.firstElementAddress))
-  }
-  #endif
 }
 
 extension Array {

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -98,7 +98,11 @@ where Indices == Range<Int> {
   var capacity: Int { get }
 
   /// An object that keeps the elements stored in this buffer alive.
+  #if $Embedded
+  var owner: Builtin.NativeObject { get }
+  #else
   var owner: AnyObject { get }
+  #endif
 
   /// A pointer to the first element.
   ///

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -97,12 +97,12 @@ where Indices == Range<Int> {
   /// The number of elements the buffer can store without reallocation.
   var capacity: Int { get }
 
-  /// An object that keeps the elements stored in this buffer alive.
   #if $Embedded
-  var owner: Builtin.NativeObject { get }
-  #else
-  var owner: AnyObject { get }
+  typealias AnyObject = Builtin.NativeObject
   #endif
+
+  /// An object that keeps the elements stored in this buffer alive.
+  var owner: AnyObject { get }
 
   /// A pointer to the first element.
   ///

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -102,7 +102,7 @@ extension Collection {
   internal func _makeCollectionDescription(
     withTypeName type: String? = nil
   ) -> String {
-#if !SWIFT_STDLIB_STATIC_PRINT && !$Embedded
+#if !SWIFT_STDLIB_STATIC_PRINT
     var result = ""
     if let type = type {
       result += "\(type)(["

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -94,6 +94,7 @@ func _finalizeUninitializedArray<Element>(
 }
 #endif
 
+@_unavailableInEmbedded
 extension Collection {  
   // Utility method for collections that wish to implement
   // CustomStringConvertible and CustomDebugStringConvertible using a bracketed
@@ -101,7 +102,7 @@ extension Collection {
   internal func _makeCollectionDescription(
     withTypeName type: String? = nil
   ) -> String {
-#if !SWIFT_STDLIB_STATIC_PRINT
+#if !SWIFT_STDLIB_STATIC_PRINT && !$Embedded
     var result = ""
     if let type = type {
       result += "\(type)(["

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1152,18 +1152,6 @@ extension ArraySlice: CustomStringConvertible, CustomDebugStringConvertible {
 }
 
 extension ArraySlice {
-  #if $Embedded
-  @usableFromInline @_transparent
-  @_unavailableInEmbedded
-  internal func _cPointerArgs() -> (Builtin.NativeObject?, UnsafeRawPointer?) {
-    let p = _baseAddressIfContiguous
-    if _fastPath(p != nil || isEmpty) {
-      return (_owner, UnsafeRawPointer(p))
-    }
-    let n = ContiguousArray(self._buffer)._buffer
-    return (n.owner, UnsafeRawPointer(n.firstElementAddress))
-  }
-  #else
   @usableFromInline @_transparent
   internal func _cPointerArgs() -> (AnyObject?, UnsafeRawPointer?) {
     let p = _baseAddressIfContiguous
@@ -1173,7 +1161,6 @@ extension ArraySlice {
     let n = ContiguousArray(self._buffer)._buffer
     return (n.owner, UnsafeRawPointer(n.firstElementAddress))
   }
-  #endif
 }
 
 extension ArraySlice {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -261,6 +261,10 @@ extension ArraySlice: _ArrayProtocol {
     return _getCapacity()
   }
 
+  #if $Embedded
+  public typealias AnyObject = Builtin.NativeObject
+  #endif
+
   /// An object that guarantees the lifetime of this array's elements.
   @inlinable
   public // @testable
@@ -1133,6 +1137,7 @@ extension ArraySlice: CustomReflectable {
 }
 #endif
 
+@_unavailableInEmbedded
 extension ArraySlice: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the array and its elements.
   public var description: String {
@@ -1147,6 +1152,18 @@ extension ArraySlice: CustomStringConvertible, CustomDebugStringConvertible {
 }
 
 extension ArraySlice {
+  #if $Embedded
+  @usableFromInline @_transparent
+  @_unavailableInEmbedded
+  internal func _cPointerArgs() -> (Builtin.NativeObject?, UnsafeRawPointer?) {
+    let p = _baseAddressIfContiguous
+    if _fastPath(p != nil || isEmpty) {
+      return (_owner, UnsafeRawPointer(p))
+    }
+    let n = ContiguousArray(self._buffer)._buffer
+    return (n.owner, UnsafeRawPointer(n.firstElementAddress))
+  }
+  #else
   @usableFromInline @_transparent
   internal func _cPointerArgs() -> (AnyObject?, UnsafeRawPointer?) {
     let p = _baseAddressIfContiguous
@@ -1156,6 +1173,7 @@ extension ArraySlice {
     let n = ContiguousArray(self._buffer)._buffer
     return (n.owner, UnsafeRawPointer(n.firstElementAddress))
   }
+  #endif
 }
 
 extension ArraySlice {

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -18,7 +18,11 @@ where Indices == Range<Int> {
   var capacity: Int { get }
 
   /// An object that guarantees the lifetime of this array's elements.
+  #if !$Embedded
   var _owner: AnyObject? { get }
+  #else
+  var _owner: Builtin.NativeObject? { get }
+  #endif
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -17,12 +17,12 @@ where Indices == Range<Int> {
   /// The number of elements the Array can store without reallocation.
   var capacity: Int { get }
 
-  /// An object that guarantees the lifetime of this array's elements.
-  #if !$Embedded
-  var _owner: AnyObject? { get }
-  #else
-  var _owner: Builtin.NativeObject? { get }
+  #if $Embedded
+  typealias AnyObject = Builtin.NativeObject
   #endif
+
+  /// An object that guarantees the lifetime of this array's elements.
+  var _owner: AnyObject? { get }
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -89,11 +89,13 @@ internal func _fatalErrorFlags() -> UInt32 {
 @usableFromInline
 @inline(never)
 @_semantics("programtermination_point")
+@_alwaysEmitIntoClient
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: StaticString,
   file: StaticString, line: UInt,
   flags: UInt32
 ) -> Never {
+#if !$Embedded
   prefix.withUTF8Buffer {
     (prefix) -> Void in
     message.withUTF8Buffer {
@@ -109,6 +111,7 @@ internal func _assertionFailure(
       }
     }
   }
+#endif
   Builtin.int_trap()
 }
 
@@ -120,6 +123,7 @@ internal func _assertionFailure(
 @usableFromInline
 @inline(never)
 @_semantics("programtermination_point")
+@_unavailableInEmbedded
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: String,
   file: StaticString, line: UInt,
@@ -152,6 +156,7 @@ internal func _assertionFailure(
 @usableFromInline
 @inline(never)
 @_semantics("programtermination_point")
+@_unavailableInEmbedded
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: String,
   flags: UInt32
@@ -168,6 +173,16 @@ internal func _assertionFailure(
     }
   }
 
+  Builtin.int_trap()
+}
+
+@usableFromInline
+@inline(never)
+@_semantics("programtermination_point")
+internal func _assertionFailure(
+  _ prefix: StaticString, _ message: StaticString,
+  flags: UInt32
+) -> Never {
   Builtin.int_trap()
 }
 
@@ -202,6 +217,7 @@ func _unimplementedInitializer(className: StaticString,
   // redundant parameter values (#file etc.) are eliminated, and don't leak
   // information about the user's source.
 
+#if !$Embedded
   if _isDebugAssertConfiguration() {
     className.withUTF8Buffer {
       (className) in
@@ -230,10 +246,12 @@ func _unimplementedInitializer(className: StaticString,
       }
     }
   }
+#endif
 
   Builtin.int_trap()
 }
 
+@_unavailableInEmbedded
 public // COMPILER_INTRINSIC
 func _undefined<T>(
   _ message: @autoclosure () -> String = String(),
@@ -254,9 +272,13 @@ internal func _diagnoseUnexpectedEnumCaseValue<SwitchedValue, RawValue>(
   type: SwitchedValue.Type,
   rawValue: RawValue
 ) -> Never {
+#if !$Embedded
   _assertionFailure("Fatal error",
                     "unexpected enum case '\(type)(rawValue: \(rawValue))'",
                     flags: _fatalErrorFlags())
+#else
+  Builtin.int_trap()
+#endif
 }
 
 /// Called when falling off the end of a switch and the value is not safe to
@@ -270,10 +292,14 @@ internal func _diagnoseUnexpectedEnumCaseValue<SwitchedValue, RawValue>(
 internal func _diagnoseUnexpectedEnumCase<SwitchedValue>(
   type: SwitchedValue.Type
 ) -> Never {
+#if !$Embedded
   _assertionFailure(
     "Fatal error",
     "unexpected enum case while switching on value of type '\(type)'",
     flags: _fatalErrorFlags())
+#else
+  Builtin.int_trap()
+#endif
 }
 
 /// Called when a function marked `unavailable` with `@available` is invoked

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -175,6 +175,7 @@ internal func _assertionFailure(
   Builtin.int_trap()
 }
 
+#if $Embedded
 @usableFromInline
 @inline(never)
 @_semantics("programtermination_point")
@@ -184,6 +185,7 @@ internal func _assertionFailure(
 ) -> Never {
   Builtin.int_trap()
 }
+#endif
 
 /// This function should be used only in the implementation of stdlib
 /// assertions.

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -89,7 +89,6 @@ internal func _fatalErrorFlags() -> UInt32 {
 @usableFromInline
 @inline(never)
 @_semantics("programtermination_point")
-@_alwaysEmitIntoClient
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: StaticString,
   file: StaticString, line: UInt,

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -19,6 +19,7 @@ import SwiftShims
 /// generated code for API availability checking.
 @_semantics("availability.osversion")
 @_effects(readnone)
+@_unavailableInEmbedded
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -48,6 +49,7 @@ public func _stdlib_isOSVersionAtLeast(
 // generated code for API availability checking.
 @_semantics("availability.osversion")
 @_effects(readnone)
+@_unavailableInEmbedded
 public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -71,6 +73,7 @@ public typealias _SwiftStdlibVersion = SwiftShims._SwiftStdlibVersion
 ///
 /// This function must not be called from inlinable code.
 @inline(__always)
+@_unavailableInEmbedded
 internal func _isExecutableLinkedOnOrAfter(
   _ stdlibVersion: _SwiftStdlibVersion
 ) -> Bool {
@@ -102,13 +105,18 @@ extension _SwiftStdlibVersion {
 }
 
 @available(SwiftStdlib 5.7, *)
+@_unavailableInEmbedded
 extension _SwiftStdlibVersion: CustomStringConvertible {
   @available(SwiftStdlib 5.7, *)
   public var description: String {
+    #if $Embedded
+    fatalError()
+    #else
     let major = _value >> 16
     let minor = (_value >> 8) & 0xFF
     let patch = _value & 0xFF
     return "\(major).\(minor).\(patch)"
+    #endif
   }
 }
 

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -109,14 +109,10 @@ extension _SwiftStdlibVersion {
 extension _SwiftStdlibVersion: CustomStringConvertible {
   @available(SwiftStdlib 5.7, *)
   public var description: String {
-    #if $Embedded
-    fatalError()
-    #else
     let major = _value >> 16
     let minor = (_value >> 8) & 0xFF
     let patch = _value & 0xFF
     return "\(major).\(minor).\(patch)"
-    #endif
   }
 }
 

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -111,6 +111,7 @@ public struct Bool: Sendable {
   /// - Returns: Either `true` or `false`, randomly chosen with equal
   ///   probability.
   @inlinable
+  @_unavailableInEmbedded
   public static func random<T: RandomNumberGenerator>(
     using generator: inout T
   ) -> Bool {
@@ -134,6 +135,7 @@ public struct Bool: Sendable {
   /// - Returns: Either `true` or `false`, randomly chosen with equal
   ///   probability.
   @inlinable
+  @_unavailableInEmbedded
   public static func random() -> Bool {
     var g = SystemRandomNumberGenerator()
     return Bool.random(using: &g)
@@ -170,6 +172,7 @@ extension Bool: _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLiteral
   }
 }
 
+@_unavailableInEmbedded
 extension Bool: CustomStringConvertible {
   /// A textual representation of the Boolean value.
   @inlinable
@@ -197,6 +200,7 @@ extension Bool: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 extension Bool: LosslessStringConvertible {
   /// Creates a new Boolean value from the given string.
   ///

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -487,6 +487,7 @@ func _getNonTagBits(_ x: Builtin.BridgeObject) -> UInt {
 // Values -> BridgeObject
 @inline(__always)
 @inlinable
+@_unavailableInEmbedded
 public func _bridgeObject(fromNative x: AnyObject) -> Builtin.BridgeObject {
   _internalInvariant(!_isObjCTaggedPointer(x))
   let object = Builtin.castToBridgeObject(x, 0._builtinWordValue)
@@ -496,6 +497,7 @@ public func _bridgeObject(fromNative x: AnyObject) -> Builtin.BridgeObject {
 
 @inline(__always)
 @inlinable
+@_unavailableInEmbedded
 public func _bridgeObject(
   fromNonTaggedObjC x: AnyObject
 ) -> Builtin.BridgeObject {
@@ -558,6 +560,7 @@ public func _bridgeObject(toTagPayload x: Builtin.BridgeObject) -> UInt {
 
 @inline(__always)
 @inlinable
+@_unavailableInEmbedded
 public func _bridgeObject(
   fromNativeObject x: Builtin.NativeObject
 ) -> Builtin.BridgeObject {
@@ -570,6 +573,7 @@ public func _bridgeObject(
 
 @inlinable
 @inline(__always)
+@_unavailableInEmbedded
 public func _nativeObject(fromNative x: AnyObject) -> Builtin.NativeObject {
   _internalInvariant(!_isObjCTaggedPointer(x))
   let native = Builtin.unsafeCastToNativeObject(x)
@@ -579,6 +583,7 @@ public func _nativeObject(fromNative x: AnyObject) -> Builtin.NativeObject {
 
 @inlinable
 @inline(__always)
+@_unavailableInEmbedded
 public func _nativeObject(
   fromBridge x: Builtin.BridgeObject
 ) -> Builtin.NativeObject {
@@ -611,6 +616,7 @@ extension ManagedBufferPointer {
 ///   `bits & _objectPointerSpareBits == bits`.
 @inlinable
 @inline(__always)
+@_unavailableInEmbedded
 internal func _makeNativeBridgeObject(
   _ nativeObject: AnyObject, _ bits: UInt
 ) -> Builtin.BridgeObject {
@@ -624,6 +630,7 @@ internal func _makeNativeBridgeObject(
 /// Create a `BridgeObject` around the given `objCObject`.
 @inlinable
 @inline(__always)
+@_unavailableInEmbedded
 public // @testable
 func _makeObjCBridgeObject(
   _ objCObject: AnyObject
@@ -644,6 +651,7 @@ func _makeObjCBridgeObject(
 ///      _objectPointerIsObjCBit`.
 @inlinable
 @inline(__always)
+@_unavailableInEmbedded
 internal func _makeBridgeObject(
   _ object: AnyObject, _ bits: UInt
 ) -> Builtin.BridgeObject {
@@ -784,6 +792,7 @@ internal func _isComputed(_ value: Int) -> Bool {
 
 /// Extract an object reference from an Any known to contain an object.
 @inlinable
+@_unavailableInEmbedded
 internal func _unsafeDowncastToAnyObject(fromAny any: Any) -> AnyObject {
   _internalInvariant(type(of: any) is AnyObject.Type
                || type(of: any) is AnyObject.Protocol,
@@ -1048,6 +1057,7 @@ public func _openExistential<ExistentialType, ContainedType, ResultType>(
 /// in the function containing the call to this SPI.
 @_transparent
 @_alwaysEmitIntoClient
+@_unavailableInEmbedded
 public // @SPI(OSLog)
 func _getGlobalStringTablePointer(_ constant: String) -> UnsafePointer<CChar> {
   return UnsafePointer<CChar>(Builtin.globalStringTablePointer(constant));

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -10,231 +10,251 @@
 #
 #===----------------------------------------------------------------------===#
 
-# The complete list of sources in the core standard library.
-set(SWIFTLIB_SOURCES
+function(split_embedded_sources)
+  cmake_parse_arguments(SPLIT1 "" "OUT_LIST_EMBEDDED;OUT_LIST_NORMAL" "EMBEDDED;NORMAL" ${ARGN})
+  string(REPLACE "EMBEDDED" "NORMAL" ARGN2 "${ARGN}")
+  cmake_parse_arguments(SPLIT2 "" "OUT_LIST_EMBEDDED;OUT_LIST_NORMAL" "EMBEDDED;NORMAL" ${ARGN2})
+  set(${SPLIT1_OUT_LIST_EMBEDDED} "${SPLIT1_EMBEDDED}" PARENT_SCOPE)
+  set(${SPLIT1_OUT_LIST_NORMAL} "${SPLIT2_NORMAL}" PARENT_SCOPE)
+endfunction()
+
+# The complete list of sources in the core standard library. Each file is
+# annotated with either "EMBEDDED" which means it contributes to both the
+# embedded Swift stdlib and the regular stdlib, or "NORMAL" which means it only
+# contributes to the regular stdlib. The split_embedded_sources splits this list
+# into SWIFTLIB_EMBEDDED_SOURCES and SWIFTLIB_SOURCES accordingly.
+split_embedded_sources(
+  OUT_LIST_EMBEDDED SWIFTLIB_EMBEDDED_SOURCES
+  OUT_LIST_NORMAL SWIFTLIB_SOURCES
+
   ### "ESSENTIAL" SOURCES
   ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
   # Some files can't be sorted alphabetically, see notes in the list below.
-  Algorithm.swift
-  ArrayBody.swift
-  ArrayBuffer.swift
-  ArrayBufferProtocol.swift
-  ArrayCast.swift
-  Array.swift
-  ArrayShared.swift
-  ArraySlice.swift
-  ArrayType.swift
-  ASCII.swift
-  Assert.swift
-  AssertCommon.swift
-  BidirectionalCollection.swift
-  Bitset.swift
-  Bool.swift
-  BridgeObjectiveC.swift
-  BridgeStorage.swift
-  BridgingBuffer.swift
-  Builtin.swift
-  BuiltinMath.swift
-  Character.swift
-  CocoaArray.swift
-  Codable.swift
-  Collection.swift
-  CollectionAlgorithms.swift
-  Comparable.swift
-  CompilerProtocols.swift
-  Sendable.swift
-  ContiguousArray.swift
-  ContiguouslyStored.swift
-  ClosedRange.swift
-  ContiguousArrayBuffer.swift
-  CString.swift
-  CTypes.swift
-  DebuggerSupport.swift
-  Dictionary.swift
-  DictionaryBridging.swift
-  DictionaryBuilder.swift
-  DictionaryCasting.swift
-  DictionaryStorage.swift
-  DictionaryVariant.swift
-  DropWhile.swift
-  Dump.swift
-  EmptyCollection.swift
-  Equatable.swift
-  ErrorType.swift
-  ExistentialCollection.swift
-  Filter.swift
-  FixedArray.swift
-  FlatMap.swift
-  Flatten.swift
-  FloatingPoint.swift
-  Hashable.swift
+  EMBEDDED Algorithm.swift
+  EMBEDDED ArrayBody.swift
+  EMBEDDED ArrayBuffer.swift
+  EMBEDDED ArrayBufferProtocol.swift
+    NORMAL ArrayCast.swift
+  EMBEDDED Array.swift
+  EMBEDDED ArrayShared.swift
+  EMBEDDED ArraySlice.swift
+  EMBEDDED ArrayType.swift
+    NORMAL ASCII.swift
+  EMBEDDED Assert.swift
+  EMBEDDED AssertCommon.swift
+  EMBEDDED BidirectionalCollection.swift
+    NORMAL Bitset.swift
+  EMBEDDED Bool.swift
+    NORMAL BridgeObjectiveC.swift
+    NORMAL BridgeStorage.swift
+    NORMAL BridgingBuffer.swift
+  EMBEDDED Builtin.swift
+    NORMAL BuiltinMath.swift
+    NORMAL Character.swift
+    NORMAL CocoaArray.swift
+    NORMAL Codable.swift
+  EMBEDDED Collection.swift
+  EMBEDDED CollectionAlgorithms.swift
+  EMBEDDED Comparable.swift
+  EMBEDDED CompilerProtocols.swift
+  EMBEDDED Sendable.swift
+  EMBEDDED ContiguousArray.swift
+    NORMAL ContiguouslyStored.swift
+  EMBEDDED ClosedRange.swift
+  EMBEDDED ContiguousArrayBuffer.swift
+    NORMAL CString.swift
+  EMBEDDED CTypes.swift
+    NORMAL DebuggerSupport.swift
+    NORMAL Dictionary.swift
+    NORMAL DictionaryBridging.swift
+    NORMAL DictionaryBuilder.swift
+    NORMAL DictionaryCasting.swift
+    NORMAL DictionaryStorage.swift
+    NORMAL DictionaryVariant.swift
+    NORMAL DropWhile.swift
+    NORMAL Dump.swift
+  EMBEDDED EmptyCollection.swift
+  EMBEDDED Equatable.swift
+  EMBEDDED ErrorType.swift
+  EMBEDDED ExistentialCollection.swift
+    NORMAL Filter.swift
+    NORMAL FixedArray.swift
+    NORMAL FlatMap.swift
+    NORMAL Flatten.swift
+  EMBEDDED FloatingPoint.swift
+  EMBEDDED Hashable.swift
   # WORKAROUND: This file name is not sorted alphabetically in the list because
   # if we do so, the compiler crashes.
-  AnyHashable.swift
+  EMBEDDED AnyHashable.swift
   # END WORKAROUND
-  Hasher.swift
-  Hashing.swift
-  HashTable.swift
-  Identifiable.swift
-  Indices.swift
-  InputStream.swift
-  IntegerParsing.swift
-  Integers.swift
-  Join.swift
-  KeyPath.swift
-  KeyValuePairs.swift
-  LazyCollection.swift
-  LazySequence.swift
-  LegacyABI.swift
-  LifetimeManager.swift
-  Macros.swift
-  ManagedBuffer.swift
-  Map.swift
-  MemoryLayout.swift
-  UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
-  Mirrors.swift
-  Misc.swift
-  MutableCollection.swift
-  NativeDictionary.swift
-  NativeSet.swift
-  NewtypeWrapper.swift
-  NFC.swift
-  NFD.swift
-  ObjectIdentifier.swift
-  Optional.swift
-  OptionSet.swift
-  OutputStream.swift
-  Pointer.swift
-  Policy.swift
-  PrefixWhile.swift
-  Prespecialize.swift
-  Print.swift
-  PtrAuth.swift
-  Random.swift
-  RandomAccessCollection.swift
-  Range.swift
-  RangeReplaceableCollection.swift
-  ReflectionMirror.swift
-  Repeat.swift
-  REPL.swift
-  Result.swift
-  Reverse.swift
-  Runtime.swift
-  RuntimeFunctionCounters.swift
-  SipHash.swift
-  Sequence.swift
-  SequenceAlgorithms.swift
-  Set.swift
-  SetAlgebra.swift
-  SetAnyHashableExtensions.swift
-  SetBridging.swift
-  SetBuilder.swift
-  SetCasting.swift
-  SetStorage.swift
-  SetVariant.swift
-  ShadowProtocols.swift
-  Shims.swift
-  Slice.swift
-  SmallString.swift
-  Sort.swift
-  StaticString.swift
-  StaticPrint.swift
-  Stride.swift
-  StringHashable.swift  # ORDER DEPENDENCY: Must precede String.swift
-  String.swift
-  StringBreadcrumbs.swift
-  StringBridge.swift
-  StringCharacterView.swift
-  StringComparable.swift
-  StringComparison.swift
-  StringCreate.swift
-  StringGuts.swift
-  StringGutsSlice.swift
-  StringGutsRangeReplaceable.swift
-  StringObject.swift
-  StringProtocol.swift
-  StringIndex.swift
-  StringIndexConversions.swift
-  StringIndexValidation.swift
-  StringInterpolation.swift
-  StringLegacy.swift
-  StringNormalization.swift
-  StringRangeReplaceableCollection.swift
-  StringStorage.swift
-  StringStorageBridge.swift
-  StringSwitch.swift
-  StringTesting.swift
-  StringUnicodeScalarView.swift
-  StringUTF16View.swift
-  StringUTF8View.swift
-  StringUTF8Validation.swift
-  StringWordBreaking.swift
-  Substring.swift
-  SwiftNativeNSArray.swift
-  TemporaryAllocation.swift
-  ThreadLocalStorage.swift
-  UIntBuffer.swift
-  UnavailableStringAPIs.swift
-  UnicodeData.swift
-  UnicodeEncoding.swift
-  UnicodeBreakProperty.swift
-  UnicodeHelpers.swift
-  UnicodeParser.swift
-  UnicodeScalarProperties.swift
-  CharacterProperties.swift # ORDER DEPENDENCY: UnicodeScalarProperties.swift
-  UnicodeSPI.swift
-  Unmanaged.swift
-  UnmanagedOpaqueString.swift
-  UnmanagedString.swift
-  UnsafePointer.swift
-  UnsafeRawPointer.swift
-  UTFEncoding.swift
-  UTF8.swift
-  UTF16.swift
-  UTF32.swift
-  Unicode.swift # ORDER DEPENDENCY: must follow new unicode support
-  StringGraphemeBreaking.swift # ORDER DEPENDENCY: Must follow UTF16.swift
-  ValidUTF8Buffer.swift
-  WriteBackMutableSlice.swift
-  MigrationSupport.swift
+  EMBEDDED Hasher.swift
+    NORMAL Hashing.swift
+    NORMAL HashTable.swift
+  EMBEDDED Identifiable.swift
+  EMBEDDED Indices.swift
+    NORMAL InputStream.swift
+    NORMAL IntegerParsing.swift
+  EMBEDDED Integers.swift
+    NORMAL Join.swift
+    NORMAL KeyPath.swift
+    NORMAL KeyValuePairs.swift
+    NORMAL LazyCollection.swift
+    NORMAL LazySequence.swift
+    NORMAL LegacyABI.swift
+  EMBEDDED LifetimeManager.swift
+    NORMAL Macros.swift
+  EMBEDDED ManagedBuffer.swift
+    NORMAL Map.swift
+  EMBEDDED MemoryLayout.swift
+    NORMAL UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
+    NORMAL Mirrors.swift
+  EMBEDDED Misc.swift
+  EMBEDDED MutableCollection.swift
+    NORMAL NativeDictionary.swift
+    NORMAL NativeSet.swift
+    NORMAL NewtypeWrapper.swift
+    NORMAL NFC.swift
+    NORMAL NFD.swift
+  EMBEDDED ObjectIdentifier.swift
+  EMBEDDED Optional.swift
+    NORMAL OptionSet.swift
+    NORMAL OutputStream.swift
+  EMBEDDED Pointer.swift
+  EMBEDDED Policy.swift
+    NORMAL PrefixWhile.swift
+    NORMAL Prespecialize.swift
+    NORMAL Print.swift
+    NORMAL PtrAuth.swift
+  EMBEDDED Random.swift
+  EMBEDDED RandomAccessCollection.swift
+  EMBEDDED Range.swift
+  EMBEDDED RangeReplaceableCollection.swift
+    NORMAL ReflectionMirror.swift
+  EMBEDDED Repeat.swift
+    NORMAL REPL.swift
+  EMBEDDED Result.swift
+  EMBEDDED Reverse.swift
+  EMBEDDED Runtime.swift
+    NORMAL RuntimeFunctionCounters.swift
+  EMBEDDED SipHash.swift
+  EMBEDDED Sequence.swift
+  EMBEDDED SequenceAlgorithms.swift
+    NORMAL Set.swift
+    NORMAL SetAlgebra.swift
+    NORMAL SetAnyHashableExtensions.swift
+    NORMAL SetBridging.swift
+    NORMAL SetBuilder.swift
+    NORMAL SetCasting.swift
+    NORMAL SetStorage.swift
+    NORMAL SetVariant.swift
+    NORMAL ShadowProtocols.swift
+    NORMAL Shims.swift
+  EMBEDDED Slice.swift
+    NORMAL SmallString.swift
+  EMBEDDED Sort.swift
+  EMBEDDED StaticString.swift
+    NORMAL StaticPrint.swift
+  EMBEDDED Stride.swift
+    NORMAL StringHashable.swift  # ORDER DEPENDENCY: Must precede String.swift
+    NORMAL String.swift
+    NORMAL StringBreadcrumbs.swift
+    NORMAL StringBridge.swift
+    NORMAL StringCharacterView.swift
+    NORMAL StringComparable.swift
+    NORMAL StringComparison.swift
+    NORMAL StringCreate.swift
+    NORMAL StringGuts.swift
+    NORMAL StringGutsSlice.swift
+    NORMAL StringGutsRangeReplaceable.swift
+    NORMAL StringObject.swift
+    NORMAL StringProtocol.swift
+    NORMAL StringIndex.swift
+    NORMAL StringIndexConversions.swift
+    NORMAL StringIndexValidation.swift
+    NORMAL StringInterpolation.swift
+    NORMAL StringLegacy.swift
+    NORMAL StringNormalization.swift
+    NORMAL StringRangeReplaceableCollection.swift
+    NORMAL StringStorage.swift
+    NORMAL StringStorageBridge.swift
+    NORMAL StringSwitch.swift
+    NORMAL StringTesting.swift
+    NORMAL StringUnicodeScalarView.swift
+    NORMAL StringUTF16View.swift
+    NORMAL StringUTF8View.swift
+    NORMAL StringUTF8Validation.swift
+    NORMAL StringWordBreaking.swift
+    NORMAL Substring.swift
+  EMBEDDED SwiftNativeNSArray.swift
+  EMBEDDED TemporaryAllocation.swift
+    NORMAL ThreadLocalStorage.swift
+    NORMAL UIntBuffer.swift
+    NORMAL UnavailableStringAPIs.swift
+    NORMAL UnicodeData.swift
+    NORMAL UnicodeEncoding.swift
+    NORMAL UnicodeBreakProperty.swift
+    NORMAL UnicodeHelpers.swift
+    NORMAL UnicodeParser.swift
+    NORMAL UnicodeScalarProperties.swift
+    NORMAL CharacterProperties.swift # ORDER DEPENDENCY: UnicodeScalarProperties.swift
+    NORMAL UnicodeSPI.swift
+  EMBEDDED Unmanaged.swift
+    NORMAL UnmanagedOpaqueString.swift
+    NORMAL UnmanagedString.swift
+  EMBEDDED UnsafePointer.swift
+  EMBEDDED UnsafeRawPointer.swift
+    NORMAL UTFEncoding.swift
+    NORMAL UTF8.swift
+    NORMAL UTF16.swift
+    NORMAL UTF32.swift
+    NORMAL Unicode.swift # ORDER DEPENDENCY: must follow new unicode support
+    NORMAL StringGraphemeBreaking.swift # ORDER DEPENDENCY: Must follow UTF16.swift
+    NORMAL ValidUTF8Buffer.swift
+  EMBEDDED WriteBackMutableSlice.swift
+    NORMAL MigrationSupport.swift
 
-  ### "NON-ESSENTIAL" SOURCES, LAYERED ON TOP OF THE "ESSENTIAL" ONES
-  ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
-  Availability.swift
-  CollectionDifference.swift
-  CollectionOfOne.swift
-  Diffing.swift
-  Duration.swift
-  DurationProtocol.swift
-  FloatingPointRandom.swift
-  Instant.swift
-  Mirror.swift
-  PlaygroundDisplay.swift
-  CommandLine.swift
-  SliceBuffer.swift
-  StaticBigInt.swift
-  UnfoldSequence.swift
-  UnsafeBufferPointerSlice.swift
-  VarArgs.swift
-  Zip.swift
-  "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
+    ### "NON-ESSENTIAL" SOURCES, LAYERED ON TOP OF THE "ESSENTIAL" ONES
+    ### -- PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER ###
+  EMBEDDED Availability.swift
+    NORMAL CollectionDifference.swift
+  EMBEDDED CollectionOfOne.swift
+    NORMAL Diffing.swift
+  EMBEDDED Duration.swift
+  EMBEDDED DurationProtocol.swift
+    NORMAL FloatingPointRandom.swift
+  EMBEDDED Instant.swift
+    NORMAL Mirror.swift
+    NORMAL PlaygroundDisplay.swift
+    NORMAL CommandLine.swift
+  EMBEDDED SliceBuffer.swift
+    NORMAL StaticBigInt.swift
+    NORMAL UnfoldSequence.swift
+    NORMAL UnsafeBufferPointerSlice.swift
+    NORMAL VarArgs.swift
+  EMBEDDED Zip.swift
+    NORMAL "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
   )
 
-set(SWIFTLIB_GYB_SOURCES
-  AtomicInt.swift.gyb
-  FloatingPointParsing.swift.gyb
-  FloatingPointTypes.swift.gyb
-  IntegerTypes.swift.gyb
-  UnsafeBufferPointer.swift.gyb
-  UnsafeRawBufferPointer.swift.gyb
-  Int128.swift.gyb
-  Tuple.swift.gyb
+split_embedded_sources(
+  OUT_LIST_EMBEDDED SWIFTLIB_EMBEDDED_GYB_SOURCES
+  OUT_LIST_NORMAL SWIFTLIB_GYB_SOURCES
+
+    NORMAL AtomicInt.swift.gyb
+    NORMAL FloatingPointParsing.swift.gyb
+  EMBEDDED FloatingPointTypes.swift.gyb
+  EMBEDDED IntegerTypes.swift.gyb
+  EMBEDDED UnsafeBufferPointer.swift.gyb
+  EMBEDDED UnsafeRawBufferPointer.swift.gyb
+  EMBEDDED Int128.swift.gyb
+  EMBEDDED Tuple.swift.gyb
   )
 
 if(SWIFT_STDLIB_ENABLE_VECTOR_TYPES)
   list(APPEND SWIFTLIB_SOURCES SIMDVector.swift)
   list(APPEND SWIFTLIB_GYB_SOURCES SIMDConcreteOperations.swift.gyb SIMDVectorTypes.swift.gyb)
 endif()
+
+list(APPEND SWIFTLIB_EMBEDDED_SOURCES EmbeddedStubs.swift)
 
 set(GROUP_INFO_JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json)
 set(swift_core_link_flags "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
@@ -358,3 +378,47 @@ add_swift_target_library(swiftCore
                   MACCATALYST_BUILD_FLAVOR
                     zippered
                  )
+
+# Embedded standard library - embedded libraries are built as .swiftmodule only,
+# i.e. there is no .o or .a file produced (no binary code is actually produced)
+# and only users of a library are going to actually compile any needed code.
+#
+# For now, we build a hardcoded list of target triples of the embedded stdlib,
+# and only when building Swift on macOS.
+if(SWIFT_HOST_VARIANT STREQUAL "macosx")
+  add_custom_target(embedded-stdlib ALL)
+  set(EMBEDDED_STDLIB_TARGET_TRIPLES
+    # arch module_name            target triple
+    "armv7 armv7-apple-none-macho armv7-apple-none-macho"
+    "arm64 arm64-apple-none-macho arm64-apple-none-macho"
+    "arm64 arm64-apple-macos      arm64-apple-macos11"
+    )
+
+  set(SWIFT_ENABLE_REFLECTION OFF)
+  set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
+  set(SWIFT_STDLIB_STABLE_ABI OFF)
+  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
+
+  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
+    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
+    list(GET list 0 arch)
+    list(GET list 1 mod)
+    list(GET list 2 triple)
+    
+    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
+    add_swift_target_library_single(
+      embedded-stdlib-${triple}
+      swiftCore
+      ONLY_SWIFTMODULE
+      IS_STDLIB IS_STDLIB_CORE
+      ${SWIFTLIB_EMBEDDED_SOURCES}
+      GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
+      SWIFT_COMPILE_FLAGS -target "${triple}" -Xcc -D__MACH__ -enable-experimental-feature Embedded
+      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+      SDK "embedded"
+      ARCHITECTURE "${arch}"
+      INSTALL_IN_COMPONENT "never_install"
+      )
+    add_dependencies(embedded-stdlib embedded-stdlib-${triple})
+  endforeach()
+endif()

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -207,6 +207,7 @@ extension OpaquePointer: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 extension OpaquePointer: CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
   public var debugDescription: String {
@@ -264,13 +265,18 @@ public struct CVaListPointer {
   }
 }
 
+@_unavailableInEmbedded
 extension CVaListPointer: CustomDebugStringConvertible {
   public var debugDescription: String {
+    #if !$Embedded
     return "(\(_value.__stack.debugDescription), " +
            "\(_value.__gr_top.debugDescription), " +
            "\(_value.__vr_top.debugDescription), " +
            "\(_value.__gr_off), " +
            "\(_value.__vr_off))"
+    #else
+    fatalError()
+    #endif
   }
 }
 
@@ -288,6 +294,7 @@ public struct CVaListPointer {
   }
 }
 
+@_unavailableInEmbedded
 extension CVaListPointer: CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
   public var debugDescription: String {

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -268,15 +268,11 @@ public struct CVaListPointer {
 @_unavailableInEmbedded
 extension CVaListPointer: CustomDebugStringConvertible {
   public var debugDescription: String {
-    #if !$Embedded
     return "(\(_value.__stack.debugDescription), " +
            "\(_value.__gr_top.debugDescription), " +
            "\(_value.__vr_top.debugDescription), " +
            "\(_value.__gr_off), " +
            "\(_value.__vr_off))"
-    #else
-    fatalError()
-    #endif
   }
 }
 

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -380,19 +380,29 @@ extension ClosedRange: Hashable where Bound: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 extension ClosedRange: CustomStringConvertible {
   /// A textual representation of the range.
   @inlinable // trivial-implementation...
   public var description: String {
+    #if $Embedded
+    fatalError()
+    #else
     return "\(lowerBound)...\(upperBound)"
+    #endif
   }
 }
 
+@_unavailableInEmbedded
 extension ClosedRange: CustomDebugStringConvertible {
   /// A textual representation of the range, suitable for debugging.
   public var debugDescription: String {
+    #if $Embedded
+    fatalError()
+    #else
     return "ClosedRange(\(String(reflecting: lowerBound))"
     + "...\(String(reflecting: upperBound)))"
+    #endif
   }
 }
 
@@ -477,8 +487,12 @@ extension ClosedRange {
 public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
   where Bound.Stride: SignedInteger
 
+@_unavailableInEmbedded
 extension ClosedRange: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
+    #if $Embedded
+    fatalError()
+    #else
     var container = try decoder.unkeyedContainer()
     let lowerBound = try container.decode(Bound.self)
     let upperBound = try container.decode(Bound.self)
@@ -489,9 +503,11 @@ extension ClosedRange: Decodable where Bound: Decodable {
           debugDescription: "Cannot initialize \(ClosedRange.self) with a lowerBound (\(lowerBound)) greater than upperBound (\(upperBound))"))
     }
     self.init(_uncheckedBounds: (lower: lowerBound, upper: upperBound))
+    #endif
   }
 }
 
+@_unavailableInEmbedded
 extension ClosedRange: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -385,11 +385,7 @@ extension ClosedRange: CustomStringConvertible {
   /// A textual representation of the range.
   @inlinable // trivial-implementation...
   public var description: String {
-    #if $Embedded
-    fatalError()
-    #else
     return "\(lowerBound)...\(upperBound)"
-    #endif
   }
 }
 
@@ -397,12 +393,8 @@ extension ClosedRange: CustomStringConvertible {
 extension ClosedRange: CustomDebugStringConvertible {
   /// A textual representation of the range, suitable for debugging.
   public var debugDescription: String {
-    #if $Embedded
-    fatalError()
-    #else
     return "ClosedRange(\(String(reflecting: lowerBound))"
     + "...\(String(reflecting: upperBound)))"
-    #endif
   }
 }
 
@@ -490,9 +482,6 @@ public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
 @_unavailableInEmbedded
 extension ClosedRange: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
-    #if $Embedded
-    fatalError()
-    #else
     var container = try decoder.unkeyedContainer()
     let lowerBound = try container.decode(Bound.self)
     let upperBound = try container.decode(Bound.self)
@@ -503,7 +492,6 @@ extension ClosedRange: Decodable where Bound: Decodable {
           debugDescription: "Cannot initialize \(ClosedRange.self) with a lowerBound (\(lowerBound)) greater than upperBound (\(upperBound))"))
     }
     self.init(_uncheckedBounds: (lower: lowerBound, upper: upperBound))
-    #endif
   }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -923,6 +923,7 @@ extension Collection {
   ///   sequence may change when your program is compiled using a different
   ///   version of Swift.
   @inlinable
+  @_unavailableInEmbedded
   public func randomElement<T: RandomNumberGenerator>(
     using generator: inout T
   ) -> Element? {
@@ -951,6 +952,7 @@ extension Collection {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
   ///   of the collection.
   @inlinable
+  @_unavailableInEmbedded
   public func randomElement() -> Element? {
     var g = SystemRandomNumberGenerator()
     return randomElement(using: &g)

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -455,6 +455,7 @@ extension Collection {
 // shuffled()/shuffle()
 //===----------------------------------------------------------------------===//
 
+@_unavailableInEmbedded
 extension Sequence {
   /// Returns the elements of the sequence, shuffled using the given generator
   /// as a source for randomness.
@@ -509,6 +510,7 @@ extension Sequence {
   }
 }
 
+@_unavailableInEmbedded
 extension MutableCollection where Self: RandomAccessCollection {
   /// Shuffles the collection in place, using the given generator as a source
   /// for randomness.

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -162,11 +162,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
 extension CollectionOfOne: CustomDebugStringConvertible {
   /// A textual representation of the collection, suitable for debugging.
   public var debugDescription: String {
-    #if !$Embedded
     return "CollectionOfOne(\(String(reflecting: _element)))"
-    #else
-    fatalError()
-    #endif
   }
 }
 

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -158,10 +158,15 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   }
 }
 
+@_unavailableInEmbedded
 extension CollectionOfOne: CustomDebugStringConvertible {
   /// A textual representation of the collection, suitable for debugging.
   public var debugDescription: String {
+    #if !$Embedded
     return "CollectionOfOne(\(String(reflecting: _element)))"
+    #else
+    fatalError()
+    #endif
   }
 }
 

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -762,6 +762,7 @@ public protocol ExpressibleByDictionaryLiteral {
 /// `StringInterpolationProtocol` and have a matching `StringLiteralType`.
 ///
 /// For more information, see the `StringInterpolationProtocol` documentation.
+@_unavailableInEmbedded
 public protocol ExpressibleByStringInterpolation
   : ExpressibleByStringLiteral {
   
@@ -787,6 +788,7 @@ public protocol ExpressibleByStringInterpolation
   init(stringInterpolation: StringInterpolation)
 }
 
+@_unavailableInEmbedded
 extension ExpressibleByStringInterpolation
   where StringInterpolation == DefaultStringInterpolation {
   
@@ -940,6 +942,7 @@ public protocol _ExpressibleByColorLiteral {
 
 /// A type that can be initialized using an image literal (e.g.
 /// `#imageLiteral(resourceName: "hi.png")`).
+@_unavailableInEmbedded
 public protocol _ExpressibleByImageLiteral {
   /// Creates an instance initialized with the given resource name.
   ///
@@ -950,6 +953,7 @@ public protocol _ExpressibleByImageLiteral {
 
 /// A type that can be initialized using a file reference literal (e.g.
 /// `#fileLiteral(resourceName: "resource.txt")`).
+@_unavailableInEmbedded
 public protocol _ExpressibleByFileReferenceLiteral {
   /// Creates an instance initialized with the given resource name.
   ///

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -147,20 +147,16 @@ extension ContiguousArray: _ArrayProtocol {
     return _getCapacity()
   }
 
+  #if $Embedded
+  public typealias AnyObject = Builtin.NativeObject
+  #endif
+
   /// An object that guarantees the lifetime of this array's elements.
-  #if !$Embedded
   @inlinable
   public // @testable
   var _owner: AnyObject? {
     return _buffer.owner
   }
-  #else
-  @inlinable
-  public // @testable
-  var _owner: Builtin.NativeObject? {
-    return _buffer.owner
-  }
-  #endif
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
@@ -1060,18 +1056,6 @@ extension ContiguousArray: CustomStringConvertible, CustomDebugStringConvertible
 }
 
 extension ContiguousArray {
-  #if $Embedded
-  @usableFromInline @_transparent
-  @_unavailableInEmbedded
-  internal func _cPointerArgs() -> (Builtin.NativeObject?, UnsafeRawPointer?) {
-    let p = _baseAddressIfContiguous
-    if _fastPath(p != nil || isEmpty) {
-      return (_owner, UnsafeRawPointer(p))
-    }
-    let n = ContiguousArray(self._buffer)._buffer
-    return (n.owner, UnsafeRawPointer(n.firstElementAddress))
-  }
-  #else
   @usableFromInline @_transparent
   internal func _cPointerArgs() -> (AnyObject?, UnsafeRawPointer?) {
     let p = _baseAddressIfContiguous
@@ -1081,7 +1065,6 @@ extension ContiguousArray {
     let n = ContiguousArray(self._buffer)._buffer
     return (n.owner, UnsafeRawPointer(n.firstElementAddress))
   }
-  #endif
 }
 
 extension ContiguousArray {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -844,31 +844,25 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   }
 #endif
 
-  #if !$Embedded
+  #if $Embedded
+  public typealias AnyObject = Builtin.NativeObject
+  #endif
+
   /// An object that keeps the elements stored in this buffer alive.
   @inlinable
   internal var owner: AnyObject {
+    #if !$Embedded
     return _storage
+    #else
+    return Builtin.castToNativeObject(_storage)
+    #endif
   }
 
   /// An object that keeps the elements stored in this buffer alive.
   @inlinable
   internal var nativeOwner: AnyObject {
-    return _storage
+    return owner
   }
-  #else
-  /// An object that keeps the elements stored in this buffer alive.
-  @inlinable
-  internal var owner: Builtin.NativeObject {
-    return Builtin.castToNativeObject(_storage)
-  }
-
-  /// An object that keeps the elements stored in this buffer alive.
-  @inlinable
-  internal var nativeOwner: Builtin.NativeObject {
-    return Builtin.castToNativeObject(_storage)
-  }
-  #endif
 
   /// A value that identifies the storage used by the buffer.
   ///

--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -209,6 +209,7 @@ extension Duration {
 }
 
 @available(SwiftStdlib 5.7, *)
+@_unavailableInEmbedded
 extension Duration: Codable {
   @available(SwiftStdlib 5.7, *)
   public init(from decoder: Decoder) throws {
@@ -325,6 +326,7 @@ extension Duration {
 }
 
 @available(SwiftStdlib 5.7, *)
+@_unavailableInEmbedded
 extension Duration: CustomStringConvertible {
   @available(SwiftStdlib 5.7, *)
   public var description: String {

--- a/stdlib/public/core/EmbeddedStubs.swift
+++ b/stdlib/public/core/EmbeddedStubs.swift
@@ -104,6 +104,9 @@ extension String {
 }
 
 @_unavailableInEmbedded
+extension String: ExpressibleByStringInterpolation { }
+
+@_unavailableInEmbedded
 public protocol LosslessStringConvertible: CustomStringConvertible {
   init?(_ description: String)
 }

--- a/stdlib/public/core/EmbeddedStubs.swift
+++ b/stdlib/public/core/EmbeddedStubs.swift
@@ -1,0 +1,303 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftShims
+
+/// String
+
+@_unavailableInEmbedded
+public struct String: Hashable { 
+    public var utf8CString: ContiguousArray<CChar> { fatalError() }
+    public init() {}
+}
+
+@_unavailableInEmbedded
+extension String {
+  public init<Subject>(describing instance: Subject) { fatalError() }
+  public init<Subject>(reflecting instance: Subject) { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String {
+  public static func + (lhs: String, rhs: String) -> String { fatalError() }
+  public static func += (lhs: inout String, rhs: String) { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String {
+  public var isContiguousUTF8: Bool { fatalError() }
+  public mutating func makeContiguousUTF8() { fatalError() }
+  public mutating func withUTF8<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R { fatalError() }
+  public var utf8: ContiguousArray<UInt8> { fatalError() }
+  public var utf16: ContiguousArray<UInt16> { fatalError() }
+  public var debugDescription: String { fatalError() }
+}
+
+@_unavailableInEmbedded
+public func debugPrint(_ items: Any..., separator: String = " ", terminator: String = "\n") { fatalError() }
+
+@_unavailableInEmbedded
+public func debugPrint<Target: TextOutputStream>(_ items: Any..., separator: String = " ", terminator: String = "\n", to output: inout Target) { fatalError() }
+
+@_unavailableInEmbedded
+extension String: TextOutputStream {
+  public mutating func write(_ other: String) { fatalError() }
+  public mutating func _writeASCII(_ buffer: UnsafeBufferPointer<UInt8>) { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String: _ExpressibleByBuiltinUnicodeScalarLiteral {
+  public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) { fatalError() }
+  public init(_ scalar: UInt32) { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String: _ExpressibleByBuiltinExtendedGraphemeClusterLiteral {
+  public init(_builtinExtendedGraphemeClusterLiteral start: Builtin.RawPointer, utf8CodeUnitCount: Builtin.Word, isASCII: Builtin.Int1) { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String: _ExpressibleByBuiltinStringLiteral {
+  public init(_builtinStringLiteral start: Builtin.RawPointer, utf8CodeUnitCount: Builtin.Word, isASCII: Builtin.Int1) { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) { fatalError() }
+}
+
+@_unavailableInEmbedded
+public protocol CustomStringConvertible {
+ var description: String { get }
+}
+
+@_unavailableInEmbedded
+public protocol CustomDebugStringConvertible {
+  var debugDescription: String { get }
+}
+
+@_unavailableInEmbedded
+public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable {
+  public typealias StringLiteralType = String
+
+  public init(literalCapacity: Int, interpolationCount: Int) { fatalError() }
+  public mutating func appendLiteral(_ literal: StringLiteralType) { fatalError() }
+  public mutating func appendInterpolation<T>(_: T) { fatalError() }
+
+  internal __consuming func make() -> String { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String {
+  @inlinable
+  @_effects(readonly)
+  public init(stringInterpolation: DefaultStringInterpolation) { fatalError() }
+}
+
+@_unavailableInEmbedded
+public protocol LosslessStringConvertible: CustomStringConvertible {
+  init?(_ description: String)
+}
+
+@_unavailableInEmbedded
+public protocol TextOutputStream {
+  mutating func _lock()
+  mutating func _unlock()
+  mutating func write(_ string: String)
+  mutating func _writeASCII(_ buffer: UnsafeBufferPointer<UInt8>)
+}
+
+@_unavailableInEmbedded
+extension TextOutputStream {
+  public mutating func _lock() {}
+  public mutating func _unlock() {}
+  public mutating func _writeASCII(_ buffer: UnsafeBufferPointer<UInt8>) {}
+}
+
+@_unavailableInEmbedded
+public protocol TextOutputStreamable {
+  func write<Target: TextOutputStream>(to target: inout Target)
+}
+
+@_unavailableInEmbedded
+extension String {
+  internal static func _fromUTF8Repairing(_ input: UnsafeBufferPointer<UInt8>) -> (result: String, repairsMade: Bool) { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String {
+  internal static func _fromASCII(_ input: UnsafeBufferPointer<UInt8>) -> String { fatalError() }
+  internal static func _uncheckedFromUTF8( _ input: UnsafeBufferPointer<UInt8>) -> String { fatalError() }
+  internal static func _uncheckedFromUTF8(_ input: UnsafeBufferPointer<UInt8>, isASCII: Bool) -> String { fatalError() }
+  internal static func _uncheckedFromUTF8(_ input: UnsafeBufferPointer<UInt8>, asciiPreScanResult: Bool) -> String { fatalError() }
+}
+
+@_unavailableInEmbedded
+extension String {
+  public init<T: BinaryInteger>(_ value: T, radix: Int = 10, uppercase: Bool = false) { fatalError() }
+}
+
+/// Unicode.Scalar
+
+public enum Unicode {}
+
+extension Unicode {
+  public struct Scalar: Sendable {
+    internal var _value: UInt32
+    internal init(_value: UInt32) {
+      self._value = _value
+    }
+  }
+}
+
+extension Unicode.Scalar : _ExpressibleByBuiltinUnicodeScalarLiteral, ExpressibleByUnicodeScalarLiteral {
+  public var value: UInt32 { return _value }
+  public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
+    self._value = UInt32(value)
+  }
+  public init(unicodeScalarLiteral value: Unicode.Scalar) {
+    self = value
+  }
+  public init?(_ v: UInt32) {
+    if (v < 0xD800 || v > 0xDFFF) && v <= 0x10FFFF {
+      self._value = v
+      return
+    }
+    return nil
+  }
+  public init?(_ v: UInt16) {
+    self.init(UInt32(v))
+  }
+  public init(_ v: UInt8) {
+    self._value = UInt32(v)
+  }
+  public init(_ v: Unicode.Scalar) {
+    self = v
+  }
+  @_unavailableInEmbedded
+  public func escaped(asASCII forceASCII: Bool) -> String { fatalError() }
+  @_unavailableInEmbedded
+  internal func _escaped(asASCII forceASCII: Bool) -> String? { fatalError() }
+  public var isASCII: Bool {
+    return value <= 127
+  }
+  internal var _isPrintableASCII: Bool {
+    return (self >= Unicode.Scalar(0o040) && self <= Unicode.Scalar(0o176))
+  }
+}
+
+extension Unicode.Scalar: Equatable {
+  public static func == (lhs: Unicode.Scalar, rhs: Unicode.Scalar) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+extension Unicode.Scalar: Comparable {
+  public static func < (lhs: Unicode.Scalar, rhs: Unicode.Scalar) -> Bool {
+    return lhs.value < rhs.value
+  }
+}
+
+public typealias UTF8 = Unicode.UTF8
+
+extension Unicode {
+  public enum UTF8 {
+  }
+}
+
+extension Unicode.UTF8 {
+  public typealias CodeUnit = UInt8
+}
+
+/// Codable
+
+@_unavailableInEmbedded
+public protocol Encodable {
+  func encode(to encoder: any Encoder) throws
+}
+
+@_unavailableInEmbedded
+public protocol Decodable {
+  init(from decoder: any Decoder) throws
+}
+
+@_unavailableInEmbedded
+public typealias Codable = Encodable & Decodable
+
+@_unavailableInEmbedded
+public protocol CodingKey { }
+
+@_unavailableInEmbedded
+public struct KeyedDecodingContainer<K: CodingKey> { }
+
+@_unavailableInEmbedded
+public struct KeyedEncodingContainer<K: CodingKey> { }
+
+@_unavailableInEmbedded
+public protocol UnkeyedDecodingContainer { 
+  mutating func decode<T>(_ type: T.Type) throws -> T
+}
+
+@_unavailableInEmbedded
+public protocol UnkeyedEncodingContainer { 
+  mutating func encode<T>(_ value: T) throws
+}
+
+@_unavailableInEmbedded
+public protocol SingleValueDecodingContainer { }
+
+@_unavailableInEmbedded
+public protocol SingleValueEncodingContainer { }
+
+@_unavailableInEmbedded
+public protocol Encoder {
+  var codingPath: [any CodingKey] { get }
+  func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key>
+  func unkeyedContainer() -> any UnkeyedEncodingContainer
+  func singleValueContainer() -> any SingleValueEncodingContainer
+}
+
+@_unavailableInEmbedded
+public protocol Decoder {
+  var codingPath: [any CodingKey] { get }
+  func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key>
+  func unkeyedContainer() throws -> any UnkeyedDecodingContainer
+  func singleValueContainer() throws -> any SingleValueDecodingContainer
+}
+
+@_unavailableInEmbedded
+public enum DecodingError: Error {
+  public struct Context: Sendable {
+    public init(codingPath: [any CodingKey], debugDescription: String, underlyingError: Error? = nil) { fatalError() }
+  }
+  case typeMismatch(Any.Type, Context)
+  case valueNotFound(Any.Type, Context)
+  case keyNotFound(any CodingKey, Context)
+  case dataCorrupted(Context)
+}
+
+/// KeyPath
+
+@_unavailableInEmbedded
+public class AnyKeyPath {
+  @usableFromInline
+  internal var _storedInlineOffset: Int? { fatalError() }
+}
+
+@_unavailableInEmbedded
+public class PartialKeyPath<Root>: AnyKeyPath { }
+
+@_unavailableInEmbedded
+public class KeyPath<Root, Value>: PartialKeyPath<Root> { }
+
+@_unavailableInEmbedded
+public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> { }

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -246,6 +246,19 @@ extension Equatable {
 /// - Parameters:
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
+#if !$Embedded
+@inlinable // trivial-implementation
+public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
+  switch (lhs, rhs) {
+  case let (l?, r?):
+    return ObjectIdentifier(l) == ObjectIdentifier(r)
+  case (nil, nil):
+    return true
+  default:
+    return false
+  }
+}
+#else
 @inlinable // trivial-implementation
 public func ===<T: AnyObject, U: AnyObject>(lhs: T?, rhs: U?) -> Bool {
   switch (lhs, rhs) {
@@ -257,6 +270,7 @@ public func ===<T: AnyObject, U: AnyObject>(lhs: T?, rhs: U?) -> Bool {
     return false
   }
 }
+#endif
 
 /// Returns a Boolean value indicating whether two references point to
 /// different object instances.
@@ -268,9 +282,14 @@ public func ===<T: AnyObject, U: AnyObject>(lhs: T?, rhs: U?) -> Bool {
 /// - Parameters:
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
+#if !$Embedded
+@inlinable // trivial-implementation
+public func !== (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
+  return !(lhs === rhs)
+}
+#else
 @inlinable // trivial-implementation
 public func !==<T: AnyObject, U: AnyObject>(lhs: T, rhs: U) -> Bool {
   return !(lhs === rhs)
 }
-
-
+#endif

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -247,10 +247,10 @@ extension Equatable {
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
 @inlinable // trivial-implementation
-public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
+public func ===<T: AnyObject, U: AnyObject>(lhs: T?, rhs: U?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
-    return ObjectIdentifier(l) == ObjectIdentifier(r)
+    return Builtin.bridgeToRawPointer(l) == Builtin.bridgeToRawPointer(r)
   case (nil, nil):
     return true
   default:
@@ -269,7 +269,7 @@ public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
 @inlinable // trivial-implementation
-public func !== (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
+public func !==<T: AnyObject, U: AnyObject>(lhs: T, rhs: U) -> Bool {
   return !(lhs === rhs)
 }
 

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -1361,6 +1361,7 @@ extension AnySequence {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyCollection {
   /// Returns an iterator over the elements of this collection.
   @inline(__always)
@@ -1449,6 +1450,7 @@ extension AnyCollection {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyBidirectionalCollection {
   /// Returns an iterator over the elements of this collection.
   @inline(__always)
@@ -1543,6 +1545,7 @@ extension AnyBidirectionalCollection {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyRandomAccessCollection {
   /// Returns an iterator over the elements of this collection.
   @inline(__always)
@@ -1690,6 +1693,7 @@ internal final class _IndexBox<BaseIndex: Comparable>: _AnyIndexBox {
 
 /// A wrapper over an underlying index that hides the specific underlying type.
 @frozen
+@_unavailableInEmbedded
 public struct AnyIndex {
   @usableFromInline
   internal var _box: _AnyIndexBox
@@ -1711,6 +1715,7 @@ public struct AnyIndex {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyIndex: Comparable {
   /// Returns a Boolean value indicating whether two indices wrap equal
   /// underlying indices.
@@ -1758,6 +1763,7 @@ protocol _AnyCollectionProtocol: Collection {
 /// same `Element` type, hiding the specifics of the underlying
 /// collection.
 @frozen
+@_unavailableInEmbedded
 public struct AnyCollection<Element> {
   @usableFromInline
   internal let _box: _AnyCollectionBox<Element>
@@ -1768,6 +1774,7 @@ public struct AnyCollection<Element> {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyCollection: Collection {
   public typealias Indices = DefaultIndices<AnyCollection>
   public typealias Iterator = AnyIterator<Element>
@@ -1959,6 +1966,7 @@ extension AnyCollection: Collection {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyCollection: _AnyCollectionProtocol {
   /// Uniquely identifies the stored underlying collection.
   @inlinable
@@ -1975,6 +1983,7 @@ extension AnyCollection: _AnyCollectionProtocol {
 /// same `Element` type, hiding the specifics of the underlying
 /// collection.
 @frozen
+@_unavailableInEmbedded
 public struct AnyBidirectionalCollection<Element> {
   @usableFromInline
   internal let _box: _AnyBidirectionalCollectionBox<Element>
@@ -1985,6 +1994,7 @@ public struct AnyBidirectionalCollection<Element> {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyBidirectionalCollection: BidirectionalCollection {
   public typealias Indices = DefaultIndices<AnyBidirectionalCollection>
   public typealias Iterator = AnyIterator<Element>
@@ -2184,6 +2194,7 @@ extension AnyBidirectionalCollection: BidirectionalCollection {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyBidirectionalCollection: _AnyCollectionProtocol {
   /// Uniquely identifies the stored underlying collection.
   @inlinable
@@ -2200,6 +2211,7 @@ extension AnyBidirectionalCollection: _AnyCollectionProtocol {
 /// same `Element` type, hiding the specifics of the underlying
 /// collection.
 @frozen
+@_unavailableInEmbedded
 public struct AnyRandomAccessCollection<Element> {
   @usableFromInline
   internal let _box: _AnyRandomAccessCollectionBox<Element>
@@ -2210,6 +2222,7 @@ public struct AnyRandomAccessCollection<Element> {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyRandomAccessCollection: RandomAccessCollection {
   public typealias Indices = DefaultIndices<AnyRandomAccessCollection>
   public typealias Iterator = AnyIterator<Element>
@@ -2398,6 +2411,7 @@ extension AnyRandomAccessCollection: RandomAccessCollection {
   }
 }
 
+@_unavailableInEmbedded
 extension AnyRandomAccessCollection: _AnyCollectionProtocol {
   /// Uniquely identifies the stored underlying collection.
   @inlinable

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -92,6 +92,7 @@ public struct ${Self} {
 }
 
 ${Availability(bits)}
+@_unavailableInEmbedded
 extension ${Self}: CustomStringConvertible {
   /// A textual representation of the value.
   ///
@@ -114,6 +115,7 @@ extension ${Self}: CustomStringConvertible {
 }
 
 ${Availability(bits)}
+@_unavailableInEmbedded
 extension ${Self}: CustomDebugStringConvertible {
   /// A textual representation of the value, suitable for debugging.
   ///
@@ -129,6 +131,7 @@ extension ${Self}: CustomDebugStringConvertible {
 }
 
 ${Availability(bits)}
+@_unavailableInEmbedded
 extension ${Self}: TextOutputStreamable {
   public func write<Target>(to target: inout Target) where Target: TextOutputStream {
     var (buffer, length) = _float${bits}ToString(self, debug: true)
@@ -1003,6 +1006,7 @@ extension ${Self}: Hashable {
 }
 
 % if bits != 16:
+@_unavailableInEmbedded
 extension ${Self}: _HasCustomAnyHashableRepresentation {
   // Not @inlinable
   public func _toCustomAnyHashable() -> AnyHashable? {
@@ -1279,6 +1283,7 @@ extension ${Self}: Strideable {
 //===----------------------------------------------------------------------===//
 
 % if bits != 16:
+@_unavailableInEmbedded
 internal struct _${Self}AnyHashableBox: _AnyHashableBox {
   internal typealias Base = ${Self}
 

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -243,7 +243,8 @@
     "Int128.swift",
     "Duration.swift",
     "DurationProtocol.swift",
-    "Instant.swift"
+    "Instant.swift",
+    "EmbeddedStubs.swift"
   ],
   "Result": [
     "Result.swift"

--- a/stdlib/public/core/Identifiable.swift
+++ b/stdlib/public/core/Identifiable.swift
@@ -39,6 +39,7 @@
 /// lifetime of an object. If an object has a stronger notion of identity, it
 /// may be appropriate to provide a custom implementation.
 @available(SwiftStdlib 5.1, *)
+@_unavailableInEmbedded
 public protocol Identifiable<ID> {
 
   /// A type representing the stable identity of the entity associated with
@@ -50,6 +51,7 @@ public protocol Identifiable<ID> {
 }
 
 @available(SwiftStdlib 5.1, *)
+@_unavailableInEmbedded
 extension Identifiable where Self: AnyObject {
   public var id: ObjectIdentifier {
     return ObjectIdentifier(self)

--- a/stdlib/public/core/Int128.swift.gyb
+++ b/stdlib/public/core/Int128.swift.gyb
@@ -51,12 +51,14 @@ internal struct _${U}Int128 {
   internal static var one: Self { Self(high: 0, low: 1) }
 }
 
+@_unavailableInEmbedded
 extension _${U}Int128: CustomStringConvertible {
   internal var description: String {
     String(self, radix: 10)
   }
 }
 
+@_unavailableInEmbedded
 extension _${U}Int128: CustomDebugStringConvertible {
   internal var debugDescription: String {
     description

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1689,6 +1689,7 @@ extension ${Self}: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 extension ${Self}: _HasCustomAnyHashableRepresentation {
   // Not @inlinable
   public func _toCustomAnyHashable() -> AnyHashable? {
@@ -1803,6 +1804,7 @@ internal func _unsafeMinus(_ lhs: Int, _ rhs: Int) -> Int {
 #endif
 }
 
+@_unavailableInEmbedded
 internal struct _IntegerAnyHashableBox<
   Base: FixedWidthInteger
 >: _AnyHashableBox {

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3046,7 +3046,14 @@ extension FixedWidthInteger {
   @inline(__always)
   public init<T: BinaryFloatingPoint>(_ source: T) {
     guard let value = Self._convert(from: source).value else {
-      fatalError()
+      #if !$Embedded
+      fatalError("""
+        \(T.self) value cannot be converted to \(Self.self) because it is \
+        outside the representable range
+        """)
+      #else
+      fatalError("value not representable")
+      #endif
     }
     self = value
   }

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1903,12 +1903,12 @@ extension BinaryInteger {
 #if !$Embedded
 public typealias _LosslessStringConvertibleOrNone = LosslessStringConvertible
 #else
-public typealias _LosslessStringConvertibleOrNone = Any
+public protocol _LosslessStringConvertibleOrNone {}
 #endif
 
 public protocol FixedWidthInteger: BinaryInteger, _LosslessStringConvertibleOrNone
 where Magnitude: FixedWidthInteger & UnsignedInteger,
-      Stride: FixedWidthInteger & SignedInteger, Stride.Stride == Stride {
+      Stride: FixedWidthInteger & SignedInteger {
   /// The number of bits used for the underlying binary representation of
   /// values of this type.
   ///

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -2735,7 +2735,7 @@ extension FixedWidthInteger {
     // If we used &+ instead, the result would be zero, which isn't helpful,
     // so we actually need to handle this case separately.
     if delta == Magnitude.max {
-      return Self(truncatingIfNeeded: generator.next())
+      return Self(truncatingIfNeeded: generator.next() as Magnitude)
     }
     // Need to widen delta to account for the right-endpoint of a closed range.
     delta += 1

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -178,6 +178,7 @@ public func _withUnprotectedUnsafePointer<T, Result>(
 #endif
 }
 
+#if !$Embedded
 extension String {
   /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of UTF-8 code units.
@@ -199,6 +200,7 @@ extension String {
     return try _guts.withCString(body)
   }
 }
+#endif
 
 /// Takes in a value at +0 and performs a Builtin.copy upon it.
 ///

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -564,11 +564,13 @@ public func isKnownUniquelyReferenced<T: AnyObject>(_ object: inout T) -> Bool
   return _isUnique(&object)
 }
 
+#if $Embedded
 @inlinable
 public func isKnownUniquelyReferenced(_ object: inout Builtin.NativeObject) -> Bool
 {
   return _isUnique(&object)
 }
+#endif
 
 /// Returns a Boolean value indicating whether the given object is known to
 /// have a single strong reference.

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -564,6 +564,12 @@ public func isKnownUniquelyReferenced<T: AnyObject>(_ object: inout T) -> Bool
   return _isUnique(&object)
 }
 
+@inlinable
+public func isKnownUniquelyReferenced(_ object: inout Builtin.NativeObject) -> Bool
+{
+  return _isUnique(&object)
+}
+
 /// Returns a Boolean value indicating whether the given object is known to
 /// have a single strong reference.
 ///

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -224,6 +224,7 @@ extension MemoryLayout {
   ///   `nil`, it can be because `key` is computed, has observers, requires
   ///   reabstraction, or overlaps storage with other properties.
   @_transparent
+  @_unavailableInEmbedded
   public static func offset(of key: PartialKeyPath<T>) -> Int? {
     return key._storedInlineOffset
   }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -57,6 +57,7 @@ func _getFunctionFullNameFromMangledNameImpl(
 /// Given a function's mangled name, return a human readable name.
 /// Used e.g. by Distributed.RemoteCallTarget to hide mangled names.
 @available(SwiftStdlib 5.7, *)
+@_unavailableInEmbedded
 public // SPI (Distributed)
 func _getFunctionFullNameFromMangledName(mangledName: String) -> String? {
   let mangledNameUTF8 = Array(mangledName.utf8)
@@ -86,6 +87,7 @@ public func _getTypeName(_ type: Any.Type, qualified: Bool)
 
 /// Returns the demangled qualified name of a metatype.
 @_semantics("typeName")
+@_unavailableInEmbedded
 public // @testable
 func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
   let (stringPtr, count) = _getTypeName(type, qualified: qualified)
@@ -100,6 +102,7 @@ public func _getMangledTypeName(_ type: Any.Type)
 
 /// Returns the mangled name for a given type.
 @available(SwiftStdlib 5.3, *)
+@_unavailableInEmbedded
 public // SPI
 func _mangledTypeName(_ type: Any.Type) -> String? {
   let (stringPtr, count) = _getMangledTypeName(type)
@@ -117,6 +120,7 @@ func _mangledTypeName(_ type: Any.Type) -> String? {
 
 /// Lookup a class given a name. Until the demangled encoding of type
 /// names is stabilized, this is limited to top-level class names (Foo.bar).
+@_unavailableInEmbedded
 public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -68,11 +68,7 @@ public struct ObjectIdentifier: Sendable {
 extension ObjectIdentifier: CustomDebugStringConvertible {
   /// A textual representation of the identifier, suitable for debugging.
   public var debugDescription: String {
-    #if !$Embedded
     return "ObjectIdentifier(\(_rawPointerToString(_value)))"
-    #else
-    fatalError()
-    #endif
   }
 }
 

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -64,10 +64,15 @@ public struct ObjectIdentifier: Sendable {
   }
 }
 
+@_unavailableInEmbedded
 extension ObjectIdentifier: CustomDebugStringConvertible {
   /// A textual representation of the identifier, suitable for debugging.
   public var debugDescription: String {
+    #if !$Embedded
     return "ObjectIdentifier(\(_rawPointerToString(_value)))"
+    #else
+    fatalError()
+    #endif
   }
 }
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -289,6 +289,7 @@ public enum Optional<Wrapped>: ExpressibleByNilLiteral {
   }
 }
 
+@_unavailableInEmbedded
 extension Optional: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -68,6 +68,7 @@ extension Never: Error {}
 extension Never: Equatable, Comparable, Hashable {}
 
 @available(SwiftStdlib 5.5, *)
+@_unavailableInEmbedded
 extension Never: Identifiable {
   @available(SwiftStdlib 5.5, *)
   public var id: Never {
@@ -76,12 +77,14 @@ extension Never: Identifiable {
 }
 
 @available(SwiftStdlib 5.9, *)
+@_unavailableInEmbedded
 extension Never: Encodable {
   @available(SwiftStdlib 5.9, *)
   public func encode(to encoder: any Encoder) throws {}
 }
 
 @available(SwiftStdlib 5.9, *)
+@_unavailableInEmbedded
 extension Never: Decodable {
   @available(SwiftStdlib 5.9, *)
   public init(from decoder: any Decoder) throws {
@@ -150,11 +153,14 @@ public typealias FloatLiteralType = Double
 public typealias BooleanLiteralType = Bool
 
 /// The default type for an otherwise-unconstrained unicode scalar literal.
+@_unavailableInEmbedded
 public typealias UnicodeScalarType = String
 /// The default type for an otherwise-unconstrained Unicode extended
 /// grapheme cluster literal.
+@_unavailableInEmbedded
 public typealias ExtendedGraphemeClusterType = String
 /// The default type for an otherwise-unconstrained string literal.
+@_unavailableInEmbedded
 public typealias StringLiteralType = String
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -51,6 +51,7 @@ import SwiftShims
 ///
 /// Types that conform to `RandomNumberGenerator` should specifically document
 /// the thread safety and quality of the generator.
+@_unavailableInEmbedded
 public protocol RandomNumberGenerator {
   /// Returns a value from a uniform, independent distribution of binary data.
   ///
@@ -63,6 +64,7 @@ public protocol RandomNumberGenerator {
   mutating func next() -> UInt64
 }
 
+@_unavailableInEmbedded
 extension RandomNumberGenerator {
   
   // An unavailable default implementation of next() prevents types that do
@@ -147,6 +149,7 @@ extension RandomNumberGenerator {
 ///   from `/dev/urandom`.
 /// - Windows uses `BCryptGenRandom`.
 @frozen
+@_unavailableInEmbedded
 public struct SystemRandomNumberGenerator: RandomNumberGenerator, Sendable {
   /// Creates a new instance of the system's default random number generator.
   @inlinable

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -375,19 +375,29 @@ extension Range {
   }
 }
 
+@_unavailableInEmbedded
 extension Range: CustomStringConvertible {
   /// A textual representation of the range.
   @inlinable // trivial-implementation
   public var description: String {
+    #if $Embedded
+    fatalError()
+    #else
     return "\(lowerBound)..<\(upperBound)"
+    #endif
   }
 }
 
+@_unavailableInEmbedded
 extension Range: CustomDebugStringConvertible {
   /// A textual representation of the range, suitable for debugging.
   public var debugDescription: String {
+    #if !$Embedded
     return "Range(\(String(reflecting: lowerBound))"
     + "..<\(String(reflecting: upperBound)))"
+    #else
+    fatalError()
+    #endif
   }
 }
 
@@ -438,8 +448,10 @@ extension Range: Hashable where Bound: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 extension Range: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
+    #if !$Embedded
     var container = try decoder.unkeyedContainer()
     let lowerBound = try container.decode(Bound.self)
     let upperBound = try container.decode(Bound.self)
@@ -450,9 +462,13 @@ extension Range: Decodable where Bound: Decodable {
           debugDescription: "Cannot initialize \(Range.self) with a lowerBound (\(lowerBound)) greater than upperBound (\(upperBound))"))
     }
     self.init(_uncheckedBounds: (lower: lowerBound, upper: upperBound))
+    #else
+    fatalError()
+    #endif
   }
 }
 
+@_unavailableInEmbedded
 extension Range: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
@@ -503,6 +519,7 @@ extension PartialRangeUpTo: RangeExpression {
   }
 }
 
+@_unavailableInEmbedded
 extension PartialRangeUpTo: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
@@ -510,6 +527,7 @@ extension PartialRangeUpTo: Decodable where Bound: Decodable {
   }
 }
 
+@_unavailableInEmbedded
 extension PartialRangeUpTo: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
@@ -558,6 +576,7 @@ extension PartialRangeThrough: RangeExpression {
   }
 }
 
+@_unavailableInEmbedded
 extension PartialRangeThrough: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
@@ -565,6 +584,7 @@ extension PartialRangeThrough: Decodable where Bound: Decodable {
   }
 }
 
+@_unavailableInEmbedded
 extension PartialRangeThrough: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
@@ -708,6 +728,7 @@ extension PartialRangeFrom: Sequence
   }
 }
 
+@_unavailableInEmbedded
 extension PartialRangeFrom: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
@@ -715,6 +736,7 @@ extension PartialRangeFrom: Decodable where Bound: Decodable {
   }
 }
 
+@_unavailableInEmbedded
 extension PartialRangeFrom: Encodable where Bound: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
@@ -1029,6 +1051,7 @@ extension PartialRangeThrough: Sendable where Bound: Sendable { }
 extension PartialRangeFrom: Sendable where Bound: Sendable { }
 extension PartialRangeFrom.Iterator: Sendable where Bound: Sendable { }
 
+#if !$Embedded
 extension Range where Bound == String.Index {
   @_alwaysEmitIntoClient // Swift 5.7
   internal var _encodedOffsetRange: Range<Int> {
@@ -1039,3 +1062,4 @@ extension Range where Bound == String.Index {
       _uncheckedBounds: (lowerBound._encodedOffset, upperBound._encodedOffset))
   }
 }
+#endif

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -380,11 +380,7 @@ extension Range: CustomStringConvertible {
   /// A textual representation of the range.
   @inlinable // trivial-implementation
   public var description: String {
-    #if $Embedded
-    fatalError()
-    #else
     return "\(lowerBound)..<\(upperBound)"
-    #endif
   }
 }
 
@@ -392,12 +388,8 @@ extension Range: CustomStringConvertible {
 extension Range: CustomDebugStringConvertible {
   /// A textual representation of the range, suitable for debugging.
   public var debugDescription: String {
-    #if !$Embedded
     return "Range(\(String(reflecting: lowerBound))"
     + "..<\(String(reflecting: upperBound)))"
-    #else
-    fatalError()
-    #endif
   }
 }
 
@@ -451,7 +443,6 @@ extension Range: Hashable where Bound: Hashable {
 @_unavailableInEmbedded
 extension Range: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {
-    #if !$Embedded
     var container = try decoder.unkeyedContainer()
     let lowerBound = try container.decode(Bound.self)
     let upperBound = try container.decode(Bound.self)
@@ -462,9 +453,6 @@ extension Range: Decodable where Bound: Decodable {
           debugDescription: "Cannot initialize \(Range.self) with a lowerBound (\(lowerBound)) greater than upperBound (\(upperBound))"))
     }
     self.init(_uncheckedBounds: (lower: lowerBound, upper: upperBound))
-    #else
-    fatalError()
-    #endif
   }
 }
 

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -126,6 +126,7 @@ func _stdlib_atomicCompareExchangeStrongPtr<T>(
 
 @_transparent
 @discardableResult
+@_unavailableInEmbedded
 public // @testable
 func _stdlib_atomicInitializeARCRef(
   object target: UnsafeMutablePointer<AnyObject?>,
@@ -149,6 +150,7 @@ func _stdlib_atomicInitializeARCRef(
 }
 
 @_transparent
+@_unavailableInEmbedded
 public // @testable
 func _stdlib_atomicLoadARCRef(
   object target: UnsafeMutablePointer<AnyObject?>
@@ -163,6 +165,7 @@ func _stdlib_atomicLoadARCRef(
 @_transparent
 @_alwaysEmitIntoClient
 @discardableResult
+@_unavailableInEmbedded
 public func _stdlib_atomicAcquiringInitializeARCRef<T: AnyObject>(
   object target: UnsafeMutablePointer<T?>,
   desired: __owned T
@@ -189,6 +192,7 @@ public func _stdlib_atomicAcquiringInitializeARCRef<T: AnyObject>(
 
 @_alwaysEmitIntoClient
 @_transparent
+@_unavailableInEmbedded
 public func _stdlib_atomicAcquiringLoadARCRef<T: AnyObject>(
   object target: UnsafeMutablePointer<T?>
 ) -> Unmanaged<T>? {
@@ -346,6 +350,7 @@ internal func _float16ToStringImpl(
 ) -> Int
 
 @available(SwiftStdlib 5.3, *)
+@_unavailableInEmbedded
 internal func _float16ToString(
   _ value: Float16,
   debug: Bool
@@ -371,6 +376,7 @@ internal func _float32ToStringImpl(
   _ debug: Bool
 ) -> UInt64
 
+@_unavailableInEmbedded
 internal func _float32ToString(
   _ value: Float32,
   debug: Bool
@@ -395,6 +401,7 @@ internal func _float64ToStringImpl(
   _ debug: Bool
 ) -> UInt64
 
+@_unavailableInEmbedded
 internal func _float64ToString(
   _ value: Float64,
   debug: Bool
@@ -422,6 +429,7 @@ internal func _float80ToStringImpl(
   _ debug: Bool
 ) -> UInt64
 
+@_unavailableInEmbedded
 internal func _float80ToString(
   _ value: Float80,
   debug: Bool
@@ -448,6 +456,7 @@ internal func _int64ToStringImpl(
   _ uppercase: Bool
 ) -> UInt64
 
+@_unavailableInEmbedded
 internal func _int64ToString(
   _ value: Int64,
   radix: Int64 = 10,
@@ -485,6 +494,7 @@ internal func _uint64ToStringImpl(
   _ uppercase: Bool
 ) -> UInt64
 
+@_unavailableInEmbedded
 public // @testable
 func _uint64ToString(
     _ value: UInt64,
@@ -511,6 +521,7 @@ func _uint64ToString(
 }
 
 @inlinable
+@_unavailableInEmbedded
 internal func _rawPointerToString(_ value: Builtin.RawPointer) -> String {
   var result = _uint64ToString(
     UInt64(

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -26,14 +26,9 @@ internal struct _SliceBuffer<Element>
   @usableFromInline
   internal typealias NativeBuffer = _ContiguousArrayBuffer<Element>
 
-  #if $Embedded
   /// An object that keeps the elements stored in this buffer alive.
   @usableFromInline
-  internal var owner: Builtin.NativeObject
-  #else
-  @usableFromInline
   internal var owner: AnyObject
-  #endif
 
   @usableFromInline
   internal let subscriptBaseAddress: UnsafeMutablePointer<Element>

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -17,13 +17,23 @@ internal struct _SliceBuffer<Element>
   : _ArrayBufferProtocol,
     RandomAccessCollection
 {
+  #if $Embedded
+  @usableFromInline
+  typealias AnyObject = Builtin.NativeObject
+  #endif
+
   internal typealias NativeStorage = _ContiguousArrayStorage<Element>
   @usableFromInline
   internal typealias NativeBuffer = _ContiguousArrayBuffer<Element>
 
+  #if $Embedded
   /// An object that keeps the elements stored in this buffer alive.
   @usableFromInline
+  internal var owner: Builtin.NativeObject
+  #else
+  @usableFromInline
   internal var owner: AnyObject
+  #endif
 
   @usableFromInline
   internal let subscriptBaseAddress: UnsafeMutablePointer<Element>
@@ -67,7 +77,11 @@ internal struct _SliceBuffer<Element>
   @inlinable
   internal init() {
     let empty = _ContiguousArrayBuffer<Element>()
-    self.owner = empty.owner
+    #if $Embedded
+    self.owner = Builtin.castToNativeObject(_emptyArrayStorage)
+    #else
+    self.owner = _emptyArrayStorage
+    #endif
     self.subscriptBaseAddress = empty.firstElementAddress
     self.startIndex = empty.startIndex
     self.endIndexAndFlags = 1
@@ -87,7 +101,12 @@ internal struct _SliceBuffer<Element>
   @inlinable // FIXME(sil-serialize-all)
   internal func _invariantCheck() {
     let isNative = _hasNativeBuffer
-    let isNativeStorage: Bool = owner is __ContiguousArrayStorageBase
+    let isNativeStorage: Bool
+    #if !$Embedded
+    isNativeStorage = owner is __ContiguousArrayStorageBase
+    #else
+    isNativeStorage = true
+    #endif
     _internalInvariant(isNativeStorage == isNative)
     if isNative {
       _internalInvariant(count <= nativeBuffer.count)
@@ -102,8 +121,13 @@ internal struct _SliceBuffer<Element>
   @inlinable
   internal var nativeBuffer: NativeBuffer {
     _internalInvariant(_hasNativeBuffer)
+    #if !$Embedded
     return NativeBuffer(
       owner as? __ContiguousArrayStorageBase ?? _emptyArrayStorage)
+    #else
+    return NativeBuffer(unsafeBitCast(_nativeObject(toNative: owner),
+      to: __ContiguousArrayStorageBase.self))
+    #endif
   }
 
   @inlinable

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -205,7 +205,11 @@ public struct StaticString: Sendable {
       return body(UnsafeBufferPointer(
         start: utf8Start, count: utf8CodeUnitCount))
     } else {
+      #if $Embedded
+      fatalError()
+      #else
       return unicodeScalar.withUTF8CodeUnits { body($0) }
+      #endif
     }
   }
 }
@@ -292,6 +296,7 @@ extension StaticString: ExpressibleByStringLiteral {
   }
 }
 
+@_unavailableInEmbedded
 extension StaticString: CustomStringConvertible {
 
   /// A textual representation of the static string.
@@ -300,6 +305,7 @@ extension StaticString: CustomStringConvertible {
   }
 }
 
+@_unavailableInEmbedded
 extension StaticString: CustomDebugStringConvertible {
 
   /// A textual representation of the static string, suitable for debugging.

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -206,7 +206,7 @@ public struct StaticString: Sendable {
         start: utf8Start, count: utf8CodeUnitCount))
     } else {
       #if $Embedded
-      fatalError()
+      fatalError("non-pointer representation not support in embedded Swift")
       #else
       return unicodeScalar.withUTF8CodeUnits { body($0) }
       #endif

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -507,6 +507,7 @@ internal class __ContiguousArrayStorageBase
 
   /// A type that every element in the array is.
   @inlinable
+  @_unavailableInEmbedded
   internal var staticElementType: Any.Type {
     _internalInvariantFailure(
       "Concrete subclasses must implement staticElementType")

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -191,10 +191,12 @@ extension Unicode.Scalar :
   /// - Parameter forceASCII: Pass `true` if you need the result to use only
   ///   ASCII characters; otherwise, pass `false`.
   /// - Returns: A string representation of the scalar.
+  @_unavailableInEmbedded
   public func escaped(asASCII forceASCII: Bool) -> String {
     _escaped(asASCII: forceASCII) ?? String(self)
   }
 
+  @_unavailableInEmbedded
   internal func _escaped(asASCII forceASCII: Bool) -> String? {
     func lowNibbleAsHex(_ v: UInt32) -> String {
       let nibble = v & 15
@@ -278,6 +280,7 @@ extension Unicode.Scalar :
   }
 }
 
+@_unavailableInEmbedded
 extension Unicode.Scalar: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the Unicode scalar.
   @inlinable
@@ -292,6 +295,7 @@ extension Unicode.Scalar: CustomStringConvertible, CustomDebugStringConvertible 
   }
 }
 
+@_unavailableInEmbedded
 extension Unicode.Scalar: LosslessStringConvertible {
   @inlinable
   public init?(_ description: String) {

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -15,6 +15,7 @@
 /// When you use this type, you become partially responsible for
 /// keeping the object alive.
 @frozen
+@_unavailableInEmbedded
 public struct Unmanaged<Instance: AnyObject> {
   @usableFromInline
   internal unowned(unsafe) var _value: Instance
@@ -243,5 +244,6 @@ public struct Unmanaged<Instance: AnyObject> {
 #endif
 }
 
+@_unavailableInEmbedded
 extension Unmanaged: Sendable where Instance: Sendable { }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -1190,11 +1190,16 @@ extension Unsafe${Mutable}BufferPointer {
   }
 }
 
+@_unavailableInEmbedded
 extension Unsafe${Mutable}BufferPointer: CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
+  #if $Embedded
+  fatalError()
+  #else
     return "Unsafe${Mutable}BufferPointer"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
+  #endif
   }
 }
 %end

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -1194,12 +1194,8 @@ extension Unsafe${Mutable}BufferPointer {
 extension Unsafe${Mutable}BufferPointer: CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
-  #if $Embedded
-  fatalError()
-  #else
     return "Unsafe${Mutable}BufferPointer"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
-  #endif
   }
 }
 %end

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -370,6 +370,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
   ///            by the key path, or `nil`.
   @inlinable
   @_alwaysEmitIntoClient
+  @_unavailableInEmbedded
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
@@ -1131,6 +1132,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   ///            by the key path, or `nil`.
   @inlinable
   @_alwaysEmitIntoClient
+  @_unavailableInEmbedded
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
@@ -1153,6 +1155,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   ///            by the key path, or `nil`.
   @inlinable
   @_alwaysEmitIntoClient
+  @_unavailableInEmbedded
   public func pointer<Property>(
     to property: WritableKeyPath<Pointee, Property>
   ) -> UnsafeMutablePointer<Property>? {

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1143,11 +1143,16 @@ extension Unsafe${Mutable}RawBufferPointer {
   }
 }
 
+@_unavailableInEmbedded
 extension Unsafe${Mutable}RawBufferPointer: CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
+  #if $Embedded
+  fatalError()
+  #else
     return "${Self}"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
+  #endif
   }
 }
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1147,12 +1147,8 @@ extension Unsafe${Mutable}RawBufferPointer {
 extension Unsafe${Mutable}RawBufferPointer: CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
-  #if $Embedded
-  fatalError()
-  #else
     return "${Self}"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
-  #endif
   }
 }
 

--- a/test/embedded/basic-errors-no-stdlib.swift
+++ b/test/embedded/basic-errors-no-stdlib.swift
@@ -1,9 +1,9 @@
-// RUN: not %target-swift-frontend -emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -wmo 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -verify %s -parse-stdlib -enable-experimental-feature Embedded -wmo
 
 public protocol Player {}
 struct Concrete: Player {}
 
-// CHECK: error: existential can cause metadata allocation or locks
 public func test() -> any Player {
-  Concrete()
+  Concrete() // expected-error {{existential can cause metadata allocation or locks}}
+  // expected-note@-1 {{called from here}}
 }

--- a/test/embedded/basic-modules-generics-no-stdlib.swift
+++ b/test/embedded/basic-modules-generics-no-stdlib.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-ir     -I %t                      %t/Main.swift     -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s
+
+// BEGIN MyModule.swift
+
+precedencegroup AssignmentPrecedence { assignment: true }
+
+public struct NonGenericType {
+  public init() {}
+}
+
+public struct GenericType<T> {
+  var t: T
+  public init(_ t: T) { self.t = t }
+}
+
+public protocol Protocol {}
+
+public func nonGenericFunc() {
+}
+
+public func genericFunc<T>(_ t: T) -> T {
+  return t
+}
+
+public func protocolBoundFunc<T: Protocol>(_ t: T) {
+
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+struct Bool {}
+
+extension Bool: Protocol {}
+
+extension GenericType: Protocol {}
+
+public func main() {
+  nonGenericFunc()
+  _ = genericFunc(Bool())
+  _ = NonGenericType()
+  _ = GenericType<Bool>(Bool())
+  protocolBoundFunc(Bool())
+  protocolBoundFunc(GenericType<Bool>(Bool()))
+}
+
+// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}void @"$s4Main4BoolVACycfC"()
+// CHECK: define {{.*}}void @"$s4Main4mainyyF"()
+// CHECK: define {{.*}}void @"$s8MyModule14nonGenericFuncyyF"()
+// CHECK: define {{.*}}void @"$s8MyModule11genericFuncyxxlF4Main4BoolV_Tg5"()
+// CHECK: define {{.*}}void @"$s8MyModule14NonGenericTypeVACycfC"()
+// CHECK: define {{.*}}void @"$s8MyModule11GenericTypeVyACyxGxcfC4Main4BoolV_Tgm5"()
+// CHECK: define {{.*}}void @"$s8MyModule17protocolBoundFuncyyxAA8ProtocolRzlF4Main4BoolV_Tg5"()
+// CHECK: define {{.*}}void @"$s8MyModule17protocolBoundFuncyyxAA8ProtocolRzlFAA11GenericTypeVy4Main4BoolVG_Tg5"()

--- a/test/embedded/basic-modules-generics-no-stdlib.swift
+++ b/test/embedded/basic-modules-generics-no-stdlib.swift
@@ -4,6 +4,8 @@
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -emit-ir     -I %t                      %t/Main.swift     -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s
 
+// REQUIRES: swift_in_compiler
+
 // BEGIN MyModule.swift
 
 precedencegroup AssignmentPrecedence { assignment: true }

--- a/test/embedded/collection.swift
+++ b/test/embedded/collection.swift
@@ -1,0 +1,91 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ \
+// RUN:   -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
+// RUN: %target-clang %t/a.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+// REQUIRES: CPU=arm64
+
+@_silgen_name("putchar")
+func putchar(_: UInt8)
+
+public func print(_ s: StaticString, terminator: StaticString = "\n") {
+  var p = s.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+  p = terminator.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+}
+
+@_silgen_name("vprintf")
+func vprintf(_: UnsafePointer<UInt8>, _: UnsafeRawPointer)
+
+var global: Int = 0
+public func print(_ n: Int) {
+    let f: StaticString = "%d\n"
+    global = n
+    vprintf(f.utf8Start, &global)
+}
+
+@_silgen_name("malloc")
+func malloc(_: Int) -> UnsafeMutableRawPointer
+
+struct Bytes<T>: Collection {
+    var storage: UnsafeMutableBufferPointer<T>
+    var size: Int
+    init(size: Int, initialValue: T) {
+        self.storage = .init(start: malloc(MemoryLayout<T>.stride * size).assumingMemoryBound(to: T.self), count: size)
+        self.storage.initialize(repeating: initialValue)
+        self.size = size
+    }
+    
+    func index(after i: Int) -> Int {
+        return i + 1
+    }
+    
+    subscript(position: Int) -> T {
+        get {
+            return storage[position]
+        }
+        set(newValue) {
+            storage[position] = newValue
+        }
+    }
+    
+    public subscript(bounds: Range<Index>) -> SubSequence {
+        get { fatalError() }
+        set { fatalError() }
+    }
+    
+    var startIndex: Int { return 0 }
+    
+    var endIndex: Int { return size }
+    
+    typealias Element = T
+    
+    typealias Index = Int
+    
+    typealias SubSequence = Bytes
+}
+
+func foo() {
+    var bytes = Bytes<Int>(size: 10, initialValue: 0)
+    bytes[4] = 42
+    bytes[2] = 22
+    bytes[6] = 13
+    bytes[6] = 15
+    bytes[8] = 9
+    bytes[9] = -1
+    print(bytes[0]) // CHECK: 0
+    print(bytes.max()!)// CHECK: 42
+    print(bytes.min()!) // CHECK: -1
+}
+
+foo()

--- a/test/embedded/conditionals.swift
+++ b/test/embedded/conditionals.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s --check-prefix EMBEDDED
+
+#if $Embedded
+public func embedded() { }
+#else
+public func regular() { }
+#endif
+
+// CHECK:    define swiftcc void @"$s12conditionals7regularyyF"()
+// EMBEDDED: define swiftcc void @"$s12conditionals8embeddedyyF"()

--- a/test/embedded/conditionals.swift
+++ b/test/embedded/conditionals.swift
@@ -7,5 +7,5 @@ public func embedded() { }
 public func regular() { }
 #endif
 
-// CHECK:    define swiftcc void @"$s12conditionals7regularyyF"()
-// EMBEDDED: define swiftcc void @"$s12conditionals8embeddedyyF"()
+// CHECK:    define {{.*}}void @"$s12conditionals7regularyyF"()
+// EMBEDDED: define {{.*}}void @"$s12conditionals8embeddedyyF"()

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ \
+// RUN:   -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
+// RUN: %target-clang %t/a.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+// REQUIRES: CPU=arm64
+
+@_silgen_name("putchar")
+func putchar(_: UInt8)
+
+public func print(_ s: StaticString, terminator: StaticString = "\n") {
+  var p = s.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+  p = terminator.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+}
+
+print("Hello, Embedded Swift!")
+// CHECK: Hello, Embedded Swift!

--- a/test/embedded/lto.swift
+++ b/test/embedded/lto.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ \
+// RUN:   -lto=llvm-full %s -enable-experimental-feature Embedded -emit-bc -o %t/a.o
+// RUN: %target-clang %t/a.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+// REQUIRES: CPU=arm64
+
+@_silgen_name("putchar")
+func putchar(_: UInt8)
+
+public func print(_ s: StaticString, terminator: StaticString = "\n") {
+  var p = s.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+  p = terminator.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+}
+
+print("Hello, Embedded Swift!")
+// CHECK: Hello, Embedded Swift!

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+public func bool() -> Bool {
+  return true
+}
+
+public func int() -> Int {
+  return 42
+}
+
+public func ptr(p: UnsafeRawPointer, n: Int) -> UnsafeRawPointer {
+  return p.advanced(by: n)
+}
+
+public func optional() -> Int? {
+  return nil
+}
+
+public func staticstring() -> StaticString {
+  return "hello"
+}
+
+// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i1 @"$s4main4boolSbyF"()
+// CHECK: define {{.*}}i1 @"$sSb22_builtinBooleanLiteralSbBi1__tcfC"(i1 %0)
+// CHECK: define {{.*}}{{i32|i64}} @"$s4main3intSiyF"()
+// CHECK: define {{.*}}{{i32|i64}} @"$sSi22_builtinIntegerLiteralSiBI_tcfC"(ptr %0, {{i32|i64}} %1)
+// CHECK: define {{.*}}ptr @"$s4main3ptr1p1nS2V_SitF"(ptr %0, {{i32|i64}} %1)
+// CHECK: define {{.*}}ptr @"$sSV8advanced2bySVSi_tF"({{i32|i64}} %0, ptr %1)
+// CHECK: define {{.*}}{ {{i32|i64}}, i8 } @"$s4main8optionalSiSgyF"()
+// CHECK: define {{.*}}{ {{i32|i64}}, {{i32|i64}}, i8 } @"$s4main12staticstrings12StaticStringVyF"()
+// CHECK: define {{.*}}{ {{i32|i64}}, {{i32|i64}}, i8 } @"$ss12StaticStringV08_builtinB7Literal17utf8CodeUnitCount7isASCIIABBp_BwBi1_tcfC"(ptr %0, {{i32|i64}} %1, i1 %2)

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// REQUIRES: VENDOR=apple
+
 public func bool() -> Bool {
   return true
 }

--- a/test/embedded/wmo-with-embedded-diag.swift
+++ b/test/embedded/wmo-with-embedded-diag.swift
@@ -1,3 +1,7 @@
-// RUN: not %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -parse-stdlib %s -enable-experimental-feature Embedded
+// RUN: not %target-swift-frontend -typecheck -parse-stdlib %s -primary-file %s -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
+
+// RUN: %target-swiftc_driver -typecheck -parse-stdlib %s -enable-experimental-feature Embedded -wmo
+// RUN: not %target-swiftc_driver -typecheck -parse-stdlib %s -enable-experimental-feature Embedded 2>&1 | %FileCheck %s
 
 // CHECK: error: Whole module optimization (wmo) must be enabled with embedded Swift.


### PR DESCRIPTION
This isn't a "complete" port of the standard library for embedded Swift, but something that should serve as a starting point for further iterations on the stdlib. PR adds a few executable tests that exercise some parts of the stdlib (not any arrays/collections yet, though) in embedded Swift mode -- this achieves actually runnable programs compiled in embedded Swift (!).

- General CMake logic for building a library as ".swiftmodule only" (ONLY_SWIFTMODULE).
- CMake logic in stdlib/public/core/CMakeLists.txt to start building the embedded stdlib for a handful of hardcoded target triples.
- Lots of annotations throughout the standard library to make types, functions, protocols unavailable in embedded Swift (@_unavailableInEmbedded).
- Mainly this is about stdlib functionality that relies on existentials, type erasure, metatypes, reflection, string interpolations.
- We rely on function body removal of unavailable functions to eliminate the actual problematic SIL code (existentials).
- Many .swift files are not included in the compilation of embedded stdlib at all, to simplify the scope of the annotations.
- EmbeddedStubs.swift is used to stub out (as unavailable and fatalError'd) the missing functionality.
