### PR TITLE
Update build-windows-toolchain.bat

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -855,8 +855,9 @@ endlocal
 :FetchWiX
 setlocal enableextensions enabledelayedexpansion
 
+if exist wix-4.0.1 goto :eof
 curl.exe -sL https://www.nuget.org/api/v2/package/wix/4.0.1 -o wix-4.0.1.zip
-md WiX-4.0.1 || exit (/b)
+md WiX-4.0.1
 cd WiX-4.0.1 || exit (/b)
 tar -xf ../wix-4.0.1.zip || exit (/b)
 


### PR DESCRIPTION
Attempt to repair the CI hosts where the extraction of WiX would fail due to the file existing.