### PR TITLE
[Runtime] Add layout string handling in swift_arrayAssignWithCopyFron…

### DIFF
--- a/stdlib/public/runtime/Array.cpp
+++ b/stdlib/public/runtime/Array.cpp
@@ -111,6 +111,16 @@ static void array_copy_operation(OpaqueValue *dest, OpaqueValue *src,
 
   // Call the witness to do the copy.
   if (copyKind == ArrayCopy::NoAlias || copyKind == ArrayCopy::FrontToBack) {
+    if (self->hasLayoutString() && destOp == ArrayDest::Init &&
+        srcOp == ArraySource::Copy) {
+      return swift_generic_arrayInitWithCopy(dest, src, count, stride, self);
+    }
+
+    if (self->hasLayoutString() && destOp == ArrayDest::Assign &&
+        srcOp == ArraySource::Copy) {
+      return swift_generic_arrayAssignWithCopy(dest, src, count, stride, self);
+    }
+
     auto copy = get_witness_function<destOp, srcOp>(wtable);
     for (size_t i = 0; i < count; ++i) {
       auto offset = i * stride;
@@ -124,10 +134,6 @@ static void array_copy_operation(OpaqueValue *dest, OpaqueValue *src,
   // Back-to-front copy.
   assert(copyKind == ArrayCopy::BackToFront);
   assert(count != 0);
-
-  if (self->hasLayoutString() && destOp == ArrayDest::Init && srcOp == ArraySource::Copy) {
-      return swift_generic_arrayInitWithCopy(dest, src, count, stride, self);
-  }
 
   auto copy = get_witness_function<destOp, srcOp>(wtable);
   size_t i = count;

--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -1827,6 +1827,19 @@ swift_generic_assignWithCopy(swift::OpaqueValue *dest, swift::OpaqueValue *src,
   return dest;
 }
 
+void swift::swift_generic_arrayAssignWithCopy(swift::OpaqueValue *dest,
+                                              swift::OpaqueValue *src,
+                                              size_t count, size_t stride,
+                                              const Metadata *metadata) {
+  const uint8_t *layoutStr = metadata->getLayoutString();
+  for (size_t i = 0; i < count; i++) {
+    LayoutStringReader1 reader{layoutStr + layoutStringHeaderSize};
+    uintptr_t addrOffset = i * stride;
+    handleRefCountsAssignWithCopy(metadata, reader, addrOffset, (uint8_t *)dest,
+                                  (uint8_t *)src);
+  }
+}
+
 extern "C" swift::OpaqueValue *
 swift_generic_assignWithTake(swift::OpaqueValue *dest, swift::OpaqueValue *src,
                              const Metadata *metadata) {

--- a/stdlib/public/runtime/BytecodeLayouts.h
+++ b/stdlib/public/runtime/BytecodeLayouts.h
@@ -245,6 +245,10 @@ void swift_generic_arrayInitWithCopy(swift::OpaqueValue *dest,
                                      size_t stride,
                                      const Metadata *metadata);
 
+void swift_generic_arrayAssignWithCopy(swift::OpaqueValue *dest,
+                                       swift::OpaqueValue *src, size_t count,
+                                       size_t stride, const Metadata *metadata);
+
 constexpr size_t layoutStringHeaderSize = sizeof(uint64_t) + sizeof(size_t);
 
 } // namespace swift

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -39,6 +39,15 @@ public struct Simple {
     }
 }
 
+public struct GenericStruct<T> {
+    let x: Int = 0
+    let y: T
+
+    public init(_ y: T) {
+        self.y = y
+    }
+}
+
 public class GenericClass<T> {
     let x: T
 
@@ -600,4 +609,19 @@ public func testGenericInit<T>(_ ptr: __owned UnsafeMutableRawPointer, to x: T) 
 public func testGenericDestroy<T>(_ ptr: __owned UnsafeMutableRawPointer, of tpe: T.Type) {
     let ptr = ptr.assumingMemoryBound(to: InternalGeneric<T>.self)
     testDestroy(ptr)
+}
+
+@inline(never)
+public func testGenericArrayDestroy<T>(_ buffer: UnsafeMutableBufferPointer<T>) {
+    buffer.deinitialize()
+}
+
+@inline(never)
+public func testGenericArrayInitWithCopy<T>(dest: UnsafeMutableBufferPointer<T>, src: UnsafeMutableBufferPointer<T>) {
+    dest.initialize(fromContentsOf: src)
+}
+
+@inline(never)
+public func testGenericArrayAssignWithCopy<T>(dest: UnsafeMutableBufferPointer<T>, src: UnsafeMutableBufferPointer<T>) {
+    dest.update(fromContentsOf: src)
 }

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -1059,6 +1059,79 @@ func testSinglePayloadSimpleResolve() {
 
 testSinglePayloadSimpleResolve()
 
+func testArrayDestroy() {
+    let buffer = UnsafeMutableBufferPointer<GenericStruct<SimpleClass>>.allocate(capacity: 20)
+
+    defer {
+        buffer.deallocate()
+    }
+
+    buffer.initialize(repeating: GenericStruct(SimpleClass(x: 23)))
+
+    // CHECK: Before destroy
+    print("Before destroy")
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testGenericArrayDestroy(buffer)
+}
+
+testArrayDestroy()
+
+func testArrayInitWithCopy() {
+    let src = UnsafeMutableBufferPointer<GenericStruct<SimpleClass>>.allocate(capacity: 20)
+    let dest = UnsafeMutableBufferPointer<GenericStruct<SimpleClass>>.allocate(capacity: 20)
+
+    defer {
+        src.deallocate()
+        dest.deallocate()
+    }
+
+    src.initialize(repeating: GenericStruct(SimpleClass(x: 23)))
+
+    testGenericArrayInitWithCopy(dest: dest, src: src)
+
+    // CHECK: Before src deinit
+    print("Before src deinit")
+    src.deinitialize()
+
+    // CHECK-NEXT: Before dest deinit
+    print("Before dest deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    dest.deinitialize()
+}
+
+testArrayInitWithCopy()
+
+func testArrayAssignWithCopy() {
+    let src = UnsafeMutableBufferPointer<GenericStruct<SimpleClass>>.allocate(capacity: 20)
+    let dest = UnsafeMutableBufferPointer<GenericStruct<SimpleClass>>.allocate(capacity: 20)
+
+    defer {
+        src.deallocate()
+        dest.deallocate()
+    }
+
+    src.initialize(repeating: GenericStruct(SimpleClass(x: 23)))
+    dest.initialize(repeating: GenericStruct(SimpleClass(x: 32)))
+
+    // CHECK: Before assign
+    print("Before assign")
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testGenericArrayAssignWithCopy(dest: dest, src: src)
+
+    // CHECK: Before src deinit
+    print("Before src deinit")
+    src.deinitialize()
+
+    // CHECK-NEXT: Before dest deinit
+    print("Before dest deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    dest.deinitialize()
+}
+
+testArrayAssignWithCopy()
+
 #if os(macOS)
 
 import Foundation


### PR DESCRIPTION
…tToBack

By using a specialize function, we only call through the witness table and fetch the layout string once for the whoe buffer, instead of once per element.
