### PR TITLE
[Gardening] Updated comment.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -15,8 +15,8 @@
 //       let myNewTest = 
 //       FunctionTest("my_new_test") { function, arguments, context in
 //       }
-// - In SwiftCompilerSources/Sources/SIL/Test.swift's registerSILTests function,
-//   register the new test:
+// - In SwiftCompilerSources/Sources/SIL/Test.swift's registerOptimizerTests
+//   function, register the new test:
 //       registerFunctionTest(myNewTest)
 //
 //===----------------------------------------------------------------------===//
@@ -57,6 +57,7 @@
 // 1) A test test/SILOptimizer/interesting_functionality_unit.sil runs the
 //    TestRunner pass:
 //     // RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+//     // REQUIRES: swift_in_compiler
 // 2) A function in interesting_functionality_unit.sil contains the
 //    specify_test instruction.
 //      sil @f : $() -> () {


### PR DESCRIPTION
Mention that running FunctionTests written in swift requires swift-in-compiler and fixed the name of the register function.
