### PR TITLE
[build] Update base preset for cross compiler ci for Wasm

### DIFF
--- a/test/Concurrency/async_task_base_priority.swift
+++ b/test/Concurrency/async_task_base_priority.swift
@@ -13,6 +13,7 @@
 // UNSUPPORTED: DARWIN_SIMULATOR=watchos
 // UNSUPPORTED: DARWIN_SIMULATOR=ios
 // UNSUPPORTED: DARWIN_SIMULATOR=tvos
+// UNSUPPORTED: single_threaded_concurrency
 
 import StdlibUnittest
 import Dispatch

--- a/test/Sanitizers/tsan/once.swift
+++ b/test/Sanitizers/tsan/once.swift
@@ -3,6 +3,7 @@
 // RUN: env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
+// UNSUPPORTED: threading_none
 
 // rdar://101876380
 // UNSUPPORTED: OS=ios

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1273,7 +1273,7 @@ sourcekit-lsp=0
 # TODO: This does not build stdlib for wasm32 for now.
 # Enable stdlib cross-compile after build-script will support it.
 [preset: buildbot_incremental_linux_crosscompile_wasm]
-mixin-preset=buildbot_incremental_linux_base
+mixin-preset=buildbot_linux
 llvm-targets-to-build=X86;ARM;AArch64;WebAssembly
 # Ensure single-thread-mode is not broken because it's used
 # by stdlib for wasm32 in SwiftWasm fork.

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1275,10 +1275,6 @@ sourcekit-lsp=0
 [preset: buildbot_incremental_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux
 llvm-targets-to-build=X86;ARM;AArch64;WebAssembly
-# Ensure single-thread-mode is not broken because it's used
-# by stdlib for wasm32 in SwiftWasm fork.
-swift-stdlib-single-threaded-concurrency=1
-swift-threading-package=none
 
 #===------------------------------------------------------------------------===#
 # OS X Package Builders

--- a/validation-test/Runtime/ConcurrentMetadata.swift
+++ b/validation-test/Runtime/ConcurrentMetadata.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// UNSUPPORTED: single_threaded_runtime
 // UNSUPPORTED: threading_none
 
 // Exercise the metadata cache from multiple threads to shake out any

--- a/validation-test/Runtime/weak-reference-racetests-dispatch.swift
+++ b/validation-test/Runtime/weak-reference-racetests-dispatch.swift
@@ -4,6 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: stress_test
 // REQUIRES: libdispatch
+// UNSUPPORTED: threading_none
 
 import StdlibUnittest
 import Dispatch

--- a/validation-test/Runtime/weak-reference-racetests.swift
+++ b/validation-test/Runtime/weak-reference-racetests.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: stress_test
-// UNSUPPORTED: single_threaded_runtime
+// UNSUPPORTED: threading_none
 
 import StdlibUnittest
 

--- a/validation-test/SILOptimizer/string_switch.swift
+++ b/validation-test/SILOptimizer/string_switch.swift
@@ -5,7 +5,7 @@
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: stress_test
 // REQUIRES: executable_test
-// UNSUPPORTED: single_threaded_runtime
+// UNSUPPORTED: threading_none
 
 import StdlibUnittest
 

--- a/validation-test/StdlibUnittest/AtomicInt.swift
+++ b/validation-test/StdlibUnittest/AtomicInt.swift
@@ -5,7 +5,7 @@
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 // REQUIRES: stress_test
-// UNSUPPORTED: single_threaded_runtime
+// UNSUPPORTED: threading_none
 
 import SwiftPrivate
 import StdlibUnittest

--- a/validation-test/StdlibUnittest/RaceTest.swift
+++ b/validation-test/StdlibUnittest/RaceTest.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -Xfrontend -disable-access-control -module-name a %s -o %t.out
 // RUN: %target-run %t.out | %FileCheck %s
 // REQUIRES: stress_test
-// UNSUPPORTED: single_threaded_runtime
+// UNSUPPORTED: threading_none
 
 import SwiftPrivate
 import StdlibUnittest

--- a/validation-test/stdlib/ArrayBridging.swift
+++ b/validation-test/stdlib/ArrayBridging.swift
@@ -10,7 +10,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 // REQUIRES: stress_test
-// UNSUPPORTED: single_threaded_runtime
+// UNSUPPORTED: threading_none
 
 import StdlibUnittest
 import Foundation

--- a/validation-test/stdlib/CommandLine.swift
+++ b/validation-test/stdlib/CommandLine.swift
@@ -8,7 +8,7 @@
 // RUN: %target-run %t/CommandLineStressTest foo bar baz qux quux corge grault garply waldo fred plugh xyzzy and thud
 // REQUIRES: executable_test
 // REQUIRES: stress_test
-// UNSUPPORTED: single_threaded_runtime
+// UNSUPPORTED: threading_none
 
 // REQUIRES: rdar70423908
 

--- a/validation-test/stdlib/DictionaryBridging.swift
+++ b/validation-test/stdlib/DictionaryBridging.swift
@@ -9,7 +9,7 @@
 // REQUIRES: stress_test
 
 // REQUIRES: objc_interop
-// UNSUPPORTED: single_threaded_runtime
+// UNSUPPORTED: threading_none
 
 import StdlibUnittest
 import Foundation

--- a/validation-test/stdlib/ErrorProtocol.swift
+++ b/validation-test/stdlib/ErrorProtocol.swift
@@ -2,7 +2,7 @@
 // REQUIRES: executable_test
 // REQUIRES: stress_test
 // REQUIRES: objc_interop
-// UNSUPPORTED: single_threaded_runtime
+// UNSUPPORTED: threading_none
 
 import SwiftPrivate
 import StdlibUnittest


### PR DESCRIPTION
`buildbot_incremental_linux_base` is not actively checked in the ci.swift.org, and brings non-wasm related issues frequently, so use actively used one instead.


