### PR TITLE
Sema: Only complain about the import when it does restrict the access level

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -114,7 +114,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
   ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
   if (problematicImport.has_value() &&
-      diagAccessLevel == problematicImport->accessLevel) {
+      problematicImport->accessLevel < D->getFormalAccess()) {
     Context.Diags.diagnose(problematicImport->accessLevelLoc,
                            diag::decl_import_via_here, D,
                            problematicImport->accessLevel,

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -268,6 +268,12 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
       static_cast<const IdentTypeRepr*>(complainRepr)->getBoundDecl();
     assert(VD && "findTypeWithScope should return bound TypeReprs only");
     complainImport = VD->getImportAccessFrom(useDC);
+
+    // Don't complain about an import that doesn't restrict the access
+    // level of the decl. This can happen with imported `package` decls.
+    if (complainImport.has_value() &&
+        complainImport->accessLevel >= VD->getFormalAccess())
+      complainImport = llvm::None;
   }
 
   diagnose(problematicAccessScope, complainRepr, downgradeToWarning,


### PR DESCRIPTION
Fix the note pointing to the import when using a package type in a public declaration or inlinable code. We want a note on the import only when it actually lowers the access level of the imported decl.

The note about a `package import` was simply superfluous, while the same note about a `public import` would trigger an assert later on.