### PR TITLE
[AutoDiff] Enable AutoDiff differentiable_protocol_requirements.swift test

### DIFF
--- a/test/AutoDiff/validation-test/differentiable_protocol_requirements.swift
+++ b/test/AutoDiff/validation-test/differentiable_protocol_requirements.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift
+// REQUIRES: executable_test
 
 // Test is unexpectedly passing on no_assert config on Linux
 

--- a/test/AutoDiff/validation-test/differentiable_protocol_requirements.swift
+++ b/test/AutoDiff/validation-test/differentiable_protocol_requirements.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift
-// REQUIRES: executable_test
 
 // Test is unexpectedly passing on no_assert config on Linux
-// REQUIRES: rdar89860761
 
 // FIXME: Disabled due to test failure with `-O` (https://github.com/apple/swift/issues/55690).
 // XFAIL: swift_test_mode_optimize


### PR DESCRIPTION
This test has been passing since a while.