### PR TITLE
[test][IRGen] Avoid redefinition of bool in huge_c_type.swift

### DIFF
--- a/test/IRGen/Inputs/huge_c_type.h
+++ b/test/IRGen/Inputs/huge_c_type.h
@@ -1,7 +1,5 @@
 #include <stdint.h>
 
-typedef uint8_t bool;
-
 #define CREATE_ARRAY(T, N)                                                     \
   struct {                                                                     \
     T data[N];                                                                 \
@@ -15,7 +13,7 @@ typedef struct {
 
 typedef struct {
   uint64_t a;
-  bool b;
+  uint8_t b;
   CREATE_ARRAY(Thing, 16) c;
   uint32_t d;
   uint64_t e;


### PR DESCRIPTION
musl and wasi-libc modules contains stdint.h and stdbool.h in their modulemap, and `#incnlude <stdint.h>` in huge_c_type.h leads including stdbool.h also in the scope. This results in conflicting the bool definition, so we should avoid the redefinition.
