### PR TITLE
[5.10 🍒][Dependency Scanning] Process implicit imports of the source module first, emulating implicit builds

### DIFF
--- a/test/CAS/module_deps.swift
+++ b/test/CAS/module_deps.swift
@@ -159,20 +159,6 @@ import SubE
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
 
-/// --------Swift module Swift
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "clang": "SwiftShims"
-
-/// --------Clang module SwiftShims
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SwiftShims-{{.*}}.pcm",
-// CHECK: "contextHash": "[[SHIMS_CONTEXT:.*]]",
-// CHECK: "-o"
-// CHECK-NEXT: SwiftShims-{{.*}}[[SHIMS_CONTEXT]].pcm
-// CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"
-
 /// --------Clang module C
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
 
@@ -205,3 +191,17 @@ import SubE
 // CHECK-MAKE-DEPS-SAME: Bridging.h
 // CHECK-MAKE-DEPS-SAME: BridgingOther.h
 // CHECK-MAKE-DEPS-SAME: module.modulemap
+
+/// --------Swift module Swift
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-NEXT: "clang": "SwiftShims"
+
+/// --------Clang module SwiftShims
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SwiftShims-{{.*}}.pcm",
+// CHECK: "contextHash": "[[SHIMS_CONTEXT:.*]]",
+// CHECK: "-o"
+// CHECK-NEXT: SwiftShims-{{.*}}[[SHIMS_CONTEXT]].pcm
+// CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -153,20 +153,6 @@ import SubE
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
 
-/// --------Swift module Swift
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "clang": "SwiftShims"
-
-/// --------Clang module SwiftShims
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SwiftShims-{{.*}}.pcm",
-// CHECK: "contextHash": "[[SHIMS_CONTEXT:.*]]",
-// CHECK: "-o"
-// CHECK-NEXT: SwiftShims-{{.*}}[[SHIMS_CONTEXT]].pcm
-// CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"
-
 /// --------Clang module C
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
 
@@ -199,3 +185,17 @@ import SubE
 // CHECK-MAKE-DEPS-SAME: Bridging.h
 // CHECK-MAKE-DEPS-SAME: BridgingOther.h
 // CHECK-MAKE-DEPS-SAME: module.modulemap
+
+/// --------Swift module Swift
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-NEXT: "clang": "SwiftShims"
+
+/// --------Clang module SwiftShims
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SwiftShims-{{.*}}.pcm",
+// CHECK: "contextHash": "[[SHIMS_CONTEXT:.*]]",
+// CHECK: "-o"
+// CHECK-NEXT: SwiftShims-{{.*}}[[SHIMS_CONTEXT]].pcm
+// CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"

--- a/test/CAS/plugin_cas.swift
+++ b/test/CAS/plugin_cas.swift
@@ -142,20 +142,6 @@ import SubE
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
 
-/// --------Swift module Swift
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "clang": "SwiftShims"
-
-/// --------Clang module SwiftShims
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SwiftShims-{{.*}}.pcm",
-// CHECK: "contextHash": "[[SHIMS_CONTEXT:.*]]",
-// CHECK: "-o"
-// CHECK-NEXT: SwiftShims-{{.*}}[[SHIMS_CONTEXT]].pcm
-// CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"
-
 /// --------Clang module C
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}C-{{.*}}.pcm",
 
@@ -188,3 +174,18 @@ import SubE
 // CHECK-MAKE-DEPS-SAME: Bridging.h
 // CHECK-MAKE-DEPS-SAME: BridgingOther.h
 // CHECK-MAKE-DEPS-SAME: module.modulemap
+
+/// --------Swift module Swift
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-NEXT: "clang": "SwiftShims"
+
+/// --------Clang module SwiftShims
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SwiftShims-{{.*}}.pcm",
+// CHECK: "contextHash": "[[SHIMS_CONTEXT:.*]]",
+// CHECK: "-o"
+// CHECK-NEXT: SwiftShims-{{.*}}[[SHIMS_CONTEXT]].pcm
+// CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"
+

--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -12,16 +12,9 @@
 import ImportsMacroSpecificClangModule
 
 // CHECK:      "directDependencies": [
-// CHECK-NEXT:        {
 // CHECK-DAG:          "swift": "ImportsMacroSpecificClangModule"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
 // CHECK-DAG:          "swift": "Swift"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
 // CHECK-DAG:          "swift": "SwiftOnoneSupport"
-// CHECK-NEXT:        }
-// CHECK-NEXT:      ],
 
 //CHECK:      "swift": "ImportsMacroSpecificClangModule"
 //CHECK-NEXT:    },

--- a/test/ModuleInterface/extension-transitive-availability.swift
+++ b/test/ModuleInterface/extension-transitive-availability.swift
@@ -13,17 +13,9 @@ func foo() {
 }
 
 // CHECK:      "directDependencies": [
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "swift": "ExtensionAvailable"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "swift": "Swift"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "swift": "SwiftOnoneSupport"
-// CHECK-NEXT:        }
-// CHECK-NEXT:      ],
-
+// CHECK-DAG:          "swift": "ExtensionAvailable"
+// CHECK-DAG:          "swift": "Swift"
+// CHECK-DAG:          "swift": "SwiftOnoneSupport"
 
 // CHECK:      "swift": "ExtensionAvailable"
 // CHECK-NEXT:    },

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -114,21 +114,10 @@ import SubE
 // CHECK-LABEL: modulePath": "{{.*}}{{/|\\}}E-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
