### PR TITLE
Revert "test: un-XFAIL on Windows for rebranch"

### DIFF
--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,4 +1,4 @@
-// XFAIL: OS=linux-gnu, OS=openbsd, OS=linux-android, OS=linux-androideabi
+// XFAIL: OS=linux-gnu, OS=openbsd, OS=windows-msvc, OS=linux-android, OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/only-skip-once/* %t


### PR DESCRIPTION
This reverts commit https://github.com/apple/swift/commit/ed9e4dbc197ee918e339b278d3a63f341fffa84a.

This test has started failing again, as it was before September, so I'm
going to revert the removal of the xfail. It's testing the old driver
anyway, which folks shouldn't be using.