### PR TITLE
benchmarks: use dedicated module-cache directory for building the benchmarks

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -354,6 +354,7 @@ function (swift_benchmark_compile_archopts)
   set(common_options
       "-c"
       "-target" "${target}"
+      "-module-cache-path" "${CMAKE_CURRENT_BINARY_DIR}/modulecache"
       "-${BENCH_COMPILE_ARCHOPTS_OPT}" ${PAGE_ALIGNMENT_OPTION})
       #"-Xfrontend" "-enable-experimental-feature"
       #"-Xfrontend" "LayoutPrespecialization")


### PR DESCRIPTION
So that it cannot interfere with some leftovers from other compiler runs. This is important for SDK modules which are generated from swiftinterface files (like Foundation). The cached SDK module should be built with the compiler to benchmark (and not being reused from other compiler runs).
