### PR TITLE
[ASTGen] Relax assertion on `BridgedSourceLoc` initializer

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -20,7 +20,7 @@ extension BridgedSourceLoc {
     at position: AbsolutePosition,
     in buffer: UnsafeBufferPointer<UInt8>
   ) {
-    precondition(position.utf8Offset >= 0 && position.utf8Offset < buffer.count)
+    precondition(position.utf8Offset >= 0 && position.utf8Offset <= buffer.count)
     self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer.baseAddress!), SwiftInt(position.utf8Offset))
   }
 }

--- a/test/SourceKit/CursorInfo/at_eof_in_macro.swift
+++ b/test/SourceKit/CursorInfo/at_eof_in_macro.swift
@@ -1,0 +1,3 @@
+// RUN: %sourcekitd-test -req=cursor -pos=3:37 %s -- %s
+@freestanding(expression)
+macro powerAssert() = #externalMacro


### PR DESCRIPTION
We do allow `SourceLoc` to point to the address right after the buffer ends to point to the end of a file.

Fixes an issue found by the SourceKit stress tester.
Resolves #66924