### PR TITLE
[embedded] Fix embedded Swift builds with -Xcc -ffreestanding and -fno-builtin

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/LibcShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcShims.h
@@ -41,8 +41,8 @@ __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
 // General utilities <stdlib.h>
 // Memory management functions
 extern int posix_memalign(void *_Nullable *_Nonnull memptr, __swift_size_t alignment, __swift_size_t size);
+extern void free(void *_Nullable);
 static inline void _swift_stdlib_free(void *_Nullable ptr) {
-  extern void free(void *_Nullable);
   free(ptr);
 }
 

--- a/test/embedded/fno-builtin.swift
+++ b/test/embedded/fno-builtin.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-ir %s %S/Inputs/print.swift -module-name main -Xcc -fno-builtin -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-emit-ir %s %S/Inputs/print.swift -module-name main -Xcc -ffreestanding -enable-experimental-feature Embedded | %FileCheck %s
+
+public func foo() -> [Int] {
+	var a = [1, 2, 3]
+	a.append(4)
+	let b = a.sorted()
+	return b
+}
+
+// CHECK: define {{.*}}@"$s4main3fooSaySiGyF"()

--- a/test/embedded/fno-builtin.swift
+++ b/test/embedded/fno-builtin.swift
@@ -1,6 +1,10 @@
 // RUN: %target-swift-emit-ir %s %S/Inputs/print.swift -module-name main -Xcc -fno-builtin -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-emit-ir %s %S/Inputs/print.swift -module-name main -Xcc -ffreestanding -enable-experimental-feature Embedded | %FileCheck %s
 
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
 public func foo() -> [Int] {
 	var a = [1, 2, 3]
 	a.append(4)


### PR DESCRIPTION
The attached testcase shows the problem: With -Xcc -fno-builtin, or with -Xcc -ffreestanding, the compiler crashes during deserialization due to the "free" function not showing up in SwiftShims. This turns out to be caused by the declaration of free not being at the top level in LibcShims.h.

```
lib/swift/embedded/Swift.swiftmodule/arm64-apple-macos.swiftmodule:1:1: error: reference to top-level declaration 'free' broken by a context change; 'free' is not found, it was expected to be in 'SwiftShims'
SwiftShims.free
^
<unknown>:0: note: the declaration was expected to be found in module 'SwiftShims'
<unknown>:0: note: declarations in the  clang module 'SwiftShims' may be hidden by clang preprocessor macros
Stack dump:
3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for main)
4.	While running pass #51 SILModuleTransform "MandatorySILLinker".
5.	While deserializing SIL function "swift_deallocClassInstance"
6.	While deserializing SIL function "free"
7.	*** DESERIALIZATION FAILURE ***
```