### PR TITLE
[Concurrency] Diagnose Sendable violations in captures of local functions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5236,8 +5236,9 @@ ERROR(concurrent_access_of_inout_param,none,
       "concurrently-executing code",
       (DeclName))
 ERROR(non_sendable_capture,none,
-      "capture of %1 with non-sendable type %0 in a `@Sendable` closure",
-      (Type, DeclName))
+      "capture of %1 with non-sendable type %0 in a `@Sendable` "
+      "%select{local function|closure}2",
+      (Type, DeclName, bool))
 ERROR(implicit_async_let_non_sendable_capture,none,
       "capture of %1 with non-sendable type %0 in 'async let' binding",
       (Type, DeclName))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2118,9 +2118,9 @@ namespace {
     }
 
     /// Check closure captures for Sendable violations.
-    void checkClosureCaptures(AbstractClosureExpr *closure) {
+    void checkLocalCaptures(AnyFunctionRef localFunc) {
       SmallVector<CapturedValue, 2> captures;
-      closure->getCaptureInfo().getLocalCaptures(captures);
+      localFunc.getCaptureInfo().getLocalCaptures(captures);
       for (const auto &capture : captures) {
         if (capture.isDynamicSelfMetadata())
           continue;
@@ -2130,14 +2130,19 @@ namespace {
         // If the closure won't execute concurrently with the context in
         // which the declaration occurred, it's okay.
         auto decl = capture.getDecl();
-        if (!mayExecuteConcurrentlyWith(closure, decl->getDeclContext()))
+        auto *context = localFunc.getAsDeclContext();
+        if (!mayExecuteConcurrentlyWith(context, decl->getDeclContext()))
           continue;
 
         Type type = getDeclContext()
             ->mapTypeIntoContext(decl->getInterfaceType())
             ->getReferenceStorageReferent();
 
-        if (closure->isImplicit()) {
+        if (type->hasError())
+          continue;
+
+        auto *closure = localFunc.getAbstractClosureExpr();
+        if (closure && closure->isImplicit()) {
           auto *patternBindingDecl = getTopPatternBindingDecl();
           if (patternBindingDecl && patternBindingDecl->isAsyncLet()) {
             diagnoseNonSendableTypes(
@@ -2152,7 +2157,8 @@ namespace {
           }
         } else {
           diagnoseNonSendableTypes(type, getDeclContext(), capture.getLoc(),
-                                   diag::non_sendable_capture, decl->getName());
+                                   diag::non_sendable_capture, decl->getName(),
+                                   /*closure=*/closure != nullptr);
         }
       }
     }
@@ -2220,6 +2226,10 @@ namespace {
 
     PreWalkAction walkToDeclPre(Decl *decl) override {
       if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+        if (func->isLocalContext()) {
+          checkLocalCaptures(func);
+        }
+
         contextStack.push_back(func);
       }
 
@@ -2254,7 +2264,7 @@ namespace {
 
       if (auto *closure = dyn_cast<AbstractClosureExpr>(expr)) {
         closure->setActorIsolation(determineClosureIsolation(closure));
-        checkClosureCaptures(closure);
+        checkLocalCaptures(closure);
         contextStack.push_back(closure);
         return Action::Continue(expr);
       }

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -299,7 +299,7 @@ func blender(_ peeler : () -> Void) {
   await (((wisk)))((wisk)((wisk)(1)))
 
   blender((peelBanana))
-  // expected-warning@-1 2{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
+  // expected-warning@-1 {{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
 
   await wisk(peelBanana)
   // expected-complete-warning@-1{{passing argument of non-sendable type '() -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
@@ -314,7 +314,12 @@ func blender(_ peeler : () -> Void) {
 
   await {wisk}()(1)
 
+  // FIXME: Poor diagnostic. The issue is that the invalid function conversion
+  // to remove '@BananaActor' on 'wisk' cannot influence which solution is chosen.
+  // So, the constraint system cannot determine whether the type of this expression
+  // is '(Any) -> Void' or '@BananaActor (Any) -> Void'.
   await (true ? wisk : {n in return})(1)
+  // expected-error@-1 {{type of expression is ambiguous without a type annotation}}
 }
 
 actor Chain {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -472,7 +472,7 @@ func testGlobalActorClosures() {
     return 17
   }
 
-  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning 2{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
+  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning {{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -100,7 +100,7 @@ func testCalls(x: X) {
   // expected-complete-sns-error @-1 {{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
 
   // Ok with minimal/targeted concurrency, Not ok with complete.
-  let _: () -> Void = onMainActorAlways // expected-complete-sns-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
+  let _: () -> Void = onMainActorAlways // expected-complete-sns-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
   // both okay with minimal/targeted... an error with complete.
   let c = MyModelClass() // expected-complete-sns-error {{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
@@ -111,7 +111,7 @@ func testCallsWithAsync() async {
   onMainActorAlways() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
 
-  let _: () -> Void = onMainActorAlways // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
+  let _: () -> Void = onMainActorAlways // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
   let c = MyModelClass() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -250,6 +250,7 @@ final class NonSendable {
   // expected-note @-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   // SendNonSendable emits 3 fewer errors here.
   // expected-targeted-and-complete-note @-3 5 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  // expected-complete-and-sns-note @-4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   var value = ""
 
   @MainActor
@@ -304,4 +305,14 @@ func callNonisolatedAsyncClosure(
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
+}
+
+@available(SwiftStdlib 5.1, *)
+func testLocalCaptures() {
+  let ns = NonSendable()
+
+  @Sendable func a2() -> NonSendable {
+    return ns
+    // expected-complete-and-sns-warning@-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
+  }
 }

--- a/validation-test/Sema/SwiftUI/rdar94462333.swift
+++ b/validation-test/Sema/SwiftUI/rdar94462333.swift
@@ -10,9 +10,6 @@ import SwiftUI
 struct ContentView: View {
   var body: some View {
     VStack {
-      // In the future this warning should go away too, but it remains since the isolation of the closure
-      // passed to the VStack is not inferred yet during constraint solving.
-      // expected-warning@+1 {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
       Button(action: someMainActorFn) {
         Text("Sign In")
       }


### PR DESCRIPTION
Previously, the actor isolation checker only checked local captures of closures. This change correctly diagnoses the following code:

```swift
class NonSendable {}

func testLocalCaptures() {
  let ns = NonSendable()

  @Sendable func a2() -> NonSendable {
    return ns // error:  capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function
  }
}
```

(Note that this PR currently contains the change for https://github.com/apple/swift/pull/68685)

Resolves rdar://113293502