### PR TITLE
Fix incorrect library name

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -230,7 +230,7 @@ module WinSDK [system] {
       header "dinput.h"
       export *
 
-      link "dinput.lib"
+      link "dinput8.lib"
     }
 
     link "dxguid.lib"


### PR DESCRIPTION
Fixes an incorrect library name that resulted in linking errors.

This fixes issue #68887
@compnerd