### PR TITLE
[5.10] Various bug fixes

### DIFF
--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -910,8 +910,12 @@ public:
     return MetatypeTypeRef::create(*this, instance, WasAbstract);
   }
 
+  void pushGenericParams(llvm::ArrayRef<std::pair<unsigned, unsigned>> parameterPacks) {}
+  void popGenericParams() {}
+
   const GenericTypeParameterTypeRef *
   createGenericTypeParameterType(unsigned depth, unsigned index) {
+    // FIXME: variadic generics
     return GenericTypeParameterTypeRef::create(*this, depth, index);
   }
 

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -559,6 +559,7 @@ RewriteContext::getRelativeSubstitutionSchemaFromType(
     ArrayRef<Term> substitutions,
     SmallVectorImpl<Term> &result) {
   assert(!concreteType->isTypeParameter() && "Must have a concrete type here");
+  assert(!concreteType->is<PackExpansionType>());
 
   if (!concreteType->hasTypeParameter())
     return concreteType;
@@ -604,6 +605,7 @@ RewriteContext::getSubstitutionSchemaFromType(CanType concreteType,
                                               const ProtocolDecl *proto,
                                               SmallVectorImpl<Term> &result) {
   assert(!concreteType->isTypeParameter() && "Must have a concrete type here");
+  assert(!concreteType->is<PackExpansionType>());
 
   if (!concreteType->hasTypeParameter())
     return concreteType;

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -620,7 +620,8 @@ AbstractGenericSignatureRequest::evaluate(
             return Type(type);
           },
           MakeAbstractConformanceForGenericType(),
-          SubstFlags::AllowLoweredTypes);
+          SubstFlags::AllowLoweredTypes |
+          SubstFlags::PreservePackExpansionLevel);
       resugaredRequirements.push_back(resugaredReq);
     }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -7023,11 +7023,10 @@ ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,
   assert(visitor.varAddr && "didn't find var in pattern?");
   
   // Load and reabstract the value if needed.
-  auto genericSig = F.getLoweredFunctionType()->getInvocationGenericSignature();
   auto substVarTy = var->getTypeInContext()->getCanonicalType();
-  auto substAbstraction = AbstractionPattern(genericSig, substVarTy);
-  return emitLoad(loc, visitor.varAddr, substAbstraction, substVarTy,
-                  getTypeLowering(substAbstraction, substVarTy),
+  return emitLoad(loc, visitor.varAddr,
+                  AbstractionPattern::getOpaque(), substVarTy,
+                  getTypeLowering(substVarTy),
                   SGFContext(), IsNotTake);
 }
 

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -57,11 +57,11 @@ public:
              .getTypeExpansionContext()
              .shouldLookThroughOpaqueTypeArchetypes())
       return ty;
-    // Remap types containing opaque result types in the current context.
-    return getBuilder()
-        .getTypeLowering(SILType::getPrimitiveObjectType(ty))
-        .getLoweredType()
-        .getASTType();
+
+    return substOpaqueTypesWithUnderlyingTypes(
+        ty,
+        TypeExpansionContext(getBuilder().getFunction()),
+        /*allowLoweredTypes=*/false);
   }
 
   ProtocolConformanceRef remapConformance(Type ty,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -806,7 +806,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     if (options.is(TypeResolverContext::ExistentialConstraint))
       options |= TypeResolutionFlags::DisallowOpaqueTypes;
     auto argOptions = options.withoutContext().withContext(
-        TypeResolverContext::GenericArgument);
+        TypeResolverContext::ProtocolGenericArgument);
     auto genericResolution = resolution.withOptions(argOptions);
 
     SmallVector<Type, 2> argTys;

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1869,6 +1869,9 @@ public:
     return BuiltType();
   }
 
+  void pushGenericParams(llvm::ArrayRef<std::pair<unsigned, unsigned>> parameterPacks) {}
+  void popGenericParams() {}
+
   BuiltType
   createGenericTypeParameterType(unsigned depth, unsigned index) const {
     // Use the callback, when provided.

--- a/test/DebugInfo/variadic-generics-closure.swift
+++ b/test/DebugInfo/variadic-generics-closure.swift
@@ -1,4 +1,14 @@
-// RUN: %target-swift-frontend -emit-ir %s -g | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -g -module-name closure | %FileCheck %s
 
-// CHECK: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxxQp_QSiIgp_D", {{.*}})
+// CHECK-DAG: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxxQp_QSiIgp_D", {{.*}})
 public func f<each Input>(builder: (repeat each Input) -> ()) {}
+
+public protocol P {
+  func f() -> Self
+}
+
+// CHECK-DAG: !{{[0-9]+}} = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxxQp_tz_xxQp_QP_Rvz7closure1PRzlXXD", {{.*}})
+public func foo<each T: P>(t: repeat each T) -> () -> () {
+  var x = (repeat each t)
+  return { x = (repeat (each x).f()) }
+}

--- a/test/Generics/rdar115538386.swift
+++ b/test/Generics/rdar115538386.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -typecheck %s -disable-availability-checking
+
+protocol P<A> {
+  associatedtype A
+}
+
+struct S<each T>: P {
+  typealias A = (repeat each T)
+}
+
+func foo<each T>() -> some P<(repeat each T)> {
+  S<repeat each T>()
+}

--- a/test/Generics/rdar115538574.swift
+++ b/test/Generics/rdar115538574.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P<A> {
+  associatedtype A
+}
+
+func f<each T>(_: some P<repeat each T>) {}
+// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+// expected-error@-2 {{generic parameter 'T' is not used in function signature}}

--- a/test/SIL/Serialization/opaque_return_type_serialize.swift
+++ b/test/SIL/Serialization/opaque_return_type_serialize.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %s -disable-availability-checking
+
+// We substitute away opaque archetypes after serialization;
+// make sure this correctly handles unlowered types like
+// AST functions and packs.
+
+public func horse<T>(_: T) {}
+
+@_transparent public func packCallee<each T>(_ t: repeat each T) {
+  repeat horse(each t)
+}
+
+@inlinable public func packCaller() {
+  packCallee(opaque())
+}
+
+public func opaque() -> some Any { return 3 }

--- a/test/SILGen/async_let_reabstraction.swift
+++ b/test/SILGen/async_let_reabstraction.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking
+// REQUIRES: concurrency
+
+public func callee() async -> (() -> ()) {
+    fatalError()
+}
+
+public func caller() async {
+  async let future = callee()
+  let result = await future
+  result()
+}

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -15,6 +15,7 @@ protocol P<T> {
 }
 
 func f4<each T>() -> any P<repeat each T> {}
+// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
 
 typealias T1<each T> = repeat each T
 // expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}


### PR DESCRIPTION
* Explanation: Various simple bug fixes for parameter packs, and an older small SILGen fix for `async let` that didn't make the 5.10 branch cut.

* Radars: rdar://114823719, rdar://115538574, rdar://115355709, rdar://115459973.

* Tested: Each commit is a straightforward change with a test case.

* Reviewed by: @hborla. The async let fix is actually already in 5.9: https://github.com/apple/swift/pull/68400/