### PR TITLE
[5.10] SIL: need to handle explicit_copy_addr in SILInstruction::mayRelease

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1150,6 +1150,13 @@ bool SILInstruction::mayRelease() const {
     return Cast->getConsumptionKind() == CastConsumptionKind::TakeAlways;
   }
 
+  case SILInstructionKind::ExplicitCopyAddrInst: {
+    auto *CopyAddr = cast<ExplicitCopyAddrInst>(this);
+    // copy_addr without initialization can cause a release.
+    return CopyAddr->isInitializationOfDest() ==
+           IsInitialization_t::IsNotInitialization;
+  }
+
   case SILInstructionKind::CopyAddrInst: {
     auto *CopyAddr = cast<CopyAddrInst>(this);
     // copy_addr without initialization can cause a release.

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1182,3 +1182,16 @@ bb0(%0 : $*T, %1 : $*T):
   return %4 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_explicit_copy_addr
+// CHECK-NEXT:  [%0: read v**, copy v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate,deinit_barrier]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @test_explicit_copy_addr : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %1 = alloc_stack $T
+  explicit_copy_addr %0 to [init] %1 : $*T
+  destroy_addr %1 : $*T
+  dealloc_stack %1 : $*T
+  %r = tuple()
+  return %r : $()
+}


### PR DESCRIPTION
* **Explanation**: This fixes a compiler crash when using the `copy` operator. The corresponding `explicit_copy_addr` instruction was not handled in `SILInstruction::mayRelease()`.

* **Issue**: rdar://116102136

* **Risk**: Very low. The change implements a case which would have otherwise run into a fatal error.

* **Testing**: With a regression test.

* **Reviewer**: @gottesmm

* **Main branch PR**: https://github.com/apple/swift/pull/68932
