### PR TITLE
[Test] Print to stdout.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -164,6 +164,7 @@ private func functionTestThunk(
   let invocation = castToInvocation(fromOpaquePointer: erasedInvocation)
   let context = FunctionPassContext(_bridged: BridgedPassContext(invocation: passInvocation.invocation))
   invocation(function.function, arguments.native, context)
+  fflush(stdout)
 }
 
 /// Bitcast a thin test closure to void *.
@@ -202,46 +203,36 @@ private func castToInvocation(fromOpaquePointer erasedInvocation: UnsafeMutableR
 //   - something to identify the instance (mostly this means calling dump)
 let parseTestSpecificationTest = 
 FunctionTest(name: "test_specification_parsing") { function, arguments, context in 
-  struct _Stderr : TextOutputStream {
-    public init() {}
-
-    public mutating func write(_ string: String) {
-      for c in string.utf8 {
-        writeCharToStderr(CInt(c))
-      }
-    }
-  }
-  var stderr = _Stderr()
   let expectedFields = arguments.takeString()
   for expectedField in expectedFields.string {
     switch expectedField {
     case "A":
       let argument = arguments.takeArgument()
-      print("argument:\n\(argument)", to: &stderr)
+      print("argument:\n\(argument)")
     case "F":
       let function = arguments.takeFunction()
-      print("function: \(function.name)", to: &stderr)
+      print("function: \(function.name)")
     case "B":
       let block = arguments.takeBlock()
-      print("block:\n\(block)", to: &stderr)
+      print("block:\n\(block)")
     case "I":
       let instruction = arguments.takeInstruction()
-      print("instruction: \(instruction)", to: &stderr)
+      print("instruction: \(instruction)")
     case "V":
       let value = arguments.takeValue()
-      print("value: \(value)", to: &stderr)
+      print("value: \(value)")
     case "O":
       let operand = arguments.takeOperand()
-      print("operand: \(operand)", to: &stderr)
+      print("operand: \(operand)")
     case "u":
       let u = arguments.takeInt()
-      print("uint: \(u)", to: &stderr)
+      print("uint: \(u)")
     case "b":
       let b = arguments.takeBool()
-      print("bool: \(b)", to: &stderr)
+      print("bool: \(b)")
     case "s":
       let s = arguments.takeString()
-      print("string: \(s)", to: &stderr)
+      print("string: \(s)")
     default:
       fatalError("unknown field type was expected?!");
     }

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -166,9 +166,9 @@ static FunctionTest IsLexicalTest("is-lexical", [](auto &function,
                                                    auto &test) {
   auto value = arguments.takeValue();
   auto isLexical = value->isLexical();
-  value->dump();
+  value->print(llvm::outs());
   auto *boolString = isLexical ? "true" : "false";
-  llvm::errs() << boolString << "\n";
+  llvm::outs() << boolString << "\n";
 });
 } // end namespace swift::test
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2758,7 +2758,7 @@ static FunctionTest PrintTypeLowering("print-type-lowering", [](auto &function,
                                                                 auto &test) {
   auto value = arguments.takeValue();
   auto ty = value->getType();
-  function.getModule().Types.getTypeLowering(ty, function).print(llvm::dbgs());
+  function.getModule().Types.getTypeLowering(ty, function).print(llvm::outs());
 });
 } // end namespace swift::test
 

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -1024,12 +1024,12 @@ static FunctionTest FieldSensitiveMultiDefUseLiveRangeTest(
         TypeTreeLeafTypeRange range(begin, end);
         liveness.updateForUse(inst, range, lifetimeEnding);
       }
-      liveness.print(llvm::errs());
+      liveness.print(llvm::outs());
 
       FieldSensitivePrunedLivenessBoundary boundary(
           liveness.getNumSubElements());
       liveness.computeBoundary(boundary);
-      boundary.print(llvm::errs());
+      boundary.print(llvm::outs());
     });
 } // end namespace swift::test
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -375,10 +375,10 @@ static FunctionTest
     GetTypedAccessAddress("get_typed_access_address",
                           [](auto &function, auto &arguments, auto &test) {
                             auto address = arguments.takeValue();
-                            function.dump();
-                            llvm::dbgs() << "Address: " << address;
+                            function.print(llvm::outs());
+                            llvm::outs() << "Address: " << address;
                             auto access = getTypedAccessAddress(address);
-                            llvm::dbgs() << "Access: " << access;
+                            llvm::outs() << "Access: " << access;
                           });
 } // end namespace swift::test
 
