### PR TITLE
[Sema] NFC: Remove obsolete `isInResultBuilderContext` method

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5497,10 +5497,6 @@ public:
   /// part of the constraint system.
   void forEachExpr(Expr *expr, llvm::function_ref<Expr *(Expr *)> callback);
 
-  /// Determine whether one of the parent closures the given one is nested
-  /// in (if any) has a result builder applied to its body.
-  bool isInResultBuilderContext(ClosureExpr *closure) const;
-
   /// Determine whether referencing the given member on the
   /// given existential base type is supported. This is the case only if the
   /// type of the member, spelled in the context of \p baseTy, does not contain

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -1539,25 +1539,6 @@ void ConstraintSystem::generateConstraints(ArrayRef<ExprPattern *> exprPatterns,
                     referencedTypeVars);
 }
 
-bool ConstraintSystem::isInResultBuilderContext(ClosureExpr *closure) const {
-  if (!closure->hasSingleExpressionBody()) {
-    auto *DC = closure->getParent();
-    do {
-      // Result builder is applied to a function/getter body.
-      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
-        if (resultBuilderTransformed.count(AFD))
-          return true;
-      }
-
-      if (auto *parentClosure = dyn_cast<ClosureExpr>(DC)) {
-        if (resultBuilderTransformed.count(parentClosure))
-          return true;
-      }
-    } while ((DC = DC->getParent()));
-  }
-  return false;
-}
-
 bool isConditionOfStmt(ConstraintLocatorBuilder locator) {
   if (!locator.endsWith<LocatorPathElt::Condition>())
     return false;


### PR DESCRIPTION
Type-checking of result builder transformed closure is enabled by default now, 
so this method is no longer used.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
