### PR TITLE
[5.10] ModuleInterface: prepare to accept access-level on imports in swiftinterfaces

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -348,6 +348,10 @@ static void printImports(raw_ostream &out,
         out << "@_spi(" << spiName << ") ";
     }
 
+    if (M->getASTContext().LangOpts.isSwiftVersionAtLeast(6)) {
+      out << "public ";
+    }
+
     out << "import ";
     if (Opts.AliasModuleNames &&
         AliasModuleNamesTargets.contains(importedModule->getName().str()))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -968,7 +968,8 @@ void AttributeChecker::visitLazyAttr(LazyAttr *attr) {
 
 bool AttributeChecker::visitAbstractAccessControlAttr(
     AbstractAccessControlAttr *attr) {
-  // Access control attr may only be used on value decls and extensions.
+  // Access control attr may only be used on value decls, extensions and
+  // imports.
   if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D) && !isa<ImportDecl>(D)) {
     diagnoseAndRemoveAttr(attr, diag::invalid_decl_modifier, attr);
     return true;
@@ -996,7 +997,9 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
   }
 
   if (auto importDecl = dyn_cast<ImportDecl>(D)) {
-    if (!D->getASTContext().LangOpts.hasFeature(Feature::AccessLevelOnImport)) {
+    SourceFile *File = D->getDeclContext()->getParentSourceFile();
+    if (!D->getASTContext().LangOpts.hasFeature(Feature::AccessLevelOnImport) &&
+        File && File->Kind != SourceFileKind::Interface) {
       diagnoseAndRemoveAttr(attr, diag::access_level_on_import_not_enabled);
       return true;
     }

--- a/test/ModuleInterface/imports-swift6.swift
+++ b/test/ModuleInterface/imports-swift6.swift
@@ -1,0 +1,36 @@
+/// Swift 6 variant to imports.swift. Both can be reintegrated once
+/// -swift-version 6 is accepted by release compilers.
+// REQUIRES: asserts
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/empty.swiftmodule %S/../Inputs/empty.swift
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/emptyButWithLibraryEvolution.swiftmodule %S/../Inputs/empty.swift -enable-library-evolution
+
+/// Swift 6 variant.
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 6
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
+// RUN: %FileCheck -implicit-check-not BAD -check-prefix CHECK-6 %s < %t.swiftinterface
+
+@_exported import empty // expected-warning {{module 'empty' was not compiled with library evolution support; using it means binary compatibility for 'main' can't be guaranteed}}
+@_exported import emptyButWithLibraryEvolution
+import B.B2
+import func C.c // expected-warning {{scoped imports are not yet supported in module interfaces}}
+import D
+@_implementationOnly import Secret_BAD
+
+@_implementationOnly import NotSoSecret // expected-note {{imported as implementation-only here}}
+import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported as implementation-only}}
+
+// CHECK-6-NOT: import
+// CHECK-6: {{^}}public import A{{$}}
+// CHECK-6-NEXT: {{^}}public import B{{$}}
+// CHECK-6-NEXT: {{^}}public import B.B2{{$}}
+// CHECK-6-NEXT: {{^}}public import B.B3{{$}}
+// CHECK-6-NEXT: {{^}}public import C/*.c*/{{$}}
+// CHECK-6-NEXT: {{^}}public import D{{$}}
+// CHECK-6-NEXT: {{^}}public import NotSoSecret{{$}}
+// CHECK-6-NEXT: {{^}}public import NotSoSecret2{{$}}
+// CHECK-6-NEXT: {{^}}public import Swift{{$}}
+// CHECK-6-NEXT: {{^}}@_exported public import empty{{$}}
+// CHECK-6-NEXT: {{^}}@_exported public import emptyButWithLibraryEvolution{{$}}
+// CHECK-6-NOT: import

--- a/test/ModuleInterface/imports.swift
+++ b/test/ModuleInterface/imports.swift
@@ -5,6 +5,10 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
 // RUN: %FileCheck -implicit-check-not BAD %s < %t.swiftinterface
 
+/// Swift 6 variant.
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 6
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
+// RUN: %FileCheck -implicit-check-not BAD -check-prefix CHECK-6 %s < %t.swiftinterface
 
 @_exported import empty // expected-warning {{module 'empty' was not compiled with library evolution support; using it means binary compatibility for 'imports' can't be guaranteed}}
 @_exported import emptyButWithLibraryEvolution
@@ -29,3 +33,17 @@ import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported
 // CHECK-NEXT: {{^}}@_exported import empty{{$}}
 // CHECK-NEXT: {{^}}@_exported import emptyButWithLibraryEvolution{{$}}
 // CHECK-NOT: import
