### PR TITLE
[SIL] Renamed specify_test instruction.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -4330,13 +4330,13 @@ It is code-generated to a NOP instruction.
 Testing
 ~~~~~~~
 
-test_specification
-``````````````````
+specify_test
+````````````
 ::
 
-  sil-instruction ::= 'test_specification' string-literal
+  sil-instruction ::= 'specify_test' string-literal
 
-  test_specification "parsing @trace[3] @function[other].block[2].instruction[1]"
+  specify_test "parsing @trace[3] @function[other].block[2].instruction[1]"
 
 Exists only for writing FileCheck tests.  Specifies a list of test arguments
 which should be used in order to run a particular test "in the context" of the
@@ -4349,10 +4349,11 @@ The following types of test arguments are supported:
 - boolean: true false
 - unsigned integer: 0...ULONG_MAX
 - string
+- value: %name
 - function: @function <-- the current function
             @function[uint] <-- function at index ``uint``
             @function[name] <-- function named ``name``
-- block: @block <-- the block containing the test_specification instruction
+- block: @block <-- the block containing the specify_test instruction
          @block[+uint] <-- the block ``uint`` blocks after the containing block
          @block[-uint] <-- the block ``uint`` blocks before the containing block
          @block[uint] <-- the block at index ``uint``
@@ -4366,9 +4367,9 @@ The following types of test arguments are supported:
             @argument[uint] <-- the argument at index ``uint`` of the current block
             @{block}.{argument} <-- the indicated argument in the indicated block
             @{function}.{argument} <-- the indicated argument in the entry block of the indicated function
-- instruction: @instruction <-- the instruction after* the test_specification instruction
-               @instruction[+uint] <-- the instruction ``uint`` instructions after* the test_specification instruction
-               @instruction[-uint] <-- the instruction ``uint`` instructions before* the test_specification instruction
+- instruction: @instruction <-- the instruction after* the specify_test instruction
+               @instruction[+uint] <-- the instruction ``uint`` instructions after* the specify_test instruction
+               @instruction[-uint] <-- the instruction ``uint`` instructions before* the specify_test instruction
                @instruction[uint] <-- the instruction at index ``uint``
                @{function}.{instruction} <-- the indicated instruction in the indicated function
                Example: @function[baz].instruction[19]
@@ -4383,7 +4384,7 @@ The following types of test arguments are supported:
 * Not counting instructions that are deleted when processing functions for tests.
   The following instructions currently are deleted:
 
-      test_specification
+      specify_test
       debug_value [trace]
 
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -545,7 +545,7 @@ ERROR(expected_sil_profiler_counter_total,none,
       "expected profiler counter total", ())
 ERROR(expected_sil_profiler_counter_hash,none,
       "expected profiler counter hash", ())
