### PR TITLE
5.10: [OSSALifetimeCompletion] Handle unavailable blocks in dead-end regions.

### DIFF
--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -87,7 +87,7 @@ public:
 
   static void visitUnreachableLifetimeEnds(
       SILValue value, const SSAPrunedLiveness &liveness,
-      llvm::function_ref<void(UnreachableInst *)> visit);
+      llvm::function_ref<void(SILInstruction *)> visit);
 
 protected:
   bool analyzeAndUpdateLifetime(SILValue value, bool forceBoundaryCompletion);

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -518,13 +518,13 @@ public:
 
 #ifndef NDEBUG
   /// Print the ID of the block, bbN.
-  void dumpID() const;
+  void dumpID(bool newline = true) const;
 
   /// Print the ID of the block with \p OS, bbN.
-  void printID(llvm::raw_ostream &OS) const;
+  void printID(llvm::raw_ostream &OS, bool newline = true) const;
 
   /// Print the ID of the block with \p Ctx, bbN.
-  void printID(SILPrintContext &Ctx) const;
+  void printID(SILPrintContext &Ctx, bool newline = true) const;
 #endif
 
   /// getSublistAccess() - returns pointer to member of instruction list

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -136,6 +136,10 @@ class CanonicalOSSAConsumeInfo final {
   /// Map blocks on the lifetime boundary to the last consuming instruction.
   llvm::SmallDenseMap<SILBasicBlock *, SILInstruction *, 4> finalBlockConsumes;
 
+  /// The instructions on the availability boundary of the dead-end region where
+  /// this value is not consumed.
+  SmallPtrSet<SILInstruction *, 4> unreachableLifetimeEnds;
+
 public:
   void clear() { finalBlockConsumes.clear(); }
 
@@ -159,6 +163,14 @@ public:
       return true;
     }
     return false;
+  }
+
+  void recordUnreachableLifetimeEnd(SILInstruction *inst) {
+    unreachableLifetimeEnds.insert(inst);
+  }
+
+  bool isUnreachableLifetimeEnd(SILInstruction *inst) {
+    return unreachableLifetimeEnds.contains(inst);
   }
 
   CanonicalOSSAConsumeInfo() {}
@@ -408,6 +420,10 @@ private:
   void recordConsumingUse(Operand *use) { recordConsumingUser(use->getUser()); }
   void recordConsumingUser(SILInstruction *user) {
     consumingBlocks.insert(user->getParent());
+  }
+  void recordUnreachableLifetimeEnd(SILInstruction *user) {
+    recordConsumingUser(user);
+    consumes.recordUnreachableLifetimeEnd(user);
   }
   bool computeCanonicalLiveness();
 

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -247,9 +247,12 @@ private:
   SILValue currentDef;
 
   /// Original points in the CFG where the current value's lifetime is consumed
-  /// or destroyed. For guaranteed values it remains empty. A backward walk from
-  /// these blocks must discover all uses on paths that lead to a return or
-  /// throw.
+  /// or destroyed.  Each block either contains a consuming instruction (e.g.
+  /// `destroy_value`) or is on the availability boundary of the value in a
+  /// dead-end region (e.g. `unreachable`).
+  ///
+  /// For guaranteed values it remains empty. A backward walk from these blocks
+  /// must discover all uses on paths that lead to a return or throw.
   ///
   /// These blocks are not necessarily in the pruned live blocks since
   /// pruned liveness does not consider destroy_values.
@@ -418,6 +421,11 @@ private:
   void recordDebugValue(DebugValueInst *dvi) { debugValues.insert(dvi); }
 
   void recordConsumingUse(Operand *use) { recordConsumingUser(use->getUser()); }
+  /// Record that the value is consumed at `user`.
+  ///
+  /// Either `user` is a consuming use (e.g. `destroy_value`) or it is the
+  /// terminator of a block on the availability boundary of the value in a
+  /// dead-end region (e.g. `unreachable`).
   void recordConsumingUser(SILInstruction *user) {
     consumingBlocks.insert(user->getParent());
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -853,8 +853,11 @@ public:
   }
 
 #ifndef NDEBUG
