### PR TITLE
[5.9] [Runtime] Wrap _checkGenericRequirements for _instantiateCheckedGenericMetadata

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2838,17 +2838,29 @@ const Metadata *swift::_swift_instantiateCheckedGenericMetadata(
     return nullptr;
   }
 
-  DemanglerForRuntimeTypeResolution<StackAllocatedDemangler<2048>> demangler;
+  llvm::SmallVector<const void *, 8> extraArguments;
 
-  llvm::ArrayRef<MetadataOrPack> genericArgsRef(
-      reinterpret_cast<const MetadataOrPack *>(genericArgs), genericArgsSize);
-  llvm::SmallVector<unsigned, 8> genericParamCounts;
-  llvm::SmallVector<const void *, 8> allGenericArgs;
+  for (size_t i = 0; i != genericArgsSize; i += 1) {
+    extraArguments.push_back(genericArgs[i]);
+  }
 
-  auto result = _gatherGenericParameters(context, genericArgsRef,
-                                         /* parent */ nullptr,
-                                         genericParamCounts, allGenericArgs,
-                                         demangler);
+  // Check whether the generic requirements are satisfied, collecting
+  // any extra arguments we need for the instantiation function.
+  //
+  // Note: The extra arguemnts provided are not complete and do not include
+  // witness tables. This is fine for _checkGenericRequirements because it does
+  // not look for any of those.
+  SubstGenericParametersFromMetadata substitutions(context, extraArguments.data());
+
+  auto result = _checkGenericRequirements(
+      context->getGenericContext()->getGenericRequirements(), extraArguments,
+      [&substitutions](unsigned depth, unsigned index) {
+        return substitutions.getMetadata(depth, index).Ptr;
+      },
+      [](const Metadata *type, unsigned index) {
+        // In fact, just don't offer any witness tables if asked for one.
+        return nullptr;
+      }, /* allowsUnresolvedSubject */ true);
 
   // _gatherGenericParameters returns llvm::None on success.
   if (result.hasValue()) {
@@ -2857,7 +2869,7 @@ const Metadata *swift::_swift_instantiateCheckedGenericMetadata(
 
   auto accessFunction = context->getAccessFunction();
 
-  return accessFunction(MetadataState::Complete, allGenericArgs).Value;
+  return accessFunction(MetadataState::Complete, extraArguments).Value;
 }
 
 #if SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -523,7 +523,8 @@ public:
       llvm::ArrayRef<GenericRequirementDescriptor> requirements,
       llvm::SmallVectorImpl<const void *> &extraArguments,
       SubstGenericParameterFn substGenericParam,
-      SubstDependentWitnessTableFn substWitnessTable);
+      SubstDependentWitnessTableFn substWitnessTable,
+      bool allowsUnresolvedSubject = false);
 
   /// A helper function which avoids performing a store if the destination
   /// address already contains the source value.  This is useful when

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1336,24 +1336,37 @@ static llvm::Optional<TypeLookupError>
 checkGenericRequirement(const GenericRequirementDescriptor &req,
                         llvm::SmallVectorImpl<const void *> &extraArguments,
                         SubstGenericParameterFn substGenericParam,
-                        SubstDependentWitnessTableFn substWitnessTable) {
+                        SubstDependentWitnessTableFn substWitnessTable,
+                        bool allowsUnresolvedSubject) {
   assert(!req.getFlags().isPackRequirement());
 
   // Make sure we understand the requirement we're dealing with.
   if (!req.hasKnownKind())
     return TypeLookupError("unknown kind");
 
+  const Metadata *subjectType = nullptr;
+
   // Resolve the subject generic parameter.
   auto result = swift_getTypeByMangledName(
       MetadataState::Abstract, req.getParam(), extraArguments.data(),
       substGenericParam, substWitnessTable);
-  if (result.getError())
+
+  if (!allowsUnresolvedSubject && result.isError()) {
     return *result.getError();
-  const Metadata *subjectType = result.getType().getMetadata();
+  }
+
+  if (!result.isError()) {
+    subjectType = result.getType().getMetadata();
+  }
 
   // Check the requirement.
   switch (req.getKind()) {
   case GenericRequirementKind::Protocol: {
+    // Protocol requirements _require_ a subject type.
+    if (result.isError()) {
+      return *result.getError();
+    }
+
     const WitnessTable *witnessTable = nullptr;
     if (!_conformsToProtocol(nullptr, subjectType, req.getProtocol(),
                              &witnessTable)) {
@@ -1374,16 +1387,37 @@ checkGenericRequirement(const GenericRequirementDescriptor &req,
   }
 
   case GenericRequirementKind::SameType: {
+    // Same type requirements don't require a valid subject.
+
+    const Metadata *sameType = nullptr;
+
     // Demangle the second type under the given substitutions.
     auto result = swift_getTypeByMangledName(
         MetadataState::Abstract, req.getMangledTypeName(),
         extraArguments.data(), substGenericParam, substWitnessTable);
-    if (result.getError())
+
+    if (!allowsUnresolvedSubject && result.isError()) {
       return *result.getError();
-    auto otherType = result.getType().getMetadata();
+    }
+
+    if (!result.isError()) {
+      sameType = result.getType().getMetadata();
+    }
+
+    // If we don't have one of either the subject type or the same type and we
+    // have the other, then return this as a success. This assumes the given
+    // extra arguments have provided only the required key arguments in which
+    // case some same type constraints may concretize some generic arguments
+    // making them non-key.
+    //
+    // Note: We don't need to check for allowsUnresolvedSubject here because
+    // these can only be null in the case where we do allow it.
+    if ((!subjectType && sameType) || (subjectType && !sameType)) {
+      return llvm::None;
+    }
 
     // Check that the types are equivalent.
-    if (subjectType != otherType) {
+    if (subjectType != sameType) {
       return TYPE_LOOKUP_ERROR_FMT(
           "subject type %.*s does not match %.*s", (int)req.getParam().size(),
           req.getParam().data(), (int)req.getMangledTypeName().size(),
@@ -1394,10 +1428,20 @@ checkGenericRequirement(const GenericRequirementDescriptor &req,
   }
 
   case GenericRequirementKind::Layout: {
+    // Layout requirements _require_ a subject type.
+    if (result.isError()) {
+      return *result.getError();
+    }
+
     return satisfiesLayoutConstraint(req, subjectType);
   }
 
   case GenericRequirementKind::BaseClass: {
+    // Base class requirements _require_ a subject type.
+    if (result.isError()) {
+      return *result.getError();
+    }
+
     // Demangle the base type under the given substitutions.
     auto result = swift_getTypeByMangledName(
         MetadataState::Abstract, req.getMangledTypeName(),
@@ -1586,7 +1630,8 @@ llvm::Optional<TypeLookupError> swift::_checkGenericRequirements(
     llvm::ArrayRef<GenericRequirementDescriptor> requirements,
     llvm::SmallVectorImpl<const void *> &extraArguments,
     SubstGenericParameterFn substGenericParam,
-    SubstDependentWitnessTableFn substWitnessTable) {
+    SubstDependentWitnessTableFn substWitnessTable,
+    bool allowsUnresolvedSubject) {
   for (const auto &req : requirements) {
     if (req.getFlags().isPackRequirement()) {
       auto error = checkGenericPackRequirement(req, extraArguments,
@@ -1597,7 +1642,8 @@ llvm::Optional<TypeLookupError> swift::_checkGenericRequirements(
     } else {
       auto error = checkGenericRequirement(req, extraArguments,
                                            substGenericParam,
-                                           substWitnessTable);
+                                           substWitnessTable,
+                                           allowsUnresolvedSubject);
       if (error)
         return error;
     }


### PR DESCRIPTION
Cherry pick of: https://github.com/apple/swift/pull/68844

* Explanation: The `_swift_instantiateCheckedGenericMetadata` is a new runtime entry not used by anyone yet, but previously it only worked by passing in all generic arguments instead of allow only key arguments. Fix this to allow key argument input.
* Scope: Swift Runtime
* Risk: Very low, affects a function that isn't used anywhere in the runtime and preserves the same behavior with the other runtime function it affects.
* Testing: Passes the current test suite
* Issues: rdar://116748040
* Reviewer: Mike Ash (@mikeash)