### PR TITLE
[embedded] Initial Swift Concurrency for embedded Swift

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2478,6 +2478,8 @@ enum class TaskOptionRecordKind : uint8_t {
   AsyncLet  = 2,
   /// Request a child task for an 'async let'.
   AsyncLetWithBuffer = 3,
+  /// Information about the result type of the task, used in embedded Swift.
+  ResultTypeInfo = 4,
   /// Request a child task for swift_task_run_inline.
   RunInline = UINT8_MAX,
 };

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -185,6 +185,61 @@ public:
   }
 };
 
+/// Descibes type information and offers value methods for an arbitrary concrete
+/// type in a way that's compatible with regular Swift and embedded Swift. In
+/// regular Swift, just holds a Metadata pointer and dispatches to the value
+/// witness table. In embedded Swift, because we do not have any value witness
+/// tables present at runtime, the witnesses are stored and referenced directly.
+///
+/// This structure is created from swift_task_create, where in regular Swift, the
+/// compiler provides the Metadata pointer, and in embedded Swift, a
+/// TaskOptionRecord is used to provide the witnesses.
+struct ResultTypeInfo {
+#if !SWIFT_CONCURRENCY_EMBEDDED
+  const Metadata *metadata = nullptr;
+  size_t vw_size() {
+    return metadata->vw_size();
+  }
+  size_t vw_alignment() {
+    return metadata->vw_alignment();
+  }
+  void vw_initializeWithCopy(OpaqueValue *result, OpaqueValue *src) {
+    metadata->vw_initializeWithCopy(result, src);
+  }
+  void vw_storeEnumTagSinglePayload(OpaqueValue *v, unsigned whichCase,
+                                    unsigned emptyCases) {
+    metadata->vw_storeEnumTagSinglePayload(v, whichCase, emptyCases);
+  }
+  void vw_destroy(OpaqueValue *v) {
+    metadata->vw_destroy(v);
+  }
+#else
+  size_t size = 0;
+  size_t alignMask = 0;
+  void (*initializeWithCopy)(OpaqueValue *result, OpaqueValue *src) = nullptr;
+  void (*storeEnumTagSinglePayload)(OpaqueValue *v, unsigned whichCase,
+                                    unsigned emptyCases) = nullptr;
+  void (*destroy)(OpaqueValue *) = nullptr;
+
+  size_t vw_size() {
+    return size;
+  }
+  size_t vw_alignment() {
+    return alignMask + 1;
+  }
+  void vw_initializeWithCopy(OpaqueValue *result, OpaqueValue *src) {
+    initializeWithCopy(result, src);
+  }
+  void vw_storeEnumTagSinglePayload(OpaqueValue *v, unsigned whichCase,
+                                    unsigned emptyCases) {
+    storeEnumTagSinglePayload(v, whichCase, emptyCases);
+  }
+  void vw_destroy(OpaqueValue *v) {
+    destroy(v);
+  }
+#endif
+};
+
 /// An asynchronous task.  Tasks are the analogue of threads for
 /// asynchronous functions: that is, they are a persistent identity
 /// for the overall async computation.
@@ -503,7 +558,7 @@ public:
     std::atomic<WaitQueueItem> waitQueue;
 
     /// The type of the result that will be produced by the future.
-    const Metadata *resultType;
+    ResultTypeInfo resultType;
 
     SwiftError *error = nullptr;
 
@@ -513,14 +568,14 @@ public:
     friend class AsyncTask;
 
   public:
-    explicit FutureFragment(const Metadata *resultType)
+    explicit FutureFragment(ResultTypeInfo resultType)
       : waitQueue(WaitQueueItem::get(Status::Executing, nullptr)),
         resultType(resultType) { }
 
     /// Destroy the storage associated with the future.
     void destroy();
 
-    const Metadata *getResultType() const {
+    ResultTypeInfo getResultType() const {
       return resultType;
     }
 
@@ -534,7 +589,7 @@ public:
       // `this` must have the same value modulo that alignment as
       // `fragmentOffset` has in that function.
       char *fragmentAddr = reinterpret_cast<char *>(this);
-      uintptr_t alignment = resultType->vw_alignment();
+      uintptr_t alignment = resultType.vw_alignment();
       char *resultAddr = fragmentAddr + sizeof(FutureFragment);
       uintptr_t unalignedResultAddrInt =
         reinterpret_cast<uintptr_t>(resultAddr);
@@ -553,12 +608,12 @@ public:
     /// Determine the size of the future fragment given the result type
     /// of the future.
     static size_t fragmentSize(size_t fragmentOffset,
-                               const Metadata *resultType) {
+                               ResultTypeInfo resultType) {
       assert((fragmentOffset & (alignof(FutureFragment) - 1)) == 0);
-      size_t alignment = resultType->vw_alignment();
+      size_t alignment = resultType.vw_alignment();
       size_t resultOffset = fragmentOffset + sizeof(FutureFragment);
       resultOffset = (resultOffset + alignment - 1) & ~(alignment - 1);
-      size_t endOffset = resultOffset + resultType->vw_size();
+      size_t endOffset = resultOffset + resultType.vw_size();
       return (endOffset - fragmentOffset);
     }
   };

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -197,6 +197,9 @@ public:
 struct ResultTypeInfo {
 #if !SWIFT_CONCURRENCY_EMBEDDED
   const Metadata *metadata = nullptr;
+  bool isNull() {
+    return metadata == nullptr;
+  }
   size_t vw_size() {
     return metadata->vw_size();
   }
@@ -221,6 +224,9 @@ struct ResultTypeInfo {
                                     unsigned emptyCases) = nullptr;
   void (*destroy)(OpaqueValue *) = nullptr;
 
+  bool isNull() {
+    return initializeWithCopy == nullptr;
+  }
   size_t vw_size() {
     return size;
   }

--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -141,6 +141,19 @@ public:
   }
 };
 
