### PR TITLE
[ConstraintSystem] Solve `where` clauses of for-in loops separately

### DIFF
--- a/include/swift/Sema/SyntacticElementTarget.h
+++ b/include/swift/Sema/SyntacticElementTarget.h
@@ -147,7 +147,7 @@ private:
       ForEachStmt *stmt;
       DeclContext *dc;
       Pattern *pattern;
-      bool bindPatternVarsOneWay;
+      bool ignoreWhereClause;
       ForEachStmtInfo info;
     } forEachStmt;
 
@@ -227,11 +227,11 @@ public:
   }
 
   SyntacticElementTarget(ForEachStmt *stmt, DeclContext *dc,
-                         bool bindPatternVarsOneWay)
+                         bool ignoreWhereClause)
       : kind(Kind::forEachStmt) {
     forEachStmt.stmt = stmt;
     forEachStmt.dc = dc;
-    forEachStmt.bindPatternVarsOneWay = bindPatternVarsOneWay;
+    forEachStmt.ignoreWhereClause = ignoreWhereClause;
   }
 
   /// Form a target for the initialization of a pattern from an expression.
@@ -249,7 +249,7 @@ public:
   /// Form a target for a for-in loop.
   static SyntacticElementTarget forForEachStmt(ForEachStmt *stmt,
                                                DeclContext *dc,
-                                               bool bindPatternVarsOneWay);
+                                               bool ignoreWhereClause = false);
 
   /// Form a target for a property with an attached property wrapper that is
   /// initialized out-of-line.
@@ -469,10 +469,6 @@ public:
   bool shouldBindPatternVarsOneWay() const {
     if (kind == Kind::expression)
       return expression.bindPatternVarsOneWay;
-
-    if (kind == Kind::forEachStmt)
-      return forEachStmt.bindPatternVarsOneWay;
-
     return false;
   }
 
