### PR TITLE
[embedded] Resolve empty -sdk path warning in embedded stdlib build, take 2

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -230,7 +230,7 @@ function(_add_target_variant_swift_compile_flags
     ${ARGN})
 
   # On Windows, we don't set SWIFT_SDK_WINDOWS_PATH_ARCH_{ARCH}_PATH, so don't include it.
-  if (NOT "${sdk}" STREQUAL "WINDOWS")
+  if ((NOT "${sdk}" STREQUAL "WINDOWS") AND NOT ("${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}" STREQUAL ""))
     list(APPEND result "-sdk" "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}")
   endif()
 

--- a/stdlib/public/SwiftShims/swift/shims/LibcShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcShims.h
@@ -41,8 +41,8 @@ __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
 // General utilities <stdlib.h>
 // Memory management functions
 extern int posix_memalign(void *_Nullable *_Nonnull memptr, __swift_size_t alignment, __swift_size_t size);
+extern void free(void *_Nullable);
 static inline void _swift_stdlib_free(void *_Nullable ptr) {
-  extern void free(void *_Nullable);
   free(ptr);
 }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -420,6 +420,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
+    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     add_swift_target_library_single(
       embedded-stdlib-${triple}
       swiftCore
@@ -427,7 +428,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       IS_STDLIB IS_STDLIB_CORE
       ${SWIFTLIB_EMBEDDED_SOURCES}
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
-      SWIFT_COMPILE_FLAGS -target "${triple}" -Xcc -D__MACH__ -enable-experimental-feature Embedded
+      SWIFT_COMPILE_FLAGS -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"


### PR DESCRIPTION
Previous attempt needed to be reverted: https://github.com/apple/swift/pull/68809