### PR TITLE
[5.10 🍒] Always disable requiring Foundation for '@objc' when building/typechecking interfaces

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -730,6 +730,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                                OPT_disable_testable_attr_requires_testable_module)) {
     Opts.EnableTestableAttrRequiresTestableModule
       = A->getOption().matches(OPT_enable_testable_attr_requires_testable_module);
+  } else if (FrontendOpts.RequestedAction ==
+             FrontendOptions::ActionType::TypecheckModuleFromInterface ||
+	     FrontendOpts.RequestedAction ==
+             FrontendOptions::ActionType::CompileModuleFromInterface) {
+    Opts.EnableObjCAttrRequiresFoundation = false;
   }
 
   if (Args.getLastArg(OPT_debug_cycles))

--- a/test/ModuleInterface/ExplicitInterfaceObjC.swiftinterface
+++ b/test/ModuleInterface/ExplicitInterfaceObjC.swiftinterface
@@ -1,0 +1,13 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name ExplicitInterfaceObjC
+
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -compile-module-from-interface -module-name ExplicitInterfaceObjC -explicit-interface-module-build -o %/t/ExplicitInterfaceObjC.swiftmodule %s -verify
+// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name ExplicitInterfaceObjC -explicit-interface-module-build -o %/t/ExplicitInterfaceObjC.swiftmodule %s -verify
+import Swift
+
+final public class Foo {
+  @objc deinit
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68913
---------------------------------------
• Release: Swift 5.10
• Explanation: Today, this (`-disable-objc-attr-requires-foundation-module`) is an extra flag we add in `InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface`, which does not seem right for all cases, such as explicit interface build and verify jobs, as it is not inherited from the parent invocation. It should instead just be the default for these frontend actions.
• Scope of Issue: Explicit module builds invoke interface verification jobs which may hard fail upon encountering `@objc` if `Foundation` module is not imported by the interface. This is not meant to be a hard error. 
• Risk: Minimal, this change sets the default to match behavior of implicit builds.
• Origination: Explicit Module Build feature development.

Resolves rdar://116008985 

