### PR TITLE
[Concurrency] Allow default arguments to require actor isolation.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1973,6 +1973,15 @@ private:
   SourceRange getOriginalInitRange() const;
   void setInit(Expr *E);
 
+  /// Get the required actor isolation for evaluating the initializer
+  /// expression synchronously (if there is one). 
+  ///
+  /// If this pattern binding entry is for a stored instance property, the
+  /// initializer can only be used in an `init` that meets the required
+  /// isolation; otherwise, the property must be explicitly initialized in
+  /// the `init`.
+  ActorIsolation getInitializerIsolation() const;
+
   /// Gets the text of the initializer expression, stripping out inactive
   /// branches of any #ifs inside the expression.
   StringRef getInitStringRepresentation(SmallVectorImpl<char> &scratch) const;
@@ -2224,6 +2233,10 @@ public:
 
   void setOriginalInit(unsigned i, Expr *E) {
     getMutablePatternList()[i].setOriginalInit(E);
+  }
+
+  ActorIsolation getInitializerIsolation(unsigned i) const {
+    return getPatternList()[i].getInitializerIsolation();
   }
 
   Pattern *getPattern(unsigned i) const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6415,6 +6415,11 @@ public:
   /// at the call site in order to have the correct context information.
   Expr *getTypeCheckedDefaultExpr() const;
 
+  /// The actor isolation required of the caller in order to use the
+  /// default argument for this parameter. If the required isolation is
+  /// not met, an argument must be written explicitly at the call-site.
+  ActorIsolation getDefaultArgumentIsolation() const;
+
   /// Retrieve the potentially un-type-checked default argument expression for
   /// this parameter, which can be queried for information such as its source
   /// range and textual representation. Returns \c nullptr if there is no

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2273,7 +2273,9 @@ public:
   void setInitializerSubsumed(unsigned i) {
     getMutablePatternList()[i].setInitializerSubsumed();
   }
-  
+
+  ActorIsolation getInitializerIsolation(unsigned i) const;
+
   /// Does this binding declare something that requires storage?
   bool hasStorage() const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1973,15 +1973,6 @@ private:
   SourceRange getOriginalInitRange() const;
   void setInit(Expr *E);
 
-  /// Get the required actor isolation for evaluating the initializer
-  /// expression synchronously (if there is one). 
-  ///
-  /// If this pattern binding entry is for a stored instance property, the
-  /// initializer can only be used in an `init` that meets the required
-  /// isolation; otherwise, the property must be explicitly initialized in
-  /// the `init`.
-  ActorIsolation getInitializerIsolation() const;
-
   /// Gets the text of the initializer expression, stripping out inactive
   /// branches of any #ifs inside the expression.
   StringRef getInitStringRepresentation(SmallVectorImpl<char> &scratch) const;
@@ -2233,10 +2224,6 @@ public:
 
   void setOriginalInit(unsigned i, Expr *E) {
     getMutablePatternList()[i].setOriginalInit(E);
-  }
-
-  ActorIsolation getInitializerIsolation(unsigned i) const {
-    return getPatternList()[i].getInitializerIsolation();
   }
 
   Pattern *getPattern(unsigned i) const {
@@ -5986,6 +5973,19 @@ public:
     return getParentExecutableInitializer() != nullptr;
   }
 
+  /// Get the required actor isolation for evaluating the initializer
+  /// expression synchronously (if there is one).
+  ///
+  /// If this VarDecl is a stored instance property, the initializer
+  /// can only be used in an `init` that meets the required isolation.
+  /// Otherwise, the property must be explicitly initialized in the `init`.
+  ///
+  /// If this is a ParamDecl, the initializer isolation is required at
+  /// the call-site in order to use the default argument for this parameter.
+  /// If the required isolation is not met, an argument must be written
+  /// explicitly at the call-site.
+  ActorIsolation getInitializerIsolation() const;
+
   // Return whether this VarDecl has an initial value, either by checking
   // if it has an initializer in its parent pattern binding or if it has
   // the @_hasInitialValue attribute.
@@ -6427,11 +6427,6 @@ public:
   /// check whether the code is valid. Such default arguments get re-created
   /// at the call site in order to have the correct context information.
   Expr *getTypeCheckedDefaultExpr() const;
