### PR TITLE
[embedded] In -throws-as-traps mode, avoid swift_willThrow calls from the stdlib

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -577,8 +577,13 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     // the error return register. We also have to pass a fake context
     // argument due to how swiftcc works in clang.
 
-    auto fn = IGF.IGM.getWillThrowFunctionPointer();
     auto error = args.claimNext();
+
+    if (IGF.IGM.Context.LangOpts.ThrowsAsTraps) {
+      return;
+    }
+
+    auto fn = IGF.IGM.getWillThrowFunctionPointer();
     auto errorTy = IGF.IGM.Context.getErrorExistentialType();
     auto errorBuffer = IGF.getCalleeErrorResultSlot(
         SILType::getPrimitiveObjectType(errorTy));

--- a/test/embedded/throw-trap-stdlib.swift
+++ b/test/embedded/throw-trap-stdlib.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public func test() {
+  withUnsafeTemporaryAllocation(byteCount: MemoryLayout<Int>.size, alignment: MemoryLayout<Int>.alignment) { p in
+    p[0] = 42
+  }
+}
+
+// CHECK-NOT: swift_willThrow


### PR DESCRIPTION
For early experimentation with embedded Swift mode, the -throws-as-traps is useful before we get real compiler support for throwing (typed throws). Let's extend this flag (-throws-as-traps) to also cover the case where the embedded stdlib contains the throw sites in unreachable blocks, where the actual throw is not reachable but we end up producing a runtime call to swift_willThrow.