### PR TITLE
[5.10 🍒][Explicit Modules] Fix detection of a type-checking action in 'ExplicitModuleInterfaceBuilder'

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -641,6 +641,10 @@ public:
   /// Whether this compiler instance supports caching.
   bool supportCaching() const;
 
+  /// Whether errors during interface verification can be downgrated
+  /// to warnings.
+  bool downgradeInterfaceVerificationErrors() const;
+
   /// Gets the SourceFile which is the primary input for this CompilerInstance.
   /// \returns the primary SourceFile, or nullptr if there is no primary input;
   /// if there are _multiple_ primary inputs, fails with an assertion.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -507,6 +507,9 @@ public:
   /// Whether we're configured to track system intermodule dependencies.
   bool shouldTrackSystemDependencies() const;
   
+  /// Whether we are configured with -typecheck or -typecheck-module-from-interface actuin
+  bool isTypeCheckAction() const;
+
   /// Whether to emit symbol graphs for the output module.
   bool EmitSymbolGraph = false;
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1128,6 +1128,18 @@ bool CompilerInstance::supportCaching() const {
       Invocation.getFrontendOptions().RequestedAction);
 }
 
+bool CompilerInstance::downgradeInterfaceVerificationErrors() const {
+  auto &FrontendOpts = Invocation.getFrontendOptions();
+  if (Context->blockListConfig.hasBlockListAction(FrontendOpts.ModuleName,
+                                             BlockListKeyKind::ModuleName,
+                        BlockListAction::DowngradeInterfaceVerificationFailure)) {
+    Context->Diags.diagnose(SourceLoc(), diag::interface_block_listed_broken,
+                            FrontendOpts.ModuleName);
+    return true;
+  }
+  return FrontendOpts.DowngradeInterfaceVerificationError;
+}
+
 ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
   auto &frontendOpts = Invocation.getFrontendOptions();
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -928,3 +928,8 @@ bool FrontendOptions::shouldTrackSystemDependencies() const {
   return IntermoduleDependencyTracking ==
          IntermoduleDepTrackingMode::IncludeSystem;
 }
+
+bool FrontendOptions::isTypeCheckAction() const {
+  return RequestedAction == FrontendOptions::ActionType::Typecheck ||
+  RequestedAction == FrontendOptions::ActionType::TypecheckModuleFromInterface;
+}

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1464,13 +1464,17 @@ static bool performCompile(CompilerInstance &Instance,
   }() && "Only supports parsing .swift files");
 
   bool hadError = performAction(Instance, ReturnValue, observer);
+  auto canIgnoreErrorForExit = [&Instance, &opts]() {
+    return opts.AllowModuleWithCompilerErrors ||
+      (opts.isTypeCheckAction() && Instance.downgradeInterfaceVerificationErrors());
+  };
 
   // We might have freed the ASTContext already, but in that case we would
   // have already performed these actions.
   if (Instance.hasASTContext() &&
       FrontendOptions::doesActionPerformEndOfPipelineActions(Action)) {
     performEndOfPipelineActions(Instance);
-    if (!opts.AllowModuleWithCompilerErrors)
+    if (!canIgnoreErrorForExit())
       hadError |= Instance.getASTContext().hadError();
   }
   return hadError;

--- a/test/ModuleInterface/downgrade-module-verification-error-explicit.swift
+++ b/test/ModuleInterface/downgrade-module-verification-error-explicit.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "// swift-interface-format-version: 1.0" > %t/Main.swiftinterface
+// RUN: echo "// swift-module-flags: -module-name Foo" >> %t/Main.swiftinterface
+// RUN: echo "malfunctioned" >> %t/Main.swiftinterface
+
+// Verify with '-downgrade-typecheck-interface-error'
+// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Main.swiftinterface -module-name Foo -downgrade-typecheck-interface-error -explicit-interface-module-build 2>&1 | %FileCheck %s
+
+// Verify with a blocklist
+// RUN: echo "---" > %t/blocklist.yml
+// RUN: echo "DowngradeInterfaceVerificationFailure:" >> %t/blocklist.yml
+// RUN: echo "  ModuleName:" >> %t/blocklist.yml
+// RUN: echo "    - Foo" >> %t/blocklist.yml
+// RUN: %target-swift-frontend -typecheck-module-from-interface %t/Main.swiftinterface -module-name Foo -blocklist-file %t/blocklist.yml -explicit-interface-module-build 2>&1 | %FileCheck %s
+
+// CHECK: warning:
+// CHECK-NOT: error:


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68598
------------------------------------
• **Release**: Swift 5.10
• Explanation: When we run an interface verification tasks with Explicit module builds, we directly invoke a '-explicit-interface-module-build' instance with a '-typecheck-module-from-interface' action. So the builder needs to recognize this as a typechecking invocation. In implicit builds, this gets lowered into a separate compiler sub-instance with a '-typecheck' action, for some reason.
• Scope of Issue: Clients who disable verification of emitted module interface will still see error diagnostics, instead of expected warnings, from verification jobs.
• Origination: Explicit Module Build feature development recently enabled explicit interface build for Interface verification jobs.
• Reviewed By: @tshortli @xymus @nkcsgexi 
• Automated Testing: Test added to the compiler test suite




resolves rdar://115565571