+class ResultTypeInfoTaskOptionRecord : public TaskOptionRecord {
+ public:
+  size_t size;
+  size_t alignMask;
+  void (*initializeWithCopy)(OpaqueValue *, OpaqueValue *);
+  void (*storeEnumTagSinglePayload)(OpaqueValue *, unsigned, unsigned);
+  void (*destroy)(OpaqueValue *);
+
+  static bool classof(const TaskOptionRecord *record) {
+    return record->getKind() == TaskOptionRecordKind::ResultTypeInfo;
+  }
+};
+
 class RunInlineTaskOptionRecord : public TaskOptionRecord {
   void *allocation;
   size_t allocationBytes;

--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -141,6 +141,7 @@ public:
   }
 };
 
+#if SWIFT_CONCURRENCY_EMBEDDED
 class ResultTypeInfoTaskOptionRecord : public TaskOptionRecord {
  public:
   size_t size;
@@ -153,6 +154,7 @@ class ResultTypeInfoTaskOptionRecord : public TaskOptionRecord {
     return record->getKind() == TaskOptionRecordKind::ResultTypeInfo;
   }
 };
+#endif
 
 class RunInlineTaskOptionRecord : public TaskOptionRecord {
   void *allocation;

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1012,7 +1012,8 @@ public:
   }
 
   static LinkEntity forValueWitness(CanType concreteType, ValueWitness witness) {
-    assert(!isEmbedded(concreteType));
+    // Explicitly allowed in embedded Swift because we generate value witnesses
+    // (but not witness tables) for Swift Concurrency usage.
     LinkEntity entity;
     entity.Pointer = concreteType.getPointer();
     entity.Data = LINKENTITY_SET_FIELD(Kind, unsigned(Kind::ValueWitness))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3133,6 +3133,8 @@ bool CompilerInvocation::parseArgs(
     IRGenOpts.DisableLegacyTypeInfo = true;
     IRGenOpts.ReflectionMetadata = ReflectionMetadataMode::None;
     IRGenOpts.EnableReflectionNames = false;
+    TypeCheckerOpts.SkipFunctionBodies = FunctionBodySkipping::None;
+    SILOpts.SkipFunctionBodies = FunctionBodySkipping::None;
     SILOpts.CMOMode = CrossModuleOptimizationMode::Everything;
     SILOpts.EmbeddedSwift = true;
   }

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -326,7 +326,15 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
         (Builtin.ID == BuiltinValueKind::CreateAsyncTaskInGroup)
         ? args.claimNext()
         : nullptr;
-    auto futureResultType = args.claimNext();
+
+    // In embedded Swift, futureResultType is a thin metatype, not backed by any
+    // actual value.
+    llvm::Value *futureResultType =
+        llvm::ConstantPointerNull::get(IGF.IGM.Int8PtrTy);
+    if (!IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+      futureResultType = args.claimNext();
+    }
+
     auto taskFunction = args.claimNext();
     auto taskContext = args.claimNext();
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -671,6 +671,15 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     SwiftTaskOptionRecordTy,    // Base option record
     SwiftTaskGroupPtrTy,        // Task group
   });
