### PR TITLE
[cxx-interop] Add conversion to Bool for types that define `operator bool()`

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -107,6 +107,7 @@ PROTOCOL(DistributedTargetInvocationDecoder)
 PROTOCOL(DistributedTargetInvocationResultHandler)
 
 // C++ Standard Library Overlay:
+PROTOCOL(CxxConvertibleToBool)
 PROTOCOL(CxxConvertibleToCollection)
 PROTOCOL(CxxDictionary)
 PROTOCOL(CxxOptional)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1131,6 +1131,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   case KnownProtocolKind::DistributedTargetInvocationResultHandler:
     M = getLoadedModule(Id_Distributed);
     break;
+  case KnownProtocolKind::CxxConvertibleToBool:
   case KnownProtocolKind::CxxConvertibleToCollection:
   case KnownProtocolKind::CxxDictionary:
   case KnownProtocolKind::CxxPair:

--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -28,6 +28,12 @@ void conformToCxxIteratorIfNeeded(ClangImporter::Implementation &impl,
                                   NominalTypeDecl *decl,
                                   const clang::CXXRecordDecl *clangDecl);
 
+/// If the decl defines `operator bool()`, synthesize a conformance to the
+/// CxxConvertibleToBool protocol, which is defined in the Cxx module.
+void conformToCxxConvertibleToBoolIfNeeded(
+    ClangImporter::Implementation &impl, NominalTypeDecl *decl,
+    const clang::CXXRecordDecl *clangDecl);
+
 /// If the decl is an instantiation of C++ `std::optional`, synthesize a
 /// conformance to CxxOptional protocol, which is defined in the Cxx module.
 void conformToCxxOptionalIfNeeded(ClangImporter::Implementation &impl,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2818,6 +2818,7 @@ namespace {
         auto nominalDecl = cast<NominalTypeDecl>(result);
         conformToCxxIteratorIfNeeded(Impl, nominalDecl, decl);
         conformToCxxSequenceIfNeeded(Impl, nominalDecl, decl);
+        conformToCxxConvertibleToBoolIfNeeded(Impl, nominalDecl, decl);
         conformToCxxSetIfNeeded(Impl, nominalDecl, decl);
         conformToCxxDictionaryIfNeeded(Impl, nominalDecl, decl);
         conformToCxxPairIfNeeded(Impl, nominalDecl, decl);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6519,6 +6519,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::DistributedTargetInvocationEncoder:
   case KnownProtocolKind::DistributedTargetInvocationDecoder:
   case KnownProtocolKind::DistributedTargetInvocationResultHandler:
+  case KnownProtocolKind::CxxConvertibleToBool:
   case KnownProtocolKind::CxxConvertibleToCollection:
   case KnownProtocolKind::CxxDictionary:
   case KnownProtocolKind::CxxPair:

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -7,6 +7,7 @@ if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
 endif()
 
 add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY IS_FRAGILE
+    CxxConvertibleToBool.swift
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
     CxxPair.swift

--- a/stdlib/public/Cxx/CxxConvertibleToBool.swift
+++ b/stdlib/public/Cxx/CxxConvertibleToBool.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A C++ type that can be converted to a Boolean value.
+///
+/// Any C++ type that defines `operator bool()` conforms to this protocol.
+public protocol CxxConvertibleToBool {
+  /// Do not implement this function manually in Swift.
+  func __convertToBool() -> Bool
+}
+
+extension Bool {
+  @inlinable
+  public init<B: CxxConvertibleToBool>(fromCxx convertible: __shared B) {
+    self = convertible.__convertToBool()
+  }
+}

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -9,7 +9,7 @@
 // CHECK:   mutating func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK: }
 
-// CHECK: struct LoadableBoolWrapper {
+// CHECK: struct LoadableBoolWrapper
 // CHECK:   prefix static func ! (lhs: inout LoadableBoolWrapper) -> LoadableBoolWrapper
 // CHECK:   func __convertToBool() -> Bool
 // CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/convertible-to-bool.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/convertible-to-bool.h
@@ -1,0 +1,18 @@
+struct BoolBox {
+  bool value;
+
+  operator bool() const { return value; }
+};
+
+struct NonConstBoolBox {
+  bool value;
+
+  operator bool() { return value; }
+};
+
+struct DualOverloadBoolBox {
+  bool value;
+
+  operator bool() const { return value; }
+  operator bool() { return value; }
+};

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/module.modulemap
@@ -1,3 +1,8 @@
+module ConvertibleToBool {
+  header "convertible-to-bool.h"
+  requires cplusplus
+}
+
 module CustomSequence {
   header "custom-iterator.h" // TODO: extract into another module
   header "custom-sequence.h"

--- a/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-module-interface.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ConvertibleToBool -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+
+// CHECK: struct BoolBox : CxxConvertibleToBool {
+// CHECK: }
+
+// CHECK: struct NonConstBoolBox {
+// CHECK: }
+
+// CHECK: struct DualOverloadBoolBox : CxxConvertibleToBool {
+// CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-typechecker.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+
+import ConvertibleToBool
+
+let _ = Bool(fromCxx: BoolBox())
+let _ = Bool(fromCxx: NonConstBoolBox()) // expected-error {{initializer 'init(fromCxx:)' requires that 'NonConstBoolBox' conform to 'CxxConvertibleToBool'}}
+let _ = Bool(fromCxx: DualOverloadBoolBox())

--- a/test/Interop/Cxx/stdlib/overlay/convertible-to-bool.swift
+++ b/test/Interop/Cxx/stdlib/overlay/convertible-to-bool.swift
@@ -1,0 +1,26 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import ConvertibleToBool
+
+var CxxConvertibleToBoolTestSuite = TestSuite("CxxConvertibleToBool")
+
+CxxConvertibleToBoolTestSuite.test("BoolBox as CxxConvertibleToBool") {
+  let b1 = BoolBox(value: true)
+  expectTrue(Bool(fromCxx: b1))
+
+  let b2 = BoolBox(value: false)
+  expectFalse(Bool(fromCxx: b2))
+}
+
+CxxConvertibleToBoolTestSuite.test("DualOverloadBoolBox as CxxConvertibleToBool") {
+  let b1 = DualOverloadBoolBox(value: true)
+  expectTrue(Bool(fromCxx: b1))
+
+  let b2 = DualOverloadBoolBox(value: false)
+  expectFalse(Bool(fromCxx: b2))
+}
+
+runAllTests()


### PR DESCRIPTION
C++ `operator bool()` is currently imported into Swift as `__convertToBool()`, which shouldn't be used by clients directly.

This adds a new protocol into the C++ stdlib overlay: `CxxConvertibleToBool`, along with an intitializer for `Swift.Bool` taking an instance of `CxxConvertibleToBool`.

rdar://115074954