### PR TITLE
Preparation for lazily populating associated conformances

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -191,6 +191,27 @@ public:
     return false;
   }
 
+  /// Apply the given function object to each associated conformance requirement
+  /// within this protocol conformance.
+  ///
+  /// \returns true if the function ever returned true
+  template<typename F>
+  bool forEachAssociatedConformance(F f) const {
+    const ProtocolDecl *protocol = getProtocol();
+    unsigned index = 0;
+    for (auto req : protocol->getRequirementSignature().getRequirements()) {
+      if (req.getKind() != RequirementKind::Conformance)
+        continue;
+
+      if (f(req.getFirstType(), req.getProtocolDecl(), index))
+        return true;
+
+      ++index;
+    }
+
+    return false;
+  }
+
   /// Retrieve the value witness declaration corresponding to the given
   /// requirement.
   ValueDecl *getWitnessDecl(ValueDecl *requirement) const;

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -480,7 +480,6 @@ class NormalProtocolConformance : public RootProtocolConformance,
 
   /// Conformances that satisfy each of conformance requirements of the
   /// requirement signature of the protocol.
-  ArrayRef<ProtocolConformanceRef> SignatureConformances;
   MutableArrayRef<llvm::Optional<ProtocolConformanceRef>> AssociatedConformances;
 
   /// The lazy member loader provides callbacks for populating imported and
@@ -545,7 +544,6 @@ public:
   /// Mark this conformance as invalid.
   void setInvalid() {
     ContextAndBits.setInt(ContextAndBits.getInt() | InvalidFlag);
-    SignatureConformances = {};
   }
 
   /// Whether this is an "unchecked" conformance.
@@ -665,19 +663,6 @@ public:
 
   /// Override the witness for a given requirement.
   void overrideWitness(ValueDecl *requirement, Witness newWitness);
-
-  /// Retrieve the protocol conformances that satisfy the requirements of the
-  /// protocol, which line up with the conformance constraints in the
-  /// protocol's requirement signature.
-  ArrayRef<ProtocolConformanceRef> getSignatureConformances() const {
-    if (Loader)
-      resolveLazyInfo();
-    return SignatureConformances;
-  }
-
-  /// Copy the given protocol conformances for the requirement signature into
-  /// the normal conformance.
-  void setSignatureConformances(ArrayRef<ProtocolConformanceRef> conformances);
 
   /// Populate the signature conformances without checking if they satisfy
   /// requirements. Can only be used with parsed or imported conformances.

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -481,6 +481,7 @@ class NormalProtocolConformance : public RootProtocolConformance,
   /// Conformances that satisfy each of conformance requirements of the
   /// requirement signature of the protocol.
   ArrayRef<ProtocolConformanceRef> SignatureConformances;
+  MutableArrayRef<llvm::Optional<ProtocolConformanceRef>> AssociatedConformances;
 
   /// The lazy member loader provides callbacks for populating imported and
   /// deserialized conformances.
@@ -635,6 +636,16 @@ public:
   /// return its associated conformance.
   ProtocolConformanceRef
   getAssociatedConformance(Type assocType, ProtocolDecl *protocol) const;
+
+  /// Allocate the backing array if needed, computing its size from the
+  ///protocol's requirement signature.
+  void createAssociatedConformanceArray();
+
+  llvm::Optional<ProtocolConformanceRef>
+  getAssociatedConformance(unsigned index) const;
+
+  void
+  setAssociatedConformance(unsigned index, ProtocolConformanceRef assocConf);
 
   /// Retrieve the value witness corresponding to the given requirement.
   Witness getWitness(ValueDecl *requirement) const;

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -444,13 +444,18 @@ class NormalProtocolConformance : public RootProtocolConformance,
 
     /// The conformance was labeled with @unchecked.
     UncheckedFlag = 0x02,
+
+    /// We have allocated the AssociatedConformances array (but not necessarily
+    /// populated any of its elements).
+    HasComputedAssociatedConformancesFlag = 0x04,
   };
 
   /// The declaration context containing the ExtensionDecl or
   /// NominalTypeDecl that declared the conformance.
   ///
-  /// Also stores the "invalid" and "unchecked" bits.
-  llvm::PointerIntPair<DeclContext *, 2, unsigned> ContextAndBits;
+  /// Also stores the "invalid", "unchecked" and "has computed associated
+  /// conformances" bits.
+  llvm::PointerIntPair<DeclContext *, 3, unsigned> ContextAndBits;
 
   /// The reason that this conformance exists.
   ///
