### PR TITLE
[embedded] Fix arm64e pointer signing in embedded heap object destruction

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
@@ -28,10 +28,8 @@
 extern "C" {
 #endif
 
-#define SWIFT_CC __attribute__((swiftcall))
-#define SWIFT_CONTEXT __attribute__((swift_context))
-
-typedef void SWIFT_CC (*HeapObjectDestroyer)(SWIFT_CONTEXT void *object);
+typedef void __attribute__((swiftcall)) (*HeapObjectDestroyer)(
+    __attribute__((swift_context)) void *object);
 
 static inline void _swift_embedded_invoke_heap_object_destroy(void *object) {
   void *metadata = *(void **)object;

--- a/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
@@ -35,7 +35,7 @@ static inline void _swift_embedded_invoke_heap_object_destroy(void *object) {
   void *metadata = *(void **)object;
   void **destroy_location = &((void **)metadata)[1];
 #if __has_feature(ptrauth_calls)
-  (*(__ptrauth(0,1,0xbbbf) HeapObjectDestroyer *)destroy_location)(object);
+  (*(HeapObjectDestroyer __ptrauth(0,1,0xbbbf) *)destroy_location)(object);
 #else
   (*(HeapObjectDestroyer *)destroy_location)(object);
 #endif

--- a/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
@@ -33,9 +33,14 @@ extern "C" {
 
 typedef void SWIFT_CC (*HeapObjectDestroyer)(SWIFT_CONTEXT void *object);
 
-static inline void _swift_runtime_invoke_heap_object_destroy(
-    const void *destroy, void *self) {
-  ((HeapObjectDestroyer)destroy)(self);
+static inline void _swift_embedded_invoke_heap_object_destroy(void *object) {
+  void *metadata = *(void **)object;
+  void **destroy_location = &((void **)metadata)[1];
+#if __has_feature(ptrauth_calls)
+  (*(__ptrauth(0,1,0xbbbf) HeapObjectDestroyer *)destroy_location)(object);
+#else
+  (*(HeapObjectDestroyer *)destroy_location)(object);
+#endif
 }
 
 #ifdef __cplusplus

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -117,7 +117,7 @@ public func swift_release(object: Builtin.RawPointer) {
   if o.pointee.refcount == HeapObject.immortalRefCount { return }
   o.pointee.refcount -= 1
   if (o.pointee.refcount & HeapObject.refcountMask) == 0 {
-    _swift_runtime_invoke_heap_object_destroy(o.pointee.metadata.pointee.destroy, o)
+    _swift_embedded_invoke_heap_object_destroy(o)
   }
 }
 


### PR DESCRIPTION
Some embedded tests today crash under arm64e -- we need to properly authenticate the ptrauth signed "destroy" function pointer when making the runtime call to destroy a class instance.