### PR TITLE
build: enable macros during the build

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -351,6 +351,7 @@ config.gyb = make_path(config.swift_utils, 'gyb.py')
 config.rth = make_path(config.swift_utils, 'rth') # Resilience test helper
 config.scale_test = make_path(config.swift_utils, 'scale-test')
 config.PathSanitizingFileCheck = make_path(config.swift_utils, 'PathSanitizingFileCheck')
+config.swift_bin_dir = make_path(config.swift, '..', '..', 'bin')
 config.swift_lib_dir = make_path(config.swift, '..', '..', 'lib')
 config.round_trip_syntax_test = make_path(config.swift_utils, 'round-trip-syntax-test')
 config.refactor_check_compiles = make_path(config.swift_utils, 'refactor-check-compiles.py')

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -192,7 +192,7 @@ cmake ^
 cmake --build "%BuildRoot%\curl" || (exit /b)
 cmake --build "%BuildRoot%\curl" --target install || (exit /b)
 
-path %BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\PFiles64\Swift\Runtimes\0.0.0\usr\bin;%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\PFiles64\Swift\Toolchains\0.0.0+Asserts\usr\bin;%Path%
+path %BuildRoot%\toolchains\5.9.0\PFiles64\Swift\runtime-development\usr\bin;%BuildRoot%\toolchains\5.9.0\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin;%Path%
 
 :: Build Swift Syntax
 cmake ^
@@ -205,8 +205,8 @@ cmake ^
   -D CMAKE_CXX_COMPILER=cl ^
   -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" ^
   -D CMAKE_MT=mt ^
-  -D CMAKE_Swift_COMPILER=%BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Toolchains/0.0.0+Asserts/usr/bin/swiftc.exe ^
-  -D CMAKE_Swift_FLAGS="-sdk %BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
+  -D CMAKE_Swift_COMPILER=%BuildRoot%/toolchains/5.9.0/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe ^
+  -D CMAKE_Swift_FLAGS="-sdk %BuildRoot%/toolchains/5.9.0/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
   -D CMAKE_EXE_LINKER_FLAGS="/INCREMENTAL:NO" ^
   -D CMAKE_SHARED_LINKER_FLAGS="/INCREMENTAL:NO" ^
   -D CMAKE_Swift_FLAGS_RELEASE="-O" ^
@@ -236,8 +236,8 @@ cmake ^
 
   -D CMAKE_INSTALL_PREFIX="%InstallRoot%" ^
 
-  -D CMAKE_Swift_COMPILER="%BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Toolchains/0.0.0+Asserts/usr/bin/swiftc.exe" ^
-  -D CMAKE_Swift_FLAGS="-sdk %BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
+  -D CMAKE_Swift_COMPILER="%BuildRoot%/toolchains/5.9.0/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe" ^
+  -D CMAKE_Swift_FLAGS="-sdk %BuildRoot%/toolchains/5.9.0/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
 
   -D LLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-windows-msvc ^
 
@@ -265,7 +265,7 @@ cmake ^
   -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE="%SourceRoot%\swift-corelibs-libdispatch" ^
   -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE="%SourceRoot%\swift-syntax" ^
   -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=%SourceRoot%\swift-experimental-string-processing ^
-  -D SWIFT_PATH_TO_SWIFT_SDK="%BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
+  -D SWIFT_PATH_TO_SWIFT_SDK="%BuildRoot%/toolchains/5.9.0/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
 
   -G Ninja ^
   -S llvm-project\llvm || (exit /b)
@@ -866,12 +866,14 @@ endlocal
 :FetchX64Toolchain
 setlocal enableextensions enabledelayedexpansion
 
