### PR TITLE
PerformanceDiagnostics: fix handling of infinite loops and change error handling

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -157,12 +157,11 @@ bool PerformanceDiagnostics::visitFunction(SILFunction *function,
   if (!function->isDefinition())
     return false;
 
-  ReachingReturnBlocks rrBlocks(function);
-  NonErrorHandlingBlocks neBlocks(function);
-                                       
   for (SILBasicBlock &block : *function) {
-    if (!rrBlocks.reachesReturn(&block) || !neBlocks.isNonErrorHandling(&block))
+    // Exclude fatal-error blocks.
+    if (isa<UnreachableInst>(block.getTerminator()))
       continue;
+
     for (SILInstruction &inst : block) {
       if (visitInst(&inst, perfConstr, parentLoc))
         return true;


### PR DESCRIPTION
* Don't exclude code which end up in an infinite loop. rdar://116705459
* Don't exclude error handling code (throw, catch). Errors are existentials and will always allocate. Once we have typed throws it will be possible to do error handling without allocations.
