### PR TITLE
Add support for objective c protocol symbolic references

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -108,6 +108,10 @@ The following symbolic reference kinds are currently implemented:
      symbolic-extended-existential-type-shape ::= '\x0B' .{4} // Reference points directly to a NonUniqueExtendedExistentialTypeShape
    #endif
 
+   #if SWIFT_RUNTIME_VERSION >= 5.TBD
+    objective-c-protocol-relative-reference  ::=  `\x0C`  .{4} // Reference points directly to a objective-c protcol reference
+   #endif
+
 A mangled name may also include ``\xFF`` bytes, which are only used for
 alignment padding. They do not affect what the mangled name references and can
 be skipped over and ignored.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -944,6 +944,10 @@ public:
   /// that fixes up the value witness table of @_rawLayout dependent types.
   AvailabilityContext getInitRawStructMetadataAvailability();
 
+  /// Get the runtime availability of being able to use symbolic references to
+  /// objective c protocols.
+  AvailabilityContext getObjCSymbolicReferencesAvailability();
+
   /// Get the runtime availability of features introduced in the Swift 5.2
   /// compiler for the target platform.
   AvailabilityContext getSwift52Availability();

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -399,6 +399,8 @@ public:
   /// Enable runtime instantiation of value witness strings for generic types
   unsigned EnableLayoutStringValueWitnessesInstantiation : 1;
 
+  unsigned EnableObjectiveCProtocolSymbolicReferences : 1;
+
   /// Instrument code to generate profiling information.
   unsigned GenerateProfile : 1;
 
@@ -518,6 +520,7 @@ public:
         UseTypeLayoutValueHandling(true), ForceStructTypeLayouts(false),
         EnableLayoutStringValueWitnesses(false),
         EnableLayoutStringValueWitnessesInstantiation(false),
+        EnableObjectiveCProtocolSymbolicReferences(false),
         GenerateProfile(false), EnableDynamicReplacementChaining(false),
         DisableDebuggerShadowCopies(false),
         DisableConcreteTypeMetadataMangledNameAccessors(false),

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -371,5 +371,8 @@ NODE(OpaqueReturnTypeParent)
 // Added in Swift 5.9 + 1
 NODE(AsyncRemoved)
 
