### PR TITLE
IRGen: fix emission of constant single-case enums

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -425,6 +425,8 @@ namespace {
         getLoadableSingleton()->reexplode(params, out);
     }
 
+    bool emitPayloadDirectlyIntoConstant() const override { return true; }
+
     void destructiveProjectDataForLoad(IRGenFunction &IGF,
                                        SILType T,
                                        Address enumAddr) const override {

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -334,6 +334,11 @@ public:
                                   Explosion &params,
                                   Explosion &out) const = 0;
   
+  /// Return true for single-case (singleton) enums.
+  /// The enum doesn't need any tag bits and the payload of the enum case can
+  /// (and needs!) to be emitted as-is into a constant.
+  virtual bool emitPayloadDirectlyIntoConstant() const { return false; }
+
   /// Return an i1 value that indicates whether the specified loadable enum
   /// value holds the specified case.  This is a light-weight form of a switch.
   virtual llvm::Value *emitValueCaseTest(IRGenFunction &IGF,

--- a/test/SILOptimizer/static_enums.swift
+++ b/test/SILOptimizer/static_enums.swift
@@ -218,6 +218,12 @@ func printFunctionEnum() {
   }
 }
 
+enum SingleCaseEnum {
+  case a(b: Bool, i: Int)
+
+  static var x = Self.a(b:true, i: 42)
+}
+
 @main
 struct Main {
   static func main() {
@@ -293,6 +299,8 @@ struct Main {
     print("optSalmon:", optSalmon as Any)
     // CHECK-OUTPUT: test.C: 27
     printFunctionEnum()
+    // CHECK-OUTPUT: SingleCaseEnum: a(b: true, i: 42)
+    print("SingleCaseEnum:", SingleCaseEnum.x)
   }
 }
 


### PR DESCRIPTION
Enums which have a single case with a payload were emitted with wrong field alignement into the data section.

Fixes a miscompile:
rdar://115251963
