### PR TITLE
🍒[5.10][Distributed] Generic reqs must be forwarded to accessor from enclosing actor

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -269,8 +269,16 @@ static CanSILFunctionType getAccessorType(IRGenModule &IGM,
     auto *actor = getDistributedActorOf(Target);
     assert(actor);
 
-    for (auto *genericParam : actor->getInnermostGenericParamTypes())
+    for (auto *genericParam : actor->getInnermostGenericParamTypes()) {
       genericParams.push_back(genericParam);
+
+      // and also forward all requirements this generic parameter might have.
+      for (auto req : actor->getGenericRequirements()) {
+        if (req.getFirstType()->isEqual(genericParam)) {
+          genericRequirements.push_back(req);
+        }
+      }
+    }
 
     // Add a generic parameter `D` which stands for decoder type in the
     // accessor signature - `inout D`.

--- a/test/Distributed/Runtime/distributed_actor_generic_constraint_issue_115497090.swift
+++ b/test/Distributed/Runtime/distributed_actor_generic_constraint_issue_115497090.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Distributed
+import FakeDistributedActorSystems
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+protocol SomeProtocol {
+  static var isInteger: Bool { get }
+}
+
+distributed actor TestActor<Value> where Value: Codable & Identifiable, Value.ID: SomeProtocol {
+  distributed func requirementsFromActor(value: Value) async throws {
+    print("OK: \(value)")
+  }
+  distributed func requirementsFromActorAndMethod(value: Value) async throws where Value: VerySpecific {
+    print("OK: \(value)")
+  }
+}
+
+protocol VerySpecific {}
+
+struct TheValue: Codable, Identifiable, VerySpecific {
+  let id: String
+  init() {
+    self.id = "id"
+  }
+}
+extension String: SomeProtocol {
+  static var isInteger: Bool { false }
+}
+
+@main struct Main {
+  static func main() async throws {
+    let ta: TestActor<TheValue> = TestActor(actorSystem: .init())
+    try await ta.requirementsFromActor(value: TheValue())
+    try await ta.requirementsFromActorAndMethod(value: TheValue())
+    // CHECK: OK
+  }
+}
+
+// FIXME: repro testing
+// export VER=5.9; swiftly install $VER && swiftly use $VER; swiftly list | grep use; swift build --build-tests; if [[ "$?" -eq 0 ]]; then echo "$VER: OK" >> ../checks; else echo "$VER: broken" >> ../checks; fi


### PR DESCRIPTION
**Issue:** Without this change, in debug builds the requirement machine validation infra would crash to compile. This prevents advanced Distributed Actors users with lots of generics from using NIGHTLY builds. Stable builds have this assertion turned off.


**Description:** If we don't do this, the generic parameter has no requirements at all, which a) is incorrect to begin with, it should have the exact same signature as the method it is the accessor for, and b) it would trip up verification which is enabled on linux in snapshot builds -- causing crashes.


**Affected versions:** All the way since initial introduction, but ONLY in debug builds -- i.e. _nightly snapshots on linux_. Released stable Swift versions don't have this assertion and would "happen to work".


**Risk:** Low, this only adds missing requirements to distributed function accessors which is the correct thing to do. Missing them "worked by accident".


**Review by:** @slavapestov @xedin 

**Testing:** CI testing; verified manually on reproducer project provided in issue

**Radar:** rdar://115497090

**Original PR:** ~https://github.com/apple/swift/pull/68859~ https://github.com/apple/swift/pull/70785

Resolves https://github.com/apple/swift/issues/68517