### PR TITLE
[SwiftCompilerSources] NFC: Renamed two helper fns

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -144,7 +144,7 @@ public func registerOptimizerTests() {
 
 private func registerFunctionTest(_ test: FunctionTest) {
   test.name._withBridgedStringRef { ref in
-    registerFunctionTest(ref, eraseInvocation(test.invocation))
+    registerFunctionTest(ref, castToOpaquePointer(fromInvocation: test.invocation))
   }
 }
 
@@ -161,7 +161,7 @@ private func functionTestThunk(
   _ function: BridgedFunction, 
   _ arguments: BridgedTestArguments, 
   _ passInvocation: BridgedSwiftPassInvocation) {
-  let invocation = uneraseInvocation(erasedInvocation)
+  let invocation = castToInvocation(fromOpaquePointer: erasedInvocation)
   let context = FunctionPassContext(_bridged: BridgedPassContext(invocation: passInvocation.invocation))
   invocation(function.function, arguments.native, context)
 }
@@ -170,7 +170,7 @@ private func functionTestThunk(
 ///
 /// Needed so that the closure can be represented in C++ for storage in the test
 /// registry.
-private func eraseInvocation(_ invocation: FunctionTestInvocation) -> UnsafeMutableRawPointer {
+private func castToOpaquePointer(fromInvocation invocation: FunctionTestInvocation) -> UnsafeMutableRawPointer {
   return unsafeBitCast(invocation, to: UnsafeMutableRawPointer.self)
 }
 
@@ -178,7 +178,7 @@ private func eraseInvocation(_ invocation: FunctionTestInvocation) -> UnsafeMuta
 ///
 /// Needed so that the closure stored in the C++ test registry can be invoked
 /// via the functionTestThunk.
-private func uneraseInvocation(_ erasedInvocation: UnsafeMutableRawPointer) -> FunctionTestInvocation {
+private func castToInvocation(fromOpaquePointer erasedInvocation: UnsafeMutableRawPointer) -> FunctionTestInvocation {
   return unsafeBitCast(erasedInvocation, to: FunctionTestInvocation.self)
 }
 


### PR DESCRIPTION
Rename in terms of casting rather than erasure.
