### PR TITLE
AccessUtils: fix handling of indexing in overlap checks

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
@@ -329,7 +329,13 @@ struct AccessPath : CustomStringConvertible {
     if !base.isEqual(to: other.base) {
       return nil
     }
-    return projectionPath.subtract(from: other.projectionPath)
+    if let resultPath = projectionPath.subtract(from: other.projectionPath),
+       // Indexing is not a projection where the base overlaps the projected address.
+       !resultPath.pop().kind.isIndexedElement
+    {
+      return resultPath
+    }
+    return nil
   }
 
   /// Like `getProjection`, but also requires that the resulting projection path is materializable.

--- a/SwiftCompilerSources/Sources/SIL/SmallProjectionPath.swift
+++ b/SwiftCompilerSources/Sources/SIL/SmallProjectionPath.swift
@@ -103,7 +103,7 @@ public struct SmallProjectionPath : Hashable, CustomStringConvertible, NoReflect
       }
     }
 
-    var isIndexedElement: Bool {
+    public var isIndexedElement: Bool {
       switch self {
       case .anyIndexedElement, .indexedElement:
         return true

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1660,3 +1660,35 @@ bb0(%0 : $*(Klass, Klass)):
   %7 = tuple ()
   return %7 : $()
 }
+
+// CHECK-LABEL: sil @indexing_is_not_overlapping :
+// CHECK:         store %0
+// CHECK:         store %0
+// CHECK:       end sil function 'indexing_is_not_overlapping'
+sil @indexing_is_not_overlapping : $@convention(thin) (Int, Builtin.RawPointer) -> () {
+bb0(%0 : $Int, %1 : $Builtin.RawPointer):
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int
+  %3 = integer_literal $Builtin.Word, 3
+  %4 = index_addr [stack_protection] %2 : $*Int, %3 : $Builtin.Word
+  store %0 to %4 : $*Int
+  store %0 to %2 : $*Int
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @indexing_is_not_overlapping2 :
+// CHECK:         store %1
+// CHECK:         store %0
+// CHECK:       end sil function 'indexing_is_not_overlapping2'
+sil @indexing_is_not_overlapping2 : $@convention(thin) (Int, Builtin.Int64, Builtin.RawPointer) -> () {
+bb0(%0 : $Int, %1 : $Builtin.Int64, %2 : $Builtin.RawPointer):
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*Int
+  %4 = integer_literal $Builtin.Word, 3
+  %5 = index_addr [stack_protection] %3 : $*Int, %4 : $Builtin.Word
+  %6 = struct_element_addr %5 : $*Int, #Int.value
+  store %1 to %6 : $*Builtin.Int64
+  store %0 to %3 : $*Int
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
Indexing is not a projection where the base overlaps the "projected" address. Fixes a miscompile.

rdar://115747816