@@ -552,6 +557,17 @@ public:
   void setUnchecked() {
     // OK to mutate because the flags are not part of the folding set node ID.
     ContextAndBits.setInt(ContextAndBits.getInt() | UncheckedFlag);
+  }
+
+  /// Determine whether we've lazily computed the associated conformance array
+  /// already.
+  bool hasComputedAssociatedConformances() const {
+    return ContextAndBits.getInt() & HasComputedAssociatedConformancesFlag;
+  }
+
+  /// Mark this conformance as having computed the assocaited conformance array.
+  void setHasComputedAssociatedConformances() {
+    ContextAndBits.setInt(ContextAndBits.getInt() | HasComputedAssociatedConformancesFlag);
   }
 
   /// Get the kind of source from which this conformance comes.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2737,6 +2737,30 @@ public:
   void cacheResult(Witness value) const;
 };
 
+class AssociatedConformanceRequest
+    : public SimpleRequest<AssociatedConformanceRequest,
+                           ProtocolConformanceRef(NormalProtocolConformance *,
+                                                  CanType, ProtocolDecl *,
+                                                  unsigned),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ProtocolConformanceRef
+  evaluate(Evaluator &evaluator, NormalProtocolConformance *conformance,
+           CanType t, ProtocolDecl *proto, unsigned index) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  llvm::Optional<ProtocolConformanceRef> getCachedResult() const;
+  void cacheResult(ProtocolConformanceRef value) const;
+};
+
 struct PreCheckResultBuilderDescriptor {
   AnyFunctionRef Fn;
   bool SuppressDiagnostics;

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -403,6 +403,10 @@ SWIFT_REQUEST(TypeChecker, TypeWitnessRequest,
               TypeWitnessAndDecl(NormalProtocolConformance *,
                                  AssociatedTypeDecl *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, AssociatedConformanceRequest,
+              ProtocolConformanceRef(NormalProtocolConformance *,
+                                     Type, ProtocolDecl *, unsigned),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ValueWitnessRequest,
               Witness(NormalProtocolConformance *, ValueDecl *),
               SeparatelyCached, NoLocationInfo)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3414,7 +3414,8 @@ public:
       });
     }
 
-    printRecRange(T->getGenericArguments(), "generic_arguments");
+    for (auto arg : T->getGenericArguments())
+      printRec(arg);
 
     printFoot();
   }
@@ -3886,14 +3887,16 @@ namespace {
 
       printFieldQuoted(T->getDecl()->printRef(), "decl");
       if (auto underlying = T->getSinglyDesugaredType()) {
-        printField(underlying, "underlying", TypeColor);
+        printRec(underlying, "underlying");
       } else {
+        // This can't actually happen
         printFlag("unresolved_underlying");
       }
 
       if (T->getParent())
         printRec(T->getParent(), "parent");
-      printRecRange(T->getDirectGenericArgs(), "direct_generic_args");
+      for (auto arg : T->getDirectGenericArgs())
+        printRec(arg);
 
       printFoot();
     }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3550,6 +3550,7 @@ public:
             });
             return false;
           });
+
           normal->forEachValueWitness([&](const ValueDecl *req,
                                           Witness witness) {
             printRecArbitrary([&](StringRef label) {
@@ -3567,9 +3568,17 @@ public:
             });
           });
 
-          for (auto sigConf : normal->getSignatureConformances()) {
-            printRec(sigConf, visited);
-          }
+          normal->forEachAssociatedConformance(
+              [&](Type t, ProtocolDecl *proto, unsigned index) {
+                printRecArbitrary([&](StringRef label) {
+                  printHead("assoc_conformance", ASTNodeColor, label);
+                  printFieldQuoted(t, "type", TypeColor);
+                  printFieldQuoted(proto->getName(), "proto");
+                  printRec(normal->getAssociatedConformance(t, proto), visited);
+                  printFoot();
+                });
+                return false;
+              });
         }
 
         if (auto condReqs = normal->getConditionalRequirementsIfAvailable()) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2878,40 +2878,6 @@ public:
           continue;
         }
       }
