### PR TITLE
[ASTGen] Make ASTGenVisitor not conform to SyntaxTransformVisitor

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -1,8 +1,6 @@
 import CASTBridging
 import CBasicBridging
 
-// Needed to use SyntaxTransformVisitor's visit method.
-@_spi(SyntaxTransformVisitor)
 // Needed to use BumpPtrAllocator
 @_spi(RawSyntax)
 import SwiftSyntax
@@ -61,7 +59,7 @@ class Boxed<Value> {
   }
 }
 
-struct ASTGenVisitor: SyntaxTransformVisitor {
+struct ASTGenVisitor {
   typealias ResultType = ASTNode
 
   fileprivate let diagnosticEngine: BridgedDiagnosticEngine
@@ -86,27 +84,12 @@ struct ASTGenVisitor: SyntaxTransformVisitor {
     self.ctx = astContext
   }
 
-  // TODO: this some how messes up the witness table when I uncomment it locally :/
-  //  public func visit<T>(_ node: T?) -> [UnsafeMutableRawPointer]? {
-  //    if let node = node { return visit(node) }
-  //    return nil
-  //  }
-
-  @_disfavoredOverload
-  public func visit(_ node: SourceFileSyntax) -> ASTNode {
-    fatalError("Use other overload.")
-  }
-
-  public func visitAny(_ node: Syntax) -> ASTNode {
-    fatalError("Not implemented.")
-  }
-
-  public func visit(_ node: SourceFileSyntax) -> [UnsafeMutableRawPointer] {
+  public func generate(_ node: SourceFileSyntax) -> [UnsafeMutableRawPointer] {
     var out = [UnsafeMutableRawPointer]()
 
     for element in node.statements {
       let loc = element.bridgedSourceLoc(in: self)
-      let swiftASTNodes = visit(element)
+      let swiftASTNodes = generate(element)
       switch swiftASTNodes {
       case .decl(let d):
         out.append(d)
@@ -147,32 +130,183 @@ extension ASTGenVisitor {
   }
 }
 
+extension ASTGenVisitor {
+  func generate(_ node: DeclSyntax) -> ASTNode {
+    return generate(Syntax(node))
+  }
+
+  func generate(_ node: ExprSyntax) -> ASTNode {
+    return generate(Syntax(node))
+  }
+
+  func generate(_ node: PatternSyntax) -> ASTNode {
+    return generate(Syntax(node))
+  }
+
+  func generate(_ node: StmtSyntax) -> ASTNode {
+    return generate(Syntax(node))
+  }
+
+  func generate(_ node: TypeSyntax) -> ASTNode {
+    return generate(Syntax(node))
+  }
+
+  func generate(_ node: some SyntaxChildChoices) -> ASTNode {
+    return self.generate(Syntax(node))
+  }
+    
+  func generate(_ node: Syntax) -> ASTNode {
+    switch node.as(SyntaxEnum.self) {
+    case .actorDecl(let node):
+      return generate(node)
+    case .arrayElement(let node):
+      return generate(node)
+    case .arrayExpr(let node):
+      return generate(node)
+    case .arrayType(let node):
+      return generate(node)
+    case .associatedTypeDecl(let node):
+      return generate(node)
+    case .attributedType(let node):
+      return generate(node)
+    case .booleanLiteralExpr(let node):
+      return generate(node)
+    case .classDecl(let node):
+      return generate(node)
+    case .closureExpr(let node):
+      return generate(node)
+    case .codeBlock(let node):
+      return generate(node)
+    case .codeBlockItem(let node):
+      return generate(node)
+    case .compositionType(let node):
+      return generate(node)
+    case .conditionElement(let node):
+      return generate(node)
+    case .declReferenceExpr(let node):
+      return generate(node)
+    case .deinitializerDecl(let node):
+      return generate(node)
+    case .dictionaryType(let node):
+      return generate(node)
+    case .enumCaseDecl(let node):
+      return generate(node)
+    case .enumCaseElement(let node):
+      return generate(node)
+    case .enumCaseParameter(let node):
+      return generate(node)
+    case .enumCaseParameterClause(let node):
+      return generate(node)
+    case .enumDecl(let node):
+      return generate(node)
+    case .expressionStmt(let node):
+     return generate(node)
+    case .extensionDecl(let node):
+      return generate(node)
+    case .functionCallExpr(let node):
+      return generate(node)
+    case .functionDecl(let node):
+      return generate(node)
+    case .functionParameter(let node):
+      return generate(node)
+    case .functionParameterClause(let node):
+      return generate(node)
+    case .functionType(let node):
+      return generate(node)
+    case .genericParameter(let node):
+      return generate(node)
+    case .genericParameterClause(let node):
+      return generate(node)
+    case .genericWhereClause(let node):
+      return generate(node)
+    case .identifierPattern(let node):
+      return generate(node)
+    case .identifierType(let node):
+      return generate(node)
+    case .ifExpr(let node):
+      return generate(node)
+    case .implicitlyUnwrappedOptionalType(let node):
+      return generate(node)
+    case .importDecl(let node):
+      return generate(node)
+    case .initializerClause(let node):
+      return generate(node)
+    case .initializerDecl(let node):
+      return generate(node)
+    case .integerLiteralExpr(let node):
+      return generate(node)
+    case .labeledExprList:
+      fatalError("case does not correspond to an ASTNode")
+    case .memberAccessExpr(let node):
+      return generate(node)
+    case .memberBlockItem(let node):
+      return generate(node)
+    case .memberType(let node):
+      return generate(node)
+    case .metatypeType(let node):
+      return generate(node)
+    case .namedOpaqueReturnType(let node):
+      return generate(node)
+    case .nilLiteralExpr(let node):
+      return generate(node)
+    case .operatorDecl(let node):
+      return generate(node)
+    case .optionalType(let node):
+      return generate(node)
+    case .packExpansionType(let node):
+      return generate(node)
+    case .precedenceGroupDecl(let node):
+      return generate(node)
+    case .protocolDecl(let node):
+      return generate(node)
+    case .returnStmt(let node):
+      return generate(node)
+    case .someOrAnyType(let node):
+      return generate(node)
+    case .stringLiteralExpr(let node):
+      return generate(node)
+    case .structDecl(let node):
+      return generate(node)
+    case .tupleExpr(let node):
+      return generate(node)
+    case .tupleType(let node):
+      return generate(node)
+    case .typeAliasDecl(let node):
+      return generate(node)
+    case .variableDecl(let node):
+      return generate(node)
+    default:
+      fatalError("not implemented")
+    }
+  }
+}
+
 // Misc visits.
 // TODO: Some of these are called within a single file/method; we may want to move them to the respective files.
 extension ASTGenVisitor {
-  public func visit(_ node: MemberBlockItemSyntax) -> ASTNode {
-    visit(Syntax(node.decl))
+  public func generate(_ node: MemberBlockItemSyntax) -> ASTNode {
+    generate(node.decl)
   }
 
-  public func visit(_ node: InitializerClauseSyntax) -> ASTNode {
-    visit(node.value)
+  public func generate(_ node: InitializerClauseSyntax) -> ASTNode {
+    generate(node.value)
   }
 
-  public func visit(_ node: ConditionElementSyntax) -> ASTNode {
-    visit(node.condition)
+  public func generate(_ node: ConditionElementSyntax) -> ASTNode {
+    generate(node.condition)
   }
 
-  public func visit(_ node: CodeBlockItemSyntax) -> ASTNode {
-    visit(node.item)
+  public func generate(_ node: CodeBlockItemSyntax) -> ASTNode {
+    generate(node.item)
   }
 
-  public func visit(_ node: ArrayElementSyntax) -> ASTNode {
-    visit(node.expression)
+  public func generate(_ node: ArrayElementSyntax) -> ASTNode {
+    generate(node.expression)
   }
 
   @inline(__always)
-  func visit(_ node: CodeBlockItemListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.visit($0).bridged }.bridgedArray(in: self)
+  func generate(_ node: CodeBlockItemListSyntax) -> BridgedArrayRef {
+    node.lazy.map { self.generate($0).bridged }.bridgedArray(in: self)
   }
 }
 
@@ -180,76 +314,76 @@ extension ASTGenVisitor {
 // 'self.visit(<expr>)' recursion pattern between optional and non-optional inputs.
 extension ASTGenVisitor {
   @inline(__always)
-  func visit(_ node: TypeSyntax?) -> ASTNode? {
+  func generate(_ node: TypeSyntax?) -> ASTNode? {
     guard let node else {
       return nil
     }
 
-    return self.visit(node)
+    return self.generate(node)
   }
 
   @inline(__always)
-  func visit(_ node: ExprSyntax?) -> ASTNode? {
+  func generate(_ node: ExprSyntax?) -> ASTNode? {
     guard let node else {
       return nil
     }
 
-    return self.visit(node)
+    return self.generate(node)
   }
 
   @inline(__always)
-  func visit(_ node: (some SyntaxChildChoices)?) -> ASTNode? {
+  func generate(_ node: (some SyntaxChildChoices)?) -> ASTNode? {
     guard let node else {
       return nil
     }
 
     // This call recurses without disambiguation.
-    return (self.visit as (_) -> ASTNode)(node)
+    return self.generate(node) as ASTNode
   }
 
   @inline(__always)
-  func visit(_ node: GenericParameterClauseSyntax?) -> ASTNode? {
+  func generate(_ node: GenericParameterClauseSyntax?) -> ASTNode? {
     guard let node else {
       return nil
     }
 
-    return self.visit(node)
+    return self.generate(node)
   }
 
   @inline(__always)
-  func visit(_ node: GenericWhereClauseSyntax?) -> ASTNode? {
+  func generate(_ node: GenericWhereClauseSyntax?) -> ASTNode? {
     guard let node else {
       return nil
     }
 
-    return self.visit(node)
+    return self.generate(node)
   }
 
   @inline(__always)
-  func visit(_ node: EnumCaseParameterClauseSyntax?) -> ASTNode? {
+  func generate(_ node: EnumCaseParameterClauseSyntax?) -> ASTNode? {
     guard let node else {
       return nil
     }
 
-    return self.visit(node)
+    return self.generate(node)
   }
 
   @inline(__always)
-  func visit(_ node: InheritedTypeListSyntax?) -> BridgedArrayRef {
+  func generate(_ node: InheritedTypeListSyntax?) -> BridgedArrayRef {
     guard let node else {
       return .init()
     }
 
-    return self.visit(node)
+    return self.generate(node)
   }
 
   @inline(__always)
-  func visit(_ node: PrecedenceGroupNameListSyntax?) -> BridgedArrayRef {
+  func generate(_ node: PrecedenceGroupNameListSyntax?) -> BridgedArrayRef {
     guard let node else {
       return .init()
     }
 
-    return self.visit(node)
+    return self.generate(node)
   }
 }
 
@@ -336,7 +470,7 @@ public func buildTopLevelASTNodes(
       declContext: BridgedDeclContext(raw: dc),
       astContext: BridgedASTContext(raw: ctx)
     )
-    .visit(sourceFile.pointee.syntax)
+    .generate(sourceFile.pointee.syntax)
     .forEach { callback($0, outputContext) }
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -45,18 +45,18 @@ extension SyntaxProtocol {
   ///
   /// - Parameter astgen: The visitor providing the source buffer.
   @inline(__always)
-  func bridgedSourceLoc(in astgen: ASTGenVisitor) -> BridgedSourceLoc { 
+  func bridgedSourceLoc(in astgen: ASTGenVisitor) -> BridgedSourceLoc {
     return BridgedSourceLoc(at: self.positionAfterSkippingLeadingTrivia, in: astgen.base)
   }
 }
 
-extension Optional where Wrapped: SyntaxProtocol { 
+extension Optional where Wrapped: SyntaxProtocol {
   /// Obtains the bridged start location of the node excluding leading trivia in the source buffer provided by `astgen`.
   ///
   /// - Parameter astgen: The visitor providing the source buffer.
   @inline(__always)
-  func bridgedSourceLoc(in astgen: ASTGenVisitor) -> BridgedSourceLoc { 
-    guard let self else { 
+  func bridgedSourceLoc(in astgen: ASTGenVisitor) -> BridgedSourceLoc {
+    guard let self else {
       return nil
     }
     

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -1,7 +1,5 @@
 import CASTBridging
 
-// Needed to use SyntaxTransformVisitor's visit method.
-@_spi(SyntaxTransformVisitor)
 @_spi(ExperimentalLanguageFeatures)
 import SwiftSyntax
 import SwiftDiagnostics
@@ -9,7 +7,7 @@ import SwiftDiagnostics
 // MARK: - TypeDecl
 
 extension ASTGenVisitor {
-  public func visit(_ node: TypeAliasDeclSyntax) -> ASTNode {
+  public func generate(_ node: TypeAliasDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     return .decl(
@@ -19,15 +17,15 @@ extension ASTGenVisitor {
         typealiasKeywordLoc: node.typealiasKeyword.bridgedSourceLoc(in: self),
         name: name,
         nameLoc: nameLoc,
-        genericParamList: self.visit(node.genericParameterClause)?.rawValue,
+        genericParamList: self.generate(node.genericParameterClause)?.rawValue,
         equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
-        underlyingType: self.visit(node.initializer.value).rawValue,
-        genericWhereClause: self.visit(node.genericWhereClause)?.rawValue
+        underlyingType: self.generate(node.initializer.value).rawValue,
+        genericWhereClause: self.generate(node.genericWhereClause)?.rawValue
       )
     )
   }
 
-  public func visit(_ node: EnumDeclSyntax) -> ASTNode {
+  public func generate(_ node: EnumDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     let decl = EnumDecl_create(
@@ -36,20 +34,20 @@ extension ASTGenVisitor {
       enumKeywordLoc: node.enumKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.visit(node.genericParameterClause)?.rawValue,
-      inheritedTypes: self.visit(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.visit(node.genericWhereClause)?.rawValue,
+      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
       braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self)
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.visit(node.memberBlock.members), ofDecl: decl.asDecl)
+      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
     }
 
     return .decl(decl.asDecl)
   }
 
-  public func visit(_ node: StructDeclSyntax) -> ASTNode {
+  public func generate(_ node: StructDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     let decl = StructDecl_create(
@@ -58,20 +56,20 @@ extension ASTGenVisitor {
       structKeywordLoc: node.structKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.visit(node.genericParameterClause)?.rawValue,
-      inheritedTypes: self.visit(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.visit(node.genericWhereClause)?.rawValue,
+      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
       braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self)
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.visit(node.memberBlock.members), ofDecl: decl.asDecl)
+      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
     }
 
     return .decl(decl.asDecl)
   }
 
-  public func visit(_ node: ClassDeclSyntax) -> ASTNode {
+  public func generate(_ node: ClassDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     let decl = ClassDecl_create(
@@ -80,21 +78,21 @@ extension ASTGenVisitor {
       classKeywordLoc: node.classKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.visit(node.genericParameterClause)?.rawValue,
-      inheritedTypes: self.visit(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.visit(node.genericWhereClause)?.rawValue,
+      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
       braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self),
       isActor: false
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.visit(node.memberBlock.members), ofDecl: decl.asDecl)
+      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
     }
 
     return .decl(decl.asDecl)
   }
 
-  public func visit(_ node: ActorDeclSyntax) -> ASTNode {
+  public func generate(_ node: ActorDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     let decl = ClassDecl_create(
@@ -103,21 +101,21 @@ extension ASTGenVisitor {
       classKeywordLoc: node.actorKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.visit(node.genericParameterClause)?.rawValue,
-      inheritedTypes: self.visit(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.visit(node.genericWhereClause)?.rawValue,
+      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
       braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self),
       isActor: true
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.visit(node.memberBlock.members), ofDecl: decl.asDecl)
+      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
     }
 
     return .decl(decl.asDecl)
   }
 
-  func visit(_ node: ProtocolDeclSyntax) -> ASTNode {
+  func generate(_ node: ProtocolDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
     let primaryAssociatedTypeNames = node.primaryAssociatedTypeClause?.primaryAssociatedTypes.lazy.map {
       $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
@@ -130,19 +128,19 @@ extension ASTGenVisitor {
       name: name,
       nameLoc: nameLoc,
       primaryAssociatedTypeNames: primaryAssociatedTypeNames.bridgedArray(in: self),
-      inheritedTypes: self.visit(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.visit(node.genericWhereClause)?.rawValue,
+      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
       braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self)
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.visit(node.memberBlock.members), ofDecl: decl.asDecl)
+      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
     }
 
     return .decl(decl.asDecl)
   }
 
-  func visit(_ node: AssociatedTypeDeclSyntax) -> ASTNode {
+  func generate(_ node: AssociatedTypeDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     return .decl(
@@ -152,9 +150,9 @@ extension ASTGenVisitor {
         associatedtypeKeywordLoc: node.associatedtypeKeyword.bridgedSourceLoc(in: self),
         name: name,
         nameLoc: nameLoc,
-        inheritedTypes: self.visit(node.inheritanceClause?.inheritedTypes),
-        defaultType: self.visit(node.initializer?.value)?.rawValue,
-        genericWhereClause: self.visit(node.genericWhereClause)?.rawValue
+        inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
+        defaultType: self.generate(node.initializer?.value)?.rawValue,
+        genericWhereClause: self.generate(node.genericWhereClause)?.rawValue
       )
     )
   }
@@ -163,19 +161,19 @@ extension ASTGenVisitor {
 // MARK: - ExtensionDecl
 
 extension ASTGenVisitor {
-  func visit(_ node: ExtensionDeclSyntax) -> ASTNode {
+  func generate(_ node: ExtensionDeclSyntax) -> ASTNode {
     let decl = ExtensionDecl_create(
       astContext: self.ctx,
       declContext: self.declContext,
       extensionKeywordLoc: node.extensionKeyword.bridgedSourceLoc(in: self),
-      extendedType: self.visit(node.extendedType).rawValue,
-      inheritedTypes: self.visit(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.visit(node.genericWhereClause)?.rawValue,
+      extendedType: self.generate(node.extendedType).rawValue,
+      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
       braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self)
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.visit(node.memberBlock.members), ofDecl: decl.asDecl)
+      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
     }
 
     return .decl(decl.asDecl)
@@ -185,7 +183,7 @@ extension ASTGenVisitor {
 // MARK: - EnumCaseDecl
 
 extension ASTGenVisitor {
-  func visit(_ node: EnumCaseElementSyntax) -> ASTNode {
+  func generate(_ node: EnumCaseElementSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     return .decl(
@@ -194,19 +192,19 @@ extension ASTGenVisitor {
         declContext: self.declContext,
         name: name,
         nameLoc: nameLoc,
-        parameterList: self.visit(node.parameterClause)?.rawValue,
+        parameterList: self.generate(node.parameterClause)?.rawValue,
         equalsLoc: (node.rawValue?.equal).bridgedSourceLoc(in: self),
-        rawValue: self.visit(node.rawValue?.value)?.rawValue
+        rawValue: self.generate(node.rawValue?.value)?.rawValue
       )
     )
   }
 
-  func visit(_ node: EnumCaseDeclSyntax) -> ASTNode {
+  func generate(_ node: EnumCaseDeclSyntax) -> ASTNode {
     .decl(
       EnumCaseDecl_create(
         declContext: self.declContext,
         caseKeywordLoc: node.caseKeyword.bridgedSourceLoc(in: self),
-        elements: node.elements.lazy.map { self.visit($0).rawValue }.bridgedArray(in: self)
+        elements: node.elements.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self)
       )
     )
   }
@@ -215,9 +213,9 @@ extension ASTGenVisitor {
 // MARK: - AbstractStorageDecl
 
 extension ASTGenVisitor {
-  public func visit(_ node: VariableDeclSyntax) -> ASTNode {
-    let pattern = visit(node.bindings.first!.pattern).rawValue
-    let initializer = visit(node.bindings.first!.initializer!).rawValue
+  public func generate(_ node: VariableDeclSyntax) -> ASTNode {
+    let pattern = generate(node.bindings.first!.pattern).rawValue
+    let initializer = generate(node.bindings.first!.initializer!).rawValue
 
     let isStatic = false  // TODO: compute this
     let isLet = node.bindingSpecifier.tokenKind == .keyword(.let)
@@ -239,7 +237,7 @@ extension ASTGenVisitor {
 // MARK: - AbstractFunctionDecl
 
 extension ASTGenVisitor {
-  public func visit(_ node: FunctionDeclSyntax) -> ASTNode {
+  public func generate(_ node: FunctionDeclSyntax) -> ASTNode {
     // FIXME: Compute this location
     let staticLoc: BridgedSourceLoc = nil
 
@@ -252,49 +250,49 @@ extension ASTGenVisitor {
       funcKeywordLoc: node.funcKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.visit(node.genericParameterClause)?.rawValue,
-      parameterList: self.visit(node.signature.parameterClause).rawValue,
+      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      parameterList: self.generate(node.signature.parameterClause).rawValue,
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.visit(node.signature.effectSpecifiers?.thrownError?.type)?.rawValue,
-      returnType: self.visit(node.signature.returnClause?.type)?.rawValue,
-      genericWhereClause: self.visit(node.genericWhereClause)?.rawValue
+      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type)?.rawValue,
+      returnType: self.generate(node.signature.returnClause?.type)?.rawValue,
+      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue
     )
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        AbstractFunctionDecl_setBody(self.visit(body).rawValue, ofDecl: decl.asDecl)
+        AbstractFunctionDecl_setBody(self.generate(body).rawValue, ofDecl: decl.asDecl)
       }
     }
 
     return .decl(decl.asDecl)
   }
 
-  func visit(_ node: InitializerDeclSyntax) -> ASTNode {
+  func generate(_ node: InitializerDeclSyntax) -> ASTNode {
     let decl = ConstructorDecl_create(
       astContext: self.ctx,
       declContext: self.declContext,
       initKeywordLoc: node.initKeyword.bridgedSourceLoc(in: self),
       failabilityMarkLoc: node.optionalMark.bridgedSourceLoc(in: self),
       isIUO: node.optionalMark?.tokenKind == .exclamationMark,
-      genericParamList: self.visit(node.genericParameterClause)?.rawValue,
-      parameterList: self.visit(node.signature.parameterClause).rawValue,
+      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      parameterList: self.generate(node.signature.parameterClause).rawValue,
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.visit(node.signature.effectSpecifiers?.thrownError?.type)?.rawValue,
-      genericWhereClause: self.visit(node.genericWhereClause)?.rawValue
+      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type)?.rawValue,
+      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue
     )
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        AbstractFunctionDecl_setBody(self.visit(body).rawValue, ofDecl: decl.asDecl)
+        AbstractFunctionDecl_setBody(self.generate(body).rawValue, ofDecl: decl.asDecl)
       }
     }
 
     return .decl(decl.asDecl)
   }
 
-  func visit(_ node: DeinitializerDeclSyntax) -> ASTNode {
+  func generate(_ node: DeinitializerDeclSyntax) -> ASTNode {
     let decl = DestructorDecl_create(
       astContext: self.ctx,
       declContext: self.declContext,
@@ -303,7 +301,7 @@ extension ASTGenVisitor {
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        AbstractFunctionDecl_setBody(self.visit(body).rawValue, ofDecl: decl.asDecl)
+        AbstractFunctionDecl_setBody(self.generate(body).rawValue, ofDecl: decl.asDecl)
       }
     }
 
@@ -325,7 +323,7 @@ extension BridgedOperatorFixity {
 }
 
 extension ASTGenVisitor {
-  func visit(_ node: OperatorDeclSyntax) -> ASTNode {
+  func generate(_ node: OperatorDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
     let (precedenceGroupName, precedenceGroupLoc) = (node.operatorPrecedenceAndTypes?.precedenceGroup).bridgedIdentifierAndSourceLoc(in: self)
 
@@ -367,7 +365,7 @@ extension BridgedAssociativity {
 }
 
 extension ASTGenVisitor {
-  func visit(_ node: PrecedenceGroupDeclSyntax) -> ASTNode {
+  func generate(_ node: PrecedenceGroupDeclSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     struct PrecedenceGroupBody {
@@ -454,9 +452,9 @@ extension ASTGenVisitor {
         assignmentValueLoc: (body.assignment?.value).bridgedSourceLoc(in: self),
         isAssignment: assignmentValue,
         higherThanKeywordLoc: (body.higherThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-        higherThanNames: self.visit(body.higherThanRelation?.precedenceGroups),
+        higherThanNames: self.generate(body.higherThanRelation?.precedenceGroups),
         lowerThanKeywordLoc: (body.lowerThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-        lowerThanNames: self.visit(body.lowerThanRelation?.precedenceGroups),
+        lowerThanNames: self.generate(body.lowerThanRelation?.precedenceGroups),
         rightBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
       )
     )
@@ -481,7 +479,7 @@ extension BridgedImportKind {
 }
 
 extension ASTGenVisitor {
-  func visit(_ node: ImportDeclSyntax) -> ASTNode {
+  func generate(_ node: ImportDeclSyntax) -> ASTNode {
     let importKind: BridgedImportKind
     if let specifier = node.importKindSpecifier {
       if let value = BridgedImportKind(from: specifier.tokenKind) {
@@ -511,17 +509,17 @@ extension ASTGenVisitor {
 
 extension ASTGenVisitor {
   @inline(__always)
-  func visit(_ node: MemberBlockItemListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.visit($0).rawValue }.bridgedArray(in: self)
+  func generate(_ node: MemberBlockItemListSyntax) -> BridgedArrayRef {
+    node.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self)
   }
 
   @inline(__always)
-  func visit(_ node: InheritedTypeListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.visit($0.type).rawValue }.bridgedArray(in: self)
+  func generate(_ node: InheritedTypeListSyntax) -> BridgedArrayRef {
+    node.lazy.map { self.generate($0.type).rawValue }.bridgedArray(in: self)
   }
 
   @inline(__always)
-  func visit(_ node: PrecedenceGroupNameListSyntax) -> BridgedArrayRef {
+  func generate(_ node: PrecedenceGroupNameListSyntax) -> BridgedArrayRef {
     node.lazy.map {
       $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
     }.bridgedArray(in: self)

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -1,24 +1,21 @@
 import CASTBridging
 import CBasicBridging
-
-// Needed to use SyntaxTransformVisitor's visit method.
-@_spi(SyntaxTransformVisitor)
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  func visit(_ node: GenericParameterClauseSyntax) -> ASTNode {
+  func generate(_ node: GenericParameterClauseSyntax) -> ASTNode {
     .misc(
       GenericParamList_create(
         astContext: self.ctx,
         leftAngleLoc: node.leftAngle.bridgedSourceLoc(in: self),
-        parameters: node.parameters.lazy.map { self.visit($0).rawValue }.bridgedArray(in: self),
-        genericWhereClause: self.visit(node.genericWhereClause)?.rawValue,
+        parameters: node.parameters.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self),
+        genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
         rightAngleLoc: node.rightAngle.bridgedSourceLoc(in: self)
       )
     )
   }
 
-  func visit(_ node: GenericParameterSyntax) -> ASTNode {
+  func generate(_ node: GenericParameterSyntax) -> ASTNode {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     var genericParameterIndex: Int?
@@ -39,28 +36,28 @@ extension ASTGenVisitor {
         eachKeywordLoc: node.eachKeyword.bridgedSourceLoc(in: self),
         name: name,
         nameLoc: nameLoc,
-        inheritedType: self.visit(node.inheritedType)?.rawValue,
+        inheritedType: self.generate(node.inheritedType)?.rawValue,
         index: SwiftInt(genericParameterIndex)
       )
     )
   }
 
-  func visit(_ node: GenericWhereClauseSyntax) -> ASTNode {
+  func generate(_ node: GenericWhereClauseSyntax) -> ASTNode {
     let requirements = node.requirements.lazy.map {
       switch $0.requirement {
       case .conformanceRequirement(let conformance):
         return BridgedRequirementRepr(
           SeparatorLoc: conformance.colon.bridgedSourceLoc(in: self),
           Kind: .typeConstraint,
-          FirstType: self.visit(conformance.leftType).rawValue,
-          SecondType: self.visit(conformance.rightType).rawValue
+          FirstType: self.generate(conformance.leftType).rawValue,
+          SecondType: self.generate(conformance.rightType).rawValue
         )
       case .sameTypeRequirement(let sameType):
         return BridgedRequirementRepr(
           SeparatorLoc: sameType.equal.bridgedSourceLoc(in: self),
           Kind: .sameType,
-          FirstType: self.visit(sameType.leftType).rawValue,
-          SecondType: self.visit(sameType.rightType).rawValue
+          FirstType: self.generate(sameType.leftType).rawValue,
+          SecondType: self.generate(sameType.rightType).rawValue
         )
       case .layoutRequirement(_):
         // FIXME: Implement layout requirement translation.

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -2,7 +2,7 @@ import CASTBridging
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func visit(_ node: StringLiteralExprSyntax) -> ASTNode {
+  public func generate(_ node: StringLiteralExprSyntax) -> ASTNode {
     let openDelimiterOrQuoteLoc = (node.openingPounds ?? node.openingQuote).bridgedSourceLoc(in: self)
 
     // FIXME: Handle interpolated strings.
@@ -14,7 +14,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func visit(_ node: IntegerLiteralExprSyntax) -> ASTNode {
+  public func generate(_ node: IntegerLiteralExprSyntax) -> ASTNode {
     var segment = node.literal.text
     return .expr(
       segment.withBridgedString { bridgedSegment in
@@ -23,14 +23,14 @@ extension ASTGenVisitor {
     )
   }
 
-  public func visit(_ node: BooleanLiteralExprSyntax) -> ASTNode {
+  public func generate(_ node: BooleanLiteralExprSyntax) -> ASTNode {
     let value = node.literal.tokenKind == .keyword(.true)
     return .expr(BooleanLiteralExpr_create(ctx, value, node.literal.bridgedSourceLoc(in: self)))
   }
 
-  public func visit(_ node: ArrayExprSyntax) -> ASTNode {
+  public func generate(_ node: ArrayExprSyntax) -> ASTNode {
     let expressions = node.elements.lazy.map {
-      self.visit($0).rawValue
+      self.generate($0).rawValue
     }
 
     let commaLocations = node.elements.compactMap(in: self) {
@@ -48,7 +48,7 @@ extension ASTGenVisitor {
     )
   }
 
-  func visit(_ node: NilLiteralExprSyntax) -> ASTNode {
+  func generate(_ node: NilLiteralExprSyntax) -> ASTNode {
     .expr(NilLiteralExpr_create(astContext: self.ctx, nilKeywordLoc: node.nilKeyword.bridgedSourceLoc(in: self)))
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -17,9 +17,6 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
 import SwiftCompilerPluginMessageHandling
-
-// Needed to use SyntaxTransformVisitor's visit method.
-@_spi(SyntaxTransformVisitor)
 import SwiftSyntax
 
 extension SyntaxProtocol {

--- a/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
+++ b/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
@@ -11,9 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import CASTBridging
-
-// Needed to use SyntaxTransformVisitor's visit method.
-@_spi(SyntaxTransformVisitor)
 import SwiftSyntax
 
 // MARK: - ParamDecl
@@ -57,11 +54,11 @@ extension EnumCaseParameterSyntax: ValueParameterSyntax {
 }
 
 extension ASTGenVisitor {
-  func visit(_ node: FunctionParameterSyntax) -> ASTNode {
+  func generate(_ node: FunctionParameterSyntax) -> ASTNode {
     self.makeParamDecl(node)
   }
 
-  func visit(_ node: EnumCaseParameterSyntax) -> ASTNode {
+  func generate(_ node: EnumCaseParameterSyntax) -> ASTNode {
     self.makeParamDecl(node)
   }
 
@@ -88,8 +85,8 @@ extension ASTGenVisitor {
         firstNameLoc: node.optionalFirstName.bridgedSourceLoc(in: self),
         secondName: secondName,
         secondNameLoc: secondNameLoc,
-        type: self.visit(node.optionalType)?.rawValue,
-        defaultValue: self.visit(node.defaultValue?.value)?.rawValue
+        type: self.generate(node.optionalType)?.rawValue,
+        defaultValue: self.generate(node.defaultValue?.value)?.rawValue
       )
     )
   }
@@ -98,23 +95,23 @@ extension ASTGenVisitor {
 // MARK: - ParameterList
 
 extension ASTGenVisitor {
-  func visit(_ node: FunctionParameterClauseSyntax) -> ASTNode {
+  func generate(_ node: FunctionParameterClauseSyntax) -> ASTNode {
     .misc(
       ParameterList_create(
         astContext: self.ctx,
         leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
-        parameters: self.visit(node.parameters),
+        parameters: self.generate(node.parameters),
         rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
       )
     )
   }
 
-  func visit(_ node: EnumCaseParameterClauseSyntax) -> ASTNode {
+  func generate(_ node: EnumCaseParameterClauseSyntax) -> ASTNode {
     .misc(
       ParameterList_create(
         astContext: self.ctx,
         leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
-        parameters: node.parameters.lazy.map { self.visit($0).rawValue }.bridgedArray(in: self),
+        parameters: node.parameters.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self),
         rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
       )
     )
@@ -123,7 +120,7 @@ extension ASTGenVisitor {
 
 extension ASTGenVisitor {
   @inline(__always)
-  func visit(_ node: FunctionParameterListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.visit($0).rawValue }.bridgedArray(in: self)
+  func generate(_ node: FunctionParameterListSyntax) -> BridgedArrayRef {
+    node.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self)
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -2,19 +2,19 @@ import CASTBridging
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func visit(_ node: CodeBlockSyntax) -> ASTNode {
+  public func generate(_ node: CodeBlockSyntax) -> ASTNode {
     .stmt(
       BraceStmt_create(
         self.ctx,
         node.leftBrace.bridgedSourceLoc(in: self),
-        self.visit(node.statements),
+        self.generate(node.statements),
         node.rightBrace.bridgedSourceLoc(in: self)
       )
     )
   }
 
   func makeIfStmt(_ node: IfExprSyntax) -> ASTNode {
-    let conditions = node.conditions.map { self.visit($0).rawValue }
+    let conditions = node.conditions.map { self.generate($0).rawValue }
     assert(conditions.count == 1)  // TODO: handle multiple conditions.
 
     return .stmt(
@@ -22,14 +22,14 @@ extension ASTGenVisitor {
         self.ctx,
         node.ifKeyword.bridgedSourceLoc(in: self),
         conditions.first!,
-        self.visit(node.body).rawValue,
+        self.generate(node.body).rawValue,
         node.elseKeyword.bridgedSourceLoc(in: self),
-        self.visit(node.elseBody)?.rawValue
+        self.generate(node.elseBody)?.rawValue
       )
     )
   }
 
-  public func visit(_ node: ExpressionStmtSyntax) -> ASTNode {
+  public func generate(_ node: ExpressionStmtSyntax) -> ASTNode {
     switch Syntax(node.expression).as(SyntaxEnum.self) {
     case .ifExpr(let e):
       return makeIfStmt(e)
@@ -38,12 +38,12 @@ extension ASTGenVisitor {
     }
   }
 
-  public func visit(_ node: ReturnStmtSyntax) -> ASTNode {
+  public func generate(_ node: ReturnStmtSyntax) -> ASTNode {
     .stmt(
       ReturnStmt_create(
         self.ctx,
         node.returnKeyword.bridgedSourceLoc(in: self),
-        self.visit(node.expression)?.rawValue
+        self.generate(node.expression)?.rawValue
       )
     )
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->

1. Removal of conformance of `ASTGenVisitor` to `SyntaxTransformVisitor`.
2. Implementation of a `visit(Syntax)` method similar to `SytnaxTransformVisitor.visit(Syntax)` but that only handles the correct nodes in `ASTGen`.
3. Renamed the `visit` methods to `generate`.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #68350 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
