### PR TITLE
[Explicit Module Builds] Restore prior behavior of consuming `.h` dependencies of binary module dependencies directly, instead of attempting to load their PCH

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -158,6 +158,7 @@ namespace swift {
     bool EmbeddedSwiftModule = false;
     bool IsOSSA = false;
     bool SkipNonExportableDecls = false;
+    bool ExplicitModuleBuild = false;
   };
 
 } // end namespace swift

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -240,6 +240,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
 
   serializationOpts.SkipNonExportableDecls = opts.SkipNonExportableDecls;
 
+  serializationOpts.ExplicitModuleBuild = FrontendOpts.DisableImplicitModules;
+
   return serializationOpts;
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -53,6 +53,8 @@
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Strings.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Serialization/ASTReader.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
@@ -1297,15 +1299,27 @@ void Serializer::writeInputBlock() {
     off_t importedHeaderSize = 0;
     time_t importedHeaderModTime = 0;
     std::string contents;
-    if (!Options.ImportedHeader.empty()) {
+    auto importedHeaderPath = Options.ImportedHeader;
+    // We do not want to serialize the explicitly-specified .pch path if one was
+    // provided. Instead we write out the path to the original header source so
+    // that clients can consume it.
+    if (llvm::sys::path::extension(importedHeaderPath)
+            .endswith(file_types::getExtension(file_types::TY_PCH)))
+      importedHeaderPath = clangImporter->getClangInstance()
+                               .getASTReader()
+                               ->getModuleManager()
+                               .lookupByFileName(importedHeaderPath)
+                               ->OriginalSourceFileName;
+
+    if (!importedHeaderPath.empty()) {
       contents = clangImporter->getBridgingHeaderContents(
-          Options.ImportedHeader, importedHeaderSize, importedHeaderModTime);
+          importedHeaderPath, importedHeaderSize, importedHeaderModTime);
     }
     assert(publicImportSet.count(bridgingHeaderImport));
     ImportedHeader.emit(ScratchRecord,
                         publicImportSet.count(bridgingHeaderImport),
                         importedHeaderSize, importedHeaderModTime,
-                        Options.ImportedHeader);
+                        importedHeaderPath);
     if (!contents.empty()) {
       contents.push_back('\0');
       ImportedHeaderContents.emit(ScratchRecord, contents);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1303,7 +1303,8 @@ void Serializer::writeInputBlock() {
     // We do not want to serialize the explicitly-specified .pch path if one was
     // provided. Instead we write out the path to the original header source so
     // that clients can consume it.
-    if (llvm::sys::path::extension(importedHeaderPath)
+    if (Options.ExplicitModuleBuild &&
+        llvm::sys::path::extension(importedHeaderPath)
             .endswith(file_types::getExtension(file_types::TY_PCH)))
       importedHeaderPath = clangImporter->getClangInstance()
                                .getASTReader()


### PR DESCRIPTION
- [Serialization] Serialize source `.h` path when an explicit `.pch` bridging header is provided. In explicit module builds, bridging header is passed directly as a `.pch` input. Loading clients may not be able to directly import this PCH because it was built against mis-matched dependencies with a different context hash. So instead they should directly ingest the `.h` dependency and build it against their own set of dependencies.
- [Dependency Scanning] Do now write out bridging header dependencies of binary modules unless in CAS mode. We only record these dependencies in CAS mode, because we require explicit PCH tasks to be produced for imported header of binary module dependencies. In the meantime, in non-CAS mode loading clients will consume the `.h` files encoded in the `.swiftmodules` directly. Followup changes to SwiftDriver will enable explicit PCH compilation of such dependencies, but for the time being restore prior behavior for non-CAS explicit module builds.

Resolves rdar://116006619