### PR TITLE
[rebranch] Revert "Disabling failing Cxx Interop tests for rebranch"

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar115062687
-
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar115062687
-
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar115062687
-
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 
 // REQUIRES: executable_test

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar115062687
-
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // FIXME: also run in C++20 mode when conformance works properly on UBI platform (rdar://109366764):
 // %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=gnu++20)


### PR DESCRIPTION
This reverts commit 3aea04c440ce86ed402f9e7f7cc79d10e4d05429.
