### PR TITLE
Add `Differentiable` requirements to pattern substitutions / pattern generic signature

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -36,6 +36,7 @@ class AbstractFunctionDecl;
 class AnyFunctionType;
 class SourceFile;
 class SILFunctionType;
+class SILResultInfo;
 class TupleType;
 class VarDecl;
 
@@ -621,8 +622,16 @@ IndexSubset *getFunctionSemanticResultIndices(
 IndexSubset *getLoweredParameterIndices(IndexSubset *astParameterIndices,
                                         AnyFunctionType *functionType);
 
+/// Collects the semantic results of the given function type in
+/// `originalResults`. The semantic results are formal results followed by
+/// semantic result parameters, in type order.
+void
+getSemanticResults(SILFunctionType *functionType,
+                   IndexSubset *parameterIndices,
+                   SmallVectorImpl<SILResultInfo> &originalResults);
+
 /// "Constrained" derivative generic signatures require all differentiability
-/// parameters to conform to the `Differentiable` protocol.
+/// parameters / results to conform to the `Differentiable` protocol.
 ///
 /// "Constrained" transpose generic signatures additionally require all
 /// linearity parameters to satisfy `Self == Self.TangentVector`.
@@ -630,9 +639,11 @@ IndexSubset *getLoweredParameterIndices(IndexSubset *astParameterIndices,
 /// Returns the "constrained" derivative/transpose generic signature given:
 /// - An original SIL function type.
 /// - Differentiability/linearity parameter indices.
+/// - Differentiability/linearity result indices.
 /// - A possibly "unconstrained" derivative/transpose generic signature.
 GenericSignature getConstrainedDerivativeGenericSignature(
-    SILFunctionType *originalFnTy, IndexSubset *diffParamIndices,
+    SILFunctionType *originalFnTy,
+    IndexSubset *diffParamIndices, IndexSubset *diffResultIndices,
     GenericSignature derivativeGenSig, LookupConformanceFn lookupConformance,
     bool isTranspose = false);
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -576,7 +576,8 @@ emitDerivativeFunctionReference(
                 .second->getDerivativeGenericSignature();
       auto derivativeConstrainedGenSig =
           autodiff::getConstrainedDerivativeGenericSignature(
-              originalFn->getLoweredFunctionType(), desiredParameterIndices,
+              originalFn->getLoweredFunctionType(),
+              desiredParameterIndices, desiredResultIndices,
               contextualDerivativeGenSig,
               LookUpConformanceInModule(context.getModule().getSwiftModule()));
       minimalWitness = SILDifferentiabilityWitness::createDefinition(

--- a/test/AutoDiff/compiler_crashers_fixed/issue-68777-lack-of-diff-requirement.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-68777-lack-of-diff-requirement.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// https://github.com/apple/swift/pull/68777
+// We used not to constrain the derivative type properly, 
+// the `Differentiable` requirement was missed if the function type had
+// pattern substitution resulting in assertion:
+//
+// Invalid type parameter in getReducedType()
+// Original type: Optional<τ_0_0.TangentVector>
+// Simplified term: τ_0_0.[Differentiable:TangentVector]
+// Longest valid prefix: τ_0_0
+// Prefix type: τ_0_0
+//
+// Requirement machine for <τ_0_0, τ_0_1>
+// Rewrite system: {
+// }
+// }
+// Property map: {
+// }
+// Conformance paths: {
+// }
+//
+// Note that the generic signature <τ_0_0, τ_0_1> should be
+// <τ_0_0 : Differentiable, τ_0_1 : Differentiable>, otherwise
+// there is no way to derive associated type τ_0_0.TangentVector
+
+import _Differentiation; 
+
+public struct D<T>: Differentiable {}
+extension D {@differentiable(reverse, wrt: self) mutating func m(r: @differentiable(reverse) (T?) -> T?) {}}


### PR DESCRIPTION
when calculating constrained function type. Also, add requirements for differentiable results as well.

Fixes #65487