### PR TITLE
[Concurrency] Hide `async_Main` from other object files

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -538,8 +538,13 @@ SILLinkage SILDeclRef::getDefinitionLinkage() const {
   // The main entry-point is public.
   if (kind == Kind::EntryPoint)
     return SILLinkage::Public;
-  if (kind == Kind::AsyncEntryPoint)
-    return SILLinkage::Hidden;
+  if (kind == Kind::AsyncEntryPoint) {
+    // async main entrypoint is referenced only from @main and
+    // they are in the same SIL module. Hiding this entrypoint
+    // from other object file makes it possible to link multiple
+    // executable targets for SwiftPM testing with -entry-point-function-name
+    return SILLinkage::Private;
+  }
 
   // Calling convention thunks have shared linkage.
   if (isForeignToNativeThunk())

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -40,7 +40,7 @@ func asyncFunc() async {
 
 
 // async_Main
-// CHECK-SIL-LABEL: sil hidden @async_Main : $@convention(thin) @async () -> () {
+// CHECK-SIL-LABEL: sil private @async_Main : $@convention(thin) @async () -> () {
 // call main
 // CHECK-SIL:  %0 = metatype $@thin MyProgram.Type             // user: %2
 // CHECK-SIL-NEXT:  // function_ref static MyProgram.$main()

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -3,7 +3,7 @@
 // a
 // CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1aSivp : $Int
 
-// CHECK-LABEL: sil hidden [ossa] @async_Main
+// CHECK-LABEL: sil private [ossa] @async_Main
 // CHECK: bb0:
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[GET_MAIN:%.*]] = function_ref @swift_task_getMainExecutor


### PR DESCRIPTION
Multiple executable targets with asyc entrypoints within a single package were not able to be tested due to the following linkage failure.
The sync `main` entrypoint is usually referenced by crt, so it should be visible from the outside of the object file and linked image unit. Therefore, the sync `main` entrypoints are renamed using `-entry-point-function-name` by SwiftPM to avoid conflicting with other executable targets.
On the other hand, the async `async_Main` entrypoint is only referenced from the sync `main`, so it doesn't need to be visible from other object files. Therefore, we can just hide it from other object files to avoid static link-time conflicts.

The `async_Main` symbol was defined as `hidden` SIL visibility, but `hidden` is still visible from other object files (not visible from other image unit), so this PR makes it `private`, which corresponds to `internal` LLVM visibility.

Resolves rdar://114231968

```
$ ../swift-DEVELOPMENT-SNAPSHOT-2023-10-09-a-ubuntu20.04/usr/bin/swift test
Building for debugging...
error: link command failed with exit code 1 (use -v to see invocation)
/usr/bin/ld.gold: error: /tmp/tmp.o984OA4fPZ/spm-async-main-repro/.build/x86_64-unknown-linux-gnu/debug/b.build/B.swift.o: multiple definition of 'async_Main'
/usr/bin/ld.gold: /tmp/tmp.o984OA4fPZ/spm-async-main-repro/.build/x86_64-unknown-linux-gnu/debug/a.build/A.swift.o: previous definition here
/usr/bin/ld.gold: error: /tmp/tmp.o984OA4fPZ/spm-async-main-repro/.build/x86_64-unknown-linux-gnu/debug/b.build/B.swift.o: multiple definition of 'async_MainTu'
/usr/bin/ld.gold: /tmp/tmp.o984OA4fPZ/spm-async-main-repro/.build/x86_64-unknown-linux-gnu/debug/a.build/A.swift.o: previous definition here
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
error: fatalError
[39/40] Linking spm-async-main-reproPackageTests.xctest
error: fatalError
```

<details>

```swift
let package = Package(
    name: "spm-async-main-repro",
    dependencies: [ ],
    targets: [
        .executableTarget(name: "a", dependencies: []),
        .executableTarget(name: "b", dependencies: []),

        .testTarget(name: "reproTests", dependencies: ["a", "b"]),
    ]
)
```

</details>