### PR TITLE
[embedded] Add a temporary flag that turns throws into traps so that programs that use throwing can at least be compiled for now

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -272,6 +272,9 @@ namespace swift {
     /// Allow throwing call expressions without annotation with 'try'.
     bool EnableThrowWithoutTry = false;
 
+    /// Turn all throw sites into immediate traps.
+    bool ThrowsAsTraps = false;
+
     /// If set, inserts instrumentation useful for testing the debugger.
     bool DebuggerTestingTransform = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -802,6 +802,9 @@ def enable_source_import : Flag<["-"], "enable-source-import">,
 def enable_throw_without_try : Flag<["-"], "enable-throw-without-try">,
   HelpText<"Allow throwing function calls without 'try'">;
 
+def throws_as_traps : Flag<["-"], "throws-as-traps">,
+  HelpText<"Turn all throw sites into immediate traps">;
+
 def import_module : Separate<["-"], "import-module">,
   HelpText<"Implicitly import the specified module">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -720,6 +720,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableThrowWithoutTry |= Args.hasArg(OPT_enable_throw_without_try);
 
+  Opts.ThrowsAsTraps |= Args.hasArg(OPT_throws_as_traps);
+
   if (auto A = Args.getLastArg(OPT_enable_objc_attr_requires_foundation_module,
                                OPT_disable_objc_attr_requires_foundation_module)) {
     Opts.EnableObjCAttrRequiresFoundation

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -762,8 +762,7 @@ void StmtEmitter::visitReturnStmt(ReturnStmt *S) {
 
 void StmtEmitter::visitThrowStmt(ThrowStmt *S) {
   if (SGF.getASTContext().LangOpts.ThrowsAsTraps) {
-    SGF.B.createBuiltin(S, SGF.SGM.getASTContext().getIdentifier("int_trap"),
-                        SGF.SGM.Types.getEmptyTupleType(), {}, {});
+    SGF.B.createUnconditionalFail(S, "throw turned into a trap");
     SGF.B.createUnreachable(S);
     return;
   }
@@ -1483,8 +1482,7 @@ void SILGenFunction::emitThrow(SILLocation loc, ManagedValue exnMV,
          "calling emitThrow with invalid throw destination!");
 
   if (getASTContext().LangOpts.ThrowsAsTraps) {
-    B.createBuiltin(loc, SGM.getASTContext().getIdentifier("int_trap"),
-                    SGM.Types.getEmptyTupleType(), {}, {});
+    B.createUnconditionalFail(loc, "throw turned into a trap");
     B.createUnreachable(loc);
     return;
   }

--- a/test/embedded/throw-trap.swift
+++ b/test/embedded/throw-trap.swift
@@ -28,13 +28,15 @@ public func catching1() {
 // CHECK-TRAPS-SIL:      sil @$s4main9throwing1SiyKF : $@convention(thin) () -> (Int, @error any Error) {
 // CHECK-TRAPS-SIL-NEXT: bb0:
 // CHECK-TRAPS-SIL-NEXT:   debug_value
-// CHECK-TRAPS-SIL-NEXT:   %1 = builtin "int_trap"
+// CHECK-TRAPS-SIL-NEXT:   %1 = integer_literal $Builtin.Int1, -1
+// CHECK-TRAPS-SIL-NEXT:   cond_fail %1 : $Builtin.Int1, "throw turned into a trap"
 // CHECK-TRAPS-SIL-NEXT:   unreachable
 // CHECK-TRAPS-SIL-NEXT: }
 
 
 // CHECK-TRAPS-IR:      define {{.*}}@"$s4main9throwing1SiyKF"{{.*}}{
 // CHECK-TRAPS-IR-NEXT: entry:
-// CHECK-TRAPS-IR-NEXT:   call void @llvm.trap()
+// CHECK-TRAPS-IR:        call void @llvm.trap()
 // CHECK-TRAPS-IR-NEXT:   unreachable
 // CHECK-TRAPS-IR-NEXT: }
+// CHECK-TRAPS-IR:      define {{.*}}@"$s4main9catching1yyF"{{.*}}{

--- a/test/embedded/throw-trap.swift
+++ b/test/embedded/throw-trap.swift
@@ -1,0 +1,40 @@
+// RUN: not %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded 2>&1 | %FileCheck %s --check-prefix CHECK-EXISTENTIALS
+// RUN: %target-swift-frontend -emit-sil %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s --check-prefix CHECK-TRAPS-SIL
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s --check-prefix CHECK-TRAPS-IR
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+enum MyError : Error {
+  case a
+}
+
+public func throwing1() throws -> Int {
+  throw MyError.a
+}
+
+public func catching1() {
+  do {
+    try throwing1()
+  } catch let e as MyError {
+    _ = e
+  } catch {
+    _ = error
+  }
+}
+
+// CHECK-EXISTENTIALS: error: existential can cause metadata allocation or locks
+
+// CHECK-TRAPS-SIL:      sil @$s4main9throwing1SiyKF : $@convention(thin) () -> (Int, @error any Error) {
+// CHECK-TRAPS-SIL-NEXT: bb0:
+// CHECK-TRAPS-SIL-NEXT:   debug_value
+// CHECK-TRAPS-SIL-NEXT:   %1 = builtin "int_trap"
+// CHECK-TRAPS-SIL-NEXT:   unreachable
+// CHECK-TRAPS-SIL-NEXT: }
+
+
+// CHECK-TRAPS-IR:      define {{.*}}@"$s4main9throwing1SiyKF"{{.*}}{
+// CHECK-TRAPS-IR-NEXT: entry:
+// CHECK-TRAPS-IR-NEXT:   call void @llvm.trap()
+// CHECK-TRAPS-IR-NEXT:   unreachable
+// CHECK-TRAPS-IR-NEXT: }


### PR DESCRIPTION
Only intended as an experimentation tool to be used when trying to get existing Swift programs to compile under embedded Swift.