### PR TITLE
[Linux] Make the backtracing symbol reference conditional.

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -99,8 +99,10 @@ set(LLVM_OPTIONAL_SOURCES
     ${swift_runtime_leaks_sources}
     ${swift_runtime_backtracing_sources})
 
+set(swift_enable_backtracing)
 if(SWIFT_ENABLE_BACKTRACING)
   list(APPEND swift_runtime_sources ${swift_runtime_backtracing_sources})
+  set(swift_enable_backtracing -DSWIFT_ENABLE_BACKTRACING)
 endif()
 
 set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
@@ -159,7 +161,9 @@ endforeach()
 add_swift_target_library(swiftImageRegistrationObjectELF
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
                   SwiftRT-ELF.cpp
-                  C_COMPILE_FLAGS ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
+                  C_COMPILE_FLAGS
+                    ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
+                    ${swift_enable_backtracing}
                   C_COMPILE_FLAGS_LINUX -fno-lto
                   LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
                   TARGET_SDKS ${ELFISH_SDKS}
@@ -170,7 +174,9 @@ add_swift_target_library(swiftImageRegistrationObjectELF
 add_swift_target_library(swiftImageRegistrationObjectCOFF
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
                   SwiftRT-COFF.cpp
-                  C_COMPILE_FLAGS ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
+                  C_COMPILE_FLAGS
+                    ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
+                    ${swift_enable_backtracing}
                   LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
                   TARGET_SDKS ${COFF_SDKS}
                   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -19,10 +19,12 @@
 
 extern "C" const char __dso_handle[];
 
+#if SWIFT_ENABLE_BACKTRACING
 // Drag in a symbol from the backtracer, to force the static linker to include
 // the code.
 static const void *__backtraceRef __attribute__((used))
   = (const void *)swift::runtime::backtrace::_swift_backtrace_isThunkFunction;
+#endif
 
 // Create empty sections to ensure that the start/stop symbols are synthesized
 // by the linker.  Otherwise, we may end up with undefined symbol references as


### PR DESCRIPTION
On the LSan builds, we disable the backtracer, which results in a link error because we completely remove the code from libswiftCore.

rdar://116105222
