### PR TITLE
[embedded] Add an embedded test for -enable-import-ptrauth-field-function-pointers, fix deserialization

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2368,7 +2368,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILValue op = getLocalValue(
         ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     auto accessKind = SILAccessKind(Attr & 0x3);
-    auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x3);
+    auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x07);
     bool noNestedConflict = (Attr >> 4) & 0x01;
     bool fromBuiltin = (Attr >> 5) & 0x01;
     ResultInst = Builder.createBeginAccess(Loc, op, accessKind, enforcement,
@@ -2410,7 +2410,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getLocalValue(ValID2, getSILType(MF->getType(TyID2),
                                          (SILValueCategory)TyCategory2, Fn));
     auto accessKind = SILAccessKind(Attr & 0x3);
-    auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x03);
+    auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x07);
     bool noNestedConflict = (Attr >> 4) & 0x01;
     bool fromBuiltin = (Attr >> 5) & 0x01;
     ResultInst = Builder.createBeginUnpairedAccess(
@@ -2422,7 +2422,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILValue op = getLocalValue(
         ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     bool aborted = Attr & 0x1;
-    auto enforcement = SILAccessEnforcement((Attr >> 1) & 0x03);
+    auto enforcement = SILAccessEnforcement((Attr >> 1) & 0x07);
     bool fromBuiltin = (Attr >> 3) & 0x01;
     ResultInst = Builder.createEndUnpairedAccess(Loc, op, enforcement, aborted,
                                                  fromBuiltin);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2369,8 +2369,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     auto accessKind = SILAccessKind(Attr & 0x3);
     auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x07);
-    bool noNestedConflict = (Attr >> 4) & 0x01;
-    bool fromBuiltin = (Attr >> 5) & 0x01;
+    bool noNestedConflict = (Attr >> 5) & 0x01;
+    bool fromBuiltin = (Attr >> 6) & 0x01;
     ResultInst = Builder.createBeginAccess(Loc, op, accessKind, enforcement,
                                            noNestedConflict, fromBuiltin);
     break;
@@ -2411,8 +2411,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                          (SILValueCategory)TyCategory2, Fn));
     auto accessKind = SILAccessKind(Attr & 0x3);
     auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x07);
-    bool noNestedConflict = (Attr >> 4) & 0x01;
-    bool fromBuiltin = (Attr >> 5) & 0x01;
+    bool noNestedConflict = (Attr >> 5) & 0x01;
+    bool fromBuiltin = (Attr >> 6) & 0x01;
     ResultInst = Builder.createBeginUnpairedAccess(
         Loc, source, buffer, accessKind, enforcement, noNestedConflict,
         fromBuiltin);
@@ -2423,7 +2423,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     bool aborted = Attr & 0x1;
     auto enforcement = SILAccessEnforcement((Attr >> 1) & 0x07);
-    bool fromBuiltin = (Attr >> 3) & 0x01;
+    bool fromBuiltin = (Attr >> 4) & 0x01;
     ResultInst = Builder.createEndUnpairedAccess(Loc, op, enforcement, aborted,
                                                  fromBuiltin);
     break;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 809; // typed throws
