### PR TITLE
[5.10][Concurrency] An assortment of bug fixes in `Sendable` and actor isolation checking.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -68,10 +68,10 @@ public:
     /// For example, a mutable stored property or synchronous function within
     /// the actor is isolated to the instance of that actor.
     ActorInstance,
-    /// The declaration is explicitly specified to be independent of any actor,
+    /// The declaration is explicitly specified to be not isolated to any actor,
     /// meaning that it can be used from any actor but is also unable to
     /// refer to the isolated state of any given actor.
-    Independent,
+    Nonisolated,
     /// The declaration is isolated to a global actor. It can refer to other
     /// entities with the same global actor.
     GlobalActor,
@@ -104,8 +104,8 @@ public:
     return ActorIsolation(Unspecified, nullptr);
   }
 
-  static ActorIsolation forIndependent() {
-    return ActorIsolation(Independent, nullptr);
+  static ActorIsolation forNonisolated() {
+    return ActorIsolation(Nonisolated, nullptr);
   }
 
   static ActorIsolation forActorInstanceSelf(NominalTypeDecl *actor) {
@@ -128,7 +128,7 @@ public:
 
   bool isUnspecified() const { return kind == Unspecified; }
   
-  bool isIndependent() const { return kind == Independent; }
+  bool isNonisolated() const { return kind == Nonisolated; }
 
   /// Retrieve the parameter to which actor-instance isolation applies.
   ///
@@ -146,7 +146,7 @@ public:
       return true;
 
     case Unspecified:
-    case Independent:
+    case Nonisolated:
       return false;
     }
   }
@@ -195,7 +195,7 @@ public:
       return false;
 
     switch (lhs.getKind()) {
-    case Independent:
+    case Nonisolated:
     case Unspecified:
       return true;
 

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -240,26 +240,6 @@ bool isSameActorIsolated(ValueDecl *value, DeclContext *dc);
 /// Determines whether this function's body uses flow-sensitive isolation.
 bool usesFlowSensitiveIsolation(AbstractFunctionDecl const *fn);
 
-/// Check if it is safe for the \c globalActor qualifier to be removed from
-/// \c ty, when the function value of that type is isolated to that actor.
-///
-/// In general this is safe in a narrow but common case: a global actor
-/// qualifier can be dropped from a function type while in a DeclContext
-/// isolated to that same actor, as long as the value is not Sendable.
-///
-/// \param dc the innermost context in which the cast to remove the global actor
-///           is happening.
-/// \param globalActor global actor that was dropped from \c ty.
-/// \param ty a function type where \c globalActor was removed from it.
-/// \param getClosureActorIsolation function that knows how to produce accurate
-///        information about the isolation of a closure.
-/// \return true if it is safe to drop the global-actor qualifier.
-bool safeToDropGlobalActor(
-                DeclContext *dc, Type globalActor, Type ty,
-                llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
-                    getClosureActorIsolation =
-                        __AbstractClosureExpr_getActorIsolation);
-
 void simple_display(llvm::raw_ostream &out, const ActorIsolation &state);
 
 } // end namespace swift

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5236,8 +5236,9 @@ ERROR(concurrent_access_of_inout_param,none,
       "concurrently-executing code",
       (DeclName))
 ERROR(non_sendable_capture,none,
-      "capture of %1 with non-sendable type %0 in a `@Sendable` closure",
-      (Type, DeclName))
+      "capture of %1 with non-sendable type %0 in a `@Sendable` "
+      "%select{local function|closure}2",
+      (Type, DeclName, bool))
 ERROR(implicit_async_let_non_sendable_capture,none,
       "capture of %1 with non-sendable type %0 in 'async let' binding",
       (Type, DeclName))

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3967,7 +3967,7 @@ public:
 
     case ActorIsolation::ActorInstance:
       return ClosureActorIsolation::forActorInstance(
-          actorIsolation.getCapturedActor(), preconcurrency);
+          actorIsolation.getActorInstance(), preconcurrency);
 
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3774,92 +3774,6 @@ public:
   }
 };
 
