### PR TITLE
[embedded] Remove unspecialized functions before running IRGen

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -276,6 +276,9 @@ public:
   /// is a single SILModule in a single thread.
   bool checkSILModuleLeaks = false;
 
+  /// Are we building in embedded Swift mode?
+  bool EmbeddedSwift = false;
+
   /// The name of the file to which the backend should save optimization
   /// records.
   std::string OptRecordFile;

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -781,6 +781,12 @@ public:
     return getLoweredFunctionType()->hasIndirectFormalResults();
   }
 
+  // Returns true if the function has any generic arguments.
+  bool isGeneric() const {
+    auto s = getLoweredFunctionType()->getInvocationGenericSignature();
+    return s && !s->areAllParamsConcrete();
+  }
+
   /// Returns true if this function ie either a class method, or a
   /// closure that captures the 'self' value or its metatype.
   ///

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3118,6 +3118,7 @@ bool CompilerInvocation::parseArgs(
     IRGenOpts.InternalizeAtLink = true;
     IRGenOpts.DisableLegacyTypeInfo = true;
     SILOpts.CMOMode = CrossModuleOptimizationMode::Everything;
+    SILOpts.EmbeddedSwift = true;
   }
 
   return false;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1308,7 +1308,7 @@ void IRGenerator::emitGlobalTopLevel(
     //   bool isGeneric = loweredFunctionHasGenericArguments(&f);
     //   if (isGeneric) {
     //     llvm::errs() << "Unspecialized function: \n" << f << "\n";
-    //     assert(0 && "unspecialized function present in embedded Swift");
+    //     llvm_unreachable("unspecialized function present in embedded Swift");
     //   }
     // }
 

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -842,11 +842,6 @@ bool SILFunction::hasValidLinkageForFragileRef() const {
   return hasPublicVisibility(getLinkage());
 }
 
-static bool loweredFunctionHasGenericArguments(const SILFunction *f) {
-  auto s = f->getLoweredFunctionType()->getInvocationGenericSignature();
-  return s && !s->areAllParamsConcrete();
-}
-
 bool
 SILFunction::isPossiblyUsedExternally() const {
   auto linkage = getLinkage();
@@ -873,13 +868,6 @@ SILFunction::isPossiblyUsedExternally() const {
   if (markedAsAlwaysEmitIntoClient() &&
       hasOpaqueResultTypeWithAvailabilityConditions())
     return true;
-
-  // In embedded Swift, generic functions, even public ones cannot be used
-  // externally.
-  bool embedded = getASTContext().LangOpts.hasFeature(Feature::Embedded);
-  bool generic = loweredFunctionHasGenericArguments(this);
-  if (embedded && generic)
-    return false;
 
   return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
 }

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -842,6 +842,11 @@ bool SILFunction::hasValidLinkageForFragileRef() const {
   return hasPublicVisibility(getLinkage());
 }
 
+static bool loweredFunctionHasGenericArguments(const SILFunction *f) {
+  auto s = f->getLoweredFunctionType()->getInvocationGenericSignature();
+  return s && !s->areAllParamsConcrete();
+}
+
 bool
 SILFunction::isPossiblyUsedExternally() const {
   auto linkage = getLinkage();
@@ -868,6 +873,13 @@ SILFunction::isPossiblyUsedExternally() const {
   if (markedAsAlwaysEmitIntoClient() &&
       hasOpaqueResultTypeWithAvailabilityConditions())
     return true;
+
+  // In embedded Swift, generic functions, even public ones cannot be used
+  // externally.
+  bool embedded = getASTContext().LangOpts.hasFeature(Feature::Embedded);
+  bool generic = loweredFunctionHasGenericArguments(this);
+  if (embedded && generic)
+    return false;
 
   return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
 }

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -431,8 +431,7 @@ class DeadFunctionAndGlobalElimination {
     for (SILFunction &F : *Module) {
       // In embedded Swift, generic functions, even public ones cannot be used
       // externally and are not anchors.
-      bool embedded =
-          Module->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+      bool embedded = Module->getOptions().EmbeddedSwift;
       bool generic = loweredFunctionHasGenericArguments(&F);
       bool ignoreAnchor =
           embedded && generic && removeUnspecializedFunctionsInEmbeddedSwift;

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -31,11 +31,6 @@ STATISTIC(NumDeadGlobals, "Number of dead global variables eliminated");
 
 namespace {
 
-static bool loweredFunctionHasGenericArguments(const SILFunction *f) {
-  auto s = f->getLoweredFunctionType()->getInvocationGenericSignature();
-  return s && !s->areAllParamsConcrete();
-}
-
 class DeadFunctionAndGlobalElimination {
   /// Represents a function which is implementing a vtable or witness table
   /// method.
@@ -100,7 +95,7 @@ class DeadFunctionAndGlobalElimination {
     // In embedded Swift, (even public) generic functions *after serialization*
     // cannot be used externally and are not anchors.
     bool embedded = Module->getOptions().EmbeddedSwift;
-    bool generic = loweredFunctionHasGenericArguments(F);
+    bool generic = F->isGeneric();
     bool isSerialized = Module->isSerialized();
     if (embedded && generic && isSerialized)
       return false;

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -891,13 +891,6 @@ SILPassPipelinePlan::getIRGenPreparePassPipeline(const SILOptions &Options) {
   // boundaries as required by the ABI.
   P.addLoadableByAddress();
 
-  if (Options.EmbeddedSwift) {
-    // For embedded Swift: Remove all unspecialized functions. This is important
-    // to avoid having debuginfo references to these functions that we don't
-    // want to emit in IRGen.
-    P.addLateDeadFunctionAndGlobalElimination();
-  }
-
   if (Options.EnablePackMetadataStackPromotion) {
     // Insert marker instructions indicating where on-stack pack metadata
     // deallocation must occur.
@@ -1050,6 +1043,13 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   // This is mainly there to optimize `Builtin.isConcrete`, which must not be
   // constant folded before any generic specialization.
   P.addLateOnoneSimplification();
+
+  if (Options.EmbeddedSwift) {
+    // For embedded Swift: Remove all unspecialized functions. This is important
+    // to avoid having debuginfo references to these functions that we don't
+    // want to emit in IRGen.
+    P.addLateDeadFunctionAndGlobalElimination();
+  }
 
   P.addCleanupDebugSteps();
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -891,6 +891,9 @@ SILPassPipelinePlan::getIRGenPreparePassPipeline(const SILOptions &Options) {
   // boundaries as required by the ABI.
   P.addLoadableByAddress();
 
+  // For embedded Swift: Remove all unspecialized functions.
+  P.addLateDeadFunctionAndGlobalElimination();
+
   if (Options.EnablePackMetadataStackPromotion) {
     // Insert marker instructions indicating where on-stack pack metadata
     // deallocation must occur.

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -891,8 +891,12 @@ SILPassPipelinePlan::getIRGenPreparePassPipeline(const SILOptions &Options) {
   // boundaries as required by the ABI.
   P.addLoadableByAddress();
 
-  // For embedded Swift: Remove all unspecialized functions.
-  P.addLateDeadFunctionAndGlobalElimination();
+  if (Options.EmbeddedSwift) {
+    // For embedded Swift: Remove all unspecialized functions. This is important
+    // to avoid having debuginfo references to these functions that we don't
+    // want to emit in IRGen.
+    P.addLateDeadFunctionAndGlobalElimination();
+  }
 
   if (Options.EnablePackMetadataStackPromotion) {
     // Insert marker instructions indicating where on-stack pack metadata

--- a/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
@@ -43,7 +43,7 @@ class VTableSpecializer : public SILModuleTransform {
   void run() override {
     SILModule &module = *getModule();
 
-    if (!module.getASTContext().LangOpts.hasFeature(Feature::Embedded)) return;
+    if (!module.getOptions().EmbeddedSwift) return;
 
     LLVM_DEBUG(llvm::dbgs() << "***** VTableSpecializer\n");
 

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -39,7 +39,7 @@ public:
 
     // In embedded Swift, the stdlib contains all the runtime functions needed
     // (swift_retain, etc.). Link them in so they can be referenced in IRGen.
-    if (M.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    if (M.getOptions().EmbeddedSwift) {
       linkEmbeddedRuntimeFromStdlib();
     }
   }

--- a/test/embedded/classes-methods-no-stdlib.swift
+++ b/test/embedded/classes-methods-no-stdlib.swift
@@ -9,7 +9,7 @@ public class MySubClass: MyClass {
   override func foo() { }
 }
 
-// CHECK: @"$s4main7MyClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfD", ptr @"$s4main7MyClassC3fooyyF", ptr @"$s4main7MyClassC3baryyF", ptr @"$s4main7MyClassCACycfC" }>
+// CHECK: @"$s4main7MyClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$s4main7MyClassCfD", ptr @"$s4main7MyClassC3fooyyF", ptr @"$s4main7MyClassC3baryyF", ptr @swift_deletedMethodError }>
 // CHECK: @"$s4main10MySubClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr }> <{ ptr @"$s4main7MyClassCN", ptr @"$s4main10MySubClassCfD", ptr @"$s4main10MySubClassC3fooyyF", ptr @"$s4main7MyClassC3baryyF", ptr @"$s4main10MySubClassCACycfC" }>
 
 // CHECK: define {{.*}}void @"$s4main4test1xyAA7MyClassC_tF"(ptr %0)

--- a/test/embedded/debuginfo.swift
+++ b/test/embedded/debuginfo.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend -g -emit-ir %s -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -g -O -emit-ir %s -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -g -Osize -emit-ir %s -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -O -emit-ir %s -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -Osize -emit-ir %s -enable-experimental-feature Embedded
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public func foo<T>(_ array: inout [T]) {
+    array.withUnsafeMutableBytes {
+        $0[0] = 0
+    }
+}
+
+func foo2<T>(_ array: inout [T]) {
+    array.withUnsafeMutableBytes {
+        $0[0] = 0
+    }
+}
+
+public func test() {
+    var a: [UInt8] = [1, 2, 3]
+    foo(&a)
+    foo2(&a)
+}


### PR DESCRIPTION
This fixes a problem when emitting debuginfo in IRGen where we might have an "inlined at" debuginfo reference to an unspecialized function, which in turn causes it to get lazily emitted, which crashes in embedded Swift. See the attached testcase for a small reproducer.

```
Assertion failed: (!loweredFunctionHasGenericArguments(f)), function addLazyFunction, file GenDecl.cpp, line 1557.
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
7  swift-frontend           0x00000001053e89e8 swift::irgen::IRGenerator::noteUseOfTypeGlobals(swift::NominalTypeDecl*, bool, swift::irgen::RequireMetadata_t) (.cold.1) + 0
8  swift-frontend           0x0000000100a48c2c swift::irgen::IRGenerator::addLazyFunction(swift::SILFunction*) + 368
9  swift-frontend           0x0000000100a4ab24 swift::irgen::IRGenModule::getAddrOfSILFunction(swift::SILFunction*, swift::ForDefinition_t, bool, bool) + 484
10 swift-frontend           0x0000000100b547f4 (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateScope(swift::SILDebugScope const*) + 812
11 swift-frontend           0x0000000100b5a680 (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateContext(swift::DeclContext*) + 144
12 swift-frontend           0x0000000100b54e7c (anonymous namespace)::IRGenDebugInfoImpl::emitFunction(swift::SILDebugScope const*, llvm::Function*, swift::SILFunctionTypeRepresentation, swift::SILType, swift::DeclContext*, llvm::StringRef) + 1280
13 swift-frontend           0x0000000100b55aa4 (anonymous namespace)::IRGenDebugInfoImpl::emitFunction(swift::SILFunction&, llvm::Function*) + 160
14 swift-frontend           0x0000000100b8d968 (anonymous namespace)::IRGenSILFunction::emitSILFunction() + 840
15 swift-frontend           0x0000000100b8d078 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) + 1528
```
