### PR TITLE
[5.10][build] Enable swift parser integration in linux lldb preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2905,7 +2905,6 @@ skip-test-swift
 skip-build-benchmarks
 skip-test-foundation
 
-# Temporarily disable early swift driver/syntax builds so that linux images
+# Temporarily disable early swift driver builds so that linux images
 # can use the swift release images as a base.
 skip-early-swift-driver
-skip-early-swiftsyntax


### PR DESCRIPTION
Cherry-pick #68962 into release/5.10

* **Explanation**: swift-backtrace currently doesn't build property in `bootstrapping` mode. Although we should fix the 'bootstrapping' issue separately, since lldb should be built with parser integration, enable it.
* **Scope**: lldb CI job in Linux
* **Risk**: Low. Just updating a CI job not used for creating toolchain releases.
* **Testing**: Passes current test suite, and the updating preset
* **Issues**: rdar://116470411
* **Reviewer**: Ben Barham (@bnbarham)