### PR TITLE
Another follow-up on the bridging rework

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -40,9 +40,10 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagID : uint32_t {
 #include "swift/AST/DiagnosticsAll.def"
 } BridgedDiagID;
 
-struct BridgedDiagnosticEngine {
+// Must match the definition of BridgedDiagnosticEngine in CASTBridging.h.
+typedef struct {
   void * _Nonnull object;
-};
+} BridgedDiagnosticEngine;
 
 struct BridgedOptionalDiagnosticEngine {
   void *_Nullable object;

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -67,7 +67,7 @@ public:
 };
 
 class BridgedDiagnosticFixIt {
-  int64_t storage[6];
+  int64_t storage[7];
 
 public:
 #ifdef USED_IN_CPP_SOURCE

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -35,7 +35,7 @@ BridgedDiagnosticArgument::BridgedDiagnosticArgument(BridgedStringRef s)
   : BridgedDiagnosticArgument(DiagnosticArgument(s.get())) {}
 
 static_assert(sizeof(BridgedDiagnosticFixIt) >= sizeof(DiagnosticInfo::FixIt),
-              "BridgedDiagnosticArgument has wrong size");
+              "BridgedDiagnosticFixIt has wrong size");
 
 static SourceLoc getSourceLoc(BridgedSourceLoc bridgedLoc) {
   return SourceLoc(llvm::SMLoc::getFromPointer(bridgedLoc.getLoc()));


### PR DESCRIPTION
This is another follow-up on https://github.com/apple/swift/pull/69039

* make BridgedDiagnosticEngine a typedef again. rdar://116686158
* fix storage size of BridgedDiagnosticFixIt and fix the static_assert error message