-
-      // Make sure we have the right signature conformances.
-      if (!normal->isInvalid()){
-        auto conformances = normal->getSignatureConformances();
-        unsigned idx = 0;
-        auto reqs = proto->getRequirementSignature().getRequirements();
-        for (const auto &req : reqs) {
-          if (req.getKind() != RequirementKind::Conformance)
-            continue;
-
-          if (idx >= conformances.size()) {
-            Out << "error: not enough conformances for requirement signature\n";
-            normal->dump(Out);
-            abort();
-          }
-
-          auto reqProto = req.getProtocolDecl();
-          if (reqProto != conformances[idx].getRequirement()) {
-            Out << "error: wrong protocol in signature conformances: have "
-              << conformances[idx].getRequirement()->getName().str()
-              << ", expected " << reqProto->getName().str()<< "\n";
-            normal->dump(Out);
-            abort();
-          }
-
-          ++idx;
-        }
-
-        if (idx != conformances.size()) {
-          Out << "error: too many conformances for requirement signature\n";
-          normal->dump(Out);
-          abort();
-        }
-      }
     }
 
     void verifyChecked(GenericTypeDecl *generic) {

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -273,10 +273,11 @@ void swift::printConformanceDescription(llvm::raw_ostream &out,
     return;
   }
 
-  out << "protocol conformance to ";
-  printDeclDescription(out, conformance->getProtocol(), /*newline*/false);
-  out << " for ";
-  printTypeDescription(out, conformance->getType(), ctxt, addNewline);
+  out << "protocol conformance "
+      << conformance->getType() << ": "
+      << conformance->getProtocol()->getName() << " at ";
+  auto *decl = conformance->getDeclContext()->getInnermostDeclarationDeclContext();
+  printDeclDescription(out, decl, addNewline);
 }
 
 void swift::printSourceLocDescription(llvm::raw_ostream &out,

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -535,14 +535,14 @@ Type ProtocolConformance::getAssociatedType(Type assocType) const {
 
 ProtocolConformanceRef
 ProtocolConformance::getAssociatedConformance(Type assocType,
-                                               ProtocolDecl *protocol) const {
+                                              ProtocolDecl *protocol) const {
   CONFORMANCE_SUBCLASS_DISPATCH(getAssociatedConformance,
                                 (assocType, protocol))
 }
 
 ProtocolConformanceRef
 NormalProtocolConformance::getAssociatedConformance(Type assocType,
-                                                ProtocolDecl *protocol) const {
+                                                 ProtocolDecl *protocol) const {
   assert(assocType->isTypeParameter() &&
          "associated type must be a type parameter");
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -433,7 +433,7 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
     auto normal = concrete->getRootNormalConformance();
 
     // If we haven't set the signature conformances yet, force the issue now.
-    if (normal->getSignatureConformances().empty()) {
+    if (!normal->hasComputedAssociatedConformances()) {
       // If we're in the process of checking the type witnesses, fail
       // gracefully.
       // FIXME: Seems like we should be able to get at the intermediate state

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1197,6 +1197,26 @@ void ValueWitnessRequest::cacheResult(Witness type) const {
 }
 
 //----------------------------------------------------------------------------//
+// AssociatedConformanceRequest computation.
+//----------------------------------------------------------------------------//
+
+llvm::Optional<ProtocolConformanceRef>
+AssociatedConformanceRequest::getCachedResult() const {
+  auto *conformance = std::get<0>(getStorage());
+  unsigned index = std::get<3>(getStorage());
+
+  return conformance->getAssociatedConformance(index);
+}
+
+void AssociatedConformanceRequest::cacheResult(
+    ProtocolConformanceRef assocConf) const {
+  auto *conformance = std::get<0>(getStorage());
+  unsigned index = std::get<3>(getStorage());
+
+  conformance->setAssociatedConformance(index, assocConf);
+}
+
+//----------------------------------------------------------------------------//
 // PreCheckResultBuilderRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8479,7 +8479,6 @@ void ClangImporter::Implementation::finishNormalConformance(
   PrettyStackTraceConformance trace("completing import of", conformance);
 
   finishTypeWitnesses(conformance);
-  conformance->finishSignatureConformances();
 
   // Imported conformances to @objc protocols also require additional
   // initialization to complete the requirement to witness mapping.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -7008,6 +7008,75 @@ ValueWitnessRequest::evaluate(Evaluator &eval,
   return known->second;
 }
 
+/// A stripped-down version of Type::subst that only works on the protocol
+/// Self type wrapped in zero or more DependentMemberTypes.
+static Type
+recursivelySubstituteBaseType(ModuleDecl *module,
+                              NormalProtocolConformance *conformance,
+                              DependentMemberType *depMemTy) {
+  Type origBase = depMemTy->getBase();
+
+  // Recursive case.
+  if (auto *depBase = origBase->getAs<DependentMemberType>()) {
+    Type substBase = recursivelySubstituteBaseType(
+        module, conformance, depBase);
+    return depMemTy->substBaseType(module, substBase);
+  }
+
+  // Base case. The associated type's protocol should be either the
+  // conformance protocol or an inherited protocol.
+  auto *reqProto = depMemTy->getAssocType()->getProtocol();
+  assert(origBase->isEqual(reqProto->getSelfInterfaceType()));
+
+  ProtocolConformance *reqConformance = conformance;
+
+  // If we have an inherited protocol just look up the conformance.
+  if (reqProto != conformance->getProtocol()) {
+    reqConformance = module->lookupConformance(conformance->getType(), reqProto)
+                         .getConcrete();
+  }
+
+  return reqConformance->getTypeWitness(depMemTy->getAssocType());
+}
+
+ProtocolConformanceRef
+AssociatedConformanceRequest::evaluate(Evaluator &eval,
+                                       NormalProtocolConformance *conformance,
+                                       CanType origTy, ProtocolDecl *reqProto,
+                                       unsigned index) const {
+  auto *module = conformance->getDeclContext()->getParentModule();
+  Type substTy;
+
+  if (origTy->isEqual(conformance->getProtocol()->getSelfInterfaceType())) {
+    substTy = conformance->getType();
+  } else {
+    auto *depMemTy = origTy->castTo<DependentMemberType>();
+    substTy = recursivelySubstituteBaseType(module, conformance, depMemTy);
+  }
+
+  // Looking up a conformance for a contextual type and mapping the
+  // conformance context produces a more accurate result than looking
+  // up a conformance from an interface type.
+  //
+  // This can happen if the conformance has an associated conformance
+  // depending on an associated type that is made concrete in a
+  // refining protocol.
+  //
+  // That is, the conformance of an interface type G<T> : P really
+  // depends on the generic signature of the current context, because
+  // performing the lookup in a "more" constrained extension than the
+  // one where the conformance was defined must produce concrete
+  // conformances.
+  //
+  // FIXME: Eliminate this, perhaps by adding a variant of
+  // lookupConformance() taking a generic signature.
+  if (substTy->hasTypeParameter())
+    substTy = conformance->getDeclContext()->mapTypeIntoContext(substTy);
+
+  return module->lookupConformance(substTy, reqProto, /*allowMissing=*/true)
+      .mapConformanceOutOfContext();
+}
+
 ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
                                                   NominalTypeDecl *TypeDecl,
                                                   ValueDecl *Requirement) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5062,7 +5062,6 @@ static void diagnoseInvariantSelfRequirement(
 }
 
 void ConformanceChecker::ensureRequirementsAreSatisfied() {
-  Conformance->finishSignatureConformances();
   auto proto = Conformance->getProtocol();
   auto &diags = proto->getASTContext().Diags;
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/NameLookupRequests.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeMatcher.h"
@@ -1161,6 +1162,8 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
       QuerySubstitutionMap{substitutions}, options)) {
   case CheckGenericArgumentsResult::RequirementFailure:
     ++NumSolutionStatesFailedCheck;
+    LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+               << "+ Requirement failure\n";);
     return true;
 
   case CheckGenericArgumentsResult::Success:
@@ -1186,6 +1189,9 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
 
     ++NumConstrainedExtensionChecks;
     if (checkConstrainedExtension(ext)) {
+      LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                 << "+ Constrained extension failed: " <<
+                 ext->getExtendedType() << "\n";);
       ++NumConstrainedExtensionChecksFailed;
       return true;
     }
@@ -1432,6 +1438,22 @@ void AssociatedTypeInference::findSolutions(
   SmallVector<std::pair<ValueDecl *, ValueDecl *>, 4> valueWitnesses;
   findSolutionsRec(unresolvedAssocTypes, solutions, nonViableSolutions,
                    valueWitnesses, 0, 0, 0);
+
+  for (auto solution : solutions) {
+    LLVM_DEBUG(llvm::dbgs() << "=== Valid solution:\n";);
+    for (auto pair : solution.TypeWitnesses) {
+      LLVM_DEBUG(llvm::dbgs() << pair.first->getName() << " := "
+                              << pair.second.first << "\n";);
+    }
+  }
+
+  for (auto solution : nonViableSolutions) {
+    LLVM_DEBUG(llvm::dbgs() << "=== Invalid solution:\n";);
+    for (auto pair : solution.TypeWitnesses) {
+      LLVM_DEBUG(llvm::dbgs() << pair.first->getName() << " := "
+                              << pair.second.first << "\n";);
+    }
+  }
 }
 
 void AssociatedTypeInference::findSolutionsRec(
@@ -1462,6 +1484,8 @@ void AssociatedTypeInference::findSolutionsRec(
           if (!missingTypeWitness)
             missingTypeWitness = assocType;
 
+          LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                     << "+ Recorded an erroneous type witness\n";);
           return;
         }
       }
