### PR TITLE
[embedded] Fix compiler asserts when building closures

### DIFF
--- a/test/embedded/closures.swift
+++ b/test/embedded/closures.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: swift_in_compiler
+
+public func foo<Result>(_ body: () -> Result) -> Result {
+  return body()
+}
+
+public func main() {
+    foo() { }
+}


### PR DESCRIPTION
See the added testcase, which previously triggered an assert. Two fixes:
- Improve detection of generic functions, just checking the SubstGenericSignature is flagging `@substituted` functions as generic even if they're specialized.
- Don't flag lazy emission of functions with external visibility because in embedded Swift, those can be gain public / externally-visible functions by deserializing them from imported modules, or by the CMO pass making local functions public. This is a workaround and not a real fix, it should probably be handled by some SIL pass that internalizes functions.