### PR TITLE
Sema: warn on imports that are too public and remark source of entities in API

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2451,6 +2451,12 @@ REMARK(add_predates_concurrency_import,none,
      "%select{| as warnings}0", (bool, Identifier))
 REMARK(remove_predates_concurrency_import,none,
      "'@preconcurrency' attribute on module %0 is unused", (Identifier))
+WARNING(remove_public_import,none,
+        "public import of %0 was not used in public declarations or inlinable code",
+        (const ModuleDecl *))
+WARNING(remove_package_import,none,
+        "package import of %0 was not used in package declarations",
+        (const ModuleDecl *))
 WARNING(public_decl_needs_sendable,none,
         "public %kind0 does not specify whether it is 'Sendable' or not",
         (const ValueDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1126,6 +1126,20 @@ REMARK(module_loaded,none,
        "; source: '%2', loaded: '%3'",
        (Identifier, unsigned, StringRef, StringRef))
 
+REMARK(module_api_import,none,
+       "%select{|implicitly used }4"
+       "%kind0 is imported via %1"
+       "%select{, which reexports definition from %2|}3",
+       (const Decl *, ModuleDecl *, ModuleDecl *, bool, bool))
+REMARK(module_api_import_conformance,none,
+       "conformance of %0 to %kind1 used here is imported via %2"
+       "%select{ which reexports the definition from %3|}4",
+       (const Type, const Decl *, ModuleDecl *, ModuleDecl *, bool))
+REMARK(module_api_import_aliases,none,
+       "typealias underlying type %kind0 is imported via %1"
+       "%select{, which reexports definition from %2|}3",
+       (const Decl *, ModuleDecl *, ModuleDecl *, bool))
+
 REMARK(macro_loaded,none,
        "loaded macro implementation module %0 from "
        "%select{shared library '%2'|executable '%2'|"

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -591,7 +591,7 @@ struct AttributedImport {
 
   /// Location of the attribute that defined \c accessLevel. Also indicates
   /// if the access level was implicit or explicit.
-  SourceLoc accessLevelLoc;
+  SourceRange accessLevelRange;
 
   AttributedImport(ModuleInfo module, SourceLoc importLoc = SourceLoc(),
                    ImportOptions options = ImportOptions(),
@@ -599,11 +599,11 @@ struct AttributedImport {
                    SourceRange preconcurrencyRange = {},
                    llvm::Optional<AccessLevel> docVisibility = llvm::None,
                    AccessLevel accessLevel = AccessLevel::Public,
-                   SourceLoc accessLevelLoc = SourceLoc())
+                   SourceRange accessLevelRange = SourceRange())
       : module(module), importLoc(importLoc), options(options),
         sourceFileArg(filename), spiGroups(spiGroups),
         preconcurrencyRange(preconcurrencyRange), docVisibility(docVisibility),
-        accessLevel(accessLevel), accessLevelLoc(accessLevelLoc) {
+        accessLevel(accessLevel), accessLevelRange(accessLevelRange) {
     assert(!(options.contains(ImportFlags::Exported) &&
              options.contains(ImportFlags::ImplementationOnly)) ||
            options.contains(ImportFlags::Reserved));
@@ -614,7 +614,7 @@ struct AttributedImport {
     : AttributedImport(module, other.importLoc, other.options,
                        other.sourceFileArg, other.spiGroups,
                        other.preconcurrencyRange, other.docVisibility,
-                       other.accessLevel, other.accessLevelLoc) { }
+                       other.accessLevel, other.accessLevelRange) { }
 
   friend bool operator==(const AttributedImport<ModuleInfo> &lhs,
                          const AttributedImport<ModuleInfo> &rhs) {
@@ -624,7 +624,7 @@ struct AttributedImport {
            lhs.spiGroups == rhs.spiGroups &&
            lhs.docVisibility == rhs.docVisibility &&
            lhs.accessLevel == rhs.accessLevel &&
-           lhs.accessLevelLoc == rhs.accessLevelLoc;
+           lhs.accessLevelRange == rhs.accessLevelRange;
   }
 
   AttributedImport<ImportedModule> getLoaded(ModuleDecl *loadedModule) const {
@@ -802,7 +802,7 @@ struct DenseMapInfo<swift::AttributedImport<ModuleInfo>> {
            a.spiGroups == b.spiGroups &&
            a.docVisibility == b.docVisibility &&
            a.accessLevel == b.accessLevel &&
-           a.accessLevelLoc == b.accessLevelLoc;
+           a.accessLevelRange == b.accessLevelRange;
   }
 };
 }

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -115,6 +115,10 @@ private:
   llvm::SmallDenseSet<AttributedImport<ImportedModule>>
       PreconcurrencyImportsUsed;
 
+  /// The highest access level of declarations referencing each import.
+  llvm::DenseMap<AttributedImport<ImportedModule>, AccessLevel>
+      ImportsUseAccessLevel;
+
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
   /// same module.
@@ -364,6 +368,15 @@ public:
   /// Note that the given import has used @preconcurrency/
   void setImportUsedPreconcurrency(
       AttributedImport<ImportedModule> import);
+
+  /// Return the highest access level of the declarations referencing
+  /// this import in signature or inlinable code.
+  AccessLevel
+  getMaxAccessLevelUsingImport(AttributedImport<ImportedModule> import) const;
+
+  /// Register the use of \p import from an API with \p accessLevel.
+  void registerAccessLevelUsingImport(AttributedImport<ImportedModule> import,
+                                      AccessLevel accessLevel);
 
   enum ImportQueryKind {
     /// Return the results for testable or private imports.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -246,6 +246,9 @@ namespace swift {
     /// Emit remarks about contextual inconsistencies in loaded modules.
     bool EnableModuleRecoveryRemarks = false;
 
+    /// Emit remarks about the source of each element exposed by the module API.
+    bool EnableModuleApiImportRemarks = false;
+
      /// Emit a remark after loading a macro implementation.
     bool EnableMacroLoadingRemarks = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -397,6 +397,9 @@ def remark_loading_module : Flag<["-"], "Rmodule-loading">,
 def remark_module_recovery : Flag<["-"], "Rmodule-recovery">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit remarks about contextual inconsistencies in loaded modules">;
+def remark_module_api_import : Flag<["-"], "Rmodule-api-import">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit remarks about the import briging in each element composing the API">;
 
 def remark_macro_loading : Flag<["-"], "Rmacro-loading">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1481,7 +1481,11 @@ ArrayRef<ValueDecl *> ImportDecl::getDecls() const {
 
 AccessLevel ImportDecl::getAccessLevel() const {
   if (auto attr = getAttrs().getAttribute<AccessControlAttr>()) {
-    return attr->getAccess();
+    if (attr->getAccess() == AccessLevel::Open) {
+      // Use a conservative import if the level given is invalid.
+      return AccessLevel::Internal;
+    } else
+      return attr->getAccess();
   }
 
   auto &LangOpts = getASTContext().LangOpts;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3087,6 +3087,25 @@ void SourceFile::setImportUsedPreconcurrency(
   PreconcurrencyImportsUsed.insert(import);
 }
 
+AccessLevel
+SourceFile::getMaxAccessLevelUsingImport(
+    AttributedImport<ImportedModule> import) const {
+  auto known = ImportsUseAccessLevel.find(import);
+  if (known == ImportsUseAccessLevel.end())
+    return AccessLevel::Internal;
+  return known->second;
+}
+
+void SourceFile::registerAccessLevelUsingImport(
+    AttributedImport<ImportedModule> import,
+    AccessLevel accessLevel) {
+  auto known = ImportsUseAccessLevel.find(import);
+  if (known == ImportsUseAccessLevel.end())
+    ImportsUseAccessLevel[import] = accessLevel;
+  else
+    ImportsUseAccessLevel[import] = std::max(accessLevel, known->second);
+}
+
 bool HasImportsMatchingFlagRequest::evaluate(Evaluator &evaluator,
                                              SourceFile *SF,
                                              ImportFlags flag) const {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1021,6 +1021,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
   Opts.EnableModuleRecoveryRemarks = Args.hasArg(OPT_remark_module_recovery);
+  Opts.EnableModuleApiImportRemarks = Args.hasArg(OPT_remark_module_api_import);
   Opts.EnableMacroLoadingRemarks = Args.hasArg(OPT_remark_macro_loading);
   Opts.EnableIndexingSystemModuleRemarks = Args.hasArg(OPT_remark_indexing_system_module);
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -570,7 +570,7 @@ UnboundImport::UnboundImport(ImportDecl *ID)
 
   import.accessLevel = ID->getAccessLevel();
   if (auto attr = ID->getAttrs().getAttribute<AccessControlAttr>()) {
-    import.accessLevelLoc = attr->getLocation();
+    import.accessLevelRange = attr->getLocation();
   }
 
   if (ID->getAttrs().hasAttribute<SPIOnlyAttr>())
@@ -822,9 +822,9 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
                                      SF.getParentModule()->getName());
 
   if (ctx.LangOpts.hasFeature(Feature::AccessLevelOnImport)) {
-    SourceLoc attrLoc = import.accessLevelLoc;
-    if (attrLoc.isValid())
-      inFlight.fixItReplace(attrLoc, "internal");
+    SourceRange attrRange = import.accessLevelRange;
+    if (attrRange.isValid())
+      inFlight.fixItReplace(attrRange, "internal");
     else
       inFlight.fixItInsert(import.importLoc, "internal ");
   } else {

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -69,6 +69,15 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
     if (SF)
       SF->registerAccessLevelUsingImport(problematicImport.value(),
                                          AccessLevel::Public);
+
+    if (Context.LangOpts.EnableModuleApiImportRemarks) {
+      ModuleDecl *importedVia = problematicImport->module.importedModule,
+                 *sourceModule = D->getModuleContext();
+      Context.Diags.diagnose(loc, diag::module_api_import,
+                             D, importedVia, sourceModule,
+                             importedVia == sourceModule,
+                             /*isImplicit*/false);
+    }
   }
 
   // General check on access-level of the decl.
@@ -150,6 +159,14 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
     if (SF)
       SF->registerAccessLevelUsingImport(problematicImport.value(),
                                          AccessLevel::Public);
+
+    if (ctx.LangOpts.EnableModuleApiImportRemarks) {
+      ModuleDecl *importedVia = problematicImport->module.importedModule,
+                 *sourceModule = D->getModuleContext();
+      ctx.Diags.diagnose(loc, diag::module_api_import_aliases,
+                             D, importedVia, sourceModule,
+                             importedVia == sourceModule);
+    }
   }
 
   auto ignoredDowngradeToWarning = DowngradeToWarning::No;
@@ -313,6 +330,15 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
     if (SF)
       SF->registerAccessLevelUsingImport(problematicImport.value(),
                                          AccessLevel::Public);
+
+    if (ctx.LangOpts.EnableModuleApiImportRemarks) {
+      ModuleDecl *importedVia = problematicImport->module.importedModule,
+                 *sourceModule = ext->getModuleContext();
+      ctx.Diags.diagnose(loc, diag::module_api_import_conformance,
+                         rootConf->getType(), rootConf->getProtocol(),
+                         importedVia, sourceModule,
+                         importedVia == sourceModule);
+    }
   }
 
   auto originKind = getDisallowedOriginKind(ext, where);

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -60,8 +60,18 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   if (D->getDeclContext()->isLocalContext())
     return false;
 
-  // General check on access-level of the decl.
   auto *DC = where.getDeclContext();
+  auto &Context = DC->getASTContext();
+
+  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
+  if (problematicImport.has_value()) {
+    auto SF = DC->getParentSourceFile();
+    if (SF)
+      SF->registerAccessLevelUsingImport(problematicImport.value(),
+                                         AccessLevel::Public);
+  }
+
+  // General check on access-level of the decl.
   auto declAccessScope =
       D->getFormalAccessScope(/*useDC=*/DC,
                               /*allowUsableFromInline=*/true);
@@ -71,8 +81,6 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   // from diagnoseDeclRefExportability().
   if (declAccessScope.isPublic())
     return false;
-
-  auto &Context = DC->getASTContext();
 
   // Dynamic declarations were mistakenly not checked in Swift 4.2.
   // Do enforce the restriction even in pre-Swift-5 modes if the module we're
@@ -112,7 +120,6 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
 
   Context.Diags.diagnose(D, diag::resilience_decl_declared_here, D);
 
-  ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
   if (problematicImport.has_value() &&
       problematicImport->accessLevel < D->getFormalAccess()) {
     Context.Diags.diagnose(problematicImport->importLoc,
@@ -133,14 +140,23 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
   if (!D)
     return false;
 
+  auto exportingModule = where.getDeclContext()->getParentModule();
+  ASTContext &ctx = exportingModule->getASTContext();
+
+  ImportAccessLevel problematicImport = D->getImportAccessFrom(
+                                                       where.getDeclContext());
+  if (problematicImport.has_value()) {
+    auto SF = where.getDeclContext()->getParentSourceFile();
+    if (SF)
+      SF->registerAccessLevelUsingImport(problematicImport.value(),
+                                         AccessLevel::Public);
+  }
+
   auto ignoredDowngradeToWarning = DowngradeToWarning::No;
   auto originKind =
       getDisallowedOriginKind(D, where, ignoredDowngradeToWarning);
   if (originKind == DisallowedOriginKind::None)
     return false;
-
-  auto exportingModule = where.getDeclContext()->getParentModule();
-  ASTContext &ctx = exportingModule->getASTContext();
 
   // As an exception, if the import of the module that defines the desugared
   // decl is just missing (as opposed to imported explicitly with reduced
@@ -184,7 +200,7 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
     assert(limitImport.has_value() &&
            limitImport->accessLevel < AccessLevel::Public &&
            "The import should still be non-public");
-    ctx.Diags.diagnose(limitImport->accessLevelLoc,
+    ctx.Diags.diagnose(limitImport->importLoc,
                        diag::decl_import_via_here, D,
                        limitImport->accessLevel,
                        limitImport->module.importedModule);
@@ -288,12 +304,20 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
   if (ext->getParentModule()->isBuiltinModule())
     return false;
 
+  ModuleDecl *M = ext->getParentModule();
+  ASTContext &ctx = M->getASTContext();
+
+  ImportAccessLevel problematicImport = ext->getImportAccessFrom(where.getDeclContext());
+  if (problematicImport.has_value()) {
+    auto SF = where.getDeclContext()->getParentSourceFile();
+    if (SF)
+      SF->registerAccessLevelUsingImport(problematicImport.value(),
+                                         AccessLevel::Public);
+  }
+
   auto originKind = getDisallowedOriginKind(ext, where);
   if (originKind == DisallowedOriginKind::None)
     return false;
-
-  ModuleDecl *M = ext->getParentModule();
-  ASTContext &ctx = M->getASTContext();
 
   auto reason = where.getExportabilityReason();
   if (!reason.has_value())
@@ -323,7 +347,7 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
     assert(limitImport.has_value() &&
            limitImport->accessLevel < AccessLevel::Public &&
            "The import should still be non-public");
-    ctx.Diags.diagnose(limitImport->accessLevelLoc,
+    ctx.Diags.diagnose(limitImport->importLoc,
                        diag::decl_import_via_here, ext,
                        limitImport->accessLevel,
                        limitImport->module.importedModule);

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -115,7 +115,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   ImportAccessLevel problematicImport = D->getImportAccessFrom(DC);
   if (problematicImport.has_value() &&
       problematicImport->accessLevel < D->getFormalAccess()) {
-    Context.Diags.diagnose(problematicImport->accessLevelLoc,
+    Context.Diags.diagnose(problematicImport->importLoc,
                            diag::decl_import_via_here, D,
                            problematicImport->accessLevel,
                            problematicImport->module.importedModule);

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -203,6 +203,17 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
                                                         : AccessLevel::Package;
           SF->registerAccessLevelUsingImport(import.value(), useLevel);
         }
+
+        if (Context.LangOpts.EnableModuleApiImportRemarks) {
+          SourceLoc diagLoc = typeRepr? typeRepr->getLoc()
+                                      : extractNearestSourceLoc(useDC);
+          ModuleDecl *importedVia = import->module.importedModule,
+                     *sourceModule = VD->getModuleContext();
+          Context.Diags.diagnose(diagLoc, diag::module_api_import,
+                                 VD, importedVia, sourceModule,
+                                 importedVia == sourceModule,
+                                 /*isImplicit*/!typeRepr);
+        }
       }
     };
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -339,13 +339,13 @@ static void noteLimitingImport(ASTContext &ctx,
 
   if (auto ITR = dyn_cast_or_null<IdentTypeRepr>(complainRepr)) {
     ValueDecl *VD = ITR->getBoundDecl();
-    ctx.Diags.diagnose(limitImport->accessLevelLoc,
+    ctx.Diags.diagnose(limitImport->importLoc,
                        diag::decl_import_via_here,
                        VD,
                        limitImport->accessLevel,
                        limitImport->module.importedModule);
   } else {
-    ctx.Diags.diagnose(limitImport->accessLevelLoc, diag::module_imported_here,
+    ctx.Diags.diagnose(limitImport->importLoc, diag::module_imported_here,
                        limitImport->module.importedModule,
                        limitImport->accessLevel);
   }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -297,6 +297,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
   }
 
   diagnoseUnnecessaryPreconcurrencyImports(*SF);
+  diagnoseUnnecessaryPublicImports(*SF);
 
   // Check to see if there are any inconsistent imports.
   evaluateOrDefault(

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1547,6 +1547,9 @@ public:
   }
 };
 
+/// Report imports that are marked public but are not used in API.
+void diagnoseUnnecessaryPublicImports(SourceFile &SF);
+
 } // end namespace swift
 
 #endif

--- a/test/Sema/access-level-and-non-resilient-import.swift
+++ b/test/Sema/access-level-and-non-resilient-import.swift
@@ -45,7 +45,9 @@
 
 import DefaultLib // expected-error {{module 'DefaultLib' was not compiled with library evolution support; using it means binary compatibility for 'Client_Swift5' can't be guaranteed}} {{1-1=internal }}
 public import PublicLib // expected-error {{module 'PublicLib' was not compiled with library evolution support; using it means binary compatibility for 'Client_Swift5' can't be guaranteed}} {{1-7=internal}}
+// expected-warning @-1 {{public import of 'PublicLib' was not used in public declarations or inlinable code}}
 package import PackageLib
+// expected-warning @-1 {{package import of 'PackageLib' was not used in package declarations}}
 internal import InternalLib
 fileprivate import FileprivateLib
 private import PrivateLib
@@ -54,7 +56,9 @@ private import PrivateLib
 
 import DefaultLib
 public import PublicLib // expected-error {{module 'PublicLib' was not compiled with library evolution support; using it means binary compatibility for 'Client_Swift6' can't be guaranteed}} {{1-7=internal}}
+// expected-warning @-1 {{public import of 'PublicLib' was not used in public declarations or inlinable code}}
 package import PackageLib
+// expected-warning @-1 {{package import of 'PackageLib' was not used in package declarations}}
 internal import InternalLib
 fileprivate import FileprivateLib
 private import PrivateLib

--- a/test/Sema/access-level-import-diag-priority.swift
+++ b/test/Sema/access-level-import-diag-priority.swift
@@ -91,7 +91,6 @@ public func publicFuncUsesPackageLevelPackageImportedType(_ a: PackageLevelPacka
 
 /// Local vs imports
 //--- LocalVsImportClient.swift
-public import PublicLib
 internal import InternalLib
 fileprivate import FileprivateLib // expected-note {{struct 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
 

--- a/test/Sema/access-level-import-exportability.swift
+++ b/test/Sema/access-level-import-exportability.swift
@@ -119,10 +119,10 @@ public struct PrivateLibWrapper<T> {
 
 /// Short test mostly to count the notes.
 //--- MinimalClient.swift
-public import PublicLib
-package import PackageLib
-internal import InternalLib // expected-note@:1 {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
-fileprivate import FileprivateLib // expected-note@:1 {{class 'FileprivateImportClass' imported as 'fileprivate' from 'FileprivateLib' here}}
+public import PublicLib // expected-warning {{public import of 'PublicLib' was not used in public declarations or inlinable code}}
+package import PackageLib // expected-warning {{package import of 'PackageLib' was not used in package declarations}}
+internal import InternalLib // expected-note {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
+fileprivate import FileprivateLib // expected-note {{class 'FileprivateImportClass' imported as 'fileprivate' from 'FileprivateLib' here}}
 private import PrivateLib
 
 public func PublicFuncUsesInternal(_: InternalImportType) { // expected-error {{function cannot be declared public because its parameter uses an internal type}}

--- a/test/Sema/access-level-import-flag-check.swift
+++ b/test/Sema/access-level-import-flag-check.swift
@@ -32,7 +32,9 @@
 
 //--- ClientWithoutTheFlag.swift
 public import PublicLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+// expected-warning @-1 {{public import of 'PublicLib' was not used in public declarations or inlinable code}}
 package import PackageLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+// expected-warning @-1 {{package import of 'PackageLib' was not used in package declarations}}
 internal import InternalLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
 fileprivate import FileprivateLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
 private import PrivateLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -24,8 +24,8 @@ public struct LibType {}
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
 // RUN:   -package-name package
 //--- OneFile_AllExplicit.swift
-public import Lib
-package import Lib
+public import Lib // expected-warning {{public import of 'Lib' was not used in public declarations or inlinable code}}
+package import Lib // expected-warning {{package import of 'Lib' was not used in package declarations}}
 internal import Lib
 fileprivate import Lib
 private import Lib
@@ -34,9 +34,9 @@ private import Lib
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
 // RUN:   -package-name package
 //--- ManyFiles_AllExplicit_FileA.swift
-public import Lib
+public import Lib // expected-warning {{public import of 'Lib' was not used in public declarations or inlinable code}}
 //--- ManyFiles_AllExplicit_FileB.swift
-package import Lib
+package import Lib // expected-warning {{package import of 'Lib' was not used in package declarations}}
 //--- ManyFiles_AllExplicit_FileC.swift
 internal import Lib
 //--- ManyFiles_AllExplicit_FileD.swift

--- a/test/Sema/access-level-import-parsing.swift
+++ b/test/Sema/access-level-import-parsing.swift
@@ -22,8 +22,8 @@
 //--- OpenLib.swift
 
 //--- Client.swift
-public import PublicLib
-package import PackageLib
+public import PublicLib // expected-warning {{public import of 'PublicLib' was not used in public declarations or inlinable code}}
+package import PackageLib // expected-warning {{package import of 'PackageLib' was not used in package declarations}}
 internal import InternalLib
 fileprivate import FileprivateLib
 private import PrivateLib

--- a/test/Sema/conflicting-import-restrictions.swift
+++ b/test/Sema/conflicting-import-restrictions.swift
@@ -54,10 +54,11 @@
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 
 //--- Public_Exported.swift
-@_exported public import Lib
+@_exported public import Lib // expected-warning {{public import of 'Lib' was not used in public declarations or inlinable code}}
 
 //--- Package_Exported.swift
 @_exported package import Lib // expected-error {{'@_exported' is incompatible with 'package'; it can only be applied to public imports}}
+// expected-warning @-1 {{package import of 'Lib' was not used in package declarations}}
 
 //--- Internal_Exported.swift
 @_exported internal import Lib // expected-error {{'@_exported' is incompatible with 'internal'; it can only be applied to public imports}}

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -150,10 +150,17 @@ private import LocalClang
 // RUN:   -library-level api -verify
 //--- ExplicitlyPublicImports.swift
 public import PublicSwift
+// expected-warning @-1 {{public import of 'PublicSwift' was not used in public declarations or inlinable code}}
 public import PrivateSwift // expected-error{{private module 'PrivateSwift' is imported publicly from the public module 'MainLib'}}
+// expected-warning @-1 {{public import of 'PrivateSwift' was not used in public declarations or inlinable code}}
 
 public import PublicClang
+// expected-warning @-1 {{public import of 'PublicClang' was not used in public declarations or inlinable code}}
 public import PublicClang_Private // expected-error{{private module 'PublicClang_Private' is imported publicly from the public module 'MainLib'}}
+// expected-warning @-1 {{public import of 'PublicClang_Private' was not used in public declarations or inlinable code}}
 public import FullyPrivateClang // expected-error{{private module 'FullyPrivateClang' is imported publicly from the public module 'MainLib'}}
+// expected-warning @-1 {{public import of 'FullyPrivateClang' was not used in public declarations or inlinable code}}
 public import LocalClang // expected-error{{private module 'LocalClang' is imported publicly from the public module 'MainLib'}}
+// expected-warning @-1 {{public import of 'LocalClang' was not used in public declarations or inlinable code}}
 @_exported public import MainLib // expected-warning{{private module 'MainLib' is imported publicly from the public module 'MainLib'}}
+// expected-warning @-1 {{public import of 'MainLib' was not used in public declarations or inlinable code}}

--- a/test/Sema/package-only-references.swift
+++ b/test/Sema/package-only-references.swift
@@ -51,7 +51,7 @@ package struct PackageStruct : IndirectProtocol {
 }
 
 //--- Client.swift
-public import PackageLib
+import PackageLib
 
 let t = getIndirectType() // expected-error {{cannot find 'getIndirectType' in scope}}
 t.someMethod()

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -1,0 +1,157 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+// REQUIRES: asserts
+
+/// Build the libraries.
+// RUN: %target-swift-frontend -emit-module %t/DepUsedFromInlinableCode.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/DepUsedInSignature.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/Exportee.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/Exporter.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/ConformanceBaseTypes.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/ConformanceDefinition.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/AliasesBase.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/Aliases.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/UnusedImport.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/UnusedPackageImport.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/ImportNotUseFromAPI.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/ImportUsedInPackage.swift -o %t -I %t
+
+/// Check diagnostics.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -package-name pkg -Rmodule-api-import -swift-version 6
+// RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -swift-version 5
+
+//--- DepUsedFromInlinableCode.swift
+public struct TypeUsedFromInlinableCode {}
+public func funcUsedFromInlinableCode() {}
+
+public func funcUsedFromDefaultValue() -> Int { 42 }
+
+//--- DepUsedInSignature.swift
+public struct TypeUsedInSignature {}
+public protocol ComposedProtoA {}
+public protocol ComposedProtoB {}
+
+//--- Exportee.swift
+public struct ExportedType {}
+
+//--- Exporter.swift
+@_exported import Exportee
+
+//--- ConformanceBaseTypes.swift
+public protocol Proto {}
+public struct ConformingType {
+    public init () {}
+}
+
+//--- ConformanceDefinition.swift
+import ConformanceBaseTypes
+extension ConformingType : Proto  {}
+
+//--- AliasesBase.swift
+open class Clazz {}
+
+//--- Aliases.swift
+import AliasesBase
+public typealias ClazzAlias = Clazz
+
+//--- UnusedImport.swift
+
+//--- UnusedPackageImport.swift
+
+//--- ImportNotUseFromAPI.swift
+public struct NotAnAPIType {}
+public func notAnAPIFunc() -> NotAnAPIType { return NotAnAPIType() }
+
+//--- ImportUsedInPackage.swift
+public struct PackageType {}
+public func packageFunc() -> PackageType { return PackageType() }
+
+//--- Client_Swift5.swift
+/// No diagnostics should be raised on the implicit access level.
+import UnusedImport // expected-error {{ambiguous implicit access level for import of 'UnusedImport'; it is imported as 'public' elsewhere}}
+public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-7=internal}}
+// expected-note @-1 {{imported 'public' here}}
+
+//--- Client.swift
+public import DepUsedFromInlinableCode
+public import DepUsedInSignature
+public import Exporter
+public import ConformanceBaseTypes
+public import ConformanceDefinition
+public import AliasesBase
+public import Aliases
+
+public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
+public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
+package import UnusedImport // expected-warning {{package import of 'UnusedImport' was not used in package declarations}} {{1-9=}}
+
+package import UnusedPackageImport // expected-warning {{package import of 'UnusedPackageImport' was not used in package declarations}} {{1-9=}}
+public import ImportNotUseFromAPI // expected-warning {{public import of 'ImportNotUseFromAPI' was not used in public declarations or inlinable code}} {{1-8=}}
+public import ImportUsedInPackage // expected-warning {{public import of 'ImportUsedInPackage' was not used in public declarations or inlinable code}} {{1-7=package}}
+
+public func useInSignature(_ a: TypeUsedInSignature) {} // expected-remark {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
+public func exportedTypeUseInSignature(_ a: ExportedType) {} // expected-remark {{struct 'ExportedType' is imported via 'Exporter', which reexports definition from 'Exportee'}}
+
+public func useInDefaultValue(_ a: Int = funcUsedFromDefaultValue()) {}
+// expected-remark @-1 {{struct 'Int' is imported via 'Swift'}}
+// expected-remark @-2 {{global function 'funcUsedFromDefaultValue()' is imported via 'DepUsedFromInlinableCode'}}
+
+public func genericType(_ a: Array<TypeUsedInSignature>) {}
+// expected-remark @-1 {{generic struct 'Array' is imported via 'Swift'}}
+// expected-remark @-2 {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
+
+public func protocolComposition(_ a: any ComposedProtoA & ComposedProtoB) {}
+// expected-remark @-1 {{protocol 'ComposedProtoA' is imported via 'DepUsedInSignature'}}
+// expected-remark @-2 {{protocol 'ComposedProtoB' is imported via 'DepUsedInSignature'}}
+
+public func useConformance(_ a: any Proto = ConformingType()) {}
+// expected-remark @-1 {{protocol 'Proto' is imported via 'ConformanceBaseTypes'}}
+// expected-remark @-2 {{conformance of 'ConformingType' to protocol 'Proto' used here is imported via 'ConformanceDefinition'}}
+// expected-remark @-3 {{struct 'ConformingType' is imported via 'ConformanceBaseTypes'}}
+// expected-remark @-4 {{initializer 'init()' is imported via 'ConformanceBaseTypes'}}
+
+@usableFromInline internal func useInDefaultValue(_ a: TypeUsedInSignature) {} // expected-remark {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
+
+@inlinable
+public func publicFuncUsesPrivate() {
+  let _: TypeUsedFromInlinableCode // expected-remark {{struct 'TypeUsedFromInlinableCode' is imported via 'DepUsedFromInlinableCode'}}
+  let _: ExportedType // expected-remark {{struct 'ExportedType' is imported via 'Exporter', which reexports definition from 'Exportee'}}
+  funcUsedFromInlinableCode() // expected-remark {{global function 'funcUsedFromInlinableCode()' is imported via 'DepUsedFromInlinableCode'}}
+
+  let _: Array<TypeUsedInSignature>
+  // expected-remark @-1 {{generic struct 'Array' is imported via 'Swift'}}
+  // expected-remark @-2 {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
+
+  let _: any ComposedProtoA & ComposedProtoB
+  // expected-remark @-1 {{protocol 'ComposedProtoA' is imported via 'DepUsedInSignature'}}
+  // expected-remark @-2 {{protocol 'ComposedProtoB' is imported via 'DepUsedInSignature'}}
+
+  let _: any Proto = ConformingType()
+  // expected-remark @-1 {{protocol 'Proto' is imported via 'ConformanceBaseTypes'}}
+  // expected-remark @-2 {{conformance of 'ConformingType' to protocol 'Proto' used here is imported via 'ConformanceDefinition'}}
+  // expected-remark @-3 {{struct 'ConformingType' is imported via 'ConformanceBaseTypes'}}
+  // expected-remark @-4 {{initializer 'init()' is imported via 'ConformanceBaseTypes'}}
+
+  let _: ClazzAlias
+  // expected-remark @-1 {{type alias 'ClazzAlias' is imported via 'Aliases'}}
+  // expected-remark @-2 2 {{typealias underlying type class 'Clazz' is imported via 'AliasesBase'}}
+}
+
+public struct Struct { // expected-remark {{implicitly used struct 'Int' is imported via 'Swift'}}
+  public var propWithInferredIntType = 42
+  public var propWithExplicitType: String = "Text" // expected-remark {{struct 'String' is imported via 'Swift'}}
+}
+
+public func publicFunction() {
+    let _: NotAnAPIType = notAnAPIFunc()
+}
+
+internal func internalFunc(a: NotAnAPIType = notAnAPIFunc()) {}
+func implicitlyInternalFunc(a: NotAnAPIType = notAnAPIFunc()) {}
+
+// For package decls we only remark on types used in signatures, not for inlinable code.
+package func packageFunc(a: PackageType = packageFunc()) {} // expected-remark {{struct 'PackageType' is imported via 'ImportUsedInPackage'}}

--- a/test/attr/package-modifier-outside-of-package.swift
+++ b/test/attr/package-modifier-outside-of-package.swift
@@ -15,6 +15,7 @@ public struct PackageImportType {}
 
 //--- Client.swift
 package import PackageLib // expected-error {{the package access level requires a package name; set it with the compiler flag -package-name}}
+// expected-warning @-1 {{package import of 'PackageLib' was not used in package declarations}}
 
 package struct PackageStruct { // expected-error {{the package access level used on 'PackageStruct' requires a package name; set it with the compiler flag -package-name}}
   package func explicitlyPackage() {} // expected-error {{the package access level used on 'explicitlyPackage()' requires a package name; set it with the compiler flag -package-name}}


### PR DESCRIPTION
This PR introduces two new features based on tracking which import was the source of each entities used in API.

The compiler will warn on imports that are marked either `public` or `package` but aren't used as such by the local file. A fixit will suggest to downgrade them to either `package` or `internal`. This logic ignores anything below internal.

Using `-Rmodule-api-import` the compiler will print a remark about the import bringing in every decl used in public function signatures or inlinable code. It also remarks on the source of conformances use, the source of typealias underlying types, and implicitly used decls.