### PR TITLE
Sema: Lift flag requirement for access levels on imports now that SE-0409 has been accepted

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2356,9 +2356,6 @@ ERROR(spi_only_imports_not_enabled, none,
       ())
 
 // Access level on imports
-ERROR(access_level_on_import_not_enabled, none,
-      "Access level on imports require '-enable-experimental-feature AccessLevelOnImport'",
-      ())
 ERROR(access_level_on_import_unsupported, none,
       "The access level %0 is unsupported on imports: "
       "only 'public', 'package', 'internal', 'fileprivate' and 'private' "

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -117,6 +117,7 @@ UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
 UPCOMING_FEATURE(ExistentialAny, 335, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
 UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
+UPCOMING_FEATURE(InternalImportsByDefault, 409, 6)
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3436,6 +3436,10 @@ static bool usesFeatureDisableOutwardActorInference(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureInternalImportsByDefault(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureImportSymbolicCXXDecls(Decl *decl) { return false; }
 
 static bool usesFeatureGenerateBindingsForThrowingFunctionsInCXX(Decl *decl) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1506,9 +1506,8 @@ AccessLevel ImportDecl::getAccessLevel() const {
   }
 
   auto &LangOpts = getASTContext().LangOpts;
-  if (LangOpts.isSwiftVersionAtLeast(6) &&
-      LangOpts.hasFeature(Feature::AccessLevelOnImport)) {
-    // Tentative Swift 6 mode where the default import is internal.
+  if (LangOpts.hasFeature(Feature::InternalImportsByDefault)) {
+    // Swift 6 mode where the default import is internal.
     return AccessLevel::Internal;
   } else {
     return AccessLevel::Public;

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -233,6 +233,7 @@ static void printImports(raw_ostream &out,
                          ModuleDecl *M,
                          const llvm::SmallSet<StringRef, 4>
                            &AliasModuleNamesTargets) {
+  auto &ctx = M->getASTContext();
   // FIXME: This is very similar to what's in Serializer::writeInputBlock, but
   // it's not obvious what higher-level optimization would be factored out here.
   ModuleDecl::ImportFilter allImportFilter = {
@@ -290,7 +291,7 @@ static void printImports(raw_ostream &out,
     M->getMissingImportedModules(allImports);
 
   ImportedModule::removeDuplicates(allImports);
-  diagnoseScopedImports(M->getASTContext().Diags, allImports);
+  diagnoseScopedImports(ctx.Diags, allImports);
 
   // Collect the public imports as a subset so that we can mark them with
   // '@_exported'.
@@ -310,7 +311,7 @@ static void printImports(raw_ostream &out,
     // 'import Builtin' in the interface. '-parse-stdlib' still implicitly
     // imports it however...
     if (importedModule->isBuiltinModule() &&
-        !M->getASTContext().LangOpts.hasFeature(Feature::BuiltinModule)) {
+        !ctx.LangOpts.hasFeature(Feature::BuiltinModule)) {
       continue;
     }
 
@@ -348,7 +349,7 @@ static void printImports(raw_ostream &out,
         out << "@_spi(" << spiName << ") ";
     }
 
-    if (M->getASTContext().LangOpts.isSwiftVersionAtLeast(6)) {
+    if (ctx.LangOpts.hasFeature(Feature::InternalImportsByDefault)) {
       out << "public ";
     }
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2452,7 +2452,7 @@ void swift::diagnoseUnnecessaryPublicImports(SourceFile &SF) {
 
       if (levelUsed == AccessLevel::Package) {
         inFlight.fixItReplace(import.accessLevelRange, "package");
-      } else if (ctx.isSwiftVersionAtLeast(6)) {
+      } else if (ctx.LangOpts.hasFeature(Feature::InternalImportsByDefault)) {
         // Let it default to internal.
         inFlight.fixItRemove(import.accessLevelRange);
       } else {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -998,13 +998,6 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
 
   SourceFile *File = D->getDeclContext()->getParentSourceFile();
   if (auto importDecl = dyn_cast<ImportDecl>(D)) {
-    if (!D->getASTContext().LangOpts.hasFeature(Feature::AccessLevelOnImport) &&
-        !D->getASTContext().LangOpts.hasFeature(Feature::InternalImports) &&
-        File && File->Kind != SourceFileKind::Interface) {
-      diagnoseAndRemoveAttr(attr, diag::access_level_on_import_not_enabled);
-      return true;
-    }
-
     if (attr->getAccess() == AccessLevel::Open) {
       diagnoseAndRemoveAttr(attr, diag::access_level_on_import_unsupported,
                             attr);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -999,6 +999,7 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
   SourceFile *File = D->getDeclContext()->getParentSourceFile();
   if (auto importDecl = dyn_cast<ImportDecl>(D)) {
     if (!D->getASTContext().LangOpts.hasFeature(Feature::AccessLevelOnImport) &&
+        !D->getASTContext().LangOpts.hasFeature(Feature::InternalImports) &&
         File && File->Kind != SourceFileKind::Interface) {
       diagnoseAndRemoveAttr(attr, diag::access_level_on_import_not_enabled);
       return true;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -310,7 +310,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
       CheckInconsistentSPIOnlyImportsRequest{SF},
       {});
 
-  if (!Ctx.LangOpts.isSwiftVersionAtLeast(6)) {
+  if (!Ctx.LangOpts.hasFeature(Feature::InternalImportsByDefault)) {
     evaluateOrDefault(
       Ctx.evaluator,
       CheckInconsistentAccessLevelOnImport{SF},

--- a/test/ModuleInterface/access-level-import-swiftinterfaces.swift
+++ b/test/ModuleInterface/access-level-import-swiftinterfaces.swift
@@ -1,5 +1,6 @@
 /// Check that only public imports are printed in modules interfaces,
 /// package imports and below are not.
+// REQUIRES: asserts
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
@@ -28,8 +29,8 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -I %t \
 // RUN:   -module-name Client
 
-// RUN: %FileCheck %s < %t/Client.swiftinterface
-// RUN: %FileCheck %s < %t/Client.private.swiftinterface
+// RUN: %FileCheck --check-prefixes=CHECK,CHECK-5 %s < %t/Client.swiftinterface
+// RUN: %FileCheck --check-prefixes=CHECK,CHECK-5 %s < %t/Client.private.swiftinterface
 
 /// Build a client composed of many files.
 // RUN: %target-swift-frontend -typecheck %t/MultiFiles?.swift -I %t \
@@ -43,8 +44,37 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/MultiFiles.private.swiftinterface) -I %t \
 // RUN:   -module-name MultiFiles
 
-// RUN: %FileCheck %s < %t/MultiFiles.swiftinterface
-// RUN: %FileCheck %s < %t/MultiFiles.private.swiftinterface
+// RUN: %FileCheck --check-prefixes=CHECK,CHECK-5 %s < %t/MultiFiles.swiftinterface
+// RUN: %FileCheck --check-prefixes=CHECK,CHECK-5 %s < %t/MultiFiles.private.swiftinterface
+
+/// Swift 6 mode.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name TestPackage -module-name Client_Swift6 \
+// RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -emit-module-interface-path %t/Client_Swift6.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Client_Swift6.private.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client_Swift6.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client_Swift6.private.swiftinterface) -I %t \
+// RUN:   -module-name Client_Swift6
+
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-6 < %t/Client_Swift6.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-6 < %t/Client_Swift6.private.swiftinterface
+
+/// Feature flag.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name TestPackage -module-name Client_FeatureFlag \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-interface-path %t/Client_FeatureFlag.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Client_FeatureFlag.private.swiftinterface \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client_FeatureFlag.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client_FeatureFlag.private.swiftinterface) -I %t \
+// RUN:   -module-name Client_FeatureFlag
+
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-6,CHECK-FLAG < %t/Client_FeatureFlag.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-6,CHECK-FLAG < %t/Client_FeatureFlag.private.swiftinterface
 
 //--- PublicLib.swift
 //--- PackageLib.swift
@@ -53,6 +83,10 @@
 //--- PrivateLib.swift
 
 //--- Client.swift
+// CHECK-5-NOT: public
+// CHECK-FLAG: -enable-upcoming-feature InternalImportsByDefault
+// CHECK-6: public
+
 public import PublicLib
 // CHECK: PublicLib
 

--- a/test/ModuleInterface/access-level-import-swiftinterfaces.swift
+++ b/test/ModuleInterface/access-level-import-swiftinterfaces.swift
@@ -22,8 +22,7 @@
 // RUN:   -package-name TestPackage \
 // RUN:   -enable-library-evolution -swift-version 5 \
 // RUN:   -emit-module-interface-path %t/Client.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -I %t \
@@ -37,8 +36,7 @@
 // RUN:   -package-name TestPackage \
 // RUN:   -enable-library-evolution -swift-version 5 \
 // RUN:   -emit-module-interface-path %t/MultiFiles.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/MultiFiles.private.swiftinterface \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -emit-private-module-interface-path %t/MultiFiles.private.swiftinterface
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/MultiFiles.swiftinterface) -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/MultiFiles.private.swiftinterface) -I %t \

--- a/test/ModuleInterface/imports-swift6.swift
+++ b/test/ModuleInterface/imports-swift6.swift
@@ -3,23 +3,47 @@
 // REQUIRES: asserts
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/empty.swiftmodule %S/../Inputs/empty.swift
-// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/emptyButWithLibraryEvolution.swiftmodule %S/../Inputs/empty.swift -enable-library-evolution
+// RUN: split-file --leading-lines %s %t
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/nonResilient.swiftmodule %t/empty.swift
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/resilient.swiftmodule %t/empty.swift -enable-library-evolution
 
-/// Swift 6 variant.
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 6
+/// Check errors.
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/clientWithError.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -verify -swift-version 6
+
+/// Check Swift 6 imports printed in swiftinterface from 2 source files.
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %t/main.swift %t/main-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 6
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
 // RUN: %FileCheck -implicit-check-not BAD -check-prefix CHECK-6 %s < %t.swiftinterface
 
-@_exported import empty // expected-warning {{module 'empty' was not compiled with library evolution support; using it means binary compatibility for 'main' can't be guaranteed}}
-@_exported import emptyButWithLibraryEvolution
-import B.B2
-import func C.c // expected-warning {{scoped imports are not yet supported in module interfaces}}
+//--- empty.swift
+
+//--- main.swift
+@_exported public import resilient // expected-warning {{public import of 'resilient' was not used in public declarations or inlinable code}}
+public import B.B2 // expected-warning {{public import of 'B2' was not used in public declarations or inlinable code}}
+// expected-warning @-1 {{public import of 'B' was not used in public declarations or inlinable code}}
+// FIXME: We don't want this last warning.
+
+public import func C.c // expected-warning {{public import of 'C' was not used in public declarations or inlinable code}}
+// expected-warning @-1 {{scoped imports are not yet supported in module interfaces}}
 import D
 @_implementationOnly import Secret_BAD
 
 @_implementationOnly import NotSoSecret // expected-note {{imported as implementation-only here}}
-import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported as implementation-only}}
+public import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported as implementation-only}}
+// expected-warning @-1 {{public import of 'NotSoSecret2' was not used in public declarations or inlinable code}}
+
+//--- main-other.swift
+public import A // expected-warning {{public import of 'A' was not used in public declarations or inlinable code}}
+public import B.B3 // expected-warning {{public import of 'B3' was not used in public declarations or inlinable code}}
+// expected-warning @-1 {{public import of 'B' was not used in public declarations or inlinable code}}
+public import D // expected-warning {{public import of 'D' was not used in public declarations or inlinable code}}
+
+public import NotSoSecret // expected-warning {{'NotSoSecret' inconsistently imported as implementation-only}}
+// expected-warning @-1 {{public import of 'NotSoSecret' was not used in public declarations or inlinable code}}
+@_implementationOnly import NotSoSecret2 // expected-note {{imported as implementation-only here}}
+//--- clientWithError.swift
+@_exported public import nonResilient // expected-error {{module 'nonResilient' was not compiled with library evolution support; using it means binary compatibility for 'clientWithError' can't be guaranteed}}
+// expected-warning @-1 {{public import of 'nonResilient' was not used in public declarations or inlinable code}}
 
 // CHECK-6-NOT: import
 // CHECK-6: {{^}}public import A{{$}}
@@ -31,6 +55,5 @@ import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported
 // CHECK-6-NEXT: {{^}}public import NotSoSecret{{$}}
 // CHECK-6-NEXT: {{^}}public import NotSoSecret2{{$}}
 // CHECK-6-NEXT: {{^}}public import Swift{{$}}
-// CHECK-6-NEXT: {{^}}@_exported public import empty{{$}}
-// CHECK-6-NEXT: {{^}}@_exported public import emptyButWithLibraryEvolution{{$}}
+// CHECK-6-NEXT: {{^}}@_exported public import resilient{{$}}
 // CHECK-6-NOT: import

--- a/test/ScanDependencies/required_deps_of_testable_imports.swift
+++ b/test/ScanDependencies/required_deps_of_testable_imports.swift
@@ -8,7 +8,7 @@
 @testable import Foo
 
 // Step 1: build swift interface and swift module side by side, make them testable
-// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name -I %S/Inputs/CHeaders -I %S/Inputs/Swift -enable-testing -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -emit-module-interface-path %t/Foo.swiftmodule/%target-swiftinterface-name -I %S/Inputs/CHeaders -I %S/Inputs/Swift -enable-testing
 
 // Step 2: scan dependencies
 // RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -sdk %t -prebuilt-module-cache-path %t/clang-module-cache -I %S/Inputs/CHeaders -I %S/Inputs/Swift

--- a/test/Sema/access-level-import-conformances.swift
+++ b/test/Sema/access-level-import-conformances.swift
@@ -6,8 +6,7 @@
 // RUN: %target-swift-frontend -emit-module %t/ConformanceDefinition.swift -o %t -I %t
 
 /// Check diagnostics.
-// RUN: %target-swift-frontend -typecheck -verify %t/Client.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -typecheck -verify %t/Client.swift -I %t
 
 //--- ConformanceBaseTypes.swift
 public protocol Proto {}

--- a/test/Sema/access-level-import-diag-priority.swift
+++ b/test/Sema/access-level-import-diag-priority.swift
@@ -14,14 +14,11 @@
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -package-name pkg
+// RUN:   -package-name pkg -verify
 // RUN: %target-swift-frontend -typecheck %t/PackageTypeImportedAsPackageClient.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -package-name pkg
+// RUN:   -package-name pkg -verify
 // RUN: %target-swift-frontend -typecheck %t/LocalVsImportClient.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -package-name pkg
+// RUN:   -package-name pkg -verify
 
 //--- PublicLib.swift
 public struct PublicImportType {}

--- a/test/Sema/access-level-import-exportability.swift
+++ b/test/Sema/access-level-import-exportability.swift
@@ -15,21 +15,17 @@
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/MinimalClient.swift -I %t \
-// RUN:   -package-name TestPackage -swift-version 5 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -package-name TestPackage -swift-version 5 -verify
 // RUN: %target-swift-frontend -typecheck %t/CompletenessClient.swift -I %t \
-// RUN:   -package-name TestPackage -swift-version 5 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -package-name TestPackage -swift-version 5 -verify
 
 /// Check diagnostics with library-evolution.
 // RUN: %target-swift-frontend -typecheck %t/MinimalClient.swift -I %t \
 // RUN:   -package-name TestPackage -swift-version 5 \
-// RUN:   -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-library-evolution -verify
 // RUN: %target-swift-frontend -typecheck %t/CompletenessClient.swift -I %t \
 // RUN:   -package-name TestPackage -swift-version 5 \
-// RUN:   -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -enable-library-evolution -verify
 
 //--- PublicLib.swift
 public protocol PublicImportProto {

--- a/test/Sema/access-level-import-flag-check.swift
+++ b/test/Sema/access-level-import-flag-check.swift
@@ -19,6 +19,9 @@
 // RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -package-name package
+// RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault \
+// RUN:   -package-name package
 // REQUIRES: asserts
 
 /// swiftinterfaces don't need the flag.

--- a/test/Sema/access-level-import-flag-check.swift
+++ b/test/Sema/access-level-import-flag-check.swift
@@ -14,14 +14,11 @@
 // RUN:   -enable-library-evolution
 
 /// Check flag requirement, without and with the flag.
-// RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t -verify \
-// RUN:   -package-name package
 // RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
-// RUN:   -package-name package
+// RUN:   -package-name package -verify
 // RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault \
-// RUN:   -package-name package
+// RUN:   -package-name package -verify
 // REQUIRES: asserts
 
 /// swiftinterfaces don't need the flag.
@@ -34,13 +31,13 @@
 //--- PrivateLib.swift
 
 //--- ClientWithoutTheFlag.swift
-public import PublicLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+public import PublicLib
 // expected-warning @-1 {{public import of 'PublicLib' was not used in public declarations or inlinable code}}
-package import PackageLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+package import PackageLib
 // expected-warning @-1 {{package import of 'PackageLib' was not used in package declarations}}
-internal import InternalLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
-fileprivate import FileprivateLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
-private import PrivateLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+internal import InternalLib
+fileprivate import FileprivateLib
+private import PrivateLib
 
 //--- Client.swiftinterface
 // swift-interface-format-version: 1.0

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -62,6 +62,8 @@ package import Lib // expected-note {{imported 'package' here}} @:1
 
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_AmbiguitySwift6_File?.swift -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify -swift-version 6
+// RUN: %target-swift-frontend -typecheck %t/ManyFiles_AmbiguitySwift6_File?.swift -I %t \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault -verify
 //--- ManyFiles_AmbiguitySwift6_FileA.swift
 import Lib
 //--- ManyFiles_AmbiguitySwift6_FileB.swift

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -21,8 +21,7 @@
 public struct LibType {}
 
 // RUN: %target-swift-frontend -typecheck %t/OneFile_AllExplicit.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -package-name package
+// RUN:   -package-name package -verify
 //--- OneFile_AllExplicit.swift
 public import Lib // expected-warning {{public import of 'Lib' was not used in public declarations or inlinable code}}
 package import Lib // expected-warning {{package import of 'Lib' was not used in package declarations}}
@@ -31,8 +30,7 @@ fileprivate import Lib
 private import Lib
 
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_AllExplicit_File?.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -package-name package
+// RUN:   -package-name package -verify
 //--- ManyFiles_AllExplicit_FileA.swift
 public import Lib // expected-warning {{public import of 'Lib' was not used in public declarations or inlinable code}}
 //--- ManyFiles_AllExplicit_FileB.swift
@@ -45,23 +43,21 @@ fileprivate import Lib
 private import Lib
 
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_ImplicitVsInternal_FileB.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -primary-file %t/ManyFiles_ImplicitVsInternal_FileA.swift
+// RUN:   -primary-file %t/ManyFiles_ImplicitVsInternal_FileA.swift -verify
 //--- ManyFiles_ImplicitVsInternal_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'internal' elsewhere}}
 //--- ManyFiles_ImplicitVsInternal_FileB.swift
 internal import Lib // expected-note {{imported 'internal' here}}
 
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_ImplicitVsPackage_FileB.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -primary-file %t/ManyFiles_ImplicitVsPackage_FileA.swift
+// RUN:   -primary-file %t/ManyFiles_ImplicitVsPackage_FileA.swift -verify
 //--- ManyFiles_ImplicitVsPackage_FileA.swift
 import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'package' elsewhere}}
 //--- ManyFiles_ImplicitVsPackage_FileB.swift
 package import Lib // expected-note {{imported 'package' here}} @:1
 
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_AmbiguitySwift6_File?.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify -swift-version 6
+// RUN:   -verify -swift-version 6
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_AmbiguitySwift6_File?.swift -I %t \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault -verify
 //--- ManyFiles_AmbiguitySwift6_FileA.swift

--- a/test/Sema/access-level-import-inlinable.swift
+++ b/test/Sema/access-level-import-inlinable.swift
@@ -18,8 +18,7 @@
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -enable-library-evolution -swift-version 5 \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -enable-library-evolution -swift-version 5 -verify \
 // RUN:   -package-name package
 
 //--- PublicLib.swift

--- a/test/Sema/access-level-import-parsing.swift
+++ b/test/Sema/access-level-import-parsing.swift
@@ -11,8 +11,7 @@
 
 /// Check that all access levels are accepted, except for 'open'.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -package-name package
+// RUN:   -package-name package -verify
 
 //--- PublicLib.swift
 //--- PackageLib.swift

--- a/test/Sema/access-level-import-typealias.swift
+++ b/test/Sema/access-level-import-typealias.swift
@@ -10,6 +10,9 @@
 // RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -I %t \
 // RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -I %t \
+// RUN:   -swift-version 5 -enable-library-evolution \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault
 
 //--- Original.swift
 open class Clazz {}

--- a/test/Sema/access-level-import-typealias.swift
+++ b/test/Sema/access-level-import-typealias.swift
@@ -8,8 +8,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Aliases.swiftinterface) -I %t
 
 // RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -I %t \
-// RUN:   -swift-version 5 -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -I %t \
 // RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault

--- a/test/Sema/conflicting-import-restrictions.swift
+++ b/test/Sema/conflicting-import-restrictions.swift
@@ -38,20 +38,15 @@
 
 /// Access levels on imports
 // RUN: %target-swift-frontend -typecheck %t/Public_Exported.swift -I %t -verify \
-// RUN:   -experimental-spi-only-imports -verify \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/Package_Exported.swift -I %t -verify \
-// RUN:   -experimental-spi-only-imports -verify \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/Internal_Exported.swift -I %t -verify \
-// RUN:   -experimental-spi-only-imports -verify \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/Fileprivate_Exported.swift -I %t -verify \
-// RUN:   -experimental-spi-only-imports -verify \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -experimental-spi-only-imports -verify
 // RUN: %target-swift-frontend -typecheck %t/Private_Exported.swift -I %t -verify \
-// RUN:   -experimental-spi-only-imports -verify \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -experimental-spi-only-imports -verify
 
 //--- Public_Exported.swift
 @_exported public import Lib // expected-warning {{public import of 'Lib' was not used in public declarations or inlinable code}}

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -102,7 +102,6 @@ import LocalClang
 @_exported import MainLib
 
 // RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/InternalImports.swift \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -module-name MainLib -module-cache-path %t \
 // RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
 // RUN:   -library-level api -verify
@@ -116,7 +115,6 @@ internal import FullyPrivateClang
 internal import LocalClang
 
 // RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/FileprivateImports.swift \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -module-name MainLib -module-cache-path %t \
 // RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
 // RUN:   -library-level api -verify
@@ -130,7 +128,6 @@ fileprivate import FullyPrivateClang
 fileprivate import LocalClang
 
 // RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/PrivateImports.swift \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -module-name MainLib -module-cache-path %t \
 // RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
 // RUN:   -library-level api -verify
@@ -144,7 +141,6 @@ private import FullyPrivateClang
 private import LocalClang
 
 // RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/ExplicitlyPublicImports.swift \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -module-name MainLib -module-cache-path %t \
 // RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
 // RUN:   -library-level api -verify

--- a/test/Sema/missing-import-inlinable-code.swift
+++ b/test/Sema/missing-import-inlinable-code.swift
@@ -60,7 +60,7 @@ extension ImportedType : SomeProtocol {}
 
 /// Client module
 // BEGIN clientFileA-Swift5.swift
-import libA
+public import libA
 
 @inlinable public func bar() {
   let a = ImportedType()
@@ -75,7 +75,7 @@ import libA
 }
 
 // BEGIN clientFileA-OldCheck.swift
-import libA
+public import libA
 @_implementationOnly import empty
 
 @inlinable public func bar() {
@@ -90,7 +90,7 @@ import libA
 }
 
 // BEGIN clientFileA-Swift6.swift
-import libA
+public import libA
 
 @inlinable public func bar() {
   let a = ImportedType()
@@ -104,7 +104,7 @@ import libA
 
 // BEGIN clientFileB.swift
 @_implementationOnly import libB
-import libA
+public import libA
 extension ImportedType {
     public func localModuleMethod() {}
 }

--- a/test/Sema/missing-import-typealias-swift6.swift
+++ b/test/Sema/missing-import-typealias-swift6.swift
@@ -28,7 +28,7 @@ public typealias ClazzAlias = Clazz
 
 //--- UsesAliasesNoImport.swift
 
-import Aliases
+public import Aliases
 
 // expected-error@+1 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used here because 'Original' was not imported by this file}}
 public class InheritsFromClazzAlias: ClazzAlias {}

--- a/test/Sema/package-only-references.swift
+++ b/test/Sema/package-only-references.swift
@@ -5,27 +5,22 @@
 
 /// Build the libraries.
 // RUN: %target-swift-frontend -emit-module %t/PackageImportedLib.swift -o %t \
-// RUN:   -swift-version 5 -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t \
 // RUN:   -swift-version 5 -enable-library-evolution -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -package-name MyPackage
 
 /// A client in the same package builds fine.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -package-name MyPackage -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -package-name MyPackage -I %t
 
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -package-name MyPackage -I %t \
-// RUN:   -enable-deserialization-safety \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-deserialization-safety
 
 /// A client outside of the package raises errors.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -package-name NotMyPackage -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN:   -package-name NotMyPackage -I %t -verify
 
 //--- PackageImportedLib.swift
 public struct IndirectType {

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -23,11 +23,9 @@
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -package-name pkg -Rmodule-api-import -swift-version 6
+// RUN:   -package-name pkg -Rmodule-api-import -swift-version 6 -verify
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
-// RUN:   -swift-version 5
+// RUN:   -swift-version 5 -verify
 
 //--- DepUsedFromInlinableCode.swift
 public struct TypeUsedFromInlinableCode {}

--- a/test/Serialization/access-level-import-dependencies.swift
+++ b/test/Serialization/access-level-import-dependencies.swift
@@ -26,20 +26,15 @@ private import HiddenDep
 
 /// With resilience, non-public dependencies should be hidden.
 // RUN: %target-swift-frontend -emit-module %t/PublicDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution -package-name MyPackage \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution -package-name MyPackage
 // RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/FileprivateDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/PrivateDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution
 
 // RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
 // RUN:   -package-name MyOtherPackage \
@@ -59,17 +54,12 @@ import FileprivateDep
 import PrivateDep
 
 /// Without resilience, all access-level dependencies are visible to clients.
-// RUN: %target-swift-frontend -emit-module %t/PublicDep.swift -o %t -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/PublicDep.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t -I %t \
-// RUN:   -package-name MyPackage \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
-// RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
-// RUN: %target-swift-frontend -emit-module %t/FileprivateDep.swift -o %t -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
-// RUN: %target-swift-frontend -emit-module %t/PrivateDep.swift -o %t -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -package-name MyPackage
+// RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/FileprivateDep.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/PrivateDep.swift -o %t -I %t
 
 // RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
@@ -79,20 +69,15 @@ import PrivateDep
 /// Even with resilience and testing enabled, all non-public dependencies are
 /// hidden if there are no testable imports.
 // RUN: %target-swift-frontend -emit-module %t/PublicDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution -enable-testing \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution -enable-testing
 // RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution -enable-testing -package-name MyPackage \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution -enable-testing -package-name MyPackage
 // RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution -enable-testing \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution -enable-testing
 // RUN: %target-swift-frontend -emit-module %t/FileprivateDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution -enable-testing \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution -enable-testing
 // RUN: %target-swift-frontend -emit-module %t/PrivateDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution -enable-testing \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution -enable-testing
 
 // RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
@@ -120,8 +105,7 @@ import PrivateDep
 /// Non-public imports from the reexported modules are not loaded, we could
 /// revisit this if desired.
 // RUN: %target-swift-frontend -emit-module %t/Exporter.swift -o %t -I %t \
-// RUN:   -enable-library-evolution -enable-testing \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution -enable-testing
 // RUN: %target-swift-frontend -typecheck %t/ExporterClient.swift -I %t \
 // RUN:   -index-system-modules -index-ignore-stdlib -index-store-path %t/idx \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefixes=CHECK-EXPORTER,HIDDEN-DEP %s

--- a/test/Serialization/package-dependencies.swift
+++ b/test/Serialization/package-dependencies.swift
@@ -5,11 +5,9 @@
 // RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t
 // RUN: %target-swift-frontend -emit-module %t/ResilientDep.swift -o %t \
 // RUN:   -package-name MyPackage -I %t \
-// RUN:   -enable-library-evolution \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/NonResilientDep.swift -o %t \
-// RUN:   -package-name MyPackage -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN:   -package-name MyPackage -I %t
 
 //--- PackageDep.swift
 
@@ -23,13 +21,11 @@ package import PackageDep
 /// is only visible to modules from the same package.
 // RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift \
 // RUN:   -package-name MyPackage -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s
 // VISIBLE-PACKAGE-DEP: loaded module 'PackageDep'
 
 // RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift \
 // RUN:   -package-name NotMyPackage -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=HIDDEN-PACKAGE-DEP %s
 // HIDDEN-PACKAGE-DEP-NOT: loaded module 'PackageDep'
 
@@ -40,7 +36,6 @@ import ResilientDep
 /// see the package dependency.
 // RUN: %target-swift-frontend -typecheck %t/NonResilientClient.swift \
 // RUN:   -package-name NotMyPackage -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s
 
 //--- NonResilientClient.swift

--- a/test/SourceKit/CodeComplete/complete_docbrief_package.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_package.swift
@@ -27,7 +27,7 @@ package struct S: P {
 package import DocBriefTest
 
 func test() {
-  // RUN: %sourcekitd-test -req=complete -pos=%(line+1):7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser -package-name DocPackage -enable-experimental-feature AccessLevelOnImport | %FileCheck %s -check-prefix=CHECK
+  // RUN: %sourcekitd-test -req=complete -pos=%(line+1):7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser -package-name DocPackage | %FileCheck %s -check-prefix=CHECK
   S().foo()
 
   // CHECK: {

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -101,7 +101,7 @@ var unterminatedEmptySubject = 0
 duplicateAttr(1) // expected-error{{argument passed to call that takes no arguments}}
 
 // CHECK ALLOWED DECLS
-private import Swift // expected-error {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport}}
+private import Swift
 private(set) infix operator ~~~ // expected-error {{unexpected attribute private in operator declaration}} {{1-14=}}
 
 private typealias MyInt = Int

--- a/test/attr/package-modifier-outside-of-package.swift
+++ b/test/attr/package-modifier-outside-of-package.swift
@@ -4,10 +4,8 @@
 // RUN: split-file --leading-lines %s %t
 
 // RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t -verify
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -package-name pkg
 
 //--- PackageLib.swift


### PR DESCRIPTION
The proposal [SE-0409 Access level on imports](https://github.com/apple/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md) has been accepted, let's lift the flag requirement!

Also adds the upcoming feature flag `InternalImportsByDefault` for imports to default to internal. This is the Swift 6 behavior that can be enabled in Swift 5 using this new flag. The logic is cleaned but by moving all the Swift 6 specific logic being this flag.

rdar://107566870