### PR TITLE
[Caching] Change swift cache key computation

### DIFF
--- a/include/swift-c/DependencyScan/DependencyScan.h
+++ b/include/swift-c/DependencyScan/DependencyScan.h
@@ -437,17 +437,6 @@ typedef struct swiftscan_cas_options_s *swiftscan_cas_options_t;
 /// ActionCache.
 typedef struct swiftscan_cas_s *swiftscan_cas_t;
 
-/// Enum types for output types for cache key computation.
-/// TODO: complete the list.
-typedef enum {
-  SWIFTSCAN_OUTPUT_TYPE_OBJECT = 0,
-  SWIFTSCAN_OUTPUT_TYPE_SWIFTMODULE = 1,
-  SWIFTSCAN_OUTPUT_TYPE_SWIFTINTERFACE = 2,
-  SWIFTSCAN_OUTPUT_TYPE_SWIFTPRIVATEINTERFACE = 3,
-  SWIFTSCAN_OUTPUT_TYPE_CLANG_MODULE = 4,
-  SWIFTSCAN_OUTPUT_TYPE_CLANG_PCH = 5
-} swiftscan_output_kind_t;
-
 /// Create a \c CASOptions for creating CAS inside scanner specified.
 SWIFTSCAN_PUBLIC swiftscan_cas_options_t swiftscan_cas_options_create(void);
 
@@ -489,13 +478,15 @@ SWIFTSCAN_PUBLIC swiftscan_string_ref_t
 swiftscan_cas_store(swiftscan_cas_t cas, uint8_t *data, unsigned size,
                     swiftscan_string_ref_t *error);
 
-/// Compute \c CacheKey for output of \c kind from the compiler invocation \c
-/// argc and \c argv with \c input. Return \c CacheKey as string.
+/// Compute \c CacheKey for the outputs of a primary input file from a compiler
+/// invocation with command-line \c argc and \c argv. When primary input file
+/// is not available for compilation, e.g., using WMO, primary file is the first
+/// swift input on the command-line by convention. Return \c CacheKey as string.
 /// If error happens, the error message is returned via `error` parameter, and
 /// caller needs to free the error message via `swiftscan_string_dispose`.
-SWIFTSCAN_PUBLIC swiftscan_string_ref_t swiftscan_compute_cache_key(
-    swiftscan_cas_t cas, int argc, const char **argv, const char *input,
-    swiftscan_output_kind_t kind, swiftscan_string_ref_t *error);
+SWIFTSCAN_PUBLIC swiftscan_string_ref_t
+swiftscan_cache_compute_key(swiftscan_cas_t cas, int argc, const char **argv,
+                            const char *input, swiftscan_string_ref_t *error);
 
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -494,7 +494,7 @@ ERROR(error_caching_no_cas_fs, none,
 ERROR(error_prefix_mapping, none, "cannot create scanner prefix mapping: '%0'", (StringRef))
 
 REMARK(replay_output, none, "replay output file '%0': key '%1'", (StringRef, StringRef))
-REMARK(output_cache_miss, none, "cache miss output file '%0': key '%1'", (StringRef, StringRef))
+REMARK(output_cache_miss, none, "cache miss for input file '%0': key '%1'", (StringRef, StringRef))
 
 // CAS related diagnostics
 ERROR(error_invalid_cas_id, none, "invalid CASID '%0' (%1)", (StringRef, StringRef))

--- a/include/swift/Basic/FileTypes.h
+++ b/include/swift/Basic/FileTypes.h
@@ -58,6 +58,9 @@ bool isAfterLLVM(ID Id);
 /// These need to be passed to the Swift frontend
 bool isPartOfSwiftCompilation(ID Id);
 
+/// Returns true of the type of the output is produced from a diagnostic engine.
+bool isProducedFromDiagnostics(ID Id);
+
 static inline void forAllTypes(llvm::function_ref<void(file_types::ID)> fn) {
   for (uint8_t i = 0; i < static_cast<uint8_t>(TY_INVALID); ++i)
     fn(static_cast<ID>(i));

--- a/include/swift/Frontend/CASOutputBackends.h
+++ b/include/swift/Frontend/CASOutputBackends.h
@@ -1,0 +1,60 @@
+//===------CASOutputBackends.h-- ---------------------------------*-C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_CASOUTPUTBACKENDS_H
+#define SWIFT_FRONTEND_CASOUTPUTBACKENDS_H
+
+#include "swift/Frontend/FrontendInputsAndOutputs.h"
+#include "swift/Frontend/FrontendOptions.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/VirtualOutputBackends.h"
+#include "llvm/Support/VirtualOutputFile.h"
+
+namespace swift::cas {
+
+class SwiftCASOutputBackend : public llvm::vfs::OutputBackend {
+  void anchor() override;
+
+protected:
+  llvm::IntrusiveRefCntPtr<OutputBackend> cloneImpl() const override;
+
+  llvm::Expected<std::unique_ptr<llvm::vfs::OutputFileImpl>>
+  createFileImpl(llvm::StringRef ResolvedPath,
+                 llvm::Optional<llvm::vfs::OutputConfig> Config) override;
+
+  virtual llvm::Error storeImpl(llvm::StringRef Path, llvm::StringRef Bytes,
+                                llvm::StringRef CorrespondingInput,
+                                file_types::ID OutputKind);
+
+private:
+  file_types::ID getOutputFileType(llvm::StringRef Path) const;
+
+public:
+  SwiftCASOutputBackend(llvm::cas::ObjectStore &CAS,
+                        llvm::cas::ActionCache &Cache,
+                        llvm::cas::ObjectRef BaseKey,
+                        const FrontendInputsAndOutputs &InputsAndOutputs,
+                        FrontendOptions::ActionType Action);
+  ~SwiftCASOutputBackend();
+
+  llvm::Error storeCachedDiagnostics(llvm::StringRef InputFile,
+                                     llvm::StringRef Bytes);
+
+private:
+  class Implementation;
+  Implementation &Impl;
+};
+
+} // end namespace swift::cas
+
+#endif

--- a/include/swift/Frontend/CompileJobCacheKey.h
+++ b/include/swift/Frontend/CompileJobCacheKey.h
@@ -41,8 +41,7 @@ createCompileJobBaseCacheKey(llvm::cas::ObjectStore &CAS,
 llvm::Expected<llvm::cas::ObjectRef>
 createCompileJobCacheKeyForOutput(llvm::cas::ObjectStore &CAS,
                                   llvm::cas::ObjectRef BaseKey,
-                                  StringRef ProducingInput,
-                                  file_types::ID OutputType);
+                                  StringRef ProducingInput);
 } // namespace swift
 
 #endif

--- a/include/swift/Frontend/CompileJobCacheResult.h
+++ b/include/swift/Frontend/CompileJobCacheResult.h
@@ -1,0 +1,114 @@
+//===------CompileJobCacheResult.h-- -----------------------------*-C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_COMPILEJOBCACHERESULT_H
+#define SWIFT_FRONTEND_COMPILEJOBCACHERESULT_H
+
+#include "swift/Basic/FileTypes.h"
+#include "llvm/CAS/CASNodeSchema.h"
+#include "llvm/CAS/ObjectStore.h"
+
+namespace swift::cas {
+
+class CompileJobResultSchema;
+class CompileJobCacheResult : public llvm::cas::ObjectProxy {
+public:
+  /// A single output file or stream.
+  struct Output {
+    /// The CAS object for this output.
+    llvm::cas::ObjectRef Object;
+    /// The output kind.
+    file_types::ID Kind;
+
+    bool operator==(const Output &Other) const {
+      return Object == Other.Object && Kind == Other.Kind;
+    }
+  };
+
+  /// Retrieves each \c Output from this result.
+  llvm::Error
+  forEachOutput(llvm::function_ref<llvm::Error(Output)> Callback) const;
+
+  /// Loads all outputs concurrently and passes the resulting \c ObjectProxy
+  /// objects to \p Callback. If there was an error during loading then the
+  /// callback will not be invoked.
+  llvm::Error forEachLoadedOutput(
+      llvm::function_ref<llvm::Error(Output, std::optional<ObjectProxy>)>
+          Callback);
+
+  size_t getNumOutputs() const;
+
+  Output getOutput(size_t I) const;
+
+  /// Retrieves a specific output specified by \p Kind, if it exists.
+  llvm::Optional<Output> getOutput(file_types::ID Kind) const;
+
+  /// Print this result to \p OS.
+  llvm::Error print(llvm::raw_ostream &OS);
+
+  /// Helper to build a \c CompileJobCacheResult from individual outputs.
+  class Builder {
+  public:
+    Builder();
+    ~Builder();
+    /// Treat outputs added for \p Path as having the given \p Kind. Otherwise
+    /// they will have kind \c Unknown.
+    void addKindMap(file_types::ID Kind, StringRef Path);
+    /// Add an output with an explicit \p Kind.
+    void addOutput(file_types::ID Kind, llvm::cas::ObjectRef Object);
+    /// Add an output for the given \p Path. There must be a a kind map for it.
+    llvm::Error addOutput(StringRef Path, llvm::cas::ObjectRef Object);
+    /// Build a single \c ObjectRef representing the provided outputs. The
+    /// result can be used with \c CompileJobResultSchema to retrieve the
+    /// original outputs.
+    llvm::Expected<llvm::cas::ObjectRef> build(llvm::cas::ObjectStore &CAS);
+
+  private:
+    struct PrivateImpl;
+    PrivateImpl &Impl;
+  };
+
+private:
+  llvm::cas::ObjectRef getOutputObject(size_t I) const;
+  llvm::cas::ObjectRef getPathsListRef() const;
+  file_types::ID getOutputKind(size_t I) const;
+  llvm::Expected<llvm::cas::ObjectRef> getOutputPath(size_t I) const;
+
+private:
+  friend class CompileJobResultSchema;
+  CompileJobCacheResult(const ObjectProxy &);
+};
+
+class CompileJobResultSchema
+    : public llvm::RTTIExtends<CompileJobResultSchema, llvm::cas::NodeSchema> {
+public:
+  static char ID;
+
+  CompileJobResultSchema(llvm::cas::ObjectStore &CAS);
+
+  /// Attempt to load \p Ref as a \c CompileJobCacheResult if it matches the
+  /// schema.
+  llvm::Expected<CompileJobCacheResult> load(llvm::cas::ObjectRef Ref) const;
+
+  bool isRootNode(const CompileJobCacheResult::ObjectProxy &Node) const final;
+  bool isNode(const CompileJobCacheResult::ObjectProxy &Node) const final;
+
+  /// Get this schema's marker node.
+  llvm::cas::ObjectRef getKindRef() const { return KindRef; }
+
+private:
+  llvm::cas::ObjectRef KindRef;
+};
+
+} // namespace swift::cas
+
+#endif

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -30,6 +30,7 @@
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/Frontend/CASOutputBackends.h"
 #include "swift/Frontend/CachedDiagnostics.h"
 #include "swift/Frontend/DiagnosticVerifier.h"
 #include "swift/Frontend/FrontendOptions.h"
@@ -483,6 +484,10 @@ class CompilerInstance {
   /// Virtual OutputBackend.
   llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend = nullptr;
 
+  /// CAS OutputBackend.
+  llvm::IntrusiveRefCntPtr<swift::cas::SwiftCASOutputBackend> CASOutputBackend =
+      nullptr;
+
   /// The verification output backend.
   using HashBackendTy = llvm::vfs::HashingOutputBackend<llvm::BLAKE3>;
   llvm::IntrusiveRefCntPtr<HashBackendTy> HashBackend;
@@ -537,6 +542,10 @@ public:
   llvm::vfs::OutputBackend &getOutputBackend() const {
     return *OutputBackend;
   }
+  swift::cas::SwiftCASOutputBackend &getCASOutputBackend() const {
+    return *CASOutputBackend;
+  }
+
   void
   setOutputBackend(llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> Backend) {
     OutputBackend = std::move(Backend);

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -372,14 +372,14 @@ def profile_stats_entities: Flag<["-"], "profile-stats-entities">,
   HelpText<"Profile changes to stats in -stats-output-dir, subdivided by source entity">;
 
 def emit_dependencies : Flag<["-"], "emit-dependencies">,
-  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput, CacheInvariant]>,
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Emit basic Make-compatible dependencies files">;
 def track_system_dependencies : Flag<["-"], "track-system-dependencies">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Track system dependencies while emitting Make-style dependencies">;
 
 def emit_loaded_module_trace : Flag<["-"], "emit-loaded-module-trace">,
-  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput, CacheInvariant]>,
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Emit a JSON file containing information about what modules were loaded">;
 def emit_loaded_module_trace_path : Separate<["-"], "emit-loaded-module-trace-path">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
@@ -391,7 +391,7 @@ def emit_loaded_module_trace_path_EQ : Joined<["-"], "emit-loaded-module-trace-p
          SupplementaryOutput, CacheInvariant]>,
   Alias<emit_loaded_module_trace_path>;
 def emit_cross_import_remarks : Flag<["-"], "Rcross-import">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, CacheInvariant]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit a remark if a cross-import of a module is triggered.">;
 
 def remark_loading_module : Flag<["-"], "Rmodule-loading">,
