### PR TITLE
test: adjust test for ce6ae0b2a26b1ec2f770b2b9474cc4486d60c586

### DIFF
--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -38,8 +38,8 @@ public func testCaptureGlobal() {
 
 // CHECK-x86_64-SYSV-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="all"{{.*}}
 // CHECK-x86_64-SYSV-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"frame-pointer"="all" {{.*}}"target-cpu"
-// CHECK-x86_64-WIN-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="none"{{.*}}
-// CHECK-x86_64-WIN-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"frame-pointer"="none" {{.*}}"target-cpu"
+// CHECK-x86_64-WIN-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}
+// CHECK-x86_64-WIN-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"target-cpu"
 
 // CHECK-armv7-SYSV-DAG: attributes [[CLANG_FUNC_ATTR]] = { noinline nounwind {{.*}}"frame-pointer"="all"{{.*}}
 // CHECK-armv7-SYSV-DAG: attributes [[SWIFT_FUNC_ATTR]] = { {{.*}}"frame-pointer"="all" {{.*}}"target-cpu"

--- a/test/IRGen/framepointer.sil
+++ b/test/IRGen/framepointer.sil
@@ -34,7 +34,7 @@ entry(%i : $Int32):
 // CHECK: }
 
 // CHECK-SYSV: attributes [[ATTR]] = { {{.*}}"frame-pointer"="all"
-// CHECK-WIN: attributes [[ATTR]] = { {{.*}}"frame-pointer"="none"
+// CHECK-WIN: attributes [[ATTR]] = { {{.*}}
 
 // CHECK-ALL: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {
 // CHECK-ALL: entry:
@@ -48,7 +48,7 @@ entry(%i : $Int32):
 // CHECK-ALL: }
 
 // CHECK-SYSV-ALL: attributes [[ATTR]] = {{{.*}}"frame-pointer"="all"
-// CHECK-WIN-ALL: attributes [[ATTR]] = {{{.*}}"frame-pointer"="none"
+// CHECK-WIN-ALL: attributes [[ATTR]] = {{{.*}}
 
 // LEAF: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {
 // LEAF: entry:
@@ -62,7 +62,7 @@ entry(%i : $Int32):
 // LEAF: }
 
 // LEAF-SYSV: attributes [[ATTR]] = {{{.*}}"frame-pointer"="non-leaf"
-// LEAF-WIN: attributes [[ATTR]] = {{{.*}}"frame-pointer"="none"
+// LEAF-WIN: attributes [[ATTR]] = {{{.*}}
 
 // NOFP: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {
 // NOFP: entry:
@@ -76,7 +76,7 @@ entry(%i : $Int32):
 // NOFP: }
 
 // The clang frontend's -fomit-frame-pointer no longer leads to frame-pointer=none
-// attributes [[ATTR]] = {{{.*}}"frame-pointer"="none"
+// attributes [[ATTR]] = {{{.*}}
 
 // Silence other os-archs.
 // CHECKASM: {{.*}}


### PR DESCRIPTION
clang will no longer emit the `"frame-pointer"="none"` in IR to reduce the IR traffic.  Adjust expectations accordingly.