### PR TITLE
[cxx-interop] Use more correct type names in C++ template parameters

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2817,15 +2817,16 @@ namespace {
       // conformances to Swift protocols from the Cxx module.
       auto clangModule = Impl.getClangOwningModule(result->getClangNode());
       if (clangModule && requiresCPlusPlus(clangModule)) {
-        auto nominalDecl = cast<NominalTypeDecl>(result);
-        conformToCxxIteratorIfNeeded(Impl, nominalDecl, decl);
-        conformToCxxSequenceIfNeeded(Impl, nominalDecl, decl);
-        conformToCxxConvertibleToBoolIfNeeded(Impl, nominalDecl, decl);
-        conformToCxxSetIfNeeded(Impl, nominalDecl, decl);
-        conformToCxxDictionaryIfNeeded(Impl, nominalDecl, decl);
-        conformToCxxPairIfNeeded(Impl, nominalDecl, decl);
-        conformToCxxOptionalIfNeeded(Impl, nominalDecl, decl);
-        conformToCxxVectorIfNeeded(Impl, nominalDecl, decl);
+        if (auto nominalDecl = dyn_cast<NominalTypeDecl>(result)) {
+          conformToCxxIteratorIfNeeded(Impl, nominalDecl, decl);
+          conformToCxxSequenceIfNeeded(Impl, nominalDecl, decl);
+          conformToCxxConvertibleToBoolIfNeeded(Impl, nominalDecl, decl);
+          conformToCxxSetIfNeeded(Impl, nominalDecl, decl);
+          conformToCxxDictionaryIfNeeded(Impl, nominalDecl, decl);
+          conformToCxxPairIfNeeded(Impl, nominalDecl, decl);
+          conformToCxxOptionalIfNeeded(Impl, nominalDecl, decl);
+          conformToCxxVectorIfNeeded(Impl, nominalDecl, decl);
+        }
       }
 
       if (auto *ntd = dyn_cast<NominalTypeDecl>(result))

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2217,7 +2217,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
                             version, givenName);
     if (!isa<clang::ClassTemplatePartialSpecializationDecl>(D)) {
       auto getSwiftBuiltinTypeName =
-          [&](const clang::BuiltinType *builtin) -> std::optional<StringRef> {
+          [&](const clang::BuiltinType *builtin) -> std::optional<std::string> {
         Type swiftType = nullptr;
         switch (builtin->getKind()) {
         case clang::BuiltinType::Void:
@@ -2240,8 +2240,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         }
 
         if (swiftType) {
-          if (auto nominal = swiftType->getAs<NominalType>()) {
-            return nominal->getDecl()->getNameStr();
+          if (swiftType->is<NominalType>()) {
+            return swiftType->getStringAsComponent();
           }
         }
         return std::nullopt;

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -5,7 +5,7 @@
 // CHECK-NEXT:   @available(*, unavailable, message: "virtual functions are not yet available in Swift")
 // CHECK-NEXT:   mutating func foo()
 
-// CHECK: struct Derived<Int32> {
+// CHECK: struct Derived<CInt> {
 // CHECK: @available(*, unavailable, message: "virtual functions are not yet available in Swift")
 // CHECK:  mutating func foo()
 // CHECK: }

--- a/test/Interop/Cxx/namespace/class-inline-namespace-irgen.swift
+++ b/test/Interop/Cxx/namespace/class-inline-namespace-irgen.swift
@@ -48,7 +48,7 @@ extension Parent.TypedefInInlineChild {
     return ""
   }
 }
-// CHECK: define hidden swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbV4testE6stringSSvg"()
+// CHECK: define hidden swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0034TemplateInInlineChildCChar_ckBDjAbV4testE6stringSSvg"()
 
 extension Parent.InInlineChild {
   func doSomething() {
@@ -70,22 +70,22 @@ extension Parent.InlineChild.InSecondInlineChild {
 }
 // define hidden swiftcc {{.*}} @"$sSo6ParentO11InlineChildO06SecondbC0O02IndbC0V4testE1ySivg"()
 
-// CHECK: define hidden swiftcc {{.*}} @"$s4test3useySSSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbVF"()
-// CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbV4testE6stringSSvg"
+// CHECK: define hidden swiftcc {{.*}} @"$s4test3useySSSo6ParentO11InlineChildO0034TemplateInInlineChildCChar_ckBDjAbVF"()
+// CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0034TemplateInInlineChildCChar_ckBDjAbV4testE6stringSSvg"
 func use(_ x: Parent.TypedefInInlineChild) -> String {
   let s = x.string
   return s
 }
 
-// CHECK: define hidden swiftcc {{.*}} @"$s4test4use2ySSSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbVF"()
-// CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbV4testE6stringSSvg"
+// CHECK: define hidden swiftcc {{.*}} @"$s4test4use2ySSSo6ParentO11InlineChildO0034TemplateInInlineChildCChar_ckBDjAbVF"()
+// CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0034TemplateInInlineChildCChar_ckBDjAbV4testE6stringSSvg"
 func use2(_ x: Parent.InlineChild.TypedefInInlineChild) -> String {
   let s = x.string
   return s
 }
 
 // define swiftcc void @"$s4testAAyySo6ParentO11InlineChildO02IncD0VF"()
-// CHECK: alloca %TSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbV
+// CHECK: alloca %TSo6ParentO11InlineChildO0034TemplateInInlineChildCChar_ckBDjAbV
 // CHECK: call {{.*}} @{{_ZN6Parent11InlineChild21TemplateInInlineChildIcEC|"\?\?0\?\$TemplateInInlineChild@D@InlineChild@Parent@@QEAA@XZ"}}
 // CHECK: call swiftcc void @"$sSo6ParentO11InlineChildO02InbC0V4testE11doSomethingyyF"(
 // CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO06SecondbC0O02IndbC0V4testE1xSivg"(

--- a/test/Interop/Cxx/namespace/templates-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-module-interface.swift
@@ -3,7 +3,7 @@
 // CHECK:     enum TemplatesNS1 {
 // CHECK-NEXT:   enum TemplatesNS2 {
 // CHECK-NEXT:     static func forwardDeclaredFunctionTemplate<T>(_: T) -> UnsafePointer<CChar>!
-// CHECK-NEXT:     struct ForwardDeclaredClassTemplate<Int8> {
+// CHECK-NEXT:     struct ForwardDeclaredClassTemplate<CChar> {
 // CHECK-NEXT:       init()
 // CHECK-NEXT:       mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:     }
@@ -11,51 +11,51 @@
 // CHECK-NEXT:     struct ForwardDeclaredClassTemplate<> {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     static func forwardDeclaredFunctionTemplateOutOfLine<T>(_: T) -> UnsafePointer<CChar>!
-// CHECK-NEXT:     struct ForwardDeclaredClassTemplateOutOfLine<Int8> {
+// CHECK-NEXT:     struct ForwardDeclaredClassTemplateOutOfLine<CChar> {
 // CHECK-NEXT:       init()
 // CHECK-NEXT:       mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:     }
 // CHECK-NEXT:     @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:     struct ForwardDeclaredClassTemplateOutOfLine<> {
 // CHECK-NEXT:     }
-// CHECK-NEXT:     typealias BasicClassTemplateChar = TemplatesNS1.TemplatesNS3.BasicClassTemplate<Int8>
+// CHECK-NEXT:     typealias BasicClassTemplateChar = TemplatesNS1.TemplatesNS3.BasicClassTemplate<CChar>
 // CHECK-NEXT:     static func takesClassTemplateFromSibling(_: TemplatesNS1.TemplatesNS2.BasicClassTemplateChar) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   }
 // CHECK-NEXT:   static func basicFunctionTemplate<T>(_: T) -> UnsafePointer<CChar>!
-// CHECK-NEXT:   struct BasicClassTemplate<Int8> {
+// CHECK-NEXT:   struct BasicClassTemplate<CChar> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:     mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct BasicClassTemplate<> {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   typealias BasicClassTemplateChar = TemplatesNS1.BasicClassTemplate<Int8>
+// CHECK-NEXT:   typealias BasicClassTemplateChar = TemplatesNS1.BasicClassTemplate<CChar>
 // CHECK-NEXT:   static func basicFunctionTemplateDefinedInDefs<T>(_: T) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct BasicClassTemplateDefinedInDefs<> {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   typealias UseTemplate = TemplatesNS4.HasSpecialization<Int8>
-// CHECK-NEXT:   typealias UseSpecialized = TemplatesNS4.HasSpecialization<Int32>
+// CHECK-NEXT:   typealias UseTemplate = TemplatesNS4.HasSpecialization<CChar>
+// CHECK-NEXT:   typealias UseSpecialized = TemplatesNS4.HasSpecialization<CInt>
 // CHECK-NEXT:   enum TemplatesNS3 {
-// CHECK-NEXT:     struct BasicClassTemplate<Int8> {
+// CHECK-NEXT:     struct BasicClassTemplate<CChar> {
 // CHECK-NEXT:       init()
 // CHECK-NEXT:     }
 // CHECK-NEXT:     @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:     struct BasicClassTemplate<> {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct ForwardDeclaredClassTemplate<Int8> {
+// CHECK-NEXT:   struct ForwardDeclaredClassTemplate<CChar> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:     mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   }
-// CHECK-NEXT:   typealias ForwardDeclaredClassTemplateChar = TemplatesNS1.TemplatesNS2.ForwardDeclaredClassTemplate<Int8>
+// CHECK-NEXT:   typealias ForwardDeclaredClassTemplateChar = TemplatesNS1.TemplatesNS2.ForwardDeclaredClassTemplate<CChar>
 // CHECK-NEXT: }
-// CHECK-NEXT: typealias ForwardDeclaredClassTemplateOutOfLineChar = TemplatesNS1.TemplatesNS2.ForwardDeclaredClassTemplateOutOfLine<Int8>
+// CHECK-NEXT: typealias ForwardDeclaredClassTemplateOutOfLineChar = TemplatesNS1.TemplatesNS2.ForwardDeclaredClassTemplateOutOfLine<CChar>
 // CHECK-NEXT: enum TemplatesNS4 {
-// CHECK-NEXT:   struct HasSpecialization<Int8> {
+// CHECK-NEXT:   struct HasSpecialization<CChar> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct HasSpecialization<Int32> {
+// CHECK-NEXT:   struct HasSpecialization<CInt> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")

--- a/test/Interop/Cxx/namespace/templates-second-header-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-second-header-module-interface.swift
@@ -2,10 +2,10 @@
 
 // CHECK: enum TemplatesNS1 {
 // CHECK:   static func basicFunctionTemplateDefinedInDefs<T>(_: T) -> UnsafePointer<CChar>!
-// CHECK:   struct BasicClassTemplateDefinedInDefs<Int8> {
+// CHECK:   struct BasicClassTemplateDefinedInDefs<CChar> {
 // CHECK:     init()
 // CHECK:     mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK:   }
 // CHECK: }
 
-// CHECK: typealias BasicClassTemplateDefinedInDefsChar = TemplatesNS1.BasicClassTemplateDefinedInDefs<Int8>
+// CHECK: typealias BasicClassTemplateDefinedInDefsChar = TemplatesNS1.BasicClassTemplateDefinedInDefs<CChar>

--- a/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
@@ -1,21 +1,21 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=TemplatesWithForwardDecl -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      enum NS1 {
-// CHECK-NEXT:   struct ForwardDeclared<Int32> {
+// CHECK-NEXT:   struct ForwardDeclared<CInt> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct ForwardDeclared<T> {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct Decl<Int32> {
+// CHECK-NEXT:   struct Decl<CInt> {
 // CHECK-NEXT:     init()
-// CHECK-NEXT:     init(fwd: NS1.ForwardDeclared<Int32>)
+// CHECK-NEXT:     init(fwd: NS1.ForwardDeclared<CInt>)
 // CHECK-NEXT:     typealias MyInt = Int32
-// CHECK-NEXT:     var fwd: NS1.ForwardDeclared<Int32>
-// CHECK-NEXT:     static let intValue: NS1.Decl<Int32>.MyInt
+// CHECK-NEXT:     var fwd: NS1.ForwardDeclared<CInt>
+// CHECK-NEXT:     static let intValue: NS1.Decl<CInt>.MyInt
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct Decl<T> {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   typealias di = NS1.Decl<Int32>
+// CHECK-NEXT:   typealias di = NS1.Decl<CInt>
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/objc-correctness/init-String-with-NSString-utf8String.swift
+++ b/test/Interop/Cxx/objc-correctness/init-String-with-NSString-utf8String.swift
@@ -7,7 +7,7 @@ import CxxStdlib
 
 // CHECK: @"\01L_selector(UTF8String)"
 // CHECK: @objc_msgSend
-// CHECK: call swiftcc void @"$sSo3stdO3__1O0067basic_stringInt8char_traitsInt8allocatorInt8_FABErpaBGcqaGHerapGgqaV9CxxStdlibEyAFSPys4Int8VGSgcfC"
+// CHECK: call swiftcc void @"$sSo3stdO3__1O0071basic_stringCCharchar_traitsCCharallocatorCChar_mHGHsqaGJcraCCfsaqChraaV9CxxStdlibEyAFSPys4Int8VGSgcfC"
 
 let ObjCStr: NSString = "hello"
 let CxxStr = std.string(ObjCStr.utf8String) // Should not crash here

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -94,7 +94,7 @@
 
 // CHECK: struct TemplatedArray<T> {
 // CHECK: }
-// CHECK: struct TemplatedArray<Double> {
+// CHECK: struct TemplatedArray<CDouble> {
 // CHECK:   subscript(i: Int32) -> Double
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
@@ -103,7 +103,7 @@
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ i: Int32) -> UnsafePointer<Double>
 // CHECK: }
-// CHECK: typealias TemplatedDoubleArray = TemplatedArray<Double>
+// CHECK: typealias TemplatedDoubleArray = TemplatedArray<CDouble>
 
 
 // CHECK: struct TemplatedSubscriptArray {
@@ -140,12 +140,12 @@
 
 // CHECK: struct TemplatedArrayByVal<T> {
 // CHECK: }
-// CHECK: struct TemplatedArrayByVal<Double> {
+// CHECK: struct TemplatedArrayByVal<CDouble> {
 // CHECK:   subscript(i: Int32) -> Double { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscriptConst(_ i: Int32) -> Double
 // CHECK: }
-// CHECK: typealias TemplatedDoubleArrayByVal = TemplatedArrayByVal<Double>
+// CHECK: typealias TemplatedDoubleArrayByVal = TemplatedArrayByVal<CDouble>
 
 // CHECK: struct TemplatedByVal<T> {
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
@@ -10,14 +10,14 @@
 
 // CHECK-IOSFWD: enum std {
 // CHECK-IOSFWD:   enum __1 {
-// CHECK-IOSFWD:     struct basic_string<Int8, char_traits<Int8>, allocator<Int8>> : CxxRandomAccessCollection {
+// CHECK-IOSFWD:     struct basic_string<CChar, char_traits<CChar>, allocator<CChar>> : CxxRandomAccessCollection {
 // CHECK-IOSFWD:       typealias value_type = CChar
 // CHECK-IOSFWD:     }
-// CHECK-IOSFWD:     struct basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>> : CxxRandomAccessCollection {
+// CHECK-IOSFWD:     struct basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>> : CxxRandomAccessCollection {
 // CHECK-IOSFWD:       typealias value_type = CWideChar
 // CHECK-IOSFWD:     }
-// CHECK-IOSFWD:     typealias string = std.__1.basic_string<Int8, char_traits<Int8>, allocator<Int8>>
-// CHECK-IOSFWD:     typealias wstring = std.__1.basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>>
+// CHECK-IOSFWD:     typealias string = std.__1.basic_string<CChar, char_traits<CChar>, allocator<CChar>>
+// CHECK-IOSFWD:     typealias wstring = std.__1.basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>>
 // CHECK-IOSFWD:   }
 // CHECK-IOSFWD: }
 

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -11,11 +11,11 @@
 // REQUIRES: OS=linux-gnu
 
 // CHECK-STD: enum std {
-// CHECK-STRING:   struct basic_string<Int8, char_traits<Int8>, allocator<Int8>> : CxxRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = std.char_traits<Int8>.char_type
+// CHECK-STRING:   struct basic_string<CChar, char_traits<CChar>, allocator<CChar>> : CxxRandomAccessCollection {
+// CHECK-STRING:     typealias value_type = std.char_traits<CChar>.char_type
 // CHECK-STRING:   }
-// CHECK-STRING:   struct basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>> : CxxRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = std.char_traits<Scalar>.char_type
+// CHECK-STRING:   struct basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>> : CxxRandomAccessCollection {
+// CHECK-STRING:     typealias value_type = std.char_traits<CWideChar>.char_type
 // CHECK-STRING:   }
 
 // CHECK-TO-STRING:   static func to_string(_ __val: Int32) -> std{{(.__cxx11)?}}.string
@@ -23,6 +23,6 @@
 
 // CHECK-SIZE-T:   typealias size_t = Int
 
-// CHECK-STRING:   typealias string =  std{{(.__cxx11)?}}.basic_string<Int8, char_traits<Int8>, allocator<Int8>>
-// CHECK-STRING:   typealias wstring =  std{{(.__cxx11)?}}.basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>>
+// CHECK-STRING:   typealias string =  std{{(.__cxx11)?}}.basic_string<CChar, char_traits<CChar>, allocator<CChar>>
+// CHECK-STRING:   typealias wstring =  std{{(.__cxx11)?}}.basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>>
 // CHECK-STD: }

--- a/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
@@ -12,13 +12,13 @@
 // CHECK-STRING:   typealias size_t = size_t
 // CHECK-STRING:   static func to_string(_ _Val: Int32) -> std.string
 // CHECK-STRING:   static func to_wstring(_ _Val: Int32) -> std.wstring
-// CHECK-STRING:   struct basic_string<Int8, char_traits<Int8>, allocator<Int8>> : CxxRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<CChar, char_traits<CChar>, allocator<CChar>> : CxxRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = CChar
 // CHECK-STRING:   }
-// CHECK-STRING:   struct basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>> : CxxRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>> : CxxRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = CWideChar
 // CHECK-STRING:   }
-// CHECK-STRING:   typealias string = std.basic_string<Int8, char_traits<Int8>, allocator<Int8>>
-// CHECK-STRING:   typealias wstring = std.basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>>
+// CHECK-STRING:   typealias string = std.basic_string<CChar, char_traits<CChar>, allocator<CChar>>
+// CHECK-STRING:   typealias wstring = std.basic_string<CWideChar, char_traits<CWideChar>, allocator<CWideChar>>
 // CHECK-STRING: }
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
@@ -18,14 +18,14 @@
 // CHECK:   typealias RawIterator = SimpleCollectionReadOnly.iterator
 // CHECK: }
 
-// CHECK: struct HasInheritedTemplatedConstRACIterator<Int32> : CxxRandomAccessCollection {
-// CHECK:   typealias Element = InheritedTemplatedConstRACIterator<Int32>.Pointee
-// CHECK:   typealias Iterator = CxxIterator<HasInheritedTemplatedConstRACIterator<Int32>>
-// CHECK:   typealias RawIterator = InheritedTemplatedConstRACIterator<Int32>
+// CHECK: struct HasInheritedTemplatedConstRACIterator<CInt> : CxxRandomAccessCollection {
+// CHECK:   typealias Element = InheritedTemplatedConstRACIterator<CInt>.Pointee
+// CHECK:   typealias Iterator = CxxIterator<HasInheritedTemplatedConstRACIterator<CInt>>
+// CHECK:   typealias RawIterator = InheritedTemplatedConstRACIterator<CInt>
 // CHECK: }
 
-// CHECK: struct HasInheritedTemplatedConstRACIteratorOutOfLineOps<Int32> : CxxRandomAccessCollection {
-// CHECK:   typealias Element = InheritedTemplatedConstRACIteratorOutOfLineOps<Int32>.Pointee
-// CHECK:   typealias Iterator = CxxIterator<HasInheritedTemplatedConstRACIteratorOutOfLineOps<Int32>>
-// CHECK:   typealias RawIterator = InheritedTemplatedConstRACIteratorOutOfLineOps<Int32>
+// CHECK: struct HasInheritedTemplatedConstRACIteratorOutOfLineOps<CInt> : CxxRandomAccessCollection {
+// CHECK:   typealias Element = InheritedTemplatedConstRACIteratorOutOfLineOps<CInt>.Pointee
+// CHECK:   typealias Iterator = CxxIterator<HasInheritedTemplatedConstRACIteratorOutOfLineOps<CInt>>
+// CHECK:   typealias RawIterator = InheritedTemplatedConstRACIteratorOutOfLineOps<CInt>
 // CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -86,24 +86,24 @@
 // CHECK-NOT: struct HasNoPreIncrementOperator : UnsafeCxxInputIterator
 // CHECK-NOT: struct HasNoDereferenceOperator : UnsafeCxxInputIterator
 
-// CHECK: struct TemplatedIterator<Int32> : UnsafeCxxInputIterator {
-// CHECK:   func successor() -> TemplatedIterator<Int32>
+// CHECK: struct TemplatedIterator<CInt> : UnsafeCxxInputIterator {
+// CHECK:   func successor() -> TemplatedIterator<CInt>
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
-// CHECK:   static func == (lhs: TemplatedIterator<Int32>, other: TemplatedIterator<Int32>) -> Bool
+// CHECK:   static func == (lhs: TemplatedIterator<CInt>, other: TemplatedIterator<CInt>) -> Bool
 // CHECK: }
 
-// CHECK: struct TemplatedIteratorOutOfLineEq<Int32> : UnsafeCxxInputIterator {
-// CHECK:   func successor() -> TemplatedIteratorOutOfLineEq<Int32>
+// CHECK: struct TemplatedIteratorOutOfLineEq<CInt> : UnsafeCxxInputIterator {
+// CHECK:   func successor() -> TemplatedIteratorOutOfLineEq<CInt>
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK: }
 
-// CHECK: struct TemplatedRACIteratorOutOfLineEq<Int32> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
-// CHECK:   func successor() -> TemplatedRACIteratorOutOfLineEq<Int32>
+// CHECK: struct TemplatedRACIteratorOutOfLineEq<CInt> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK:   func successor() -> TemplatedRACIteratorOutOfLineEq<CInt>
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
-// CHECK:   typealias Distance = TemplatedRACIteratorOutOfLineEq<Int32>.difference_type
+// CHECK:   typealias Distance = TemplatedRACIteratorOutOfLineEq<CInt>.difference_type
 // CHECK: }
 
 // CHECK: struct BaseIntIterator {
@@ -113,17 +113,17 @@
 
 // CHECK: struct InheritedTemplatedConstIterator<T> {
 // CHECK: }
-// CHECK: struct InheritedTemplatedConstIterator<Int32> : UnsafeCxxInputIterator {
+// CHECK: struct InheritedTemplatedConstIterator<CInt> : UnsafeCxxInputIterator {
 // CHECK: }
 
 // CHECK: struct InheritedTemplatedConstRACIterator<T> {
 // CHECK: }
-// CHECK: struct InheritedTemplatedConstRACIterator<Int32> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct InheritedTemplatedConstRACIterator<CInt> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK: }
 
 // CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<T> {
 // CHECK: }
-// CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<Int32> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<CInt> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK: }
 
 // CHECK: struct InputOutputIterator : UnsafeCxxMutableInputIterator {

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -50,12 +50,12 @@
 // CHECK-NOT:   typealias Iterator
 // CHECK-NOT:   typealias RawIterator
 // CHECK: }
-// CHECK: struct HasTemplatedIterator<Int32, NoDefinition<Int32>> {
+// CHECK: struct HasTemplatedIterator<CInt, NoDefinition<CInt>> {
 // CHECK-NOT:   typealias Element
 // CHECK-NOT:   typealias Iterator
 // CHECK-NOT:   typealias RawIterator
 // CHECK: }
-// CHECK: typealias HasUninstantiatableIterator = HasTemplatedIterator<Int32, NoDefinition<Int32>>
+// CHECK: typealias HasUninstantiatableIterator = HasTemplatedIterator<CInt, NoDefinition<CInt>>
 
 // CHECK: struct HasInputOutputConstIterator : CxxConvertibleToCollection {
 // CHECK:   typealias Element = InputOutputConstIterator.Pointee

--- a/test/Interop/Cxx/templates/class-template-instantiation-demangling.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-demangling.swift
@@ -8,5 +8,5 @@ public func returnInstantiation() -> WrappedMagicInt {
   return WrappedMagicInt()
 }
 
-// CHECK: $s4main20receiveInstantiationyySo0025MagicWrapperInt32_lsFCfibVzF(ptr ---> @$s4main20receiveInstantiationyySo0025MagicWrapperInt32_lsFCfibVzF(ptr
-// CHECK: $s4main19returnInstantiationSo0025MagicWrapperInt32_lsFCfibVyF() ---> @$s4main19returnInstantiationSo0025MagicWrapperInt32_lsFCfibVyF()
+// CHECK: $s4main20receiveInstantiationyySo0024MagicWrapperCInt_npAIefbVzF(ptr ---> @$s4main20receiveInstantiationyySo0024MagicWrapperCInt_npAIefbVzF(ptr
+// CHECK: $s4main19returnInstantiationSo0024MagicWrapperCInt_npAIefbVyF() ---> @$s4main19returnInstantiationSo0024MagicWrapperCInt_npAIefbVyF()

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-irgen.swift
@@ -5,5 +5,5 @@ import ClassTemplateNonTypeParameter
 let p = MagicIntPair()
 let t = MagicIntTriple()
 
-// CHECK: @"${{s4main1pSo0034MagicArrayInt32_UInt_2_zoAFhhiEngcVvp|s4main1pSo0036MagicArrayInt32_UInt(64|32)_2_JsAEiFiuomcVvp}}"
-// CHECK: @"${{s4main1tSo0034MagicArrayInt32_UInt_3_zoAFhhiEngcVvp|s4main1tSo0036MagicArrayInt32_UInt(64|32)_3_JsAEiFiuomcVvp}}"
+// CHECK: @"${{s4main1pSo0042MagicArrayCInt_CUnsignedLong_2_DFABlHknrCcVvp|s4main1pSo0047MagicArrayCInt_CUnsignedLongLong_2_ofBJmlmartjdVvp}}"
+// CHECK: @"${{s4main1tSo0042MagicArrayCInt_CUnsignedLong_3_DFABlHknrCcVvp|s4main1tSo0047MagicArrayCInt_CUnsignedLongLong_3_ofBJmlmartjdVvp}}"

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
@@ -3,17 +3,17 @@
 // CHECK: struct MagicArray<T, Size> {
 // CHECK: }
 
-// CHECK: struct MagicArray<Int32, _UInt{{.*}}_2> {
+// CHECK: struct MagicArray<CInt, _C{{.*}}_2> {
 // CHECK:   init()
 // CHECK:   init(t: (Int32, Int32))
 // CHECK:   var t: (Int32, Int32)
 // CHECK: }
 
-// CHECK: struct MagicArray<Int32, _UInt{{.*}}_3> {
+// CHECK: struct MagicArray<CInt, _C{{.*}}_3> {
 // CHECK:   init()
 // CHECK:   init(t: (Int32, Int32, Int32))
 // CHECK:   var t: (Int32, Int32, Int32)
 // CHECK: }
 
-// CHECK: typealias MagicIntPair = MagicArray<Int32, _UInt{{.*}}_2>
-// CHECK: typealias MagicIntTriple = MagicArray<Int32, _UInt{{.*}}_3>
+// CHECK: typealias MagicIntPair = MagicArray<CInt, _C{{.*}}_2>
+// CHECK: typealias MagicIntTriple = MagicArray<CInt, _C{{.*}}_3>

--- a/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithTypedef -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK: struct Lander<Int8> {
+// CHECK: struct Lander<CChar> {
 // CHECK:   init()
 // CHECK:   typealias size_type = {{UInt|UInt32}}
 // CHECK:   mutating func test(_: {{UInt|UInt32}})
 // CHECK: }
-// CHECK: typealias Surveyor = Lander<Int8>
+// CHECK: typealias Surveyor = Lander<CChar>

--- a/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
+++ b/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ExplicitClassSpecialization -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK: struct HasEmptySpecializationAndStaticDateMember<Int32> {
+// CHECK: struct HasEmptySpecializationAndStaticDateMember<CInt> {
 // CHECK:   static let value: Bool
 // CHECK: }
 
-// CHECK: struct HasEmptySpecializationAndStaticDateMember<Int8> {
+// CHECK: struct HasEmptySpecializationAndStaticDateMember<CChar> {
 // CHECK:   static let value: Bool
 // CHECK: }

--- a/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
@@ -3,13 +3,13 @@
 // CHECK: struct HasTypeWithSelfAsParam<T> {
 // CHECK: }
 
-// CHECK: struct HasTypeWithSelfAsParam<Int32> {
+// CHECK: struct HasTypeWithSelfAsParam<CInt> {
 // CHECK:   init()
-// CHECK:   typealias TT = HasTypeWithSelfAsParam<HasTypeWithSelfAsParam<Int32>>
+// CHECK:   typealias TT = HasTypeWithSelfAsParam<HasTypeWithSelfAsParam<CInt>>
 // CHECK: }
 
-// CHECK: typealias WillBeInfinite = HasTypeWithSelfAsParam<Int32>
+// CHECK: typealias WillBeInfinite = HasTypeWithSelfAsParam<CInt>
 
 // TODO: we should not be importing functions that use this type in their
 // signature (such as the function below).
-// CHECK: mutating func test1() -> RegressionTest.ValExpr<SliceExpr<SliceExpr<Array<Int32>, _Int32_1>, _Int32_1>>
+// CHECK: mutating func test1() -> RegressionTest.ValExpr<SliceExpr<SliceExpr<Array<CInt>, _CInt_1>, _CInt_1>>

--- a/test/Interop/Cxx/templates/mangling-irgen.swift
+++ b/test/Interop/Cxx/templates/mangling-irgen.swift
@@ -2,19 +2,19 @@
 
 import Mangling
 
+public func receiveInstantiation(_ i: inout WrappedMagicBool) {}
+
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0025MagicWrapperCBool_lsFCfibVzF"(ptr nocapture dereferenceable(1) %0)
+
 public func receiveInstantiation(_ i: inout WrappedMagicInt) {}
 
 // Don't forget to update manglings.txt when changing s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0025MagicWrapperInt32_lsFCfibVzF"(ptr nocapture dereferenceable(1) %0)
-
-public func receiveInstantiation(_ i: inout WrappedMagicBool) {}
-
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0024MagicWrapperBool_npAIefbVzF"(ptr nocapture dereferenceable(1) %0)
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0024MagicWrapperCInt_npAIefbVzF"(ptr nocapture dereferenceable(1) %0)
 
 public func returnInstantiation() -> WrappedMagicInt {
   return WrappedMagicInt()
 }
 
 // Don't forget to update manglings.txt when changing s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main19returnInstantiationSo0025MagicWrapperInt32_lsFCfibVyF"()
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main19returnInstantiationSo0024MagicWrapperCInt_npAIefbVyF"()
 

--- a/test/Interop/Cxx/templates/mangling-silgen.swift
+++ b/test/Interop/Cxx/templates/mangling-silgen.swift
@@ -5,16 +5,16 @@ import Mangling
 public func recvInstantiation(_ i: inout WrappedMagicInt) {}
 
 // CHECK: // recvInstantiation(_:)
-// CHECK: sil @$s4main17recvInstantiationyySo0025MagicWrapperInt32_lsFCfibVzF : $@convention(thin) (@inout MagicWrapper<Int32>) -> ()
+// CHECK: sil @$s4main17recvInstantiationyySo0024MagicWrapperCInt_npAIefbVzF : $@convention(thin) (@inout MagicWrapper<CInt>) -> ()
 
 public func recvInstantiation(_ i: inout WrappedMagicBool) {}
 
 // CHECK: // recvInstantiation(_:)
-// CHECK: sil @$s4main17recvInstantiationyySo0024MagicWrapperBool_npAIefbVzF : $@convention(thin) (@inout MagicWrapper<Bool>) -> ()
+// CHECK: sil @$s4main17recvInstantiationyySo0025MagicWrapperCBool_lsFCfibVzF : $@convention(thin) (@inout MagicWrapper<CBool>) -> ()
 
 public func returnInstantiation() -> WrappedMagicInt {
   return WrappedMagicInt()
 }
 
 // CHECK: // returnInstantiation()
-// CHECK: sil @$s4main19returnInstantiationSo0025MagicWrapperInt32_lsFCfibVyF : $@convention(thin) () -> MagicWrapper<Int32>
+// CHECK: sil @$s4main19returnInstantiationSo0024MagicWrapperCInt_npAIefbVyF : $@convention(thin) () -> MagicWrapper<CInt>

--- a/test/Interop/Cxx/templates/member-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/member-templates-module-interface.swift
@@ -12,13 +12,13 @@
 // CHECK:   mutating func make42Ref<T>(_ val: inout T)
 // CHECK: }
 
-// CHECK: struct TemplateClassWithMemberTemplates<Int32> {
+// CHECK: struct TemplateClassWithMemberTemplates<CInt> {
 // CHECK:   init(_ val: Int32)
 // CHECK:   var value: Int32
 // CHECK:   mutating func setValue<U>(_ val: U)
 // CHECK: }
 
-// CHECK: typealias IntWrapper = TemplateClassWithMemberTemplates<Int32>
+// CHECK: typealias IntWrapper = TemplateClassWithMemberTemplates<CInt>
 
 // CHECK: struct HasStaticMemberTemplates {
 // CHECK:   init()
@@ -27,13 +27,13 @@
 // CHECK:   static func removeReference<T>(_ a: inout T) -> T
 // CHECK: }
 
-// CHECK: struct MyTemplatedStruct<Int32> {
+// CHECK: struct MyTemplatedStruct<CInt> {
 // CHECK:   init()
 // CHECK: }
 
 // CHECK: struct HasTemplatedField {
-// CHECK:   init(x: MyTemplatedStruct<Int32>)
-// CHECK:   var x: MyTemplatedStruct<Int32>
+// CHECK:   init(x: MyTemplatedStruct<CInt>)
+// CHECK:   var x: MyTemplatedStruct<CInt>
 // CHECK: }
 
 // CHECK: struct HasUninstantiatableTemplateMember<NoDefinition, TemplateClassWithMemberTemplates<NoDefinition>> {

--- a/test/Interop/Cxx/templates/member-templates-silgen.swift
+++ b/test/Interop/Cxx/templates/member-templates-silgen.swift
@@ -36,8 +36,8 @@ func basicTest() {
 
 // CHECK-LABEL: sil hidden @$s4main12testSetValueyyF : $@convention(thin) () -> ()
 
-// CHECK: [[SET_VALUE:%.*]] = function_ref @{{_ZN32TemplateClassWithMemberTemplatesIiE8setValueIlEEvT_|\?\?\$setValue@_J@\?\$TemplateClassWithMemberTemplates@H@@QEAAX_J@Z}} : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<Int32>) -> ()
-// CHECK: apply [[SET_VALUE]]({{.*}}) : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<Int32>) -> ()
+// CHECK: [[SET_VALUE:%.*]] = function_ref @{{_ZN32TemplateClassWithMemberTemplatesIiE8setValueIlEEvT_|\?\?\$setValue@_J@\?\$TemplateClassWithMemberTemplates@H@@QEAAX_J@Z}} : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<CInt>) -> ()
+// CHECK: apply [[SET_VALUE]]({{.*}}) : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<CInt>) -> ()
 
 // CHECK-LABEL: end sil function '$s4main12testSetValueyyF'
 func testSetValue() {

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -174,7 +174,7 @@ public struct Strct {
 // CHECK-NEXT: #endif
 
 
-// CHECK: SWIFT_EXTERN void $s8UseCxxTy13retNonTrivialSo2nsO0031NonTrivialTemplateInt32_fbGJhubVyF(SWIFT_INDIRECT_RESULT void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL; // retNonTrivial()
+// CHECK: SWIFT_EXTERN void $s8UseCxxTy13retNonTrivialSo2nsO0030NonTrivialTemplateCInt_hHAFhrbVyF(SWIFT_INDIRECT_RESULT void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL; // retNonTrivial()
 // CHECK: SWIFT_EXTERN struct swift_interop_returnStub_UseCxxTy_uint32_t_0_4 $s8UseCxxTy10retTrivialSo0E0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retTrivial()
 
 // CHECK: ns::Immortal *_Nonnull retImmortal() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
@@ -182,7 +182,7 @@ public struct Strct {
 // CHECK-NEXT: }
 
 // CHECK:  ns::ImmortalTemplate<int> *_Nonnull retImmortalTemplate() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: return _impl::$s8UseCxxTy19retImmortalTemplateSo2nsO0029ImmortalTemplateInt32_hEFAhqbVyF();
+// CHECK-NEXT: return _impl::$s8UseCxxTy19retImmortalTemplateSo2nsO0028ImmortalTemplateCInt_jBAGgnbVyF();
 // CHECK-NEXT: }
 
 // CHECK: } // end namespace
@@ -191,7 +191,7 @@ public struct Strct {
 // CHECK-NEXT: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: // Type metadata accessor for NonTrivialTemplateInt
-// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO0031NonTrivialTemplateInt32_fbGJhubVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO0030NonTrivialTemplateCInt_hHAFhrbVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
@@ -203,7 +203,7 @@ public struct Strct {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateInt> {
 // CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo2nsO0031NonTrivialTemplateInt32_fbGJhubVMa(0)._0;
+// CHECK-NEXT:     return _impl::$sSo2nsO0030NonTrivialTemplateCInt_hHAFhrbVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
@@ -218,7 +218,7 @@ public struct Strct {
 // CHECK: SWIFT_INLINE_THUNK ns::NonTrivialTemplate<int> retNonTrivial() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<int>)) char storage[sizeof(ns::NonTrivialTemplate<int>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<int> *>(storage);
-// CHECK-NEXT: _impl::$s8UseCxxTy13retNonTrivialSo2nsO0031NonTrivialTemplateInt32_fbGJhubVyF(storage);
+// CHECK-NEXT: _impl::$s8UseCxxTy13retNonTrivialSo2nsO0030NonTrivialTemplateCInt_hHAFhrbVyF(storage);
 // CHECK-NEXT: ns::NonTrivialTemplate<int> result(static_cast<ns::NonTrivialTemplate<int> &&>(*storageObjectPtr));
 // CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
 // CHECK-NEXT: return result;
@@ -286,7 +286,7 @@ public struct Strct {
 // CHECK-NEXT: }
 
 // CHECK: void takeImmortalTemplate(ns::ImmortalTemplate<int> *_Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   return _impl::$s8UseCxxTy20takeImmortalTemplateyySo2nsO0029ImmortalTemplateInt32_hEFAhqbVF(x);
+// CHECK-NEXT:   return _impl::$s8UseCxxTy20takeImmortalTemplateyySo2nsO0028ImmortalTemplateCInt_jBAGgnbVF(x);
 // CHECK-NEXT: }
 
 // CHECK: SWIFT_INLINE_THUNK void takeNonTrivial2(const ns::NonTrivialTemplate<ns::TrivialinNS>& x) noexcept SWIFT_SYMBOL({{.*}}) {

--- a/test/SILGen/opaque_values_cxx.swift
+++ b/test/SILGen/opaque_values_cxx.swift
@@ -7,14 +7,14 @@
 
 import Cxx
 
-// CHECK-LABEL: sil {{.*}}[ossa] @$sSo3stdO{{(3__1O)?}}0042vectorUInt32allocatorUInt32_mzFHjGjjqraEeaV3Cxx0B8SequenceSCA{{.*}}P13__beginUnsafe11RawIteratorQzyFTW : {{.*}} {
+// CHECK-LABEL: sil {{.*}}[ossa] @$sSo3stdO3__1O0055vectorCUnsignedIntallocatorCUnsignedInt_iqGBpboaivxaEhaV3Cxx0B8SequenceSCAgHP13__beginUnsafe11RawIteratorQzyFTW : {{.*}} {
 // CHECK:       bb0([[VECTOR_ADDR:%[^,]+]] :
 // CHECK:         [[VECTOR:%[^,]+]] = load_borrow [[VECTOR_ADDR]]
 // CHECK:         [[BEGIN_FN:%[^,]+]] = function_ref
 // CHECK:         [[BEGIN:%[^,]+]] = apply [[BEGIN_FN]]([[VECTOR]])
 // CHECK:         end_borrow [[VECTOR]]
 // CHECK:         return [[BEGIN]]
-// CHECK-LABEL: } // end sil function '$sSo3stdO{{(3__1O)?}}0042vectorUInt32allocatorUInt32_mzFHjGjjqraEeaV3Cxx0B8SequenceSCA{{.*}}P13__beginUnsafe11RawIteratorQzyFTW'
+// CHECK-LABEL: } // end sil function '$sSo3stdO3__1O0055vectorCUnsignedIntallocatorCUnsignedInt_iqGBpboaivxaEhaV3Cxx0B8SequenceSCAgHP13__beginUnsafe11RawIteratorQzyFTW'
 // CHECK-LABEL: sil {{.*}}[ossa] @$sSo3stdO{{(3__1O)?}}0020___wrap_iter__udAAdDaVSQSCSQ2eeoiySbx_xtFZTW : {{.*}} {
 // CHECK:       bb0([[LHS:%[^,]+]] : $std.__1.__wrap_iter<_>, [[RHS:%[^,]+]] :
 // CHECK:         [[CALLEE:%[^,]+]] = function_ref @$sSo2eeoiySbSo3stdO{{(3__1O)?}}0020___wrap_iter__udAAdDaV_AGtFTO

--- a/test/SourceKit/InterfaceGen/gen_clang_cxx_module_with_unavailable.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_cxx_module_with_unavailable.swift
@@ -34,5 +34,5 @@ func testMe() {
 // CHECK: @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT: public struct X<T> {
 // CHECK-NEXT: }
-// CHECK: public struct X<Int32> {
-// CHECK: public typealias XofInt = X<Int32>
+// CHECK: public struct X<CInt> {
+// CHECK: public typealias XofInt = X<CInt>

--- a/test/SourceKit/InterfaceGen/gen_clang_libcxx_sdk_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_libcxx_sdk_module.swift
@@ -3,4 +3,4 @@
 // REQUIRES: OS=macosx
 
 // CHECK: import CxxStdlib.vector
-// CHECK: extension std.basic_string<Int8, char_traits<Int8>, allocator<Int8>> {
+// CHECK: extension std.basic_string<CChar, char_traits<CChar>, allocator<CChar>> {


### PR DESCRIPTION
When importing a C++ class template instantiation, Swift translates the template parameter type names from C++ into their Swift equivalent.

For instance, `basic_string<wchar_t, char_traits<wchar_t>, allocator<wchar_t>>` gets imported as `basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>>`: `wchar_t` is imported as `CWideChar`, which is a typealias for `Scalar` on most platforms including Darwin. Notice that Swift goes through the `CWideChar` typealias on the specific platform. Another instantiation `basic_string<uint32_t, char_traits<uint32_t>, allocator<uint32_t>>` also gets imported as `basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>>`: `uint32_t` is also imported as `Scalar`. This is problematic because we have two distinct C++ types that have the same name in Swift.

This change makes sure Swift doesn't go through typealiases when emitting names of template parameters, so `wchar_t` would now get printed as `CWideChar`, `int` would get printed as `CInt`, etc.

This also encourages clients to use the correct type (`CInt`, `CWideChar`, etc) instead of relying on platform-specific typealiases.

rdar://115673622