### PR TITLE
[CompilerCaching] Path Remapping for canonicalization

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -485,6 +485,7 @@ REMARK(matching_output_produced,none,
 // Caching related diagnostics
 ERROR(error_caching_no_cas_fs, none,
     "caching is enabled without -cas-fs option, input is not immutable", ())
+ERROR(error_prefix_mapping, none, "cannot create scanner prefix mapping: '%0'", (StringRef))
 
 REMARK(replay_output, none, "replay output file '%0': key '%1'", (StringRef, StringRef))
 REMARK(output_cache_miss, none, "cache miss output file '%0': key '%1'", (StringRef, StringRef))

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -34,6 +34,7 @@
 
 namespace llvm {
 class FileCollectorBase;
+class TreePathPrefixMapper;
 namespace vfs {
 class OutputBackend;
 }
@@ -345,6 +346,7 @@ public:
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                         InterfaceSubContextDelegate &delegate,
+                        llvm::TreePathPrefixMapper *mapper = nullptr,
                         bool isTestableImport = false) = 0;
 };
 

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -461,6 +461,9 @@ public:
   /// Don't look in for compiler-provided modules.
   bool SkipRuntimeLibraryImportPaths = false;
 
+  /// Scanner Prefix Mapper.
+  std::vector<std::string> ScannerPrefixMapper;
+
   /// When set, don't validate module system dependencies.
   ///
   /// If a system header is modified and this is not set, the compiler will

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -434,9 +434,10 @@ public:
 
   void verifyAllModules() override;
 
+  using RemapPathCallback = llvm::function_ref<std::string(StringRef)>;
   llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1> bridgeClangModuleDependencies(
       const clang::tooling::dependencies::ModuleDepsGraph &clangDependencies,
-      StringRef moduleOutputPath);
+      StringRef moduleOutputPath, RemapPathCallback remapPath = nullptr);
 
   llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
   getModuleDependencies(StringRef moduleName, StringRef moduleOutputPath,
@@ -444,6 +445,7 @@ public:
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                         InterfaceSubContextDelegate &delegate,
+                        llvm::TreePathPrefixMapper *mapper,
                         bool isTestableImport = false) override;
 
   void recordBridgingHeaderOptions(

--- a/include/swift/Frontend/CachingUtils.h
+++ b/include/swift/Frontend/CachingUtils.h
@@ -20,6 +20,7 @@
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CASReference.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/VirtualOutputBackend.h"
 #include <memory>
@@ -59,6 +60,10 @@ llvm::Error storeCachedCompilerOutput(llvm::cas::ObjectStore &CAS,
 llvm::Expected<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
 createCASFileSystem(llvm::cas::ObjectStore &CAS, ArrayRef<std::string> FSRoots,
                     ArrayRef<std::string> IncludeTreeRoots);
-}
+
+std::vector<std::string> remapPathsFromCommandLine(
+    ArrayRef<std::string> Args,
+    llvm::function_ref<std::string(StringRef)> RemapCallback);
+} // namespace swift
 
 #endif

--- a/include/swift/Frontend/CompileJobCacheKey.h
+++ b/include/swift/Frontend/CompileJobCacheKey.h
@@ -43,6 +43,6 @@ createCompileJobCacheKeyForOutput(llvm::cas::ObjectStore &CAS,
                                   llvm::cas::ObjectRef BaseKey,
                                   StringRef ProducingInput,
                                   file_types::ID OutputType);
-}
+} // namespace swift
 
 #endif

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -148,6 +148,9 @@ public:
   /// CacheKey for input file.
   std::string InputFileKey;
 
+  /// CacheReplay PrefixMap.
+  std::vector<std::string> CacheReplayPrefixMap;
+
   /// Number of retry opening an input file if the previous opening returns
   /// bad file descriptor error.
   unsigned BadFileDescriptorRetryCount = 0;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -79,13 +79,13 @@ def backup_module_interface_path_EQ :
 
 } // end let Flags = [FrontendOption, NoDriverOption, CacheInvariant]
 