@@ -519,6 +515,11 @@ public:
   unsigned getInitializationPatternBindingIndex() const {
     assert(isForInitialization());
     return expression.initialization.patternBindingIndex;
+  }
+
+  bool ignoreForEachWhereClause() const {
+    assert(isForEachStmt());
+    return forEachStmt.ignoreWhereClause;
   }
 
   const ForEachStmtInfo &getForEachStmtInfo() const {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4536,11 +4536,8 @@ generateForEachStmtConstraints(ConstraintSystem &cs,
                                            /*flags=*/0);
   {
     auto nextType = cs.getType(forEachStmtInfo.nextCall);
-    // Note that `OptionalObject` is not used here. This is due to inference
-    // behavior where it would bind `elementType` to the `initType` before
-    // resolving `optional object` constraint which is sometimes too eager.
-    cs.addConstraint(ConstraintKind::Conversion, nextType,
-                     OptionalType::get(elementType), elementTypeLoc);
+    cs.addConstraint(ConstraintKind::OptionalObject, nextType, elementType,
+                     elementTypeLoc);
     cs.addConstraint(ConstraintKind::Conversion, elementType, initType,
                      elementLocator);
   }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4546,12 +4546,9 @@ generateForEachStmtConstraints(ConstraintSystem &cs,
   }
 
   // Generate constraints for the "where" expression, if there is one.
-  if (auto *whereExpr = stmt->getWhere()) {
-    auto *boolDecl = dc->getASTContext().getBoolDecl();
-    if (!boolDecl)
-      return llvm::None;
-
-    Type boolType = boolDecl->getDeclaredInterfaceType();
+  auto *whereExpr = stmt->getWhere();
+  if (whereExpr && !target.ignoreForEachWhereClause()) {
+    Type boolType = dc->getASTContext().getBoolType();
     if (!boolType)
       return llvm::None;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6303,10 +6303,22 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::OptionalPayload: {
+    if (lhs->isPlaceholder() || rhs->isPlaceholder())
+      return true;
+
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))
       return true;
 
+    if (path.size() > 1) {
+      path.pop_back();
+      if (path.back().is<LocatorPathElt::SequenceElementType>()) {
+        conversionsOrFixes.push_back(
+            CollectionElementContextualMismatch::create(
+                *this, lhs, rhs, getConstraintLocator(anchor, path)));
+        return true;
+      }
+    }
     break;
   }
 

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -629,6 +629,10 @@ private:
   ///
   /// - From sequence to pattern, when pattern has no type information.
   void visitForEachPattern(Pattern *pattern, ForEachStmt *forEachStmt) {
+    // The `where` clause should be ignored because \c visitForEachStmt
+    // records it as a separate conjunction element to allow for a more
+    // granular control over what contextual information is brought into
+    // the scope during pattern + sequence and `where` clause solving.
     auto target = SyntacticElementTarget::forForEachStmt(
         forEachStmt, context.getAsDeclContext(),
         /*ignoreWhereClause=*/true);
@@ -955,9 +959,9 @@ private:
 
     // For-each pattern.
     //
-    // Note that we don't record a sequence or where clause here,
-    // they would be handled together with pattern because pattern can
-    // inform a type of sequence element e.g. `for i: Int8 in 0 ..< 8`
+    // Note that we don't record a sequence here, it would be handled
+    // together with pattern because pattern can inform a type of sequence
+    // element e.g. `for i: Int8 in 0 ..< 8`
     elements.push_back(makeElement(forEachStmt->getPattern(), stmtLoc));
 
     // Where clause if any.

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -178,9 +178,8 @@ SyntacticElementTarget SyntacticElementTarget::forInitialization(
 
 SyntacticElementTarget
 SyntacticElementTarget::forForEachStmt(ForEachStmt *stmt, DeclContext *dc,
-                                       bool bindPatternVarsOneWay) {
-  SyntacticElementTarget target(
-      stmt, dc, bindPatternVarsOneWay || bool(stmt->getWhere()));
+                                       bool ignoreWhereClause) {
+  SyntacticElementTarget target(stmt, dc, ignoreWhereClause);
   return target;
 }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -901,8 +901,7 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
     return true;
   };
 
-  auto target = SyntacticElementTarget::forForEachStmt(
-      stmt, dc, /*bindPatternVarsOneWay=*/false);
+  auto target = SyntacticElementTarget::forForEachStmt(stmt, dc);
   if (!typeCheckTarget(target))
     return failed();
 

--- a/test/Constraints/rdar107651291.swift
+++ b/test/Constraints/rdar107651291.swift
@@ -7,6 +7,6 @@ func foo(xs: [String: [String]], ys: [String: [String]]) {
     for (a, b) in zip(xs, ys) {}
     // expected-error@-1 {{type 'Dictionary<String, [String]>.Element' (aka '(key: String, value: Array<String>)') cannot conform to 'Sequence'}}
     // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
-    // expected-note@-3 {{required by referencing instance method 'next()'}}
+    // expected-note@-3 {{required by global function 'zip' where 'Sequence2' = 'Dictionary<String, [String]>.Element' (aka '(key: String, value: Array<String>)')}}
   }
 }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -273,3 +273,25 @@ do {
   // https://github.com/apple/swift/issues/65650 - Make sure we say 'String', not 'Any'.
   for (x, y) in [""] {} // expected-error {{tuple pattern cannot match values of non-tuple type 'String'}}
 }
+
+do {
+  class Base : Hashable {
+    static func ==(_: Base, _: Base) -> Bool { false }
+
+    func hash(into hasher: inout Hasher) {}
+  }
+
+  class Child : Base {
+    var value: Int = 0
+  }
+
+  struct Range {
+    func contains(_: Base) -> Bool { return false }
+  }
+
+  func test(data: Set<Child>, _ range: Range) {
+    for v in data where range.contains(v) {
+      _ = v.value // Ok (`v` is inferred from `data` and not from `range`)
+    }
+  }
+}


### PR DESCRIPTION
Doing so fits better into conjunction model which leads to more granular control
over what variables are brought into scope during `where` clause expression checking.

These changes also remove "one-way bind" flag from "for-in" statement target.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
