### PR TITLE
[CSSimplify] Determine whether type is know Foundation entity in a sa…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2761,10 +2761,17 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
   if (locator.isForRequirement(RequirementKind::Conformance)) {
     // Increase the impact of a conformance fix for a standard library
     // or foundation type, as it's unlikely to be a good suggestion.
-    if (resolvedTy->isStdlibType() ||
-        getKnownFoundationEntity(resolvedTy->getString())) {
-      impact += 2;
+    {
+      if (resolvedTy->isStdlibType()) {
+        impact += 2;
+      }
+
+      if (auto *NTD = resolvedTy->getAnyNominal()) {
+        if (getKnownFoundationEntity(NTD->getNameStr()))
+          impact += 2;
+      }
     }
+
     // Also do the same for the builtin compiler types Any and AnyObject, but
     // bump the impact even higher as they cannot conform to protocols at all.
     if (resolvedTy->isAny() || resolvedTy->isAnyObject())


### PR DESCRIPTION
…fer way

Instead of trying to get string representation of the type itself, let's just get it based on the type name, which works well with the list of types we have.

Resolves: rdar://113675093

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
