### PR TITLE
permit parsing of `~` in general type syntaxes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2347,8 +2347,8 @@ ERROR(inferred_opaque_type,none,
       "return type of another declaration", (Type))
 
 // Inverse Constraints
-ERROR(inverse_type_not_invertable,none,
-      "type %0 is not invertable", (Type))
+ERROR(inverse_type_not_invertible,none,
+      "type %0 is not invertible", (Type))
 
 // Extensions
 ERROR(non_nominal_extension,none,

--- a/include/swift/AST/KnownProtocols.h
+++ b/include/swift/AST/KnownProtocols.h
@@ -46,7 +46,7 @@ using KnownProtocolSet = FixedBitSet<NumKnownProtocols, KnownProtocolKind>;
 
 /// Produces a set of all protocols that have an inverse, i.e., for every
 /// known protocol KP in the set, ~KP exists.
-KnownProtocolSet getInvertableProtocols();
+KnownProtocolSet getInvertibleProtocols();
 
 /// Retrieve the name of the given known protocol.
 llvm::StringRef getProtocolName(KnownProtocolKind kind);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -102,7 +102,7 @@ llvm::StringRef swift::getProtocolName(KnownProtocolKind kind) {
   llvm_unreachable("bad KnownProtocolKind");
 }
 
-KnownProtocolSet swift::getInvertableProtocols() {
+KnownProtocolSet swift::getInvertibleProtocols() {
   return { KnownProtocolKind::Copyable };
 }
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -732,7 +732,7 @@ void swift::rewriting::realizeInheritedRequirements(
   auto inheritedTypes = decl->getInherited();
   auto *dc = decl->getInnermostDeclContext();
   auto *moduleForInference = dc->getParentModule();
-  auto defaults = getInvertableProtocols();
+  auto defaults = getInvertibleProtocols();
 
   for (auto index : inheritedTypes.getIndices()) {
     Type inheritedType =

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5057,10 +5057,10 @@ NeverNullType TypeResolver::resolveInverseType(InverseTypeRepr *repr,
   if (auto protoTy = ty->getAs<ProtocolType>())
     if (auto protoDecl = protoTy->getDecl())
       if (auto kp = protoDecl->getKnownProtocolKind())
-        if (getInvertableProtocols().contains(*kp))
+        if (getInvertibleProtocols().contains(*kp))
           return ty;
 
-  diagnoseInvalid(repr, repr->getLoc(), diag::inverse_type_not_invertable, ty);
+  diagnoseInvalid(repr, repr->getLoc(), diag::inverse_type_not_invertible, ty);
   return ErrorType::get(getASTContext());
 }
 

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -28,11 +28,11 @@ protocol HasReturnNonNull {
 extension ReturnsNonNullValue: HasReturnNonNull {}
 
 
-protocol Invertable {
+protocol Invertible {
   static prefix func !(obj: Self) -> Self
 }
 
-extension HasOperatorExclaim: Invertable {}
+extension HasOperatorExclaim: Invertible {}
 
 extension HasOperatorEqualEqual: Equatable {}
 

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -9,31 +9,31 @@ enum Maybe<Thing: ~Copyable> : ~Copyable {}
 func more() {
   let _: any ~Copyable = 19
 
-  let _: any ~Equatable = 19  // expected-error@:14 {{type 'Equatable' is not invertable}}
+  let _: any ~Equatable = 19  // expected-error@:14 {{type 'Equatable' is not invertible}}
 
-  let _: any (~Copyable & ~Equatable) // expected-error{{type 'Equatable' is not invertable}}
+  let _: any (~Copyable & ~Equatable) // expected-error{{type 'Equatable' is not invertible}}
 
-  let _: ~Any // expected-error {{type 'Any' is not invertable}}
-  let _: ~AnyObject // expected-error {{type 'AnyObject' is not invertable}}
+  let _: ~Any // expected-error {{type 'Any' is not invertible}}
+  let _: ~AnyObject // expected-error {{type 'AnyObject' is not invertible}}
 }
 
-struct S4: ~(Copyable & Equatable) {} // expected-error {{type 'Copyable & Equatable' is not invertable}}
+struct S4: ~(Copyable & Equatable) {} // expected-error {{type 'Copyable & Equatable' is not invertible}}
 
 func blah<T>(_ t: T) where T: ~Copyable,
-                           T: ~Hashable {}  // expected-error@:31 {{type 'Hashable' is not invertable}}
+                           T: ~Hashable {}  // expected-error@:31 {{type 'Hashable' is not invertible}}
 
 func foo<T: ~Copyable>(x: T) {}
 
 struct Buurap<T: ~Copyable> {}
 
 protocol Foo where Self: ~Copyable {
-    func test<T>(_ t: T) where T: ~Self  // expected-error {{type 'Self' is not invertable}}
+    func test<T>(_ t: T) where T: ~Self  // expected-error {{type 'Self' is not invertible}}
 }
 
 protocol Sando { func make() }
 
 class C: ~Copyable,
-         ~Sando // expected-error {{type 'Sando' is not invertable}}
+         ~Sando // expected-error {{type 'Sando' is not invertible}}
          {}
 
 public struct MoveOnlyS1<T> : ~Copyable { /*deinit {}*/ }
@@ -47,7 +47,7 @@ protocol Rope<Element>: Hashable, ~ Copyable {
 
 extension S: ~Copyable {}
 
-struct S: ~U, // expected-error {{type 'U' is not invertable}}
+struct S: ~U, // expected-error {{type 'U' is not invertible}}
           ~Copyable {}
 
 func greenBay<each T: ~Copyable>(_ r: repeat each T) {}
@@ -73,12 +73,12 @@ func what(one: ~Copyable..., // expected-error {{type 'any Copyable' is not inve
 struct A { struct B { struct C {} } }
 
 typealias Z1 = (~Copyable).Type // FIXME: should be an error
-typealias Z1 = ~Copyable.Type // expected-error {{type 'any Copyable.Type' is not invertable}}
-typealias Z2 = ~A.B.C // expected-error {{type 'A.B.C' is not invertable}}
-typealias Z3 = ~A? // expected-error {{type 'A?' is not invertable}}
-typealias Z4 = ~Rope<Int> // expected-error {{type 'Rope<Int>' is not invertable}}
-typealias Z5 = (~Int) -> Void // expected-error {{type 'Int' is not invertable}}
+typealias Z1 = ~Copyable.Type // expected-error {{type 'any Copyable.Type' is not invertible}}
+typealias Z2 = ~A.B.C // expected-error {{type 'A.B.C' is not invertible}}
+typealias Z3 = ~A? // expected-error {{type 'A?' is not invertible}}
+typealias Z4 = ~Rope<Int> // expected-error {{type 'Rope<Int>' is not invertible}}
+typealias Z5 = (~Int) -> Void // expected-error {{type 'Int' is not invertible}}
 typealias Z6 = ~() -> () // expected-error {{single argument function types require parentheses}}
-                         // expected-error@-1 {{type '()' is not invertable}}
-typealias Z7 = ~(Copyable & Hashable) // expected-error {{type 'Copyable & Hashable' is not invertable}}
+                         // expected-error@-1 {{type '()' is not invertible}}
+typealias Z7 = ~(Copyable & Hashable) // expected-error {{type 'Copyable & Hashable' is not invertible}}
 typealias Z8 = ~Copyable & Hashable

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -1,0 +1,84 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+
+// REQUIRES: asserts
+
+protocol U {}
+
+enum Maybe<Thing: ~Copyable> : ~Copyable {}
+
+func more() {
+  let _: any ~Copyable = 19
+
+  let _: any ~Equatable = 19  // expected-error@:14 {{type 'Equatable' is not invertable}}
+
+  let _: any (~Copyable & ~Equatable) // expected-error{{type 'Equatable' is not invertable}}
+
+  let _: ~Any // expected-error {{type 'Any' is not invertable}}
+  let _: ~AnyObject // expected-error {{type 'AnyObject' is not invertable}}
+}
+
+struct S4: ~(Copyable & Equatable) {} // expected-error {{type 'Copyable & Equatable' is not invertable}}
+
+func blah<T>(_ t: T) where T: ~Copyable,
+                           T: ~Hashable {}  // expected-error@:31 {{type 'Hashable' is not invertable}}
+
+func foo<T: ~Copyable>(x: T) {}
+
+struct Buurap<T: ~Copyable> {}
+
+protocol Foo where Self: ~Copyable {
+    func test<T>(_ t: T) where T: ~Self  // expected-error {{type 'Self' is not invertable}}
+}
+
+protocol Sando { func make() }
+
+class C: ~Copyable,
+         ~Sando // expected-error {{type 'Sando' is not invertable}}
+         {}
+
+public struct MoveOnlyS1<T> : ~Copyable { /*deinit {}*/ }
+public struct MoveOnlyS2<T: Equatable> : ~Copyable { /*deinit {}*/ }
+public struct MoveOnlyS3<T: ~Copyable> : ~Copyable { /*deinit {}*/ }
+
+protocol Rope<Element>: Hashable, ~ Copyable {
+
+  associatedtype Element: ~Copyable
+}
+
+extension S: ~Copyable {}
+
+struct S: ~U, // expected-error {{type 'U' is not invertable}}
+          ~Copyable {}
+
+func greenBay<each T: ~Copyable>(_ r: repeat each T) {}
+
+typealias Clone = Copyable
+func dup<D: ~Clone>(_ d: D) {}
+
+func superb(_ thing: some ~Copyable, thing2: some ~Clone) {}
+
+func ownership1(_ t: borrowing any ~Equatable) {} // expected-error {{type 'Equatable' is not invertible}}
+
+func ownership2(_ t: ~ borrowing Int) {} // expected-error {{cannot find type 'borrowing' in scope}}
+                                         // expected-error@-1 {{unnamed parameters must be written with the empty name '_'}}
+                                         // expected-error@-2 {{expected ',' separator}}
+
+func ownership3(_ t: consuming some ~Clone) {}
+
+func what(one: ~Copyable..., // expected-error {{type 'any Copyable' is not invertible}}
+          two: ~(Copyable...) // expected-error {{variadic parameter cannot appear outside of a function parameter list}}
+                              // expected-error@-1 {{type 'any Copyable' is not invertible}}
+          ) {}
+
+struct A { struct B { struct C {} } }
+
+typealias Z1 = (~Copyable).Type // FIXME: should be an error
+typealias Z1 = ~Copyable.Type // expected-error {{type 'any Copyable.Type' is not invertable}}
+typealias Z2 = ~A.B.C // expected-error {{type 'A.B.C' is not invertable}}
+typealias Z3 = ~A? // expected-error {{type 'A?' is not invertable}}
+typealias Z4 = ~Rope<Int> // expected-error {{type 'Rope<Int>' is not invertable}}
+typealias Z5 = (~Int) -> Void // expected-error {{type 'Int' is not invertable}}
+typealias Z6 = ~() -> () // expected-error {{single argument function types require parentheses}}
+                         // expected-error@-1 {{type '()' is not invertable}}
+typealias Z7 = ~(Copyable & Hashable) // expected-error {{type 'Copyable & Hashable' is not invertable}}
+typealias Z8 = ~Copyable & Hashable


### PR DESCRIPTION
With `NoncopyableGenerics` enabled, we want to permit the syntax
`any ~Copyable`, and `~Copyable` generally anywhere a type can be
written. We also want to give proper error messages and deal with
typealiases of `Copyable` correctly when `~` precedes some token other
than `Copyable`.

This patch defines the `~` operator to attach rather tightly to simple
types like identifier-like types. The precedence order is roughly like
this within the syntax of types, from higher to lower:

1. `.` (member lookup)
2. postfix optionals: `?`, `!`
3. inverse `~`
4. postfix `...`, etc.

It's also invalid to write something like `~ any T`, as we'll treat
`any` as if it were a type identifier. You must parenthesize such types
to say `~(any T)`. Similarly, we parse `~T.Type` as `~(T.Type)` and not
`(~T).Type`. That might be controversial, but I don't think inverses
can ever support metatypes; they're not even "real" types.

rdar://115913356

depends on companion PR https://github.com/apple/swift-syntax/pull/2230