+
+// CHECK-6-NOT: import
+// CHECK-6: {{^}}public import A{{$}}
+// CHECK-6-NEXT: {{^}}public import B{{$}}
+// CHECK-6-NEXT: {{^}}public import B.B2{{$}}
+// CHECK-6-NEXT: {{^}}public import B.B3{{$}}
+// CHECK-6-NEXT: {{^}}public import C/*.c*/{{$}}
+// CHECK-6-NEXT: {{^}}public import D{{$}}
+// CHECK-6-NEXT: {{^}}public import NotSoSecret{{$}}
+// CHECK-6-NEXT: {{^}}public import NotSoSecret2{{$}}
+// CHECK-6-NEXT: {{^}}public import Swift{{$}}
+// CHECK-6-NEXT: {{^}}@_exported public import empty{{$}}
+// CHECK-6-NEXT: {{^}}@_exported public import emptyButWithLibraryEvolution{{$}}
+// CHECK-6-NOT: import

--- a/test/ModuleInterface/imports.swift
+++ b/test/ModuleInterface/imports.swift
@@ -5,11 +5,6 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
 // RUN: %FileCheck -implicit-check-not BAD %s < %t.swiftinterface
 
-/// Swift 6 variant.
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 6
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
-// RUN: %FileCheck -implicit-check-not BAD -check-prefix CHECK-6 %s < %t.swiftinterface
-
 @_exported import empty // expected-warning {{module 'empty' was not compiled with library evolution support; using it means binary compatibility for 'imports' can't be guaranteed}}
 @_exported import emptyButWithLibraryEvolution
 import B.B2
@@ -33,17 +28,3 @@ import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported
 // CHECK-NEXT: {{^}}@_exported import empty{{$}}
 // CHECK-NEXT: {{^}}@_exported import emptyButWithLibraryEvolution{{$}}
 // CHECK-NOT: import
-
-// CHECK-6-NOT: import
-// CHECK-6: {{^}}public import A{{$}}
-// CHECK-6-NEXT: {{^}}public import B{{$}}
-// CHECK-6-NEXT: {{^}}public import B.B2{{$}}
-// CHECK-6-NEXT: {{^}}public import B.B3{{$}}
-// CHECK-6-NEXT: {{^}}public import C/*.c*/{{$}}
-// CHECK-6-NEXT: {{^}}public import D{{$}}
-// CHECK-6-NEXT: {{^}}public import NotSoSecret{{$}}
-// CHECK-6-NEXT: {{^}}public import NotSoSecret2{{$}}
-// CHECK-6-NEXT: {{^}}public import Swift{{$}}
-// CHECK-6-NEXT: {{^}}@_exported public import empty{{$}}
-// CHECK-6-NEXT: {{^}}@_exported public import emptyButWithLibraryEvolution{{$}}
-// CHECK-6-NOT: import

--- a/test/Sema/access-level-import-flag-check.swift
+++ b/test/Sema/access-level-import-flag-check.swift
@@ -2,11 +2,16 @@
 // RUN: split-file %s %t
 
 /// Build the libraries.
-// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t
-// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t
-// RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t
-// RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t
-// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t \
+// RUN:   -enable-library-evolution
 
 /// Check flag requirement, without and with the flag.
 // RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t -verify \
@@ -17,7 +22,7 @@
 // REQUIRES: asserts
 
 /// swiftinterfaces don't need the flag.
-// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface)
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
 
 //--- PublicLib.swift
 //--- PackageLib.swift
@@ -34,5 +39,9 @@ private import PrivateLib // expected-error@:1 {{Access level on imports require
 
 //--- Client.swiftinterface
 // swift-interface-format-version: 1.0
-// swift-module-flags: -enable-library-evolution
-public import Swift
+// swift-module-flags: -enable-library-evolution -package-name MyPackage
+public import PublicLib
+package import PackageLib
+internal import InternalLib
+fileprivate import FileprivateLib
+private import PrivateLib

--- a/test/Sema/access-level-import-flag-check.swift
+++ b/test/Sema/access-level-import-flag-check.swift
@@ -16,6 +16,9 @@
 // RUN:   -package-name package
 // REQUIRES: asserts
 
+/// swiftinterfaces don't need the flag.
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface)
+
 //--- PublicLib.swift
 //--- PackageLib.swift
 //--- InternalLib.swift
@@ -28,3 +31,8 @@ package import PackageLib // expected-error@:1 {{Access level on imports require
 internal import InternalLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
 fileprivate import FileprivateLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
 private import PrivateLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+
+//--- Client.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-library-evolution
+public import Swift


### PR DESCRIPTION
This adds forward looking support for swiftinterfaces and the Access-levels on import features. Ensure the compiler accepts future swiftinterfaces using access-level keywords on imports without the flag. And print the public access-level keyword in Swift 6 mode.

- Scope: Module interface printing (in Swift 6 mode only) and reading in all language modes.
- Risk: Low, in Swift 5 mode the compiler is more tolerant when reading swifinterfaces.
- Testing: Added regression test.
- Reviewed by: @artemcm and @tshortli 
- Cherry-pick of #68523.