+  SwiftResultTypeInfoTaskOptionRecordTy = createStructType(
+      *this, "swift.result_type_info_task_option", {
+    SwiftTaskOptionRecordTy,    // Base option record
+    SizeTy,
+    SizeTy,
+    Int8PtrTy,
+    Int8PtrTy,
+    Int8PtrTy,
+  });
   ExecutorFirstTy = SizeTy;
   ExecutorSecondTy = SizeTy;
   SwiftExecutorTy = createStructType(*this, "swift.executor", {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -780,6 +780,7 @@ public:
   llvm::PointerType *SwiftTaskGroupPtrTy;
   llvm::StructType  *SwiftTaskOptionRecordTy;
   llvm::StructType  *SwiftTaskGroupTaskOptionRecordTy;
+  llvm::StructType  *SwiftResultTypeInfoTaskOptionRecordTy;
   llvm::PointerType *SwiftJobPtrTy;
   llvm::IntegerType *ExecutorFirstTy;
   llvm::IntegerType *ExecutorSecondTy;
@@ -1570,6 +1571,11 @@ public:
   Address getAddrOfEnumCase(EnumElementDecl *Case,
                             ForDefinition_t forDefinition);
   Address getAddrOfFieldOffset(VarDecl *D, ForDefinition_t forDefinition);
+  llvm::Function *getOrCreateValueWitnessFunction(ValueWitness index,
+                                                  FixedPacking packing,
+                                                  CanType abstractType,
+                                                  SILType concreteType,
+                                                  const TypeInfo &type);
   llvm::Function *getAddrOfValueWitness(CanType concreteType,
                                         ValueWitness index,
                                         ForDefinition_t forDefinition);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -663,7 +663,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   // ...but we don't actually expose individual value witnesses (right now).
   case Kind::ValueWitness: {
     auto *nominal = getType().getAnyNominal();
-    if (getDeclLinkage(nominal) == FormalLinkage::PublicNonUnique)
+    if (nominal && getDeclLinkage(nominal) == FormalLinkage::PublicNonUnique)
       return SILLinkage::Shared;
     assert(forDefinition);
     return SILLinkage::Private;

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -135,6 +135,26 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
 endif()
 
 if(SWIFT_BUILD_STDLIB)
+  set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB TRUE)
+  if(NOT SWIFT_HOST_VARIANT STREQUAL "macosx")
+    set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
+  elseif(NOT SWIFT_INCLUDE_TOOLS)
+    # Temporarily, only build embedded stdlib when building the compiler, to
+    # unblock CI jobs that run against old(er) toolchains.
+    set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
+  endif()
+
+  set(EMBEDDED_STDLIB_TARGET_TRIPLES
+    # arch    module_name               target triple
+    "armv7    armv7-apple-none-macho    armv7-apple-none-macho"
+    "arm64    arm64-apple-none-macho    arm64-apple-none-macho"
+    "x86_64   x86_64-apple-macos        x86_64-apple-macos10.13"
+    "arm64    arm64-apple-macos         arm64-apple-macos10.13"
+    "arm64e   arm64e-apple-macos        arm64e-apple-macos10.13"
+    )
+endif()
+
+if(SWIFT_BUILD_STDLIB)
   # These must be kept in dependency order so that any referenced targets
   # exist at the time we look for them in add_swift_*.
   add_subdirectory(runtime)

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1985,11 +1985,15 @@ static void swift_task_enqueueImpl(Job *job, ExecutorRef executor) {
     return swift_defaultActor_enqueue(job, executor.getDefaultActor());
   }
 
+#if SWIFT_CONCURRENCY_EMBEDDED
+  swift_unreachable("custom executors not supported in embedded Swift");
+#else
   // For main actor or actors with custom executors
   auto wtable = executor.getSerialExecutorWitnessTable();
   auto executorObject = executor.getIdentity();
   auto executorType = swift_getObjectType(executorObject);
   _swift_task_enqueueOnExecutor(job, executorObject, executorType, wtable);
+#endif
 }
 
 static void

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -395,7 +395,7 @@ static void _asyncLet_finish_continuation(
   if (error) {
     swift_errorRelease((SwiftError*)error);
   } else {
-    alet->getTask()->futureFragment()->getResultType()->vw_destroy(resultBuffer);
+    alet->getTask()->futureFragment()->getResultType().vw_destroy(resultBuffer);
   }
 
   // Clean up the async let now that the task has finished.
@@ -417,7 +417,7 @@ static void swift_asyncLet_finishImpl(SWIFT_ASYNC_CONTEXT AsyncContext *callerCo
   // If the result buffer is already populated, then we just need to destroy
   // the value in it and then clean up the task.
   if (asImpl(alet)->hasResultInBuffer()) {
-    task->futureFragment()->getResultType()->vw_destroy(
+    task->futureFragment()->getResultType().vw_destroy(
                                   reinterpret_cast<OpaqueValue*>(resultBuffer));
     return asyncLet_finish_after_task_completion(callerContext,
                                                  alet,

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -10,18 +10,6 @@
 #
 #===----------------------------------------------------------------------===#
 
-if(NOT swift_concurrency_extra_sources)
-  set(swift_concurrency_extra_sources
-    Clock.swift
-    ContinuousClock.swift
-    SuspendingClock.swift
-    TaskSleepDuration.swift)
-endif()
-
-if(NOT swift_concurrency_install_component)
-  set(swift_concurrency_install_component stdlib)
-endif()
-
 set(SWIFT_RUNTIME_CONCURRENCY_C_FLAGS)
 set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS)
 
@@ -75,17 +63,31 @@ endif()
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
   "-D__STDC_WANT_LIB_EXT1__=1")
 
-add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+set(SWIFT_RUNTIME_CONCURRENCY_C_SOURCES
   ../CompatibilityOverride/CompatibilityOverride.cpp
   Actor.cpp
-  Actor.swift
   AsyncLet.cpp
-  AsyncLet.swift
-  CheckedContinuation.swift
   Clock.cpp
   GlobalExecutor.cpp
-  Errors.swift
+  EmbeddedSupport.cpp
   Error.cpp
+  Setup.cpp
+  Task.cpp
+  TaskAlloc.cpp
+  TaskStatus.cpp
+  TaskGroup.cpp
+  TaskLocal.cpp
+  ThreadingError.cpp
+  TracingSignpost.cpp
+  AsyncStream.cpp
+  linker-support/magic-symbols-for-install-name.c
+)
+
+set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
+  Actor.swift
+  AsyncLet.swift
+  CheckedContinuation.swift
+  Errors.swift
   Executor.swift
   ExecutorAssertions.swift
   AsyncCompactMapSequence.swift
@@ -107,25 +109,16 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   GlobalActor.swift
   MainActor.swift
   PartialAsyncTask.swift
-  Setup.cpp
   SourceCompatibilityShims.swift
-  Task.cpp
   Task.swift
   TaskCancellation.swift
-  TaskAlloc.cpp
-  TaskStatus.cpp
-  TaskGroup.cpp
   TaskGroup.swift
   DiscardingTaskGroup.swift
-  TaskLocal.cpp
   TaskLocal.swift
   TaskSleep.swift
-  ThreadingError.cpp
-  TracingSignpost.cpp
   AsyncStreamBuffer.swift
   AsyncStream.swift
   AsyncThrowingStream.swift
-  AsyncStream.cpp
   Deque/_DequeBuffer.swift
   Deque/_DequeBufferHeader.swift
   Deque/_DequeSlot.swift
@@ -145,8 +138,15 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   Deque/Deque+Hashable.swift
   Deque/Deque+Testing.swift
   Deque/UnsafeMutableBufferPointer+Utilities.swift
-  ${swift_concurrency_extra_sources}
-  linker-support/magic-symbols-for-install-name.c
+  Clock.swift
+  ContinuousClock.swift
+  SuspendingClock.swift
+  TaskSleepDuration.swift
+)
+
+add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  ${SWIFT_RUNTIME_CONCURRENCY_C_SOURCES}
+  ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES}
 
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc
@@ -170,6 +170,63 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     -diagnostic-style swift
     ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
   ${swift_concurrency_options}
-  INSTALL_IN_COMPONENT ${swift_concurrency_install_component}
+  INSTALL_IN_COMPONENT stdlib
   MACCATALYST_BUILD_FLAVOR zippered
 )
+
+# Embedded Swift Concurrency library
+# For now, we build a hardcoded list of target triples of the embedded stdlib,
+# and only when building Swift on macOS.
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+  add_custom_target(embedded-concurrency ALL)
+
+  set(SWIFT_ENABLE_REFLECTION OFF)
+  set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
+  set(SWIFT_STDLIB_STABLE_ABI OFF)
+  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
+  set(SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY TRUE)
+
+  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
+    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
+    list(GET list 0 arch)
+    list(GET list 1 mod)
+    list(GET list 2 triple)
+
+    # TODO: Only build embedded Swift Concurrency for macOS, for now.
+    if(NOT "${mod}" MATCHES "-macos$")
+      continue()
+    endif()
+    
+    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
+    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
+    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
+    add_swift_target_library_single(
+      embedded-concurrency-${mod}
+      swift_Concurrency
+      STATIC
+      IS_STDLIB
+
+      ${SWIFT_RUNTIME_CONCURRENCY_C_SOURCES}
+      # TODO: Only a handful of Swift Concurrency .swift sources, for now.
+      Task.swift
+      AsyncLet.swift
+      Errors.swift
+
+      SWIFT_COMPILE_FLAGS
+        -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
+        -parse-stdlib -DSWIFT_CONCURRENCY_EMBEDDED
+        ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
+      C_COMPILE_FLAGS
+        -D__MACH__ -D__APPLE__ -ffreestanding
+        ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1
+      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+      SDK "embedded"
+      ARCHITECTURE "${mod}"
+      DEPENDS embedded-stdlib-${mod}
+      INSTALL_IN_COMPONENT "never_install"
+      )
+    set_property(TARGET embedded-concurrency-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
+
+    add_dependencies(embedded-concurrency embedded-concurrency-${mod})
+  endforeach()
+endif()

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -210,7 +210,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       # TODO: Only a handful of Swift Concurrency .swift sources, for now.
       Task.swift
       AsyncLet.swift
+      Executor.swift
       Errors.swift
+      PartialAsyncTask.swift
 
       SWIFT_COMPILE_FLAGS
         -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded

--- a/stdlib/public/Concurrency/EmbeddedSupport.cpp
+++ b/stdlib/public/Concurrency/EmbeddedSupport.cpp
@@ -1,0 +1,40 @@
+//===--- EmbeddedSupport.cpp ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Miscellaneous support code for Swift Concurrency on embedded Swift.
+//
+//===----------------------------------------------------------------------===//
+
+#if SWIFT_CONCURRENCY_EMBEDDED
+
+#include "swift/shims/Visibility.h"
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+
+// TSan hooks not supported in embedded Swift.
+
+SWIFT_RUNTIME_EXPORT
+void (*_swift_tsan_acquire)(const void *) = nullptr;
+
+SWIFT_RUNTIME_EXPORT
+void (*_swift_tsan_release)(const void *) = nullptr;
+
+// TODO: Concurrency Exclusivity tracking not yet supported in embedded Swift.
+
+SWIFT_RUNTIME_EXPORT
+void swift_task_enterThreadLocalContext(char *state) {}
+
+SWIFT_RUNTIME_EXPORT
+void swift_task_exitThreadLocalContext(char *state) {}
+
+#endif

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -97,6 +97,7 @@ public struct UnownedJob: Sendable {
 }
 
 @available(SwiftStdlib 5.9, *)
+@_unavailableInEmbedded
 extension UnownedJob: CustomStringConvertible {
   @available(SwiftStdlib 5.9, *)
   public var description: String {
@@ -147,6 +148,7 @@ public struct Job: Sendable {
 
   // TODO: move only types cannot conform to protocols, so we can't conform to CustomStringConvertible;
   //       we can still offer a description to be called explicitly though.
+  @_unavailableInEmbedded
   public var description: String {
     let id = _getJobTaskId(UnownedJob(context: self.context))
     /// Tasks are always assigned an unique ID, however some jobs may not have it set,
@@ -215,6 +217,7 @@ public struct ExecutorJob: Sendable {
 
   // TODO: move only types cannot conform to protocols, so we can't conform to CustomStringConvertible;
   //       we can still offer a description to be called explicitly though.
+  @_unavailableInEmbedded
   public var description: String {
     let id = _getJobTaskId(UnownedJob(context: self.context))
     /// Tasks are always assigned an unique ID, however some jobs may not have it set,

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1601,7 +1601,6 @@ static void swift_task_asyncMainDrainQueueImpl() {
   swift_task_donateThreadToGlobalExecutorUntil([](void *context) {
     return *reinterpret_cast<bool*>(context);
   }, &Finished);
-  exit(0);
 #elif !SWIFT_CONCURRENCY_ENABLE_DISPATCH
   // FIXME: consider implementing a concurrent global main queue for
   // these environments?

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -691,8 +691,8 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
       break;
     }
     case TaskOptionRecordKind::ResultTypeInfo: {
-      auto *typeInfo = cast<ResultTypeInfoTaskOptionRecord>(option);
 #if SWIFT_CONCURRENCY_EMBEDDED
+      auto *typeInfo = cast<ResultTypeInfoTaskOptionRecord>(option);
       futureResultType = {
           .size = typeInfo->size,
           .alignMask = typeInfo->alignMask,
@@ -700,8 +700,10 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
           .storeEnumTagSinglePayload = typeInfo->storeEnumTagSinglePayload,
           .destroy = typeInfo->destroy,
       };
-#endif
       break;
+#else
+      swift_unreachable("ResultTypeInfo in non-embedded");
+#endif
     }
     }
   }

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -650,7 +650,7 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   TaskGroup *group = nullptr;
   AsyncLet *asyncLet = nullptr;
   bool hasAsyncLetResultBuffer = false;
-  RunInlineTaskOptionRecord *runInlineOption = nullptr;  
+  RunInlineTaskOptionRecord *runInlineOption = nullptr;
   for (auto option = options; option; option = option->getParent()) {
     switch (option->getKind()) {
     case TaskOptionRecordKind::Executor:

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -247,7 +247,7 @@ extension Task: Equatable {
   }
 }
 
-#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY && !SWIFT_CONCURRENCY_EMBEDDED
 @available(SwiftStdlib 5.9, *)
 extension Task where Failure == Error {
     @_spi(MainActorUtilities)
@@ -270,7 +270,7 @@ extension Task where Failure == Error {
 }
 #endif
 
-#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY && !SWIFT_CONCURRENCY_EMBEDDED
 @available(SwiftStdlib 5.9, *)
 extension Task where Failure == Never {
     @_spi(MainActorUtilities)
@@ -382,6 +382,7 @@ extension TaskPriority: Comparable {
 
 
 @available(SwiftStdlib 5.9, *)
+@_unavailableInEmbedded
 extension TaskPriority: CustomStringConvertible {
   @available(SwiftStdlib 5.9, *)
   public var description: String {
@@ -400,8 +401,10 @@ extension TaskPriority: CustomStringConvertible {
   }
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 @available(SwiftStdlib 5.1, *)
 extension TaskPriority: Codable { }
+#endif
 
 @available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
@@ -837,6 +840,7 @@ extension Task where Failure == Error {
 // ==== Voluntary Suspension -----------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)
+@_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
 
   /// Suspends the current task and allows other tasks to execute.
@@ -991,7 +995,7 @@ extension UnsafeCurrentTask: Equatable {
 // ==== Internal ---------------------------------------------------------------
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_getCurrent")
-func _getCurrentAsyncTask() -> Builtin.NativeObject?
+public func _getCurrentAsyncTask() -> Builtin.NativeObject?
 
 @_silgen_name("swift_task_startOnMainActor")
 fileprivate func _startTaskOnMainActor(_ task: Builtin.NativeObject)
@@ -1035,7 +1039,7 @@ internal func _getMainExecutor() -> Builtin.Executor
 internal func _runAsyncMain(_ asyncFun: @Sendable @escaping () async throws -> ()) {
   fatalError("Unavailable in task-to-thread concurrency model")
 }
-#else
+#elseif !SWIFT_CONCURRENCY_EMBEDDED
 @available(SwiftStdlib 5.1, *)
 @usableFromInline
 @preconcurrency
@@ -1072,7 +1076,7 @@ public func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_cancel")
-func _taskCancel(_ task: Builtin.NativeObject)
+public func _taskCancel(_ task: Builtin.NativeObject)
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_isCancelled")

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -209,7 +209,7 @@ public:
     /// object itself.
     OpaqueValue *storage;
 
-    const Metadata *successType;
+    ResultTypeInfo successType;
 
     /// The completed task, if necessary to keep alive until consumed by next().
     ///
@@ -234,7 +234,7 @@ public:
       };
     }
 
-    static PollResult getEmpty(const Metadata *successType) {
+    static PollResult getEmpty(ResultTypeInfo successType) {
       return PollResult{
           /*status*/PollStatus::Empty,
           /*storage*/nullptr,
@@ -248,7 +248,7 @@ public:
       return PollResult{
           /*status*/PollStatus::Error,
           /*storage*/reinterpret_cast<OpaqueValue *>(error),
-          /*successType*/nullptr,
+          /*successType*/ResultTypeInfo(),
           /*task*/nullptr
       };
     }
@@ -330,9 +330,9 @@ protected:
   /// AsyncTask.
   NaiveTaskGroupQueue<ReadyQueueItem> readyQueue;
 
-  const Metadata *successType;
+  ResultTypeInfo successType;
 
-  explicit TaskGroupBase(const Metadata* T, uint64_t initialStatus)
+  explicit TaskGroupBase(ResultTypeInfo T, uint64_t initialStatus)
     : TaskGroupTaskStatusRecord(),
       status(initialStatus),
       waitQueue(nullptr),
@@ -579,6 +579,7 @@ struct TaskGroupStatus {
         "error: %sTaskGroup: detected pending task count overflow, in task group %p! Status: %s",
         group->isDiscardingResults() ? "Discarding" : "", group, status.to_string(group).c_str());
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
     if (_swift_shouldReportFatalErrorsToDebugger()) {
       RuntimeErrorDetails details = {
           .version = RuntimeErrorDetails::currentVersion,
@@ -588,6 +589,7 @@ struct TaskGroupStatus {
       };
       _swift_reportToDebugger(RuntimeErrorFlagFatal, message, &details);
     }
+#endif
 
 #if defined(_WIN32)
     #define STDERR_FILENO 2
@@ -768,7 +770,7 @@ class AccumulatingTaskGroup: public TaskGroupBase {
 
 public:
 
-  explicit AccumulatingTaskGroup(const Metadata *T)
+  explicit AccumulatingTaskGroup(ResultTypeInfo T)
     : TaskGroupBase(T, TaskGroupStatus::initial().status) {}
 
   virtual void destroy() override;
@@ -815,7 +817,7 @@ class DiscardingTaskGroup: public TaskGroupBase {
 
 public:
 
-  explicit DiscardingTaskGroup(const Metadata *T)
+  explicit DiscardingTaskGroup(ResultTypeInfo T)
     : TaskGroupBase(T, TaskGroupStatus::initial().status) {}
 
   virtual void destroy() override;
@@ -957,6 +959,13 @@ SWIFT_CC(swift)
 static void swift_taskGroup_initializeWithFlagsImpl(size_t rawGroupFlags,
                                                     TaskGroup *group, const Metadata *T) {
 
+  ResultTypeInfo resultType;
+  #if !SWIFT_CONCURRENCY_EMBEDDED
+  resultType.metadata = T;
+  #else
+  swift_unreachable("task groups not supported yet in embedded Swift");
+  #endif
+
   TaskGroupFlags groupFlags(rawGroupFlags);
   SWIFT_TASK_GROUP_DEBUG_LOG_0(group, "create group, from task:%p; flags: isDiscardingResults=%d",
                                swift_task_getCurrent(),
@@ -964,9 +973,9 @@ static void swift_taskGroup_initializeWithFlagsImpl(size_t rawGroupFlags,
 
   TaskGroupBase *impl;
   if (groupFlags.isDiscardResults()) {
-    impl = ::new(group) DiscardingTaskGroup(T);
+    impl = ::new(group) DiscardingTaskGroup(resultType);
   } else {
-    impl = ::new(group) AccumulatingTaskGroup(T);
+    impl = ::new(group) AccumulatingTaskGroup(resultType);
   }
 
   TaskGroupTaskStatusRecord *record = impl->getTaskRecord();
@@ -1104,21 +1113,19 @@ static void fillGroupNextResult(TaskFutureWaitAsyncContext *context,
 
   case PollStatus::Success: {
     // Initialize the result as an Optional<Success>.
-    const Metadata *successType = result.successType;
     OpaqueValue *destPtr = context->successResultPointer;
     // TODO: figure out a way to try to optimistically take the
     // value out of the finished task's future, if there are no
     // remaining references to it.
-    successType->vw_initializeWithCopy(destPtr, result.storage);
-    successType->vw_storeEnumTagSinglePayload(destPtr, 0, 1);
+    result.successType.vw_initializeWithCopy(destPtr, result.storage);
+    result.successType.vw_storeEnumTagSinglePayload(destPtr, 0, 1);
     return;
   }
 
   case PollStatus::Empty: {
     // Initialize the result as a .none Optional<Success>.
-    const Metadata *successType = result.successType;
     OpaqueValue *destPtr = context->successResultPointer;
-    successType->vw_storeEnumTagSinglePayload(destPtr, 1, 1);
+    result.successType.vw_storeEnumTagSinglePayload(destPtr, 1, 1);
     return;
   }
   }
@@ -1669,7 +1676,7 @@ PollResult AccumulatingTaskGroup::poll(AsyncTask *waitingTask) {
 
   PollResult result;
   result.storage = nullptr;
-  result.successType = nullptr;
+  result.successType = ResultTypeInfo();
   result.retainedTask = nullptr;
 
   // Have we suspended the task?
@@ -1751,7 +1758,7 @@ reevaluate_if_taskgroup_has_results:;
           result.status = PollStatus::Error;
           result.storage =
               reinterpret_cast<OpaqueValue *>(futureFragment->getError());
-          result.successType = nullptr;
+          result.successType = ResultTypeInfo();
           result.retainedTask = item.getTask();
           assert(result.retainedTask && "polled a task, it must be not null");
           _swift_tsan_acquire(static_cast<Job *>(result.retainedTask));

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -959,12 +959,9 @@ SWIFT_CC(swift)
 static void swift_taskGroup_initializeWithFlagsImpl(size_t rawGroupFlags,
                                                     TaskGroup *group, const Metadata *T) {
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
   ResultTypeInfo resultType;
-  #if !SWIFT_CONCURRENCY_EMBEDDED
   resultType.metadata = T;
-  #else
-  swift_unreachable("task groups not supported yet in embedded Swift");
-  #endif
 
   TaskGroupFlags groupFlags(rawGroupFlags);
   SWIFT_TASK_GROUP_DEBUG_LOG_0(group, "create group, from task:%p; flags: isDiscardingResults=%d",
@@ -990,6 +987,9 @@ static void swift_taskGroup_initializeWithFlagsImpl(size_t rawGroupFlags,
     }
     return true;
   });
+#else
+  swift_unreachable("task groups not supported yet in embedded Swift");
+#endif
 }
 
 // =============================================================================

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -289,12 +289,9 @@ public:
   void *_reserved;
 
   void fillWithSuccess(AsyncTask::FutureFragment *future) {
-    fillWithSuccess(future->getStoragePtr(), future->getResultType(),
-                    successResultPointer);
-  }
-  void fillWithSuccess(OpaqueValue *src, const Metadata *successType,
-                       OpaqueValue *result) {
-    successType->vw_initializeWithCopy(result, src);
+    OpaqueValue *src = future->getStoragePtr();
+    OpaqueValue *result = successResultPointer;
+    future->getResultType().vw_initializeWithCopy(result, src);
   }
 
   void fillWithError(AsyncTask::FutureFragment *future) {

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -388,24 +388,8 @@ add_swift_target_library(swiftCore
 #
 # For now, we build a hardcoded list of target triples of the embedded stdlib,
 # and only when building Swift on macOS.
-set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB TRUE)
-if(NOT SWIFT_HOST_VARIANT STREQUAL "macosx")
-  set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
-elseif(NOT SWIFT_INCLUDE_TOOLS)
-  # Temporarily, only build embedded stdlib when building the compiler, to
-  # unblock CI jobs that run against old(er) toolchains.
-  set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
-endif()
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-stdlib ALL)
-  set(EMBEDDED_STDLIB_TARGET_TRIPLES
-    # arch    module_name               target triple
-    "armv7    armv7-apple-none-macho    armv7-apple-none-macho"
-    "arm64    arm64-apple-none-macho    arm64-apple-none-macho"
-    "x86_64   x86_64-apple-macos        x86_64-apple-macos10.13"
-    "arm64    arm64-apple-macos         arm64-apple-macos10.13"
-    "arm64e   arm64e-apple-macos        arm64e-apple-macos10.13"
-    )
 
   set(SWIFT_ENABLE_REFLECTION OFF)
   set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
@@ -422,7 +406,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     add_swift_target_library_single(
-      embedded-stdlib-${triple}
+      embedded-stdlib-${mod}
       swiftCore
       ONLY_SWIFTMODULE
       IS_STDLIB IS_STDLIB_CORE IS_FRAGILE
@@ -435,6 +419,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       FILE_DEPENDS ${swiftCore_common_dependencies}
       INSTALL_IN_COMPONENT stdlib
       )
-    add_dependencies(embedded-stdlib embedded-stdlib-${triple})
+    add_dependencies(embedded-stdlib embedded-stdlib-${mod})
   endforeach()
 endif()

--- a/test/embedded/concurrency-builtins.swift
+++ b/test/embedded/concurrency-builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-irgen %s -enable-experimental-feature Embedded -enable-builtin-module | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -emit-irgen %s -enable-experimental-feature Embedded -enable-builtin-module | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/concurrency-builtins.swift
+++ b/test/embedded/concurrency-builtins.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -enable-builtin-module
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+import Builtin
+
+public func test() async {
+    _ = Builtin.createAsyncTask(0) { () async throws -> Int in
+      return 42
+    }
+}

--- a/test/embedded/concurrency-builtins.swift
+++ b/test/embedded/concurrency-builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -enable-builtin-module
+// RUN: %target-swift-frontend -emit-irgen %s -enable-experimental-feature Embedded -enable-builtin-module | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -12,3 +12,18 @@ public func test() async {
       return 42
     }
 }
+
+// CHECK: define {{.*}}@"$s4main4testyyYaF"(ptr swiftasync %0)
+// CHECK: entry:
+// CHECK:   %result_type_info = alloca %swift.result_type_info_task_option
+// CHECK:   call {{.*}}@llvm.coro.id.async
+// CHECK:   call {{.*}}@llvm.coro.begin
+// CHECK:   call {{.*}}@llvm.coro.async.resume
+// CHECK:   call {{.*}}@llvm.coro.suspend.async.sl_p0s
+// CHECK:   call {{.*}}@__swift_async_resume_get_context
+// CHECK:   call {{.*}}@swift_allocObject
+// CHECK:   call {{.*}}%swift.async_task_and_context @swift_task_create
+// CHECK:   call {{.*}}@swift_release
+// CHECK:   call {{.*}}@llvm.coro.end.async
+// CHECK:   unreachable
+// CHECK: }

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -23,32 +23,24 @@ public func test() async -> Int {
   return v
 }
 
-@_silgen_name("swift_task_asyncMainDrainQueue")
-func _asyncMainDrainQueue() -> Never
-
 @main
 struct Main {
-  static func main() {
+  static func main() async {
     print("main")
     // CHECK: main
-
-    Task {
+    let t = Task {
       print("task")
       let x = await test()
       print(x == 42 ? "42" : "???")
     }
-    print("drain")
-    // CHECK-NEXT: drain
-
-    _asyncMainDrainQueue()
+    print("after task")
+    await t.value
+    // CHECK-NEXT: after task
     // CHECK-NEXT: task
     // CHECK-NEXT: test
     // CHECK-NEXT: await
     // CHECK-NEXT: return 42
     // CHECK-NEXT: return
     // CHECK-NEXT: 42
-
-    print("done")
-    // CHECK-NOT: done
   }
 }

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s %S/Inputs/print.swift -c -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+import _Concurrency
+
+public func test() async -> Int {
+  print("test")
+  let t = Task {
+    print("return 42")
+    return 42
+  }
+  print("await")
+  let v = await t.value
+  print("return")
+  return v
+}
+
+@_silgen_name("swift_task_asyncMainDrainQueue")
+func _asyncMainDrainQueue() -> Never
+
+@main
+struct Main {
+  static func main() {
+    print("main")
+    // CHECK: main
+
+    Task {
+      print("task")
+      let x = await test()
+      print(x == 42 ? "42" : "???")
+    }
+    print("drain")
+    // CHECK-NEXT: drain
+
+    _asyncMainDrainQueue()
+    // CHECK-NEXT: task
+    // CHECK-NEXT: test
+    // CHECK-NEXT: await
+    // CHECK-NEXT: return 42
+    // CHECK-NEXT: return
+    // CHECK-NEXT: 42
+
+    print("done")
+    // CHECK-NOT: done
+  }
+}


### PR DESCRIPTION
PR starts building a (simplified, cut-down) embedded version of the Swift Concurrency runtime library, implements a modified contract between the compiler and swift_task_create() that doesn't rely on metadata, and adds an executable test that exercises a simple task creation showing the setup working (!).

Note that there is definitely a lot of Swift Concurrency functionality still missing, this doesn't achieve full Swift Concurrency parity.

Major parts involved:
- SILOptimizer rewrites CreateAsyncTask builtin to use a thin metatype instead of thick
- IRGen of CreateAsyncTask builtin synthesizes a set of witnesses for the result type and passes that to the runtime as a new TaskOptionRecord.
- swift_task_create() parses the new TaskOptionRecord, forms a ResultTypeInfo (data structure in the runtime can hold either a Metadata*, or the separate witnesses pass down by the compiler)
- FutureFragment, PollResult, TaskGroup stop using Metadata* in favor of ResultTypeInfo
- CMake for Concurrency starts building a subset of the Concurrency runtime, for macOS only for now.
