### PR TITLE
IRGen: fix emission of constant single-case enums without payload

### DIFF
--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -275,7 +275,10 @@ Explosion irgen::emitConstantValue(IRGenModule &IGM, SILValue operand,
   } else if (auto *ei = dyn_cast<EnumInst>(operand)) {
     auto &strategy = getEnumImplStrategy(IGM, ei->getType());
     if (strategy.emitPayloadDirectlyIntoConstant()) {
-      return emitConstantValue(IGM, ei->getOperand(), flatten);
+      if (ei->hasOperand()) {
+        return emitConstantValue(IGM, ei->getOperand(), flatten);
+      }
+      return Explosion();
     }
 
     Explosion data;

--- a/test/SILOptimizer/static_enums.swift
+++ b/test/SILOptimizer/static_enums.swift
@@ -224,6 +224,18 @@ enum SingleCaseEnum {
   static var x = Self.a(b:true, i: 42)
 }
 
+enum SingleCaseEnumWithoutPayload {
+  case a
+  static var x = Self.a
+}
+
+enum NestedSingleCaseEnum {
+  case u
+  case v(SingleCaseEnumWithoutPayload)
+
+  static var x = Self.v(.a)
+}
+
 @main
 struct Main {
   static func main() {
@@ -301,6 +313,10 @@ struct Main {
     printFunctionEnum()
     // CHECK-OUTPUT: SingleCaseEnum: a(b: true, i: 42)
     print("SingleCaseEnum:", SingleCaseEnum.x)
+    // CHECK-OUTPUT: SingleCaseEnumWithoutPayload: a
+    print("SingleCaseEnumWithoutPayload:", SingleCaseEnumWithoutPayload.x)
+    // CHECK-OUTPUT: NestedSingleCaseEnum: v(test.SingleCaseEnumWithoutPayload.a)
+    print("NestedSingleCaseEnum:", NestedSingleCaseEnum.x)
   }
 }
 

--- a/validation-test/SILOptimizer/static_enums_fuzzing.swift
+++ b/validation-test/SILOptimizer/static_enums_fuzzing.swift
@@ -12,7 +12,7 @@
 createTestfile()
 
 func createTestfile() {
-  let globals = createGlobals(count: 500)
+  let globals = createGlobals(count: 1000)
 
   print(typeDefinitions)
 
@@ -75,6 +75,10 @@ var typeDefinitions: String {
 
     public enum SPSCE<T> {
       case A(T)
+    }
+
+    public enum SCEWP {
+      case A
     }
 
     public enum SPE<T> {
@@ -322,6 +326,33 @@ struct SinglePayloadSingleCaseEnum : Value {
   var containsEnum: Bool { true }
 }
 
+struct SingleCaseEnumWithoutPayload : Value {
+  
+  init(generator: inout RandomGenerator, depth: Int) {
+  }
+  
+  func getType() -> String {
+    "SCEWP"
+  }
+
+  func getInitValue() -> String  {
+    return "SCEWP.A"
+  }
+
+  func getExpectedOutput(topLevel: Bool) -> String  {
+    let prefix = topLevel ? "" : "\(getRuntimeTypeName(topLevel: topLevel))."
+    return "\(prefix)A"
+  }
+
+  func getRuntimeTypeName(topLevel: Bool) -> String {
+    let prefix = topLevel ? "" : "test."
+    return "\(prefix)SCEWP"
+  }
+
+  var containsEnum: Bool { true }
+}
+
+
 struct SinglePayloadEnum : Value {
   let payload: any Value
   let caseIdx: Int
@@ -477,7 +508,8 @@ struct RandomGenerator : RandomNumberGenerator {
     LargeString.self,
     Function.self,
     Enum.self,
-    Size24Enum.self
+    Size24Enum.self,
+    SingleCaseEnumWithoutPayload.self
   ]
   private static let allValueTypes: [any Value.Type] = allTerminalTypes + [
     OptionalValue.self,


### PR DESCRIPTION
This is a follow-up of https://github.com/apple/swift/pull/68516 which didn't handle the no-payload case correctly

Fixes a compiler crash

rdar://115666971
