### PR TITLE
Fixes throwing super.init() diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4807,6 +4807,12 @@ ERROR(return_init_non_nil,none,
       "'nil' is the only return value permitted in an initializer",
       ())
 
+ERROR(implicit_throws_super_init,none,
+      "missing call to superclass's initializer; "
+      "'super.init' is a throwing initializer and requires either an explicit "
+      "call or that this initializer is also marked as 'throws'",
+      ())
+
 ERROR(implicit_async_super_init,none,
       "missing call to superclass's initializer; "
       "'super.init' is 'async' and requires an explicit call",

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2236,7 +2236,17 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
       fromCtor->diagnose(diag::availability_unavailable_implicit_init,
                          ctor, superclassDecl->getName());
     }
-
+    
+    // Only allowed to synthesize a throwing super.init() call if the init being
+    // checked is also throwing.
+    if (ctor->hasThrows()) {
+      // Diagnose on nonthrowing or rethrowing initializer.
+      if (!fromCtor->hasThrows() || fromCtor->hasPolymorphicEffect(EffectKind::Throws)) {
+        fromCtor->diagnose(diag::implicit_throws_super_init);
+        return true; // considered an error
+      }
+    }
+    
     // Not allowed to implicitly generate a super.init() call if the init
     // is async; that would hide the 'await' from the programmer.
     if (ctor->hasAsync()) {

--- a/test/Sema/throwing_super_init.swift
+++ b/test/Sema/throwing_super_init.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+
+class ThrowingInitSuperclass {
+  init() throws { }
+}
+
+// Implicitly calling the super.init IS possible here because the initializer
+// is a throwing initializer.
+class ThrowingInitClass: ThrowingInitSuperclass {
+  init(simpleArgument: Int) throws { }
+}
+
+// Implicitly calling the super.init IS NOT possible here because the
+// initializer is not a throwing initializer.
+class NonThrowingInitClass: ThrowingInitSuperclass {
+  init(simpleArgument: Int) { } // expected-error {{missing call to superclass's initializer; 'super.init' is a throwing initializer and requires either an explicit call or that this initializer is also marked as 'throws'}}
+}
+
+// Implicitly calling the super.init IS NOT possible here because the
+// initializer is a rethrowing initializer, which means it can only
+// rethrow errors from its parameters.
+class RethrowingInitClass: ThrowingInitSuperclass {
+  init(throwingArgument: () throws -> Void) rethrows { } // expected-error {{missing call to superclass's initializer; 'super.init' is a throwing initializer and requires either an explicit call or that this initializer is also marked as 'throws'}}
+}


### PR DESCRIPTION
### Problem

If we have a class with a throwing initializer and a subclass that implements an initializer and doesn't call the `super.init` explicitly, like this:
```swift
class ThrowingInitClass {
    init() throws {}
}

class ExampleSubclass: ThrowingInitClass {
    let exampleVariable: Int
    
    init(exampleParameter: Int) {
        self.exampleVariable = exampleParameter
    }
}
```
The compiler doesn't behave appropriately, as can be seen here:
`<unknown>:0: error: call can throw, but it is not marked with 'try' and the error is not handled.`

Note: This is not a problem if the subclass's initializer is also a throwing initializer (like `init(exampleParameter: Int) throws`). It compiles without errors or warnings.

### Solution Context

If we were to replace the `throws` on the previous block of code with `async`, we would hit the situation described on this excerpt from [
The Swift Programming Language (5.9) > Initialization > Initializer Inheritance and Overriding](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/initialization/#Initializer-Inheritance-and-Overriding):
>If a subclass initializer performs no customization in phase 2 of the initialization process, and the superclass has a synchronous, zero-argument designated initializer, you can omit a call to super.init() after assigning values to all of the subclass’s stored properties. **If the superclass’s initializer is asynchronous, you need to write await super.init() explicitly**.

As the related diagnostic in that case is:
`missing call to superclass's initializer; 'super.init' is 'async' and requires an explicit call`

### Implemented Solution

The solution I implemented mirrors the `async` approach to improve the diagnostic for the throwing case:
`missing call to superclass's initializer; 'super.init' is a throwing initializer and requires an explicit call`

This error only shows when the `super.init` is throwing while the subclass's initializer is not. If both are throwing, the current behavior (synthesizing what is probably something like `try super.init()`) should still work.

### Improvements Considered

1. I considered ending the error message with `"[...] requires an explicit call or that this initializer becomes a throwing initializer"` but I think it would be too long.

2. I also considered adding a fix-it for writing `throws` on the initializer, which would enable the synthetization to work. But I think that doing this would imply that this is the ideal solution on most cases, and it's not clear to me that this is true.

3. I also considered adding a fix-it for writing the `try super.init()` statement explicitly, which would then result on the `Errors thrown from here are not handled` error. But although I think this could be useful, I'm not confident on how to thoroughly test an implementation like that, so I decided to not go that deep for now.

4. I think we should clarify this situation on the paragraph I cited from the documentation and I plan on exploring if there are ways to do that if this pull request is approved.

Fixes #56650.