### PR TITLE
Keep certain function that are potentially used in the debugger

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -845,6 +845,10 @@ public:
   /// current SILModule.
   bool isPossiblyUsedExternally() const;
 
+  /// Helper method which returns whether this function should be preserved so
+  /// it can potentially be used in the debugger.
+  bool shouldBePreservedForDebugger() const;
+
   /// In addition to isPossiblyUsedExternally() it returns also true if this
   /// is a (private or internal) vtable method which can be referenced by
   /// vtables of derived classes outside the compilation unit.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1252,12 +1252,6 @@ static bool isLazilyEmittedFunction(SILFunction &f, SILModule &m) {
   if (f.getDynamicallyReplacedFunction())
     return false;
 
-  // Needed by lldb to print global variables which are propagated by the
-  // mandatory GlobalOpt.
-  if (m.getOptions().OptMode == OptimizationMode::NoOptimization &&
-      f.isGlobalInit())
-    return false;
-
   return true;
 }
 
@@ -3520,8 +3514,14 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   // Mark as llvm.used if @_used, set section if @_section
   if (f->markedAsUsed())
     addUsedGlobal(fn);
+
   if (!f->section().empty())
     fn->setSection(f->section());
+
+  // Also mark as llvm.used any functions that should be kept for the debugger.
+  // Only definitions should be kept.
+  if (f->shouldBePreservedForDebugger() && !fn->isDeclaration())
+    addUsedGlobal(fn);
 
   // If `hasCReferences` is true, then the function is either marked with
   // @_silgen_name OR @_cdecl.  If it is the latter, it must have a definition

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -862,6 +862,9 @@ SILFunction::isPossiblyUsedExternally() const {
   if (markedAsUsed())
     return true;
 
+  if (shouldBePreservedForDebugger())
+    return true;
+
   // Declaration marked as `@_alwaysEmitIntoClient` that
   // returns opaque result type with availability conditions
   // has to be kept alive to emit opaque type metadata descriptor.
@@ -870,6 +873,35 @@ SILFunction::isPossiblyUsedExternally() const {
     return true;
 
   return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
+}
+
+bool SILFunction::shouldBePreservedForDebugger() const {
+  // Only preserve for the debugger at Onone.
+  if (getEffectiveOptimizationMode() != OptimizationMode::NoOptimization)
+    return false;
+
+  // Only keep functions defined in this module.
+  if (!isDefinition())
+    return false;
+
+  // Needed by lldb to print global variables which are propagated by the
+  // mandatory GlobalOpt.
+  if (isGlobalInit())
+    return true;
+
+  // Preserve any user-written functions.
+  if (auto declContext = getDeclContext())
+    if (auto decl = declContext->getAsDecl())
+      if (!decl->isImplicit())
+        return true;
+
+  // Keep any setters/getters, even compiler generated ones.
+  if (auto *accessorDecl =
+          llvm::dyn_cast_or_null<swift::AccessorDecl>(getDeclContext()))
+    if (accessorDecl->isGetterOrSetter())
+      return true;
+
+  return false;
 }
 
 bool SILFunction::isExternallyUsedSymbol() const {

--- a/test/IRGen/preserve_for_debugger.swift
+++ b/test/IRGen/preserve_for_debugger.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swiftc_driver %s -g -Onone -emit-ir | %FileCheck %s
+
+// Check that unused functions are preserved at Onone.
+func unused() {
+}
+
+// Property wrappers generate transparent getters, which we would like to check still exist at Onone.
+@propertyWrapper
+struct IntWrapper {
+  private var storage = 42
+    var wrappedValue: Int {
+      return storage
+    }
+}
+
+public class User {
+  @IntWrapper private var number: Int
+
+  func f() {
+    // Force the generation of the getter
+    _ = self.number 
+  }
+}
+let c = User()
+c.f()
+
+// CHECK: !DISubprogram(name: "unused", linkageName: "$s21preserve_for_debugger6unusedyyF"
+// CHECK: !DISubprogram(name: "number.get"


### PR DESCRIPTION
Currently, when compiling with no optimizations on, we still delete functions that are sometimes used in the debugger. For example, users might want to call functions which are unused, or compiler generated setters/getters.

rdar://101046198
