### PR TITLE
[swift-syntax] Reduce number of jobs that verify generated files

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -371,7 +371,6 @@ sourcekit-lsp
 # Failing to build in CI: rdar://78408440
 # swift-inspect
 swiftsyntax
-swiftsyntax-verify-generated-files
 swiftformat
 
 skstresstester
@@ -631,7 +630,6 @@ libcxx
 llbuild
 swiftpm
 swiftsyntax
-swiftsyntax-verify-generated-files
 swiftformat
 swift-driver
 indexstore-db
@@ -1160,7 +1158,6 @@ xctest
 foundation
 libdispatch
 swiftsyntax
-swiftsyntax-verify-generated-files
 swiftformat
 indexstore-db
 sourcekit-lsp
@@ -1303,10 +1300,6 @@ playgroundsupport
 indexstore-db
 sourcekit-lsp
 swiftdocc
-
-# Don't generate the SwiftSyntax gyb files. Instead verify that up-to-date ones
-# are checked in.
-swiftsyntax-verify-generated-files
 
 # Build with debug info, this allows us to symbolicate crashes from
 # production builds.
@@ -1905,8 +1898,6 @@ assertions
 swiftsyntax
 swiftsyntax-enable-rawsyntax-validation
 swiftsyntax-enable-test-fuzzing
-swiftsyntax-verify-generated-files
-swiftsyntax-lint
 sourcekit-lsp
 swiftformat
 


### PR DESCRIPTION
We were checking that the generated files matched the code in CodeGeneration in a number of jobs, which was still a relict from when `gyb_syntax_support` lived in the swift repo and was thus possible to break with a PR to the swift repo. Now, CodeGeneration lives exclusively in the swift-syntax repo and thus the checked in generated files can only be broken by a swift-syntax change.

Reduce the number of jobs that verify the generated files to:
- swift-syntax macOS PR testing (no need to run CodeGeneration on macOS and Linux)
- `buildbot_all_platforms,tools=RA,stdlib=RA`, which is used fro the macOS Pull Request status bot so we get signal if two PRs in swift-syntax raced and broke the checked in generated files

And while at it, also only verify the formatting of swift-syntax on macOS. There’s no need to verify it on all platforms.