### PR TITLE
ASTDemangler: Fix round-tripping of SILBoxTypeWithLayout

### DIFF
--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -910,8 +910,12 @@ public:
     return MetatypeTypeRef::create(*this, instance, WasAbstract);
   }
 
+  void pushGenericParams(llvm::ArrayRef<std::pair<unsigned, unsigned>> parameterPacks) {}
+  void popGenericParams() {}
+
   const GenericTypeParameterTypeRef *
   createGenericTypeParameterType(unsigned depth, unsigned index) {
+    // FIXME: variadic generics
     return GenericTypeParameterTypeRef::create(*this, depth, index);
   }
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1869,6 +1869,9 @@ public:
     return BuiltType();
   }
 
+  void pushGenericParams(llvm::ArrayRef<std::pair<unsigned, unsigned>> parameterPacks) {}
+  void popGenericParams() {}
+
   BuiltType
   createGenericTypeParameterType(unsigned depth, unsigned index) const {
     // Use the callback, when provided.

--- a/test/DebugInfo/variadic-generics-closure.swift
+++ b/test/DebugInfo/variadic-generics-closure.swift
@@ -1,4 +1,14 @@
-// RUN: %target-swift-frontend -emit-ir %s -g | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -g -module-name closure | %FileCheck %s
 
-// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxxQp_QSiIgp_D", {{.*}})
+// CHECK-DAG: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxxQp_QSiIgp_D", {{.*}})
 public func f<each Input>(builder: (repeat each Input) -> ()) {}
+
+public protocol P {
+  func f() -> Self
+}
+
+// CHECK-DAG: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxxQp_tz_xxQp_QP_Rvz7closure1PRzlXXD", {{.*}})
+public func foo<each T: P>(t: repeat each T) -> () -> () {
+  var x = (repeat each t)
+  return { x = (repeat (each x).f()) }
+}


### PR DESCRIPTION
The more awkward setup with pushGenericParams()/popGenericParams()
is required so that when demangling requirements and field types
we get the correct pack-ness for each type parameter. The pack-ness
is encoded as part of the generic signature, and not as part of
the type parameter mangling itself.

Fixes the ASTDemangler issue from rdar://problem/115459973.