### PR TITLE
[5.10][Macros] Diagnose attached and freestanding declaration macros that produce something other than a declaration.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7225,7 +7225,7 @@ ERROR(experimental_no_metadata_feature_can_only_be_used_when_enabled,
 ERROR(expected_macro_expansion_expr,PointsToFirstBadToken,
       "expected macro expansion to produce an expression", ())
 ERROR(expected_macro_expansion_decls,PointsToFirstBadToken,
-      "expected macro expansion to produce declarations", ())
+      "expected macro expansion to produce a declaration", ())
 ERROR(macro_undefined,PointsToFirstBadToken,
       "no macro named %0", (Identifier))
 ERROR(external_macro_not_found,none,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -687,7 +687,18 @@ static void validateMacroExpansion(SourceFile *expansionBuffer,
             introducedNameSet.count(MacroDecl::getArbitraryName()));
   };
 
-  for (auto *decl : expansionBuffer->getTopLevelDecls()) {
+  for (auto item : expansionBuffer->getTopLevelItems()) {
+    auto *decl = item.dyn_cast<Decl *>();
+    if (!decl) {
+      if (role != MacroRole::CodeItem) {
+        auto &ctx = expansionBuffer->getASTContext();
+        ctx.Diags.diagnose(item.getStartLoc(),
+                           diag::expected_macro_expansion_decls);
+      }
+
+      continue;
+    }
+
     // Certain macro roles can generate special declarations.
     if ((isa<AccessorDecl>(decl) && role == MacroRole::Accessor) ||
         (isa<ExtensionDecl>(decl) && role == MacroRole::Conformance)) {
@@ -1153,11 +1164,16 @@ swift::expandFreestandingMacro(MacroExpansionDecl *med) {
     return llvm::None;
 
   MacroDecl *macro = cast<MacroDecl>(med->getMacroRef().getDecl());
+  auto macroRoles = macro->getMacroRoles();
+  assert(macroRoles.contains(MacroRole::Declaration) ||
+         macroRoles.contains(MacroRole::CodeItem));
   DeclContext *dc = med->getDeclContext();
 
   validateMacroExpansion(macroSourceFile, macro,
                          /*attachedTo*/nullptr,
-                         MacroRole::Declaration);
+                         macroRoles.contains(MacroRole::Declaration) ?
+                             MacroRole::Declaration :
+                             MacroRole::CodeItem);
 
   PrettyStackTraceDecl debugStack(
       "type checking expanded declaration macro", med);

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2054,3 +2054,20 @@ extension RequiredDefaultInitMacro: MemberMacro {
     return [ decl ]
   }
 }
+
+public struct FakeCodeItemMacro: DeclarationMacro, PeerMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["guard true else { return }"]
+  }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["if true { return }"]
+  }
+}


### PR DESCRIPTION
* **Explanation**: Attached and freestanding macros cannot expand to statements. However, the macro validation code was completely ignoring any ASTNode that isn't a declaration, allowing statement-producing macros to compile. Furthermore, for freestanding declaration macros, the experimental implementation of code item macros caused the invalid statements to be visited during SILGen, resulting in runtime crashes. This change diagnoses macro expansions that contain statements immediately after expansion.
* **Scope**: Only impacts freestanding and attached macros that allow parsing ASTNodes that are not declarations.
* **Risk**: Low.
* **Testing**: Added a new regression test.
* **Reviewer**: @DougGregor 
* **Main branch PR**: https://github.com/apple/swift/pull/69089