### PR TITLE
Sema: Partial revert of #67939 [5.9]

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -352,16 +352,6 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
         return Action::SkipChildren;
       }
 
-      // Don't walk into generic type alias substitutions. This does
-      // not constrain `T`:
-      //
-      //   typealias Foo<T> = Int
-      //   func foo<T>(_: Foo<T>) {}
-      if (auto *aliasTy = dyn_cast<TypeAliasType>(ty.getPointer())) {
-        Type(aliasTy->getSinglyDesugaredType()).walk(*this);
-        return Action::SkipChildren;
-      }
-
       return Action::Continue;
     }
 

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -106,4 +106,4 @@ func unusedParameterPack1<each T: Sequence>(_: repeat (each T).Element) {}
 typealias First<T, U> = T
 
 func unusedParameterPack2<each T>(_: repeat First<Int, each T>) {}
-// expected-error@-1 {{generic parameter 'T' is not used in function signature}}
+// allowed


### PR DESCRIPTION
* Description: We require that a generic function mentions all generic parameters in its interface type, so that the solver can actually bind them when type checking a call to a function. PR #67939 fixed a bug in this analysis with parameter packs and type aliases. The second part of the fix was source breaking, so we decided not to take it in 5.9.

* Risk: None.

* Reviewed by: @hborla 