### PR TITLE
[Typed throws] Handle function conversions involving different thrown errors

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -615,6 +615,9 @@ ERROR(throws_functiontype_mismatch,none,
       "invalid conversion from throwing function of type %0 to "
       "non-throwing function type %1", (Type, Type))
 
+ERROR(thrown_error_type_mismatch,none,
+      "invalid conversion of thrown error type %0 to %1", (Type, Type))
+
 ERROR(async_functiontype_mismatch,none,
       "invalid conversion from 'async' function of type %0 to "
       "synchronous function type %1", (Type, Type))

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -275,6 +275,9 @@ ABSTRACT_LOCATOR_PATH_ELT(PatternDecl)
 /// A function type global actor.
 SIMPLE_LOCATOR_PATH_ELT(GlobalActorType)
 
+/// The thrown error of a function type.
+SIMPLE_LOCATOR_PATH_ELT(ThrownErrorType)
+
 /// A type coercion operand.
 SIMPLE_LOCATOR_PATH_ELT(CoercionOperand)
 

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -115,6 +115,11 @@ class Traversal : public TypeVisitor<Traversal, bool>
         return true;
     }
 
+    if (Type thrownError = ty->getThrownError()) {
+      if (doIt(thrownError))
+        return true;
+    }
+
     return doIt(ty->getResult());
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7096,6 +7096,12 @@ bool ThrowingFunctionConversionFailure::diagnoseAsError() {
   return true;
 }
 
+bool ThrownErrorTypeConversionFailure::diagnoseAsError() {
+  emitDiagnostic(diag::thrown_error_type_mismatch, getFromType(),
+                 getToType());
+  return true;
+}
+
 bool AsyncFunctionConversionFailure::diagnoseAsError() {
   auto *locator = getLocator();
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -933,6 +933,24 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose failures related to conversion between the thrown error type
+/// of two function types, e.g.,
+///
+/// ```swift
+/// func foo<T>(_ t: T) throws(MyError) -> Void {}
+/// let _: (Int) throws (OtherError)-> Void = foo
+///   // `MyError` can't be implicitly converted to `OtherError`
+/// ```
+class ThrownErrorTypeConversionFailure final : public ContextualFailure {
+public:
+  ThrownErrorTypeConversionFailure(const Solution &solution, Type fromType,
+                                    Type toType, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {
+  }
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose failures related to conversion between 'async' function type
 /// and a synchronous one e.g.
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1627,6 +1627,21 @@ DropThrowsAttribute *DropThrowsAttribute::create(ConstraintSystem &cs,
       DropThrowsAttribute(cs, fromType, toType, locator);
 }
 
+bool IgnoreThrownErrorMismatch::diagnose(const Solution &solution,
+                                   bool asNote) const {
+  ThrownErrorTypeConversionFailure failure(solution, getFromType(),
+                                           getToType(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+IgnoreThrownErrorMismatch *IgnoreThrownErrorMismatch::create(ConstraintSystem &cs,
+                                                 Type fromErrorType,
+                                                 Type toErrorType,
+                                                 ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      IgnoreThrownErrorMismatch(cs, fromErrorType, toErrorType, locator);
+}
+
 bool DropAsyncAttribute::diagnose(const Solution &solution,
                                    bool asNote) const {
   AsyncFunctionConversionFailure failure(solution, getFromType(),

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2453,7 +2453,6 @@ namespace {
       auto resultLocator =
           CS.getConstraintLocator(closure, ConstraintLocator::ClosureResult);
 
-      // FIXME: Need a better locator.
       auto thrownErrorLocator =
         CS.getConstraintLocator(closure, ConstraintLocator::ClosureThrownError);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2978,7 +2978,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   Type neverType = getASTContext().getNeverType();
   Type thrownError1 = func1->getEffectiveThrownInterfaceType().value_or(neverType);
   Type thrownError2 = func2->getEffectiveThrownInterfaceType().value_or(neverType);
-  if (!thrownError1->isEqual(thrownError2)) {
+  if (thrownError1 && thrownError2 && !thrownError1->isEqual(thrownError2)) {
     auto thrownErrorKind1 = getThrownErrorKind(thrownError1);
     auto thrownErrorKind2 = getThrownErrorKind(thrownError2);
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -109,6 +109,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::GlobalActorType:
   case ConstraintLocator::CoercionOperand:
   case ConstraintLocator::PackExpansionType:
+  case ConstraintLocator::ThrownErrorType:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -517,6 +518,10 @@ void LocatorPathElt::dump(raw_ostream &out) const {
     auto expansionElt = elt.castTo<LocatorPathElt::PackExpansionType>();
     out << "pack expansion type ("
         << expansionElt.getOpenedType()->getString(PO) << ")";
+    break;
+  }
+  case ConstraintLocator::ThrownErrorType: {
+    out << "thrown error type";
     break;
   }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5971,6 +5971,9 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::GenericParameter:
       break;
 
+    case ConstraintLocator::ThrownErrorType:
+      break;
+
     case ConstraintLocator::OpenedGeneric:
     case ConstraintLocator::OpenedOpaqueArchetype:
       break;

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1118,9 +1118,6 @@ public:
           classifyFunctionBody(fnRef,
                                PotentialEffectReason::forApply(),
                                kind));
-        assert(result.getConditionalKind(kind)
-               != ConditionalEffectKind::None &&
-               "body classification decided function had no effect?");
       }
     };
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3633,6 +3633,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     if (thrownTy->hasError()) {
       thrownTy = Type();
     } else if (!options.contains(TypeResolutionFlags::SilenceErrors) &&
+               !thrownTy->hasTypeParameter() &&
                !TypeChecker::conformsToProtocol(
                   thrownTy, ctx.getErrorDecl(),
                   resolution.getDeclContext()->getParentModule())) {

--- a/test/attr/typed_throws_availability_osx.swift
+++ b/test/attr/typed_throws_availability_osx.swift
@@ -10,6 +10,3 @@ enum MyError: Error {
 @available(macOS 12, *)
 func throwMyErrorBadly() throws(MyError) { }
 // expected-error@-1{{'MyError' is only available in macOS 13 or newer}}
-
-
-

--- a/test/attr/typed_throws_availability_osx.swift
+++ b/test/attr/typed_throws_availability_osx.swift
@@ -1,15 +1,15 @@
-// RUN: %swift -typecheck -verify -target x86_64-apple-macosx10.10 %s -enable-experimental-feature TypedThrows
+// RUN: %swift -typecheck -verify -target %target-cpu-apple-macosx11 %s -enable-experimental-feature TypedThrows
 
 // REQUIRES: OS=macosx
 
-@available(macOS 12, *)
+@available(macOS 13, *)
 enum MyError: Error {
   case fail
 }
 
-@available(macOS 11, *)
+@available(macOS 12, *)
 func throwMyErrorBadly() throws(MyError) { }
-// expected-error@-1{{'MyError' is only available in macOS 12 or newer}}
+// expected-error@-1{{'MyError' is only available in macOS 13 or newer}}
 
 
 


### PR DESCRIPTION
Teach the constraint solver about the subtyping rule that permits converting one function type to another when the effective thrown error type of one is a subtype of the effective thrown error type of the other, using `any Error` for untyped throws and `Never` for non-throwing.

With minor other fixes, this allows us to use typed throws for generic functions that carry a typed error from their arguments through to themselves, which is in effect a typed `rethrows`:

```swift
func mapArray<T, U, E: Error>(_ array: [T], body: (T) throws(E) -> U)
throws(E) -> [U] {
  var resultArray: [U] = .init()
  for value in array {
    resultArray.append(try body(value))
  }
  return resultArray
}
```
