### PR TITLE
[Concurrency] Rename `IsolatedDefaultArguments` to `IsolatedDefaultValues`.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -222,8 +222,8 @@ EXPERIMENTAL_FEATURE(SendNonSendable, false)
 /// Within strict concurrency, narrow global variable isolation requirements.
 EXPERIMENTAL_FEATURE(GlobalConcurrency, false)
 
-/// Allow default arguments to require isolation at the call-site.
-EXPERIMENTAL_FEATURE(IsolatedDefaultArguments, false)
+/// Allow default values to require isolation at the call-site.
+EXPERIMENTAL_FEATURE(IsolatedDefaultValues, false)
 
 /// Enable extended callbacks (with additional parameters) to be used when the
 /// "playground transform" is enabled.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3551,7 +3551,7 @@ static bool usesFeatureSendNonSendable(Decl *decl) {
 
 static bool usesFeatureGlobalConcurrency(Decl *decl) { return false; }
 
-static bool usesFeatureIsolatedDefaultArguments(Decl *decl) {
+static bool usesFeatureIsolatedDefaultValues(Decl *decl) {
   return false;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10472,7 +10472,7 @@ ActorIsolation swift::getActorIsolationOfContext(
   //     that meet the required isolation.
   if (auto *var = dcToUse->getNonLocalVarDecl()) {
     auto &ctx = dc->getASTContext();
-    if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultArguments) &&
+    if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues) &&
         var->isInstanceMember() &&
         !var->getAttrs().hasAttribute<LazyAttr>()) {
       return ActorIsolation::forNonisolated();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2277,7 +2277,7 @@ namespace {
     ActorIsolation computeRequiredIsolation(Expr *expr) {
       auto &ctx = getDeclContext()->getASTContext();
 
-      if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultArguments))
+      if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues))
         requiredIsolationLoc = expr->getLoc();
 
       expr->walk(*this);

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultArguments -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultArguments -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultArguments %S/Inputs/serialized_default_arguments.swift
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultValues %S/Inputs/serialized_default_arguments.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-experimental-feature IsolatedDefaultArguments
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-experimental-feature IsolatedDefaultValues
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultArguments -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultArguments -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts


### PR DESCRIPTION
To match what's proposed in https://github.com/hborla/swift-evolution/blob/isolated-default-values/proposals/NNNN-isolated-default-values.md