### PR TITLE
Typed throws

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -124,6 +124,24 @@ public:
     return TheFunction.get<AbstractClosureExpr *>()->getType();
   }
 
+  Type getThrownErrorType() const {
+    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      if (Type thrownError = AFD->getThrownInterfaceType())
+        return AFD->mapTypeIntoContext(thrownError);
+
+      return Type();
+    }
+
+    Type closureType = TheFunction.get<AbstractClosureExpr *>()->getType();
+    if (!closureType)
+      return Type();
+
+    if (auto closureFnType = closureType->getAs<AnyFunctionType>())
+      return closureFnType->getThrownError();
+
+    return Type();
+  }
+
   Type getBodyResultType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
       if (auto *FD = dyn_cast<FuncDecl>(AFD))

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -341,24 +341,26 @@ void AbstractFunctionDecl_setBody(void *opaqueBody, void *opaqueDecl);
 
 SWIFT_NAME("FuncDecl_create(astContext:declContext:staticLoc:funcKeywordLoc:"
            "name:nameLoc:genericParamList:parameterList:asyncSpecifierLoc:"
-           "throwsSpecifierLoc:returnType:genericWhereClause:)")
+           "throwsSpecifierLoc:thrownType:returnType:genericWhereClause:)")
 struct BridgedDeclContextAndDecl
 FuncDecl_create(BridgedASTContext cContext, BridgedDeclContext cDeclContext,
                 BridgedSourceLoc cStaticLoc, BridgedSourceLoc cFuncKeywordLoc,
                 BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
                 void *_Nullable opaqueGenericParamList,
                 void *opaqueParameterList, BridgedSourceLoc cAsyncLoc,
-                BridgedSourceLoc cThrowsLoc, void *_Nullable opaqueReturnType,
+                BridgedSourceLoc cThrowsLoc, void *_Nullable opaqueThrownType,
+                void *_Nullable opaqueReturnType,
                 void *_Nullable opaqueGenericWhereClause);
 
 SWIFT_NAME("ConstructorDecl_create(astContext:declContext:initKeywordLoc:"
            "failabilityMarkLoc:isIUO:genericParamList:parameterList:"
-           "asyncSpecifierLoc:throwsSpecifierLoc:genericWhereClause:)")
+           "asyncSpecifierLoc:throwsSpecifierLoc:thrownType:genericWhereClause:)")
 BridgedDeclContextAndDecl ConstructorDecl_create(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cInitKeywordLoc, BridgedSourceLoc cFailabilityMarkLoc,
     _Bool isIUO, void *_Nullable opaqueGenericParams, void *opaqueParameterList,
     BridgedSourceLoc cAsyncLoc, BridgedSourceLoc cThrowsLoc,
+    void *_Nullable opaqueThrownType,
     void *_Nullable opaqueGenericWhereClause);
 
 SWIFT_NAME("DestructorDecl_create(astContext:declContext:deinitKeywordLoc:)")
