### PR TITLE
[5.9] [Sema] Catch invalid if/switch exprs in more places

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3850,7 +3850,20 @@ class SingleValueStmtUsageChecker final : public ASTWalker {
   llvm::DenseSet<SingleValueStmtExpr *> ValidSingleValueStmtExprs;
 
 public:
-  SingleValueStmtUsageChecker(ASTContext &ctx) : Ctx(ctx), Diags(ctx.Diags) {}
+  SingleValueStmtUsageChecker(
+      ASTContext &ctx, ASTNode root,
+      llvm::Optional<ContextualTypePurpose> contextualPurpose)
+      : Ctx(ctx), Diags(ctx.Diags) {
+    assert(!root.is<Expr *>() || contextualPurpose &&
+           "Must provide contextual purpose for expr");
+
+    // If we have a contextual purpose, this is for an expression. Check if it's
+    // an expression in a valid position.
+    if (contextualPurpose) {
+      markAnyValidTopLevelSingleValueStmt(root.get<Expr *>(),
+                                          *contextualPurpose);
+    }
+  }
 
 private:
   /// Mark a given expression as a valid position for a SingleValueStmtExpr.
@@ -3862,8 +3875,23 @@ private:
       ValidSingleValueStmtExprs.insert(SVE);
   }
 
+  /// Mark a valid top-level expression with a given contextual purpose.
+  void markAnyValidTopLevelSingleValueStmt(Expr *E, ContextualTypePurpose ctp) {
+    // Allowed in returns, throws, and bindings.
+    switch (ctp) {
+    case CTP_ReturnStmt:
+    case CTP_ReturnSingleExpr:
+    case CTP_ThrowStmt:
+    case CTP_Initialization:
+      markValidSingleValueStmt(E);
+      break;
+    default:
+      break;
+    }
+  }
+
   MacroWalking getMacroWalkingBehavior() const override {
-    return MacroWalking::Expansion;
+    return MacroWalking::ArgumentsAndExpansion;
   }
 
   AssignExpr *findAssignment(Expr *E) const {
@@ -3989,18 +4017,25 @@ private:
     if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
       for (auto idx : range(PBD->getNumPatternEntries()))
         markValidSingleValueStmt(PBD->getInit(idx));
+
+      return Action::Continue();
     }
-    // Valid as a single expression body of a function. This is needed in
-    // addition to ReturnStmt checking, as we will remove the return if the
-    // expression is inferred to be Never.
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-      if (AFD->hasSingleExpressionBody())
-        markValidSingleValueStmt(AFD->getSingleExpressionBody());
-    }
-    return Action::Continue();
+    // We don't want to walk into any other decl, we will visit them as part of
+    // typeCheckDecl.
+    return Action::SkipChildren();
   }
 };
 } // end anonymous namespace
+
+void swift::diagnoseOutOfPlaceExprs(
+    ASTContext &ctx, ASTNode root,
+    llvm::Optional<ContextualTypePurpose> contextualPurpose) {
+  // TODO: We ought to consider moving this into pre-checking such that we can
+  // still diagnose on invalid code, and don't have to traverse over implicit
+  // exprs. We need to first separate out SequenceExpr folding though.
+  SingleValueStmtUsageChecker sveChecker(ctx, root, contextualPurpose);
+  root.walk(sveChecker);
+}
 
 /// Apply the warnings managed by VarDeclUsageChecker to the top level
 /// code declarations that haven't been checked yet.
@@ -4009,8 +4044,6 @@ performTopLevelDeclDiagnostics(TopLevelCodeDecl *TLCD) {
   auto &ctx = TLCD->getDeclContext()->getASTContext();
   VarDeclUsageChecker checker(TLCD, ctx.Diags);
   TLCD->walk(checker);
-  SingleValueStmtUsageChecker sveChecker(ctx);
-  TLCD->walk(sveChecker);
 }
 
 /// Perform diagnostics for func/init/deinit declarations.
