### PR TITLE
Add a lit test for Xcode project generation

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -70,7 +70,10 @@ class CMakeProduct(product.Product):
                            + self.args.extra_cmake_options + [self.source_dir],
                            env=env)
 
-        if not self.args.skip_build or self.product_name() == "llvm":
+        is_llvm = self.product_name() == "llvm"
+        if (not is_llvm and not self.args.skip_build) or (
+            is_llvm and self.args._build_llvm
+        ):
             cmake_opts = [self.build_dir, "--config", build_type]
 
             if self.args.cmake_generator == "Xcode":

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -216,20 +216,11 @@ class LLVM(cmake_product.CMakeProduct):
                 # space/time efficient than -g on that platform.
                 llvm_cmake_options.define('LLVM_USE_SPLIT_DWARF:BOOL', 'YES')
 
-        build_targets = ['all']
-
-        if self.args.llvm_ninja_targets_for_cross_compile_hosts and \
-           self.is_cross_compile_target(host_target):
-            build_targets = (self.args.llvm_ninja_targets_for_cross_compile_hosts)
-        elif self.args.llvm_ninja_targets:
-            build_targets = (self.args.llvm_ninja_targets)
-
-        # indicating we don't want to build LLVM should
-        # override any custom ninja target we specified
         if not self.args._build_llvm:
-            build_targets = ['clean']
-
-        if self.args.skip_build or not self.args.build_llvm:
+            # Indicating we don't want to build LLVM at all should
+            # override everything.
+            build_targets = []
+        elif self.args.skip_build or not self.args.build_llvm:
             # We can't skip the build completely because the standalone
             # build of Swift depends on these.
             build_targets = ['llvm-tblgen', 'clang-resource-headers',
@@ -248,6 +239,14 @@ class LLVM(cmake_product.CMakeProduct):
                     'llvm-nm',
                     'llvm-size'
                 ])
+        else:
+            build_targets = ['all']
+
+            if self.args.llvm_ninja_targets_for_cross_compile_hosts and \
+               self.is_cross_compile_target(host_target):
+                build_targets = (self.args.llvm_ninja_targets_for_cross_compile_hosts)
+            elif self.args.llvm_ninja_targets:
+                build_targets = (self.args.llvm_ninja_targets)
 
         if self.args.host_libtool:
             llvm_cmake_options.define('CMAKE_LIBTOOL', self.args.host_libtool)

--- a/validation-test/BuildSystem/generate_xcode.test
+++ b/validation-test/BuildSystem/generate_xcode.test
@@ -1,0 +1,17 @@
+# RUN: %empty-directory(%t)
+# RUN: %empty-directory(%t/Xcode)
+
+# Build system generation for 'swift' depends on several LLVM tools
+# (e.g. llvm-tblgen). This is why we still build them with '--skip-build' or
+# '--skip-build-llvm' set, and have an additional '--build-llvm' option to
+# actually skip building that bare minimum too.
+#
+# To save time, borrow these dependencies from the current build directories,
+# and test Xcode project generation only for 'swift'.
+
+# RUN: ln -s %swift_obj_root/../cmark-%target-os-%target-arch %t/Xcode/cmark-%target-os-%target-arch
+# RUN: ln -s %swift_obj_root/../llvm-%target-os-%target-arch %t/Xcode/llvm-%target-os-%target-arch
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --swift-darwin-supported-archs="$(uname -m)" --build-subdir="Xcode" --skip-build-cmark --build-llvm=0 --xcode
+
+# REQUIRES: standalone_build
+# REQUIRES: OS=macosx

--- a/validation-test/BuildSystem/llvm-targets-options.test
+++ b/validation-test/BuildSystem/llvm-targets-options.test
@@ -8,7 +8,7 @@
 # RUN: mkdir -p %t
 # RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
 
-# BUILD-LLVM-0-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} clean
+# BUILD-LLVM-0-CHECK-NOT: cmake --build {{.*}}/Ninja-DebugAssert/llvm
 
 
 # RUN: %empty-directory(%t)

--- a/validation-test/BuildSystem/skip_build_xcode.test
+++ b/validation-test/BuildSystem/skip_build_xcode.test
@@ -1,5 +1,4 @@
 # RUN: %empty-directory(%t)
-# RUN: mkdir -p %t
 # RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --xcode --release --swift-darwin-supported-archs="$(uname -m)" --dry-run --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build


### PR DESCRIPTION
The test takes ~100s on my machine. 

Changes to CMake code tend to break Xcode project generation every other month or so. Although these issues are often fixed in a matter of days and are not as big of a deal for seasoned contributors, Xcode is the editor of choice for many, if not most, newcomers, and I believe this makes un interested in promising a functional invocation with the Xcode version used in CI.
