### PR TITLE
[build] Build the SourceKit stress tester and SwiftEvolve next to each other

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -634,10 +634,10 @@ class BuildScriptInvocation(object):
                             is_enabled=self.args.build_swiftpm)
         builder.add_product(products.SwiftSyntax,
                             is_enabled=self.args.build_swiftsyntax)
-        builder.add_product(products.SKStressTester,
-                            is_enabled=self.args.build_skstresstester)
         builder.add_product(products.SwiftFormat,
                             is_enabled=self.args.build_swiftformat)
+        builder.add_product(products.SKStressTester,
+                            is_enabled=self.args.build_skstresstester)
         builder.add_product(products.SwiftEvolve,
                             is_enabled=self.args.build_swiftevolve)
         builder.add_product(products.IndexStoreDB,


### PR DESCRIPTION
It doesn’t really matter but the SourceKit stress tester and SwiftEvolve share the same repo and have a very similar build architecture and they should be build next to each other by build-script.