### PR TITLE
[5.10] Legacy Driver: Make `--ld-path` option consistently use single dash

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -905,7 +905,7 @@ def use_ld : Joined<["-"], "use-ld=">,
   Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Specifies the flavor of the linker to be used">;
 
-def ld_path : Joined<["--"], "ld-path=">,
+def ld_path : Joined<["-"], "ld-path=">,
   Flags<[HelpHidden, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Specifies the path to the linker to be used">;
 


### PR DESCRIPTION
Cherry-pick of #68495.

The original `--ld-path` option hasn't been included in a released version yet, so it's ok to break.
The vast majority of other options on Swift Driver already use a single dash.
