### PR TITLE
[embedded] Allow serialization of SILLinkage::shared functions without promoting them to public

### DIFF
--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -32,7 +32,7 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
   if (auto fn = mod.lookUpFunction(name)) {
     assert(fn->getLoweredFunctionType() == type);
     assert(stripExternalFromLinkage(fn->getLinkage()) ==
-           stripExternalFromLinkage(linkage));
+           stripExternalFromLinkage(linkage) || mod.getOptions().EmbeddedSwift);
     return fn;
   }
 

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -491,7 +491,7 @@ void CrossModuleOptimization::serializeFunction(SILFunction *function,
   if (function->isSerialized())
     return;
   
-  if (!canSerializeFlags.lookup(function))
+  if (!everything && !canSerializeFlags.lookup(function))
     return;
 
   function->setSerialized(IsSerialized);
@@ -588,9 +588,14 @@ void CrossModuleOptimization::keepMethodAlive(SILDeclRef method) {
 
 void CrossModuleOptimization::makeFunctionUsableFromInline(SILFunction *function) {
   assert(canUseFromInline(function));
-  if (!isAvailableExternally(function->getLinkage()) &&
-      function->getLinkage() != SILLinkage::Public) {
-    function->setLinkage(SILLinkage::Public);
+  if (!isAvailableExternally(function->getLinkage())) {
+    bool shouldPromoteToPublic = function->getLinkage() != SILLinkage::Public;
+    if (everything)
+      shouldPromoteToPublic = function->getLinkage() != SILLinkage::Public &&
+                              function->getLinkage() != SILLinkage::Shared;
+    if (shouldPromoteToPublic) {
+      function->setLinkage(SILLinkage::Public);
+    }
   }
 }
 

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -491,7 +491,7 @@ void CrossModuleOptimization::serializeFunction(SILFunction *function,
   if (function->isSerialized())
     return;
   
-  if (!everything && !canSerializeFlags.lookup(function))
+  if (!canSerializeFlags.lookup(function))
     return;
 
   function->setSerialized(IsSerialized);
@@ -588,14 +588,9 @@ void CrossModuleOptimization::keepMethodAlive(SILDeclRef method) {
 
 void CrossModuleOptimization::makeFunctionUsableFromInline(SILFunction *function) {
   assert(canUseFromInline(function));
-  if (!isAvailableExternally(function->getLinkage())) {
-    bool shouldPromoteToPublic = function->getLinkage() != SILLinkage::Public;
-    if (everything)
-      shouldPromoteToPublic = function->getLinkage() != SILLinkage::Public &&
-                              function->getLinkage() != SILLinkage::Shared;
-    if (shouldPromoteToPublic) {
-      function->setLinkage(SILLinkage::Public);
-    }
+  if (!isAvailableExternally(function->getLinkage()) &&
+      function->getLinkage() != SILLinkage::Public) {
+    function->setLinkage(SILLinkage::Public);
   }
 }
 

--- a/test/embedded/shared-linkage.swift
+++ b/test/embedded/shared-linkage.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/Module.swiftmodule %t/Module.swift -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-ir %t/Main.swift -I%t -enable-experimental-feature Embedded
+
+// RUN: %target-swift-frontend -O -emit-module -o %t/Module.swiftmodule %t/Module.swift -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -O -emit-ir %t/Main.swift -I%t -enable-experimental-feature Embedded
+
+// RUN: %target-swift-frontend -Osize -emit-module -o %t/Module.swiftmodule %t/Module.swift -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -Osize -emit-ir %t/Main.swift -I%t -enable-experimental-feature Embedded
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// BEGIN Module.swift
+
+public func bar<R>(count: Int, _ body: (UnsafeMutableBufferPointer<Int>) -> R) -> R {
+  let pointer = UnsafeMutablePointer<Int>(bitPattern: 42)!
+  let inoutBufferPointer = UnsafeMutableBufferPointer(start: pointer, count: count)
+  return body(inoutBufferPointer)
+}
+
+public func foo<R>(_ body: () -> R) -> R {
+  bar(count: 10) { p in
+    body()
+  }
+}
+
+public func module_func() {
+  foo {
+    return 0
+  }
+}
+
+// BEGIN Main.swift
+
+import Module
+
+public func test() {
+  module_func()
+}
+
+public func client_func() {
+  foo {
+    return 0
+  }
+}


### PR DESCRIPTION
Currently, CMO's "everything" serialization promotes shared functions (thunks, specializations) to public. This isn't generally a problem, unless an importing module triggers specialization of the the exact same function, in which case we end up tripping the following assert (see the test case demonstrating this):

```
Assertion failed: (stripExternalFromLinkage(fn->getLinkage()) == stripExternalFromLinkage(linkage)), function getOrCreateFunction, file SILFunctionBuilder.cpp, line 35.

3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for Main)
4.	While running pass #456 SILModuleTransform "MandatoryPerformanceOptimizations".

7  swift-frontend           0x0000000109d0cfe4 swift::SILFunctionBuilder::getOrCreateFunction(swift::SILLocation, llvm::StringRef, swift::SILLinkage, swift::CanTypeWrapper<swift::SILFunctionType>, swift::IsBare_t, swift::IsTransparent_t, swift::IsSerialized_t, swift::IsDynamicallyReplaceable_t, swift::IsDistributed_t, swift::IsRuntimeAccessible_t, swift::ProfileCounter, swift::IsThunk_t, swift::SubclassScope) (.cold.3) + 0
8  swift-frontend           0x0000000105aa1114 swift::SILFunctionBuilder::getOrCreateFunction(swift::SILLocation, llvm::StringRef, swift::SILLinkage, swift::CanTypeWrapper<swift::SILFunctionType>, swift::IsBare_t, swift::IsTransparent_t, swift::IsSerialized_t, swift::IsDynamicallyReplaceable_t, swift::IsDistributed_t, swift::IsRuntimeAccessible_t, swift::ProfileCounter, swift::IsThunk_t, swift::SubclassScope) + 520
9  swift-frontend           0x0000000105aa26cc swift::SILFunctionBuilder::getOrCreateSharedFunction(swift::SILLocation, llvm::StringRef, swift::CanTypeWrapper<swift::SILFunctionType>, swift::IsBare_t, swift::IsTransparent_t, swift::IsSerialized_t, swift::ProfileCounter, swift::IsThunk_t, swift::IsDynamicallyReplaceable_t, swift::IsDistributed_t, swift::IsRuntimeAccessible_t) + 84
10 swift-frontend           0x000000010580b97c swift::trySpecializeApplyOfGeneric(swift::SILOptFunctionBuilder&, swift::ApplySite, llvm::SmallSetVector<swift::SILInstruction*, 8u>&, llvm::SmallVectorImpl<swift::SILFunction*>&, swift::OptRemark::Emitter&, bool) + 13468
11 swift-frontend           0x0000000105733b70 swift::specializeAppliesInFunction(swift::SILFunction&, swift::SILTransform*, bool) + 808
12 swift-frontend           0x0000000104cb4e58 $s9Optimizer19FunctionPassContextV17specializeApplies2in11isMandatorySb3SIL0B0C_SbtF + 44
13 swift-frontend           0x0000000104cb7658 $s9Optimizer33mandatoryPerformanceOptimizationsAA10ModulePassVvpfiyAA0eF7ContextVcfU_ + 1456
```

The problem is that getOrCreateSharedFunction expects that if the function already exists, it must be shared and not public. Let's fix this by not promoting the linkage to public during serialization in the "everything" mode.
