### PR TITLE
test: correctly mark the test as XFAIL

### DIFF
--- a/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
@@ -4,7 +4,7 @@
 // invalid decl.
 
 // Windows doesn't fail at all here which seems ok (and probably should be the case for other platforms too).
-// XFAIL: windows
+// XFAIL: OS=windows-msvc
 
 // CHECK: error: type 'int' cannot be used prior to '::' because it has no members
 // CHECK: {{note: in instantiation of template class 'GetTypeValue<int>' requested here|note: in instantiation of static data member 'GetTypeValue<int>::value' requested here}}


### PR DESCRIPTION
This was happening to pass previously due to an unrelated error matching. This corrects the XFAIL annotation to fix the test on rebranch.

Thanks to @bnbarham for pointing out the invalid XFAIL string!