+// Added in Swift 5.TBD
+NODE(ObjectiveCProtocolSymbolicReference)
+
 #undef CONTEXT_NODE
 #undef NODE

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -383,6 +383,8 @@ enum class SymbolicReferenceKind : uint8_t {
   UniqueExtendedExistentialTypeShape,
   /// A symbolic reference to a non-unique extended existential type shape.
   NonUniqueExtendedExistentialTypeShape,
+  /// A symbolic reference to a objective C protocol ref.
+  ObjectiveCProtocol,
 };
 
 using SymbolicReferenceResolver_t = NodePointer (SymbolicReferenceKind,

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -754,6 +754,7 @@ protected:
     case NodeKind::ConstrainedExistentialSelf:
       return Builder.createGenericTypeParameterType(/*depth*/ 0, /*index*/ 0);
 
+    case NodeKind::ObjectiveCProtocolSymbolicReference:
     case NodeKind::Protocol:
     case NodeKind::ProtocolSymbolicReference: {
       if (auto Proto = decodeMangledProtocolType(Node, depth + 1)) {
@@ -1574,8 +1575,9 @@ private:
     if (node->getKind() == NodeKind::Type)
       return decodeMangledProtocolType(node->getChild(0), depth + 1);
 
-    if ((node->getNumChildren() < 2 || node->getKind() != NodeKind::Protocol)
-        && node->getKind() != NodeKind::ProtocolSymbolicReference)
+    if ((node->getNumChildren() < 2 || node->getKind() != NodeKind::Protocol) &&
+        node->getKind() != NodeKind::ProtocolSymbolicReference &&
+        node->getKind() != NodeKind::ObjectiveCProtocolSymbolicReference)
       return BuiltProtocolDecl();
 
 #if SWIFT_OBJC_INTEROP

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1233,6 +1233,13 @@ def disable_new_llvm_pass_manager :
   Flag<["-"], "disable-new-llvm-pass-manager">,
   HelpText<"Disable the new llvm pass manager">;
 
+def enable_objective_c_protocol_symbolic_references :
+  Flag<["-"], "enable-objective-c-protocol-symbolic-references">,
+  HelpText<"Enable objective-c protocol symbolic references">;
+def disable_objective_c_protocol_symbolic_references :
+  Flag<["-"], "disable-objective-c-protocol-symbolic-references">,
+  HelpText<"Disable objective-c protocol symbolic references">;
+
 def disable_emit_generic_class_ro_t_list :
   Flag<["-"], "disable-emit-generic-class-ro_t-list">,
   HelpText<"Disable emission of a section with references to class_ro_t of "

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -512,6 +512,33 @@ public:
                           Node::Kind::NonUniqueExtendedExistentialTypeShapeSymbolicReference,
                           resolved.getResolvedAddress().getAddressData());
       }
+      case Demangle::SymbolicReferenceKind::ObjectiveCProtocol: {
+        // 'resolved' points to a struct of two relative addresses.
+        // The second entry is a relative address to the mangled protocol
+        // without symbolic references.
+        auto addr =
+            resolved.getResolvedAddress().getAddressData() + sizeof(int32_t);
+        int32_t offset;
+        Reader->readInteger(RemoteAddress(addr), &offset);
+        auto addrOfTypeRef = addr + offset;
+        resolved = Reader->getSymbol(RemoteAddress(addrOfTypeRef));
+
+        // Dig out the protocol from the protocol list.
+        auto protocolList = readMangledName(resolved.getResolvedAddress(),
+                                            MangledNameKind::Type, dem);
+        assert(protocolList->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getKind() == Node::Kind::Protocol);
+        auto protocol = protocolList->getFirstChild()
+                            ->getFirstChild()
+                            ->getFirstChild()
+                            ->getFirstChild();
+        auto protocolType = dem.createNode(Node::Kind::Type);
+        protocolType->addChild(protocol, dem);
+        return protocolType;
+      }
       }
 
       return nullptr;

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -585,6 +585,10 @@ ASTContext::getInitRawStructMetadataAvailability() {
   return getSwiftFutureAvailability();
 }
 
+AvailabilityContext ASTContext::getObjCSymbolicReferencesAvailability() {
+  return getSwiftFutureAvailability();
+}
+
 AvailabilityContext ASTContext::getSwift52Availability() {
   auto target = LangOpts.Target;
 

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -626,6 +626,7 @@ private:
     case Node::Kind::NonUniqueExtendedExistentialTypeShapeSymbolicReference:
     case Node::Kind::SymbolicExtendedExistentialType:
     case Node::Kind::HasSymbolQuery:
+    case Node::Kind::ObjectiveCProtocolSymbolicReference:
       return false;
     }
     printer_unreachable("bad node kind");
@@ -3191,6 +3192,10 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     return nullptr;
   case Node::Kind::NonUniqueExtendedExistentialTypeShapeSymbolicReference:
     Printer << "non-unique existential shape symbolic reference 0x";
