### PR TITLE
[ASTGen]: Assert that the position is within buffer bounds for BridgedSourceLoc

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -32,13 +32,8 @@ extension BridgedSourceLoc {
     at position: AbsolutePosition,
     in buffer: UnsafeBufferPointer<UInt8>
   ) {
-    if let start = buffer.baseAddress,
-      position.utf8Offset >= 0 && position.utf8Offset < buffer.count {
-      assert(position.utf8Offset >= 0 && position.utf8Offset < buffer.count)
-      self = SourceLoc_advanced(BridgedSourceLoc(raw: start), SwiftInt(position.utf8Offset))
-    } else {
-      self = nil
-    }
+    precondition(position.utf8Offset >= 0 && position.utf8Offset < buffer.count)
+    self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer.baseAddress), SwiftInt(position.utf8Offset))
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -30,10 +30,10 @@ extension BridgedSourceLoc {
   /// Form a source location at the given absolute position in `buffer`.
   init(
     at position: AbsolutePosition,
-    in buffer: UnsafeBufferPointer<UInt8>
+    in buffer: UnsafeBufferPointer<UInt8>?
   ) {
-    precondition(position.utf8Offset >= 0 && position.utf8Offset < buffer.count)
-    self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer.baseAddress), SwiftInt(position.utf8Offset))
+    precondition(position.utf8Offset >= 0 && position.utf8Offset < buffer!.count)
+    self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer!.baseAddress), SwiftInt(position.utf8Offset))
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -34,6 +34,7 @@ extension BridgedSourceLoc {
   ) {
     if let start = buffer.baseAddress,
       position.utf8Offset >= 0 && position.utf8Offset < buffer.count {
+      assert(position.utf8Offset >= 0 && position.utf8Offset < buffer.count)
       self = SourceLoc_advanced(BridgedSourceLoc(raw: start), SwiftInt(position.utf8Offset))
     } else {
       self = nil

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -30,10 +30,10 @@ extension BridgedSourceLoc {
   /// Form a source location at the given absolute position in `buffer`.
   init(
     at position: AbsolutePosition,
-    in buffer: UnsafeBufferPointer<UInt8>?
+    in buffer: UnsafeBufferPointer<UInt8>
   ) {
-    precondition(position.utf8Offset >= 0 && position.utf8Offset < buffer!.count)
-    self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer!.baseAddress), SwiftInt(position.utf8Offset))
+    precondition(position.utf8Offset >= 0 && position.utf8Offset < buffer.count)
+    self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer.baseAddress!), SwiftInt(position.utf8Offset))
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Addition of an `assert` if the position is within buffer bounds added to ` BridgeSourceLoc.init`.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #68610

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
