### PR TITLE
[Dependency Scanning] Revert: Remove Swift Overlay dependencies from the set of direct dependencies

### DIFF
--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -120,7 +120,8 @@ private:
       const ModuleDependencyID &moduleID,
       const std::vector<std::string> &clangDependencies,
       ModuleDependenciesCache &cache,
-      ModuleDependencyIDSetVector &swiftOverlayDependencies);
+      ModuleDependencyIDSetVector &swiftOverlayDependencies,
+      ModuleDependencyIDSetVector &directDependencies);
 
   /// Identify all cross-import overlay modules of the specified
   /// dependency set and apply an action for each.


### PR DESCRIPTION
Reverts https://github.com/apple/swift/pull/67928.
We must still support potentially older drivers which are not ready for this change due to: https://github.com/apple/swift-driver/pull/1438