### PR TITLE
[build][Android] Skip building Swift Syntax into the compiler

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -36,7 +36,7 @@ To follow along with this guide, you'll need:
    instructions in the Swift project README.
 2. The latest build of the Swift compiler for your Linux distro, available at
    https://www.swift.org/download/ or sometimes your distro package manager.
-3. The latest version of the Android LTS NDK (r25b at the time of this writing),
+3. The latest version of the Android LTS NDK (r25c at the time of this writing),
    available to download here:
    https://developer.android.com/ndk/downloads
 4. An Android device with remote debugging enabled or the emulator. We require
@@ -54,9 +54,9 @@ and the prebuilt Swift toolchain (add --skip-early-swift-driver if you already
 have a Swift toolchain in your path):
 
 ```
-$ NDK_PATH=path/to/android-ndk-r25b
-$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a-ubuntu20.04/usr/bin
-$ git checkout swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a
+$ NDK_PATH=path/to/android-ndk-r25c
+$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a-ubuntu20.04/usr/bin
+$ git checkout swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a
 $ utils/build-script \
     -R \                                       # Build in ReleaseAssert mode.
     --android \                                # Build for Android.
@@ -83,8 +83,8 @@ Then use the standalone Swift stdlib from the previous step to compile a Swift
 source file, targeting Android:
 
 ```
-$ NDK_PATH="path/to/android-ndk-r25b"
-$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a-ubuntu20.04/usr/bin
+$ NDK_PATH="path/to/android-ndk-r25c"
+$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a-ubuntu20.04/usr/bin
 $ $SWIFT_PATH/swiftc \                                               # The prebuilt Swift compiler you downloaded
                                                                      # The location of the tools used to build Android binaries
     -tools-directory ${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/ \
@@ -133,7 +133,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libBlo
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the
@@ -176,7 +176,7 @@ $ utils/build-script \
   -R \                               # Build in ReleaseAssert mode.
   -T \                               # Run all tests, including on the Android device (add --host-test to only run Android tests on the Linux host).
   --android \                        # Build for Android.
-  --android-ndk ~/android-ndk-r25b \  # Path to an Android NDK.
+  --android-ndk ~/android-ndk-r25c \  # Path to an Android NDK.
   --android-arch aarch64 \           # Optionally specify Android architecture, alternately armv7
   --android-api-level 21
 ```

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -992,6 +992,7 @@ install-swiftsyntax
 
 skip-test-linux
 skip-build-benchmarks
+skip-early-swiftsyntax
 
 reconfigure
 


### PR DESCRIPTION
The community CI doesn't have a prebuilt Swift compiler right now, so this unbreaks the build on there. Also, update the doc with the latest working LTS NDK and trunk snapshot.

@drodriguez, this will get the community CI running again, as you asked for.