### PR TITLE
[Distributed] Fix effectiveLabel implementation to expected semantics

### DIFF
--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -790,11 +790,20 @@ public struct RemoteCallArgument<Value> {
   /// the user-visible name of this argument.
   public let label: String?
 
-  /// The effective label of this argument, i.e. if no explicit `label` was set
-  /// this defaults to the `name`. This reflects the semantics of call sites of
-  /// function declarations without explicit label definitions in Swift.
+  /// The effective label of this argument. This reflects the semantics
+  /// of call sites of function declarations without explicit label
+  /// definitions in Swift.
+  ///
+  /// For example, for a method declared like `func hi(a: String)` the effective
+  /// label is `a` while for a method like `func hi(a b: String)` or
+  /// `func hi(_ b: String)` the label is the explicitly declared one,
+  /// so `a` and `_` respectively.
   public var effectiveLabel: String {
-    return label ?? name
+    if let label {
+      return label
+    } else {
+      return "_"
+    }
   }
 
   /// The internal name of parameter this argument is accessible as in the

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_argument_labels.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_argument_labels.swift
@@ -1,0 +1,225 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// UNSUPPORTED: OS=windows-msvc
+
+import Distributed
+
+@available(SwiftStdlib 5.5, *)
+distributed actor ParamsDA {
+
+  // CHECK: argument.label: Optional("a")
+  // CHECK: argument.name: a
+  // CHECK: argument.effectiveLabel: a
+  distributed func callMe(a: String) {}
+
+  // CHECK: argument.label: Optional("b")
+  // CHECK: argument.name: c
+  // CHECK: argument.effectiveLabel: b
+  distributed func callMe(b c: String) {}
+
+  // CHECK: argument.label: nil
+  // CHECK: argument.name: d
+  // CHECK: argument.effectiveLabel: _
+  distributed func callMe(_ d: String) {}
+
+  // CHECK: argument.label: nil
+  // CHECK: argument.name: p0
+  // CHECK: argument.effectiveLabel: _
+  distributed func callMe2(_: String) {}
+}
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+@main struct Main {
+  static func main() async {
+    let system = FakeActorSystem()
+    let pda = try! ParamsDA.resolve(id: .init(parse: "x"), using: system)
+    print("--- (a a)")
+    try! await pda.callMe(a: "")
+    print("--- (b c)")
+    try! await pda.callMe(b: "")
+    print("--- (_ d)")
+    try! await pda.callMe(_: "")
+    print("--- (_)")
+    try! await pda.callMe2(_: "")
+    print("OK")
+  }
+}
+
+
+// ==== Fake Transport ---------------------------------------------------------
+struct ActorAddress: Sendable, Hashable, Codable {
+  let address: String
+  init(parse address: String) {
+    self.address = address
+  }
+}
+
+struct FakeActorSystem: DistributedActorSystem {
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    let id = ActorAddress(parse: "xxx")
+    return id
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
+
+  func resignID(_ id: ActorID) {
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+    .init()
+  }
+
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SerializationRequirement {
+    fatalError("INVOKED REMOTE CALL")
+  }
+
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error {
+    return // expected; mock out replying
+  }
+}
+
+struct FakeInvocationEncoder: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = Codable
+
+  var substitutions: [Any.Type] = []
+  var arguments: [Any] = []
+  var returnType: Any.Type? = nil
+  var errorType: Any.Type? = nil
+
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {
+    substitutions.append(type)
+  }
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {
+    print("argument.label: \(String(describing: argument.label))")
+    print("argument.name: \(argument.name)")
+    print("argument.effectiveLabel: \(argument.effectiveLabel)")
+    arguments.append(argument.value)
+  }
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {
+    self.errorType = type
+  }
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {
+    self.returnType = type
+  }
+  mutating func doneRecording() throws {}
+
+  // For testing only
+  func makeDecoder() -> FakeInvocationDecoder {
+    return .init(
+      args: arguments,
+      substitutions: substitutions,
+      returnType: returnType,
+      errorType: errorType
+    )
+  }
+}
+
+
+class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Codable
+
+  var arguments: [Any] = []
+  var substitutions: [Any.Type] = []
+  var returnType: Any.Type? = nil
+  var errorType: Any.Type? = nil
+
+  init(
+    args: [Any],
+    substitutions: [Any.Type] = [],
+    returnType: Any.Type? = nil,
+    errorType: Any.Type? = nil
+  ) {
+    self.arguments = args
+    self.substitutions = substitutions
+    self.returnType = returnType
+    self.errorType = errorType
+  }
+
+  // === Receiving / decoding -------------------------------------------------
+  func decodeGenericSubstitutions() throws -> [Any.Type] {
+    return substitutions
+  }
+
+  var argumentIndex: Int = 0
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument {
+    guard argumentIndex < arguments.count else {
+      fatalError("Attempted to decode more arguments than stored! Index: \(argumentIndex), args: \(arguments)")
+    }
+
+    let anyArgument = arguments[argumentIndex]
+    guard let argument = anyArgument as? Argument else {
+      fatalError("Cannot cast argument\(anyArgument) to expected \(Argument.self)")
+    }
+
+    if (argumentIndex == 0 && Argument.self == Int???.self) {
+      throw ExecuteDistributedTargetError(message: "Failed to decode of Int??? (for a test)")
+    }
+
+    argumentIndex += 1
+    return argument
+  }
+
+  func decodeErrorType() throws -> Any.Type? {
+    self.errorType
+  }
+
+  func decodeReturnType() throws -> Any.Type? {
+    self.returnType
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+struct FakeResultHandler: DistributedTargetInvocationResultHandler {
+  typealias SerializationRequirement = Codable
+
+  func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  func onReturnVoid() async throws {
+    print("RETURN VOID: ()")
+  }
+  func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
+}
+
+// ==== ------------------------------------------------------------------------


### PR DESCRIPTION
This has been around for a while but might be nice to fix.

Resolves: rdar://97775548

The original report was on the swift forums:

>  https://forums.swift.org/t/accepted-se-0344-distributed-actor-runtime/56416
>  
>  @ktoso I have played around a little with Xcode 14.0 beta 3 (I currently cannot check beta 4) and have noticed that the behavior regarding RemoteCallArgument does not match the documentation. For these functions, the properties are currently filled as follows:
>  
>  ```
>  // label: "a", name: "a", effectiveLabel: "a"
>  distributed func callMe(a: String) {}
>  
>  // label: "b", name: "c", effectiveLabel: "b"
>  distributed func callMe(b c: String) {}
>  
>  // label: nil, name: "d", effectiveLabel: "d"
>  distributed func callMe(_ d: String) {}
>  As per the documentation, in the first case, label should be nil.
>  ```
>  
>  I think, the behavior as currently implemented makes much more sense. However, effectiveLabel is now pretty superfluous and returns the wrong string in the third case.

I thought about this a bunch and arrived at the: we should make `effectiveLabel` do what it sounds like it should be doing: so it's the "label" at the call site, if you wanted to construct the `hi(a:b:_:)` yourself".

