### PR TITLE
[DNM] [POC] Allow default parameters to be added to operator functions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1185,7 +1185,7 @@ ERROR(unary_op_missing_prepos_attribute,none,
 NOTE(unary_operator_declaration_here,none,
    "%select{prefix|postfix}0 operator found here", (bool))
 ERROR(invalid_arg_count_for_operator,none,
-      "operators must have one or two arguments", ())
+      "operators must have one or two non-default arguments", ())
 ERROR(operator_in_local_scope,none,
       "operator functions can only be declared at global or in type scope", ())
 ERROR(nonstatic_operator_in_nominal,none,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9852,18 +9852,41 @@ bool FuncDecl::isUnaryOperator() const {
   if (!isOperator())
     return false;
   
-  auto *params = getParameters();
-  return params->size() == 1 && !params->get(0)->isVariadic();
+  ArrayRef<ParamDecl*> params = getParameters()->getArray();
+
+  // Count the number of non-default parameters
+  unsigned nonDefaultParamCount = llvm::count_if(params, [](ParamDecl* param) {
+    return !param->isDefaultArgument();
+  });
+
+  if (nonDefaultParamCount != 1) return false;
+
+  // Find the non-default parameter
+  auto nonDefaultParam = llvm::find_if(params, [](ParamDecl* param) {
+    return !param->isDefaultArgument();
+  });
+
+  // Check if the non-default parameter is not variadic
+  return !(*nonDefaultParam)->isVariadic();
 }
 
 bool FuncDecl::isBinaryOperator() const {
   if (!isOperator())
     return false;
-  
-  auto *params = getParameters();
-  return params->size() == 2 &&
-    !params->get(0)->isVariadic() &&
-    !params->get(1)->isVariadic();
+
+    ArrayRef<ParamDecl*> params = getParameters()->getArray();
+
+    // Filter out default parameters into a new container
+    std::vector<ParamDecl*> nonDefaultParams;
+    llvm::copy_if(params, std::back_inserter(nonDefaultParams), [](ParamDecl* param) {
+        return !param->isDefaultArgument();
+    });
+
+    // Check if there are exactly 2 non-default parameters and neither is variadic
+    return nonDefaultParams.size() == 2 && 
+           llvm::all_of(nonDefaultParams, [](ParamDecl* param) {
+               return !param->isVariadic();
+           });
 }
 
 SelfAccessKind FuncDecl::getSelfAccessKind() const {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2516,7 +2516,7 @@ bool DisjunctionChoice::isUnaryOperator() const {
     return false;
 
   auto func = cast<FuncDecl>(decl);
-  return func->getParameters()->size() == 1;
+  return func->isUnaryOperator();
 }
 
 void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -56,15 +56,32 @@ static bool matchesDeclRefKind(ValueDecl *value, DeclRefKind refKind) {
 
   // A binary-operator reference only honors FuncDecls with a certain type.
   case DeclRefKind::BinaryOperator:
-    return (getNumArgs(value) == 2);
+    if (auto *func = dyn_cast<FuncDecl>(value)) {
+      unsigned nonDefaultParamCount = llvm::count_if(func->getParameters()->getArray(), [](ParamDecl* param) {
+        return !param->isDefaultArgument();
+      });
+      return nonDefaultParamCount == 2;
+    }
+    return ~0U;
 
   case DeclRefKind::PrefixOperator:
-    return (!value->getAttrs().hasAttribute<PostfixAttr>() &&
-            getNumArgs(value) == 1);
+    if (auto *func = dyn_cast<FuncDecl>(value)) {
+      unsigned nonDefaultParamCount = llvm::count_if(func->getParameters()->getArray(), [](ParamDecl* param) {
+        return !param->isDefaultArgument();
+      });
+      return (nonDefaultParamCount == 1 && value->getAttrs().hasAttribute<PrefixAttr>());
+    }
+    return ~0U;
+
 
   case DeclRefKind::PostfixOperator:
-    return (value->getAttrs().hasAttribute<PostfixAttr>() &&
-            getNumArgs(value) == 1);
+    if (auto *func = dyn_cast<FuncDecl>(value)) {
+      unsigned nonDefaultParamCount = llvm::count_if(func->getParameters()->getArray(), [](ParamDecl* param) {
+        return !param->isDefaultArgument();
+      });
+      return (nonDefaultParamCount == 1 && value->getAttrs().hasAttribute<PostfixAttr>());
+    }
+    return ~0U;
   }
   llvm_unreachable("bad declaration reference kind");
 }

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -27,7 +27,7 @@ public struct S {
 // expected-error@+8{{expected 'func' keyword in operator function declaration}}
 // expected-error@+7{{operator '/' declared in type 'S' must be 'static'}}
 // expected-error@+6{{expected '(' in argument list of function declaration}}
-// expected-error@+5{{operators must have one or two arguments}}
+// expected-error@+5{{operators must have one or two non-default arguments}}
 // expected-error@+4{{member operator '/()' must have at least one argument of type 'S'}}
 // expected-error@+3{{expected '{' in body of function declaration}}
 // expected-error@+2 {{consecutive declarations on a line must be separated by ';}}

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -3,8 +3,8 @@
 infix operator %%%
 infix operator %%%%
 
-func %%%() {} // expected-error {{operators must have one or two arguments}}
-func %%%%(a: Int, b: Int, c: Int) {} // expected-error {{operators must have one or two arguments}}
+func %%%() {} // expected-error {{operators must have one or two non-default arguments}}
+func %%%%(a: Int, b: Int, c: Int) {} // expected-error {{operators must have one or two non-default arguments}}
 
 struct X {}
 struct Y {}

--- a/test/decl/func/operator_with_defaults.swift
+++ b/test/decl/func/operator_with_defaults.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -Xllvm -swift-diagnostics-assert-on-warning=1
+
+infix operator %%%%%
+prefix operator **-
+postfix operator **+
+
+func %%%%% (lhs: Int, rhs: Int, file: String = #file) -> String { file } // no-err
+prefix func **- (a: Int, file: String = #file) -> String { file } // no-err
+postfix func **+ (a: Int, file: String = #file) -> String { file } // no-err
+
+print(3 %%%%% 4) // no-err
+print(**-3) // no-err
+print(3**+) // no-err


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR allows operator functions to have more than one or two parameters as long as they are default parameters, allowing something like :
```swift 
infix operator <-
// Still infix because it has 2 formal arguments and 1 default
public func <- (lhs: T, rhs :T, file: StaticString = #file) -> U { /**/ }
```

This can be useful in scenarios when you want to pass some other parameters for other purposes like logging. 

This PR changes the previous logic of checking the operator function's parameter count directly to only check the parameters that do not have default values.

This is an additive feature to the swift language and does not have backwards-breaking changes. 

According to the original issue, this addition requires a swift evolution review, so this PR is for POC purposes. It still needs proper formatting and some code-level optimizations. 🙃

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #54301

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
