### PR TITLE
[5.10 🍒][Explicit Module Builds] Restore prior behavior of consuming .h dependencies of binary module dependencies directly, instead of attempting to load their PCH

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -158,6 +158,7 @@ namespace swift {
     bool EmbeddedSwiftModule = false;
     bool IsOSSA = false;
     bool SerializeExternalDeclsOnly = false;
+    bool ExplicitModuleBuild = false;
   };
 
 } // end namespace swift

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -233,6 +233,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   serializationOpts.SerializeExternalDeclsOnly =
       opts.SerializeExternalDeclsOnly;
 
+  serializationOpts.ExplicitModuleBuild = FrontendOpts.DisableImplicitModules;
+
   return serializationOpts;
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -52,6 +52,8 @@
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Strings.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Serialization/ASTReader.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
@@ -1296,15 +1298,27 @@ void Serializer::writeInputBlock() {
     off_t importedHeaderSize = 0;
     time_t importedHeaderModTime = 0;
     std::string contents;
-    if (!Options.ImportedHeader.empty()) {
+    auto importedHeaderPath = Options.ImportedHeader;
+    // We do not want to serialize the explicitly-specified .pch path if one was
+    // provided. Instead we write out the path to the original header source so
+    // that clients can consume it.
+    if (llvm::sys::path::extension(importedHeaderPath)
+            .endswith(file_types::getExtension(file_types::TY_PCH)))
+      importedHeaderPath = clangImporter->getClangInstance()
+                               .getASTReader()
+                               ->getModuleManager()
+                               .lookupByFileName(importedHeaderPath)
+                               ->OriginalSourceFileName;
+
+    if (!importedHeaderPath.empty()) {
       contents = clangImporter->getBridgingHeaderContents(
-          Options.ImportedHeader, importedHeaderSize, importedHeaderModTime);
+          importedHeaderPath, importedHeaderSize, importedHeaderModTime);
     }
     assert(publicImportSet.count(bridgingHeaderImport));
     ImportedHeader.emit(ScratchRecord,
                         publicImportSet.count(bridgingHeaderImport),
                         importedHeaderSize, importedHeaderModTime,
-                        Options.ImportedHeader);
+                        importedHeaderPath);
     if (!contents.empty()) {
       contents.push_back('\0');
       ImportedHeaderContents.emit(ScratchRecord, contents);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1302,7 +1302,8 @@ void Serializer::writeInputBlock() {
     // We do not want to serialize the explicitly-specified .pch path if one was
     // provided. Instead we write out the path to the original header source so
     // that clients can consume it.
-    if (llvm::sys::path::extension(importedHeaderPath)
+    if (Options.ExplicitModuleBuild &&
+        llvm::sys::path::extension(importedHeaderPath)
             .endswith(file_types::getExtension(file_types::TY_PCH)))
       importedHeaderPath = clangImporter->getClangInstance()
                                .getASTReader()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/69109
--------------------
• Release: Swift 5.10
• Explanation: We will now only record these dependencies in CAS mode, because we require explicit PCH tasks to be produced for imported header of binary module dependencies. In the meantime, in non-CAS mode loading clients will consume the `.h` files encoded in the `.swiftmodules` directly.

Followup changes to SwiftDriver will enable explicit PCH compilation of such dependenceis, but for the time being restore prior behavior for non-CAS explicit module builds.
• Scope of Issue: Explicit module builds 
• Risk: Minimal, this change affects only code paths for explicit module builds, which are not yet default.
• Origination: Explicit Module Build feature development and addition of CAS-specific functionality. 

Resolves rdar://116006619