-/// Actor isolation for a closure.
-class ClosureActorIsolation {
-public:
-  enum Kind {
-    /// The closure is not isolated to any actor.
-    Nonisolated,
-
-    /// The closure is tied to the actor instance described by the given
-    /// \c VarDecl*, which is the (captured) `self` of an actor.
-    ActorInstance,
-
-    /// The closure is tied to the global actor described by the given type.
-    GlobalActor,
-  };
-
-private:
-    /// The actor to which this closure is isolated, plus a bit indicating
-    /// whether the isolation was imposed by a preconcurrency declaration.
-    ///
-    /// There are three possible states for the pointer:
-    ///   - NULL: The closure is independent of any actor.
-    ///   - VarDecl*: The 'self' variable for the actor instance to which
-    ///     this closure is isolated. It will always have a type that conforms
-    ///     to the \c Actor protocol.
-    ///   - Type: The type of the global actor on which
-  llvm::PointerIntPair<llvm::PointerUnion<VarDecl *, Type>, 1, bool> storage;
-
-  ClosureActorIsolation(VarDecl *selfDecl, bool preconcurrency)
-      : storage(selfDecl, preconcurrency) { }
-  ClosureActorIsolation(Type globalActorType, bool preconcurrency)
-      : storage(globalActorType, preconcurrency) { }
-
-public:
-  ClosureActorIsolation(bool preconcurrency = false)
-      : storage(nullptr, preconcurrency) { }
-
-  static ClosureActorIsolation forNonisolated(bool preconcurrency) {
-    return ClosureActorIsolation(preconcurrency);
-  }
-
-  static ClosureActorIsolation forActorInstance(VarDecl *selfDecl,
-                                                bool preconcurrency) {
-    return ClosureActorIsolation(selfDecl, preconcurrency);
-  }
-
-  static ClosureActorIsolation forGlobalActor(Type globalActorType,
-                                              bool preconcurrency) {
-    return ClosureActorIsolation(globalActorType, preconcurrency);
-  }
-
-  /// Determine the kind of isolation.
-  Kind getKind() const {
-    if (storage.getPointer().isNull())
-      return Kind::Nonisolated;
-
-    if (storage.getPointer().is<VarDecl *>())
-      return Kind::ActorInstance;
-
-    return Kind::GlobalActor;
-  }
-
-  /// Whether the closure is isolated at all.
-  explicit operator bool() const {
-    return getKind() != Kind::Nonisolated;
-  }
-
-  /// Whether the closure is isolated at all.
-  operator Kind() const {
-    return getKind();
-  }
-
-  VarDecl *getActorInstance() const {
-    return storage.getPointer().dyn_cast<VarDecl *>();
-  }
-
-  Type getGlobalActor() const {
-    return storage.getPointer().dyn_cast<Type>();
-  }
-
-  bool preconcurrency() const {
-    return storage.getInt();
-  }
-
-  ActorIsolation getActorIsolation() const;
-};
-
 /// A base class for closure expressions.
 class AbstractClosureExpr : public DeclContext, public Expr {
   CaptureInfo Captures;
@@ -3955,29 +3869,6 @@ public:
 
   void setActorIsolation(ActorIsolation actorIsolation) {
     this->actorIsolation = actorIsolation;
-  }
-
-  ClosureActorIsolation getClosureActorIsolation() const {
-    bool preconcurrency = actorIsolation.preconcurrency();
-
-    switch (actorIsolation) {
-    case ActorIsolation::Unspecified:
-    case ActorIsolation::Nonisolated:
-      return ClosureActorIsolation::forNonisolated(preconcurrency);
-
-    case ActorIsolation::ActorInstance:
-      return ClosureActorIsolation::forActorInstance(
-          actorIsolation.getActorInstance(), preconcurrency);
-
-    case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
-      return ClosureActorIsolation::forGlobalActor(
-          actorIsolation.getGlobalActor(), preconcurrency);
-    }
-  }
-
-  void setActorIsolation(ClosureActorIsolation closureIsolation) {
-    this->actorIsolation = closureIsolation.getActorIsolation();
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3948,7 +3948,9 @@ public:
   /// returns nullptr if the closure doesn't have a body
   BraceStmt *getBody() const;
 
-  ClosureActorIsolation getActorIsolation() const { return actorIsolation; }
+  ClosureActorIsolation getClosureActorIsolation() const {
+    return actorIsolation;
+  }
 
   void setActorIsolation(ClosureActorIsolation actorIsolation) {
     this->actorIsolation = actorIsolation;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3778,8 +3778,8 @@ public:
 class ClosureActorIsolation {
 public:
   enum Kind {
-    /// The closure is independent of any actor.
-    Independent,
+    /// The closure is not isolated to any actor.
+    Nonisolated,
 
     /// The closure is tied to the actor instance described by the given
     /// \c VarDecl*, which is the (captured) `self` of an actor.
@@ -3810,7 +3810,7 @@ public:
   ClosureActorIsolation(bool preconcurrency = false)
       : storage(nullptr, preconcurrency) { }
 
-  static ClosureActorIsolation forIndependent(bool preconcurrency) {
+  static ClosureActorIsolation forNonisolated(bool preconcurrency) {
     return ClosureActorIsolation(preconcurrency);
   }
 
@@ -3827,7 +3827,7 @@ public:
   /// Determine the kind of isolation.
   Kind getKind() const {
     if (storage.getPointer().isNull())
-      return Kind::Independent;
+      return Kind::Nonisolated;
 
     if (storage.getPointer().is<VarDecl *>())
       return Kind::ActorInstance;
@@ -3837,7 +3837,7 @@ public:
 
   /// Whether the closure is isolated at all.
   explicit operator bool() const {
-    return getKind() != Kind::Independent;
+    return getKind() != Kind::Nonisolated;
   }
 
   /// Whether the closure is isolated at all.

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -131,7 +131,7 @@ class CompletionLookup final : public swift::VisibleDeclConsumer {
   bool CanCurrDeclContextHandleAsync = false;
   /// Actor isolations that were determined during constraint solving but that
   /// haven't been saved to the AST.
-  llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+  llvm::DenseMap<AbstractClosureExpr *, ActorIsolation>
       ClosureActorIsolations;
   bool HaveDot = false;
   bool IsUnwrappedOptional = false;
@@ -253,7 +253,7 @@ public:
   }
 
   void setClosureActorIsolations(
-      llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+      llvm::DenseMap<AbstractClosureExpr *, ActorIsolation>
           ClosureActorIsolations) {
     this->ClosureActorIsolations = ClosureActorIsolations;
   }

--- a/include/swift/IDE/PostfixCompletion.h
+++ b/include/swift/IDE/PostfixCompletion.h
@@ -63,7 +63,7 @@ class PostfixCompletionCallback : public TypeCheckCompletionCallback {
 
     /// Actor isolations that were determined during constraint solving but that
     /// haven't been saved to the AST.
-    llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+    llvm::DenseMap<AbstractClosureExpr *, ActorIsolation>
         ClosureActorIsolations;
 
     /// Checks whether this result has the same \c BaseTy and \c BaseDecl as

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -318,9 +318,9 @@ namespace swift {
   bool completionContextUsesConcurrencyFeatures(const DeclContext *dc);
 
   /// Determine the isolation of a particular closure.
-  ClosureActorIsolation determineClosureActorIsolation(
+  ActorIsolation determineClosureActorIsolation(
       AbstractClosureExpr *closure, llvm::function_ref<Type(Expr *)> getType,
-      llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+      llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
           getClosureActorIsolation);
 
   /// If the capture list shadows any declarations using shorthand syntax, i.e.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2592,7 +2592,7 @@ public:
     PrintWithColorRAII(OS, DiscriminatorColor)
       << " discriminator=" << E->getRawDiscriminator();
 
-    switch (auto isolation = E->getActorIsolation()) {
+    switch (auto isolation = E->getClosureActorIsolation()) {
     case ClosureActorIsolation::Nonisolated:
       break;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2592,16 +2592,18 @@ public:
     PrintWithColorRAII(OS, DiscriminatorColor)
       << " discriminator=" << E->getRawDiscriminator();
 
-    switch (auto isolation = E->getClosureActorIsolation()) {
-    case ClosureActorIsolation::Nonisolated:
+    switch (auto isolation = E->getActorIsolation()) {
+    case ActorIsolation::Unspecified:
+    case ActorIsolation::Nonisolated:
       break;
 
-    case ClosureActorIsolation::ActorInstance:
+    case ActorIsolation::ActorInstance:
       PrintWithColorRAII(OS, CapturesColor) << " actor-isolated="
         << isolation.getActorInstance()->printRef();
       break;
 
-    case ClosureActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
       PrintWithColorRAII(OS, CapturesColor) << " global-actor-isolated="
         << isolation.getGlobalActor().getString();
       break;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2593,7 +2593,7 @@ public:
       << " discriminator=" << E->getRawDiscriminator();
 
     switch (auto isolation = E->getActorIsolation()) {
-    case ClosureActorIsolation::Independent:
+    case ClosureActorIsolation::Nonisolated:
       break;
 
     case ClosureActorIsolation::ActorInstance:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10501,6 +10501,33 @@ void swift::simple_display(llvm::raw_ostream &out, AnyFunctionRef fn) {
     out << "closure";
 }
 
+ActorIsolation::ActorIsolation(Kind kind, NominalTypeDecl *actor,
+                               unsigned parameterIndex)
+    : actorInstance(actor), kind(kind), 
+      isolatedByPreconcurrency(false),
+      parameterIndex(parameterIndex) { }
+
+ActorIsolation::ActorIsolation(Kind kind, VarDecl *capturedActor)
+    : actorInstance(capturedActor), kind(kind),
+      isolatedByPreconcurrency(false), 
+      parameterIndex(0) { }
+
+NominalTypeDecl *ActorIsolation::getActor() const {
+  assert(getKind() == ActorInstance);
+
+  if (auto *instance = actorInstance.dyn_cast<VarDecl *>()) {
+    return instance->getTypeInContext()
+        ->getReferenceStorageReferent()->getAnyActor();
+  }
+
+  return actorInstance.get<NominalTypeDecl *>();
+}
+
+VarDecl *ActorIsolation::getCapturedActor() const {
+  assert(getKind() == ActorInstance);
+  return actorInstance.dyn_cast<VarDecl *>();
+}
+
 bool ActorIsolation::isMainActor() const {
   if (isGlobalActor()) {
     if (auto *nominal = getGlobalActor()->getAnyNominal())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2354,7 +2354,7 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
             break;
 
           case ActorIsolation::ActorInstance:
-          case ActorIsolation::Independent:
+          case ActorIsolation::Nonisolated:
           case ActorIsolation::GlobalActor:
             return true;
         }
@@ -10210,7 +10210,7 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
 
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
       switch (auto isolation = closure->getActorIsolation()) {
-      case ClosureActorIsolation::Independent:
+      case ClosureActorIsolation::Nonisolated:
       case ClosureActorIsolation::GlobalActor:
         return false;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10209,7 +10209,7 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
     }
 
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
-      switch (auto isolation = closure->getActorIsolation()) {
+      switch (auto isolation = closure->getClosureActorIsolation()) {
       case ClosureActorIsolation::Nonisolated:
       case ClosureActorIsolation::GlobalActor:
         return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10209,12 +10209,14 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
     }
 
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
-      switch (auto isolation = closure->getClosureActorIsolation()) {
-      case ClosureActorIsolation::Nonisolated:
-      case ClosureActorIsolation::GlobalActor:
+      switch (auto isolation = closure->getActorIsolation()) {
+      case ActorIsolation::Unspecified:
+      case ActorIsolation::Nonisolated:
+      case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
         return false;
 
-      case ClosureActorIsolation::ActorInstance:
+      case ActorIsolation::ActorInstance:
         auto isolatedVar = isolation.getActorInstance();
         return isolatedVar->isSelfParameter() ||
             isolatedVar-isSelfParamCapture();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10237,7 +10237,7 @@ ActorIsolation swift::getActorIsolation(ValueDecl *value) {
 
 ActorIsolation swift::getActorIsolationOfContext(
     DeclContext *dc,
-    llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+    llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation) {
   auto dcToUse = dc;
   // Defer bodies share actor isolation of their enclosing context.
@@ -10253,7 +10253,7 @@ ActorIsolation swift::getActorIsolationOfContext(
     return getActorIsolation(var);
 
   if (auto *closure = dyn_cast<AbstractClosureExpr>(dcToUse)) {
-    return getClosureActorIsolation(closure).getActorIsolation();
+    return getClosureActorIsolation(closure);
   }
 
   if (auto *tld = dyn_cast<TopLevelCodeDecl>(dcToUse)) {
@@ -10523,7 +10523,7 @@ NominalTypeDecl *ActorIsolation::getActor() const {
   return actorInstance.get<NominalTypeDecl *>();
 }
 
-VarDecl *ActorIsolation::getCapturedActor() const {
+VarDecl *ActorIsolation::getActorInstance() const {
   assert(getKind() == ActorInstance);
   return actorInstance.dyn_cast<VarDecl *>();
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -920,7 +920,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
       break;
     }
 
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::Unspecified:
       Out << "nonisolated";
       break;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1875,8 +1875,8 @@ RebindSelfInConstructorExpr::getCalledConstructor(bool &isChainToSuper) const {
 
 ActorIsolation ClosureActorIsolation::getActorIsolation() const {
   switch (getKind()) {
-  case ClosureActorIsolation::Independent:
-    return ActorIsolation::forIndependent().withPreconcurrency(
+  case ClosureActorIsolation::Nonisolated:
+    return ActorIsolation::forNonisolated().withPreconcurrency(
         preconcurrency());
 
   case ClosureActorIsolation::GlobalActor: {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2012,14 +2012,9 @@ Expr *AbstractClosureExpr::getSingleExpressionBody() const {
   return nullptr;
 }
 
-ClosureActorIsolation
+ActorIsolation
 swift::__AbstractClosureExpr_getActorIsolation(AbstractClosureExpr *CE) {
-  return CE->getClosureActorIsolation();
-}
-
-llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
-swift::_getRef__AbstractClosureExpr_getActorIsolation() {
-  return __AbstractClosureExpr_getActorIsolation;
+  return CE->getActorIsolation();
 }
 
 #define FORWARD_SOURCE_LOCS_TO(CLASS, NODE) \

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1890,8 +1890,8 @@ ActorIsolation ClosureActorIsolation::getActorIsolation() const {
         selfDecl->getTypeInContext()->getReferenceStorageReferent()->getAnyActor();
     assert(actor && "Bad closure actor isolation?");
     // FIXME: This could be a parameter... or a capture... hmmm.
-    return ActorIsolation::forActorInstanceSelf(actor).withPreconcurrency(
-        preconcurrency());
+    return ActorIsolation::forActorInstanceCapture(
+        getActorInstance()).withPreconcurrency(preconcurrency());
   }
   }
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2014,7 +2014,7 @@ Expr *AbstractClosureExpr::getSingleExpressionBody() const {
 
 ClosureActorIsolation
 swift::__AbstractClosureExpr_getActorIsolation(AbstractClosureExpr *CE) {
-  return CE->getActorIsolation();
+  return CE->getClosureActorIsolation();
 }
 
 llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1873,29 +1873,6 @@ RebindSelfInConstructorExpr::getCalledConstructor(bool &isChainToSuper) const {
   return otherCtorRef;
 }
 
-ActorIsolation ClosureActorIsolation::getActorIsolation() const {
-  switch (getKind()) {
-  case ClosureActorIsolation::Nonisolated:
-    return ActorIsolation::forNonisolated().withPreconcurrency(
-        preconcurrency());
-
-  case ClosureActorIsolation::GlobalActor: {
-    return ActorIsolation::forGlobalActor(getGlobalActor(), /*unsafe=*/false)
-        .withPreconcurrency(preconcurrency());
-  }
-
-  case ClosureActorIsolation::ActorInstance: {
-    auto selfDecl = getActorInstance();
-    auto actor =
-        selfDecl->getTypeInContext()->getReferenceStorageReferent()->getAnyActor();
-    assert(actor && "Bad closure actor isolation?");
-    // FIXME: This could be a parameter... or a capture... hmmm.
-    return ActorIsolation::forActorInstanceCapture(
-        getActorInstance()).withPreconcurrency(preconcurrency());
-  }
-  }
-}
-
 unsigned AbstractClosureExpr::getDiscriminator() const {
   auto raw = getRawDiscriminator();
   if (raw != InvalidDiscriminator)

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1605,7 +1605,7 @@ SourceLoc MacroDefinitionRequest::getNearestLoc() const {
 bool ActorIsolation::requiresSubstitution() const {
   switch (kind) {
   case ActorInstance:
-  case Independent:
+  case Nonisolated:
   case Unspecified:
     return false;
 
@@ -1619,7 +1619,7 @@ bool ActorIsolation::requiresSubstitution() const {
 ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   switch (kind) {
   case ActorInstance:
-  case Independent:
+  case Nonisolated:
   case Unspecified:
     return *this;
 
@@ -1643,8 +1643,8 @@ void swift::simple_display(
       out << "actor " << state.getActor()->getName();
       break;
 
-    case ActorIsolation::Independent:
-      out << "actor-independent";
+    case ActorIsolation::Nonisolated:
+      out << "nonisolated";
       break;
 
     case ActorIsolation::Unspecified:

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -788,7 +788,7 @@ void CompletionLookup::analyzeActorIsolation(
     break;
   }
   case ActorIsolation::Unspecified:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
     return;
   }
 

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -777,7 +777,7 @@ void CompletionLookup::analyzeActorIsolation(
       if (isolation != ClosureActorIsolations.end()) {
         return isolation->second;
       } else {
-        return CE->getActorIsolation();
+        return CE->getClosureActorIsolation();
       }
     };
     auto contextIsolation = getActorIsolationOfContext(

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -777,7 +777,7 @@ void CompletionLookup::analyzeActorIsolation(
       if (isolation != ClosureActorIsolations.end()) {
         return isolation->second;
       } else {
-        return CE->getClosureActorIsolation();
+        return CE->getActorIsolation();
       }
     };
     auto contextIsolation = getActorIsolationOfContext(

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -111,7 +111,7 @@ void PostfixCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
                              [&](const Solution &S) { sawSolution(S); });
 }
 
-static ClosureActorIsolation
+static ActorIsolation
 getClosureActorIsolation(const Solution &S, AbstractClosureExpr *ACE) {
   auto getType = [&S](Expr *E) -> Type {
     // Prefer the contextual type of the closure because it might be 'weaker'
@@ -213,7 +213,7 @@ void PostfixCompletionCallback::sawSolutionImpl(
       isImplicitSingleExpressionReturn(CS, CompletionExpr);
 
   bool IsInAsyncContext = isContextAsync(S, DC);
-  llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+  llvm::DenseMap<AbstractClosureExpr *, ActorIsolation>
       ClosureActorIsolations;
   for (auto SAT : S.targets) {
     if (auto ACE = getAsExpr<AbstractClosureExpr>(SAT.second.getAsASTNode())) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5514,7 +5514,7 @@ RValue SILGenFunction::emitApply(
       break;
 
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
       llvm_unreachable("Not isolated");
       break;
     }

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -595,7 +595,7 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
       return true;
 
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
       return false;

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1593,7 +1593,7 @@ void SILGenFunction::emitHopToActorValue(SILLocation loc, ManagedValue actor) {
   }
   auto isolation =
       getActorIsolationOfContext(FunctionDC, [](AbstractClosureExpr *CE) {
-        return CE->getClosureActorIsolation();
+        return CE->getActorIsolation();
       });
   if (isolation != ActorIsolation::Nonisolated
       && isolation != ActorIsolation::Unspecified) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1380,19 +1380,21 @@ void SILGenFunction::emitProlog(
     }
   } else if (auto *closureExpr = dyn_cast<AbstractClosureExpr>(FunctionDC)) {
     bool wantExecutor = F.isAsync() || wantDataRaceChecks;
-    auto actorIsolation = closureExpr->getClosureActorIsolation();
+    auto actorIsolation = closureExpr->getActorIsolation();
     switch (actorIsolation.getKind()) {
-    case ClosureActorIsolation::Nonisolated:
+    case ActorIsolation::Unspecified:
+    case ActorIsolation::Nonisolated:
       break;
 
-    case ClosureActorIsolation::ActorInstance: {
+    case ActorIsolation::ActorInstance: {
       if (wantExecutor) {
         loadExpectedExecutorForLocalVar(actorIsolation.getActorInstance());
       }
       break;
     }
 
-    case ClosureActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
       if (wantExecutor) {
         ExpectedExecutor =
           emitLoadGlobalActorExecutor(actorIsolation.getGlobalActor());

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1280,7 +1280,7 @@ void SILGenFunction::emitProlog(
           // the instance properties of the class.
           return false;
 
-        case ActorIsolation::Independent:
+        case ActorIsolation::Nonisolated:
         case ActorIsolation::Unspecified:
           return false;
         }
@@ -1331,7 +1331,7 @@ void SILGenFunction::emitProlog(
     auto actorIsolation = getActorIsolation(funcDecl);
     switch (actorIsolation.getKind()) {
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
       break;
 
     case ActorIsolation::ActorInstance: {
@@ -1382,7 +1382,7 @@ void SILGenFunction::emitProlog(
     bool wantExecutor = F.isAsync() || wantDataRaceChecks;
     auto actorIsolation = closureExpr->getActorIsolation();
     switch (actorIsolation.getKind()) {
-    case ClosureActorIsolation::Independent:
+    case ClosureActorIsolation::Nonisolated:
       break;
 
     case ClosureActorIsolation::ActorInstance: {
@@ -1569,7 +1569,7 @@ SILGenFunction::emitExecutor(SILLocation loc, ActorIsolation isolation,
                              llvm::Optional<ManagedValue> maybeSelf) {
   switch (isolation.getKind()) {
   case ActorIsolation::Unspecified:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
     return llvm::None;
 
   case ActorIsolation::ActorInstance: {
@@ -1595,9 +1595,9 @@ void SILGenFunction::emitHopToActorValue(SILLocation loc, ManagedValue actor) {
       getActorIsolationOfContext(FunctionDC, [](AbstractClosureExpr *CE) {
         return CE->getActorIsolation();
       });
-  if (isolation != ActorIsolation::Independent
+  if (isolation != ActorIsolation::Nonisolated
       && isolation != ActorIsolation::Unspecified) {
-    // TODO: Explicit hop with no hop-back should only be allowed in independent
+    // TODO: Explicit hop with no hop-back should only be allowed in nonisolated
     // async functions. But it needs work for any closure passed to
     // Task.detached, which currently has unspecified isolation.
     llvm::report_fatal_error(

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1380,7 +1380,7 @@ void SILGenFunction::emitProlog(
     }
   } else if (auto *closureExpr = dyn_cast<AbstractClosureExpr>(FunctionDC)) {
     bool wantExecutor = F.isAsync() || wantDataRaceChecks;
-    auto actorIsolation = closureExpr->getActorIsolation();
+    auto actorIsolation = closureExpr->getClosureActorIsolation();
     switch (actorIsolation.getKind()) {
     case ClosureActorIsolation::Nonisolated:
       break;
@@ -1593,7 +1593,7 @@ void SILGenFunction::emitHopToActorValue(SILLocation loc, ManagedValue actor) {
   }
   auto isolation =
       getActorIsolationOfContext(FunctionDC, [](AbstractClosureExpr *CE) {
-        return CE->getActorIsolation();
+        return CE->getClosureActorIsolation();
       });
   if (isolation != ActorIsolation::Nonisolated
       && isolation != ActorIsolation::Unspecified) {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1027,7 +1027,7 @@ void LifetimeChecker::injectActorHops() {
     break;
 
   case ActorIsolation::Unspecified:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
   case ActorIsolation::GlobalActorUnsafe:
   case ActorIsolation::GlobalActor:
     return;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2968,7 +2968,7 @@ static bool okToRemoveGlobalActor(ConstraintSystem &cs,
     // So, I expect the existing isolation to always be set to the default.
     // If the assertion below starts tripping, then this ad-hoc inference
     // is no longer needed!
-    auto existingIso = ace->getActorIsolation();
+    auto existingIso = ace->getClosureActorIsolation();
     if (existingIso != ClosureActorIsolation()) {
       assert(false && "somebody set the closure's isolation already?");
       return existingIso;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2938,23 +2938,6 @@ bool ConstraintSystem::hasPreconcurrencyCallee(
   return calleeOverload->choice.getDecl()->preconcurrency();
 }
 
-/// Determines whether a DeclContext is preconcurrency, using information
-/// tracked by the solver to aid in answering that.
-static bool isPreconcurrency(ConstraintSystem &cs, DeclContext *dc) {
-  if (auto *decl = dc->getAsDecl())
-    return decl->preconcurrency();
-
-  if (auto *ce = dyn_cast<ClosureExpr>(dc)) {
-    return ClosureIsolatedByPreconcurrency{cs}(ce);
-  }
-
-  if (auto *autoClos = dyn_cast<AutoClosureExpr>(dc)) {
-    return isPreconcurrency(cs, autoClos->getParent());
-  }
-
-  llvm_unreachable("unhandled DeclContext kind in isPreconcurrency");
-}
-
 ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2960,7 +2960,7 @@ static bool isPreconcurrency(ConstraintSystem &cs, DeclContext *dc) {
 static bool okToRemoveGlobalActor(ConstraintSystem &cs,
                                   DeclContext *dc,
                                   Type globalActor, Type ty) {
-  auto findGlobalActorForClosure = [&](AbstractClosureExpr *ace) -> ClosureActorIsolation {
+  auto findGlobalActorForClosure = [&](AbstractClosureExpr *ace) -> ActorIsolation {
     // FIXME: Because the actor isolation checking happens after constraint
     // solving, the closure expression does not yet have its actor isolation
     // set, i.e., the code that would call
@@ -2968,8 +2968,8 @@ static bool okToRemoveGlobalActor(ConstraintSystem &cs,
     // So, I expect the existing isolation to always be set to the default.
     // If the assertion below starts tripping, then this ad-hoc inference
     // is no longer needed!
-    auto existingIso = ace->getClosureActorIsolation();
-    if (existingIso != ClosureActorIsolation()) {
+    auto existingIso = ace->getActorIsolation();
+    if (existingIso != ActorIsolation::forUnspecified()) {
       assert(false && "somebody set the closure's isolation already?");
       return existingIso;
     }
@@ -2980,8 +2980,8 @@ static bool okToRemoveGlobalActor(ConstraintSystem &cs,
     if (auto closType = GetClosureType{cs}(ace)) {
       if (auto fnTy = closType->getAs<AnyFunctionType>()) {
         if (auto globActor = fnTy->getGlobalActor()) {
-          return ClosureActorIsolation::forGlobalActor(globActor,
-                                                       isPreconcurrency(cs, ace));
+          return ActorIsolation::forGlobalActor(globActor, /*unsafe=*/false)
+              .withPreconcurrency(isPreconcurrency(cs, ace));
         }
       }
     }
@@ -2989,8 +2989,8 @@ static bool okToRemoveGlobalActor(ConstraintSystem &cs,
     // otherwise, check for an explicit annotation
     if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
       if (auto globActor = getExplicitGlobalActor(ce)) {
-        return ClosureActorIsolation::forGlobalActor(globActor,
-                                                     isPreconcurrency(cs, ce));
+        return ActorIsolation::forGlobalActor(globActor, /*unsafe=*/false)
+            .withPreconcurrency(isPreconcurrency(cs, ace));
       }
     }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -104,7 +104,7 @@ static bool requiresFlowIsolation(ActorIsolation typeIso,
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
       return false;
 
     case ActorIsolation::ActorInstance:
@@ -463,7 +463,7 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
     return false;
 
   switch (varIsolation) {
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
   case ActorIsolation::Unspecified:
     // if nonisolated, it's OK
     return true;
@@ -1527,7 +1527,7 @@ static bool wasLegacyEscapingUseRestriction(AbstractFunctionDecl *fn) {
   // according to today's isolation, determine whether it use to have the
   // escaping-use restriction
   switch (getActorIsolation(fn).getKind()) {
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
       // convenience inits did not have the restriction.
@@ -1747,7 +1747,7 @@ static ActorIsolation getInnermostIsolatedContext(
   switch (auto isolation =
               getActorIsolationOfContext(mutableDC, getClosureActorIsolation)) {
   case ActorIsolation::ActorInstance:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
   case ActorIsolation::Unspecified:
     return isolation;
 
@@ -1838,7 +1838,7 @@ static void noteGlobalActorOnContext(DeclContext *dc, Type globalActor) {
       case ActorIsolation::ActorInstance:
       case ActorIsolation::GlobalActor:
       case ActorIsolation::GlobalActorUnsafe:
-      case ActorIsolation::Independent:
+      case ActorIsolation::Nonisolated:
         return;
 
       case ActorIsolation::Unspecified:
@@ -2446,7 +2446,7 @@ namespace {
         if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
           auto isolation = getClosureActorIsolation(closure);
           switch (isolation) {
-          case ClosureActorIsolation::Independent:
+          case ClosureActorIsolation::Nonisolated:
             if (isSendableClosure(closure, /*forActorIsolation=*/true)) {
               return ReferencedActor(var, isPotentiallyIsolated, ReferencedActor::SendableClosure);
             }
@@ -2501,7 +2501,7 @@ namespace {
         // while general isolation is declaration-based.
         switch (auto isolation =
                     getActorIsolationOfContext(dc, getClosureActorIsolation)) {
-        case ActorIsolation::Independent:
+        case ActorIsolation::Nonisolated:
         case ActorIsolation::Unspecified:
           // Local functions can capture an isolated parameter.
           // FIXME: This really should be modeled by getActorIsolationOfContext.
@@ -2833,7 +2833,7 @@ namespace {
             break;
 
           case ActorReferenceResult::ExitsActorToNonisolated:
-            unsatisfiedIsolation = ActorIsolation::forIndependent();
+            unsatisfiedIsolation = ActorIsolation::forNonisolated();
             break;
 
           case ActorReferenceResult::EntersActor:
@@ -2891,7 +2891,7 @@ namespace {
       // an isolated context, then we're exiting the actor context.
       if (mayExitToNonisolated && fnType->isAsync() &&
           getContextIsolation().isActorIsolated())
-        unsatisfiedIsolation = ActorIsolation::forIndependent();
+        unsatisfiedIsolation = ActorIsolation::forNonisolated();
 
       // If there was no unsatisfied actor isolation, we're done.
       if (!unsatisfiedIsolation)
@@ -3074,7 +3074,7 @@ namespace {
           auto isolation = getActorIsolationForReference(
               decl, getDeclContext());
           switch (isolation) {
-          case ActorIsolation::Independent:
+          case ActorIsolation::Nonisolated:
           case ActorIsolation::Unspecified:
             break;
 
@@ -3253,7 +3253,7 @@ namespace {
             break;
 
           case ActorIsolation::Unspecified:
-          case ActorIsolation::Independent:
+          case ActorIsolation::Nonisolated:
             refKind = ReferencedActor::NonIsolatedContext;
             break;
           }
@@ -3325,7 +3325,7 @@ namespace {
       // Sendable closures are actor-independent unless the closure has
       // specifically opted into inheriting actor isolation.
       if (isSendableClosure(closure, /*forActorIsolation=*/true))
-        return ClosureActorIsolation::forIndependent(preconcurrency);
+        return ClosureActorIsolation::forNonisolated(preconcurrency);
 
       // A non-Sendable closure gets its isolation from its context.
       auto parentIsolation = getActorIsolationOfContext(
@@ -3334,9 +3334,9 @@ namespace {
 
       // We must have parent isolation determined to get here.
       switch (parentIsolation) {
-      case ActorIsolation::Independent:
+      case ActorIsolation::Nonisolated:
       case ActorIsolation::Unspecified:
-        return ClosureActorIsolation::forIndependent(preconcurrency);
+        return ClosureActorIsolation::forNonisolated(preconcurrency);
 
       case ActorIsolation::GlobalActor:
       case ActorIsolation::GlobalActorUnsafe: {
@@ -3350,7 +3350,7 @@ namespace {
         if (auto param = closure->getCaptureInfo().getIsolatedParamCapture())
           return ClosureActorIsolation::forActorInstance(param, preconcurrency);
 
-        return ClosureActorIsolation::forIndependent(preconcurrency);
+        return ClosureActorIsolation::forNonisolated(preconcurrency);
       }
     }
     }
@@ -3511,7 +3511,7 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
   // If the declaration is explicitly marked 'nonisolated', report it as
   // independent.
   if (nonisolatedAttr) {
-    return ActorIsolation::forIndependent();
+    return ActorIsolation::forNonisolated();
   }
 
   // If the declaration is marked with a global actor, report it as being
@@ -3582,7 +3582,7 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
 
       case ActorIsolation::GlobalActor:
       case ActorIsolation::GlobalActorUnsafe:
-      case ActorIsolation::Independent:
+      case ActorIsolation::Nonisolated:
         break;
       }
 
@@ -3606,7 +3606,7 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
       case ActorIsolation::ActorInstance:
         llvm_unreachable("protocol requirements cannot be actor instances");
 
-      case ActorIsolation::Independent:
+      case ActorIsolation::Nonisolated:
         // We only need one nonisolated.
         if (sawActorIndependent)
           return true;
@@ -3656,7 +3656,7 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
     switch (auto protoIsolation = getActorIsolation(proto)) {
     case ActorIsolation::ActorInstance:
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
       break;
 
     case ActorIsolation::GlobalActor:
@@ -3713,7 +3713,7 @@ getIsolationFromWrappers(NominalTypeDecl *nominal) {
     switch (isolation) {
     case ActorIsolation::ActorInstance:
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
       break;
 
     case ActorIsolation::GlobalActor:
@@ -3903,7 +3903,7 @@ static bool checkClassGlobalActorIsolation(
   auto superIsolation = getActorIsolation(superclassDecl);
   switch (superIsolation) {
   case ActorIsolation::Unspecified:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
     return false;
 
   case ActorIsolation::ActorInstance:
@@ -4150,7 +4150,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
   if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
     // A @Sendable function is assumed to be actor-independent.
     if (func->isSendable()) {
-      defaultIsolation = ActorIsolation::forIndependent();
+      defaultIsolation = ActorIsolation::forNonisolated();
     }
   }
 
@@ -4159,7 +4159,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
     if (nominal->isAnyActor())
       if (auto ctor = dyn_cast<ConstructorDecl>(value))
         if (!ctor->hasAsync())
-          defaultIsolation = ActorIsolation::forIndependent();
+          defaultIsolation = ActorIsolation::forNonisolated();
 
   // Look for and remember the overridden declaration's isolation.
   llvm::Optional<ActorIsolation> overriddenIso;
@@ -4196,7 +4196,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
       // inferred, so that (e.g.) it will be printed and serialized.
       ASTContext &ctx = value->getASTContext();
       switch (inferred) {
-      case ActorIsolation::Independent:
+      case ActorIsolation::Nonisolated:
         // Stored properties cannot be non-isolated, so don't infer it.
         if (auto var = dyn_cast<VarDecl>(value)) {
           if (!var->isStatic() && var->hasStorage())
@@ -4255,7 +4255,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
     if (func->isLocalCapture() && !func->isSendable()) {
       switch (auto enclosingIsolation =
                   getActorIsolationOfContext(func->getDeclContext())) {
-      case ActorIsolation::Independent:
+      case ActorIsolation::Nonisolated:
       case ActorIsolation::Unspecified:
         // Do nothing.
         break;
@@ -4425,7 +4425,7 @@ bool HasIsolatedSelfRequest::evaluate(
   // isolation.
   if (auto var = dyn_cast<VarDecl>(value)) {
     switch (auto isolation = getActorIsolationFromWrappedProperty(var)) {
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::Unspecified:
       break;
 
@@ -4774,7 +4774,7 @@ bool swift::checkSendableConformance(
   switch (getActorIsolation(nominal)) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::ActorInstance:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
     break;
 
   case ActorIsolation::GlobalActor:
@@ -5244,7 +5244,7 @@ AnyFunctionType *swift::adjustFunctionTypeForConcurrency(
   if (decl) {
     switch (auto isolation = getActorIsolation(decl)) {
     case ActorIsolation::ActorInstance:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::Unspecified:
       return fnType;
 
@@ -5443,7 +5443,7 @@ static ActorIsolation getActorIsolationForReference(
   // FIXME: Expand this out to local variables?
   if (auto var = dyn_cast<VarDecl>(decl)) {
     if (var->isLet() && isStoredProperty(var) &&
-        declIsolation.isIndependent()) {
+        declIsolation.isNonisolated()) {
       if (auto nominal = var->getDeclContext()->getSelfNominalTypeDecl()) {
         if (nominal->isAnyActor())
           return ActorIsolation::forActorInstanceSelf(nominal);
@@ -5528,7 +5528,7 @@ bool swift::isAccessibleAcrossActors(
   if (isa<ConstructorDecl>(value) || isa<EnumElementDecl>(value)) {
     switch (isolation) {
     case ActorIsolation::ActorInstance:
-    case ActorIsolation::Independent:
+    case ActorIsolation::Nonisolated:
     case ActorIsolation::Unspecified:
       return true;
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1749,7 +1749,7 @@ static bool checkedByFlowIsolation(DeclContext const *refCxt,
 /// Get the actor isolation of the innermost relevant context.
 static ActorIsolation getInnermostIsolatedContext(
     const DeclContext *dc,
-    llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+    llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation) {
   // Retrieve the actor isolation of the context.
   auto mutableDC = const_cast<DeclContext *>(dc);
@@ -1789,7 +1789,7 @@ bool swift::isAsyncDecl(ConcreteDeclRef declRef) {
 
 bool swift::safeToDropGlobalActor(
     DeclContext *dc, Type globalActor, Type ty,
-    llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+    llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation) {
   auto funcTy = ty->getAs<AnyFunctionType>();
   if (!funcTy)
@@ -1926,7 +1926,7 @@ namespace {
     SmallVector<std::pair<OpaqueValueExpr *, Expr *>, 4> opaqueValues;
     SmallVector<const PatternBindingDecl *, 2> patternBindingStack;
     llvm::function_ref<Type(Expr *)> getType;
-    llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+    llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation;
 
     /// Keeps track of the capture context of variables that have been
@@ -2165,7 +2165,7 @@ namespace {
     ActorIsolationChecker(
         const DeclContext *dc,
         llvm::function_ref<Type(Expr *)> getType = __Expr_getType,
-        llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+        llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
             getClosureActorIsolation = __AbstractClosureExpr_getActorIsolation)
         : ctx(dc->getASTContext()), getType(getType),
           getClosureActorIsolation(getClosureActorIsolation) {
@@ -2455,14 +2455,15 @@ namespace {
         if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
           auto isolation = getClosureActorIsolation(closure);
           switch (isolation) {
-          case ClosureActorIsolation::Nonisolated:
+          case ActorIsolation::Unspecified:
+          case ActorIsolation::Nonisolated:
             if (isSendableClosure(closure, /*forActorIsolation=*/true)) {
               return ReferencedActor(var, isPotentiallyIsolated, ReferencedActor::SendableClosure);
             }
 
             return ReferencedActor(var, isPotentiallyIsolated, specificNonIsoClosureKind(dc));
 
-          case ClosureActorIsolation::ActorInstance:
+          case ActorIsolation::ActorInstance:
             // If the closure is isolated to the same variable, we're all set.
             if (isPotentiallyIsolated &&
                 (var == isolation.getActorInstance() ||
@@ -2474,7 +2475,8 @@ namespace {
 
             return ReferencedActor(var, isPotentiallyIsolated, specificNonIsoClosureKind(dc));
 
-          case ClosureActorIsolation::GlobalActor:
+          case ActorIsolation::GlobalActor:
+          case ActorIsolation::GlobalActorUnsafe:
             return ReferencedActor::forGlobalActor(
                 var, isPotentiallyIsolated, isolation.getGlobalActor());
           }
@@ -3316,7 +3318,7 @@ namespace {
     ///
     /// This function assumes that enclosing closures have already had their
     /// isolation checked.
-    ClosureActorIsolation determineClosureIsolation(
+    ActorIsolation determineClosureIsolation(
         AbstractClosureExpr *closure) {
       bool preconcurrency = false;
 
@@ -3324,22 +3326,24 @@ namespace {
         preconcurrency = explicitClosure->isIsolatedByPreconcurrency();
 
         // If the closure specifies a global actor, use it.
-        if (Type globalActorType = resolveGlobalActorType(explicitClosure))
-          return ClosureActorIsolation::forGlobalActor(globalActorType,
-                                                       preconcurrency);
+        if (Type globalActor = resolveGlobalActorType(explicitClosure))
+          return ActorIsolation::forGlobalActor(globalActor, /*unsafe=*/false)
+              .withPreconcurrency(preconcurrency);
       }
 
       // If a closure has an isolated parameter, it is isolated to that
       // parameter.
       for (auto param : *closure->getParameters()) {
         if (param->isIsolated())
-          return ClosureActorIsolation::forActorInstance(param, preconcurrency);
+          return ActorIsolation::forActorInstanceCapture(param)
+              .withPreconcurrency(preconcurrency);
       }
 
-      // Sendable closures are actor-independent unless the closure has
+      // Sendable closures are nonisolated unless the closure has
       // specifically opted into inheriting actor isolation.
       if (isSendableClosure(closure, /*forActorIsolation=*/true))
-        return ClosureActorIsolation::forNonisolated(preconcurrency);
+        return ActorIsolation::forNonisolated()
+            .withPreconcurrency(preconcurrency);
 
       // A non-Sendable closure gets its isolation from its context.
       auto parentIsolation = getActorIsolationOfContext(
@@ -3350,21 +3354,24 @@ namespace {
       switch (parentIsolation) {
       case ActorIsolation::Nonisolated:
       case ActorIsolation::Unspecified:
-        return ClosureActorIsolation::forNonisolated(preconcurrency);
+        return ActorIsolation::forNonisolated()
+            .withPreconcurrency(preconcurrency);
 
       case ActorIsolation::GlobalActor:
       case ActorIsolation::GlobalActorUnsafe: {
-        Type globalActorType = closure->mapTypeIntoContext(
+        Type globalActor = closure->mapTypeIntoContext(
             parentIsolation.getGlobalActor()->mapTypeOutOfContext());
-        return ClosureActorIsolation::forGlobalActor(globalActorType,
-                                                     preconcurrency);
+        return ActorIsolation::forGlobalActor(globalActor, /*unsafe=*/false)
+            .withPreconcurrency(preconcurrency);
       }
 
       case ActorIsolation::ActorInstance: {
         if (auto param = closure->getCaptureInfo().getIsolatedParamCapture())
-          return ClosureActorIsolation::forActorInstance(param, preconcurrency);
+          return ActorIsolation::forActorInstanceCapture(param)
+            .withPreconcurrency(preconcurrency);
 
-        return ClosureActorIsolation::forNonisolated(preconcurrency);
+        return ActorIsolation::forNonisolated()
+            .withPreconcurrency(preconcurrency);
       }
     }
     }
@@ -3460,9 +3467,9 @@ void swift::checkPropertyWrapperActorIsolation(
   expr->walk(checker);
 }
 
-ClosureActorIsolation swift::determineClosureActorIsolation(
+ActorIsolation swift::determineClosureActorIsolation(
     AbstractClosureExpr *closure, llvm::function_ref<Type(Expr *)> getType,
-    llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+    llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation) {
   ActorIsolationChecker checker(closure->getParent(), getType,
                                 getClosureActorIsolation);
@@ -5596,7 +5603,7 @@ ActorReferenceResult ActorReferenceResult::forReference(
     llvm::Optional<ReferencedActor> actorInstance,
     llvm::Optional<ActorIsolation> knownDeclIsolation,
     llvm::Optional<ActorIsolation> knownContextIsolation,
-    llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+    llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation) {
   // If not provided, compute the isolation of the declaration, adjusted
   // for references.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1516,6 +1516,15 @@ static bool isStoredProperty(ValueDecl const *member) {
   return false;
 }
 
+static bool isNonInheritedStorage(ValueDecl const *member,
+                                  DeclContext const *useDC) {
+  auto *nominal = useDC->getParent()->getSelfNominalTypeDecl();
+  if (!nominal)
+    return false;
+
+  return isStoredProperty(member) && member->getDeclContext() == nominal;
+}
+
 /// Based on the former escaping-use restriction, which was replaced by
 /// flow-isolation. We need this to support backwards compatability in the
 /// type-checker for programs prior to Swift 6.
@@ -1731,7 +1740,7 @@ static bool checkedByFlowIsolation(DeclContext const *refCxt,
     return false;
 
   // Stored properties are definitely OK.
-  if (isStoredProperty(member))
+  if (isNonInheritedStorage(member, fnDecl))
     return true;
 
   return false;
@@ -5663,7 +5672,7 @@ ActorReferenceResult ActorReferenceResult::forReference(
   // FIXME: At the very least, we should consistently use
   // isActorInitOrDeInitContext here, but it only wants to think about actors.
   if (actorInstance && actorInstance->isSelf() &&
-      isStoredProperty(declRef.getDecl()) &&
+      isNonInheritedStorage(declRef.getDecl(), fromDC) &&
       declIsolation.isGlobalActor() &&
       (isa<ConstructorDecl>(fromDC) || isa<DestructorDecl>(fromDC)))
     return forSameConcurrencyDomain(declIsolation);

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -240,7 +240,7 @@ public:
       llvm::Optional<ReferencedActor> actorInstance = llvm::None,
       llvm::Optional<ActorIsolation> knownDeclIsolation = llvm::None,
       llvm::Optional<ActorIsolation> knownContextIsolation = llvm::None,
-      llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+      llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
           getClosureActorIsolation = __AbstractClosureExpr_getActorIsolation);
 
   operator Kind() const { return kind; }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -33,7 +33,6 @@ class ActorIsolation;
 class AnyFunctionType;
 class ASTContext;
 class ClassDecl;
-class ClosureActorIsolation;
 class ClosureExpr;
 class ConcreteDeclRef;
 class CustomAttr;

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -246,16 +246,17 @@ public:
   operator Kind() const { return kind; }
 };
 
-/// Specifies whether checks applied to function types should
-/// apply to their params, results, or both
+/// Individual options used with \c FunctionCheckOptions
 enum class FunctionCheckKind {
-  /// Check params and results
-  ParamsResults,
-  /// Check params only
-  Params,
-  /// Check results only
-  Results,
+  /// Check params
+  Params = 1 << 0,
+  /// Check results
+  Results = 1 << 1,
 };
+
+/// Specifies whether checks applied to function types should apply to
+/// their parameters, their results, both, or neither.
+using FunctionCheckOptions = OptionSet<FunctionCheckKind>;
 
 /// Diagnose the presence of any non-sendable types when referencing a
 /// given declaration from a particular declaration context.
@@ -280,7 +281,7 @@ enum class FunctionCheckKind {
 /// \param refKind Describes what kind of reference is being made, which is
 /// used to tailor the diagnostic.
 ///
-/// \param funcCheckKind Describes whether function types in this reference
+/// \param funcCheckOptions Describes whether function types in this reference
 /// should be checked for sendability of their results, params, or both
 ///
 /// \param diagnoseLoc Provides an alternative source location to `refLoc`
@@ -293,7 +294,10 @@ bool diagnoseNonSendableTypesInReference(
     const DeclContext *fromDC, SourceLoc refLoc,
     SendableCheckReason refKind,
     llvm::Optional<ActorIsolation> knownIsolation = llvm::None,
-    FunctionCheckKind funcCheckKind = FunctionCheckKind::ParamsResults,
+    FunctionCheckOptions funcCheckOptions =
+        (FunctionCheckOptions() |
+         FunctionCheckKind::Params |
+         FunctionCheckKind::Results),
     SourceLoc diagnoseLoc = SourceLoc());
 
 /// Produce a diagnostic for a missing conformance to Sendable.

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -481,7 +481,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD, ObjCReason Reason) {
     // in the generated header.
     return false;
 
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
   case ActorIsolation::Unspecified:
     return false;
   }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -97,7 +97,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
 
   case ActorIsolation::GlobalActor:
   case ActorIsolation::GlobalActorUnsafe:
-  case ActorIsolation::Independent:
+  case ActorIsolation::Nonisolated:
   case ActorIsolation::Unspecified:
     break;
   }

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -299,7 +299,7 @@ func blender(_ peeler : () -> Void) {
   await (((wisk)))((wisk)((wisk)(1)))
 
   blender((peelBanana))
-  // expected-warning@-1 2{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
+  // expected-warning@-1 {{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
 
   await wisk(peelBanana)
   // expected-complete-warning@-1{{passing argument of non-sendable type '() -> ()' into global actor 'BananaActor'-isolated context may introduce data races}}
@@ -314,7 +314,12 @@ func blender(_ peeler : () -> Void) {
 
   await {wisk}()(1)
 
+  // FIXME: Poor diagnostic. The issue is that the invalid function conversion
+  // to remove '@BananaActor' on 'wisk' cannot influence which solution is chosen.
+  // So, the constraint system cannot determine whether the type of this expression
+  // is '(Any) -> Void' or '@BananaActor (Any) -> Void'.
   await (true ? wisk : {n in return})(1)
+  // expected-error@-1 {{type of expression is ambiguous without a type annotation}}
 }
 
 actor Chain {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1497,3 +1497,31 @@ extension MyActor {
     }
   }
 }
+
+@MainActor
+class SuperWithNonisolatedInit {
+  static func isolatedToMainActor() {}
+
+  // expected-note@+1 2 {{mutation of this property is only permitted within the actor}}
+  var x: Int = 0 {
+    didSet {
+      SuperWithNonisolatedInit.isolatedToMainActor()
+    }
+  }
+
+  nonisolated init() {}
+}
+
+class OverridesNonsiolatedInit: SuperWithNonisolatedInit {
+  override nonisolated init() {
+    super.init()
+
+    // expected-error@+1 {{main actor-isolated property 'x' can not be mutated from a non-isolated context}}
+    super.x = 10
+  }
+
+  nonisolated func f() {
+    // expected-error@+1 {{main actor-isolated property 'x' can not be mutated from a non-isolated context}}
+    super.x = 10
+  }
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -472,7 +472,7 @@ func testGlobalActorClosures() {
     return 17
   }
 
-  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning 2{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
+  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning {{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -100,7 +100,7 @@ func testCalls(x: X) {
   // expected-complete-sns-error @-1 {{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
 
   // Ok with minimal/targeted concurrency, Not ok with complete.
-  let _: () -> Void = onMainActorAlways // expected-complete-sns-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
+  let _: () -> Void = onMainActorAlways // expected-complete-sns-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
   // both okay with minimal/targeted... an error with complete.
   let c = MyModelClass() // expected-complete-sns-error {{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
@@ -111,7 +111,7 @@ func testCallsWithAsync() async {
   onMainActorAlways() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
 
-  let _: () -> Void = onMainActorAlways // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
+  let _: () -> Void = onMainActorAlways // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
   let c = MyModelClass() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -250,6 +250,7 @@ final class NonSendable {
   // expected-note @-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   // SendNonSendable emits 3 fewer errors here.
   // expected-targeted-and-complete-note @-3 5 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  // expected-complete-and-sns-note @-4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   var value = ""
 
   @MainActor
@@ -304,4 +305,14 @@ func callNonisolatedAsyncClosure(
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
+}
+
+@available(SwiftStdlib 5.1, *)
+func testLocalCaptures() {
+  let ns = NonSendable()
+
+  @Sendable func a2() -> NonSendable {
+    return ns
+    // expected-complete-and-sns-warning@-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
+  }
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -249,7 +249,7 @@ func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> 
 final class NonSendable {
   // expected-note @-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   // SendNonSendable emits 3 fewer errors here.
-  // expected-targeted-and-complete-note @-3 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  // expected-targeted-and-complete-note @-3 4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   var value = ""
 
   @MainActor
@@ -283,4 +283,16 @@ func testNonSendableBaseArg() async {
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
+}
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+func callNonisolatedAsyncClosure(
+  ns: NonSendable,
+  g: (NonSendable) async -> Void
+) async {
+  // FIXME: This should also produce a diagnostic with SendNonSendable, because
+  // the 'ns' parameter should be merged into the MainActor's region.
+  await g(ns)
+  // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -249,7 +249,7 @@ func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> 
 final class NonSendable {
   // expected-note @-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   // SendNonSendable emits 3 fewer errors here.
-  // expected-targeted-and-complete-note @-3 4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  // expected-targeted-and-complete-note @-3 5 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   var value = ""
 
   @MainActor
@@ -286,13 +286,22 @@ func testNonSendableBaseArg() async {
 }
 
 @available(SwiftStdlib 5.1, *)
+@Sendable
+func globalSendable(_ ns: NonSendable) async {}
+
+@available(SwiftStdlib 5.1, *)
 @MainActor
 func callNonisolatedAsyncClosure(
   ns: NonSendable,
   g: (NonSendable) async -> Void
 ) async {
-  // FIXME: This should also produce a diagnostic with SendNonSendable, because
-  // the 'ns' parameter should be merged into the MainActor's region.
+  // FIXME: Both cases below should also produce a diagnostic with SendNonSendable,
+  // because the 'ns' parameter should be merged into the MainActor's region.
+
   await g(ns)
+  // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
+
+  let f: (NonSendable) async -> () = globalSendable // okay
+  await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
 }

--- a/validation-test/Sema/SwiftUI/rdar94462333.swift
+++ b/validation-test/Sema/SwiftUI/rdar94462333.swift
@@ -10,9 +10,6 @@ import SwiftUI
 struct ContentView: View {
   var body: some View {
     VStack {
-      // In the future this warning should go away too, but it remains since the isolation of the closure
-      // passed to the VStack is not inferred yet during constraint solving.
-      // expected-warning@+1 {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
       Button(action: someMainActorFn) {
         Text("Sign In")
       }


### PR DESCRIPTION
* **Explanation**: This change fills a number of known holes and bugs in the static data-race-safety checking, including:
  * An issue where a `nonisolated` initializer of a subclass could invoke global-actor-isolated properties in the superclass.
  * An issue with `Sendable` checking for function references where parameter and result types were `Sendable`-checked at the point of partial application when there was no function conversion. Sendability of function references depends only on captures, and applies when the function itself is passed across isolation boundaries. Parameter and result values can only cross isolation boundaries when the function is called, so they shouldn't be checked when checking a reference for Sendable violations.
  * Diagnose Sendable violations in captures of local functions, which were previously completely unchecked.
  * Correctness issues / false positives with the diagnostics for erasing actor-isolation via function conversions 
 
This change also includes a minor refactoring to consolidate the representation of actor isolation across function declarations and closures.
* **Scope**: Primarily impacts strict concurrency checking. The constraint system change around global actor isolation can impact existing code but the impacted cases are very narrow.
* **Risk**: Low.
* **Testing**: Added and updated many tests in `test/Concurrency/`.
* **Issue**: rdar://86550653, rdar://104129168, rdar://113293502
* **Main branch PR**: 
  * https://github.com/apple/swift/pull/68414
  * https://github.com/apple/swift/pull/68420
  * https://github.com/apple/swift/pull/68567
  * https://github.com/apple/swift/pull/68685
  * https://github.com/apple/swift/pull/68693
  * https://github.com/apple/swift/pull/68752