### PR TITLE
SwiftCompilerSources: Replace BlockArgument with Phi and TermResult.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
@@ -267,7 +267,7 @@ private struct ComputeOuterBlockrange : EscapeVisitorWithResult {
     // instructions (for which the `visitUse` closure is not called).
     result.insert(operandsDefinitionBlock)
 
-    // We need to explicitly add predecessor blocks of phi-arguments becaues they
+    // We need to explicitly add predecessor blocks of phis becaues they
     // are not necesesarily visited during the down-walk in `isEscaping()`.
     // This is important for the special case where there is a back-edge from the
     // inner range to the inner rage's begin-block:
@@ -278,8 +278,8 @@ private struct ComputeOuterBlockrange : EscapeVisitorWithResult {
     //     %k = alloc_ref $Klass   // innerInstRange.begin
     //     cond_br bb2, bb1(%k)    // back-edge to bb1 == innerInstRange.blockRange.begin
     //
-    if value is BlockArgument {
-      result.insert(contentsOf: operandsDefinitionBlock.predecessors)
+    if let phi = Phi(value) {
+      result.insert(contentsOf: phi.predecessors)
     }
     return .continueWalk
   }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyRefCasts.swift
@@ -111,7 +111,7 @@ private extension UnaryInstruction {
 private func insertCompensatingInstructions(for inst: Instruction, in failureBlock: BasicBlock, _ context: SimplifyContext) {
   assert(failureBlock.arguments.count == 1)
   let sourceValue = inst.operands[0].value
-  let newArg = failureBlock.addBlockArgument(type: sourceValue.type, ownership: sourceValue.ownership, context)
+  let newArg = failureBlock.addArgument(type: sourceValue.type, ownership: sourceValue.ownership, context)
   let builder = Builder(atBeginOf: failureBlock, context)
   let newInst: SingleValueInstruction
   switch inst {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -400,9 +400,9 @@ extension Undef {
 }
 
 extension BasicBlock {
-  func addBlockArgument(type: Type, ownership: Ownership, _ context: some MutatingContext) -> BlockArgument {
+  func addArgument(type: Type, ownership: Ownership, _ context: some MutatingContext) -> Argument {
     context.notifyInstructionsChanged()
-    return bridged.addBlockArgument(type.bridged, ownership._bridged).blockArgument
+    return bridged.addBlockArgument(type.bridged, ownership._bridged).argument
   }
   
   func eraseArgument(at index: Int, _ context: some MutatingContext) {

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/SILPrinter.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/SILPrinter.swift
@@ -29,8 +29,8 @@ func runSILPrinter(function: Function, context: FunctionPassContext) {
       for use in arg.uses {
         print("      user: \(use.instruction)")
       }
-      if let blockArg = arg as? BlockArgument, blockArg.isPhiArgument {
-        for incoming in blockArg.incomingPhiValues {
+      if let phi = Phi(arg) {
+        for incoming in phi.incomingValues {
           print("      incoming: \(incoming)")
         }
       }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
@@ -389,9 +389,8 @@ extension PointerToAddressInst {
 
       mutating func walkUp(value: Value, path: SmallProjectionPath) -> WalkResult {
         switch value {
-        case is BlockArgument, is MarkDependenceInst, is CopyValueInst,
-             is StructExtractInst, is TupleExtractInst, is StructInst, is TupleInst,
-             is FunctionArgument, is AddressToPointerInst:
+        case is Argument, is MarkDependenceInst, is CopyValueInst,
+             is StructExtractInst, is TupleExtractInst, is StructInst, is TupleInst, is AddressToPointerInst:
           return walkUpDefault(value: value, path: path)
         default:
           return .abortWalk

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -680,11 +680,11 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       return cachedWalkDown(addressOrValue: def, path: path.with(knownType: def.type))
     case is AllocBoxInst:
       return cachedWalkDown(addressOrValue: def, path: path.with(knownType: nil))
-    case let arg as BlockArgument:
-      let block = arg.parentBlock
-      switch block.singlePredecessor!.terminator {
+    case let arg as Argument:
+      guard let termResult = TerminatorResult(arg) else { return isEscaping }
+      switch termResult.terminator {
       case let ta as TryApplyInst:
-        if block != ta.normalBlock { return isEscaping }
+        if termResult.successor != ta.normalBlock { return isEscaping }
         return walkUpApplyResult(apply: ta, path: path.with(knownType: nil))
       default:
         return isEscaping

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -36,7 +36,7 @@ public func registerSILClasses() {
   register(PlaceholderValue.self)
 
   register(FunctionArgument.self)
-  register(BlockArgument.self)
+  register(Argument.self)
 
   register(StoreInst.self)
   register(StoreWeakInst.self)

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -69,7 +69,7 @@ void registerBridgedClass(StringRef className, SwiftMetatype metatype) {
     return SILBasicBlock::registerBridgedMetatype(metatype);
   if (className == "GlobalVariable")
     return SILGlobalVariable::registerBridgedMetatype(metatype);
-  if (className == "BlockArgument") {
+  if (className == "Argument") {
     nodeMetatypes[(unsigned)SILNodeKind::SILPhiArgument] = metatype;
     return;
   }


### PR DESCRIPTION
All SILArgument types are "block arguments". There are three kinds:
1. Function arguments
2. Phis
3. Terminator results

In every situation where the source of the block argument matters, we need to distinguish between these three. Accidentally failing to handle one of the cases is an perpetual source of compiler bugs. Attempting to handle both phis and terminator results uniformly is *always* a bug, especially once OSSA has phi flags. Even when all cases are handled correctly, the code that deals with data flow across blocks is incomprehensible without giving each case a type. This continues to be a massive waste of time literally every time I review code that involves cross-block control flow.

Unfortunately, we don't have these C++ types yet (nothing big is blocking that, it just wasn't done). That's manageable because we can use wrapper types on the Swift side for now. Wrapper types don't create any more complexity than protocols, but they do sacrifice some usability in switch cases.

There is no reason for a BlockArgument type. First, a function argument is a block argument just as much as any other. BlockArgument provides no useful information beyond Argument. And it is nearly always a mistake to care about whether a value is a function argument and not care whether it is a phi or terminator result.