-curl.exe -k -sOL "https://github.com/thebrowsercompany/swift-build/releases/download/20230919.2/installer-amd64.exe" || (exit /b)
-"WiX-4.0.1\tools\net6.0\any\wix.exe" burn extract installer-amd64.exe -o %BuildRoot%\toolchains || (exit /b)
-msiexec.exe /qn /a "%BuildRoot%\toolchains\a0" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\PFiles64\Swift\Runtimes\0.0.0\usr\bin\" || (exit /b)
-msiexec.exe /qn /a "%BuildRoot%\toolchains\a1" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)
-msiexec.exe /qn /a "%BuildRoot%\toolchains\a2" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)
-msiexec.exe /qn /a "%BuildRoot%\toolchains\a5" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)
+curl.exe -k -sOL "https://download.swift.org/swift-5.9-release/windows10/swift-5.9-RELEASE/swift-5.9-RELEASE-windows10.exe" || (exit /b)
+"WiX-4.0.1\tools\net6.0\any\wix.exe" burn extract swift-5.9-RELEASE-windows10.exe -o %BuildRoot%\toolchains || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a0" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a1" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a2" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a3" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a4" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a5" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
 
 goto :eof
 endlocal

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -872,8 +872,6 @@ msiexec.exe /qn /a "%BuildRoot%\toolchains\a0" TARGETDIR="%BuildRoot%\toolchains
 msiexec.exe /qn /a "%BuildRoot%\toolchains\a1" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
 msiexec.exe /qn /a "%BuildRoot%\toolchains\a2" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
 msiexec.exe /qn /a "%BuildRoot%\toolchains\a3" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
-msiexec.exe /qn /a "%BuildRoot%\toolchains\a4" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
-msiexec.exe /qn /a "%BuildRoot%\toolchains\a5" TARGETDIR="%BuildRoot%\toolchains\5.9.0\" || (exit /b)
 
 goto :eof
 endlocal

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -882,6 +882,7 @@ setlocal enableextensions enabledelayedexpansion
 :: Test Swift
 :: TODO(compnerd) make lit adjust the path properly
 path %BuildRoot%\3;%BuildRoot%\1\bin;%PATH%;%SystemDrive%\Program Files\Git\usr\bin
+tree %BuildRoot%\1\tools\swift\unittests\SourceKit\SwiftLang\CMakeFiles\SourceKitSwiftLangTests.dir
 cmake --build %BuildRoot%\1 --target check-swift || (exit /b)
 
 goto :eof

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -18,7 +18,10 @@ set ProductTag=
 :: Identify the SourceRoot
 :: Normalize the SourceRoot to make it easier to read the output.
 cd %~dp0\..\..
-set SourceRoot=%CD%
+subst S: /d
+subst S: . || (exit /b)
+set SourceRoot=S:
+cd /d %SourceRoot%
 
 :: Identify the BuildRoot
 set BuildRoot=%SourceRoot%\build
@@ -882,7 +885,6 @@ setlocal enableextensions enabledelayedexpansion
 :: Test Swift
 :: TODO(compnerd) make lit adjust the path properly
 path %BuildRoot%\3;%BuildRoot%\1\bin;%PATH%;%SystemDrive%\Program Files\Git\usr\bin
-tree %BuildRoot%\1\tools\swift\unittests\SourceKit\SwiftLang\CMakeFiles\SourceKitSwiftLangTests.dir
 cmake --build %BuildRoot%\1 --target check-swift || (exit /b)
 
 goto :eof

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -54,6 +54,8 @@ del /f /q "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
 del /f /q "%VCToolsInstallDir%\include\module.modulemap"
 del /f /q "%VCToolsInstallDir%\include\vcruntime.apinotes"
 
+call :FetchWiX || (exit /b)
+call :FetchX64Toolchain || (exit /b)
 call :CloneDependencies || (exit /b)
 call :CloneRepositories || (exit /b)
 
@@ -190,6 +192,33 @@ cmake ^
 cmake --build "%BuildRoot%\curl" || (exit /b)
 cmake --build "%BuildRoot%\curl" --target install || (exit /b)
 
