### PR TITLE
[embedded] Disable autolinking in embedded Swift

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1459,6 +1459,9 @@ void IRGenModule::addLinkLibrary(const LinkLibrary &linkLib) {
   // emit it into the IR of debugger expressions.
   if (Context.LangOpts.DebuggerSupport)
     return;
+
+  if (Context.LangOpts.hasFeature(Feature::Embedded))
+    return;
   
   switch (linkLib.getKind()) {
   case LibraryKind::Library: {

--- a/test/embedded/no-autolink.swift
+++ b/test/embedded/no-autolink.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public func staticstring() -> StaticString {
+  return "hello"
+}
+
+// CHECK: !llvm.linker.options = !{}
+// CHECK-NOT: -lswiftCore


### PR DESCRIPTION
In embedded Swift, we propose a different library distribution model (compared to traditional linkage of .a / .dylib files), as mentioned in the Embedded Swift Vision Document, the idea is to force "alwaysEmitIntoClient" (conceptually equivalent to "header-only" libraries in the C/C++ world) of all library content, therefore clients of libraries should not need to link the libraries. This means auto-linking is unnecessary at best, and sometimes even harmful (on Darwin it can create an undesired linkage against the system's Swift libraries causing a dependency that might not be appropriate). This PR disables auto-linking in embedded Swift mode.