### PR TITLE
[Vim] vim syntax update for concurrency keyword

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -16,6 +16,7 @@ if exists("b:current_syntax")
 endif
 
 syn keyword swiftKeyword
+      \ await
       \ break
       \ case
       \ catch
@@ -47,6 +48,7 @@ syn keyword swiftImport skipwhite skipempty nextgroup=swiftImportModule
       \ import
 
 syn keyword swiftDefinitionModifier
+      \ async
       \ convenience
       \ dynamic
       \ fileprivate
@@ -59,6 +61,7 @@ syn keyword swiftDefinitionModifier
       \ prefix
       \ private
       \ public
+      \ reasync
       \ required
       \ rethrows
       \ static


### PR DESCRIPTION
Update swift.vim to contain concurrency keywords like `async` and `await`.