-// CHECK-NEXT: "swift": "Swift"
+// CHECK: "swift": "Swift"
 
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
-
-/// --------Swift module Swift
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "clang": "SwiftShims"
-
-
-/// --------Clang module SwiftShims
-// CHECK-LABEL: "modulePath": "{{.*}}/SwiftShims-{{.*}}.pcm",
 
 /// --------Clang module C
 // CHECK-LABEL: "modulePath": "{{.*}}/C-{{.*}}.pcm",
@@ -139,7 +128,7 @@ import SubE
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-NEXT: "clang": "B"
+// CHECK: "clang": "B"
 
 // CHECK: "moduleMapPath"
 // CHECK-SAME: module.modulemap
@@ -164,5 +153,16 @@ import SubE
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-NEXT: "clang": "A"
+// CHECK: "clang": "A"
 // CHECK-NEXT: }
+
+/// --------Swift module Swift
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK: "clang": "SwiftShims"
+
+/// --------Clang module SwiftShims
+// CHECK-LABEL: "modulePath": "{{.*}}/SwiftShims-{{.*}}.pcm",
+

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -77,6 +77,13 @@ import SomeExternalModule
 // CHECK-NEXT:    "-Xcc",
 // CHECK:         "-fapinotes-swift-version=4"
 
+/// --------Swift external module SomeExternalModule
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SomeExternalModule.swiftmodule",
+// CHECK-NEXT: "details": {
+// CHECK-NEXT: "swiftPlaceholder": {
+// CHECK-NEXT: "moduleDocPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftdoc",
+// CHECK-NEXT: "moduleSourceInfoPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftsourceinfo"
+
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
 
@@ -93,9 +100,3 @@ import SomeExternalModule
 // CHECK-MAKE-DEPS-SAME: BridgingOther.h
 // CHECK-MAKE-DEPS-SAME: module.modulemap
 
-/// --------Swift external module SomeExternalModule
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SomeExternalModule.swiftmodule",
-// CHECK-NEXT: "details": {
-// CHECK-NEXT: "swiftPlaceholder": {
-// CHECK-NEXT: "moduleDocPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftdoc",
-// CHECK-NEXT: "moduleSourceInfoPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftsourceinfo"

--- a/test/ScanDependencies/module_framework.swift
+++ b/test/ScanDependencies/module_framework.swift
@@ -13,21 +13,11 @@ import CryptoKit
 
 // CHECK: "mainModuleName": "deps"
 // CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "CryptoKit"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "Swift"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "_Concurrency"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "_StringProcessing"
-// CHECK-NEXT: }
-// CHECK-NEXT: ],
+// CHECK-DAG: "swift": "CryptoKit"
+// CHECK-DAG: "swift": "Swift"
+// CHECK-DAG: "swift": "SwiftOnoneSupport"
+// CHECK-DAG: "swift": "_Concurrency"
+// CHECK-DAG: "swift": "_StringProcessing"
+// CHECK: ],
 
 // CHECK: "isFramework": true

--- a/test/ScanDependencies/prescan_deps.swift
+++ b/test/ScanDependencies/prescan_deps.swift
@@ -14,13 +14,13 @@ import G
 import SubE
 
 // CHECK: "imports": [
-// CHECK-NEXT:  "C",
-// CHECK-NEXT:  "E",
-// CHECK-NEXT:  "G",
-// CHECK-NEXT:  "SubE",
-// CHECK-NEXT:  "Swift",
-// CHECK-NEXT:  "SwiftOnoneSupport",
-// CHECK-NEXT:  "_Concurrency",
-// CHECK-NEXT:  "_SwiftConcurrencyShims",
-// CHECK-NEXT:  "_StringProcessing"
-// CHECK-NEXT: ]
+// CHECK-DAG:  "C"
+// CHECK-DAG:  "E"
+// CHECK-DAG:  "G"
+// CHECK-DAG:  "SubE"
+// CHECK-DAG:  "Swift"
+// CHECK-DAG:  "SwiftOnoneSupport"
+// CHECK-DAG:  "_Concurrency"
+// CHECK-DAG:  "_SwiftConcurrencyShims"
+// CHECK-DAG:  "_StringProcessing"
+// CHECK: ]


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68677
-----------------------------------
• Release: Swift 5.10
• Explanation: In case import resolution order somehow sometimes matters, it's prudent to process/resolve/locate implicitly-imported modules first.
• Scope of Issue: Some projects which rely on import order-dependent behavior for Clang module resolution may be affected and see different behavior with explicit module builds.
• Risk: Minimal, this changes explicit module dependency scanning code-path **only** to match the behavior currently exercise by implicit module builds 
• Origination: Explicit Module Build feature development. Scanner's default order of module resolution unintentionally differed from implicit module flow.


Resolves rdar://113917657
