### PR TITLE
[Parser] Improve diagnostics for generic parameter list in enum cases

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -226,6 +226,8 @@ ERROR(let_cannot_be_addressed_property,none,
 ERROR(disallowed_var_multiple_getset,none,
       "'var' declarations with multiple variables cannot have explicit"
       " getters/setters", ())
+ERROR(unexpected_generic_in_enum_case,none,
+      "enum cases cannot have generic parameters. did you mean to attach it to enum declaration?", ())
 
 ERROR(disallowed_init,none,
       "initial value is not allowed here", ())

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8902,7 +8902,7 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
 
   // Parse comma-separated enum elements.
   SmallVector<EnumElementDecl*, 4> Elements;
-  
+
   SourceLoc CommaLoc;
   for (;;) {
     Identifier Name;
@@ -8968,6 +8968,12 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
       } else {
         diagnose(CaseLoc, diag::expected_identifier_in_decl, "enum 'case'");
       }
+    }
+
+    // See if there's an illegal generic parameter list.
+    if (startsWithLess(Tok)) {
+      diagnose(Tok, diag::unexpected_generic_in_enum_case);
+      skipUntilGreaterInTypeList();
     }
 
     // See if there's a following argument type.

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -636,3 +636,10 @@ if case nil = foo1 {} // Okay
 if case .none? = foo1 {} // Okay
 if case nil = foo2 {} // Okay
 if case .none?? = foo2 {} // Okay
+
+enum UnsupportedGenericEnumCase { 
+  case one<Type>(param: Type) // expected-error {{enum cases cannot have generic parameters. did you mean to attach it to enum declaration?}} 
+  // expected-error@-1 {{cannot find type 'Type' in scope}}
+  case two<Partial(param: Int) // expected-error {{enum cases cannot have generic parameters. did you mean to attach it to enum declaration?}}
+  case three<(param: Int) // expected-error {{enum cases cannot have generic parameters. did you mean to attach it to enum declaration?}}
+}


### PR DESCRIPTION
```
enum Foo {
    case bar<T>(baz: T)
            ^
}
```

above code results in

```
Consecutive declarations on a line must be separated by ';'
Expected declaration
```
which is not very helpful for informing the user that generics are not available as a case in enums.

Something like `enum cases cannot have generic parameters. did you mean to attach it to enum declaration` could be emitted for better guidance to the users.

Resolves #69036

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
