### PR TITLE
Rename BridgedDiagnosticEngine -> BridgedDiagEngine

### DIFF
--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -52,16 +52,16 @@ public struct DiagnosticFixIt {
 }
 
 public struct DiagnosticEngine {
-  private let bridged: BridgedDiagnosticEngine
+  private let bridged: BridgedDiagEngine
 
-  public init(bridged: BridgedDiagnosticEngine) {
+  public init(bridged: BridgedDiagEngine) {
     self.bridged = bridged
   }
   public init?(bridged: BridgedOptionalDiagnosticEngine) {
     guard let object = bridged.object else {
       return nil
     }
-    self.bridged = BridgedDiagnosticEngine(object: object)
+    self.bridged = BridgedDiagEngine(object: object)
   }
 
   public func diagnose(_ position: SourceLoc?,

--- a/SwiftCompilerSources/Sources/Parse/Regex.swift
+++ b/SwiftCompilerSources/Sources/Parse/Regex.swift
@@ -93,7 +93,7 @@ public func _RegexLiteralParsingFn(
   _ captureStructureOut: UnsafeMutableRawPointer,
   _ captureStructureSize: CUnsignedInt,
   _ bridgedDiagnosticBaseLoc: BridgedSourceLoc,
-  _ bridgedDiagnosticEngine: BridgedDiagnosticEngine
+  _ bridgedDiagnosticEngine: BridgedDiagEngine
 ) -> Bool {
   let str = String(cString: inputPtr)
   let captureBuffer = UnsafeMutableRawBufferPointer(

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -40,10 +40,10 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagID : uint32_t {
 #include "swift/AST/DiagnosticsAll.def"
 } BridgedDiagID;
 
-// Must match the definition of BridgedDiagnosticEngine in CASTBridging.h.
-typedef struct {
+// The name must not collide with BridgedDiagnosticEngine in CASTBridging.h.
+struct BridgedDiagEngine {
   void * _Nonnull object;
-} BridgedDiagnosticEngine;
+};
 
 struct BridgedOptionalDiagnosticEngine {
   void *_Nullable object;
@@ -83,12 +83,12 @@ public:
 };
 
 // FIXME: Can we bridge InFlightDiagnostic?
-void DiagnosticEngine_diagnose(BridgedDiagnosticEngine, BridgedSourceLoc loc,
+void DiagnosticEngine_diagnose(BridgedDiagEngine, BridgedSourceLoc loc,
                                BridgedDiagID diagID, BridgedArrayRef arguments,
                                BridgedSourceLoc highlightStart, uint32_t hightlightLength,
                                BridgedArrayRef fixIts);
 
-bool DiagnosticEngine_hadAnyError(BridgedDiagnosticEngine);
+bool DiagnosticEngine_hadAnyError(BridgedDiagEngine);
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/include/swift/AST/BridgingUtils.h
+++ b/include/swift/AST/BridgingUtils.h
@@ -18,7 +18,7 @@
 
 namespace swift {
 
-inline BridgedDiagnosticEngine getBridgedDiagnosticEngine(DiagnosticEngine *D) {
+inline BridgedDiagEngine getBridgedDiagnosticEngine(DiagnosticEngine *D) {
   return {(void *)D};
 }
 inline BridgedOptionalDiagnosticEngine

--- a/include/swift/Parse/RegexParserBridging.h
+++ b/include/swift/Parse/RegexParserBridging.h
@@ -58,7 +58,7 @@ typedef bool (*RegexLiteralParsingFn)(/*InputPtr*/ const char *_Nonnull,
                                       /*CaptureStructureOut*/ void *_Nonnull,
                                       /*CaptureStructureSize*/ unsigned,
                                       /*DiagnosticBaseLoc*/ BridgedSourceLoc,
-                                      BridgedDiagnosticEngine);
+                                      BridgedDiagEngine);
 void Parser_registerRegexLiteralParsingFn(RegexLiteralParsingFn _Nullable fn);
 
 #endif // REGEX_PARSER_BRIDGING

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -18,8 +18,8 @@
 using namespace swift;
 
 namespace {
-/// BridgedDiagnosticEngine -> DiagnosticEngine *.
-DiagnosticEngine *getDiagnosticEngine(const BridgedDiagnosticEngine &bridged) {
+/// BridgedDiagEngine -> DiagnosticEngine *.
+DiagnosticEngine *getDiagnosticEngine(const BridgedDiagEngine &bridged) {
   return static_cast<DiagnosticEngine *>(bridged.object);
 }
 
@@ -48,7 +48,7 @@ BridgedDiagnosticFixIt::BridgedDiagnosticFixIt(BridgedSourceLoc start, uint32_t 
       llvm::ArrayRef<DiagnosticArgument>())) {}
 
 void DiagnosticEngine_diagnose(
-    BridgedDiagnosticEngine bridgedEngine, BridgedSourceLoc loc,
+    BridgedDiagEngine bridgedEngine, BridgedSourceLoc loc,
     BridgedDiagID bridgedDiagID,
     BridgedArrayRef /*BridgedDiagnosticArgument*/ bridgedArguments,
     BridgedSourceLoc highlightStart, uint32_t hightlightLength,
@@ -76,7 +76,7 @@ void DiagnosticEngine_diagnose(
   }
 }
 
-bool DiagnosticEngine_hadAnyError(BridgedDiagnosticEngine bridgedEngine) {
+bool DiagnosticEngine_hadAnyError(BridgedDiagEngine bridgedEngine) {
   auto *D = getDiagnosticEngine(bridgedEngine);
   return D->hadAnyError();
 }


### PR DESCRIPTION
So that it does not collide with BridgedDiagnosticEngine in CASTBridging.h. This hopefully fixes an asan crash.
rdar://116686158
