### PR TITLE
[5.10] Serialization: Ignore missing potentially non-required dependencies when listing imports

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -496,20 +496,20 @@ void ModuleFile::getImportedModules(SmallVectorImpl<ImportedModule> &results,
         continue;
 
     } else if (dep.isImplementationOnly()) {
-      if (!filter.contains(ModuleDecl::ImportFilterKind::ImplementationOnly))
+      // Pretend we didn't have potentially optional imports if we weren't
+      // originally asked to load it.
+      if (!filter.contains(ModuleDecl::ImportFilterKind::ImplementationOnly) ||
+          !dep.isLoaded())
         continue;
-      if (!dep.isLoaded()) {
-        // Pretend we didn't have this import if we weren't originally asked to
-        // load it.
-        continue;
-      }
 
     } else if (dep.isInternalOrBelow()) {
-      if (!filter.contains(ModuleDecl::ImportFilterKind::InternalOrBelow))
+      if (!filter.contains(ModuleDecl::ImportFilterKind::InternalOrBelow) ||
+          !dep.isLoaded())
         continue;
 
     } else if (dep.isPackageOnly()) {
-      if (!filter.contains(ModuleDecl::ImportFilterKind::PackageOnly))
+      if (!filter.contains(ModuleDecl::ImportFilterKind::PackageOnly) ||
+          !dep.isLoaded())
         continue;
 
     } else {

--- a/test/Serialization/access-level-import-dependencies.swift
+++ b/test/Serialization/access-level-import-dependencies.swift
@@ -123,6 +123,7 @@ import PrivateDep
 // RUN:   -enable-library-evolution -enable-testing \
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 // RUN: %target-swift-frontend -typecheck %t/ExporterClient.swift -I %t \
+// RUN:   -index-system-modules -index-ignore-stdlib -index-store-path %t/idx \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefixes=CHECK-EXPORTER,HIDDEN-DEP %s
 // CHECK-EXPORTER: 'InternalDep' has an ignored transitive dependency on 'HiddenDep'
 


### PR DESCRIPTION
Indexing looks through all dependencies recursively to index to find all system modules to index. Make sure it ignores dependencies that were not loaded, we can trust the earlier dependency loading logic to have correctly loaded dependencies depending on the context.
- Introduced by access-level on imports.
- Scope: Indexing.
- Risk: Low, indexing will simply try to do less work.
- Testing: Added regression test.
- Resolves: rdar://115372249
- Cherry-pick of #68480.