### PR TITLE
Updated ASTGen.swift

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -4,7 +4,7 @@ import CBasicBridging
 // Needed to use SyntaxTransformVisitor's visit method.
 @_spi(SyntaxTransformVisitor)
 // Needed to use BumpPtrAllocator
-@_spi(RawSyntax)
+@_spi(BumpPtrAllocator) // Update the import statement here
 import SwiftSyntax
 import struct SwiftDiagnostics.Diagnostic
 


### PR DESCRIPTION
In the PR , we've marked BumpPtrAllocator with @_spi(BumpPtrAllocator) and updated the import statement for SwiftSyntax to use @_spi(BumpPtrAllocator) as you requested.

Resolves #68351   

