### PR TITLE
Always disable requiring Foundation for '@objc' when building/typechecking interfaces

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -735,6 +735,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                                OPT_disable_testable_attr_requires_testable_module)) {
     Opts.EnableTestableAttrRequiresTestableModule
       = A->getOption().matches(OPT_enable_testable_attr_requires_testable_module);
+  } else if (FrontendOpts.RequestedAction ==
+             FrontendOptions::ActionType::TypecheckModuleFromInterface ||
+	     FrontendOpts.RequestedAction ==
+             FrontendOptions::ActionType::CompileModuleFromInterface) {
+    Opts.EnableObjCAttrRequiresFoundation = false;
   }
 
   if (Args.getLastArg(OPT_debug_cycles))

--- a/test/ModuleInterface/ExplicitInterfaceObjC.swiftinterface
+++ b/test/ModuleInterface/ExplicitInterfaceObjC.swiftinterface
@@ -1,0 +1,13 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name ExplicitInterfaceObjC
+
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -compile-module-from-interface -module-name ExplicitInterfaceObjC -explicit-interface-module-build -o %/t/ExplicitInterfaceObjC.swiftmodule %s -verify
+// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name ExplicitInterfaceObjC -explicit-interface-module-build -o %/t/ExplicitInterfaceObjC.swiftmodule %s -verify
+import Swift
+
+final public class Foo {
+  @objc deinit
+}


### PR DESCRIPTION
Today, this (`-disable-objc-attr-requires-foundation-module`) is an extra flag we add in `InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface`, which does not seem right for all cases, as it is not inherited from the parent invocation. It should instead just be the default for these frontend actions. 