### PR TITLE
TBDGen: Improve the accuracy of swift-api-extract output

### DIFF
--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -222,26 +222,6 @@ public:
     return irEntity;
   }
 
-  /// Returns the associated decl.
-  const ValueDecl *getDecl() const {
-    switch (kind) {
-    case Kind::SIL: {
-      if (silDeclRef.hasDecl())
-        return silDeclRef.getDecl();
-      return nullptr;
-    }
-    case Kind::Global:
-      return Global;
-    case Kind::IR:
-      if (irEntity.hasDecl())
-        return irEntity.getDecl();
-      return nullptr;
-    case Kind::LinkerDirective:
-    case Kind::Unknown:
-      return nullptr;
-    }
-  }
-
   /// Typecheck the entity wrapped by this `SymbolSource`
   void typecheck() const {
     switch (kind) {

--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -222,6 +222,26 @@ public:
     return irEntity;
   }
 
+  /// Returns the associated decl.
+  const ValueDecl *getDecl() const {
+    switch (kind) {
+    case Kind::SIL: {
+      if (silDeclRef.hasDecl())
+        return silDeclRef.getDecl();
+      return nullptr;
+    }
+    case Kind::Global:
+      return Global;
+    case Kind::IR:
+      if (irEntity.hasDecl())
+        return irEntity.getDecl();
+      return nullptr;
+    case Kind::LinkerDirective:
+    case Kind::Unknown:
+      return nullptr;
+    }
+  }
+
   /// Typecheck the entity wrapped by this `SymbolSource`
   void typecheck() const {
     switch (kind) {

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -674,19 +674,11 @@ public:
 
     apigen::APIAvailability availability;
     auto access = apigen::APIAccess::Public;
-    if (source.kind == SymbolSource::Kind::SIL) {
-      auto ref = source.getSILDeclRef();
-      if (ref.hasDecl()) {
-        availability = getAvailability(ref.getDecl());
-        if (isSPI(ref.getDecl()))
-          access = apigen::APIAccess::Private;
-      }
-    } else if (source.kind == SymbolSource::Kind::IR) {
-      auto ref = source.getIRLinkEntity();
-      if (ref.hasDecl()) {
-        if (isSPI(ref.getDecl()))
-          access = apigen::APIAccess::Private;
-      }
+    auto decl = source.getDecl();
+    if (decl) {
+      availability = getAvailability(decl);
+      if (isSPI(decl))
+        access = apigen::APIAccess::Private;
     }
 
     api.addSymbol(symbol, moduleLoc, apigen::APILinkage::Exported,

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -655,10 +655,11 @@ void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
 }
 
 class APIGenRecorder final : public APIRecorder {
-  bool isSPI(const ValueDecl* VD) {
-    assert(VD);
-    return VD->isSPI() || VD->isAvailableAsSPI();
+  static bool isSPI(const Decl *decl) {
+    assert(decl);
+    return decl->isSPI() || decl->isAvailableAsSPI();
   }
+
 public:
   APIGenRecorder(apigen::API &api, ModuleDecl *module)
       : api(api), module(module) {
@@ -704,7 +705,7 @@ public:
       if (method.getDecl()->getDescriptiveKind() ==
           DescriptiveDeclKind::ClassMethod)
         isInstanceMethod = false;
-      if (method.getDecl()->isSPI())
+      if (isSPI(method.getDecl()))
         access = apigen::APIAccess::Private;
     }
 
@@ -770,7 +771,7 @@ private:
       superCls = super->getObjCRuntimeName(buffer);
     apigen::APIAvailability availability = getAvailability(decl);
     apigen::APIAccess access =
-        decl->isSPI() ? apigen::APIAccess::Private : apigen::APIAccess::Public;
+        isSPI(decl) ? apigen::APIAccess::Private : apigen::APIAccess::Public;
     apigen::APILinkage linkage =
         decl->getFormalAccess() == AccessLevel::Public && decl->isObjC()
             ? apigen::APILinkage::Exported
@@ -803,7 +804,7 @@ private:
     buildCategoryName(decl, cls, nameBuffer);
     apigen::APIAvailability availability = getAvailability(decl);
     apigen::APIAccess access =
-        decl->isSPI() ? apigen::APIAccess::Private : apigen::APIAccess::Public;
+        isSPI(decl) ? apigen::APIAccess::Private : apigen::APIAccess::Public;
     apigen::APILinkage linkage =
         decl->getMaxAccessLevel() == AccessLevel::Public
             ? apigen::APILinkage::Exported

--- a/lib/IRGen/TBDGenVisitor.h
+++ b/lib/IRGen/TBDGenVisitor.h
@@ -62,7 +62,7 @@ public:
   virtual ~APIRecorder() {}
 
   virtual void addSymbol(StringRef name, llvm::MachO::SymbolKind kind,
-                         SymbolSource source) {}
+                         SymbolSource source, Decl *decl) {}
   virtual void addObjCInterface(const ClassDecl *decl) {}
   virtual void addObjCCategory(const ExtensionDecl *decl) {}
   virtual void addObjCMethod(const GenericContext *ctx, SILDeclRef method) {}
@@ -71,14 +71,15 @@ public:
 class SimpleAPIRecorder final : public APIRecorder {
 public:
   using SymbolCallbackFn = llvm::function_ref<void(
-      StringRef, llvm::MachO::SymbolKind, SymbolSource)>;
+      StringRef, llvm::MachO::SymbolKind, SymbolSource, Decl *)>;
 
   SimpleAPIRecorder(SymbolCallbackFn func) : func(func) {}
 
   void addSymbol(StringRef symbol, llvm::MachO::SymbolKind kind,
-                 SymbolSource source) override {
-    func(symbol, kind, source);
+                 SymbolSource source, Decl *decl) override {
+    func(symbol, kind, source, decl);
   }
+
 private:
   SymbolCallbackFn func;
 };

--- a/test/APIJSON/access.swift
+++ b/test/APIJSON/access.swift
@@ -4,8 +4,9 @@
 
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ModuleCache)
 // RUN: cp %s %t/MyModule.swiftinterface
-// RUN: %target-swift-api-extract -target x86_64-apple-macos11.0 -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
+// RUN: %target-swift-api-extract -target x86_64-apple-macos11.0 -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t/ModuleCache | %FileCheck %s
 
 public func publicFunction()
 internal func internalFunction()

--- a/test/APIJSON/apigen.swift
+++ b/test/APIJSON/apigen.swift
@@ -9,6 +9,7 @@ import Foundation
 @available(macOS 10.13, *)
 public class Test : NSObject {
   @objc public func method1() {}
+  @available(macOS 10.14, *)
   @objc public class func method2() {}
   public func nonObjc() {}
 }
@@ -80,13 +81,15 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:     "name": "_$s8MyModule11myGlobalVarSivg",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule11myGlobalVarSivs",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestC7method1yyFTj",
@@ -104,13 +107,15 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:     "name": "_$s8MyModule4TestC7method2yyFZTj",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.14"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestC7method2yyFZTq",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.14"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestC7nonObjcyyFTj",
@@ -140,7 +145,8 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:     "name": "_$s8MyModule4TestCMa",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestCMn",
@@ -167,7 +173,8 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:     "name": "_$s8MyModule4TestCN",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestCfD",
@@ -317,7 +324,8 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:     "name": "_$s8MyModule7DerivedCMa",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule7DerivedCMn",
@@ -337,7 +345,8 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:     "name": "_$s8MyModule7DerivedCN",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule7DerivedCfD",
@@ -370,7 +379,8 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "name": "method2",
 // CHECK-NEXT:         "access": "public",
-// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:         "introduced": "10.14"
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ]
 // CHECK-NEXT:   },

--- a/test/APIJSON/apigen.swift
+++ b/test/APIJSON/apigen.swift
@@ -146,19 +146,22 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:     "name": "_$s8MyModule4TestCMn",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestCMo",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestCMu",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestCN",
@@ -320,13 +323,15 @@ public var myGlobalVar: Int = 42
 // CHECK-NEXT:     "name": "_$s8MyModule7DerivedCMn",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule7DerivedCMo",
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule7DerivedCN",

--- a/test/APIJSON/apigen.swift
+++ b/test/APIJSON/apigen.swift
@@ -43,6 +43,9 @@ public func myFunction1() {}
 @available(*, unavailable)
 public func myFunction2() {}
 
+@available(macOS 10.13, *)
+public var myGlobalVar: Int = 42
+
 // CHECK:      "target"
 // CHECK-NEXT: "globals": [
 // CHECK-NEXT:   {
@@ -65,6 +68,25 @@ public func myFunction2() {}
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
 // CHECK-NEXT:     "linkage": "exported",
 // CHECK-NEXT:     "unavailable": true
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule11myGlobalVarSivM",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule11myGlobalVarSivg",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule11myGlobalVarSivs",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "name": "_$s8MyModule4TestC7method1yyFTj",

--- a/test/APIJSON/apigen.swift
+++ b/test/APIJSON/apigen.swift
@@ -1,7 +1,8 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t/ModuleCache | %FileCheck %s
 
 import Foundation
 

--- a/test/APIJSON/extension.swift
+++ b/test/APIJSON/extension.swift
@@ -1,7 +1,8 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t/ModuleCache | %FileCheck %s
 
 import Foundation
 

--- a/test/APIJSON/non-objc-class.swift
+++ b/test/APIJSON/non-objc-class.swift
@@ -1,7 +1,8 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t/ModuleCache | %FileCheck %s
 
 import Foundation
 

--- a/test/APIJSON/non-swift-api.swift
+++ b/test/APIJSON/non-swift-api.swift
@@ -4,7 +4,7 @@
 // RUN: cp %S/Inputs/module.modulemap %t/NativeDep.framework/Modules
 // RUN: cp %S/Inputs/NativeDep.h %t/NativeDep.framework/Headers
 
-// RUN: %target-swift-frontend %s -emit-module -emit-module-interface-path %t/MyModule.swiftinterface -emit-module-path %t/MyModule.swiftmodule -F %t -enable-library-evolution -module-cache-path %t/cache -module-name MyModule -swift-version 5
+// RUN: %target-swift-frontend %s -parse-as-library -emit-module -emit-module-interface-path %t/MyModule.swiftinterface -emit-module-path %t/MyModule.swiftmodule -F %t -enable-library-evolution -module-cache-path %t/cache -module-name MyModule -swift-version 5
 
 /// Check that both swiftmodule and swiftinterface can be used as input.
 // RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftmodule -module-name MyModule -module-cache-path %t/cache -F %t | %FileCheck %s

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -33,13 +33,15 @@ public func spiAvailableFunc() {}
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTj",
 // CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "unavailable": true
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTq",
 // CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "unavailable": true
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CACycfC",
@@ -191,13 +193,15 @@ public func spiAvailableFunc() {}
 // CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTj",
 // CHECK-SPI-NEXT:       "access": "private",
 // CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
-// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:       "linkage": "exported",
+// CHECK-SPI-NEXT:       "introduced": "10.10"
 // CHECK-SPI-NEXT:     },
 // CHECK-SPI-NEXT:     {
 // CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTq",
 // CHECK-SPI-NEXT:       "access": "private",
 // CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
-// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:       "linkage": "exported",
+// CHECK-SPI-NEXT:       "introduced": "10.10"
 // CHECK-SPI-NEXT:     },
 // CHECK-SPI-NEXT:     {
 // CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2C9spiMethodyyFTj",

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -1,10 +1,11 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t/ModuleCache | %FileCheck %s
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %s -emit-module -emit-module-path %t/MyModule.swiftmodule -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftmodule -module-name MyModule -module-cache-path %t | %FileCheck %s --check-prefix=CHECK-SPI
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftmodule -module-name MyModule -module-cache-path %t/ModuleCache | %FileCheck %s --check-prefix=CHECK-SPI
 
 import Foundation
 

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -318,7 +318,7 @@ public func spiAvailableFunc() {}
 // CHECK-SPI-NEXT:         },
 // CHECK-SPI-NEXT:         {
 // CHECK-SPI-NEXT:           "name": "spiAvailableMethod",
-// CHECK-SPI-NEXT:           "access": "public",
+// CHECK-SPI-NEXT:           "access": "private",
 // CHECK-SPI-NEXT:           "file": "/@input/MyModule.swiftmodule",
 // CHECK-SPI-NEXT:           "introduced": "10.10"
 // CHECK-SPI-NEXT:         },

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -16,6 +16,10 @@ import Foundation
 
 public class MyClass2 : NSObject {
   @_spi(Experimental) @objc public func spiMethod() {}
+
+  @_spi_available(macOS 10.10, tvOS 14.0, *)
+  @available(iOS 8.0, *)
+  @objc public func spiAvailableMethod() {}
 }
 
 @_spi_available(macOS 10.10, tvOS 14.0, *)
@@ -25,6 +29,18 @@ public func spiAvailableFunc() {}
 // CHECK:      {
 // CHECK-NEXT:   "target":
 // CHECK-NEXT:   "globals": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTj",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTq",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CACycfC",
 // CHECK-NEXT:       "access": "public",
@@ -51,6 +67,12 @@ public func spiAvailableFunc() {}
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMo",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMu",
 // CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
 // CHECK-NEXT:       "linkage": "exported"
@@ -83,6 +105,12 @@ public func spiAvailableFunc() {}
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "super": "NSObject",
 // CHECK-NEXT:       "instanceMethods": [
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "name": "spiAvailableMethod",
+// CHECK-NEXT:           "access": "public",
+// CHECK-NEXT:           "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:           "unavailable": true
+// CHECK-NEXT:         },
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "name": "init",
 // CHECK-NEXT:           "access": "public",
@@ -155,6 +183,18 @@ public func spiAvailableFunc() {}
 // CHECK-SPI-NEXT:     },
 // CHECK-SPI-NEXT:     {
 // CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCfD",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTj",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2C18spiAvailableMethodyyFTq",
 // CHECK-SPI-NEXT:       "access": "private",
 // CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
 // CHECK-SPI-NEXT:       "linkage": "exported"
@@ -271,6 +311,12 @@ public func spiAvailableFunc() {}
 // CHECK-SPI-NEXT:           "name": "spiMethod",
 // CHECK-SPI-NEXT:           "access": "private",
 // CHECK-SPI-NEXT:           "file": "/@input/MyModule.swiftmodule"
+// CHECK-SPI-NEXT:         },
+// CHECK-SPI-NEXT:         {
+// CHECK-SPI-NEXT:           "name": "spiAvailableMethod",
+// CHECK-SPI-NEXT:           "access": "public",
+// CHECK-SPI-NEXT:           "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:           "introduced": "10.10"
 // CHECK-SPI-NEXT:         },
 // CHECK-SPI-NEXT:         {
 // CHECK-SPI-NEXT:           "name": "init",

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -155,7 +155,7 @@ public func spiAvailableFunc() {}
 // CHECK-SPI-NEXT:     },
 // CHECK-SPI-NEXT:     {
 // CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCMa",
-// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "access": "private",
 // CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
 // CHECK-SPI-NEXT:       "linkage": "exported"
 // CHECK-SPI-NEXT:     },
@@ -179,7 +179,7 @@ public func spiAvailableFunc() {}
 // CHECK-SPI-NEXT:     },
 // CHECK-SPI-NEXT:     {
 // CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCN",
-// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "access": "private",
 // CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
 // CHECK-SPI-NEXT:       "linkage": "exported"
 // CHECK-SPI-NEXT:     },

--- a/test/APIJSON/struct.swift
+++ b/test/APIJSON/struct.swift
@@ -39,7 +39,8 @@ public struct TestStruct {
 // CHECK-NEXT:       "name": "_$s8MyModule10TestStructVMn",
 // CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "10.13"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule10TestStructVN",

--- a/test/APIJSON/struct.swift
+++ b/test/APIJSON/struct.swift
@@ -33,7 +33,8 @@ public struct TestStruct {
 // CHECK-NEXT:       "name": "_$s8MyModule10TestStructVMa",
 // CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "10.13"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_$s8MyModule10TestStructVMn",
@@ -46,7 +47,8 @@ public struct TestStruct {
 // CHECK-NEXT:       "name": "_$s8MyModule10TestStructVN",
 // CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "10.13"
 // CHECK-NEXT:     }
 // CHECK-NEXT:   ],
 // CHECK-NEXT:   "interfaces": [],

--- a/test/APIJSON/struct.swift
+++ b/test/APIJSON/struct.swift
@@ -1,7 +1,8 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %target-swift-frontend %s -typecheck -parse-as-library -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t/ModuleCache | %FileCheck %s
 
 // Struct has no objc data.
 @available(macOS 10.13, *)


### PR DESCRIPTION
The output of `swift-api-extract` had inaccurate visibility and availability for many symbols because `APIRecorder` did not consistently have access to a representative `Decl` to query for those attributes. We can plumb the currently visited `Decl` through from `SILSymbolVisitor` to provide more consistent context.