### PR TITLE
[Dependency Scanning] Revert: Remove Swift Overlay dependencies from the set of direct dependencies

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -627,6 +627,10 @@ resolveDependencies(CompilerInstance &instance, ModuleDependencyID moduleID,
               ctx.getSwiftModuleDependencies(clangDep, cache, ASTDelegate)) {
         if (clangDep != moduleID.first) {
           swiftOverlayDependencies.insert({clangDep, found.value()->getKind()});
+	  // FIXME: Once all clients know to fetch these dependencies from
+          // `swiftOverlayDependencies`, the goal is to no longer have them in
+          // `directDependencies` so the following will need to go away.
+          directDependencies.insert({clangDep, found.value()->getKind()});
         }
       }
     }


### PR DESCRIPTION
Equivalent change to `main`'s: https://github.com/apple/swift/pull/68775
-----------------------------------------------

Functionally reverts #67928.
We must still support potentially older drivers which are not ready for this change due to: apple/swift-driver#1438
