### PR TITLE
Add an alias for -import-objc-header flag: -import-bridging-header

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -320,6 +320,9 @@ def import_underlying_module : Flag<["-"], "import-underlying-module">,
 def import_objc_header : Separate<["-"], "import-objc-header">,
   Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
   HelpText<"Implicitly imports an Objective-C header file">;
+def import_bridging_header : Separate<["-"], "import-bridging-header">,
+  Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
+  Alias<import_objc_header>;
 
 def pch_output_dir: Separate<["-"], "pch-output-dir">,
   Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,

--- a/test/IRGen/objc_direct.swift
+++ b/test/IRGen/objc_direct.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-ir -import-objc-header %S/../Inputs/objc_direct.h -o - %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -import-bridging-header %S/../Inputs/objc_direct.h -o - %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
For platforms that do not have ObjC interop, it's very weird that the only way to import a bridging header is a flag with "objc" in its name, `-import-objc-header`. Let's add an alias, `-import-bridging-header`.