### PR TITLE
[Linux] Provide a statically linked swift-backtrace binary.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2545,7 +2545,8 @@ endfunction()
 #     The Swift installation component that this executable belongs to.
 #     Defaults to never_install.
 function(_add_swift_target_executable_single name)
-  set(options)
+  set(options
+    NOSWIFTRT)
   set(single_parameter_options
     ARCHITECTURE
     SDK
@@ -2622,6 +2623,15 @@ function(_add_swift_target_executable_single name)
   add_executable(${name}
       ${SWIFTEXE_SINGLE_SOURCES}
       ${SWIFTEXE_SINGLE_EXTERNAL_SOURCES})
+
+  # ELF and COFF need swiftrt
+  if(("${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_OBJECT_FORMAT}" STREQUAL "ELF" OR
+      "${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_OBJECT_FORMAT}" STREQUAL "COFF")
+     AND NOT SWIFTEXE_SINGLE_NOSWIFTRT)
+    target_sources(${name}
+      PRIVATE
+      $<TARGET_OBJECTS:swiftImageRegistrationObject${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFTEXE_SINGLE_SDK}_LIB_SUBDIR}-${SWIFTEXE_SINGLE_ARCHITECTURE}>)
+  endif()
 
   add_dependencies_multiple_targets(
       TARGETS "${name}"
@@ -2713,7 +2723,8 @@ function(add_swift_target_executable name)
     EXCLUDE_FROM_ALL
     BUILD_WITH_STDLIB
     BUILD_WITH_LIBEXEC
-    PREFER_STATIC)
+    PREFER_STATIC
+    NOSWIFTRT)
   set(SWIFTEXE_single_parameter_options
     INSTALL_IN_COMPONENT)
   set(SWIFTEXE_multiple_parameter_options
@@ -2916,6 +2927,7 @@ function(add_swift_target_executable name)
 
       _add_swift_target_executable_single(
           ${VARIANT_NAME}
+          ${SWIFTEXE_TARGET_NOSWIFTRT_keyword}
           ${SWIFTEXE_TARGET_SOURCES}
           DEPENDS
             ${SWIFTEXE_TARGET_DEPENDS_with_suffix}

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1518,8 +1518,14 @@ function(add_swift_target_library_single target name)
         "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}")
     target_link_directories(${target_static} PRIVATE
       ${library_search_directories})
+
+    _list_add_string_suffix(
+        "${SWIFTLIB_SINGLE_PRIVATE_LINK_LIBRARIES}"
+        "-static"
+        target_private_libs)
+
     target_link_libraries("${target_static}" PRIVATE
-        ${SWIFTLIB_SINGLE_PRIVATE_LINK_LIBRARIES})
+        ${target_private_libs})
 
     # Force executables linker language to be CXX so that we do not link using the
     # host toolchain swiftc.
@@ -2680,6 +2686,24 @@ function(_add_swift_target_executable_single name)
   set_target_properties(${name} PROPERTIES FOLDER "Swift executables")
 endfunction()
 
