### PR TITLE
Sema: Fix two bugs with type resolution of generic arguments [5.10]

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5669,7 +5669,7 @@ ERROR(superclass_with_pack,none,
       "cannot inherit from a generic class that declares a type pack", ())
 ERROR(expansion_not_allowed,none,
       "pack expansion %0 can only appear in a function parameter list, "
-      "tuple element, or generic argument list", (Type))
+      "tuple element, or generic argument of a variadic type", (Type))
 ERROR(expansion_expr_not_allowed,none,
       "value pack expansion can only appear inside a function argument list "
       "or tuple element", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4373,10 +4373,21 @@ ERROR(cannot_specialize_self,none,
       "cannot specialize 'Self'", ())
 NOTE(specialize_explicit_type_instead,none,
      "did you mean to explicitly reference %0 instead?", (Type))
-ERROR(type_parameter_count_mismatch,none,
-      "generic type %0 specialized with %select{too many|too few}3 type "
-      "parameters (got %2, but expected %select{%1|at least %1}4)",
-      (Identifier, unsigned, unsigned, bool, bool))
+ERROR(too_few_generic_arguments,none,
+      "generic type %0 specialized with too few type parameters "
+      "(got %1, but expected %2)",
+      (Identifier, unsigned, unsigned))
+ERROR(too_few_generic_arguments_pack,none,
+      "generic type %0 specialized with too few type parameters "
+      "(got %1, but expected at least %2)",
+      (Identifier, unsigned, unsigned))
+ERROR(too_many_generic_arguments,none,
+      "generic type %0 specialized with too many type parameters "
+      "(got %1, but expected %2)",
+      (Identifier, unsigned, unsigned))
+ERROR(generic_argument_pack_mismatch,none,
+      "generic type %0 specialized with mismatched type parameter pack",
+      (Identifier))
 ERROR(generic_type_requires_arguments,none,
       "reference to generic type %0 requires arguments in <...>", (Type))
 NOTE(descriptive_generic_type_declared_here,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -17,6 +17,7 @@
 #include "CSDiagnostics.h"
 #include "MiscDiagnostics.h"
 #include "TypeCheckProtocol.h"
+#include "TypeCheckType.h"
 #include "TypoCorrection.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
@@ -9173,7 +9174,9 @@ bool OutOfPlaceThenStmtFailure::diagnoseAsError() {
 }
 
 bool InvalidTypeSpecializationArity::diagnoseAsError() {
-  emitDiagnostic(diag::type_parameter_count_mismatch, D->getBaseIdentifier(),
-                 NumParams, NumArgs, NumArgs < NumParams, HasParameterPack);
+  diagnoseInvalidGenericArguments(getLoc(), D,
+                                  NumArgs, NumParams,
+                                  HasParameterPack,
+                                  /*generic=*/nullptr);
   return true;
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -816,37 +816,6 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
       return ErrorType::get(ctx);
     }
 
-    // Build ParameterizedProtocolType if the protocol has a primary associated
-    // type and we're in a supported context.
-    if (resolution.getOptions().isConstraintImplicitExistential() &&
-        !ctx.LangOpts.hasFeature(Feature::ImplicitSome)) {
-
-      if (!genericArgs.empty()) {
-
-        SmallVector<Type, 2> argTys;
-        for (auto *genericArg : genericArgs) {
-          Type argTy = resolution.resolveType(genericArg);
-          if (!argTy || argTy->hasError())
-            return ErrorType::get(ctx);
-
-          argTys.push_back(argTy);
-        }
-
-        auto parameterized =
-            ParameterizedProtocolType::get(ctx, protoType, argTys);
-        diags.diagnose(loc, diag::existential_requires_any, parameterized,
-                       ExistentialType::get(parameterized),
-                       /*isAlias=*/isa<TypeAliasType>(type.getPointer()));
-      } else {
-        diags.diagnose(loc, diag::existential_requires_any,
-                       protoDecl->getDeclaredInterfaceType(),
-                       protoDecl->getDeclaredExistentialType(),
-                       /*isAlias=*/isa<TypeAliasType>(type.getPointer()));
-      }
-
-      return ErrorType::get(ctx);
-    }
-
     // Disallow opaque types anywhere in the structure of the generic arguments
     // to a parameterized existential type.
     if (options.is(TypeResolverContext::ExistentialConstraint))
@@ -855,6 +824,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
         TypeResolverContext::ProtocolGenericArgument);
     auto genericResolution = resolution.withOptions(argOptions);
 
+    // Resolve the generic arguments.
     SmallVector<Type, 2> argTys;
     for (auto *genericArg : genericArgs) {
       Type argTy = genericResolution.resolveType(genericArg, silContext);
@@ -864,7 +834,20 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
       argTys.push_back(argTy);
     }
 
-    return ParameterizedProtocolType::get(ctx, protoType, argTys);
+    auto parameterized =
+        ParameterizedProtocolType::get(ctx, protoType, argTys);
+
+    // Build ParameterizedProtocolType if the protocol has primary associated
+    // types and we're in a supported context.
+    if (resolution.getOptions().isConstraintImplicitExistential() &&
+        !ctx.LangOpts.hasFeature(Feature::ImplicitSome)) {
+      diags.diagnose(loc, diag::existential_requires_any, parameterized,
+                     ExistentialType::get(parameterized),
+                     /*isAlias=*/isa<TypeAliasType>(type.getPointer()));
+      return ErrorType::get(ctx);
+    }
+
+    return parameterized;
   }
 
   // We must either have an unbound generic type, or a generic type alias.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -144,8 +144,8 @@ static unsigned getGenericRequirementKind(TypeResolutionOptions options) {
   case TypeResolverContext::FunctionInput:
   case TypeResolverContext::PackElement:
   case TypeResolverContext::TupleElement:
