### PR TITLE
[wasm] Add `@_expose(wasm)` attribute for top-level functions

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -427,6 +427,16 @@ in the generated C++ binding header.
 The optional "cxxName" string will be used as the name of
 the generated C++ declaration.
 
+### `_expose(wasm[, <"wasmExportName">])`
+
+Indicates that a particular function declaration should be
+exported from the linked WebAssembly.
+
+The optional "wasmExportName" string will be used as the
+the export name.
+
+It's the equivalent of clang's `__attribute__((export_name))`.
+
 ## `@_fixed_layout`
 
 Same as `@frozen` but also works for classes.

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -398,7 +398,7 @@ SIMPLE_DECL_ATTR(_alwaysEmitConformanceMetadata, AlwaysEmitConformanceMetadata,
   OnProtocol | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   132)
 DECL_ATTR(_expose, Expose,
-  OnFunc | OnNominalType | OnVar | OnConstructor | LongAttribute | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  OnFunc | OnNominalType | OnVar | AllowMultipleAttributes | OnConstructor | LongAttribute | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   133)
 SIMPLE_DECL_ATTR(_spiOnly, SPIOnly,
   OnImport | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -172,6 +172,10 @@ protected:
       kind : 1
     );
 
+    SWIFT_INLINE_BITFIELD(ExposeAttr, DeclAttribute, NumExposureKindBits,
+      kind : NumExposureKindBits
+    );
+
     SWIFT_INLINE_BITFIELD(SynthesizedProtocolAttr, DeclAttribute, 1,
       isUnchecked : 1
     );
@@ -2309,14 +2313,22 @@ public:
 /// header used by C/C++ to interoperate with Swift.
 class ExposeAttr : public DeclAttribute {
 public:
-  ExposeAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
-      : DeclAttribute(DAK_Expose, AtLoc, Range, Implicit), Name(Name) {}
+  ExposeAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range,
+             ExposureKind Kind, bool Implicit)
+      : DeclAttribute(DAK_Expose, AtLoc, Range, Implicit), Name(Name) {
+    Bits.ExposeAttr.kind = static_cast<unsigned>(Kind);
+  }
 
-  ExposeAttr(StringRef Name, bool Implicit)
-      : ExposeAttr(Name, SourceLoc(), SourceRange(), Implicit) {}
+  ExposeAttr(StringRef Name, ExposureKind Kind, bool Implicit)
+      : ExposeAttr(Name, SourceLoc(), SourceRange(), Kind, Implicit) {}
 
   /// The exposed declaration name.
   const StringRef Name;
