### PR TITLE
Sema: Report public extensions using non-publicly imported types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3463,7 +3463,7 @@ ERROR(decl_from_hidden_module,none,
       "%2 was imported for SPI only|"
       "%2 was not imported by this file|"
       "C++ types from imported module %2 do not support library evolution|"
-      "<<ERROR>>}3",
+      "%2 was not imported publicly}3",
       (const Decl *, unsigned, Identifier, unsigned))
 ERROR(typealias_desugars_to_type_from_hidden_module,none,
       "%0 aliases '%1.%2' and cannot be used %select{here|"
@@ -6603,7 +6603,7 @@ ERROR(inlinable_decl_ref_from_hidden_module,
       "%2 was imported for SPI only|"
       "%2 was not imported by this file|"
       "C++ APIs from imported module %2 do not support library evolution|"
-      "<<ERROR>>}3",
+      "%2 was not imported publicly}3",
       (const ValueDecl *, unsigned, Identifier, unsigned))
 
 WARNING(inlinable_decl_ref_from_hidden_module_warn,

--- a/test/Sema/access-level-import-classic-exportability.swift
+++ b/test/Sema/access-level-import-classic-exportability.swift
@@ -58,35 +58,150 @@ private import PrivateLib // expected-note 2 {{struct 'PrivateImportType' import
 
 public protocol PublicConstrainedExtensionProto {}
 extension Array: PublicConstrainedExtensionProto where Element == PublicImportType {}
-
 extension PublicImportType {
-    public func foo() {}
+    public func publicMethod() {}
+}
+
+package protocol PublicConstrainedExtensionProtoInPackage {}
+extension Array: PublicConstrainedExtensionProtoInPackage where Element == PackageImportType {}
+extension PublicImportType {
+    package func packageMethod() {}
+}
+
+internal protocol PublicConstrainedExtensionProtoInInternal {}
+extension Array: PublicConstrainedExtensionProtoInInternal where Element == PublicImportType {}
+extension PublicImportType {
+    internal func internalMethod() {}
+}
+
+fileprivate protocol PublicConstrainedExtensionProtoInFileprivate {}
+extension Array: PublicConstrainedExtensionProtoInFileprivate where Element == PublicImportType {}
+extension PublicImportType {
+    fileprivate func fileprivateMethod() {}
+}
+
+private protocol PublicConstrainedExtensionProtoInPrivate {}
+extension Array: PublicConstrainedExtensionProtoInPrivate where Element == PublicImportType {}
+extension PublicImportType {
+    private func privateMethod() {}
 }
 
 public protocol PackageConstrainedExtensionProto {}
 extension Array: PackageConstrainedExtensionProto where Element == PackageImportType {} // expected-error {{cannot use struct 'PackageImportType' in an extension with conditional conformances; 'PackageLib' was not imported publicly}}
-
 extension PackageImportType { // expected-error {{cannot use struct 'PackageImportType' in an extension with public or '@usableFromInline' members; 'PackageLib' was not imported publicly}}
-    public func foo() {}
+    public func publicMethod() {}
+}
+
+package protocol PackageConstrainedExtensionProtoInPackage {}
+extension Array: PackageConstrainedExtensionProtoInPackage where Element == PackageImportType {}
+extension PackageImportType {
+    package func packageMethod() {}
+}
+
+internal protocol PackageConstrainedExtensionProtoInInternal {}
+extension Array: PackageConstrainedExtensionProtoInInternal where Element == PackageImportType {}
+extension PackageImportType {
+    internal func internalMethod() {}
+}
+
+fileprivate protocol PackageConstrainedExtensionProtoInFileprivate {}
+extension Array: PackageConstrainedExtensionProtoInFileprivate where Element == PackageImportType {}
+extension PackageImportType {
+    fileprivate func fileprivateMethod() {}
+}
+
+private protocol PackageConstrainedExtensionProtoInPrivate {}
+extension Array: PackageConstrainedExtensionProtoInPrivate where Element == PackageImportType {}
+extension PackageImportType {
+    private func privateMethod() {}
 }
 
 public protocol InternalConstrainedExtensionProto {}
 extension Array: InternalConstrainedExtensionProto where Element == InternalImportType {} // expected-error {{cannot use struct 'InternalImportType' in an extension with conditional conformances; 'InternalLib' was not imported publicly}}
-
 extension InternalImportType { // expected-error {{cannot use struct 'InternalImportType' in an extension with public or '@usableFromInline' members; 'InternalLib' was not imported publicly}}
     public func foo() {}
 }
 
+package protocol InternalConstrainedExtensionProtoInPackage {}
+extension Array: InternalConstrainedExtensionProtoInPackage where Element == InternalImportType {}
+extension InternalImportType {
+    package func packageMethod() {}
+}
+
+internal protocol InternalConstrainedExtensionProtoInInternal {}
+extension Array: InternalConstrainedExtensionProtoInInternal where Element == InternalImportType {}
+extension InternalImportType {
+    internal func internalMethod() {}
+}
+
+fileprivate protocol InternalConstrainedExtensionProtoInFileprivate {}
+extension Array: InternalConstrainedExtensionProtoInFileprivate where Element == InternalImportType {}
+extension InternalImportType {
+    fileprivate func fileprivateMethod() {}
+}
+
+private protocol InternalConstrainedExtensionProtoInPrivate {}
+extension Array: InternalConstrainedExtensionProtoInPrivate where Element == InternalImportType {}
+extension InternalImportType {
+    private func privateMethod() {}
+}
+
 public protocol FileprivateConstrainedExtensionProto {}
 extension Array: FileprivateConstrainedExtensionProto where Element == FileprivateImportType {} // expected-error {{cannot use struct 'FileprivateImportType' in an extension with conditional conformances; 'FileprivateLib' was not imported publicly}}
-
 extension FileprivateImportType { // expected-error {{cannot use struct 'FileprivateImportType' in an extension with public or '@usableFromInline' members; 'FileprivateLib' was not imported publicly}}
     public func foo() {}
 }
 
+package protocol FileprivateConstrainedExtensionProtoInPackage {}
+extension Array: FileprivateConstrainedExtensionProtoInPackage where Element == FileprivateImportType {}
+extension FileprivateImportType {
+    package func packageMethod() {}
+}
+
+internal protocol FileprivateConstrainedExtensionProtoInInternal {}
+extension Array: FileprivateConstrainedExtensionProtoInInternal where Element == FileprivateImportType {}
+extension FileprivateImportType {
+    internal func internalMethod() {}
+}
+
+fileprivate protocol FileprivateConstrainedExtensionProtoInFileprivate {}
+extension Array: FileprivateConstrainedExtensionProtoInFileprivate where Element == FileprivateImportType {}
+extension FileprivateImportType {
+    fileprivate func fileprivateMethod() {}
+}
+
+private protocol FileprivateConstrainedExtensionProtoInPrivate {}
+extension Array: FileprivateConstrainedExtensionProtoInPrivate where Element == FileprivateImportType {}
+extension FileprivateImportType {
+    private func privateMethod() {}
+}
+
 public protocol PrivateConstrainedExtensionProto {}
 extension Array: PrivateConstrainedExtensionProto where Element == PrivateImportType {} // expected-error {{cannot use struct 'PrivateImportType' in an extension with conditional conformances; 'PrivateLib' was not imported publicly}}
-
 extension PrivateImportType { // expected-error {{cannot use struct 'PrivateImportType' in an extension with public or '@usableFromInline' members; 'PrivateLib' was not imported publicly}}
     public func foo() {}
+}
+
+package protocol PrivateConstrainedExtensionProtoInPackage {}
+extension Array: PrivateConstrainedExtensionProtoInPackage where Element == PrivateImportType {}
+extension PrivateImportType {
+    package func packageMethod() {}
+}
+
+internal protocol PrivateConstrainedExtensionProtoInInternal {}
+extension Array: PrivateConstrainedExtensionProtoInInternal where Element == PrivateImportType {}
+extension PrivateImportType {
+    internal func internalMethod() {}
+}
+
+fileprivate protocol PrivateConstrainedExtensionProtoInFileprivate {}
+extension Array: PrivateConstrainedExtensionProtoInFileprivate where Element == PrivateImportType {}
+extension PrivateImportType {
+    fileprivate func fileprivateMethod() {}
+}
+
+private protocol PrivateConstrainedExtensionProtoInPrivate {}
+extension Array: PrivateConstrainedExtensionProtoInPrivate where Element == PrivateImportType {}
+extension PrivateImportType {
+    private func privateMethod() {}
 }

--- a/test/Sema/access-level-import-classic-exportability.swift
+++ b/test/Sema/access-level-import-classic-exportability.swift
@@ -1,0 +1,92 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+/// Build the libraries.
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t \
+// RUN:   -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t \
+// RUN:   -enable-library-evolution
+
+/// Check diagnostics.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name TestPackage -swift-version 5 \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+
+/// Check diagnostics with library-evolution.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name TestPackage -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+
+//--- PublicLib.swift
+public struct PublicImportType {
+    public init() {}
+}
+
+//--- PackageLib.swift
+public struct PackageImportType {
+    public init() {}
+}
+
+//--- InternalLib.swift
+public struct InternalImportType {
+    public init() {}
+}
+
+//--- FileprivateLib.swift
+public struct FileprivateImportType {
+    public init() {}
+}
+
+//--- PrivateLib.swift
+public struct PrivateImportType {
+    public init() {}
+}
+
+//--- Client.swift
+public import PublicLib
+package import PackageLib // expected-note 2 {{struct 'PackageImportType' imported as 'package' from 'PackageLib' here}}
+internal import InternalLib // expected-note 2 {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
+fileprivate import FileprivateLib // expected-note 2 {{struct 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
+private import PrivateLib // expected-note 2 {{struct 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
+
+public protocol PublicConstrainedExtensionProto {}
+extension Array: PublicConstrainedExtensionProto where Element == PublicImportType {}
+
+extension PublicImportType {
+    public func foo() {}
+}
+
+public protocol PackageConstrainedExtensionProto {}
+extension Array: PackageConstrainedExtensionProto where Element == PackageImportType {} // expected-error {{cannot use struct 'PackageImportType' in an extension with conditional conformances; 'PackageLib' was not imported publicly}}
+
+extension PackageImportType { // expected-error {{cannot use struct 'PackageImportType' in an extension with public or '@usableFromInline' members; 'PackageLib' was not imported publicly}}
+    public func foo() {}
+}
+
+public protocol InternalConstrainedExtensionProto {}
+extension Array: InternalConstrainedExtensionProto where Element == InternalImportType {} // expected-error {{cannot use struct 'InternalImportType' in an extension with conditional conformances; 'InternalLib' was not imported publicly}}
+
+extension InternalImportType { // expected-error {{cannot use struct 'InternalImportType' in an extension with public or '@usableFromInline' members; 'InternalLib' was not imported publicly}}
+    public func foo() {}
+}
+
+public protocol FileprivateConstrainedExtensionProto {}
+extension Array: FileprivateConstrainedExtensionProto where Element == FileprivateImportType {} // expected-error {{cannot use struct 'FileprivateImportType' in an extension with conditional conformances; 'FileprivateLib' was not imported publicly}}
+
+extension FileprivateImportType { // expected-error {{cannot use struct 'FileprivateImportType' in an extension with public or '@usableFromInline' members; 'FileprivateLib' was not imported publicly}}
+    public func foo() {}
+}
+
+public protocol PrivateConstrainedExtensionProto {}
+extension Array: PrivateConstrainedExtensionProto where Element == PrivateImportType {} // expected-error {{cannot use struct 'PrivateImportType' in an extension with conditional conformances; 'PrivateLib' was not imported publicly}}
+
+extension PrivateImportType { // expected-error {{cannot use struct 'PrivateImportType' in an extension with public or '@usableFromInline' members; 'PrivateLib' was not imported publicly}}
+    public func foo() {}
+}

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -11,6 +11,9 @@
 // RUN: %target-swift-frontend -emit-module %t/ConformanceDefinition.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/AliasesBase.swift -o %t
 // RUN: %target-swift-frontend -emit-module %t/Aliases.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/ExtensionA.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/ExtensionB.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/PropertyWrapper.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/UnusedImport.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/UnusedPackageImport.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ImportNotUseFromAPI.swift -o %t -I %t
@@ -58,6 +61,27 @@ open class Clazz {}
 import AliasesBase
 public typealias ClazzAlias = Clazz
 
+//--- ExtensionA.swift
+import ConformanceBaseTypes
+extension ConformingType {
+    public func extFuncA() {}
+}
+
+//--- ExtensionB.swift
+import ConformanceBaseTypes
+extension ConformingType {
+    public func extFuncB() {}
+}
+
+//--- PropertyWrapper.swift
+@propertyWrapper
+public struct MyPropertyWrapper<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue value: T) { self.wrappedValue = value }
+  public init(_ value: T) { self.wrappedValue = value }
+}
+
 //--- UnusedImport.swift
 
 //--- UnusedPackageImport.swift
