### PR TITLE
NFC: Correct a declaration in TypeCheckerTypeIDZone.def.

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4405,7 +4405,7 @@ class SerializeAttrGenericSignatureRequest
     : public SimpleRequest<SerializeAttrGenericSignatureRequest,
                            GenericSignature(const AbstractFunctionDecl *,
                                             SpecializeAttr *),
-                           RequestFlags::Cached> {
+                           RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -501,5 +501,5 @@ SWIFT_REQUEST(TypeChecker, ExpandChildTypeRefinementContextsRequest,
               bool(Decl *, TypeRefinementContext *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SerializeAttrGenericSignatureRequest,
-              bool(Decl *, SpecializeAttr *),
-              Cached, NoLocationInfo)
+              GenericSignature(Decl *, SpecializeAttr *),
+              SeparatelyCached, NoLocationInfo)

--- a/unittests/ClangImporter/CMakeLists.txt
+++ b/unittests/ClangImporter/CMakeLists.txt
@@ -8,6 +8,7 @@ add_swift_unittest(SwiftClangImporterTests
 target_link_libraries(SwiftClangImporterTests
     PRIVATE
     swiftClangImporter
+    swiftSema
     swiftParse
     swiftAST
 )

--- a/unittests/Driver/CMakeLists.txt
+++ b/unittests/Driver/CMakeLists.txt
@@ -7,4 +7,5 @@ add_swift_unittest(SwiftDriverTests
 target_link_libraries(SwiftDriverTests PRIVATE
    swiftAST
    swiftClangImporter
+   swiftSema
    swiftDriver)


### PR DESCRIPTION
Follow up to https://github.com/apple/swift/pull/68555.