@@ -587,6 +589,7 @@ void *EmptyCompositionTypeRepr_create(BridgedASTContext cContext,
 void *FunctionTypeRepr_create(BridgedASTContext cContext, void *argsTy,
                               BridgedSourceLoc cAsyncLoc,
                               BridgedSourceLoc cThrowsLoc,
+                              void * _Nullable thrownType,
                               BridgedSourceLoc cArrowLoc, void *returnType);
 void *GenericIdentTypeRepr_create(BridgedASTContext cContext,
                                   BridgedIdentifier name,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7066,6 +7066,13 @@ public:
   /// Retrieves the thrown interface type.
   Type getThrownInterfaceType() const;
 
+  /// Retrieve the "effective" thrown interface type, or llvm::None if
+  /// this function cannot throw.
+  ///
+  /// Functions with untyped throws will produce "any Error", functions that
+  /// cannot throw or are specified to throw "Never" will return llvm::None.
+  llvm::Optional<Type> getEffectiveThrownInterfaceType() const;
+
   /// Returns if the function throws or is async.
   bool hasEffect(EffectKind kind) const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6836,6 +6836,7 @@ void simple_display(llvm::raw_ostream &out, BodyAndFingerprint value);
 /// Base class for function-like declarations.
 class AbstractFunctionDecl : public GenericContext, public ValueDecl {
   friend class NeedsNewVTableEntryRequest;
+  friend class ThrownTypeRequest;
 
 public:
   /// records the kind of SILGen-synthesized body this decl represents

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1690,6 +1690,13 @@ ERROR(attr_type_eraser_expected_type_name,none,
 ERROR(attr_type_eraser_expected_rparen,none,
       "expected ')' after type name for @_typeEraser", ())
 
+ERROR(expected_thrown_error_type,none,
+      "expected thrown error type after 'throws('", ())
+ERROR(expected_rparen_after_thrown_error_type,none,
+      "expected ')' after thrown error type", ())
+ERROR(rethrows_with_thrown_error,none,
+      "'rethrows' cannot be combined with a specific thrown error type", ())
+
 ERROR(attr_private_import_expected_rparen,none,
       "expected ')' after function name for @_private", ())
 ERROR(attr_private_import_expected_sourcefile, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5048,6 +5048,12 @@ WARNING(no_throw_in_try,none,
 WARNING(no_throw_in_do_with_catch,none,
         "'catch' block is unreachable because no errors are thrown in 'do' block", ())
 
+ERROR(experimental_typed_throws,none,
+      "typed throws is an experimental feature", ())
+
+ERROR(thrown_type_not_error,none,
+      "thrown type %0 does not conform to the 'Error' protocol", (Type))
+
 //------------------------------------------------------------------------------
 // MARK: Concurrency
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -336,7 +336,9 @@ ERROR(cannot_convert_to_return_type_nil,none,
       "'nil' is incompatible with return type %0", (Type))
 
 ERROR(cannot_convert_thrown_type,none,
-      "thrown expression type %0 does not conform to 'Error'", (Type))
+      "thrown expression type %0 %select{cannot be converted to error type %1|"
+      "does not conform to 'Error'}2",
+      (Type, Type, bool))
 ERROR(cannot_throw_error_code,none,
       "thrown error code type %0 does not conform to 'Error'; construct an %1 "
       "instance", (Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2267,10 +2267,10 @@ ERROR(function_type_access,none,
       "%select{private|fileprivate|internal|package|%error|%error}1|private or fileprivate}2"
       "|cannot be declared "
       "%select{in this context|fileprivate|internal|package|public|open}1}0 "
-      "because its %select{parameter|result}5 uses "
+      "because its %select{parameter|thrown error|result}5 uses "
       "%select{a private|a fileprivate|an internal|a package|an '@_spi'|an '@_spi'}3"
       "%select{| API wrapper}6 type",
-      (bool, AccessLevel, bool, AccessLevel, unsigned, bool, bool))
+      (bool, AccessLevel, bool, AccessLevel, unsigned, unsigned, bool))
 ERROR(function_type_spi,none,
       "%select{function|method|initializer}0 "
       "cannot be declared '@_spi' "
@@ -2282,10 +2282,10 @@ WARNING(function_type_access_warn,none,
         "%select{function|method|initializer}4 "
         "%select{should be declared %select{private|fileprivate|internal|package|%error|%error}1"
         "|should not be declared %select{in this context|fileprivate|internal|package|public|open}1}0 "
-        "because its %select{parameter|result}5 uses "
+        "because its %select{parameter|thrown error|result}5 uses "
         "%select{a private|a fileprivate|an internal|a package|%error|%error}3 "
         "%select{|API wrapper}6 type",
-        (bool, AccessLevel, bool, AccessLevel, unsigned, bool, bool))
+        (bool, AccessLevel, bool, AccessLevel, unsigned, unsigned, bool))
 ERROR(function_type_usable_from_inline,none,
       "the %select{parameter|result}1%select{| API wrapper}2 of a "
       "'@usableFromInline' %select{function|method|initializer}0 "

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3847,6 +3847,13 @@ public:
   /// Return whether this closure is throwing when fully applied.
   bool isBodyThrowing() const;
 
+  /// Retrieve the "effective" thrown interface type, or llvm::None if
+  /// this closure cannot throw.
+  ///
+  /// Closures with untyped throws will produce "any Error", functions that
+  /// cannot throw or are specified to throw "Never" will return llvm::None.
+  llvm::Optional<Type> getEffectiveThrownType() const;
+
   /// \brief Return whether this closure is async when fully applied.
   bool isBodyAsync() const;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2222,6 +2222,27 @@ public:
   void cacheResult(ParamSpecifier value) const;
 };
 
+/// Determines the explicitly-written thrown result type of a function.
+class ThrownTypeRequest
+    : public SimpleRequest<ThrownTypeRequest,
+                           Type(AbstractFunctionDecl *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Type evaluate(Evaluator &evaluator, AbstractFunctionDecl *func) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  llvm::Optional<Type> getCachedResult() const;
+  void cacheResult(Type value) const;
+};
+
 /// Determines the result type of a function or element type of a subscript.
 class ResultTypeRequest
     : public SimpleRequest<ResultTypeRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -346,6 +346,8 @@ SWIFT_REQUEST(TypeChecker, NeedsNewVTableEntryRequest,
               bool(AbstractFunctionDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ParamSpecifierRequest,
               ParamDecl::Specifier(ParamDecl *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ThrownTypeRequest,
+              Type(AbstractFunctionDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResultTypeRequest,
               Type(ValueDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AreAllStoredPropertiesDefaultInitableRequest,

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -499,13 +499,16 @@ class FunctionTypeRepr : public TypeRepr {
 
   TupleTypeRepr *ArgsTy;
   TypeRepr *RetTy;
+  TypeRepr *ThrownTy;
   SourceLoc AsyncLoc;
   SourceLoc ThrowsLoc;
   SourceLoc ArrowLoc;
 
 public:
   FunctionTypeRepr(GenericParamList *genericParams, TupleTypeRepr *argsTy,
-                   SourceLoc asyncLoc, SourceLoc throwsLoc, SourceLoc arrowLoc,
+                   SourceLoc asyncLoc, SourceLoc throwsLoc, 
+                   TypeRepr *thrownTy,
+                   SourceLoc arrowLoc,
                    TypeRepr *retTy,
                    GenericParamList *patternGenericParams = nullptr,
                    ArrayRef<TypeRepr *> patternSubs = {},
@@ -515,7 +518,7 @@ public:
       InvocationSubs(invocationSubs),
       PatternGenericParams(patternGenericParams),
       PatternSubs(patternSubs),
-      ArgsTy(argsTy), RetTy(retTy),
+      ArgsTy(argsTy), RetTy(retTy), ThrownTy(thrownTy),
       AsyncLoc(asyncLoc), ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc) {
   }
 
@@ -545,6 +548,7 @@ public:
   }
 
   TupleTypeRepr *getArgsTypeRepr() const { return ArgsTy; }
+  TypeRepr *getThrownTypeRepr() const { return ThrownTy; }
   TypeRepr *getResultTypeRepr() const { return RetTy; }
   bool isAsync() const { return AsyncLoc.isValid(); }
   bool isThrowing() const { return ThrowsLoc.isValid(); }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -407,13 +407,14 @@ protected:
 
   SWIFT_INLINE_BITFIELD_EMPTY(ParenType, SugarType);
 
-  SWIFT_INLINE_BITFIELD_FULL(AnyFunctionType, TypeBase, NumAFTExtInfoBits+1+1+1+16,
+  SWIFT_INLINE_BITFIELD_FULL(AnyFunctionType, TypeBase, NumAFTExtInfoBits+1+1+1+1+16,
     /// Extra information which affects how the function is called, like
     /// regparm and the calling convention.
     ExtInfoBits : NumAFTExtInfoBits,
     HasExtInfo : 1,
     HasClangTypeInfo : 1,
     HasGlobalActor : 1,
+    HasThrownError : 1,
     : NumPadBits,
     NumParams : 16
   );
@@ -3319,6 +3320,8 @@ protected:
           !Info.value().getClangTypeInfo().empty();
       Bits.AnyFunctionType.HasGlobalActor =
           !Info.value().getGlobalActor().isNull();
+      Bits.AnyFunctionType.HasThrownError =
+          !Info.value().getThrownError().isNull();
       // The use of both assert() and static_assert() is intentional.
       assert(Bits.AnyFunctionType.ExtInfoBits == Info.value().getBits() &&
              "Bits were dropped!");
@@ -3330,6 +3333,7 @@ protected:
       Bits.AnyFunctionType.HasClangTypeInfo = false;
       Bits.AnyFunctionType.ExtInfoBits = 0;
       Bits.AnyFunctionType.HasGlobalActor = false;
+      Bits.AnyFunctionType.HasThrownError = false;
     }
     Bits.AnyFunctionType.NumParams = NumParams;
     assert(Bits.AnyFunctionType.NumParams == NumParams && "Params dropped!");
@@ -3372,10 +3376,15 @@ public:
     return Bits.AnyFunctionType.HasGlobalActor;
   }
 
+  bool hasThrownError() const {
+    return Bits.AnyFunctionType.HasThrownError;
+  }
+
   ClangTypeInfo getClangTypeInfo() const;
   ClangTypeInfo getCanonicalClangTypeInfo() const;
 
   Type getGlobalActor() const;
+  Type getThrownError() const;
 
   /// Returns true if the function type stores a Clang type that cannot
   /// be derived from its Swift type. Returns false otherwise, including if
@@ -3400,23 +3409,14 @@ public:
   ExtInfo getExtInfo() const {
     assert(hasExtInfo());
     return ExtInfo(Bits.AnyFunctionType.ExtInfoBits, getClangTypeInfo(),
-                   getGlobalActor());
+                   getGlobalActor(), getThrownError());
   }
 
   /// Get the canonical ExtInfo for the function type.
   ///
   /// The parameter useClangFunctionType is present only for staging purposes.
   /// In the future, we will always use the canonical clang function type.
-  ExtInfo getCanonicalExtInfo(bool useClangFunctionType) const {
-    assert(hasExtInfo());
-    Type globalActor = getGlobalActor();
-    if (globalActor)
-      globalActor = globalActor->getCanonicalType();
-    return ExtInfo(Bits.AnyFunctionType.ExtInfoBits,
-                   useClangFunctionType ? getCanonicalClangTypeInfo()
-                                        : ClangTypeInfo(),
-                   globalActor);
-  }
+  ExtInfo getCanonicalExtInfo(bool useClangFunctionType) const;
 
   bool hasSameExtInfoAs(const AnyFunctionType *otherFn);
 
@@ -3642,7 +3642,7 @@ class FunctionType final
   }
 
   size_t numTrailingObjects(OverloadToken<Type>) const {
-    return hasGlobalActor() ? 1 : 0;
+    return hasGlobalActor() + hasThrownError();
   }
 
 public:
@@ -3667,9 +3667,15 @@ public:
   Type getGlobalActor() const {
     if (!hasGlobalActor())
       return Type();
-    return *getTrailingObjects<Type>();
+    return getTrailingObjects<Type>()[0];
   }
 
+  Type getThrownError() const {
+    if (!hasThrownError())
+      return Type();
+    return getTrailingObjects<Type>()[hasGlobalActor()];
+  }
+                                      
   void Profile(llvm::FoldingSetNodeID &ID) {
     llvm::Optional<ExtInfo> info = llvm::None;
     if (hasExtInfo())
@@ -3774,7 +3780,7 @@ class GenericFunctionType final : public AnyFunctionType,
   }
                                     
   size_t numTrailingObjects(OverloadToken<Type>) const {
-    return hasGlobalActor() ? 1 : 0;
+    return hasGlobalActor() + hasThrownError();
   }
 
   /// Construct a new generic function type.
@@ -3796,9 +3802,15 @@ public:
   Type getGlobalActor() const {
     if (!hasGlobalActor())
       return Type();
-    return *getTrailingObjects<Type>();
+    return getTrailingObjects<Type>()[0];
   }
 
+  Type getThrownError() const {
+    if (!hasThrownError())
+      return Type();
+    return getTrailingObjects<Type>()[hasGlobalActor()];
+  }
+                                    
   /// Retrieve the generic signature of this function type.
   GenericSignature getGenericSignature() const {
     return Signature;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3386,6 +3386,13 @@ public:
   Type getGlobalActor() const;
   Type getThrownError() const;
 
+  /// Retrieve the "effective" thrown interface type, or llvm::None if
+  /// this function cannot throw.
+  ///
+  /// Functions with untyped throws will produce "any Error", functions that
+  /// cannot throw or are specified to throw "Never" will return llvm::None.
+  llvm::Optional<Type> getEffectiveThrownInterfaceType() const;
+  
   /// Returns true if the function type stores a Clang type that cannot
   /// be derived from its Swift type. Returns false otherwise, including if
   /// the function type is not @convention(c) or @convention(block).
@@ -3612,7 +3619,8 @@ BEGIN_CAN_TYPE_WRAPPER(AnyFunctionType, Type)
   }
 
   PROXY_CAN_TYPE_SIMPLE_GETTER(getResult)
-  
+  PROXY_CAN_TYPE_SIMPLE_GETTER(getThrownError)
+
   CanAnyFunctionType withExtInfo(ExtInfo info) const {
     return CanAnyFunctionType(getPointer()->withExtInfo(info));
   }

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -235,8 +235,12 @@ EXPERIMENTAL_FEATURE(RawLayout, true)
 /// Enables the "embedded" swift mode (no runtime).
 EXPERIMENTAL_FEATURE(Embedded, true)
 
+
 /// Enables noncopyable generics
 EXPERIMENTAL_FEATURE(NoncopyableGenerics, false)
+
+/// Enables typed throws.
+EXPERIMENTAL_FEATURE(TypedThrows, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1279,6 +1279,7 @@ public:
   ParserStatus parseGetEffectSpecifier(ParsedAccessors &accessors,
                                        SourceLoc &asyncLoc,
                                        SourceLoc &throwsLoc,
+                                       TypeRepr *&thrownTy,
                                        bool &hasEffectfulGet,
                                        AccessorKind currentKind,
                                        SourceLoc const& currentLoc);
@@ -1623,6 +1624,7 @@ public:
                                       bool &reasync,
                                       SourceLoc &throws,
                                       bool &rethrows,
+                                      TypeRepr *&thrownType,
                                       TypeRepr *&retType);
 
   /// Parse 'async' and 'throws', if present, putting the locations of the
@@ -1639,10 +1641,14 @@ public:
   /// lieu of 'throws'.
   ParserStatus parseEffectsSpecifiers(SourceLoc existingArrowLoc,
                                       SourceLoc &asyncLoc, bool *reasync,
-                                      SourceLoc &throwsLoc, bool *rethrows);
+                                      SourceLoc &throwsLoc, bool *rethrows,
+                                      TypeRepr *&thrownType);
+
+  /// Returns 'true' if \p T is consider a throwing effect specifier.
+  static bool isThrowsEffectSpecifier(const Token &T);
 
   /// Returns 'true' if \p T is considered effects specifier.
-  bool isEffectsSpecifier(const Token &T);
+  static bool isEffectsSpecifier(const Token &T);
 
   //===--------------------------------------------------------------------===//
   // Pattern Parsing
@@ -1870,6 +1876,7 @@ public:
           ParameterList *&params,
           SourceLoc &asyncLoc,
           SourceLoc &throwsLoc,
+          TypeExpr *&thrownType,
           SourceLoc &arrowLoc,
           TypeExpr *&explicitResultType,
           SourceLoc &inLoc);

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -54,6 +54,9 @@ SIMPLE_LOCATOR_PATH_ELT(AutoclosureResult)
 /// The result of a closure.
 SIMPLE_LOCATOR_PATH_ELT(ClosureResult)
 
+/// The thrown error of a closure.
+SIMPLE_LOCATOR_PATH_ELT(ClosureThrownError)
+
 /// FIXME: Misleading name: this locator is used only for single-expression
 /// closure returns.
 ///

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -454,10 +454,13 @@ Type ASTBuilder::createFunctionType(
     clangFunctionType = Ctx.getClangFunctionType(funcParams, output,
                                                  representation);
 
+  // FIXME: Populate thrownError
+  Type thrownError;
+
   auto einfo =
       FunctionType::ExtInfoBuilder(representation, noescape, flags.isThrowing(),
-                                   resultDiffKind, clangFunctionType,
-                                   globalActor)
+                                   thrownError, resultDiffKind,
+                                   clangFunctionType, globalActor)
           .withAsync(flags.isAsync())
           .withConcurrent(flags.isSendable())
           .build();

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1450,6 +1450,10 @@ namespace {
         }
       }
 
+      if (auto thrownTypeRepr = D->getThrownTypeRepr()) {
+        printRec(thrownTypeRepr, "thrown_type");
+      }
+
       if (auto fac = D->getForeignAsyncConvention()) {
         printRecArbitrary([&](StringRef label) {
           printHead("foreign_async_convention", ASTNodeColor, label);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4179,6 +4179,9 @@ namespace {
         printFlag(T->isAsync(), "async");
         printFlag(T->isThrowing(), "throws");
       }
+      if (Type thrownError = T->getThrownError()) {
+        printFieldQuoted(thrownError.getString(), "thrown_error");
+      }
       if (Type globalActor = T->getGlobalActor()) {
         printFieldQuoted(globalActor.getString(), "global_actor");
       }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4404,8 +4404,19 @@ void PrintAST::printFunctionParameters(AbstractFunctionDecl *AFD) {
     if (AFD->hasThrows()) {
       if (AFD->getAttrs().hasAttribute<RethrowsAttr>())
         Printer << " " << tok::kw_rethrows;
-      else
+      else {
         Printer << " " << tok::kw_throws;
+
+        if (auto thrownType = AFD->getThrownInterfaceType()) {
+          auto errorType = AFD->getASTContext().getErrorExistentialType();
+          TypeRepr *thrownTypeRepr = AFD->getThrownTypeRepr();
+          if (!errorType || !thrownType->isEqual(errorType) ||
+              (thrownTypeRepr && Options.PreferTypeRepr)) {
+            TypeLoc thrownTyLoc(thrownTypeRepr, thrownType);
+            printTypeLoc(thrownTyLoc);
+          }
+        }
+      }
     }
   }
 }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1014,9 +1014,15 @@ public:
     }
 
     void verifyChecked(ThrowStmt *S) {
-      checkSameType(S->getSubExpr()->getType(),
-                    checkExceptionTypeExists("throw expression"),
-                    "throw operand");
+      Type thrownError;
+      if (!Functions.empty()) {
+        if (auto fn = AnyFunctionRef::fromDeclContext(Functions.back()))
+          thrownError = fn->getThrownErrorType();
+      }
+
+      if (!thrownError)
+        thrownError = checkExceptionTypeExists("throw expression");
+      checkSameType(S->getSubExpr()->getType(), thrownError, "throw operand");
       verifyCheckedBase(S);
     }
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -507,6 +507,11 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (visit(AFD->getParameters()))
       return true;
 
+    if (auto *const ThrownTyR = AFD->getThrownTypeRepr()) {
+      if (doIt(ThrownTyR))
+        return true;
+    }
+
     if (auto *FD = dyn_cast<FuncDecl>(AFD)) {
       if (!isa<AccessorDecl>(FD))
         if (auto *const TyR = FD->getResultTypeRepr())
@@ -996,6 +1001,11 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (visit(expr->getParameters()))
       return nullptr;
 
+    if (auto thrownTypeRepr = expr->getExplicitThrownTypeRepr()) {
+      if (doIt(thrownTypeRepr))
+        return nullptr;
+    }
+
     if (expr->hasExplicitResultType()) {
       if (doIt(expr->getExplicitResultTypeRepr()))
         return nullptr;
@@ -1085,6 +1095,11 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       Args = doIt(Args);
       if (!Args) return nullptr;
       E->setArgsExpr(Args);
+    }
+    if (Expr *Thrown = E->getThrownTypeExpr()) {
+      Thrown = doIt(Thrown);
+      if (!Thrown) return nullptr;
+      E->setThrownTypeExpr(Thrown);
     }
     if (Expr *Result = E->getResultExpr()) {
       Result = doIt(Result);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -343,7 +343,7 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType) {
   DeclName Name(Context, Id, paramList);
   auto *const FD = FuncDecl::createImplicit(
       Context, StaticSpellingKind::None, Name, /*NameLoc=*/SourceLoc(),
-      /*Async=*/false, /*Throws=*/false,
+      /*Async=*/false, /*Throws=*/false, /*thrownType=*/Type(),
       /*GenericParams=*/nullptr, paramList, ResType, DC);
   FD->setAccess(AccessLevel::Public);
   return FD;
@@ -364,7 +364,7 @@ getBuiltinFunctionImpl(SynthesisContext &SC, Identifier id,
   DeclName name(SC.Context, id, params);
   auto *FD = FuncDecl::createImplicit(
       SC.Context, StaticSpellingKind::None, name, /*NameLoc=*/SourceLoc(),
-      extInfo.isAsync(), extInfo.isThrowing(),
+      extInfo.isAsync(), extInfo.isThrowing(), /*thrownType=*/Type(),
       genericParams, params, resultType, SC.DC);
   FD->setAccess(AccessLevel::Public);
   FD->setGenericSignature(signature);
@@ -450,7 +450,7 @@ getBuiltinGenericFunction(Identifier Id,
       Context, StaticSpellingKind::None, Name,
       /*NameLoc=*/SourceLoc(),
       Async,
-      Throws != BuiltinThrowsKind::None,
+      Throws != BuiltinThrowsKind::None, /*thrownType=*/Type(),
       GenericParams, paramList, ResType, DC);
 
   func->setAccess(AccessLevel::Public);

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -432,7 +432,8 @@ FuncDecl_create(BridgedASTContext cContext, BridgedDeclContext cDeclContext,
                 BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
                 void *_Nullable opaqueGenericParamList,
                 void *opaqueParameterList, BridgedSourceLoc cAsyncLoc,
-                BridgedSourceLoc cThrowsLoc, void *_Nullable opaqueReturnType,
+                BridgedSourceLoc cThrowsLoc, void *_Nullable opaqueThrownType,
+                void *_Nullable opaqueReturnType,
                 void *_Nullable opaqueGenericWhereClause) {
   ASTContext &context = convertASTContext(cContext);
 
@@ -440,11 +441,13 @@ FuncDecl_create(BridgedASTContext cContext, BridgedDeclContext cDeclContext,
   auto declName = DeclName(context, convertIdentifier(cName), paramList);
   auto asyncLoc = convertSourceLoc(cAsyncLoc);
   auto throwsLoc = convertSourceLoc(cThrowsLoc);
+  // FIXME: rethrows
 
   auto *decl = FuncDecl::create(
       context, convertSourceLoc(cStaticLoc), StaticSpellingKind::None,
       convertSourceLoc(cFuncKeywordLoc), declName, convertSourceLoc(cNameLoc),
       asyncLoc.isValid(), asyncLoc, throwsLoc.isValid(), throwsLoc,
+      static_cast<TypeRepr *>(opaqueThrownType),
       static_cast<GenericParamList *>(opaqueGenericParamList), paramList,
       static_cast<TypeRepr *>(opaqueReturnType),
       convertDeclContext(cDeclContext));
@@ -459,6 +462,7 @@ BridgedDeclContextAndDecl ConstructorDecl_create(
     BridgedSourceLoc cInitKeywordLoc, BridgedSourceLoc cFailabilityMarkLoc,
     bool isIUO, void *_Nullable opaqueGenericParams, void *opaqueParameterList,
     BridgedSourceLoc cAsyncLoc, BridgedSourceLoc cThrowsLoc,
+    void *_Nullable opaqueThrownType,
     void *_Nullable opaqueGenericWhereClause) {
   assert((bool)cFailabilityMarkLoc.raw || !isIUO);
 
@@ -470,11 +474,12 @@ BridgedDeclContextAndDecl ConstructorDecl_create(
   auto asyncLoc = convertSourceLoc(cAsyncLoc);
   auto throwsLoc = convertSourceLoc(cThrowsLoc);
   auto failabilityMarkLoc = convertSourceLoc(cFailabilityMarkLoc);
+  // FIXME: rethrows
 
   auto *decl = new (context) ConstructorDecl(
       declName, convertSourceLoc(cInitKeywordLoc), failabilityMarkLoc.isValid(),
       failabilityMarkLoc, asyncLoc.isValid(), asyncLoc, throwsLoc.isValid(),
-      throwsLoc, parameterList,
+      throwsLoc, static_cast<TypeRepr *>(opaqueThrownType), parameterList,
       static_cast<GenericParamList *>(opaqueGenericParams),
       convertDeclContext(cDeclContext));
   decl->setTrailingWhereClause(
@@ -544,7 +549,8 @@ void *ClosureExpr_create(BridgedASTContext cContext, void *body,
 
   auto *out = new (context)
       ClosureExpr(attributes, bracketRange, nullptr, nullptr, asyncLoc,
-                  throwsLoc, arrowLoc, inLoc, nullptr, declContext);
+                  throwsLoc, /*FIXME:thrownType=*/nullptr, arrowLoc, inLoc,
+                  nullptr, declContext);
   out->setBody((BraceStmt *)body, true);
   out->setParameterList(params);
   return (Expr *)out;
@@ -1061,11 +1067,12 @@ void *CompositionTypeRepr_create(BridgedASTContext cContext,
 void *FunctionTypeRepr_create(BridgedASTContext cContext, void *argsTy,
                               BridgedSourceLoc cAsyncLoc,
                               BridgedSourceLoc cThrowsLoc,
+                              void * _Nullable thrownType,
                               BridgedSourceLoc cArrowLoc, void *returnType) {
   ASTContext &context = convertASTContext(cContext);
   return new (context) FunctionTypeRepr(
       nullptr, (TupleTypeRepr *)argsTy, convertSourceLoc(cAsyncLoc),
-      convertSourceLoc(cThrowsLoc), convertSourceLoc(cArrowLoc),
+      convertSourceLoc(cThrowsLoc), (TypeRepr *)thrownType, convertSourceLoc(cArrowLoc),
       (TypeRepr *)returnType);
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -952,6 +952,18 @@ Type AbstractFunctionDecl::getThrownInterfaceType() const {
       Type());
 }
 
+llvm::Optional<Type> 
+AbstractFunctionDecl::getEffectiveThrownInterfaceType() const {
+  Type interfaceType = getInterfaceType();
+  if (hasImplicitSelfDecl()) {
+    if (auto fnType = interfaceType->getAs<AnyFunctionType>())
+      interfaceType = fnType->getResult();
+  }
+
+  return interfaceType->castTo<AnyFunctionType>()
+      ->getEffectiveThrownInterfaceType();
+}
+
 Expr *AbstractFunctionDecl::getSingleExpressionBody() const {
   assert(hasSingleExpressionBody() && "Not a single-expression body");
   auto braceStmt = getBody();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -946,13 +946,10 @@ bool Decl::preconcurrency() const {
 }
 
 Type AbstractFunctionDecl::getThrownInterfaceType() const {
-  if (!hasThrows())
-    return Type();
-
-  // TODO: if there was an explicitly-specified thrown error type
-  // representation, use that for the computation.
-
-  return getASTContext().getErrorExistentialType();
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      ThrownTypeRequest{const_cast<AbstractFunctionDecl *>(this)},
+      Type());
 }
 
 Expr *AbstractFunctionDecl::getSingleExpressionBody() const {
@@ -3238,7 +3235,7 @@ mapSignatureExtInfo(AnyFunctionType::ExtInfo info,
       .withRepresentation(info.getRepresentation())
       .withConcurrent(info.isSendable())
       .withAsync(info.isAsync())
-      .withThrows(info.isThrowing())
+      .withThrows(info.isThrowing(), info.getThrownError())
       .withClangFunctionType(info.getClangTypeInfo().getType())
       .build();
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2035,6 +2035,13 @@ bool ClosureExpr::hasEmptyBody() const {
   return getBody()->empty();
 }
 
+void ClosureExpr::setExplicitThrownType(Type thrownType) {
+  assert(thrownType && !thrownType->hasTypeVariable() &&
+         !thrownType->hasPlaceholder());
+  assert(ThrownType);
+  ThrownType->setType(MetatypeType::get(thrownType));
+}
+
 void ClosureExpr::setExplicitResultType(Type ty) {
   assert(ty && !ty->hasTypeVariable() && !ty->hasPlaceholder());
   ExplicitResultTypeAndBodyState.getPointer()

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1930,6 +1930,11 @@ Type AbstractClosureExpr::getResultType(
   return T->castTo<FunctionType>()->getResult();
 }
 
+llvm::Optional<Type> AbstractClosureExpr::getEffectiveThrownType() const {
+  return getType()->castTo<AnyFunctionType>()
+      ->getEffectiveThrownInterfaceType();
+}
+
 bool AbstractClosureExpr::isBodyThrowing() const {
   if (!getType() || getType()->hasError()) {
     // Scan the closure body to infer effects.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5419,6 +5419,24 @@ AnyFunctionType *AnyFunctionType::getWithoutThrowing() const {
   return withExtInfo(info);
 }
 
+llvm::Optional<Type> AnyFunctionType::getEffectiveThrownInterfaceType() const {
+  // A non-throwing function... has no thrown interface type.
+  if (!isThrowing())
+    return llvm::None;
+
+  // If there is no specified thrown error type, it throws "any Error".
+  Type thrownError = getThrownError();
+  if (!thrownError)
+    return getASTContext().getErrorExistentialType();
+
+  // If the thrown interface type is "Never", this function does not throw.
+  if (thrownError->isEqual(getASTContext().getNeverType()))
+    return llvm::None;
+
+  // Otherwise, return the typed error.
+  return thrownError;
+}
+
 llvm::Optional<TangentSpace>
 TypeBase::getAutoDiffTangentSpace(LookupConformanceFn lookupConformance) {
   assert(lookupConformance);

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -952,6 +952,24 @@ void ParamSpecifierRequest::cacheResult(ParamSpecifier specifier) const {
 }
 
 //----------------------------------------------------------------------------//
+// ThrownTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+llvm::Optional<Type> ThrownTypeRequest::getCachedResult() const {
+  auto *const func = std::get<0>(getStorage());
+  Type thrownType = func->ThrownType.getType();
+  if (thrownType.isNull())
+    return llvm::None;
+
+  return thrownType;
+}
+
+void ThrownTypeRequest::cacheResult(Type type) const {
+  auto *const func = std::get<0>(getStorage());
+  func->ThrownType.setType(type);
+}
+
+//----------------------------------------------------------------------------//
 // ResultTypeRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -329,6 +329,13 @@ void FunctionTypeRepr::printImpl(ASTPrinter &Printer,
   if (isThrowing()) {
     Printer << " ";
     Printer.printKeyword("throws", Opts);
+
+    if (ThrownTy) {
+      // FIXME: Do we need a PrintStructureKind for this?
+      Printer << "(";
+      printTypeRepr(ThrownTy, Printer, Opts);
+      Printer << ")";
+    }
   }
   Printer << " -> ";
   Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -87,8 +87,13 @@ FunctionType *GenericFunctionType::substGenericArgs(
 
   auto resultTy = substFn(getResult());
 
+  Type thrownError = getThrownError();
+  if (thrownError)
+    thrownError = substFn(thrownError);
+
   // Build the resulting (non-generic) function type.
-  return FunctionType::get(params, resultTy, getExtInfo());
+  return FunctionType::get(params, resultTy,
+                           getExtInfo().withThrows(isThrowing(), thrownError));
 }
 
 CanFunctionType

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -255,6 +255,7 @@ extension ASTGenVisitor {
       parameterList: self.visit(node.signature.parameterClause).rawValue,
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
+      thrownType: self.visit(node.signature.effectSpecifiers?.thrownType?.type)?.rawValue,
       returnType: self.visit(node.signature.returnClause?.type)?.rawValue,
       genericWhereClause: self.visit(node.genericWhereClause)?.rawValue
     )
@@ -279,6 +280,7 @@ extension ASTGenVisitor {
       parameterList: self.visit(node.signature.parameterClause).rawValue,
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
+      thrownType: self.visit(node.signature.effectSpecifiers?.thrownType?.type)?.rawValue,
       genericWhereClause: self.visit(node.genericWhereClause)?.rawValue
     )
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -256,7 +256,7 @@ extension ASTGenVisitor {
       parameterList: self.visit(node.signature.parameterClause).rawValue,
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.visit(node.signature.effectSpecifiers?.thrownType?.type)?.rawValue,
+      thrownType: self.visit(node.signature.effectSpecifiers?.thrownError?.type)?.rawValue,
       returnType: self.visit(node.signature.returnClause?.type)?.rawValue,
       genericWhereClause: self.visit(node.genericWhereClause)?.rawValue
     )
@@ -281,7 +281,7 @@ extension ASTGenVisitor {
       parameterList: self.visit(node.signature.parameterClause).rawValue,
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.visit(node.signature.effectSpecifiers?.thrownType?.type)?.rawValue,
+      thrownType: self.visit(node.signature.effectSpecifiers?.thrownError?.type)?.rawValue,
       genericWhereClause: self.visit(node.genericWhereClause)?.rawValue
     )
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -2,6 +2,7 @@ import CASTBridging
 
 // Needed to use SyntaxTransformVisitor's visit method.
 @_spi(SyntaxTransformVisitor)
+@_spi(ExperimentalLanguageFeatures)
 import SwiftSyntax
 import SwiftDiagnostics
 

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -36,6 +36,7 @@ extension Parser.ExperimentalFeatures {
       }
     }
     mapFeature(.ThenStatements, to: .thenStatements)
+    mapFeature(.TypedThrows, to: .typedThrows)
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -159,6 +159,7 @@ extension ASTGenVisitor {
         ),
         (node.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
         (node.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
+        self.visit(node.effectSpecifiers?.thrownType?.type)?.rawValue,
         node.returnClause.arrow.bridgedSourceLoc(in: self),
         visit(node.returnClause.type).rawValue
       )

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -160,7 +160,7 @@ extension ASTGenVisitor {
         ),
         (node.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
         (node.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-        self.visit(node.effectSpecifiers?.thrownType?.type)?.rawValue,
+        self.visit(node.effectSpecifiers?.thrownError?.type)?.rawValue,
         node.returnClause.arrow.bridgedSourceLoc(in: self),
         visit(node.returnClause.type).rawValue
       )

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -2,6 +2,7 @@ import CASTBridging
 
 // Needed to use SyntaxTransformVisitor's visit method.
 @_spi(SyntaxTransformVisitor)
+@_spi(ExperimentalLanguageFeatures)
 import SwiftSyntax
 import SwiftDiagnostics
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -109,11 +109,12 @@ createFuncOrAccessor(ClangImporter::Implementation &impl, SourceLoc funcLoc,
         /*accessorKeywordLoc*/ SourceLoc(), accessorInfo->Kind,
         accessorInfo->Storage,
         /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None, async,
-        /*AsyncLoc=*/SourceLoc(), throws, /*ThrowsLoc=*/SourceLoc(), bodyParams,
-        resultTy, dc, clangNode);
+        /*AsyncLoc=*/SourceLoc(), throws, /*ThrowsLoc=*/SourceLoc(), 
+        /*ThrownType=*/TypeLoc(), bodyParams, resultTy, dc, clangNode);
   } else {
     decl = FuncDecl::createImported(impl.SwiftContext, funcLoc, name, nameLoc,
-                                    async, throws, bodyParams, resultTy,
+                                    async, throws, /*thrownType=*/Type(),
+                                    bodyParams, resultTy,
                                     genericParams, dc, clangNode);
   }
   impl.importSwiftAttrAttributes(decl);
@@ -624,7 +625,8 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), params, stringTy, swiftDecl);
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, stringTy, swiftDecl);
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
   getterDecl->setIsTransparent(false);
@@ -3522,7 +3524,7 @@ namespace {
             /*failable=*/false, /*FailabilityLoc=*/SourceLoc(),
             /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
             /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-            bodyParams, genericParams, dc);
+            /*ThrownType=*/TypeLoc(), bodyParams, genericParams, dc);
       } else {
         auto resultTy = importedType.getType();
 
@@ -6045,8 +6047,8 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
       decl, AccessLevel::Public, name, /*NameLoc=*/SourceLoc(),
       failable, /*FailabilityLoc=*/SourceLoc(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), parameterList,
-      /*GenericParams=*/nullptr, dc);
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      parameterList, /*GenericParams=*/nullptr, dc);
   result->setImplicitlyUnwrappedOptional(isIUO);
   result->getASTContext().evaluator.cacheOutput(InitKindRequest{result},
                                                 std::move(initKind));
@@ -6559,7 +6561,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
       /*NameLoc=*/SourceLoc(), failability, /*FailabilityLoc=*/SourceLoc(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/importedName.getErrorInfo().has_value(),
-      /*ThrowsLoc=*/SourceLoc(), bodyParams,
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(), bodyParams,
       /*GenericParams=*/nullptr, const_cast<DeclContext *>(dc));
 
   addObjCAttribute(result, selector);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -92,7 +92,8 @@ static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), params, getterType, importedDecl, clangNode);
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, getterType, importedDecl, clangNode);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
@@ -121,7 +122,8 @@ static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), params, voidTy, importedDecl, clangNode);
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, voidTy, importedDecl, clangNode);
   setterDecl->setIsObjC(false);
   setterDecl->setIsDynamic(false);
   setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
@@ -407,7 +409,8 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), params, type, dc);
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, type, dc);
   func->setStatic(isStatic);
   func->setAccess(getOverridableAccessLevel(dc));
   func->setIsObjC(false);
@@ -488,7 +491,8 @@ SwiftDeclSynthesizer::createDefaultConstructor(NominalTypeDecl *structDecl) {
       ConstructorDecl(name, structDecl->getLoc(),
                       /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
                       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), emptyPL,
+                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), 
+                      /*ThrownType=*/TypeLoc(), emptyPL,
                       /*GenericParams=*/nullptr, structDecl);
 
   constructor->setAccess(AccessLevel::Public);
@@ -618,7 +622,8 @@ ConstructorDecl *SwiftDeclSynthesizer::createValueConstructor(
       ConstructorDecl(name, structDecl->getLoc(),
                       /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
                       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), paramList,
+                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), 
+                      /*ThrownType=*/TypeLoc(), paramList,
                       /*GenericParams=*/nullptr, structDecl);
 
   constructor->setAccess(AccessLevel::Public);
@@ -1262,7 +1267,8 @@ SwiftDeclSynthesizer::makeEnumRawValueConstructor(EnumDecl *enumDecl) {
       ConstructorDecl(name, enumDecl->getLoc(),
                       /*Failable=*/true, /*FailabilityLoc=*/SourceLoc(),
                       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), paramPL,
+                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), 
+                      /*ThrownType=*/TypeLoc(), paramPL,
                       /*GenericParams=*/nullptr, enumDecl);
   ctorDecl->setImplicit();
   ctorDecl->setAccess(AccessLevel::Public);
