### PR TITLE
[SE-0331][stdlib] Mark unsafe pointer conformances to Sendable as explicitly unavailable

### DIFF
--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -76,6 +76,7 @@ KNOWN_STDLIB_TYPE_DECL(UnsafeRawPointer, NominalTypeDecl, 0)
 KNOWN_STDLIB_TYPE_DECL(UnsafeMutablePointer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(UnsafePointer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(OpaquePointer, NominalTypeDecl, 0)
+KNOWN_STDLIB_TYPE_DECL(CVaListPointer, NominalTypeDecl, 0)
 KNOWN_STDLIB_TYPE_DECL(AutoreleasingUnsafeMutablePointer, NominalTypeDecl, 1)
 
 KNOWN_STDLIB_TYPE_DECL(UnsafeBufferPointer, NominalTypeDecl, 1)

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -589,7 +589,8 @@ extension UnsafeRawPointer {
   }
 }
 
-extension AutoreleasingUnsafeMutablePointer { }
+@available(*, unavailable)
+extension AutoreleasingUnsafeMutablePointer: Sendable { }
 
 internal struct _CocoaFastEnumerationStackBuf {
   // Clang uses 16 pointers.  So do we.

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -211,6 +211,9 @@ extension OpaquePointer: Hashable {
   }
 }
 
+@available(*, unavailable)
+extension OpaquePointer : Sendable { }
+
 @_unavailableInEmbedded
 extension OpaquePointer: CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
@@ -303,6 +306,9 @@ extension CVaListPointer: CustomDebugStringConvertible {
 }
 
 #endif
+
+@available(*, unavailable)
+extension CVaListPointer: Sendable { }
 
 /// Copy `size` bytes of memory from `src` into `dest`.
 ///

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -1198,7 +1198,13 @@ extension Unsafe${Mutable}BufferPointer: CustomDebugStringConvertible {
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
   }
 }
+
+@available(*, unavailable)
+extension Unsafe${Mutable}BufferPointer: Sendable { }
 %end
+
+@available(*, unavailable)
+extension UnsafeBufferPointer.Iterator: Sendable { }
 
 
 // ${'Local Variables'}:

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -1175,3 +1175,8 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
     )._unsafelyUnwrappedUnchecked
   }
 }
+
+@available(*, unavailable)
+extension UnsafePointer: Sendable { }
+@available(*, unavailable)
+extension UnsafeMutablePointer: Sendable { }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1304,6 +1304,14 @@ public func _withUnprotectedUnsafeBytes<T, Result>(
   return try body(buffer)
 }
 
+@available(*, unavailable)
+extension UnsafeRawBufferPointer: Sendable { }
+@available(*, unavailable)
+extension UnsafeRawBufferPointer.Iterator: Sendable { }
+@available(*, unavailable)
+extension UnsafeMutableRawBufferPointer: Sendable { }
+
+
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1486,3 +1486,8 @@ extension OpaquePointer {
     self._rawValue = unwrapped._rawValue
   }
 }
+
+@available(*, unavailable)
+extension UnsafeRawPointer: Sendable { }
+@available(*, unavailable)
+extension UnsafeMutableRawPointer: Sendable { }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -318,3 +318,36 @@ func testLocalCaptures() {
     // expected-complete-and-sns-warning@-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
   }
 }
+
+func testPointersAreNotSendable() {
+  func testSendable<T: Sendable>(_: T) {}
+
+  func testUnsafePointer(ptr: UnsafePointer<Int>,
+                         mutablePtr: UnsafeMutablePointer<String>) {
+    testSendable(ptr) // expected-warning {{conformance of 'UnsafePointer<Pointee>' to 'Sendable' is unavailable}}
+    testSendable(mutablePtr) // expected-warning {{conformance of 'UnsafeMutablePointer<Pointee>' to 'Sendable' is unavailable}}
+  }
+
+  func testRawPointer(ptr: UnsafeRawPointer,
+                            mutablePtr: UnsafeMutableRawPointer) {
+    testSendable(ptr) // expected-warning {{conformance of 'UnsafeRawPointer' to 'Sendable' is unavailable}}
+    testSendable(mutablePtr) // expected-warning {{conformance of 'UnsafeMutableRawPointer' to 'Sendable' is unavailable}}
+  }
+
+  func testOpaqueAndCPointers(opaquePtr: OpaquePointer, cPtr: CVaListPointer, autoReleasePtr: AutoreleasingUnsafeMutablePointer<Int>) {
+    testSendable(opaquePtr) // expected-warning {{conformance of 'OpaquePointer' to 'Sendable' is unavailable}}
+    testSendable(cPtr) // expected-warning {{conformance of 'CVaListPointer' to 'Sendable' is unavailable}}
+    testSendable(autoReleasePtr) // expected-warning {{conformance of 'AutoreleasingUnsafeMutablePointer<Pointee>' to 'Sendable' is unavailable}}
+  }
+
+  func testBufferPointers(buffer: UnsafeBufferPointer<Int>, mutableBuffer: UnsafeMutableBufferPointer<Int>,
+                          rawBuffer: UnsafeRawBufferPointer, rawMutableBuffer: UnsafeMutableRawBufferPointer) {
+    testSendable(buffer) // expected-warning {{conformance of 'UnsafeBufferPointer<Element>' to 'Sendable' is unavailable}}
+    testSendable(mutableBuffer) // expected-warning {{conformance of 'UnsafeMutableBufferPointer<Element>' to 'Sendable' is unavailable}}
+    testSendable(buffer.makeIterator()) // expected-warning {{conformance of 'UnsafeBufferPointer<Element>.Iterator' to 'Sendable' is unavailable}}
+    testSendable(rawBuffer) // expected-warning {{conformance of 'UnsafeRawBufferPointer' to 'Sendable' is unavailable}}
+    testSendable(rawBuffer.makeIterator()) // expected-warning {{conformance of 'UnsafeRawBufferPointer.Iterator' to 'Sendable' is unavailable}}
+    testSendable(rawMutableBuffer) // expected-warning {{conformance of 'UnsafeMutableRawBufferPointer' to 'Sendable' is unavailable}}
+    testSendable(rawMutableBuffer.makeIterator()) // expected-warning {{conformance of 'UnsafeRawBufferPointer.Iterator' to 'Sendable' is unavailable}}
+  }
+}


### PR DESCRIPTION
This is a preferred way to make sure that Sendable inference doesn't
happen for these types because they are marked as `@frozen`.

Resolves: rdar://101980108

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
