### PR TITLE
Rework effects checking to maintain thrown type information.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8892,7 +8892,7 @@ static Expr *wrapAsyncLetInitializer(
       ConstraintSystem &cs, Expr *initializer, DeclContext *dc) {
   // Form the autoclosure type. It is always 'async', and will be 'throws'.
   Type initializerType = initializer->getType();
-  bool throws = TypeChecker::canThrow(initializer);
+  bool throws = TypeChecker::canThrow(cs.getASTContext(), initializer);
   auto extInfo = ASTExtInfoBuilder()
     .withAsync()
     .withConcurrent()

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1176,7 +1176,11 @@ void checkEnumElementEffects(EnumElementDecl *D, Expr *expr);
 void checkPropertyWrapperEffects(PatternBindingDecl *binding, Expr *expr);
 
 /// Whether the given expression can throw.
-bool canThrow(Expr *expr);
+bool canThrow(ASTContext &ctx, Expr *expr);
+
+/// Given two error types, merge them into the "union" of both error types
+/// that is a supertype of both error types.
+Type errorUnion(Type type1, Type type2);
 
 /// If an expression references 'self.init' or 'super.init' in an
 /// initializer context, returns the implicit 'self' decl of the constructor.


### PR DESCRIPTION
While here, eliminate some redundancy in the implementation of effects checking be consolidating the logic for computing a `Classification` from a particular expression or other entity.
