### PR TITLE
[embedded] Require no_asan in the LTO test

### DIFF
--- a/test/embedded/lto.swift
+++ b/test/embedded/lto.swift
@@ -7,6 +7,11 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
+// For LTO, the linker dlopen()'s the libLTO library, which is a scenario that
+// ASan cannot work in ("Interceptors are not working, AddressSanitizer is
+// loaded too late").
+// REQUIRES: no_asan
+
 @_silgen_name("putchar")
 func putchar(_: UInt8)
 


### PR DESCRIPTION
'