@@ -418,7 +418,7 @@ def remark_skip_explicit_interface_build : Flag<["-"], "Rskip-explicit-interface
 
 def emit_tbd : Flag<["-"], "emit-tbd">,
   HelpText<"Emit a TBD file">,
-  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput, CacheInvariant]>;
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>;
 def emit_tbd_path : Separate<["-"], "emit-tbd-path">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
          SupplementaryOutput, CacheInvariant]>,
@@ -433,7 +433,7 @@ def embed_tbd_for_module : Separate<["-"], "embed-tbd-for-module">,
   HelpText<"Embed symbols from the module in the emitted tbd file">;
 
 def serialize_diagnostics : Flag<["-"], "serialize-diagnostics">,
-  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput, CacheInvariant]>,
   HelpText<"Serialize diagnostics in a binary format">;
 def serialize_diagnostics_path : Separate<["-"], "serialize-diagnostics-path">,
   Flags<[FrontendOption, SwiftAPIDigesterOption, NoBatchOption,
@@ -555,7 +555,7 @@ def export_as : Separate<["-"], "export-as">,
   HelpText<"Module name to use when referenced in clients module interfaces">;
 
 def emit_module : Flag<["-"], "emit-module">,
-  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput, CacheInvariant]>,
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Emit an importable module">;
 def emit_module_path : Separate<["-"], "emit-module-path">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
@@ -569,7 +569,7 @@ def emit_module_path_EQ : Joined<["-"], "emit-module-path=">,
 
 def emit_module_summary :
   Flag<["-"], "emit-module-summary">,
-  Flags<[NoInteractiveOption, SupplementaryOutput, CacheInvariant]>,
+  Flags<[NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Output module summary file">;
 def emit_module_summary_path :
   Separate<["-"], "emit-module-summary-path">,
@@ -579,7 +579,7 @@ def emit_module_summary_path :
 
 def emit_module_interface :
   Flag<["-"], "emit-module-interface">,
-  Flags<[NoInteractiveOption, SupplementaryOutput, CacheInvariant]>,
+  Flags<[NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Output module interface file">;
 def emit_module_interface_path :
   Separate<["-"], "emit-module-interface-path">,
@@ -616,7 +616,7 @@ def emit_module_source_info_path :
 def emit_parseable_module_interface :
   Flag<["-"], "emit-parseable-module-interface">,
   Alias<emit_module_interface>,
-  Flags<[NoInteractiveOption, HelpHidden, SupplementaryOutput, CacheInvariant]>;
+  Flags<[NoInteractiveOption, HelpHidden, SupplementaryOutput]>;
 def emit_parseable_module_interface_path :
   Separate<["-"], "emit-parseable-module-interface-path">,
   Alias<emit_module_interface_path>,
@@ -644,7 +644,7 @@ def emit_api_descriptor_path :
   HelpText<"Output a JSON file describing the module's API to <path>">;
 
 def emit_objc_header : Flag<["-"], "emit-objc-header">,
-  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput, CacheInvariant]>,
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Emit an Objective-C header file">;
 def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
@@ -1136,7 +1136,7 @@ def modes_Group : OptionGroup<"<mode options>">, HelpText<"MODES">;
 class ModeOpt : Group<modes_Group>;
 
 // Output Modes
-let Flags = [FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild, CacheInvariant] in {
+let Flags = [FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild] in {
 
 def emit_object : Flag<["-"], "emit-object">,
   HelpText<"Emit object file(s) (-c)">, ModeOpt;
@@ -1161,7 +1161,7 @@ def emit_imported_modules : Flag<["-"], "emit-imported-modules">,
 def emit_pcm : Flag<["-"], "emit-pcm">,
   HelpText<"Emit a precompiled Clang module from a module map">, ModeOpt;
 
-} // end let Flags = [FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild, CacheInvariant]
+} // end let Flags = [FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]
 
 def emit_executable : Flag<["-"], "emit-executable">,
   HelpText<"Emit a linked executable">, ModeOpt,

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -235,3 +235,60 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   // Work around MSVC warning: not all control paths return a value
   llvm_unreachable("All switch cases are covered");
 }
+
+bool file_types::isProducedFromDiagnostics(ID Id) {
+  switch (Id) {
+  case file_types::TY_SerializedDiagnostics:
+  case file_types::TY_SwiftFixIt:
+  case file_types::TY_CachedDiagnostics:
+    return true;
+  case file_types::TY_Swift:
+  case file_types::TY_SIL:
+  case file_types::TY_RawSIL:
+  case file_types::TY_SIB:
+  case file_types::TY_RawSIB:
+  case file_types::TY_Assembly:
+  case file_types::TY_LLVM_IR:
+  case file_types::TY_LLVM_BC:
+  case file_types::TY_Object:
+  case file_types::TY_Dependencies:
+  case file_types::TY_ClangHeader:
+  case file_types::TY_AutolinkFile:
+  case file_types::TY_PCH:
+  case file_types::TY_ImportedModules:
+  case file_types::TY_TBD:
+  case file_types::TY_Image:
+  case file_types::TY_dSYM:
+  case file_types::TY_SwiftModuleFile:
+  case file_types::TY_SwiftModuleDocFile:
+  case file_types::TY_SwiftModuleInterfaceFile:
+  case file_types::TY_PrivateSwiftModuleInterfaceFile:
+  case file_types::TY_SwiftSourceInfoFile:
+  case file_types::TY_SwiftCrossImportDir:
+  case file_types::TY_SwiftOverlayFile:
+  case file_types::TY_SwiftModuleSummaryFile:
+  case file_types::TY_ClangModuleFile:
+  case file_types::TY_SwiftDeps:
+  case file_types::TY_ExternalSwiftDeps:
+  case file_types::TY_Nothing:
+  case file_types::TY_ASTDump:
+  case file_types::TY_Remapping:
+  case file_types::TY_IndexData:
+  case file_types::TY_ModuleTrace:
+  case file_types::TY_YAMLOptRecord:
+  case file_types::TY_BitstreamOptRecord:
+  case file_types::TY_JSONDependencies:
+  case file_types::TY_JSONFeatures:
+  case file_types::TY_IndexUnitOutputPath:
+  case file_types::TY_SwiftABIDescriptor:
+  case file_types::TY_SwiftAPIDescriptor:
+  case file_types::TY_ConstValues:
+  case file_types::TY_ModuleSemanticInfo:
+    return false;
+  case file_types::TY_INVALID:
+    llvm_unreachable("Invalid type ID.");
+  }
+
+  // Work around MSVC warning: not all control paths return a value
+  llvm_unreachable("All switch cases are covered");
+}

