### PR TITLE
[docs] GettingStarted: Send readers to ci.swift.org for the min Xcode version

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -136,11 +136,10 @@ toolchain as a one-off, there are a couple of differences:
 
 ### macOS
 
-1. Install [Xcode 13 beta 4][Xcode] or newer:
-   The required version of Xcode changes frequently and is often a beta release.
-   Check this document or the host information on <https://ci.swift.org> for the
-   current required version.
-2. Install [CMake][], [Ninja][] and [Sccache][]:
+1. Install Xcode. The minimum required version is specified in the node
+   information on <https://ci.swift.org>, may change frequently, and is often
+   a beta release.
+1. Install [CMake][], [Ninja][] and [Sccache][]:
    - Via [Homebrew][] (recommended):
      ```sh
      brew install cmake ninja sccache


### PR DESCRIPTION
This inline Xcode version is a maintenance bother with no apparent justification, and shall it ever fall out of sync (like right now), it can start causing build failures for newcomers.