### PR TITLE
[5.10][CodeCompletion] Suggest `init` as accessor

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -879,6 +879,7 @@ static void addLetVarKeywords(CodeCompletionResultSink &Sink) {
 static void addAccessorKeywords(CodeCompletionResultSink &Sink) {
   addKeyword(Sink, "get", CodeCompletionKeywordKind::None);
   addKeyword(Sink, "set", CodeCompletionKeywordKind::None);
+  addKeyword(Sink, "init", CodeCompletionKeywordKind::None);
 }
 
 static void addObserverKeywords(CodeCompletionResultSink &Sink) {

--- a/test/IDE/complete_accessor.swift
+++ b/test/IDE/complete_accessor.swift
@@ -3,6 +3,7 @@
 
 // WITH_GETSET: Keyword/None:                       get; name=get
 // WITH_GETSET: Keyword/None:                       set; name=set
+// WITH_GETSET: Keyword/None:                       init; name=init
 // NO_GETSET-NOT: get
 // NO_GETSET-NOT: set
 


### PR DESCRIPTION
* **Explanation**: Suggests `init` when completing in an accessor block
* **Scope**: Code completion inside an accessor block
* **Risk**: Very low
* **Testing**: Added regression test
* **Issue**: rdar://115500788
* **Reviewer**:  @hamishknight on https://github.com/apple/swift/pull/68605