### PR TITLE
[Dependency Scanning] Post-process imports that fail to resolve against the cache entries added by other resolved imports

### DIFF
--- a/test/ScanDependencies/Inputs/Frameworks/ScannerTestKit.framework/Modules/ScannerTestKit.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/Frameworks/ScannerTestKit.framework/Modules/ScannerTestKit.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.9
+// swift-module-flags: -target arm64-apple-macos10.13 -enable-library-evolution -swift-version 5 -module-name ScannerTestKit
+import Swift

--- a/test/ScanDependencies/Inputs/Frameworks/ScannerTestKit.framework/Modules/ScannerTestKit.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/Frameworks/ScannerTestKit.framework/Modules/ScannerTestKit.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.9
+// swift-module-flags: -target arm64e-apple-macos10.13 -enable-library-evolution -swift-version 5 -module-name ScannerTestKit
+import Swift

--- a/test/ScanDependencies/Inputs/Frameworks/ScannerTestKit.framework/Modules/ScannerTestKit.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/Frameworks/ScannerTestKit.framework/Modules/ScannerTestKit.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.9
+// swift-module-flags: -target x86_64-apple-macos10.13 -enable-library-evolution -swift-version 5 -module-name ScannerTestKit
+import Swift

--- a/test/ScanDependencies/Inputs/Frameworks/WithAuxClangModule.framework/Headers/AuxClangModule.h
+++ b/test/ScanDependencies/Inputs/Frameworks/WithAuxClangModule.framework/Headers/AuxClangModule.h
@@ -1,0 +1,1 @@
+void funcAux(void);

--- a/test/ScanDependencies/Inputs/Frameworks/WithAuxClangModule.framework/Headers/WithAuxClangModule.h
+++ b/test/ScanDependencies/Inputs/Frameworks/WithAuxClangModule.framework/Headers/WithAuxClangModule.h
@@ -1,0 +1,2 @@
+#include "WithAuxClangModule/AuxClangModule.h"
+void funcWithAux(void);

--- a/test/ScanDependencies/Inputs/Frameworks/WithAuxClangModule.framework/Modules/module.modulemap
+++ b/test/ScanDependencies/Inputs/Frameworks/WithAuxClangModule.framework/Modules/module.modulemap
@@ -1,0 +1,9 @@
+framework module WithAuxClangModule {
+  header "WithAuxClangModule.h"
+  export *
+}
+
+framework module AuxClangModule {
+  header "AuxClangModule.h"
+  export *
+}

--- a/test/ScanDependencies/clang_auxiliary_module_framework.swift
+++ b/test/ScanDependencies/clang_auxiliary_module_framework.swift
@@ -1,0 +1,20 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -F %S/Inputs/Frameworks -verify
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+// Ensure that round-trip serialization does not affect result
+// RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -F %S/Inputs/Frameworks -verify
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+import WithAuxClangModule
+import AuxClangModule
+
+// CHECK: "mainModuleName": "deps"
+// CHECK: directDependencies
+// CHECK-DAG: "clang": "WithAuxClangModule"
+// CHECK-DAG: "clang": "AuxClangModule"
+// CHECK-DAG: "swift": "Swift"
+// CHECK-DAG: "swift": "SwiftOnoneSupport"
+// CHECK: ],

--- a/test/ScanDependencies/module_framework.swift
+++ b/test/ScanDependencies/module_framework.swift
@@ -1,23 +1,20 @@
+// REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -Xcc -Xclang
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -F %S/Inputs/Frameworks
 // Check the contents of the JSON output
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // Ensure that round-trip serialization does not affect result
-// RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -swift-version 4 -Xcc -Xclang
+// RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization %s -o %t/deps.json -emit-dependencies -emit-dependencies-path %t/deps.d -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -F %S/Inputs/Frameworks
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
-// REQUIRES: OS=macosx
-
-import CryptoKit
+import ScannerTestKit
 
 // CHECK: "mainModuleName": "deps"
 // CHECK: directDependencies
-// CHECK-DAG: "swift": "CryptoKit"
+// CHECK-DAG: "swift": "ScannerTestKit"
 // CHECK-DAG: "swift": "Swift"
 // CHECK-DAG: "swift": "SwiftOnoneSupport"
-// CHECK-DAG: "swift": "_Concurrency"
-// CHECK-DAG: "swift": "_StringProcessing"
 // CHECK: ],
 
 // CHECK: "isFramework": true


### PR DESCRIPTION
It is possible that import resolution failed because we are attempting to resolve a module which can only be brought in via a `.modulemap` of a different Clang module dependency which is not otherwise on the current search paths. For example, suppose we are scanning a `.swiftinterface` for module `Foo`, which contains:
```
@_exported import Foo
import Bar
...
```
Where `Foo` is the underlying Framework clang module whose `.modulemap` defines an auxiliary module `Bar`. Because `Foo` is a framework, its `.modulemap` is under `<some_framework_search_path>/Foo.framework/Modules/module.modulemap`. Which means that lookup of `Bar` alone from Swift will not be able to locate the module in it. However, the lookup of `Foo` will itself bring in the auxiliary module because the Clang scanner instance scanning for clang module `Foo` will be able to find it in the corresponding framework module's `.modulemap` and register it as a dependency which means it will be registered with the scanner's cache. To handle such cases, we first add all successfully-resolved modules and (for Clang modules) their transitive dependencies to the cache, and then attempt to re-query imports for which resolution originally failed from the cache. If this fails, then the scanner genuinely failed to resolve this dependency.