-  case TypeResolverContext::GenericArgument:
-  case TypeResolverContext::ProtocolGenericArgument:
+  case TypeResolverContext::ScalarGenericArgument:
+  case TypeResolverContext::VariadicGenericArgument:
   case TypeResolverContext::ExtensionBinding:
   case TypeResolverContext::TypeAliasDecl:
   case TypeResolverContext::GenericTypeAliasDecl:
@@ -793,6 +793,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
 
   auto genericArgs = generic->getGenericArgs();
 
+  // Parameterized protocol types have their own code path.
   if (auto *protoType = type->getAs<ProtocolType>()) {
     auto *protoDecl = protoType->getDecl();
 
@@ -807,6 +808,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
       return ErrorType::get(ctx);
     }
 
+    // Make sure we have the right number of generic arguments.
     if (genericArgs.size() != assocTypes.size()) {
       diags.diagnose(loc,
                      diag::parameterized_protocol_type_argument_count_mismatch,
@@ -821,7 +823,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     if (options.is(TypeResolverContext::ExistentialConstraint))
       options |= TypeResolutionFlags::DisallowOpaqueTypes;
     auto argOptions = options.withoutContext().withContext(
-        TypeResolverContext::ProtocolGenericArgument);
+        TypeResolverContext::ScalarGenericArgument);
     auto genericResolution = resolution.withOptions(argOptions);
 
     // Resolve the generic arguments.
@@ -837,8 +839,6 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     auto parameterized =
         ParameterizedProtocolType::get(ctx, protoType, argTys);
 
-    // Build ParameterizedProtocolType if the protocol has primary associated
-    // types and we're in a supported context.
     if (resolution.getOptions().isConstraintImplicitExistential() &&
         !ctx.LangOpts.hasFeature(Feature::ImplicitSome)) {
       diags.diagnose(loc, diag::existential_requires_any, parameterized,
@@ -873,15 +873,20 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
   auto *unboundType = type->castTo<UnboundGenericType>();
   auto *decl = unboundType->getDecl();
 
-  // Make sure we have the right number of generic arguments.
   auto genericParams = decl->getGenericParams();
   auto hasParameterPack = llvm::any_of(
       *genericParams, [](auto *paramDecl) {
           return paramDecl->isParameterPack();
       });
 
+  // If the type declares at least one parameter pack, allow pack expansions
+  // anywhere in the argument list. We'll use the PackMatcher to ensure that
+  // everything lines up. Otherwise, don't allow pack expansions to appear
+  // at all.
   auto argOptions = options.withoutContext().withContext(
-      TypeResolverContext::GenericArgument);
+      hasParameterPack
+      ? TypeResolverContext::VariadicGenericArgument
+      : TypeResolverContext::ScalarGenericArgument);
   auto genericResolution = resolution.withOptions(argOptions);
 
   // In SIL mode, Optional<T> interprets T as a SIL type.
@@ -904,6 +909,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     args.push_back(substTy);
   }
 
+  // Make sure we have the right number of generic arguments.
   if (!hasParameterPack) {
     // For generic types without type parameter packs, we require
     // the number of declared generic parameters match the number of
@@ -970,6 +976,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     }
   }
 
