### PR TITLE
test: replace shell with python to enable portability

### DIFF
--- a/test/Inputs/process_fine_grained_swiftdeps_with_fingerprints.py
+++ b/test/Inputs/process_fine_grained_swiftdeps_with_fingerprints.py
@@ -1,0 +1,39 @@
+
+import subprocess
+import sys
+
+# Fine-grained swiftdeps files use multiple lines for each graph node.
+# Compress such a file so that each entry is one line of the form:
+# <kind> <aspect> <context> <name> <isProvides> <fingerprint>
+# Also sort for consistency, since the node order can vary.
+
+output = subprocess.run(
+    [
+        sys.argv[1],
+        "--to-yaml",
+        "--input-filename={}".format(sys.argv[2]),
+        "--output-filename=-",
+    ],
+    stdout=subprocess.PIPE,
+)
+entries = []
+k = a = c = f = n = s = p = ""
+for line in output.stdout.decode("utf-8").split("\n"):
+    if "kind:" in line:
+        k = line.split()[1]
+        f = "<no fingerprint>"
+    if "aspect:" in line:
+        a = line.split()[1]
+    if "context:" in line:
+        c = line.split()[1]
+    if "fingerprint:" in line:
+        f = line.split()[1]
+    if "name:" in line:
+        n = ' '.join(line.split()[1:])
+    if "sequenceNumber:" in line:
+        s = line.split()[1]
+    if "isProvides:" in line:
+        p = line.split()[1]
+        entries.append(' '.join([k, a, c, n, p, f]))
+entries.sort()
+print("\n".join(entries))

--- a/test/Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh
+++ b/test/Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-# Fine-grained swiftdeps files use multiple lines for each graph node.
-# Compress such a file so that each entry is one line of the form:
-# <kind> <aspect> <context> <name> <isProvides>
-# Also sort for consistency, since the node order can vary.
-
-${1} --to-yaml --input-filename=${2} --output-filename=${3}.tmp
-
-awk '/kind:/ {k = $2; f  = "<no fingerprint>"}; /aspect:/ {a = $2}; /context:/ {c = $2}; /name/ {n = $2}; /sequenceNumber/ {s = $2}; /fingerprint:/ {f = $2 }; /isProvides:/ {isP = $2; print k, a, c, n, isP, f}' < ${3}.tmp | sort > ${3}

