### PR TITLE
[Reachability] NFC: Distinguish initial blocks from barrier blocks.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -347,6 +347,7 @@ public:
   ///     void visitBarrierInstruction(SILInstruction *)
   ///     void visitBarrierPhi(SILBasicBlock *)
   ///     void visitBarrierBlock(SILBasicBlock *)
+  ///     void visitInitialBlock(SILBasicBlock *)
   /// }
   template <typename Visitor>
   void findBarriers(Visitor &visitor);
@@ -423,6 +424,7 @@ private:
   ///     void visitBarrierInstruction(SILInstruction *)
   ///     void visitBarrierPhi(SILBasicBlock *)
   ///     void visitBarrierBlock(SILBasicBlock *)
+  ///     void visitInitialBlock(SILBasicBlock *)
   /// }
   template <typename Visitor>
   bool findBarrier(SILInstruction *from, SILBasicBlock *block,
@@ -710,6 +712,10 @@ IterativeBackwardReachability<Effects>::meetOverSuccessors(
 ///     /// Additionally, this may be invoked with the effective def block if
 ///     /// no barriers are found between the gens and it.
 ///     void visitBarrierBlock(SILBasicBlock *)
+///
+///     /// Invoked with either the function entry block or one of the specified
+///     /// initial blocks.
+///     void visitInitialBlock(SILBasicBlock *)
 /// }
 template <typename Effects>
 template <typename Visitor>
@@ -765,6 +771,10 @@ void IterativeBackwardReachability<Effects>::findBarriers(Visitor &visitor) {
 ///     /// Additionally, this may be invoked with the effective def block if
 ///     /// no barriers are found between the gens and it.
 ///     void visitBarrierBlock(SILBasicBlock *)
+///
+///     /// Invoked with either the function entry block or one of the specified
+///     /// initial blocks.
+///     void visitInitialBlock(SILBasicBlock *)
 /// }
 template <typename Effects>
 template <typename Visitor>
@@ -793,7 +803,7 @@ bool IterativeBackwardReachability<Effects>::findBarrier(SILInstruction *from,
   }
   assert(result.getEffectForBlock(block) != Effect::Kill());
   if (stopAtBlock(block)) {
-    visitor.visitBarrierBlock(block);
+    visitor.visitInitialBlock(block);
     return true;
   }
   return false;
@@ -921,6 +931,12 @@ struct ReachableBarriers final {
   /// (1) the target block is reachable-at-begin
   /// (2) at least one adjacent edge's target is not reachable-at-begin.
   llvm::SmallVector<SILBasicBlock *, 4> edges;
+
+  /// Terminal blocks that were reached; blocks such that
+  /// (1) the block is reachable-at-begin
+  /// (2) it is either the function's entry block or one of the blocks passed
+  /// to findBarriersBackward's \p initialBlocks parameter.
+  llvm::SmallVector<SILBasicBlock *, 2> initialBlocks;
 
   ReachableBarriers() {}
   ReachableBarriers(ReachableBarriers const &) = delete;

--- a/lib/SILOptimizer/Analysis/Reachability.cpp
+++ b/lib/SILOptimizer/Analysis/Reachability.cpp
@@ -70,6 +70,10 @@ private:
   void visitBarrierBlock(SILBasicBlock *block) {
     barriers.edges.push_back(block);
   }
+
+  void visitInitialBlock(SILBasicBlock *block) {
+    barriers.initialBlocks.push_back(block);
+  }
 };
 
 FindBarriersBackwardDataflow::Effect

--- a/lib/SILOptimizer/Transforms/DestroyAddrHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/DestroyAddrHoisting.cpp
@@ -318,6 +318,10 @@ private:
       result.barrierBlocks.insert(block);
     }
 
+    void visitInitialBlock(SILBasicBlock *block) {
+      result.barrierBlocks.insert(block);
+    }
+
     /// VisitBarrierAccessScopes::Visitor
 
     ArrayRef<SILBasicBlock *> roots();

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -287,16 +287,15 @@ void CanonicalizeOSSALifetime::extendLivenessToDeinitBarriers() {
     }
   }
   for (auto *edge : barriers.edges) {
-    if (edge == getCurrentDef()->getParentBlock()) {
-      // A destroy should be inserted at the begin of this block, but that does
-      // not require adding any instructions to liveness.
-      continue;
-    }
     auto *predecessor = edge->getSinglePredecessorBlock();
     assert(predecessor);
     liveness->updateForUse(&predecessor->back(),
                            /*lifetimeEnding*/ false);
   }
+  // Ignore barriers.initialBlocks.  If the collection is non-empty, it
+  // contains the def-block.  Its presence means that no barriers were found
+  // between lifetime ends and def.  In that case, no new instructions need to
+  // be added to liveness.
 }
 
 // Return true if \p inst is an end_access whose access scope overlaps the end

--- a/lib/SILOptimizer/Utils/LexicalDestroyHoisting.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyHoisting.cpp
@@ -184,6 +184,10 @@ private:
   void visitBarrierBlock(SILBasicBlock *block) {
     barriers.blocks.push_back(block);
   }
+
+  void visitInitialBlock(SILBasicBlock *block) {
+    barriers.blocks.push_back(block);
+  }
 };
 
 Dataflow::Classification

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -213,6 +213,10 @@ private:
   void visitBarrierBlock(SILBasicBlock *block) {
     barriers.blocks.push_back(block);
   }
+
+  void visitInitialBlock(SILBasicBlock *block) {
+    barriers.blocks.push_back(block);
+  }
 };
 
 /// Whether the specified value is %lifetime or its iterated copy_value.


### PR DESCRIPTION
Although by analogy with def instructions as barrier instructions one could understand how a block where the def appears as a phi could be regarded as a barrier block, the analogy is nonobvious.

Reachability knows the difference between an initial block and a barrier block.  Although most current clients don't care about this distinction, one does.  Here, Reachability calls back with visitInitialBlock for the former and visitBarrierBlock for the latter.

Most clients are updated to have the same implementation in both visitBarrierBlock and visitInitialBlock.  The findBarriersBackward client is updated to retain the distinction and pass it on to its clients.  Its one client, CanonicalizeOSSALifetime is updated to have a simpler handling for barrier edges and to ignore the initial blocks.
