### PR TITLE
[5.10][SourceKit] Fix RPATH to lib/swift/host in SourceKit frameworks

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -433,7 +433,7 @@ macro(add_sourcekit_framework name)
         BINARY_DIR ${SOURCEKIT_RUNTIME_OUTPUT_INTDIR}
         LIBRARY_DIR ${SOURCEKIT_LIBRARY_OUTPUT_INTDIR})
     set(RPATH_LIST)
-    add_sourcekit_swift_runtime_link_flags(${name} "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}" ${SOURCEKITFW_HAS_SWIFT_MODULES})
+    add_sourcekit_swift_runtime_link_flags(${name} "${framework_location}/Versions/A" ${SOURCEKITFW_HAS_SWIFT_MODULES})
     file(RELATIVE_PATH relative_lib_path
       "${framework_location}/Versions/A" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}")
     list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}")


### PR DESCRIPTION
Cherry-pick #68807 into release/5.10

* **Explanation**: SourceKit frameworks didn't have correct RPATH to `lib/swift/host` in the toolchain. All tests happened to work because the parent executables happened to have the RPATH to `lib/swift/host`. 
* **Scope**: SourceKit
* **Risk**: Low, this only affects clients who wants to use SourceKit frameworks directly, and it only corrects RPATHs.
* **Testing**: Current test suite passes. And fixes ASAN CI jobs failing.
* **Issues**: rdar://115976985
* **Reviewer**: Ben Barham (@bnbarham)