### PR TITLE
[NFC][Concurrency] Minor cleanup for actor isolation.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -240,26 +240,6 @@ bool isSameActorIsolated(ValueDecl *value, DeclContext *dc);
 /// Determines whether this function's body uses flow-sensitive isolation.
 bool usesFlowSensitiveIsolation(AbstractFunctionDecl const *fn);
 
-/// Check if it is safe for the \c globalActor qualifier to be removed from
-/// \c ty, when the function value of that type is isolated to that actor.
-///
-/// In general this is safe in a narrow but common case: a global actor
-/// qualifier can be dropped from a function type while in a DeclContext
-/// isolated to that same actor, as long as the value is not Sendable.
-///
-/// \param dc the innermost context in which the cast to remove the global actor
-///           is happening.
-/// \param globalActor global actor that was dropped from \c ty.
-/// \param ty a function type where \c globalActor was removed from it.
-/// \param getClosureActorIsolation function that knows how to produce accurate
-///        information about the isolation of a closure.
-/// \return true if it is safe to drop the global-actor qualifier.
-bool safeToDropGlobalActor(
-                DeclContext *dc, Type globalActor, Type ty,
-                llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
-                    getClosureActorIsolation =
-                        __AbstractClosureExpr_getActorIsolation);
-
 void simple_display(llvm::raw_ostream &out, const ActorIsolation &state);
 
 } // end namespace swift

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2938,23 +2938,6 @@ bool ConstraintSystem::hasPreconcurrencyCallee(
   return calleeOverload->choice.getDecl()->preconcurrency();
 }
 
-/// Determines whether a DeclContext is preconcurrency, using information
-/// tracked by the solver to aid in answering that.
-static bool isPreconcurrency(ConstraintSystem &cs, DeclContext *dc) {
-  if (auto *decl = dc->getAsDecl())
-    return decl->preconcurrency();
-
-  if (auto *ce = dyn_cast<ClosureExpr>(dc)) {
-    return ClosureIsolatedByPreconcurrency{cs}(ce);
-  }
-
-  if (auto *autoClos = dyn_cast<AutoClosureExpr>(dc)) {
-    return isPreconcurrency(cs, autoClos->getParent());
-  }
-
-  llvm_unreachable("unhandled DeclContext kind in isPreconcurrency");
-}
-
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,


### PR DESCRIPTION
* Use `warnUntilSwiftVersion(6)` in `safeToDropGlobalActor`. Now that there's only one call-site of `safeToDropGlobalActor`, it doesn't need to be exposed in the ActorIsolation header, and it doesn't need to avoid `warnUntilSwiftVersion` to match constraint system diagnostics.
* Remove an unused `isPreconcurrency` function in CSSimplify. The only caller of this function was removed in https://github.com/apple/swift/pull/68685.