### PR TITLE
[Runtime] Wrap _checkGenericRequirements for _instantiateCheckedGenericMetadata

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2846,17 +2846,29 @@ const Metadata *swift::_swift_instantiateCheckedGenericMetadata(
     return nullptr;
   }
 
-  DemanglerForRuntimeTypeResolution<StackAllocatedDemangler<2048>> demangler;
+  llvm::SmallVector<const void *, 8> extraArguments;
 
-  llvm::ArrayRef<MetadataOrPack> genericArgsRef(
-      reinterpret_cast<const MetadataOrPack *>(genericArgs), genericArgsSize);
-  llvm::SmallVector<unsigned, 8> genericParamCounts;
-  llvm::SmallVector<const void *, 8> allGenericArgs;
+  for (size_t i = 0; i != genericArgsSize; i += 1) {
+    extraArguments.push_back(genericArgs[i]);
+  }
 
-  auto result = _gatherGenericParameters(context, genericArgsRef,
-                                         /* parent */ nullptr,
-                                         genericParamCounts, allGenericArgs,
-                                         demangler);
+  // Check whether the generic requirements are satisfied, collecting
+  // any extra arguments we need for the instantiation function.
+  //
+  // Note: The extra arguemnts provided are not complete and do not include
+  // witness tables. This is fine for _checkGenericRequirements because it does
+  // not look for any of those.
+  SubstGenericParametersFromMetadata substitutions(context, extraArguments.data());
+
+  auto result = _checkGenericRequirements(
+      context->getGenericContext()->getGenericRequirements(), extraArguments,
+      [&substitutions](unsigned depth, unsigned index) {
+        return substitutions.getMetadata(depth, index).Ptr;
+      },
+      [](const Metadata *type, unsigned index) {
+        // In fact, just don't offer any witness tables if asked for one.
+        return nullptr;
+      }, /* allowsUnresolvedSubject */ true);
 
   // _gatherGenericParameters returns llvm::None on success.
   if (result.hasValue()) {
@@ -2865,7 +2877,7 @@ const Metadata *swift::_swift_instantiateCheckedGenericMetadata(
 
   auto accessFunction = context->getAccessFunction();
 
-  return accessFunction(MetadataState::Complete, allGenericArgs).Value;
+  return accessFunction(MetadataState::Complete, extraArguments).Value;
 }
 
 #if SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -523,7 +523,8 @@ public:
       llvm::ArrayRef<GenericRequirementDescriptor> requirements,
       llvm::SmallVectorImpl<const void *> &extraArguments,
       SubstGenericParameterFn substGenericParam,
-      SubstDependentWitnessTableFn substWitnessTable);
+      SubstDependentWitnessTableFn substWitnessTable,
+      bool allowsUnresolvedSubject = false);
 
   /// A helper function which avoids performing a store if the destination
   /// address already contains the source value.  This is useful when


### PR DESCRIPTION
Previously, callers to `_gatherGenericParameters` had to provide all generic parameters, even non-key ones. This made initializing something like:

```swift
struct A<T> {}

extension A where T == Int {
  struct B {}
}
```
with `B` pretty awkward because the metadata accessor only has a single parameter (the request) and has 0 key arguments. Teach `_gatherGenericParameters` to handle callers only passing in the required key generic parameters.