@@ -1476,6 +1500,8 @@ void AssociatedTypeInference::findSolutionsRec(
       if (!missingTypeWitness)
         missingTypeWitness = assocType;
 
+      LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                 << "+ Failed to infer abstract witnesses\n";);
       return;
     }
 
@@ -1496,8 +1522,11 @@ void AssociatedTypeInference::findSolutionsRec(
         continue;
 
       Type replaced = substCurrentTypeWitnesses(known->first);
-      if (replaced.isNull())
+      if (replaced.isNull()) {
+        LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                   << "+ Failed substitution of " << known->first << "\n";);
         return;
+      }
 
       known->first = replaced;
     }
@@ -1516,14 +1545,29 @@ void AssociatedTypeInference::findSolutionsRec(
 
     // If we've seen this solution already, bail out; there's no point in
     // checking further.
-    if (llvm::any_of(solutions, matchesSolution) ||
-        llvm::any_of(nonViableSolutions, matchesSolution)) {
+    if (llvm::any_of(solutions, matchesSolution)) {
+      LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                 << "+ Duplicate valid solution found\n";);
+      ++NumDuplicateSolutionStates;
+      return;
+    }
+    if (llvm::any_of(nonViableSolutions, matchesSolution)) {
+      LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                 << "+ Duplicate invalid solution found\n";);
       ++NumDuplicateSolutionStates;
       return;
     }
 
     /// Check the current set of type witnesses.
     bool invalid = checkCurrentTypeWitnesses(valueWitnesses);
