### PR TITLE
[tests] Add a `%batch-code-completion` lit substitution

### DIFF
--- a/test/IDE/complete_accessor.swift
+++ b/test/IDE/complete_accessor.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // WITH_GETSET: Keyword/None:                       get; name=get
 // WITH_GETSET: Keyword/None:                       set; name=set

--- a/test/IDE/complete_after_self.swift
+++ b/test/IDE/complete_after_self.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 //===---
 //===--- Tests for code completion after 'self'.

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -1,8 +1,7 @@
 // RUN: sed -n -e '/VERIFY_BEGIN/,/VERIFY_END$/ p' %s > %t_no_errors.swift
 // RUN: %target-swift-frontend -verify -typecheck %t_no_errors.swift
 
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // NO_CONSTRUCTORS-NOT: init(
 

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct A {
   func doAThings() -> A { return self }

--- a/test/IDE/complete_async_context.swift
+++ b/test/IDE/complete_async_context.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t 
+// RUN: %batch-code-completion
 
 // REQUIRES: concurrency
 

--- a/test/IDE/complete_asyncannotation.swift
+++ b/test/IDE/complete_asyncannotation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t 
+// RUN: %batch-code-completion
 
 // REQUIRES: concurrency
 

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // NORESULT: Token
 

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 var i1 = 1
 var i2 = 2

--- a/test/IDE/complete_concurrency_specifier.swift
+++ b/test/IDE/complete_concurrency_specifier.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t 
+// RUN: %batch-code-completion
 
 // REQUIRES: concurrency
 

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func freeFunc() {}
 

--- a/test/IDE/complete_dont_filter_overloads_with_cc_token.swift
+++ b/test/IDE/complete_dont_filter_overloads_with_cc_token.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func buildView<T>(@MyViewBuilder _ x: () -> T) {}
 

--- a/test/IDE/complete_effectful_accessor.swift
+++ b/test/IDE/complete_effectful_accessor.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 var globalAsyncVar: Int {
   get async {

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 //===---
 //===--- Test that we can complete enum elements.

--- a/test/IDE/complete_enum_unresolved_dot_argument_labels.swift
+++ b/test/IDE/complete_enum_unresolved_dot_argument_labels.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 enum DragState {
   case inactive

--- a/test/IDE/complete_expr_after_paren.swift
+++ b/test/IDE/complete_expr_after_paren.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 protocol MyProtocol {
   init(init1: Int)

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 //
 // Test code completion at the beginning of expr-postfix.

--- a/test/IDE/complete_global_actorisolation.swift
+++ b/test/IDE/complete_global_actorisolation.swift
@@ -1,5 +1,5 @@
 // REQUIRES: concurrency
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t 
+// RUN: %batch-code-completion
 
 class MyNonSendable {}
 struct MySendable {}

--- a/test/IDE/complete_globalactorunsafe.swift
+++ b/test/IDE/complete_globalactorunsafe.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t 
+// RUN: %batch-code-completion
 // REQUIRES: concurrency
 
 // SAFE_NOTREC: Begin completions, 2 items

--- a/test/IDE/complete_in_accessors.swift
+++ b/test/IDE/complete_in_accessors.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 //===--- Helper types that are used in this test
 

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // EMTPY: Token
 // EMPTY-NOT: Begin completions

--- a/test/IDE/complete_in_ifconfig.swift
+++ b/test/IDE/complete_in_ifconfig.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct MyStruct {
     init() {}

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -1,5 +1,4 @@
-// RUN %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 @resultBuilder
 struct TupleBuilder<T> {

--- a/test/IDE/complete_inout.swift
+++ b/test/IDE/complete_inout.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct Bar() {
     init?(withInout: inout Int) {}

--- a/test/IDE/complete_invalid_result_builder.swift
+++ b/test/IDE/complete_invalid_result_builder.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 enum Either<T,U> { case first(T), second(U) }
 indirect enum ResultBuilderTerm<Expression> {

--- a/test/IDE/complete_issue-56810.swift
+++ b/test/IDE/complete_issue-56810.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // https://github.com/apple/swift/issues/56810
 

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // KW_RETURN: Keyword[return]/None: return{{; name=.+$}}
 // KW_NO_RETURN-NOT: Keyword[return]

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 {
   1.#^LITERAL1^#

--- a/test/IDE/complete_macro_attribute.swift
+++ b/test/IDE/complete_macro_attribute.swift
@@ -1,6 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t/output
-
+// RUN: %batch-code-completion
 
 @freestanding(#^FREESTANDING_ROLE^#)
 macro FreestandingMacro

--- a/test/IDE/complete_macro_declaration.swift
+++ b/test/IDE/complete_macro_declaration.swift
@@ -1,6 +1,5 @@
 // REQUIRES: swift_swift_parser
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 let globalVar = 1
 macro expect(file: Int = #^DEFAULT_ARG^#) = #externalMacro(module: "MyModule", type: "MyMacro")

--- a/test/IDE/complete_member_type.swift
+++ b/test/IDE/complete_member_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 class A {
   typealias T = Int

--- a/test/IDE/complete_multibracestmt.swift
+++ b/test/IDE/complete_multibracestmt.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 enum E {
   case bar

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func globalFunc1(fn1: () -> Int, fn2: () -> String) {}
 func testGlobalFunc() {

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 protocol MyProtocol {
   associatedtype Mistery

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct S {}
 postfix operator ++ {}

--- a/test/IDE/complete_optional_binding.swift
+++ b/test/IDE/complete_optional_binding.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 let topLevelOpt: Int?
 

--- a/test/IDE/complete_optional_function.swift
+++ b/test/IDE/complete_optional_function.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t) 
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func foo(_ x: ((_ x: Int, _ y: Int) -> Void)?) {
   x?(1, #^OPTIONAL_PARAMETER^#)

--- a/test/IDE/complete_pattern.swift
+++ b/test/IDE/complete_pattern.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 //===--- Helper types that are used in this test
 

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 enum MyEnum {
   case east, west

--- a/test/IDE/complete_protocol_static_member.swift
+++ b/test/IDE/complete_protocol_static_member.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 protocol FontStyle {}
 struct FontStyleOne: FontStyle {}

--- a/test/IDE/complete_protocol_typealias.swift
+++ b/test/IDE/complete_protocol_typealias.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 protocol MyProto {
   typealias Content = Int

--- a/test/IDE/complete_rdar71005827.swift
+++ b/test/IDE/complete_rdar71005827.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 private enum GlobalPrivateE {
     case foo, bar

--- a/test/IDE/complete_rdar80489548.swift
+++ b/test/IDE/complete_rdar80489548.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t.ccp)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // KW_IN: Keyword[in]/None: in{{; name=.+$}}
 // KW_NO_IN-NOT: Keyword[in]

--- a/test/IDE/complete_result_builder_func_signature.swift
+++ b/test/IDE/complete_result_builder_func_signature.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 @resultBuilder struct MyBuilder {
     static func buildBlock() -> Int

--- a/test/IDE/complete_sequence_invalid.swift
+++ b/test/IDE/complete_sequence_invalid.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // GLOBAL: Decl[GlobalVar]/CurrModule:         invalidDecl[#<<error type>>#];
 let invalidDecl = INVALID

--- a/test/IDE/complete_shadowing.swift
+++ b/test/IDE/complete_shadowing.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // LOCAL_STRING_TESTVALUE-NOT: name=testValue
 // LOCAL_STRING_TESTVALUE:     Decl[LocalVar]/Local: testValue[#String#]; name=testValue

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // MARK: Single-expression closures
 

--- a/test/IDE/complete_sself.swift
+++ b/test/IDE/complete_sself.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // NOSELF-NOT: name=Self
 

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct FooStruct {
   var instanceVar : Int

--- a/test/IDE/complete_super_self.swift
+++ b/test/IDE/complete_super_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 class BaseClass {
   func returnSelf() -> Self {}

--- a/test/IDE/complete_trailing_if_expr.swift
+++ b/test/IDE/complete_trailing_if_expr.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct MyStruct {
   func takeAnotherClosure(_ y: () -> Void) {}

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 //===--- Helper types that are used in this test
 

--- a/test/IDE/complete_type_any.swift
+++ b/test/IDE/complete_type_any.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func testAnyInParamList(a: #^ANY_IN_FUNC_PARAM^#
 // ANY_IN_FUNC_PARAM-DAG: Keyword/None: Any[#Any#]; name=Any

--- a/test/IDE/complete_type_attribute.swift
+++ b/test/IDE/complete_type_attribute.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // TYPEATTR-NOT: myIntValue
 // TYPEATTR-DAG: Keyword/None:                       autoclosure[#Type Attribute#]; name=autoclosure

--- a/test/IDE/complete_type_in_func_param.swift
+++ b/test/IDE/complete_type_in_func_param.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 //===--- Helper types that are used in this test
 

--- a/test/IDE/complete_unapplied_static_ref_to_func_with_error.swift
+++ b/test/IDE/complete_unapplied_static_ref_to_func_with_error.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 // Check that we don't crash
 
 func myGlobalFunction() -> Invalid {}

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // Test code completion of expressions that produce a value.
 

--- a/test/IDE/complete_value_literals.swift
+++ b/test/IDE/complete_value_literals.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func testAll0() {
   // Not type context.

--- a/test/IDE/complete_with_adjacent_string_literal.swift
+++ b/test/IDE/complete_with_adjacent_string_literal.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func takeClosure(x: () -> Void) {}
 func takeString(_ a: String) -> MyStruct {}

--- a/test/IDE/complete_with_trailing_closure.swift
+++ b/test/IDE/complete_with_trailing_closure.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 public struct ItemWrapper {
   let content: Int

--- a/test/IDE/complete_without_constraint_type.swift
+++ b/test/IDE/complete_without_constraint_type.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct FileDescriptor: ~#^COMPLETE^# {}
 // FIXME: This should be emitting a `Copyable` declaration instead of a keyword, once there is a declaration for `Copyable`

--- a/test/IDE/complete_yield.swift
+++ b/test/IDE/complete_yield.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct YieldVariables {
   var stringValue: String

--- a/test/IDE/copy_expr.swift
+++ b/test/IDE/copy_expr.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func test(myParam: Int) {
   copy #^COPY^#

--- a/test/IDE/move_expr.swift
+++ b/test/IDE/move_expr.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func test(myParam: Int) {
   consume #^CONSUME^#

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2582,9 +2582,6 @@ config.substitutions.append(('%scale-test',
                              '{} {} --swiftc-binary={} --tmpdir=%t --exclude-timers'.format(
                                  shell_quote(sys.executable), config.scale_test,
                                  config.swiftc)))
-config.substitutions.append(('%empty-directory\(([^)]+)\)',
-                             SubstituteCaptures(r'rm -rf "\1" && mkdir -p "\1"')))
-
 config.substitutions.append(('%target-sil-opt\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s' % (
                                  escape_for_substitute_captures(subst_target_sil_opt_mock_sdk),
@@ -2596,6 +2593,8 @@ config.substitutions.append(('%target-sil-opt', config.target_sil_opt))
 config.substitutions.append(('%target-sil-func-extractor', config.target_sil_func_extractor))
 config.substitutions.append(('%target-sil-llvm-gen', config.target_sil_llvm_gen))
 config.substitutions.append(('%target-sil-nm', config.target_sil_nm))
+
+config.substitutions.append(('%batch-code-completion', '%empty-directory(%t/batch-code-completion) && %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t/batch-code-completion'))
 
 config.substitutions.append(('%target-swift-ide-test\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s -swift-version %s' % (
@@ -2609,6 +2608,9 @@ config.substitutions.append(('%target-swift-ide-test',
 
 config.substitutions.append(('%target-swift-symbolgraph-extract', config.target_swift_symbolgraph_extract))
 config.substitutions.append(('%target-swift-api-extract', config.target_swift_api_extract))
+
+config.substitutions.append(('%empty-directory\(([^)]+)\)',
+                             SubstituteCaptures(r'rm -rf "\1" && mkdir -p "\1"')))
 
 if not hasattr(config, 'target_swift_reflection_test'):
     config.target_swift_reflection_test = inferSwiftBinary(swift_reflection_test_name)

--- a/validation-test/IDE/crashers_2_fixed/0037-constructor-with-error-type.swift
+++ b/validation-test/IDE/crashers_2_fixed/0037-constructor-with-error-type.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 public struct AnyError {
 

--- a/validation-test/IDE/crashers_2_fixed/0038-setTypeForArgumentIgnoredForCompletion.swift
+++ b/validation-test/IDE/crashers_2_fixed/0038-setTypeForArgumentIgnoredForCompletion.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func overloaded(content: () -> Int) {}
 func overloaded(@MyResultBuilder stuff: () -> Int) {}

--- a/validation-test/IDE/crashers_2_fixed/0039-not-all-primary-assoc-types-specified.swift
+++ b/validation-test/IDE/crashers_2_fixed/0039-not-all-primary-assoc-types-specified.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 protocol Publisher<Output, Failure> {
   associatedtype Output

--- a/validation-test/IDE/crashers_fixed/subexpr-literal-in-sequence-expr.swift
+++ b/validation-test/IDE/crashers_fixed/subexpr-literal-in-sequence-expr.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename=%s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 func test1() {
   1 + [0]#^A^#

--- a/validation-test/IDE/issues_fixed/issue-55423.swift
+++ b/validation-test/IDE/issues_fixed/issue-55423.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // https://github.com/apple/swift/issues/55423
 

--- a/validation-test/IDE/issues_fixed/issue-57041.swift
+++ b/validation-test/IDE/issues_fixed/issue-57041.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // https://github.com/apple/swift/issues/57041
 

--- a/validation-test/IDE/issues_fixed/issue-57439.swift
+++ b/validation-test/IDE/issues_fixed/issue-57439.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 // https://github.com/apple/swift/issues/57439
 

--- a/validation-test/IDE/issues_fixed/rdar63063279.swift
+++ b/validation-test/IDE/issues_fixed/rdar63063279.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 enum A {
     case one, two

--- a/validation-test/IDE/issues_fixed/rdar64227741.swift
+++ b/validation-test/IDE/issues_fixed/rdar64227741.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 struct Earthquake {
   var magnitude: Float

--- a/validation-test/IDE/issues_fixed/rdar69813796.swift
+++ b/validation-test/IDE/issues_fixed/rdar69813796.swift
@@ -1,5 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %batch-code-completion
 
 enum E {
   case foo, bar


### PR DESCRIPTION
I could never remember the command to run batch code completion tests. Add a lit substitution for it.