+def primary_file : Separate<["-"], "primary-file">,
+  Flags<[FrontendOption, NoDriverOption, ArgumentIsPath]>,
+  HelpText<"Produce output for this file, not the whole module">;
 
 let Flags = [FrontendOption, NoDriverOption] in {
 
 def triple : Separate<["-"], "triple">, Alias<target>;
-
-def primary_file : Separate<["-"], "primary-file">,
-  HelpText<"Produce output for this file, not the whole module">;
 
 def frontend_parseable_output : Flag<["-"], "frontend-parseable-output">,
   HelpText<"Emit textual output in a parseable format">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1865,6 +1865,10 @@ def scanner_prefix_map_toolchain : Separate<["-"], "scanner-prefix-map-toolchain
   Flags<[NewDriverOnlyOption]>,
   HelpText<"Remap paths within toolchain directory reported by dependency scanner">, MetaVarName<"<path>">;
 
+def cache_replay_prefix_map: Separate<["-"], "cache-replay-prefix-map">,
+  Flags<[FrontendOption, NoDriverOption, CacheInvariant]>,
+  HelpText<"Remap paths when replaying outputs from cache">, MetaVarName<"<prefix=replacement>">;
+
 // END ONLY SUPPORTED IN NEW DRIVER
 
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1853,6 +1853,18 @@ def clang_scanner_module_cache_path : Separate<["-"], "clang-scanner-module-cach
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Specifies the Clang dependency scanner module cache path">;
 
+def scanner_prefix_map : Separate<["-"], "scanner-prefix-map">,
+  Flags<[FrontendOption, NewDriverOnlyOption]>,
+  HelpText<"Remap paths reported by dependency scanner">, MetaVarName<"<prefix=replacement>">;
+
+def scanner_prefix_map_sdk : Separate<["-"], "scanner-prefix-map-sdk">,
+  Flags<[NewDriverOnlyOption]>,
+  HelpText<"Remap paths within SDK reported by dependency scanner">, MetaVarName<"<path>">;
+
+def scanner_prefix_map_toolchain : Separate<["-"], "scanner-prefix-map-toolchain">,
+  Flags<[NewDriverOnlyOption]>,
+  HelpText<"Remap paths within toolchain directory reported by dependency scanner">, MetaVarName<"<path>">;
+
 // END ONLY SUPPORTED IN NEW DRIVER
 
 

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -103,6 +103,7 @@ public:
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                         InterfaceSubContextDelegate &delegate,
+                        llvm::TreePathPrefixMapper *mapper,
                         bool isTestableImport) override;
 };
 }

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -17,6 +17,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleLoader.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/PrefixMapper.h"
 
 namespace swift {
 class ModuleFile;
@@ -247,6 +248,7 @@ public:
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                         InterfaceSubContextDelegate &delegate,
+                        llvm::TreePathPrefixMapper *mapper,
                         bool isTestableImport) override;
 };
 

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -187,14 +187,16 @@ ModuleDependencyScanningWorker::scanFilesystemForModuleDependency(
           moduleName, cache.getModuleOutputPath(),
           cache.getScanService().getCachingFS(),
           cache.getAlreadySeenClangModules(), clangScanningTool,
-          *ScanningASTDelegate, isTestableImport);
+          *ScanningASTDelegate, cache.getScanService().getPrefixMapper(),
+          isTestableImport);
 
   if (moduleDependencies.empty())
     moduleDependencies = clangScannerModuleLoader->getModuleDependencies(
         moduleName, cache.getModuleOutputPath(),
         cache.getScanService().getCachingFS(),
         cache.getAlreadySeenClangModules(), clangScanningTool,
-        *ScanningASTDelegate, isTestableImport);
+        *ScanningASTDelegate, cache.getScanService().getPrefixMapper(),
+        isTestableImport);
 
   return moduleDependencies;
 }
@@ -205,7 +207,8 @@ ModuleDependencyScanningWorker::scanFilesystemForSwiftModuleDependency(
   return swiftScannerModuleLoader->getModuleDependencies(
       moduleName, cache.getModuleOutputPath(),
       cache.getScanService().getCachingFS(), cache.getAlreadySeenClangModules(),
-      clangScanningTool, *ScanningASTDelegate, false);
+      clangScanningTool, *ScanningASTDelegate,
+      cache.getScanService().getPrefixMapper(), false);
 }
 
 ModuleDependencyVector
