### PR TITLE
IRGen: workaround linker failure after rebranch

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1630,6 +1630,9 @@ void AutolinkKind::collectEntriesFromLibraries(
         continue;
       }
       case LibraryKind::Framework: {
+        if (!IGM.Triple.isOSBinFormatMachO())
+          continue;
+
         llvm::Metadata *args[] = {llvm::MDString::get(ctx, "-framework"),
                                   llvm::MDString::get(ctx, linkLib.getName())};
         Entries.insert(llvm::MDNode::get(ctx, args));


### PR DESCRIPTION
When building swift-corelibs-foundation on the rebranch, we see a failure due to the emission of `-framework CoreFoundation` into the linker directive even when building on Windows. Although we use the framework layout to build Foundation against CoreFoundation, the option cannot be emitted into the linker directives due to the option being specific to ld64.  Assume that the option applies to any MachO linker as a heuristic rather than limiting to Apple platforms. This repairs the build of Foundation on Windows.