### PR TITLE
ASTGen: Expose BumpPtrAllocator as @_spi(BumpPtrAllocator) 

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -4,7 +4,7 @@ import CBasicBridging
 // Needed to use SyntaxTransformVisitor's visit method.
 @_spi(SyntaxTransformVisitor)
 // Needed to use BumpPtrAllocator
-@_spi(RawSyntax)
+@_spi(BumpPtrAllocator)
 import SwiftSyntax
 import struct SwiftDiagnostics.Diagnostic
 


### PR DESCRIPTION
changed @_spi(RawSyntax) import SwiftSyntax in ASTGen.swift to @_spi(BumpPtrAllocator) import SwiftSyntax.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #68351.

Coupled with https://github.com/apple/swift-syntax/pull/2249.