### PR TITLE
[test][IRGen] Split windows autolink checks into a separate file 

### DIFF
--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -13,13 +13,6 @@
 // CHECK-ELF-DAG: !llvm.dependent-libraries = !{
 // CHECK-ELF-DAG: !{{[0-9]+}} = !{!"empty"}
 
-// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-unknown-windows-msvc -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-COFF
-// RUN: %target-swift-emit-ir -target x86_64-unknown-windows-msvc -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-COFF
-
-// CHECK-COFF-DAG: !llvm.linker.options = !{
-// CHECK-COFF-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:empty.lib"}
-
 
 import empty
 
@@ -44,17 +37,6 @@ import empty
 // CHECK-ELF-MERGE-DAG: !{{[0-9]+}} = !{!"module"}
 // CHECK-ELF-MERGE-DAG: !{{[0-9]+}} = !{!"transitive-module"}
 // CHECK-ELF-MERGE-DAG: !{{[0-9]+}} = !{!"autolink-module-map-link"}
-
-
-// RUN: %target-swift-frontend -target %target-cpu-unknown-windows-msvc -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target %target-cpu-unknown-windows-msvc -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-COFF
-// RUN: %target-swift-emit-ir -target %target-cpu-unknown-windows-msvc -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-COFF
-
-// CHECK-COFF-MERGE-DAG: !llvm.linker.options = !{
-// CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:empty.lib"}
-// CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:module.lib"}
-// CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:transitive-module.lib"}
-// CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:autolink-module-map-link.lib"}
 
 
 #if TEST_CLANG_OPTIONS_MERGE

--- a/test/IRGen/lto_autolink_windows.swift
+++ b/test/IRGen/lto_autolink_windows.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target x86_64-unknown-windows-msvc -lto=llvm-full -parse-stdlib -I %t %S/lto_autolink.swift | %FileCheck %s --check-prefix CHECK-COFF
+// RUN: %target-swift-emit-ir -target x86_64-unknown-windows-msvc -lto=llvm-thin -parse-stdlib -I %t %S/lto_autolink.swift | %FileCheck %s --check-prefix CHECK-COFF
+
+// REQUIRES: OS=windows-msvc
+
+// CHECK-COFF-DAG: !llvm.linker.options = !{
+// CHECK-COFF-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:empty.lib"}
+
+// RUN: %target-swift-frontend -target %target-cpu-unknown-windows-msvc -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-windows-msvc -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %S/lto_autolink.swift | %FileCheck %s --check-prefix CHECK-COFF
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-windows-msvc -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %S/lto_autolink.swift | %FileCheck %s --check-prefix CHECK-COFF
+
+// CHECK-COFF-MERGE-DAG: !llvm.linker.options = !{
+// CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:empty.lib"}
+// CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:module.lib"}
+// CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:transitive-module.lib"}
+// CHECK-COFF-MERGE-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:autolink-module-map-link.lib"}


### PR DESCRIPTION
Since it can construct invalid target triples like wasm32-unknown-windows-msvc, which can hit internal compiler crash in llvm. So split into a separate file to run the test only on archs windows supports.