### PR TITLE
test: un-XFAIL on Windows for rebranch

### DIFF
--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,4 +1,4 @@
-// XFAIL: OS=linux-gnu, OS=openbsd, OS=windows-msvc, OS=linux-android, OS=linux-androideabi
+// XFAIL: OS=linux-gnu, OS=openbsd, OS=linux-android, OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/only-skip-once/* %t


### PR DESCRIPTION
This test is now passing on Windows.  Simply remove the XFAIL to match the current state.