### PR TITLE
[NFC][Concurrency] Add a regression test for a bogus missing `try` diagnostic with `async let`.

### DIFF
--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -203,6 +203,13 @@ func testAsyncLet() async throws {
   _ = await x5
 }
 
+func search(query: String) async throws -> [String] {
+  let entities: [String] = []
+
+  async let r = entities.filter { $0.contains(query) }.map { String($0) }
+  return await r
+}
+
 // expected-note@+1 3{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}} {{30-30= async}}
 func testAsyncLetOutOfAsync() {
   async let x = 1 // expected-error{{'async let' in a function that does not support concurrency}}


### PR DESCRIPTION
```swift
func search(query: String) async throws -> [String] {
  let entities: [String] = []

  async let r = entities.filter { $0.contains(query) }.map { String($0) }
  return await r
}
```

The above example was reported as diagnosing `error: reading 'async let' can throw but is not marked with 'try'`. This has since been fixed on main, so this change is just adding a test case for the future.

Resolves rdar://96830163