### PR TITLE
[SwiftCompilerSources] Moved Test into Optimizer.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -20,7 +20,7 @@ public func initializeSwiftModules() {
   registerSwiftAnalyses()
   registerSwiftPasses()
   initializeSwiftParseModules()
-  registerSILTests()
+  registerOptimizerTests()
 }
 
 private func registerPass(

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -14,4 +14,5 @@ swift_compiler_sources(Optimizer
   AccessUtils.swift
   SSAUpdater.swift
   StaticInitCloner.swift
+  Test.swift
 )

--- a/SwiftCompilerSources/Sources/SIL/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/SIL/CMakeLists.txt
@@ -24,7 +24,6 @@ add_swift_compiler_module(SIL
     Registration.swift
     SmallProjectionPath.swift
     SubstitutionMap.swift
-    Test.swift
     Type.swift
     Utils.swift
     Value.swift

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -16,7 +16,7 @@ import SILBridging
 public struct Operand : CustomStringConvertible, NoReflectionChildren {
   fileprivate let bridged: BridgedOperand
 
-  init(bridged: BridgedOperand) {
+  public init(bridged: BridgedOperand) {
     self.bridged = bridged
   }
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1657,14 +1657,13 @@ struct BridgedTestArguments {
   BridgedFunction takeFunction() const;
 };
 
-struct BridgedTestContext {
+struct BridgedSwiftPassInvocation {
   swift::SwiftPassInvocation *_Nonnull invocation;
 };
 
-using SwiftNativeFunctionTestThunk = void (*_Nonnull)(void *_Nonnull,
-                                                      BridgedFunction,
-                                                      BridgedTestArguments,
-                                                      BridgedTestContext);
+using SwiftNativeFunctionTestThunk =
+    void (*_Nonnull)(void *_Nonnull, BridgedFunction, BridgedTestArguments,
+                     BridgedSwiftPassInvocation);
 
 void registerFunctionTestThunk(SwiftNativeFunctionTestThunk);
 

--- a/include/swift/SIL/Test.h
+++ b/include/swift/SIL/Test.h
@@ -167,7 +167,7 @@ public:
   template <typename Analysis, typename Transform = SILFunctionTransform>
   Analysis *getAnalysis();
 
-  BridgedTestContext getContext();
+  SwiftPassInvocation *getInvocation();
 
 //===----------------------------------------------------------------------===//
 //=== MARK: Implementation Details                                         ===

--- a/lib/SIL/Utils/Test.cpp
+++ b/lib/SIL/Utils/Test.cpp
@@ -99,7 +99,7 @@ void FunctionTest::run(SILFunction &function, Arguments &arguments,
   } else {
     auto *fn = invocation.get<NativeSwiftInvocation>();
     Registry::get().getFunctionTestThunk()(fn, {&function}, {&arguments},
-                                           getContext());
+                                           {getInvocation()});
   }
   this->pass = nullptr;
   this->function = nullptr;
@@ -114,6 +114,6 @@ SILPassManager *FunctionTest::getPassManager() {
   return dependencies->getPassManager();
 }
 
-BridgedTestContext FunctionTest::getContext() {
-  return BridgedTestContext{dependencies->getInvocation()};
+SwiftPassInvocation *FunctionTest::getInvocation() {
+  return dependencies->getInvocation();
 }


### PR DESCRIPTION
Based on https://github.com/apple/swift/pull/69007 .

In order to change the type of the context argument to FunctionPassContext.  In the fullness of time could be sunk into the SIL module.
