### PR TITLE
[embedded][ptrauth] Guard extra ptrauth verification on objc interop …

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -196,6 +196,8 @@ static void sanityCheckStdlib(IRGenModule &IGM) {
   // Only run the sanity check when we're building the real stdlib.
   if (!lookupSimple(IGM.getSwiftModule(), { "String" })) return;
 
+  if (!IGM.ObjCInterop) return;
+
   checkPointerAuthAssociatedTypeDiscriminator(IGM, { "_ObjectiveCBridgeable", "_ObjectiveCType" }, SpecialPointerAuthDiscriminators::ObjectiveCTypeDiscriminator);
   checkPointerAuthWitnessDiscriminator(IGM, { "_ObjectiveCBridgeable", "_bridgeToObjectiveC" }, SpecialPointerAuthDiscriminators::bridgeToObjectiveCDiscriminator);
   checkPointerAuthWitnessDiscriminator(IGM, { "_ObjectiveCBridgeable", "_forceBridgeFromObjectiveC" }, SpecialPointerAuthDiscriminators::forceBridgeFromObjectiveCDiscriminator);

--- a/test/embedded/ptr-auth-irgen-verify-no-stdlib.swift
+++ b/test/embedded/ptr-auth-irgen-verify-no-stdlib.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -Xcc -fptrauth-calls -module-name Swift | %FileCheck %s
+
+// Windows does not have SwiftCompilerSources.
+// XFAIL: OS=windows-msvc
+
+// Some verification is blocked on string lookup succeeding.
+struct String {}
+
+public func test() { }
+
+// CHECK-LABEL: define {{.*}}void @"$ss4testyyF"()


### PR DESCRIPTION
…being enabled.

This verification runs on ObjC briging types which are not present in embedded stdlib or when objc interop is not enabled.