@@ -1334,7 +1340,8 @@ void SwiftDeclSynthesizer::makeEnumRawValueGetter(EnumDecl *enumDecl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), params, rawTy, enumDecl);
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, rawTy, enumDecl);
   getterDecl->setImplicit();
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
@@ -1398,7 +1405,8 @@ AccessorDecl *SwiftDeclSynthesizer::makeStructRawValueGetter(
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), params, computedType, structDecl);
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, computedType, structDecl);
   getterDecl->setImplicit();
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
@@ -1427,7 +1435,8 @@ AccessorDecl *SwiftDeclSynthesizer::buildSubscriptGetterDecl(
       /*StaticLoc=*/SourceLoc(), subscript->getStaticSpelling(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), params, elementTy, dc, getter->getClangNode());
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, elementTy, dc, getter->getClangNode());
 
   thunk->setAccess(getOverridableAccessLevel(dc));
 
@@ -1470,7 +1479,8 @@ AccessorDecl *SwiftDeclSynthesizer::buildSubscriptSetterDecl(
       /*StaticLoc=*/SourceLoc(), subscript->getStaticSpelling(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), valueIndicesPL, TupleType::getEmpty(C), dc,
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      valueIndicesPL, TupleType::getEmpty(C), dc,
       setter->getClangNode());
 
   thunk->setAccess(getOverridableAccessLevel(dc));
