### PR TITLE
[Windows] Don't build earlyswiftsyntax in Windows

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -190,31 +190,6 @@ cmake --build "%BuildRoot%\curl" --target install || (exit /b)
 
 path %BuildRoot%\toolchains\5.9.0\PFiles64\Swift\runtime-development\usr\bin;%BuildRoot%\toolchains\5.9.0\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin;%Path%
 
-:: Build Swift Syntax
-cmake ^
-  -B "%BuildRoot%\99" ^
-
-  -D BUILD_SHARED_LIBS=YES ^
-  -D CMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
-  -D CMAKE_C_COMPILER=cl.exe ^
-  -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" ^
-  -D CMAKE_CXX_COMPILER=cl ^
-  -D CMAKE_CXX_FLAGS="/GS- /Oy /Gw /Gy" ^
-  -D CMAKE_MT=mt ^
-  -D CMAKE_Swift_COMPILER=%BuildRoot%/toolchains/5.9.0/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain/usr/bin/swiftc.exe ^
-  -D CMAKE_Swift_FLAGS="-sdk %BuildRoot%/toolchains/5.9.0/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" ^
-  -D CMAKE_EXE_LINKER_FLAGS="/INCREMENTAL:NO" ^
-  -D CMAKE_SHARED_LINKER_FLAGS="/INCREMENTAL:NO" ^
-
-  -D CMAKE_INSTALL_PREFIX="%InstallRoot%" ^
-
-  -D SWIFT_SYNTAX_ENABLE_WMO_PRE_3_26=YES ^
-
-  -G Ninja ^
-  -S %SourceRoot%\swift-syntax || (exit /b)
-cmake --build %BuildRoot%\99 || (exit /b)
-cmake --build %BuildRoot%\99 --target install || (exit /b)
-
 :: Build Toolchain
 cmake ^
   -B "%BuildRoot%\1" ^
@@ -257,7 +232,6 @@ cmake ^
   -D LLVM_EXTERNAL_CMARK_SOURCE_DIR="%SourceRoot%\cmark" ^
   -D PYTHON_HOME=%PYTHON_HOME% ^
   -D PYTHON_EXECUTABLE=%PYTHON_HOME%\python.exe ^
-  -D SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR="%BuildRoot%\99" ^
   -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE="%SourceRoot%\swift-corelibs-libdispatch" ^
   -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE="%SourceRoot%\swift-syntax" ^
   -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=%SourceRoot%\swift-experimental-string-processing ^


### PR DESCRIPTION
`build-windows-toolchain.bat` used to build and install 'swift-syntax' for the compiler. Now that swift-syntax is built as a part of 'swift' build. So no need to built it separately anymore.

(Depends on #68867)