### PR TITLE
[embedded] Mark basic-irgen-no-stdlib.swift as REQUIRES: swift_in_compiler

### DIFF
--- a/test/embedded/basic-irgen-no-stdlib.swift
+++ b/test/embedded/basic-irgen-no-stdlib.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s
 
-// TODO: investigate why windows is generating more metadata.
-// XFAIL: OS=windows-msvc
+// REQUIRES: swift_in_compiler
 
 struct Bool {}
 


### PR DESCRIPTION
Otherwise the test fails when building with bootstrapping disabled.