-  void printID(const SILBasicBlock *BB) {
-    *this << Ctx.getID(BB) << "\n";
+  void printID(const SILBasicBlock *BB, bool newline) {
+    *this << Ctx.getID(BB);
+    if (newline) {
+      *this << "\n";
+    }
   }
 #endif
 
@@ -3108,17 +3111,17 @@ void SILBasicBlock::print(SILPrintContext &Ctx) const {
 }
 
 #ifndef NDEBUG
-void SILBasicBlock::dumpID() const {
-  printID(llvm::errs());
+void SILBasicBlock::dumpID(bool newline) const {
+  printID(llvm::errs(), newline);
 }
 
-void SILBasicBlock::printID(llvm::raw_ostream &OS) const {
+void SILBasicBlock::printID(llvm::raw_ostream &OS, bool newline) const {
   SILPrintContext Ctx(OS);
-  printID(Ctx);
+  printID(Ctx, newline);
 }
 
-void SILBasicBlock::printID(SILPrintContext &Ctx) const {
-  SILPrinter(Ctx).printID(this);
+void SILBasicBlock::printID(SILPrintContext &Ctx, bool newline) const {
+  SILPrinter(Ctx).printID(this, newline);
 }
 #endif
 

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -1858,8 +1858,7 @@ right:
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         cond_br undef, [[BB1:bb[0-9]+]], [[BB4:bb[0-9]+]]
 // CHECK:       [[BB1]]:
-// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
-// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = move_value [lexical] [[COPY]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         cond_br undef, [[BB2:bb[0-9]+]], [[BB3:bb[0-9]+]]
 // CHECK:       [[BB2]]:
 // CHECK:         destroy_value [[LIFETIME_OWNED]]

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -212,3 +212,189 @@ bb0(%0 : @guaranteed $C):
   return %12 : $()
 }
 
+// Insert destroy on availability boundary of `value` within the region after
+// the non-lifetime-ending boundary of `value`.  Namely, in to_die_11.
+// CHECK-LABEL: sil [ossa] @availability_boundary_1 : {{.*}} {
+// CHECK:         [[VALUE:%[^,]+]] = move_value [lexical]
+// CHECK:         br [[CONDITION_1:bb[0-9]+]]
+// CHECK:       [[CONDITION_1]]:
+// CHECK:         cond_br undef, [[CONDITION_2:bb[0-9]+]], [[TO_DIE_1:bb[0-9]+]]
+// CHECK:       [[CONDITION_2]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[TO_DIE_2:bb[0-9]+]]
+// CHECK:       [[TO_DIE_1]]:
+// CHECK:         br [[TO_DIE_11:bb[0-9]+]]
+// CHECK:       [[TO_DIE_11]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         br [[DIE:bb[0-9]+]]
+// CHECK:       [[TO_DIE_2]]:
+// CHECK:         br [[DIE]]
+// CHECK:       [[DIE]]:
+// CHECK:         unreachable
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'availability_boundary_1'
+sil [ossa] @availability_boundary_1 : $@convention(thin) () -> () {
+entry:
+  %value = apply undef() : $@convention(thin) () -> @owned C
+  %lexical = move_value [lexical] %value : $C // required (for lexicality)
+  debug_value [trace] %lexical : $C
+  test_specification "ossa-lifetime-completion @trace[0]"
+  br condition_1
+
+condition_1:
+  cond_br undef, condition_2, to_die_1
+
+condition_2:
+  destroy_value %lexical : $C
+  cond_br undef, exit, to_die_2
+
+to_die_1:
+  br to_die_11
+
+to_die_11:
+  // End lifetime here.
+  br die
+
+to_die_2:
+  br die
+
+die:
+  unreachable
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @availability_boundary_2_after_loop : {{.*}} {
+// CHECK:         [[REGISTER_1:%[^,]+]] = move_value [lexical]
+// CHECK:         br [[CONDITION_1:bb[0-9]+]]
+// CHECK:       [[CONDITION_1]]:
+// CHECK:         cond_br undef, [[CONDITION_2:bb[0-9]+]], [[PREHEADER:bb[0-9]+]]
+// CHECK:       [[CONDITION_2]]:
+// CHECK:         destroy_value [[REGISTER_1]]
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[TO_DIE_2:bb[0-9]+]]
+// CHECK:       [[PREHEADER]]:
+// CHECK:         br [[HEADER:bb[0-9]+]]
+// CHECK:       [[HEADER]]:
+// CHECK:         br [[LATCH:bb[0-9]+]]
+// CHECK:       [[LATCH]]:
+// CHECK:         cond_br undef, [[BACKEDGE:bb[0-9]+]], [[TO_DIE_1:bb[0-9]+]]
+// CHECK:       [[BACKEDGE]]:
+// CHECK:         br [[HEADER]]
+// CHECK:       [[TO_DIE_1]]:
+// CHECK:         destroy_value [[REGISTER_1]]
+// CHECK:         br [[DIE:bb[0-9]+]]
+// CHECK:       [[TO_DIE_2]]:
+// CHECK:         br [[DIE]]
+// CHECK:       [[DIE]]:
+// CHECK:         unreachable
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'availability_boundary_2_after_loop'
+sil [ossa] @availability_boundary_2_after_loop : $@convention(thin) () -> () {
+entry:
+  %value = apply undef() : $@convention(thin) () -> @owned C
+  %lexical = move_value [lexical] %value : $C // required (for lexicality)
+  debug_value [trace] %lexical : $C
+  test_specification "ossa-lifetime-completion @trace[0]"
+  br condition_1
+
+condition_1:
+  cond_br undef, condition_2, preheader
+
+condition_2:
+  destroy_value %lexical : $C
+  cond_br undef, exit, to_die_2
+
+preheader:
+  br header
+
+header:
+  br latch
+
+latch:
+  cond_br undef, backedge, to_die_1
+
+backedge:
+  br header
+
+to_die_1:
+  br die
+
+to_die_2:
+  br die
+
+die:
+  unreachable
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @availability_boundary_3_after_loop : {{.*}} {
+// CHECK:         [[VALUE:%[^,]+]] = move_value [lexical]
+// CHECK:         br [[CONDITION_1:bb[0-9]+]]
+// CHECK:       [[CONDITION_1]]:
+// CHECK:         cond_br undef, [[CONDITION_2:bb[0-9]+]], [[PREHEADER:bb[0-9]+]]
+// CHECK:       [[CONDITION_2]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[TO_BODY:bb[0-9]+]]
+// CHECK:       [[TO_BODY]]:
+// CHECK:         br [[BODY:bb[0-9]+]]
+// CHECK:       [[PREHEADER]]:
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         br [[HEADER:bb[0-9]+]]
+// CHECK:       [[HEADER]]:
+// CHECK:         br [[BODY]]
+// CHECK:       [[BODY]]:
+// CHECK:         br [[LATCH:bb[0-9]+]]
+// CHECK:       [[LATCH]]:
+// CHECK:         cond_br undef, [[BACKEDGE:bb[0-9]+]], [[DIE:bb[0-9]+]]
+// CHECK:       [[BACKEDGE]]:
+// CHECK:         br [[HEADER]]
+// CHECK:       [[DIE]]:
+// CHECK:         unreachable
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'availability_boundary_3_after_loop'
+sil [ossa] @availability_boundary_3_after_loop : $@convention(thin) () -> () {
+entry:
+  %value = apply undef() : $@convention(thin) () -> @owned C
+  %lexical = move_value [lexical] %value : $C // required (for lexicality)
+  debug_value [trace] %lexical : $C
+  test_specification "ossa-lifetime-completion @trace[0]"
+  br condition_1
+
+condition_1:
+  cond_br undef, condition_2, preheader
+
+condition_2:
+  destroy_value %lexical : $C
+  cond_br undef, exit, to_body2
+
+to_body2:
+  br body
+
+preheader:
+  // End lifetime here.
+  br header
+
+header:
+  br body
+
+body:
+  br latch
+
+latch:
+  cond_br undef, backedge, die
+
+backedge:
+  br header
+
+die:
+  unreachable
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
**Description:** Fix overconsume on unreachable-terminated paths by handling conditional availability of values in dead-end regions in lifetime completion.

The function `OSSALifetimeCompletion::visitUnreachableLifetimeEnds` is used (1) to complete OSSA lifetimes and--while OSSA lifetime completion remains disabled--(2) to canonicalize lexical OSSA lifetimes.  The function visits the instructions at which the lifetime implicitly ends--implicitly because with incomplete lifetimes, it's valid for a value not to be destroyed on paths that terminate in `unreachable`.  

Previously, its determination for those ends was incorrect in the face of unavailable blocks in dead-end regions.  Specifically, it simply walked forward from the non-lifetime-ending boundary until finding `unreachable` instructions.  (Such `unreachable` instructions are guaranteed to exist because the lifetime is "partially complete" by precondition.)  That walk alone is insufficient, however:  It's possible that the value isn't available at those `unreachable` instructions.  For example, if a value isn't destroyed on one path to the unreachable but is destroyed on another path to it, then the value isn't available at the unreachable.  Inserting a destroy at the `unreachable` would result in an overconsume on the path on which the value was destroyed.

Here, the determination is fixed by computing availability within the region discovered by that initial walk.  This is done via a forward iterative dataflow within the region, propagating availability.  The visited instructions are then the terminators of the last blocks in the region in which the value is available.  In the preceeding example, rather than visiting the `unreachable` instruction, the terminator of the last block on the path to it where the value has not yet been destroyed would be visited.

**Risk:** Low.  The fix uses a well-known dataflow implementation to propagate availability.

**Scope:** Narrow.  Only affects lifetimes in dead end blocks.

**Original PR:** https://github.com/apple/swift/pull/68975

**Reviewed By:** Andrew Trick ( @atrick )

**Testing:** Added tests.

**Resolves:** rdar://116255254
