### PR TITLE
NFC: Fix a couple of warnings

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6755,8 +6755,8 @@ void AbstractStorageDecl::AccessorRecord::removeAccessor(
 ) {
   // Remove this accessor from the list of accessors.
   assert(getAccessor(accessor->getAccessorKind()) == accessor);
-  std::remove(getAccessorsBuffer().begin(), getAccessorsBuffer().end(),
-              accessor);
+  (void)std::remove(getAccessorsBuffer().begin(), getAccessorsBuffer().end(),
+                    accessor);
 
   // Clear out the accessor kind -> index mapping.
   std::memset(AccessorIndices, 0, sizeof(AccessorIndices));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2938,23 +2938,6 @@ bool ConstraintSystem::hasPreconcurrencyCallee(
   return calleeOverload->choice.getDecl()->preconcurrency();
 }
 
-/// Determines whether a DeclContext is preconcurrency, using information
-/// tracked by the solver to aid in answering that.
-static bool isPreconcurrency(ConstraintSystem &cs, DeclContext *dc) {
-  if (auto *decl = dc->getAsDecl())
-    return decl->preconcurrency();
-
-  if (auto *ce = dyn_cast<ClosureExpr>(dc)) {
-    return ClosureIsolatedByPreconcurrency{cs}(ce);
-  }
-
-  if (auto *autoClos = dyn_cast<AutoClosureExpr>(dc)) {
-    return isPreconcurrency(cs, autoClos->getParent());
-  }
-
-  llvm_unreachable("unhandled DeclContext kind in isPreconcurrency");
-}
-
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,


### PR DESCRIPTION
Fixes the following warnings:

```
.../swift-project/swift/lib/Sema/CSSimplify.cpp:2943:13: warning: function 'isPreconcurrency' is not needed and will not be emitted [-Wunneeded-internal-declaration]
static bool isPreconcurrency(ConstraintSystem &cs, DeclContext *dc) {
            ^

.../swift-project/swift/lib/AST/Decl.cpp:6758:3: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
  std::remove(getAccessorsBuffer().begin(), getAccessorsBuffer().end(),
  ^~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```