### PR TITLE
Account for the generic zero-sized payload enum cases.

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -667,9 +667,11 @@ public:
     assert(getCases().size() > 1); // At least 2 cases
     assert(Cases[0].TR != 0); // At least 2 payloads
     // assert(Cases[1].TR != 0);
-    // At least one payload is non-empty (otherwise this
-    // would get laid out as a non-payload enum)
-    assert(getNumNonEmptyPayloadCases() > 0);
+    // At least one payload is non-empty (otherwise this would get
+    // laid out as a non-payload enum). Commented out this assert
+    // because it doesn't hold when there are generic cases with
+    // zero-sized payload.
+    // assert(getNumNonEmptyPayloadCases() > 0);
     // There's a tag, so the total size must be bigger than any payload
     // assert(getSize() > getPayloadSize());
   }

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_bulky.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_bulky.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_bulky | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic2.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic2 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic3 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic4 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic5 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic6 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic7 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic_empty.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic_empty.swift
@@ -1,0 +1,79 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_generic_empty
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_generic_empty
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_generic_empty | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+struct S {
+}
+
+public enum AppearanceBasedConfiguration<T> {
+  case single(T)
+  case appearanceBased(light: T, dark: T)
+}
+
+reflect(enum: AppearanceBasedConfiguration<S>.single(S()))
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic_empty.AppearanceBasedConfiguration
+// CHECK-NEXT:   (struct reflect_Enum_MultiPayload_generic_empty.S))
+
+// CHECK: Type info:
+// X64-NEXT: (multi_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
+// X64-NEXT:   (case name=single index=0 offset=0
+// X64-NEXT:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:   (case name=appearanceBased index=1 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field offset=0
+// X64-NEXT:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:       (field offset=0
+// X64-NEXT:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))
+
+// CHECK: Mangled name: $s39reflect_Enum_MultiPayload_generic_empty28AppearanceBasedConfigurationOyAA1SVG
+// CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic_empty.AppearanceBasedConfiguration<reflect_Enum_MultiPayload_generic_empty.S>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=single index=0
+// CHECK-NEXT: (struct reflect_Enum_MultiPayload_generic_empty.S)
+// CHECK-NEXT: )
+
+reflect(enum: AppearanceBasedConfiguration<S>.appearanceBased(light: S(), dark: S()))
+
+// CHECK: Reflecting an enum.
+// CHECK-NEXT: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (bound_generic_enum reflect_Enum_MultiPayload_generic_empty.AppearanceBasedConfiguration
+// CHECK-NEXT:   (struct reflect_Enum_MultiPayload_generic_empty.S))
+
+// CHECK: Type info:
+// X64-NEXT: (multi_payload_enum size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1
+// X64-NEXT:   (case name=single index=0 offset=0
+// X64-NEXT:     (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:   (case name=appearanceBased index=1 offset=0
+// X64-NEXT:     (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// X64-NEXT:       (field offset=0
+// X64-NEXT:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// X64-NEXT:       (field offset=0
+// X64-NEXT:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1)))))
+
+// CHECK: Mangled name: $s39reflect_Enum_MultiPayload_generic_empty28AppearanceBasedConfigurationOyAA1SVG
+// CHECK-NEXT: Demangled name: reflect_Enum_MultiPayload_generic_empty.AppearanceBasedConfiguration<reflect_Enum_MultiPayload_generic_empty.S>
+
+// CHECK: Enum value:
+// CHECK-NEXT: (enum_value name=appearanceBased index=1
+// CHECK-NEXT: (tuplelight = 
+// CHECK-NEXT:   (struct reflect_Enum_MultiPayload_generic_empty.S)dark = 
+// CHECK-NEXT:   (struct reflect_Enum_MultiPayload_generic_empty.S))
+// CHECK-NEXT: )
+
+doneReflecting()
+
+// CHECK: Done.

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_large.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_large.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_large | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_value.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_value.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_value | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_value_indirect.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_value_indirect.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_value | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 

--- a/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
@@ -4,7 +4,6 @@
 
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCaseCFPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
-// REQUIRES: objc_interop
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib

--- a/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
+++ b/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SinglePayload_generic1 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
 
 // REQUIRES: reflection_test_support
-// REQUIRES: objc_interop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 


### PR DESCRIPTION
This fixes an assert failure:

    // At least one payload is non-empty (otherwise this
    // would get laid out as a non-payload enum)
    assert(getNumNonEmptyPayloadCases() > 0);

in TaggedMultiPayloadEnumTypeInfo when you have a generic but zero-sized payload enum cases.
