### PR TITLE
Make ObjC isEqual: delegate to Equatable when Hashable isn't available

### DIFF
--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -196,6 +196,16 @@ extension Equatable {
   }
 }
 
+// Called by the SwiftValue implementation.
+@_silgen_name("_swift_stdlib_Equatable_isEqual_indirect")
+internal func Equatable_isEqual_indirect<T: Equatable>(
+  _ lhs: UnsafePointer<T>,
+  _ rhs: UnsafePointer<T>
+) -> Bool {
+  return lhs.pointee == rhs.pointee
+}
+
+
 //===----------------------------------------------------------------------===//
 // Reference comparison
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/runtime/SwiftEquatableSupport.h
+++ b/stdlib/public/runtime/SwiftEquatableSupport.h
@@ -1,0 +1,38 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_SWIFT_EQUATABLE_SUPPORT_H
+#define SWIFT_RUNTIME_SWIFT_EQUATABLE_SUPPORT_H
+
+#include "swift/Runtime/Metadata.h"
+#include <stdint.h>
+
+namespace swift {
+namespace equatable_support {
+
+extern "C" const ProtocolDescriptor PROTOCOL_DESCR_SYM(SQ);
+static constexpr auto &EquatableProtocolDescriptor = PROTOCOL_DESCR_SYM(SQ);
+
+struct EquatableWitnessTable;
+
+/// Calls `Equatable.==` through a `Equatable` (not Equatable!) witness
+/// table.
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+bool _swift_stdlib_Equatable_isEqual_indirect(
+    const void *lhsValue, const void *rhsValue, const Metadata *type,
+    const EquatableWitnessTable *wt);
+
+} // namespace equatable_support
+} // namespace swift
+
+#endif
+

--- a/test/stdlib/BridgeEquatableToObjC.swift
+++ b/test/stdlib/BridgeEquatableToObjC.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+var BridgeEquatableToObjC = TestSuite("BridgeEquatableToObjC")
+
+struct MyEquatableStruct: Equatable {
+  var text: String
+}
+
+struct MyNonEquatableStruct {
+  var text: String
+}
+
+BridgeEquatableToObjC.test("Bridge equatable struct") {
+  let swiftA = MyEquatableStruct(text: "xABC")
+  let swiftB = swiftA
+  let swiftResult = swiftA == swiftB
+
+  let objcA = swiftA as AnyObject
+  let objcB = swiftB as AnyObject
+  let objcResult = objcA.isEqual(objcB)
+
+  expectEqual(swiftResult, true)
+  expectEqual(objcResult, true)
+}
+
+BridgeEquatableToObjC.test("Bridge non-equatable struct") {
+  let swiftA = MyNonEquatableStruct(text: "xABC")
+  let swiftB = swiftA
+
+  let objcA = swiftA as AnyObject
+  let objcB = swiftB as AnyObject
+  let objcResult = objcA.isEqual(objcB)
+
+  expectEqual(objcResult, false)
+}
+
+
+runAllTests()

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -61,6 +61,15 @@ bool _swift_anyHashableDownCastConditionalIndirect(
   abort();
 }
 
+// SwiftEquatableSupport
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+bool _swift_stdlib_Equatable_isEqual_indirect(
+  const void *lhsValue, const void *rhsValue, const Metadata *type,
+  const void *wt) {
+  abort();
+}
+
 // Casting
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL


### PR DESCRIPTION
When a Swift struct gets bridged to Obj-C, we box it into an opaque `_SwiftValue` Obj-C object.  This object previously supported the Obj-C `isEqual:` and `hash` selectors by dispatching to the Swift Hashable conformance, if present.

This does not work if the Swift struct conforms to Equatable but does not conform to Hashable.  This case seems to have been overlooked in PR #4124.

This PR extends the earlier work to support `isEqual:` by first checking for a Hashable conformance, then falling back on an Equatable conformance if there is no Hashable conformance.

Resolves rdar://114294889