### PR TITLE
[SwiftCompilerSources] Simplified test registration.

### DIFF
--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1527,6 +1527,10 @@ struct Arguments;
 class FunctionTest;
 } // namespace swift::test
 
+struct BridgedFunctionTest {
+  swift::test::FunctionTest *_Nonnull test;
+};
+
 struct BridgedTestArguments {
   swift::test::Arguments *_Nonnull arguments;
 
@@ -1562,10 +1566,15 @@ struct BridgedTestContext {
   swift::SwiftPassInvocation *_Nonnull invocation;
 };
 
-typedef void (*_Nonnull BridgedFunctionTestThunk)(BridgedFunction,
-                                                  BridgedTestArguments,
-                                                  BridgedTestContext);
-void registerFunctionTest(llvm::StringRef, BridgedFunctionTestThunk thunk);
+using SwiftNativeFunctionTestThunk = void (*_Nonnull)(void *_Nonnull,
+                                                      BridgedFunction,
+                                                      BridgedTestArguments,
+                                                      BridgedTestContext);
+
+void registerFunctionTestThunk(SwiftNativeFunctionTestThunk);
+
+void registerFunctionTest(llvm::StringRef,
+                          void *_Nonnull nativeSwiftInvocation);
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/include/swift/SIL/Test.h
+++ b/include/swift/SIL/Test.h
@@ -130,12 +130,11 @@ public:
   ///                    values such as the results of analyses
   using Invocation = void (*)(SILFunction &, Arguments &, FunctionTest &);
 
-  using InvocationWithContext = void (*)(SILFunction &, Arguments &,
-                                         FunctionTest &, void *);
+  using NativeSwiftInvocation = void *;
 
 private:
   /// The lambda to be run.
-  TaggedUnion<Invocation, std::pair<InvocationWithContext, void *>> invocation;
+  TaggedUnion<Invocation, NativeSwiftInvocation> invocation;
 
 public:
   /// Creates a test that will run \p invocation and stores it in the global
@@ -151,7 +150,7 @@ public:
   ///     } // end namespace swift::test
   FunctionTest(StringRef name, Invocation invocation);
 
-  FunctionTest(StringRef name, void *context, InvocationWithContext invocation);
+  FunctionTest(StringRef name, NativeSwiftInvocation invocation);
 
   /// Computes and returns the function's dominance tree.
   DominanceInfo *getDominanceInfo();

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -133,14 +133,8 @@ void registerBridgedClass(StringRef className, SwiftMetatype metatype) {
 //                                Test
 //===----------------------------------------------------------------------===//
 
-void registerFunctionTest(llvm::StringRef name,
-                          BridgedFunctionTestThunk thunk) {
-  new swift::test::FunctionTest(
-      name, reinterpret_cast<void *>(thunk),
-      [](auto &function, auto &args, auto &test, void *ctx) {
-        auto thunk = reinterpret_cast<BridgedFunctionTestThunk>(ctx);
-        thunk({&function}, {&args}, test.getContext());
-      });
+void registerFunctionTest(llvm::StringRef name, void *nativeSwiftInvocation) {
+  new swift::test::FunctionTest(name, nativeSwiftInvocation);
 }
 
 bool BridgedTestArguments::hasUntaken() const {


### PR DESCRIPTION
At the cost of adding an unsafe bitcast implementation detail, simplified the code involved to register a new FunctionTest when adding one.

Also simplifies how Swift native `FunctionTest`s are registered with the C++ registry.

Now, the to-be-executed thin closure for native Swift `FunctionTest`s is stored within the swift::test::FunctionTest instance corresponding to it.  Because its type isn't representable in C++, `void *` is used instead.  When the FunctionTest is invoked, a global thunk is called which takes the actual test function and bridged versions of the arguments. That thunk unwraps the arguments, casts the stored function to the appropriate type, and invokes it.

Thanks to Andrew Trick for the idea.
