### PR TITLE
Keep certain function that are potentially used in the debugger

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -845,6 +845,10 @@ public:
   /// current SILModule.
   bool isPossiblyUsedExternally() const;
 
+  /// Helper method which returns whether this function should be preserved so
+  /// it can potentially be used in the debugger.
+  bool shouldBePreservedForDebugger() const;
+
   /// In addition to isPossiblyUsedExternally() it returns also true if this
   /// is a (private or internal) vtable method which can be referenced by
   /// vtables of derived classes outside the compilation unit.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1252,12 +1252,6 @@ static bool isLazilyEmittedFunction(SILFunction &f, SILModule &m) {
   if (f.getDynamicallyReplacedFunction())
     return false;
 
-  // Needed by lldb to print global variables which are propagated by the
-  // mandatory GlobalOpt.
-  if (m.getOptions().OptMode == OptimizationMode::NoOptimization &&
-      f.isGlobalInit())
-    return false;
-
   return true;
 }
 
@@ -3554,8 +3548,14 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   // Mark as llvm.used if @_used, set section if @_section
   if (f->markedAsUsed())
     addUsedGlobal(fn);
+
   if (!f->section().empty())
     fn->setSection(f->section());
+
+  // Also mark as llvm.used any functions that should be kept for the debugger.
+  // Only definitions should be kept.
+  if (f->shouldBePreservedForDebugger() && !fn->isDeclaration())
+    addUsedGlobal(fn);
 
   // If `hasCReferences` is true, then the function is either marked with
   // @_silgen_name OR @_cdecl.  If it is the latter, it must have a definition

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -862,6 +862,9 @@ SILFunction::isPossiblyUsedExternally() const {
   if (markedAsUsed())
     return true;
 
+  if (shouldBePreservedForDebugger())
+    return true;
+
   // Declaration marked as `@_alwaysEmitIntoClient` that
   // returns opaque result type with availability conditions
   // has to be kept alive to emit opaque type metadata descriptor.
@@ -870,6 +873,39 @@ SILFunction::isPossiblyUsedExternally() const {
     return true;
 
   return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
+}
+
+bool SILFunction::shouldBePreservedForDebugger() const {
+  // Only preserve for the debugger at Onone.
+  if (getEffectiveOptimizationMode() != OptimizationMode::NoOptimization)
+    return false;
+
+  // Only keep functions defined in this module.
+  if (!isDefinition())
+    return false;
+
+  // Don't preserve anything markes as always emit into client.
+  if (markedAsAlwaysEmitIntoClient())
+    return false;
+
+  // Needed by lldb to print global variables which are propagated by the
+  // mandatory GlobalOpt.
+  if (isGlobalInit())
+    return true;
+
+  // Preserve any user-written functions.
+  if (auto declContext = getDeclContext())
+    if (auto decl = declContext->getAsDecl())
+      if (!decl->isImplicit())
+        return true;
+
+  // Keep any setters/getters, even compiler generated ones.
+  if (auto *accessorDecl =
+          llvm::dyn_cast_or_null<swift::AccessorDecl>(getDeclContext()))
+    if (accessorDecl->isGetterOrSetter())
+      return true;
+
+  return false;
 }
 
 bool SILFunction::isExternallyUsedSymbol() const {

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -11,19 +11,22 @@ _ = atan2test(0.0, 0.0)
 
 
 // Ordinary Swift definitions
-// The unused internal and private functions are expected to be eliminated.
+// The unused internal and private functions are expected to be kept as they 
+// may be used from the debugger in unoptimized builds.
 
 public   func PlainPublic()   { }
 internal func PlainInternal() { }
 private  func PlainPrivate()  { }
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s7asmname11PlainPublic
-// CHECK-NOT: PlainInternal
-// CHECK-NOT: PlainPrivate
+// CHECK: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s7asmname13PlainInternalyyF
+// CHECK: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$s7asmname12PlainPrivate
 
 
 // Swift _silgen_name definitions
-// The private function is expected to be eliminated
-// but the internal function must survive for C use.
+// The private function is expected 
+// to be eliminated as it may be used from the
+// debugger in unoptimized builds,
+// and the internal function must survive for C use.
 // Only the C-named definition is emitted.
 
 @_silgen_name("silgen_name_public")   public   func SilgenNamePublic()   { }
@@ -31,13 +34,13 @@ private  func PlainPrivate()  { }
 @_silgen_name("silgen_name_private")  private  func SilgenNamePrivate()  { }
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @silgen_name_public
 // CHECK: define hidden swiftcc void @silgen_name_internal
-// CHECK-NOT: silgen_name_private
+// CHECK: define internal swiftcc void @silgen_name_private
 // CHECK-NOT: SilgenName
 
 
 // Swift cdecl definitions
-// The private functions are expected to be eliminated
-// but the internal functions must survive for C use.
+// The private functions are expected to be kept as it may be used from the debugger,
+// and the internal functions must survive for C use.
 // Both a C-named definition and a Swift-named definition are emitted.
 
 @_cdecl("cdecl_public")   public   func CDeclPublic()   { }
@@ -47,4 +50,4 @@ private  func PlainPrivate()  { }
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s7asmname11CDeclPublic
 // CHECK: define hidden void @cdecl_internal
 // CHECK: define hidden swiftcc void @"$s7asmname13CDeclInternal
-// CHECK-NOT: cdecl_private
+// CHECK: define internal void @cdecl_private()

--- a/test/IRGen/async/run-call-class-witnessmethod-void-to-void.swift
+++ b/test/IRGen/async/run-call-class-witnessmethod-void-to-void.swift
@@ -28,8 +28,8 @@ protocol P {
 // CHECK: exiting call_f
 
 // CHECK-LL: @"$s4main1PPAAE1fyyYaFTu" = hidden global %swift.async_func_pointer
-// CHECK-LL: @"$s4main6call_fyyxYaAA1PRzlFTu" = hidden global %swift.async_func_pointer
 // CHECK-LL: @"$s4main1XCAA1PA2aDP1fyyYaFTWTu" = internal global %swift.async_func_pointer
+// CHECK-LL: @"$s4main6call_fyyxYaAA1PRzlFTu" = hidden global %swift.async_func_pointer
 
 extension P {
   // CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main1PPAAE1fyyYaF"(

--- a/test/IRGen/objc_implementation.swift
+++ b/test/IRGen/objc_implementation.swift
@@ -6,6 +6,9 @@
 // RUN: %FileCheck --input-file %t.ir --check-prefix NEGATIVE %s
 // REQUIRES: objc_interop
 
+// CHECK: [[selector_data_implProperty:@[^, ]+]] = private global [13 x i8] c"implProperty\00", section "__TEXT,__objc_methname,cstring_literals", align 1
+// CHECK: [[selector_data_setImplProperty_:@[^, ]+]] = private global [17 x i8] c"setImplProperty:\00", section "__TEXT,__objc_methname,cstring_literals", align 1
+
 // CHECK: [[selector_data_mainMethod_:@[^, ]+]] = private global [12 x i8] c"mainMethod:\00", section "__TEXT,__objc_methname,cstring_literals", align 1
 
 //
@@ -19,8 +22,6 @@
 // TODO: Why the extra i32 field above?
 
 // Class
-// CHECK: [[selector_data_implProperty:@[^, ]+]] = private global [13 x i8] c"implProperty\00", section "__TEXT,__objc_methname,cstring_literals", align 1
-// CHECK: [[selector_data_setImplProperty_:@[^, ]+]] = private global [17 x i8] c"setImplProperty:\00", section "__TEXT,__objc_methname,cstring_literals", align 1
 // CHECK: [[selector_data__cxx_destruct:@[^, ]+]] = private global [14 x i8] c".cxx_destruct\00", section "__TEXT,__objc_methname,cstring_literals", align 1
 // CHECK: [[_INSTANCE_METHODS_ImplClass:@[^, ]+]] = internal constant { i32, i32, [7 x { ptr, ptr, ptr }] } { i32 24, i32 7, [7 x { ptr, ptr, ptr }] [{ ptr, ptr, ptr } { ptr @"\01L_selector_data(init)", ptr @".str.7.@16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEABycfcTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_implProperty]], ptr @".str.7.i16@0:8", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvgTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_setImplProperty_]], ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvsTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_mainMethod_]], ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE10mainMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(copyWithZone:)", ptr @".str.11.@24@0:8^v16", ptr @"$sSo9ImplClassC19objc_implementationE4copy4withypSg10ObjectiveC6NSZoneVSg_tFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(dealloc)", ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEfDTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data__cxx_destruct]], ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassCfETo{{(\.ptrauth)?}}" }] }, section "__DATA, __objc_data", align 8
 // CHECK: [[_IVARS_ImplClass:@[^, ]+]] = internal constant { i32, i32, [2 x { ptr, ptr, ptr, i32, i32 }] } { i32 32, i32 2, [2 x { ptr, ptr, ptr, i32, i32 }] [{ ptr, ptr, ptr, i32, i32 } { ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvpWvd", ptr @.str.12.implProperty, ptr @.str.0., i32 2, i32 4 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo9ImplClassC19objc_implementationE13implProperty2So8NSObjectCSgvpWvd", ptr @.str.13.implProperty2, ptr @.str.0., i32 3, i32 8 }] }, section "__DATA, __objc_const", align 8

--- a/test/IRGen/preserve_for_debugger.swift
+++ b/test/IRGen/preserve_for_debugger.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swiftc_driver %s -g -Onone -emit-ir | %FileCheck %s
+
+// Check that unused functions are preserved at Onone.
+func unused() {
+}
+
+// Property wrappers generate transparent getters, which we would like to check still exist at Onone.
+@propertyWrapper
+struct IntWrapper {
+  private var storage = 42
+    var wrappedValue: Int {
+      return storage
+    }
+}
+
+public class User {
+  @IntWrapper private var number: Int
+
+  func f() {
+    // Force the generation of the getter
+    _ = self.number 
+  }
+}
+let c = User()
+c.f()
+
+// CHECK: !DISubprogram(name: "unused", linkageName: "$s21preserve_for_debugger6unusedyyF"
+// CHECK: !DISubprogram(name: "number.get"

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_distinct_generic_class.swift
@@ -117,18 +117,6 @@ func doit() {
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
-// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
-// CHECK-SAME:     ptr undef, 
-// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
-// CHECK-SAME:   )
-//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
-//      CHECK: }
-
-
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]LLCyAA9Argument1ACLLCySiGAA9Argument2ACLLCySSGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {{(section)?.*}}{
 //         CHECK: entry:
 //         CHECK:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
@@ -147,3 +135,13 @@ doit()
 //   CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }
 
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
+// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:   )
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_different_value.swift
@@ -109,18 +109,6 @@ func doit() {
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
-// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
-// CHECK-SAME:     ptr undef, 
-// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//      CHECK:   )
-//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
-//      CHECK: }
-
-
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]LLCyAA9Argument1ACLLCySiGAFySSGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {{(section)?.*}}{
 //         CHECK: entry:
 //         CHECK:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
@@ -141,4 +129,13 @@ doit()
 //   CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }
 
-
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
+// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:   )
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-2argument-1_distinct_use-1st_argument_generic_class-2nd_argument_same_generic_class_same_value.swift
@@ -108,20 +108,6 @@ func doit() {
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK: entry:
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
-// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
-// CHECK-SAME:     ptr undef, 
-// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
-// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMz
-//      CHECK:   )
-//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
-//      CHECK: }
-
-
 //             CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]LLCyAA9Argument1ACLLCySiGAGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {{(section)?.*}}{
 //             CHECK: entry:
 //             CHECK:  call swiftcc %swift.metadata_response @"$s4main9Argument1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
@@ -141,3 +127,16 @@ doit()
 //       CHECK-apple:  [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //       CHECK-apple:  ret %swift.metadata_response [[METADATA_RESPONSE]]
 //             CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT1_METADATA:%[0-9]+]], ptr [[ARGUMENT2_METADATA:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: entry:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr [[ARGUMENT1_METADATA]], 
+// CHECK-SAME:     ptr [[ARGUMENT2_METADATA]], 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMz
+//      CHECK:   )
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_con_double.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_con_double.swift
@@ -122,6 +122,18 @@ func doit() {
 }
 doit()
 
+//         CHECK: ; Function Attrs: noinline nounwind memory(none)
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) #{{[0-9]+}} {{(section)?.*}}{
+//         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+// CHECK-unknown:   ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
 //      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
@@ -161,18 +173,6 @@ doit()
 // CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
-
-//         CHECK: ; Function Attrs: noinline nounwind memory(none)
-//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) #{{[0-9]+}} {{(section)?.*}}{
-//         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
-//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
-// CHECK-unknown:   ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
-//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
-//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
-//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
-//         CHECK: }
 
 // CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] {{%[0-9]+}})
 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_subclass_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_con_int-2nd_anc_gen-1st-arg_subclass_arg.swift
@@ -120,6 +120,19 @@ func doit() {
 }
 doit()
 
+//         CHECK: ; Function Attrs: noinline nounwind memory(none)
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) #{{[0-9]+}} {{(section)?.*}}{
+//         CHECK: entry:
+//         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
+// CHECK-unknown:   ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
 //      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
@@ -155,19 +168,6 @@ doit()
 // CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
-
-//         CHECK: ; Function Attrs: noinline nounwind memory(none)
-//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CySSGMb"([[INT]] {{%[0-9]+}}) #{{[0-9]+}} {{(section)?.*}}{
-//         CHECK: entry:
-//         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
-//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]CySiGMb"([[INT]] 0)
-// CHECK-unknown:   ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
-//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]CySSGMf" 
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
-//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
-//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
-//         CHECK: }
 
 // CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]CySiGMb"([[INT]] {{%[0-9]+}})
 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subclass_arg-2nd_anc_gen-1st-arg_con_int.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subclass_arg-2nd_anc_gen-1st-arg_con_int.swift
@@ -120,6 +120,19 @@ func doit() {
 }
 doit()
 
+//         CHECK: ; Function Attrs: noinline nounwind memory(none)
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] {{%[0-9]+}}) #{{[0-9]+}} {{(section)?.*}}{
+//         CHECK: entry:
+//         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
+//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+// CHECK-unknown:   ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]LLCySSGMf" 
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
 //      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
 //      CHECK:   call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
@@ -155,19 +168,6 @@ doit()
 // CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
-
-//         CHECK: ; Function Attrs: noinline nounwind memory(none)
-//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] {{%[0-9]+}}) #{{[0-9]+}} {{(section)?.*}}{
-//         CHECK: entry:
-//         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] 0)
-//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
-// CHECK-unknown:   ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
-//    CHECK-SAME:        @"$s4main5Value[[UNIQUE_ID_1]]LLCySSGMf" 
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
-//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
-//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
-//         CHECK: }
 
 // CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySSGMb"([[INT]] {{%[0-9]+}})
 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1arg-2ancs-1distinct_use-1st_anc_gen-1arg-1st_arg_subcls_arg-2nd_anc_gen-1st-arg_subcls_arg.swift
@@ -118,6 +118,19 @@ func doit() {
 }
 doit()
 
+//         CHECK: ; Function Attrs: noinline nounwind memory(none)
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
+//         CHECK: entry:
+//         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
+// CHECK-unknown:   ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+//         CHECK: }
+
 //      CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr [[ARGUMENT:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
@@ -153,19 +166,6 @@ doit()
 // CHECK-SAME:   )
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
-
-//         CHECK: ; Function Attrs: noinline nounwind memory(none)
-//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
-//         CHECK: entry:
-//         CHECK:   call swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
-//     CHECK-NOT:   call swiftcc %swift.metadata_response @"$s4main9Ancestor2[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] 0)
-// CHECK-unknown:   ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
-//    CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCySiGMf
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
-//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
-//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
-//         CHECK: }
 
 
 // CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCySiGMb"

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-fileprivate.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-fileprivate.swift
@@ -95,8 +95,6 @@ doit()
 //              CHECK:   call swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"
 //              CHECK: }
 
-//              CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCMa"
-
 //              CHECK: ; Function Attrs: noinline nounwind memory(none)
 //              CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
 //         CHECK-NEXT: entry:
@@ -109,4 +107,5 @@ doit()
 //        CHECK-apple:   ret %swift.metadata_response [[COMPLETE_RESPONSE]]
 //              CHECK: }
 
+//              CHECK: define internal swiftcc %swift.metadata_response @"$s4main9Ancestor1[[UNIQUE_ID_1]]LLCMa"
 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use-1st_argument_generic_class-1argument.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use-1st_argument_generic_class-1argument.swift
@@ -183,6 +183,16 @@ func doit() {
 }
 doit()
 
+// CHECK:; Function Attrs: noinline nounwind memory(none)
+//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMb"([[INT]] [[REQUEST:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
+// CHECK-unknown:    ret
+//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+//    CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf
+//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
+//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+// CHECK: }
+
 //      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 //      CHECK: entry:
 //      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
@@ -195,12 +205,3 @@ doit()
 //      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 //      CHECK: }
 
-// CHECK:; Function Attrs: noinline nounwind memory(none)
-//         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMb"([[INT]] [[REQUEST:%[0-9]+]]) #{{[0-9]+}} {{(section)?.*}}{
-// CHECK-unknown:    ret
-//   CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
-//    CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CyAA9Argument1ACLLCySiGGMf
-//   CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
-//   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
-//   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
-// CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use.swift
@@ -85,6 +85,14 @@ func doit() {
 }
 doit()
 
+// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]CySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {{(section)?.*}}{
+// CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
+// CHECK-apple-SAME:    $s4main5Value[[UNIQUE_ID_1]]CySiGMf
+// CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
+// CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
+// CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
+// CHECK: }
+
 // CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
 // CHECK:        call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
 // CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
@@ -95,11 +103,3 @@ doit()
 // CHECK:   ret %swift.metadata_response {{%[0-9]+}}
 // CHECK: }
 
-
-// CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_4]]CySiGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]}} {{(section)?.*}}{
-// CHECK-apple:  [[INITIALIZED_CLASS:%[0-9]+]] = call ptr @objc_opt_self(
-// CHECK-apple-SAME:    $s4main5Value[[UNIQUE_ID_1]]CySiGMf
-// CHECK-apple:   [[PARTIAL_METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response undef, ptr [[INITIALIZED_CLASS]], 0
-// CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
-// CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
-// CHECK: }

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class.swift
@@ -100,17 +100,6 @@ func doit() {
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK: entry:
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     ptr %1, 
-// CHECK-SAME:     ptr undef, 
-// CHECK-SAME:     ptr undef, 
-// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
-//      CHECK: }
-
 //         CHECK: ; Function Attrs: noinline nounwind memory(none)
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
 //         CHECK: entry:
@@ -122,4 +111,15 @@ doit()
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: entry:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_class_specialized_at_generic_class.swift
@@ -109,18 +109,6 @@ func doit() {
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK: entry:
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-//      CHECK:     [[INT]] [[METADATA_REQUEST]],
-//      CHECK:     ptr %1,
-//      CHECK:     ptr undef,
-//      CHECK:     ptr undef,
-// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
-//      CHECK:   )
-//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
-//      CHECK: }
-
 //         CHECK: ; Function Attrs: noinline nounwind memory(none)
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCyAA3BoxACLLCyAA5InnerACLLCySiGGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
 //         CHECK: entry:
@@ -137,5 +125,17 @@ doit()
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]LLCMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: entry:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]],
+//      CHECK:     ptr %1,
+//      CHECK:     ptr undef,
+//      CHECK:     ptr undef,
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]LLCMn
+//      CHECK:   )
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
 
 

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_enum.swift
@@ -5,7 +5,9 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-//              CHECK: @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]CyAA6EitherACLLOySiGGMf" = linkonce_odr hidden 
+// CHECK: @"$s4main6Either[[UNIQUE_ID_1:[A-Za-z0-9_]+]]OySiGMf" =
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMf" = linkonce_odr hidden 
 //   CHECK-apple-SAME: global 
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
@@ -92,7 +94,6 @@
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main6Either[[UNIQUE_ID_1]]OySiGMf" =
 
 fileprivate class Value<First> {
   let first_Value: First
@@ -125,17 +126,6 @@ func doit() {
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK: entry:
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
-//      CHECK:     ptr %1, 
-//      CHECK:     ptr undef, 
-//      CHECK:     ptr undef, 
-// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
-//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
-//      CHECK: }
-
 //         CHECK: ; Function Attrs: noinline nounwind memory(none)
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA6EitherACLLOySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
 // CHECK-unknown: ret
@@ -153,3 +143,15 @@ doit()
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: entry:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+//      CHECK:     [[INT]] [[METADATA_REQUEST]], 
+//      CHECK:     ptr %1, 
+//      CHECK:     ptr undef, 
+//      CHECK:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }
+

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1distinct_use_generic_struct.swift
@@ -5,7 +5,9 @@
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
-//              CHECK: @"$s4main5Value[[UNIQUE_ID_1:[A-Za-z0-9_]+]]CyAA4LeftACLLVySiGGMf" = linkonce_odr hidden 
+// CHECK: @"$s4main4Left[[UNIQUE_ID_1:[A-Za-z0-9_]+]]VySiGMf" =
+
+//              CHECK: @"$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMf" = linkonce_odr hidden 
 //   CHECK-apple-SAME: global 
 // CHECK-unknown-SAME: constant 
 //         CHECK-SAME: <{
@@ -64,7 +66,6 @@
 //         CHECK-SAME: }>,
 //         CHECK-SAME: align [[ALIGNMENT]]
 
-// CHECK: @"$s4main4Left[[UNIQUE_ID_1]]VySiGMf" =
 
 fileprivate class Value<First> {
   let first_Value: First
@@ -96,17 +97,6 @@ func doit() {
 }
 doit()
 
-//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
-//      CHECK: entry:
-//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
-// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
-// CHECK-SAME:     ptr %1, 
-// CHECK-SAME:     ptr undef, 
-// CHECK-SAME:     ptr undef, 
-// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
-//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
-//      CHECK: }
-
 //         CHECK: ; Function Attrs: noinline nounwind memory(none)
 //         CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CyAA4LeftACLLVySiGGMb"([[INT]] {{%[0-9]+}}) {{#[0-9]+}} {{(section)?.*}}{
 // CHECK-unknown: ret
@@ -117,3 +107,14 @@ doit()
 //   CHECK-apple:   [[METADATA_RESPONSE:%[0-9]+]] = insertvalue %swift.metadata_response [[PARTIAL_METADATA_RESPONSE]], [[INT]] 0, 1
 //   CHECK-apple:   ret %swift.metadata_response [[METADATA_RESPONSE]]
 //         CHECK: }
+
+//      CHECK: define internal swiftcc %swift.metadata_response @"$s4main5Value[[UNIQUE_ID_1]]CMa"([[INT]] [[METADATA_REQUEST:%[0-9]+]], ptr %1) #{{[0-9]+}} {{(section)?.*}}{
+//      CHECK: entry:
+//      CHECK:   {{%[0-9]+}} = call swiftcc %swift.metadata_response @__swift_instantiateCanonicalPrespecializedGenericMetadata(
+// CHECK-SAME:     [[INT]] [[METADATA_REQUEST]], 
+// CHECK-SAME:     ptr %1, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     ptr undef, 
+// CHECK-SAME:     $s4main5Value[[UNIQUE_ID_1]]CMn
+//      CHECK:   ret %swift.metadata_response {{%[0-9]+}}
+//      CHECK: }

--- a/test/IRGen/weak_import_deployment_target.swift
+++ b/test/IRGen/weak_import_deployment_target.swift
@@ -23,11 +23,11 @@ public func callsNew() {
 }
 
 // CHECK-OLD-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper13hasDefaultArgyySiF"(i64)
+// CHECK-OLD-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper8functionSiyF"()
 // CHECK-OLD-LABEL: declare extern_weak swiftcc void @"$s36weak_import_deployment_target_helper22hasAvailableDefaultArgyySiF"(i64)
 // CHECK-OLD-LABEL: declare extern_weak swiftcc i64 @"$s36weak_import_deployment_target_helper17availableFunctionSiyF"()
-// CHECK-OLD-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper8functionSiyF"()
 
 // CHECK-NEW-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper13hasDefaultArgyySiF"(i64)
+// CHECK-NEW-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper8functionSiyF"()
 // CHECK-NEW-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper22hasAvailableDefaultArgyySiF"(i64)
 // CHECK-NEW-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper17availableFunctionSiyF"()
-// CHECK-NEW-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper8functionSiyF"()

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -335,6 +335,8 @@ public func test() {
 // CHECK-NEXT: unreachable
 // CHECK-NEXT: }
 
+// CHECK: i32 @__gxx_personality_v0(...)
+
 // CHECK: define {{.*}} @"$s4test0A11MethodCallss5Int32VyF"() #[[#SWIFTUWMETA]] personality
 // CHECK: call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
 // CHECK: invoke i32 @_ZNK9TestClass6methodEi
@@ -465,10 +467,7 @@ public func test() {
 // CHECK-NOT: invoke
 // CHECK: }
 
-// CHECK: i32 @__gxx_personality_v0(...)
-
 // CHECK: attributes #[[#SWIFTMETA]] = {
-// CHECK-NOT: uwtable
 // CHECK: attributes #[[#SWIFTUWMETA]] = {
 // CHECK-SAME: uwtable
 

--- a/test/Profiler/coverage_dead_code_elim_onone.swift
+++ b/test/Profiler/coverage_dead_code_elim_onone.swift
@@ -1,8 +1,9 @@
 // RUN: %target-swift-frontend -emit-sil  -profile-generate -profile-coverage-mapping -module-name coverage_deadcode %s | %FileCheck %s -check-prefix SIL
 // RUN: %target-swift-frontend -emit-ir -profile-generate -profile-coverage-mapping -module-name coverage_deadcode %s | %FileCheck %s -check-prefix IR
 
-// This function needs to be present in the SIL for the mandatory passes, but
-// we can drop it in IRGen. We still need to emit its coverage map though.
+// This function needs to be present in the SIL for the mandatory passes, 
+// and in the IR as it may be used in the debugger, we need to emit its 
+// coverage map as well.
 func unused() -> Int { 5 }
 
 // SIL: sil hidden @$s17coverage_deadcode6unusedSiyF : $@convention(thin) () -> Int
@@ -11,4 +12,4 @@ func unused() -> Int { 5 }
 // IR: @__covrec
 // IR: @__llvm_coverage_mapping
 // IR: @__llvm_prf_nm
-// IR-NOT: define {{.*}} @"$s17coverage_deadcode6unusedSiyF"
+// IR: define {{.*}} @"$s17coverage_deadcode6unusedSiyF"


### PR DESCRIPTION
Currently, when compiling with no optimizations on, we still delete
functions that are sometimes used in the debugger. For example, users
might want to call functions which are unused, or compiler generated
setters/getters.

rdar://101046198