### PR TITLE
Use a substitute drive for the sources root

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -15,10 +15,12 @@ path %PATH%;%PYTHON_HOME%
 set ProductVersion=5.9.0
 set ProductTag=
 
-:: Identify the SourceRoot
-:: Normalize the SourceRoot to make it easier to read the output.
+:: Identify the SourceRoot and use a substitute drive to shorten paths
 cd %~dp0\..\..
-set SourceRoot=%CD%
+subst S: /d
+subst S: . || (exit /b)
+set SourceRoot=S:
+cd /d %SourceRoot%
 
 :: Identify the BuildRoot
 set BuildRoot=%SourceRoot%\build


### PR DESCRIPTION
We are running into the MAX_PATH source length limitations in CI. Attempt to use a substitute drive to shorten source paths (in addition to the existing one for build paths.

See https://ci-external.swift.org/job/swift-PR-build-toolchain-windows/902/
```
Traceback (most recent call last):
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit.py", line 6, in <module>
    main()
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit\main.py", line 45, in main
    discovered_tests = lit.discovery.find_tests_for_inputs(lit_config, opts.test_paths,
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit\discovery.py", line 278, in find_tests_for_inputs
    tests.extend(getTests(input, lit_config, test_suite_cache,
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit\discovery.py", line 243, in getTestsInSuite
    for res in subiter:
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit\discovery.py", line 243, in getTestsInSuite
    for res in subiter:
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit\discovery.py", line 243, in getTestsInSuite
    for res in subiter:
  [Previous line repeated 11 more times]
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit\discovery.py", line 199, in getTestsInSuite
    for res in lc.test_format.getTestsInDirectory(ts, path_in_suite,
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit\formats\googletest.py", line 54, in getTestsInDirectory
    for fn in lit.util.listdir_files(dir_path,
  File "C:\Users\swift-ci\jenkins\workspace\swift-PR-build-toolchain-windows\llvm-project\llvm\utils\lit\lit\util.py", line 199, in listdir_files
    for filename in os.listdir(dirname):
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\Users\\swift-ci\\jenkins\\workspace\\swift-PR-build-toolchain-windows\\build\\1\\tools\\swift\\unittests\\SourceKit\\SwiftLang\\CMakeFiles\\SourceKitSwiftLangTests.dir\\C_\\Users\\swift-ci\\jenkins\\workspace\\swift-PR-build-toolchain-windows\\llvm-project\\llvm\\resources\\.'
FAILED: tools/swift/test/CMakeFiles/check-swift-windows-x86_64 
cmd.exe /C "cd /D T:\1\tools\swift\test && "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E remove_directory T:/1/./swift-test-results/x86_64-unknown-windows-msvc && "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E make_directory T:/1/./swift-test-results/x86_64-unknown-windows-msvc && "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E env "C:/Program Files (x86)/Microsoft Visual Studio/Shared/Python39_64/python.exe" C:/Users/swift-ci/jenkins/workspace/swift-PR-build-toolchain-windows/llvm-project/llvm/utils/lit/lit.py -sv --xunit-xml-output=T:/1/./swift-test-results/x86_64-unknown-windows-msvc/lit-tests.xml --param differentiable_programming --param concurrency --param distributed --param string_processing --param observation --param threading=win32 --param swift_test_subset=primary --param swift_test_mode=optimize_none T:/1/tools/swift/test-windows-x86_64"
ninja: build stopped: subcommand failed.
```