### PR TITLE
[Concurrency] Remove `ClosureActorIsolation`.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3951,7 +3951,9 @@ public:
   /// returns nullptr if the closure doesn't have a body
   BraceStmt *getBody() const;
 
-  ClosureActorIsolation getActorIsolation() const { return actorIsolation; }
+  ClosureActorIsolation getClosureActorIsolation() const {
+    return actorIsolation;
+  }
 
   void setActorIsolation(ClosureActorIsolation actorIsolation) {
     this->actorIsolation = actorIsolation;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3970,7 +3970,7 @@ public:
 
     case ActorIsolation::ActorInstance:
       return ClosureActorIsolation::forActorInstance(
-          actorIsolation.getCapturedActor(), preconcurrency);
+          actorIsolation.getActorInstance(), preconcurrency);
 
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3777,92 +3777,6 @@ public:
   }
 };
 
-/// Actor isolation for a closure.
-class ClosureActorIsolation {
-public:
-  enum Kind {
-    /// The closure is not isolated to any actor.
-    Nonisolated,
-
-    /// The closure is tied to the actor instance described by the given
-    /// \c VarDecl*, which is the (captured) `self` of an actor.
-    ActorInstance,
-
-    /// The closure is tied to the global actor described by the given type.
-    GlobalActor,
-  };
-
-private:
-    /// The actor to which this closure is isolated, plus a bit indicating
-    /// whether the isolation was imposed by a preconcurrency declaration.
-    ///
-    /// There are three possible states for the pointer:
-    ///   - NULL: The closure is independent of any actor.
-    ///   - VarDecl*: The 'self' variable for the actor instance to which
-    ///     this closure is isolated. It will always have a type that conforms
-    ///     to the \c Actor protocol.
-    ///   - Type: The type of the global actor on which
-  llvm::PointerIntPair<llvm::PointerUnion<VarDecl *, Type>, 1, bool> storage;
-
-  ClosureActorIsolation(VarDecl *selfDecl, bool preconcurrency)
-      : storage(selfDecl, preconcurrency) { }
-  ClosureActorIsolation(Type globalActorType, bool preconcurrency)
-      : storage(globalActorType, preconcurrency) { }
-
-public:
-  ClosureActorIsolation(bool preconcurrency = false)
-      : storage(nullptr, preconcurrency) { }
-
-  static ClosureActorIsolation forNonisolated(bool preconcurrency) {
-    return ClosureActorIsolation(preconcurrency);
-  }
-
-  static ClosureActorIsolation forActorInstance(VarDecl *selfDecl,
-                                                bool preconcurrency) {
-    return ClosureActorIsolation(selfDecl, preconcurrency);
-  }
-
-  static ClosureActorIsolation forGlobalActor(Type globalActorType,
-                                              bool preconcurrency) {
-    return ClosureActorIsolation(globalActorType, preconcurrency);
-  }
-
-  /// Determine the kind of isolation.
-  Kind getKind() const {
-    if (storage.getPointer().isNull())
-      return Kind::Nonisolated;
-
-    if (storage.getPointer().is<VarDecl *>())
-      return Kind::ActorInstance;
-
-    return Kind::GlobalActor;
-  }
-
-  /// Whether the closure is isolated at all.
-  explicit operator bool() const {
-    return getKind() != Kind::Nonisolated;
-  }
-
-  /// Whether the closure is isolated at all.
-  operator Kind() const {
-    return getKind();
-  }
-
-  VarDecl *getActorInstance() const {
-    return storage.getPointer().dyn_cast<VarDecl *>();
-  }
-
-  Type getGlobalActor() const {
-    return storage.getPointer().dyn_cast<Type>();
-  }
-
-  bool preconcurrency() const {
-    return storage.getInt();
-  }
-
-  ActorIsolation getActorIsolation() const;
-};
-
 /// A base class for closure expressions.
 class AbstractClosureExpr : public DeclContext, public Expr {
   CaptureInfo Captures;
@@ -3958,29 +3872,6 @@ public:
 
   void setActorIsolation(ActorIsolation actorIsolation) {
     this->actorIsolation = actorIsolation;
-  }
-
-  ClosureActorIsolation getClosureActorIsolation() const {
-    bool preconcurrency = actorIsolation.preconcurrency();
-
-    switch (actorIsolation) {
-    case ActorIsolation::Unspecified:
-    case ActorIsolation::Nonisolated:
-      return ClosureActorIsolation::forNonisolated(preconcurrency);
-
-    case ActorIsolation::ActorInstance:
-      return ClosureActorIsolation::forActorInstance(
-          actorIsolation.getActorInstance(), preconcurrency);
-
-    case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
-      return ClosureActorIsolation::forGlobalActor(
-          actorIsolation.getGlobalActor(), preconcurrency);
-    }
-  }
-
-  void setActorIsolation(ClosureActorIsolation closureIsolation) {
-    this->actorIsolation = closureIsolation.getActorIsolation();
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3871,14 +3871,15 @@ class AbstractClosureExpr : public DeclContext, public Expr {
   ParameterList *parameterList;
 
   /// Actor isolation of the closure.
-  ClosureActorIsolation actorIsolation;
+  ActorIsolation actorIsolation;
 
 public:
   AbstractClosureExpr(ExprKind Kind, Type FnType, bool Implicit,
                       DeclContext *Parent)
       : DeclContext(DeclContextKind::AbstractClosureExpr, Parent),
         Expr(Kind, Implicit, FnType),
-        parameterList(nullptr) {
+        parameterList(nullptr),
+        actorIsolation(ActorIsolation::forUnspecified()) {
     Bits.AbstractClosureExpr.Discriminator = InvalidDiscriminator;
   }
 
@@ -3951,12 +3952,35 @@ public:
   /// returns nullptr if the closure doesn't have a body
   BraceStmt *getBody() const;
 
-  ClosureActorIsolation getClosureActorIsolation() const {
+  ActorIsolation getActorIsolation() const {
     return actorIsolation;
   }
 
-  void setActorIsolation(ClosureActorIsolation actorIsolation) {
+  void setActorIsolation(ActorIsolation actorIsolation) {
     this->actorIsolation = actorIsolation;
+  }
+
+  ClosureActorIsolation getClosureActorIsolation() const {
+    bool preconcurrency = actorIsolation.preconcurrency();
+
+    switch (actorIsolation) {
+    case ActorIsolation::Unspecified:
+    case ActorIsolation::Nonisolated:
+      return ClosureActorIsolation::forNonisolated(preconcurrency);
+
+    case ActorIsolation::ActorInstance:
+      return ClosureActorIsolation::forActorInstance(
+          actorIsolation.getCapturedActor(), preconcurrency);
+
+    case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
+      return ClosureActorIsolation::forGlobalActor(
+          actorIsolation.getGlobalActor(), preconcurrency);
+    }
+  }
+
+  void setActorIsolation(ClosureActorIsolation closureIsolation) {
+    this->actorIsolation = closureIsolation.getActorIsolation();
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -131,7 +131,7 @@ class CompletionLookup final : public swift::VisibleDeclConsumer {
   bool CanCurrDeclContextHandleAsync = false;
   /// Actor isolations that were determined during constraint solving but that
   /// haven't been saved to the AST.
-  llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+  llvm::DenseMap<AbstractClosureExpr *, ActorIsolation>
       ClosureActorIsolations;
   bool HaveDot = false;
   bool IsUnwrappedOptional = false;
@@ -253,7 +253,7 @@ public:
   }
 
   void setClosureActorIsolations(
-      llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+      llvm::DenseMap<AbstractClosureExpr *, ActorIsolation>
           ClosureActorIsolations) {
     this->ClosureActorIsolations = ClosureActorIsolations;
   }

--- a/include/swift/IDE/PostfixCompletion.h
+++ b/include/swift/IDE/PostfixCompletion.h
@@ -63,7 +63,7 @@ class PostfixCompletionCallback : public TypeCheckCompletionCallback {
 
     /// Actor isolations that were determined during constraint solving but that
     /// haven't been saved to the AST.
-    llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+    llvm::DenseMap<AbstractClosureExpr *, ActorIsolation>
         ClosureActorIsolations;
 
     /// Checks whether this result has the same \c BaseTy and \c BaseDecl as

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -318,9 +318,9 @@ namespace swift {
   bool completionContextUsesConcurrencyFeatures(const DeclContext *dc);
 
   /// Determine the isolation of a particular closure.
-  ClosureActorIsolation determineClosureActorIsolation(
+  ActorIsolation determineClosureActorIsolation(
       AbstractClosureExpr *closure, llvm::function_ref<Type(Expr *)> getType,
-      llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+      llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
           getClosureActorIsolation);
 
   /// If the capture list shadows any declarations using shorthand syntax, i.e.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2687,7 +2687,7 @@ public:
 
     printField(E->getRawDiscriminator(), "discriminator", DiscriminatorColor);
 
-    switch (auto isolation = E->getActorIsolation()) {
+    switch (auto isolation = E->getClosureActorIsolation()) {
     case ClosureActorIsolation::Nonisolated:
       break;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2687,16 +2687,18 @@ public:
 
     printField(E->getRawDiscriminator(), "discriminator", DiscriminatorColor);
 
-    switch (auto isolation = E->getClosureActorIsolation()) {
-    case ClosureActorIsolation::Nonisolated:
+    switch (auto isolation = E->getActorIsolation()) {
+    case ActorIsolation::Unspecified:
+    case ActorIsolation::Nonisolated:
       break;
 
-    case ClosureActorIsolation::ActorInstance:
+    case ActorIsolation::ActorInstance:
       printFieldQuoted(isolation.getActorInstance()->printRef(),
                        "actor_isolated", CapturesColor);
       break;
 
-    case ClosureActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
       printFieldQuoted(isolation.getGlobalActor().getString(),
                        "global_actor_isolated", CapturesColor);
       break;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10333,7 +10333,7 @@ ActorIsolation swift::getActorIsolation(ValueDecl *value) {
 
 ActorIsolation swift::getActorIsolationOfContext(
     DeclContext *dc,
-    llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+    llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation) {
   auto dcToUse = dc;
   // Defer bodies share actor isolation of their enclosing context.
@@ -10349,7 +10349,7 @@ ActorIsolation swift::getActorIsolationOfContext(
     return getActorIsolation(var);
 
   if (auto *closure = dyn_cast<AbstractClosureExpr>(dcToUse)) {
-    return getClosureActorIsolation(closure).getActorIsolation();
+    return getClosureActorIsolation(closure);
   }
 
   if (auto *tld = dyn_cast<TopLevelCodeDecl>(dcToUse)) {
@@ -10619,7 +10619,7 @@ NominalTypeDecl *ActorIsolation::getActor() const {
   return actorInstance.get<NominalTypeDecl *>();
 }
 
-VarDecl *ActorIsolation::getCapturedActor() const {
+VarDecl *ActorIsolation::getActorInstance() const {
   assert(getKind() == ActorInstance);
   return actorInstance.dyn_cast<VarDecl *>();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10305,7 +10305,7 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
     }
 
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
-      switch (auto isolation = closure->getActorIsolation()) {
+      switch (auto isolation = closure->getClosureActorIsolation()) {
       case ClosureActorIsolation::Nonisolated:
       case ClosureActorIsolation::GlobalActor:
         return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10597,6 +10597,33 @@ void swift::simple_display(llvm::raw_ostream &out, AnyFunctionRef fn) {
     out << "closure";
 }
 
+ActorIsolation::ActorIsolation(Kind kind, NominalTypeDecl *actor,
+                               unsigned parameterIndex)
+    : actorInstance(actor), kind(kind), 
+      isolatedByPreconcurrency(false),
+      parameterIndex(parameterIndex) { }
+
+ActorIsolation::ActorIsolation(Kind kind, VarDecl *capturedActor)
+    : actorInstance(capturedActor), kind(kind),
+      isolatedByPreconcurrency(false), 
+      parameterIndex(0) { }
+
+NominalTypeDecl *ActorIsolation::getActor() const {
+  assert(getKind() == ActorInstance);
+
+  if (auto *instance = actorInstance.dyn_cast<VarDecl *>()) {
+    return instance->getTypeInContext()
+        ->getReferenceStorageReferent()->getAnyActor();
+  }
+
+  return actorInstance.get<NominalTypeDecl *>();
+}
+
+VarDecl *ActorIsolation::getCapturedActor() const {
+  assert(getKind() == ActorInstance);
+  return actorInstance.dyn_cast<VarDecl *>();
+}
+
 bool ActorIsolation::isMainActor() const {
   if (isGlobalActor()) {
     if (auto *nominal = getGlobalActor()->getAnyNominal())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10305,12 +10305,14 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
     }
 
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
-      switch (auto isolation = closure->getClosureActorIsolation()) {
-      case ClosureActorIsolation::Nonisolated:
-      case ClosureActorIsolation::GlobalActor:
+      switch (auto isolation = closure->getActorIsolation()) {
+      case ActorIsolation::Unspecified:
+      case ActorIsolation::Nonisolated:
+      case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
         return false;
 
-      case ClosureActorIsolation::ActorInstance:
+      case ActorIsolation::ActorInstance:
         auto isolatedVar = isolation.getActorInstance();
         return isolatedVar->isSelfParameter() ||
             isolatedVar-isSelfParamCapture();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1895,8 +1895,8 @@ ActorIsolation ClosureActorIsolation::getActorIsolation() const {
         selfDecl->getTypeInContext()->getReferenceStorageReferent()->getAnyActor();
     assert(actor && "Bad closure actor isolation?");
     // FIXME: This could be a parameter... or a capture... hmmm.
-    return ActorIsolation::forActorInstanceSelf(actor).withPreconcurrency(
-        preconcurrency());
+    return ActorIsolation::forActorInstanceCapture(
+        getActorInstance()).withPreconcurrency(preconcurrency());
   }
   }
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1878,29 +1878,6 @@ RebindSelfInConstructorExpr::getCalledConstructor(bool &isChainToSuper) const {
   return otherCtorRef;
 }
 
-ActorIsolation ClosureActorIsolation::getActorIsolation() const {
-  switch (getKind()) {
-  case ClosureActorIsolation::Nonisolated:
-    return ActorIsolation::forNonisolated().withPreconcurrency(
-        preconcurrency());
-
-  case ClosureActorIsolation::GlobalActor: {
-    return ActorIsolation::forGlobalActor(getGlobalActor(), /*unsafe=*/false)
-        .withPreconcurrency(preconcurrency());
-  }
-
-  case ClosureActorIsolation::ActorInstance: {
-    auto selfDecl = getActorInstance();
-    auto actor =
-        selfDecl->getTypeInContext()->getReferenceStorageReferent()->getAnyActor();
-    assert(actor && "Bad closure actor isolation?");
-    // FIXME: This could be a parameter... or a capture... hmmm.
-    return ActorIsolation::forActorInstanceCapture(
-        getActorInstance()).withPreconcurrency(preconcurrency());
-  }
-  }
-}
-
 unsigned AbstractClosureExpr::getDiscriminator() const {
   auto raw = getRawDiscriminator();
   if (raw != InvalidDiscriminator)

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2019,7 +2019,7 @@ Expr *AbstractClosureExpr::getSingleExpressionBody() const {
 
 ClosureActorIsolation
 swift::__AbstractClosureExpr_getActorIsolation(AbstractClosureExpr *CE) {
-  return CE->getActorIsolation();
+  return CE->getClosureActorIsolation();
 }
 
 llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2017,14 +2017,9 @@ Expr *AbstractClosureExpr::getSingleExpressionBody() const {
   return nullptr;
 }
 
-ClosureActorIsolation
+ActorIsolation
 swift::__AbstractClosureExpr_getActorIsolation(AbstractClosureExpr *CE) {
-  return CE->getClosureActorIsolation();
-}
-
-llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
-swift::_getRef__AbstractClosureExpr_getActorIsolation() {
-  return __AbstractClosureExpr_getActorIsolation;
+  return CE->getActorIsolation();
 }
 
 #define FORWARD_SOURCE_LOCS_TO(CLASS, NODE) \

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -777,7 +777,7 @@ void CompletionLookup::analyzeActorIsolation(
       if (isolation != ClosureActorIsolations.end()) {
         return isolation->second;
       } else {
-        return CE->getActorIsolation();
+        return CE->getClosureActorIsolation();
       }
     };
     auto contextIsolation = getActorIsolationOfContext(

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -777,7 +777,7 @@ void CompletionLookup::analyzeActorIsolation(
       if (isolation != ClosureActorIsolations.end()) {
         return isolation->second;
       } else {
-        return CE->getClosureActorIsolation();
+        return CE->getActorIsolation();
       }
     };
     auto contextIsolation = getActorIsolationOfContext(

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -111,7 +111,7 @@ void PostfixCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
                              [&](const Solution &S) { sawSolution(S); });
 }
 
-static ClosureActorIsolation
+static ActorIsolation
 getClosureActorIsolation(const Solution &S, AbstractClosureExpr *ACE) {
   auto getType = [&S](Expr *E) -> Type {
     // Prefer the contextual type of the closure because it might be 'weaker'
@@ -213,7 +213,7 @@ void PostfixCompletionCallback::sawSolutionImpl(
       isImplicitSingleExpressionReturn(CS, CompletionExpr);
 
   bool IsInAsyncContext = isContextAsync(S, DC);
-  llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+  llvm::DenseMap<AbstractClosureExpr *, ActorIsolation>
       ClosureActorIsolations;
   for (auto SAT : S.targets) {
     if (auto ACE = getAsExpr<AbstractClosureExpr>(SAT.second.getAsASTNode())) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1593,7 +1593,7 @@ void SILGenFunction::emitHopToActorValue(SILLocation loc, ManagedValue actor) {
   }
   auto isolation =
       getActorIsolationOfContext(FunctionDC, [](AbstractClosureExpr *CE) {
-        return CE->getClosureActorIsolation();
+        return CE->getActorIsolation();
       });
   if (isolation != ActorIsolation::Nonisolated
       && isolation != ActorIsolation::Unspecified) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1380,19 +1380,21 @@ void SILGenFunction::emitProlog(
     }
   } else if (auto *closureExpr = dyn_cast<AbstractClosureExpr>(FunctionDC)) {
     bool wantExecutor = F.isAsync() || wantDataRaceChecks;
-    auto actorIsolation = closureExpr->getClosureActorIsolation();
+    auto actorIsolation = closureExpr->getActorIsolation();
     switch (actorIsolation.getKind()) {
-    case ClosureActorIsolation::Nonisolated:
+    case ActorIsolation::Unspecified:
+    case ActorIsolation::Nonisolated:
       break;
 
-    case ClosureActorIsolation::ActorInstance: {
+    case ActorIsolation::ActorInstance: {
       if (wantExecutor) {
         loadExpectedExecutorForLocalVar(actorIsolation.getActorInstance());
       }
       break;
     }
 
-    case ClosureActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
       if (wantExecutor) {
         ExpectedExecutor =
           emitLoadGlobalActorExecutor(actorIsolation.getGlobalActor());

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1380,7 +1380,7 @@ void SILGenFunction::emitProlog(
     }
   } else if (auto *closureExpr = dyn_cast<AbstractClosureExpr>(FunctionDC)) {
     bool wantExecutor = F.isAsync() || wantDataRaceChecks;
-    auto actorIsolation = closureExpr->getActorIsolation();
+    auto actorIsolation = closureExpr->getClosureActorIsolation();
     switch (actorIsolation.getKind()) {
     case ClosureActorIsolation::Nonisolated:
       break;
@@ -1593,7 +1593,7 @@ void SILGenFunction::emitHopToActorValue(SILLocation loc, ManagedValue actor) {
   }
   auto isolation =
       getActorIsolationOfContext(FunctionDC, [](AbstractClosureExpr *CE) {
-        return CE->getActorIsolation();
+        return CE->getClosureActorIsolation();
       });
   if (isolation != ActorIsolation::Nonisolated
       && isolation != ActorIsolation::Unspecified) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2968,7 +2968,7 @@ static bool okToRemoveGlobalActor(ConstraintSystem &cs,
     // So, I expect the existing isolation to always be set to the default.
     // If the assertion below starts tripping, then this ad-hoc inference
     // is no longer needed!
-    auto existingIso = ace->getActorIsolation();
+    auto existingIso = ace->getClosureActorIsolation();
     if (existingIso != ClosureActorIsolation()) {
       assert(false && "somebody set the closure's isolation already?");
       return existingIso;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2960,7 +2960,7 @@ static bool isPreconcurrency(ConstraintSystem &cs, DeclContext *dc) {
 static bool okToRemoveGlobalActor(ConstraintSystem &cs,
                                   DeclContext *dc,
                                   Type globalActor, Type ty) {
-  auto findGlobalActorForClosure = [&](AbstractClosureExpr *ace) -> ClosureActorIsolation {
+  auto findGlobalActorForClosure = [&](AbstractClosureExpr *ace) -> ActorIsolation {
     // FIXME: Because the actor isolation checking happens after constraint
     // solving, the closure expression does not yet have its actor isolation
     // set, i.e., the code that would call
@@ -2968,8 +2968,8 @@ static bool okToRemoveGlobalActor(ConstraintSystem &cs,
     // So, I expect the existing isolation to always be set to the default.
     // If the assertion below starts tripping, then this ad-hoc inference
     // is no longer needed!
-    auto existingIso = ace->getClosureActorIsolation();
-    if (existingIso != ClosureActorIsolation()) {
+    auto existingIso = ace->getActorIsolation();
+    if (existingIso != ActorIsolation::forUnspecified()) {
       assert(false && "somebody set the closure's isolation already?");
       return existingIso;
     }
@@ -2980,8 +2980,8 @@ static bool okToRemoveGlobalActor(ConstraintSystem &cs,
     if (auto closType = GetClosureType{cs}(ace)) {
       if (auto fnTy = closType->getAs<AnyFunctionType>()) {
         if (auto globActor = fnTy->getGlobalActor()) {
-          return ClosureActorIsolation::forGlobalActor(globActor,
-                                                       isPreconcurrency(cs, ace));
+          return ActorIsolation::forGlobalActor(globActor, /*unsafe=*/false)
+              .withPreconcurrency(isPreconcurrency(cs, ace));
         }
       }
     }
@@ -2989,8 +2989,8 @@ static bool okToRemoveGlobalActor(ConstraintSystem &cs,
     // otherwise, check for an explicit annotation
     if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
       if (auto globActor = getExplicitGlobalActor(ce)) {
-        return ClosureActorIsolation::forGlobalActor(globActor,
-                                                     isPreconcurrency(cs, ce));
+        return ActorIsolation::forGlobalActor(globActor, /*unsafe=*/false)
+            .withPreconcurrency(isPreconcurrency(cs, ace));
       }
     }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -240,7 +240,7 @@ public:
       llvm::Optional<ReferencedActor> actorInstance = llvm::None,
       llvm::Optional<ActorIsolation> knownDeclIsolation = llvm::None,
       llvm::Optional<ActorIsolation> knownContextIsolation = llvm::None,
-      llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+      llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
           getClosureActorIsolation = __AbstractClosureExpr_getActorIsolation);
 
   operator Kind() const { return kind; }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -33,7 +33,6 @@ class ActorIsolation;
 class AnyFunctionType;
 class ASTContext;
 class ClassDecl;
-class ClosureActorIsolation;
 class ClosureExpr;
 class ConcreteDeclRef;
 class CustomAttr;


### PR DESCRIPTION
This change removes `ClosureActorIsolation` and replaces all uses with `ActorIsolation`. `ActorIsolation` can now store a `VarDecl` to directly represent an actor instance when the actor isolation kind is `ActorIsolation::ActorInstance`, which is currently always used for closures isolated to actor instances. This is the first step toward unifying the isolation computation for closures and local functions.