### PR TITLE
[CI] fix test when asserts are off

### DIFF
--- a/test/Generics/inverse_constraints.swift
+++ b/test/Generics/inverse_constraints.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // CHECK-LABEL: (file).genericFn@
 // CHECK: Generic signature: <T where T : Copyable>


### PR DESCRIPTION
For some reason, this test was failing in the configuration `oss-swift_tools-R_stdlib-RD_test-simulator`, which is a build with no asserts and run in a simulator.

This refactoring of the RUN line magically fixes it.

rdar://115881645