--- a/test/InterfaceHash/added_method-type.swift
+++ b/test/InterfaceHash/added_method-type.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 class C {
@@ -39,17 +35,17 @@ class C {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' C true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1C{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1C{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_class_private_property.swift
+++ b/test/InterfaceHash/added_private_class_private_property.swift
@@ -1,17 +1,13 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 private class C {
@@ -37,17 +33,17 @@ private class C {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface '' C true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1C{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1C{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_class_property.swift
+++ b/test/InterfaceHash/added_private_class_property.swift
@@ -1,17 +1,13 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 class C {
@@ -37,17 +33,17 @@ class C {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface '' C true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1C{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1C{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_enum_private_property.swift
+++ b/test/InterfaceHash/added_private_enum_private_property.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 
 // BEGIN a.swift
@@ -40,17 +36,17 @@ private enum A {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' A true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1A{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1A{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_enum_property.swift
+++ b/test/InterfaceHash/added_private_enum_property.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 enum A {
@@ -39,17 +35,17 @@ enum A {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' A true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1A{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1A{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_method.swift
+++ b/test/InterfaceHash/added_private_method.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 class C {
@@ -39,17 +35,17 @@ class C {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' C true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' C true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' C true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1C{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1C{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1C{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1C{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_method_value_types.swift
+++ b/test/InterfaceHash/added_private_method_value_types.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 struct A {
@@ -57,32 +53,32 @@ enum B {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' A true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' A true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' A true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1A{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1A{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1A{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1A{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' B true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' B true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' B true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' B true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' B true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' B true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' B true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' B true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1B{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1B{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1B{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1B{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1B{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1B{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1B{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1B{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1B{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_protocol_method.swift
+++ b/test/InterfaceHash/added_private_protocol_method.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 private protocol P {
@@ -34,17 +30,17 @@ private protocol P {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' P true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' P true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' P true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' P true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1P{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1P{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_protocol_property.swift
+++ b/test/InterfaceHash/added_private_protocol_property.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 private protocol P {
@@ -34,17 +30,17 @@ private protocol P {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' P true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' P true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' P true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' P true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' P true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1P{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1P{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1P{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1P{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_struct_private_property.swift
+++ b/test/InterfaceHash/added_private_struct_private_property.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 struct S {
@@ -40,17 +36,17 @@ struct S {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' S true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' S true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' S true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' S true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1S{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1S{{[^ ]+}} '' true

--- a/test/InterfaceHash/added_private_struct_property.swift
+++ b/test/InterfaceHash/added_private_struct_property.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: not diff %t/{a,b}-processed.swiftdeps >%t/diffs
+// RUN: not diff -u %t/a-processed.swiftdeps %t/b-processed.swiftdeps > %t/diffs
 
 // BEGIN a.swift
 private struct S {
@@ -40,17 +36,17 @@ private struct S {
 
 // CHECK-SAME-INTERFACE-HASH-NOT: sourceFileProvides
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel implementation '' S true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < topLevel interface      '' S true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel implementation '' S true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > topLevel interface      '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel implementation '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -topLevel interface      '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel implementation '' S true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +topLevel interface      '' S true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal implementation 4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < nominal interface      4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal implementation 4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > nominal interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -nominal interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +nominal interface      4main1S{{[^ ]+}} '' true
 
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember implementation 4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: < potentialMember interface      4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember implementation 4main1S{{[^ ]+}} '' true
-// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: > potentialMember interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: -potentialMember interface      4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember implementation 4main1S{{[^ ]+}} '' true
+// CHECK-DIFFERENT-TYPE-FINGERPRINT-DAG: +potentialMember interface      4main1S{{[^ ]+}} '' true

--- a/test/InterfaceHash/edited_method_body.swift
+++ b/test/InterfaceHash/edited_method_body.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,13 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// We can use `diff` here because this test isn't run on Windows
-// RUN: diff %t/{a,b}-processed.swiftdeps
+// RUN: diff %t/a-processed.swiftdeps %t/b-processed.swiftdeps
 
 // BEGIN a.swift
 class C {

--- a/test/InterfaceHash/edited_property_getter.swift
+++ b/test/InterfaceHash/edited_property_getter.swift
@@ -1,7 +1,3 @@
-// REQUIRES: shell
-// Also uses awk:
-// XFAIL OS=windows
-
 // When adding a private protocol method, the interface hash should stay the same
 // The per-type fingerprint should change
 
@@ -9,12 +5,12 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 // RUN: cp %t/{a,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/a-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/a-processed.swiftdeps
 // RUN: cp %t/{b,x}.swift
 // RUN: %target-swift-frontend -typecheck -primary-file %t/x.swift -emit-reference-dependencies-path %t/x.swiftdeps -module-name main
-// RUN: %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.sh %swift-dependency-tool %t/x.swiftdeps %t/b-processed.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps_with_fingerprints.py %swift-dependency-tool %t/x.swiftdeps > %t/b-processed.swiftdeps
 
-// RUN: cmp %t/{a,b}-processed.swiftdeps 
+// RUN: cmp %t/a-processed.swiftdeps %t/b-processed.swiftdeps
 
 // BEGIN a.swift
 class C {


### PR DESCRIPTION
This replaces the `process_fine_grained_swiftdeps_with_fingerprints` helper with a python script that mimics the shell behaviour. Adjust the generated interface diffs to use unified formats. This allows us to enable these tests on Windows.