### PR TITLE
[Test][Backtracing] Make FatalError test more lenient.

### DIFF
--- a/test/Backtracing/FatalError.swift
+++ b/test/Backtracing/FatalError.swift
@@ -37,7 +37,7 @@ struct FatalError {
   }
 }
 
-// CHECK: *** Program crashed: Illegal instruction at 0x{{[0-9a-f]+}} ***
+// CHECK: *** Program crashed: {{Illegal instruction|System trap}} at 0x{{[0-9a-f]+}} ***
 
 // CHECK: Thread 0 {{(".*" )?}}crashed:
 
@@ -50,4 +50,3 @@ struct FatalError {
 // CHECK-NEXT: 6 [ra]          0x{{[0-9a-f]+}} static FatalError.main() + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift:36:5
 // CHECK-NEXT: 7 [ra] [system] 0x{{[0-9a-f]+}} static FatalError.$main() + {{[0-9]+}} in FatalError at {{.*}}/<compiler-generated>
 // CHECK-NEXT: 8 [ra] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in FatalError at {{.*}}/FatalError.swift
-


### PR DESCRIPTION
Somehow since this passed PR testing, `Builtin.int_trap()` has changed from generating `SIGILL` to `SIGTRAP`.  Accept either.

rdar://116584708
