### PR TITLE
Tests: Fix skip-function-bodies-clang-enum-init-raw-value.swift on Windows

### DIFF
--- a/test/SILGen/Inputs/open_enum.h
+++ b/test/SILGen/Inputs/open_enum.h
@@ -1,5 +1,5 @@
 
-typedef enum __attribute__((enum_extensibility(open))) YesOrNo {
+typedef enum __attribute__((enum_extensibility(open))) YesOrNo : int {
   Yes,
   No,
 } YesOrNo;

--- a/test/SILGen/skip-function-bodies-clang-enum-init-raw-value.swift
+++ b/test/SILGen/skip-function-bodies-clang-enum-init-raw-value.swift
@@ -3,9 +3,6 @@
 // RUN: %target-swift-frontend -emit-silgen %s -import-objc-header %S/Inputs/open_enum.h -experimental-skip-non-inlinable-function-bodies-without-types | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen %s -import-objc-header %S/Inputs/open_enum.h -debug-forbid-typecheck-prefix SKIP_ALL_NO_TYPECHECK -experimental-skip-all-function-bodies | %FileCheck %s --check-prefix=CHECK-SKIP-ALL
 
-// Imported clang enums have different signedness when building for Windows.
-// UNSUPPORTED: OS=windows-msvc
-
 // CHECK-SKIP-ALL-NOT: s4main13inlinableFuncSo7YesOrNoVyF
 
 // CHECK: sil [serialized]{{.*}} @$s4main13inlinableFuncSo7YesOrNoVyF : $@convention(thin) () -> YesOrNo {
@@ -17,8 +14,8 @@
   return YesOrNo(rawValue: 1)!
 }
 
-// CHECK-SKIP-ALL-NOT: sSo7YesOrNoV8rawValueABSgs6UInt32V_tcfC
+// CHECK-SKIP-ALL-NOT: sSo7YesOrNoV8rawValueABSgs5Int32V_tcfC
 
-// CHECK: sil shared [serialized]{{.*}} @$sSo7YesOrNoV8rawValueABSgs6UInt32V_tcfC : $@convention(method) (UInt32, @thin YesOrNo.Type) -> Optional<YesOrNo> {
+// CHECK: sil shared [serialized]{{.*}} @$sSo7YesOrNoV8rawValueABSgs5Int32V_tcfC : $@convention(method) (Int32, @thin YesOrNo.Type) -> Optional<YesOrNo> {
 // CHECK:   return {{%.*}} : $Optional<YesOrNo>
-// CHECK: } // end sil function '$sSo7YesOrNoV8rawValueABSgs6UInt32V_tcfC'
+// CHECK: } // end sil function '$sSo7YesOrNoV8rawValueABSgs5Int32V_tcfC'


### PR DESCRIPTION
Declare an explicit type for the enum to make SILGen output consistent across platforms.