### PR TITLE
Pass through file-compilation-dir to the ClangImporter.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1553,6 +1553,13 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
       Opts.ExtraArgs.push_back("-fdebug-prefix-map=" + Val);
   }
 
+  if (auto *A = Args.getLastArg(OPT_file_compilation_dir)) {
+    // Forward the -file-compilation-dir flag to correctly set the
+    // debug compilation directory.
+    std::string Val(A->getValue());
+    Opts.ExtraArgs.push_back("-ffile-compilation-dir=" + Val);
+  }
+
   if (FrontendOpts.CASFSRootIDs.empty() &&
       FrontendOpts.ClangIncludeTrees.empty()) {
     if (!workingDirectory.empty()) {

--- a/test/DebugInfo/module-compilation-dir.swift
+++ b/test/DebugInfo/module-compilation-dir.swift
@@ -1,0 +1,6 @@
+// Emit the explicit module.
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-pcm -g -module-name Macro -o %t/Macro.pcm -file-compilation-dir /compdir %S/Inputs/module.modulemap
+// RUN: %llvm-dwarfdump %t/Macro.pcm | %FileCheck %s
+
+// CHECK: DW_AT_comp_dir	("/compdir")


### PR DESCRIPTION
This change passes through the `-file-compilation-dir` flag to the ClangImporter instance as `-ffile-compilation-dir`. When used in conjunction with https://github.com/llvm/llvm-project/pull/67744 this will allow for setting the compilation directory of pcm files using the -file-compilation-dir flag.
