### PR TITLE
[Concurrency] Try harder to downgrade preconcurrency errors to warnings in Swift 5 mode.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2932,12 +2932,14 @@ namespace {
       // we're in an asynchronous context.
       if (requiresAsync && !getDeclContext()->isAsyncContext()) {
         if (calleeDecl) {
+          auto preconcurrency = getContextIsolation().preconcurrency() ||
+              calleeDecl->preconcurrency();
           ctx.Diags.diagnose(
               apply->getLoc(), diag::actor_isolated_call_decl,
               *unsatisfiedIsolation,
               calleeDecl,
               getContextIsolation())
-            .warnUntilSwiftVersionIf(getContextIsolation().preconcurrency(), 6);
+            .warnUntilSwiftVersionIf(preconcurrency, 6);
           calleeDecl->diagnose(diag::actor_isolated_sync_func, calleeDecl);
         } else {
           ctx.Diags.diagnose(
@@ -3573,7 +3575,8 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
       isUnsafe = true;
 
     return ActorIsolation::forGlobalActor(
-        globalActorType->mapTypeOutOfContext(), isUnsafe);
+        globalActorType->mapTypeOutOfContext(), isUnsafe)
+        .withPreconcurrency(decl->preconcurrency());
   }
 
   llvm_unreachable("Forgot about an attribute?");
@@ -5460,7 +5463,8 @@ static ActorIsolation getActorIsolationForReference(
               return closure->isIsolatedByPreconcurrency();
             })) {
       declIsolation = ActorIsolation::forGlobalActor(
-          declIsolation.getGlobalActor(), /*unsafe=*/false);
+          declIsolation.getGlobalActor(), /*unsafe=*/false)
+          .withPreconcurrency(declIsolation.preconcurrency());
     } else {
       declIsolation = ActorIsolation::forUnspecified();
     }
@@ -5727,7 +5731,7 @@ ActorReferenceResult ActorReferenceResult::forReference(
   Options options = llvm::None;
 
   // Note if the reference originates from a @preconcurrency-isolated context.
-  if (contextIsolation.preconcurrency())
+  if (contextIsolation.preconcurrency() || declIsolation.preconcurrency())
     options |= Flags::Preconcurrency;
 
   // If the declaration isn't asynchronous, promote to async.

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -210,7 +210,7 @@ class MyButton : NXButton {
   }
 
   @SomeGlobalActor func testOther() {
-    onButtonPress() // expected-error{{call to main actor-isolated instance method 'onButtonPress()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
+    onButtonPress() // expected-warning{{call to main actor-isolated instance method 'onButtonPress()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
   }
 
   func test() {

--- a/test/ClangImporter/objc_isolation_complete.swift
+++ b/test/ClangImporter/objc_isolation_complete.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -strict-concurrency=complete -parse-as-library
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+import Foundation
+import ObjCConcurrency
+
+// expected-note@+1 2{{add '@MainActor' to make global function 'unsatisfiedPreconcurrencyIsolation(view:)' part of global actor 'MainActor'}}
+func unsatisfiedPreconcurrencyIsolation(view: MyView) {
+  // expected-warning@+1 {{call to main actor-isolated instance method 'display()' in a synchronous nonisolated context}}
+  view.display()
+
+  // expected-warning@+1 {{main actor-isolated property 'isVisible' can not be referenced from a non-isolated context}}
+  _ = view.isVisible
+}

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -20,11 +20,11 @@ struct Outer {
 
 func test() {
   var _: Outer.FN = {
-    f() // expected-complete-sns-error {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    f() // expected-complete-sns-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
   }
 
   var _: FN = {
-    f() // expected-complete-sns-error {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    f() // expected-complete-sns-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
     print("Hello")
   }
 
@@ -39,11 +39,11 @@ func test() {
 @available(SwiftStdlib 5.1, *)
 func testAsync() async {
   var _: Outer.FN = {
-    f() // expected-error{{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    f() // expected-warning{{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
   }
 
   var _: FN = {
-    f() // expected-error{{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    f() // expected-warning{{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
     print("Hello")
   }
 

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -97,7 +97,7 @@ func testCalls(x: X) {
     })
 
   onMainActorAlways() // okay with minimal/targeted concurrency. Not ok with complete.
-  // expected-complete-sns-error @-1 {{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
+  // expected-complete-sns-warning @-1 {{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
 
   // Ok with minimal/targeted concurrency, Not ok with complete.
   let _: () -> Void = onMainActorAlways // expected-complete-sns-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -327,4 +327,10 @@ UI_ACTOR
 - (void)icedMochaService:(NSObject *)mochaService generateMochaWithCompletion:(void (^)(NSObject *_Nullable ingredient1, NSObject *ingredient2, NSObject *ingredient3))completionHandler;
 @end
 
+MAIN_ACTOR
+@interface MyView : NSObject
+- (void)display;
+@property(readonly) BOOL isVisible;
+@end
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
Per SE-0337, when you annotate a ValueDecl with `@preconcurrency`, the compiler should allow uses of that declaration in Swift 5 mode to violate strict concurrency checking by downgrading errors in the actor isolation checker to warnings. Previously, the actor isolation checker only checked whether the caller's context was preconcurrency when deciding to downgrade, so referencing preconcurrency declarations directly remained errors. Preconcurrency was also dropped when computing actor isolation for declarations imported from clang, which are always preconcurrency. This meant that calling any `@MainActor` function imported from Objective-C from a non-`MainActor`-isolated context resulted in an error under `-strict-concurrency=complete`.

Resolves rdar://101979691