### PR TITLE
[embedded] Deserialize and import global variables in embedded Swift mode

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -418,6 +418,15 @@ void SILLinkerVisitor::visitMetatypeInst(MetatypeInst *MI) {
   linkInVTable(C);
 }
 
+void SILLinkerVisitor::visitGlobalAddrInst(GlobalAddrInst *GAI) {
+  if (!Mod.getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return;
+
+  SILGlobalVariable *G = GAI->getReferencedGlobal();
+  G->setDeclaration(false);
+  G->setLinkage(stripExternalFromLinkage(G->getLinkage()));
+}
+
 //===----------------------------------------------------------------------===//
 //                             Top Level Routine
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -127,6 +127,7 @@ public:
   void visitAllocRefInst(AllocRefInst *ARI);
   void visitAllocRefDynamicInst(AllocRefDynamicInst *ARI);
   void visitMetatypeInst(MetatypeInst *MI);
+  void visitGlobalAddrInst(GlobalAddrInst *i);
 
 private:
   /// Cause a function to be deserialized, and visit all other functions

--- a/test/embedded/modules-globals-exec.swift
+++ b/test/embedded/modules-globals-exec.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/tiny-runtime-dummy-refcounting.c -o %t/runtime.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o %t/runtime.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// BEGIN MyModule.swift
+
+public var global_in_module_used_in_module = 0
+public var global_in_module_unused_in_module = 0
+
+public func foo() {
+  global_in_module_used_in_module += 1
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+@_silgen_name("putchar")
+func putchar(_: UInt8)
+
+public func print(_ s: StaticString, terminator: StaticString = "\n") {
+  var p = s.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+  p = terminator.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+}
+
+@_silgen_name("print_long")
+func print_long(_: Int)
+
+public func print(_ n: Int, terminator: StaticString = "\n") {
+    print_long(n)
+    print("", terminator: terminator)
+}
+
+func test() {
+  print("Testing globals...") // CHECK: Testing globals...
+  print(global_in_module_used_in_module) // CHECK-NEXT: 0
+  print(global_in_module_unused_in_module) // CHECK-NEXT: 0
+  foo()
+  print(global_in_module_used_in_module) // CHECK-NEXT: 1
+  print(global_in_module_unused_in_module) // CHECK-NEXT: 0
+}
+
+test()

--- a/test/embedded/modules-globals-many.swift
+++ b/test/embedded/modules-globals-many.swift
@@ -8,6 +8,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // Dependencies look like this:
 //

--- a/test/embedded/modules-globals-many.swift
+++ b/test/embedded/modules-globals-many.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleA.swiftmodule %t/MyModuleA.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleB.swiftmodule %t/MyModuleB.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleC.swiftmodule %t/MyModuleC.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// Dependencies look like this:
+//
+//              ┌───  ModuleB  ◀─┐
+//  ModuleA  ◀──┤                ├───   Main
+//              └───  ModuleC  ◀─┘
+
+// BEGIN MyModuleA.swift
+
+public var global = 0
+
+public func foo() { global += 1 }
+
+// BEGIN MyModuleB.swift
+
+import MyModuleA
+
+public func foo() { global += 1 }
+
+// BEGIN MyModuleC.swift
+
+import MyModuleA
+
+public func foo() { global += 1 }
+
+// BEGIN Main.swift
+
+import MyModuleB
+import MyModuleC
+
+public func main() {
+  MyModuleB.foo()
+  MyModuleC.foo()
+}
+
+// CHECK: @"$s9MyModuleA6globalSivp" = global %TSi zeroinitializer

--- a/test/embedded/modules-globals-many.swift
+++ b/test/embedded/modules-globals-many.swift
@@ -7,6 +7,7 @@
 // RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
 
 // Dependencies look like this:
 //

--- a/test/embedded/modules-globals.swift
+++ b/test/embedded/modules-globals.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // BEGIN MyModule.swift
 

--- a/test/embedded/modules-globals.swift
+++ b/test/embedded/modules-globals.swift
@@ -5,6 +5,7 @@
 // RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
 
 // BEGIN MyModule.swift
 

--- a/test/embedded/modules-globals.swift
+++ b/test/embedded/modules-globals.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// BEGIN MyModule.swift
+
+public var global_in_module_used_in_module = 0
+public var global_in_module_unused_in_module = 0
+
+public func foo() {
+  global_in_module_used_in_module += 1
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+public var global_in_client_used_in_client = 0
+public var global_in_client_unused_in_client = 0
+
+public func main() {
+  global_in_module_used_in_module = 42
+  global_in_module_unused_in_module = 42
+  global_in_client_used_in_client = 42
+  foo()
+}
+
+// CHECK: @"$s4Main022global_in_client_used_c1_D0Sivp" = global %TSi zeroinitializer
+// CHECK: @"$s4Main024global_in_client_unused_c1_D0Sivp" = global %TSi zeroinitializer
+// CHECK: @"$s8MyModule022global_in_module_used_d1_E0Sivp" = global %TSi zeroinitializer
+// CHECK: @"$s8MyModule024global_in_module_unused_d1_E0Sivp" = global %TSi zeroinitializer


### PR DESCRIPTION
This expands the "alwaysEmitIntoClient" library distribution model described in the Embedded Swift Vision Document (https://github.com/apple/swift-evolution/blob/488e96672f2f54bbe0716dfe63cc5df753c3436f/visions/embedded-swift.md) to also apply to global variables. Before this change, global variables are never deserialized into actual definitions, but only into (external) declarations, and that causes a problem when using libraries in embedded Swift mode. The attached test cases demonstrate the failure (they all fail to link due to the missing global symbols at link time). With the deserialization fix, the test cases start to work.