### PR TITLE
Preliminary IRGen support for typed throws

### DIFF
--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -214,6 +214,11 @@ public:
     return getSILType(funcTy->getErrorResult(), context);
   }
 
+  bool isTypedError() const {
+    return !funcTy->getErrorResult()
+        .getInterfaceType()->isExistentialWithError();
+  }
+
   /// Returns an array of result info.
   /// Provides convenient access to the underlying SILFunctionType.
   ArrayRef<SILResultInfo> getResults() const {

--- a/lib/IRGen/EntryPointArgumentEmission.h
+++ b/lib/IRGen/EntryPointArgumentEmission.h
@@ -45,6 +45,7 @@ class NativeCCEntryPointArgumentEmission
 public:
   virtual void mapAsyncParameters() = 0;
   virtual llvm::Value *getCallerErrorResultArgument() = 0;
+  virtual llvm::Value *getCallerTypedErrorResultArgument() = 0;
   virtual llvm::Value *getContext() = 0;
   virtual Explosion getArgumentExplosion(unsigned index, unsigned size) = 0;
   virtual llvm::Value *getSelfWitnessTable() = 0;

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -581,7 +581,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     auto error = args.claimNext();
     auto errorTy = IGF.IGM.Context.getErrorExistentialType();
     auto errorBuffer = IGF.getCalleeErrorResultSlot(
-        SILType::getPrimitiveObjectType(errorTy));
+        SILType::getPrimitiveObjectType(errorTy), false);
     IGF.Builder.CreateStore(error, errorBuffer);
     
     auto context = llvm::UndefValue::get(IGF.IGM.Int8PtrTy);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1118,6 +1118,10 @@ public:
   void forwardErrorResult() override {
     llvm::Value *errorResultPtr = origParams.claimNext();
     args.add(errorResultPtr);
+    if (origConv.isTypedError()) {
+      auto *typedErrorResultPtr = origParams.claimNext();
+      args.add(typedErrorResultPtr);
+    }
   }
   llvm::CallInst *createCall(FunctionPointer &fnPtr) override {
     return subIGF.Builder.CreateCall(fnPtr, args.claimAll());
@@ -1289,8 +1293,12 @@ public:
   }
 
   void forwardErrorResult() override {
-    // Nothing to do here.  The error result pointer is already in the
-    // appropriate position.
+    // The error result pointer is already in the appropriate position but the
+    // type error address is not.
+    if (origConv.isTypedError()) {
+      auto *typedErrorResultPtr = origParams.claimNext();
+      args.add(typedErrorResultPtr);
+    }
   }
   llvm::CallInst *createCall(FunctionPointer &fnPtr) override {
     PointerAuthInfo newAuthInfo =

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -90,7 +90,7 @@ public:
 
   friend class Scope;
 
-  Address createErrorResultSlot(SILType errorType, bool isAsync);
+  Address createErrorResultSlot(SILType errorType, bool isAsync, bool setSwiftErrorFlag = true, bool isTypedError = false);
 
   //--- Function prologue and epilogue
   //-------------------------------------------
@@ -122,14 +122,19 @@ public:
   ///
   /// For async functions, this is different from the caller result slot because
   /// that is a gep into the %swift.context.
-  Address getCalleeErrorResultSlot(SILType errorType);
-  Address getAsyncCalleeErrorResultSlot(SILType errorType);
+  Address getCalleeErrorResultSlot(SILType errorType,
+                                   bool isTypedError);
 
   /// Return the error result slot provided by the caller.
   Address getCallerErrorResultSlot();
 
   /// Set the error result slot for the current function.
   void setCallerErrorResultSlot(Address address);
+  /// Set the error result slot for a typed throw for the current function.
+  void setCallerTypedErrorResultSlot(Address address);
+
+  Address getCallerTypedErrorResultSlot();
+  Address getCalleeTypedErrorResultSlot(SILType errorType);
 
   /// Are we currently emitting a coroutine?
   bool isCoroutine() {
@@ -198,6 +203,8 @@ private:
   Address CalleeErrorResultSlot;
   Address AsyncCalleeErrorResultSlot;
   Address CallerErrorResultSlot;
+  Address CallerTypedErrorResultSlot;
+  Address CalleeTypedErrorResultSlot;
   llvm::Value *CoroutineHandle = nullptr;
   llvm::Value *AsyncCoroutineCurrentResume = nullptr;
   llvm::Value *AsyncCoroutineCurrentContinuationContext = nullptr;

--- a/test/IRGen/pack_metadata_marker_inserter.sil
+++ b/test/IRGen/pack_metadata_marker_inserter.sil
@@ -15,14 +15,19 @@ case some(T)
 struct Int {
   var _value: Builtin.Int64
 }
+class AnyObject {}
 
-protocol Error {}
+sil_vtable AnyObject {}
+
+protocol Error : class {}
+
+protocol NonError {}
 
 struct S1 {}
 struct S2 {}
 struct S3 {}
 
-struct GVT<each T> : Error {
+struct GVT<each T> : NonError {
 }
 
 struct GV<each T> {

--- a/test/IRGen/typed_throws.sil
+++ b/test/IRGen/typed_throws.sil
@@ -1,0 +1,274 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-irgen | %FileCheck %s --check-prefix=CHECK
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct S {
+  var x: A
+  var y: A
+}
+
+class A {}
+
+sil_vtable A {}
+
+sil @create_error : $@convention(thin) () -> @owned A
+
+// CHECK: define{{.*}} swiftcc void @throw_error(ptr swiftself %0, ptr noalias nocapture swifterror dereferenceable({{.*}}) %1, ptr %2)
+// CHECK:   [[ERR:%.*]] = call swiftcc ptr @create_error()
+// CHECK:   call ptr @swift_retain(ptr returned [[ERR]])
+// CHECK:   store ptr inttoptr (i64 1 to ptr), ptr %1
+// CHECK:   [[F1:%.*]] = getelementptr inbounds %T12typed_throws1SV, ptr %2, i32 0, i32 0
+// CHECK:   store ptr [[ERR]], ptr [[F1]]
+// CHECK:   [[F2:%.*]] = getelementptr inbounds %T12typed_throws1SV, ptr %2, i32 0, i32 1
+// CHECK:   store ptr [[ERR]], ptr [[F2]]
+// CHECK:   ret void
+// CHECK: }
+
+sil @throw_error : $@convention(thin) () -> @error S {
+  %0 = function_ref @create_error : $@convention(thin) () -> @owned A
+  %1 = apply %0() : $@convention(thin) () -> @owned A
+  retain_value %1 : $A
+  %2 = struct $S(%1: $A, %1 : $A)
+  throw %2 : $S
+}
+
+sil @doesnt_throw : $@convention(thin) () -> (@owned A, @error S) {
+  %0 = function_ref @create_error : $@convention(thin) () -> @owned A
+  %1 = apply %0() : $@convention(thin) () -> @owned A
+  return %1 : $A
+}
+
+sil @try_apply_helper : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error S)
+
+// CHECK: define{{.*}} swiftcc void @try_apply(ptr %0)
+// CHECK: entry:
+// CHECK:   %swifterror = alloca swifterror ptr
+// CHECK:   store ptr null, ptr %swifterror
+// CHECK:   %swifterror1 = alloca %T12typed_throws1SV
+// CHECK:   [[RES:%.*]] = call swiftcc ptr @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias nocapture swifterror dereferenceable({{.*}}) %swifterror, ptr %swifterror1)
+// CHECK:   [[ERRFLAG:%.*]] = load ptr, ptr %swifterror
+// CHECK:   [[C:%.*]] = icmp ne ptr [[ERRFLAG]], null
+// CHECK:   br i1 [[C]], label %[[ERR_B:.*]], label %[[SUCC_B:[0-9]+]]
+
+// CHECK: [[ERR_B]]:
+// CHECK:   %swifterror1.x = getelementptr inbounds %T12typed_throws1SV, ptr %swifterror1, i32 0, i32 0
+// CHECK:   [[ERR_v1:%.*]] = load ptr, ptr %swifterror1.x
+// CHECK:   %swifterror1.y = getelementptr inbounds %T12typed_throws1SV, ptr %swifterror1, i32 0, i32 1
+// CHECK:   [[ERR_v2:%.*]] = load ptr, ptr %swifterror1.y
+// CHECK:   br label %[[ERR2_B:[0-9]+]]
+
+// CHECK: [[SUCC_B]]:
+// CHECK:   [[R:%.*]] = phi ptr [ [[RES]], %entry ]
+// CHECK:   call void @swift_{{.*}}elease(ptr [[R]])
+// CHECK:   br label %[[RET_B:[0-9]+]]
+
+// CHECK: [[ERR2_B]]:
+// CHECK:   [[E1:%.*]] = phi ptr [ [[ERR_v1]], %[[ERR_B]] ]
+// CHECK:   [[E2:%.*]] = phi ptr [ [[ERR_v2]], %[[ERR_B]] ]
+// CHECK:   store ptr null, ptr %swifterror
+// CHECK:   call void @swift_release(ptr [[E1]])
+// CHECK:   call void @swift_release(ptr [[E2]])
+// CHECK:   br label %[[RET_B]]
+
+// CHECK: [[RET_B]]:
+// CHECK:   ret void
+// CHECK: }
+
+sil @try_apply : $@convention(thin) (@owned AnyObject) -> () {
+entry(%0 : $AnyObject):
+  %1 = function_ref @try_apply_helper : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error S)
+  try_apply %1(%0) : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error S), normal bb1, error bb2
+
+bb1(%2 : $AnyObject):
+  strong_release %2 : $AnyObject
+  br bb3
+
+bb2(%3 : $S):
+  release_value %3 : $S
+  br bb3
+
+bb3:
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil @try_apply_helper2 : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error A)
+
+sil @try_apply_multiple : $@convention(thin) (@owned AnyObject) -> () {
+entry(%0 : $AnyObject):
+  %1 = function_ref @try_apply_helper : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error S)
+  try_apply %1(%0) : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error S), normal bb1, error bb2
+
+bb1(%2 : $AnyObject):
+  strong_release %2 : $AnyObject
+  br bb3
+
+bb2(%3 : $S):
+  release_value %3 : $S
+  br bb3
+
+bb3:
+  %4 = function_ref @try_apply_helper2 : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error A)
+  retain_value %0 : $AnyObject
+  try_apply %4(%0) : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error A), normal bb4, error bb5
+
+bb4(%5 : $AnyObject):
+  strong_release %5 : $AnyObject
+  br bb6
+
+bb5(%6 : $A):
+  release_value %6 : $A
+  br bb6
+
+bb6:
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK: define{{.*}} swifttailcc void @does_throw_async(ptr swiftasync %0, ptr %1)
+// CHECK:   %.x = getelementptr inbounds %T12typed_throws1SV, ptr %1, i32 0, i32 0
+// CHECK:   store ptr {{.*}}, ptr %.x
+// CHECK:   %.y = getelementptr inbounds %T12typed_throws1SV, ptr %1, i32 0, i32 1
+// CHECK:   store ptr {{.*}}, ptr %.y
+// CHECK:   call i1 (ptr, i1, ...) @llvm.coro.end.async(ptr {{.*}}, i1 false, ptr @does_throw_async.0, ptr {{.*}}, ptr {{.*}}, ptr inttoptr (i64 1 to ptr))
+// CHECK:   ret void
+
+sil @does_throw_async : $@convention(thin) @async () -> @error S {
+  %0 = function_ref @create_error : $@convention(thin) () -> @owned A
+  %1 = apply %0() : $@convention(thin) () -> @owned A
+  retain_value %1 : $A
+  %2 = struct $S(%1: $A, %1 : $A)
+  throw %2 : $S
+}
+
+// CHECK: define{{.*}} swifttailcc void @does_not_throw_async(ptr swiftasync %0, ptr %1)
+// CHECK:   [[R:%.*]] = call swiftcc ptr @create_error()
+// CHECK:  call i1 (ptr, i1, ...) @llvm.coro.end.async(ptr {{.*}}, i1 false, ptr @does_not_throw_async.0, ptr {{.*}}, ptr {{.*}}, ptr [[R]], ptr null)
+// CHECK:   ret void
+sil @does_not_throw_async : $@convention(thin) @async () -> (@owned A, @error S) {
+  %0 = function_ref @create_error : $@convention(thin) () -> @owned A
+  %1 = apply %0() : $@convention(thin) () -> @owned A
+  return %1 : $A
+}
+
+
+sil @try_apply_helper_async : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error S)
+
+sil @try_apply_async : $@convention(thin) @async (@owned AnyObject) -> () {
+entry(%0 : $AnyObject):
+  %1 = function_ref @try_apply_helper_async : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error S)
+  try_apply %1(%0) : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error S), normal bb1, error bb2
+
+bb1(%2 : $AnyObject):
+  strong_release %2 : $AnyObject
+  br bb3
+
+bb2(%3 : $S):
+  release_value %3 : $S
+  br bb3
+
+bb3:
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil @try_apply_helper_async2 : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error A)
+
+sil @try_apply_multiple_async : $@convention(thin) @async (@owned AnyObject) -> () {
+entry(%0 : $AnyObject):
+  %1 = function_ref @try_apply_helper_async : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error S)
+  try_apply %1(%0) : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error S), normal bb1, error bb2
+
+bb1(%2 : $AnyObject):
+  strong_release %2 : $AnyObject
+  br bb3
+
+bb2(%3 : $S):
+  release_value %3 : $S
+  br bb3
+
+bb3:
+  %4 = function_ref @try_apply_helper_async2 : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error A)
+  retain_value %0 : $AnyObject
+  try_apply %4(%0) : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error A), normal bb4, error bb5
+
+bb4(%5 : $AnyObject):
+  strong_release %5 : $AnyObject
+  br bb6
+
+bb5(%6 : $A):
+  release_value %6 : $A
+  br bb6
+
+bb6:
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK: define{{.*}} internal swiftcc ptr @"$s16try_apply_helperTA"(ptr swiftself %0, ptr noalias nocapture swifterror dereferenceable({{.*}}) %1, ptr %2)
+// CHECK:   tail call swiftcc ptr @try_apply_helper(ptr {{.*}}, ptr swiftself undef, ptr noalias nocapture swifterror dereferenceable({{.*}}) %1, ptr %2)
+// CHECK:   ret ptr
+
+sil @partial_apply_test : $@convention(thin) (@owned AnyObject) -> @owned @callee_guaranteed () ->(@owned AnyObject, @error S) {
+entry(%0: $AnyObject):
+  %f = function_ref @try_apply_helper : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error S)
+  %36 = partial_apply [callee_guaranteed] %f(%0) : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error S)
+  return %36 : $@callee_guaranteed () ->(@owned AnyObject, @error S)
+}
+
+// CHECK: define{{.*}} internal swifttailcc void @"$s22try_apply_helper_asyncTA"(ptr swiftasync %0, ptr swiftself %1, ptr %2)
+// CHECK: call { ptr, ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0p0s(i32 512, ptr {{.*}}, ptr @__swift_async_resume_project_context, ptr @"$s22try_apply_helper_asyncTA.0", ptr @try_apply_helper_async, ptr {{.*}}, ptr {{.*}}, ptr %2)
+
+sil @partial_apply_test_async : $@convention(thin)  (@owned AnyObject) -> @owned @callee_guaranteed @async () ->(@owned AnyObject, @error S) {
+entry(%0: $AnyObject):
+  %f = function_ref @try_apply_helper_async : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error S)
+  %36 = partial_apply [callee_guaranteed] %f(%0) : $@convention(thin) @async (@owned AnyObject) -> (@owned AnyObject, @error S)
+  return %36 : $@callee_guaranteed @async () ->(@owned AnyObject, @error S)
+}
+
+// CHECK:define{{.*}} swiftcc void @apply_closure(ptr %0, ptr %1)
+// CHECK:entry:
+// CHECK:  %swifterror = alloca swifterror ptr
+// CHECK:  store ptr null, ptr %swifterror
+// CHECK:  %swifterror1 = alloca %T12typed_throws1SV
+// CHECK:  call swiftcc ptr %0(ptr swiftself %1, ptr noalias nocapture swifterror dereferenceable({{[0-9]+}}) %swifterror, ptr %swifterror1)
+
+sil @apply_closure : $@convention(thin) (@guaranteed @callee_guaranteed () -> (@owned AnyObject, @error S)) -> () {
+entry(%0 : $@callee_guaranteed () ->(@owned AnyObject, @error S)):
+  try_apply %0() : $@callee_guaranteed () -> (@owned AnyObject, @error S), normal bb4, error bb5
+
+bb4(%5 : $AnyObject):
+  strong_release %5 : $AnyObject
+  br bb6
+
+bb5(%6 : $S):
+  release_value %6 : $S
+  br bb6
+
+bb6:
+  %t = tuple()
+  return %t : $()
+}
+
+// CHECK: define{{.*}} swifttailcc void @apply_closure_async(ptr swiftasync %0, ptr %1, ptr %2)
+// CHECK: %swifterror = alloca %T12typed_throws1SV
+// CHECK: call { ptr, ptr, ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0p0p0s(i32 512, ptr %{{[0-9]+}}, ptr @__swift_async_resume_project_context, ptr @apply_closure_async.0, ptr %{{[0-9]+}}, ptr %{{[0-9]+}}, ptr %2, ptr %swifterror)
+sil @apply_closure_async : $@convention(thin) @async (@guaranteed @callee_guaranteed @async () -> (@owned AnyObject, @error S)) -> () {
+entry(%0 : $@callee_guaranteed @async () ->(@owned AnyObject, @error S)):
+  try_apply %0() : $@callee_guaranteed @async () -> (@owned AnyObject, @error S), normal bb4, error bb5
+
+bb4(%5 : $AnyObject):
+  strong_release %5 : $AnyObject
+  br bb6
+
+bb5(%6 : $S):
+  release_value %6 : $S
+  br bb6
+
+bb6:
+  %t = tuple()
+  return %t : $()
+}


### PR DESCRIPTION
Typed errors are returned indirectly in this version. No support for non-loadable typed errors.