### PR TITLE
IRGen: fix -disable-llvm-optzns

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -369,8 +369,6 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
     MPM.addPass(InlineTreePrinterPass());
 
   // Add bitcode/ll output passes to pass manager.
-  ModulePassManager EmptyPassManager;
-  auto &PassManagerToRun = Opts.DisableLLVMOptzns ? EmptyPassManager : MPM;
 
   switch (Opts.OutputKind) {
   case IRGenOutputKind::LLVMAssemblyBeforeOptimization:
@@ -380,7 +378,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
   case IRGenOutputKind::Module:
     break;
   case IRGenOutputKind::LLVMAssemblyAfterOptimization:
-    PassManagerToRun.addPass(PrintModulePass(*out, "", false));
+    MPM.addPass(PrintModulePass(*out, "", false));
     break;
   case IRGenOutputKind::LLVMBitcode: {
     // Emit a module summary by default for Regular LTO except ld64-based ones
@@ -389,7 +387,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
         TargetMachine->getTargetTriple().getVendor() != llvm::Triple::Apple;
 
     if (Opts.LLVMLTOKind == IRGenLLVMLTOKind::Thin) {
-      PassManagerToRun.addPass(ThinLTOBitcodeWriterPass(*out, nullptr));
+      MPM.addPass(ThinLTOBitcodeWriterPass(*out, nullptr));
     } else {
       if (EmitRegularLTOSummary) {
         Module->addModuleFlag(llvm::Module::Error, "ThinLTO", uint32_t(0));
@@ -399,14 +397,14 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
         Module->addModuleFlag(llvm::Module::Error, "EnableSplitLTOUnit",
                               uint32_t(1));
       }
-      PassManagerToRun.addPass(BitcodeWriterPass(
+      MPM.addPass(BitcodeWriterPass(
           *out, /*ShouldPreserveUseListOrder*/ false, EmitRegularLTOSummary));
     }
     break;
   }
   }
 
-  PassManagerToRun.run(*Module, MAM);
+  MPM.run(*Module, MAM);
 
   if (AlignModuleToPageSize) {
     align(Module);

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -g -enable-objc-interop  -primary-file %s -emit-ir -sil-verify-all -disable-llvm-optzns -disable-swift-specific-llvm-optzns | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -g -enable-objc-interop  -primary-file %s -emit-irgen -sil-verify-all | %IRGenFileCheck %s
 // RUN: %target-swift-frontend  -enable-objc-interop  -primary-file %s -emit-ir -sil-verify-all
 
 // REQUIRES: concurrency

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %IRGenFileCheck %s -check-prefix CHECK-%target-abi
+// RUN: %target-swift-frontend -primary-file %s -module-name=test -emit-irgen -sil-verify-all | %IRGenFileCheck %s -check-prefix CHECK-%target-abi
 
 // REQUIRES: concurrency
 

--- a/test/IRGen/async/unreachable.swift
+++ b/test/IRGen/async/unreachable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -g -emit-ir  -disable-availability-checking -disable-llvm-optzns -disable-swift-specific-llvm-optzns | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -g -emit-irgen  -disable-availability-checking | %FileCheck %s
 // REQUIRES: concurrency
 
 // CHECK: call i1 (ptr, i1, ...) @llvm.coro.end.async

--- a/test/IRGen/clang_inline.swift
+++ b/test/IRGen/clang_inline.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -enable-objc-interop -sdk %S/Inputs -primary-file %s -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -sdk %S/Inputs -primary-file %s -O -disable-sil-perf-optzns -emit-irgen -Xcc -fstack-protector -I %t | %FileCheck %s
 
 // RUN: %empty-directory(%t/Empty.framework/Modules/Empty.swiftmodule)
 // RUN: %target-swift-frontend -emit-module-path %t/Empty.framework/Modules/Empty.swiftmodule/%target-swiftmodule-name %S/../Inputs/empty.swift -module-name Empty -I %t
-// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -I %t -F %t -DIMPORT_EMPTY -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -I %t -F %t -DIMPORT_EMPTY -O -disable-sil-perf-optzns -emit-irgen -Xcc -fstack-protector -enable-objc-interop | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/debug_fragment_merge.swift
+++ b/test/IRGen/debug_fragment_merge.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-sil -O -g | %FileCheck %s --check-prefix CHECK-SIL
-// RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-ir -disable-llvm-optzns -O -g | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-irgen -O -g | %FileCheck %s
 
 // REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=arm64e
 

--- a/test/IRGen/disable-llvm-optzns.swift
+++ b/test/IRGen/disable-llvm-optzns.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -primary-file %s -disable-availability-checking -c -o /dev/null -O -disable-llvm-optzns
+
+// REQUIRES: concurrency
+
+// Check that -disable-llvm-optzns does not crash the compiler
+
+func testit() async {
+  print(1)
+}

--- a/test/IRGen/modifyaccessor.swift
+++ b/test/IRGen/modifyaccessor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -disable-swift-specific-llvm-optzns -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-irgen -primary-file %s | %FileCheck %s
 extension Dictionary {
   subscript(alternate key: Key) -> Value? {
     get {

--- a/test/IRGen/yield_once.sil
+++ b/test/IRGen/yield_once.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -disable-swift-specific-llvm-optzns %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth
 
 import Builtin
 

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -disable-swift-specific-llvm-optzns %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
 // UNSUPPORTED: CPU=arm64_32
 
 import Builtin

--- a/test/IRGen/yield_once_biggish.sil
+++ b/test/IRGen/yield_once_biggish.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -disable-swift-specific-llvm-optzns %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
 
 // i386 uses a scalar result count of 3 instead of 4, so this test would need
 // to be substantially different to test the functionality there.  It's easier

--- a/test/IRGen/yield_once_indirect.sil
+++ b/test/IRGen/yield_once_indirect.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -disable-swift-specific-llvm-optzns %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
 
 import Builtin
 import Swift


### PR DESCRIPTION
If LLVM optimizations are to be disabled, we cannot just not run all LLVM passes, because there are some mandatory LLVM passes, like coro splitting. Instead, just run the `-O0` LLVM pipeline if `-disable-llvm-optzns` is used.

Fixes compiler crashes if `-disable-llvm-optzns` is used.

Note: if one wants to see the output of IRGen, `-emit-irgen` can be used.