-
-  /// The actor isolation required of the caller in order to use the
-  /// default argument for this parameter. If the required isolation is
-  /// not met, an argument must be written explicitly at the call-site.
-  ActorIsolation getDefaultArgumentIsolation() const;
 
   /// Retrieve the potentially un-type-checked default argument expression for
   /// this parameter, which can be queried for information such as its source

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5236,6 +5236,10 @@ ERROR(distributed_actor_isolated_non_self_reference,none,
       "distributed actor-isolated %kind0 can not be accessed from a "
       "non-isolated context",
       (const ValueDecl *))
+ERROR(isolated_default_argument,none,
+      "%0 default argument cannot be synchronously evaluated from a "
+      "%1 context",
+      (ActorIsolation, ActorIsolation))
 ERROR(distributed_actor_needs_explicit_distributed_import,none,
       "'Distributed' module not imported, required for 'distributed actor'",
       ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5240,6 +5240,9 @@ ERROR(isolated_default_argument,none,
       "%0 default argument cannot be synchronously evaluated from a "
       "%1 context",
       (ActorIsolation, ActorIsolation))
+ERROR(conflicting_default_argument_isolation,none,
+      "default argument cannot be both %0 and %1",
+      (ActorIsolation, ActorIsolation))
 ERROR(distributed_actor_needs_explicit_distributed_import,none,
       "'Distributed' module not imported, required for 'distributed actor'",
       ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4569,6 +4569,11 @@ public:
   /// expression within the context of the call site.
   Expr *getCallerSideDefaultExpr() const;
 
+  /// Get the required actor isolation for evaluating this default argument
+  /// synchronously. If the caller does not meet the required isolation, the
+  /// argument must be written explicitly at the call-site.
+  ActorIsolation getRequiredIsolation() const;
+
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::DefaultArgument;
   }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2935,10 +2935,10 @@ public:
 };
 
 /// Compute the actor isolation needed to synchronously evaluate the
-/// default argument for the given parameter.
-class DefaultArgumentIsolation
-    : public SimpleRequest<DefaultArgumentIsolation,
-                           ActorIsolation(ParamDecl *),
+/// default initializer expression.
+class DefaultInitializerIsolation
+    : public SimpleRequest<DefaultInitializerIsolation,
+                           ActorIsolation(Initializer *, Expr *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2946,11 +2946,15 @@ public:
 private:
   friend SimpleRequest;
 
-  ActorIsolation evaluate(Evaluator &evaluator, ParamDecl *param) const;
+  ActorIsolation evaluate(Evaluator &evaluator, 
+                          Initializer *init,
+                          Expr *initExpr) const;
 
 public:
   bool isCached() const { return true; }
 };
+
+void simple_display(llvm::raw_ostream &out, Initializer *init);
 
 /// Computes the fully type-checked caller-side default argument within the
 /// context of the call site that it will be inserted into.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2938,7 +2938,7 @@ public:
 /// default initializer expression.
 class DefaultInitializerIsolation
     : public SimpleRequest<DefaultInitializerIsolation,
-                           ActorIsolation(Initializer *, Expr *),
+                           ActorIsolation(VarDecl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2947,8 +2947,7 @@ private:
   friend SimpleRequest;
 
   ActorIsolation evaluate(Evaluator &evaluator, 
-                          Initializer *init,
-                          Expr *initExpr) const;
+                          VarDecl *) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2934,6 +2934,24 @@ public:
   void cacheResult(Type type) const;
 };
 
