### PR TITLE
[DRAFT] Replacing 'synthesized initializers' with 'default initializers' on diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1981,16 +1981,16 @@ NOTE(requires_stored_property_inits_here,none,
 ERROR(class_without_init,none,
       "%select{class|actor}0 %1 has no initializers", (bool, Type))
 NOTE(note_no_in_class_init_1,none,
-     "stored property %0 without initial value prevents synthesized "
+     "stored property %0 without initial value prevents default "
      "initializers",
      (Identifier))
 NOTE(note_no_in_class_init_2,none,
-     "stored properties %0 and %1 without initial values prevent synthesized "
+     "stored properties %0 and %1 without initial values prevent default "
      "initializers",
      (Identifier, Identifier))
 NOTE(note_no_in_class_init_3plus,none,
      "stored properties %0, %1, %select{and %2|%2, and others}3 "
-     "without initial values prevent synthesized initializers",
+     "without initial values prevent default initializers",
      (Identifier, Identifier, Identifier, bool))
 ERROR(missing_unimplemented_init_runtime,none,
       "standard library error: missing _unimplementedInitializer", ())


### PR DESCRIPTION
As highlighted by [this issue](https://github.com/apple/swift/issues/43376), the official documentation doesn't seem to use the word 'synthesized initializer' as some of the diagnostics do. It, instead, uses 'default initializers' to refer to this concept, as can be seen at the [The Swift Programming Language (5.9) > Initialization > Default Initializers section](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/initialization#Default-Initializers).

This pull request simply replaces one term by the other on 3 diagnostics, which are related to eachother and seem to be the only ones using the 'synthesized' term.

Resolves #43376