+path %BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\PFiles64\Swift\Runtimes\0.0.0\usr\bin;%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\PFiles64\Swift\Toolchains\0.0.0+Asserts\usr\bin;%Path%
+
+:: Build Swift Syntax
+cmake ^
+  -B "%BuildRoot%\99" ^
+
+  -D BUILD_SHARED_LIBS=YES ^
+  -D CMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
+  -D CMAKE_C_COMPILER=cl.exe ^
+  -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" ^
+  -D CMAKE_CXX_COMPILER=cl ^
+  -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" ^
+  -D CMAKE_MT=mt ^
+  -D CMAKE_Swift_COMPILER=%BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Toolchains/0.0.0+Asserts/usr/bin/swiftc.exe ^
+  -D CMAKE_Swift_FLAGS="-sdk %BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
+  -D CMAKE_EXE_LINKER_FLAGS="/INCREMENTAL:NO" ^
+  -D CMAKE_SHARED_LINKER_FLAGS="/INCREMENTAL:NO" ^
+
+  -D CMAKE_INSTALL_PREFIX="%InstallRoot%" ^
+
+  -D SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26=YES ^
+
+  -G Ninja ^
+  -S %SourceRoot%\swift-syntax || (exit /b)
+cmake --build %BuildRoot%\99 || (exit /b)
+cmake --build %BuildRoot%\99 --target install || (exit /b)
+
 :: Build Toolchain
 cmake ^
   -B "%BuildRoot%\1" ^
@@ -207,11 +236,17 @@ cmake ^
 
   -D CMAKE_INSTALL_PREFIX="%InstallRoot%" ^
 
+  -D CMAKE_Swift_COMPILER="%BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Toolchains/0.0.0+Asserts/usr/bin/swiftc.exe" ^
+  -D CMAKE_Swift_FLAGS="-sdk %BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
+
   -D LLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-windows-msvc ^
 
   -D PACKAGE_VENDOR="swift.org" ^
   -D CLANG_VENDOR="swift.org" ^
   -D CLANG_VENDOR_UTI="org.swift" ^
+  -D LLDB_PYTHON_EXE_RELATIVE_PATH=python.exe ^
+  -D LLDB_PYTHON_EXT_SUFFIX=.pyd ^
+  -D LLDB_PYTHON_RELATIVE_PATH=lib/site-packages ^
   -D LLVM_APPEND_VC_REV=NO ^
   -D LLVM_VERSION_SUFFIX="" ^
 
@@ -226,9 +261,11 @@ cmake ^
   -D LLVM_EXTERNAL_CMARK_SOURCE_DIR="%SourceRoot%\cmark" ^
   -D PYTHON_HOME=%PYTHON_HOME% ^
   -D PYTHON_EXECUTABLE=%PYTHON_HOME%\python.exe ^
+  -D SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR="%BuildRoot%\99" ^
   -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE="%SourceRoot%\swift-corelibs-libdispatch" ^
   -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE="%SourceRoot%\swift-syntax" ^
   -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=%SourceRoot%\swift-experimental-string-processing ^
+  -D SWIFT_PATH_TO_SWIFT_SDK="%BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
 
   -G Ninja ^
   -S llvm-project\llvm || (exit /b)
@@ -811,6 +848,30 @@ git clone --quiet --no-tags --depth 1 --branch v2.9.12 https://github.com/gnome/
 git clone --quiet --no-tags --depth 1 --branch version-3.36.0 https://github.com/sqlite/sqlite
 git clone --quiet --no-tags --depth 1 --branch maint/maint-69 https://github.com/unicode-org/icu
 git clone --quiet --no-tags --depth 1 --branch curl-7_77_0 https://github.com/curl/curl
