### PR TITLE
[stdlib] remove pointer conversion from inlined runtime code

### DIFF
--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -133,13 +133,16 @@ func _stdlib_atomicInitializeARCRef(
 ) -> Bool {
   // Note: this assumes that AnyObject? is layout-compatible with a RawPointer
   // that simply points to the same memory.
-  var expected: UnsafeRawPointer?
+  var expected: UnsafeRawPointer? = nil
   let unmanaged = Unmanaged.passRetained(desired)
   let desiredPtr = unmanaged.toOpaque()
   let rawTarget = UnsafeMutableRawPointer(target).assumingMemoryBound(
     to: Optional<UnsafeRawPointer>.self)
-  let wonRace = _stdlib_atomicCompareExchangeStrongPtr(
-    object: rawTarget, expected: &expected, desired: desiredPtr)
+  let wonRace = withUnsafeMutablePointer(to: &expected) {
+    _stdlib_atomicCompareExchangeStrongPtr(
+      object: rawTarget, expected: $0, desired: desiredPtr
+    )
+  }
   if !wonRace {
     // Some other thread initialized the value.  Balance the retain that we
     // performed on 'desired'.


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/68715.
Removes an inout-to-pointer conversion for inlinable runtime code that is completely expressed in Swift.

If pointer conversions were to be completely disallowed in pure Swift code, the presence of this pointer conversion in a pre-existing standard library would prevent the compiler from building from scratch.

After this change, we get the same generated assembly as before when compiling in release mode.

Addresses rdar://116374967
