### PR TITLE
[embedded] Mark embedded/fno-builtin.swift as REQUIRES: optimized_stdlib

### DIFF
--- a/test/embedded/fno-builtin.swift
+++ b/test/embedded/fno-builtin.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-emit-ir %s %S/Inputs/print.swift -module-name main -Xcc -ffreestanding -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
To resolve build failure at <https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators/3249/>.