### PR TITLE
[embedded] Disallow use of VWTs for take/copy/assign/destroy operations, even under -Osize

### DIFF
--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -214,6 +214,10 @@ static bool canUseValueWitnessForValueOp(IRGenModule &IGM, SILType T) {
   if (!IGM.getSILModule().isTypeMetadataForLayoutAccessible(T))
     return false;
 
+  // No value witness tables in embedded Swift.
+  if (IGM.Context.LangOpts.hasFeature(Feature::Embedded))
+    return false;
+
   // It is not a good code size trade-off to instantiate a metatype for
   // existentials, and also does not back-deploy gracefully in the case of
   // constrained protocols.

--- a/test/embedded/array-builtins-no-stdlib.swift
+++ b/test/embedded/array-builtins-no-stdlib.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-emit-ir %s -parse-stdlib -module-name Swift -enable-experimental-feature Embedded -wmo -target arm64e-apple-none | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -parse-stdlib -module-name Swift -enable-experimental-feature Embedded -wmo -target arm64e-apple-none -Osize | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -parse-stdlib -module-name Swift -enable-experimental-feature Embedded -wmo -target arm64e-apple-none -O | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 


### PR DESCRIPTION
Building code in embedded Swift mode that uses Builtin.copyArray / Builtin.takeArray... / etc. under -Osize tries to use the value witness table for the type as a codesize optimization and that ends up crashing the compiler (because metadata is disallowed in embedded Swift). Let's disallow this.