### PR TITLE
Emit diagnostics/remarks out of wrapped ModularizationError

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7518,9 +7518,9 @@ ModuleFile::getClangType(ClangTypeID TID) {
   return clangType;
 }
 
-Decl *handleErrorAndSupplyMissingClassMember(ASTContext &context,
-                                             llvm::Error &&error,
-                                             ClassDecl *containingClass) {
+Decl *ModuleFile::handleErrorAndSupplyMissingClassMember(
+    ASTContext &context, llvm::Error &&error,
+    ClassDecl *containingClass) const {
   Decl *suppliedMissingMember = nullptr;
   auto handleMissingClassMember = [&](const DeclDeserializationError &error) {
     if (error.isDesignatedInitializer())
@@ -7534,7 +7534,26 @@ Decl *handleErrorAndSupplyMissingClassMember(ASTContext &context,
         error.getNumberOfVTableEntries(),
         error.needsFieldOffsetVectorEntry());
   };
-  llvm::handleAllErrors(std::move(error), handleMissingClassMember);
+
+  // Emit the diagnostics/remarks out of the ModularizationError
+  // wrapped in a TypeError (eg. coming from resolveCrossReference),
+  // which is otherwise just dropped but could help better understand
+  // C/C++ interop issues.
+  assert(context.LangOpts.EnableDeserializationRecovery);
+  auto handleModularizationError = [&](ModularizationError &error)
+      -> llvm::Error {
+    if (context.LangOpts.EnableModuleRecoveryRemarks)
+      error.diagnose(this, DiagnosticBehavior::Remark);
+    return llvm::Error::success();
+  };
+  auto handleTypeError = [&](TypeError &typeError) {
+    handleMissingClassMember(typeError);
+    typeError.diagnoseUnderlyingReason(handleModularizationError);
+    if (context.LangOpts.EnableModuleRecoveryRemarks)
+      typeError.diagnose(this);
+  };
+  llvm::handleAllErrors(std::move(error), handleTypeError,
+      handleMissingClassMember);
   return suppliedMissingMember;
 }
 

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -349,6 +349,9 @@ private:
   Decl *handleErrorAndSupplyMissingMember(ASTContext &context,
                                           Decl *container,
                                           llvm::Error &&error) const;
+  Decl *handleErrorAndSupplyMissingClassMember(
+      ASTContext &context, llvm::Error &&error,
+      ClassDecl *containingClass) const;
 
 public:
   /// Change the status of the current module.

--- a/test/Serialization/Inputs/wrapped-modularization-error-remarks/A/A.swift
+++ b/test/Serialization/Inputs/wrapped-modularization-error-remarks/A/A.swift
@@ -1,0 +1,7 @@
+import CxxLib
+
+open class Window {
+    open func queryInterface(_ iid: IID) -> Int32? {
+        return nil
+    }
+}

--- a/test/Serialization/Inputs/wrapped-modularization-error-remarks/B/B.swift
+++ b/test/Serialization/Inputs/wrapped-modularization-error-remarks/B/B.swift
@@ -1,0 +1,4 @@
+import A
+
+public class CustomWindow: Window {
+}

--- a/test/Serialization/Inputs/wrapped-modularization-error-remarks/CxxLib/include/CxxLib.h
+++ b/test/Serialization/Inputs/wrapped-modularization-error-remarks/CxxLib/include/CxxLib.h
@@ -1,0 +1,10 @@
+#ifndef GUID_DEFINED
+#define GUID_DEFINED
+typedef struct _GUID {
+} GUID;
+#endif
+
+#ifndef __IID_DEFINED__
+#define __IID_DEFINED__
+typedef GUID IID;
+#endif

--- a/test/Serialization/Inputs/wrapped-modularization-error-remarks/CxxLib/include/module.modulemap
+++ b/test/Serialization/Inputs/wrapped-modularization-error-remarks/CxxLib/include/module.modulemap
@@ -1,0 +1,5 @@
+module CxxLib {
+  header "CxxLib.h"
+
+  export *
+}

--- a/test/Serialization/wrapped-modularization-error-remarks.swift
+++ b/test/Serialization/wrapped-modularization-error-remarks.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/wrapped-modularization-error-remarks/A/A.swift -cxx-interoperability-mode=default -Xcc -fmodule-map-file=%S/Inputs/wrapped-modularization-error-remarks/CxxLib/include/module.modulemap -Xcc -I -Xcc %S/Inputs/wrapped-modularization-error-remarks/CxxLib/include -module-name A -o %t/A.swiftmodule
+// RUN: not %target-swift-frontend -c -primary-file %S/Inputs/wrapped-modularization-error-remarks/B/B.swift -cxx-interoperability-mode=default -I %t -Xcc -fmodule-map-file=%S/Inputs/wrapped-modularization-error-remarks/CxxLib/include/module.modulemap -Xcc -I -Xcc %S/Inputs/wrapped-modularization-error-remarks/CxxLib/include -module-name B -o %t/B.swift.o -Rmodule-recovery 2>&1 | %FileCheck %s
+// REQUIRES: OS=windows-msvc
+
+// Check that the diagnostics/remark from the wrapped ModularizationError is emitted.
+// CHECK: remark: reference to type '_GUID' broken by a context change; '_GUID' is not found, it was expected to be in 'CxxLib'
+// CHECK: note: could not deserialize type for 'queryInterface'
+// CHECK: error: cannot inherit from class 'Window' because it has overridable members that could not be loaded
+// CHECK: note: could not deserialize 'queryInterface'


### PR DESCRIPTION
The diagnostics/remarks out of the ModularizationError wrapped in a TypeError (eg. coming from resolveCrossReference) is otherwise just dropped but could help better understand C/C++ interop issues.
