### PR TITLE
[WASILibc] Exclude semaphore APIs from overlay

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -383,7 +383,7 @@ internal var _ignore = _UnsupportedPlatformError()
 // semaphore.h
 //===----------------------------------------------------------------------===//
 
-#if !os(Windows) 
+#if !os(Windows) && !os(WASI)
 
 #if os(OpenBSD)
 public typealias Semaphore = UnsafeMutablePointer<sem_t?>

--- a/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
@@ -76,7 +76,7 @@ static inline void _swift_stdlib_setErrno(int value) {
 }
 
 // Semaphores <semaphore.h>
-#if !defined(_WIN32) || defined(__CYGWIN__)
+#if (!defined(_WIN32) && !defined(__wasi__)) || defined(__CYGWIN__)
 static inline sem_t *_stdlib_sem_open2(const char *name, int oflag) {
   return sem_open(name, oflag);
 }


### PR DESCRIPTION
Exclude semaphore APIs from WASILibc overlay since wasi-libc does not support those APIs that imply thread features