### PR TITLE
NFC: Fix unused function and variable warnings

### DIFF
--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -363,7 +363,6 @@ static void enqueueDiagnostic(
       info.Loc.getOpaquePointerValue(),
       highlightRanges.data(), highlightRanges.size() / 2);
 }
-#endif
 
 /// Retrieve the stack of source buffers from the provided location out to
 /// a physical source file, with source buffer IDs for each step along the way
@@ -389,7 +388,6 @@ static SmallVector<unsigned, 1> getSourceBufferStack(
   }
 }
 
-#if SWIFT_BUILD_SWIFT_SYNTAX
 void PrintingDiagnosticConsumer::queueBuffer(
     SourceManager &sourceMgr, unsigned bufferID) {
   QueuedBuffer knownSourceFile = queuedBuffers[bufferID];


### PR DESCRIPTION
Fixes the following warnings:
```
../swift-project/swift/lib/Frontend/PrintingDiagnosticConsumer.cpp:374:33: warning: unused function 'getSourceBufferStack' [-Wunused-function]
static SmallVector<unsigned, 1> getSourceBufferStack(
                                ^
../swift-project/swift/lib/Sema/TypeCheckMacros.cpp:184:15: warning: unused variable 'ctx' [-Wunused-variable]
  ASTContext &ctx = macro->getASTContext();
              ^
../swift-project/swift/lib/Sema/TypeCheckMacros.cpp:191:8: warning: unused variable 'sourceFile' [-Wunused-variable]
  auto sourceFile = macro->getParentSourceFile();
       ^
../swift-project/swift/lib/Sema/TypeCheckMacros.cpp:999:13: warning: unused variable 'macroRole' [-Wunused-variable]
  MacroRole macroRole =
            ^
../swift-project/swift/lib/Sema/TypeCheckMacros.cpp:165:25: warning: unused function 'handleExternalMacroDefinition' [-Wunused-function]
static MacroDefinition  handleExternalMacroDefinition(
                        ^
../swift-project/swift/lib/Sema/TypeCheckMacros.cpp:940:16: warning: unused function 'getRawMacroRole' [-Wunused-function]
static uint8_t getRawMacroRole(MacroRole role) {
               ^
```