### PR TITLE
Sema: Don't allow PackExpansionType in the generic arguments of a ParameterizedProtocolType

### DIFF
--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -559,6 +559,7 @@ RewriteContext::getRelativeSubstitutionSchemaFromType(
     ArrayRef<Term> substitutions,
     SmallVectorImpl<Term> &result) {
   assert(!concreteType->isTypeParameter() && "Must have a concrete type here");
+  assert(!concreteType->is<PackExpansionType>());
 
   if (!concreteType->hasTypeParameter())
     return concreteType;
@@ -604,6 +605,7 @@ RewriteContext::getSubstitutionSchemaFromType(CanType concreteType,
                                               const ProtocolDecl *proto,
                                               SmallVectorImpl<Term> &result) {
   assert(!concreteType->isTypeParameter() && "Must have a concrete type here");
+  assert(!concreteType->is<PackExpansionType>());
 
   if (!concreteType->hasTypeParameter())
     return concreteType;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -806,7 +806,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     if (options.is(TypeResolverContext::ExistentialConstraint))
       options |= TypeResolutionFlags::DisallowOpaqueTypes;
     auto argOptions = options.withoutContext().withContext(
-        TypeResolverContext::GenericArgument);
+        TypeResolverContext::ProtocolGenericArgument);
     auto genericResolution = resolution.withOptions(argOptions);
 
     SmallVector<Type, 2> argTys;

--- a/test/Generics/rdar115538574.swift
+++ b/test/Generics/rdar115538574.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P<A> {
+  associatedtype A
+}
+
+func f<each T>(_: some P<repeat each T>) {}
+// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+// expected-error@-2 {{generic parameter 'T' is not used in function signature}}

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -15,6 +15,7 @@ protocol P<T> {
 }
 
 func f4<each T>() -> any P<repeat each T> {}
+// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
 
 typealias T1<each T> = repeat each T
 // expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}


### PR DESCRIPTION
We already had a separate TypeResolverContext::ProtocolGenericArgument that
did not allow PackExpansionTypes, but it was never used.

Fixes rdar://problem/115538574.