### PR TITLE
[embedded] Pass all default stdlib SWIFT_COMPILE_FLAGS to the embedded stdlib build too

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -412,7 +412,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       IS_STDLIB IS_STDLIB_CORE IS_FRAGILE
       ${SWIFTLIB_EMBEDDED_SOURCES}
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
-      SWIFT_COMPILE_FLAGS -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
+      SWIFT_COMPILE_FLAGS
+        ${swift_stdlib_compile_flags} -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"


### PR DESCRIPTION
This resolves a problem that currently the macOS toolchain CI job is excluding the embedded Swift.swiftmodule from the nightly toolchain because recursive lipo doesn't expect the x86-compiler-produced .swiftmodule and arm64-compiler-produced .swiftmodule to differ, but they do (because they embed file paths because of a missing -enable-experimental-concise-pound-file flag):

```
-- Warning: non-executable source files are different, skipping:
./macosx-arm64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/armv7-apple-none-macho.swiftmodule
./macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/armv7-apple-none-macho.swiftmodule
-- Warning: non-executable source files are different, skipping:
./macosx-arm64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/arm64-apple-macos.swiftmodule
./macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/arm64-apple-macos.swiftmodule
-- Warning: non-executable source files are different, skipping:
./macosx-arm64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/arm64-apple-none-macho.swiftmodule
./macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/arm64-apple-none-macho.swiftmodule
-- Warning: non-executable source files are different, skipping:
./macosx-arm64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/arm64e-apple-macos.swiftmodule
./macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/arm64e-apple-macos.swiftmodule
-- Warning: non-executable source files are different, skipping:
./macosx-arm64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/x86_64-apple-macos.swiftmodule
./macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-08-a.xctoolchain/usr/lib/swift/embedded/Swift.swiftmodule/x86_64-apple-macos.swiftmodule
```
