### PR TITLE
[5.10] IRGen: fix emission of constant single-case enums

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -425,6 +425,8 @@ namespace {
         getLoadableSingleton()->reexplode(params, out);
     }
 
+    bool emitPayloadDirectlyIntoConstant() const override { return true; }
+
     void destructiveProjectDataForLoad(IRGenFunction &IGF,
                                        SILType T,
                                        Address enumAddr) const override {

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -334,6 +334,11 @@ public:
                                   Explosion &params,
                                   Explosion &out) const = 0;
   
+  /// Return true for single-case (singleton) enums.
+  /// The enum doesn't need any tag bits and the payload of the enum case can
+  /// (and needs!) to be emitted as-is into a constant.
+  virtual bool emitPayloadDirectlyIntoConstant() const { return false; }
+
   /// Return an i1 value that indicates whether the specified loadable enum
   /// value holds the specified case.  This is a light-weight form of a switch.
   virtual llvm::Value *emitValueCaseTest(IRGenFunction &IGF,

--- a/test/SILOptimizer/static_enums.swift
+++ b/test/SILOptimizer/static_enums.swift
@@ -218,6 +218,12 @@ func printFunctionEnum() {
   }
 }
 
+enum SingleCaseEnum {
+  case a(b: Bool, i: Int)
+
+  static var x = Self.a(b:true, i: 42)
+}
+
 @main
 struct Main {
   static func main() {
@@ -293,6 +299,8 @@ struct Main {
     print("optSalmon:", optSalmon as Any)
     // CHECK-OUTPUT: test.C: 27
     printFunctionEnum()
+    // CHECK-OUTPUT: SingleCaseEnum: a(b: true, i: 42)
+    print("SingleCaseEnum:", SingleCaseEnum.x)
   }
 }
 


### PR DESCRIPTION
* **Explanation**: This fixes a mis-compile when a single-case enum with a payload is put into a global variable, or an array literal contains such an enum. This only happens if the payload of the enum case has two fields and alignment padding needs to be inserted. The problem was that the alignment padding wasn't inserted.

* **Issue**: rdar://115251963

* **Risk**: Low. The change only affects single-case enums with payloads of multiple fields - which is quite rare.

* **Testing**: With a regression test.

* **Reviewer**: @aschwaighofer

* **Main branch PR**: https://github.com/apple/swift/pull/68516
