### PR TITLE
Frontend: Introduce -experimental-skip-non-exportable-decls

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -183,8 +183,11 @@ public:
   /// when possible.
   bool EnablePackMetadataStackPromotion = true;
 
-  // The kind of function bodies to skip emitting.
+  /// The kind of function bodies to skip emitting.
   FunctionBodySkipping SkipFunctionBodies = FunctionBodySkipping::None;
+
+  /// Whether to skip declarations that are internal to the module.
+  bool SkipNonExportableDecls = false;
 
   /// Optimization mode being used.
   OptimizationMode OptMode = OptimizationMode::NotSet;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -324,9 +324,8 @@ public:
   /// times) when compiling a module interface?
   bool SerializeModuleInterfaceDependencyHashes = false;
 
-  /// Should we only serialize decls that may be referenced externally in the
-  /// binary module?
-  bool SerializeExternalDeclsOnly = false;
+  /// Should we skip decls that cannot be referenced externally?
+  bool SkipNonExportableDecls = false;
 
   /// Should we warn if an imported module needed to be rebuilt from a
   /// module interface file?

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -197,10 +197,6 @@ def serialize_debugging_options : Flag<["-"], "serialize-debugging-options">,
 def serialized_path_obfuscate : Separate<["-"], "serialized-path-obfuscate">,
     HelpText<"Remap source paths in debug info">, MetaVarName<"<prefix=replacement>">;
 
-def experimental_serialize_external_decls_only
-  : Flag<["-"], "experimental-serialize-external-decls-only">,
-  HelpText<"Only serialize decls that should be exposed to clients">;
-
 def empty_abi_descriptor : Flag<["-"], "empty-abi-descriptor">,
   HelpText<"Avoid printing actual module content into ABI descriptor file">;
 
@@ -1134,6 +1130,10 @@ def experimental_allow_module_with_compiler_errors:
   Flag<["-"], "experimental-allow-module-with-compiler-errors">,
   Flags<[HelpHidden]>,
   HelpText<"Attempt to output .swiftmodule, regardless of compilation errors">;
+
+def experimental_skip_non_exportable_decls
+  : Flag<["-"], "experimental-skip-non-exportable-decls">,
+  HelpText<"Skip decls that are not exported to clients">;
 
 def bad_file_descriptor_retry_count:
   Separate<["-"], "bad-file-descriptor-retry-count">,

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -157,7 +157,7 @@ namespace swift {
     bool HermeticSealAtLink = false;
     bool EmbeddedSwiftModule = false;
     bool IsOSSA = false;
-    bool SerializeExternalDeclsOnly = false;
+    bool SkipNonExportableDecls = false;
   };
 
 } // end namespace swift

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -320,8 +320,8 @@ bool ArgsToFrontendOptionsConverter::convert(
         A->getOption().matches(OPT_serialize_debugging_options);
   }
 
-  Opts.SerializeExternalDeclsOnly |=
-      Args.hasArg(OPT_experimental_serialize_external_decls_only);
+  Opts.SkipNonExportableDecls |=
+      Args.hasArg(OPT_experimental_skip_non_exportable_decls);
   Opts.DebugPrefixSerializedDebuggingOptions |=
       Args.hasArg(OPT_prefix_serialized_debugging_options);
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2000,6 +2000,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   // -experimental-skip-*-function-bodies to SIL.
   Opts.SkipFunctionBodies = TCOpts.SkipFunctionBodies;
 
+  // Propagate -experimental-skip-non-exportable-decls to SIL.
+  Opts.SkipNonExportableDecls = FEOpts.SkipNonExportableDecls;
+
   // Parse the optimization level.
   // Default to Onone settings if no option is passed.
   Opts.OptMode = OptimizationMode::NoOptimization;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -238,8 +238,7 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
 
   serializationOpts.IsOSSA = getSILOptions().EnableOSSAModules;
 
-  serializationOpts.SerializeExternalDeclsOnly =
-      opts.SerializeExternalDeclsOnly;
+  serializationOpts.SkipNonExportableDecls = opts.SkipNonExportableDecls;
 
   return serializationOpts;
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4863,12 +4863,11 @@ static bool canSkipWhenInvalid(const Decl *D) {
 }
 
 bool Serializer::shouldSkipDecl(const Decl *D) const {
-  // The presence of -experimental-serialize-external-decls-only is the only
+  // The presence of -experimental-skip-non-exportable-decls is the only
   // reason to omit decls during serialization.
-  if (!Options.SerializeExternalDeclsOnly)
+  if (!Options.SkipNonExportableDecls)
     return false;
 
-  // For our purposes, "deserialization safe" is the same thing as "external".
   if (DeclSerializer::isDeserializationSafe(D))
     return false;
 

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -enable-library-evolution -parse-as-library -package-name Package -DFLAG -typecheck -verify
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path %t/lazy_typecheck.swiftmodule -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path %t/lazy_typecheck.swiftmodule -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
 
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t
 

--- a/test/TBD/lazy-typecheck.swift
+++ b/test/TBD/lazy-typecheck.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -target arm64-apple-macosx10.13 -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-serialize-external-decls-only
+// RUN: %target-swift-frontend -target arm64-apple-macosx10.13 -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
 // RUN: %llvm-readtapi %t/lazy_typecheck.tbd %t/expected.tbd
 
 // REQUIRES: OS=macosx


### PR DESCRIPTION
Rename `-experimental-serialize-external-decls-only` to `-experimental-skip-non-exportable-decls` in preparation for the flag being used to influence more than just serialization.

Resolves rdar://116771543
