### PR TITLE
[Concurrency] tighten-up rules about isolated generic parameters

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5331,6 +5331,9 @@ NOTE(protocol_isolated_to_global_actor_here,none,
 
 ERROR(isolated_parameter_not_actor,none,
       "'isolated' parameter has non-actor type %0", (Type))
+ERROR(isolated_parameter_no_actor_conformance,none,
+      "'isolated' parameter %0 must conform to 'Actor' "
+      "or 'DistributedActor' protocol", (Type))
 ERROR(isolated_parameter_duplicate,none,
       "cannot have more than one 'isolated' parameter", ())
 ERROR(isolated_parameter_duplicate_type,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4092,12 +4092,26 @@ ActorIsolation ActorIsolationRequest::evaluate(
   if (auto paramIdx = getIsolatedParamIndex(value)) {
     checkDeclWithIsolatedParameter(value);
 
-    // FIXME: This doesn't allow us to find an Actor or DistributedActor
-    // bound on the parameter type effectively.
-    auto param = getParameterList(value)->get(*paramIdx);
+    ParamDecl *param = getParameterList(value)->get(*paramIdx);
     Type paramType = param->getInterfaceType();
     if (paramType->isTypeParameter()) {
       paramType = param->getDeclContext()->mapTypeIntoContext(paramType);
+
+      auto &ctx = value->getASTContext();
+      auto conformsTo = [&](KnownProtocolKind kind) {
+        if (auto *proto = ctx.getProtocol(kind))
+          return value->getModuleContext()->conformsToProtocol(paramType, proto);
+        return ProtocolConformanceRef::forInvalid();
+      };
+
+      // The type parameter must be bound by Actor or DistributedActor, as they
+      // have an unownedExecutor. AnyActor does NOT have an unownedExecutor!
+      if (!conformsTo(KnownProtocolKind::Actor)
+          && !conformsTo(KnownProtocolKind::DistributedActor)) {
+        ctx.Diags.diagnose(param->getLoc(),
+                           diag::isolated_parameter_no_actor_conformance,
+                           paramType);
+      }
     }
 
     if (auto actor = paramType->getAnyActor())

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -348,3 +348,12 @@ func getValues(
     actor.dictionary[key]
   }
 }
+
+func isolated_generic_bad_1<T>(_ t: isolated T) {}
+// expected-error@-1 {{'isolated' parameter 'T' must conform to 'Actor' or 'DistributedActor' protocol}}
+func isolated_generic_bad_2<T: Equatable>(_ t: isolated T) {}
+// expected-error@-1 {{'isolated' parameter 'T' must conform to 'Actor' or 'DistributedActor' protocol}}
+func isolated_generic_bad_3<T: AnyActor>(_ t: isolated T) {}
+// expected-error@-1 {{'isolated' parameter 'T' must conform to 'Actor' or 'DistributedActor' protocol}}
+
+func isolated_generic_ok_1<T: Actor>(_ t: isolated T) {}

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -258,3 +258,5 @@ extension Greeting where SerializationRequirement == Codable {
     try await greetLocal(name: "Alice") // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
   }
 }
+
+func isolated_generic_ok<T: DistributedActor>(_ t: isolated T) {}


### PR DESCRIPTION
[Concurrency] tighten-up rules about isolated generic parameters

We were missing a check for conformance to `Actor` or `DistributedActor`
when an isolated parameter's type is a generic parameter.

Previously, if you used a generic parameter constrained to just `AnyActor`,
you'd crash the compiler in LowerHopToExecutor because it doesn't know
how to obtain the executor for such a value. Since `AnyActor` has no
`unownedExecutor` requirement, there's no way to get the executor without
emitting code to do dynamic casts down to `Actor` or `DistributedActor`.

Rather than have the compiler silently emit dynamic casting, I figured
it's best to ban it. This forces people to either do the dynamic casts
themselves, or use one of the more specific types to constrain their
parameter.

For other generic parameters, we would silently treat the function
as though it is nonisolated (i.e., as if the `isolated` wasn't written
on the parameter at all).

resolves rdar://109059544