+
+  /// Returns the kind of exposure.
+  ExposureKind getExposureKind() const {
+    return static_cast<ExposureKind>(Bits.ExposeAttr.kind);
+  }
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Expose;

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -102,6 +102,15 @@ enum class EffectsKind : uint8_t {
 enum : unsigned { NumEffectsKindBits =
   countBitsUsed(static_cast<unsigned>(EffectsKind::Last_EffectsKind)) };
 
+/// This enum represents the possible values of the @_expose attribute.
+enum class ExposureKind: uint8_t {
+  Cxx,
+  Wasm,
+  Last_ExposureKind = Wasm
+};
+
+enum : unsigned { NumExposureKindBits =
+  countBitsUsed(static_cast<unsigned>(ExposureKind::Last_ExposureKind)) };
   
 enum DeclAttrKind : unsigned {
 #define DECL_ATTR(_, NAME, ...) DAK_##NAME,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1838,6 +1838,9 @@ ERROR(section_not_at_top_level,none,
 ERROR(section_empty_name,none,
       "@_section section name cannot be empty", ())
 
+ERROR(expose_wasm_not_at_top_level_func,none,
+      "@_expose attribute with 'wasm' can only be applied to global functions", ())
+
 ERROR(expose_only_non_other_attr,none,
       "@_expose attribute cannot be applied to an '%0' declaration", (StringRef))
 ERROR(expose_inside_unexposed_decl,none,

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -299,6 +299,10 @@ private:
   /// Name of a section if @_section attribute was used, otherwise empty.
   StringRef Section;
 
+  /// Name of a Wasm export if @_expose(wasm) attribute was used, otherwise
+  /// empty.
+  StringRef WasmExportName;
+
   /// Has value if there's a profile for this function
   /// Contains Function Entry Count
   ProfileCounter EntryCount;
@@ -1263,6 +1267,10 @@ public:
   /// Return custom section name if @_section was used, otherwise empty
   StringRef section() const { return Section; }
   void setSection(StringRef value) { Section = value; }
+
+  /// Return Wasm export name if @_expose(wasm) was used, otherwise empty
+  StringRef wasmExportName() const { return WasmExportName; }
+  void setWasmExportName(StringRef value) { WasmExportName = value; }
 
   /// Returns true if this function belongs to a declaration that returns
   /// an opaque result type with one or more availability conditions that are

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1122,14 +1122,22 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     Printer << "@_cdecl(\"" << cast<CDeclAttr>(this)->Name << "\")";
     break;
 
-  case DAK_Expose:
+  case DAK_Expose: {
     Printer.printAttrName("@_expose");
-    Printer << "(Cxx";
+    auto Attr = cast<ExposeAttr>(this);
+    switch (Attr->getExposureKind()) {
+    case ExposureKind::Wasm:
+      Printer << "(wasm";
+      break;
+    case ExposureKind::Cxx:
+      Printer << "(Cxx";
+      break;
+    }
     if (!cast<ExposeAttr>(this)->Name.empty())
       Printer << ", \"" << cast<ExposeAttr>(this)->Name << "\"";
     Printer << ")";
     break;
-
+  }
   case DAK_Section:
     Printer.printAttrName("@_section");
     Printer << "(\"" << cast<SectionAttr>(this)->Name << "\")";

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -158,9 +158,9 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
                                       CustomNamesOnly_t customNamesOnly) {
   ASTContext& ctx = VD->getASTContext();
 
-  if (const auto *Expose = VD->getAttrs().getAttribute<ExposeAttr>()) {
-    if (Expose->getExposureKind() == ExposureKind::Cxx && !Expose->Name.empty())
-      return Expose->Name;
+  for (auto *EA : VD->getAttrs().getAttributes<ExposeAttr>()) {
+    if (EA->getExposureKind() == ExposureKind::Cxx && !EA->Name.empty())
+      return EA->Name;
   }
 
   if (customNamesOnly)

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -159,7 +159,7 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
   ASTContext& ctx = VD->getASTContext();
 
   if (const auto *Expose = VD->getAttrs().getAttribute<ExposeAttr>()) {
-    if (!Expose->Name.empty())
+    if (Expose->getExposureKind() == ExposureKind::Cxx && !Expose->Name.empty())
       return Expose->Name;
   }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3554,6 +3554,11 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
     addUsedGlobal(fn);
   if (!f->section().empty())
     fn->setSection(f->section());
+  if (!f->wasmExportName().empty()) {
+    llvm::AttrBuilder attrBuilder(getLLVMContext());
+    attrBuilder.addAttribute("wasm-export-name", f->wasmExportName());
+    fn->addFnAttrs(attrBuilder);
+  }
 
   // If `hasCReferences` is true, then the function is either marked with
   // @_silgen_name OR @_cdecl.  If it is the latter, it must have a definition

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2825,8 +2825,10 @@ static bool hasExposeAttr(const ValueDecl *VD, bool isExtension = false) {
   // Clang decls don't need to be explicitly exposed.
   if (VD->hasClangNode())
     return true;
-  if (VD->getAttrs().hasAttribute<ExposeAttr>())
-    return true;
+  if (auto *EA = VD->getAttrs().getAttribute<ExposeAttr>()) {
+    if (EA->getExposureKind() == ExposureKind::Cxx)
+      return true;
+  }
   if (const auto *NMT = dyn_cast<NominalTypeDecl>(VD->getDeclContext()))
     return hasExposeAttr(NMT);
   if (const auto *ED = dyn_cast<ExtensionDecl>(VD->getDeclContext())) {

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2825,7 +2825,7 @@ static bool hasExposeAttr(const ValueDecl *VD, bool isExtension = false) {
   // Clang decls don't need to be explicitly exposed.
   if (VD->hasClangNode())
     return true;
-  if (auto *EA = VD->getAttrs().getAttribute<ExposeAttr>()) {
+  for (auto *EA : VD->getAttrs().getAttributes<ExposeAttr>()) {
     if (EA->getExposureKind() == ExposureKind::Cxx)
       return true;
   }

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -218,7 +218,7 @@ void SILFunctionBuilder::addFunctionAttributes(
   if (Attrs.hasAttribute<SILGenNameAttr>() || Attrs.hasAttribute<CDeclAttr>())
     F->setHasCReferences(true);
 
-  if (auto *EA = Attrs.getAttribute<ExposeAttr>()) {
+  for (auto *EA : Attrs.getAttributes<ExposeAttr>()) {
     bool shouldExportDecl = true;
     if (Attrs.hasAttribute<CDeclAttr>()) {
       // If the function is marked with @cdecl, expose only C compatible

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5795,10 +5795,11 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
       }
 
       case decls_block::Expose_DECL_ATTR: {
+        unsigned kind;
         bool isImplicit;
         serialization::decls_block::ExposeDeclAttrLayout::readRecord(
-            scratch, isImplicit);
-        Attr = new (ctx) ExposeAttr(blobData, isImplicit);
+            scratch, kind, isImplicit);
+        Attr = new (ctx) ExposeAttr(blobData, (ExposureKind)kind, isImplicit);
         break;
       }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 807; // keypath accessor
+const uint16_t SWIFTMODULE_VERSION_MINOR = 808; // @_expose(wasm)
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2317,6 +2317,7 @@ namespace decls_block {
   >;
 
   using ExposeDeclAttrLayout = BCRecordLayout<Expose_DECL_ATTR,
+                                              BCFixed<1>, // exposure kind
                                               BCFixed<1>, // implicit flag
                                               BCBlob      // declaration name
                                               >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3092,7 +3092,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto *theAttr = cast<ExposeAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[ExposeDeclAttrLayout::Code];
       ExposeDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                       theAttr->isImplicit(), theAttr->Name);
+                                       (unsigned)theAttr->getExposureKind(), theAttr->isImplicit(), theAttr->Name);
       return;
     }
 

--- a/test/Interop/WebAssembly/expose-swift-decls-to-wasm.swift
+++ b/test/Interop/WebAssembly/expose-swift-decls-to-wasm.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -emit-ir -module-name Expose | %FileCheck %s
+
+import Swift
+
+// CHECK: define{{.*}} swiftcc void @"$s6Expose8exposed1yyF"() [[EA1:#[0-9]+]]
+@_expose(wasm)
+public func exposed1() {
+}
+
+// CHECK: define{{.*}} swiftcc void @"$s6Expose18exposed2NotExposedyyF"() [[DEFAULT_A:#[0-9]+]]
+public func exposed2NotExposed() {
+}
+
+// CHECK: define{{.*}} swiftcc void @"$s6Expose22exposed3WithCustomNameyyF"() [[EA3:#[0-9]+]]
+@_expose(wasm, "exposed3_with_custom_name")
+public func exposed3WithCustomName() {
+}
+
+
+// CHECK: define{{.*}} swiftcc void @"$s6Expose17exposed4NonCIdentyyF"() [[EA4:#[0-9]+]]
+@_expose(wasm, "exposed4-non-c-ident")
+public func exposed4NonCIdent() {
+}
+
+// CHECK: define{{.*}} swiftcc i32 @"$s6Expose17exposed5ReturnInts5Int32VyF"() [[EA5:#[0-9]+]]
+@_expose(wasm)
+public func exposed5ReturnInt() -> Int32 {
+  return 0
+}
+
+// If @_cdecl is applied at the same time as @_expose, expose C thunk instead of Swift function.
+// CHECK: define{{.*}} void @exposed6WithCDecl() [[EA6:#[0-9]+]]
+// CHECK: define{{.*}} swiftcc void @"$s6Expose17exposed6WithCDeclyyF"() [[DEFAULT:#[0-9]+]]
+@_expose(wasm)
+@_cdecl("exposed6WithCDecl")
+public func exposed6WithCDecl() {
+}
+
+// CHECK: define{{.*}} void @exposed7WithCDecl() [[EA7:#[0-9]+]]
+// CHECK: define{{.*}} swiftcc void @"$s6Expose018exposed7WithCDecl_C13DifferentNameyyF"() [[DEFAULT_A:#[0-9]+]]
+@_expose(wasm, "exposed7WithCDecl:WithDifferentName")
+@_cdecl("exposed7WithCDecl")
+public func exposed7WithCDecl_WithDifferentName() {
+}
+
+// CHECK-NOT: attributes [[DEFAULT_A]] = {{.*}} "wasm-export-name"="{{.*}}"
+// CHECK: attributes [[EA1]] = {{{.*}} "wasm-export-name"="$s6Expose8exposed1yyF" {{.*}}}
+// CHECK-NOT: attributes {{.*}} = {{{.*}} "wasm-export-name"="$s6Expose18exposed2NotExposedyyF" {{.*}}}
+// CHECK: attributes [[EA3]] = {{{.*}} "wasm-export-name"="exposed3_with_custom_name" {{.*}}}
+// CHECK: attributes [[EA4]] = {{{.*}} "wasm-export-name"="exposed4-non-c-ident" {{.*}}}
+// CHECK: attributes [[EA5]] = {{{.*}} "wasm-export-name"="$s6Expose17exposed5ReturnInts5Int32VyF" {{.*}}}
+// CHECK: attributes [[EA6]] = {{{.*}} "wasm-export-name"="exposed6WithCDecl" {{.*}}}
+// CHECK: attributes [[EA7]] = {{{.*}} "wasm-export-name"="exposed7WithCDecl:WithDifferentName" {{.*}}}

--- a/test/attr/attr_expose.swift
+++ b/test/attr/attr_expose.swift
@@ -33,6 +33,9 @@ struct ExposedStruct {
     @_expose(Cxx, "initWith")
     init(with y: Int) {}
 }
+@_expose(Cxx)
+@_expose(Cxx) // expected-error {{duplicate attribute}}
+func exposeToCxxCxx() {}
 
 @_expose(wasm) func exposeToWasm() {}
 @_expose(wasm, "with_name") func wasmName() {}
@@ -47,3 +50,14 @@ func wasmNested() {
   func errorOnInnerExpose() {}
 }
 
+@_expose(Cxx)
+@_expose(wasm)
+func exposeToCxxWasm() {}
+
+@_expose(wasm)
+@_expose(Cxx)
+func exposeToWasmCxx() {}
+
+@_expose(wasm)
+@_expose(wasm) // expected-error {{duplicate attribute}}
+func exposeToWasmWasm() {}

--- a/test/attr/attr_expose.swift
+++ b/test/attr/attr_expose.swift
@@ -33,3 +33,17 @@ struct ExposedStruct {
     @_expose(Cxx, "initWith")
     init(with y: Int) {}
 }
+
+@_expose(wasm) func exposeToWasm() {}
+@_expose(wasm, "with_name") func wasmName() {}
+@_expose(wasm, "") func wasmEmptyNameOk() {}
+
+@_expose(wasm) struct WasmErrorOnStruct { // expected-error {{@_expose attribute with 'wasm' can only be applied to global functions}}
+  @_expose(wasm) func errorOnMethod() {} // expected-error {{@_expose attribute with 'wasm' can only be applied to global functions}}
+}
+
+func wasmNested() {
+  @_expose(wasm) // expected-error {{attribute '_expose' can only be used in a non-local scope}}
+  func errorOnInnerExpose() {}
+}
+


### PR DESCRIPTION
Today, there is no way to create an ["export"](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-export) from Swift. (The current workaround is using `@_cdecl` and linker option, or linking C source[^1]).

This PR adds a new variant of `@_expose` attribute with `wasm` parameter (and optionally with custom name).
This attribute instructs the compiler that this function declaration should be "export"ed from this .wasm module. It's equivalent of Clang's [`__attribute__((export_name("name")))`](https://clang.llvm.org/docs/AttributeReference.html#export-name)

The attribute doesn't have any effect on to function signature and calling convention but only adds LLVM meta attribute to the function. If it's applied with `@_cdecl` at the same time, only C thunk is exported.

Radar: rdar://115502069
[^1]: https://book.swiftwasm.org/examples/exporting-function.html