### PR TITLE
[embedded] Stop emitting metadata for extensions

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5678,7 +5678,7 @@ static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
 void IRGenModule::emitExtension(ExtensionDecl *ext) {
   emitNestedTypeDecls(ext->getMembers());
 
-  if (ext->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
     return;
   }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5678,6 +5678,10 @@ static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
 void IRGenModule::emitExtension(ExtensionDecl *ext) {
   emitNestedTypeDecls(ext->getMembers());
 
+  if (ext->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    return;
+  }
+
   addLazyConformances(ext);
 
   // Generate a category if the extension either introduces a

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1295,6 +1295,8 @@ bool IRGenerator::canEmitWitnessTableLazily(SILWitnessTable *wt) {
 }
 
 void IRGenerator::addLazyWitnessTable(const ProtocolConformance *Conf) {
+  assert(!SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded));
+
   if (auto *wt = SIL.lookUpWitnessTable(Conf)) {
     // Add it to the queue if it hasn't already been put there.
     if (canEmitWitnessTableLazily(wt) &&

--- a/test/embedded/extensions.swift
+++ b/test/embedded/extensions.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -parse-stdlib -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-ir     -I %t                      %t/Main.swift     -parse-stdlib -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// BEGIN MyModule.swift
+
+public protocol MyProtocol {}
+
+// BEGIN Main.swift
+
+import MyModule
+
+struct MyStruct {}
+
+extension MyStruct: MyProtocol {}
+
+// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK-NOT: MyStruct
+// CHECK-NOT: MyProtocol


### PR DESCRIPTION
Currently, we get a compiler crash when using extensions that conform types to protocols, because an extension ends up requesting a lazy emissions of a witness table. The added test showcases this crash:

```
Assertion failed: (LazyWitnessTables.empty()), function emitLazyDefinitions, file GenDecl.cpp, line 1429.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: ...
...
3.	While evaluating request IRGenRequest(IR Generation for module Main)
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
...
7  swift-frontend           0x000000010945859c swift::irgen::IRGenerator::emitLazyDefinitions() (.cold.53) + 0
8  swift-frontend           0x0000000104a858d4 swift::irgen::IRGenerator::emitLazyDefinitions() + 2560
9  swift-frontend           0x0000000104b7eb54 swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const + 2588
```

In embedded Swift, we simply want to avoid emitting witness tables altogether. Also added an assert so that we can catch this problem at the lazy request side, not when actually processing the lazy lists.