### PR TITLE
[embedded] Use -1 as the swift_once predicate indicator, to match Darwin expectations in the compiler

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -137,6 +137,7 @@ public func swift_once(predicate: UnsafeMutablePointer<Int>, fn: (@convention(c)
   if predicate.pointee == 0 {
     predicate.pointee = 1
     fn(context)
+    predicate.pointee = -1
   }
 }
 

--- a/test/embedded/once.swift
+++ b/test/embedded/once.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 // RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -lto=llvm-full %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -lto=llvm-full %lto_flags %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib

--- a/test/embedded/once.swift
+++ b/test/embedded/once.swift
@@ -1,0 +1,34 @@
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -lto=llvm-full %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// For LTO, the linker dlopen()'s the libLTO library, which is a scenario that
+// ASan cannot work in ("Interceptors are not working, AddressSanitizer is
+// loaded too late").
+// REQUIRES: no_asan
+
+public struct MyStruct {
+  static var singleton = MyStruct()
+
+  init() {
+    print("MyStruct.init")
+  }
+
+  func foo() {
+    print("MyStruct.foo")
+  }
+}
+
+@main
+struct Main {
+  static func main() {
+    MyStruct.singleton.foo()
+    // CHECK: MyStruct.init
+    // CHECK: MyStruct.foo
+  }
+}


### PR DESCRIPTION
The attached testcase demonstrates the problem: On Darwin, the compiler expects that after after swift_once completes, the predicate value is "-1", and under LTO the optimizer ends up seeing through the swift_once implementation and turning the failed expectation into a trap.

This PR is still a stopgap in terms of swift_once becoming "real", but the -1 value matching Darwin resolves the immediate problem and is harmless on non-Darwin.