### PR TITLE
[AST] Add #if _atomicBitWidth as a valid compilation conditional

### DIFF
--- a/include/swift/AST/PlatformConditionKinds.def
+++ b/include/swift/AST/PlatformConditionKinds.def
@@ -46,5 +46,8 @@ PLATFORM_CONDITION(TargetEnvironment, "targetEnvironment")
 /// Pointer authentication enabled
 PLATFORM_CONDITION_(PtrAuth, "ptrauth")
 
+/// The active arch target's max atomic bit width.
+PLATFORM_CONDITION_(AtomicBitWidth, "atomicBitWidth")
+
 #undef PLATFORM_CONDITION
 #undef PLATFORM_CONDITION_

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -677,6 +677,9 @@ namespace swift {
     /// by name.
     bool hasFeature(llvm::StringRef featureName) const;
 
+    /// Sets the "_atomicBitWidth" conditional.
+    void setAtomicBitWidth(llvm::Triple triple);
+
     /// Returns true if the given platform condition argument represents
     /// a supported target operating system.
     ///
@@ -714,7 +717,7 @@ namespace swift {
     }
 
   private:
-    llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 6>
+    llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 10>
         PlatformConditionValues;
     llvm::SmallVector<std::string, 2> CustomConditionalCompilationFlags;
   };

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -107,6 +107,12 @@ static const SupportedConditionalValue SupportedConditionalCompilationPtrAuthSch
   "_arm64e",
 };
 
+static const SupportedConditionalValue SupportedConditionalCompilationAtomicBitWidths[] = {
+  "_32",
+  "_64",
+  "_128"
+};
+
 static const PlatformConditionKind AllPublicPlatformConditionKinds[] = {
 #define PLATFORM_CONDITION(LABEL, IDENTIFIER) PlatformConditionKind::LABEL,
 #define PLATFORM_CONDITION_(LABEL, IDENTIFIER)
@@ -131,6 +137,8 @@ ArrayRef<SupportedConditionalValue> getSupportedConditionalCompilationValues(con
     return SupportedConditionalCompilationTargetEnvironments;
   case PlatformConditionKind::PtrAuth:
     return SupportedConditionalCompilationPtrAuthSchemes;
+  case PlatformConditionKind::AtomicBitWidth:
+    return SupportedConditionalCompilationAtomicBitWidths;
   }
   llvm_unreachable("Unhandled PlatformConditionKind in switch");
 }