+
+    if (invalid) {
+      LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                 << "+ Invalid solution found\n";);
+    } else {
+      LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                 << "+ Valid solution found\n";);
+    }
 
     auto &solutionList = invalid ? nonViableSolutions : solutions;
     solutionList.push_back(InferredTypeWitnessesSolution());
@@ -1583,6 +1627,12 @@ void AssociatedTypeInference::findSolutionsRec(
     TypeWitnessesScope typeWitnessesScope(typeWitnesses);
 
     // Record this value witness, popping it when we exit the current scope.
+    LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+               << "+ Pushing ";
+               inferredReq.first->dumpRef(llvm::dbgs());
+               llvm::dbgs() << " := ";
+               witnessReq.Witness->dumpRef(llvm::dbgs());
+               llvm::dbgs() << "\n";);
     valueWitnesses.push_back({inferredReq.first, witnessReq.Witness});
     if (!isa<TypeDecl>(inferredReq.first) &&
         witnessReq.Witness->getDeclContext()->getExtendedProtocolDecl())
@@ -1593,6 +1643,13 @@ void AssociatedTypeInference::findSolutionsRec(
         --numValueWitnessesInProtocolExtensions;
 
       valueWitnesses.pop_back();
+
+      LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                 << "+ Popping ";
+                 inferredReq.first->dumpRef(llvm::dbgs());
+                 llvm::dbgs() << " := ";
+                 witnessReq.Witness->dumpRef(llvm::dbgs());
+                 llvm::dbgs() << "\n";);
     };
 
     // Introduce each of the type witnesses into the hash table.
@@ -1637,9 +1694,19 @@ void AssociatedTypeInference::findSolutionsRec(
           numTypeWitnessesBeforeConflict = numTypeWitnesses;
         }
 
+        LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                   << "+ Failed " << typeWitness.first->getName()
+                   << " := " << typeWitness.second->getCanonicalType()
+                   << "\n";);
+
         failed = true;
         break;
       }
+
+      LLVM_DEBUG(llvm::dbgs() << std::string(valueWitnesses.size(), '+')
+                 << "+ Recording " << typeWitness.first->getName()
+                 << " := " << typeWitness.second->getCanonicalType()
+                 << "\n";);
 
       // Record the type witness.
       ++numTypeWitnesses;
@@ -2224,10 +2291,20 @@ bool AssociatedTypeInference::canAttemptEagerTypeWitnessDerivation(
 
 auto AssociatedTypeInference::solve(ConformanceChecker &checker)
     -> llvm::Optional<InferredTypeWitnesses> {
+  LLVM_DEBUG(llvm::dbgs() << "============ Start " << conformance->getType()
+                          << ": " << conformance->getProtocol()->getName()
+                          << " ============\n";);
+
   // Track when we are checking type witnesses.
   ProtocolConformanceState initialState = conformance->getState();
   conformance->setState(ProtocolConformanceState::CheckingTypeWitnesses);
-  SWIFT_DEFER { conformance->setState(initialState); };
+  SWIFT_DEFER {
+    conformance->setState(initialState);
+
+    LLVM_DEBUG(llvm::dbgs() << "============ Finish " << conformance->getType()
+                            << ": " << conformance->getProtocol()->getName()
+                            << " ============\n";);
+  };
 
   // Try to resolve type witnesses via name lookup.
   llvm::SetVector<AssociatedTypeDecl *> unresolvedAssocTypes;
@@ -2251,9 +2328,13 @@ auto AssociatedTypeInference::solve(ConformanceChecker &checker)
     switch (checker.resolveTypeWitnessViaLookup(assocType)) {
     case ResolveWitnessResult::Success:
       // Success. Move on to the next.
+      LLVM_DEBUG(llvm::dbgs() << "Associated type " << assocType->getName()
+                              << " has a valid witness\n";);
       continue;
 
     case ResolveWitnessResult::ExplicitFailed:
+      LLVM_DEBUG(llvm::dbgs() << "Associated type " << assocType->getName()
+                              << " has an invalid witness\n";);
       continue;
 
     case ResolveWitnessResult::Missing:
@@ -2307,6 +2388,8 @@ auto AssociatedTypeInference::solve(ConformanceChecker &checker)
       // A declaration that can become a witness has shown up. Go
       // perform the resolution again now that we have more
       // information.
+      LLVM_DEBUG(llvm::dbgs() << "Associated type " << assocType->getName()
+                              << " now has a valid witness\n";);
       return solve(checker);
 
     case ResolveWitnessResult::Missing:
@@ -2332,6 +2415,9 @@ auto AssociatedTypeInference::solve(ConformanceChecker &checker)
         replacement = replacement->mapTypeOutOfContext();
       }
 
+      LLVM_DEBUG(llvm::dbgs() << "Best witness for " << assocType->getName()
+                              << " is " << replacement->getCanonicalType()
+                              << "\n";);
       result->push_back({assocType, replacement});
     }
 
@@ -2643,6 +2729,9 @@ TypeWitnessSystem::compareResolvedTypes(Type ty1, Type ty2) {
 }
 
 void ConformanceChecker::resolveTypeWitnesses() {
+  PrettyStackTraceConformance trace("performing associated type inference on",
+                                    Conformance);
+
   // Attempt to infer associated type witnesses.
   AssociatedTypeInference inference(getASTContext(), Conformance);
   if (auto inferred = inference.solve(*this)) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7990,6 +7990,10 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
   }
   conformance->setSignatureConformances(reqConformances);
 
+  for (unsigned index : indices(reqConformances)) {
+    conformance->setAssociatedConformance(index, reqConformances[index]);
+  }
+
   ArrayRef<uint64_t>::iterator rawIDIter = rawIDs.begin() + conformanceCount;
 
   TypeWitnessMap typeWitnesses;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7988,7 +7988,6 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
           llvm::inconvertibleErrorCode()));
     }
   }
