### PR TITLE
[Linux] Provide a statically linked swift-backtrace binary.

### DIFF
--- a/stdlib/public/Backtracing/CMakeLists.txt
+++ b/stdlib/public/Backtracing/CMakeLists.txt
@@ -78,7 +78,7 @@ add_swift_target_library(swift_Backtracing ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
 
   SWIFT_MODULE_DEPENDS ${concurrency}
 
-  LINK_LIBRARIES ${swift_backtracing_link_libraries}
+  PRIVATE_LINK_LIBRARIES ${swift_backtracing_link_libraries}
 
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}

--- a/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
+++ b/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
@@ -26,13 +26,18 @@ set(BACKTRACING_COMPILE_FLAGS
   "-Xcc;-I${SWIFT_SOURCE_DIR}/include"
   "-Xcc;-I${CMAKE_BINARY_DIR}/include")
 
-add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
+set(BACKTRACING_SOURCES
   main.swift
   AnsiColor.swift
   TargetMacOS.swift
   TargetLinux.swift
   Themes.swift
   Utils.swift
+  )
+
+
+add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
+  ${BACKTRACING_SOURCES}
 
   SWIFT_MODULE_DEPENDS         ${backtracing}
 
@@ -47,3 +52,22 @@ add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
 
   TARGET_SDKS OSX LINUX)
 
+if(SWIFT_BUILD_STATIC_STDLIB)
+  add_swift_target_executable(swift-backtrace-static BUILD_WITH_LIBEXEC
+    PREFER_STATIC
+
+    ${BACKTRACING_SOURCES}
+
+    SWIFT_MODULE_DEPENDS         ${backtracing}
+
+    SWIFT_MODULE_DEPENDS_OSX     ${darwin}
+    SWIFT_MODULE_DEPENDS_WINDOWS ${wincrt_sdk}
+    SWIFT_MODULE_DEPENDS_LINUX   ${glibc}
+
+    INSTALL_IN_COMPONENT libexec
+    COMPILE_FLAGS
+      ${BACKTRACING_COMPILE_FLAGS}
+      -parse-as-library
+
+    TARGET_SDKS LINUX)
+endif()


### PR DESCRIPTION
This adds a new binary, `swift-backtrace-static`, to the build.  The runtime will not by default use this binary as the backtracer, but if you want to statically link your own binaries against the standard library you can copy `swift-backtrace-static` rather than `swift-backtrace` alongside your binary, naming it `swift-backtrace`, and the runtime should find and use it, which will mean you don't need to have `libswiftCore.so` et al installed.

rdar://115278959