@@ -194,6 +202,7 @@ checkPlatformConditionSupported(PlatformConditionKind Kind, StringRef Value,
   case PlatformConditionKind::Runtime:
   case PlatformConditionKind::TargetEnvironment:
   case PlatformConditionKind::PtrAuth:
+  case PlatformConditionKind::AtomicBitWidth:
     return isMatching(Kind, Value, suggestedKind, suggestedValues);
   case PlatformConditionKind::CanImport:
     // All importable names are valid.
@@ -266,6 +275,104 @@ bool LangOptions::hasFeature(llvm::StringRef featureName) const {
     return hasFeature(*feature);
 
   return false;
+}
+
+void LangOptions::setAtomicBitWidth(llvm::Triple triple) {
+  // We really want to use Clang's getMaxAtomicInlineWidth(), but that requires
+  // a Clang::TargetInfo and we're setting up lang opts very early in the
+  // pipeline before any ASTContext or any ClangImporter instance where we can
+  // access the target's info.
+
+  switch (triple.getArch()) {
+  // ARM is only a 32 bit arch and all archs besides the microcontroller profile
+  // ones have double word atomics.
+  case llvm::Triple::ArchType::arm:
+  case llvm::Triple::ArchType::thumb:
+    switch (triple.getSubArch()) {
+    case llvm::Triple::SubArchType::ARMSubArch_v6m:
+    case llvm::Triple::SubArchType::ARMSubArch_v7m:
+      addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_32");
+      break;
+
+    default:
+      addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_64");
+      break;
+    }
+    break;
+
+  // AArch64 (arm64) supports double word atomics on all archs besides the
+  // microcontroller profiles.
+  case llvm::Triple::ArchType::aarch64:
+    switch (triple.getSubArch()) {
+    case llvm::Triple::SubArchType::ARMSubArch_v8m_baseline:
+    case llvm::Triple::SubArchType::ARMSubArch_v8m_mainline:
+    case llvm::Triple::SubArchType::ARMSubArch_v8_1m_mainline:
+      addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_64");
+      break;
+
+    default:
+      addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_128");
+      break;
+    }
+    break;
+
+  // arm64_32 has 32 bit pointer words, but it has the same architecture as
+  // arm64 and supports 128 bit atomics.
+  case llvm::Triple::ArchType::aarch64_32:
+    addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_128");
+    break;
+
+  // PowerPC does not support double word atomics.
+  case llvm::Triple::ArchType::ppc:
+    addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_32");
+    break;
+
+  // All of the 64 bit PowerPC flavors do not support double word atomics.
+  case llvm::Triple::ArchType::ppc64:
+  case llvm::Triple::ArchType::ppc64le:
+    addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_64");
+    break;
+
+  // SystemZ (s390x) does not support double word atomics.
+  case llvm::Triple::ArchType::systemz:
+    addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_64");
+    break;
+
+  // Wasm32 supports double word atomics.
+  case llvm::Triple::ArchType::wasm32:
+    addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_64");
+    break;
+
+  // x86 supports double word atomics.
+  //
+  // Technically, this is incorrect. However, on all x86 platforms where Swift
+  // is deployed this is true.
+  case llvm::Triple::ArchType::x86:
+    addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_64");
+    break;
+
+  // x86_64 supports double word atomics.
+  //
+  // Technically, this is incorrect. However, on all x86_64 platforms where Swift
+  // is deployed this is true. If the ClangImporter ever stops unconditionally
+  // adding '-mcx16' to its Clang instance, then be sure to update this below.
+  case llvm::Triple::ArchType::x86_64:
+    addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_128");
+    break;
+
+  default:
+    // Some exotic architectures may not support atomics at all. If that's the
+    // case please update the switch with your flavor of arch. Otherwise assume
+    // every arch supports at least word atomics.
+
+    if (triple.isArch32Bit()) {
+      addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_32");
+    }
+
+    if (triple.isArch64Bit()) {
+      addPlatformConditionValue(PlatformConditionKind::AtomicBitWidth, "_64");
+    }
+  }
 }
 
 std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
@@ -438,6 +545,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   if (tripleIsMacCatalystEnvironment(Target))
     addPlatformConditionValue(PlatformConditionKind::TargetEnvironment,
                               "macabi");
+
+  // Set the "_atomicBitWidth" platform condition.
+  setAtomicBitWidth(triple);
 
   // If you add anything to this list, change the default size of
   // PlatformConditionValues to not require an extra allocation

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -380,7 +380,7 @@ public:
       return E;
     }
 
-    // ( 'os' | 'arch' | '_endian' | '_pointerBitWidth' | '_runtime' ) '(' identifier ')''
+    // ( 'os' | 'arch' | '_endian' | '_pointerBitWidth' | '_runtime' | '_atomicBitWidth' ) '(' identifier ')''
     auto Kind = getPlatformConditionKind(*KindName);
     if (!Kind.has_value()) {
       D.diagnose(E->getLoc(), diag::unsupported_platform_condition_expression);
@@ -422,6 +422,8 @@ public:
         DiagName = "target environment"; break;
       case PlatformConditionKind::PtrAuth:
         DiagName = "pointer authentication scheme"; break;
+      case PlatformConditionKind::AtomicBitWidth:
+        DiagName = "atomic bit width"; break;
       case PlatformConditionKind::Runtime:
         llvm_unreachable("handled above");
       }

