### PR TITLE
[Typed throws] Compute and use the caught error type of a do..catch block

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1425,6 +1425,12 @@ public:
   /// errors out of its catch block(s).
   bool isSyntacticallyExhaustive() const;
 
+  // Determines the type of the error that is thrown out of the 'do' block
+  // and caught by the various 'catch' clauses. If this the catch clauses
+  // aren't exhausive, this is also the type of the error that is implicitly
+  // rethrown.
+  Type getCaughtErrorType() const;
+
   static bool classof(const Stmt *S) {
     return S->getKind() == StmtKind::DoCatch;
   }

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -476,6 +476,15 @@ bool DoCatchStmt::isSyntacticallyExhaustive() const {
   return false;
 }
 
+Type DoCatchStmt::getCaughtErrorType() const {
+  return getCatches()
+    .front()
+    ->getCaseLabelItems()
+    .front()
+    .getPattern()
+    ->getType();
+}
+
 void LabeledConditionalStmt::setCond(StmtCondition e) {
   // When set a condition into a Conditional Statement, inform each of the
   // variables bound in any patterns that this is the owning statement for the

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1111,12 +1111,7 @@ void StmtEmitter::visitDoStmt(DoStmt *S) {
 }
 
 void StmtEmitter::visitDoCatchStmt(DoCatchStmt *S) {
-  Type formalExnType = S->getCatches()
-                           .front()
-                           ->getCaseLabelItems()
-                           .front()
-                           .getPattern()
-                           ->getType();
+  Type formalExnType = S->getCaughtErrorType();
   auto &exnTL = SGF.getTypeLowering(formalExnType);
 
   // Create the throw destination at the end of the function.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1678,10 +1678,26 @@ public:
     // Do-catch statements always limit exhaustivity checks.
     bool limitExhaustivityChecks = true;
 
+    Type caughtErrorType = TypeChecker::catchErrorType(Ctx, S);
     auto catches = S->getCatches();
     checkSiblingCaseStmts(catches.begin(), catches.end(),
                           CaseParentKind::DoCatch, limitExhaustivityChecks,
-                          getASTContext().getErrorExistentialType());
+                          caughtErrorType);
+
+    if (!S->isSyntacticallyExhaustive()) {
+      // If we're implicitly rethrowing the error out of this do..catch, make
+      // sure that we can throw an error of this type out of this context.
+      // FIXME: Unify this lookup of the type with that from ThrowStmt.
+      if (auto TheFunc = AnyFunctionRef::fromDeclContext(DC)) {
+        if (Type expectedErrorType = TheFunc->getThrownErrorType()) {
+          OpaqueValueExpr *opaque = new (Ctx) OpaqueValueExpr(
+              catches.back()->getEndLoc(), caughtErrorType);
+          Expr *rethrowExpr = opaque;
+          TypeChecker::typeCheckExpression(
+              rethrowExpr, DC, {expectedErrorType, CTP_ThrowStmt});
+        }
+      }
+    }
 
     return S;
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1178,6 +1178,13 @@ void checkPropertyWrapperEffects(PatternBindingDecl *binding, Expr *expr);
 /// Whether the given expression can throw.
 bool canThrow(ASTContext &ctx, Expr *expr);
 
+/// Determine the error type that is thrown out of the body of the given
+/// do-catch statement.
+///
+/// The error type is used in the catch clauses and, for a nonexhausive
+/// do-catch, is implicitly rethrown out of the do...catch block.
+Type catchErrorType(ASTContext &ctx, DoCatchStmt *stmt);
+
 /// Given two error types, merge them into the "union" of both error types
 /// that is a supertype of both error types.
 Type errorUnion(Type type1, Type type2);

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -1,0 +1,121 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TypedThrows
+
+enum MyError: Error {
+case failed
+case epicFailed
+}
+
+enum HomeworkError: Error {
+case dogAteIt
+case forgot
+}
+
+func processMyError(_: MyError) { }
+
+func doSomething() throws(MyError) { }
+func doHomework() throws(HomeworkError) { }
+
+func testDoCatchErrorTyped() {
+  #if false
+  // FIXME: Deal with throws directly in the do...catch blocks.
+  do {
+    throw MyError.failed
+  } catch {
+    assert(error == .failed)
+    processMyError(error)
+  }
+  #endif
+
+  // Throwing a typed error in a do...catch catches the error with that type.
+  do {
+    try doSomething()
+  } catch {
+    assert(error == .failed)
+    processMyError(error)
+  }
+
+  // Throwing a typed error in a do...catch lets us pattern-match against that
+  // type.
+  do {
+    try doSomething()
+  } catch .failed {
+    // okay, matches one of the cases of MyError
+  } catch {
+    assert(error == .epicFailed)
+  }
+
+  // Rethrowing an error because the catch is not exhaustive.
+  do {
+    try doSomething()
+    // expected-error@-1{{errors thrown from here are not handled because the enclosing catch is not exhaustive}}
+  } catch .failed {
+  }
+
+  // "as X" errors are never exhaustive.
+  do {
+    try doSomething()
+    // FIXME: should error errors thrown from here are not handled because the enclosing catch is not exhaustive
+  } catch let error as MyError { // expected-warning{{'as' test is always true}}
+    _ = error
+  }
+
+    // Rethrowing an error because the catch is not exhaustive.
+  do {
+    try doSomething()
+    // expected-error@-1{{errors thrown from here are not handled because the enclosing catch is not exhaustive}}
+  } catch is HomeworkError {
+    // expected-warning@-1{{cast from 'MyError' to unrelated type 'HomeworkError' always fails}}
+  }
+}
+
+func testDoCatchMultiErrorType() {
+  // Throwing different typed errors results in 'any Error'
+  do {
+    try doSomething()
+    try doHomework()
+  } catch .failed { // expected-error{{type 'any Error' has no member 'failed'}}
+    
+  } catch {
+    let _: Int = error // expected-error{{cannot convert value of type 'any Error' to specified type 'Int'}}
+  }  
+}
+
+func testDoCatchRethrowsUntyped() throws {
+  do {
+    try doSomething()
+  } catch .failed {
+  } // okay, rethrows with a conversion to 'any Error'
+}
+
+func testDoCatchRethrowsTyped() throws(HomeworkError) {
+  do {
+    try doHomework()
+  } catch .dogAteIt {
+  } // okay, rethrows
+
+  do {
+    try doSomething()
+  } catch .failed {
+    
+  } // expected-error{{thrown expression type 'MyError' cannot be converted to error type 'HomeworkError'}}
+
+  do {
+    try doSomething()
+    try doHomework()
+  } catch let e as HomeworkError {
+    _ = e
+  } // expected-error{{thrown expression type 'any Error' cannot be converted to error type 'HomeworkError'}}
+
+  do {
+    try doSomething()
+    try doHomework()
+  } catch {
+
+  } // okay, the thrown 'any Error' has been caught
+}
+
+func testTryIncompatibleTyped() throws(HomeworkError) {
+  try doHomework() // okay
+
+  try doSomething() // FIXME: should error
+}


### PR DESCRIPTION
The type that is caught by the `catch` clauses in a `do..catch` block is determined by the union of the thrown error types in the `do` statement. Compute this type and use it for the catch clauses. This does several things at once:

* Makes the type of the implicit `error` be a more-specific concrete type when all throwing sites throw that same type
* When there's a concrete type for the error, one can use patterns like `.cancelled`
* Check that this error type can be rethrown in the current context
* Verify that SIL generation involving do..catch with typed errors doesn't require any existentials.