@@ -84,7 +108,11 @@ public import ConformanceBaseTypes
 public import ConformanceDefinition
 public import AliasesBase
 public import Aliases
+public import ExtensionA
+public import ExtensionB
+public import PropertyWrapper
 
+/// Repeat some imports to make sure we report all of them.
 public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
 public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
 package import UnusedImport // expected-warning {{package import of 'UnusedImport' was not used in package declarations}} {{1-9=}}
@@ -114,7 +142,7 @@ public func useConformance(_ a: any Proto = ConformingType()) {}
 // expected-remark @-3 {{struct 'ConformingType' is imported via 'ConformanceBaseTypes'}}
 // expected-remark @-4 {{initializer 'init()' is imported via 'ConformanceBaseTypes'}}
 
-@usableFromInline internal func useInDefaultValue(_ a: TypeUsedInSignature) {} // expected-remark {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
+@usableFromInline internal func usableFromInlineFunc(_ a: TypeUsedInSignature) {} // expected-remark {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
 
 @inlinable
 public func publicFuncUsesPrivate() {
@@ -139,6 +167,16 @@ public func publicFuncUsesPrivate() {
   let _: ClazzAlias
   // expected-remark @-1 {{type alias 'ClazzAlias' is imported via 'Aliases'}}
   // expected-remark @-2 2 {{typealias underlying type class 'Clazz' is imported via 'AliasesBase'}}
+
+  let x = ConformingType()
+  // expected-remark @-1 {{struct 'ConformingType' is imported via 'ConformanceBaseTypes'}}
+  // expected-remark @-2 {{initializer 'init()' is imported via 'ConformanceBaseTypes'}}
+  x.extFuncA() // expected-remark {{instance method 'extFuncA()' is imported via 'ExtensionA'}}
+  x.extFuncB() // expected-remark {{instance method 'extFuncB()' is imported via 'ExtensionB'}}
+}
+
+public struct StructUsingPropertyWrapper {
+  @MyPropertyWrapper(42) public var wrapped: Any // expected-remark 2 {{generic struct 'MyPropertyWrapper' is imported via 'PropertyWrapper'}}
 }
 
 public struct Struct { // expected-remark {{implicitly used struct 'Int' is imported via 'Swift'}}


### PR DESCRIPTION
Access levels on extensions are special. They're not handled by the main access level checks. Let's make sure we report public extensions referencing non-public imported types using the preexisting general exportability checks.

Record and remark on the use of the import at the same time.