### PR TITLE
[wasm][test] WASI platform does not support injecting dynamic library

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2314,7 +2314,7 @@ if run_vendor != 'apple':
 
 if 'remote_run_host' in lit_config.params:
     configure_remote_run()
-elif not kIsWindows:
+elif not kIsWindows and not run_os == 'wasi':
     if 'use_os_stdlib' in lit_config.params:
         config.available_features.add('use_os_stdlib')
 


### PR DESCRIPTION
WASI does not provide any interface to inject dynamic library at runtime and all stdlib are now always statically linked, so don't need to inject dynamically.

