### PR TITLE
[Diagnostics]: Bad diagnostic for initialization of property wrapper with custom init

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1471,10 +1471,10 @@ ERROR(missing_argument_labels,none,
       "%select{call|subscript|macro expansion}2",
       (bool, StringRef, unsigned))
 ERROR(wrong_argument_labels,none,
-      "incorrect argument label%select{|s}0 in "
-      "%select{call|subscript|macro expansion}3 "
-      "(have '%1', expected '%2')",
-      (bool, StringRef, StringRef, unsigned))
+      "property wrapper type must provide an "
+      "initializer with either no parameters "
+      "or a first parameter with argument label '%1'\n",
+      (bool, StringRef))
 ERROR(argument_out_of_order_named_named,none,
       "argument %0 must precede argument %1", (Identifier, Identifier))
 ERROR(argument_out_of_order_named_unnamed,none,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2166,7 +2166,6 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
           haveBuffer += '_';
         else
           haveBuffer += haveName.str();
-        haveBuffer += ':';
       }
 
       for (auto expected : newNames) {
@@ -2178,11 +2177,9 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
       }
 
       StringRef haveStr = haveBuffer;
-      StringRef expectedStr = expectedBuffer;
       diagOpt.emplace(diags.diagnose(argList->getLoc(),
                                      diag::wrong_argument_labels,
-                                     plural, haveStr, expectedStr,
-                                     static_cast<unsigned>(paramContext)));
+                                     plural, haveStr));
     } else if (numMissing > 0) {
       StringRef missingStr = missingBuffer;
       diagOpt.emplace(diags.diagnose(argList->getLoc(),

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -118,3 +118,16 @@ func local() {
   anotherVar = "hello!"
   _ = anotherVar
 }
+
+// https://github.com/apple/swift/issues/69066
+
+ @propertyWrapper
+ struct Wrapper {
+   var wrappedValue: Int
+
+   init(i: Int) {}
+ }
+
+ do {
+   @Wrapper var w: Int = 0 // expected-error {{property wrapper type must provide an initializer with either no parameters or a first parameter with argument label 'wrappedValue'}}
+ }


### PR DESCRIPTION
<!-- What's in this pull request? -->

Updates error message for initialization of property wrapper with a custom `init`.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #69066

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
