### PR TITLE
Platform: add missing header for OLE32

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -382,6 +382,7 @@ module WinSDK [system] {
 
   module OLE32 {
     header "oaidl.h"
+    header "oleauto.h"
     export *
 
     link "OleAut32.Lib"


### PR DESCRIPTION
We should include `oleauto.h` in the OLE32 module.  This ensures that we are able to access the BSTR APIs which are used extensively in OLE.