### PR TITLE
Don't delete begin_access with just end_access users

### DIFF
--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -463,7 +463,10 @@ visitUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *UBCI) {
 }
 
 SILValue InstSimplifier::visitBeginAccessInst(BeginAccessInst *BAI) {
-  // Remove "dead" begin_access.
+  // Don't just delete dead dynamic enforcement access scopes.
+  if (BAI->getEnforcement() == SILAccessEnforcement::Dynamic) {
+    return SILValue();
+  }
   if (llvm::all_of(BAI->getUses(), [](Operand *operand) -> bool {
         return isIncidentalUse(operand->getUser());
       })) {

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -46,12 +46,13 @@ namespace {
 // FIXME: Reconcile the similarities between this and
 //        isInstructionTriviallyDead.
 static bool seemsUseful(SILInstruction *I) {
-  // Even though begin_access/destroy_value/copy_value/end_lifetime have
-  // side-effects, they can be DCE'ed if they do not have useful
-  // dependencies/reverse dependencies
-  if (isa<BeginAccessInst>(I) || isa<CopyValueInst>(I) ||
-      isa<DestroyValueInst>(I) || isa<EndLifetimeInst>(I) ||
-      isa<EndBorrowInst>(I))
+  // Even though these instructions have side-effects, they can be DCE'ed if
+  // they do not have useful dependencies/reverse dependencies
+  if (auto *bai = dyn_cast<BeginAccessInst>(I)) {
+    return bai->getEnforcement() == SILAccessEnforcement::Dynamic;
+  }
+  if (isa<CopyValueInst>(I) || isa<DestroyValueInst>(I) ||
+      isa<EndLifetimeInst>(I) || isa<EndBorrowInst>(I))
     return false;
 
   // A load [copy] is okay to be DCE'ed if there are no useful dependencies

--- a/test/SILOptimizer/dead_code_elimination.sil
+++ b/test/SILOptimizer/dead_code_elimination.sil
@@ -261,7 +261,7 @@ bb3:
 // CHECK-LABEL: end sil function 'dead_access'
 sil @dead_access : $@convention(thin) (@in Container) -> () {
 bb0(%0 : $*Container):
-  %1 = begin_access [modify] [dynamic] %0 : $*Container
+  %1 = begin_access [modify] [signed] %0 : $*Container
   end_access %1 : $*Container
   
   %3 = begin_access [read] [static] %0 : $*Container

--- a/test/SILOptimizer/dead_code_elimination_access.swift
+++ b/test/SILOptimizer/dead_code_elimination_access.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift(-O -g -o %t/dead_code_elimination_access  -Xfrontend -enable-experimental-move-only)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+class Foo {}
+
+var global = Foo()
+
+@inline(never)
+func useFoo(x: Foo) {
+  global = Foo()
+}
+
+@inline(never)
+func callUseFoo() {
+  useFoo(x: _borrow global)
+}
+
+var DeadExclusivityTest = TestSuite("DeadExclusivityTest")
+
+DeadExclusivityTest.test("deadAccessScope") {
+  expectCrashLater(withMessage: "Fatal access conflict detected")
+  callUseFoo()
+}
+
+runAllTests()

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -285,7 +285,7 @@ bb3:
 // CHECK-LABEL: } // end sil function 'dead_access'
 sil [ossa] @dead_access : $@convention(thin) (@in Container) -> () {
 bb0(%0 : $*Container):
-  %1 = begin_access [modify] [dynamic] %0 : $*Container
+  %1 = begin_access [modify] [signed] %0 : $*Container
   end_access %1 : $*Container
 
   %3 = begin_access [read] [static] %0 : $*Container

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -325,34 +325,6 @@ public class B {
   deinit
 }
 
-// simplify access markers
-sil @simplify_accesssil : $@convention(method) (@guaranteed A) -> () {
-bb0(%0 : $A):
-  %badr = ref_element_addr %0 : $A, #A.b
-  %ba1 = begin_access [read] [dynamic] %badr : $*B
-  end_access %ba1 : $*B
-  %ba2 = begin_access [read] [dynamic] %badr : $*B
-  fix_lifetime %ba2 : $*B
-  end_access %ba2 : $*B
-  %ba3 = begin_access [read] [dynamic] %badr : $*B
-  %b = load %ba3 : $*B
-  end_access %ba3 : $*B
-  %xadr = ref_element_addr %b : $B, #B.x
-  %xaccess = begin_access [read] [dynamic] %xadr : $*Int
-  end_access %xaccess : $*Int
-
-  %r = tuple ()
-  return %r : $()
-}
-
-// CHECK-LABEL: sil @simplify_accesssil : $@convention(method) (@guaranteed A) -> () {
-// CHECK: bb0(%0 : $A):
-// CHECK-NEXT: [[ADR:%.*]] = ref_element_addr %0 : $A, #A.b
-// CHECK-NEXT: fix_lifetime [[ADR]] : $*B
-// CHECK-NEXT: %{{.*}} = tuple ()
-// CHECK-NEXT: return %{{.*}} : $()
-// CHECK-LABEL: } // end sil function 'simplify_accesssil'
-
 // Test replacement of metatype instructions with metatype arguments.
 protocol SomeP {}
 

--- a/test/SILOptimizer/sil_simplify_instrs_ossa.sil
+++ b/test/SILOptimizer/sil_simplify_instrs_ossa.sil
@@ -368,37 +368,6 @@ public class B {
   deinit
 }
 
-// simplify access markers
-
-// CHECK-LABEL: sil [ossa] @simplify_accesssil : $@convention(method) (@guaranteed A) -> () {
-// CHECK: bb0(%0 : @guaranteed $A):
-// CHECK-NEXT: [[ADR:%.*]] = ref_element_addr %0 : $A, #A.b
-// CHECK-NEXT: fix_lifetime [[ADR]] : $*B
-// CHECK-NEXT: %{{.*}} = tuple ()
-// CHECK-NEXT: return %{{.*}} : $()
-// CHECK: } // end sil function 'simplify_accesssil'
-sil [ossa] @simplify_accesssil : $@convention(method) (@guaranteed A) -> () {
-bb0(%0 : @guaranteed $A):
-  %badr = ref_element_addr %0 : $A, #A.b
-  %ba1 = begin_access [read] [dynamic] %badr : $*B
-  end_access %ba1 : $*B
-  %ba2 = begin_access [read] [dynamic] %badr : $*B
-  fix_lifetime %ba2 : $*B
-  end_access %ba2 : $*B
-  %ba3 = begin_access [read] [dynamic] %badr : $*B
-  %b = load [copy] %ba3 : $*B
-  end_access %ba3 : $*B
-  %bb = begin_borrow %b : $B
-  %xadr = ref_element_addr %bb : $B, #B.x
-  %xaccess = begin_access [read] [dynamic] %xadr : $*Int
-  end_access %xaccess : $*Int
-  end_borrow %bb : $B
-  destroy_value %b : $B
-
-  %r = tuple ()
-  return %r : $()
-}
-
 // Test replacement of metatype instructions with metatype arguments.
 protocol SomeP {}
 


### PR DESCRIPTION
The base operand should be analyzed for such an optimization.

Added a swift test where there is no exclusivity error when compiler with optimizations.

Fixes rdar://116508574