### PR TITLE
AST/SILGen: Requestify function body skipping

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4423,6 +4423,25 @@ public:
   void cacheResult(GenericSignature signature) const;
 };
 
+class IsFunctionBodySkippedRequest
+    : public SimpleRequest<IsFunctionBodySkippedRequest,
+                           bool(const AbstractFunctionDecl *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, const AbstractFunctionDecl *) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  llvm::Optional<bool> getCachedResult() const;
+  void cacheResult(bool isSkipped) const;
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -503,3 +503,6 @@ SWIFT_REQUEST(TypeChecker, ExpandChildTypeRefinementContextsRequest,
 SWIFT_REQUEST(TypeChecker, SerializeAttrGenericSignatureRequest,
               GenericSignature(Decl *, SpecializeAttr *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsFunctionBodySkippedRequest,
+              bool(const AbstractFunctionDecl *),
+              SeparatelyCached, NoLocationInfo)

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -496,7 +496,6 @@ public:
       switch (afd->getBodyKind()) {
       case AbstractFunctionDecl::BodyKind::None:
       case AbstractFunctionDecl::BodyKind::TypeChecked:
-      case AbstractFunctionDecl::BodyKind::Skipped:
       case AbstractFunctionDecl::BodyKind::SILSynthesize:
       case AbstractFunctionDecl::BodyKind::Deserialized:
         return true;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1457,11 +1457,13 @@ llvm::Optional<BraceStmt *>
 TypeCheckFunctionBodyRequest::getCachedResult() const {
   using BodyKind = AbstractFunctionDecl::BodyKind;
   auto *afd = std::get<0>(getStorage());
+  if (afd->isBodySkipped())
+    return nullptr;
+
   switch (afd->getBodyKind()) {
   case BodyKind::Deserialized:
   case BodyKind::SILSynthesize:
   case BodyKind::None:
-  case BodyKind::Skipped:
     // These cases don't have any body available.
     return nullptr;
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -91,7 +91,6 @@ ParseAbstractFunctionBodyRequest::evaluate(Evaluator &evaluator,
   case BodyKind::Deserialized:
   case BodyKind::SILSynthesize:
   case BodyKind::None:
-  case BodyKind::Skipped:
     return {};
 
   case BodyKind::TypeChecked:

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1056,6 +1056,7 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
     if (fd->requiresUnavailableDeclABICompatibilityStubs())
       emitApplyOfUnavailableCodeReached();
 
+    assert(!fd->isBodySkipped());
     emitProfilerIncrement(fd->getTypecheckedBody());
 
     // Emit the actual function body as usual

--- a/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
@@ -66,9 +66,12 @@ static bool shouldHaveSkippedFunction(const SILFunction &F) {
   if (isa<DestructorDecl>(func) || isa<ConstructorDecl>(func))
     return false;
 
-  // See DeclChecker::shouldSkipBodyTypechecking. Can't skip didSet for now.
+  // Some AccessorDecls can't be skipped (see IsFunctionBodySkippedRequest).
   if (auto *AD = dyn_cast<AccessorDecl>(func)) {
     if (AD->getAccessorKind() == AccessorKind::DidSet)
+      return false;
+
+    if (AD->hasForcedStaticDispatch())
       return false;
   }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2401,7 +2401,8 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
       }
     }
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
-      if (AFD->hasBody() && !AFD->isBodyTypeChecked()) {
+      if (AFD->hasBody() && !AFD->isBodyTypeChecked() &&
+          !AFD->isBodySkipped()) {
         // Pre-check the function body if needed.
         (void)evaluateOrDefault(evaluator, PreCheckFunctionBodyRequest{AFD},
                                 nullptr);
@@ -2648,6 +2649,8 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
 BraceStmt *
 PreCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
                                       AbstractFunctionDecl *AFD) const {
+  assert(!AFD->isBodySkipped());
+
   auto &ctx = AFD->getASTContext();
   auto *body = AFD->getBody();
   assert(body && "Expected body");
@@ -2701,6 +2704,8 @@ PreCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
 BraceStmt *
 TypeCheckFunctionBodyRequest::evaluate(Evaluator &eval,
                                        AbstractFunctionDecl *AFD) const {
+  assert(!AFD->isBodySkipped());
+
   ASTContext &ctx = AFD->getASTContext();
 
   llvm::Optional<FunctionBodyTimer> timer;

--- a/test/Frontend/skip-function-bodies.swift
+++ b/test/Frontend/skip-function-bodies.swift
@@ -18,9 +18,8 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Skip.noninlinable.swiftinterface) -module-name Skip
 // RUN: %FileCheck %s --check-prefixes CHECK,CHECK-TEXTUAL --input-file %t/Skip.noninlinable.swiftinterface
 // RUN: %target-swift-emit-module-interface(%t/Skip.all.swiftinterface) %s -module-name Skip -experimental-skip-all-function-bodies
-// FIXME: The interface emitted with -experimental-skip-all-function-bodies is very broken.
-// %target-swift-typecheck-module-from-interface(%t/Skip.all.swiftinterface) -module-name Skip
-// %FileCheck %s --check-prefixes CHECK,CHECK-TEXTUAL --input-file %t/Skip.all.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Skip.all.swiftinterface) -module-name Skip
+// RUN: %FileCheck %s --check-prefixes CHECK,CHECK-TEXTUAL --input-file %t/Skip.all.swiftinterface
 
 // Verify that the emitted interfaces match an interface emitted without any
 // body skipping flags.
@@ -213,9 +212,8 @@ public func funcPublicWithNestedTypeStructInNestedFunc() {
   _blackHole(INLINENOTYPECHECK_local)
 
   func noType() {
-    // FIXME: This should be NEVERTYPECHECK but there is overeager typechecking.
-    let INLINENOTYPECHECK_innerLocal = "funcPublicWithNestedTypeStructInNestedFunc()@noType()"
-    _blackHole(INLINENOTYPECHECK_innerLocal)
+    let NEVERTYPECHECK_innerLocal = "funcPublicWithNestedTypeStructInNestedFunc()@noType()"
+    _blackHole(NEVERTYPECHECK_innerLocal)
   }
 
   func type() {
@@ -232,9 +230,7 @@ public func funcPublicWithNestedTypeStructInNestedFunc() {
 
 // CHECK-TEXTUAL-NOT: "funcPublicWithNestedTypeStructInNestedFunc()@noType()"
 // CHECK-SIL-NO-SKIP: "funcPublicWithNestedTypeStructInNestedFunc()@noType()"
-// CHECK-SIL-SKIP-NONINLINE-NOT: "funcPublicWithNestedTypeStructInNestedFunc()@noType()"
-// FIXME: This shouldn't need to be SILGen'd.
-// CHECK-SIL-SKIP-WITHOUTTYPES: "funcPublicWithNestedTypeStructInNestedFunc()@noType()"
+// CHECK-SIL-SKIP-NONINLINE-OR-WITHOUTTYPES-NOT: "funcPublicWithNestedTypeStructInNestedFunc()@noType()"
 
 // CHECK-TEXTUAL-NOT: "funcPublicWithNestedTypeStructInNestedFunc()@type()"
 // CHECK-SIL-NO-SKIP: "funcPublicWithNestedTypeStructInNestedFunc()@type()"

--- a/test/SILGen/Inputs/open_enum.h
+++ b/test/SILGen/Inputs/open_enum.h
@@ -1,0 +1,5 @@
+
+typedef enum __attribute__((enum_extensibility(open))) YesOrNo {
+  Yes,
+  No,
+} YesOrNo;

--- a/test/SILGen/skip-function-bodies-clang-enum-init-raw-value.swift
+++ b/test/SILGen/skip-function-bodies-clang-enum-init-raw-value.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-silgen %s -import-objc-header %S/Inputs/open_enum.h -experimental-skip-non-inlinable-function-bodies | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -import-objc-header %S/Inputs/open_enum.h -experimental-skip-non-inlinable-function-bodies-without-types | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -import-objc-header %S/Inputs/open_enum.h -debug-forbid-typecheck-prefix SKIP_ALL_NO_TYPECHECK -experimental-skip-all-function-bodies | %FileCheck %s --check-prefix=CHECK-SKIP-ALL
+
+// Imported clang enums have different signedness when building for Windows.
+// UNSUPPORTED: OS=windows-msvc
+
+// CHECK-SKIP-ALL-NOT: s4main13inlinableFuncSo7YesOrNoVyF
+
+// CHECK: sil [serialized]{{.*}} @$s4main13inlinableFuncSo7YesOrNoVyF : $@convention(thin) () -> YesOrNo {
+// CHECK:   return {{%.*}} : $YesOrNo
+// CHECK: } // end sil function '$s4main13inlinableFuncSo7YesOrNoVyF'
+@inlinable public func inlinableFunc() -> YesOrNo {
+  let SKIP_ALL_NO_TYPECHECK = 1
+  _ = SKIP_ALL_NO_TYPECHECK
+  return YesOrNo(rawValue: 1)!
+}
+
+// CHECK-SKIP-ALL-NOT: sSo7YesOrNoV8rawValueABSgs6UInt32V_tcfC
+
+// CHECK: sil shared [serialized]{{.*}} @$sSo7YesOrNoV8rawValueABSgs6UInt32V_tcfC : $@convention(method) (UInt32, @thin YesOrNo.Type) -> Optional<YesOrNo> {
+// CHECK:   return {{%.*}} : $Optional<YesOrNo>
+// CHECK: } // end sil function '$sSo7YesOrNoV8rawValueABSgs6UInt32V_tcfC'

--- a/test/SILGen/skip-function-bodies-forced-static-dispatch-accessor.swift
+++ b/test/SILGen/skip-function-bodies-forced-static-dispatch-accessor.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-silgen %s -experimental-skip-non-inlinable-function-bodies | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -experimental-skip-non-inlinable-function-bodies-without-types | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -import-objc-header %S/Inputs/open_enum.h -debug-forbid-typecheck-prefix SKIP_ALL_NO_TYPECHECK -experimental-skip-all-function-bodies | %FileCheck %s --check-prefix=CHECK-SKIP-ALL
+
+public protocol P {
+  @_borrowed var x: Int { get }
+}
+
+public struct S: P {
+  /// Since x implements a `@_borrowed` requirement of `P` the synthesized
+  /// `_read` accessor has forced static dispatch and is a serialized function
+  /// even though it is not `@_transparent`.
+  public var x: Int
+
+  // CHECK-SKIP-ALL-NOT: s4main1SV1xSivr
+  // CHECK: sil shared [serialized]{{.*}} @$s4main1SV1xSivr : $@yield_once @convention(method) (S) -> @yields Int {
+  // CHECK:   yield
+  // CHECK: } // end sil function '$s4main1SV1xSivr'
+}

--- a/test/SILGen/skip-function-bodies-lazy-property.swift
+++ b/test/SILGen/skip-function-bodies-lazy-property.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-silgen %s -experimental-skip-non-inlinable-function-bodies | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -experimental-skip-non-inlinable-function-bodies-without-types | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -experimental-skip-all-function-bodies | %FileCheck %s --check-prefix=CHECK-SKIP-ALL
+
+public struct S {
+  public lazy var x: Int = generateNumber()
+
+  // CHECK-SKIP-ALL-NOT: s4main1SV1xSivg
+  // CHECK: sil [lazy_getter]{{.*}} @$s4main1SV1xSivg : $@convention(method) (@inout S) -> Int {
+  // CHECK:   function_ref @$s4main1SV14generateNumberSiyF
+  // CHECK: } // end sil function '$s4main1SV1xSivg'
+
+  func generateNumber() -> Int { return 1 }
+}


### PR DESCRIPTION
Function bodies are skipped during typechecking when one of the `-experimental-skip-*-function-bodies` flags is passed to the frontend. This was implemented by setting the "body kind" of an `AbstractFunctionDecl` during decl checking in `TypeCheckDeclPrimary`. This approach had a couple of issues:

- It is incompatible with skipping function bodies during lazy typechecking, since the skipping is only evaluated during a phase of eager typechecking.
- It prevents skipped function bodies from being parsed on-demand ("skipped" is a state that is distinct from "parsed", when they ought to be orthogonal). This needlessly prevented complete module interfaces from being emitted with `-experimental-skip-all-function-bodies`.
    
Storing the skipped status of a function separately from body kind and requestifying the determination of whether to skip a function solves these problems.
    
Resolves rdar://116020403