### PR TITLE
Namespace bridging-mode cmake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,7 @@ How to build the swift compiler modules. Possible values are
                                    compiler, provided in `SWIFT_NATIVE_SWIFT_TOOLS_PATH`
 ]=] OFF)
 
-option(BRIDGING_MODE [=[
+option(SWIFT_BRIDGING_MODE [=[
 How swift-C++ bridging code is compiled:
     INLINE:       uses full swift C++ interop and briding functions are inlined
     PURE:         uses limited C++ interp an bridging functions are not inlined
@@ -398,13 +398,13 @@ set(SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY
   CACHE STRING "MSVC Runtime Library for the standard library")
 
 
-if(BRIDGING_MODE STREQUAL "DEFAULT" OR NOT BRIDGING_MODE)
+if(SWIFT_BRIDGING_MODE STREQUAL "DEFAULT" OR NOT SWIFT_BRIDGING_MODE)
   if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
     # In debug builds, to workaround a problem with LLDB's `po` command (rdar://115770255).
     # On windows to workaround a build problem.
-    set(BRIDGING_MODE "PURE")
+    set(SWIFT_BRIDGING_MODE "PURE")
   else()
-    set(BRIDGING_MODE "INLINE")
+    set(SWIFT_BRIDGING_MODE "INLINE")
   endif()
 endif()
 

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -92,7 +92,7 @@ function(add_swift_compiler_modules_library name)
     list(APPEND swift_compile_options "-Xcc" "-DNDEBUG")
   endif()
 
-  if("${BRIDGING_MODE}" STREQUAL "PURE")
+  if("${SWIFT_BRIDGING_MODE}" STREQUAL "PURE")
     list(APPEND swift_compile_options "-Xcc" "-DPURE_BRIDGING_MODE")
   endif()
 

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -352,7 +352,7 @@ macro(swift_common_cxx_warnings)
   # Disallow calls to objc_msgSend() with no function pointer cast.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOBJC_OLD_DISPATCH_PROTOTYPES=0")
 
-  if(BRIDGING_MODE STREQUAL "PURE")
+  if(SWIFT_BRIDGING_MODE STREQUAL "PURE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPURE_BRIDGING_MODE")
   endif()
 endmacro()


### PR DESCRIPTION
`BRIDGING_MODE` affects Swift. Namespacing it to Swift to avoid inadvertently affecting other things.