+# Conditionally append -static to a name, if that variant is a valid target
+function(append_static name result_var_name)
+  cmake_parse_arguments(APPEND_TARGET
+    "STATIC_SWIFT_STDLIB"
+    ""
+    ""
+    ${ARGN})
+  if(STATIC_SWIFT_STDLIB)
+    if(TARGET "${name}-static")
+      set("${result_var_name}" "${name}-static" PARENT_SCOPE)
+    else()
+      set("${result_var_name}" "${name}" PARENT_SCOPE)
+    endif()
+  else()
+    set("${result_var_name}" "${name}" PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Add an executable for each target variant. Executables are given suffixes
 # with the variant SDK and ARCH.
 #
@@ -2688,7 +2712,8 @@ function(add_swift_target_executable name)
   set(SWIFTEXE_options
     EXCLUDE_FROM_ALL
     BUILD_WITH_STDLIB
-    BUILD_WITH_LIBEXEC)
+    BUILD_WITH_LIBEXEC
+    PREFER_STATIC)
   set(SWIFTEXE_single_parameter_options
     INSTALL_IN_COMPONENT)
   set(SWIFTEXE_multiple_parameter_options
@@ -2874,8 +2899,12 @@ function(add_swift_target_executable name)
         list(APPEND swiftexe_module_dependency_targets
           "swift${mod}${MODULE_VARIANT_SUFFIX}")
 
-        list(APPEND swiftexe_link_libraries_targets
-          "swift${mod}${VARIANT_SUFFIX}")
+        set(library_target "swift${mod}${VARIANT_SUFFIX}")
+        if(SWIFTEXE_TARGET_PREFER_STATIC AND TARGET "${library_target}-static")
+          set(library_target "${library_target}-static")
+        endif()
+
+        list(APPEND swiftexe_link_libraries_targets "${library_target}")
       endforeach()
 
       # Don't add the ${arch} to the suffix.  We want to link against fat

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -903,11 +903,6 @@ function(_compile_swift_files
 
   # First generate the obj dirs
   list(REMOVE_DUPLICATES dirs_to_create)
-  add_custom_command_target(
-      create_dirs_dependency_target
-      COMMAND "${CMAKE_COMMAND}" -E make_directory ${dirs_to_create}
-      OUTPUT ${dirs_to_create}
-      COMMENT "Generating dirs for ${first_output}")
 
   # Then we can compile both the object files and the swiftmodule files
   # in parallel in this target for the object file, and ...
@@ -937,6 +932,7 @@ function(_compile_swift_files
 
   add_custom_command_target(
       dependency_target
+      COMMAND "${CMAKE_COMMAND}" -E make_directory ${dirs_to_create}
       COMMAND
         ${set_environment_args}
         "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --

--- a/stdlib/public/Backtracing/CMakeLists.txt
+++ b/stdlib/public/Backtracing/CMakeLists.txt
@@ -78,7 +78,7 @@ add_swift_target_library(swift_Backtracing ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
 
   SWIFT_MODULE_DEPENDS ${concurrency}
 
-  LINK_LIBRARIES ${swift_backtracing_link_libraries}
+  PRIVATE_LINK_LIBRARIES ${swift_backtracing_link_libraries}
 
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}

--- a/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
+++ b/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
@@ -26,13 +26,18 @@ set(BACKTRACING_COMPILE_FLAGS
   "-Xcc;-I${SWIFT_SOURCE_DIR}/include"
   "-Xcc;-I${CMAKE_BINARY_DIR}/include")
 
-add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
+set(BACKTRACING_SOURCES
   main.swift
   AnsiColor.swift
   TargetMacOS.swift
   TargetLinux.swift
   Themes.swift
   Utils.swift
+  )
+
+
+add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
+  ${BACKTRACING_SOURCES}
 
   SWIFT_MODULE_DEPENDS         ${backtracing}
 
@@ -47,3 +52,22 @@ add_swift_target_executable(swift-backtrace BUILD_WITH_LIBEXEC
 
   TARGET_SDKS OSX LINUX)
 
+if(SWIFT_BUILD_STATIC_STDLIB)
+  add_swift_target_executable(swift-backtrace-static BUILD_WITH_LIBEXEC
+    PREFER_STATIC
+
+    ${BACKTRACING_SOURCES}
+
+    SWIFT_MODULE_DEPENDS         ${backtracing}
+
+    SWIFT_MODULE_DEPENDS_OSX     ${darwin}
+    SWIFT_MODULE_DEPENDS_WINDOWS ${wincrt_sdk}
+    SWIFT_MODULE_DEPENDS_LINUX   ${glibc}
+
+    INSTALL_IN_COMPONENT libexec
+    COMPILE_FLAGS
+      ${BACKTRACING_COMPILE_FLAGS}
+      -parse-as-library
+
+    TARGET_SDKS LINUX)
+endif()

--- a/test/Backtracing/StaticBacktracer.swift
+++ b/test/Backtracing/StaticBacktracer.swift
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library %import-static-libdispatch -Onone -g -o %t/StaticBacktracer
+// RUN: %target-codesign %t/StaticBacktracer
+// RUN: /usr/bin/ldd %backtracer-static | %FileCheck %s --check-prefix LIBS
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer-static %target-run %t/StaticBacktracer 2>&1 || true) | %FileCheck %s
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: static_stdlib
+// REQUIRES: OS=linux-gnu
+
+func level1() {
+  level2()
+}
+
+func level2() {
+  level3()
+}
+
+func level3() {
+  level4()
+}
+
+func level4() {
+  level5()
+}
+
+func level5() {
+  print("About to crash")
+  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+  ptr.pointee = 42
+}
+
+@main
+struct StaticBacktracer {
+  static func main() {
+    level1()
+  }
+}
+
+// CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// CHECK: Thread 0 {{(".*" )?}}crashed:
+
+// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in StaticBacktracer at {{.*}}/StaticBacktracer.swift:34:15
+// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in StaticBacktracer at {{.*}}/StaticBacktracer.swift:28:3
+// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in StaticBacktracer at {{.*}}/StaticBacktracer.swift:24:3
+// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in StaticBacktracer at {{.*}}/StaticBacktracer.swift:20:3
+// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in StaticBacktracer at {{.*}}/StaticBacktracer.swift:16:3
+// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static StaticBacktracer.main() + {{[0-9]+}} in StaticBacktracer at {{.*}}/StaticBacktracer.swift:40:5
+// CHECK-NEXT: 6 [ra] [system] 0x{{[0-9a-f]+}} static StaticBacktracer.$main() + {{[0-9]+}} in StaticBacktracer at {{.*}}/<compiler-generated>
+// CHECK-NEXT: 7 [ra] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in StaticBacktracer at {{.*}}/StaticBacktracer.swift
+
+// CHECK: Registers:
+
+// CHECK: Images ({{[0-9]+}} omitted):
+
+// CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{([0-9a-f]+|<no build ID>)}}{{ +}}StaticBacktracer{{ +}}{{.*}}/StaticBacktracer
+
+// .............................................................................
+
+// We mustn't have any Swift libraries dynamically linked here; that's the
+// entire point.
+
+// LIBS-NOT: libswift{{.*}}.so


### PR DESCRIPTION
This adds a new binary, `swift-backtrace-static`, to the build.  The runtime will not by default use this binary as the backtracer, but if you want to statically link your own binaries against the standard library you can copy `swift-backtrace-static` rather than `swift-backtrace` alongside your binary, naming it `swift-backtrace`, and the runtime should find and use it, which will mean you don't need to have `libswiftCore.so` et al installed.

rdar://115278959
