### PR TITLE
[embedded] Add executable tests for array builtins

### DIFF
--- a/test/embedded/array-builtins-exec.swift
+++ b/test/embedded/array-builtins-exec.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -enable-builtin-module -c -o %t/main.o
+// RUN: %target-clang -x c -c %S/Inputs/tiny-runtime-dummy-refcounting.c -o %t/runtime.o
+// RUN: %target-clang %t/main.o %t/runtime.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+import Builtin
+
+var NoisyLifeCount = 0
+var NoisyDeathCount = 0
+
+protocol P {}
+
+class Noisy : P {
+  init() { NoisyLifeCount += 1 }
+  deinit { NoisyDeathCount += 1 }
+}
+
+struct Large : P {
+  var a, b, c, d: Noisy
+
+  init() {
+    self.a = Noisy()
+    self.b = Noisy()
+    self.c = Noisy()
+    self.d = Noisy()
+  }
+}
+
+func exerciseArrayValueWitnesses<T>(_ value: T) {
+  let buf = UnsafeMutablePointer<T>.allocate(capacity: 5)
+
+  (buf + 0).initialize(to: value)
+  (buf + 1).initialize(to: value)
+  
+  Builtin.copyArray(T.self, (buf + 2)._rawValue, buf._rawValue, 2._builtinWordValue)
+  Builtin.takeArrayBackToFront(T.self, (buf + 1)._rawValue, buf._rawValue, 4._builtinWordValue)
+  Builtin.takeArrayFrontToBack(T.self, buf._rawValue, (buf + 1)._rawValue, 4._builtinWordValue)
+  Builtin.destroyArray(T.self, buf._rawValue, 4._builtinWordValue)
+
+  buf.deallocate()
+}
+
+func test() {
+  NoisyLifeCount = 0
+  NoisyDeathCount = 0
+  do {
+    exerciseArrayValueWitnesses(44)
+    exerciseArrayValueWitnesses(Noisy())
+    exerciseArrayValueWitnesses(Large())
+  }
+  precondition(NoisyLifeCount == NoisyDeathCount)
+  print("Checks out")
+  // CHECK: Checks out
+}
+
+@main struct Main { static func main() { test() } }


### PR DESCRIPTION
The array builtins (copyArray, takeArrayBackToFront, destroyArray, etc.) have custom IRGen in embedded Swift that avoids runtime calls. Let's cover these with an executable test (code taken from existing test/stdlib/Builtins.swift executable test).