### PR TITLE
[embedded] Do not emit .swiftinterface files for fragile modules (embedded stdlib, Cxx.swiftmodule)

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -646,7 +646,7 @@ function(_compile_swift_files
     set(sibopt_file "${module_base}.O.sib")
     set(sibgen_file "${module_base}.sibgen")
 
-    if(SWIFT_ENABLE_MODULE_INTERFACES)
+    if(SWIFT_ENABLE_MODULE_INTERFACES AND NOT SWIFTFILE_IS_FRAGILE)
       set(interface_file "${module_base}.swiftinterface")
       set(interface_file_static "${module_base_static}.swiftinterface")
       set(private_interface_file "${module_base}.private.swiftinterface")
@@ -705,7 +705,7 @@ function(_compile_swift_files
 
       set(maccatalyst_module_outputs "${maccatalyst_module_file}" "${maccatalyst_module_doc_file}")
 
-      if(SWIFT_ENABLE_MODULE_INTERFACES)
+      if(SWIFT_ENABLE_MODULE_INTERFACES AND NOT SWIFTFILE_IS_FRAGILE)
         set(maccatalyst_interface_file "${maccatalyst_module_base}.swiftinterface")
         set(maccatalyst_private_interface_file "${maccatalyst_module_base}.private.swiftinterface")
         list(APPEND maccatalyst_module_outputs "${maccatalyst_interface_file}" "${maccatalyst_private_interface_file}")

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -423,7 +423,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       embedded-stdlib-${triple}
       swiftCore
       ONLY_SWIFTMODULE
-      IS_STDLIB IS_STDLIB_CORE
+      IS_STDLIB IS_STDLIB_CORE IS_FRAGILE
       ${SWIFTLIB_EMBEDDED_SOURCES}
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS -target "${triple}" -Xcc -D__MACH__ -enable-experimental-feature Embedded

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -50,6 +50,12 @@ for filename in os.listdir(sdk_overlay_dir):
     ]:
         continue
 
+    # Cxx and CxxStdlib are built without library evolution and don't have a
+    # .swiftinterface file
+    if module_name in ["Cxx", "CxxStdlib"]:
+        if not os.path.exists(interface_file):
+            continue
+
     # swift -build-module-from-parseable-interface
     output_path = os.path.join(output_dir, module_name + ".swiftmodule")
     compiler_args = ["-o", output_path, "-module-name", module_name,


### PR DESCRIPTION
Currently, we get warnings like this:

```
[1/13] Generating /Users/kuba/swift-github-main/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/./lib/swift/macosx/Cxx.swiftmodule/arm64-apple-macos.swiftmodule
<unknown>:0: warning: module interfaces are only supported with -enable-library-evolution
<unknown>:0: warning: module interfaces are only supported with -enable-library-evolution
[13/13] Generating /Users/kuba/swift-github-main/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/lib/swift/embedded/Swift.swiftmodule/arm64-apple-macos.swiftmodule
<unknown>:0: warning: module interfaces are only supported with -enable-library-evolution
<unknown>:0: warning: module interfaces are only supported with -enable-library-evolution
```

Let's fix it (by not generating the .swiftinterface for these fragile modules), for both the embedded stdlib, and the Cxx module.