### PR TITLE
[5.10] Add missing %target-codesigns to a couple of tests

### DIFF
--- a/test/SILOptimizer/target-const-prop.swift
+++ b/test/SILOptimizer/target-const-prop.swift
@@ -3,6 +3,7 @@
 // Make a runtime test to check that the values are correct.
 // RUN: %empty-directory(%t) 
 // RUN: %target-build-swift -O -module-name=test %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 
 // REQUIRES: executable_test,optimized_stdlib


### PR DESCRIPTION
*5.10 cherry-pick of https://github.com/apple/swift/pull/68458*

- Explanation: Adds a missing code-signing step to a test
- Scope: Test-only change
- Issue: rdar://115505198
- Risk: None
- Testing: Passes test suite
- Reviewer: Meghana Gupta