### PR TITLE
SILGen: Don't stub unavailable raw value initializers for clang enums

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/TypeWalker.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Platform.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include <map>
 
 using namespace swift;
@@ -312,7 +313,7 @@ bool Decl::isAvailableDuringLowering() const {
       UnavailableDeclOptimization::Complete)
     return true;
 
-  if (hasClangNode())
+  if (isa<ClangModuleUnit>(getDeclContext()->getModuleScopeContext()))
     return true;
 
   return !isUnconditionallyUnavailable(this);
@@ -323,6 +324,9 @@ bool Decl::requiresUnavailableDeclABICompatibilityStubs() const {
   // -unavailable-decl-optimization=stub is specified.
   if (getASTContext().LangOpts.UnavailableDeclOptimizationMode !=
       UnavailableDeclOptimization::Stub)
+    return false;
+
+  if (isa<ClangModuleUnit>(getDeclContext()->getModuleScopeContext()))
     return false;
 
   return isUnconditionallyUnavailable(this);

--- a/test/SILGen/unavailable_clang_enum_typedef.swift
+++ b/test/SILGen/unavailable_clang_enum_typedef.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-emit-silgen %t/Overlay.swift -I %t -import-objc-header %t/MyOptions.h -unavailable-decl-optimization=none | %FileCheck %t/Overlay.swift
+// RUN: %target-swift-emit-silgen %t/Overlay.swift -I %t -import-objc-header %t/MyOptions.h -unavailable-decl-optimization=stub | %FileCheck %t/Overlay.swift
+// RUN: %target-swift-emit-silgen %t/Overlay.swift -I %t -import-objc-header %t/MyOptions.h -unavailable-decl-optimization=complete | %FileCheck %t/Overlay.swift
+
+//--- MyOptions.h
+
+__attribute__((availability(swift, unavailable, message="Unavailable in Swift")))
+typedef enum : int {
+  SomeOption,
+} MyOptions;
+
+typedef MyOptions MyOptionsTypedef;
+
+//--- Overlay.swift
+
+// This really shouldn't be allowed, but it is.
+let _ = MyOptionsTypedef(rawValue: 1)
+
+// CHECK-LABEL: sil shared [transparent] [serialized]{{.*}} @$sSo9MyOptionsa8rawValueABs5Int32V_tcfC : $@convention(method) (Int32, @thin MyOptions.Type) -> MyOptions {
+// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb
+// CHECK:       } // end sil function '$sSo9MyOptionsa8rawValueABs5Int32V_tcfC'


### PR DESCRIPTION
We must be conservative when generating SIL for raw value initializers of clang enums and not insert an unavailable code reached trap, even if the enum is technically unavailable. It appears that there is a long-standing loophole that allows a clang module to typedef an unavailable type in order to make that type available in Swift even though the underlying type is declared to be unavailable in Swift. This loophole is load-bearing for some existing Swift overlays.

Resolves rdar://116378269