@@ -404,10 +404,10 @@ static FunctionTest GetAccessBaseTest("get_access_base",
                                       [](auto &function, auto &arguments,
                                          auto &test) {
                                         auto address = arguments.takeValue();
-                                        function.dump();
-                                        llvm::dbgs() << "Address: " << address;
+                                        function.print(llvm::outs());
+                                        llvm::outs() << "Address: " << address;
                                         auto base = getAccessBase(address);
-                                        llvm::dbgs() << "Base: " << base;
+                                        llvm::outs() << "Base: " << base;
                                       });
 } // end namespace swift::test
 
@@ -1196,10 +1196,10 @@ static FunctionTest ComputeAccessStorage("compute_access_storage",
                                       [](auto &function, auto &arguments,
                                          auto &test) {
                                         auto address = arguments.takeValue();
-                                        function.dump();
-                                        llvm::dbgs() << "Address: " << address;
+                                        function.print(llvm::outs());
+                                        llvm::outs() << "Address: " << address;
                                         auto accessStorage = AccessStorage::compute(address);
-                                        accessStorage.dump();
+                                        accessStorage.print(llvm::outs());
                                       });
 } // end namespace swift::test
 
@@ -2070,7 +2070,7 @@ static FunctionTest AccessPathBaseTest("accesspath-base", [](auto &function,
                                                              auto &arguments,
                                                              auto &test) {
   auto value = arguments.takeValue();
-  function.dump();
+  function.print(llvm::outs());
   llvm::outs() << "Access path base: " << value;
   auto accessPathWithBase = AccessPathWithBase::compute(value);
   AccessUseTestVisitor visitor;

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -364,10 +364,10 @@ static FunctionTest OSSALifetimeCompletionTest(
     "ossa-lifetime-completion",
     [](auto &function, auto &arguments, auto &test) {
       SILValue value = arguments.takeValue();
-      llvm::dbgs() << "OSSA lifetime completion: " << value;
+      llvm::outs() << "OSSA lifetime completion: " << value;
       OSSALifetimeCompletion completion(&function, /*domInfo*/ nullptr);
       completion.completeOSSALifetime(value);
-      function.dump();
+      function.print(llvm::outs());
     });
 } // end namespace swift::test
 

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -378,8 +378,8 @@ static FunctionTest LinearLivenessTest("linear-liveness", [](auto &function,
                                                              auto &arguments,
                                                              auto &test) {
   SILValue value = arguments.takeValue();
-  function.dump();
-  llvm::dbgs() << "Linear liveness: " << value;
+  function.print(llvm::outs());
+  llvm::outs() << "Linear liveness: " << value;
   LinearLiveness liveness(value);
   liveness.compute();
   liveness.print(llvm::outs());
@@ -399,8 +399,8 @@ static FunctionTest
     InteriorLivenessTest("interior-liveness",
                          [](auto &function, auto &arguments, auto &test) {
                            SILValue value = arguments.takeValue();
-                           function.dump();
-                           llvm::dbgs() << "Interior liveness: " << value;
+                           function.print(llvm::outs());
+                           llvm::outs() << "Interior liveness: " << value;
                            auto *domTree = test.getDominanceInfo();
                            InteriorLiveness liveness(value);
                            auto handleInnerScope = [](SILValue innerBorrow) {
@@ -423,8 +423,8 @@ static FunctionTest
 static FunctionTest ExtendedLinearLivenessTest(
     "extended-liveness", [](auto &function, auto &arguments, auto &test) {
       SILValue value = arguments.takeValue();
-      function.dump();
-      llvm::dbgs() << "Extended liveness: " << value;
+      function.print(llvm::outs());
+      llvm::outs() << "Extended liveness: " << value;
       ExtendedLinearLiveness liveness(value);
       liveness.compute();
       liveness.print(llvm::outs());

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -105,9 +105,9 @@ static FunctionTest OwnershipUtilsHasPointerEscape(
     "has-pointer-escape", [](auto &function, auto &arguments, auto &test) {
       auto value = arguments.takeValue();
       auto has = findPointerEscape(value);
-      value->print(llvm::errs());
+      value->print(llvm::outs());
       auto *boolString = has ? "true" : "false";
-      llvm::errs() << boolString << "\n";
+      llvm::outs() << boolString << "\n";
     });
 } // end namespace swift::test
 
@@ -2057,10 +2057,10 @@ namespace swift::test {
 // - the enclosing defs
 static FunctionTest FindEnclosingDefsTest(
     "find-enclosing-defs", [](auto &function, auto &arguments, auto &test) {
-      function.dump();
-      llvm::dbgs() << "Enclosing Defs:\n";
+      function.print(llvm::outs());
+      llvm::outs() << "Enclosing Defs:\n";
       visitEnclosingDefs(arguments.takeValue(), [](SILValue def) {
-        def->dump();
+        def->print(llvm::outs());
         return true;
       });
     });
@@ -2082,10 +2082,10 @@ namespace swift::test {
 // - the borrow introducers
 static FunctionTest FindBorrowIntroducers(
     "find-borrow-introducers", [](auto &function, auto &arguments, auto &test) {
-      function.dump();
-      llvm::dbgs() << "Introducers:\n";
+      function.print(llvm::outs());
+      llvm::outs() << "Introducers:\n";
       visitBorrowIntroducers(arguments.takeValue(), [](SILValue def) {
-        def->dump();
+        def->print(llvm::outs());
         return true;
       });
     });
@@ -2202,10 +2202,10 @@ namespace swift::test {
 static FunctionTest VisitInnerAdjacentPhisTest(
     "visit-inner-adjacent-phis",
     [](auto &function, auto &arguments, auto &test) {
-      function.dump();
+      function.print(llvm::outs());
       visitInnerAdjacentPhis(cast<SILPhiArgument>(arguments.takeValue()),
                              [](auto *argument) -> bool {
-                               argument->dump();
+                               argument->print(llvm::outs());
                                return true;
                              });
     });

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -182,8 +182,9 @@ static FunctionTest
           while (arguments.hasUntaken()) {
             boundary.lastUsers.push_back(arguments.takeInstruction());
           }
-          boundary.visitInsertionPoints(
-              [](SILBasicBlock::iterator point) { point->dump(); });
+          boundary.visitInsertionPoints([](SILBasicBlock::iterator point) {
+            point->print(llvm::outs());
+          });
         });
 } // end namespace swift::test
 

--- a/lib/SIL/Utils/Test.cpp
+++ b/lib/SIL/Utils/Test.cpp
@@ -97,6 +97,7 @@ void FunctionTest::run(SILFunction &function, Arguments &arguments,
     auto fn = invocation.get<Invocation>();
     fn(function, arguments, *this);
   } else {
+    llvm::outs().flush();
     auto *fn = invocation.get<NativeSwiftInvocation>();
     Registry::get().getFunctionTestThunk()(fn, {&function}, {&arguments},
                                            {getInvocation()});

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -394,8 +394,8 @@ static FunctionTest IsDeinitBarrierTest("is-deinit-barrier", [](auto &function,
   auto *instruction = arguments.takeInstruction();
   auto *analysis = test.template getAnalysis<BasicCalleeAnalysis>();
   auto isBarrier = isDeinitBarrier(instruction, analysis);
-  instruction->dump();
+  instruction->print(llvm::outs());
   auto *boolString = isBarrier ? "true" : "false";
-  llvm::errs() << boolString << "\n";
+  llvm::outs() << boolString << "\n";
 });
 } // namespace swift::test

--- a/lib/SILOptimizer/UtilityPasses/TestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/TestRunner.cpp
@@ -77,7 +77,7 @@ void TestRunner::printTestLifetime(bool begin, unsigned testIndex,
                                    unsigned testCount, StringRef name,
                                    ArrayRef<StringRef> components) {
   StringRef word = begin ? "\nbegin" : "end";
-  llvm::errs() << word << " running test " << testIndex + 1 << " of "
+  llvm::outs() << word << " running test " << testIndex + 1 << " of "
                << testCount << " on " << getFunction()->getName() << ": "
                << name << " with: ";
   for (unsigned long index = 0, size = components.size(); index < size;
@@ -86,18 +86,18 @@ void TestRunner::printTestLifetime(bool begin, unsigned testIndex,
     if (componentString.empty())
       continue;
 
-    llvm::errs() << componentString;
+    llvm::outs() << componentString;
     if (index != size - 1) {
-      llvm::errs() << ", ";
+      llvm::outs() << ", ";
     }
   }
-  llvm::errs() << "\n";
+  llvm::outs() << "\n";
 }
 
 void TestRunner::runTest(StringRef name, Arguments &arguments) {
   auto *test = FunctionTest::get(name);
   if (!test) {
-    llvm::errs() << "No test named: " << name << "\n";
+    llvm::outs() << "No test named: " << name << "\n";
     assert(false && "Invalid test name");
   }
   auto *function = getFunction();
@@ -137,7 +137,7 @@ void TestRunner::run() {
 // - the function
 static FunctionTest DumpFunctionTest("dump-function",
                                      [](auto &function, auto &, auto &) {
-                                       function.dump();
+                                       function.print(llvm::outs());
                                      });
 
 // Arguments: NONE
@@ -145,7 +145,7 @@ static FunctionTest DumpFunctionTest("dump-function",
 static FunctionTest FunctionGetSelfArgumentIndex(
     "function-get-self-argument-index", [](auto &function, auto &, auto &) {
       auto index = BridgedFunction{&function}.getSelfArgumentIndex();
-      llvm::errs() << "self argument index = " << index << "\n";
+      llvm::outs() << "self argument index = " << index << "\n";
     });
 
 } // namespace swift::test

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -867,6 +867,6 @@ static FunctionTest CanonicalizeBorrowScopeTest(
       InstructionDeleter deleter;
       CanonicalizeBorrowScope canonicalizer(value->getFunction(), deleter);
       canonicalizer.canonicalizeBorrowScope(borrowedValue);
-      function.dump();
+      function.print(llvm::outs());
     });
 } // end namespace swift::test

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -1249,7 +1249,7 @@ static FunctionTest CanonicalizeOSSALifetimeTest(
           calleeAnalysis, deleter);
       auto value = arguments.takeValue();
       canonicalizer.canonicalizeValueLifetime(value);
-      function.dump();
+      function.print(llvm::outs());
     });
 } // end namespace swift::test
 

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -314,10 +314,10 @@ static FunctionTest DeleterDeleteIfDeadTest(
     "deleter-delete-if-dead", [](auto &function, auto &arguments, auto &test) {
       auto *inst = arguments.takeInstruction();
       InstructionDeleter deleter;
-      llvm::dbgs() << "Deleting-if-dead " << *inst;
+      llvm::outs() << "Deleting-if-dead " << *inst;
       auto deleted = deleter.deleteIfDead(inst);
-      llvm::dbgs() << "deleteIfDead returned " << deleted << "\n";
-      function.dump();
+      llvm::outs() << "deleteIfDead returned " << deleted << "\n";
+      function.print(llvm::outs());
     });
 } // namespace swift::test
 

--- a/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
@@ -814,6 +814,6 @@ static FunctionTest LexicalDestroyFoldingTest(
       auto *bbi = cast<BeginBorrowInst>(value);
       InstructionDeleter deleter;
       foldDestroysOfCopiedLexicalBorrow(bbi, *domTree, deleter);
-      function.dump();
+      function.print(llvm::outs());
     });
 } // end namespace swift::test

--- a/lib/SILOptimizer/Utils/LexicalDestroyHoisting.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyHoisting.cpp
@@ -426,6 +426,6 @@ static FunctionTest LexicalDestroyHoistingTest(
       auto value = arguments.takeValue();
       hoistDestroysOfOwnedLexicalValue(value, *value->getFunction(), deleter,
                                        calleeAnalysis);
-      function.dump();
+      function.print(llvm::outs());
     });
 } // end namespace swift::test

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -513,19 +513,19 @@ static FunctionTest ShrinkBorrowScopeTest(
       SmallVector<CopyValueInst *, 4> modifiedCopyValueInsts;
       InstructionDeleter deleter(
           InstModCallbacks().onDelete([&](auto *instruction) {
-            llvm::errs() << "DELETED:\n";
-            instruction->dump();
+            llvm::outs() << "DELETED:\n";
+            instruction->print(llvm::outs());
           }));
       auto shrunk =
           shrinkBorrowScope(*bbi, deleter, analysis, modifiedCopyValueInsts);
       unsigned index = 0;
       for (auto *cvi : modifiedCopyValueInsts) {
         auto expectedCopy = arguments.takeValue();
-        llvm::errs() << "rewritten copy " << index << ":\n";
-        llvm::errs() << "expected:\n";
-        expectedCopy->print(llvm::errs());
-        llvm::errs() << "got:\n";
-        cvi->dump();
+        llvm::outs() << "rewritten copy " << index << ":\n";
+        llvm::outs() << "expected:\n";
+        expectedCopy->print(llvm::outs());
+        llvm::outs() << "got:\n";
+        cvi->print(llvm::outs());
         assert(cvi == expectedCopy);
         ++index;
       }

--- a/test/SILOptimizer/address_lowering_preprocessed.sil
+++ b/test/SILOptimizer/address_lowering_preprocessed.sil
@@ -1,6 +1,5 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-sil-opt -test-runner -address-lowering -enable-sil-opaque-values -emit-sorted-sil -sil-verify-none %s > %t/out.sil
-// RUN: %target-sil-opt -emit-sorted-sil -sil-verify-all %t/out.sil | %FileCheck %s
+// RUN: %target-sil-opt -test-runner -address-lowering -enable-sil-opaque-values -sil-disable-input-verify -emit-sorted-sil %s | %FileCheck %s
 
 import Builtin
 import Swift


### PR DESCRIPTION
In the C++ sources it is slightly more convenient to dump to stderr than to print to stdout, but it is rather more unpleasant to print to stderr from the Swift sources.  Switch to stdout.  Also allows the dump functions to be marked debug only.
