### PR TITLE
Lazy construction of associated conformances

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -664,10 +664,6 @@ public:
   /// Override the witness for a given requirement.
   void overrideWitness(ValueDecl *requirement, Witness newWitness);
 
-  /// Populate the signature conformances without checking if they satisfy
-  /// requirements. Can only be used with parsed or imported conformances.
-  void finishSignatureConformances();
-
   /// Determine whether the witness for the given type requirement
   /// is the default definition.
   bool usesDefaultDefinition(AssociatedTypeDecl *requirement) const {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -588,28 +588,6 @@ void NormalProtocolConformance::setAssociatedConformance(
   AssociatedConformances[index] = assocConf;
 }
 
-/// Collect conformances for the requirement signature.
-void NormalProtocolConformance::finishSignatureConformances() {
-  if (Loader)
-    resolveLazyInfo();
-
-  if (hasComputedAssociatedConformances())
-    return;
-
-  createAssociatedConformanceArray();
-
-  auto &ctx = getDeclContext()->getASTContext();
-
-  forEachAssociatedConformance(
-    [&](Type origTy, ProtocolDecl *reqProto, unsigned index) {
-      auto canTy = origTy->getCanonicalType();
-      evaluateOrDefault(ctx.evaluator,
-                        AssociatedConformanceRequest{this, canTy, reqProto, index},
-                        ProtocolConformanceRef::forInvalid());
-      return false;
-    });
-}
-
 Witness RootProtocolConformance::getWitness(ValueDecl *requirement) const {
   ROOT_CONFORMANCE_SUBCLASS_DISPATCH(getWitness, (requirement))
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5196,10 +5196,8 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
     return false;
   });
 
-  for (auto req : proto->getRequirementSignature().getRequirements()) {
-    if (req.getKind() == RequirementKind::Conformance) {
-      auto depTy = req.getFirstType();
-      auto *proto = req.getProtocolDecl();
+  Conformance->forEachAssociatedConformance(
+    [&](Type depTy, ProtocolDecl *proto, unsigned index) {
       auto conformance = Conformance->getAssociatedConformance(depTy, proto);
       if (conformance.isConcrete()) {
         auto *concrete = conformance.getConcrete();
@@ -5208,8 +5206,9 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
                                         conformance, where,
                                         depTy, replacementTy);
       }
-    }
-  }
+
+      return false;
+    });
 }
 
 #pragma mark Protocol conformance checking

--- a/test/Generics/rdar116434843.swift
+++ b/test/Generics/rdar116434843.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+
+struct X: P {}
+
+protocol Q {
+  typealias A = X
+}
+
+protocol R {
+  associatedtype A: Q
+  associatedtype B: P
+}
+
+protocol S {}
+
+extension S where Self: R {
+  typealias B = Self.A.A
+}
+
+typealias T<A: Q> = G<A>.B
+
+struct G<A: Q>: R, S {
+  typealias A = A
+}

--- a/validation-test/compiler_crashers_2_fixed/issue-59772.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-59772.swift
@@ -1,0 +1,97 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+private typealias Word = UInt
+
+/// Returns the offset at which the `i`th bit can be found in an array of
+/// `Word`s.
+private func wordOffset(ofBit i: Int) -> Int {
+  precondition(i >= 0)
+  return i / Word.bitWidth
+}
+
+/// Returns a mask that isolates the `i`th bit within its `Word` in an array of
+/// `Word`s.
+private func wordMask(ofBit i: Int) -> Word {
+  precondition(i >= 0)
+  return (1 as Word) << (i % Word.bitWidth)
+}
+
+/// An adapter that presents a base instance of `S` as a sequence of bits packed
+/// into `Word`, where `true` and `false` in the base are represented as `1` and
+/// `0` bits in an element of `self`, respectively.
+private struct PackedIntoWords<S: Sequence>: Sequence where S.Element == Bool {
+  /// The iteration state of a traversal of a `PackedIntoWords`.
+  struct Iterator: IteratorProtocol {
+    var base: S.Iterator
+
+    mutating func next() -> Word? {
+      guard let b = base.next() else { return nil }
+      var r: Word = b ? 1 : 0
+      for i in 1..<Word.bitWidth {
+        guard let b = base.next() else { return r }
+        if b { r |= wordMask(ofBit: i) }
+      }
+      return r
+    }
+  }
+  /// Returns a new iterator over `self`.
+  func makeIterator() -> Iterator { Iterator(base: base.makeIterator()) }
+
+  /// Returns a number no greater than the number of elements in `self`.
+  var underestimatedCount: Int {
+    (base.underestimatedCount + Word.bitWidth - 1) / Word.bitWidth
+  }
+
+  /// The underlying sequence of `Bool`.
+  let base: S
+
+  init(_ base: S) { self.base = base }
+}
+
+struct Bits<Base: Sequence>: Sequence
+  where Base.Element: FixedWidthInteger
+{
+  public var base: Base
+  typealias Element = Bool
+
+  func makeIterator() -> Iterator { Iterator(base: base.makeIterator()) }
+
+  struct Iterator: IteratorProtocol {
+    typealias Element = Bool
+
+    var base: Base.Iterator
+    var buffer: Base.Element.Magnitude = 0
+
+    mutating func next() -> Bool? {
+      let r = buffer & 0x1 != 0
+      buffer >>= 1
+      if buffer != 0 { return r }
+      guard let b = base.next() else { return nil }
+      let r1 = b & 0x1 != 0
+      buffer = Base.Element.Magnitude(truncatingIfNeeded: b)
+      buffer >>= 1
+      buffer |= 1 << (Base.Element.bitWidth - 1)
+      return r1
+    }
+  }
+}
+
+extension Bits: Equatable where Base: Equatable {}
+extension Bits: Hashable where Base: Hashable {}
+
+extension Bits: RandomAccessCollection, BidirectionalCollection, Collection
+  where Base: RandomAccessCollection
+{
+//  typealias Index = Int
+  var startIndex: Int { return 0 }
+  var endIndex: Int { return base.count * Base.Element.bitWidth }
+
+  fileprivate func baseIndex(_ i: Int) -> Base.Index {
+    base.index(base.startIndex, offsetBy: i / Base.Element.bitWidth)
+  }
+
+  subscript(i: Int) -> Bool {
+    base[baseIndex(i)] & (1 << (i % Base.Element.bitWidth)) != 0
+  }
+}
+

--- a/validation-test/compiler_crashers_2_fixed/rdar110806272.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar110806272.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+struct SyntaxCollectionIterator<E: SyntaxProtocol>: IteratorProtocol {
+  typealias Element = E
+}
+
+protocol SyntaxCollection: BidirectionalCollection {}
+
+extension SyntaxCollection {
+  typealias Iterator = SyntaxCollectionIterator<Element>
+}
+
+struct AccessorListSyntax: SyntaxCollection {
+  typealias Element = Int
+}


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/69038 that makes `NormalProtocolConformance::getAssociatedConformance()` fully lazy, via the new `AssociatedConformanceRequest`.

Fixes https://github.com/apple/swift/issues/59772, rdar://89097705, rdar://89369029, rdar://110806272, and rdar://116434843.