### PR TITLE
[Sema] Add sourceloc to the error on importing a package module from swiftinterface

### DIFF
--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -770,7 +770,7 @@ void UnboundImport::validateInterfaceWithPackageName(ModuleDecl *topLevelModule,
   if (!topLevelModule->getPackageName().empty() &&
       topLevelModule->getPackageName().str() == ctx.LangOpts.PackageName &&
       topLevelModule->isBuiltFromInterface()) {
-      ctx.Diags.diagnose(SourceLoc(),
+      ctx.Diags.diagnose(import.module.getModulePath().front().Loc,
                          diag::in_package_module_not_compiled_from_source,
                          topLevelModule->getBaseIdentifier(),
                          ctx.LangOpts.PackageName,


### PR DESCRIPTION
Importing a package module rebuilt from its swiftinterface loses all package decls, it is reported as an error. Make the error point to the import.