### PR TITLE
tests: fix AutoDiff/stdlib/callee_differential_not_leaked_in_func_with_loops.swift for 32 bit architectures

### DIFF
--- a/test/AutoDiff/stdlib/callee_differential_not_leaked_in_func_with_loops.swift
+++ b/test/AutoDiff/stdlib/callee_differential_not_leaked_in_func_with_loops.swift
@@ -44,14 +44,14 @@ extension LifetimeTracked {
 func f(ltti: LifetimeTracked) -> Float {
     for _ in 0..<1 {
     }
-    return ltti.callee(0xDEADBEEF)
+    return ltti.callee(0xDEADBEE)
 }
 
 var Tests = TestSuite("CalleeDifferentialLeakTest")
 
 Tests.test("dontLeakCalleeDifferential") {
   do {
-    let ltti = LifetimeTracked(0xDEADBEEF)
+    let ltti = LifetimeTracked(0xDEADBEE)
     let _ = valueWithPullback(at: ltti, of: f)
   }
   expectEqual(0, LifetimeTracked.instances)


### PR DESCRIPTION
It failed because the constant overflows a signed 32 bit integer.

And sorry, little insects, I didn't mean it that way.
