### PR TITLE
[embedded] Add swift_initStaticObject to the embedded runtime

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -80,6 +80,13 @@ public func swift_deallocClassInstance(object: UnsafeMutablePointer<HeapObject>,
   free(object)
 }
 
+@_silgen_name("swift_initStaticObject")
+public func swift_initStaticObject(metadata: UnsafeMutablePointer<ClassMetadata>, object: UnsafeMutablePointer<HeapObject>) -> UnsafeMutablePointer<HeapObject> {
+  object.pointee.metadata = metadata
+  object.pointee.refcount = HeapObject.immortalRefCount
+  return object
+}
+
 @_silgen_name("swift_initStackObject")
 public func swift_initStackObject(metadata: UnsafeMutablePointer<ClassMetadata>, object: UnsafeMutablePointer<HeapObject>) -> UnsafeMutablePointer<HeapObject> {
   object.pointee.metadata = metadata

--- a/test/embedded/static-object.swift
+++ b/test/embedded/static-object.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -O -emit-irgen %s %S/Inputs/print.swift -module-name main -parse-as-library -enable-experimental-feature Embedded | %FileCheck %s --check-prefix CHECK-IR
+// RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public func stringArray() -> [StaticString] {
+  return ["a", "b", "c", "d"]
+}
+// CHECK-IR:      define {{.*}}@"$s4main11stringArraySays12StaticStringVGyF"
+// CHECK-IR-NEXT: entry:
+// CHECK-IR-NEXT:   call {{.*}}@swift_initStaticObject
+
+@main
+struct Main {
+  static func main() {
+    for c in stringArray() {
+      print(c)
+      // CHECK: a
+      // CHECK: b
+      // CHECK: c
+      // CHECK: d
+    }
+  }
+}


### PR DESCRIPTION
Add a -O test that promotes a class instance allocation to be statically allocated in the data section instead, and implement swift_initStaticObject to handle that.