### PR TITLE
Require swift_in_compiler in dist. ownership verify sil

### DIFF
--- a/test/Distributed/SIL/distributed_id_system_ownership_verify_sil.swift
+++ b/test/Distributed/SIL/distributed_id_system_ownership_verify_sil.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: distributed
+// REQUIRES: swift_in_compiler
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
Commit 5bc036661c60 introduced changes to
distributed_id_system_ownership_verify_sil.swift that don't work unless you have SwiftCompilerSources enabled. Gating test on that.