--- a/lib/DriverTool/swift_cache_tool_main.cpp
+++ b/lib/DriverTool/swift_cache_tool_main.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 //
 #include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/FileTypes.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "swift/Basic/Version.h"
@@ -186,8 +187,11 @@ private:
       llvm::errs() << "missing swift-frontend command-line after --\n";
       return true;
     }
-    // drop swift-frontend executable path from command-line.
+    // drop swift-frontend executable path and leading `-frontend` from
+    // command-line.
     if (StringRef(FrontendArgs[0]).endswith("swift-frontend"))
+      FrontendArgs.erase(FrontendArgs.begin());
+    if (StringRef(FrontendArgs[0]).equals("-frontend"))
       FrontendArgs.erase(FrontendArgs.begin());
 
     SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 4>
@@ -285,7 +289,7 @@ int SwiftCacheToolInvocation::printOutputKeys() {
   auto addOutputKey = [&](StringRef InputPath, file_types::ID OutputKind,
                           StringRef OutputPath) {
     auto OutputKey =
-        createCompileJobCacheKeyForOutput(CAS, *BaseKey, InputPath, OutputKind);
+        createCompileJobCacheKeyForOutput(CAS, *BaseKey, InputPath);
     if (!OutputKey) {
       llvm::errs() << "cannot create cache key for " << OutputPath << ": "
                    << toString(OutputKey.takeError()) << "\n";
@@ -307,7 +311,7 @@ int SwiftCacheToolInvocation::printOutputKeys() {
         .SupplementaryOutputs.forEachSetOutputAndType(
             [&](const std::string &File, file_types::ID ID) {
               // Dont print serialized diagnostics.
-              if (ID == file_types::ID::TY_SerializedDiagnostics)
+              if (file_types::isProducedFromDiagnostics(ID))
                 return;
 
               addOutputKey(InputPath, ID, File);
@@ -348,8 +352,7 @@ readOutputEntriesFromFile(StringRef Path) {
 
   auto JSONValue = llvm::json::parse((*JSONContent)->getBuffer());
   if (!JSONValue)
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "failed to parse input file as JSON");
+    return JSONValue.takeError();
 
   auto Keys = JSONValue->getAsArray();
   if (!Keys)
@@ -363,6 +366,8 @@ int SwiftCacheToolInvocation::validateOutputs() {
   auto DB = CASOpts.getOrCreateDatabases();
   if (!DB)
     report_fatal_error(DB.takeError());
+
+  auto &CAS = *DB->first;
 
   PrintingDiagnosticConsumer PDC;
   Instance.getDiags().addConsumer(PDC);
@@ -378,12 +383,38 @@ int SwiftCacheToolInvocation::validateOutputs() {
     for (const auto& Entry : *Keys) {
       if (auto *Obj = Entry.getAsObject()) {
         if (auto Key = Obj->getString("CacheKey")) {
-          if (auto Buffer = loadCachedCompileResultFromCacheKey(
-                  *DB->first, *DB->second, Instance.getDiags(), *Key))
-            continue;
-          llvm::errs() << "failed to find output for cache key " << *Key
-                       << "\n";
-          return true;
+          auto ID = CAS.parseID(*Key);
+          if (!ID) {
+            llvm::errs() << "failed to parse ID " << Key << ": "
+                         << toString(ID.takeError()) << "\n";
+            return true;
+          }
+          auto Ref = CAS.getReference(*ID);
+          if (!Ref) {
+            llvm::errs() << "failed to find output for cache key " << Key
+                         << "\n";
+            return true;
+          }
+          cas::CachedResultLoader Loader(*DB->first, *DB->second, *Ref);
+          auto Result = Loader.replay(
+                  [&](file_types::ID Kind, ObjectRef Ref) -> llvm::Error {
+                    auto Proxy = CAS.getProxy(Ref);
+                    if (!Proxy)
+                      return Proxy.takeError();
+                    return llvm::Error::success();
+                  });
+
+          if (!Result) {
+            llvm::errs() << "failed to find output for cache key " << *Key
+                         << ": " << toString(Result.takeError()) << "\n";
+            return true;
+          }
+          if (!*Result) {
+            llvm::errs() << "failed to load output for cache key " << *Key
+                         << "\n";
+            return true;
+          }
+          continue;
         }
       }
       llvm::errs() << "can't read cache key from " << Path << "\n";
@@ -423,7 +454,8 @@ int SwiftCacheToolInvocation::renderDiags() {
         if (auto Key = Obj->getString("CacheKey")) {
           if (auto Buffer = loadCachedCompileResultFromCacheKey(
                   Instance.getObjectStore(), Instance.getActionCache(),
-                  Instance.getDiags(), *Key)) {
+                  Instance.getDiags(), *Key,
+                  file_types::ID::TY_CachedDiagnostics)) {
             if (auto E = CDP->replayCachedDiagnostics(Buffer->getBuffer())) {
               llvm::errs() << "failed to replay cache: "
                            << toString(std::move(E)) << "\n";

--- a/lib/Frontend/CASOutputBackends.cpp
+++ b/lib/Frontend/CASOutputBackends.cpp
@@ -1,0 +1,249 @@
+//===--- CASOutputBackends.cpp ----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Frontend/CASOutputBackends.h"
+
+#include "swift/Basic/FileTypes.h"
+#include "swift/Frontend/CachingUtils.h"
+#include "swift/Frontend/CompileJobCacheKey.h"
+#include "swift/Frontend/CompileJobCacheResult.h"
+#include "clang/Frontend/CompileJobCacheResult.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/CAS/HierarchicalTreeBuilder.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/Debug.h"
+#include <optional>
+
+#define DEBUG_TYPE "swift-cas-backend"
+
+using namespace swift;
+using namespace llvm;
+using namespace llvm::cas;
+using namespace llvm::vfs;
+
+namespace {
+class SwiftCASOutputFile final : public OutputFileImpl {
+public:
+  Error keep() override { return OnKeep(Path, Bytes); }
+  Error discard() override { return Error::success(); }
+  raw_pwrite_stream &getOS() override { return OS; }
+
+  using OnKeepType = llvm::unique_function<Error(StringRef, StringRef)>;
+  SwiftCASOutputFile(StringRef Path, OnKeepType OnKeep)
+      : Path(Path.str()), OS(Bytes), OnKeep(std::move(OnKeep)) {}
+
+private:
+  std::string Path;
+  SmallString<16> Bytes;
+  raw_svector_ostream OS;
+  OnKeepType OnKeep;
+};
+} // namespace
+
+namespace swift::cas {
+void SwiftCASOutputBackend::anchor() {}
+
+class SwiftCASOutputBackend::Implementation {
+public:
+  Implementation(ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
+                 const FrontendInputsAndOutputs &InputsAndOutputs,
+                 FrontendOptions::ActionType Action)
+      : CAS(CAS), Cache(Cache), BaseKey(BaseKey),
+        InputsAndOutputs(InputsAndOutputs), Action(Action) {
+    initBackend(InputsAndOutputs);
+  }
+
+  llvm::Expected<std::unique_ptr<llvm::vfs::OutputFileImpl>>
+  createFileImpl(llvm::StringRef ResolvedPath,
+                 llvm::Optional<llvm::vfs::OutputConfig> Config) {
+    auto ProducingInput = OutputToInputMap.find(ResolvedPath);
+    assert(ProducingInput != OutputToInputMap.end() && "Unknown output file");
+
+    std::string InputFilename = ProducingInput->second.first.getFileName();
+    auto OutputType = ProducingInput->second.second;
+
+    // Uncached output kind.
+    if (file_types::isProducedFromDiagnostics(OutputType))
+      return std::make_unique<llvm::vfs::NullOutputFileImpl>();
+
+    return std::make_unique<SwiftCASOutputFile>(
+        ResolvedPath,
+        [this, InputFilename, OutputType](StringRef Path,
+                                          StringRef Bytes) -> Error {
+          return storeImpl(Path, Bytes, InputFilename, OutputType);
+        });
+  }
+
+  void initBackend(const FrontendInputsAndOutputs &InputsAndOutputs);
+
+  Error storeImpl(StringRef Path, StringRef Bytes, StringRef CorrespondingInput,
+                  file_types::ID OutputKind);
+
+  Error finalizeCacheKeysFor(StringRef Input);
+
+private:
+  friend class SwiftCASOutputBackend;
+  ObjectStore &CAS;
+  ActionCache &Cache;
+  ObjectRef BaseKey;
+  const FrontendInputsAndOutputs &InputsAndOutputs;
+  FrontendOptions::ActionType Action;
+
+  StringMap<std::pair<const InputFile &, file_types::ID>> OutputToInputMap;
+  StringMap<DenseMap<file_types::ID, ObjectRef>> OutputRefs;
+};
+
+SwiftCASOutputBackend::SwiftCASOutputBackend(
+    ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
+    const FrontendInputsAndOutputs &InputsAndOutputs,
+    FrontendOptions::ActionType Action)
+    : Impl(*new SwiftCASOutputBackend::Implementation(
+          CAS, Cache, BaseKey, InputsAndOutputs, Action)) {}
+
+SwiftCASOutputBackend::~SwiftCASOutputBackend() { delete &Impl; }
+
+IntrusiveRefCntPtr<OutputBackend> SwiftCASOutputBackend::cloneImpl() const {
+  return makeIntrusiveRefCnt<SwiftCASOutputBackend>(
+      Impl.CAS, Impl.Cache, Impl.BaseKey, Impl.InputsAndOutputs, Impl.Action);
+}
+
+Expected<std::unique_ptr<OutputFileImpl>>
+SwiftCASOutputBackend::createFileImpl(StringRef ResolvedPath,
+                                      Optional<OutputConfig> Config) {
+  return Impl.createFileImpl(ResolvedPath, Config);
+}
+
+file_types::ID SwiftCASOutputBackend::getOutputFileType(StringRef Path) const {
+  return file_types::lookupTypeForExtension(llvm::sys::path::extension(Path));
+}
+
+Error SwiftCASOutputBackend::storeImpl(StringRef Path, StringRef Bytes,
+                                       StringRef CorrespondingInput,
+                                       file_types::ID OutputKind) {
+  return Impl.storeImpl(Path, Bytes, CorrespondingInput, OutputKind);
+}
+
+Error SwiftCASOutputBackend::storeCachedDiagnostics(StringRef InputFile,
+                                                    StringRef Bytes) {
+  return storeImpl("<cached-diagnostics>", Bytes, InputFile,
+                   file_types::ID::TY_CachedDiagnostics);
+}
+
+void SwiftCASOutputBackend::Implementation::initBackend(
+    const FrontendInputsAndOutputs &InputsAndOutputs) {
+  // FIXME: The output to input map might not be enough for example all the
+  // outputs can be written to `-`, but the backend cannot distinguish which
+  // input it actually comes from. Maybe the solution is just not to cache
+  // any commands write output to `-`.
+  file_types::ID mainOutputType = InputsAndOutputs.getPrincipalOutputType();
+  auto addInput = [&](const InputFile &Input) {
+    if (!Input.outputFilename().empty())
+      OutputToInputMap.insert(
+          {Input.outputFilename(), {Input, mainOutputType}});
+    Input.getPrimarySpecificPaths()
+        .SupplementaryOutputs.forEachSetOutputAndType(
+            [&](const std::string &Out, file_types::ID ID) {
+              if (!file_types::isProducedFromDiagnostics(ID))
+                OutputToInputMap.insert({Out, {Input, ID}});
+            });
+  };
+  llvm::for_each(InputsAndOutputs.getAllInputs(), addInput);
+}
+
+Error SwiftCASOutputBackend::Implementation::storeImpl(
+    StringRef Path, StringRef Bytes, StringRef CorrespondingInput,
+    file_types::ID OutputKind) {
+  Optional<ObjectRef> BytesRef;
+  if (Error E = CAS.storeFromString(None, Bytes).moveInto(BytesRef))
+    return E;
+
+  LLVM_DEBUG(llvm::dbgs() << "DEBUG: producing CAS output of type \'"
+                          << file_types::getTypeName(OutputKind)
+                          << "\' for input \'" << CorrespondingInput << "\': \'"
+                          << CAS.getID(*BytesRef).toString() << "\'\n";);
+
+  OutputRefs[CorrespondingInput].insert({OutputKind, *BytesRef});
+
+  return finalizeCacheKeysFor(CorrespondingInput);
+}
+
+Error SwiftCASOutputBackend::Implementation::finalizeCacheKeysFor(
+    StringRef Input) {
+  auto Entry = OutputRefs.find(Input);
+  assert(Entry != OutputRefs.end() && "Unexpected input");
+
+  // If not all outputs for the input are emitted, return.
+  if (!llvm::all_of(OutputToInputMap, [&](auto &E) {
+        return (E.second.first.getFileName() != Input ||
+                Entry->second.count(E.second.second));
+      }))
+    return Error::success();
+
+  std::vector<std::pair<file_types::ID, ObjectRef>> OutputsForInput;
+  llvm::for_each(Entry->second, [&OutputsForInput](auto E) {
+    OutputsForInput.emplace_back(E.first, E.second);
+  });
+  // Sort to a stable ordering for deterministic output cache object.
+  llvm::sort(OutputsForInput,
+             [](auto &LHS, auto &RHS) { return LHS.first < RHS.first; });
+
+  Optional<ObjectRef> Result;
+  // Use a clang compatible result CAS object schema when emiting PCM.
+  if (Action == FrontendOptions::ActionType::EmitPCM) {
+    clang::cas::CompileJobCacheResult::Builder Builder;
+
+    for (auto &Outs : OutputsForInput) {
+      if (Outs.first == file_types::ID::TY_ClangModuleFile)
+        Builder.addOutput(
+            clang::cas::CompileJobCacheResult::OutputKind::MainOutput,
+            Outs.second);
+      else if (Outs.first == file_types::ID::TY_CachedDiagnostics)
+        Builder.addOutput(clang::cas::CompileJobCacheResult::OutputKind::
+                              SerializedDiagnostics,
+                          Outs.second);
+      else if (Outs.first == file_types::ID::TY_Dependencies)
+        Builder.addOutput(
+            clang::cas::CompileJobCacheResult::OutputKind::Dependencies,
+            Outs.second);
+      else
+        llvm_unreachable("Unexpected output when compiling clang module");
+    }
+
+    if (auto Err = Builder.build(CAS).moveInto(Result))
+      return Err;
+
+  } else {
+    swift::cas::CompileJobCacheResult::Builder Builder;
+
+    for (auto &Outs : OutputsForInput)
+      Builder.addOutput(Outs.first, Outs.second);
+
+    if (auto Err = Builder.build(CAS).moveInto(Result))
+      return Err;
+  }
+
+  auto CacheKey = createCompileJobCacheKeyForOutput(CAS, BaseKey, Input);
+  if (!CacheKey)
+    return CacheKey.takeError();
+
+  LLVM_DEBUG(llvm::dbgs() << "DEBUG: writing cache entry for input \'" << Input
+                          << "\': \'" << CAS.getID(*CacheKey).toString()
+                          << "\' => \'" << CAS.getID(*Result).toString()
+                          << "\'\n";);
+
+  if (auto E = Cache.put(CAS.getID(*CacheKey), CAS.getID(*Result)))
+    return E;
+
+  return Error::success();
+}
+
+} // end namespace swift::cas

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -5,7 +5,9 @@ add_swift_host_library(swiftFrontend STATIC
   ArgsToFrontendOutputsConverter.cpp
   CachedDiagnostics.cpp
   CachingUtils.cpp
+  CASOutputBackends.cpp
   CompileJobCacheKey.cpp
+  CompileJobCacheResult.cpp
   CompilerInvocation.cpp
   DependencyVerifier.cpp
   DiagnosticVerifier.cpp

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -774,10 +774,8 @@ CachingDiagnosticsProcessor::CachingDiagnosticsProcessor(
     StringRef Content = Compression.empty() ? Output : toStringRef(Compression);
     // Store CachedDiagnostics in the CAS/Cache. There is no real associated
     // inputs.
-    auto Err = storeCachedCompilerOutput(
-        Instance.getObjectStore(), Instance.getActionCache(),
-        "<cached-diagnostics>", Content, *Instance.getCompilerBaseKey(),
-        "<cached-diagnostics>", file_types::ID::TY_CachedDiagnostics);
+    auto Err = Instance.getCASOutputBackend().storeCachedDiagnostics(
+        "<cached-diagnostics>", Content);
 
     if (Err) {
       Instance.getDiags().diagnose(SourceLoc(), diag::error_cas,

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -14,7 +14,11 @@
 
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/FileTypes.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Frontend/CASOutputBackends.h"
 #include "swift/Frontend/CompileJobCacheKey.h"
+#include "swift/Frontend/CompileJobCacheResult.h"
+#include "swift/Frontend/FrontendOptions.h"
 #include "swift/Option/Options.h"
 #include "clang/CAS/CASOptions.h"
 #include "clang/CAS/IncludeTree.h"
@@ -30,6 +34,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/VirtualOutputBackends.h"
@@ -39,204 +44,183 @@
 #define DEBUG_TYPE "cache-util"
 
 using namespace swift;
+using namespace swift::cas;
 using namespace llvm;
 using namespace llvm::cas;
 using namespace llvm::vfs;
 
-namespace {
-class SwiftCASOutputFile final : public OutputFileImpl {
-public:
-  Error keep() override { return OnKeep(Path, Bytes); }
-  Error discard() override { return Error::success(); }
-  raw_pwrite_stream &getOS() override { return OS; }
-
-  using OnKeepType = llvm::unique_function<Error(StringRef, StringRef)>;
-  SwiftCASOutputFile(StringRef Path, OnKeepType OnKeep)
-      : Path(Path.str()), OS(Bytes), OnKeep(std::move(OnKeep)) {}
-
-private:
-  std::string Path;
-  SmallString<16> Bytes;
-  raw_svector_ostream OS;
-  OnKeepType OnKeep;
-};
-
-class SwiftCASOutputBackend final : public OutputBackend {
-  void anchor() override {}
-
-protected:
-  IntrusiveRefCntPtr<OutputBackend> cloneImpl() const override {
-    return makeIntrusiveRefCnt<SwiftCASOutputBackend>(CAS, Cache, BaseKey,
-                                                      InputsAndOutputs);
-  }
-
-  Expected<std::unique_ptr<OutputFileImpl>>
-  createFileImpl(StringRef ResolvedPath,
-                 Optional<OutputConfig> Config) override {
-    auto ProducingInput = OutputToInputMap.find(ResolvedPath);
-    assert(ProducingInput != OutputToInputMap.end() && "Unknown output file");
-
-    std::string InputFilename = ProducingInput->second.first.getFileName();
-    auto OutputType = ProducingInput->second.second;
-
-    // Uncached output kind.
-    if (OutputType == file_types::ID::TY_SerializedDiagnostics)
-      return std::make_unique<llvm::vfs::NullOutputFileImpl>();
-
-    return std::make_unique<SwiftCASOutputFile>(
-        ResolvedPath, [=](StringRef Path, StringRef Bytes) -> Error {
-          return storeCachedCompilerOutput(CAS, Cache, Path, Bytes, BaseKey,
-                                           InputFilename, OutputType);
-        });
-  }
-
-private:
-  void initBackend(const FrontendInputsAndOutputs &InputsAndOutputs) {
-    // FIXME: The output to input map might not be enough for example all the
-    // outputs can be written to `-`, but the backend cannot distinguish which
-    // input it actually comes from. Maybe the solution is just not to cache
-    // any commands write output to `-`.
-    file_types::ID mainOutputType = InputsAndOutputs.getPrincipalOutputType();
-    auto addInput = [&](const InputFile &Input) {
-      if (!Input.outputFilename().empty())
-        OutputToInputMap.insert(
-            {Input.outputFilename(), {Input, mainOutputType}});
-      Input.getPrimarySpecificPaths()
-          .SupplementaryOutputs.forEachSetOutputAndType(
-              [&](const std::string &Out, file_types::ID ID) {
-                OutputToInputMap.insert({Out, {Input, ID}});
-              });
-    };
-    llvm::for_each(InputsAndOutputs.getAllInputs(), addInput);
-  }
-
-  file_types::ID getOutputFileType(StringRef Path) const {
-    return file_types::lookupTypeForExtension(llvm::sys::path::extension(Path));
-  }
-
-public:
-  SwiftCASOutputBackend(ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
-                        const FrontendInputsAndOutputs &InputsAndOutputs)
-      : CAS(CAS), Cache(Cache), BaseKey(BaseKey),
-        InputsAndOutputs(InputsAndOutputs) {
-    initBackend(InputsAndOutputs);
-  }
-
-private:
-  ObjectStore &CAS;
-  ActionCache &Cache;
-  ObjectRef BaseKey;
-
-  StringMap<std::pair<const InputFile &, file_types::ID>> OutputToInputMap;
-  const FrontendInputsAndOutputs &InputsAndOutputs;
-};
-}
-
 namespace swift {
 
-llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend>
+llvm::IntrusiveRefCntPtr<SwiftCASOutputBackend>
 createSwiftCachingOutputBackend(
     llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &Cache,
     llvm::cas::ObjectRef BaseKey,
-    const FrontendInputsAndOutputs &InputsAndOutputs) {
+    const FrontendInputsAndOutputs &InputsAndOutputs,
+    FrontendOptions::ActionType Action) {
   return makeIntrusiveRefCnt<SwiftCASOutputBackend>(CAS, Cache, BaseKey,
-                                                    InputsAndOutputs);
+                                                    InputsAndOutputs, Action);
+}
+
+Expected<bool> cas::CachedResultLoader::replay(CallbackTy Callback) {
+  // Lookup the cache key for the input file.
+  auto OutID = CAS.getID(CacheKey);
+  auto Lookup = Cache.get(OutID);
+  if (!Lookup)
+    return Lookup.takeError();
+
+  if (!*Lookup)
+    return false;
+
+  auto OutputRef = CAS.getReference(**Lookup);
+  if (!OutputRef)
+    return false;
+
+  auto ResultProxy = CAS.getProxy(*OutputRef);
+  if (!ResultProxy)
+    return ResultProxy.takeError();
+
+  {
+    swift::cas::CompileJobResultSchema Schema(CAS);
+    if (Schema.isRootNode(*ResultProxy)) {
+      auto Result = Schema.load(*OutputRef);
+      if (!Result)
+        return Result.takeError();
+
+      if (auto Err = Result->forEachOutput(
+              [&](swift::cas::CompileJobCacheResult::Output Output) -> Error {
+                return Callback(Output.Kind, Output.Object);
+              }))
+        return Err;
+
+      return true;
+    }
+  }
+  {
+    clang::cas::CompileJobResultSchema Schema(CAS);
+    if (Schema.isRootNode(*ResultProxy)) {
+      auto Result = Schema.load(*OutputRef);
+      if (!Result)
+        return Result.takeError();
+      if (auto Err = Result->forEachOutput(
+          [&](clang::cas::CompileJobCacheResult::Output Output) -> Error {
+            file_types::ID OutputKind = file_types::ID::TY_INVALID;
+            switch (Output.Kind) {
+            case clang::cas::CompileJobCacheResult::OutputKind::MainOutput:
+              OutputKind = file_types::ID::TY_ClangModuleFile;
+              break;
+            case clang::cas::CompileJobCacheResult::OutputKind::Dependencies:
+              OutputKind = file_types::ID::TY_Dependencies;
+              break;
+            case clang::cas::CompileJobCacheResult::OutputKind::
+                SerializedDiagnostics:
+              OutputKind = file_types::ID::TY_CachedDiagnostics;
+              break;
+            }
+            assert(OutputKind != file_types::ID::TY_INVALID &&
+                   "Unexpected output kind in clang cached result");
+            return Callback(OutputKind, Output.Object);
+          }))
+        return Err;
+
+      return true;
+    }
+  }
+
+  return createStringError(inconvertibleErrorCode(),
+                           "unexpected output schema for cached result");
 }
 
 bool replayCachedCompilerOutputs(
     ObjectStore &CAS, ActionCache &Cache, ObjectRef BaseKey,
     DiagnosticEngine &Diag, const FrontendInputsAndOutputs &InputsAndOutputs,
     CachingDiagnosticsProcessor &CDP, bool CacheRemarks) {
-  clang::cas::CompileJobResultSchema Schema(CAS);
   bool CanReplayAllOutput = true;
   struct OutputEntry {
     std::string Path;
-    std::string Key;
-    llvm::cas::ObjectProxy Proxy;
+    CASID Key;
+    ObjectProxy Proxy;
   };
   SmallVector<OutputEntry> OutputProxies;
+  Optional<OutputEntry> DiagnosticsOutput;
 
-  auto replayOutputFile = [&](StringRef InputName, file_types::ID OutputKind,
-                              StringRef OutputPath) -> Optional<OutputEntry> {
-    LLVM_DEBUG(llvm::dbgs()
-                   << "DEBUG: lookup output \'" << OutputPath << "\' type \'"
-                   << file_types::getTypeName(OutputKind) << "\' input \'"
-                   << InputName << "\n";);
+  auto replayOutputsForInputFile = [&](const std::string &InputPath,
+                                       const DenseMap<file_types::ID,
+                                                      std::string> &Outputs) {
+    auto lookupFailed = [&CanReplayAllOutput] { CanReplayAllOutput = false; };
+    auto OutputKey = createCompileJobCacheKeyForOutput(CAS, BaseKey, InputPath);
 
-    auto OutputKey =
-        createCompileJobCacheKeyForOutput(CAS, BaseKey, InputName, OutputKind);
     if (!OutputKey) {
       Diag.diagnose(SourceLoc(), diag::error_cas,
                     toString(OutputKey.takeError()));
-      return None;
+      return lookupFailed();
     }
-    auto OutputKeyID = CAS.getID(*OutputKey);
-    auto Lookup = Cache.get(OutputKeyID);
-    if (!Lookup) {
-      Diag.diagnose(SourceLoc(), diag::error_cas, toString(Lookup.takeError()));
-      return None;
-    }
-    if (!*Lookup) {
-      if (CacheRemarks)
-        Diag.diagnose(SourceLoc(), diag::output_cache_miss, OutputPath,
-                      OutputKeyID.toString());
-      return None;
-    }
-    auto OutputRef = CAS.getReference(**Lookup);
-    if (!OutputRef) {
-      return None;
-    }
-    auto Result = Schema.load(*OutputRef);
-    if (!Result) {
-      Diag.diagnose(SourceLoc(), diag::error_cas, toString(Result.takeError()));
-      return None;
-    }
-    auto MainOutput = Result->getOutput(
-        clang::cas::CompileJobCacheResult::OutputKind::MainOutput);
-    if (!MainOutput) {
-      return None;
-    }
-    auto LoadedResult = CAS.getProxy(MainOutput->Object);
-    if (!LoadedResult) {
+    CachedResultLoader Loader(CAS, Cache, *OutputKey);
+
+    auto OutID = CAS.getID(*OutputKey);
+    LLVM_DEBUG(llvm::dbgs() << "DEBUG: lookup cache key \'" << OutID.toString()
+                            << "\' for input \'" << InputPath << "\n";);
+
+    auto LookupResult = Loader.replay([&](file_types::ID Kind,
+                                          ObjectRef Ref) -> Error {
+      auto OutputPath = Outputs.find(Kind);
+      if (OutputPath == Outputs.end())
+        return createStringError(inconvertibleErrorCode(),
+                                 "unexpected output kind in the cached output");
+      auto Proxy = CAS.getProxy(Ref);
+      if (!Proxy)
+        return Proxy.takeError();
+
+      if (Kind == file_types::ID::TY_CachedDiagnostics) {
+        assert(!DiagnosticsOutput && "more than 1 diagnotics found");
+        DiagnosticsOutput = OutputEntry{OutputPath->second, OutID, *Proxy};
+      } else
+        OutputProxies.emplace_back(
+            OutputEntry{OutputPath->second, OutID, *Proxy});
+      return Error::success();
+    });
+
+    if (!LookupResult) {
       Diag.diagnose(SourceLoc(), diag::error_cas,
-                    toString(LoadedResult.takeError()));
-      return None;
+                    toString(LookupResult.takeError()));
+      return lookupFailed();
     }
 
-    return OutputEntry{OutputPath.str(), OutputKeyID.toString(), *LoadedResult};
+    if (!*LookupResult) {
+      if (CacheRemarks)
+        Diag.diagnose(SourceLoc(), diag::output_cache_miss, InputPath,
+                      OutID.toString());
+      return lookupFailed();
+    }
   };
 
   auto replayOutputFromInput = [&](const InputFile &Input) {
     auto InputPath = Input.getFileName();
-    if (!Input.outputFilename().empty()) {
-      if (auto Result = replayOutputFile(
-              InputPath, InputsAndOutputs.getPrincipalOutputType(),
-              Input.outputFilename()))
-        OutputProxies.emplace_back(*Result);
-      else
-        CanReplayAllOutput = false;
-    }
+    DenseMap<file_types::ID, std::string> Outputs;
+    if (!Input.outputFilename().empty())
+      Outputs.try_emplace(InputsAndOutputs.getPrincipalOutputType(),
+                          Input.outputFilename());
 
     Input.getPrimarySpecificPaths()
         .SupplementaryOutputs.forEachSetOutputAndType(
             [&](const std::string &File, file_types::ID ID) {
-              if (ID == file_types::ID::TY_SerializedDiagnostics)
+              if (file_types::isProducedFromDiagnostics(ID))
                 return;
 
-              if (auto Result = replayOutputFile(InputPath, ID, File))
-                OutputProxies.emplace_back(*Result);
-              else
-                CanReplayAllOutput = false;
+              Outputs.try_emplace(ID, File);
             });
+
+    // Nothing to replay.
+    if (Outputs.empty())
+      return;
+
+    return replayOutputsForInputFile(InputPath, Outputs);
   };
 
   llvm::for_each(InputsAndOutputs.getAllInputs(), replayOutputFromInput);
 
-  auto DiagnosticsOutput = replayOutputFile(
-      "<cached-diagnostics>", file_types::ID::TY_CachedDiagnostics,
-      "<cached-diagnostics>");
-  if (!DiagnosticsOutput)
-    CanReplayAllOutput = false;
+  replayOutputsForInputFile(
+      "<cached-diagnostics>",
+      {{file_types::ID::TY_CachedDiagnostics, "<cached-diagnostics>"}});
 
   if (!CanReplayAllOutput)
     return false;
@@ -248,11 +232,11 @@ bool replayCachedCompilerOutputs(
     Diag.diagnose(SourceLoc(), diag::error_replay_cached_diag,
                   toString(std::move(E)));
     return false;
-  } else {
-    if (CacheRemarks)
-      Diag.diagnose(SourceLoc(), diag::replay_output, "<cached-diagnostics>",
-                    DiagnosticsOutput->Key);
   }
+
+  if (CacheRemarks)
+    Diag.diagnose(SourceLoc(), diag::replay_output, "<cached-diagnostics>",
+                  DiagnosticsOutput->Key.toString());
 
   // Replay the result only when everything is resolved.
   // Use on disk output backend directly here to write to disk.
@@ -271,91 +255,49 @@ bool replayCachedCompilerOutputs(
       continue;
     }
     if (CacheRemarks)
-      Diag.diagnose(SourceLoc(), diag::replay_output, Output.Path, Output.Key);
+      Diag.diagnose(SourceLoc(), diag::replay_output, Output.Path,
+                    Output.Key.toString());
   }
 
   return true;
 }
 
-static Expected<std::unique_ptr<llvm::MemoryBuffer>>
-loadCachedCompileResultFromCacheKeyImpl(ObjectStore &CAS, ActionCache &Cache,
-                                        StringRef CacheKey,
-                                        StringRef Filename) {
-  auto ID = CAS.parseID(CacheKey);
-  if (!ID)
-    return ID.takeError();
-
-  auto Result = Cache.get(*ID);
-  if (!Result)
-    return Result.takeError();
-  if (!*Result)
-    return nullptr;
-
-  auto OutputRef = CAS.getReference(**Result);
-  if (!OutputRef)
-    return nullptr;
-  clang::cas::CompileJobResultSchema Schema(CAS);
-  auto CachedOutput = Schema.load(*OutputRef);
-
-  if (!CachedOutput)
-    return CachedOutput.takeError();
-
-  auto Output = CachedOutput->getOutput(
-      clang::cas::CompileJobCacheResult::OutputKind::MainOutput);
-  if (!Output)
-    return nullptr;
-
-  auto Proxy = CAS.getProxy(Output->Object);
-  if (!Proxy)
-    return Proxy.takeError();
-
-  return Proxy->getMemoryBuffer(Filename);
-}
-
 std::unique_ptr<llvm::MemoryBuffer>
 loadCachedCompileResultFromCacheKey(ObjectStore &CAS, ActionCache &Cache,
                                     DiagnosticEngine &Diag, StringRef CacheKey,
-                                    StringRef Filename) {
-  auto Output =
-      loadCachedCompileResultFromCacheKeyImpl(CAS, Cache, CacheKey, Filename);
-  if (!Output) {
-    Diag.diagnose(SourceLoc(), diag::error_cas, toString(Output.takeError()));
+                                    file_types::ID Kind, StringRef Filename) {
+  auto failure = [&](Error Err) {
+    Diag.diagnose(SourceLoc(), diag::error_cas, toString(std::move(Err)));
     return nullptr;
-  }
-  return std::move(*Output);
-}
+  };
+  auto ID = CAS.parseID(CacheKey);
+  if (!ID)
+    return failure(ID.takeError());
+  auto Ref = CAS.getReference(*ID);
+  if (!Ref)
+    return nullptr;
 
-Error storeCachedCompilerOutput(llvm::cas::ObjectStore &CAS,
-                                llvm::cas::ActionCache &Cache, StringRef Path,
-                                StringRef Bytes, llvm::cas::ObjectRef BaseKey,
-                                StringRef CorrespondingInput,
-                                file_types::ID OutputKind) {
-  Optional<ObjectRef> BytesRef;
-  if (Error E = CAS.storeFromString(None, Bytes).moveInto(BytesRef))
-    return E;
+  CachedResultLoader Loader(CAS, Cache, *Ref);
+  std::unique_ptr<llvm::MemoryBuffer> Buffer;
+  auto Result = Loader.replay([&](file_types::ID Type, ObjectRef Ref) -> Error {
+    if (Kind != Type)
+      return Error::success();
 
-  auto CacheKey = createCompileJobCacheKeyForOutput(
-      CAS, BaseKey, CorrespondingInput, OutputKind);
-  if (!CacheKey)
-    return CacheKey.takeError();
+    auto Proxy = CAS.getProxy(Ref);
+    if (!Proxy)
+      return Proxy.takeError();
 
-  LLVM_DEBUG(llvm::dbgs() << "DEBUG: writing output \'" << Path << "\' type \'"
-                          << file_types::getTypeName(OutputKind)
-                          << "\' input \'" << CorrespondingInput << "\' hash \'"
-                          << CAS.getID(*CacheKey).toString() << "\'\n";);
+    Buffer = Proxy->getMemoryBuffer(Filename);
+    return Error::success();
+  });
 
-  // Use clang compiler job output for now.
-  clang::cas::CompileJobCacheResult::Builder Builder;
-  Builder.addOutput(clang::cas::CompileJobCacheResult::OutputKind::MainOutput,
-                    *BytesRef);
-  auto Result = Builder.build(CAS);
   if (!Result)
-    return Result.takeError();
+    return failure(Result.takeError());
 
-  if (auto E = Cache.put(CAS.getID(*CacheKey), CAS.getID(*Result)))
-    return E;
+  if (!*Result)
+    return nullptr;
 
-  return Error::success();
+  return Buffer;
 }
 
 static llvm::Error createCASObjectNotFoundError(const llvm::cas::CASID &ID) {

--- a/lib/Frontend/CompileJobCacheKey.cpp
+++ b/lib/Frontend/CompileJobCacheKey.cpp
@@ -86,11 +86,10 @@ llvm::Expected<llvm::cas::ObjectRef> swift::createCompileJobBaseCacheKey(
 
 llvm::Expected<llvm::cas::ObjectRef> swift::createCompileJobCacheKeyForOutput(
     llvm::cas::ObjectStore &CAS, llvm::cas::ObjectRef BaseKey,
-    StringRef ProducingInput, file_types::ID OutputType) {
+    StringRef ProducingInput) {
   SmallString<256> OutputInfo;
 
-  // Encode the OutputType as first byte, then append the input file path.
-  OutputInfo.emplace_back((char)OutputType);
+  // CacheKey is the producting input + the base key.
   OutputInfo.append(ProducingInput);
 
   return CAS.storeFromString({BaseKey}, OutputInfo);

--- a/lib/Frontend/CompileJobCacheResult.cpp
+++ b/lib/Frontend/CompileJobCacheResult.cpp
@@ -1,0 +1,185 @@
+//===--- CompileJobCacheResult.cpp - compile cache result schema ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the cache schema for swift cached compile job result.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Frontend/CompileJobCacheResult.h"
+#include "swift/Basic/FileTypes.h"
+
+using namespace swift;
+using namespace swift::cas;
+using namespace llvm;
+using namespace llvm::cas;
+
+Error CompileJobCacheResult::forEachOutput(
+    llvm::function_ref<Error(Output)> Callback) const {
+  size_t Count = getNumOutputs();
+  for (size_t I = 0; I < Count; ++I) {
+    file_types::ID Kind = getOutputKind(I);
+    ObjectRef Object = getOutputObject(I);
+    if (auto Err = Callback({Object, Kind}))
+      return Err;
+  }
+  return Error::success();
+}
+
+Error CompileJobCacheResult::forEachLoadedOutput(
+    llvm::function_ref<Error(Output, std::optional<ObjectProxy>)> Callback) {
+  // Kick-off materialization for all outputs concurrently.
+  SmallVector<std::future<AsyncProxyValue>, 4> FutureOutputs;
+  size_t Count = getNumOutputs();
+  for (size_t I = 0; I < Count; ++I) {
+    ObjectRef Ref = getOutputObject(I);
+    FutureOutputs.push_back(getCAS().getProxyFuture(Ref));
+  }
+
+  // Make sure all the outputs have materialized.
+  std::optional<Error> OccurredError;
+  SmallVector<std::optional<ObjectProxy>, 4> Outputs;
+  for (auto &FutureOutput : FutureOutputs) {
+    auto Obj = FutureOutput.get().take();
+    if (!Obj) {
+      if (!OccurredError)
+        OccurredError = Obj.takeError();
+      else
+        OccurredError =
+            llvm::joinErrors(std::move(*OccurredError), Obj.takeError());
+      continue;
+    }
+    Outputs.push_back(*Obj);
+  }
+  if (OccurredError)
+    return std::move(*OccurredError);
+
+  // Pass the loaded outputs.
+  for (size_t I = 0; I < Count; ++I) {
+    if (auto Err = Callback({getOutputObject(I), getOutputKind(I)}, Outputs[I]))
+      return Err;
+  }
+  return Error::success();
+}
+
+CompileJobCacheResult::Output CompileJobCacheResult::getOutput(size_t I) const {
+  return Output{getOutputObject(I), getOutputKind(I)};
+}
+
+Optional<CompileJobCacheResult::Output>
+CompileJobCacheResult::getOutput(file_types::ID Kind) const {
+  size_t Count = getNumOutputs();
+  for (size_t I = 0; I < Count; ++I) {
+    file_types::ID K = getOutputKind(I);
+    if (Kind == K)
+      return Output{getOutputObject(I), Kind};
+  }
+  return None;
+}
+
+Error CompileJobCacheResult::print(llvm::raw_ostream &OS) {
+  return forEachOutput([&](Output O) -> Error {
+    OS << file_types::getTypeName(O.Kind) << "    " << getCAS().getID(O.Object)
+       << '\n';
+    return Error::success();
+  });
+}
+
+size_t CompileJobCacheResult::getNumOutputs() const { return getData().size(); }
+ObjectRef CompileJobCacheResult::getOutputObject(size_t I) const {
+  return getReference(I);
+}
+
+file_types::ID
+CompileJobCacheResult::getOutputKind(size_t I) const {
+  return static_cast<file_types::ID>(getData()[I]);
+}
+
+CompileJobCacheResult::CompileJobCacheResult(const ObjectProxy &Obj)
+    : ObjectProxy(Obj) {}
+
+struct CompileJobCacheResult::Builder::PrivateImpl {
+  SmallVector<ObjectRef> Objects;
+  SmallVector<file_types::ID> Kinds;
+
+  struct KindMap {
+    file_types::ID Kind;
+    std::string Path;
+  };
+  SmallVector<KindMap> KindMaps;
+};
+
+CompileJobCacheResult::Builder::Builder() : Impl(*new PrivateImpl) {}
+CompileJobCacheResult::Builder::~Builder() { delete &Impl; }
+
+void CompileJobCacheResult::Builder::addKindMap(file_types::ID Kind,
+                                                StringRef Path) {
+  Impl.KindMaps.push_back({Kind, std::string(Path)});
+}
+void CompileJobCacheResult::Builder::addOutput(file_types::ID Kind,
+                                               ObjectRef Object) {
+  Impl.Kinds.push_back(Kind);
+  Impl.Objects.push_back(Object);
+}
+Error CompileJobCacheResult::Builder::addOutput(StringRef Path,
+                                                ObjectRef Object) {
+  Impl.Objects.push_back(Object);
+  for (auto &KM : Impl.KindMaps) {
+    if (KM.Path == Path) {
+      Impl.Kinds.push_back(KM.Kind);
+      return Error::success();
+    }
+  }
+  return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                 "cached output file has unknown path '" +
+                                     Path + "'");
+}
+
+Expected<ObjectRef> CompileJobCacheResult::Builder::build(ObjectStore &CAS) {
+  CompileJobResultSchema Schema(CAS);
+  // The resulting Refs contents are:
+  // Object 0...N, SchemaKind
+  SmallVector<ObjectRef> Refs;
+  std::swap(Impl.Objects, Refs);
+  Refs.push_back(Schema.getKindRef());
+  return CAS.store(Refs, {(char *)Impl.Kinds.begin(), Impl.Kinds.size()});
+}
+
+static constexpr llvm::StringLiteral CompileJobResultSchemaName =
+    "swift::cas::schema::compile_job_result::v1";
+
+char CompileJobResultSchema::ID = 0;
+
+CompileJobResultSchema::CompileJobResultSchema(ObjectStore &CAS)
+    : CompileJobResultSchema::RTTIExtends(CAS),
+      KindRef(
+          llvm::cantFail(CAS.storeFromString({}, CompileJobResultSchemaName))) {
+}
+
+Expected<CompileJobCacheResult>
+CompileJobResultSchema::load(ObjectRef Ref) const {
+  auto Proxy = CAS.getProxy(Ref);
+  if (!Proxy)
+    return Proxy.takeError();
+  if (!isNode(*Proxy))
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "not a compile job result");
+  return CompileJobCacheResult(*Proxy);
+}
+
+bool CompileJobResultSchema::isRootNode(const ObjectProxy &Node) const {
+  return isNode(Node);
+}
+
+bool CompileJobResultSchema::isNode(const ObjectProxy &Node) const {
+  size_t N = Node.getNumReferences();
+  return N && Node.getReference(N - 1) == getKindRef();
+}

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2620,7 +2620,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   Opts.UseProfile = ProfileUse ? ProfileUse->getValue() : "";
 
   Opts.PrintInlineTree |= Args.hasArg(OPT_print_llvm_inline_tree);
-  Opts.AlwaysCompile |= Args.hasArg(OPT_always_compile_output_files);
+  // Always producing all outputs when caching is enabled.
+  Opts.AlwaysCompile |= Args.hasArg(OPT_always_compile_output_files) ||
+                        Args.hasArg(OPT_cache_compile_job);
 
   Opts.EnableDynamicReplacementChaining |=
       Args.hasArg(OPT_enable_dynamic_replacement_chaining);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -456,9 +456,10 @@ void CompilerInstance::setupOutputBackend() {
 
   // Mirror the output into CAS.
   if (supportCaching()) {
-    auto CASOutputBackend = createSwiftCachingOutputBackend(
+    CASOutputBackend = createSwiftCachingOutputBackend(
         *CAS, *ResultCache, *CompileJobBaseKey,
-        Invocation.getFrontendOptions().InputsAndOutputs);
+        Invocation.getFrontendOptions().InputsAndOutputs,
+        Invocation.getFrontendOptions().RequestedAction);
     OutputBackend =
         llvm::vfs::makeMirroringOutputBackend(OutputBackend, CASOutputBackend);
   }
@@ -564,15 +565,18 @@ bool CompilerInstance::setUpVirtualFileSystemOverlays() {
     if (!ClangOpts.BridgingHeaderPCHCacheKey.empty()) {
       if (auto loadedBuffer = loadCachedCompileResultFromCacheKey(
               getObjectStore(), getActionCache(), Diagnostics,
-              ClangOpts.BridgingHeaderPCHCacheKey, ClangOpts.BridgingHeader))
+              ClangOpts.BridgingHeaderPCHCacheKey, file_types::ID::TY_PCH,
+              ClangOpts.BridgingHeader))
         MemFS->addFile(Invocation.getClangImporterOptions().BridgingHeader, 0,
                        std::move(loadedBuffer));
     }
     if (!Opts.InputFileKey.empty()) {
       auto InputPath = Opts.InputsAndOutputs.getFilenameOfFirstInput();
+      auto Type = file_types::lookupTypeForExtension(
+          llvm::sys::path::extension(InputPath));
       if (auto loadedBuffer = loadCachedCompileResultFromCacheKey(
               getObjectStore(), getActionCache(), Diagnostics,
-              Opts.InputFileKey, InputPath))
+              Opts.InputFileKey, Type, InputPath))
         MemFS->addFile(InputPath, 0, std::move(loadedBuffer));
     }
     llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayVFS =

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2384,7 +2384,8 @@ struct ExplicitCASModuleLoader::Implementation {
         if (!Deps.second.moduleCacheKey)
           return nullptr;
         return loadCachedCompileResultFromCacheKey(
-            CAS, Cache, Diags, *Deps.second.moduleCacheKey, Path);
+            CAS, Cache, Diags, *Deps.second.moduleCacheKey,
+            file_types::ID::TY_SwiftModuleFile, Path);
       }
     }
     return nullptr;
@@ -2439,8 +2440,9 @@ bool ExplicitCASModuleLoader::findModule(
   // FIXME: the loaded module buffer doesn't set an identifier so it
   // is not tracked in dependency tracker, which doesn't handle modules
   // that are not located on disk.
-  auto moduleBuf = loadCachedCompileResultFromCacheKey(Impl.CAS, Impl.Cache,
-                                                       Ctx.Diags, moduleCASID);
+  auto moduleBuf = loadCachedCompileResultFromCacheKey(
+      Impl.CAS, Impl.Cache, Ctx.Diags, moduleCASID,
+      file_types::ID::TY_SwiftModuleFile);
   if (!moduleBuf) {
     // We cannot read the module content, diagnose.
     Ctx.Diags.diagnose(SourceLoc(), diag::error_opening_explicit_module_file,

--- a/test/CAS/cache_replay.swift
+++ b/test/CAS/cache_replay.swift
@@ -1,26 +1,48 @@
 // RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
 /// Run the command first time, expect cache miss.
 /// FIXME: This command doesn't use `-cas-fs` so it is not a good cache entry. It is currently allowed so it is easier to write tests.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
 
 /// Expect cache hit for second time.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
 
-/// Expect cache hit a subset of outputs.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c \
+/// Expect cache miss a subset of outputs.
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+
+/// Cache hit for retry.
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
 
 /// Skip cache
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -cache-disable-replay %s -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -cache-disable-replay %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c \
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --allow-empty --check-prefix=SKIP-CACHE %s
 
-// CACHE-MISS: remark: cache miss output file
+/// Check clang module
+// RUN: %target-swift-frontend -emit-pcm -module-name Dummy %t/module.modulemap -cache-compile-job -Rcache-compile-job -cas-path %t/cas \
+// RUN:   -allow-unstable-cache-key-for-testing -o %t/dummy.pcm 2>&1 | %FileCheck --allow-empty --check-prefix=CACHE-MISS %s
+// RUN: %target-swift-frontend -emit-pcm -module-name Dummy %t/module.modulemap -cache-compile-job -Rcache-compile-job -cas-path %t/cas \
+// RUN:   -allow-unstable-cache-key-for-testing -o %t/dummy.pcm 2>&1 | %FileCheck --allow-empty --check-prefix=CACHE-HIT-CLANG %s
+
+// CACHE-MISS: remark: cache miss for input
 // CACHE-HIT: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
 // CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': key 'llvmcas://{{.*}}'
 // CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}Test.swiftmodule': key 'llvmcas://{{.*}}'
+// CACHE-HIT-CLANG: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
+// CACHE-HIT-CLANG: remark: replay output file '{{.*}}{{/|\\}}dummy.pcm': key 'llvmcas://{{.*}}'
 // SKIP-CACHE-NOT: remark:
 
+//--- test.swift
 func testFunc() {}
+
+//--- module.modulemap
+module Dummy {
+ umbrella header "Dummy.h"
+}
+
+//--- Dummy.h
+void dummy(void);

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -1,8 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/cas
 // RUN: split-file %s %t
-// RUN: %target-swift-emit-pcm -module-cache-path %t/clang-module-cache -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/SwiftShims.pcm
-// RUN: %target-swift-emit-pcm -module-cache-path %t/clang-module-cache -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/_SwiftConcurrencyShims.pcm
+// RUN: %target-swift-emit-pcm -Xfrontend -cache-compile-job -Xfrontend -allow-unstable-cache-key-for-testing -Xfrontend -cas-path -Xfrontend %t/cas -module-cache-path %t/clang-module-cache -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/SwiftShims.pcm
+// RUN: %target-swift-emit-pcm -Xfrontend -cache-compile-job -Xfrontend -allow-unstable-cache-key-for-testing -Xfrontend -cas-path -Xfrontend %t/cas -module-cache-path %t/clang-module-cache -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/SwiftShims.pcm -### > %t/Shims.cmd
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- @%t/Shims.cmd > %t/Shims.key.json
+// RUN: %S/Inputs/ExtractOutputKey.py %t/Shims.key.json %t/SwiftShims.pcm | tr -d '\n' > %t/Shims.key
+
+// RUN: %target-swift-emit-pcm -Xfrontend -cache-compile-job -Xfrontend -allow-unstable-cache-key-for-testing -module-cache-path %t/clang-module-cache -Xfrontend -cas-path -Xfrontend %t/cas -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/_SwiftConcurrencyShims.pcm
+// RUN: %target-swift-emit-pcm -Xfrontend -cache-compile-job -Xfrontend -allow-unstable-cache-key-for-testing -module-cache-path %t/clang-module-cache -Xfrontend -cas-path -Xfrontend %t/cas -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/_SwiftConcurrencyShims.pcm -### > %t/ConcurrencyShims.cmd
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- @%t/ConcurrencyShims.cmd > %t/ConcurrencyShims.key.json
+// RUN: %S/Inputs/ExtractOutputKey.py %t/ConcurrencyShims.key.json %t/_SwiftConcurrencyShims.pcm | tr -d '\n' > %t/ConcurrencyShims.key
+
 // RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %t/A.swift -o %t/A.swiftmodule -swift-version 5
 // RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %t/B.swift -o %t/B.swiftmodule -I %t -swift-version 5
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/Test.swift -o %t/deps.json -I %t -swift-version 5 -cache-compile-job -cas-path %t/cas
@@ -32,14 +40,6 @@
 // RUN: llvm-cas --cas %t/cas --make-blob --data %string_processing_module | tr -d '\n' > %t/String.key
 // RUN: llvm-cas --cas %t/cas --make-node --data %t/kind.blob @%t/String.key @%t/schema.casid > %t/String.casid
 // RUN: llvm-cas --cas %t/cas --put-cache-key @%t/String.key @%t/String.casid
-
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/SwiftShims.pcm | tr -d '\n' > %t/Shims.key
-// RUN: llvm-cas --cas %t/cas --make-node --data %t/kind.blob @%t/Shims.key @%t/schema.casid > %t/Shims.casid
-// RUN: llvm-cas --cas %t/cas --put-cache-key @%t/Shims.key @%t/Shims.casid
-
-// RUN: llvm-cas --cas %t/cas --make-blob --data %t/_SwiftConcurrencyShims.pcm | tr -d '\n' > %t/ConcurrencyShims.key
-// RUN: llvm-cas --cas %t/cas --make-node --data %t/kind.blob @%t/ConcurrencyShims.key @%t/schema.casid > %t/ConcurrencyShims.casid
-// RUN: llvm-cas --cas %t/cas --put-cache-key @%t/ConcurrencyShims.key @%t/ConcurrencyShims.casid
 
 // RUN: echo "[{" > %/t/map.json
 // RUN: echo "\"moduleName\": \"A\"," >> %/t/map.json
@@ -133,7 +133,7 @@
 // CHECK-DAG: loaded module '_Concurrency'
 // CHECK-DAG: loaded module 'SwiftOnoneSupport'
 
-// CACHE-MISS: remark: cache miss output file
+// CACHE-MISS: remark: cache miss for input
 // VERIFY-OUTPUT: warning: module 'A' was not compiled with library evolution support
 // CACHE-HIT: remark: replay output file
 

--- a/tools/libSwiftScan/libSwiftScan.exports
+++ b/tools/libSwiftScan/libSwiftScan.exports
@@ -83,5 +83,5 @@ swiftscan_cas_options_set_ondisk_path
 swiftscan_cas_options_set_plugin_path
 swiftscan_cas_options_set_option
 swiftscan_cas_store
-swiftscan_compute_cache_key
+swiftscan_cache_compute_key
 invoke_swift_compiler


### PR DESCRIPTION
Update swift cache key computation mechanism from one cache key per output, to one cache key per primary input file (for all outputs that associated with that input).

The new schema allows fewer cache lookups while still preserving most of the flexibility for batch mode and incremental mode.
