### PR TITLE
Set clang module directory correctly with fmodule-file-home-is-cwd

### DIFF
--- a/test/DebugInfo/module-file-home-is-cwd.swift
+++ b/test/DebugInfo/module-file-home-is-cwd.swift
@@ -1,0 +1,16 @@
+// First populate the module cache to avoid issues with implicit modules
+// and -fmodule-file-home-is-cwd.
+// RUN: %target-swift-frontend -module-cache-path %t.mcp -emit-ir %s \
+// RUN:   -g -I %S/Inputs -o /dev/null
+
+// RUN: %target-swift-frontend -module-cache-path %t.mcp -emit-ir %s \
+// RUN:   -g -I %S/Inputs -file-compilation-dir /CWD \
+// RUN:   -Xcc -Xclang -Xcc -fmodule-file-home-is-cwd \
+// RUN:   -o - | %FileCheck %s
+
+import ClangModule.SubModule
+
+let _ = someFunc(0)
+
+// Ensure compilation directory is set to the debug compilation directory.
+// CHECK: !DIFile(filename: "ClangModule", directory: "/CWD")


### PR DESCRIPTION
When building and importing modules built with `-fmodule-file-home-is-cwd` we should be setting the debug info directory to the current working directory. This matches the behavior in clang: https://reviews.llvm.org/D134911
