### PR TITLE
[embedded] Fix a warning in stdlib build about never executed switch case

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -717,8 +717,10 @@ extension ${Self}: BinaryFloatingPoint {
       _value = Builtin.int_ceil_FPIEEE${bits}(_value)
     case .down:
       _value = Builtin.int_floor_FPIEEE${bits}(_value)
+    #if !$Embedded
     @unknown default:
       self._roundSlowPath(rule)
+    #endif
     }
   }
   


### PR DESCRIPTION
We currently get a warning during the embedded stdlib build...
```
/Users/kuba/swift-github-main/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/stdlib/public/core/8/FloatingPointTypes.swift:468:5: warning: default will never be executed
    @unknown default:
    ^
```
...because the embedded stdlib is built without resilience on and therefore enums cannot get unknown future cases. Let's fix the warning.