### PR TITLE
Tests: Re-enable skip-function-bodies.swift

### DIFF
--- a/test/Frontend/skip-function-bodies.swift
+++ b/test/Frontend/skip-function-bodies.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
 
-// REQUIRES: rdar95219987
-
 // Check -emit-ir and -c are invalid when skipping function bodies
 // RUN: not %target-swift-frontend -emit-ir %s -experimental-skip-non-inlinable-function-bodies %s 2>&1 | %FileCheck %s --check-prefix ERROR
 // RUN: not %target-swift-frontend -c %s -experimental-skip-non-inlinable-function-bodies %s 2>&1 | %FileCheck %s --check-prefix ERROR


### PR DESCRIPTION
It doesn't appear to be failing anymore.
