### PR TITLE
Include llvm::SmallSetVector

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -33,6 +33,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/ErrorHandling.h"


### PR DESCRIPTION
Module.h returns an llvm::SmallSetVector and requires the full definition. Something changed in the transitive includes so that it's no longer included and the file fails to build. Including it now.