### PR TITLE
tests: require an optimized stdlib for the embedded/array-to-pointer test

### DIFF
--- a/test/embedded/array-to-pointer.swift
+++ b/test/embedded/array-to-pointer.swift
@@ -6,6 +6,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
Fixes a CI failure: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators/3192
