### PR TITLE
[CodeCompletion] Completion for `@storageRestrictions` attribute

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -105,6 +105,9 @@ class CompletionLookup final : public swift::VisibleDeclConsumer {
     TypeInDeclContext,
     ImportFromModule,
     GenericRequirement,
+
+    /// Look up stored properties within a type.
+    StoredProperty,
   };
 
   LookupKind Kind;
@@ -527,6 +530,9 @@ public:
   /// can use \p VD to enrich call pattern completions of \p ExprType.
   void getValueExprCompletions(Type ExprType, ValueDecl *VD = nullptr,
                                bool IsDeclUnapplied = false);
+
+  /// Add completions for stored properties of \p D.
+  void getStoredPropertyCompletions(const NominalTypeDecl *D);
 
   void collectOperators(SmallVectorImpl<OperatorDecl *> &results);
 

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -36,6 +36,25 @@ enum class CustomSyntaxAttributeKind {
   Available,
   FreestandingMacro,
   AttachedMacro,
+  StorageRestrictions
+};
+
+/// A bit of a hack. When completing inside the '@storageRestrictions'
+/// attribute, we use the \c ParamIndex field to communicate where inside the
+/// attribute we are performing the completion.
+enum class StorageRestrictionsCompletionKind : int {
+  /// We are completing directly after the '(' and require a 'initializes' or
+  /// 'accesses' label.
+  Label,
+  /// We are completing in a context that only allows arguments (ie. accessed or
+  /// initialized variables) and doesn't permit an argument label.
+  Argument,
+  /// Completion in a context that allows either an argument or the
+  /// 'initializes' label.
+  ArgumentOrInitializesLabel,
+  /// Completion in a context that allows either an argument or the
+  /// 'accesses' label.
+  ArgumentOrAccessesLabel
 };
 
 /// Parser's interface to code completion.

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2251,7 +2251,7 @@ void CompletionLookup::foundDecl(ValueDecl *D, DeclVisibilityKind Reason,
     return;
   case LookupKind::StoredProperty:
     if (auto *VD = dyn_cast<VarDecl>(D)) {
-      if (VD->getImplInfo().hasStorage()) {
+      if (VD->hasStorage()) {
         addVarDeclRef(VD, Reason, dynamicLookupInfo);
       }
       return;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1305,6 +1305,7 @@ bool CompletionLookup::isImplicitlyCurriedInstanceMethod(
 
   switch (Kind) {
   case LookupKind::ValueExpr:
+  case LookupKind::StoredProperty:
     return ExprType->is<AnyMetatypeType>();
   case LookupKind::ValueInDeclContext:
     if (InsideStaticMethod)
@@ -2248,6 +2249,13 @@ void CompletionLookup::foundDecl(ValueDecl *D, DeclVisibilityKind Reason,
     }
 
     return;
+  case LookupKind::StoredProperty:
+    if (auto *VD = dyn_cast<VarDecl>(D)) {
+      if (VD->getImplInfo().hasStorage()) {
+        addVarDeclRef(VD, Reason, dynamicLookupInfo);
+      }
+      return;
+    }
   }
 }
 
@@ -2461,6 +2469,17 @@ void CompletionLookup::getValueExprCompletions(Type ExprType, ValueDecl *VD,
                            IncludeInstanceMembers,
                            /*includeDerivedRequirements*/ false,
                            /*includeProtocolExtensionMembers*/ true);
+}
+
+void CompletionLookup::getStoredPropertyCompletions(const NominalTypeDecl *D) {
+  Kind = LookupKind::StoredProperty;
+  NeedLeadingDot = false;
+
+  lookupVisibleMemberDecls(*this, D->getDeclaredInterfaceType(),
+                           /*DotLoc=*/SourceLoc(), CurrDeclContext,
+                           /*IncludeInstanceMembers*/ true,
+                           /*includeDerivedRequirements*/ false,
+                           /*includeProtocolExtensionMembers*/ false);
 }
 
 void CompletionLookup::collectOperators(
@@ -3051,6 +3070,43 @@ void CompletionLookup::getAttributeDeclParamCompletions(
       break;
     }
     break;
+  case CustomSyntaxAttributeKind::StorageRestrictions: {
+    bool suggestInitializesLabel = false;
+    bool suggestAccessesLabel = false;
+    bool suggestArgument = false;
+    switch (static_cast<StorageRestrictionsCompletionKind>(ParamIndex)) {
+    case StorageRestrictionsCompletionKind::Label:
+      suggestAccessesLabel = true;
+      suggestInitializesLabel = true;
+      break;
+    case StorageRestrictionsCompletionKind::Argument:
+      suggestArgument = true;
+      break;
+    case StorageRestrictionsCompletionKind::ArgumentOrInitializesLabel:
+      suggestArgument = true;
+      suggestInitializesLabel = true;
+      break;
+    case StorageRestrictionsCompletionKind::ArgumentOrAccessesLabel:
+      suggestArgument = true;
+      suggestAccessesLabel = true;
+      break;
+    }
+    if (suggestInitializesLabel) {
+      addDeclAttrParamKeyword(
+          "initializes", /*Parameters=*/{},
+          "Specify stored properties initialized by the accessor", true);
+    }
+    if (suggestAccessesLabel) {
+      addDeclAttrParamKeyword(
+          "accesses", /*Parameters=*/{},
+          "Specify stored properties accessed by the accessor", true);
+    }
+    if (suggestArgument) {
+      if (auto NT = dyn_cast<NominalTypeDecl>(CurrDeclContext)) {
+        getStoredPropertyCompletions(NT);
+      }
+    }
+  }
   }
 }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3533,7 +3533,8 @@ bool HasStorageRequest::evaluate(Evaluator &evaluator,
       storage->getParsedAccessor(AccessorKind::Address) ||
       storage->getParsedAccessor(AccessorKind::Set) ||
       storage->getParsedAccessor(AccessorKind::Modify) ||
-      storage->getParsedAccessor(AccessorKind::MutableAddress))
+      storage->getParsedAccessor(AccessorKind::MutableAddress) ||
+      storage->getParsedAccessor(AccessorKind::Init))
     return false;
 
   // willSet or didSet in an overriding property imply that there is no storage.

