### PR TITLE
[Linux] Provide a statically linked swift-backtrace binary.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1530,8 +1530,18 @@ function(add_swift_target_library_single target name)
         "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}")
     target_link_directories(${target_static} PRIVATE
       ${library_search_directories})
+
+    set(target_private_libs)
+    foreach(library ${SWIFTLIB_SINGLE_PRIVATE_LINK_LIBRARIES})
+      if(TARGET "${library}-static")
+        list(APPEND target_private_libs "${library}-static")
+      else()
+        list(APPEND target_private_libs "${library}")
+      endif()
+    endforeach()
+
     target_link_libraries("${target_static}" PRIVATE
-        ${SWIFTLIB_SINGLE_PRIVATE_LINK_LIBRARIES})
+        ${target_private_libs})
 
     # Force executables linker language to be CXX so that we do not link using the
     # host toolchain swiftc.
@@ -2692,6 +2702,24 @@ function(_add_swift_target_executable_single name)
   set_target_properties(${name} PROPERTIES FOLDER "Swift executables")
 endfunction()
 
+# Conditionally append -static to a name, if that variant is a valid target
+function(append_static name result_var_name)
+  cmake_parse_arguments(APPEND_TARGET
+    "STATIC_SWIFT_STDLIB"
+    ""
+    ""
+    ${ARGN})
+  if(STATIC_SWIFT_STDLIB)
+    if(TARGET "${name}-static")
+      set("${result_var_name}" "${name}-static" PARENT_SCOPE)
+    else()
+      set("${result_var_name}" "${name}" PARENT_SCOPE)
+    endif()
+  else()
+    set("${result_var_name}" "${name}" PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Add an executable for each target variant. Executables are given suffixes
 # with the variant SDK and ARCH.
 #
@@ -2700,7 +2728,8 @@ function(add_swift_target_executable name)
   set(SWIFTEXE_options
     EXCLUDE_FROM_ALL
     BUILD_WITH_STDLIB
-    BUILD_WITH_LIBEXEC)
+    BUILD_WITH_LIBEXEC
+    PREFER_STATIC)
   set(SWIFTEXE_single_parameter_options
     INSTALL_IN_COMPONENT)
   set(SWIFTEXE_multiple_parameter_options
@@ -2886,8 +2915,12 @@ function(add_swift_target_executable name)
         list(APPEND swiftexe_module_dependency_targets
           "swift${mod}${MODULE_VARIANT_SUFFIX}")
 
-        list(APPEND swiftexe_link_libraries_targets
-          "swift${mod}${VARIANT_SUFFIX}")
+        set(library_target "swift${mod}${VARIANT_SUFFIX}")
+        if(SWIFTEXE_TARGET_PREFER_STATIC AND TARGET "${library_target}-static")
+          set(library_target "${library_target}-static")
+        endif()
+
+        list(APPEND swiftexe_link_libraries_targets "${library_target}")
       endforeach()
 
       # Don't add the ${arch} to the suffix.  We want to link against fat

--- a/stdlib/public/Backtracing/CMakeLists.txt
+++ b/stdlib/public/Backtracing/CMakeLists.txt
@@ -78,7 +78,7 @@ add_swift_target_library(swift_Backtracing ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
 
   SWIFT_MODULE_DEPENDS ${concurrency}
 
-  LINK_LIBRARIES ${swift_backtracing_link_libraries}
+  PRIVATE_LINK_LIBRARIES ${swift_backtracing_link_libraries}
 
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}

--- a/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
+++ b/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
@@ -26,13 +26,18 @@ set(BACKTRACING_COMPILE_FLAGS
   "-Xcc;-I${SWIFT_SOURCE_DIR}/include"
   "-Xcc;-I${CMAKE_BINARY_DIR}/include")
 
-add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
+set(BACKTRACING_SOURCES
   main.swift
   AnsiColor.swift
   TargetMacOS.swift
   TargetLinux.swift
   Themes.swift
   Utils.swift
+  )
+
+
+add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
+  ${BACKTRACING_SOURCES}
 
   SWIFT_MODULE_DEPENDS         ${backtracing}
 
@@ -47,3 +52,22 @@ add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
 
   TARGET_SDKS OSX LINUX)
 
+if(SWIFT_BUILD_STATIC_STDLIB)
+  add_swift_target_executable(swift-backtrace-static BUILD_WITH_LIBEXEC
+    PREFER_STATIC
+
+    ${BACKTRACING_SOURCES}
+
+    SWIFT_MODULE_DEPENDS         ${backtracing}
+
+    SWIFT_MODULE_DEPENDS_OSX     ${darwin}
+    SWIFT_MODULE_DEPENDS_WINDOWS ${wincrt_sdk}
+    SWIFT_MODULE_DEPENDS_LINUX   ${glibc}
+
+    INSTALL_IN_COMPONENT libexec
+    COMPILE_FLAGS
+      ${BACKTRACING_COMPILE_FLAGS}
+      -parse-as-library
+
+    TARGET_SDKS LINUX)
+endif()


### PR DESCRIPTION
This adds a new binary, `swift-backtrace-static`, to the build.  The runtime will not by default use this binary as the backtracer, but if you want to statically link your own binaries against the standard library you can copy `swift-backtrace-static` rather than `swift-backtrace` alongside your binary, naming it `swift-backtrace`, and the runtime should find and use it, which will mean you don't need to have `libswiftCore.so` et al installed.

rdar://115278959