@@ -1616,7 +1626,8 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
       ctx, getterImpl->getLoc(), getterImpl->getLoc(), AccessorKind::Get,
       subscript, SourceLoc(), subscript->getStaticSpelling(),
       /*async*/ false, SourceLoc(),
-      /*throws*/ false, SourceLoc(), bodyParams, elementTy, dc);
+      /*throws*/ false, SourceLoc(), /*ThrownType=*/TypeLoc(),
+      bodyParams, elementTy, dc);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setImplicit();
   getterDecl->setIsDynamic(false);
@@ -1643,8 +1654,8 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
         ctx, setterImpl->getLoc(), setterImpl->getLoc(), AccessorKind::Set,
         subscript, SourceLoc(), subscript->getStaticSpelling(),
         /*async*/ false, SourceLoc(),
-        /*throws*/ false, SourceLoc(), setterParamList,
-        TupleType::getEmpty(ctx), dc);
+        /*throws*/ false, SourceLoc(), /*ThrownType=*/TypeLoc(),
+        setterParamList, TupleType::getEmpty(ctx), dc);
     setterDecl->setAccess(AccessLevel::Public);
     setterDecl->setImplicit();
     setterDecl->setIsDynamic(false);
@@ -1696,8 +1707,8 @@ SwiftDeclSynthesizer::makeDereferencedPointeeProperty(FuncDecl *getter,
       ctx, getterImpl->getLoc(), getterImpl->getLoc(), AccessorKind::Get,
       result, SourceLoc(), StaticSpellingKind::None,
       /*async*/ false, SourceLoc(),
-      /*throws*/ false, SourceLoc(), ParameterList::createEmpty(ctx), elementTy,
-      dc);
+      /*throws*/ false, SourceLoc(), /*ThrownType=*/TypeLoc(),
+      ParameterList::createEmpty(ctx), elementTy, dc);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setImplicit();
   getterDecl->setIsDynamic(false);
@@ -1728,8 +1739,8 @@ SwiftDeclSynthesizer::makeDereferencedPointeeProperty(FuncDecl *getter,
         ctx, setterImpl->getLoc(), setterImpl->getLoc(), AccessorKind::Set,
         result, SourceLoc(), StaticSpellingKind::None,
         /*async*/ false, SourceLoc(),
-        /*throws*/ false, SourceLoc(), setterParamList,
-        TupleType::getEmpty(ctx), dc);
+        /*throws*/ false, SourceLoc(), /*ThrownType=*/TypeLoc(),
+        setterParamList, TupleType::getEmpty(ctx), dc);
     setterDecl->setAccess(AccessLevel::Public);
     setterDecl->setImplicit();
     setterDecl->setIsDynamic(false);
