### PR TITLE
[wasm][test] Add objc_codegen feature to exclude enable-objc-interop tests

### DIFF
--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-objc-interop  -primary-file %s -emit-ir -sil-verify-all | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-objc,CHECK-%target-ptrsize
 // RUN: %target-swift-frontend -disable-objc-interop -primary-file %s -emit-ir -sil-verify-all | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-native,CHECK-%target-ptrsize
 
-// REQUIRES: concurrency
+// REQUIRES: concurrency, objc_codegen
 // XFAIL: CPU=arm64e
 
 sil_stage canonical

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -g -enable-objc-interop  -primary-file %s -emit-irgen -sil-verify-all | %IRGenFileCheck %s
 // RUN: %target-swift-frontend  -enable-objc-interop  -primary-file %s -emit-ir -sil-verify-all
 
-// REQUIRES: concurrency
+// REQUIRES: concurrency, objc_codegen
 
 import Builtin
 import Swift

--- a/test/IRGen/async/partial_apply_forwarder.sil
+++ b/test/IRGen/async/partial_apply_forwarder.sil
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -g -enable-objc-interop  -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-objc
 // RUN: %target-swift-frontend  -g -disable-objc-interop -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-native
 
-// REQUIRES: concurrency
+// REQUIRES: concurrency, objc_codegen
 
 sil_stage canonical
 

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix %target-cpu -check-prefix %target-abi-%target-cpu
+// REQUIRES: objc_codegen
 
 // This is deliberately not a SIL test so that we can test SILGen too.
 

