### PR TITLE
[5.10][CSSimplify] Determine whether type is know Foundation entity in a safer way

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2761,10 +2761,17 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
   if (locator.isForRequirement(RequirementKind::Conformance)) {
     // Increase the impact of a conformance fix for a standard library
     // or foundation type, as it's unlikely to be a good suggestion.
-    if (resolvedTy->isStdlibType() ||
-        getKnownFoundationEntity(resolvedTy->getString())) {
-      impact += 2;
+    {
+      if (resolvedTy->isStdlibType()) {
+        impact += 2;
+      }
+
+      if (auto *NTD = resolvedTy->getAnyNominal()) {
+        if (getKnownFoundationEntity(NTD->getNameStr()))
+          impact += 2;
+      }
     }
+
     // Also do the same for the builtin compiler types Any and AnyObject, but
     // bump the impact even higher as they cannot conform to protocols at all.
     if (resolvedTy->isAny() || resolvedTy->isAnyObject())


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68964

---

- Explanation:

Addresses a common source of crashes in 5.9

Instead of trying to get string representation of the type itself, 
let's just get it based on the type name, which works well with
the list of types we have.

- Scope: Based on the stacktrace - expressions with some generic types that do not satisfy contextual conformance requirements.

- Main Branch PR: https://github.com/apple/swift/pull/68964

- Resolves: rdar://113675093

- Risk: Low

- Reviewed By: @hborla 

- Testing: No tests because this is a speculative fix. 

Resolves: rdar://113675093
(cherry picked from commit b83a73d177dc423c4d1eebaa57c8aeffdfcf6699)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