+  // Construct the substituted type.
   const auto result = resolution.applyUnboundGenericArguments(
       decl, unboundType->getParent(), loc, args);
 
@@ -4422,7 +4429,7 @@ NeverNullType
 TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
                                     TypeResolutionOptions options) {
   auto argOptions = options.withoutContext().withContext(
-      TypeResolverContext::GenericArgument);
+      TypeResolverContext::ScalarGenericArgument);
 
   auto keyTy = resolveType(repr->getKey(), argOptions);
   if (keyTy->hasError()) {
@@ -4496,8 +4503,8 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     break;
   case TypeResolverContext::PackElement:
   case TypeResolverContext::TupleElement:
-  case TypeResolverContext::GenericArgument:
-  case TypeResolverContext::ProtocolGenericArgument:
+  case TypeResolverContext::ScalarGenericArgument:
+  case TypeResolverContext::VariadicGenericArgument:
   case TypeResolverContext::VariadicFunctionInput:
   case TypeResolverContext::ForEachStmt:
   case TypeResolverContext::ExtensionBinding:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -38,6 +38,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeLoc.h"
+#include "swift/AST/TypeRepr.h"
 #include "swift/AST/TypeResolutionStage.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
@@ -667,6 +668,51 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
   llvm_unreachable("invalid requirement check type");
 }
 
+void swift::diagnoseInvalidGenericArguments(SourceLoc loc,
+                                            ValueDecl *decl,
+                                            unsigned argCount,
+                                            unsigned paramCount,
+                                            bool hasParameterPack,
+                                            GenericIdentTypeRepr *generic) {
+  auto &ctx = decl->getASTContext();
+  auto &diags = ctx.Diags;
+
+  if (!hasParameterPack) {
+    // For generic types without type parameter packs, we require
+    // the number of declared generic parameters match the number of
+    // arguments.
+    if (argCount < paramCount) {
+      auto diag = diags
+          .diagnose(loc, diag::too_few_generic_arguments, decl->getBaseIdentifier(),
+                    argCount, paramCount);
+      if (generic)
+        diag.highlight(generic->getAngleBrackets());
+    } else {
+      auto diag = diags
+          .diagnose(loc, diag::too_many_generic_arguments, decl->getBaseIdentifier(),
+                    argCount, paramCount);
+      if (generic)
+        diag.highlight(generic->getAngleBrackets());
+    }
+  } else {
+    if (argCount < paramCount - 1) {
+      auto diag = diags
+          .diagnose(loc, diag::too_few_generic_arguments_pack, decl->getBaseIdentifier(),
+                    argCount, paramCount - 1);
+      if (generic)
+        diag.highlight(generic->getAngleBrackets());
+    } else {
+      auto diag = diags
+          .diagnose(loc, diag::generic_argument_pack_mismatch, decl->getBaseIdentifier());
+      if (generic)
+        diag.highlight(generic->getAngleBrackets());
+    }
+  }
+
+  decl->diagnose(diag::kind_declname_declared_here,
+                 DescriptiveDeclKind::GenericType, decl->getName());
+}
+
 /// Apply generic arguments to the given type.
 ///
 /// If the type is itself not generic, this does nothing.