--- a/test/IRGen/clang_empty_type.swift
+++ b/test/IRGen/clang_empty_type.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir -verify -enable-objc-interop -import-objc-header %S/Inputs/clang_empty_type.h %s
+// REQUIRES: objc_codegen
 
 public func projectTrailingArray(x: inout TrailingArray) {
   x.size = 2

--- a/test/IRGen/clang_inline_opt.swift
+++ b/test/IRGen/clang_inline_opt.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-objc-interop -import-objc-header %S/Inputs/c_functions.h -primary-file %s -O -emit-ir -disable-llvm-optzns | %FileCheck %s
+// REQUIRES: objc_codegen
 
 func return10() -> UInt32 {
 	return return7() + 3

--- a/test/IRGen/class_metadata.swift
+++ b/test/IRGen/class_metadata.swift
@@ -2,6 +2,7 @@
 // RUN: %{python} %utils/chex.py < %s > %t/class_metadata.swift
 // RUN: %target-swift-frontend  -enable-objc-interop -emit-ir %s | %FileCheck %t/class_metadata.swift -check-prefixes=CHECK,CHECK-%target-ptrsize,CHECK-%target-import-type,CHECK-%target-cpu -D#MDSIZE=7
 // RUN: %target-swift-frontend -disable-objc-interop -emit-ir %s | %FileCheck %t/class_metadata.swift -check-prefixes=CHECK,CHECK-%target-ptrsize,CHECK-%target-import-type,CHECK-%target-cpu -D#MDSIZE=4
+// REQUIRES: objc_codegen
 
 class A {}
 

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -6,6 +6,7 @@
 // RUN: %target-swift-frontend -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-%target-import-type-objc-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
 // RUN: %target-swift-frontend -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/class_resilience.swift | %FileCheck %t/class_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
 // RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution -O %t/class_resilience.swift
+// REQUIRES: objc_codegen
 
 // CHECK: @"$s16class_resilience26ClassWithResilientPropertyC1s16resilient_struct4SizeVvpWvd" = hidden global [[INT]] 0
 // CHECK: @"$s16class_resilience26ClassWithResilientPropertyC5colors5Int32VvpWvd" = hidden global [[INT]] 0

--- a/test/IRGen/generic_vtable.swift
+++ b/test/IRGen/generic_vtable.swift
@@ -2,6 +2,7 @@
 // RUN: %{python} %utils/chex.py < %s > %t/generic_vtable.swift
 // RUN: %target-swift-frontend -enable-objc-interop  %t/generic_vtable.swift -emit-ir | %FileCheck %t/generic_vtable.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-import-type,CHECK-%target-abi -DINT=i%target-ptrsize
 // RUN: %target-swift-frontend -disable-objc-interop %t/generic_vtable.swift -emit-ir | %FileCheck %t/generic_vtable.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-import-type,CHECK-%target-abi -DINT=i%target-ptrsize
+// REQUIRES: objc_codegen
 
 public class Base {
   public func m1() {}

--- a/test/IRGen/local_types.swift
+++ b/test/IRGen/local_types.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/local_types_helper.swift -o %t
 // RUN: %target-swift-frontend -enable-objc-interop -emit-ir -parse-as-library %s -I %t | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE %s
+// REQUIRES: objc_codegen
 
 import local_types_helper
 

--- a/test/IRGen/nested_imported_type_context_descriptor.swift
+++ b/test/IRGen/nested_imported_type_context_descriptor.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-objc-interop -import-objc-header %S/Inputs/nested_imported_type_context_descriptor.h | %FileCheck %s
+// REQUIRES: objc_codegen
 
 // Nominal type descriptors for the imported type X and both of its nested
 // anonymous struct should get emitted as ODR.

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -primary-file %s -enable-objc-interop -import-objc-header %S/Inputs/objc_bridged_generic_conformance.h | %FileCheck %s
+// REQUIRES: objc_codegen
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/objc_class_empty_fields.swift
+++ b/test/IRGen/objc_class_empty_fields.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -primary-file %s -enable-objc-interop -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: objc_codegen
 
 // https://github.com/apple/swift/issues/43667
 

--- a/test/IRGen/objc_class_in_storage_decls.swift
+++ b/test/IRGen/objc_class_in_storage_decls.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// REQUIRES: objc_codegen
 
 struct WrapperStruct {
   subscript() -> Void {

--- a/test/IRGen/objc_dependent_type_closure_argument.swift
+++ b/test/IRGen/objc_dependent_type_closure_argument.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -primary-file %s -enable-objc-interop -import-objc-header %S/Inputs/objc_dependent_type_closure_argument.h
+// REQUIRES: objc_codegen
 
 // Regression test for https://github.com/apple/swift/pull/40295
 public protocol SwiftProtocol {

--- a/test/IRGen/objc_enum_multi_file.swift
+++ b/test/IRGen/objc_enum_multi_file.swift
@@ -3,6 +3,7 @@
 
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -emit-module %S/Inputs/objc_enum_multi_file_helper.swift -o %t
 // RUN: %target-swift-frontend -module-name main -primary-file %s -I %t -DIMPORT -emit-ir | %FileCheck %s
+// REQUIRES: objc_codegen
 
 #if IMPORT
 import objc_enum_multi_file_helper

--- a/test/IRGen/objc_extensions_jit.swift
+++ b/test/IRGen/objc_extensions_jit.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop %s -emit-ir -disable-objc-attr-requires-foundation-module -use-jit | %FileCheck %s
+// REQUIRES: objc_codegen
 
 import Foundation
 import objc_generics

--- a/test/IRGen/objc_generic_protocol_conformance.swift
+++ b/test/IRGen/objc_generic_protocol_conformance.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -primary-file %s -enable-objc-interop -import-objc-header %S/Inputs/objc_generic_protocol_conformance.h | %FileCheck --check-prefix=SIL %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -primary-file %s -enable-objc-interop -import-objc-header %S/Inputs/objc_generic_protocol_conformance.h | %FileCheck --check-prefix=IR %s
+// REQUIRES: objc_codegen
 
 protocol P {
   func foo()

--- a/test/IRGen/objc_int_encoding.sil
+++ b/test/IRGen/objc_int_encoding.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: objc_codegen
 
 // CHECK: [[SELECTOR:@.*]] = private global {{.*}} c"fooWithX:\00"
 

--- a/test/IRGen/objc_properties_jit.swift
+++ b/test/IRGen/objc_properties_jit.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop %s -emit-ir -disable-objc-attr-requires-foundation-module -use-jit | %FileCheck %s
+// REQUIRES: objc_codegen
 
 import Foundation
 

--- a/test/IRGen/objc_protocol_multi_file.swift
+++ b/test/IRGen/objc_protocol_multi_file.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -enable-objc-interop -primary-file %s %S/Inputs/objc_protocol_multi_file_helper.swift -g -emit-ir | %FileCheck %s
+// REQUIRES: objc_codegen
 
 // This used to crash <rdar://problem/17929944>.
 // To tickle the crash, SubProto must not be used elsewhere in this file.

--- a/test/IRGen/objc_protocol_vars.sil
+++ b/test/IRGen/objc_protocol_vars.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -parse-as-library -emit-ir %s | %FileCheck %s --check-prefix=CHECK-%target-object-format
+// REQUIRES: objc_codegen
 
 // It tests whether the vars @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_"
 // and @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_" are in llvm.used.

--- a/test/IRGen/objc_runtime_visible.sil
+++ b/test/IRGen/objc_runtime_visible.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-objc-interop -I %S/../Inputs/custom-modules %s -emit-ir | %FileCheck %s
+// REQUIRES: objc_codegen
 
 sil_stage raw
 

--- a/test/IRGen/objc_runtime_visible_conformance.swift
+++ b/test/IRGen/objc_runtime_visible_conformance.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-objc-interop -I %S/../Inputs/custom-modules %s -emit-ir | %FileCheck %s
+// REQUIRES: objc_codegen
 
 import ObjCRuntimeVisible
 

--- a/test/IRGen/objc_selector.sil
+++ b/test/IRGen/objc_selector.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
+// REQUIRES: objc_codegen
 
 sil_stage canonical
 

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=simplification -enable-objc-interop  -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-objc
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=simplification -disable-objc-interop -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefixes=CHECK,CHECK-native
+// REQUIRES: objc_codegen
 sil_stage canonical
 
 import Builtin

--- a/test/IRGen/related_entity.sil
+++ b/test/IRGen/related_entity.sil
@@ -2,6 +2,7 @@
 // RUN: %{python} %utils/chex.py < %s > %t/checkfile
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir -o - -primary-file %s -import-objc-header %S/Inputs/error_domains.h > %t/out.ir
 // RUN: %FileCheck --input-file=%t/out.ir %t/checkfile --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// REQUIRES: objc_codegen
 
 sil_stage canonical
 

--- a/test/IRGen/swift_native_objc_runtime_base.sil
+++ b/test/IRGen/swift_native_objc_runtime_base.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-objc-interop -emit-ir %s | %FileCheck %s
+// REQUIRES: objc_codegen
 
 // CHECK-LABEL: @"$s30swift_native_objc_runtime_base1CCMm" = hidden global %objc_class {
 // -- metaclass "isa" is root metaclass

--- a/test/IRGen/trap-function-clang.swift
+++ b/test/IRGen/trap-function-clang.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -trap-function oopsie -enable-objc-interop -emit-ir -module-name trap_function -I %t | %FileCheck %s -check-prefix=TRAPFN
 // RUN: %target-swift-frontend -O -sdk %S/Inputs -primary-file %s -trap-function oopsie -enable-objc-interop -emit-ir -module-name trap_function -I %t | %FileCheck %s -check-prefix=TRAPFN_OPT
 // RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -enable-objc-interop -emit-ir -module-name trap_function -I %t | %FileCheck %s -check-prefix=NOTRAPFN
+// REQUIRES: objc_codegen
 
 import gizmo
 

--- a/test/IRGen/trap-function.swift
+++ b/test/IRGen/trap-function.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend -primary-file %s -trap-function oopsie -emit-ir -module-name trap_function -I %t | %FileCheck %s -check-prefix=TRAPFN
 // RUN: %target-swift-frontend -O -primary-file %s -trap-function oopsie -emit-ir -module-name trap_function -I %t | %FileCheck %s -check-prefix=TRAPFN_OPT
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -module-name trap_function -I %t | %FileCheck %s -check-prefix=NOTRAPFN
+// REQUIRES: objc_codegen
 
 // TRAPFN-LABEL: define hidden swiftcc {{.*}} @"$s13trap_function14checkOverflow1yS2i_SitF"
 // TRAPFN: call void @llvm.trap() [[ATTR0:#[0-9]+]]

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-objc-interop  | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc-%target-ptrsize
 // RUN: %target-swift-frontend -emit-ir %s -disable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native-%target-ptrsize
+// REQUIRES: objc_codegen
 
 class C {}
 protocol P: class {}

--- a/test/IRGen/witness_table_objc_associated_type.swift
+++ b/test/IRGen/witness_table_objc_associated_type.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize
+// REQUIRES: objc_codegen
 
 protocol A {}
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -758,6 +758,10 @@ config.substitutions.insert(0,
 if platform.system() != 'Windows':
     config.available_features.add('crash-recovery')
 
+# Clang cannot enable objc language mode on WebAssembly target
+if run_cpu != 'wasm32':
+    config.available_features.add('objc_codegen')
+
 # Add each available build target CPU as a feature.
 for target in config.llvm_code_generators:
   config.available_features.add("CODEGENERATOR=" + target)


### PR DESCRIPTION
Clang does not accept `-x objective-c` with WebAssembly target and it crashes with "Objective-C support is unimplemented for object file format" for now. `-enable-objc-interop` can work without the objc runtime support (which is indicated by `objc_interop` feature), so this adds a new `objc_codegen` feature to require Objective-C support only at compile-time.
