### PR TITLE
[embedded] Serialize+deserialize vtables, fix using non-generic classes from other modules in embedded Swift

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2901,6 +2901,9 @@ CanType irgen::getSuperclassForMetadata(IRGenModule &IGM, CanType type,
 
 ClassMetadataStrategy
 IRGenModule::getClassMetadataStrategy(const ClassDecl *theClass) {
+  if (Context.LangOpts.hasFeature(Feature::Embedded))
+    return ClassMetadataStrategy::Fixed;
+
   SILType selfType = getSelfType(theClass);
   auto &selfTI = getTypeInfo(selfType).as<ClassTypeInfo>();
 

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -83,6 +83,8 @@ namespace irgen {
   /// Emit the type metadata accessor for a type for which it might be used.
   void emitLazyMetadataAccessor(IRGenModule &IGM, NominalTypeDecl *type);
 
+  void emitLazyClassMetadata(IRGenModule &IGM, CanType classType);
+
   void emitLazySpecializedClassMetadata(IRGenModule &IGM, CanType classType);
 
   void emitLazyCanonicalSpecializedMetadataAccessor(IRGenModule &IGM,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -327,6 +327,10 @@ private:
   /// The queue of lazy witness tables to emit.
   llvm::SmallVector<SILWitnessTable *, 4> LazyWitnessTables;
 
+  llvm::SmallVector<CanType, 4> LazyClassMetadata;
+
+  llvm::SmallPtrSet<TypeBase *, 4> LazilyEmittedClassMetadata;
+
   llvm::SmallVector<CanType, 4> LazySpecializedClassMetadata;
 
   llvm::SmallPtrSet<TypeBase *, 4> LazilyEmittedSpecializedClassMetadata;
@@ -476,6 +480,7 @@ public:
     }
   }
 
+  void noteUseOfClassMetadata(CanType classType);
   void noteUseOfSpecializedClassMetadata(CanType classType);
 
   void noteUseOfTypeMetadata(NominalTypeDecl *type) {

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -519,6 +519,9 @@ SILVTable *SILModule::lookUpVTable(const ClassDecl *C,
     return nullptr;
 
   if (C->walkSuperclasses([&](ClassDecl *S) {
+    auto R = VTableMap.find(S);
+    if (R != VTableMap.end())
+      return TypeWalker::Action::Continue;
     SILVTable *Vtbl = getSILLoader()->lookupVTable(S);
     if (!Vtbl) {
       return TypeWalker::Action::Stop;

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -523,7 +523,7 @@ SILVTable *SILModule::lookUpVTable(const ClassDecl *C,
     if (!Vtbl) {
       return TypeWalker::Action::Stop;
     }
-    VTableMap[C] = Vtbl;
+    VTableMap[S] = Vtbl;
     return TypeWalker::Action::Continue;
   })) {
     return nullptr;

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -518,6 +518,17 @@ SILVTable *SILModule::lookUpVTable(const ClassDecl *C,
   if (!Vtbl)
     return nullptr;
 
+  if (C->walkSuperclasses([&](ClassDecl *S) {
+    SILVTable *Vtbl = getSILLoader()->lookupVTable(S);
+    if (!Vtbl) {
+      return TypeWalker::Action::Stop;
+    }
+    VTableMap[C] = Vtbl;
+    return TypeWalker::Action::Continue;
+  })) {
+    return nullptr;
+  }
+
   // If we succeeded, map C -> VTbl in the table and return VTbl.
   VTableMap[C] = Vtbl;
   return Vtbl;

--- a/test/embedded/modules-classes.swift
+++ b/test/embedded/modules-classes.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// BEGIN MyModule.swift
+
+internal class BaseClass {
+
+}
+
+final internal class MyClass: BaseClass {
+  func foo() { print("MyClass.foo") }
+}
+
+public func foo() {
+  let o = MyClass()
+  o.foo()
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+func test() {
+  foo()
+}
+
+test()
+
+// CHECK: MyClass.foo


### PR DESCRIPTION
See the attached testcase that demonstrates the problem: Currently, the test fails to link with a missing symbol referencing the other module's class vtable, because (1) CMO doesn't serialize vtables, (2) IRGen doesn't emit class metadata when there isn't a Decl for the class in the module.