-  conformance->setSignatureConformances(reqConformances);
 
   for (unsigned index : indices(reqConformances)) {
     conformance->setAssociatedConformance(index, reqConformances[index]);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1694,12 +1694,15 @@ void Serializer::writeLocalNormalProtocolConformance(
   SmallVector<DeclID, 32> data;
   unsigned numValueWitnesses = 0;
   unsigned numTypeWitnesses = 0;
-  unsigned numSignatureConformances =
-      conformance->getSignatureConformances().size();
+  unsigned numSignatureConformances = 0;
 
-  for (auto sigConformance : conformance->getSignatureConformances()) {
-    data.push_back(addConformanceRef(sigConformance));
-  }
+  conformance->forEachAssociatedConformance(
+      [&](Type t, ProtocolDecl *proto, unsigned index) {
+        auto assocConf = conformance->getAssociatedConformance(t, proto);
+        data.push_back(addConformanceRef(assocConf));
+        ++numSignatureConformances;
+        return false;
+      });
 
   conformance->forEachTypeWitness([&](AssociatedTypeDecl *assocType,
                                       Type type, TypeDecl *typeDecl) {

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -46,8 +46,10 @@ struct Basic: P1 {
 // CHECK-NEXT: (normal_conformance type="Recur" protocol="P2"
 // CHECK-NEXT:   (assoc_type req="A" type="Recur")
 // CHECK-NEXT:   (assoc_type req="B" type="Recur")
-// CHECK-NEXT:   (normal_conformance type="Recur" protocol="P2" <details printed above>)
-// CHECK-NEXT:   (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P2"
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:   (assoc_conformance type="Self.B" proto="P2"
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>)))
 struct Recur: P2 {
     typealias A = Recur
     typealias B = Recur
@@ -59,12 +61,16 @@ struct Recur: P2 {
 // CHECK-NEXT: (normal_conformance type="NonRecur" protocol="P2"
 // CHECK-NEXT:   (assoc_type req="A" type="Recur")
 // CHECK-NEXT:   (assoc_type req="B" type="Recur")
-// CHECK-NEXT:   (normal_conformance type="Recur" protocol="P2"
-// CHECK-NEXT:     (assoc_type req="A" type="Recur")
-// CHECK-NEXT:     (assoc_type req="B" type="Recur")
-// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>)
-// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>))
-// CHECK-NEXT:   (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P2"
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2"
+// CHECK-NEXT:       (assoc_type req="A" type="Recur")
+// CHECK-NEXT:       (assoc_type req="B" type="Recur")
+// CHECK-NEXT:       (assoc_conformance type="Self.A" proto="P2"
+// CHECK-NEXT:         (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:       (assoc_conformance type="Self.B" proto="P2"
+// CHECK-NEXT:         (normal_conformance type="Recur" protocol="P2" <details printed above>))))
+// CHECK-NEXT:   (assoc_conformance type="Self.B" proto="P2"
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>)))
 struct NonRecur: P2 {
     typealias A = Recur
     typealias B = Recur
@@ -97,8 +103,10 @@ class Super<T, U> {}
 // CHECK-NEXT: (normal_conformance type="Super<T, U>" protocol="P2"
 // CHECK-NEXT:   (assoc_type req="A" type="T")
 // CHECK-NEXT:   (assoc_type req="B" type="T")
-// CHECK-NEXT:   (abstract_conformance protocol="P2")
-// CHECK-NEXT:   (abstract_conformance protocol="P2")
+// CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P2"
+// CHECK-NEXT:     (abstract_conformance protocol="P2"))
+// CHECK-NEXT:   (assoc_conformance type="Self.B" proto="P2"
+// CHECK-NEXT:     (abstract_conformance protocol="P2"))
 // CHECK-NEXT:   (requirement "T" conforms_to "P2")
 // CHECK-NEXT:   (requirement "U" conforms_to "P2"))
 extension Super: P2 where T: P2, U: P2 {
@@ -117,20 +125,26 @@ extension Super: P2 where T: P2, U: P2 {
 // CHECK-NEXT:            (normal_conformance type="NonRecur" protocol="P2"
 // CHECK-NEXT:              (assoc_type req="A" type="Recur")
 // CHECK-NEXT:              (assoc_type req="B" type="Recur")
-// CHECK-NEXT:              (normal_conformance type="Recur" protocol="P2"
-// CHECK-NEXT:                (assoc_type req="A" type="Recur")
-// CHECK-NEXT:                (assoc_type req="B" type="Recur")
-// CHECK-NEXT:                (normal_conformance type="Recur" protocol="P2" <details printed above>)
-// CHECK-NEXT:                (normal_conformance type="Recur" protocol="P2" <details printed above>))
-// CHECK-NEXT:              (normal_conformance type="Recur" protocol="P2" <details printed above>)))
+// CHECK-NEXT:              (assoc_conformance type="Self.A" proto="P2"
+// CHECK-NEXT:                (normal_conformance type="Recur" protocol="P2"
+// CHECK-NEXT:                  (assoc_type req="A" type="Recur")
+// CHECK-NEXT:                  (assoc_type req="B" type="Recur")
+// CHECK-NEXT:                  (assoc_conformance type="Self.A" proto="P2"
+// CHECK-NEXT:                    (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:                  (assoc_conformance type="Self.B" proto="P2"
+// CHECK-NEXT:                    (normal_conformance type="Recur" protocol="P2" <details printed above>))))
+// CHECK-NEXT:              (assoc_conformance type="Self.B" proto="P2"
+// CHECK-NEXT:                (normal_conformance type="Recur" protocol="P2" <details printed above>))))
 // CHECK-NEXT:         (conformance type="U"
 // CHECK-NEXT:            (normal_conformance type="Recur" protocol="P2" <details printed above>)))
 // CHECK-NEXT:     (<conditional requirements unable to be computed>)
 // CHECK-NEXT:     (normal_conformance type="Super<T, U>" protocol="P2"
 // CHECK-NEXT:       (assoc_type req="A" type="T")
 // CHECK-NEXT:       (assoc_type req="B" type="T")
-// CHECK-NEXT:       (abstract_conformance protocol="P2")
-// CHECK-NEXT:       (abstract_conformance protocol="P2")
+// CHECK-NEXT:       (assoc_conformance type="Self.A" proto="P2"
+// CHECK-NEXT:         (abstract_conformance protocol="P2"))
+// CHECK-NEXT:       (assoc_conformance type="Self.B" proto="P2"
+// CHECK-NEXT:         (abstract_conformance protocol="P2"))
 // CHECK-NEXT:       (requirement "T" conforms_to "P2")
 // CHECK-NEXT:       (requirement "U" conforms_to "P2"))))
 class Sub: Super<NonRecur, Recur> {}
@@ -141,7 +155,8 @@ class Sub: Super<NonRecur, Recur> {}
 // CHECK-LABEL: StructDecl name=RecurGeneric
 // CHECK-NEXT: (normal_conformance type="RecurGeneric<T>" protocol="P3"
 // CHECK-NEXT:   (assoc_type req="A" type="RecurGeneric<T>")
-// CHECK-NEXT:   (normal_conformance type="RecurGeneric<T>" protocol="P3" <details printed above>))
+// CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P3"
+// CHECK-NEXT:     (normal_conformance type="RecurGeneric<T>" protocol="P3" <details printed above>)))
 struct RecurGeneric<T: P3>: P3 {
     typealias A = RecurGeneric<T>
 }
@@ -149,14 +164,16 @@ struct RecurGeneric<T: P3>: P3 {
 // CHECK-LABEL: StructDecl name=Specialize
 // CHECK-NEXT: (normal_conformance type="Specialize" protocol="P3"
 // CHECK-NEXT:   (assoc_type req="A" type="RecurGeneric<Specialize>")
-// CHECK-NEXT:   (specialized_conformance type="Specialize.A" protocol="P3"
-// CHECK-NEXT:     (substitution_map generic_signature="<T where T : P3>"
-// CHECK-NEXT:       (substitution "T -> Specialize")
-// CHECK-NEXT:       (conformance type="T"
-// CHECK-NEXT:         (normal_conformance type="Specialize" protocol="P3" <details printed above>)))
-// CHECK-NEXT:     (normal_conformance type="RecurGeneric<T>" protocol="P3"
-// CHECK-NEXT:       (assoc_type req="A" type="RecurGeneric<T>")
-// CHECK-NEXT:       (normal_conformance type="RecurGeneric<T>" protocol="P3" <details printed above>))))
+// CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P3"
+// CHECK-NEXT:     (specialized_conformance type="Specialize.A" protocol="P3"
+// CHECK-NEXT:       (substitution_map generic_signature="<T where T : P3>"
+// CHECK-NEXT:         (substitution "T -> Specialize")
+// CHECK-NEXT:         (conformance type="T"
+// CHECK-NEXT:           (normal_conformance type="Specialize" protocol="P3" <details printed above>)))
+// CHECK-NEXT:       (normal_conformance type="RecurGeneric<T>" protocol="P3"
+// CHECK-NEXT:         (assoc_type req="A" type="RecurGeneric<T>")
+// CHECK-NEXT:         (assoc_conformance type="Self.A" proto="P3"
+// CHECK-NEXT:           (normal_conformance type="RecurGeneric<T>" protocol="P3" <details printed above>))))))
 struct Specialize: P3 {
     typealias A = RecurGeneric<Specialize>
 }

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -219,8 +219,9 @@ extension InheritEqual: P2 where T: P1 {} // expected-note {{requirement from co
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-NEXT:  (normal_conformance type="InheritEqual<T>" protocol="P5"
-// CHECK-NEXT:    (normal_conformance type="InheritEqual<T>" protocol="P2"
-// CHECK-NEXT:      (requirement "T" conforms_to "P1"))
+// CHECK-NEXT:    (assoc_conformance type="Self" proto="P2"
+// CHECK-NEXT:      (normal_conformance type="InheritEqual<T>" protocol="P2"
+// CHECK-NEXT:        (requirement "T" conforms_to "P1")))
 // CHECK-NEXT:    (requirement "T" conforms_to "P1"))
 extension InheritEqual: P5 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P5'}}
 func inheritequal_good<U: P1>(_: U) {
@@ -251,8 +252,9 @@ extension InheritMore: P2 where T: P1 {} // expected-note {{requirement from con
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-NEXT:  (normal_conformance type="InheritMore<T>" protocol="P5"
-// CHECK-NEXT:    (normal_conformance type="InheritMore<T>" protocol="P2"
-// CHECK-NEXT:      (requirement "T" conforms_to "P1"))
+// CHECK-NEXT:    (assoc_conformance type="Self" proto="P2"
+// CHECK-NEXT:      (normal_conformance type="InheritMore<T>" protocol="P2"
+// CHECK-NEXT:        (requirement "T" conforms_to "P1")))
 // CHECK-NEXT:    (requirement "T" conforms_to "P4"))
 extension InheritMore: P5 where T: P4 {} // expected-note 2 {{requirement from conditional conformance of 'InheritMore<U>' to 'P5'}}
 func inheritequal_good_good<U: P4>(_: U) {

--- a/test/Generics/specialized_conformance_type_witness.swift
+++ b/test/Generics/specialized_conformance_type_witness.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Row {}
+
+// Force inference of Element first
+typealias Foo<T: Sequence> = T.Element
+typealias Bar = Foo<Row>
+
+extension Row: Collection {
+    public var startIndex: Int { 0 }
+
+    public var endIndex: Int { 0 }
+
+    public func index(after: Int) -> Int {
+      fatalError()
+    }
+
+    // We should not be considering this as a candidate witness
+    public subscript<T>(_: T) -> Any {
+      fatalError()
+    }
+
+    // This is the one we want
+    public subscript(position: Int) -> String {
+      fatalError()
+    }
+}
+
+// This should type check because Row.Element == String, and not Any
+let x: Row.Element.Type = Row.Element.self
+let y: String.Type = x


### PR DESCRIPTION
Type witnesses and value witnesses have been resolved lazily forever now. However associated conformances were all looked up in one shot, in `NormalProtocolConformance::finishSignatureConformances()`. Filling in this array involves computing a substituted type for the subject type of each associated conformance requirement, then looking up the conformance of the substituted type to the conformed protocol via a global lookup. The computation of the substituted subject type could call back into `finishSignatureConformances()`, causing a crash.

This PR makes some preliminary changes in service of making it all lazy. Going all the way exposes a few problems with associated type inference in the standard library, so until those problems are resolved, I'm going to land a preliminary refactoring first.