### PR TITLE
[Linux] Use clang to build Tablegen

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -895,6 +895,10 @@ install-foundation
 install-libdispatch
 reconfigure
 
+# gcc version on amazon linux 2 is too old to configure and build tablegen.
+# Use the clang that we install in the path for macros
+llvm-cmake-options=-DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
+
 [preset: buildbot_linux]
 mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts


### PR DESCRIPTION
Build-script tries to always cross-compile. As a result, the native tablegen build tries to use /usr/bin/cc and /usr/bin/c++, which on Amazon Linux 2 is too old to build tablegen. Instead, we can use the clang/clang++ installed on the builders at /opt/swift/5.8.1/usr/bin, which is inserted first in the path on the build image.

This route is sort of the least of all evils. We're already forcing the rest of the build to use that clang, and it is capable of building for the build machine, so might as well use it to build tablegen that then emits pieces for the host build.