### PR TITLE
[embedded] Start building arm64e embedded stdlib

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -196,6 +196,8 @@ static void sanityCheckStdlib(IRGenModule &IGM) {
   // Only run the sanity check when we're building the real stdlib.
   if (!lookupSimple(IGM.getSwiftModule(), { "String" })) return;
 
+  if (!IGM.ObjCInterop) return;
+
   checkPointerAuthAssociatedTypeDiscriminator(IGM, { "_ObjectiveCBridgeable", "_ObjectiveCType" }, SpecialPointerAuthDiscriminators::ObjectiveCTypeDiscriminator);
   checkPointerAuthWitnessDiscriminator(IGM, { "_ObjectiveCBridgeable", "_bridgeToObjectiveC" }, SpecialPointerAuthDiscriminators::bridgeToObjectiveCDiscriminator);
   checkPointerAuthWitnessDiscriminator(IGM, { "_ObjectiveCBridgeable", "_forceBridgeFromObjectiveC" }, SpecialPointerAuthDiscriminators::forceBridgeFromObjectiveCDiscriminator);

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -396,11 +396,12 @@ endif()
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-stdlib ALL)
   set(EMBEDDED_STDLIB_TARGET_TRIPLES
-    # arch module_name            target triple
+    # arch    module_name               target triple
     "armv7    armv7-apple-none-macho    armv7-apple-none-macho"
     "arm64    arm64-apple-none-macho    arm64-apple-none-macho"
     "x86_64   x86_64-apple-macos        x86_64-apple-macos10.13"
     "arm64    arm64-apple-macos         arm64-apple-macos10.13"
+    "arm64e   arm64e-apple-macos        arm64e-apple-macos10.13"
     )
 
   set(SWIFT_ENABLE_REFLECTION OFF)

--- a/test/embedded/ptr-auth-irgen-verify-no-stdlib.swift
+++ b/test/embedded/ptr-auth-irgen-verify-no-stdlib.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -Xcc -fptrauth-calls -module-name Swift | %FileCheck %s
+
+// Windows does not have SwiftCompilerSources.
+// XFAIL: OS=windows-msvc
+
+// Some verification is blocked on string lookup succeeding.
+struct String {}
+
+public func test() { }
+
+// CHECK-LABEL: define {{.*}}void @"$ss4testyyF"()

--- a/test/embedded/ptr-auth-irgen-verify-no-stdlib.swift
+++ b/test/embedded/ptr-auth-irgen-verify-no-stdlib.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -Xcc -fptrauth-calls -module-name Swift | %FileCheck %s
 
-// Windows does not have SwiftCompilerSources.
-// XFAIL: OS=windows-msvc
+// REQUIRES: swift_in_compiler
 
 // Some verification is blocked on string lookup succeeding.
 struct String {}


### PR DESCRIPTION
This is needed for arm64e embedded tests to pass.