### PR TITLE
[C++20] Make `operator{==,!=}`s const.

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -536,8 +536,8 @@ public:
   ViewerIterator(const ViewerIterator& mit) : Viewer(mit.Viewer), P(mit.P) {}
   ViewerIterator& operator++();
   ViewerIterator operator++(int) {ViewerIterator tmp(*this); operator++(); return tmp;}
-  bool operator==(const ViewerIterator& rhs) {return P==rhs.P;}
-  bool operator!=(const ViewerIterator& rhs) {return P!=rhs.P;}
+  bool operator==(const ViewerIterator& rhs) const {return P==rhs.P;}
+  bool operator!=(const ViewerIterator& rhs) const {return P!=rhs.P;}
   const NodePtr& operator*() {return *P;}
 };
 

--- a/include/swift/AST/ArgumentList.h
+++ b/include/swift/AST/ArgumentList.h
@@ -95,11 +95,11 @@ public:
   /// Whether the argument is a compile-time constant value.
   bool isConst() const;
 
-  bool operator==(const Argument &other) {
+  bool operator==(const Argument &other) const {
     return LabelLoc == other.LabelLoc && Label == other.Label &&
            ArgExpr == other.ArgExpr;
   }
-  bool operator!=(const Argument &other) { return !(*this == other); }
+  bool operator!=(const Argument &other) const { return !(*this == other); }
 };
 
 /// Represents the argument list of a function call or subscript access.

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -412,7 +412,7 @@ struct DeclaredDecl {
   bool ReferredAfterRange;
   DeclaredDecl(ValueDecl* VD) : VD(VD), ReferredAfterRange(false) {}
   DeclaredDecl(): DeclaredDecl(nullptr) {}
-  bool operator==(const DeclaredDecl& other);
+  bool operator==(const DeclaredDecl& other) const;
 };
 
 struct ReferencedDecl {

--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -120,7 +120,7 @@ public:
   };
 
 
-  bool operator==(const TypeRefID &Other) {
+  bool operator==(const TypeRefID &Other) const {
     return Bits == Other.Bits;
   }
 };

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -260,8 +260,8 @@ public:
     llvm::mapped_iterator<iterator, SILType(*)(SILValue), SILType>>;
   type_range getTypes() const;
 
-  bool operator==(const SILInstructionResultArray &rhs);
-  bool operator!=(const SILInstructionResultArray &other) {
+  bool operator==(const SILInstructionResultArray &rhs) const;
+  bool operator!=(const SILInstructionResultArray &other) const {
     return !(*this == other);
   }
 

--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -183,8 +183,8 @@ public:
     }
 
     explicit operator bool() const { return !isNoEffect(); }
-    bool operator==(const Effect &other) { return value == other.value; }
-    bool operator!=(const Effect &other) { return value != other.value; }
+    bool operator==(const Effect &other) const { return value == other.value; }
+    bool operator!=(const Effect &other) const { return value != other.value; }
   };
 
   /// How reachable a point in the function is:

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -46,7 +46,7 @@ struct SerializedSourceLoc {
   unsigned FileID = 0;
   unsigned Offset = 0;
 
-  bool operator==(const SerializedSourceLoc &RHS) {
+  bool operator==(const SerializedSourceLoc &RHS) const {
     return FileID == RHS.FileID && Offset == RHS.Offset;
   }
 };

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -785,7 +785,7 @@ calculateContentRange(ArrayRef<Token> Tokens) {
   return CharSourceRange(StartLoc, Length);
 }
 
-bool DeclaredDecl::operator==(const DeclaredDecl& Other) {
+bool DeclaredDecl::operator==(const DeclaredDecl& Other) const {
   return VD == Other.VD;
 }
 

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1606,7 +1606,7 @@ bool SILInstructionResultArray::hasSameTypes(
 }
 
 bool SILInstructionResultArray::
-operator==(const SILInstructionResultArray &other) {
+operator==(const SILInstructionResultArray &other) const {
   if (size() != other.size())
     return false;
   for (auto i : indices(*this))

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -1029,7 +1029,7 @@ struct alledge_iterator {
     return copy;
   }
 
-  bool operator==(alledge_iterator rhs) {
+  bool operator==(alledge_iterator rhs) const {
     if (Wrapper->Region != rhs.Wrapper->Region)
       return false;
     if (SubregionIter != rhs.SubregionIter)
@@ -1041,7 +1041,7 @@ struct alledge_iterator {
     return BackedgeIter == rhs.BackedgeIter;
   }
 
-  bool operator!=(alledge_iterator rhs) { return !(*this == rhs); }
+  bool operator!=(alledge_iterator rhs) const { return !(*this == rhs); }
 };
 
 } // end anonymous namespace

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1137,11 +1137,11 @@ struct TrampolineDest {
   TrampolineDest(TrampolineDest &&) = default;
   TrampolineDest &operator=(TrampolineDest &&) = default;
 
-  bool operator==(const TrampolineDest &rhs) {
+  bool operator==(const TrampolineDest &rhs) const {
     return destBB == rhs.destBB
            && newSourceBranchArgs == rhs.newSourceBranchArgs;
   }
-  bool operator!=(const TrampolineDest &rhs) {
+  bool operator!=(const TrampolineDest &rhs) const {
     return !(*this == rhs);
   }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4845,7 +4845,7 @@ public:
                                 key.Arguments.hash());
     }
 
-    bool operator==(const Key &other) {
+    bool operator==(const Key &other) const {
       return Shape == other.Shape && Arguments == other.Arguments;
     }
   };


### PR DESCRIPTION
In C++20, the compiler will synthesize a version of the operator with its arguments reversed to ease commutativity. This reversed version is ambiguous with the hand-written operator when the argument is const but `this` isn't.
