### PR TITLE
[cxx-interop] ClangDirectLookup should not require the C++ struct to be already imported

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -33,22 +33,21 @@ class EnumDecl;
 
 /// The input type for a clang direct lookup request.
 struct ClangDirectLookupDescriptor final {
-  Decl *decl;
+  const ASTContext &ctx;
   const clang::Decl *clangDecl;
   DeclName name;
 
-  ClangDirectLookupDescriptor(Decl *decl, const clang::Decl *clangDecl,
-                              DeclName name)
-      : decl(decl), clangDecl(clangDecl), name(name) {}
+  ClangDirectLookupDescriptor(const ASTContext &ctx,
+                              const clang::Decl *clangDecl, DeclName name)
+      : ctx(ctx), clangDecl(clangDecl), name(name) {}
 
   friend llvm::hash_code hash_value(const ClangDirectLookupDescriptor &desc) {
-    return llvm::hash_combine(desc.name, desc.decl, desc.clangDecl);
+    return llvm::hash_combine(desc.name, desc.clangDecl);
   }
 
   friend bool operator==(const ClangDirectLookupDescriptor &lhs,
                          const ClangDirectLookupDescriptor &rhs) {
-    return lhs.name == rhs.name && lhs.decl == rhs.decl &&
-           lhs.clangDecl == rhs.clangDecl;
+    return lhs.name == rhs.name && lhs.clangDecl == rhs.clangDecl;
   }
 
   friend bool operator!=(const ClangDirectLookupDescriptor &lhs,

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -31,6 +31,8 @@ class Decl;
 class DeclName;
 class EnumDecl;
 
+void simple_display(llvm::raw_ostream &out, const clang::Decl* decl);
+
 /// The input type for a clang direct lookup request.
 struct ClangDirectLookupDescriptor final {
   const ASTContext &ctx;
@@ -131,22 +133,23 @@ private:
 
 /// The input type for a record member lookup request.
 struct ClangRecordMemberLookupDescriptor final {
-  NominalTypeDecl *recordDecl;
+  ASTContext &ctx;
+  const clang::RecordDecl *clangDecl;
   DeclName name;
 
-  ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name)
-      : recordDecl(recordDecl), name(name) {
-    assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
-  }
+  ClangRecordMemberLookupDescriptor(ASTContext &ctx,
+                                    const clang::RecordDecl *clangDecl,
+                                    DeclName name)
+      : ctx(ctx), clangDecl(clangDecl), name(name) {}
 
   friend llvm::hash_code
   hash_value(const ClangRecordMemberLookupDescriptor &desc) {
-    return llvm::hash_combine(desc.name, desc.recordDecl);
+    return llvm::hash_combine(desc.name, desc.clangDecl);
   }
 
   friend bool operator==(const ClangRecordMemberLookupDescriptor &lhs,
                          const ClangRecordMemberLookupDescriptor &rhs) {
-    return lhs.name == rhs.name && lhs.recordDecl == rhs.recordDecl;
+    return lhs.name == rhs.name && lhs.clangDecl == rhs.clangDecl;
   }
 
   friend bool operator!=(const ClangRecordMemberLookupDescriptor &lhs,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2426,7 +2426,7 @@ static void addNamespaceMembers(Decl *decl,
 
       auto lookupAndAddMembers = [&](DeclName name) {
         auto allResults = evaluateOrDefault(
-            ctx.evaluator, ClangDirectLookupRequest({decl, redecl, name}), {});
+            ctx.evaluator, ClangDirectLookupRequest({ctx, redecl, name}), {});
 
         for (auto found : allResults) {
           auto clangMember = found.get<clang::NamedDecl *>();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2039,10 +2039,10 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
         }
         return allFound;
       }
-    } else if (isa_and_nonnull<clang::RecordDecl>(decl->getClangDecl())) {
+    } else if (auto clangRecordDecl =
+                   dyn_cast_or_null<clang::RecordDecl>(decl->getClangDecl())) {
       auto allFound = evaluateOrDefault(
-          ctx.evaluator,
-          ClangRecordMemberLookup({cast<NominalTypeDecl>(decl), name}), {});
+          evaluator, ClangRecordMemberLookup({ctx, clangRecordDecl, name}), {});
       // Add all the members we found, later we'll combine these with the
       // existing members.
       for (auto found : allFound)

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -452,12 +452,16 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << "Looking up ";
   simple_display(out, desc.name);
   out << " in ";
-  simple_display(out, desc.decl);
+  if (auto namedDecl = dyn_cast<clang::NamedDecl>(desc.clangDecl)) {
+    namedDecl->printQualifiedName(out);
+  } else {
+    out << "<unnamed clang decl>";
+  }
 }
 
 SourceLoc
 swift::extractNearestSourceLoc(const ClangDirectLookupDescriptor &desc) {
-  return extractNearestSourceLoc(desc.decl);
+  return SourceLoc();
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -447,16 +447,20 @@ void UnqualifiedLookupRequest::writeDependencySink(
 // ClangDirectLookupRequest computation.
 //----------------------------------------------------------------------------//
 
+void swift::simple_display(llvm::raw_ostream &out, const clang::Decl *decl) {
+  if (auto namedDecl = dyn_cast<clang::NamedDecl>(decl)) {
+    namedDecl->printQualifiedName(out);
+  } else {
+    out << "<unnamed clang decl>";
+  }
+}
+
 void swift::simple_display(llvm::raw_ostream &out,
                            const ClangDirectLookupDescriptor &desc) {
   out << "Looking up ";
   simple_display(out, desc.name);
   out << " in ";
-  if (auto namedDecl = dyn_cast<clang::NamedDecl>(desc.clangDecl)) {
-    namedDecl->printQualifiedName(out);
-  } else {
-    out << "<unnamed clang decl>";
-  }
+  simple_display(out, desc.clangDecl);
 }
 
 SourceLoc
@@ -490,12 +494,12 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << "Looking up ";
   simple_display(out, desc.name);
   out << " in ";
-  simple_display(out, desc.recordDecl);
+  simple_display(out, desc.clangDecl);
 }
 
 SourceLoc
 swift::extractNearestSourceLoc(const ClangRecordMemberLookupDescriptor &desc) {
-  return extractNearestSourceLoc(desc.recordDecl);
+  return SourceLoc();
 }
 
 //----------------------------------------------------------------------------//

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -11,6 +11,11 @@ module Polymorphism {
   requires cplusplus
 }
 
+module ReferenceToDerived {
+  header "reference-to-derived.h"
+  requires cplusplus
+}
+
 module SubTypes {
   header "sub-types.h"
 }

--- a/test/Interop/Cxx/class/inheritance/Inputs/reference-to-derived.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/reference-to-derived.h
@@ -1,0 +1,13 @@
+class E;
+
+class C {
+public:
+  E *getE() const;
+};
+
+class D : public C {};
+
+class E : public D {
+public:
+  D *getD() const;
+};

--- a/test/Interop/Cxx/class/inheritance/reference-to-derived-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/reference-to-derived-irgen.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -validate-tbd-against-ir=none
+
+import ReferenceToDerived
+
+func foo(_ x: D) {}


### PR DESCRIPTION
Doing a name lookup into a C++ struct currently causes all of its base structs to be eagerly imported into Swift. This causes degraded performance and triggers "circular reference" errors when a base struct refers to a derived struct (e.g. has a method that returns a pointer to a derived struct).

rdar://116426238