### PR TITLE
Add requires asserts to Generics/inverse_constraints.swift test

### DIFF
--- a/test/Generics/inverse_constraints.swift
+++ b/test/Generics/inverse_constraints.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
+
 // CHECK-LABEL: (file).genericFn@
 // CHECK: Generic signature: <T where T : Copyable>
 func genericFn<T>(_ t: T) {}


### PR DESCRIPTION
The test uses an experimental feature and will fail if run with a toolchain built without asserts.

Add a line to the test requiring asserts.
