### PR TITLE
[embedded] Make CMO's 'serialize everything' mode even more aggressive and allow serialization of private and shared functions

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -69,7 +69,8 @@ enum class DestroyHoistingOption : uint8_t {
 enum class CrossModuleOptimizationMode : uint8_t {
   Off = 0,
   Default = 1,
-  Aggressive = 2
+  Aggressive = 2,
+  Everything = 3,
 };
 
 class SILModule;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3117,6 +3117,7 @@ bool CompilerInvocation::parseArgs(
   if (LangOpts.hasFeature(Feature::Embedded)) {
     IRGenOpts.InternalizeAtLink = true;
     IRGenOpts.DisableLegacyTypeInfo = true;
+    SILOpts.CMOMode = CrossModuleOptimizationMode::Everything;
   }
 
   return false;

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -60,11 +60,15 @@ class CrossModuleOptimization {
   /// avoid code size increase.
   bool conservative;
 
+  /// True if CMO should serialize literally everything in the module,
+  /// regardless of linkage.
+  bool everything;
+
   typedef llvm::DenseMap<SILFunction *, bool> FunctionFlags;
 
 public:
-  CrossModuleOptimization(SILModule &M, bool conservative)
-    : M(M), conservative(conservative) { }
+  CrossModuleOptimization(SILModule &M, bool conservative, bool everything)
+    : M(M), conservative(conservative), everything(everything) { }
 
   void serializeFunctionsInModule();
 
@@ -164,9 +168,10 @@ void CrossModuleOptimization::serializeFunctionsInModule() {
 
   // Start with public functions.
   for (SILFunction &F : M) {
-    if (F.getLinkage() == SILLinkage::Public) {
-      if (canSerializeFunction(&F, canSerializeFlags, /*maxDepth*/ 64))
+    if (F.getLinkage() == SILLinkage::Public || everything) {
+      if (canSerializeFunction(&F, canSerializeFlags, /*maxDepth*/ 64)) {
         serializeFunction(&F, canSerializeFlags);
+      }
     }
   }
 }
@@ -188,6 +193,11 @@ bool CrossModuleOptimization::canSerializeFunction(
   // Temporarily set the flag to false (to avoid infinite recursion) until we set
   // it to true at the end of this function.
   canSerializeFlags[function] = false;
+
+  if (everything) {
+   canSerializeFlags[function] = true;
+   return true;
+  }
 
   if (DeclContext *funcCtxt = function->getDeclContext()) {
     if (!canUseFromInline(funcCtxt))
@@ -392,6 +402,9 @@ static bool couldBeLinkedStatically(DeclContext *funcCtxt, SILModule &module) {
 
 /// Returns true if the \p declCtxt can be used from a serialized function.
 bool CrossModuleOptimization::canUseFromInline(DeclContext *declCtxt) {
+  if (everything)
+    return true;
+
   if (!M.getSwiftModule()->canBeUsedForCrossModuleOptimization(declCtxt))
     return false;
 
@@ -410,6 +423,9 @@ bool CrossModuleOptimization::canUseFromInline(DeclContext *declCtxt) {
 
 /// Returns true if the function \p func can be used from a serialized function.
 bool CrossModuleOptimization::canUseFromInline(SILFunction *function) {
+  if (everything)
+    return true;
+
   if (DeclContext *funcCtxt = function->getDeclContext()) {
     if (!canUseFromInline(funcCtxt))
       return false;
@@ -439,13 +455,11 @@ bool CrossModuleOptimization::shouldSerialize(SILFunction *function) {
   if (function->isSerialized())
     return false;
 
+  if (everything)
+    return true;
+
   if (function->hasSemanticsAttr("optimize.no.crossmodule"))
     return false;
-
-  // In embedded Swift we serialize everything.
-  if (SerializeEverything ||
-      function->getASTContext().LangOpts.hasFeature(Feature::Embedded))
-    return true;
 
   if (!conservative) {
     // The basic heuristic: serialize all generic functions, because it makes a
@@ -652,23 +666,29 @@ class CrossModuleOptimizationPass: public SILModuleTransform {
       return;
     if (!M.isWholeModule())
       return;
-      
+
     bool conservative = false;
-    // In embedded Swift we serialize everything.
-    if (!M.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
-      switch (M.getOptions().CMOMode) {
-        case swift::CrossModuleOptimizationMode::Off:
-          return;
-        case swift::CrossModuleOptimizationMode::Default:
-          conservative = true;
-          break;
-        case swift::CrossModuleOptimizationMode::Aggressive:
-          conservative = false;
-          break;
-      }
+    bool everything = SerializeEverything;
+    switch (M.getOptions().CMOMode) {
+      case swift::CrossModuleOptimizationMode::Off:
+        break;
+      case swift::CrossModuleOptimizationMode::Default:
+        conservative = true;
+        break;
+      case swift::CrossModuleOptimizationMode::Aggressive:
+        conservative = false;
+        break;
+      case swift::CrossModuleOptimizationMode::Everything:
+        everything = true;
+        break;
     }
 
-    CrossModuleOptimization CMO(M, conservative);
+    if (!everything &&
+        M.getOptions().CMOMode == swift::CrossModuleOptimizationMode::Off) {
+      return;
+    }
+
+    CrossModuleOptimization CMO(M, conservative, everything);
     CMO.serializeFunctionsInModule();
   }
 };

--- a/test/embedded/globals.swift
+++ b/test/embedded/globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -target armv7-apple-none-macho -parse-stdlib -module-name Swift %s -enable-experimental-feature Embedded -wmo -parse-as-library | %FileCheck %s
+// RUN: %target-swift-emit-ir -target armv7-apple-none-macho -parse-stdlib -module-name Swift %s -enable-experimental-feature Embedded -wmo -parse-as-library | %FileCheck %s --check-prefix CHECK --check-prefix CHECK-NONOPT
 // RUN: %target-swift-emit-ir -target armv7-apple-none-macho -parse-stdlib -module-name Swift %s -enable-experimental-feature Embedded -wmo -parse-as-library -O | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
@@ -98,19 +98,19 @@ extension MyPublicEnum {
   public static var static_mypublicstruct_4: MyPublicStruct = MyPublicStruct(x: 0, y: 0)
 }
 
-// CHECK-NOT: global_int_1
-// CHECK: @"$ss12global_int_2Sivp" = {{.*}}zeroinitializer
-// CHECK-NOT: global_int_3
-// CHECK: @"$ss12global_int_4Sivp" = {{.*}}zeroinitializer
-// CHECK-NOT: static_int_1
-// CHECK: @"$ss12MyPublicEnumO12static_int_2SivpZ" = {{.*}}zeroinitializer
-// CHECK-NOT: static_int_3
-// CHECK: @"$ss12MyPublicEnumO12static_int_4SivpZ" = {{.*}}zeroinitializer
-// CHECK-NOT: global_my_publicstruct_1
-// CHECK: @"$ss24global_my_publicstruct_2s14MyPublicStructVvp" = {{.*}}zeroinitializer
-// CHECK-NOT: global_my_publicstruct_3
-// CHECK: @"$ss24global_my_publicstruct_4s14MyPublicStructVvp" = {{.*}}zeroinitializer
-// CHECK-NOT: stati_my_publicstruct_1
-// CHECK: @"$ss12MyPublicEnumO23static_mypublicstruct_2s0aB6StructVvpZ" = {{.*}}zeroinitializer
-// CHECK-NOT: stati_my_publicstruct_3
-// CHECK: @"$ss12MyPublicEnumO23static_mypublicstruct_4s0aB6StructVvpZ" = {{.*}}zeroinitializer
+// CHECK-NONOPT: @"$ss12global_int_133_056BEF60D619AD2945081A9CBFC2AAE9LLSivp" = {{.*}}zeroinitializer
+// CHECK:        @"$ss12global_int_2Sivp" = {{.*}}zeroinitializer
+// CHECK-NONOPT: @"$ss12global_int_333_056BEF60D619AD2945081A9CBFC2AAE9LLSivp" = {{.*}}zeroinitializer
+// CHECK:        @"$ss12global_int_4Sivp" = {{.*}}zeroinitializer
+// CHECK-NONOPT: @"$ss12MyPublicEnumO12static_int_133_056BEF60D619AD2945081A9CBFC2AAE9LLSivpZ" = {{.*}}zeroinitializer
+// CHECK:        @"$ss12MyPublicEnumO12static_int_2SivpZ" = {{.*}}zeroinitializer
+// CHECK-NONOPT: @"$ss12MyPublicEnumO12static_int_333_056BEF60D619AD2945081A9CBFC2AAE9LLSivpZ" = {{.*}}zeroinitializer
+// CHECK:        @"$ss12MyPublicEnumO12static_int_4SivpZ" = {{.*}}zeroinitializer
+// CHECK-NONOPT: @"$ss24global_my_publicstruct_133_056BEF60D619AD2945081A9CBFC2AAE9LLs14MyPublicStructVvp" = {{.*}}zeroinitializer
+// CHECK:        @"$ss24global_my_publicstruct_2s14MyPublicStructVvp" = {{.*}}zeroinitializer
+// CHECK-NONOPT: @"$ss24global_my_publicstruct_333_056BEF60D619AD2945081A9CBFC2AAE9LLs14MyPublicStructVvp" = {{.*}}zeroinitializer
+// CHECK:        @"$ss24global_my_publicstruct_4s14MyPublicStructVvp" = {{.*}}zeroinitializer
+// CHECK-NOT:    static_my_publicstruct_1
+// CHECK:        @"$ss12MyPublicEnumO23static_mypublicstruct_2s0aB6StructVvpZ" = {{.*}}zeroinitializer
+// CHECK-NOT:    static_my_publicstruct_3
+// CHECK:        @"$ss12MyPublicEnumO23static_mypublicstruct_4s0aB6StructVvpZ" = {{.*}}zeroinitializer

--- a/test/embedded/modules-print-exec.swift
+++ b/test/embedded/modules-print-exec.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/tiny-runtime-dummy-refcounting.c -o %t/runtime.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o %t/runtime.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// BEGIN MyModule.swift
+
+@_silgen_name("putchar")
+func putchar(_: UInt8)
+
+public func print(_ s: StaticString, terminator: StaticString) {
+  var p = s.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+  p = terminator.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+}
+
+@_silgen_name("print_long")
+func print_long(_: Int)
+
+public func print(_ n: Int, terminator: StaticString) {
+    print_long(n)
+    print("", terminator: terminator)
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+func test() {
+  print("Hello world", terminator: "\n") // CHECK: Hello world
+  print(42, terminator: "\n") // CHECK-NEXT: 42
+}
+
+test()


### PR DESCRIPTION
This implements a (more) complete "alwaysEmitIntoClient" model on the module serialization side for embedded Swift as mentioned in <https://github.com/apple/swift-evolution/blob/488e96672f2f54bbe0716dfe63cc5df753c3436f/visions/embedded-swift.md>. Currently, CMO's serialization is still excluding several kinds of functions from being serialized (even in the "full" serialization mode), and that is problematic for embedded Swift. One concrete case is shown in an added testcase, where a specialization of a function from the stdlib is not serialized and ends up missing on the library client side and causes a link failure. The PR adds a real "serialize everything" mode to CMO and turns that on for embedded Swift.