-ERROR(expected_sil_test_specification_body,none,
+ERROR(expected_sil_specify_test_body,none,
       "expected a string consisting of the space-separated test arguments", ())
 
 // SIL Values

--- a/include/swift/SIL/ParseTestSpecification.h
+++ b/include/swift/SIL/ParseTestSpecification.h
@@ -219,13 +219,13 @@ struct UnparsedSpecification {
 void getTestSpecificationComponents(StringRef specificationString,
                                     SmallVectorImpl<StringRef> &components);
 
-/// Finds and deletes each test_specification instruction in \p function and
+/// Finds and deletes each specify_test instruction in \p function and
 /// appends its string payload to the provided vector.
 void getTestSpecifications(
     SILFunction *function,
     SmallVectorImpl<UnparsedSpecification> &specifications);
 
-/// Given the string \p specification operand of a test_specification
+/// Given the string \p specification operand of a specify_test
 /// instruction from \p function, parse the arguments which it refers to into
 /// \p arguments and the component strings into \p argumentStrings.
 void parseTestArgumentsFromSpecification(

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -836,7 +836,7 @@ NON_VALUE_INST(DebugValueInst, debug_value,
                SILInstruction, None, DoesNotRelease)
 NON_VALUE_INST(DebugStepInst, debug_step,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
-NON_VALUE_INST(TestSpecificationInst, test_specification,
+NON_VALUE_INST(TestSpecificationInst, specify_test,
                SILInstruction, None, DoesNotRelease)
 #define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
   NON_VALUE_INST(Store##Name##Inst, store_##name, \

--- a/include/swift/SIL/Test.h
+++ b/include/swift/SIL/Test.h
@@ -1,4 +1,4 @@
-//===---- Test.h - Testing based on test_specification insts -*- C++ ----*-===//
+//===---- Test.h - Testing based on specify_test insts -*- C++ ----*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -26,7 +26,7 @@
 // of a function.  The goal is to get the same effect as calling a function and
 // checking its output.
 //
-// This is done via the test_specification instruction.  Using one or more
+// This is done via the specify_test instruction.  Using one or more
 // instances of it in your test case's SIL function, you can specify which test
 // (instance of FunctionTest) should be run and what arguments should be
 // provided to it.  The test grabs the arguments it expects out of the
@@ -59,10 +59,10 @@
 //    TestRunner pass:
 //     // RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
 // 2) A function in interesting_functionality_unit.sil contains the
-//    test_specification instruction.
+//    specify_test instruction.
 //      sil @f : $() -> () {
 //      ...
-//      test_specification "my-neato-utility 43 @trace[2] @function[other_fun]"
+//      specify_test "my-neato-utility 43 @trace[2] @function[other_fun]"
 //      ...
 //      }
 // 3) TestRunner finds the FunctionTest instance MyNeatoUtilityTest registered
@@ -109,18 +109,18 @@ namespace test {
 struct Arguments;
 class TestRunner;
 
-/// A test that is run when the corresponding test_specification instruction is
+/// A test that is run when the corresponding specify_test instruction is
 /// processed by the TestRunner pass.
 ///
 /// Tests are instantiated once at program launch.  At that time, they are
-/// stored in a registry name -> test.  When an test_specification instruction
+/// stored in a registry name -> test.  When an specify_test instruction
 /// naming a particular test is processed, that test is run.
 class FunctionTest final {
 public:
   /// Wraps a test lambda.
   ///
   /// There are three arguments in order of priority:
-  /// - SILFunction & - the function with the test_specification instruction
+  /// - SILFunction & - the function with the specify_test instruction
   /// - Arguments & - the resolved list of args specified by the instruction
   /// - FunctionTest & - the test being run; used to find less commonly used
   ///                    values such as the results of analyses

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3777,7 +3777,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   case SILInstructionKind::TestSpecificationInst: {
     // Parse the specification string.
     if (P.Tok.getKind() != tok::string_literal) {
-      P.diagnose(P.Tok, diag::expected_sil_test_specification_body);
+      P.diagnose(P.Tok, diag::expected_sil_specify_test_body);
       return true;
     }
     // Drop the double quotes.

--- a/lib/SIL/Parser/ParseTestSpecification.cpp
+++ b/lib/SIL/Parser/ParseTestSpecification.cpp
@@ -347,7 +347,7 @@ private:
     if (!consumePrefix("argument"))
       return nullptr;
     // If this is a bare @argument reference, it refers to the first argument
-    // of the block containing the test_specification.
+    // of the block containing the specify_test.
     if (!block) {
       block = context->getParent();
     }
@@ -385,7 +385,7 @@ private:
     if (empty() || peekPrefix(".")) {
       if (!within) {
         // If this is a bare @instruction reference, it refers to to the
-        // context of the test_specification.
+        // context of the specify_test.
         return context;
       }
       return getInstructionAtIndex(0, *within);
@@ -393,7 +393,7 @@ private:
     if (auto subscript = parseSubscript()) {
       // If this is a bare @instruction[...] reference, it can refer either to
       // an instruction counting from the beginning of the function or else to
-      // an instruction offset from the context of the test_specification.
+      // an instruction offset from the context of the specify_test.
       if (!within && subscript->isa<long long>()) {
         auto offset = subscript->get<long long>();
         return getInstructionOffsetFrom(context, offset);
@@ -422,7 +422,7 @@ private:
       return nullptr;
     if (empty() || peekPrefix(".")) {
       // If this is a bare @block reference, it refers to the block containing
-      // the test_specification instruction.
+      // the specify_test instruction.
       if (!within) {
         return context->getParent();
       }
@@ -432,7 +432,7 @@ private:
     if (auto subscript = parseSubscript()) {
       // If this is a bare @block[...] reference, it can refer either to a block
       // counting from the beginning of the function or else to a block offset
-      // from the block containing the context of the test_specification.
+      // from the block containing the context of the specify_test.
       if (!within && subscript->isa<long long>()) {
         return getBlockOffsetFrom(context->getParent(),
                                   subscript->get<long long>());
@@ -462,7 +462,7 @@ private:
       return nullptr;
     if (empty() || peekPrefix(".")) {
       // If this is a bare @function reference, it refers to the function
-      // containing the test_specification instruction.
+      // containing the specify_test instruction.
       if (!within) {
         return context->getFunction();
       }

--- a/test/SIL/OwnershipVerifier/guaranteed_chain.sil
+++ b/test/SIL/OwnershipVerifier/guaranteed_chain.sil
@@ -15,7 +15,7 @@ struct PairC {
 //
 sil [ossa] @testSSALongForwardingChain : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %0 : $C
   %s0 = struct $PairC(%0 : $C, %0 : $C)
   %s0a = struct_extract %s0 : $PairC, #PairC.first

--- a/test/SIL/Parser/test_instructions.sil
+++ b/test/SIL/Parser/test_instructions.sil
@@ -8,12 +8,12 @@ import Builtin
 //
 // In particular, this doesn't test parsing the components that make up the test
 // specification.
-// CHECK-LABEL: sil [ossa] @for_test_specification : {{.*}} {
-// CHECK:       test_specification "try-running-it foo bar 18 false baz"
-// CHECK-LABEL: } // end sil function 'for_test_specification'
-sil [ossa] @for_test_specification : $@convention(thin) () -> () {
+// CHECK-LABEL: sil [ossa] @for_specify_test : {{.*}} {
+// CHECK:       specify_test "try-running-it foo bar 18 false baz"
+// CHECK-LABEL: } // end sil function 'for_specify_test'
+sil [ossa] @for_specify_test : $@convention(thin) () -> () {
 entry:
-  test_specification "try-running-it foo bar 18 false baz"
+  specify_test "try-running-it foo bar 18 false baz"
   %4 = tuple()
   return %4 : $()
 }

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -108,18 +108,18 @@ entry(%0 : @owned $X):
   return %res : $X
 }
 
-// CHECK-LABEL: sil [ossa] @caller_test_specification : {{.*}} {
-// CHECK:         test_specification "foo bar baz"
-// CHECK-LABEL: } // end sil function 'caller_test_specification'
-sil [always_inline] [ossa] @callee_test_specification : $@convention(thin) () -> () {
+// CHECK-LABEL: sil [ossa] @caller_specify_test : {{.*}} {
+// CHECK:         specify_test "foo bar baz"
+// CHECK-LABEL: } // end sil function 'caller_specify_test'
+sil [always_inline] [ossa] @callee_specify_test : $@convention(thin) () -> () {
 entry:
-  test_specification "foo bar baz"
+  specify_test "foo bar baz"
   %retval = tuple ()
   return %retval : $()
 }
 
-sil [ossa] @caller_test_specification : $@convention(thin) () -> () {
-  %callee = function_ref @callee_test_specification : $@convention(thin) () -> ()
+sil [ossa] @caller_specify_test : $@convention(thin) () -> () {
+  %callee = function_ref @callee_specify_test : $@convention(thin) () -> ()
   %retval = apply %callee() : $@convention(thin) () -> ()
   return %retval : $()
 }

--- a/test/SIL/type_lowering_unit.sil
+++ b/test/SIL/type_lowering_unit.sil
@@ -11,7 +11,7 @@ struct S : ~Copyable {}
 // CHECK-LABEL: end {{.*}} print-type-lowering with: @argument[0]
 sil [ossa] @move_only_argument : $@convention(thin) (@owned S) -> () {
 bb0(%0 : @owned $S):
-  test_specification "print-type-lowering @argument[0]"
+  specify_test "print-type-lowering @argument[0]"
   destroy_value %0 : $S
   %retval = tuple ()
   return %retval : $()

--- a/test/SILOptimizer/accessbase_unit.sil
+++ b/test/SILOptimizer/accessbase_unit.sil
@@ -40,9 +40,9 @@ bb1(%box : $Box<C>):
   br exit(%value_ptr : $Builtin.RawPointer)               
 
 exit(%phi : $Builtin.RawPointer):                   
-  test_specification "get_access_base @argument"
-  test_specification "compute_access_storage @argument"
-  test_specification "accesspath-base @argument"
+  specify_test "get_access_base @argument"
+  specify_test "compute_access_storage @argument"
+  specify_test "accesspath-base @argument"
   %retval = tuple ()
   return %retval : $()
 } 
@@ -59,7 +59,7 @@ sil_global @global_c : $C
 // CHECK-LABEL: end running test {{.*}} on test_access_global
 sil @test_access_global : $@convention(thin) () -> () {
   %15 = global_addr @global_c : $*C
-  test_specification "get_typed_access_address @instruction"
+  specify_test "get_typed_access_address @instruction"
   %16 = begin_access [read] [dynamic] %15 : $*C
   end_access %16 : $*C
   %retval = tuple ()

--- a/test/SILOptimizer/accesspath_unit.sil
+++ b/test/SILOptimizer/accesspath_unit.sil
@@ -41,13 +41,13 @@ sil_global hidden @globalStruct : $S2
 // CHECK: end running test 2 of 2 on testRefElement: accesspath-base with: @trace[1]
 sil hidden [ossa] @testRefElement : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  test_specification "accesspath-base @trace[0]"
+  specify_test "accesspath-base @trace[0]"
   %p1 = ref_element_addr %0 : $Klass, #Klass.f
   debug_value [trace] %p1 : $*S
   %a1 = begin_access [read] [dynamic] %p1 : $*S
   %l1 = load [trivial] %a1 : $*S
   end_access %a1 : $*S
-  test_specification "accesspath-base @trace[1]"
+  specify_test "accesspath-base @trace[1]"
   %p2 = ref_element_addr %0 : $Klass, #Klass.f
   debug_value [trace] %p2 : $*S
   %a2 = begin_access [read] [dynamic] %p2 : $*S
@@ -78,7 +78,7 @@ bb0(%0 : @guaranteed $Klass):
 // CHECK: end running test 2 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[1]
 sil [ossa] @testGlobalAddrKlass : $@convention(thin) () -> () {
 bb0:
-  test_specification "accesspath-base @trace[0]"
+  specify_test "accesspath-base @trace[0]"
   %p1 = global_addr @globalKlass : $*Klass
   debug_value [trace] %p1 : $*Klass
   %a1 = begin_access [read] [dynamic] %p1 : $*Klass
@@ -86,7 +86,7 @@ bb0:
   end_borrow %l1 : $Klass
   end_access %a1 : $*Klass
 
-  test_specification "accesspath-base @trace[1]"
+  specify_test "accesspath-base @trace[1]"
   %p2 = global_addr @globalKlass : $*Klass
   debug_value [trace] %p2 : $*Klass
   %a2 = begin_access [read] [dynamic] %p2 : $*Klass
@@ -141,7 +141,7 @@ bb0:
 // CHECK: end running test 3 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[2]
 sil [ossa] @testGlobalAddrStruct : $@convention(thin) () -> () {
 bb0:
-  test_specification "accesspath-base @trace[0]"
+  specify_test "accesspath-base @trace[0]"
   %p3 = global_addr @globalStruct : $*S2
   debug_value [trace] %p3 : $*S2
   %a3 = begin_access [read] [dynamic] %p3 : $*S2
@@ -149,7 +149,7 @@ bb0:
   end_borrow %l3 : $S2
   end_access %a3 : $*S2
 
-  test_specification "accesspath-base @trace[1]"
+  specify_test "accesspath-base @trace[1]"
   %p4 = global_addr @globalStruct : $*S2
   debug_value [trace] %p4 : $*S2
   %a4 = begin_access [read] [dynamic] %p4 : $*S2
@@ -158,7 +158,7 @@ bb0:
   end_borrow %l4 : $Klass
   end_access %a4 : $*S2
 
-  test_specification "accesspath-base @trace[2]"
+  specify_test "accesspath-base @trace[2]"
   %p5 = global_addr @globalStruct : $*S2
   debug_value [trace] %p5 : $*S2
   %a5 = begin_access [read] [dynamic] %p5 : $*S2

--- a/test/SILOptimizer/address_lowering_preprocessed.sil
+++ b/test/SILOptimizer/address_lowering_preprocessed.sil
@@ -28,7 +28,7 @@ bb0(%t : @owned $T, %box : $*Box<T>):
   // The destroy_value appears first in the textual SIL in order to be first in
   // the use list.  Before running AddressLowering, it's sunk to after the
   // end_access.
-  test_specification "instruction-move-before @instruction @instruction[+5]"
+  specify_test "instruction-move-before @instruction @instruction[+5]"
   destroy_value %t : $T
   %copy = copy_value %t : $T
   %field_addr = struct_element_addr %box : $*Box<T>, #Box._value

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -50,21 +50,21 @@ class D : C {}
 
 sil [ossa] @introducer_identity : $@convention(thin) (@guaranteed C, @in C) -> () {
 entry(%0 : @guaranteed $C, %1 : $*C):
-  test_specification "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers @trace[0]"
   debug_value [trace] %0 : $C
   %borrow1 = begin_borrow %0 : $C
-  test_specification "find-borrow-introducers @trace[1]"
+  specify_test "find-borrow-introducers @trace[1]"
   debug_value [trace] %borrow1 : $C
 
   %borrow2 = load_borrow %1 : $*C
-  test_specification "find-borrow-introducers @trace[2]"
+  specify_test "find-borrow-introducers @trace[2]"
   debug_value [trace] %borrow2 : $C
   end_borrow %borrow2 : $C
 
   br exit(%borrow1 : $C)
 
 exit(%reborrow : @guaranteed $C):
-  test_specification "find-borrow-introducers @trace[3]"
+  specify_test "find-borrow-introducers @trace[3]"
   debug_value [trace] %reborrow : $C
   end_borrow %reborrow : $C
   destroy_addr %1 : $*C
@@ -86,7 +86,7 @@ entry:
   br none(%trivial : $FakeOptional<C>)
 
 none(%phi : @guaranteed $FakeOptional<C>):
-  test_specification "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers @trace[0]"
   debug_value [trace] %phi : $FakeOptional<C>
   %retval = tuple ()
   return %retval : $()
@@ -108,7 +108,7 @@ entry:
   br exit
 
 unreachable_loop(%phiCycle : @guaranteed $C):
-  test_specification "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers @trace[0]"
   debug_value [trace] %phiCycle : $C
   br unreachable_loop(%phiCycle : $C)
 
@@ -141,7 +141,7 @@ bb1(%payload : @guaranteed $D):
   %first = struct_extract %aggregate : $PairC, #PairC.first
   %second = struct_extract %aggregate : $PairC, #PairC.second
   %aggregate2 = struct $PairC(%first : $C, %second : $C)
-  test_specification "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers @trace[0]"
   debug_value [trace] %aggregate2 : $PairC
   br exit
 
@@ -178,7 +178,7 @@ entry(%0 : @guaranteed $C):
 bb2(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
   %first = struct_extract %phi : $PairC, #PairC.first
   %aggregate2 = struct $PairC(%reborrow : $C, %first : $C)
-  test_specification "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers @trace[0]"
   debug_value [trace] %aggregate2 : $PairC
   br exit
 
@@ -212,7 +212,7 @@ entry(%0 : @guaranteed $C):
 bb2(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
   %first = struct_extract %phi : $PairC, #PairC.first
   %aggregate2 = struct $PairC(%reborrow : $C, %first : $C)
-  test_specification "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers @trace[0]"
   debug_value [trace] %aggregate2 : $PairC
   br exit
 
@@ -229,7 +229,7 @@ exit:
 // CHECK-LABEL: end running test 1 of 1 on introducer_dependence: find-borrow-introducers with: @trace[0]
 sil [ossa] @introducer_dependence : $@convention(thin) (@guaranteed C, @guaranteed Builtin.NativeObject) -> () {
 entry(%0 : @guaranteed $C, %1 : @guaranteed $Builtin.NativeObject):
-  test_specification "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers @trace[0]"
   %dependent = mark_dependence %0 : $C on %1 : $Builtin.NativeObject
   debug_value [trace] %dependent : $C
   %retval = tuple ()
@@ -242,7 +242,7 @@ entry(%0 : @guaranteed $C, %1 : @guaranteed $Builtin.NativeObject):
 // CHECK-LABEL: end running test 1 of 1 on introducer_bridge: find-borrow-introducers with: @trace[0]
 sil [ossa] @introducer_bridge : $@convention(thin) (@guaranteed C, Builtin.Word) -> () {
 entry(%0 : @guaranteed $C, %1 : $Builtin.Word):
-  test_specification "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers @trace[0]"
   %bridge = ref_to_bridge_object %0 : $C, %1 : $Builtin.Word
   debug_value [trace] %bridge : $Builtin.BridgeObject
   %retval = tuple ()

--- a/test/SILOptimizer/canonicalize_borrow_scope_unit.sil
+++ b/test/SILOptimizer/canonicalize_borrow_scope_unit.sil
@@ -29,7 +29,7 @@ struct Unmanaged<Instance> where Instance : AnyObject {
 // CHECK-LABEL: end {{.*}} on copy_and_move_argument: canonicalize-borrow-scope
 sil [ossa] @copy_and_move_argument : $@convention(thin) <Instance where Instance : AnyObject> (@guaranteed Instance) -> Unmanaged<Instance> {
 bb0(%instance : @guaranteed $Instance):
-  test_specification "canonicalize-borrow-scope @argument"
+  specify_test "canonicalize-borrow-scope @argument"
   %copy_1 = copy_value %instance : $Instance
   %copy_2 = copy_value %copy_1 : $Instance
   %move = move_value %copy_2 : $Instance
@@ -54,7 +54,7 @@ bb0(%instance : @guaranteed $Instance):
 // CHECK-LABEL: end {{.*}} on copy_and_move_lexical_argument: canonicalize-borrow-scope
 sil [ossa] @copy_and_move_lexical_argument : $@convention(thin) <Instance where Instance : AnyObject> (@guaranteed Instance) -> Unmanaged<Instance> {
 bb0(%instance : @guaranteed $Instance):
-  test_specification "canonicalize-borrow-scope @argument"
+  specify_test "canonicalize-borrow-scope @argument"
   %copy_1 = copy_value %instance : $Instance
   %copy_2 = copy_value %copy_1 : $Instance
   %move = move_value [lexical] %copy_2 : $Instance
@@ -89,7 +89,7 @@ sil [ossa] @dont_rewrite_inner_forwarding_user : $@convention(thin) () -> (@owne
     %getD = function_ref @getD : $@convention(thin) () -> (@owned D)
     %takeC = function_ref @takeC : $@convention(thin) (@owned C) -> ()
     %d = apply %getD() : $@convention(thin) () -> (@owned D)
-    test_specification "canonicalize-borrow-scope @instruction"
+    specify_test "canonicalize-borrow-scope @instruction"
     %b = begin_borrow %d : $D
     %c2 = copy_value %b : $D
     %u2 = upcast %c2 : $D to $C
@@ -126,7 +126,7 @@ sil [ossa] @dont_rewrite_inner_forwarding_user : $@convention(thin) () -> (@owne
 // CHECK-LABEL: end running test {{.*}} on dont_hoist_inner_destructure: canonicalize-borrow-scope
 sil [ossa] @dont_hoist_inner_destructure : $@convention(thin) (@owned S) -> () {
 entry(%s : @owned $S):
-  test_specification "canonicalize-borrow-scope @instruction"
+  specify_test "canonicalize-borrow-scope @instruction"
   %s_borrow = begin_borrow %s : $S
   %s_copy = copy_value %s_borrow : $S
   cond_br undef, left, right

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -39,8 +39,8 @@ bb0(%addr : $*C):
   debug_value [trace] %instance : $C
                                                          // respect access scopes
                                                          // VVVV
-  test_specification "canonicalize-ossa-lifetime true false true @trace"
-  test_specification "canonicalize-ossa-lifetime true false false @trace"
+  specify_test "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize-ossa-lifetime true false false @trace"
                                                          // ^^^^^
                                                          // respect access scopes
   %copy = copy_value %instance : $C
@@ -63,7 +63,7 @@ bb0(%addr : $*C):
 sil [ossa] @reuse_destroy_after_barrier_phi : $@convention(thin) (@owned C) -> @owned C {
 entry(%instance : @owned $C):
   debug_value [trace] %instance : $C
-  test_specification "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize-ossa-lifetime true false true @trace"
   %get = function_ref @getOwned : $@convention(thin) () -> @owned C
   cond_br undef, through, loop
 
@@ -89,7 +89,7 @@ exit(%out : @owned $C):
 sil [ossa] @store_arg_to_out_addr : $@convention(thin) (@owned C) -> @out C {
 bb0(%0 : $*C, %instance : @owned $C):
   debug_value [trace] %instance : $C
-  test_specification "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize-ossa-lifetime true false true @trace"
   %copy = copy_value %instance : $C
   store %copy to [init] %0 : $*C
   destroy_value %instance : $C
@@ -111,7 +111,7 @@ sil [ossa] @store_arg_to_out_addr_with_barrier : $@convention(thin) (@owned C) -
 bb0(%0 : $*C, %instance : @owned $C):
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   debug_value [trace] %instance : $C
-  test_specification "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize-ossa-lifetime true false true @trace"
   %copy = copy_value %instance : $C
   store %copy to [init] %0 : $*C
   apply %barrier() : $@convention(thin) () -> ()
@@ -132,7 +132,7 @@ right2(%c2p : @owned $C):
 
 exit(%phi : @owned $C, %typhi : $S):
   debug_value [trace] %phi : $C
-  test_specification "canonicalize-ossa-lifetime true false true @trace"
+  specify_test "canonicalize-ossa-lifetime true false true @trace"
   destroy_value %phi : $C
   %retval = tuple ()
   return %retval : $()
@@ -156,7 +156,7 @@ bb0:
 // CHECK-LABEL: end running test {{.*}} on dont_move_destroy_value_of_moveonly_struct: canonicalize-ossa-lifetime with: true, false, true, @argument
 sil [ossa] @dont_move_destroy_value_of_moveonly_struct : $@convention(thin) (@owned MoS) -> () {
 entry(%instance : @owned $MoS):
-  test_specification "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
   %empty = function_ref @empty : $@convention(thin) () -> ()
   apply %empty() : $@convention(thin) () -> ()
   destroy_value %instance : $MoS
@@ -173,7 +173,7 @@ entry(%instance : @owned $MoS):
 // CHECK-LABEL: end running test {{.*}} on dont_move_destroy_value_of_moveonly_enum: canonicalize-ossa-lifetime with: true, false, true, @argument
 sil [ossa] @dont_move_destroy_value_of_moveonly_enum : $@convention(thin) (@owned MoE) -> () {
 entry(%instance : @owned $MoE):
-  test_specification "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
   %empty = function_ref @empty : $@convention(thin) () -> ()
   apply %empty() : $@convention(thin) () -> ()
   destroy_value %instance : $MoE
@@ -195,7 +195,7 @@ entry(%instance : @owned $MoE):
 // CHECK-LABEL: end running test 1 of 1 on respect_boundary_edges_when_extending_to_deinit_barriers
 sil [ossa] @respect_boundary_edges_when_extending_to_deinit_barriers : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  test_specification "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   apply %barrier() : $@convention(thin) () -> ()
   cond_br undef, die, destroy
@@ -223,7 +223,7 @@ destroy:
 // CHECK-LABEL: end running test {{.*}} on respect_boundary_edges_when_extending_to_deinit_barriers_2
 sil [ossa] @respect_boundary_edges_when_extending_to_deinit_barriers_2 : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  test_specification "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   apply %barrier() : $@convention(thin) () -> ()
   cond_br undef, die, destroy
@@ -256,7 +256,7 @@ destroy:
 // CHECK-LABEL: end running test {{.*}} on respect_boundary_edges_when_extending_to_deinit_barriers_3
 sil [ossa] @respect_boundary_edges_when_extending_to_deinit_barriers_3 : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  test_specification "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   apply %barrier() : $@convention(thin) () -> ()
   cond_br undef, die, destroy
@@ -288,7 +288,7 @@ destroy:
 // CHECK-LABEL: end running test 1 of 1 on respect_preexisting_destroy_values_when_extending_to_deinit_barriers
 sil [ossa] @respect_preexisting_destroy_values_when_extending_to_deinit_barriers : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  test_specification "canonicalize-ossa-lifetime true false true @argument"
+  specify_test "canonicalize-ossa-lifetime true false true @argument"
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   cond_br undef, die, destroy
 

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -67,24 +67,24 @@ sil [ossa] @empty_fn_caller_caller : $@convention(thin) () -> () {
 // CHECK-LABEL: end running test 6 of {{[0-9]+}} on call_functions: is-deinit-barrier
 sil [ossa] @call_functions : $@convention(thin) () -> () {
 entry:
-  test_specification "dump-function"
-  test_specification "is-deinit-barrier @instruction[1]"
+  specify_test "dump-function"
+  specify_test "is-deinit-barrier @instruction[1]"
   %empty_fn = function_ref @empty_fn : $@convention(thin) () -> ()
   apply %empty_fn() : $@convention(thin) () -> ()
 
-  test_specification "is-deinit-barrier @instruction[3]"
+  specify_test "is-deinit-barrier @instruction[3]"
   %empty_fn_caller = function_ref @empty_fn_caller : $@convention(thin) () -> ()
   apply %empty_fn_caller() : $@convention(thin) () -> ()
 
-  test_specification "is-deinit-barrier @instruction[5]"
+  specify_test "is-deinit-barrier @instruction[5]"
   %empty_fn_caller_caller = function_ref @empty_fn_caller_caller : $@convention(thin) () -> ()
   apply %empty_fn_caller_caller() : $@convention(thin) () -> ()
 
-  test_specification "is-deinit-barrier @instruction[7]"
+  specify_test "is-deinit-barrier @instruction[7]"
   %unknown = function_ref @unknown : $@convention(thin) () -> ()
   apply %unknown() : $@convention(thin) () -> ()
 
-  test_specification "is-deinit-barrier @instruction[9]"
+  specify_test "is-deinit-barrier @instruction[9]"
   %unknown_caller = function_ref @unknown_caller : $@convention(thin) () -> ()
   apply %unknown_caller() : $@convention(thin) () -> ()
 
@@ -104,7 +104,7 @@ sil @borrowA : $@yield_once @convention(thin) () -> @yields @guaranteed A
 sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
   %borrowA = function_ref @borrowA : $@yield_once @convention(thin) () -> @yields @guaranteed A
   (%a, %token) = begin_apply %borrowA() : $@yield_once @convention(thin) () -> @yields @guaranteed A
-  test_specification "is-deinit-barrier @instruction"
+  specify_test "is-deinit-barrier @instruction"
   hop_to_executor %a : $A
   end_apply %token
   %retval = tuple ()
@@ -125,15 +125,15 @@ sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
 // CHECK-LABEL: end running test 3 of {{[0-9]+}} on test_instructions_1: is-deinit-barrier
 sil [ossa] @test_instructions_1 : $@convention(thin) () -> () {
 entry:
-  test_specification "is-deinit-barrier @instruction"
+  specify_test "is-deinit-barrier @instruction"
   debug_step
 
   %my_errno = global_addr @my_errno : $*Builtin.Int32
-  test_specification "is-deinit-barrier @instruction"
+  specify_test "is-deinit-barrier @instruction"
   %my_errno_value = load [trivial] %my_errno : $*Int32
 
   %global_var = global_addr @global_var : $*Builtin.Int32
-  test_specification "is-deinit-barrier @instruction"
+  specify_test "is-deinit-barrier @instruction"
   %global_var_value = load [trivial] %global_var : $*Int32
 
   %retval = tuple ()

--- a/test/SILOptimizer/enclosing_def_unit.sil
+++ b/test/SILOptimizer/enclosing_def_unit.sil
@@ -36,10 +36,10 @@ class D : C {}
 
 sil [ossa] @enclosing_def_empty : $@convention(thin) (@guaranteed C, @in C) -> () {
 entry(%0 : @guaranteed $C, %1 : $*C):
-  test_specification "find-enclosing-defs @trace[0]"
+  specify_test "find-enclosing-defs @trace[0]"
   debug_value [trace] %0 : $C
   %borrow1 = load_borrow %1 : $*C
-  test_specification "find-enclosing-defs @trace[1]"
+  specify_test "find-enclosing-defs @trace[1]"
   debug_value [trace] %borrow1 : $C
   end_borrow %borrow1 : $C
   destroy_addr %1 : $*C
@@ -61,7 +61,7 @@ entry:
   br none(%trivial : $FakeOptional<C>)
 
 none(%phi : @guaranteed $FakeOptional<C>):
-  test_specification "find-enclosing-defs @trace[0]"
+  specify_test "find-enclosing-defs @trace[0]"
   debug_value [trace] %phi : $FakeOptional<C>
   %retval = tuple ()
   return %retval : $()
@@ -80,7 +80,7 @@ entry:
   br exit
 
 unreachable_loop(%phiCycle : @guaranteed $C):
-  test_specification "find-enclosing-defs @trace[0]"
+  specify_test "find-enclosing-defs @trace[0]"
   debug_value [trace] %phiCycle : $C
   br unreachable_loop(%phiCycle : $C)
 
@@ -114,7 +114,7 @@ bb1(%payload : @guaranteed $D):
   %first = struct_extract %aggregate : $PairC, #PairC.first
   %second = struct_extract %aggregate : $PairC, #PairC.second
   %aggregate2 = struct $PairC(%first : $C, %second : $C)
-  test_specification "find-enclosing-defs @trace[0]"
+  specify_test "find-enclosing-defs @trace[0]"
   debug_value [trace] %aggregate2 : $PairC
   br exit
 
@@ -144,7 +144,7 @@ bb2(%reborrow2 : @guaranteed $C):
   br bb3(%reborrow2 : $C)
 
 bb3(%reborrow3 : @guaranteed $C):
-  test_specification "find-enclosing-defs @trace[0]"
+  specify_test "find-enclosing-defs @trace[0]"
   debug_value [trace] %reborrow3 : $C
   end_borrow %reborrow3 : $C
   %retval = tuple ()
@@ -171,7 +171,7 @@ bb2(%reborrow_outer : @guaranteed $C, %reborrow_inner : @guaranteed $C):
   br bb3(%reborrow_inner : $C)
 
 bb3(%reborrow_inner3 : @guaranteed $C):
-  test_specification "find-enclosing-defs @trace[0]"
+  specify_test "find-enclosing-defs @trace[0]"
   debug_value [trace] %reborrow_inner3 : $C
 
   end_borrow %reborrow_inner3 : $C
@@ -198,7 +198,7 @@ entry(%0 : @guaranteed $C):
   br bb2(%borrow : $C, %first1 : $C)
 
 bb2(%reborrow_outer : @guaranteed $C, %forward : @guaranteed $C):
-  test_specification "find-enclosing-defs @trace[0]"
+  specify_test "find-enclosing-defs @trace[0]"
   debug_value [trace] %forward : $C
 
   %aggregate2 = struct $PairC(%reborrow_outer : $C, %forward : $C)

--- a/test/SILOptimizer/field_sensitive_liverange_unit.sil
+++ b/test/SILOptimizer/field_sensitive_liverange_unit.sil
@@ -21,7 +21,7 @@ sil @getC : $@convention(thin) () -> (@owned C)
 // CHECK-NEXT: at 1
 sil [ossa] @testReborrow : $@convention(thin) () -> () {
 bb0:
-  test_specification """
+  specify_test """
                      fieldsensitive-multidefuse-liverange
                      @instruction
                      defs: 
@@ -72,7 +72,7 @@ bb4:
 // CHECK-LABEL: end running test 1 of 1 on testMultiDefUseAddressReinit
 sil [ossa] @testMultiDefUseAddressReinit : $@convention(thin) (@owned C) -> () {
 bb0(%0: @owned $C):
-  test_specification """
+  specify_test """
                      fieldsensitive-multidefuse-liverange
                      @instruction
                      defs: 
@@ -120,7 +120,7 @@ bb0:
   br bb3
 
 bb1(%1 : @owned $C, %2 : @owned $C):
-  test_specification """
+  specify_test """
                      fieldsensitive-multidefuse-liverange
                      @instruction
                      defs: 
@@ -161,7 +161,7 @@ bb0:
   %stack = alloc_stack $C
   %c = apply %getC() : $@convention(thin) () -> (@owned C)
   store %c to [init] %stack : $*C
-  test_specification """
+  specify_test """
                      fieldsensitive-multidefuse-liverange
                      @instruction[-3]
                      defs: 

--- a/test/SILOptimizer/instruction_deleter.sil
+++ b/test/SILOptimizer/instruction_deleter.sil
@@ -21,7 +21,7 @@ sil [ossa] @dontDeleteDeadMoveOnlyValue : $() -> () {
   %get = function_ref @getMOS : $@convention(thin) () -> (@owned MOS)
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   %mos = apply %get() : $@convention(thin) () -> (@owned MOS)
-  test_specification "deleter-delete-if-dead @instruction"
+  specify_test "deleter-delete-if-dead @instruction"
   %mov = move_value %mos : $MOS
   apply %barrier() : $@convention(thin) () -> ()
   destroy_value %mov : $MOS

--- a/test/SILOptimizer/lexical_destroy_folding_unit.sil
+++ b/test/SILOptimizer/lexical_destroy_folding_unit.sil
@@ -24,7 +24,7 @@ sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
 // CHECK-LABEL: } // end sil function 'nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use'
 sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):
-  test_specification "lexical-destroy-folding @trace[0]"
+  specify_test "lexical-destroy-folding @trace[0]"
   %copy_2 = copy_value %instance : $C
   %lifetime = begin_borrow [lexical] %instance : $C
   debug_value [trace] %lifetime : $C

--- a/test/SILOptimizer/lexical_unit.sil
+++ b/test/SILOptimizer/lexical_unit.sil
@@ -23,7 +23,7 @@ right:
   %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
   br exit(%c2 : $C)
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
@@ -45,7 +45,7 @@ right:
   %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
   br exit(%c2 : $C)
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
@@ -67,7 +67,7 @@ right:
   %m2 = move_value [lexical] %c2 : $C
   br exit(%m2 : $C)
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
@@ -90,7 +90,7 @@ right:
   %m2 = move_value [lexical] %c2 : $C
   br exit(%m2 : $C)
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
@@ -128,7 +128,7 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
@@ -167,7 +167,7 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
@@ -206,7 +206,7 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
@@ -245,7 +245,7 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()
@@ -284,7 +284,7 @@ rb(%cr : @owned $C):
   br exit(%cr : $C)
 
 exit(%cm : @owned $C):
-  test_specification "is-lexical @block.argument"
+  specify_test "is-lexical @block.argument"
   destroy_value %cm : $C
   %retval = tuple ()
   return %retval : $()

--- a/test/SILOptimizer/liveness_incomplete_unit.sil
+++ b/test/SILOptimizer/liveness_incomplete_unit.sil
@@ -31,7 +31,7 @@ bb0(%0 : @owned $FakeOptional<C>):
   switch_enum %0 : $FakeOptional<C>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
 bb1(%payload : @owned $C):
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %payload : $C
   unreachable
 
@@ -55,7 +55,7 @@ bb2:
   br bb3(%1 : $C)
 
 bb3(%2 : @owned $C):
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %2 : $C
   unreachable
 }
@@ -67,7 +67,7 @@ bb3(%2 : @owned $C):
 sil [ossa] @testDeadInstruction : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %1 = copy_value %0 : $C
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %1 : $C
   unreachable
 }
@@ -89,7 +89,7 @@ bb0:
   br bb3
 
 bb1(%1 : @owned $C):
-  test_specification "multidef-liveness @trace[0] @trace[1]"
+  specify_test "multidef-liveness @trace[0] @trace[1]"
   debug_value [trace] %1 : $C
   %2 = move_value %1 : $C
   debug_value [trace] %2 : $C
@@ -115,7 +115,7 @@ sil shared [ossa] @testInnerUnreachable : $@convention(thin) (@guaranteed C, @th
 bb0(%0 : @guaranteed $C, %1 : $@thick Never.Type):
   %2 = alloc_stack $C
   %3 = store_borrow %0 to %2 : $*C
-  test_specification "scoped-address-liveness @trace[0]"
+  specify_test "scoped-address-liveness @trace[0]"
   debug_value [trace] %3 : $*C
   %5 = load_borrow %3 : $*C
   %6 = function_ref @genericReturn : $@convention(thin) <τ_0_0> (@guaranteed C) -> @out τ_0_0
@@ -140,7 +140,7 @@ bb0(%0 : @guaranteed $C, %1 : $@thick Never.Type):
 sil [ossa] @testMultiDefDeadDefBoundaryEdge : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %copy0 = copy_value %0 : $C
-  test_specification "multidef-liveness @trace[0] @trace[1]"
+  specify_test "multidef-liveness @trace[0] @trace[1]"
   debug_value [trace] %copy0 : $C
   cond_br undef, bb1, bb3
 

--- a/test/SILOptimizer/liveness_unit.sil
+++ b/test/SILOptimizer/liveness_unit.sil
@@ -34,7 +34,7 @@ bb0(%0 : @guaranteed $C):
 bb1(%1 : @owned $C):
   destroy_value %1 : $C
   %2 = copy_value %0 : $C
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %2 : $C
   br bb2
 
@@ -59,7 +59,7 @@ bb0:
 
 bb1(%1 : @owned $C):
   %2 = move_value %1 : $C
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %2 : $C
   br bb2
 
@@ -97,7 +97,7 @@ bb1:
 
 bb2:
   %borrow2 = begin_borrow %0 : $C
-  test_specification "multidef-liveness @trace[0] @trace[1]"
+  specify_test "multidef-liveness @trace[0] @trace[1]"
   debug_value [trace] %borrow2 : $C
   br bb3(%borrow2 : $C)
 
@@ -121,7 +121,7 @@ sil [ossa] @testGuaranteedForwarding : $@convention(thin) (@owned D) -> () {
 bb0(%0 : @owned $D):
   %borrow0 = begin_borrow %0 : $D
   %c = unchecked_ref_cast %borrow0 : $D to $C
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %c : $C
   %d = unchecked_ref_cast %c : $C to $D
   %f = ref_element_addr %d : $D, #D.object
@@ -139,7 +139,7 @@ bb0(%0 : @owned $D):
 // CHECK: last user:   end_apply
 sil [ossa] @testGuaranteedResult : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
-  test_specification "ssa-liveness @argument[0]"
+  specify_test "ssa-liveness @argument[0]"
   %2 = class_method %0 : $D, #D.borrowed!read : (D) -> () -> (), $@yield_once @convention(method) (@guaranteed D) -> @yields @guaranteed C
   (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed D) -> @yields @guaranteed C
   end_apply %4
@@ -154,7 +154,7 @@ bb0(%0 : @guaranteed $D):
 sil [ossa] @testScopedAddress : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
   %f = ref_element_addr %0 : $D, #D.object
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %f : $*C
   %access = begin_access [read] [static] %f : $*C
   %o = load [copy] %access : $*C
@@ -170,7 +170,7 @@ bb0(%0 : @guaranteed $D):
 // CHECK: last user: %{{.*}} = ref_element_addr
 sil [ossa] @testDeadAddress : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
-  test_specification "ssa-liveness @argument[0]"
+  specify_test "ssa-liveness @argument[0]"
   %f = ref_element_addr %0 : $D, #D.object
   %99 = tuple()
   return %99 : $()
@@ -197,7 +197,7 @@ bb0(%0 : @guaranteed $D):
 sil [ossa] @testMultiDefLiveOutNoBoundary : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %copy0 = copy_value %0 : $C
-  test_specification "multidef-liveness @trace[0] @trace[1] @trace[2] @trace[3]"
+  specify_test "multidef-liveness @trace[0] @trace[1] @trace[2] @trace[3]"
   debug_value [trace] %copy0 : $C
   cond_br undef, bb1, bb3
 
@@ -232,7 +232,7 @@ bb4(%phi : @owned $C):
 // CHECK-NEXT-LABEL: end running test 1 of 1 on testSSADeadRefElementAddr: ssa-liveness
 sil [ossa] @testSSADeadRefElementAddr : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "ssa-liveness @argument[0]"
+  specify_test "ssa-liveness @argument[0]"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -258,7 +258,7 @@ bb3(%phi : @guaranteed $D):
 // CHECK-NEXT: dead def: %0 = argument of bb0 : $C
 sil [ossa] @testSSAInnerReborrowedPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "ssa-liveness @argument[0]"
+  specify_test "ssa-liveness @argument[0]"
   %borrow0 = begin_borrow %0 : $C
   %aggregate = struct $PairC(%borrow0 : $C, %borrow0 : $C)
   br bb1(%borrow0 : $C, %aggregate : $PairC)
@@ -292,7 +292,7 @@ bb1(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
 // CHECK-NEXT: end running
 sil [ossa] @testSSADeadGuaranteedPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "ssa-liveness @argument[0]"
+  specify_test "ssa-liveness @argument[0]"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -325,7 +325,7 @@ bb3(%deadPhi : @guaranteed $D):
 // CHECK-NEXT: end running
 sil [ossa] @testSSADominatedPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "ssa-liveness @argument[0]"
+  specify_test "ssa-liveness @argument[0]"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -354,7 +354,7 @@ bb3(%phi : @guaranteed $D):
 // CHECK-SAME: load
 sil [ossa] @testSSAPartialDominatedPhi : $@convention(thin) (@guaranteed C, @guaranteed C) -> () {
 bb0(%0 : @guaranteed $C, %1 : @guaranteed $C):
-  test_specification "ssa-liveness @argument[0]"
+  specify_test "ssa-liveness @argument[0]"
   %borrow1 = begin_borrow %1 : $C
   %aggregate = struct $PairC(%0 : $C, %borrow1 : $C)
   br bb1(%borrow1 : $C, %aggregate : $PairC)
@@ -383,7 +383,7 @@ bb1(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
 sil [ossa] @testSSAReborrowedPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %borrow = begin_borrow %0 : $C
-  test_specification "ssa-liveness @trace[0]"
+  specify_test "ssa-liveness @trace[0]"
   debug_value [trace] %borrow : $C
   %aggregate = struct $PairC(%borrow : $C, %borrow : $C)
   br bb1(%borrow : $C, %aggregate : $PairC)
@@ -403,7 +403,7 @@ bb1(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
 //
 sil [ossa] @testSSALongForwardingChain : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "ssa-liveness @argument[0]"
+  specify_test "ssa-liveness @argument[0]"
   %s0 = struct $PairC(%0 : $C, %0 : $C)
   %s0a = struct_extract %s0 : $PairC, #PairC.first
   %s0b = struct_extract %s0 : $PairC, #PairC.second
@@ -513,7 +513,7 @@ sil [ossa] @testMultiDefUseAddressReinit : $@convention(thin) (@owned C) -> () {
 bb0(%0: @owned $C):
   %1 = alloc_stack $C
   %2 = copy_value %0 : $C
-  test_specification """
+  specify_test """
                      multidefuse-liveness defs: @instruction @block[1].instruction[2]
                      uses: @block[1].instruction[0]
                      """

--- a/test/SILOptimizer/opaque_values_unit.sil
+++ b/test/SILOptimizer/opaque_values_unit.sil
@@ -16,6 +16,6 @@ class C {}
 // CHECK-LABEL: end running test 1 of {{[^,]+}} on f: function-get-self-argument-index
 sil [ossa] @f : $@convention(method) <T> (@guaranteed C) -> @out T {
 entry(%instance : @guaranteed $C):
-    test_specification "function-get-self-argument-index"
+    specify_test "function-get-self-argument-index"
     unreachable
 }

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -19,7 +19,7 @@ public enum FakeOptional<T> {
 // CHECK-LABEL: end running test 1 of 1 on eagerConsumneOwnedArg: ossa-lifetime-completion with: @argument
 sil [ossa] @eagerConsumneOwnedArg : $@convention(thin) (@owned C) -> () {
 entry(%0 : @_eagerMove @owned $C):
-  test_specification "ossa-lifetime-completion @argument"
+  specify_test "ossa-lifetime-completion @argument"
   br exit
 
 exit:
@@ -39,7 +39,7 @@ exit:
 // CHECK-LABEL: end running test 1 of 1 on lexicalOwnedArg: ossa-lifetime-completion with: @argument
 sil [ossa] @lexicalOwnedArg : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
-  test_specification "ossa-lifetime-completion @argument"
+  specify_test "ossa-lifetime-completion @argument"
   cond_br undef, bb1, bb2
 bb1:
   br bb3
@@ -58,7 +58,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'borrowTest'
 sil [ossa] @borrowTest : $@convention(method) (@owned C) -> () {
 bb0(%0 : @owned $C):
-  test_specification "ossa-lifetime-completion @instruction[0]"
+  specify_test "ossa-lifetime-completion @instruction[0]"
   %borrow = begin_borrow %0 : $C
   cond_br undef, bb1, bb2
 
@@ -83,7 +83,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'enumTest'
 sil [ossa] @enumTest : $@convention(method) (@guaranteed FakeOptional<C>) -> () {
 bb0(%0 : @guaranteed $FakeOptional<C>):
-  test_specification "ossa-lifetime-completion @instruction[0]"
+  specify_test "ossa-lifetime-completion @instruction[0]"
   %copy = copy_value %0 : $FakeOptional<C>
   %borrow = begin_borrow %copy : $FakeOptional<C>
   switch_enum %borrow : $FakeOptional<C>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
@@ -106,7 +106,7 @@ sil @use_guaranteed : $@convention(thin) (@guaranteed C) -> ()
 
 sil [ossa] @argTest : $@convention(method) (@owned C) -> () {
 bb0(%0 : @owned $C):
-  test_specification "ossa-lifetime-completion @argument"
+  specify_test "ossa-lifetime-completion @argument"
   debug_value %0 : $C
   cond_br undef, bb1, bb2
 
@@ -130,7 +130,7 @@ bb4:
 // Ensure no assert fires while inserting dead end blocks to the worklist
 sil [ossa] @testLexicalLifetimeCompletion : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
-  test_specification "ossa-lifetime-completion @argument"
+  specify_test "ossa-lifetime-completion @argument"
   debug_value %0 : $C, let, name "newElements", argno 1
   cond_br undef, bb1, bb2
 
@@ -173,7 +173,7 @@ sil @foo : $@convention(thin) (@guaranteed C) -> ()
 // Ensure no assert fires while handling lifetime end of partial_apply
 sil [ossa] @testPartialApplyStack1 : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "ossa-lifetime-completion @instruction[0]"
+  specify_test "ossa-lifetime-completion @instruction[0]"
   %8 = copy_value %0 : $C
   %9 = begin_borrow %8 : $C
   %80 = function_ref @foo : $@convention(thin) (@guaranteed C) -> ()
@@ -197,7 +197,7 @@ bb3:
 // Ensure no assert fires while handling lifetime end of partial_apply
 sil [ossa] @testPartialApplyStack2 : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "ossa-lifetime-completion @instruction[1]"
+  specify_test "ossa-lifetime-completion @instruction[1]"
   %2 = alloc_stack $C
   %3 = copy_value %0 : $C
   %4 = begin_borrow %3 : $C

--- a/test/SILOptimizer/ownership-utils-unit.sil
+++ b/test/SILOptimizer/ownership-utils-unit.sil
@@ -42,7 +42,7 @@ exit(%instance : @owned $C):
 // CHECK:       %14 = argument of bb6 : $C
 // CHECK:       true
 // CHECK-LABEL: end running test {{[0-9]+}} of {{[0-9]+}} on test_escape_of_phi_transitive_incoming_value: has-pointer-escape with
-  test_specification "has-pointer-escape @block.argument"
+  specify_test "has-pointer-escape @block.argument"
   destroy_value %instance : $C
   %retval = tuple ()
   return %retval : $()
@@ -54,7 +54,7 @@ entry:
   br loop_entry(%instance_1 : $FakeOptional<C>)
 
 loop_entry(%18 : @owned $FakeOptional<C>):
-  test_specification "has-pointer-escape @block.argument"
+  specify_test "has-pointer-escape @block.argument"
   br loop_body
 
 loop_body:

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -38,7 +38,7 @@ sil @getC : $@convention(thin) () -> @owned C
 // CHECK-NEXT: end running test 1 of 1 on testLinearRefElementEscape
 sil [ossa] @testLinearRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "linear-liveness @trace[0]"
+  specify_test "linear-liveness @trace[0]"
   %borrow = begin_borrow %0 : $C
   debug_value [trace] %borrow : $C
   cond_br undef, bb1, bb2
@@ -69,7 +69,7 @@ bb3(%phi : @guaranteed $D):
 // CHECK-NEXT: end running test 1 of 1 on testLinearBitwiseEscape
 sil [ossa] @testLinearBitwiseEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "linear-liveness @trace[0]"
+  specify_test "linear-liveness @trace[0]"
   %borrow = begin_borrow %0 : $C
   debug_value [trace] %borrow : $C
   cond_br undef, bb1, bb2
@@ -96,7 +96,7 @@ bb3(%phi : @unowned $D):
 // CHECK-NEXT: end running test 1 of 1 on testLinearInnerReborrow
 sil [ossa] @testLinearInnerReborrow : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
-  test_specification "linear-liveness @argument[0]"
+  specify_test "linear-liveness @argument[0]"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -123,7 +123,7 @@ bb3(%phi : @guaranteed $C):
 // CHECK-NEXT: end running test 1 of 1 on testLinearAdjacentReborrow
 sil [ossa] @testLinearAdjacentReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "linear-liveness @trace[0]"
+  specify_test "linear-liveness @trace[0]"
   %borrow = begin_borrow %0 : $C
   debug_value [trace] %borrow : $C
   cond_br undef, bb1, bb2
@@ -169,7 +169,7 @@ entry:
   br exit(%c : $C, %borrow1 : $C, %borrow2 : $C, %borrow3 : $C)
 
 exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaranteed $C, %guaranteed_3 : @guaranteed $C):
-  test_specification "visit-inner-adjacent-phis @trace[0]"
+  specify_test "visit-inner-adjacent-phis @trace[0]"
   debug_value [trace] %owned : $C
   end_borrow %guaranteed_3 : $C
   end_borrow %guaranteed_2 : $C
@@ -191,7 +191,7 @@ bb0(%0 : @guaranteed $C):
   br exit(%borrow0 : $C, %d0 : $D)
 
 exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
-  test_specification "visit-inner-adjacent-phis @trace[0]"
+  specify_test "visit-inner-adjacent-phis @trace[0]"
   debug_value [trace] %reborrow : $C
   %f = ref_element_addr %phi : $D, #D.object
   %o = load [copy] %f : $*C
@@ -211,7 +211,7 @@ exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-NEXT: end running test 1 of 1 on testInteriorRefElementEscape:
 sil [ossa] @testInteriorRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   %d = unchecked_ref_cast %0 : $C to $D
   debug_value [trace] %d : $D
   %f1 = ref_element_addr %d : $D, #D.object  
@@ -228,7 +228,7 @@ bb0(%0 : @guaranteed $C):
 // CHECK-NEXT: end running test 1 of 1 on testInteriorReborrow: interior-liveness with: @trace[0]
 sil [ossa] @testInteriorReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   %borrow = begin_borrow %0 : $C
   debug_value [trace] %borrow : $C
   br bb1(%borrow : $C)
@@ -245,7 +245,7 @@ bb1(%reborrow : @guaranteed $C):
 // CHECK-NEXT: end running test 1 of 1 on testInteriorDominatedGuaranteedForwardingPhi:
 sil [ossa] @testInteriorDominatedGuaranteedForwardingPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "interior-liveness @argument[0]"
+  specify_test "interior-liveness @argument[0]"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -277,7 +277,7 @@ bb0(%0 : @guaranteed $C):
 bb1:
   %borrow1 = begin_borrow %0 : $C
   debug_value [trace] %borrow1 : $C
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   %d1 = unchecked_ref_cast %borrow1 : $C to $D
   br bb3(%borrow1 : $C, %d1 : $D)
 
@@ -305,7 +305,7 @@ bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-NEXT: end running test 1 of 1 on testInnerDominatedReborrow: interior-liveness with: @argument[0]
 sil [ossa] @testInnerDominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  test_specification "interior-liveness @argument[0]"
+  specify_test "interior-liveness @argument[0]"
   %borrow = begin_borrow %0 : $C
   br bb1(%borrow : $C)
 
@@ -327,7 +327,7 @@ sil [ossa] @testInnerDominatedReborrow2 : $@convention(thin) (@guaranteed C) -> 
 bb0(%0 : @guaranteed $C):
   %copy0a = copy_value %0 : $C
   %copy0b = copy_value %0 : $C
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   debug_value [trace] %copy0a : $C
   cond_br undef, bb1, bb2
 
@@ -359,7 +359,7 @@ bb0(%0 : @guaranteed $D):
   cond_br undef, bb1, bb2
 
 bb1:
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   %borrow1 = begin_borrow %0 : $D
   debug_value [trace] %borrow1 : $D
   %inner1 = begin_borrow %borrow1 : $D
@@ -406,7 +406,7 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   debug_value [trace] %outer3 : $D
   br bb4(%inner3 : $D)
 
@@ -444,7 +444,7 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   debug_value [trace] %outer3 : $D
   br bb4(%inner3 : $D)
 
@@ -480,7 +480,7 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   debug_value [trace] %outer3 : $D
   br bb4(%inner3 : $D)
 
@@ -516,7 +516,7 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   debug_value [trace] %inner3 : $C
   br bb4(%phi3 : $D)
 
@@ -551,7 +551,7 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   debug_value [trace] %inner3 : $C
   br bb4(%phi3 : $D)
 
@@ -586,7 +586,7 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   debug_value [trace] %inner3 : $C
   br bb4(%phi3 : $D)
 
@@ -605,7 +605,7 @@ bb4(%phi4 : @guaranteed $D):
 // CHECK-NEXT: end running test 1 of 1 on testScopedAddress: interior-liveness with: @argument[0]
 sil [ossa] @testScopedAddress : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
-  test_specification "interior-liveness @argument[0]"
+  specify_test "interior-liveness @argument[0]"
   %f = ref_element_addr %0 : $D, #D.object
   %access = begin_access [read] [static] %f : $*C
   %o = load [copy] %access : $*C
@@ -629,7 +629,7 @@ bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
 
 bb1:
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   %copy0a = copy_value %0 : $C
   debug_value [trace] %copy0a : $C
   %borrow1 = begin_borrow %copy0a : $C
@@ -658,7 +658,7 @@ bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
 
 bb1:
-  test_specification "interior-liveness @trace[0]"
+  specify_test "interior-liveness @trace[0]"
   %copy0a = copy_value %0 : $C
   %borrow1 = begin_borrow %copy0a : $C
   debug_value [trace] %borrow1 : $C
@@ -691,7 +691,7 @@ bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
 
 bb1:
-  test_specification "extended-liveness @trace[0]"
+  specify_test "extended-liveness @trace[0]"
   %copy1 = copy_value %0 : $C
   debug_value [trace] %copy1 : $C
   br bb3(%copy1 : $C)
@@ -719,7 +719,7 @@ bb0(%0 : @guaranteed $C):
 
 bb1:
   %copy1 = copy_value %0 : $C
-  test_specification "extended-liveness @trace[0]"
+  specify_test "extended-liveness @trace[0]"
   %borrow1 = begin_borrow %copy1 : $C
   debug_value [trace] %borrow1 : $C
   br bb3(%copy1 : $C, %borrow1 : $C)

--- a/test/SILOptimizer/pruned_liveness_boundary.sil
+++ b/test/SILOptimizer/pruned_liveness_boundary.sil
@@ -9,8 +9,8 @@
 // CHECK: end running test 2 of {{[^,]+}} on last_uses_merge_points: pruned-liveness-boundary-with-list-of-last-users-insertion-points
 sil [ossa] @last_uses_merge_points : $@convention(thin) () -> () {
 entry:
-  test_specification "dump-function"
-  test_specification "pruned-liveness-boundary-with-list-of-last-users-insertion-points @block[1].instruction[0] @block[2].instruction[0]"
+  specify_test "dump-function"
+  specify_test "pruned-liveness-boundary-with-list-of-last-users-insertion-points @block[1].instruction[0] @block[2].instruction[0]"
   cond_br undef, left, right
 left:
   br bottom

--- a/test/SILOptimizer/shrink_borrow_scope.unit.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.unit.sil
@@ -14,7 +14,7 @@ sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
 // CHECK-LABEL: end running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
 sil [ossa] @nohoist_over_rewritten_copy : $@convention(thin) () -> (@owned C, @owned C) {
 entry:
-  test_specification "shrink-borrow-scope @trace true @trace[1]"
+  specify_test "shrink-borrow-scope @trace true @trace[1]"
   %get_owned_c = function_ref @get_owned_c : $@convention(thin) () -> (@owned C)
   %instance = apply %get_owned_c() : $@convention(thin) () -> (@owned C)
   %lifetime = begin_borrow [lexical] %instance : $C

--- a/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
@@ -22,7 +22,7 @@ sil @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 // CHECK-LABEL: } // end sil function 'test_simplify_args1'
 sil [ossa] @test_simplify_args1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-block-args"
+  specify_test "simplify-cfg-simplify-block-args"
   %1 = begin_borrow %0 : $Klass
   br bb1(%1 : $Klass)
 
@@ -41,7 +41,7 @@ bb2(%5 : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args2'
 sil [ossa] @test_simplify_args2 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-block-args"
+  specify_test "simplify-cfg-simplify-block-args"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -65,7 +65,7 @@ bb3(%4 : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args3'
 sil [ossa] @test_simplify_args3 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-block-args"
+  specify_test "simplify-cfg-simplify-block-args"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -87,7 +87,7 @@ bb3(%4 : @owned $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args4'
 sil [ossa] @test_simplify_args4 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-block-args"
+  specify_test "simplify-cfg-simplify-block-args"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -109,7 +109,7 @@ bb3(%4 : @owned $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args5'
 sil [ossa] @test_simplify_args5 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-block-args"
+  specify_test "simplify-cfg-simplify-block-args"
   %2 = begin_borrow %0 : $Klass
   cond_br undef, bb1, bb2
 
@@ -132,7 +132,7 @@ bb3(%4 : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_args6'
 sil [ossa] @test_simplify_args6 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-block-args"
+  specify_test "simplify-cfg-simplify-block-args"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -156,7 +156,7 @@ bb4:
 // CHECK-LABEL: } // end sil function 'test_simplify_args7'
 sil [ossa] @test_simplify_args7 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-block-args"
+  specify_test "simplify-cfg-simplify-block-args"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -180,7 +180,7 @@ bb4:
 // CHECK-LABEL: } // end sil function 'test_simplify_args8'
 sil [ossa] @test_simplify_args8 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  test_specification "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify-cfg-simplify-argument @block[1] 0"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -200,7 +200,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_args9'
 sil [ossa] @test_simplify_args9 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify-cfg-simplify-argument @block[1] 0"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -223,7 +223,7 @@ bb3:
 // CHECK: return
 sil [ossa] @test_dont_remove_mandatory_dead_args : $@convention(thin) (@guaranteed AnyKlass) -> () {
 bb0(%0 : @guaranteed $AnyKlass):
-  test_specification "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify-cfg-simplify-argument @block[1] 0"
   checked_cast_br AnyKlass in %0 : $AnyKlass to Klass, bb1, bb2
 
 bb1(%1 : @guaranteed $Klass):
@@ -244,7 +244,7 @@ bb3(%4 : $Builtin.Int32):
 // CHECK-LABEL: } // end sil function 'test_simplify_enum_arg_owned'
 sil [ossa] @test_simplify_enum_arg_owned : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify-cfg-simplify-argument @block[1] 0"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   %c = copy_value %1 : $FakeOptional<Klass>
   br bb1(%1 : $FakeOptional<Klass>)
@@ -270,7 +270,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_enum_arg_guaranteed1'
 sil [ossa] @test_simplify_enum_arg_guaranteed1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify-cfg-simplify-argument @block[1] 0"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   %c = copy_value %1 : $FakeOptional<Klass>
@@ -293,7 +293,7 @@ bb2:
 // CHECK: bb1([[ARG:%.*]] : @guaranteed $NonTrivialStruct)
 sil [ossa] @test_simplify_enum_arg_guaranteed2 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-argument @block[1] 0"
+  specify_test "simplify-cfg-simplify-argument @block[1] 0"
   %b = begin_borrow %0 : $Klass
   %1 = struct $NonTrivialStruct(%b : $Klass) 
   %c = copy_value %1 : $NonTrivialStruct

--- a/test/SILOptimizer/simplify_cfg_ossa_jump_threading.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_jump_threading.sil
@@ -23,7 +23,7 @@ sil @get_klass : $@convention(thin) () -> @owned Klass
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_jump_threading1'
 sil [ossa] @test_simplify_switch_enum_jump_threading1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-try-jump-threading @instruction[1]"
+  specify_test "simplify-cfg-try-jump-threading @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb1(%1 : $FakeOptional<Klass>)
 
@@ -51,12 +51,12 @@ bb0(%0 : @owned $Klass):
   cond_br undef, bb1, bb2
 
 bb1:
-  test_specification "simplify-cfg-try-jump-threading @instruction[2]"
+  specify_test "simplify-cfg-try-jump-threading @instruction[2]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb3(%1 : $FakeOptional<Klass>)
 
 bb2:
-  test_specification "simplify-cfg-try-jump-threading @instruction[5]"
+  specify_test "simplify-cfg-try-jump-threading @instruction[5]"
   destroy_value %0 : $Klass
   %2 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
   br bb3(%2 : $FakeOptional<Klass>)
@@ -87,7 +87,7 @@ bb0(%0 : @owned $Klass):
   cond_br undef, bb1, bb2
 
 bb1:
-  test_specification "simplify-cfg-try-jump-threading @instruction[4]"
+  specify_test "simplify-cfg-try-jump-threading @instruction[4]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   br bb3(%1 : $FakeOptional<Klass>)
 
@@ -107,7 +107,7 @@ bb4:
 
 sil [ossa] @test_jump_thread_ref_ele_loop : $@convention(thin) () -> () {
 bb0:
-  test_specification "simplify-cfg-try-jump-threading @instruction[3]"
+  specify_test "simplify-cfg-try-jump-threading @instruction[3]"
   %f = function_ref @get_klass : $@convention(thin) () -> @owned Klass
   cond_br undef, bb1, bb2
 
@@ -149,7 +149,7 @@ bb0(%0 : @owned $AnyKlass, %1 : @owned $AnyKlass):
   cond_br undef, bb1, bb2
 
 bb1:
-  test_specification "simplify-cfg-try-jump-threading @instruction[2]"
+  specify_test "simplify-cfg-try-jump-threading @instruction[2]"
   %2 = copy_value %0 : $AnyKlass
   br bb6(%2 : $AnyKlass)
 

--- a/test/SILOptimizer/simplify_cfg_ossa_simplify_branch.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_simplify_branch.sil
@@ -58,7 +58,7 @@ enum E1<T> {
 // CHECK-LABEL: } // end sil function 'test_simplify_term_with_identical_dest_blocks1'
 sil [ossa] @test_simplify_term_with_identical_dest_blocks1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-term-with-identical-dest-blocks @block[0]"
+  specify_test "simplify-cfg-simplify-term-with-identical-dest-blocks @block[0]"
   %1 = begin_borrow %0 : $Klass
   br bb1(%1 : $Klass)
 
@@ -79,7 +79,7 @@ bb2(%5 : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'test_simplify_term_with_identical_dest_blocks2'
 sil [ossa] @test_simplify_term_with_identical_dest_blocks2 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-term-with-identical-dest-blocks @block[0]"
+  specify_test "simplify-cfg-simplify-term-with-identical-dest-blocks @block[0]"
   br bb1(%0 : $Klass)
 
 bb1(%3 : @owned $Klass):

--- a/test/SILOptimizer/simplify_cfg_ossa_switch_enum.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_switch_enum.sil
@@ -25,7 +25,7 @@ enum E2 {
 // CHECK-LABEL: } // end sil function 'test_canonicalize_switch_enum1'
 sil [ossa] @test_canonicalize_switch_enum1 : $@convention(thin) (@owned FakeOptional<Klass>) -> () {
 bb0(%0 : @owned $FakeOptional<Klass>):
-  test_specification "simplify-cfg-canonicalize-switch-enum"
+  specify_test "simplify-cfg-canonicalize-switch-enum"
   switch_enum %0 : $FakeOptional<Klass>, case #FakeOptional.none!enumelt: bb1, default bb2
 
 bb1:
@@ -45,7 +45,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_canonicalize_switch_enum2'
 sil [ossa] @test_canonicalize_switch_enum2 : $@convention(thin) (@owned E1) -> () {
 bb0(%0 : @owned $E1):
-  test_specification "simplify-cfg-canonicalize-switch-enum"
+  specify_test "simplify-cfg-canonicalize-switch-enum"
   switch_enum %0 : $E1, case #E1.A!enumelt: bb1, default bb2
 
 bb1(%2 : @owned $Klass):
@@ -66,7 +66,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_canonicalize_switch_enum3'
 sil [ossa] @test_canonicalize_switch_enum3 : $@convention(thin) (@owned E2) -> () {
 bb0(%0 : @owned $E2):
-  test_specification "simplify-cfg-canonicalize-switch-enum"
+  specify_test "simplify-cfg-canonicalize-switch-enum"
   switch_enum %0 : $E2, case #E2.A!enumelt: bb1, default bb2
 
 bb1(%2 : @owned $Klass):
@@ -87,7 +87,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum1'
 sil [ossa] @test_simplify_switch_enum1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-block @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -108,7 +108,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum2'
 sil [ossa] @test_simplify_switch_enum2 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-block @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -128,7 +128,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum3'
 sil [ossa] @test_simplify_switch_enum3 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-block @instruction[2]"
+  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[2]"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
@@ -153,7 +153,7 @@ sil @use_optional : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum4'
 sil [ossa] @test_simplify_switch_enum4 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-block @instruction[3]"
+  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[3]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   %f = function_ref @use_optional : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
   %c = apply %f(%1) : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
@@ -175,7 +175,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum5'
 sil [ossa] @test_simplify_switch_enum5 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-block @instruction[4]"
+  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[4]"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   %f = function_ref @use_optional : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
@@ -211,7 +211,7 @@ bb2:
   br bb3(%4 : $FakeOptional<Klass>)
 
 bb3(%6 :@owned  $FakeOptional<Klass>):
-  test_specification "simplify-cfg-simplify-switch-enum-block @instruction[5]"
+  specify_test "simplify-cfg-simplify-switch-enum-block @instruction[5]"
   switch_enum %6 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb4, case #FakeOptional.none!enumelt: bb5
 
 bb4(%8 : @owned $Klass):
@@ -231,7 +231,7 @@ bb6:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable1'
 sil [ossa] @test_simplify_switch_enum_unreachable1 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -252,7 +252,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable2'
 sil [ossa] @test_simplify_switch_enum_unreachable2 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -275,7 +275,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable3'
 sil [ossa] @test_simplify_switch_enum_unreachable3 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -296,7 +296,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable4'
 sil [ossa] @test_simplify_switch_enum_unreachable4 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -316,7 +316,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable5'
 sil [ossa] @test_simplify_switch_enum_unreachable5 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[2]"
+  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[2]"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
@@ -339,7 +339,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable6'
 sil [ossa] @test_simplify_switch_enum_unreachable6 : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[1]"
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %0 : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
 
@@ -359,7 +359,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'test_simplify_switch_enum_unreachable7'
 sil [ossa] @test_simplify_switch_enum_unreachable7 : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
-  test_specification "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[2]"
+  specify_test "simplify-cfg-simplify-switch-enum-unreachable-blocks @instruction[2]"
   %b = begin_borrow %0 : $Klass
   %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %b : $Klass
   switch_enum %1 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2

--- a/test/SILOptimizer/simplify_switch_enum_objc_ossa.sil
+++ b/test/SILOptimizer/simplify_switch_enum_objc_ossa.sil
@@ -13,7 +13,7 @@ class Test : NSObject {
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call1'
 sil [ossa] @test_switch_enum_objc_call1 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  test_specification "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
   %3 = copy_value %0 : $Optional<Test>
   switch_enum %3 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
@@ -39,7 +39,7 @@ sil @some_sideeffect : $@convention(thin) () -> ()
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call2'
 sil [ossa] @test_switch_enum_objc_call2 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  test_specification "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
   %3 = copy_value %0 : $Optional<Test>
   switch_enum %3 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
@@ -65,7 +65,7 @@ bb6:
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call3'
 sil [ossa] @test_switch_enum_objc_call3 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  test_specification "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
   %3 = copy_value %0 : $Optional<Test>
   switch_enum %3 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
@@ -91,7 +91,7 @@ bb6:
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call4'
 sil [ossa] @test_switch_enum_objc_call4 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  test_specification "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
+  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[1]"
   %3 = copy_value %0 : $Optional<Test>
   switch_enum %3 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
@@ -117,7 +117,7 @@ bb6:
 // CHECK-LABEL: } // end sil function 'test_switch_enum_objc_call5'
 sil [ossa] @test_switch_enum_objc_call5 : $@convention(thin) (@guaranteed Optional<Test>) -> () {
 bb0(%0 : @guaranteed $Optional<Test>):
-  test_specification "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[0]"
+  specify_test "simplify-cfg-simplify-switch-enum-on-objc-class-optional @instruction[0]"
   switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
 
 bb1(%8 : @guaranteed $Test):

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -60,14 +60,14 @@ import Builtin
 // CHECK-LABEL: end running test 8 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
 sil [ossa] @test_arg_parsing : $() -> () {
 entry:
-  test_specification "test-specification-parsing FFFbb @function[test_arg_parsing_reference] @function[2] @function true false"
-  test_specification "test-specification-parsing BuI @block[0] 42 @function[test_arg_parsing_callee].block[1].instruction[3]"
-  test_specification "test-specification-parsing FF @function @function[0]"
-  test_specification "test-specification-parsing BBBBB @block @function.block @function.block[0] @function[0].block @function[0].block[0]"
-  test_specification "test-specification-parsing IIIIIIII @function.block.instruction @function[0].block.instruction @function.block[0].instruction @function.block.instruction[0] @function[0].block[0].instruction @function[0].block.instruction[0] @function.block[0].instruction[0] @function[0].block[0].instruction[0]"
-  test_specification "test-specification-parsing OO @instruction[2].operand @function[test_arg_parsing_callee].trace.operand[1]"
-  test_specification "test-specification-parsing Vs @function[4].trace[0] howdy"
-  test_specification "test-specification-parsing V @instruction[0]"
+  specify_test "test-specification-parsing FFFbb @function[test_arg_parsing_reference] @function[2] @function true false"
+  specify_test "test-specification-parsing BuI @block[0] 42 @function[test_arg_parsing_callee].block[1].instruction[3]"
+  specify_test "test-specification-parsing FF @function @function[0]"
+  specify_test "test-specification-parsing BBBBB @block @function.block @function.block[0] @function[0].block @function[0].block[0]"
+  specify_test "test-specification-parsing IIIIIIII @function.block.instruction @function[0].block.instruction @function.block[0].instruction @function.block.instruction[0] @function[0].block[0].instruction @function[0].block.instruction[0] @function.block[0].instruction[0] @function[0].block[0].instruction[0]"
+  specify_test "test-specification-parsing OO @instruction[2].operand @function[test_arg_parsing_callee].trace.operand[1]"
+  specify_test "test-specification-parsing Vs @function[4].trace[0] howdy"
+  specify_test "test-specification-parsing V @instruction[0]"
   %something_remarkable = function_ref @something_remarkable : $@convention(thin) () -> ()
   %retval = tuple ()
   return %retval : $()
@@ -120,16 +120,16 @@ sil [ossa] @test_contextual_arg_parsing : $() -> () {
 entry:
   br one
 one:
-  test_specification "test-specification-parsing B @block"
+  specify_test "test-specification-parsing B @block"
   br two
 two:
-  test_specification "test-specification-parsing I @instruction"
-  test_specification "test-specification-parsing IIII @instruction[-1] @instruction[+0] @instruction[+1] @instruction[+2]"
-  test_specification "test-specification-parsing BBBB @block[-2] @block[-1] @block[+0] @block[+1]"
+  specify_test "test-specification-parsing I @instruction"
+  specify_test "test-specification-parsing IIII @instruction[-1] @instruction[+0] @instruction[+1] @instruction[+2]"
+  specify_test "test-specification-parsing BBBB @block[-2] @block[-1] @block[+0] @block[+1]"
   %retval = tuple ()
   br exit
 exit:
-  test_specification "test-specification-parsing F @function"
+  specify_test "test-specification-parsing F @function"
   return %retval : $()
 }
 
@@ -145,7 +145,7 @@ struct X {}
 // CHECK-LABEL: end running test 1 of {{[^,]+}} on test_arg_arg_parsing: test-specification-parsing
 sil [ossa] @test_arg_arg_parsing : $(X) -> () {
 entry(%instance : $X):
-  test_specification "test-specification-parsing AAA @argument @block.argument @function.argument[0]"
+  specify_test "test-specification-parsing AAA @argument @block.argument @function.argument[0]"
   %retval = tuple ()
   return %retval : $()
 }
@@ -160,7 +160,7 @@ sil [ossa] @takeC : $@convention(thin) (@owned C) -> ()
 // CHECK-LABEL: end running test 1 of 1 on fn: canonicalize-ossa-lifetime with: true, true, true, @trace
 sil [ossa] @fn : $@convention(thin) () -> () {
 entry:
-    test_specification "canonicalize-ossa-lifetime true true true @trace"
+    specify_test "canonicalize-ossa-lifetime true true true @trace"
     %getC = function_ref @getC : $@convention(thin) () -> @owned C
     %c = apply %getC() : $@convention(thin) () -> @owned C
     debug_value [trace] %c : $C
@@ -181,7 +181,7 @@ entry:
 // CHECK-LABEL: end running test 1 of {{[^,]+}} on test_arg_parsing_2
 sil @test_arg_parsing_2 : $() -> () {
 entry:
-  test_specification "test-specification-parsing Bu @block[1] 0"
+  specify_test "test-specification-parsing Bu @block[1] 0"
   br exit
 exit:
   %retval = tuple ()
@@ -197,7 +197,7 @@ exit:
 sil @test_value_literal_parsing : $(Builtin.Int1) -> () {
 entry(%0 : $Builtin.Int1):
   %2 = integer_literal $Builtin.Int64, 2
-  test_specification "test-specification-parsing VVVV %0 %1 %2 %3"
+  specify_test "test-specification-parsing VVVV %0 %1 %2 %3"
   %1 = integer_literal $Builtin.Int64, 1
   %3 = integer_literal $Builtin.Int64, 3
   apply undef(%2) : $@convention(thin) (Builtin.Int64) -> ()


### PR DESCRIPTION
Changed from test_specification which is too many characters and insufficiently active.
