### PR TITLE
IRGen: Don't mark ROData const for non generic classes

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1664,11 +1664,9 @@ namespace {
       
       auto dataSuffix = forMeta ? "_METACLASS_DATA_" : "_DATA_";
       
-      // The rodata is constant if the object layout is known entirely
-      // statically. Otherwise, the ObjC runtime may slide the InstanceSize
-      // based on changing base class layout.
+      // Otherwise, the Swift runtime currently unconditionally touches the ivar variable.
       return buildGlobalVariable(fields, dataSuffix,
-                               /*const*/ forMeta || FieldLayout->isFixedSize(),
+                               /*const*/ forMeta,
                                llvm::GlobalVariable::InternalLinkage);
     }
 

--- a/test/IRGen/objc_class_rodata_const.swift
+++ b/test/IRGen/objc_class_rodata_const.swift
@@ -7,13 +7,13 @@
 import ResilientBaseClasses
 
 // CHECK: @_METACLASS_DATA_{{.*}}9PureSwift = {{.*}} constant {{.*}} section "__DATA, __objc_const"
-// CHECK: @_DATA_{{.*}}9PureSwift = {{.*}} constant {{.*}} section "__DATA, __objc_const"
+// CHECK: @_DATA_{{.*}}9PureSwift = {{.*}} constant {{.*}} section "__DATA, __objc_data"
 class PureSwift {
     var x: Int = 0
 }
 
 // CHECK: @_METACLASS_DATA_{{.*}}12PureSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_const"
-// CHECK: @_DATA_{{.*}}12PureSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_const"
+// CHECK: @_DATA_{{.*}}12PureSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_data"
 class PureSwiftSub: PureSwift {
     var y: Int = 0
 }


### PR DESCRIPTION
The Swift runtime currently unconditionally writes to RODATA->ivar (in initObjCClass).

rdar://113642480