### PR TITLE
[test][IRGen] Split out objc-interop specific part in abitypes.swift

### DIFF
--- a/test/IRGen/Inputs/abi/CGadget.h
+++ b/test/IRGen/Inputs/abi/CGadget.h
@@ -1,0 +1,52 @@
+struct MyRect {
+  float x;
+  float y;
+  float width;
+  float height;
+};
+
+struct Trio {
+  double i;
+  double j;
+  double k;
+};
+
+struct IntPair {
+  int a;
+  int b;
+};
+
+struct NestedInts {
+  struct A {
+    int value;
+  } a;
+  struct B {
+    int value;
+  } b;
+};
+
+struct BigStruct {
+  char a[32];
+};
+
+enum RawEnum {
+  Intergalactic,
+  Planetary
+};
+
+typedef struct One {
+  float first;
+  float second;
+} One;
+
+static inline One makeOne(float f, float s) {
+  One one;
+  one.first = f;
+  one.second = s;
+
+  return one;
+}
+
+static inline float MyRect_Area(struct MyRect rect) {
+  return rect.width * rect.height;
+}

--- a/test/IRGen/Inputs/abi/Gadget.h
+++ b/test/IRGen/Inputs/abi/Gadget.h
@@ -1,35 +1,5 @@
 @import Foundation;
-
-struct MyRect {
-  float x;
-  float y;
-  float width;
-  float height;
-};
-
-struct Trio {
-  double i;
-  double j;
-  double k;
-};
-
-struct IntPair {
-  int a;
-  int b;
-};
-
-struct NestedInts {
-  struct A {
-    int value;
-  } a;
-  struct B {
-    int value;
-  } b;
-};
-
-struct BigStruct {
-  char a[32];
-};
+#include "CGadget.h"
 
 @interface StructReturns : NSObject
 - (struct MyRect)newRect;
@@ -57,28 +27,6 @@ typedef NS_ENUM(unsigned short, ChooseTo) {
   ChooseToTakeIt = 709,
   ChooseToLeaveIt = 1709
 };
-
-enum RawEnum {
-  Intergalactic,
-  Planetary
-};
-
-typedef struct One {
-  float first;
-  float second;
-} One;
-
-static inline One makeOne(float f, float s) {
-  One one;
-  one.first = f;
-  one.second = s;
-
-  return one;
-}
-
-static inline float MyRect_Area(struct MyRect rect) {
-  return rect.width * rect.height;
-}
 
 // @literals inside static inline function
 static inline void* giveMeASelector(void) {

--- a/test/IRGen/Inputs/abi/module.modulemap
+++ b/test/IRGen/Inputs/abi/module.modulemap
@@ -1,2 +1,3 @@
 module gadget { header "Gadget.h" }
+module c_gadget { header "CGadget.h" }
 module c_layout { header "c_layout.h" }

--- a/test/IRGen/abitypes_arm.swift
+++ b/test/IRGen/abitypes_arm.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name abitypes -I %S/Inputs/abi %s -emit-ir | %FileCheck -check-prefix=%target-cpu-%target-os-abi -check-prefix=%target-cpu %s
+// REQUIRES: CPU=armv7 || CPU=armv7k || CPU=armv7s
+
+import c_gadget
+
+class Foo {
+  // Test that the makeOne() that we generate somewhere below doesn't
+  // use arm_aapcscc for armv7.
+  func callInline() -> Float {
+    return makeOne(3,5).second
+  }
+}
+
+// armv7: define internal void @makeOne(ptr noalias sret({{.*}}) align 4 %agg.result, float %f, float %s)
+// armv7s: define internal void @makeOne(ptr noalias sret({{.*}}) align 4 %agg.result, float %f, float %s)
+// armv7k: define internal %struct.One @makeOne(float {{.*}}%f, float {{.*}}%s)

--- a/test/IRGen/abitypes_x86_64.swift
+++ b/test/IRGen/abitypes_x86_64.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name abitypes -I %S/Inputs/abi %s -emit-ir | %FileCheck -check-prefix=%target-cpu-%target-os-abi -check-prefix=%target-cpu %s
+// REQUIRES: CPU=x86_64
+
+import c_gadget
+
+// rdar://17631440 - Expand direct arguments that are coerced to aggregates.
+// x86_64: define{{( dllexport)?}}{{( protected)?}} swiftcc float @"$s8abitypes13testInlineAggySfSo6MyRectVF"(float %0, float %1, float %2, float %3) {{.*}} {
+// x86_64: [[COERCED:%.*]] = alloca %TSo6MyRectV, align 8
+// x86_64: store float %0,
+// x86_64: store float %1,
+// x86_64: store float %2,
+// x86_64: store float %3,
+// x86_64: [[T0:%.*]] = getelementptr inbounds { <2 x float>, <2 x float> }, ptr [[COERCED]], i32 0, i32 0
+// x86_64: [[FIRST_HALF:%.*]] = load <2 x float>, ptr [[T0]], align 8
+// x86_64: [[T0:%.*]] = getelementptr inbounds { <2 x float>, <2 x float> }, ptr [[COERCED]], i32 0, i32 1
+// x86_64: [[SECOND_HALF:%.*]] = load <2 x float>, ptr [[T0]], align 8
+// x86_64: [[RESULT:%.*]] = call float @MyRect_Area(<2 x float> [[FIRST_HALF]], <2 x float> [[SECOND_HALF]])
+// x86_64: ret float [[RESULT]]
+public func testInlineAgg(_ rect: MyRect) -> Float {
+  return MyRect_Area(rect)
+}


### PR DESCRIPTION
Split out `abitypes.swift` into 3 tests, 1 for objc-interop, 2 for x64 argument coercing, 3 for arm layout.
This improves test coverage on non-objc-interopping platforms and eliminates the need to add "XFAIL" when adding new architectures.