### PR TITLE
[github] CODEOWNERS: Override `DiagnosticsParse.def` code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,7 @@
 /include/swift/AST/*Requirement*                   @hborla @slavapestov
 /include/swift/AST/*Substitution*                  @slavapestov
 /include/swift/AST/Evaluator*                      @CodaFi @slavapestov
+/include/swift/AST/DiagnosticsParse.def            @ahoppen @bnbarham @CodaFi @DougGregor @rintaro
 /include/swift/ClangImporter                       @zoecarver @hyp @egorzhdan
 /include/swift/DependencyScan                      @artemcm
 /include/swift/Driver                              @artemcm


### PR DESCRIPTION
It makes more sense for the parser folks to own (get notified about changes to) this file.