### PR TITLE
[test][IRGen] Cover more tests for WebAssembly target

### DIFF
--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -337,6 +337,22 @@ bb0:
 // CHECK-s390x-LABEL: declare{{( dllimport)?}} signext i32 @ints(i32 signext)
 // CHECK-s390x-LABEL: declare{{( dllimport)?}} zeroext i32 @unsigneds(i32 zeroext)
 
+// CHECK-wasm32-LABEL: define swiftcc void @testIntegerExtension(i8 %0, i8 %1, i8 %2, i16 %3, i16 %4, i32 %5, i32 %6) #0 {
+// CHECK-wasm32:         call signext i8 @chareth(i8 signext %0)
+// CHECK-wasm32:         call signext i8 @signedChareth(i8 signext %1)
+// CHECK-wasm32:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
+// CHECK-wasm32:         call signext i16 @eatMyShorts(i16 signext %3)
+// CHECK-wasm32:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext %4)
+// CHECK-wasm32:         call i32 @ints(i32 %5)
+// CHECK-wasm32:         call i32 @unsigneds(i32 %6)
+// CHECK-wasm32-LABEL: declare signext i8 @chareth(i8 signext) #0
+// CHECK-wasm32-LABEL: declare signext i8 @signedChareth(i8 signext) #0
+// CHECK-wasm32-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext) #0
+// CHECK-wasm32-LABEL: declare signext i16 @eatMyShorts(i16 signext) #0
+// CHECK-wasm32-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext) #0
+// CHECK-wasm32-LABEL: declare i32 @ints(i32) #0
+// CHECK-wasm32-LABEL: declare i32 @unsigneds(i32) #0
+
 sil @testIntegerExtension : $@convention(thin) (CChar, CSignedChar, CUnsignedChar, CShort, CUnsignedShort, CInt, CUnsignedInt) -> () {
 entry(%a : $CChar, %b : $CSignedChar, %c : $CUnsignedChar, %d : $CShort, %e : $CUnsignedShort, %f : $CInt, %g : $CUnsignedInt):
   %h = function_ref @chareth : $@convention(c) (CChar) -> CChar

--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -25,6 +25,7 @@ entry:
 // CHECK-LABEL-aarch64:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr swifterror %1) {{.*}} {
 // CHECK-LABEL-arm64_32:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr swifterror %1) {{.*}} {
 // CHECK-LABEL-arm64e:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr swifterror %1) {{.*}} {
+// CHECK-LABEL-wasm32:  define swiftcc void @does_throw(ptr swiftself %0, ptr swifterror %1) {{.*}} {
 sil @does_throw : $@convention(thin) () -> @error Error {
   // CHECK: [[T0:%.*]] = call swiftcc ptr @create_error()
   %0 = function_ref @create_error : $@convention(thin) () -> @owned Error
@@ -49,6 +50,7 @@ sil @does_throw : $@convention(thin) () -> @error Error {
 // CHECK-LABEL-aarch64:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr swifterror %1) {{.*}} {
 // CHECK-LABEL-arm64e:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr swifterror %1) {{.*}} {
 // CHECK-LABEL-arm64_32:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr swifterror %1) {{.*}} {
+// CHECK-LABEL-wasm32: define swiftcc void @doesnt_throw(ptr swiftself %0, ptr swifterror %1) {{.*}} {
 sil @doesnt_throw : $@convention(thin) () -> @error Error {
   //   We don't have to do anything here because the caller always
   //   zeroes the error slot before a call.
@@ -74,6 +76,7 @@ entry(%0 : $AnyObject):
   // CHECK-aarch64:       [[ERRORSLOT:%.*]] = alloca [[SWIFTERROR:.*]] ptr, align
   // CHECK-arm64_32:       [[ERRORSLOT:%.*]] = alloca [[SWIFTERROR:.*]] ptr, align
   // CHECK-powerpc64le: [[ERRORSLOT:%.*]] = alloca [[SWIFTERROR:.*]] ptr, align
+  // CHECK-wasm32:      [[ERRORSLOT:%.*]] = alloca [[SWIFTERROR:.*]] ptr, align
   // CHECK-NEXT: store ptr null, ptr [[ERRORSLOT]], align
 
   // CHECK-objc-NEXT: [[RESULT:%.*]] = call swiftcc ptr @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias nocapture [[SWIFTERROR]]{{( )?}}dereferenceable({{.}}) [[ERRORSLOT]])

--- a/test/IRGen/has_symbol_clang.swift
+++ b/test/IRGen/has_symbol_clang.swift
@@ -11,5 +11,5 @@ public func testClangDecls() {
 }
 
 // --- clangFunc(_:) ---
-// CHECK: define linkonce_odr hidden i1 @"$sSo9clangFuncyys5Int32VFTwS"() #1 {
+// CHECK: define linkonce_odr hidden i1 @"$sSo9clangFuncyys5Int32VFTwS"() #1{{( comdat)?}} {
 // CHECK:   ret i1 icmp ne (ptr @clangFunc, ptr null)

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -26,6 +26,7 @@ func forceStuff(x: float4, y: float3) -> (Float, Float, Float, Float) {
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float> %0)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float> %0)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float> %0)
+// wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float> %0)
 sil @simd_c_args : $@convention(c) (float4) -> float4 {
 entry(%x : $float4):
   return %x : $float4
@@ -47,6 +48,7 @@ entry(%x : $float4):
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float> %0)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float> %0)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float> %0)
+// wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float> %0)
 sil @simd_c_args_float3 : $@convention(c) (float3) -> float3 {
 entry(%x : $float3):
 // x86_64: [[COERCE:%.*]] = alloca <3 x float>, align 16
@@ -66,6 +68,7 @@ entry(%x : $float3):
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(ptr noalias nocapture sret({{.*}}) %0, ptr noalias nocapture dereferenceable({{.*}}) %1)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
+// wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float %0, float %1, float %2, float %3)
 sil @simd_native_args : $@convention(thin) (float4) -> float4 {
 entry(%x : $float4):
   %f = function_ref @simd_c_args : $@convention(c) (float4) -> float4
@@ -84,6 +87,7 @@ entry(%x : $float4):
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float %0, float %1, float %2)
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float %0, float %1, float %2)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float %0, float %1, float %2)
+// wasm32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float %0, float %1, float %2)
 sil @simd_native_args_float3 : $@convention(thin) (float3) -> float3 {
 entry(%x : $float3):
   %f = function_ref @simd_c_args_float3 : $@convention(c) (float3) -> float3

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -55,19 +55,19 @@ import resilient_protocol
 // CHECK-SAME:   %swift.protocol_requirement { i32 {{(-1745420271)|(17)}}, i32 0 },
 
 // CHECK-SAME:   %swift.protocol_requirement { i32 {{(-544407535)|(17)}},
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (ptr @defaultC to [[INT]]),
+// CHECK-SAME:     {{(i32( | trunc \(i64 )sub \()?}}[[INT]] ptrtoint (ptr @defaultC to [[INT]])
 // CHECK-SAME:   },
 
 // CHECK-SAME:   %swift.protocol_requirement { i32 {{(1717370897)|(17)}},
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (ptr @defaultD to [[INT]]),
+// CHECK-SAME:     {{(i32( | trunc \(i64 )sub \()?}}[[INT]] ptrtoint (ptr @defaultD to [[INT]])
 // CHECK-SAME:   },
 
 // CHECK-SAME:   %swift.protocol_requirement { i32 {{(297926657)|(1)}},
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (ptr @defaultE to [[INT]]),
+// CHECK-SAME:     {{(i32( | trunc \(i64 )sub \()?}}[[INT]] ptrtoint (ptr @defaultE to [[INT]])
 // CHECK-SAME:   },
 
 // CHECK-SAME:   %swift.protocol_requirement { i32 {{(351797249)|(1)}},
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (ptr @defaultF to [[INT]]),
+// CHECK-SAME:     {{(i32( | trunc \(i64 )sub \()?}}[[INT]] ptrtoint (ptr @defaultF to [[INT]])
 // CHECK-SAME:   }
 // CHECK-SAME: }
 


### PR DESCRIPTION
The target differs from other archs on:

1. No `swifttailcc` support for now
2. Having comdat support
3. Using absolute 32bit function pointer for metadata fields that stores relative pointer to function address on other archs