### PR TITLE
Relax test.

### DIFF
--- a/test/DebugInfo/implicitreturn.swift
+++ b/test/DebugInfo/implicitreturn.swift
@@ -7,9 +7,9 @@ func app() {
         var x : Bool = true
         x = !x
         x = !x
-// CHECK:	.loc	[[FILEID]] [[@LINE+3]] 1
-// CHECK-NOT:.loc
+// CHECK:	.loc	[[FILEID]] [[@LINE+2]] 1
 // CHECK:	ret
 }
 
 app()
+


### PR DESCRIPTION
On Windows a separate .loc directive is emitted to introduce the function epilogue, which is not there on other platforms.

rdar://116482190

