### PR TITLE
Allow Identifiable and correct ObjectIdentifier for embedded variants

### DIFF
--- a/stdlib/public/core/Identifiable.swift
+++ b/stdlib/public/core/Identifiable.swift
@@ -39,7 +39,6 @@
 /// lifetime of an object. If an object has a stronger notion of identity, it
 /// may be appropriate to provide a custom implementation.
 @available(SwiftStdlib 5.1, *)
-@_unavailableInEmbedded
 public protocol Identifiable<ID> {
 
   /// A type representing the stable identity of the entity associated with
@@ -51,7 +50,6 @@ public protocol Identifiable<ID> {
 }
 
 @available(SwiftStdlib 5.1, *)
-@_unavailableInEmbedded
 extension Identifiable where Self: AnyObject {
   public var id: ObjectIdentifier {
     return ObjectIdentifier(self)

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -50,18 +50,31 @@ public struct ObjectIdentifier: Sendable {
   ///     // Prints "false"
   ///
   /// - Parameter x: An instance of a class.
+#if $Embedded
+  @inlinable // trivial-implementation
+  public init<Object: AnyObject>(_ x: Object) {
+    self._value = Builtin.bridgeToRawPointer(x)
+  }
+#else
   @inlinable // trivial-implementation
   public init(_ x: AnyObject) {
     self._value = Builtin.bridgeToRawPointer(x)
   }
-
+#endif
   /// Creates an instance that uniquely identifies the given metatype.
   ///
   /// - Parameter: A metatype.
+#if $Embedded
+  @inlinable // trivial-implementation
+  public init<Object>(_ x: Object.Type) {
+    self._value = unsafeBitCast(x, to: Builtin.RawPointer.self)
+  }
+#else
   @inlinable // trivial-implementation
   public init(_ x: Any.Type) {
     self._value = unsafeBitCast(x, to: Builtin.RawPointer.self)
   }
+#endif
 }
 
 @_unavailableInEmbedded


### PR DESCRIPTION
Identifiable does not really have any issue for embedded targets. ObjectIdentifier (in related areas) however does have existential uses which can be code-wise compatible by changing the signatures to no longer use the `Any.Type` and `AnyObject` existentials.