### PR TITLE
[5.10 🍒][Dependency Scanning] Only optionally try to resolve imports of 'Foo.Private' submodules to `Foo_Private` top-level modules.

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -699,7 +699,7 @@ public:
       // Special case: a submodule named "Foo.Private" can be moved to a top-level
       // module named "Foo_Private". ClangImporter has special support for this.
       if (submoduleComponent.Item.str() == "Private")
-        ImportedModuleName = ImportedModuleName + "_Private";
+        addOptionalModuleImport(ImportedModuleName + "_Private", alreadyAddedModules);
     }
 
     addModuleImport(ImportedModuleName, alreadyAddedModules);

--- a/test/ScanDependencies/Inputs/CHeaders/Y.h
+++ b/test/ScanDependencies/Inputs/CHeaders/Y.h
@@ -1,0 +1,1 @@
+void funcY(void);

--- a/test/ScanDependencies/Inputs/CHeaders/Y_Private.h
+++ b/test/ScanDependencies/Inputs/CHeaders/Y_Private.h
@@ -1,0 +1,1 @@
+void funcYPrivate(void);

--- a/test/ScanDependencies/Inputs/CHeaders/module.modulemap
+++ b/test/ScanDependencies/Inputs/CHeaders/module.modulemap
@@ -46,3 +46,10 @@ module X_Private {
   header "X_Private.h"
   export *
 }
+module Y {
+  header "Y.h"
+  export *
+  explicit module Private {
+    header "Y_Private.h"
+  }
+}

--- a/test/ScanDependencies/module_deps_clang_private_submodule.swift
+++ b/test/ScanDependencies/module_deps_clang_private_submodule.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache %s -o %t.deps.json -I %S/Inputs/CHeaders
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t.module-cache %s -o %t.deps.json -I %S/Inputs/CHeaders -verify
 
 // RUN: %validate-json %t.deps.json | %FileCheck %s
 // CHECK: "clang": "X_Private"
+// CHECK: "clang": "Y"
+// CHECK-NOT: "clang": "Y_Private"
 import X.Private
-
+import Y.Private


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68841
---------------------------
• Release: Swift 5.10
• Explanation: https://github.com/apple/swift/pull/66151 implemented support in dependency scanning for a special case of re-mapping imports of `Foo.Private` to clang modules of form `Foo_Private`. Such a module may not actually exist and the user did in fact mean a submodule of `Foo` called `Private` instead, in which case we do not want to error out during the scan on not being able to find it.
• Scope of Issue: Some projects which rely on importing a clang submodule called `Private` using the `.Private` syntax may fail to resolve the dependency.
• Risk: Minimal, this change only affects the code-path which currently leads to a hard scanning failure, making it not error on failure to resolve the potentially-optional `_Private` module.
• Origination: Explicit Module Build feature development.

Resolves rdar://109426243