@@ -851,7 +897,6 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
           return paramDecl->isParameterPack();
       });
 
-  // Resolve the types of the generic arguments.
   auto argOptions = options.withoutContext().withContext(
       TypeResolverContext::GenericArgument);
   auto genericResolution = resolution.withOptions(argOptions);
@@ -865,6 +910,7 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     }
   }
 
+  // Resolve the types of the generic arguments.
   SmallVector<Type, 2> args;
   for (auto tyR : genericArgs) {
     // Propagate failure.
@@ -881,15 +927,9 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     // arguments.
     if (genericArgs.size() != genericParams->size()) {
       if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
-        diags
-            .diagnose(loc, diag::type_parameter_count_mismatch, decl->getName(),
-                      genericParams->size(),
-                      genericArgs.size(),
-                      genericArgs.size() < genericParams->size(),
-                      /*hasParameterPack=*/0)
-            .highlight(generic->getAngleBrackets());
-        decl->diagnose(diag::kind_declname_declared_here,
-                       DescriptiveDeclKind::GenericType, decl->getName());
+        diagnoseInvalidGenericArguments(
+            loc, decl, genericArgs.size(), genericParams->size(),
+            /*hasParameterPack=*/false, generic);
       }
       return ErrorType::get(ctx);
     }
@@ -907,17 +947,11 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     }
 
     PackMatcher matcher(params, args, ctx);
-    if (matcher.match()) {
+    if (matcher.match() || matcher.pairs.size() != params.size()) {
       if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
-        diags
-            .diagnose(loc, diag::type_parameter_count_mismatch, decl->getName(),
-                      genericParams->size() - 1,
-                      genericArgs.size(),
-                      genericArgs.size() < genericParams->size(),
-                      /*hasParameterPack=*/1)
-            .highlight(generic->getAngleBrackets());
-        decl->diagnose(diag::kind_declname_declared_here,
-                       DescriptiveDeclKind::GenericType, decl->getName());
+        diagnoseInvalidGenericArguments(
+            loc, decl, genericArgs.size(), genericParams->size(),
+            /*hasParameterPack=*/true, generic);
       }
       return ErrorType::get(ctx);
     }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -31,6 +31,7 @@ class PackElementTypeRepr;
 class GenericEnvironment;
 class GenericSignature;
 class SILTypeResolutionContext;
+class GenericIdentTypeRepr;
 
 /// Flags that describe the context of type checking a pattern or
 /// type.
@@ -654,6 +655,13 @@ public:
                                     SourceLoc loc,
                                     ArrayRef<Type> genericArgs) const;
 };
