### PR TITLE
SIL: Fix opaque type erasure after clearing [serialized] flags [5.9]

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -40,42 +40,6 @@ public:
     clonedEntryBlock = fun.createBasicBlock();
   }
 
-  SILType remapType(SILType Ty) {
-    if (!Ty.getASTType()->hasOpaqueArchetype() ||
-        !getBuilder()
-             .getTypeExpansionContext()
-             .shouldLookThroughOpaqueTypeArchetypes())
-      return Ty;
-
-    return getBuilder().getTypeLowering(Ty).getLoweredType().getCategoryType(
-        Ty.getCategory());
-  }
-
-  CanType remapASTType(CanType ty) {
-    if (!ty->hasOpaqueArchetype() ||
-        !getBuilder()
-             .getTypeExpansionContext()
-             .shouldLookThroughOpaqueTypeArchetypes())
-      return ty;
-    // Remap types containing opaque result types in the current context.
-    return getBuilder()
-        .getTypeLowering(SILType::getPrimitiveObjectType(ty))
-        .getLoweredType()
-        .getASTType();
-  }
-
-  ProtocolConformanceRef remapConformance(Type ty,
-                                          ProtocolConformanceRef conf) {
-    auto context = getBuilder().getTypeExpansionContext();
-    auto conformance = conf;
-    if (ty->hasOpaqueArchetype() &&
-        context.shouldLookThroughOpaqueTypeArchetypes()) {
-      conformance =
-          substOpaqueTypesWithUnderlyingTypes(conformance, ty, context);
-    }
-    return conformance;
-  }
-
   void replace();
 };
 } // namespace

--- a/test/SIL/Serialization/opaque_return_type_serialize.swift
+++ b/test/SIL/Serialization/opaque_return_type_serialize.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %s
+
+// We substitute away opaque archetypes after serialization;
+// make sure this correctly handles unlowered types like
+// AST functions and packs.
+
+public func horse<T>(_: T) {}
+
+@_transparent public func packCallee<each T>(_ t: repeat each T) {
+  repeat horse(each t)
+}
+
+@inlinable public func packCaller() {
+  packCallee(opaque())
+}
+
+public func opaque() -> some Any { return 3 }


### PR DESCRIPTION
* Description: After serialization, we no longer need to enforce the resilience boundary between inlinable and non-inlinable functions, so we make a pass over the SIL to clear [serialized] flags and substitute any opaque return types. This duplicated a bit of logic elsewhere and did so incorrectly. Remove the unnecessary code since SILCloner already has the right support for substituting opaque return types.

* Risk: Low.

* Radar: Fixes rdar://problem/115355709.

* Reviewed by: @nate-chandler 
