### PR TITLE
tests: require an optimized stdlib for some embedded tests

### DIFF
--- a/test/embedded/arrays.swift
+++ b/test/embedded/arrays.swift
@@ -6,6 +6,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 

--- a/test/embedded/collection.swift
+++ b/test/embedded/collection.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
fixes CI failures in https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators/3185/console
