### PR TITLE
[embedded] Fix IR verification crash when using arrays of zero-sized structs

### DIFF
--- a/test/embedded/array-zero-size-struct.swift
+++ b/test/embedded/array-zero-size-struct.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public struct MyStruct {
+}
+
+public func main() {
+  var arr: [MyStruct] = []
+  var arr2: [MyStruct] = [.init()]
+  var arr3 = arr2
+  arr3.append(MyStruct())
+}
+
+public func copy(_ a: inout [MyStruct]) {
+  var a = a
+}
+
+// CHECK: define {{.*}}@"$s4mainAAyyF"
+// CHECK: define {{.*}}@"$s4main4copyyySayAA8MyStructVGzF"


### PR DESCRIPTION
The embedded Swift custom ("no runtime calls") IRGen for array builtins today doesn't handle zero-sized structs, when using an array of zero-sized structs, LLVM IR verifier complains:
```
GEP into unsized type!
  %8 = getelementptr inbounds %T4main8MyStructV, ptr %1, i64 %6
```
Let's fix that and handle zero-sized structs in GenBuiltin (we don't really need to emit the loop at all for them).