+
+goto :eof
+endlocal
+
+:FetchWiX
+setlocal enableextensions enabledelayedexpansion
+
+curl.exe -sL https://www.nuget.org/api/v2/package/wix/4.0.1 -o wix-4.0.1.zip
+md WiX-4.0.1 || exit (/b)
+cd WiX-4.0.1 || exit (/b)
+tar -xf ../wix-4.0.1.zip || exit (/b)
+
+goto :eof
+endlocal
+
+:FetchX64Toolchain
+setlocal enableextensions enabledelayedexpansion
+
+curl.exe -k -sOL "https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a-windows10.exe" || (exit /b)
+"WiX-4.0.1\tools\net6.0\any\wix.exe" burn extract swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a-windows10.exe -o %BuildRoot%\toolchains || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a0" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\PFiles64\Swift\Runtimes\0.0.0\usr\bin\" || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a1" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a2" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)
+msiexec.exe /qn /a "%BuildRoot%\toolchains\a5" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)
 
 goto :eof
 endlocal

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -209,10 +209,10 @@ cmake ^
   -D CMAKE_Swift_FLAGS="-sdk %BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
   -D CMAKE_EXE_LINKER_FLAGS="/INCREMENTAL:NO" ^
   -D CMAKE_SHARED_LINKER_FLAGS="/INCREMENTAL:NO" ^
+  -D CMAKE_Swift_FLAGS_RELEASE="-O" ^
+  -D CMAKE_Swift_FLAGS_RELWITHDEBINFO="-O" ^
 
   -D CMAKE_INSTALL_PREFIX="%InstallRoot%" ^
-
-  -D SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26=YES ^
 
   -G Ninja ^
   -S %SourceRoot%\swift-syntax || (exit /b)

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -265,7 +265,7 @@ cmake ^
   -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE="%SourceRoot%\swift-corelibs-libdispatch" ^
   -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE="%SourceRoot%\swift-syntax" ^
   -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=%SourceRoot%\swift-experimental-string-processing ^
-  -D SWIFT_PATH_TO_SWIFT_SDK="%BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk"
+  -D SWIFT_PATH_TO_SWIFT_SDK="%BuildRoot%/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/PFiles64/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
 
   -G Ninja ^
   -S llvm-project\llvm || (exit /b)

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -866,7 +866,7 @@ endlocal
 :FetchX64Toolchain
 setlocal enableextensions enabledelayedexpansion
 
-curl.exe -k -sOL "https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a-windows10.exe" || (exit /b)
+curl.exe -k -sOL "https://github.com/thebrowsercompany/swift-build/releases/download/20230919.2/installer-amd64.exe" || (exit /b)
 "WiX-4.0.1\tools\net6.0\any\wix.exe" burn extract swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a-windows10.exe -o %BuildRoot%\toolchains || (exit /b)
 msiexec.exe /qn /a "%BuildRoot%\toolchains\a0" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\PFiles64\Swift\Runtimes\0.0.0\usr\bin\" || (exit /b)
 msiexec.exe /qn /a "%BuildRoot%\toolchains\a1" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -867,7 +867,7 @@ endlocal
 setlocal enableextensions enabledelayedexpansion
 
 curl.exe -k -sOL "https://github.com/thebrowsercompany/swift-build/releases/download/20230919.2/installer-amd64.exe" || (exit /b)
-"WiX-4.0.1\tools\net6.0\any\wix.exe" burn extract swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a-windows10.exe -o %BuildRoot%\toolchains || (exit /b)
+"WiX-4.0.1\tools\net6.0\any\wix.exe" burn extract installer-amd64.exe -o %BuildRoot%\toolchains || (exit /b)
 msiexec.exe /qn /a "%BuildRoot%\toolchains\a0" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\PFiles64\Swift\Runtimes\0.0.0\usr\bin\" || (exit /b)
 msiexec.exe /qn /a "%BuildRoot%\toolchains\a1" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)
 msiexec.exe /qn /a "%BuildRoot%\toolchains\a2" TARGETDIR="%BuildRoot%\toolchains\swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a\" || (exit /b)


### PR DESCRIPTION
Use WiX to extract a future toolchain to allow building the macros support when building the toolchain. We build swift-syntax and now wire that into the build itself.