+/// Compute the actor isolation needed to synchronously evaluate the
+/// default argument for the given parameter.
+class DefaultArgumentIsolation
+    : public SimpleRequest<DefaultArgumentIsolation,
+                           ActorIsolation(ParamDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ActorIsolation evaluate(Evaluator &evaluator, ParamDecl *param) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Computes the fully type-checked caller-side default argument within the
 /// context of the call site that it will be inserted into.
 class CallerSideDefaultArgExprRequest

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -62,8 +62,9 @@ SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
               Expr *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentTypeRequest,
               Type(ParamDecl *), SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, DefaultArgumentIsolation,
-              ActorIsolation(ParamDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DefaultInitializerIsolation,
+              ActorIsolation(Initializer *, Expr *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
               Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -63,7 +63,7 @@ SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
 SWIFT_REQUEST(TypeChecker, DefaultArgumentTypeRequest,
               Type(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultInitializerIsolation,
-              ActorIsolation(Initializer *, Expr *),
+              ActorIsolation(VarDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
               Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -62,6 +62,8 @@ SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
               Expr *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentTypeRequest,
               Type(ParamDecl *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DefaultArgumentIsolation,
+              ActorIsolation(ParamDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
               Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -222,6 +222,9 @@ EXPERIMENTAL_FEATURE(SendNonSendable, false)
 /// Within strict concurrency, narrow global variable isolation requirements.
 EXPERIMENTAL_FEATURE(GlobalConcurrency, false)
 
+/// Allow default arguments to require isolation at the call-site.
+EXPERIMENTAL_FEATURE(IsolatedDefaultArguments, false)
+
 /// Enable extended callbacks (with additional parameters) to be used when the
 /// "playground transform" is enabled.
 EXPERIMENTAL_FEATURE(PlaygroundExtendedCallbacks, true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3551,6 +3551,10 @@ static bool usesFeatureSendNonSendable(Decl *decl) {
 
 static bool usesFeatureGlobalConcurrency(Decl *decl) { return false; }
 
+static bool usesFeatureIsolatedDefaultArguments(Decl *decl) {
+  return false;
+}
+
 static bool usesFeaturePlaygroundExtendedCallbacks(Decl *decl) {
   return false;
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2088,6 +2088,14 @@ bool PatternBindingDecl::isAsyncLet() const {
   return false;
 }
 
+ActorIsolation
+PatternBindingDecl::getInitializerIsolation(unsigned i) const {
+  auto *var = getPatternList()[i].getAnchoringVarDecl();
+  if (!var)
+    return ActorIsolation::forUnspecified();
+
+  return var->getInitializerIsolation();
+}
 
 bool PatternBindingDecl::hasStorage() const {
   // Walk the pattern, to check to see if any of the VarDecls included in it

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8263,6 +8263,14 @@ Type ParamDecl::getTypeOfDefaultExpr() const {
   return Type();
 }
 
+ActorIsolation ParamDecl::getDefaultArgumentIsolation() const {
+  auto &ctx = getASTContext();
+  return evaluateOrDefault(
+      ctx.evaluator,
+      DefaultArgumentIsolation{const_cast<ParamDecl *>(this)},
+      ActorIsolation::forNonisolated());
+}
+
 void ParamDecl::setDefaultExpr(Expr *E, bool isTypeChecked) {
   if (!DefaultValueAndFlags.getPointer()) {
     if (!E) return;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1606,6 +1606,12 @@ Expr *DefaultArgumentExpr::getCallerSideDefaultExpr() const {
                            new (ctx) ErrorExpr(getSourceRange(), getType()));
 }
 
+ActorIsolation
+DefaultArgumentExpr::getRequiredIsolation() const {
+  auto *param = getParamDecl();
+  return param->getDefaultArgumentIsolation();
+}
+
 ValueDecl *ApplyExpr::getCalledValue(bool skipFunctionConversions) const {
   return ::getCalledValue(Fn, skipFunctionConversions);
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1608,8 +1608,7 @@ Expr *DefaultArgumentExpr::getCallerSideDefaultExpr() const {
 
 ActorIsolation
 DefaultArgumentExpr::getRequiredIsolation() const {
-  auto *param = getParamDecl();
-  return param->getDefaultArgumentIsolation();
+  return getParamDecl()->getInitializerIsolation();
 }
 
 ValueDecl *ApplyExpr::getCalledValue(bool skipFunctionConversions) const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1303,6 +1303,24 @@ void DefaultArgumentTypeRequest::cacheResult(Type type) const {
 }
 
 //----------------------------------------------------------------------------//
+// DefaultInitializerIsolation computation.
+//----------------------------------------------------------------------------//
+
+void swift::simple_display(llvm::raw_ostream &out, Initializer *init) {
+  switch (init->getInitializerKind()) {
+  case InitializerKind::PatternBinding:
+    out << "pattern binding initializer";
+    break;
+  case InitializerKind::DefaultArgument:
+    out << "default argument initializer";
+    break;
+  case InitializerKind::PropertyWrapper:
+    out << "property wrapper initializer";
+    break;
+  }
+}
+
+//----------------------------------------------------------------------------//
 // CallerSideDefaultArgExprRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1547,7 +1547,8 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     // initializer from being evaluated synchronously (or propagating required
     // isolation through closure bodies), then the default value cannot be used
     // and the member must be explicitly initialized in the constructor.
-    auto requiredIsolation = field->getInitializerIsolation(i);
+    auto *var = field->getAnchoringVarDecl(i);
+    auto requiredIsolation = var->getInitializerIsolation();
     auto contextIsolation = getActorIsolationOfContext(dc);
     switch (requiredIsolation) {
     // 'nonisolated' expressions can be evaluated from anywhere

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3582,11 +3582,6 @@ void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
   }
 }
 
-void swift::checkInitializerActorIsolation(Initializer *init, Expr *expr) {
-  ActorIsolationChecker checker(init);
-  expr->walk(checker);
-}
-
 ActorIsolation 
 swift::computeRequiredIsolation(Initializer *init, Expr *expr) {
   ActorIsolationChecker checker(init);

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -60,6 +60,10 @@ void checkInitializerActorIsolation(Initializer *init, Expr *expr);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
 void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 
+/// Compute the actor isolation required in order to evaluate the given
+/// initializer expression synchronously.
+ActorIsolation computeRequiredIsolation(Initializer *init, Expr *expr);
+
 /// States the reason for checking the Sendability of a given declaration.
 enum class SendableCheckReason {
   /// A reference to an actor from outside that actor.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -56,7 +56,6 @@ void addAsyncNotes(AbstractFunctionDecl const* func);
 /// Check actor isolation rules.
 void checkTopLevelActorIsolation(TopLevelCodeDecl *decl);
 void checkFunctionActorIsolation(AbstractFunctionDecl *decl);
-void checkInitializerActorIsolation(Initializer *init, Expr *expr);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
 void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -59,10 +59,6 @@ void checkFunctionActorIsolation(AbstractFunctionDecl *decl);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
 void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 
-/// Compute the actor isolation required in order to evaluate the given
-/// initializer expression synchronously.
-ActorIsolation computeRequiredIsolation(Initializer *init, Expr *expr);
-
 /// States the reason for checking the Sendability of a given declaration.
 enum class SendableCheckReason {
   /// A reference to an actor from outside that actor.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1157,14 +1157,13 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
 }
 
 ActorIsolation 
-DefaultArgumentIsolation::evaluate(Evaluator &evaluator,
-                                   ParamDecl *param) const {
-  if (!param->hasDefaultExpr())
+DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
+                                      Initializer *init,
+                                      Expr *initExpr) const {
+  if (!init || !initExpr)
     return ActorIsolation::forUnspecified();
 
-  auto *dc = param->getDefaultArgumentInitContext();
-  auto *initExpr = param->getTypeCheckedDefaultExpr();
-  return computeRequiredIsolation(dc, initExpr);
+  return computeRequiredIsolation(init, initExpr);
 }
 
 Type DefaultArgumentTypeRequest::evaluate(Evaluator &evaluator,
@@ -2477,7 +2476,7 @@ public:
               PBD->getInitContext(i));
           if (initContext) {
             TypeChecker::contextualizeInitializer(initContext, init);
-            checkInitializerActorIsolation(initContext, init);
+            (void)PBD->getInitializerIsolation(i);
             TypeChecker::checkInitializerEffects(initContext, init);
           }
         }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3226,7 +3226,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
   // synthesize a computed property for '$foo'.
   Expr *projectedValueInit = nullptr;
   if (auto *projection = var->getPropertyWrapperProjectionVar()) {
-    auto *pbd = createPBD(projection);
+    createPBD(projection);
 
     if (var->hasExternalPropertyWrapper()) {
       // Projected-value initialization is currently only supported for parameters.
@@ -3240,7 +3240,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
       // Check initializer effects.
       auto *initContext = new (ctx) PropertyWrapperInitializer(
           dc, param, PropertyWrapperInitializer::Kind::ProjectedValue);
-      (void)pbd->getInitializerIsolation(0);
+      (void)projection->getInitializerIsolation();
       TypeChecker::checkInitializerEffects(initContext, projectedValueInit);
     }
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3226,7 +3226,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
   // synthesize a computed property for '$foo'.
   Expr *projectedValueInit = nullptr;
   if (auto *projection = var->getPropertyWrapperProjectionVar()) {
-    createPBD(projection);
+    auto *pbd = createPBD(projection);
 
     if (var->hasExternalPropertyWrapper()) {
       // Projected-value initialization is currently only supported for parameters.
@@ -3240,7 +3240,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
       // Check initializer effects.
       auto *initContext = new (ctx) PropertyWrapperInitializer(
           dc, param, PropertyWrapperInitializer::Kind::ProjectedValue);
-      checkInitializerActorIsolation(initContext, projectedValueInit);
+      (void)pbd->getInitializerIsolation(0);
       TypeChecker::checkInitializerEffects(initContext, projectedValueInit);
     }
   }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 810; // access enforcement
+const uint16_t SWIFTMODULE_VERSION_MINOR = 811; // default argument isolation
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -525,6 +525,17 @@ enum class DefaultArgumentKind : uint8_t {
   StoredProperty,
 };
 using DefaultArgumentField = BCFixed<4>;
+
+/// These IDs must \em not be renumbered or reordered without incrementing
+/// the module version.
+enum class ActorIsolation : uint8_t {
+  Unspecified = 0,
+  ActorInstance,
+  Nonisolated,
+  GlobalActor,
+  GlobalActorUnsafe
+};
+using ActorIsolationField = BCFixed<3>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
@@ -1568,6 +1579,8 @@ namespace decls_block {
     BCFixed<1>,              // isCompileTimeConst?
     DefaultArgumentField,    // default argument kind
     TypeIDField,             // default argument type
+    ActorIsolationField,     // default argument isolation
+    TypeIDField,             // global actor isolation
     BCBlob                   // default argument text
   >;
 

--- a/test/Concurrency/Inputs/serialized_default_arguments.swift
+++ b/test/Concurrency/Inputs/serialized_default_arguments.swift
@@ -1,0 +1,11 @@
+
+@MainActor
+public func mainActorDefaultArg() -> Int { 0 }
+
+@MainActor
+public func useMainActorDefault(_ value: Int = mainActorDefaultArg()) {}
+
+public func nonisolatedDefaultArg() -> Int { 0 }
+
+@MainActor
+public func useNonisolatedDefault(_ value: Int = nonisolatedDefaultArg()) {}

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -124,3 +124,59 @@ func closureWithIsolatedParam(
     _ = requiresMainActor()
   }
 ) {}
+
+@MainActor
+struct S1 {
+  var required: Int
+
+  var x: Int = requiresMainActor()
+
+  lazy var y: Int = requiresMainActor()
+
+  static var z: Int = requiresMainActor()
+}
+
+@SomeGlobalActor
+struct S2 {
+  var required: Int
+
+  var x: Int = requiresSomeGlobalActor()
+
+  lazy var y: Int = requiresSomeGlobalActor()
+
+  static var z: Int = requiresSomeGlobalActor()
+}
+
+@MainActor
+func initializeFromMainActor() {
+  _ = S1(required: 10)
+
+  // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a main actor-isolated context}}
+  _ = S2(required: 10)
+}
+
+@SomeGlobalActor
+func initializeFromSomeGlobalActor() {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a global actor 'SomeGlobalActor'-isolated context}}
+  _ = S1(required: 10)
+
+  _ = S2(required: 10)
+}
+
+func initializeFromNonisolated() {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  _ = S1(required: 10)
+
+  // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  _ = S2(required: 10)
+}
+
+extension A {
+  func initializeFromActorInstance() {
+    // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a actor-isolated context}}
+    _ = S1(required: 10)
+
+    // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a actor-isolated context}}
+    _ = S2(required: 10)
+  }
+}

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -1,0 +1,108 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultArguments -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultArguments -enable-experimental-feature SendNonSendable %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@globalActor
+actor SomeGlobalActor {
+  static let shared = SomeGlobalActor()
+}
+
+@MainActor
+func requiresMainActor() -> Int { 0 }
+
+// expected-note@+2 2 {{calls to global function 'requiresSomeGlobalActor()' from outside of its actor context are implicitly asynchronous}}
+@SomeGlobalActor
+func requiresSomeGlobalActor() -> Int { 0 }
+
+func mainActorDefaultArg(value: Int = requiresMainActor()) {}
+
+func mainActorClosure(
+  closure: () -> Int = {
+    requiresMainActor()
+  }
+) {}
+
+func mainActorClosureCall(
+  closure: Int = {
+    requiresMainActor()
+  }()
+) {}
+
+@MainActor func mainActorCaller() {
+  mainActorDefaultArg()
+  mainActorClosure()
+  mainActorClosureCall()
+}
+
+func nonisolatedCaller() {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorDefaultArg()
+
+  // FIXME: confusing error message.
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorClosure()
+
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorClosureCall()
+}
+
+func nonisolatedAsyncCaller() async {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorDefaultArg()
+
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorClosure()
+
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorClosureCall()
+
+  await mainActorDefaultArg(value: requiresMainActor())
+
+  // 'await' doesn't help closures in default arguments; the calling context needs a matching
+  // actor isolation for that isolation to be inferred for the closure value.
+
+  // expected-error@+2 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-warning@+1 {{no 'async' operations occur within 'await' expression}}
+  await mainActorClosure()
+
+  // expected-error@+2 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-warning@+1 {{no 'async' operations occur within 'await' expression}}
+  await mainActorClosureCall()
+}
+
+func conflictingIsolationDefaultArg(
+  // expected-error@+1 {{call to global actor 'SomeGlobalActor'-isolated global function 'requiresSomeGlobalActor()' in a synchronous nonisolated context}}
+  value: (Int, Int) = (requiresMainActor(), requiresSomeGlobalActor())
+) {}
+
+func closureLosesIsolation(
+  closure: @Sendable () -> Void = {
+    // expected-note@+1 {{calls to local function 'f()' from outside of its actor context are implicitly asynchronous}}
+    @MainActor func f() {}
+    // expected-error@+1 {{call to main actor-isolated local function 'f()' in a synchronous nonisolated context}}
+    f()
+  }
+) {}
+
+func closureIsolationMismatch(
+  closure: @SomeGlobalActor () -> Void = {
+    // expected-note@+1 {{calls to local function 'f()' from outside of its actor context are implicitly asynchronous}}
+    @MainActor func f() {}
+    // expected-error@+1 {{call to main actor-isolated local function 'f()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
+    f()
+  }
+) {}
+
+func conflictingClosureIsolation(
+  closure: () -> Void = {
+    _ = requiresMainActor()
+    // expected-error@+1 {{call to global actor 'SomeGlobalActor'-isolated global function 'requiresSomeGlobalActor()' in a synchronous nonisolated context}}
+    _ = requiresSomeGlobalActor()
+  }
+) {}

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -147,6 +147,11 @@ struct S2 {
   static var z: Int = requiresSomeGlobalActor()
 }
 
+struct S3 {
+  // expected-error@+1 {{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+  var (x, y, z) = (requiresMainActor(), requiresSomeGlobalActor(), 10)
+}
+
 @MainActor
 func initializeFromMainActor() {
   _ = S1(required: 10)

--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultArguments %S/Inputs/serialized_default_arguments.swift
+
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-experimental-feature IsolatedDefaultArguments
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+import SerializedDefaultArguments
+
+@MainActor 
+func mainActorCaller() {
+  useMainActorDefault()
+  useNonisolatedDefault()
+}
+
+func nonisolatedCaller() async {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  await useMainActorDefault()
+
+  await useMainActorDefault(mainActorDefaultArg())
+
+  await useNonisolatedDefault()
+}

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultArguments -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultArguments -enable-experimental-feature SendNonSendable %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@globalActor
+actor SomeGlobalActor {
+  static let shared = SomeGlobalActor()
+}
+
+@MainActor
+func requiresMainActor() -> Int { 0 }
+
+@SomeGlobalActor
+func requiresSomeGlobalActor() -> Int { 0 }
+
+struct S1 {
+  // expected-note@+1 2 {{'self.x' not initialized}}
+  var x = requiresMainActor()
+  // expected-note@+1 2 {{'self.y' not initialized}}
+  var y = requiresSomeGlobalActor()
+  var z = 10
+
+  // expected-error@+1 {{return from initializer without initializing all stored properties}}
+  nonisolated init(a: Int) {}
+
+  // expected-error@+1 {{return from initializer without initializing all stored properties}}
+  @MainActor init(b: Int) {}
+
+  // expected-error@+1 {{return from initializer without initializing all stored properties}}
+  @SomeGlobalActor init(c: Int) {}
+}
+
+struct S2 {
+  var x = requiresMainActor()
+  var y = requiresSomeGlobalActor()
+  var z = 10
+
+  nonisolated init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  @MainActor init(y: Int) {
+    self.y = y
+  }
+
+  @SomeGlobalActor init(x: Int) {
+    self.x = x
+  }
+}
+


### PR DESCRIPTION
Type checking a default argument expression will compute the required actor isolation for evaluating that argument value synchronously. Actor isolation checking is deferred to the caller; it is an error to use a default argument from across isolation domains.

This change enables code like the following:

```swift
@MainActor
func requiresMainActor() -> Int { 0 }

@MainActor
func useMainActorDefault(value: Int = requiresMainActor()) { ... }

@MainActor
func mainActorCaller() {
  useMainActorDefault() // okay
}

func nonisolatedCaller() {
  useMainActorDefault() // error
}
```

Currently gated behind `-enable-experimental-feature IsolatedDefaultArguments`.

Resolves https://github.com/apple/swift/issues/58177