### PR TITLE
[SIL] Allow specify_test instructions to take value literals.

### DIFF
--- a/include/swift/SIL/ParseTestSpecification.h
+++ b/include/swift/SIL/ParseTestSpecification.h
@@ -210,7 +210,14 @@ struct UnparsedSpecification {
   /// (@{instruction|block|function}) can be parsed in terms of this
   /// anchor.
   SILInstruction *context;
+  /// Map from names used in the specification to the corresponding SILValues.
+  llvm::StringMap<SILValue> values;
 };
+
+/// Populates the array \p components with the elements of \p
+/// specificationString.
+void getTestSpecificationComponents(StringRef specificationString,
+                                    SmallVectorImpl<StringRef> &components);
 
 /// Finds and deletes each test_specification instruction in \p function and
 /// appends its string payload to the provided vector.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -44,6 +44,7 @@
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ADT/ilist_node.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -5162,6 +5163,7 @@ class TestSpecificationInst final
   friend TrailingObjects;
   friend SILBuilder;
 
+  llvm::StringMap<SILValue> values;
   unsigned ArgumentsSpecificationLength;
 
   TestSpecificationInst(SILDebugLocation Loc,
@@ -5173,6 +5175,8 @@ class TestSpecificationInst final
   create(SILDebugLocation Loc, StringRef argumentsSpecification, SILModule &M);
 
 public:
+  void setValueForName(StringRef name, SILValue value) { values[name] = value; }
+  llvm::StringMap<SILValue> const &getValues() { return values; }
   StringRef getArgumentsSpecification() const {
     return StringRef(getTrailingObjects<char>(), ArgumentsSpecificationLength);
   }

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -187,3 +187,21 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test {{.*}} on test_value_literal_parsing: test-specification-parsing with: VVVV, %0, %1, %2, %3
+// CHECK:       value: %0 = argument of bb0 : $Builtin.Int1
+// CHECK:       value:   %2 = integer_literal $Builtin.Int64, 1
+// CHECK:       value:   %1 = integer_literal $Builtin.Int64, 2          
+// CHECK:       value:   %3 = integer_literal $Builtin.Int64, 3          
+// CHECK-LABEL: end running test {{.*}} on test_value_literal_parsing: test-specification-parsing with: VVVV, %0, %1, %2, %3
+sil @test_value_literal_parsing : $(Builtin.Int1) -> () {
+entry(%0 : $Builtin.Int1):
+  %2 = integer_literal $Builtin.Int64, 2
+  test_specification "test-specification-parsing VVVV %0 %1 %2 %3"
+  %1 = integer_literal $Builtin.Int64, 1
+  %3 = integer_literal $Builtin.Int64, 3
+  apply undef(%2) : $@convention(thin) (Builtin.Int64) -> ()
+  apply undef(%3) : $@convention(thin) (Builtin.Int64) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Tests can now say `%foo` to refer to a value in addition to `@instruction` or `@argument` or similar.