@@ -214,7 +217,8 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
   return clangScannerModuleLoader->getModuleDependencies(
       moduleName, cache.getModuleOutputPath(),
       cache.getScanService().getCachingFS(), cache.getAlreadySeenClangModules(),
-      clangScanningTool, *ScanningASTDelegate, false);
+      clangScanningTool, *ScanningASTDelegate,
+      cache.getScanService().getPrefixMapper(), false);
 }
 
 template <typename Function, typename... Args>

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -270,6 +270,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.CASFSRootIDs = Args.getAllArgValues(OPT_cas_fs);
   Opts.ClangIncludeTrees = Args.getAllArgValues(OPT_clang_include_tree_root);
   Opts.InputFileKey = Args.getLastArgValue(OPT_input_file_key);
+  Opts.CacheReplayPrefixMap = Args.getAllArgValues(OPT_cache_replay_prefix_map);
 
   if (Opts.EnableCaching && Opts.CASFSRootIDs.empty() &&
       Opts.ClangIncludeTrees.empty() &&

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/SMLoc.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/YAMLTraits.h"
@@ -98,8 +99,9 @@ struct SerializedGeneratedFileInfo {
 };
 
 struct DiagnosticSerializer {
-  DiagnosticSerializer(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS)
-      : SrcMgr(FS) {}
+  DiagnosticSerializer(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS,
+                       llvm::PrefixMapper &Mapper)
+      : SrcMgr(FS), Mapper(Mapper) {}
 
   using ReplayFunc = llvm::function_ref<llvm::Error(const DiagnosticInfo &)>;
 
@@ -111,10 +113,11 @@ struct DiagnosticSerializer {
   static llvm::Error
   emitDiagnosticsFromCached(llvm::StringRef Buffer, SourceManager &SrcMgr,
                             DiagnosticEngine &Diags,
+                            llvm::PrefixMapper &Mapper,
                             const FrontendInputsAndOutputs &InAndOut) {
     // Create a new DiagnosticSerializer since this cannot be shared with a
     // serialization instance.
-    DiagnosticSerializer DS(SrcMgr.getFileSystem());
+    DiagnosticSerializer DS(SrcMgr.getFileSystem(), Mapper);
     DS.addInputsToSourceMgr(InAndOut);
     return DS.doEmitFromCached(Buffer, Diags);
   }
@@ -128,7 +131,7 @@ struct DiagnosticSerializer {
     // has references to input files to find subconsumer.
     auto addInputToSourceMgr = [&](const InputFile &Input) {
       if (Input.getFileName() != "-")
-        SrcMgr.getExternalSourceBufferID(Input.getFileName());
+        SrcMgr.getExternalSourceBufferID(remapFilePath(Input.getFileName()));
       return false;
     };
     InAndOut.forEachInputProducingSupplementaryOutput(addInputToSourceMgr);
@@ -163,6 +166,9 @@ private:
   unsigned deserializeFile(const SerializedFile &File);
   llvm::Error deserializeVirtualFile(const SerializedVirtualFile &VF);
   llvm::Error deserializeGeneratedFileInfo(const SerializedGeneratedFileInfo &Info);
+  std::string remapFilePath(StringRef Path) {
+    return Mapper.mapToString(Path);
+  }
 
 public:
   std::vector<SerializedDiagnosticInfo> DiagInfos;
@@ -176,6 +182,7 @@ private:
 
   // Serializing SourceManager.
   SourceManager SrcMgr;
+  llvm::PrefixMapper &Mapper;
 
   // Mapping of the FileID between SourceManager from CompilerInstance vs.
   // the serialized FileID in cached diagnostics. Lookup tables are
@@ -482,10 +489,19 @@ DiagnosticSerializer::deserializeFixIt(const SerializedFixIt &FI) {
 
 unsigned DiagnosticSerializer::deserializeFile(const SerializedFile &File) {
   assert(File.IncludeLoc.FileID == 0 && "IncludeLoc not supported yet");
-  return File.Content.empty()
-             ? SrcMgr.getExternalSourceBufferID(File.FileName)
-             : SrcMgr.addNewSourceBuffer(llvm::MemoryBuffer::getMemBufferCopy(
-                   File.Content, File.FileName));
+  auto FileName = remapFilePath(File.FileName);
+  if (File.Content.empty() && FileName == File.FileName)
+    return SrcMgr.getExternalSourceBufferID(FileName);
+
+  std::unique_ptr<llvm::MemoryBuffer> Content;
+  if (!File.Content.empty())
+    Content = llvm::MemoryBuffer::getMemBufferCopy(File.Content, FileName);
+  else if (auto InputFileOrErr = swift::vfs::getFileOrSTDIN(
+               *SrcMgr.getFileSystem(), File.FileName))
+    Content = llvm::MemoryBuffer::getMemBufferCopy(
+        (*InputFileOrErr)->getBuffer(), FileName);
+
+  return Content ? SrcMgr.addNewSourceBuffer(std::move(Content)) : 0u;
 }
 
 llvm::Error
@@ -495,8 +511,8 @@ DiagnosticSerializer::deserializeVirtualFile(const SerializedVirtualFile &VF) {
     return Range.takeError();
   unsigned Length = (const char *)Range->getEnd().getOpaquePointerValue() -
                     (const char *)Range->getStart().getOpaquePointerValue();
-  SrcMgr.createVirtualFile(Range->getStart(), VF.FileName, VF.LineOffset,
-                           Length);
+  auto FileName = remapFilePath(VF.FileName);
+  SrcMgr.createVirtualFile(Range->getStart(), FileName, VF.LineOffset, Length);
   return llvm::Error::success();
 }
 
@@ -625,7 +641,14 @@ public:
       : InstanceSourceMgr(Instance.getSourceMgr()),
         InAndOut(
             Instance.getInvocation().getFrontendOptions().InputsAndOutputs),
-        Diags(Instance.getDiags()) {}
+        Diags(Instance.getDiags()) {
+    SmallVector<llvm::MappedPrefix, 4> Prefixes;
+    llvm::MappedPrefix::transformJoinedIfValid(
+        Instance.getInvocation().getFrontendOptions().CacheReplayPrefixMap,
+        Prefixes);
+    Mapper.addRange(Prefixes);
+    Mapper.sort();
+  }
   ~Implementation() {}
 
   void startDiagnosticCapture() {
@@ -648,7 +671,7 @@ public:
 
   llvm::Error replayCachedDiagnostics(llvm::StringRef Buffer) {
     return DiagnosticSerializer::emitDiagnosticsFromCached(
-        Buffer, getDiagnosticSourceMgr(), Diags, InAndOut);
+        Buffer, getDiagnosticSourceMgr(), Diags, Mapper, InAndOut);
   }
 
   void handleDiagnostic(SourceManager &SM,
@@ -698,7 +721,7 @@ private:
     // file system changes on later diagnostics.
     if (!Serializer) {
       Serializer.reset(
-          new DiagnosticSerializer(InstanceSourceMgr.getFileSystem()));
+          new DiagnosticSerializer(InstanceSourceMgr.getFileSystem(), Mapper));
       Serializer->addInputsToSourceMgr(InAndOut);
     }
 
@@ -717,6 +740,7 @@ private:
   SourceManager &InstanceSourceMgr;
   const FrontendInputsAndOutputs &InAndOut;
   DiagnosticEngine &Diags;
+  llvm::PrefixMapper Mapper;
 
   llvm::unique_function<bool(StringRef)> serializedOutputCallback;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1809,6 +1809,9 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
     auto SplitMap = StringRef(A).split('=');
     Opts.DeserializedPathRecoverer.addMapping(SplitMap.first, SplitMap.second);
   }
+  for (StringRef Opt : Args.getAllArgValues(OPT_scanner_prefix_map)) {
+    Opts.ScannerPrefixMapper.push_back(Opt.str());
+  }
   // Opts.RuntimeIncludePath is set by calls to
   // setRuntimeIncludePath() or setMainExecutablePath().
   // Opts.RuntimeImportPath is set by calls to

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include <system_error>
 
@@ -160,6 +161,7 @@ SourceLoader::getModuleDependencies(StringRef moduleName,
                                     const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                                     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
                                     InterfaceSubContextDelegate &delegate,
+                                    llvm::TreePathPrefixMapper* mapper,
                                     bool isTestableImport) {
   // FIXME: Implement?
   return {};

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <algorithm>
@@ -303,13 +304,14 @@ ModuleDependencyVector SerializedModuleLoaderBase::getModuleDependencies(
     const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
         &alreadySeenClangModules,
     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
-    InterfaceSubContextDelegate &delegate, bool isTestableDependencyLookup) {
+    InterfaceSubContextDelegate &delegate, llvm::TreePathPrefixMapper *mapper,
+    bool isTestableDependencyLookup) {
   ImportPath::Module::Builder builder(Ctx, moduleName, /*separator=*/'.');
   auto modulePath = builder.get();
   auto moduleId = modulePath.front().Item;
   llvm::Optional<SwiftDependencyTracker> tracker = llvm::None;
   if (CacheFS)
-    tracker = SwiftDependencyTracker(*CacheFS);
+    tracker = SwiftDependencyTracker(*CacheFS, mapper);
 
   // Instantiate dependency scanning "loaders".
   SmallVector<std::unique_ptr<SwiftModuleScanner>, 2> scanners;
@@ -345,4 +347,3 @@ ModuleDependencyVector SerializedModuleLoaderBase::getModuleDependencies(
 
   return {};
 }
-

--- a/test/CAS/cached_diagnostics.swift
+++ b/test/CAS/cached_diagnostics.swift
@@ -19,3 +19,10 @@
 
 // Verify the serialized diags have the right magic at the top.
 // CHECK-SERIALIZED: DIA
+
+/// Check path remapping.
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing %s \
+// RUN:   -import-objc-header %S/Inputs/objc.h -emit-module -emit-module-path %t/test.swiftmodule -cache-replay-prefix-map %S=/^test  2>&1 | %FileCheck %s --check-prefix REMAP
+
+// REMAP: /^test/Inputs/objc.h:3:2: warning: warning in bridging header
+// REMAP: /^test/cached_diagnostics.swift:10:10: warning: this is a warning

--- a/test/CAS/module_path_remap.swift
+++ b/test/CAS/module_path_remap.swift
@@ -1,0 +1,34 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/cas
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json \
+// RUN:  -I %S/../ScanDependencies/Inputs/CHeaders -I %S/../ScanDependencies/Inputs/Swift -emit-dependencies \
+// RUN:  -import-objc-header %S/../ScanDependencies/Inputs/CHeaders/Bridging.h -swift-version 4 -cache-compile-job \
+// RUN:  -cas-path %t/cas -clang-include-tree -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps casFSRootID > %t/deps.fs.casid
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/deps.fs.casid | %FileCheck %s -check-prefix DEPS-FS
+// DEPS-FS: /^src/test/CAS/module_path_remap.swift
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps bridgingHeader | %FileCheck %s -check-prefix DEPS-BRIDGING
+// DEPS-BRIDGING: -fmodule-file=F=/^tmp/clang-module-cache/F-{{.*}}.pcm
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json F casFSRootID > %t/F.fs.casid
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/F.fs.casid | %FileCheck %s -check-prefix F-FS
+// F-FS: /^src/test/ScanDependencies/Inputs/Swift/F.swiftinterface
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json F commandLine | %FileCheck %s -check-prefix F-CMD
+// F-CMD: /^src/test/ScanDependencies/Inputs/Swift/F.swiftinterface
+// F-CMD: -fmodule-file=SwiftShims=/^tmp/clang-module-cache/SwiftShims-{{.*}}.pcm
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F clangIncludeTree > %t/tree.casid
+// RUN: clang-cas-test --cas %t/cas --print-include-tree @%t/tree.casid | %FileCheck %s -check-prefix TREE
+// TREE: /^src/test/CAS/../ScanDependencies/Inputs/CHeaders/F.h
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:F commandLine | %FileCheck %s -check-prefix CLANG-CMD
+// CLANG-CMD: /^src/test/ScanDependencies/Inputs/CHeaders/module.modulemap
+
+


### PR DESCRIPTION
Teach dependency scanner to canonicalize the path for better cache hit and also teach swift-frontend to restore the path to the actual on disk path after canonicalization.