### PR TITLE
Add dependency edge between dispatch and clang

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -145,6 +145,10 @@ foreach(sdk ${DISPATCH_SDKS})
 
     ExternalProject_Get_Property("${LIBDISPATCH_VARIANT_NAME}" install_dir)
 
+    if(NOT SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+      add_dependencies("${LIBDISPATCH_VARIANT_NAME}" clang)
+    endif()
+
     # CMake does not like the addition of INTERFACE_INCLUDE_DIRECTORIES without
     # the directory existing.  Just create the location which will be populated
     # during the installation.


### PR DESCRIPTION
The dispatch that's built into concurrency on Linux and Windows is built with clang, but there's no dependency edge. Usually this isn't noticed because concurrency and most the things it depends on also depend on clang directly, but occasionally ninja will choose the dispatch build before building other dependencies, which then fails because there's no clang.