### PR TITLE
RequirementMachine: Pass SubstFlags::PreservePackExpansionLevel when re-sugaring requirements

### DIFF
--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -620,7 +620,8 @@ AbstractGenericSignatureRequest::evaluate(
             return Type(type);
           },
           MakeAbstractConformanceForGenericType(),
-          SubstFlags::AllowLoweredTypes);
+          SubstFlags::AllowLoweredTypes |
+          SubstFlags::PreservePackExpansionLevel);
       resugaredRequirements.push_back(resugaredReq);
     }
 

--- a/test/Generics/rdar115538386.swift
+++ b/test/Generics/rdar115538386.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -typecheck %s -disable-availability-checking
+
+protocol P<A> {
+  associatedtype A
+}
+
+struct S<each T>: P {
+  typealias A = (repeat each T)
+}
+
+func foo<each T>() -> some P<(repeat each T)> {
+  S<repeat each T>()
+}


### PR DESCRIPTION
Fixes rdar://115538386.