### PR TITLE
[ASTGen] Use standard headers in bridging interface

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -17,6 +17,8 @@
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/Nullability.h"
 
+#include <stddef.h>
+
 // NOTE: DO NOT #include any stdlib headers here. e.g. <stdint.h>. Those are
 // part of "Darwin"/"Glibc" module, so when a Swift file imports this header,
 // it causes importing the "Darwin"/"Glibc" overlay module. That violates
@@ -33,12 +35,12 @@ SWIFT_BEGIN_ASSUME_NONNULL
 
 typedef struct {
   const unsigned char *_Nullable data;
-  SwiftInt length;
+  size_t length;
 } BridgedString;
 
 typedef struct {
   const void *_Nullable data;
-  SwiftInt numElements;
+  size_t numElements;
 } BridgedArrayRef;
 
 typedef struct BridgedASTContext {
@@ -64,7 +66,7 @@ typedef struct BridgedIdentifier {
 
 typedef struct {
   void *start;
-  SwiftInt byteLength;
+  size_t byteLength;
 } BridgedCharSourceRange;
 
 typedef struct {
@@ -78,7 +80,7 @@ typedef struct {
   BridgedSourceLoc TrailingCommaLoc;
 } BridgedTupleTypeElement;
 
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedRequirementReprKind : SwiftInt {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedRequirementReprKind : size_t {
   /// A type bound T : P, where T is a type that depends on a generic
   /// parameter and P is some type that should bound T, either as a concrete
   /// supertype or a protocol to which T must conform.
@@ -105,7 +107,7 @@ typedef struct {
 } BridgedRequirementRepr;
 
 /// Diagnostic severity when reporting diagnostics.
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticSeverity : SwiftInt {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticSeverity : size_t {
   BridgedFatalError,
   BridgedError,
   BridgedWarning,
@@ -121,7 +123,7 @@ typedef struct BridgedDiagnosticEngine {
   void *raw;
 } BridgedDiagnosticEngine;
 
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : SwiftInt {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : size_t {
   /// An expanded macro.
   BridgedExpandedMacro = 0,
   /// An external macro, spelled with either the old spelling (Module.Type)
@@ -132,7 +134,7 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedMacroDefinitionKind : SwiftInt
 } BridgedMacroDefinitionKind;
 
 /// Bridged parameter specifiers
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : SwiftInt {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : size_t {
   BridgedAttributedTypeSpecifierInOut,
   BridgedAttributedTypeSpecifierBorrowing,
   BridgedAttributedTypeSpecifierConsuming,
@@ -143,7 +145,7 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : Swif
 } BridgedAttributedTypeSpecifier;
 
 // Bridged type attribute kinds, which mirror TypeAttrKind exactly.
-typedef enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : SwiftInt {
+typedef enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : size_t {
   BridgedTypeAttrKind_autoclosure,
   BridgedTypeAttrKind_convention,
   BridgedTypeAttrKind_noescape,
@@ -195,7 +197,7 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : SwiftInt {
   BridgedTypeAttrKind_Count
 } BridgedTypeAttrKind;
 
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) ASTNodeKind : SwiftInt {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) ASTNodeKind : size_t {
   ASTNodeKindExpr,
   ASTNodeKindStmt,
   ASTNodeKindDecl
@@ -325,7 +327,7 @@ void *IfStmt_create(BridgedASTContext cContext, BridgedSourceLoc cIfLoc,
 void *BraceStmt_create(BridgedASTContext cContext, BridgedSourceLoc cLBLoc,
                        BridgedArrayRef elements, BridgedSourceLoc cRBLoc);
 
-BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, SwiftInt len);
+BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, size_t len);
 
 SWIFT_NAME("ParamDecl_create(astContext:declContext:specifierLoc:firstName:"
            "firstNameLoc:secondName:secondNameLoc:type:defaultValue:)")
@@ -545,7 +547,7 @@ void *GenericTypeParamDecl_create(BridgedASTContext cContext,
                                   BridgedIdentifier cName,
                                   BridgedSourceLoc cNameLoc,
                                   void *_Nullable opaqueInheritedType,
-                                  SwiftInt index);
+                                  size_t index);
 
 SWIFT_NAME(
     "TrailingWhereClause_create(astContext:whereKeywordLoc:requirements:)")

--- a/include/swift/Basic/CBasicBridging.h
+++ b/include/swift/Basic/CBasicBridging.h
@@ -16,73 +16,8 @@
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/Nullability.h"
 
-// NOTE: DO NOT #include any stdlib headers here. e.g. <stdint.h>. Those are
-// part of "Darwin"/"Glibc" module, so when a Swift file imports this header,
-// it causes importing the "Darwin"/"Glibc" overlay module. That violates
-// layering. i.e. Darwin overlay is created by Swift compiler.
-
-// NOTE: Partially ported from SwiftShim's SwiftStdint.h. We cannot include
-// that header here because it belongs to the runtime, but we need the same
-// logic for interoperability with Swift code in the compiler itself.
-// stdint.h is provided by Clang, but it dispatches to libc's stdint.h.  As a
-// result, using stdint.h here would pull in Darwin module (which includes
-// libc). This creates a dependency cycle, so we can't use stdint.h in
-// SwiftShims.
-// On Linux, the story is different. We get the error message
-// "/usr/include/x86_64-linux-gnu/sys/types.h:146:10: error: 'stddef.h' file not
-// found"
-// This is a known Clang/Ubuntu bug.
-
-// Clang has been defining __INTxx_TYPE__ macros for a long time.
-// __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if defined(_MSC_VER) && !defined(__clang__)
-typedef __int64 __swiftc_int64_t;
-typedef unsigned __int64 __swiftc_uint64_t;
-typedef int __swiftc_int32_t;
-typedef unsigned int __swiftc_uint32_t;
-#elif !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__)
+#include <stddef.h>
 #include <stdint.h>
-typedef int64_t __swiftc_int64_t;
-typedef uint64_t __swiftc_uint64_t;
-typedef int32_t __swiftc_int32_t;
-typedef uint32_t __swiftc_uint32_t;
-typedef intptr_t __swiftc_intptr_t;
-typedef uintptr_t __swiftc_uintptr_t;
-#else
-typedef __INT64_TYPE__ __swiftc_int64_t;
-#ifdef __UINT64_TYPE__
-typedef __UINT64_TYPE__ __swiftc_uint64_t;
-#else
-typedef unsigned __INT64_TYPE__ __swiftc_uint64_t;
-#endif
-
-typedef __INT32_TYPE__ __swiftc_int32_t;
-#ifdef __UINT32_TYPE__
-typedef __UINT32_TYPE__ __swiftc_uint32_t;
-#else
-typedef unsigned __INT32_TYPE__ __swiftc_uint32_t;
-#endif
-#endif
-
-#define __swiftc_join3(a,b,c) a ## b ## c
-
-#define __swiftc_intn_t(n) __swiftc_join3(__swiftc_int, n, _t)
-#define __swiftc_uintn_t(n) __swiftc_join3(__swiftc_uint, n, _t)
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#if defined(_WIN64)
-typedef __swiftc_int64_t SwiftInt;
-typedef __swiftc_uint64_t SwiftUInt;
-#elif defined(_WIN32)
-typedef __swiftc_int32_t SwiftInt;
-typedef __swiftc_uint32_t SwiftUInt;
-#else
-#error unknown windows pointer width
-#endif
-#else
-typedef __swiftc_intn_t(__INTPTR_WIDTH__) SwiftInt;
-typedef __swiftc_uintn_t(__INTPTR_WIDTH__) SwiftUInt;
-#endif
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -103,7 +38,7 @@ SWIFT_BEGIN_ASSUME_NONNULL
 
 typedef struct BridgedData {
   const char *_Nullable baseAddress;
-  SwiftUInt size;
+  size_t size;
 } BridgedData;
 
 void BridgedData_free(BridgedData data);
@@ -132,23 +67,23 @@ _Bool JSON_value_getAsNull(void *valuePtr);
 _Bool JSON_value_getAsBoolean(void *valuePtr, _Bool *result);
 _Bool JSON_value_getAsString(void *valuePtr, BridgedData *result);
 _Bool JSON_value_getAsDouble(void *valuePtr, double *result);
-_Bool JSON_value_getAsInteger(void *valuePtr, long long *result);
+_Bool JSON_value_getAsInteger(void *valuePtr, int64_t *result);
 _Bool JSON_value_getAsObject(void *valuePtr, void *_Nullable *_Nonnull result);
 _Bool JSON_value_getAsArray(void *valuePtr, void *_Nullable *_Nonnull result);
 
-unsigned long JSON_object_getSize(void *objectPtr);
-BridgedData JSON_object_getKey(void *objectPtr, unsigned long i);
+size_t JSON_object_getSize(void *objectPtr);
+BridgedData JSON_object_getKey(void *objectPtr, size_t i);
 _Bool JSON_object_hasKey(void *objectPtr, const char *key);
 void *JSON_object_getValue(void *objectPtr, const char *key);
 
-long long JSON_array_getSize(void *arrayPtr);
-void *JSON_array_getValue(void *arrayPtr, long long index);
+size_t JSON_array_getSize(void *arrayPtr);
+void *JSON_array_getValue(void *arrayPtr, size_t index);
 
 void JSON_value_emplaceNull(void *valuePtr);
 void JSON_value_emplaceBoolean(void *valuePtr, _Bool value);
 void JSON_value_emplaceString(void *valuePtr, const char *value);
 void JSON_value_emplaceDouble(void *valuePtr, double value);
-void JSON_value_emplaceInteger(void *valuePtr, long long value);
+void JSON_value_emplaceInteger(void *valuePtr, int64_t value);
 void *JSON_value_emplaceNewObject(void *valuePtr);
 void *JSON_value_emplaceNewArray(void *valuePtr);
 
@@ -156,7 +91,7 @@ void JSON_object_setNull(void *objectPtr, const char *key);
 void JSON_object_setBoolean(void *objectPtr, const char *key, _Bool value);
 void JSON_object_setString(void *objectPtr, const char *key, const char *value);
 void JSON_object_setDouble(void *objectPtr, const char *key, double value);
-void JSON_object_setInteger(void *objectPtr, const char *key, long long value);
+void JSON_object_setInteger(void *objectPtr, const char *key, int64_t value);
 void *JSON_object_setNewObject(void *objectPtr, const char *key);
 void *JSON_object_setNewArray(void *objectPtr, const char *key);
 void *JSON_object_setNewValue(void *objectPtr, const char *key);
@@ -165,7 +100,7 @@ void JSON_array_pushNull(void *arrayPtr);
 void JSON_array_pushBoolean(void *arrayPtr, _Bool value);
 void JSON_array_pushString(void *arrayPtr, const char *value);
 void JSON_array_pushDouble(void *arrayPtr, double value);
-void JSON_array_pushInteger(void *arrayPtr, long long value);
+void JSON_array_pushInteger(void *arrayPtr, int64_t value);
 void *JSON_array_pushNewObject(void *arrayPtr);
 void *JSON_array_pushNewArray(void *arrayPtr);
 void *JSON_array_pushNewValue(void *arrayPtr);

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -192,7 +192,7 @@ bool ASTContext_langOptsHasFeature(BridgedASTContext cContext,
   return convertASTContext(cContext).LangOpts.hasFeature((Feature)feature);
 }
 
-BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, SwiftInt len) {
+BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, size_t len) {
   SourceLoc loc = convertSourceLoc(cLoc).getAdvancedLoc(len);
   return {loc.getOpaquePointerValue()};
 }
@@ -1120,7 +1120,7 @@ void *GenericTypeParamDecl_create(BridgedASTContext cContext,
                                   BridgedIdentifier cName,
                                   BridgedSourceLoc cNameLoc,
                                   void *_Nullable opaqueInheritedType,
-                                  SwiftInt index) {
+                                  size_t index) {
   auto eachLoc = convertSourceLoc(cEachLoc);
   auto *decl = GenericTypeParamDecl::createParsed(
       convertDeclContext(cDeclContext), convertIdentifier(cName),
@@ -1265,6 +1265,6 @@ bool Plugin_waitForNextMessage(PluginHandle handle, BridgedData *out) {
   auto size = message.size();
   auto outPtr = malloc(size);
   memcpy(outPtr, message.data(), size);
-  *out = BridgedData{(const char *)outPtr, (SwiftUInt)size};
+  *out = BridgedData{(const char *)outPtr, size};
   return false;
 }

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -412,7 +412,7 @@ extension Collection {
       }
     }
 
-    return .init(data: baseAddress, numElements: SwiftInt(self.count))
+    return .init(data: baseAddress, numElements: self.count)
   }
 }
 
@@ -426,7 +426,7 @@ extension LazyCollectionProtocol {
     let buffer = astgen.allocator.allocate(Element.self, count: self.count)
     _ = buffer.initialize(from: self)
 
-    return .init(data: buffer.baseAddress, numElements: SwiftInt(self.count))
+    return .init(data: buffer.baseAddress, numElements: self.count)
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -21,7 +21,7 @@ extension BridgedSourceLoc {
     in buffer: UnsafeBufferPointer<UInt8>
   ) {
     precondition(position.utf8Offset >= 0 && position.utf8Offset <= buffer.count)
-    self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer.baseAddress!), SwiftInt(position.utf8Offset))
+    self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer.baseAddress!), position.utf8Offset)
   }
 }
 
@@ -35,7 +35,7 @@ extension BridgedSourceRange {
 extension String {
   mutating func withBridgedString<R>(_ body: (BridgedString) throws -> R) rethrows -> R {
     try withUTF8 { buffer in
-      try body(BridgedString(data: buffer.baseAddress, length: SwiftInt(buffer.count)))
+      try body(BridgedString(data: buffer.baseAddress, length: buffer.count))
     }
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -37,7 +37,7 @@ extension ASTGenVisitor {
         name: name,
         nameLoc: nameLoc,
         inheritedType: self.generate(node.inheritedType)?.rawValue,
-        index: SwiftInt(genericParameterIndex)
+        index: genericParameterIndex
       )
     )
   }

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -121,7 +121,7 @@ struct CompilerPlugin {
 
   private func sendMessage(_ message: HostToPluginMessage) throws {
     let hadError = try LLVMJSON.encoding(message) { (data) -> Bool in
-      return Plugin_sendMessage(opaqueHandle, BridgedData(baseAddress: data.baseAddress, size: SwiftUInt(data.count)))
+      return Plugin_sendMessage(opaqueHandle, BridgedData(baseAddress: data.baseAddress, size: data.count))
     }
     if hadError {
       throw PluginError.failedToSendMessage
@@ -341,7 +341,7 @@ class PluginDiagnosticsEngine {
     guard let bufferBaseAddress = exportedSourceFile.pointee.buffer.baseAddress else {
       return nil
     }
-    return SourceLoc_advanced(BridgedSourceLoc(raw: bufferBaseAddress), SwiftInt(offset))
+    return SourceLoc_advanced(BridgedSourceLoc(raw: bufferBaseAddress), offset)
   }
 
   /// C++ source location from a position value from a plugin.

--- a/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
+++ b/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
@@ -35,13 +35,13 @@ public struct LLVMJSON {
     JSON_value_serialize(valuePtr, &data)
     assert(data.baseAddress != nil)
     defer { BridgedData_free(data) }
-    let buffer = UnsafeBufferPointer(start: data.baseAddress, count: Int(data.size))
+    let buffer = UnsafeBufferPointer(start: data.baseAddress, count: data.size)
     return try body(buffer)
   }
 
   /// Decode a JSON data to a Swift value.
   public static func decode<T: Decodable>(_ type: T.Type, from json: UnsafeBufferPointer<Int8>) throws -> T {
-    let data = BridgedData(baseAddress: json.baseAddress, size: SwiftUInt(json.count))
+    let data = BridgedData(baseAddress: json.baseAddress, size: json.count)
     let valuePtr = JSON_deserializedValue(data)
     defer { JSON_value_delete(valuePtr) }
 
@@ -209,7 +209,7 @@ extension LLVMJSONDecoding.KeyedContainer: KeyedDecodingContainerProtocol {
   var allKeys: [Key] {
     var keys: [Key] = []
     let size = JSON_object_getSize(objectPtr)
-    keys.reserveCapacity(Int(size))
+    keys.reserveCapacity(size)
     for i in 0 ..< size {
       let keyData = JSON_object_getKey(objectPtr, i)
       if let key = Key(stringValue: String(keyData)) {

--- a/lib/Basic/CBasicBridging.cpp
+++ b/lib/Basic/CBasicBridging.cpp
@@ -40,7 +40,7 @@ void JSON_value_serialize(void *value, BridgedData *out) {
 
   auto outPtr = malloc(result.size());
   memcpy(outPtr, result.data(), result.size());
-  *out = BridgedData{(const char *)outPtr, (unsigned long)result.size()};
+  *out = BridgedData{(const char *)outPtr, (size_t)result.size()};
 }
 
 void JSON_value_delete(void *value) {
@@ -70,7 +70,7 @@ _Bool JSON_value_getAsDouble(void *value, double *result) {
   return true;
 }
 
-_Bool JSON_value_getAsInteger(void *value, long long *result) {
+_Bool JSON_value_getAsInteger(void *value, int64_t *result) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsInteger()) {
     *result = *val;
     return false;
@@ -80,7 +80,7 @@ _Bool JSON_value_getAsInteger(void *value, long long *result) {
 
 _Bool JSON_value_getAsString(void *value, BridgedData *result) {
   if (auto val = static_cast<llvm::json::Value *>(value)->getAsString()) {
-    *result = {val->data(), (unsigned long)val->size()};
+    *result = {val->data(), val->size()};
     return false;
   }
   return true;
@@ -101,18 +101,18 @@ _Bool JSON_value_getAsArray(void *value, void **result) {
   return true;
 }
 
-unsigned long JSON_object_getSize(void *objectPtr) {
+size_t JSON_object_getSize(void *objectPtr) {
   llvm::json::Object *object = static_cast<llvm::json::Object *>(objectPtr);
   return object->size();
 }
 
-BridgedData JSON_object_getKey(void *objectPtr, unsigned long i) {
+BridgedData JSON_object_getKey(void *objectPtr, size_t i) {
   llvm::json::Object *object = static_cast<llvm::json::Object *>(objectPtr);
   std::map<int, float> map;
   auto iter = object->begin();
   std::advance(iter, i);
   auto str = llvm::StringRef(iter->first);
-  return {str.data(), (unsigned long)str.size()};
+  return {str.data(), str.size()};
 }
 
 _Bool JSON_object_hasKey(void *objectPtr, const char *key) {
@@ -124,11 +124,11 @@ void *JSON_object_getValue(void *objectPtr, const char *key) {
   return object->get(key);
 }
 
-long long JSON_array_getSize(void *objectPtr) {
+size_t JSON_array_getSize(void *objectPtr) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(objectPtr);
   return array->size();
 }
-void *JSON_array_getValue(void *objectPtr, long long index) {
+void *JSON_array_getValue(void *objectPtr, size_t index) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(objectPtr);
   return array->data() + index;
 }
@@ -149,7 +149,7 @@ void JSON_value_emplaceDouble(void *valuePtr, double newValue) {
   auto *value = static_cast<llvm::json::Value *>(valuePtr);
   *value = newValue;
 }
-void JSON_value_emplaceInteger(void *valuePtr, long long newValue) {
+void JSON_value_emplaceInteger(void *valuePtr, int64_t newValue) {
   auto *value = static_cast<llvm::json::Value *>(valuePtr);
   *value = newValue;
 }
@@ -185,7 +185,7 @@ void JSON_object_setDouble(void *objectPtr, const char *key, double value) {
   auto keyStr = std::string(key);
   (*object)[keyStr] = value;
 }
-void JSON_object_setInteger(void *objectPtr, const char *key, long long value) {
+void JSON_object_setInteger(void *objectPtr, const char *key, int64_t value) {
   llvm::json::Object *object = static_cast<llvm::json::Object *>(objectPtr);
   auto keyStr = std::string(key);
   (*object)[keyStr] = value;
@@ -225,7 +225,7 @@ void JSON_array_pushDouble(void *arrayPtr, double value) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(arrayPtr);
   array->emplace_back(value);
 }
-void JSON_array_pushInteger(void *arrayPtr, long long value) {
+void JSON_array_pushInteger(void *arrayPtr, int64_t value) {
   llvm::json::Array *array = static_cast<llvm::json::Array *>(arrayPtr);
   array->emplace_back(value);
 }

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -37,12 +37,12 @@ extern "C" void *swift_ASTGen_createQueuedDiagnostics();
 extern "C" void swift_ASTGen_destroyQueuedDiagnostics(void *queued);
 extern "C" void swift_ASTGen_addQueuedSourceFile(
       void *queuedDiagnostics,
-      SwiftInt bufferID,
+      ssize_t bufferID,
       void *sourceFile,
       const uint8_t *displayNamePtr,
       intptr_t displayNameLength,
-      SwiftInt parentID,
-      SwiftInt positionInParent);
+      ssize_t parentID,
+      ssize_t positionInParent);
 extern "C" void swift_ASTGen_addQueuedDiagnostic(
     void *queued,
     const char* text, ptrdiff_t textLength,
@@ -52,8 +52,8 @@ extern "C" void swift_ASTGen_addQueuedDiagnostic(
     ptrdiff_t numHighlightRanges
 );
 extern "C" void swift_ASTGen_renderQueuedDiagnostics(
-    void *queued, SwiftInt contextSize, SwiftInt colorize,
-    char **outBuffer, SwiftInt *outBufferLength);
+    void *queued, ssize_t contextSize, ssize_t colorize,
+    char **outBuffer, ssize_t *outBufferLength);
 extern "C" void swift_ASTGen_freeString(const char *str);
 
 // FIXME: Hack because we cannot easily get to the already-parsed source
@@ -497,7 +497,7 @@ void PrintingDiagnosticConsumer::flush(bool includeTrailingBreak) {
 #if SWIFT_BUILD_SWIFT_SYNTAX
   if (queuedDiagnostics) {
     char *renderedString = nullptr;
-    SwiftInt renderedStringLen = 0;
+    ssize_t renderedStringLen = 0;
     swift_ASTGen_renderQueuedDiagnostics(
         queuedDiagnostics, /*contextSize=*/2, ForceColors ? 1 : 0,
         &renderedString, &renderedStringLen);

--- a/tools/swift-plugin-server/Sources/CSwiftPluginServer/PluginServer.cpp
+++ b/tools/swift-plugin-server/Sources/CSwiftPluginServer/PluginServer.cpp
@@ -118,7 +118,7 @@ void PluginServer_destroyConnection(const void *server) {
   delete static_cast<const ConnectionHandle *>(server);
 }
 
-SwiftInt PluginServer_read(const void *server, void *data, SwiftUInt nbyte) {
+ptrdiff_t PluginServer_read(const void *server, void *data, size_t nbyte) {
   const auto *connection = static_cast<const ConnectionHandle *>(server);
 #if defined(_WIN32)
   return _read(connection->inputFD, data, nbyte);
@@ -127,7 +127,8 @@ SwiftInt PluginServer_read(const void *server, void *data, SwiftUInt nbyte) {
 #endif
 }
 
-SwiftInt PluginServer_write(const void *server, const void *data, SwiftUInt nbyte) {
+ptrdiff_t PluginServer_write(const void *server, const void *data,
+                             size_t nbyte) {
   const auto *connection = static_cast<const ConnectionHandle *>(server);
 #if defined(_WIN32)
   return _write(connection->outputFD, data, nbyte);

--- a/tools/swift-plugin-server/Sources/CSwiftPluginServer/include/PluginServer.h
+++ b/tools/swift-plugin-server/Sources/CSwiftPluginServer/include/PluginServer.h
@@ -13,68 +13,7 @@
 #ifndef SWIFT_PLUGINSERVER_PLUGINSERVER_H
 #define SWIFT_PLUGINSERVER_PLUGINSERVER_H
 
-// NOTE: Partially ported from SwiftShim's SwiftStdint.h. We cannot include
-// that header here because it belongs to the runtime, but we need the same
-// logic for interoperability with Swift code in the compiler itself.
-// stdint.h is provided by Clang, but it dispatches to libc's stdint.h.  As a
-// result, using stdint.h here would pull in Darwin module (which includes
-// libc). This creates a dependency cycle, so we can't use stdint.h in
-// SwiftShims.
-// On Linux, the story is different. We get the error message
-// "/usr/include/x86_64-linux-gnu/sys/types.h:146:10: error: 'stddef.h' file not
-// found"
-// This is a known Clang/Ubuntu bug.
-
-// Clang has been defining __INTxx_TYPE__ macros for a long time.
-// __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if defined(_MSC_VER) && !defined(__clang__)
-typedef __int64 __swiftc_int64_t;
-typedef unsigned __int64 __swiftc_uint64_t;
-typedef int __swiftc_int32_t;
-typedef unsigned int __swiftc_uint32_t;
-#elif !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__)
-#include <stdint.h>
-typedef int64_t __swiftc_int64_t;
-typedef uint64_t __swiftc_uint64_t;
-typedef int32_t __swiftc_int32_t;
-typedef uint32_t __swiftc_uint32_t;
-typedef intptr_t __swiftc_intptr_t;
-typedef uintptr_t __swiftc_uintptr_t;
-#else
-typedef __INT64_TYPE__ __swiftc_int64_t;
-#ifdef __UINT64_TYPE__
-typedef __UINT64_TYPE__ __swiftc_uint64_t;
-#else
-typedef unsigned __INT64_TYPE__ __swiftc_uint64_t;
-#endif
-
-typedef __INT32_TYPE__ __swiftc_int32_t;
-#ifdef __UINT32_TYPE__
-typedef __UINT32_TYPE__ __swiftc_uint32_t;
-#else
-typedef unsigned __INT32_TYPE__ __swiftc_uint32_t;
-#endif
-#endif
-
-#define __swiftc_join3(a,b,c) a ## b ## c
-
-#define __swiftc_intn_t(n) __swiftc_join3(__swiftc_int, n, _t)
-#define __swiftc_uintn_t(n) __swiftc_join3(__swiftc_uint, n, _t)
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#if defined(_WIN64)
-typedef __swiftc_int64_t SwiftInt;
-typedef __swiftc_uint64_t SwiftUInt;
-#elif defined(_WIN32)
-typedef __swiftc_int32_t SwiftInt;
-typedef __swiftc_uint32_t SwiftUInt;
-#else
-#error unknown windows pointer width
-#endif
-#else
-typedef __swiftc_intn_t(__INTPTR_WIDTH__) SwiftInt;
-typedef __swiftc_uintn_t(__INTPTR_WIDTH__) SwiftUInt;
-#endif
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -92,10 +31,11 @@ const void *PluginServer_createConnection(const char **errorMessage);
 void PluginServer_destroyConnection(const void *connHandle);
 
 /// Read bytes from the IPC communication handle.
-SwiftInt PluginServer_read(const void *connHandle, void *data, SwiftUInt nbyte);
+ptrdiff_t PluginServer_read(const void *connHandle, void *data, size_t nbyte);
 
 /// Write bytes to the IPC communication handle.
-SwiftInt PluginServer_write(const void *connHandle, const void *data, SwiftUInt nbyte);
+ptrdiff_t PluginServer_write(const void *connHandle, const void *data,
+                             size_t nbyte);
 
 //===----------------------------------------------------------------------===//
 // Dynamic link

--- a/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
+++ b/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
@@ -172,12 +172,12 @@ final class PluginHostConnection: MessageConnection {
     var ptr = buffer.baseAddress!
 
     while (bytesToWrite > 0) {
-      let writtenSize = PluginServer_write(handle, ptr, SwiftUInt(bytesToWrite))
+      let writtenSize = PluginServer_write(handle, ptr, bytesToWrite)
       if (writtenSize <= 0) {
         // error e.g. broken pipe.
         break
       }
-      ptr = ptr.advanced(by: Int(writtenSize))
+      ptr = ptr.advanced(by: writtenSize)
       bytesToWrite -= Int(writtenSize)
     }
     return buffer.count - bytesToWrite
@@ -193,13 +193,13 @@ final class PluginHostConnection: MessageConnection {
     var ptr = buffer.baseAddress!
 
     while bytesToRead > 0 {
-      let readSize = PluginServer_read(handle, ptr, SwiftUInt(bytesToRead))
+      let readSize = PluginServer_read(handle, ptr, bytesToRead)
       if (readSize <= 0) {
         // 0: EOF (the host closed), -1: Broken pipe (the host crashed?)
         break;
       }
-      ptr = ptr.advanced(by: Int(readSize))
-      bytesToRead -= Int(readSize)
+      ptr = ptr.advanced(by: readSize)
+      bytesToRead -= readSize
     }
     return buffer.count - bytesToRead
   }


### PR DESCRIPTION
For whatever reason, using standard headers in clang modules imported from Swift code (i.e. depending on Darwin overlay) is no longer an issue.

rdar://115438609