### PR TITLE
[5.10][ASTGen] Relax assertion on `BridgedSourceLoc` initializer

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Misc.swift
+++ b/lib/ASTGen/Sources/ASTGen/Misc.swift
@@ -65,7 +65,7 @@ extension BridgedSourceLoc {
     in buffer: UnsafeBufferPointer<UInt8>
   ) {
     if let start = buffer.baseAddress,
-      position.utf8Offset >= 0 && position.utf8Offset < buffer.count {
+      position.utf8Offset >= 0 && position.utf8Offset <= buffer.count {
       self = SourceLoc_advanced(BridgedSourceLoc(raw: start), SwiftInt(position.utf8Offset))
     } else {
       self = nil

--- a/test/SourceKit/CursorInfo/at_eof_in_macro.swift
+++ b/test/SourceKit/CursorInfo/at_eof_in_macro.swift
@@ -1,0 +1,3 @@
+// RUN: %sourcekitd-test -req=cursor -pos=3:37 %s -- %s
+@freestanding(expression)
+macro powerAssert() = #externalMacro


### PR DESCRIPTION
Cherry-pick the equivalent of https://github.com/apple/swift/pull/68778 to `release/5.10`.

---

We do allow `SourceLoc` to point to the address right after the buffer ends to point to the end of a file.

Fixes an issue found by the SourceKit stress tester.