@@ -4026,10 +4059,6 @@ void swift::performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD) {
     auto &ctx = AFD->getDeclContext()->getASTContext();
     VarDeclUsageChecker checker(AFD, ctx.Diags);
     AFD->walk(checker);
-
-    // Do a similar walk to check for out of place SingleValueStmtExprs.
-    SingleValueStmtUsageChecker sveChecker(ctx);
-    AFD->walk(sveChecker);
   }
 
   auto *body = AFD->getBody();
@@ -5864,10 +5893,10 @@ diagnoseDictionaryLiteralDuplicateKeyEntries(const Expr *E,
 //===----------------------------------------------------------------------===//
 
 /// Emit diagnostics for syntactic restrictions on a given expression.
-void swift::performSyntacticExprDiagnostics(const Expr *E,
-                                            const DeclContext *DC,
-                                            bool isExprStmt,
-                                            bool disableExprAvailabilityChecking) {
+void swift::performSyntacticExprDiagnostics(
+    const Expr *E, const DeclContext *DC,
+    llvm::Optional<ContextualTypePurpose> contextualPurpose, bool isExprStmt,
+    bool disableExprAvailabilityChecking, bool disableOutOfPlaceExprChecking) {
   auto &ctx = DC->getASTContext();
   TypeChecker::diagnoseSelfAssignment(E);
   diagSyntacticUseRestrictions(E, DC, isExprStmt);
@@ -5886,6 +5915,8 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   diagnoseConstantArgumentRequirement(E, DC);
   diagUnqualifiedAccessToMethodNamedSelf(E, DC);
   diagnoseDictionaryLiteralDuplicateKeyEntries(E, DC);
+  if (!disableOutOfPlaceExprChecking)
+    diagnoseOutOfPlaceExprs(ctx, const_cast<Expr *>(E), contextualPurpose);
 }
 
 void swift::performStmtDiagnostics(const Stmt *S, DeclContext *DC) {

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -28,6 +28,7 @@ namespace swift {
   class ApplyExpr;
   class CallExpr;
   class ClosureExpr;
+  enum ContextualTypePurpose : uint8_t;
   class DeclContext;
   class Decl;
   class Expr;
@@ -37,10 +38,22 @@ namespace swift {
   class ValueDecl;
   class ForEachStmt;
 
+/// Diagnose any expressions that appear in an unsupported position. If visiting
+/// an expression directly, its \p contextualPurpose should be provided to
+/// evaluate its position.
+void diagnoseOutOfPlaceExprs(
+    ASTContext &ctx, ASTNode root,
+    llvm::Optional<ContextualTypePurpose> contextualPurpose);
+
 /// Emit diagnostics for syntactic restrictions on a given expression.
+///
+/// Note: \p contextualPurpose must be non-nil, unless
+/// \p disableOutOfPlaceExprChecking is set to \c true.
 void performSyntacticExprDiagnostics(
     const Expr *E, const DeclContext *DC,
-    bool isExprStmt, bool disableExprAvailabilityChecking = false);
+    llvm::Optional<ContextualTypePurpose> contextualPurpose,
+    bool isExprStmt, bool disableExprAvailabilityChecking = false,
+    bool disableOutOfPlaceExprChecking = false);
 
 /// Emit diagnostics for a given statement.
 void performStmtDiagnostics(const Stmt *S, DeclContext *DC);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -299,7 +299,11 @@ public:
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
-    performSyntacticExprDiagnostics(expr, dcStack.back(), /*isExprStmt=*/false);
+    // We skip out-of-place expr checking here since we've already performed it.
+    performSyntacticExprDiagnostics(expr, dcStack.back(), /*ctp*/ llvm::None,
+                                    /*isExprStmt=*/false,
+                                    /*disableAvailabilityChecking*/ false,
+                                    /*disableOutOfPlaceExprChecking*/ true);
 
     if (auto closure = dyn_cast<ClosureExpr>(expr)) {
       if (closure->isSeparatelyTypeChecked()) {
@@ -346,8 +350,9 @@ void constraints::performSyntacticDiagnosticsForTarget(
   switch (target.kind) {
   case SyntacticElementTarget::Kind::expression: {
     // First emit diagnostics for the main expression.
-    performSyntacticExprDiagnostics(target.getAsExpr(), dc,
-                                    isExprStmt, disableExprAvailabilityChecking);
+    performSyntacticExprDiagnostics(
+        target.getAsExpr(), dc, target.getExprContextualTypePurpose(),
+        isExprStmt, disableExprAvailabilityChecking);
     return;
   }
 
@@ -356,17 +361,25 @@ void constraints::performSyntacticDiagnosticsForTarget(
 
     // First emit diagnostics for the main expression.
     performSyntacticExprDiagnostics(stmt->getTypeCheckedSequence(), dc,
-                                    isExprStmt,
+                                    CTP_ForEachSequence, isExprStmt,
                                     disableExprAvailabilityChecking);
 
     if (auto *whereExpr = stmt->getWhere())
-      performSyntacticExprDiagnostics(whereExpr, dc, /*isExprStmt*/ false);
+      performSyntacticExprDiagnostics(whereExpr, dc, CTP_Condition,
+                                      /*isExprStmt*/ false);
     return;
   }
 
   case SyntacticElementTarget::Kind::function: {
+    // Check for out of place expressions. This needs to be done on the entire
+    // function body rather than on individual expressions since we need the
+    // context of the parent nodes.
+    auto *body = target.getFunctionBody();
+    diagnoseOutOfPlaceExprs(dc->getASTContext(), body,
+                            /*contextualPurpose*/ llvm::None);
+
     FunctionSyntacticDiagnosticWalker walker(dc);
-    target.getFunctionBody()->walk(walker);
+    body->walk(walker);
     return;
   }
   case SyntacticElementTarget::Kind::closure:

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1149,11 +1149,9 @@ struct R_76250381<Result, Failure: Error> {
 // rdar://77022842 - crash due to a missing argument to a ternary operator
 func rdar77022842(argA: Bool? = nil, argB: Bool? = nil) {
   if let a = argA ?? false, if let b = argB ?? {
-    // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-    // expected-error@-2 {{initializer for conditional binding must have Optional type, not 'Bool'}}
-    // expected-error@-3 {{cannot convert value of type '() -> ()' to expected argument type 'Bool?'}}
-    // expected-error@-4 {{cannot convert value of type 'Void' to expected condition type 'Bool'}}
-    // expected-error@-5 {{'if' must have an unconditional 'else' to be used as expression}}
+    // expected-error@-1 {{initializer for conditional binding must have Optional type, not 'Bool'}}
+    // expected-error@-2 {{cannot convert value of type '() -> ()' to expected argument type 'Bool?'}}
+    // expected-error@-3 {{cannot convert value of type 'Void' to expected condition type 'Bool'}}
   } // expected-error {{expected '{' after 'if' condition}}
 }
 

--- a/test/Constraints/switch_expr.swift
+++ b/test/Constraints/switch_expr.swift
@@ -754,7 +754,7 @@ func builderNotPostfix() -> (Either<String, Int>, Bool) {
 
 @Builder
 func builderWithBinding() -> Either<String, Int> {
-  // Make sure the binding gets type-checked as an if expression, but the
+  // Make sure the binding gets type-checked as a switch expression, but the
   // other if block gets type-checked as a stmt.
   let str = switch Bool.random() {
     case true: "a"
@@ -767,9 +767,49 @@ func builderWithBinding() -> Either<String, Int> {
   }
 }
 
+
+@Builder
+func builderWithInvalidBinding() -> Either<String, Int> {
+  let str = (switch Bool.random() { default: "a" })
+  // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
+  if .random() {
+    str
+  } else {
+    1
+  }
+}
+
+func takesBuilder(@Builder _ fn: () -> Either<String, Int>) {}
+
+func builderClosureWithBinding() {
+  takesBuilder {
+    // Make sure the binding gets type-checked as a switch expression, but the
+    // other if block gets type-checked as a stmt.
+    let str = switch Bool.random() { case true: "a" case false: "b" }
+    switch Bool.random() {
+    case true:
+      str
+    case false:
+      1
+    }
+  }
+}
+
+func builderClosureWithInvalidBinding()  {
+  takesBuilder {
+    let str = (switch Bool.random() { case true: "a" case false: "b" })
+    // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
+    switch Bool.random() {
+    case true:
+      str
+    case false:
+      1
+    }
+  }
+}
+
 func builderInClosure() {
-  func build(@Builder _ fn: () -> Either<String, Int>) {}
-  build {
+  takesBuilder {
     switch Bool.random() {
     case true:
       ""

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1998,6 +1998,20 @@ public struct NestedMagicLiteralMacro: ExpressionMacro {
   }
 }
 
+public struct InvalidIfExprMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["""
+      func bar() {
+        let _ = (if .random() { 0 } else { 1 })
+      }
+      """]
+  }
+}
+
 public struct InitWithProjectedValueWrapperMacro: PeerMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/if_expr.swift
+++ b/test/Macros/if_expr.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: not %target-swift-frontend -typecheck %s -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -serialize-diagnostics-path %t/diags.dia
+
+// RUN: c-index-test -read-diagnostics %t/diags.dia 2>&1 | %FileCheck -check-prefix DIAGS %s
+
+// REQUIRES: swift_swift_parser
+
+@attached(member, names: named(bar))
+macro TestMacro<T>(_ x: T) = #externalMacro(module: "MacroDefinition", type: "InvalidIfExprMacro")
+
+// Make sure we diagnose both the use in the custom attribute and in the expansion.
+// DIAGS-DAG: if_expr.swift:[[@LINE+1]]:12: error: 'if' may only be used as expression in return, throw, or as the source of an assignment
+@TestMacro(if .random() { 0 } else { 0 })
+struct S {}
+
+// DIAGS-DAG: @__swiftmacro_7if_expr1S9TestMacrofMm_.swift:2:12: error: 'if' may only be used as expression in return, throw, or as the source of an assignment

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -81,9 +81,7 @@ func missingControllingExprInIf() {
 
   if { // expected-error {{missing condition in 'if' statement}}
   } // expected-error {{expected '{' after 'if' condition}}
-  // expected-error@-2 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-  // expected-error@-3 {{cannot convert value of type 'Void' to expected condition type 'Bool'}}
-  // expected-error@-4 {{'if' must have an unconditional 'else' to be used as expression}}
+  // expected-error@-2 {{cannot convert value of type 'Void' to expected condition type 'Bool'}}
 
   if // expected-error {{missing condition in 'if' statement}}
   {
@@ -239,7 +237,7 @@ func missingControllingExprInForEach() {
 func missingControllingExprInSwitch() {
   switch
 
-  switch { // expected-error {{expected expression in 'switch' statement}} expected-error {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
+  switch { // expected-error {{expected expression in 'switch' statement}}
   } // expected-error {{expected '{' after 'switch' subject expression}}
 
   switch // expected-error {{expected expression in 'switch' statement}} expected-error {{'switch' statement body must have at least one 'case' or 'default' block}}

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -508,3 +508,8 @@ func testNever1() -> Never {
 func testNever2() -> Never {
   if .random() { fatalError() } else { fatalError() }
 }
+
+func testCaptureList() -> Int {
+  let fn = { [x = if .random() { 0 } else { 1 }] in x }
+  return fn()
+}

--- a/test/SILGen/switch_expr.swift
+++ b/test/SILGen/switch_expr.swift
@@ -707,3 +707,8 @@ extension Never {
     self = switch value { case let v: v }
   }
 }
+
+func testCaptureList() -> Int {
+  let fn = { [x = switch Bool.random() { case true: 0 case false: 1 }] in x }
+  return fn()
+}

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1016,3 +1016,16 @@ func tryAwaitIf2() async throws -> Int {
   // expected-error@-1 {{'try' may not be used on 'if' expression}}
   // expected-error@-2 {{'await' may not be used on 'if' expression}}
 }
+
+struct AnyEraserP: EraserP {
+  init<T: EraserP>(erasing: T) {}
+}
+
+@_typeEraser(AnyEraserP)
+protocol EraserP {}
+struct SomeEraserP: EraserP {}
+
+// rdar://113435870 - Make sure we allow an implicit init(erasing:) call.
+dynamic func testDynamicOpaqueErase() -> some EraserP {
+  if .random() { SomeEraserP() } else { SomeEraserP() }
+}

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -371,7 +371,7 @@ var d = if .random() { if .random() { 1 } else { 2 } } else { 3 }
 
 d = if .random() { 0 } else { 1 }
 
-let e = "\(if .random() { 1 } else { 2 })" // expected-error {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+let e = "\(if .random() { 1 } else { 2 })" // expected-error 2{{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
 let f = { if .random() { 1 } else { 2 } }
 

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -115,8 +115,7 @@ takesValue(if .random() { 0 } else { 1 })
 // Cannot parse labeled if as expression.
 do {
   takesValue(x: if .random() { 0 } else { 1 })
-  // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-  // expected-error@-2 {{extraneous argument label 'x:' in call}}
+  // expected-error@-1 {{extraneous argument label 'x:' in call}}
 
   takesValue(_: x: if .random() { 0 } else { 1 })
   // expected-error@-1 {{expected expression in list of expressions}}
@@ -140,7 +139,6 @@ takesValueAndTrailingClosure(if .random() { 0 } else { 1 }) { 2 }
 func takesInOut<T>(_ x: inout T) {}
 takesInOut(&if .random() { 1 } else { 2 })
 // expected-error@-1 {{cannot pass immutable value of type 'Int' as inout argument}}
-// expected-error@-2 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
 struct HasSubscript {
   static subscript(x: Int) -> Void { () }
@@ -462,9 +460,9 @@ let o = !if .random() { true } else { false }  // expected-error {{'if' may only
 let p = if .random() { 1 } else { 2 } + // expected-error {{ambiguous use of operator '+'}}
         if .random() { 3 } else { 4 } +
         if .random() { 5 } else { 6 }
-// expected-error@-3 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-// expected-error@-3 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-// expected-error@-3 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
+let p1 = if .random() { 1 } else { 2 } +  5
+// expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 
 let q = .random() ? if .random() { 1 } else { 2 }
                   : if .random() { 3 } else { 4 }
@@ -503,8 +501,7 @@ do {
 
   // FIXME: The type error is likely due to not solving the conjunction before attempting default type var bindings.
   let _ = (if .random() { Int?.none } else { 1 as Int? })?.bitWidth
-  // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-  // expected-error@-2 {{type of expression is ambiguous without a type annotation}}
+  // expected-error@-1 {{type of expression is ambiguous without a type annotation}}
 }
 do {
   let _ = if .random() { Int?.none } else { 1 as Int? }!
@@ -598,10 +595,26 @@ func returnBranches() -> Int {
 
 func returnBranches1() -> Int {
   return if .random() { // expected-error {{cannot convert return expression of type 'Void' to return type 'Int'}}
+    return 0
+  } else {
+    return 1
+  }
+}
+
+func returnBranchVoid() {
+  return if .random() { return } else { return () }
+  // expected-error@-1 2{{cannot 'return' in 'if' when used as expression}}
+}
+
+func returnBranchBinding() -> Int {
+  let x = if .random() {
+    // expected-warning@-1 {{constant 'x' inferred to have type 'Void', which may be unexpected}}
+    // expected-note@-2 {{add an explicit type annotation to silence this warning}}
     return 0 // expected-error {{cannot 'return' in 'if' when used as expression}}
   } else {
     return 1 // expected-error {{cannot 'return' in 'if' when used as expression}}
   }
+  return x // expected-error {{cannot convert return expression of type 'Void' to return type 'Int'}}
 }
 
 func returnBranches2() -> Int {
@@ -1028,4 +1041,56 @@ struct SomeEraserP: EraserP {}
 // rdar://113435870 - Make sure we allow an implicit init(erasing:) call.
 dynamic func testDynamicOpaqueErase() -> some EraserP {
   if .random() { SomeEraserP() } else { SomeEraserP() }
+}
+
+struct NonExhaustiveProperty {
+  let i = if .random() { 0 }
+  // expected-error@-1 {{'if' must have an unconditional 'else' to be used as expression}}
+}
+
+// MARK: Out of place if exprs
+
+func inDefaultArg(x: Int = if .random() { 0 } else { 0 }) {}
+// expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
+func inDefaultArg2(x: Int = { (if .random() { 0 } else { 0 }) }()) {}
+// expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
+struct InType {
+  let inPropertyInit1 = if .random() { 0 } else { 1 }
+  let inPropertyInit2 = (if .random() { 0 } else { 1 })
+  // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
+  let inPropertyInit3 = {
+    let _ = if .random() { 0 } else { 1 }
+    let _ = (if .random() { 0 } else { 1 })
+    // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
+    func foo() {
+      let _ = if .random() { 0 } else { 1 }
+      let _ = (if .random() { 0 } else { 1 })
+      // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+    }
+    if .random() {
+      return if .random() { 0 } else { 1 }
+    } else {
+      return (if .random() { 0 } else { 1 })
+      // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+    }
+  }
+
+  subscript(x: Int = if .random() { 0 } else { 0 }) -> Int {
+    // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+
+    let _ = if .random() { 0 } else { 1 }
+    let _ = (if .random() { 0 } else { 1 })
+    // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
+    return 0
+  }
+}
+
+func testCaptureList() {
+  let _ = { [x = if .random() { 0 } else { 1 }] in x }
+  let _ = { [x = (if .random() { 0 } else { 1 })] in x }
+  // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
 }

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -1288,3 +1288,16 @@ func tryAwaitSwitch2() async throws -> Int {
   // expected-error@-1 {{'try' may not be used on 'switch' expression}}
   // expected-error@-2 {{'await' may not be used on 'switch' expression}}
 }
+
+struct AnyEraserP: EraserP {
+  init<T: EraserP>(erasing: T) {}
+}
+
+@_typeEraser(AnyEraserP)
+protocol EraserP {}
+struct SomeEraserP: EraserP {}
+
+// rdar://113435870 - Make sure we allow an implicit init(erasing:) call.
+dynamic func testDynamicOpaqueErase() -> some EraserP {
+  switch Bool.random() { default: SomeEraserP() }
+}

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -446,7 +446,7 @@ case false:
 }
 
 let e = "\(switch Bool.random() { case true: 1 case false: 2 })"
-// expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
+// expected-error@-1 2{{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
 let f = { switch Bool.random() { case true: 1 case false: 2 } }
 


### PR DESCRIPTION
*5.9 cherry-pick of https://github.com/apple/swift/pull/68207*

- Explanation: Fixes missing diagnostics for if/switch expressions in property initializers, subscript default args, and custom attribute args. Most notably this fixes a miscompile when a non-exhaustive if expression is used in a property init, subscript default arg, or custom attribute arg.
- Scope: Affects diagnostic logic for if/switch expressions
- Issue: rdar://115785675
- Risk: Low, this change applies existing diagnostic logic to more places.
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich