### PR TITLE
[Sema] Fix `try`/`await` handling for `if`/`switch` expressions

### DIFF
--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1002,6 +1002,225 @@ func tryIf3() -> Int {
   // expected-error@-1 {{'try' may not be used on 'if' expression}}
 }
 
+func tryIf4() throws -> Int {
+  return try if .random() { 0 } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+}
+
+func tryIf5() throws -> Int {
+  return try if .random() { tryIf4() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+}
+
+func tryIf6() throws -> Int {
+  try if .random() { tryIf4() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+}
+
+func tryIf7() throws -> Int {
+  let x = try if .random() { tryIf4() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+  return x
+}
+
+func tryIf8() throws -> Int {
+  return try if .random() { try tryIf4() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+}
+
+func tryIf9() throws -> Int {
+  try if .random() { try tryIf4() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+}
+
+func tryIf10() throws -> Int {
+  let x = try if .random() { try tryIf4() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  return x
+}
+
+func tryIf11() throws -> Int {
+  let x = try if .random() { try tryIf4() } else { tryIf4() }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+  return x
+}
+
+func tryIf12() throws -> Int {
+  let x = try if .random() { tryIf4() } else { tryIf4() }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 2{{call can throw but is not marked with 'try'}}
+  // expected-note@-3 2{{did you mean to use 'try'?}}
+  // expected-note@-4 2{{did you mean to handle error as optional value?}}
+  // expected-note@-5 2{{did you mean to disable error propagation?}}
+  return x
+}
+
+func tryIf13() throws -> Int {
+  let x = try if .random() { // expected-error {{'try' may not be used on 'if' expression}}
+    tryIf4() // expected-warning {{result of call to 'tryIf4()' is unused}}
+    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-note@-2 {{did you mean to use 'try'?}}
+    // expected-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-note@-4 {{did you mean to disable error propagation?}}
+
+    _ = tryIf4()
+    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-note@-2 {{did you mean to use 'try'?}}
+    // expected-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-note@-4 {{did you mean to disable error propagation?}}
+
+    _ = try tryIf4() // Okay.
+
+    // Okay.
+    do {
+      _ = try tryIf4()
+    } catch {}
+
+    print("hello")
+    throw Err()
+  } else {
+    0
+  }
+  return x
+}
+
+func throwsBool() throws -> Bool { true }
+
+func tryIf14() throws -> Int {
+  try if throwsBool() { 0 } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3 {{did you mean to use 'try'?}}
+  // expected-note@-4 {{did you mean to handle error as optional value?}}
+  // expected-note@-5 {{did you mean to disable error propagation?}}
+}
+
+func tryIf15() throws -> Int {
+  try if try throwsBool() { 0 } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+}
+
+func tryIf16() throws -> Int {
+  if throwsBool() { 0 } else { 1 }
+  // expected-error@-1 {{call can throw but is not marked with 'try'}}
+  // expected-note@-2 {{did you mean to use 'try'?}}
+  // expected-note@-3 {{did you mean to handle error as optional value?}}
+  // expected-note@-4 {{did you mean to disable error propagation?}}
+}
+
+func tryIf17() throws -> Int {
+  if .random() { tryIf4() } else { 1 }
+  // expected-error@-1 {{call can throw but is not marked with 'try'}}
+  // expected-note@-2 {{did you mean to use 'try'?}}
+  // expected-note@-3 {{did you mean to handle error as optional value?}}
+  // expected-note@-4 {{did you mean to disable error propagation?}}
+}
+
+func tryIf18() {
+  // Make sure we don't warn here.
+  do {
+    let _ = if .random() { try tryIf4() } else { 1 }
+  } catch {}
+}
+
+func tryIf19() {
+  // Make sure we don't warn here.
+  do {
+    let _ = if .random() { throw Err() } else { 1 }
+  } catch {}
+}
+
+func tryIf19() throws -> Int {
+  let x = if .random() { throw Err() } else { 1 }
+  return x
+}
+
+func tryIf20() throws -> Int {
+  if .random() { throw Err() } else { 1 }
+}
+
+func tryIf21(_ fn: () throws -> Int) rethrows -> Int {
+  let x = if .random() { try fn() } else { 1 }
+  return x
+}
+
+func tryIf22(_ fn: () throws -> Int) rethrows -> Int {
+  if .random() { try fn() } else { 1 }
+}
+
+func tryIf23(_ fn: () throws -> Int) rethrows -> Int {
+  let x = if .random() { try fn() } else { throw Err() }
+  // expected-error@-1 {{a function declared 'rethrows' may only throw if its parameter does}}
+  return x
+}
+
+func tryIf24(_ fn: () throws -> Int) rethrows -> Int {
+  let x = if .random() { try fn() } else { try tryIf4() }
+  // expected-error@-1 {{a function declared 'rethrows' may only throw if its parameter does}}
+  return x
+}
+
+func tryIf25(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = if .random() { try fn() } else { try tryIf4() }
+    return x
+  } catch {
+    return 0
+  }
+}
+
+func tryIf26(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = if .random() { try fn() } else { throw Err() }
+    return x
+  } catch {
+    return 0
+  }
+}
+
+func tryIf27(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = if .random() { try fn() } else { try tryIf4() }
+    return x
+  } catch {
+    throw error  // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func tryIf28(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = if .random() { try fn() } else { throw Err() }
+    return x
+  } catch {
+    throw error  // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func tryIf29(_ fn: () throws -> Int) rethrows -> Int {
+  do {
+    let x = if .random() { try fn() } else { 0 }
+    return x
+  } catch {
+    throw error // Okay.
+  }
+}
+
 func awaitIf1() async -> Int {
   await if .random() { 0 } else { 1 }
   // expected-error@-1 {{'await' may not be used on 'if' expression}}
@@ -1018,6 +1237,131 @@ func awaitIf3() async -> Int {
   // expected-error@-1 {{'await' may not be used on 'if' expression}}
 }
 
+func awaitIf4() async -> Int {
+  return await if .random() { 0 } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+}
+
+func awaitIf5() async -> Int {
+  return await if .random() { awaitIf4() } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+}
+
+func awaitIf6() async -> Int {
+  await if .random() { awaitIf4() } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+}
+
+func awaitIf7() async -> Int {
+  let x = await if .random() { awaitIf4() } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+  return x
+}
+
+func awaitIf8() async -> Int {
+  return await if .random() { await awaitIf4() } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+}
+
+func awaitIf9() async -> Int {
+  await if .random() { await awaitIf4() } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+}
+
+func awaitIf10() async -> Int {
+  let x = await if .random() { await awaitIf4() } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  return x
+}
+
+func awaitIf11() async -> Int {
+  let x = await if .random() { await awaitIf4() } else { awaitIf4() }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+  return x
+}
+
+func awaitIf12() async -> Int {
+  let x = await if .random() { awaitIf4() } else { awaitIf4() }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 2{{call is 'async'}}
+  return x
+}
+
+func awaitIf13() async throws -> Int {
+  let x = await if .random() { // expected-error {{'await' may not be used on 'if' expression}}
+    awaitIf4() // expected-warning {{result of call to 'awaitIf4()' is unused}}
+    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-note@-2 {{call is 'async'}}
+
+    _ = awaitIf4()
+    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-note@-2 {{call is 'async'}}
+
+    _ = await awaitIf4() // Okay.
+
+    // Okay.
+    let _ = {
+      _ = await awaitIf4()
+    }
+
+    print("hello")
+    throw Err()
+  } else {
+    0
+  }
+  return x
+}
+
+func asyncBool() async -> Bool { true }
+
+func awaitIf14() async -> Int {
+  await if asyncBool() { 0 } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-3 {{call is 'async'}}
+}
+
+func awaitIf15() async -> Int {
+  await if await asyncBool() { 0 } else { 1 }
+  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+}
+
+func awaitIf16() async -> Int {
+  if asyncBool() { 0 } else { 1 }
+  // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-2 {{call is 'async'}}
+}
+
+func awaitIf17() async -> Int {
+  if .random() { awaitIf4() } else { 1 }
+  // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-2 {{call is 'async'}}
+}
+
+func awaitIf18() {
+  let _ = {
+    let _ = if .random() { await awaitIf4() } else { 1 }
+  }
+}
+
+func awaitIf19() async -> Int {
+  let x = if .random() { await awaitIf4() } else { 1 }
+  return x
+}
+
+func awaitIf20() async -> Int {
+  if .random() { await awaitIf4() } else { 1 }
+}
+
 func tryAwaitIf1() async throws -> Int {
   try await if .random() { 0 } else { 1 }
   // expected-error@-1 {{'try' may not be used on 'if' expression}}
@@ -1028,6 +1372,123 @@ func tryAwaitIf2() async throws -> Int {
   try await if .random() { 0 } else { 1 } as Int
   // expected-error@-1 {{'try' may not be used on 'if' expression}}
   // expected-error@-2 {{'await' may not be used on 'if' expression}}
+}
+
+func tryAwaitIf3() async throws -> Int {
+  try await if .random() { tryAwaitIf2() } else { 1 } as Int
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-note@-4 {{did you mean to use 'try'?}}
+  // expected-note@-5 {{did you mean to handle error as optional value?}}
+  // expected-note@-6 {{did you mean to disable error propagation?}}
+  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-8 {{call is 'async'}}
+}
+
+func tryAwaitIf4() async throws -> Int {
+  try await if .random() { try tryAwaitIf2() } else { 1 } as Int
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-4 {{call is 'async'}}
+}
+
+func tryAwaitIf5() async throws -> Int {
+  try await if .random() { await tryAwaitIf2() } else { 1 } as Int
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-note@-4 {{did you mean to use 'try'?}}
+  // expected-note@-5 {{did you mean to handle error as optional value?}}
+  // expected-note@-6 {{did you mean to disable error propagation?}}
+}
+
+func tryAwaitIf6() async throws -> Int {
+  try await if .random() { try await tryAwaitIf2() } else { 1 } as Int
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+}
+
+func tryAwaitIf7() async throws -> Int {
+  try await if .random() { tryAwaitIf2() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-note@-4 {{did you mean to use 'try'?}}
+  // expected-note@-5 {{did you mean to handle error as optional value?}}
+  // expected-note@-6 {{did you mean to disable error propagation?}}
+  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-8 {{call is 'async'}}
+}
+
+func tryAwaitIf8() async throws -> Int {
+  try await if .random() { try tryAwaitIf2() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-4 {{call is 'async'}}
+}
+
+func tryAwaitIf9() async throws -> Int {
+  try await if .random() { await tryAwaitIf2() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-note@-4 {{did you mean to use 'try'?}}
+  // expected-note@-5 {{did you mean to handle error as optional value?}}
+  // expected-note@-6 {{did you mean to disable error propagation?}}
+}
+
+func tryAwaitIf10() async throws -> Int {
+  try await if .random() { try await tryAwaitIf2() } else { 1 }
+  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+}
+
+func tryAwaitIf11(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = if .random() { try await fn() } else { try await tryAwaitIf4() }
+    return x
+  } catch {
+    return 0
+  }
+}
+
+func tryAwaitIf12(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = if .random() { try await fn() } else { throw Err() }
+    return x
+  } catch {
+    return 0
+  }
+}
+
+func tryAwaitIf13(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = if .random() { try await fn() } else { try await tryAwaitIf4() }
+    return x
+  } catch {
+    throw error  // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func tryAwaitIf14(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = if .random() { try await fn() } else { throw Err() }
+    return x
+  } catch {
+    throw error  // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+}
+
+func tryAwaitIf15(_ fn: () async throws -> Int) async rethrows -> Int {
+  do {
+    let x = if .random() { try await fn() } else { 0 }
+    return x
+  } catch {
+    throw error // Okay.
+  }
 }
 
 struct AnyEraserP: EraserP {

--- a/test/expr/unary/if_expr_reasync.swift
+++ b/test/expr/unary/if_expr_reasync.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-concurrency
+
+// Required for '-enable-experimental-concurrency'
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+func asyncFn() async -> Int { 0 }
+
+func reasyncIf1(_ fn: () async -> Int) reasync -> Int {
+  let x = if .random() { await fn() } else { 1 }
+  return x
+}
+
+func reasyncIf2(_ fn: () async -> Int) reasync -> Int {
+  if .random() { await fn() } else { 1 }
+}
+
+// Not a very good diagnostic, but reasync is still experimental.
+func reasyncIf3(_ fn: () async -> Int) reasync -> Int {
+  // expected-note@-1 {{add 'async' to function 'reasyncIf3' to make it asynchronous}}
+  let x = if .random() { await fn() } else { await asyncFn() }
+  // expected-error@-1 {{'async' call in a function that does not support concurrency}}
+  return x
+}
+
+func reasyncIf4(_ fn: () async -> Int) reasync -> Int {
+  let _ = {
+    let x = if .random() { await fn() } else { await asyncFn() }
+    return x
+  }
+  return 0
+}

--- a/test/expr/unary/switch_expr_reasync.swift
+++ b/test/expr/unary/switch_expr_reasync.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-concurrency
+
+// Required for '-enable-experimental-concurrency'
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+func asyncFn() async -> Int { 0 }
+
+func reasyncSwitch1(_ fn: () async -> Int) reasync -> Int {
+  let x = switch Bool.random() { case true: await fn() case false: 1 }
+  return x
+}
+
+func reasyncSwitch2(_ fn: () async -> Int) reasync -> Int {
+  switch Bool.random() { case true: await fn() case false: 1 }
+}
+
+// Not a very good diagnostic, but reasync is still experimental.
+func reasyncSwitch3(_ fn: () async -> Int) reasync -> Int {
+  // expected-note@-1 {{add 'async' to function 'reasyncSwitch3' to make it asynchronous}}
+  let x = switch Bool.random() { case true: await fn() case false: await asyncFn() }
+  // expected-error@-1 {{'async' call in a function that does not support concurrency}}
+  return x
+}
+
+func reasyncSwitch4(_ fn: () async -> Int) reasync -> Int {
+  let _ = {
+    let x = switch Bool.random() { case true: await fn() case false: await asyncFn() }
+    return x
+  }
+  return 0
+}


### PR DESCRIPTION
Previously we allowed an attached `try` or `await` on an `if`/`switch` expression to cover the branches, which does not match what was proposed, and is especially harmful for multi-statement cases. Fix the effect handling logic such that we reset effect coverage for `if`/`switch` expressions similar to closures, but continue to maintain the state needed for rethrows checking. This means that we'll now consistently diagnose `try` and `await` on `if`/`switch` expressions as invalid.

rdar://116066748