### PR TITLE
[embedded] Implement retain_n and release_n in the embedded runtime

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -101,21 +101,31 @@ public func swift_isUniquelyReferenced_nonNull_native(object: UnsafeMutablePoint
 
 @_silgen_name("swift_retain")
 public func swift_retain(object: Builtin.RawPointer) -> Builtin.RawPointer {
+  return swift_retain_n(object: object, n: 1)
+}
+
+@_silgen_name("swift_retain_n")
+public func swift_retain_n(object: Builtin.RawPointer, n: UInt32) -> Builtin.RawPointer {
   if Int(Builtin.ptrtoint_Word(object)) == 0 { return object }
   let o = UnsafeMutablePointer<HeapObject>(object)
   // TODO/FIXME: Refcounting is not thread-safe, the following only works in single-threaded environments.
   if o.pointee.refcount == HeapObject.immortalRefCount { return o._rawValue }
-  o.pointee.refcount += 1
+  o.pointee.refcount += Int(n)
   return o._rawValue
 }
 
 @_silgen_name("swift_release")
 public func swift_release(object: Builtin.RawPointer) {
+  swift_release_n(object: object, n: 1)
+}
+
+@_silgen_name("swift_release_n")
+public func swift_release_n(object: Builtin.RawPointer, n: UInt32) {
   if Int(Builtin.ptrtoint_Word(object)) == 0 { return }
   let o = UnsafeMutablePointer<HeapObject>(object)
   // TODO/FIXME: Refcounting is not thread-safe, the following only works in single-threaded environments.
   if o.pointee.refcount == HeapObject.immortalRefCount { return }
-  o.pointee.refcount -= 1
+  o.pointee.refcount -= Int(n)
   if (o.pointee.refcount & HeapObject.refcountMask) == 0 {
     _swift_embedded_invoke_heap_object_destroy(o)
   }

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -128,6 +128,8 @@ public func swift_release_n(object: Builtin.RawPointer, n: UInt32) {
   o.pointee.refcount -= Int(n)
   if (o.pointee.refcount & HeapObject.refcountMask) == 0 {
     _swift_embedded_invoke_heap_object_destroy(o)
+  } else if (o.pointee.refcount & HeapObject.refcountMask) < 0 {
+    fatalError("negative refcount")
   }
 }
 


### PR DESCRIPTION
Implements retain_n and release_n in the embedded runtime. Don't have good ideas how to write a runtime test for this...