### PR TITLE
[Linux] Enable frame pointers when building Swift libraries.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -134,6 +134,11 @@ function(_add_target_variant_c_compile_link_flags)
                        "-fcoverage-mapping")
   endif()
 
+  # Use frame pointers on Linux
+  if("${CFLAGS_SDK}" STREQUAL "LINUX")
+    list(APPEND result "-fno-omit-frame-pointer")
+  endif()
+
   _compute_lto_flag("${CFLAGS_ENABLE_LTO}" _lto_flag_out)
   if (_lto_flag_out)
     list(APPEND result "${_lto_flag_out}")
@@ -308,6 +313,11 @@ function(_add_target_variant_c_compile_flags)
   if(CFLAGS_ANALYZE_CODE_COVERAGE)
     list(APPEND result "-fprofile-instr-generate"
                        "-fcoverage-mapping")
+  endif()
+
+  # Use frame pointers on Linux
+  if("${CFLAGS_SDK}" STREQUAL "LINUX")
+    list(APPEND result "-fno-omit-frame-pointer")
   endif()
 
   if((CFLAGS_ARCH STREQUAL "armv7" OR CFLAGS_ARCH STREQUAL "aarch64") AND
@@ -922,6 +932,11 @@ function(add_swift_target_library_single target name)
     set(install_in_component "never_install")
   else()
     set(install_in_component "${SWIFTLIB_SINGLE_INSTALL_IN_COMPONENT}")
+  endif()
+
+  # Use frame pointers on Linux
+  if ("${SWIFTLIB_SINGLE_SDK}" STREQUAL "LINUX")
+    list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS "-Xcc" "-fno-omit-frame-pointer")
   endif()
 
   # FIXME: don't actually depend on the libraries in SWIFTLIB_SINGLE_LINK_LIBRARIES,
@@ -2600,6 +2615,10 @@ function(_add_swift_target_executable_single name)
   if(SWIFTEXE_SINGLE_SDK STREQUAL "WINDOWS")
     list(APPEND SWIFTEXE_SINGLE_COMPILE_FLAGS
       -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}")
+  endif()
+
+  if ("${SWIFTEXE_SINGLE_SDK}" STREQUAL "LINUX")
+    list(APPEND SWIFTEXE_SINGLE_COMPILE_FLAGS "-Xcc" "-fno-omit-frame-pointer")
   endif()
 
   handle_swift_sources(

--- a/test/Backtracing/FatalError.swift
+++ b/test/Backtracing/FatalError.swift
@@ -39,9 +39,9 @@ struct FatalError {
 
 // CHECK: *** Program crashed: Illegal instruction at 0x{{[0-9a-f]+}} ***
 
-// CHECK: Thread 0 "FatalError" crashed:
+// CHECK: Thread 0 {{(".*" )?}}crashed:
 
-// CHECK:      0               0x{{[0-9a-f]+}} _assertionFailure(_:_:file:line:flags:) + {{[0-9]+}} in libswiftCore.so at {{.*}}/AssertCommon.swift:{{[0-9]+}}:{{[0-9]+}}
+// CHECK:      0               0x{{[0-9a-f]+}} _assertionFailure(_:_:file:line:flags:) + {{[0-9]+}} in libswiftCore.{{so|dylib}}
 // CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:30:3
 // CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:26:3
 // CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:22:3

--- a/test/Backtracing/FatalError.swift
+++ b/test/Backtracing/FatalError.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/FatalError
+// RUN: %target-codesign %t/FatalError
+// RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/FatalError 2>&1 || true) | %FileCheck %s
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: asan
+// REQUIRES: executable_test
+// REQUIRES: backtracing
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+func level1() {
+  level2()
+}
+
+func level2() {
+  level3()
+}
+
+func level3() {
+  level4()
+}
+
+func level4() {
+  level5()
+}
+
+func level5() {
+  fatalError("Going to crash")
+}
+
+@main
+struct FatalError {
+  static func main() {
+    level1()
+  }
+}
+
+// CHECK: *** Program crashed: Illegal instruction at 0x{{[0-9a-f]+}} ***
+
+// CHECK: Thread 0 "FatalError" crashed:
+
+// CHECK:      0               0x{{[0-9a-f]+}} _assertionFailure(_:_:file:line:flags:) + {{[0-9]+}} in libswiftCore.so at {{.*}}/AssertCommon.swift:{{[0-9]+}}:{{[0-9]+}}
+// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:30:3
+// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:26:3
+// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:22:3
+// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:18:3
+// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:14:3
+// CHECK-NEXT: 6 [ra]          0x{{[0-9a-f]+}} static FatalError.main() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:36:5
+// CHECK-NEXT: 7 [ra] [system] 0x{{[0-9a-f]+}} static FatalError.$main() + {{[0-9]+}} in FatalError at {{.*}}/<compiler-generated>
+// CHECK-NEXT: 8 [ra] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift
+


### PR DESCRIPTION
Turn on frame pointers for the Swift runtime libraries.  This makes backtraces that go through the runtimes more reliable without having to parse DWARF data.

rdar://116112040
