### PR TITLE
[CanonicalizeOSSALifetime] NFC: Use extendToNonUse when adding end_access to liveness.

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -504,7 +504,7 @@ void CanonicalizeOSSALifetime::extendLivenessThroughOverlappingAccess() {
           break;
         }
         if (endsAccessOverlappingPrunedBoundary(&inst)) {
-          liveness->updateForUse(&inst, /*lifetimeEnding*/ false);
+          liveness->extendToNonUse(&inst);
           changed = true;
           break;
         }


### PR DESCRIPTION
Use PrunedLiveness' new `extendToNonUse` API to extend liveness across overlapping access scopes.