@@ -1825,7 +1836,7 @@ FuncDecl *SwiftDeclSynthesizer::makeSuccessorFunc(FuncDecl *incrementFunc) {
 
   auto result = FuncDecl::createImplicit(
       ctx, StaticSpellingKind::None, name, SourceLoc(),
-      /*Async*/ false, /*Throws*/ false,
+      /*Async*/ false, /*Throws*/ false, /*ThrownType=*/Type(),
       /*GenericParams*/ nullptr, params, returnTy, dc);
 
   result->setAccess(AccessLevel::Public);
@@ -1947,8 +1958,8 @@ SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
 
   auto topLevelStaticFuncDecl = FuncDecl::createImplicit(
       ctx, StaticSpellingKind::None, opDeclName, SourceLoc(),
-      /*Async*/ false, /*Throws*/ false, genericParamList,
-      ParameterList::create(ctx, newParams),
+      /*Async*/ false, /*Throws*/ false, /*ThrownType=*/Type(), 
+      genericParamList, ParameterList::create(ctx, newParams),
       operatorMethod->getResultInterfaceType(), parentCtx);
 
   topLevelStaticFuncDecl->setAccess(AccessLevel::Public);
@@ -2027,7 +2038,8 @@ SwiftDeclSynthesizer::makeComputedPropertyFromCXXMethods(FuncDecl *getter,
       ctx, getter->getLoc(), getter->getLoc(), AccessorKind::Get, result,
       SourceLoc(), StaticSpellingKind::None,
       /*async*/ false, SourceLoc(),
-      /*throws*/ false, SourceLoc(), ParameterList::createEmpty(ctx),
+      /*throws*/ false, SourceLoc(), /*ThrownType=*/TypeLoc(),
+      ParameterList::createEmpty(ctx),
       getter->getResultInterfaceType(), dc);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setImplicit();
@@ -2053,8 +2065,8 @@ SwiftDeclSynthesizer::makeComputedPropertyFromCXXMethods(FuncDecl *getter,
         ctx, setter->getLoc(), setter->getLoc(), AccessorKind::Set, result,
         SourceLoc(), StaticSpellingKind::None,
         /*async*/ false, SourceLoc(),
-        /*throws*/ false, SourceLoc(), setterParamList,
-        setter->getResultInterfaceType(), dc);
+        /*throws*/ false, SourceLoc(), /*thrownType*/ TypeLoc(),
+        setterParamList, setter->getResultInterfaceType(), dc);
     setterDecl->setAccess(AccessLevel::Public);
     setterDecl->setImplicit();
     setterDecl->setIsDynamic(false);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -802,6 +802,7 @@ Parser::parseFunctionSignature(DeclBaseName SimpleName,
                                bool &reasync,
                                SourceLoc &throwsLoc,
                                bool &rethrows,
+                               TypeRepr *&thrownType,
                                TypeRepr *&retType) {
   SmallVector<Identifier, 4> NamePieces;
   ParserStatus Status;
@@ -818,9 +819,10 @@ Parser::parseFunctionSignature(DeclBaseName SimpleName,
   // Check for the 'async' and 'throws' keywords.
   reasync = false;
   rethrows = false;
+  thrownType = nullptr;
   Status |= parseEffectsSpecifiers(SourceLoc(),
                                    asyncLoc, &reasync,
-                                   throwsLoc, &rethrows);
+                                   throwsLoc, &rethrows, thrownType);
 
   // If there's a trailing arrow, parse the rest as the result type.
   SourceLoc arrowLoc;
@@ -834,7 +836,8 @@ Parser::parseFunctionSignature(DeclBaseName SimpleName,
 
     // Check for effect specifiers after the arrow, but before the return type,
     // and correct it.
-    parseEffectsSpecifiers(arrowLoc, asyncLoc, &reasync, throwsLoc, &rethrows);
+    parseEffectsSpecifiers(arrowLoc, asyncLoc, &reasync, throwsLoc, &rethrows,
+                           thrownType);
 
     ParserResult<TypeRepr> ResultType =
         parseDeclResultType(diag::expected_type_function_result);
@@ -844,13 +847,19 @@ Parser::parseFunctionSignature(DeclBaseName SimpleName,
       return Status;
 
     // Check for effect specifiers after the type and correct it.
-    parseEffectsSpecifiers(arrowLoc, asyncLoc, &reasync, throwsLoc, &rethrows);
+    parseEffectsSpecifiers(
+        arrowLoc, asyncLoc, &reasync, throwsLoc, &rethrows, thrownType);
   } else {
     // Otherwise, we leave retType null.
     retType = nullptr;
   }
 
   return Status;
+}
+
+bool Parser::isThrowsEffectSpecifier(const Token &T) {
+  return T.isAny(tok::kw_throws, tok::kw_rethrows) ||
+    (T.isAny(tok::kw_throw, tok::kw_try) && !T.isAtStartOfLine());
 }
 
 bool Parser::isEffectsSpecifier(const Token &T) {
@@ -862,8 +871,7 @@ bool Parser::isEffectsSpecifier(const Token &T) {
       T.isContextualKeyword("reasync"))
     return true;
 
-  if (T.isAny(tok::kw_throws, tok::kw_rethrows) ||
-      (T.isAny(tok::kw_throw, tok::kw_try) && !T.isAtStartOfLine()))
+  if (isThrowsEffectSpecifier(T))
     return true;
 
   return false;
@@ -873,9 +881,9 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
                                             SourceLoc &asyncLoc,
                                             bool *reasync,
                                             SourceLoc &throwsLoc,
-                                            bool *rethrows) {
+                                            bool *rethrows,
+                                            TypeRepr *&thrownType) {
   ParserStatus status;
-
   while (true) {
     // 'async'
     bool isReasync = (shouldParseExperimentalConcurrency() &&
@@ -927,8 +935,7 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
     }
 
     // 'throws'/'rethrows', or diagnose 'throw'/'try'.
-    if (Tok.isAny(tok::kw_throws, tok::kw_rethrows) ||
-        (Tok.isAny(tok::kw_throw, tok::kw_try) && !Tok.isAtStartOfLine())) {
+    if (isThrowsEffectSpecifier(Tok)) {
       bool isRethrows = Tok.is(tok::kw_rethrows);
 
       if (throwsLoc.isValid()) {
@@ -955,6 +962,31 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
         throwsLoc = Tok.getLoc();
       }
       consumeToken();
+
+      // Parse the thrown error type.
+      SourceLoc lParenLoc;
+      if (consumeIf(tok::l_paren, lParenLoc)) {
+        ParserResult<TypeRepr> parsedThrownTy =
+            parseType(diag::expected_thrown_error_type);
+        thrownType = parsedThrownTy.getPtrOrNull();
+        status |= parsedThrownTy;
+
+        SourceLoc rParenLoc;
+        parseMatchingToken(
+            tok::r_paren, rParenLoc,
+            diag::expected_rparen_after_thrown_error_type, lParenLoc);
+
+        if (isRethrows) {
+          diagnose(throwsLoc, diag::rethrows_with_thrown_error)
+            .highlight(SourceRange(lParenLoc, rParenLoc));
+
+          isRethrows = false;
+
+          if (rethrows)
+            *rethrows = false;
+        }
+      }
+
       continue;
     }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1081,6 +1081,7 @@ ParserResult<Stmt> Parser::parseStmtDefer() {
       Context, StaticSpellingKind::None, name, /*NameLoc=*/PreviousLoc,
       /*Async=*/false,
       /*Throws=*/false,
+      /*ThrownType=*/Type(),
       /*GenericParams*/ nullptr, params, TupleType::getEmpty(Context),
       CurDeclContext);
   ParserStatus Status;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2202,7 +2202,13 @@ static CanSILFunctionType getSILFunctionType(
       !foreignInfo.async) {
     assert(!origType.isForeign()
            && "using native Swift error convention for foreign type!");
-    SILType exnType = SILType::getExceptionType(TC.Context);
+    SILType exnType;
+    if (CanType thrownError = substFnInterfaceType.getThrownError()) {
+      exnType = TC.getLoweredType(thrownError, expansionContext);
+    } else {
+      // Untyped error throws the exception type.
+      exnType = SILType::getExceptionType(TC.Context);
+    }
     assert(exnType.isObject());
     errorResult = SILResultInfo(exnType.getASTType(),
                                 ResultConvention::Owned);

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4627,13 +4627,13 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
 
   // Build the uncurried function type.
   if (innerExtInfo.isThrowing())
-    extInfo = extInfo.withThrows(true);
+    extInfo = extInfo.withThrows(true, innerExtInfo.getThrownError());
   if (innerExtInfo.isAsync())
     extInfo = extInfo.withAsync(true);
 
   // Distributed thunks are always `async throws`
   if (constant.isDistributedThunk()) {
-    extInfo = extInfo.withAsync(true).withThrows(true);
+    extInfo = extInfo.withAsync(true).withThrows(true, Type());
   }
 
   // If this is a C++ constructor, don't add the metatype "self" parameter

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3415,7 +3415,7 @@ static CanAnyFunctionType getDestructorInterfaceType(DestructorDecl *dd,
          && "There are no foreign destroying destructors");
   auto extInfoBuilder =
       AnyFunctionType::ExtInfoBuilder(FunctionType::Representation::Thin,
-                                      /*throws*/ false);
+                                      /*throws*/ false, Type());
   if (isForeign)
     extInfoBuilder = extInfoBuilder.withSILRepresentation(
         SILFunctionTypeRepresentation::ObjCMethod);
@@ -3452,7 +3452,7 @@ static CanAnyFunctionType getIVarInitDestroyerInterfaceType(ClassDecl *cd,
                      : classType);
   auto extInfoBuilder =
       AnyFunctionType::ExtInfoBuilder(FunctionType::Representation::Thin,
-                                      /*throws*/ false);
+                                      /*throws*/ false, Type());
   auto extInfo = extInfoBuilder
                      .withSILRepresentation(
                          isObjC ? SILFunctionTypeRepresentation::ObjCMethod
@@ -3481,7 +3481,8 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
 
   auto innerExtInfo =
       AnyFunctionType::ExtInfoBuilder(FunctionType::Representation::Thin,
-                                      funcType->isThrowing())
+                                      funcType->isThrowing(),
+                                      funcType->getThrownError())
           .withConcurrent(funcType->isSendable())
           .withAsync(funcType->isAsync())
           .build();
@@ -3513,7 +3514,7 @@ static CanAnyFunctionType getAsyncEntryPoint(ASTContext &C) {
 
   CanType returnType = C.getVoidType()->getCanonicalType();
   FunctionType::ExtInfo extInfo =
-      FunctionType::ExtInfoBuilder().withAsync(true).withThrows(false).build();
+      FunctionType::ExtInfoBuilder().withAsync(true).build();
   return CanAnyFunctionType::get(/*genericSig*/ nullptr, {}, returnType,
                                  extInfo);
 }

--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -237,7 +237,8 @@ void SILGenFunction::emitBackDeploymentThunk(SILDeclRef thunk) {
     paramsForForwarding.emplace_back(param.forward(*this));
   }
 
-  prepareEpilog(getResultInterfaceType(AFD), AFD->hasThrows(),
+  prepareEpilog(getResultInterfaceType(AFD),
+                AFD->getEffectiveThrownInterfaceType(),
                 CleanupLocation(AFD));
 
   SILBasicBlock *availableBB = createBasicBlock("availableBB");

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -666,7 +666,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   // Create a basic block to jump to for the implicit 'self' return.
   // We won't emit this until after we've emitted the body.
   // The epilog takes a void return because the return of 'self' is implicit.
-  prepareEpilog(llvm::None, ctor->hasThrows(), CleanupLocation(ctor));
+  prepareEpilog(llvm::None, ctor->getEffectiveThrownInterfaceType(),
+                CleanupLocation(ctor));
 
   // If the constructor can fail, set up an alternative epilog for constructor
   // failure.
@@ -1170,7 +1171,8 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
 
   // Create a basic block to jump to for the implicit 'self' return.
   // We won't emit the block until after we've emitted the body.
-  prepareEpilog(llvm::None, ctor->hasThrows(), CleanupLocation(endOfInitLoc));
+  prepareEpilog(llvm::None, ctor->getEffectiveThrownInterfaceType(),
+                CleanupLocation(endOfInitLoc));
 
   auto resultType = ctor->mapTypeIntoContext(ctor->getResultInterfaceType());
 
@@ -1643,7 +1645,7 @@ void SILGenFunction::emitIVarInitializer(SILDeclRef ivarInitializer) {
   VarLocs[selfDecl] = VarLoc::get(selfArg);
 
   auto cleanupLoc = CleanupLocation(loc);
-  prepareEpilog(llvm::None, false, cleanupLoc);
+  prepareEpilog(llvm::None, llvm::None, cleanupLoc);
 
   // Emit the initializers.
   emitMemberInitializers(cd, selfDecl, cd);
@@ -1713,7 +1715,8 @@ void SILGenFunction::emitInitAccessor(AccessorDecl *accessor) {
     }
   }
 
-  prepareEpilog(accessor->getResultInterfaceType(), accessor->hasThrows(),
+  prepareEpilog(accessor->getResultInterfaceType(),
+                accessor->getEffectiveThrownInterfaceType(),
                 CleanupLocation(accessor));
 
   emitProfilerIncrement(accessor->getTypecheckedBody());

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -45,7 +45,7 @@ void SILGenFunction::emitDestroyingDestructor(DestructorDecl *dd) {
   // Create a basic block to jump to for the implicit destruction behavior
   // of releasing the elements and calling the superclass destructor.
   // We won't actually emit the block until we finish with the destructor body.
-  prepareEpilog(llvm::None, false, CleanupLocation(Loc));
+  prepareEpilog(llvm::None, llvm::None, CleanupLocation(Loc));
 
   auto cleanupLoc = CleanupLocation(Loc);
 
@@ -248,7 +248,7 @@ void SILGenFunction::emitDeallocatingMoveOnlyDestructor(DestructorDecl *dd) {
   // Create a basic block to jump to for the implicit destruction behavior
   // of releasing the elements and calling the superclass destructor.
   // We won't actually emit the block until we finish with the destructor body.
-  prepareEpilog(llvm::None, false, CleanupLocation(loc));
+  prepareEpilog(llvm::None, llvm::None, CleanupLocation(loc));
 
   auto cleanupLoc = CleanupLocation(loc);
 
@@ -286,7 +286,7 @@ void SILGenFunction::emitIVarDestroyer(SILDeclRef ivarDestroyer) {
   assert(selfValue);
 
   auto cleanupLoc = CleanupLocation(loc);
-  prepareEpilog(llvm::None, false, cleanupLoc);
+  prepareEpilog(llvm::None, llvm::None, cleanupLoc);
   {
     Scope S(*this, cleanupLoc);
     // Self is effectively guaranteed for the duration of any destructor.  For
@@ -577,7 +577,7 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
   // Create a basic block to jump to for the implicit destruction behavior
   // of releasing the elements and calling the superclass destructor.
   // We won't actually emit the block until we finish with the destructor body.
-  prepareEpilog(llvm::None, false, CleanupLocation(loc));
+  prepareEpilog(llvm::None, llvm::None, CleanupLocation(loc));
 
   emitProfilerIncrement(dd->getTypecheckedBody());
   // Emit the destructor body.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1861,12 +1861,12 @@ static bool canPeepholeLiteralClosureConversion(Type literalType,
   // TODO: We could also in principle let `async` through here, but that
   // interferes with the implementation of `reasync`.
   auto literalWithoutEffects = literalFnType->getExtInfo().intoBuilder()
-    .withThrows(false)
+    .withThrows(false, Type())
     .withNoEscape(false)
     .build();
     
   auto convertedWithoutEffects = convertedFnType->getExtInfo().intoBuilder()
-    .withThrows(false)
+    .withThrows(false, Type())
     .withNoEscape(false)
     .build();
   if (literalFnType->withExtInfo(literalWithoutEffects)

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1051,7 +1051,7 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
     emitDistributedActorFactory(fd);
   } else {
     prepareEpilog(fd->getResultInterfaceType(),
-                  fd->hasThrows(), CleanupLocation(fd));
+                  fd->getEffectiveThrownInterfaceType(), CleanupLocation(fd));
 
     if (fd->requiresUnavailableDeclABICompatibilityStubs())
       emitApplyOfUnavailableCodeReached();
@@ -1077,7 +1077,8 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
   emitProlog(captureInfo, ace->getParameters(), /*selfParam=*/nullptr,
              ace, resultIfaceTy, ace->isBodyThrowing(), ace->getLoc(),
              OrigFnType);
-  prepareEpilog(resultIfaceTy, ace->isBodyThrowing(), CleanupLocation(ace));
+  prepareEpilog(resultIfaceTy, ace->getEffectiveThrownType(),
+                CleanupLocation(ace));
 
   emitProfilerIncrement(ace);
   if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
@@ -1559,7 +1560,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
     // been recorded for this expression, not the sub-expression.
     emitProfilerIncrement(topLevelValue);
   }
-  prepareEpilog(interfaceType, false, CleanupLocation(Loc));
+  prepareEpilog(interfaceType, llvm::None, CleanupLocation(Loc));
 
   {
     llvm::Optional<SILGenFunction::OpaqueValueRAII> opaqueValue;
@@ -1622,7 +1623,7 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, VarDecl *var) {
   emitBasicProlog(/*paramList*/ nullptr, /*selfParam*/ nullptr,
                   interfaceType, dc, /*throws=*/ false,SourceLoc(),
                   /*ignored parameters*/ 0);
-  prepareEpilog(interfaceType, false, CleanupLocation(loc));
+  prepareEpilog(interfaceType, llvm::None, CleanupLocation(loc));
 
   auto pbd = var->getParentPatternBinding();
   const auto i = pbd->getPatternEntryIndexForVarDecl(var);
@@ -1678,7 +1679,7 @@ void SILGenFunction::emitGeneratorFunction(
              /*selfParam=*/nullptr, dc, resultInterfaceType, /*throws=*/false,
              SourceLoc(), pattern);
 
-  prepareEpilog(resultInterfaceType, /*hasThrows=*/false, CleanupLocation(loc));
+  prepareEpilog(resultInterfaceType, llvm::None, CleanupLocation(loc));
 
   emitStmt(body);
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1481,7 +1481,8 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
             getASTContext(),
             DeclBaseName(getASTContext().getIdentifier("_asyncMainDrainQueue")),
             /*Arguments*/ emptyParams),
-        {}, /*async*/ false, /*throws*/ false, {}, emptyParams,
+        {}, /*async*/ false, /*throws*/ false, /*thrownType*/Type(), {},
+        emptyParams,
         getASTContext().getNeverType(), moduleDecl);
     drainQueueFuncDecl->getAttrs().add(new (getASTContext()) SILGenNameAttr(
         "swift_task_asyncMainDrainQueue", /*raw*/ false, /*implicit*/ true));

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1172,12 +1172,14 @@ public:
   /// \param directResultType  If given a value, the epilog block will be
   ///                    created with arguments for each direct result of this
   ///                    function, corresponding to the formal return type.
-  /// \param isThrowing  If true, create an error epilog block.
+  /// \param exnType  If not None, create an error epilog block with the given
+  ///                 exception type.
   /// \param L           The SILLocation which should be associated with
   ///                    cleanup instructions.
-  void prepareEpilog(llvm::Optional<Type> directResultType, bool isThrowing,
+  void prepareEpilog(llvm::Optional<Type> directResultType, 
+                     llvm::Optional<Type> exnType,
                      CleanupLocation L);
-  void prepareRethrowEpilog(CleanupLocation l);
+  void prepareRethrowEpilog(Type exnType, CleanupLocation l);
   void prepareCoroutineUnwindEpilog(CleanupLocation l);
   
   /// Branch to and emit the epilog basic block. This will fuse

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1462,8 +1462,8 @@ SILValue SILGenFunction::emitMainExecutor(SILLocation loc) {
             ctx,
             DeclBaseName(ctx.getIdentifier("_getMainExecutor")),
             /*Arguments*/ emptyParams),
-        {}, /*async*/ false, /*throws*/ false, {}, emptyParams,
-        ctx.TheExecutorType,
+        {}, /*async*/ false, /*throws*/ false, /*thrownType*/Type(), {},
+        emptyParams, ctx.TheExecutorType,
         getModule().getSwiftModule());
     getMainExecutorFuncDecl->getAttrs().add(
         new (ctx) SILGenNameAttr("swift_task_getMainExecutor", /*raw*/ false,

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -41,7 +41,8 @@ void SILGenModule::emitEntryPoint(SourceFile *SF, SILFunction *TopLevel) {
   TopLevelSGF.MagicFunctionName = SwiftModule->getName();
   auto moduleCleanupLoc = CleanupLocation::getModuleCleanupLocation();
 
-  TopLevelSGF.prepareEpilog(llvm::None, true, moduleCleanupLoc);
+  TopLevelSGF.prepareEpilog(
+      llvm::None, getASTContext().getErrorExistentialType(), moduleCleanupLoc);
 
   auto prologueLoc = RegularLocation::getModuleLocation();
   prologueLoc.markAsPrologue();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8896,7 +8896,7 @@ static Expr *wrapAsyncLetInitializer(
   auto extInfo = ASTExtInfoBuilder()
     .withAsync()
     .withConcurrent()
-    .withThrows(throws)
+    .withThrows(throws, /*FIXME:*/Type())
     .build();
 
   // Form the autoclosure expression. The actual closure here encapsulates the

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2453,6 +2453,49 @@ namespace {
       auto resultLocator =
           CS.getConstraintLocator(closure, ConstraintLocator::ClosureResult);
 
+      // FIXME: Need a better locator.
+      auto thrownErrorLocator =
+        CS.getConstraintLocator(closure, ConstraintLocator::ClosureThrownError);
+
+      // Determine the thrown error type, when appropriate.
+      Type thrownErrorTy = [&] {
+        // Explicitly-specified thrown type.
+        if (auto thrownTypeRepr = closure->getExplicitThrownTypeRepr()) {
+          Type resolvedTy = resolveTypeReferenceInExpression(
+              thrownTypeRepr, TypeResolverContext::InExpression,
+              thrownErrorLocator);
+          if (resolvedTy)
+            return resolvedTy;
+        }
+
+        // Thrown type inferred from context.
+        if (auto contextualType = CS.getContextualType(
+                closure, /*forConstraint=*/false)) {
+          if (auto fnType = contextualType->getAs<AnyFunctionType>()) {
+            if (Type thrownErrorTy = fnType->getThrownError())
+              return thrownErrorTy;
+          }
+        }
+
+        // We do not try to infer a thrown error type if one isn't immediately
+        // available. We could attempt this in the future.
+        return Type();
+      }();
+
+      if (thrownErrorTy) {
+        // Record the thrown error type in the extended info for the function
+        // type of the closure.
+        extInfo = extInfo.withThrows(true, thrownErrorTy);
+
+        // Ensure that the thrown error type conforms to Error.
+        if (auto errorProto =
+                CS.getASTContext().getProtocol(KnownProtocolKind::Error)) {
+          CS.addConstraint(
+              ConstraintKind::ConformsTo, thrownErrorTy,
+              errorProto->getDeclaredInterfaceType(), thrownErrorLocator);
+        }
+      }
+
       // Closure expressions always have function type. In cases where a
       // parameter or return type is omitted, a fresh type variable is used to
       // stand in for that parameter or return type, allowing it to be inferred

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -329,6 +329,7 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
                               /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
                               /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
                               /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
+                              /*ThrownType=*/TypeLoc(),
                               paramList, /*GenericParams=*/nullptr, decl);
 
   // Mark implicit.
@@ -709,6 +710,11 @@ createDesignatedInitOverride(ClassDecl *classDecl,
     bodyParam->setInterfaceType(substTy);
   }
 
+  Type thrownType;
+  if (auto superThrownType = superclassCtor->getThrownInterfaceType()) {
+    thrownType = superThrownType.subst(subMap);
+  }
+
   // Create the initializer declaration, inheriting the name,
   // failability, and throws from the superclass initializer.
   auto implCtx = classDecl->getImplementationContext()->getAsGenericContext();
@@ -721,6 +727,7 @@ createDesignatedInitOverride(ClassDecl *classDecl,
                               /*AsyncLoc=*/SourceLoc(),
                               /*Throws=*/superclassCtor->hasThrows(),
                               /*ThrowsLoc=*/SourceLoc(),
+                              TypeLoc::withoutLoc(thrownType),
                               bodyParams, genericParams, implCtx);
 
   ctor->setImplicit();

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -727,8 +727,8 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
 
   FuncDecl *thunk = FuncDecl::createImplicit(
       C, swift::StaticSpellingKind::None, thunkName, SourceLoc(),
-      /*async=*/true, /*throws=*/true, genericParamList, params,
-      func->getResultInterfaceType(), DC);
+      /*async=*/true, /*throws=*/true, /*thrownType=*/Type(),
+      genericParamList, params, func->getResultInterfaceType(), DC);
 
   assert(thunk && "couldn't create a distributed thunk");
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -45,6 +45,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ApplyFunction:
   case ConstraintLocator::SequenceElementType:
   case ConstraintLocator::ClosureResult:
+  case ConstraintLocator::ClosureThrownError:
   case ConstraintLocator::ClosureBody:
   case ConstraintLocator::ConstructorMember:
   case ConstraintLocator::ConstructorMemberType:
@@ -185,6 +186,10 @@ void LocatorPathElt::dump(raw_ostream &out) const {
   }
   case ConstraintLocator::ClosureResult:
     out << "closure result";
+    break;
+
+  case ConstraintLocator::ClosureThrownError:
+    out << "closure thrown error";
     break;
 
   case ConstraintLocator::ClosureBody:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5809,6 +5809,16 @@ void constraints::simplifyLocator(ASTNode &anchor,
       }
       break;
 
+    case ConstraintLocator::ClosureThrownError:
+      if (auto CE = getAsExpr<ClosureExpr>(anchor)) {
+        if (auto thrownTypeRepr = CE->getExplicitThrownTypeRepr()) {
+          anchor = thrownTypeRepr;
+          path = path.slice(1);
+          break;
+        }
+      }
+      break;
+
     case ConstraintLocator::CoercionOperand: {
       auto *CE = castToExpr<CoerceExpr>(anchor);
       anchor = CE->getSubExpr()->getValueProvidingExpr();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2920,7 +2920,7 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
                                          FunctionType::ExtInfoBuilder()
                                              .withNoEscape(true)
                                              .withAsync(true)
-                                             .withThrows(true)
+                                             .withThrows(true, /*FIXME:*/Type())
                                              .build());
     FunctionType::Param args[] = {
       FunctionType::Param(noescapeClosure),
@@ -2931,7 +2931,7 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
                                      FunctionType::ExtInfoBuilder()
                                          .withNoEscape(false)
                                          .withAsync(true)
-                                         .withThrows(true)
+                                         .withThrows(true, /*FIXME:*/Type())
                                          .build());
     return {refType, refType, refType, refType};
   }
@@ -2953,7 +2953,7 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto bodyClosure = FunctionType::get(bodyArgs, result,
                                          FunctionType::ExtInfoBuilder()
                                              .withNoEscape(true)
-                                             .withThrows(true)
+                                             .withThrows(true, /*FIXME:*/Type())
                                              .withAsync(true)
                                              .build());
     FunctionType::Param args[] = {
@@ -2963,7 +2963,7 @@ static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto refType = FunctionType::get(args, result,
                                      FunctionType::ExtInfoBuilder()
                                          .withNoEscape(false)
-                                         .withThrows(true)
+                                         .withThrows(true, /*FIXME:*/Type())
                                          .withAsync(true)
                                          .build());
     return {refType, refType, refType, refType};
@@ -3227,7 +3227,7 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
   bool concurrent = expr->getAttrs().hasAttribute<SendableAttr>();
   if (throws || async) {
     return ASTExtInfoBuilder()
-      .withThrows(throws)
+      .withThrows(throws, /*FIXME:*/Type())
       .withAsync(async)
       .withConcurrent(concurrent)
       .build();
@@ -3241,7 +3241,7 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
   auto throwFinder = FindInnerThrows(expr);
   body->walk(throwFinder);
   return ASTExtInfoBuilder()
-      .withThrows(throwFinder.foundThrow())
+      .withThrows(throwFinder.foundThrow(), /*FIXME:*/Type())
       .withAsync(bool(findAsyncNode(expr)))
       .withConcurrent(concurrent)
       .build();

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -269,7 +269,7 @@ private:
     auto *Params = ParameterList::createEmpty(Ctx);
     auto *Closure = new (Ctx)
         ClosureExpr(DeclAttributes(), SourceRange(), nullptr, Params,
-                    SourceLoc(), SourceLoc(),
+                    SourceLoc(), SourceLoc(), /*thrownType=*/nullptr,
                     SourceLoc(), SourceLoc(), nullptr,
                     getCurrentDeclContext());
     Closure->setImplicit(true);

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -191,6 +191,7 @@ static ValueDecl *deriveMathOperator(DerivedConformance &derived,
       /*NameLoc=*/SourceLoc(),
       /*Async=*/false,
       /*Throws=*/false,
+      /*ThrownType=*/Type(),
       /*GenericParams=*/nullptr, params, selfInterfaceType, parentDC);
   auto bodySynthesizer = [](AbstractFunctionDecl *funcDecl,
                             void *ctx) -> std::pair<BraceStmt *, bool> {

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1240,7 +1240,8 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
   auto *const encodeDecl = FuncDecl::createImplicit(
       C, StaticSpellingKind::None, name, /*NameLoc=*/SourceLoc(),
       /*Async=*/false,
-      /*Throws=*/true, /*GenericParams=*/nullptr, params, returnType,
+      /*Throws=*/true, /*ThrownType=*/Type(),
+      /*GenericParams=*/nullptr, params, returnType,
       conformanceDC);
   encodeDecl->setSynthesized();
 
@@ -1891,7 +1892,8 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
       new (C) ConstructorDecl(name, SourceLoc(),
                               /*Failable=*/false,SourceLoc(),
                               /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                              /*Throws=*/true, SourceLoc(), paramList,
+                              /*Throws=*/true, SourceLoc(),
+                              /*ThrownType=*/TypeLoc(), paramList,
                               /*GenericParams=*/nullptr, conformanceDC);
   initDecl->setImplicit();
   initDecl->setSynthesized();

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -131,6 +131,7 @@ static ValueDecl *deriveInitDecl(DerivedConformance &derived, Type paramType,
                             /*Failable=*/true, /*FailabilityLoc=*/SourceLoc(),
                             /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
                             /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
+                            /*ThrownType=*/TypeLoc(),
                             paramList,
                             /*GenericParams=*/nullptr, parentDC);
 

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -253,6 +253,7 @@ deriveComparable_lt(
       C, StaticSpellingKind::KeywordStatic, name, /*NameLoc=*/SourceLoc(),
       /*Async=*/false,
       /*Throws=*/false,
+      /*ThrownType=*/Type(),
       /*GenericParams=*/nullptr, params, boolTy, parentDC);
   comparableDecl->setUserAccessible(false);
 

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -317,6 +317,7 @@ static ValueDecl *deriveDifferentiable_method(
       C, StaticSpellingKind::None, declName, /*NameLoc=*/SourceLoc(),
       /*Async=*/false,
       /*Throws=*/false,
+      /*ThrownType=*/Type(),
       /*GenericParams=*/nullptr, params, returnType, parentDC);
   funcDecl->setSynthesized();
   if (!nominal->getSelfClassDecl())

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -108,6 +108,7 @@ static FuncDecl *deriveDistributedActor_resolve(DerivedConformance &derived) {
                                name, SourceLoc(),
                                /*async=*/false,
                                /*throws=*/true,
+                               /*ThrownType=*/Type(),
                                /*genericParams=*/nullptr,
                                params,
                                /*returnType*/decl->getDeclaredInterfaceType(),
@@ -257,7 +258,9 @@ static FuncDecl* createLocalFunc_doInvokeOnReturn(
       DeclName(C, doInvokeLocalFuncIdent, doInvokeParamsList),
       sloc,
       /*async=*/true,
-      /*throws=*/true, doInvokeGenericParamList, doInvokeParamsList,
+      /*throws=*/true, 
+      /*ThrownType=*/Type(),
+      doInvokeGenericParamList, doInvokeParamsList,
       /*returnType=*/C.TheEmptyTupleType, parentFunc);
   doInvokeOnReturnFunc->setImplicit();
   doInvokeOnReturnFunc->setSynthesized();
@@ -419,6 +422,7 @@ static FuncDecl *deriveDistributedActorSystem_invokeHandlerOnReturn(
       FuncDecl::createImplicit(C, StaticSpellingKind::None, name, SourceLoc(),
                                /*async=*/true,
                                /*throws=*/true,
+                               /*ThrownType=*/Type(),
                                /*genericParams=*/nullptr, params,
                                /*returnType*/ TupleType::getEmpty(C), system);
   funcDecl->setSynthesized(true);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -417,7 +417,7 @@ deriveEquatable_eq(
   auto *const eqDecl = FuncDecl::createImplicit(
       C, StaticSpellingKind::KeywordStatic, name, /*NameLoc=*/SourceLoc(),
       /*Async=*/false,
-      /*Throws=*/false,
+      /*Throws=*/false, /*ThrownType=*/Type(),
       /*GenericParams=*/nullptr, params, boolTy, parentDC);
   eqDecl->setUserAccessible(false);
 
@@ -554,7 +554,7 @@ deriveHashable_hashInto(
   auto *const hashDecl = FuncDecl::createImplicit(
       C, StaticSpellingKind::None, name, /*NameLoc=*/SourceLoc(),
       /*Async=*/false,
-      /*Throws=*/false,
+      /*Throws=*/false, /*ThrownType=*/Type(),
       /*GenericParams=*/nullptr, params, returnType, parentDC);
   hashDecl->setBodySynthesizer(bodySynthesizer);
   hashDecl->copyFormalAccessFrom(derived.Nominal,
@@ -913,7 +913,8 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
       AccessorKind::Get, hashValueDecl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), params, intType, parentDC);
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, intType, parentDC);
   getterDecl->setImplicit();
   getterDecl->setBodySynthesizer(&deriveBodyHashable_hashValue);
   getterDecl->setSynthesized();

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -429,7 +429,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
                             /*Failable=*/ true, /*FailabilityLoc=*/SourceLoc(),
                             /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
                             /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-                            paramList,
+                            /*ThrownType=*/TypeLoc(), paramList,
                             /*GenericParams=*/nullptr, parentDC);
   
   initDecl->setImplicit();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -531,8 +531,8 @@ DerivedConformance::declareDerivedPropertyGetter(VarDecl *property,
       AccessorKind::Get, property,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), params,
-      property->getInterfaceType(), parentDC);
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, property->getInterfaceType(), parentDC);
   getterDecl->setImplicit();
   getterDecl->setIsTransparent(false);
   getterDecl->copyFormalAccessFrom(property);

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2014,6 +2014,12 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
           TupleTypeRepr::create(Ctx, {ErrRepr}, ArgRange);
     }
 
+    TypeRepr *ThrownTypeRepr = nullptr;
+    if (auto thrownTypeExpr = AE->getThrownTypeExpr()) {
+      ThrownTypeRepr = extractTypeRepr(thrownTypeExpr);
+      assert(ThrownTypeRepr && "Parser ensures that this never fails");
+    }
+
     TypeRepr *ResultTypeRepr = extractTypeRepr(AE->getResultExpr());
     if (!ResultTypeRepr) {
       Ctx.Diags.diagnose(AE->getResultExpr()->getLoc(),
@@ -2024,7 +2030,8 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
 
     auto NewTypeRepr = new (Ctx)
         FunctionTypeRepr(nullptr, ArgsTypeRepr, AE->getAsyncLoc(),
-                         AE->getThrowsLoc(), AE->getArrowLoc(), ResultTypeRepr);
+                         AE->getThrowsLoc(), ThrownTypeRepr, AE->getArrowLoc(),
+                         ResultTypeRepr);
     return new (Ctx) TypeExpr(NewTypeRepr);
   }
   

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2648,6 +2648,7 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
       /*NameLoc=*/SourceLoc(),
       /*Async=*/mainFunction->hasAsync(),
       /*Throws=*/mainFunction->hasThrows(),
+      mainFunction->getThrownInterfaceType(),
       /*GenericParams=*/nullptr, ParameterList::createEmpty(context),
       /*FnRetType=*/TupleType::getEmpty(context), declContext);
   func->setSynthesized(true);

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -844,7 +844,8 @@ bool swift::isRepresentableInObjC(
 
     Type completionHandlerType = FunctionType::get(
         completionHandlerParams, TupleType::getEmpty(ctx),
-        ASTExtInfoBuilder(FunctionTypeRepresentation::Block, false).build());
+        ASTExtInfoBuilder(FunctionTypeRepresentation::Block, false, Type())
+          .build());
 
     asyncConvention = ForeignAsyncConvention(
         completionHandlerType->getCanonicalType(), completionHandlerParamIndex,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -35,7 +35,7 @@ static void adjustFunctionTypeForOverride(Type &type) {
   // with one returning Never?
   auto fnType = type->castTo<AnyFunctionType>();
   auto extInfo = fnType->getExtInfo();
-  extInfo = extInfo.withThrows(false);
+  extInfo = extInfo.withThrows(false, Type());
   if (!fnType->getExtInfo().isEqualTo(extInfo, useClangTypes(fnType)))
     type = fnType->withExtInfo(extInfo);
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1195,8 +1195,6 @@ public:
     // Coerce the operand to the exception type.
     auto E = TS->getSubExpr();
 
-
-
     Type errorType;
     if (auto TheFunc = AnyFunctionRef::fromDeclContext(DC)) {
       errorType = TheFunc->getThrownErrorType();

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1195,10 +1195,20 @@ public:
     // Coerce the operand to the exception type.
     auto E = TS->getSubExpr();
 
-    if (!getASTContext().getErrorDecl())
+
+
+    Type errorType;
+    if (auto TheFunc = AnyFunctionRef::fromDeclContext(DC)) {
+      errorType = TheFunc->getThrownErrorType();
+    }
+
+    if (!errorType) {
+      errorType = getASTContext().getErrorExistentialType();
+    }
+
+    if (!errorType)
       return TS;
 
-    Type errorType = getASTContext().getErrorExistentialType();
     TypeChecker::typeCheckExpression(E, DC, {errorType, CTP_ThrowStmt});
     TS->setSubExpr(E);
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2192,8 +2192,8 @@ static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,
       ctx, loc, /*AccessorKeywordLoc*/ loc, AccessorKind::Get, storage,
       staticLoc, StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), getterParams, Type(),
-      storage->getDeclContext());
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      getterParams, Type(), storage->getDeclContext());
   getter->setSynthesized();
 
   // If we're stealing the 'self' from a lazy initializer, set it now.
@@ -2289,8 +2289,8 @@ static AccessorDecl *createSetterPrototype(AbstractStorageDecl *storage,
       ctx, loc, /*AccessorKeywordLoc*/ SourceLoc(), AccessorKind::Set, storage,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), params, Type(),
-      storage->getDeclContext());
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, Type(), storage->getDeclContext());
   setter->setSynthesized();
 
   if (isMutating)
@@ -2368,7 +2368,8 @@ createCoroutineAccessorPrototype(AbstractStorageDecl *storage,
       ctx, loc, /*AccessorKeywordLoc=*/SourceLoc(), kind, storage,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), params, retTy, dc);
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, retTy, dc);
   accessor->setSynthesized();
 
   if (isMutating)

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -192,7 +192,7 @@ enum class TypeResolverContext : uint8_t {
   AssociatedTypeInherited,
 
   /// Whether this is a custom attribute.
-  CustomAttr
+  CustomAttr,
 };
 
 /// Options that determine how type resolution should work.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 808; // @_expose(wasm)
+const uint16_t SWIFTMODULE_VERSION_MINOR = 809; // typed throws
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1505,6 +1505,7 @@ namespace decls_block {
     BCFixed<1>,  // stub implementation?
     BCFixed<1>,  // async?
     BCFixed<1>,  // throws?
+    TypeIDField,  // thrown error
     CtorInitializerKindField,  // initializer kind
     GenericSignatureIDField, // generic environment
     DeclIDField, // overridden decl
@@ -1579,6 +1580,7 @@ namespace decls_block {
     BCFixed<1>,   // has forced static dispatch?
     BCFixed<1>,   // async?
     BCFixed<1>,   // throws?
+    TypeIDField,  // thrown error
     GenericSignatureIDField, // generic environment
     TypeIDField,  // result interface type
     BCFixed<1>,   // IUO result?
@@ -1640,6 +1642,7 @@ namespace decls_block {
     BCFixed<1>,   // has forced static dispatch?
     BCFixed<1>,   // async?
     BCFixed<1>,   // throws?
+    TypeIDField,  // thrown error
     GenericSignatureIDField, // generic environment
     TypeIDField,  // result interface type
     BCFixed<1>,   // IUO result?

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -1193,6 +1193,7 @@ namespace decls_block {
     BCFixed<1>,                      // concurrent?
     BCFixed<1>,                      // async?
     BCFixed<1>,                      // throws?
+    TypeIDField,                     // thrown error
     DifferentiabilityKindField,      // differentiability kind
     TypeIDField                      // global actor
     // trailed by parameters
@@ -1286,6 +1287,7 @@ namespace decls_block {
     BCFixed<1>,                      // concurrent?
     BCFixed<1>,                      // async?
     BCFixed<1>,                      // throws?
+    TypeIDField,                     // thrown error
     DifferentiabilityKindField,      // differentiability kind
     TypeIDField,                     // global actor
     GenericSignatureIDField          // generic signature

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4358,6 +4358,7 @@ public:
                            fn->hasForcedStaticDispatch(),
                            fn->hasAsync(),
                            fn->hasThrows(),
+                           S.addTypeRef(fn->getThrownInterfaceType()),
                            S.addGenericSignatureRef(
                                                   fn->getGenericSignature()),
                            S.addTypeRef(fn->getResultInterfaceType()),
@@ -4475,6 +4476,7 @@ public:
                                fn->hasForcedStaticDispatch(),
                                fn->hasAsync(),
                                fn->hasThrows(),
+                               S.addTypeRef(fn->getThrownInterfaceType()),
                                S.addGenericSignatureRef(
                                                   fn->getGenericSignature()),
                                S.addTypeRef(fn->getResultInterfaceType()),
@@ -4640,6 +4642,7 @@ public:
                                   ctor->hasStubImplementation(),
                                   ctor->hasAsync(),
                                   ctor->hasThrows(),
+                                  S.addTypeRef(ctor->getThrownInterfaceType()),
                                   getStableCtorInitializerKind(
                                     ctor->getInitKind()),
                                   S.addGenericSignatureRef(

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5344,6 +5344,7 @@ public:
         fnTy->isSendable(),
         fnTy->isAsync(),
         fnTy->isThrowing(),
+        S.addTypeRef(fnTy->getThrownError()),
         getRawStableDifferentiabilityKind(fnTy->getDifferentiabilityKind()),
         globalActor);
 
@@ -5359,6 +5360,7 @@ public:
         S.addTypeRef(fnTy->getResult()),
         getRawStableFunctionTypeRepresentation(fnTy->getRepresentation()),
         fnTy->isSendable(), fnTy->isAsync(), fnTy->isThrowing(),
+        S.addTypeRef(fnTy->getThrownError()),
         getRawStableDifferentiabilityKind(fnTy->getDifferentiabilityKind()),
         S.addTypeRef(fnTy->getGlobalActor()),
         S.addGenericSignatureRef(genericSig));

--- a/test/ModuleInterface/typed_throws.swift
+++ b/test/ModuleInterface/typed_throws.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-feature TypedThrows
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test -enable-experimental-feature TypedThrows
+// RUN: %FileCheck %s < %t.swiftinterface
+
+public enum MyError: Error {
+  case fail
+}
+
+// CHECK: #if compiler(>=5.3) && $TypedThrows
+// CHECK-NEXT: public func throwsMyError() throws(Test.MyError)
+// CHECK-NEXT: #endif
+public func throwsMyError() throws(MyError) { }

--- a/test/Parse/typed_throws.swift
+++ b/test/Parse/typed_throws.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name test
+
+// Parsing support for typed throws.
+
+enum MyError: Error {
+  case epicFail
+}
+
+func specificThrowingFunc() throws(MyError) { }
+func anyThrowingFunc() throws(any Error) { }
+
+struct SomeStruct {
+  init() throws(MyError) { }
+}
+
+typealias ThrowingFuncType = () throws(MyError) -> Void
+
+func testClosures() {
+  let _ = { () throws(MyError) in print("hello") }
+  let _ = { (x: Int, y: Int) throws(MyError) -> Int in x + y }
+}
+
+func testTypes() {
+  let _ = [(Int, Int) throws(MyError) -> Int]()
+}
+
+func testMissingError() throws() { }
+// expected-error@-1{{expected thrown error type after 'throws('}}
+
+func testRethrowsWithThrownType() rethrows(MyError) { }
+// expected-error@-1{{'rethrows' cannot be combined with a specific thrown error type}}

--- a/test/Parse/typed_throws.swift
+++ b/test/Parse/typed_throws.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name test
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name test -enable-experimental-feature TypedThrows
 
 // Parsing support for typed throws.
 

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -1,0 +1,82 @@
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature TypedThrows | %FileCheck %s
+
+enum MyError: Error {
+  case fail
+}
+
+enum MyBigError: Error {
+  case epicFail
+}
+
+func throwsMyBigError() throws(MyBigError) { }
+
+// CHECK: sil hidden [ossa] @$s12typed_throws20doesNotThrowConcreteyyKF : $@convention(thin) () -> @error MyError
+func doesNotThrowConcrete() throws(MyError) { }
+
+// CHECK-LABEL: sil hidden [ossa] @$s12typed_throws0B8ConcreteyyKF : $@convention(thin) () -> @error MyError
+func throwsConcrete() throws(MyError) {
+  // CHECK: [[ERROR:%[0-9]+]] = enum $MyError, #MyError.fail!enumelt
+  // CHECK-NOT: builtin "willThrow"
+  // CHECK: throw [[ERROR]] : $MyError
+  throw .fail
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s12typed_throws15rethrowConcreteyyKF
+func rethrowConcrete() throws(MyError) {
+  // CHECK: try_apply [[FN:%[0-9]+]]() : $@convention(thin) () -> @error MyError, normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
+  // CHECK: [[ERRORBB]]([[ERROR:%[0-9]+]] : $MyError)
+  // CHECK-NEXT: throw [[ERROR]] : $MyError 
+  try throwsConcrete()
+}
+// CHECK-LABEL: sil hidden [ossa] @$s12typed_throws29rethrowConcreteAndExistentialyyKF
+func rethrowConcreteAndExistential() throws {
+  // CHECK: try_apply [[FN:%[0-9]+]]() : $@convention(thin) () -> @error MyError, normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
+  // CHECK: alloc_existential_box $any Error, $MyError
+  // CHECK: throw [[ERROR:%[0-9]+]] : $any Error
+  try throwsConcrete()
+}
+
+
+func sink<T: Error>(_: T) { }
+
+// CHECK-LABEL: sil hidden [ossa] @$s12typed_throws0B27OneOrTheOtherWithoutRethrowyyF
+func throwsOneOrTheOtherWithoutRethrow() {
+  do {
+    // FIXME: the generated code below could probably be better, because it
+    // currently depends on injecting into an existential error.
+
+    // CHECK: try_apply [[F1:%[0-9]+]]() : $@convention(thin) () -> @error MyError, normal [[F1_NORMAL:bb[0-9]+]], error [[F1_ERROR:bb[0-9]+]]
+    try doesNotThrowConcrete()
+
+    // CHECK: try_apply [[F2:%[0-9]+]]() : $@convention(thin) () -> @error MyError, normal [[F2_NORMAL:bb[0-9]+]], error [[F2_ERROR:bb[0-9]+]]
+    try throwsConcrete()
+    try throwsMyBigError()
+  } catch let e as MyError {
+    sink(e)
+  } catch let be as MyBigError {
+    sink(be)
+  } catch {
+    fatalError("not actually reachable")
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s12typed_throws0B24OneOrTheOtherWithRethrowyyKF
+func throwsOneOrTheOtherWithRethrow() throws {
+  do {
+    // FIXME: This probably shouldn't even have a rethrow block, because the
+    // type checker Should Know that this list of catch clauses is exhaustive.
+    // For now, we check that there is a basic block that takes an existential
+    // error, but we want that to go away.
+    //
+    // CHECK: return [[RET:%[0-9]+]] : $()
+    // CHECK-NOT: return
+    // CHECK: @owned $any Error
+    // CHECK: throw
+    try throwsConcrete()
+    try throwsMyBigError()
+  } catch let e as MyError {
+    sink(e)
+  } catch let be as MyBigError {
+    sink(be)
+  }
+}

--- a/test/Serialization/Inputs/def_typed_throws.swift
+++ b/test/Serialization/Inputs/def_typed_throws.swift
@@ -1,0 +1,15 @@
+public enum MyError: Error {
+  case fail
+}
+
+public func throwsMyError() throws(MyError) { }
+
+public struct SomeStruct {
+  public init() throws(MyError) { }
+
+  public var value: Int {
+    get throws(MyError) {
+      return 17
+    }
+  }
+}

--- a/test/Serialization/typed_throws.swift
+++ b/test/Serialization/typed_throws.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name def_typed_throws -o %t %S/Inputs/def_typed_throws.swift -enable-experimental-feature TypedThrows
+// RUN: llvm-bcanalyzer %t/def_typed_throws.swiftmodule | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -I %t
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -module-to-print=def_typed_throws -I %t -source-filename=%s | %FileCheck -check-prefix=CHECK-PRINT %s
+
+// CHECK-NOT: UnknownCode
+
+// CHECK-PRINT-DAG: func throwsMyError() throws(MyError)
+// CHECK-PRINT-DAG: init() throws(MyError)
+// CHECK-PRINT-DAG: var value: Int { get throws(MyError) }
+
+import def_typed_throws
+
+func testThrows() {
+  let _: () -> Void = throwsMyError
+  // expected-error@-1{{invalid conversion from throwing function of type '() throws(MyError) -> ()'}}
+
+  let _: () -> Void = SomeStruct.init
+  // expected-error@-1{{invalid conversion from throwing function of type '() throws(MyError) -> SomeStruct'}}
+}

--- a/test/attr/typed_throws_availability_osx.swift
+++ b/test/attr/typed_throws_availability_osx.swift
@@ -1,0 +1,15 @@
+// RUN: %swift -typecheck -verify -target x86_64-apple-macosx10.10 %s -enable-experimental-feature TypedThrows
+
+// REQUIRES: OS=macosx
+
+@available(macOS 12, *)
+enum MyError: Error {
+  case fail
+}
+
+@available(macOS 11, *)
+func throwMyErrorBadly() throws(MyError) { }
+// expected-error@-1{{'MyError' is only available in macOS 12 or newer}}
+
+
+

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name test -enable-experimental-feature TypedThrows
+
+enum MyError: Error {
+  case fail
+}
+
+enum MyBadError {
+  case epicFail
+}
+
+// Thrown types must conform to Error
+func testBadThrownError() throws(MyBadError) { }
+// expected-error@-1{{thrown type 'MyBadError' does not conform to the 'Error' protocol}}
+
+typealias BadThrowsMyError = () throws(MyBadError) -> Void
+// expected-error@-1{{thrown type 'MyBadError' does not conform to the 'Error' protocol}}
+
+func hasThrownMyError() throws(MyError) { }
+
+typealias ThrowsMyError = () throws(MyError) -> Void
+
+func testThrownMyErrorType() {
+  let _: ThrowsMyError = hasThrownMyError
+  let _: () -> Void = hasThrownMyError
+  // expected-error@-1{{invalid conversion from throwing function of type '() throws(MyError) -> ()' to non-throwing function type '() -> Void'}}
+}
+
+func throwsGeneric<T: Error>(errorType: T.Type) throws(T) { }
+
+func throwsBadGeneric<T>(errorType: T.Type) throws(T) { }
+// expected-error@-1{{thrown type 'T' does not conform to the 'Error' protocol}}
+
+func throwsUnusedInSignature<T: Error>() throws(T) { }
+// expected-error@-1{{generic parameter 'T' is not used in function signature}}
+
+
+func testSubstitutedType() {
+  let _: (_: MyError.Type) -> Void = throwsGeneric
+  // expected-error@-1{{invalid conversion from throwing function of type '(MyError.Type) throws(MyError) -> ()'}}
+}

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -module-name test -enable-experimental-feature TypedThrows
 
+// expected-note@+1{{type declared here}}
 enum MyError: Error {
   case fail
 }
@@ -60,3 +61,6 @@ func testThrowingInFunction(cond: Bool, cond2: Bool) throws(MyError) {
     // expected-error@-1{{thrown expression type 'MyBadError' cannot be converted to error type 'MyError'}}
   }
 }
+
+public func testThrowingInternal() throws(MyError) { }
+// expected-error@-1{{function cannot be declared public because its thrown error uses an internal type}}

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -4,6 +4,10 @@ enum MyError: Error {
   case fail
 }
 
+enum MyOtherError: Error {
+  case fail
+}
+
 enum MyBadError {
   case epicFail
 }
@@ -37,4 +41,22 @@ func throwsUnusedInSignature<T: Error>() throws(T) { }
 func testSubstitutedType() {
   let _: (_: MyError.Type) -> Void = throwsGeneric
   // expected-error@-1{{invalid conversion from throwing function of type '(MyError.Type) throws(MyError) -> ()'}}
+
+  let _: (_: (any Error).Type) -> Void = throwsGeneric
+  // expected-error@-1{{invalid conversion from throwing function of type '((any Error).Type) throws((any Error)) -> ()' to non-throwing function type}}
+
+  let _: (_: Never.Type) -> Void = throwsGeneric
+  // FIXME wrong: expected-error@-1{{invalid conversion from throwing function of type '(Never.Type) throws(Never) -> ()'}}
+}
+
+
+func testThrowingInFunction(cond: Bool, cond2: Bool) throws(MyError) {
+  if cond {
+    throw MyError.fail
+  } else if cond2 {
+    throw .fail
+  } else {
+    throw MyBadError.epicFail
+    // expected-error@-1{{thrown expression type 'MyBadError' cannot be converted to error type 'MyError'}}
+  }
 }

--- a/test/expr/closure/typed_throws.swift
+++ b/test/expr/closure/typed_throws.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TypedThrows
+
+enum MyError: Error {
+  case fail
+}
+
+enum MyBadError {
+  case fail
+}
+
+func testClosures() {
+  let c1 = { () throws(MyError) in
+    throw .fail
+  }
+
+  let _: () -> Void = c1
+  // expected-error@-1{{invalid conversion from throwing function of type '() throws(MyError) -> ()'}}
+
+  let _: () throws(MyError) -> Void = {
+    throw .fail
+  }
+
+  // FIXME: Terrible diagnostic.
+  // expected-error@+1{{unable to infer closure type without a type annotation}}
+  let _ = { () throws(MyBadError) in
+    throw MyBadError.fail
+  }
+
+  // We do not infer thrown error types from the body, because doing so would
+  // break existing code.
+  let c2 = { throw MyError.fail }
+  let _: Int = c2
+  // expected-error@-1{{cannot convert value of type '() throws -> ()'}}
+}
+

--- a/unittests/Sema/ConstraintGenerationTests.cpp
+++ b/unittests/Sema/ConstraintGenerationTests.cpp
@@ -126,6 +126,7 @@ TEST_F(SemaTest, TestCaptureListIsNotOpenedEarly) {
                                             ParameterList::createEmpty(Context),
                                             /*asyncLoc=*/SourceLoc(),
                                             /*throwsLoc=*/SourceLoc(),
+                                            /*thrownType*/nullptr,
                                             /*arrowLoc=*/SourceLoc(),
                                             /*inLoc=*/SourceLoc(),
                                             /*explicitResultType=*/nullptr, DC);

--- a/unittests/Sema/ConstraintSimplificationTests.cpp
+++ b/unittests/Sema/ConstraintSimplificationTests.cpp
@@ -79,6 +79,7 @@ TEST_F(SemaTest, TestClosureInferenceFromOptionalContext) {
       /*capturedSelfDecl=*/nullptr, ParameterList::create(Context, {paramDecl}),
       /*asyncLoc=*/SourceLoc(),
       /*throwsLoc=*/SourceLoc(),
+      /*thrownType=*/nullptr,
       /*arrowLoc=*/SourceLoc(),
       /*inLoc=*/SourceLoc(),
       /*explicitResultType=*/nullptr,


### PR DESCRIPTION
Start implementing typed throw specifiers with the syntax `throws(X)`. There are a large number of tasks involved in such a feature; this pull request covers the parsing and type checking aspects.

- [x] Parsing `throws(X)` as an effect specifier everywhere it is needed (functions, initializers, accessors, closures, function types, expressions that can become function types)
- [x] AST representation for having a specified thrown type on functions, initializers, accessors, closures, and function types
- [x] Function type substitution and canonicalization
- [x] AST serialization and printing support
- [x] Type checking of `throws` statements against the specified thrown type of functions/initializers/accessors
- [x] Type checking of closures with specified thrown type
- [x] Effects checking
- [x] Access control checking for thrown type
- [x] SIL type lowering and SIL generation
- [x] Subtyping relationships involving typed throws
- [x] Override relationships involving typed throws
- [x] Witness checking involving typed throws
- [x] Associated type inference from typed throws
- [x] IR generation
- [x] SIL generation for generic thrown errors
- [x] SIL generation for thunks that convert generic thrown error types
- [x] Name mangling for typed throws
- [x] Runtime type metadata and dynamic casting support for functions with typed throws
- [ ] `async let` with typed throws
- [ ] Opaque thrown error types
- [ ] Closure thrown error type inference