--- a/test/IDE/complete_storage_restriction.swift
+++ b/test/IDE/complete_storage_restriction.swift
@@ -1,0 +1,67 @@
+// RUN: %batch-code-completion
+
+struct Test {
+  var storedProperty: Int
+
+  var attrBegin: Int {
+    @#^ATTRIBUTE_BEGIN^# init(newValue) {
+      print(newValue)
+    }
+    get { 1 }
+  }
+  // ATTRIBUTE_BEGIN: Keyword/None: storageRestrictions[#Accessor Attribute#];
+
+  var bothLabels: Int {
+    @storageRestrictions(#^AFTER_PAREN^#) 
+    init(newValue) {
+    }
+    get { 1 }
+  }
+  // AFTER_PAREN: Begin completions, 2 items
+  // AFTER_PAREN-DAG: Keyword/None: initializes: [#Specify stored properties initialized by the accessor#];
+  // AFTER_PAREN-DAG: Keyword/None: accesses: [#Specify stored properties accessed by the accessor#];
+
+  var secondAccessesArgument: Int {
+    @storageRestrictions(accesses: x, #^SECOND_ACCESSES_ARGUMENT^#) 
+    init(newValue) {
+    }
+  }
+  // SECOND_ACCESSES_ARGUMENT: Begin completions, 2 items
+  // SECOND_ACCESSES_ARGUMENT-DAG: Keyword/None: initializes: [#Specify stored properties initialized by the accessor#];
+  // SECOND_ACCESSES_ARGUMENT-DAG: Decl[InstanceVar]/CurrNominal: storedProperty[#Int#];
+  
+
+  var secondInitializesArgument: Int {
+    @storageRestrictions(initializes: x, #^SECOND_INITIALIZES_ARGUMENT^#) 
+    init(newValue) {
+    }
+    get { 1 }
+  }
+  // SECOND_INITIALIZES_ARGUMENT: Begin completions, 2 items
+  // SECOND_INITIALIZES_ARGUMENT-DAG: Keyword/None: accesses: [#Specify stored properties accessed by the accessor#];
+  // SECOND_INITIALIZES_ARGUMENT-DAG: Decl[InstanceVar]/CurrNominal: storedProperty[#Int#];
+}
+
+struct TestArgument {
+  var other: Int
+
+  var otherComputed: Int { 1 }
+
+  func testFunc() {}
+
+  var firstInitializesArgument: Int {
+    @storageRestrictions(initializes: #^FIRST_INITIALIZES_ARGUMENT?check=FIRST_ARGUMENT^#) 
+    init(newValue) {
+    }
+    get { 1 }
+  }
+  // FIRST_ARGUMENT: Begin completions, 1 item
+  // FIRST_ARGUMENT-DAG: Decl[InstanceVar]/CurrNominal: other[#Int#];
+
+  var firstAccessesArgument: Int {
+    @storageRestrictions(initializes: #^FIRST_ACCESSES_ARGUMENT?check=FIRST_ARGUMENT^#) 
+    init(newValue) {
+    }
+    get { 1 }
+  }
+}

--- a/test/decl/var/init_accessors.swift
+++ b/test/decl/var/init_accessors.swift
@@ -621,6 +621,7 @@ func test_invalid_storage_restrictions() {
     var c: Int {
       @storageRestrictions(initializes: a, initializes: b)
       // expected-error@-1 {{duplicate label 'initializes' in @storageRestrictions attribute}}
+      // expected-error@-2 {{init accessor cannot refer to property 'a'; init accessors can refer only to stored properties}}
       init {}
 
       get { 0 }
@@ -629,6 +630,7 @@ func test_invalid_storage_restrictions() {
     var d: Int {
       @storageRestrictions(accesses: a, accesses: c)
       // expected-error@-1 {{duplicate label 'accesses' in @storageRestrictions attribute}}
+      // expected-error@-2 {{init accessor cannot refer to property 'a'; init accessors can refer only to stored properties}}
       init {}
 
       get { 0 }


### PR DESCRIPTION
Offer 
- `storageRestrictions` after `@`
- `initializes` and `accesses` labels inside `@storageRestrictions`
- Stored properties after the `initializes` and `accesses` labels

rdar://115501026