### PR TITLE
[embedded] Support closures with captures and promoting locals to refcounted heap objects

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3118,6 +3118,8 @@ bool CompilerInvocation::parseArgs(
   if (LangOpts.hasFeature(Feature::Embedded)) {
     IRGenOpts.InternalizeAtLink = true;
     IRGenOpts.DisableLegacyTypeInfo = true;
+    IRGenOpts.ReflectionMetadata = ReflectionMetadataMode::None;
+    IRGenOpts.EnableReflectionNames = false;
     SILOpts.CMOMode = CrossModuleOptimizationMode::Everything;
     SILOpts.EmbeddedSwift = true;
   }

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -71,6 +71,11 @@ public func swift_allocObject(metadata: UnsafeMutablePointer<ClassMetadata>, req
   return object
 }
 
+@_silgen_name("swift_deallocObject")
+public func swift_deallocObject(object: UnsafeMutablePointer<HeapObject>, allocatedSize: Int, allocatedAlignMask: Int) {
+  free(object)
+}
+
 @_silgen_name("swift_deallocClassInstance")
 public func swift_deallocClassInstance(object: UnsafeMutablePointer<HeapObject>, allocatedSize: Int, allocatedAlignMask: Int) {
   if (object.pointee.refcount & HeapObject.doNotFreeBit) != 0 {

--- a/test/embedded/closures-heap.swift
+++ b/test/embedded/closures-heap.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public class MyClass {
+  var handler: (()->())? = nil
+  func foo() {
+    handler?()
+  }
+  deinit { print("deinit") }
+}
+
+@main
+struct Main {
+  static var o: MyClass? = nil
+
+  static func main() {
+    o = MyClass()
+    o!.handler = { print("no captures") }
+    o!.foo() // CHECK: no captures
+    o = nil // CHECK: deinit
+
+    var local = 42
+    o = MyClass()
+    o!.handler = { print("capture local"); local += 1 }
+    o!.foo() // CHECK: capture local
+    print(local == 43 ? "43" : "???") // CHECK: 43
+    o = nil // CHECK: deinit
+  }
+}


### PR DESCRIPTION
Currently, IRGen of alloc_box doesn't do the right thing on embedded Swift (it produces a `swift.full_boxmetadata` with the standard Swift layout). Let's fix it by producing a layout that embedded Swift and its runtime expects (just a superclass pointer + destructor). Adding a test for escaping closures with captures.