### PR TITLE
[Concurrency] Don't allow subclasses of `nonisolated` classes to add global actor isolation.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4051,11 +4051,13 @@ static bool checkClassGlobalActorIsolation(
     return false;
 
   // Check the superclass's isolation.
+  bool downgradeToWarning = false;
   auto superIsolation = getActorIsolation(superclassDecl);
   switch (superIsolation) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
-    return false;
+    downgradeToWarning = true;
+    break;
 
   case ActorIsolation::ActorInstance:
     // This is an error that will be diagnosed later. Ignore it here.
@@ -4079,7 +4081,8 @@ static bool checkClassGlobalActorIsolation(
 
   // Complain about the mismatch.
   classDecl->diagnose(diag::actor_isolation_superclass_mismatch, isolation,
-                      classDecl, superIsolation, superclassDecl);
+                      classDecl, superIsolation, superclassDecl)
+      .warnUntilSwiftVersionIf(downgradeToWarning, 6);
   return true;
 }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -298,6 +298,7 @@ class BarFrame: PictureFrame {
 @available(SwiftStdlib 5.5, *)
 @SomeGlobalActor
 class BazFrame: NotIsolatedPictureFrame {
+// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'BazFrame' has different actor isolation from nonisolated superclass 'NotIsolatedPictureFrame'; this is an error in Swift 6}}
   init() {
     super.init(size: 0)
   }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1263,7 +1263,8 @@ actor Counter {
 class C2 { }
 
 @SomeGlobalActor
-class C3: C2 { } // it's okay to add a global actor to a nonisolated class.
+class C3: C2 { }
+// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'C3' has different actor isolation from nonisolated superclass 'C2'; this is an error in Swift 6}}
 
 @GenericGlobalActor<U>
 class GenericSuper<U> { }
@@ -1443,6 +1444,8 @@ class None {
 // try to add inferred isolation while overriding
 @MainActor
 class MA_None1: None {
+// expected-warning@-1 {{main actor-isolated class 'MA_None1' has different actor isolation from nonisolated superclass 'None'; this is an error in Swift 6}}
+
   // FIXME: bad note, since the problem is a mismatch in overridden vs inferred isolation; this wont help.
   // expected-note@+1 {{add '@MainActor' to make instance method 'method()' part of global actor 'MainActor'}}
   override func method() {
@@ -1472,6 +1475,8 @@ class None_MADirect: MADirect {
 
 @SomeGlobalActor
 class SGA_MADirect: MADirect {
+// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'SGA_MADirect' has different actor isolation from nonisolated superclass 'MADirect'; this is an error in Swift 6}}
+
   // inferred-SomeGlobalActor vs overridden-MainActor = mainactor
   override func method1() { beets_ma() }
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -246,8 +246,10 @@ class SuperclassWithGlobalActors {
   func j() { }
 }
 
-@GenericGlobalActor<String> // it's okay to add a global actor to nonisolated
+@GenericGlobalActor<String>
 class SubclassWithGlobalActors : SuperclassWithGlobalActors {
+// expected-warning@-1 {{global actor 'GenericGlobalActor<String>'-isolated class 'SubclassWithGlobalActors' has different actor isolation from nonisolated superclass 'SuperclassWithGlobalActors'; this is an error in Swift 6}}
+
   override func f() { } // okay: inferred to @GenericGlobalActor<Int>
 
   @GenericGlobalActor<String> override func g() { } // expected-error{{global actor 'GenericGlobalActor<String>'-isolated instance method 'g()' has different actor isolation from global actor 'GenericGlobalActor<Int>'-isolated overridden declaration}}


### PR DESCRIPTION
Adding global actor isolation to a subclass of a `nonisolated` superclass admits data races because actor-isolated types are `Sendable`, so this allowed bypassing `Sendable` checking, e.g.

```swift
class NonSendable {
  var x: Int = 0
}

@MainActor 
class MainActorSubclass: NonSendable {}

let mainActorSub = MainActorSubclass()

Task.detached {
  _ = mainActorSub
  _ = mainActorSub.x
  mainActorSub.x = 10 // race?
}

mainActorSub.x = 100 // oops
```

Resolves rdar://116702475