+    Printer.writeHex(Node->getIndex());
+    return nullptr;
+  case Node::Kind::ObjectiveCProtocolSymbolicReference:
+    Printer << "objective-c protocol symbolic reference 0x";
     Printer.writeHex(Node->getIndex());
     return nullptr;
   case Node::Kind::SymbolicExtendedExistentialType: {

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2877,6 +2877,12 @@ mangleNonUniqueExtendedExistentialTypeShapeSymbolicReference(Node *node,
   return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
 ManglingError
+Remangler::mangleObjectiveCProtocolSymbolicReference(Node *node,
+                                                     unsigned int depth) {
+  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
+}
+
+ManglingError
 Remangler::mangleCanonicalSpecializedGenericMetaclass(Node *node,
                                                       unsigned depth) {
   RETURN_IF_ERROR(mangleSingleChildNode(node, depth + 1)); // type

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -3474,6 +3474,14 @@ ManglingError Remangler::mangleTypeSymbolicReference(Node *node,
       depth + 1);
 }
 
+ManglingError
+Remangler::mangleObjectiveCProtocolSymbolicReference(Node *node,
+                                                     unsigned depth) {
+  return mangle(Resolver(SymbolicReferenceKind::ObjectiveCProtocol,
+                         (const void *)node->getIndex()),
+                depth + 1);
+}
+
 ManglingError Remangler::mangleProtocolSymbolicReference(Node *node,
                                                          unsigned depth) {
   return mangle(
@@ -3710,7 +3718,6 @@ mangleNonUniqueExtendedExistentialTypeShapeSymbolicReference(Node *node,
   // We don't support absolute references in the mangling of these
   return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
-
 } // anonymous namespace
 
 /// The top-level interface to the remangler.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2927,6 +2927,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     return true;
   }
 
+  Opts.EnableObjectiveCProtocolSymbolicReferences =
+    Args.hasFlag(OPT_enable_objective_c_protocol_symbolic_references,
+                 OPT_disable_objective_c_protocol_symbolic_references,
+                 Opts.EnableObjectiveCProtocolSymbolicReferences);
+
   if (const Arg *A = Args.getLastArg(options::OPT_platform_c_calling_convention)) {
     Opts.PlatformCCallingConvention =
       llvm::StringSwitch<llvm::CallingConv::ID>(A->getValue())

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -110,7 +110,7 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
       // TODO: We could assign a symbolic reference discriminator to refer
       // to objc protocol refs.
       if (auto proto = dyn_cast<ProtocolDecl>(type)) {
-        if (proto->isObjC()) {
+        if (proto->isObjC() && !IGM.canUseObjCSymbolicReferences()) {
           return false;
         }
       }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1936,6 +1936,8 @@ bool IRGenModule::shouldPrespecializeGenericMetadata() {
 }
 
 bool IRGenModule::canUseObjCSymbolicReferences() {
+  if (!IRGen.Opts.EnableObjectiveCProtocolSymbolicReferences)
+    return false;
   auto &context = getSwiftModule()->getASTContext();
   auto deploymentAvailability =
       AvailabilityContext::forDeploymentTarget(context);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1935,6 +1935,14 @@ bool IRGenModule::shouldPrespecializeGenericMetadata() {
          canPrespecializeTarget;
 }
 
+bool IRGenModule::canUseObjCSymbolicReferences() {
+  auto &context = getSwiftModule()->getASTContext();
+  auto deploymentAvailability =
+      AvailabilityContext::forDeploymentTarget(context);
+  return deploymentAvailability.isContainedIn(
+      context.getObjCSymbolicReferencesAvailability());
+}
+
 bool IRGenModule::canMakeStaticObjectsReadOnly() {
   // Unconditionally disable this until we can fix the metadata.
   // The trick of using the Empty array metadata for static arrays

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -917,7 +917,9 @@ public:
   bool shouldPrespecializeGenericMetadata();
   
   bool canMakeStaticObjectsReadOnly();
-  
+
+  bool canUseObjCSymbolicReferences();
+
   Size getAtomicBoolSize() const { return AtomicBoolSize; }
   Alignment getAtomicBoolAlignment() const { return AtomicBoolAlign; }
 
@@ -1278,6 +1280,7 @@ private:
   };
 
   llvm::DenseMap<ProtocolDecl*, ObjCProtocolPair> ObjCProtocols;
+  llvm::DenseMap<ProtocolDecl *, llvm::Constant *> ObjCProtocolSymRefs;
   llvm::SmallVector<ProtocolDecl*, 4> LazyObjCProtocolDefinitions;
   llvm::DenseMap<KeyPathPattern*, llvm::GlobalVariable*> KeyPathPatterns;
 
@@ -1301,6 +1304,7 @@ private:
   SuccessorMap<unsigned, llvm::Function*> EmittedFunctionsByOrder;
 
   ObjCProtocolPair getObjCProtocolGlobalVars(ProtocolDecl *proto);
+  llvm::Constant *getObjCProtocolRefSymRefDescriptor(ProtocolDecl *protocol);
   void emitLazyObjCProtocolDefinitions();
   void emitLazyObjCProtocolDefinition(ProtocolDecl *proto);
 

--- a/test/IRGen/objc_protocol_symbolic_reference.swift
+++ b/test/IRGen/objc_protocol_symbolic_reference.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target %target-future-triple -enable-objc-interop -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objective-c-protocol-symbolic-references -target %target-future-triple -enable-objc-interop -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: PTRSIZE=64
 // REQIURES: objc_interop

--- a/test/IRGen/objc_protocol_symbolic_reference.swift
+++ b/test/IRGen/objc_protocol_symbolic_reference.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -target %target-future-triple -enable-objc-interop -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+
+// REQUIRES: PTRSIZE=64
+// REQIURES: objc_interop
+
+@objc protocol P {}
+
+
+func requireMetadata<T>(_ t: T.Type) {}
+
+public func theTest() {
+  requireMetadata(P.self)
+}
+
+// CHECK: @"flat unique 32objc_protocol_symbolic_reference1P_p" = linkonce_odr hidden constant <{ [38 x i8], i8 }> <{ [38 x i8] c"32objc_protocol_symbolic_reference1P_p", i8 0 }>
+
+// CHECK: @"\01l_OBJC_PROTOCOL_SYMREF_$__TtP32objc_protocol_symbolic_reference1P_" = linkonce hidden constant <{ i32, i32 }> <{ i32 {{.*}} @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP32objc_protocol_symbolic_reference1P_" {{.*}} i32 {{.*}} @"flat unique 32objc_protocol_symbolic_reference1P_p"
+
+// CHECK: "symbolic ______p 32objc_protocol_symbolic_reference1PP" = linkonce_odr hidden constant <{ i8, i32, [2 x i8], i8 }> <{ i8 12, i32 {{.*}} @"\01l_OBJC_PROTOCOL_SYMREF_$__TtP32objc_protocol_symbolic_reference1P_"

--- a/test/Interpreter/objc_protocol_symbolic_reference.swift
+++ b/test/Interpreter/objc_protocol_symbolic_reference.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift  -target %target-future-triple %s -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Foundation
+
+@objc protocol TheObjCProtocol {}
+
+
+func printMetadata<T>(_ t: T.Type) {
+    print(t)
+}
+
+public func theTest() {
+  printMetadata(TheObjCProtocol.self)
+  print(ObjectIdentifier(NSObjectProtocol.self as AnyObject) == ObjectIdentifier(objc_getProtocol("NSObject")!))
+  assert(ObjectIdentifier(NSObjectProtocol.self as AnyObject) == ObjectIdentifier(objc_getProtocol("NSObject")!))
+}
+
+theTest()
+
+// CHECK: TheObjCProtocol
+// CHECK: true

--- a/test/Interpreter/objc_protocol_symbolic_reference.swift
+++ b/test/Interpreter/objc_protocol_symbolic_reference.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -target %target-future-triple %s -module-name main -o %t/main
+// RUN: %target-build-swift -Xfrontend -enable-objective-c-protocol-symbolic-references -target %target-future-triple %s -module-name main -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -5,7 +5,7 @@
 // Test objective c symbolic references
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-future-triple %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -Xfrontend -enable-objective-c-protocol-symbolic-references -target %target-future-triple %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 
 // REQUIRES: objc_interop

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -1,6 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+
+// Test objective c symbolic references
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-future-triple %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+
 // REQUIRES: objc_interop
 
 // Disable asan builds until we build swift-reflection-dump and the reflection library with the same compile: rdar://problem/30406870


### PR DESCRIPTION
Using symbolic references instead of a text based mangling avoids the expensive type descriptor scan when objective c protocols are requested.

rdar://111536582
