### PR TITLE
Platform: add an explicit `AppModel` module for Windows

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -48,6 +48,12 @@ module WinSDK [system] {
       export *
     }
 
+    // api-ms-win-appmodel-runtime-l1
+    module appmodel {
+      header "appmodel.h"
+      export *
+    }
+
     // api-ms-win-core-errhandling-l1-1-0.dll
     module errhandling {
       header "errhandlingapi.h"


### PR DESCRIPTION
Extract and isolate the AppModel APIs into its own module.  This corresponds to the contract boundary on Windows.
