### PR TITLE
[wasm][stdlib] Don't include <thread> with swift-threading-package=none

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -58,7 +58,9 @@
 #endif // SWIFT_STDLIB_HAS_LOCALE
 
 #include <limits>
+#ifndef SWIFT_THREADING_NONE
 #include <thread>
+#endif
 
 #if defined(__ANDROID__)
 #include <android/api-level.h>


### PR DESCRIPTION
We can't assume libcxx to be built with `LIBCXX_ENABLE_THREADS=YES` with none threading package, so `<thread>` is not available with such configuration. In this file, `<thread>` API is only used in `_swift_stdlib_getHardwareConcurrency` and it's guarded by `SWIFT_THREADING_NONE`, so it's safe to guard out the include.

https://github.com/apple/swift/blob/e01f23496a7ab04232d23f5143d0037402182f6f/stdlib/public/stubs/Stubs.cpp#L484-L490

Resolves part of rdar://116552886