+const uint16_t SWIFTMODULE_VERSION_MINOR = 810; // access enforcement
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -425,7 +425,7 @@ namespace sil_block {
   using SILOneOperandExtraAttributeLayout = BCRecordLayout<
     SIL_ONE_OPERAND_EXTRA_ATTR,
     SILInstOpCodeField,
-    BCFixed<6>, // Optional attributes
+    BCFixed<7>, // Optional attributes
     TypeIDField, SILTypeCategoryField, ValueIDField
   >;
 
@@ -452,7 +452,7 @@ namespace sil_block {
   using SILTwoOperandsExtraAttributeLayout = BCRecordLayout<
     SIL_TWO_OPERANDS_EXTRA_ATTR,
     SILInstOpCodeField,
-    BCFixed<6>,          // Optional attributes
+    BCFixed<7>,          // Optional attributes
     TypeIDField,
     SILTypeCategoryField,
     ValueIDField,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2029,8 +2029,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     auto *BAI = cast<BeginAccessInst>(&SI);
     unsigned attr = unsigned(BAI->getAccessKind())
                     + (unsigned(BAI->getEnforcement()) << 2)
-                    + (BAI->hasNoNestedConflict() << 4)
-                    + (BAI->isFromBuiltin() << 5);
+                    + (BAI->hasNoNestedConflict() << 5)
+                    + (BAI->isFromBuiltin() << 6);
     SILValue operand = BAI->getOperand();
 
     SILOneOperandExtraAttributeLayout::emitRecord(
@@ -2094,8 +2094,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     auto *BAI = cast<BeginUnpairedAccessInst>(&SI);
     unsigned attr = unsigned(BAI->getAccessKind())
                     + (unsigned(BAI->getEnforcement()) << 2)
-                    + (unsigned(BAI->hasNoNestedConflict()) << 4)
-                    + (unsigned(BAI->isFromBuiltin()) << 5);
+                    + (unsigned(BAI->hasNoNestedConflict()) << 5)
+                    + (unsigned(BAI->isFromBuiltin()) << 6);
     SILValue source = BAI->getSource();
     SILValue buffer = BAI->getBuffer();
 
@@ -2115,7 +2115,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     auto *EAI = cast<EndUnpairedAccessInst>(&SI);
     unsigned attr = unsigned(EAI->isAborting())
                     + (unsigned(EAI->getEnforcement()) << 1)
-                    + (unsigned(EAI->isFromBuiltin()) << 3);
+                    + (unsigned(EAI->isFromBuiltin()) << 4);
     SILValue operand = EAI->getOperand();
 
     SILOneOperandExtraAttributeLayout::emitRecord(

--- a/test/embedded/ptrauth-fieldptr1.swift
+++ b/test/embedded/ptrauth-fieldptr1.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -enable-import-ptrauth-field-function-pointers -O -emit-ir %t/Main.swift -enable-experimental-feature Embedded -import-objc-header %t/header.h | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+// REQUIRES: CPU=arm64e
+
+// BEGIN header.h
+
+struct MyStruct {
+    void (*fptr1)(void);
+    void (*__ptrauth(0, 0, 0x4242) fptr2)(void);
+};
+
+// BEGIN Main.swift
+
+public func test1(x: UnsafePointer<MyStruct>) {
+    x.pointee.fptr1()
+}
+
+public func test2(x: UnsafePointer<MyStruct>) {
+    x.pointee.fptr2()
+}
+
+// CHECK: define {{.*}}@"$s4Main5test11xySPySo8MyStructVG_tF"
+// CHECK:   call {{.*}}[ "ptrauth"(i32 0, i64 0) ]
+// CHECK: define {{.*}}@"$s4Main5test21xySPySo8MyStructVG_tF"
+// CHECK:   call {{.*}}[ "ptrauth"(i32 0, i64 16962) ]

--- a/test/embedded/ptrauth-fieldptr2.swift
+++ b/test/embedded/ptrauth-fieldptr2.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -enable-import-ptrauth-field-function-pointers -O -emit-module -o %t/Module.swiftmodule %t/Module.swift -enable-experimental-feature Embedded -import-objc-header %t/header.h
+
+// RUN: %target-swift-frontend -enable-import-ptrauth-field-function-pointers -O -emit-ir %t/Main.swift -I%t -enable-experimental-feature Embedded -import-objc-header %t/header.h
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+// REQUIRES: CPU=arm64e
+
+// BEGIN header.h
+
+#pragma once
+struct MyStruct {
+    void (*fptr1)(void);
+    void (*__ptrauth(0, 0, 0x4242) fptr2)(void);
+};
+
+// BEGIN Module.swift
+
+public func test1(x: UnsafePointer<MyStruct>) {
+    x.pointee.fptr1()
+}
+
+public func test2(x: UnsafePointer<MyStruct>) {
+    x.pointee.fptr2()
+}
+
+// BEGIN Main.swift
+
+import Module
+
+public func mainfunc(x: UnsafePointer<MyStruct>) {
+    test1(x: x)
+    test2(x: x)
+}
+
+// CHECK: define {{.*}}@"$s4Main5test11xySPySo8MyStructVG_tF"
+// CHECK:   call {{.*}}[ "ptrauth"(i32 0, i64 0) ]
+// CHECK: define {{.*}}@"$s4Main5test21xySPySo8MyStructVG_tF"
+// CHECK:   call {{.*}}[ "ptrauth"(i32 0, i64 16962) ]


### PR DESCRIPTION
Adding an arm64e test execising -enable-import-ptrauth-field-function-pointers, which also surfaced a bug in the deserialization of SILAccessEnforcement::Signed (which is enum case 4, no longer fits into a 0x03 mask).