### PR TITLE
test: Disable access merging optimization test with invariant asserts

### DIFF
--- a/test/SILOptimizer/merge_exclusivity.swift
+++ b/test/SILOptimizer/merge_exclusivity.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -O -enforce-exclusivity=checked -Xllvm -sil-disable-pass=redundant-load-elimination -emit-sil  -primary-file %s | %FileCheck %s --check-prefix=TESTSIL
 // REQUIRES: optimized_stdlib,asserts
+// REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: PTRSIZE=64
 
 public var check: UInt64 = 0


### PR DESCRIPTION
Invariant checks add extra access markers and they made the optimized code different than the expected one and made the test failed. CI presets usually set `--no-swift-stdlib-assertion`, so no effect on CI except for `buildbot_incremental_linux_crosscompile_wasm`.
