### PR TITLE
[DNM] [Sema] Check whether wrappedValue initializer exists when generating …

### DIFF
--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -279,3 +279,14 @@ func testInvalidWrapperInference() {
   // expected-error@+1 {{contextual closure type '() -> Void' expects 0 arguments, but 1 was used in closure body}}
   testExtraParameter { $value in }
 }
+
+@propertyWrapper
+struct ProjectionOnlyWrapper {
+  var wrappedValue: String
+
+  var projectedValue: String { self.wrappedValue }
+  init(projectedValue: String) { self.wrappedValue = projectedValue }
+}
+
+func testParameterWithoutWrappedValueInit(@ProjectionOnlyWrapper value: String) {}
+_ = testParameterWithoutWrappedValueInit(value: "") // expected-error {{type of expression is ambiguous without a type annotation}}


### PR DESCRIPTION
Currently, CSGen assumes that `init(wrappedValue:)` exists in the definition of property wrapper parameter's type. 
This is true when there's no other initializer in the definition as one will be synthesized. However, if there's `init(projectedValue:)` in the definition, the `init(wrappedValue:)` will not be synthesized. 

Since the current code assumes that the `init(wrappedValue:)` exists, the compiler continues to apply the constraints. However, because it is missing, the compiler crashes at https://github.com/apple/swift/blob/94c2be87da7d17b94fa2c1f1418ea6d90f9af4b9/lib/Sema/CSApply.cpp#L6149C29-L6149C52 since the property wrapper itself is visible, but doesn't have an initializer that was actually applied. 

--- 

Changes in this PR will fail the CSGen process if the `init(wrappedValue:)` is missing. However, without proper diagnostic, the error message is just shown as `type of expression is ambiguous without a type annotation`.

I think either one of these is possible:
- use `init(projectedValue:)` if `init(wrappedValue:)` doesn't exist but the initializer parameter type is identical. 
- show a better diagnostic by recording a CSFix?
- leave it as `type of expression is ambiguous without a type annotation` since the compiler at least doesn't crash. 

I want to show some better diagnostics like `cannot use property wrapper argument because 'init(wrappedValue:)' doesn't exist.`
- Am I allowed to produce the diagnostic by creating a CSFix like `RemoveProjectedValueArgument`?
- Or should I use some other pass of the compiler to produce the diagnostic, e.g. when typing checking the expression?

Resolves #68570