--- a/test/Parse/ConditionalCompilation/aarch64AndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/aarch64AndroidTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(Android) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64)
+#if arch(arm64) && os(Android) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64)
+#if arch(arm64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64)
+#if arch(arm64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armAndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/armAndroidTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(Android) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_32)
+#if arch(arm) && os(Android) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_32) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armIOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armIOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32)
+#if arch(arm) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32)
+#if arch(arm) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32)
+#if arch(i386) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32)
+#if arch(i386) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32)
+#if arch(i386) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_32) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/identifierName.swift
+++ b/test/Parse/ConditionalCompilation/identifierName.swift
@@ -6,10 +6,10 @@ func f2(
   FOO: Int,
   swift: Int, _compiler_version: Int,
   os: Int, arch: Int, _endian: Int, _pointerBitWidth: Int, _runtime: Int,
-  targetEnvironment: Int,
+  targetEnvironment: Int, _atomicBitWidth: Int,
   arm: Int, i386: Int, macOS: Int, OSX: Int, Linux: Int,
   big: Int, little: Int,
-  _32: Int, _64: Int,
+  _32: Int, _64: Int, _128: Int,
   _ObjC: Int, _Native: Int,
   simulator: Int
 ) {
@@ -28,6 +28,8 @@ func f2(
   _ = _runtime + _ObjC + _Native
 #elseif targetEnvironment(simulator)
   _ = targetEnvironment + simulator
+#elseif _atomicBitWidth(_32) && _atomicBitWidth(_64) && _atomicBitWidth(_128)
+  _ = _atomicBitWidth + _32 + _64 + _128
 #elseif swift(>=1.0) && _compiler_version("4.*.0")
   _ = swift + _compiler_version
 #endif
@@ -38,10 +40,10 @@ func f2() {
   let
     FOO = 1, swift = 1, _compiler_version = 1,
     os = 1, arch = 1, _endian = 1, _pointerBitWidth = 1, _runtime = 1,
-    targetEnvironment = 1,
+    targetEnvironment = 1, _atomicBitWidth = 1,
     arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
     big = 1, little = 1,
-    _32 = 1, _64 = 1,
+    _32 = 1, _64 = 1, _128 = 1,
     _ObjC = 1, _Native = 1,
     simulator = 1
 
@@ -59,6 +61,8 @@ func f2() {
   _ = _runtime + _ObjC + _Native
 #elseif targetEnvironment(simulator)
   _ = targetEnvironment + simulator
+#elseif _atomicBitWidth(_32) && _atomicBitWidth(_64) && _atomicBitWidth(_128)
+  _ = _atomicBitWidth + _32 + _64 + _128
 #elseif swift(>=1.0) && _compiler_version("4.*.0")
   _ = swift + _compiler_version
 #endif
@@ -69,7 +73,7 @@ struct S {
   let
     FOO = 1, swift = 1, _compiler_version = 1,
     os = 1, arch = 1, _endian = 1, _pointerBitWidth = 1, _runtime = 1,
-    targetEnvironment = 1,
+    targetEnvironment = 1, _atomicBitWidth = 1,
     arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
     big = 1, little = 1,
     _32 = 1, _64 = 1,
@@ -83,6 +87,7 @@ struct S {
 #elseif _pointerBitWidth(_32) && _pointerBitWidth(_64)
 #elseif _runtime(_ObjC) && _runtime(_Native)
 #elseif targetEnvironment(simulator)
+#elseif _atomicBitWidth(_32) && _atomicBitWidth(_64) && _atomicBitWidth(_128)
 #elseif swift(>=1.0) && _compiler_version("4.*.0")
 #endif
 

--- a/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -target powerpc64-unknown-linux-gnu -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64-unknown-linux-gnu
 
-#if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big) && _pointerBitWidth(_64)
+#if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big) && _pointerBitWidth(_64) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -target powerpc64le-unknown-linux-gnu -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64le-unknown-linux-gnu
 
-#if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64)
+#if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -target s390x-unknown-linux-gnu -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target s390x-unknown-linux-gnu
 
-#if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big) && _pointerBitWidth(_64)
+#if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big) && _pointerBitWidth(_64) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/wasm32Target.swift
+++ b/test/Parse/ConditionalCompilation/wasm32Target.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -target wasm32-unknown-wasi -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename %s -target wasm32-unknown-wasi
 
-#if arch(wasm32) && os(WASI) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_32)
+#if arch(wasm32) && os(WASI) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_32) && _atomicBitWidth(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
@@ -1,6 +1,6 @@
 // RUN: %swift -typecheck %s -verify -target x86_64-unknown-windows-cygnus -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-cygnus
-#if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -target x86_64-unknown-freebsd10 -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-freebsd10
 
-#if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -target x86_64-unknown-linux-gnu -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-linux-gnu
 
-#if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64OSXTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64OSXTarget.swift
@@ -1,14 +1,14 @@
 // RUN: %swift -typecheck %s -verify -target x86_64-apple-macosx10.9 -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-macosx10.9
 
-#if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif
 var y = x
 
 
-#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class CC {}
 var xx = CC()
 #endif

--- a/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -target x86_64-unknown-windows-msvc -disable-objc-interop -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-msvc
 
-#if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
+++ b/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(PS4) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64)
+#if arch(x86_64) && os(PS4) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_64) && _atomicBitWidth(_128)
 class C {}
 var x = C()
 #endif


### PR DESCRIPTION
This adds a new compilation conditional that returns the maximum bit width supported for atomic operations for the compiling architecture.