### PR TITLE
[build] Enable swift parser integration in linux lldb preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2897,7 +2897,6 @@ skip-test-swift
 skip-build-benchmarks
 skip-test-foundation
 
-# Temporarily disable early swift driver/syntax builds so that linux images
+# Temporarily disable early swift driver builds so that linux images
 # can use the swift release images as a base.
 skip-early-swift-driver
-skip-early-swiftsyntax


### PR DESCRIPTION
`swift-backtrace` currently doesn't build property in 'bootstrapping' mode. Although we should fix the 'bootstrapping' issue separately, since lldb should be built with parser integration, enable it.

rdar://116470411