+
+void diagnoseInvalidGenericArguments(SourceLoc loc,
+                                     ValueDecl *decl,
+                                     unsigned argCount,
+                                     unsigned paramCount,
+                                     bool hasParameterPack,
+                                     GenericIdentTypeRepr *generic);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -92,11 +92,17 @@ enum class TypeResolverContext : uint8_t {
   /// No special type handling is required.
   None,
 
-  /// Whether we are checking generic arguments of a bound generic type.
-  GenericArgument,
+  /// Whether we are checking generic arguments of a non-variadic bound generic
+  /// type. This includes parameterized protocol types. We don't allow pack
+  /// expansions here.
+  ScalarGenericArgument,
 
-  /// Whether we are checking generic arguments of a parameterized protocol type.
-  ProtocolGenericArgument,
+  /// Whether we are checking generic arguments of a variadic generic type.
+  /// We allow pack expansions in all argument positions, and then use the
+  /// PackMatcher to ensure that scalar parameters line up with scalar
+  /// arguments, and pack expansion parameters line up with pack expansion
+  /// arguments.
+  VariadicGenericArgument,
 
   /// Whether we are checking a tuple element type.
   TupleElement,
@@ -262,8 +268,8 @@ public:
     case Context::ClosureExpr:
       return true;
     case Context::None:
-    case Context::GenericArgument:
-    case Context::ProtocolGenericArgument:
+    case Context::ScalarGenericArgument:
+    case Context::VariadicGenericArgument:
     case Context::TupleElement:
     case Context::PackElement:
     case Context::FunctionInput:
@@ -308,8 +314,8 @@ public:
     case Context::MetatypeBase:
       return false;
     case Context::None:
-    case Context::GenericArgument:
-    case Context::ProtocolGenericArgument:
+    case Context::ScalarGenericArgument:
+    case Context::VariadicGenericArgument:
     case Context::PackElement:
     case Context::TupleElement:
     case Context::InExpression:
@@ -342,11 +348,11 @@ public:
     case Context::VariadicFunctionInput:
     case Context::PackElement:
     case Context::TupleElement:
-    case Context::GenericArgument:
+    case Context::VariadicGenericArgument:
       return true;
-    case Context::PatternBindingDecl:
     case Context::None:
-    case Context::ProtocolGenericArgument:
+    case Context::PatternBindingDecl:
+    case Context::ScalarGenericArgument:
     case Context::Inherited:
     case Context::GenericParameterInherited:
     case Context::AssociatedTypeInherited:
@@ -391,8 +397,8 @@ public:
     case Context::FunctionInput:
     case Context::PackElement:
     case Context::TupleElement:
-    case Context::GenericArgument:
-    case Context::ProtocolGenericArgument:
+    case Context::ScalarGenericArgument:
+    case Context::VariadicGenericArgument:
     case Context::ExtensionBinding:
     case Context::TypeAliasDecl:
     case Context::GenericTypeAliasDecl:

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -36,9 +36,9 @@ func coerceExpansion<each T>(_ value: repeat each T) {
 
 func localValuePack<each T>(_ t: repeat each T) -> (repeat each T, repeat each T) {
   let local = repeat each t
-  // expected-error@-1{{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+  // expected-error@-1{{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
   let localAnnotated: repeat each T = repeat each t
-  // expected-error@-1{{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+  // expected-error@-1{{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 
   return (repeat each local, repeat each localAnnotated)
 }
@@ -92,7 +92,7 @@ func sameShapeDiagnostics<each T, each U>(t: repeat each T, u: repeat each U) {
   _ = (repeat (Array<each T>(), each u)) // expected-error {{pack expansion requires that 'each T' and 'each U' have the same shape}}
 }
 
-func returnPackExpansionType<each T>(_ t: repeat each T) -> repeat each T { // expected-error {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+func returnPackExpansionType<each T>(_ t: repeat each T) -> repeat each T { // expected-error {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
   fatalError()
 }
 

--- a/test/Generics/rdar115538574.swift
+++ b/test/Generics/rdar115538574.swift
@@ -5,5 +5,5 @@ protocol P<A> {
 }
 
 func f<each T>(_: some P<repeat each T>) {}
-// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 // expected-error@-2 {{generic parameter 'T' is not used in function signature}}

--- a/test/Generics/variadic_generic_types.swift
+++ b/test/Generics/variadic_generic_types.swift
@@ -111,3 +111,8 @@ func invalidPackExpansion<each X, each Y, Z>(x: repeat each X, y: repeat each Y,
   typealias Seven = B<Z, repeat each X> // expected-error {{generic type 'B' specialized with mismatched type parameter pack}}
   typealias Eight = B<Z, repeat each X, repeat each Y> // expected-error {{generic type 'B' specialized with mismatched type parameter pack}}
 }
+
+func packExpansionInScalarArgument<each T>(_: repeat each T) {
+  typealias A<U> = U
+  typealias One = A<repeat each T> // expected-error {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
+}

--- a/test/Generics/variadic_generic_types.swift
+++ b/test/Generics/variadic_generic_types.swift
@@ -96,3 +96,18 @@ func bindAliasPrefixAndSuffix() {
   typealias Three = Bind<Int, String, Float> // OK
   typealias Four = Bind<Int, String, Float, Bool> // OK
 }
+
+func invalidPackExpansion<each X, each Y, Z>(x: repeat each X, y: repeat each Y, z: Z) {
+  typealias A<T, each U> = (T, repeat each U) // expected-note 4{{generic type 'A' declared here}}
+  typealias B<each T, U> = (repeat each T, U) // expected-note 4{{generic type 'B' declared here}}
+
+  typealias One = A<repeat each X> // expected-error {{generic type 'A' specialized with mismatched type parameter pack}}
+  typealias Two = A<repeat each X, repeat each Y> // expected-error {{generic type 'A' specialized with mismatched type parameter pack}}
+  typealias Three = A<repeat each X, Z> // expected-error {{generic type 'A' specialized with mismatched type parameter pack}}
+  typealias Four = A<repeat each X, repeat each Y, Z> // expected-error {{generic type 'A' specialized with mismatched type parameter pack}}
+
+  typealias Five = B<repeat each X> // expected-error {{generic type 'B' specialized with mismatched type parameter pack}}
+  typealias Six = B<repeat each X, repeat each Y> // expected-error {{generic type 'B' specialized with mismatched type parameter pack}}
+  typealias Seven = B<Z, repeat each X> // expected-error {{generic type 'B' specialized with mismatched type parameter pack}}
+  typealias Eight = B<Z, repeat each X, repeat each Y> // expected-error {{generic type 'B' specialized with mismatched type parameter pack}}
+}

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -3,7 +3,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature CodeItemMacros -module-name MacrosTest
 
 @expression macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
-// expected-note@-1 2{{'stringify' declared here}}
+// expected-note@-1 3{{'stringify' declared here}}
 // expected-warning@-2{{external macro implementation type}}
 // expected-warning@-3{{@expression has been removed in favor of @freestanding(expression)}}{{1-12=@freestanding(expression)}}
 @freestanding(expression) macro missingMacro1(_: Any) = MissingModule.MissingType // expected-note{{'missingMacro1' declared here}}

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 func f1<each T>() -> repeat each T {}
-// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 
 func f2<each T>() -> (repeat each T) {}
 // okay
@@ -15,15 +15,15 @@ protocol P<T> {
 }
 
 func f4<each T>() -> any P<repeat each T> {}
-// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 
 typealias T1<each T> = repeat each T
-// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 
 typealias T2<each T> = (repeat each T)
 
 func f4<each T>() -> repeat () -> each T {}
-// expected-error@-1 {{pack expansion 'repeat () -> each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat () -> each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 
 func f5<each T>() -> () -> (repeat each T) {}
 
@@ -35,14 +35,14 @@ enum E<each T> { // expected-error {{enums cannot declare a type pack}}
   case f2(_: G<repeat each T>)
 
   var x: repeat each T { fatalError() }
-  // expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+  // expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 
   var x: (repeat each T) { fatalError() }
 
   subscript(_: repeat each T) -> Int { fatalError() }
 
   subscript() -> repeat each T { fatalError() }
-  // expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument list}}
+  // expected-error@-1 {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 
   subscript() -> (repeat each T) { fatalError() }
 }


### PR DESCRIPTION
* Description: When resolving the generic argument list of a generic type, we didn't check for certain invalid situations involving occurrences of pack expansion types. As a result we would crash instead of producing a diagnostic.
* Risk: Very low. (Note: The middle commit is a refactoring that has been on `main` for a while. I cherry-picked it to avoid merge conflicts)
* Tested: New test cases added.
* Radar: rdar://116713961 and rdar://116716014.
* Reviewed by: @hborla 