### PR TITLE
[5.9][build] Move libdispatch earlier in the build so it can be used by the compiler validation suite

### DIFF
--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -10,17 +10,10 @@
 
 import Dispatch
 
-// Work around the inability of older Swift runtimes to print a task priority.
-extension TaskPriority: CustomStringConvertible {
-  public var description: String {
-    "TaskPriority(rawValue: \(rawValue))"
-  }
-}
-
 @available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
-    print("main priority: \(Task.currentPriority)") // CHECK: main priority: TaskPriority(rawValue: [[#MAIN_PRIORITY:]])
+    print("main priority: \(Task.currentPriority)") // CHECK: main priority: TaskPriority.medium
     await test_detach()
     await test_multiple_lo_indirectly_escalated()
   }
@@ -29,18 +22,18 @@ extension TaskPriority: CustomStringConvertible {
 @available(SwiftStdlib 5.1, *)
 func test_detach() async {
   let a1 = Task.currentPriority
-  print("a1: \(a1)") // CHECK: a1: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
+  print("a1: \(a1)") // CHECK: a1: TaskPriority.medium
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
   // task.
   await detach(priority: .userInitiated) {
     let a2 = Task.currentPriority
-    print("a2: \(a2)") // CHECK: a2: TaskPriority(rawValue: 25)
+    print("a2: \(a2)") // CHECK: a2: TaskPriority.high
   }.get()
 
   let a3 = Task.currentPriority
-  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
+  print("a3: \(a3)") // CHECK: a3: TaskPriority.medium
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/Runtime/custom_executors_complex_equality_crash.swift
+++ b/test/Concurrency/Runtime/custom_executors_complex_equality_crash.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library)
 
 // REQUIRES: concurrency
 // REQUIRES: executable_test

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1640,15 +1640,17 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     libdispatch_artifact_dir = config.libdispatch_build_path
     libdispatch_swift_module_dir = make_path(libdispatch_artifact_dir, 'src', 'swift', 'swift')
     libdispatch_source_dir = make_path(config.swift_src_root, os.pardir, 'swift-corelibs-libdispatch')
+    libdispatch_vfs_yaml =  make_path(libdispatch_artifact_dir, 'dispatch-vfs-overlay.yaml')
     libdispatch_artifacts = [
+        libdispatch_vfs_yaml,
         make_path(libdispatch_artifact_dir, 'libdispatch.so'),
         make_path(libdispatch_artifact_dir, 'libswiftDispatch.so'),
         make_path(libdispatch_swift_module_dir, 'Dispatch.swiftmodule')]
     if (all(os.path.exists(p) for p in libdispatch_artifacts)):
         config.available_features.add('libdispatch')
         config.libdispatch_artifact_dir = libdispatch_artifact_dir
-        config.import_libdispatch = ('-I %s -I %s -L %s'
-            % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_artifact_dir))
+        config.import_libdispatch = ('-I %s -I %s -L %s -vfsoverlay %s'
+            % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_artifact_dir, libdispatch_vfs_yaml))
 
     libdispatch_static_artifact_dir = os.path.join(config.libdispatch_static_build_path, 'lib')
     libdispatch_static_artifacts = [

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -606,7 +606,7 @@ class BuildScriptInvocation(object):
         # the build-script code base. The main difference is that these are all
         # build, tested, and installed all at once instead of performing build,
         # test, install like a normal build-script product.
-        builder.begin_impl_pipeline(should_run_epilogue_operations=False)
+        builder.begin_impl_pipeline(should_run_epilogue_operations=True)
 
         builder.add_impl_product(products.LibCXX,
                                  is_enabled=self.args.build_libcxx)
@@ -616,11 +616,6 @@ class BuildScriptInvocation(object):
                                  is_enabled=self.args.build_swift)
         builder.add_impl_product(products.LLDB,
                                  is_enabled=self.args.build_lldb)
-
-        # Begin a new build-script-impl pipeline that builds libraries that we
-        # build as part of build-script-impl but that we should eventually move
-        # onto build-script products.
-        builder.begin_impl_pipeline(should_run_epilogue_operations=True)
         builder.add_impl_product(products.LibDispatch,
                                  is_enabled=self.args.build_libdispatch)
         builder.add_impl_product(products.Foundation,

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -606,7 +606,7 @@ class BuildScriptInvocation(object):
         # the build-script code base. The main difference is that these are all
         # build, tested, and installed all at once instead of performing build,
         # test, install like a normal build-script product.
-        builder.begin_impl_pipeline(should_run_epilogue_operations=True)
+        builder.begin_impl_pipeline(should_run_epilogue_operations=False)
 
         builder.add_impl_product(products.LibCXX,
                                  is_enabled=self.args.build_libcxx)
@@ -618,6 +618,11 @@ class BuildScriptInvocation(object):
                                  is_enabled=self.args.build_lldb)
         builder.add_impl_product(products.LibDispatch,
                                  is_enabled=self.args.build_libdispatch)
+
+        # Begin a new build-script-impl pipeline that builds libraries that we
+        # build as part of build-script-impl but that we should eventually move
+        # onto build-script products.
+        builder.begin_impl_pipeline(should_run_epilogue_operations=True)
         builder.add_impl_product(products.Foundation,
                                  is_enabled=self.args.build_foundation)
         builder.add_impl_product(products.XCTest,


### PR DESCRIPTION
Cherrypick of #65829 and #68565

__Explanation:__ The libdispatch tests and several concurrency tests in the validation suite were inadvertently disabled a couple years ago. This enables them again by making sure the target libdispatch is built first and using the new `dispatch-vfs-overlay.yaml` it now generates.

__Scope:__ Enabling compiler tests again

__Issue:__ #53973

__Risk:__ negative, as it is only testing more code, thus lowering risk

__Testing:__ Passes all CI on trunk for the last three weeks, and I've been doing this manually on Android for years without a problem.

__Reviewer:__ @gottesmm