### PR TITLE
fix `-typecheck -verify` and experimental features

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -36,10 +36,6 @@ ERROR(error_unsupported_target_os, none,
 ERROR(error_unsupported_target_arch, none,
       "unsupported target architecture: '%0'", (StringRef))
 
-ERROR(error_experimental_feature_not_available, none,
-      "experimental feature '%0' cannot be enabled in a production compiler",
-      (StringRef))
-
 ERROR(error_upcoming_feature_on_by_default, none,
       "upcoming feature '%0' is already enabled as of Swift version %1",
       (StringRef, unsigned))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -812,9 +812,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     if (auto feature = getExperimentalFeature(value)) {
 #ifdef NDEBUG
       if (!isFeatureAvailableInProduction(*feature)) {
-        Diags.diagnose(SourceLoc(),
-                       diag::error_experimental_feature_not_available,
-                       A->getValue());
+        llvm::errs() << "error: experimental feature '" << A->getValue() 
+                     << "' cannot be enabled in a production compiler\n";
+        exit(1);
       }
 #endif
 


### PR DESCRIPTION
When using `-enable-experimental-feature` on a non-asserts build, we only emit an error diagnostic that has no source-line information and continue to enable the feature.

That doesn't actually prevent use of the experimental feature when you are passing `-typecheck -verify`, since in diagnostics verification mode, a diagnostic with an unknown error location is ignored. Thus, the experimental feature is enabled and run for type-checking, but the compiler would exit with a zero error code.

This patch takes a hammer to that escape-hatch, forcing an early non-zero exit the moment an experimental feature is requested. The error message is output to stderr so that CI and other tools should see what happened.