### PR TITLE
Enable WebAssembly target in LLVM backend by default

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1259,7 +1259,7 @@ def create_argument_parser():
            help='enable building llvm using modules')
 
     option('--llvm-targets-to-build', store,
-           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV',
+           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly',
            help='LLVM target generators to build')
 
     option('--llvm-ninja-targets', append,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -217,7 +217,7 @@ EXPECTED_DEFAULTS = {
     'llvm_ninja_targets_for_cross_compile_hosts': [],
     'llvm_max_parallel_lto_link_jobs':
         defaults.LLVM_MAX_PARALLEL_LTO_LINK_JOBS,
-    'llvm_targets_to_build': 'X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV',
+    'llvm_targets_to_build': 'X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly',
     'tsan_libdispatch_test': False,
     'long_test': False,
     'lto_type': None,


### PR DESCRIPTION
Enable WebAssembly target in LLVM backend for OSS toolchain packages since we merged all compiler fixes for Wasm target. This unlocks further CI setup for standalone stdlib build.

It seems there is no significant binary-size/build-time increase.

| | Before | After |
|:-:|:-:|:-:|
| Toolchain Size (unpacked) | 2.173 GB[^1] | 2.186 GB[^2] (+ 13 MB) |
| Toolchain Size (packed) | 667 MB  | 671 MB (+ 4 MB) |
| Toolchain Build-time | 1 hr 12 min [^3] | 1 hr 14 min [^4]|


[^1]: https://download.swift.org/tmp/pull-request/66539/594/ubuntu2004/PR-ubuntu2004.tar.gz
[^2]: https://download.swift.org/tmp/pull-request/68750/595/ubuntu2004/PR-ubuntu2004.tar.gz
[^3]: https://ci.swift.org/job/swift-PR-toolchain-Linux/594/
[^4]: https://ci.swift.org/job/swift-PR-toolchain-Linux/595/