### PR TITLE
[embedded] Mark stdlib-types.swift test as REQUIRES: optimized_stdlib

### DIFF
--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: VENDOR=apple
+// REQUIRES: optimized_stdlib
 
 class MyClass {}
 


### PR DESCRIPTION
To resolve CI failure at <https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators/3217/>.