### PR TITLE
5.10: [CanonicalizeOSSALifetime] Respect deinit barrier boundary edges.

### DIFF
--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -180,3 +180,31 @@ entry(%instance : @owned $MoE):
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on respect_boundary_edges_when_extending_to_deinit_barriers: canonicalize-ossa-lifetime with: true, false, true, @argument
+// respect_boundary_edges_when_extending_to_deinit_barriers
+// CHECK-LABEL: sil [ossa] @respect_boundary_edges_when_extending_to_deinit_barriers : {{.*}} {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         apply {{%[^,]+}}()
+// CHECK:         cond_br undef, [[DIE:bb[0-9]+]], [[DESTROY:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK:         unreachable
+// CHECK:       [[DESTROY]]:
+// CHECK:         destroy_value [[INSTANCE]] : $C
+// CHECK-LABEL: } // end sil function 'respect_boundary_edges_when_extending_to_deinit_barriers'
+// CHECK-LABEL: end running test 1 of 1 on respect_boundary_edges_when_extending_to_deinit_barriers: canonicalize-ossa-lifetime with: true, false, true, @argument
+sil [ossa] @respect_boundary_edges_when_extending_to_deinit_barriers : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  test_specification "canonicalize-ossa-lifetime true false true @argument"
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  apply %barrier() : $@convention(thin) () -> ()
+  cond_br undef, die, destroy
+
+die:
+  unreachable
+
+destroy:
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
**Description:** Work around incomplete lifetimes when canonicalizing lexical value.

When a non-lexical value's lifetime is canonicalized, copies are propagated to consuming uses and destroys to last non-consuming uses.  Shortening a lexical value's lifetime in that way isn't allowed: it doesn't respect deinit barriers.

To prevent shortening a lexical value's lifetime over deinit barriers, a backwards walk is done from destroys of the value to find deinit barriers.  Barriers that are found are treated as last non-consuming uses, forcing the value to be destroyed after them.  These barriers can be either instructions which are deinit barriers, phis, or "barrier edges" which correspond to the fact that there's a control-flow branch and the backwards walk was not able to reach the top of at least one of the branch destinations.

For incomplete OSSA lifetimes, the value's lifetime ends not just at destroys but also at "dead ends" which correspond to language-level traps.  Walking backwards from only the destroys means that barrier edges will be encountered at branches where one path leads to an unreachable that ends the value's lifetime (because the backwards walk will never reach the merge from that branch, never having walked up it at all).

Previously, barrier edges were ignored after doing this backwards walk on the assumption that they would be rediscovered later.  That assumption is correct given complete OSSA lifetimes.  Because lifetime completion has not yet been enabled, however, the assumption is incorrect.  The result would be to shorten a value's lifetime without regard for such barriers.

Here, this is addressed by discovered barrier edges as last-uses.
**Risk:** Low.  This just uses a value that was already being computed and adds it to liveness, a utility that can handle having arbitrary instructions added to it.

**Original PR:** https://github.com/apple/swift/pull/68494

**Reviewed By:** Andrew Trick ( @atrick )

**Testing:** Added test.

**Resolves:** rdar://115410893
