### PR TITLE
Prefer popcount intrinsic over manual counting

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2033,14 +2033,9 @@ public:
   }
 
   /// Determine the number of bits set.
-  static unsigned numBitsSet(uint64_t value) {
-    unsigned count = 0;
-    for (uint64_t i : range(0, 63)) {
-      if (value & (uint64_t(1) << i))
-        ++count;
-    }
+  static inline unsigned numBitsSet(uint64_t value) {
 
-    return count;
+    return static_cast<unsigned>(__builtin_popcountll(value));
   }
 
   void visitMacroDecl(MacroDecl *MD) {

--- a/stdlib/public/stubs/Unicode/UnicodeData.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeData.cpp
@@ -56,7 +56,7 @@ __swift_intptr_t _swift_stdlib_getMphIdx(__swift_uint32_t scalar,
   __swift_intptr_t resultIdx = 0;
 
   // Here, levels represent the numbers of bit arrays used for this hash table.
-  for (int i = 0; i != levels; i += 1) {
+  for (int i = 0; i < levels; i += 1) {
     auto bitArray = keys[i];
 
     // Get the specific bit that this scalar hashes to in the bit array.


### PR DESCRIPTION
We should be using intrinsics where possible, because they are faster and better-tested than manual popcounts.