### PR TITLE
[5.10] Provide ability to use CheckedContinuation when suspending for an async ObjC call

### DIFF
--- a/include/swift/AST/KnownSDKTypes.def
+++ b/include/swift/AST/KnownSDKTypes.def
@@ -37,6 +37,7 @@ KNOWN_SDK_TYPE_DECL(ObjectiveC, ObjCBool, StructDecl, 0)
 
 // TODO(async): These might move to the stdlib module when concurrency is
 // standardized
+KNOWN_SDK_TYPE_DECL(Concurrency, CheckedContinuation, NominalTypeDecl, 2)
 KNOWN_SDK_TYPE_DECL(Concurrency, UnsafeContinuation, NominalTypeDecl, 2)
 KNOWN_SDK_TYPE_DECL(Concurrency, MainActor, NominalTypeDecl, 0)
 KNOWN_SDK_TYPE_DECL(Concurrency, Job, StructDecl, 0) // TODO: remove in favor of ExecutorJob

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -389,6 +389,10 @@ namespace swift {
     bool DisableImplicitBacktracingModuleImport =
         !SWIFT_IMPLICIT_BACKTRACING_IMPORT;
 
+    // Whether to use checked continuations when making an async call from
+    // Swift into ObjC. If false, will use unchecked continuations instead.
+    bool UseCheckedAsyncObjCBridging = false;
+
     /// Should we check the target OSs of serialized modules to see that they're
     /// new enough?
     bool EnableTargetOSChecking = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -364,6 +364,10 @@ def enable_experimental_async_top_level :
 // HIDDEN FLAGS
 let Flags = [FrontendOption, NoDriverOption, HelpHidden] in {
 
+def checked_async_objc_bridging : Joined<["-"], "checked-async-objc-bridging=">,
+  HelpText<"Control whether checked continuations are used when bridging "
+           "async calls from Swift to ObjC: 'on', 'off' ">;
+
 def debug_constraints : Flag<["-"], "debug-constraints">,
   HelpText<"Debug the constraint-based type checker">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1326,6 +1326,21 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     HadError = true;
   }
 
+  if (auto A = Args.getLastArg(OPT_checked_async_objc_bridging)) {
+    auto value = llvm::StringSwitch<llvm::Optional<bool>>(A->getValue())
+                     .Case("off", false)
+                     .Case("on", true)
+                     .Default(llvm::None);
+
+    if (value) {
+      Opts.UseCheckedAsyncObjCBridging = *value;
+    } else {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      HadError = true;
+    }
+  }
+
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -767,9 +767,9 @@ public:
                            {continuation});
 
     // Stash it in a buffer for a block object.
-    auto blockStorageTy = SILType::getPrimitiveAddressType(
-        SILBlockStorageType::get(continuationTy));
-    auto blockStorage = SGF.emitTemporaryAllocation(loc, blockStorageTy);
+    auto blockStorageTy = SILBlockStorageType::get(continuationTy);
+    auto blockStorage = SGF.emitTemporaryAllocation(
+        loc, SILType::getPrimitiveAddressType(blockStorageTy));
     auto continuationAddr = SGF.B.createProjectBlockStorage(loc, blockStorage);
     SGF.B.createStore(loc, wrappedContinuation, continuationAddr,
                       StoreOwnershipQualifier::Trivial);
@@ -796,11 +796,10 @@ public:
         SGF.SGM.getOrCreateForeignAsyncCompletionHandlerImplFunction(
             cast<SILFunctionType>(
                 impFnTy->mapTypeOutOfContext()->getReducedType(sig)),
-            continuationTy->mapTypeOutOfContext()->getReducedType(sig),
-            origFormalType, sig, *calleeTypeInfo.foreign.async,
-            calleeTypeInfo.foreign.error);
+            blockStorageTy->mapTypeOutOfContext()->getReducedType(sig),
+            origFormalType, sig, calleeTypeInfo);
     auto impRef = SGF.B.createFunctionRef(loc, impl);
-    
+
     // Initialize the block object for the completion handler.
     SILValue block = SGF.B.createInitBlockStorageHeader(loc, blockStorage,
                           impRef, SILType::getPrimitiveObjectType(impFnTy),

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -467,6 +467,37 @@ SILGenModule::getCheckExpectedExecutor() {
                                     "_checkExpectedExecutor");
 }
 
+FuncDecl *
+SILGenModule::getCreateCheckedContinuation() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    CreateCheckedContinuation,
+                                    "_createCheckedContinuation");
+}
+FuncDecl *
+SILGenModule::getCreateCheckedThrowingContinuation() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    CreateCheckedThrowingContinuation,
+                                    "_createCheckedThrowingContinuation");
+}
+FuncDecl *
+SILGenModule::getResumeCheckedContinuation() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    ResumeCheckedContinuation,
+                                    "_resumeCheckedContinuation");
+}
+FuncDecl *
+SILGenModule::getResumeCheckedThrowingContinuation() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    ResumeCheckedThrowingContinuation,
+                                    "_resumeCheckedThrowingContinuation");
+}
+FuncDecl *
+SILGenModule::getResumeCheckedThrowingContinuationWithError() {
+  return lookupConcurrencyIntrinsic(
+      getASTContext(), ResumeCheckedThrowingContinuationWithError,
+      "_resumeCheckedThrowingContinuationWithError");
+}
+
 FuncDecl *SILGenModule::getAsyncMainDrainQueue() {
   return lookupConcurrencyIntrinsic(getASTContext(), AsyncMainDrainQueue,
                                     "_asyncMainDrainQueue");

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -32,6 +32,7 @@ namespace swift {
 namespace Lowering {
   class TypeConverter;
   class SILGenFunction;
+  class CalleeTypeInfo;
 
 /// An enum to indicate whether a protocol method requirement is satisfied by
 /// a free function, as for an operator requirement.
@@ -182,10 +183,9 @@ public:
   /// implementation function for an ObjC API that was imported
   /// as `async` in Swift.
   SILFunction *getOrCreateForeignAsyncCompletionHandlerImplFunction(
-      CanSILFunctionType blockType, CanType continuationTy,
+      CanSILFunctionType blockType, CanType blockStorageType,
       AbstractionPattern origFormalType, CanGenericSignature sig,
-      ForeignAsyncConvention convention,
-      llvm::Optional<ForeignErrorConvention> foreignError);
+      CalleeTypeInfo &calleeInfo);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -128,6 +128,12 @@ public:
   llvm::Optional<FuncDecl *> ResumeUnsafeThrowingContinuationWithError;
   llvm::Optional<FuncDecl *> CheckExpectedExecutor;
 
+  llvm::Optional<FuncDecl*> CreateCheckedContinuation;
+  llvm::Optional<FuncDecl*> CreateCheckedThrowingContinuation;
+  llvm::Optional<FuncDecl*> ResumeCheckedContinuation;
+  llvm::Optional<FuncDecl*> ResumeCheckedThrowingContinuation;
+  llvm::Optional<FuncDecl*> ResumeCheckedThrowingContinuationWithError;
+
   llvm::Optional<FuncDecl *> AsyncMainDrainQueue;
   llvm::Optional<FuncDecl *> GetMainExecutor;
   llvm::Optional<FuncDecl *> SwiftJobRun;
@@ -550,6 +556,17 @@ public:
   FuncDecl *getRunTaskForBridgedAsyncMethod();
   /// Retrieve the _Concurrency._checkExpectedExecutor intrinsic.
   FuncDecl *getCheckExpectedExecutor();
+
+  /// Retrieve the _Concurrency._createCheckedContinuation intrinsic.
+  FuncDecl *getCreateCheckedContinuation();
+  /// Retrieve the _Concurrency._createCheckedThrowingContinuation intrinsic.
+  FuncDecl *getCreateCheckedThrowingContinuation();
+  /// Retrieve the _Concurrency._resumeCheckedContinuation intrinsic.
+  FuncDecl *getResumeCheckedContinuation();
+  /// Retrieve the _Concurrency._resumeCheckedThrowingContinuation intrinsic.
+  FuncDecl *getResumeCheckedThrowingContinuation();
+  /// Retrieve the _Concurrency._resumeCheckedThrowingContinuationWithError intrinsic.
+  FuncDecl *getResumeCheckedThrowingContinuationWithError();
 
   /// Retrieve the _Concurrency._asyncMainDrainQueue intrinsic.
   FuncDecl *getAsyncMainDrainQueue();

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -190,8 +190,8 @@ public:
   /// as `async` in Swift.
   SILFunction *getOrCreateForeignAsyncCompletionHandlerImplFunction(
       CanSILFunctionType blockType, CanType blockStorageType,
-      AbstractionPattern origFormalType, CanGenericSignature sig,
-      CalleeTypeInfo &calleeInfo);
+      CanType continuationType, AbstractionPattern origFormalType,
+      CanGenericSignature sig, CalleeTypeInfo &calleeInfo);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -330,3 +330,50 @@ public func withCheckedThrowingContinuation<T>(
   }
 }
 
+#if _runtime(_ObjC)
+
+// Intrinsics used by SILGen to create, resume, or fail checked continuations.
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+internal func _createCheckedContinuation<T>(
+  _ continuation: __owned UnsafeContinuation<T, Never>
+) -> CheckedContinuation<T, Never> {
+  return CheckedContinuation(continuation: continuation)
+}
+
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+internal func _createCheckedThrowingContinuation<T>(
+  _ continuation: __owned UnsafeContinuation<T, Error>
+) -> CheckedContinuation<T, Error> {
+  return CheckedContinuation(continuation: continuation)
+}
+
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+internal func _resumeCheckedContinuation<T>(
+  _ continuation: CheckedContinuation<T, Never>,
+  _ value: __owned T
+) {
+  continuation.resume(returning: value)
+}
+
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+internal func _resumeCheckedThrowingContinuation<T>(
+  _ continuation: CheckedContinuation<T, Error>,
+  _ value: __owned T
+) {
+  continuation.resume(returning: value)
+}
+
+@available(SwiftStdlib 5.1, *)
+@_alwaysEmitIntoClient
+internal func _resumeCheckedThrowingContinuationWithError<T>(
+  _ continuation: CheckedContinuation<T, Error>,
+  _ error: __owned Error
+) {
+  continuation.resume(throwing: error)
+}
+
+#endif

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -404,25 +404,3 @@ func testAnyObjectWithDefault(_ x: AnyObject) {
   // CHECK: apply [[METHOD]]([[DEFARG]], [[OPENEDX]])
   x.hasDefaultParam()
 }
-
-
-// rdar://97646309 -- lookup and direct call of an optional global-actor constrained method would crash in SILGen
-@MainActor
-@objc protocol OptionalMemberLookups {
-  @objc optional func generateMaybe() async
-}
-
-extension OptionalMemberLookups {
-  // CHECK-LABEL: sil hidden [ossa] @$s14dynamic_lookup21OptionalMemberLookupsPAAE19testForceDirectCallyyYaF
-  // CHECK:         [[SELF:%[0-9]+]] = copy_value {{.*}} : $Self
-  // CHECK:         [[METH:%[0-9]+]] = objc_method {{.*}} : $Self, #OptionalMemberLookups.generateMaybe!foreign : <Self where Self : OptionalMemberLookups> (Self) -> () async -> (), $@convention(objc_method) (@convention(block) () -> (), Self) -> ()
-  // CHECK:         = function_ref @$sIeyB_yt14dynamic_lookup21OptionalMemberLookupsRzlTz_ : $@convention(c) @pseudogeneric <τ_0_0 where τ_0_0 : OptionalMemberLookups> (@inout_aliasable @block_storage UnsafeContinuation<(), Never>) -> ()
-  // CHECK:         [[BLOCK:%[0-9]+]] = init_block_storage_header {{.*}} : $*@block_storage UnsafeContinuation<(), Never>
-  // CHECK:         = apply [[METH]]([[BLOCK]], [[SELF]]) : $@convention(objc_method) (@convention(block) () -> (), Self) -> ()
-  // CHECK:         await_async_continuation {{.*}} : $Builtin.RawUnsafeContinuation, resume bb1
-  // CHECK:         hop_to_executor {{.*}} : $MainActor
-  // CHECK:        } // end sil function '$s14dynamic_lookup21OptionalMemberLookupsPAAE19testForceDirectCallyyYaF'
-  func testForceDirectCall() async -> Void {
-    await self.generateMaybe!()
-  }
-}

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules  -disable-availability-checking %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -checked-async-objc-bridging=off -I %S/Inputs/custom-modules  -disable-availability-checking %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -276,3 +276,28 @@ func testThrowingMethodFromMain(slowServer: SlowServer) async -> String {
 func checkCostcoMembership() async -> Bool {
   return await CostcoManager.shared().isCustomerEnrolled(inExecutiveProgram: Person.asCustomer())
 }
+
+// rdar://97646309 -- lookup and direct call of an optional global-actor constrained method would crash in SILGen
+@MainActor
+@objc protocol OptionalMemberLookups {
+  @objc optional func generateMaybe() async
+}
+
+extension OptionalMemberLookups {
+  // CHECK-LABEL: sil hidden [ossa] @$s10objc_async21OptionalMemberLookupsPAAE19testForceDirectCallyyYaF
+  // CHECK:         [[SELF:%[0-9]+]] = copy_value {{.*}} : $Self
+  // CHECK:         [[METH:%[0-9]+]] = objc_method {{.*}} : $Self, #OptionalMemberLookups.generateMaybe!foreign : <Self where Self : OptionalMemberLookups> (Self) -> () async -> (), $@convention(objc_method) (@convention(block) () -> (), Self) -> ()
+  // CHECK:         [[CONT:%.*]] = struct $UnsafeContinuation<(), Never> (%10 : $Builtin.RawUnsafeContinuation)
+  // CHECK:         [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage UnsafeContinuation<(), Never>
+  // CHECK:         [[PROJECTED:%.*]] = project_block_storage [[BLOCK_STORAGE]] : $*@block_storage UnsafeContinuation<(), Never>
+  // CHECK:         store [[CONT]] to [trivial] [[PROJECTED]] : $*UnsafeContinuation<(), Never>
+  // CHECK:         = function_ref @$sIeyB_yt10objc_async21OptionalMemberLookupsRzlTz_ : $@convention(c) @pseudogeneric <τ_0_0 where τ_0_0 : OptionalMemberLookups> (@inout_aliasable @block_storage UnsafeContinuation<(), Never>) -> ()
+  // CHECK:         [[BLOCK:%[0-9]+]] = init_block_storage_header {{.*}} : $*@block_storage UnsafeContinuation<(), Never>
+  // CHECK:         = apply [[METH]]([[BLOCK]], [[SELF]]) : $@convention(objc_method) (@convention(block) () -> (), Self) -> ()
+  // CHECK:         await_async_continuation {{.*}} : $Builtin.RawUnsafeContinuation, resume bb1
+  // CHECK:         hop_to_executor {{.*}} : $MainActor
+  // CHECK:        } // end sil function '$s10objc_async21OptionalMemberLookupsPAAE19testForceDirectCallyyYaF'
+  func testForceDirectCall() async -> Void {
+    await self.generateMaybe!()
+  }
+}

--- a/test/SILGen/objc_async_checked.swift
+++ b/test/SILGen/objc_async_checked.swift
@@ -1,0 +1,298 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -checked-async-objc-bridging=on -I %S/Inputs/custom-modules  -disable-availability-checking %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+import Foundation
+import ObjCConcurrency
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}14testSlowServer
+func testSlowServer(slowServer: SlowServer) async throws {
+  // CHECK: [[RESUME_BUF:%.*]] = alloc_stack $Int
+  // CHECK: [[STRINGINIT:%.*]] = function_ref @$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF :
+  // CHECK: [[ARG:%.*]] = apply [[STRINGINIT]]
+  // CHECK: [[METHOD:%.*]] = objc_method {{.*}} $@convention(objc_method) (NSString, @convention(block) (Int) -> (), SlowServer) -> ()
+  // CHECK: [[CONT:%.*]] = get_async_continuation_addr Int, [[RESUME_BUF]]
+  // CHECK: [[WRAPPED:%.*]] = struct $UnsafeContinuation<Int, Never> ([[CONT]] : $Builtin.RawUnsafeContinuation)
+  // CHECK: [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage Any
+  // CHECK: [[CONT_SLOT:%.*]] = project_block_storage [[BLOCK_STORAGE]]
+  // CHECK: [[CHECKED_CONT_SLOT:%.*]] = init_existential_addr [[CONT_SLOT]] : $*Any, $CheckedContinuation<Int, Never>
+  // CHECK: [[CHECKED_CONT_INIT_FN:%.*]] = function_ref @$ss26_createCheckedContinuationyScCyxs5NeverOGSccyxACGnlF : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, Never>) -> @out CheckedContinuation<τ_0_0, Never>
+  // CHECK: [[CHECKED_CONT:%.*]] = alloc_stack $CheckedContinuation<Int, Never>
+  // CHECK: {{.*}} = apply [[CHECKED_CONT_INIT_FN]]<Int>([[CHECKED_CONT]], [[WRAPPED]]) : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, Never>) -> @out CheckedContinuation<τ_0_0, Never>
+  // CHECK: copy_addr [take] [[CHECKED_CONT]] to [init] [[CHECKED_CONT_SLOT]] : $*CheckedContinuation<Int, Never>
+  // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[INT_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, Int) -> ()
+  // CHECK: [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] {{.*}}, invoke [[BLOCK_IMPL]]
+  // CHECK: apply [[METHOD]]([[ARG]], [[BLOCK]], %0)
+  // CHECK: [[COPY:%.*]] = copy_value [[ARG]]
+  // CHECK: destroy_value [[ARG]]
+  // CHECK: await_async_continuation [[CONT]] {{.*}}, resume [[RESUME:bb[0-9]+]]
+  // CHECK: [[RESUME]]:
+  // CHECK: [[RESULT:%.*]] = load [trivial] [[RESUME_BUF]]
+  // CHECK: fix_lifetime [[COPY]]
+  // CHECK: destroy_value [[COPY]]
+  // CHECK: dealloc_stack [[RESUME_BUF]]
+  let _: Int = await slowServer.doSomethingSlow("mail")
+
+  let _: Int = await slowServer.doSomethingSlowNullably("mail")
+
+  // CHECK: [[RESUME_BUF:%.*]] = alloc_stack $String
+  // CHECK: [[METHOD:%.*]] = objc_method {{.*}} $@convention(objc_method) (@convention(block) (Optional<NSString>, Optional<NSError>) -> (), SlowServer) -> ()
+  // CHECK: [[CONT:%.*]] = get_async_continuation_addr [throws] String, [[RESUME_BUF]]
+  // CHECK: [[WRAPPED:%.*]] = struct $UnsafeContinuation<String, any Error> ([[CONT]] : $Builtin.RawUnsafeContinuation)
+  // CHECK: [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage Any
+  // CHECK: [[CONT_SLOT:%.*]] = project_block_storage [[BLOCK_STORAGE]]
+  // CHECK: [[CHECKED_CONT_SLOT:%.*]] = init_existential_addr [[CONT_SLOT]] : $*Any, $CheckedContinuation<String, any Error>
+  // CHECK: [[CHECKED_CONT_INIT_FN:%.*]] = function_ref @$ss34_createCheckedThrowingContinuationyScCyxs5Error_pGSccyxsAB_pGnlF : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
+  // CHECK: [[CHECKED_CONT:%.*]] = alloc_stack $CheckedContinuation<String, any Error>
+  // CHECK: {{.*}} = apply [[CHECKED_CONT_INIT_FN]]<String>([[CHECKED_CONT]], [[WRAPPED]]) : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
+  // CHECK: copy_addr [take] [[CHECKED_CONT]] to [init] [[CHECKED_CONT_SLOT]] : $*CheckedContinuation<String, any Error>
+  // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[STRING_COMPLETION_THROW_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, Optional<NSString>, Optional<NSError>) -> ()
+  // CHECK: [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] {{.*}}, invoke [[BLOCK_IMPL]]
+  // CHECK: apply [[METHOD]]([[BLOCK]], %0)
+  // CHECK: await_async_continuation [[CONT]] {{.*}}, resume [[RESUME:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+  // CHECK: [[RESUME]]:
+  // CHECK: [[RESULT:%.*]] = load [take] [[RESUME_BUF]]
+  // CHECK: destroy_value [[RESULT]]
+  // CHECK: dealloc_stack [[RESUME_BUF]]
+  let _: String = try await slowServer.findAnswer()
+
+  // CHECK: objc_method {{.*}} $@convention(objc_method) (NSString, @convention(block) () -> (), SlowServer) -> ()
+  // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[VOID_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any) -> ()
+  await slowServer.serverRestart("somewhere")
+
+  // CHECK: function_ref @[[STRING_NONZERO_FLAG_THROW_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, {{.*}}Bool, Optional<NSString>, Optional<NSError>) -> ()
+  let _: String = try await slowServer.doSomethingFlaggy()
+  // CHECK: function_ref @[[STRING_ZERO_FLAG_THROW_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, Optional<NSString>, {{.*}}Bool, Optional<NSError>) -> ()
+  let _: String = try await slowServer.doSomethingZeroFlaggy()
+  // CHECK: function_ref @[[STRING_STRING_ZERO_FLAG_THROW_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, {{.*}}Bool, Optional<NSString>, Optional<NSError>, Optional<NSString>) -> ()
+  let _: (String, String) = try await slowServer.doSomethingMultiResultFlaggy()
+
+  // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[NSSTRING_INT_THROW_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, Optional<NSString>, Int, Optional<NSError>) -> ()
+  let (_, _): (String, Int) = try await slowServer.findMultipleAnswers()
+
+  let (_, _): (Bool, Bool) = try await slowServer.findDifferentlyFlavoredBooleans()
+
+  // CHECK: [[ERROR]]([[ERROR_VALUE:%.*]] : @owned $any Error):
+  // CHECK:   dealloc_stack [[RESUME_BUF]]
+  // CHECK:   br [[THROWBB:bb[0-9]+]]([[ERROR_VALUE]]
+  // CHECK: [[THROWBB]]([[ERROR_VALUE:%.*]] : @owned $any Error):
+  // CHECK:   throw [[ERROR_VALUE]]
+
+  let _: String = await slowServer.findAnswerNullably("foo")
+  let _: String = try await slowServer.doSomethingDangerousNullably("foo")
+
+  let _: NSObject? = try await slowServer.stopRecording()
+  let _: NSObject = try await slowServer.someObject()
+
+  let _: () -> Void = await slowServer.performVoid2Void()
+  let _: (Any) -> Void = await slowServer.performId2Void()
+  let _: (Any) -> Any = await slowServer.performId2Id()
+  let _: (String) -> String = await slowServer.performNSString2NSString()
+
+  let _: ((String) -> String, String) = await slowServer.performNSString2NSStringNSString()
+  let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
+
+  let _: String = try await slowServer.findAnswerFailingly()
+
+  let _: () -> Void = try await slowServer.obtainClosure()
+
+  let _: Flavor = try await slowServer.iceCreamFlavor()
+}
+
+func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {
+  let _: T? = try await x.doSomething()
+  let _: GenericObject<T>? = await x.doAnotherThing()
+}
+
+func testGeneric2<T: AnyObject, U>(x: GenericObject<T>, y: U) async throws {
+  let _: T? = try await x.doSomething()
+  let _: GenericObject<T>? = await x.doAnotherThing()
+}
+
+// CHECK: sil{{.*}}@[[INT_COMPLETION_BLOCK]]
+// CHECK:   [[CONT_ADDR:%.*]] = project_block_storage %0
+// CHECK:   [[CONT_OPENED:%.*]] = open_existential_addr immutable_access [[CONT_ADDR]] : $*Any to $*@opened("{{.*}}", Any) Self
+// CHECK:   [[CONT:%.*]] = unchecked_addr_cast [[CONT_OPENED]] : $*@opened("{{.*}}", Any) Self to $*CheckedContinuation<Int, Never>
+// CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $Int
+// CHECK:   store %1 to [trivial] [[RESULT_BUF]]
+// CHECK:   [[RESUME:%.*]] = function_ref @{{.*}}resumeCheckedContinuation
+// CHECK:   apply [[RESUME]]<Int>([[CONT]], [[RESULT_BUF]])
+
+// CHECK: sil{{.*}}@[[STRING_COMPLETION_THROW_BLOCK]]
+// CHECK:   [[RESUME_IN:%.*]] = copy_value %1
+// CHECK:   [[ERROR_IN:%.*]] = copy_value %2
+// CHECK:   [[CONT_ADDR:%.*]] = project_block_storage %0
+// CHECK:   [[CONT_OPENED:%.*]] = open_existential_addr immutable_access [[CONT_ADDR]] : $*Any to $*@opened("{{.*}}", Any) Self
+// CHECK:   [[CONT:%.*]] = unchecked_addr_cast [[CONT_OPENED]] : $*@opened("{{.*}}", Any) Self to $*CheckedContinuation<String, any Error>
+// CHECK:   [[ERROR_IN_B:%.*]] = begin_borrow [[ERROR_IN]]
+// CHECK:   switch_enum [[ERROR_IN_B]] : {{.*}}, case #Optional.some!enumelt: [[ERROR_BB:bb[0-9]+]], case #Optional.none!enumelt: [[RESUME_BB:bb[0-9]+]]
+// CHECK: [[RESUME_BB]]:
+// CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $String
+// CHECK:   [[RESUME_CP:%.*]] = copy_value [[RESUME_IN]]
+// CHECK:   [[BRIDGE:%.*]] = function_ref @{{.*}}unconditionallyBridgeFromObjectiveC
+// CHECK:   [[BRIDGED_RESULT:%.*]] = apply [[BRIDGE]]([[RESUME_CP]]
+// CHECK:   store [[BRIDGED_RESULT]] to [init] [[RESULT_BUF]]
+// CHECK:   [[RESUME:%.*]] = function_ref @{{.*}}resumeCheckedThrowingContinuation
+// CHECK:   apply [[RESUME]]<String>([[CONT]], [[RESULT_BUF]])
+// CHECK:   br [[END_BB:bb[0-9]+]]
+// CHECK: [[END_BB]]:
+// CHECK:   return
+// CHECK: [[ERROR_BB]]([[ERROR_IN_UNWRAPPED:%.*]] : @guaranteed $NSError):
+// CHECK:   [[ERROR:%.*]] = init_existential_ref [[ERROR_IN_UNWRAPPED]]
+// CHECK:   [[RESUME_WITH_ERROR:%.*]] = function_ref @{{.*}}resumeCheckedThrowingContinuationWithError
+// CHECK:   [[ERROR_COPY:%.*]] = copy_value [[ERROR]]
+// CHECK:   apply [[RESUME_WITH_ERROR]]<String>([[CONT]], [[ERROR_COPY]])
+// CHECK:   br [[END_BB]]
+
+// CHECK: sil {{.*}} @[[VOID_COMPLETION_BLOCK]]
+// CHECK:   [[CONT_ADDR:%.*]] = project_block_storage %0
+// CHECK:   [[CONT_OPENED:%.*]] = open_existential_addr immutable_access [[CONT_ADDR]] : $*Any to $*@opened("{{.*}}", Any) Self
+// CHECK:   [[CONT:%.*]] = unchecked_addr_cast [[CONT_OPENED]] : $*@opened("{{.*}}", Any) Self to $*CheckedContinuation<(), Never>
+// CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $()
+// CHECK:   [[RESUME:%.*]] = function_ref @{{.*}}resumeCheckedContinuation
+// CHECK:   apply [[RESUME]]<()>([[CONT]], [[RESULT_BUF]])
+
+// CHECK: sil{{.*}}@[[STRING_NONZERO_FLAG_THROW_BLOCK]]
+// CHECK:   [[ZERO:%.*]] = integer_literal {{.*}}, 0
+// CHECK:   switch_value {{.*}}, case [[ZERO]]: [[ZERO_BB:bb[0-9]+]], default [[NONZERO_BB:bb[0-9]+]]
+// CHECK: [[ZERO_BB]]:
+// CHECK:   function_ref{{.*}}resumeCheckedThrowingContinuation
+// CHECK: [[NONZERO_BB]]:
+// CHECK:   function_ref{{.*}}resumeCheckedThrowingContinuationWithError
+
+// CHECK: sil{{.*}}@[[STRING_ZERO_FLAG_THROW_BLOCK]]
+// CHECK:   [[ZERO:%.*]] = integer_literal {{.*}}, 0
+// CHECK:   switch_value {{.*}}, case [[ZERO]]: [[ZERO_BB:bb[0-9]+]], default [[NONZERO_BB:bb[0-9]+]]
+// CHECK: [[NONZERO_BB]]:
+// CHECK:   function_ref{{.*}}resumeCheckedThrowingContinuation
+// CHECK: [[ZERO_BB]]:
+// CHECK:   function_ref{{.*}}resumeCheckedThrowingContinuationWithError
+
+// CHECK: sil{{.*}}@[[STRING_STRING_ZERO_FLAG_THROW_BLOCK]]
+// CHECK:   [[ZERO:%.*]] = integer_literal {{.*}}, 0
+// CHECK:   switch_value {{.*}}, case [[ZERO]]: [[ZERO_BB:bb[0-9]+]], default [[NONZERO_BB:bb[0-9]+]]
+// CHECK: [[NONZERO_BB]]:
+// CHECK:   function_ref{{.*}}resumeCheckedThrowingContinuation
+// CHECK: [[ZERO_BB]]:
+// CHECK:   function_ref{{.*}}resumeCheckedThrowingContinuationWithError
+
+// CHECK: sil{{.*}}@[[NSSTRING_INT_THROW_COMPLETION_BLOCK]]
+// CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $(String, Int)
+// CHECK:   [[RESULT_0_BUF:%.*]] = tuple_element_addr [[RESULT_BUF]] {{.*}}, 0
+// CHECK:   [[BRIDGE:%.*]] = function_ref @{{.*}}unconditionallyBridgeFromObjectiveC
+// CHECK:   [[BRIDGED:%.*]] = apply [[BRIDGE]]
+// CHECK:   store [[BRIDGED]] to [init] [[RESULT_0_BUF]]
+// CHECK:   [[RESULT_1_BUF:%.*]] = tuple_element_addr [[RESULT_BUF]] {{.*}}, 1
+// CHECK:   store %2 to [trivial] [[RESULT_1_BUF]]
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}22testSlowServerFromMain
+@MainActor
+func testSlowServerFromMain(slowServer: SlowServer) async throws {
+  // CHECK: hop_to_executor {{%.*}} : $MainActor
+  // CHECK: [[RESUME_BUF:%.*]] = alloc_stack $Int
+  // CHECK: [[STRINGINIT:%.*]] = function_ref @$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF :
+  // CHECK: [[ARG:%.*]] = apply [[STRINGINIT]]
+  // CHECK: [[METHOD:%.*]] = objc_method {{.*}} $@convention(objc_method) (NSString, @convention(block) (Int) -> (), SlowServer) -> ()
+  // CHECK: [[CONT:%.*]] = get_async_continuation_addr Int, [[RESUME_BUF]]
+  // CHECK: [[WRAPPED:%.*]] = struct $UnsafeContinuation<Int, Never> ([[CONT]] : $Builtin.RawUnsafeContinuation)
+  // CHECK: [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage Any
+  // CHECK: [[CONT_SLOT:%.*]] = project_block_storage [[BLOCK_STORAGE]]
+  // CHECK: [[CHECKED_CONT_SLOT:%.*]] = init_existential_addr [[CONT_SLOT]] : $*Any, $CheckedContinuation<Int, Never>
+  // CHECK: [[CHECKED_CONT_INIT_FN:%.*]] = function_ref @$ss26_createCheckedContinuationyScCyxs5NeverOGSccyxACGnlF : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, Never>) -> @out CheckedContinuation<τ_0_0, Never>
+  // CHECK: [[CHECKED_CONT:%.*]] = alloc_stack $CheckedContinuation<Int, Never>
+  // CHECK: {{.*}} = apply [[CHECKED_CONT_INIT_FN]]<Int>([[CHECKED_CONT]], [[WRAPPED]]) : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, Never>) -> @out CheckedContinuation<τ_0_0, Never>
+  // CHECK: copy_addr [take] [[CHECKED_CONT]] to [init] [[CHECKED_CONT_SLOT]] : $*CheckedContinuation<Int, Never>
+  // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[INT_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, Int) -> ()
+  // CHECK: [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] {{.*}}, invoke [[BLOCK_IMPL]]
+  // CHECK: apply [[METHOD]]([[ARG]], [[BLOCK]], %0)
+  // CHECK: [[COPY:%.*]] = copy_value [[ARG]]
+  // CHECK: destroy_value [[ARG]]
+  // CHECK: await_async_continuation [[CONT]] {{.*}}, resume [[RESUME:bb[0-9]+]]
+  // CHECK: [[RESUME]]:
+  // CHECK: hop_to_executor {{%.*}} : $MainActor
+  // CHECK: [[RESULT:%.*]] = load [trivial] [[RESUME_BUF]]
+  // CHECK: fix_lifetime [[COPY]]
+  // CHECK: destroy_value [[COPY]]
+  // CHECK: dealloc_stack [[RESUME_BUF]]
+  let _: Int = await slowServer.doSomethingSlow("mail")
+}
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}26testThrowingMethodFromMain
+@MainActor
+func testThrowingMethodFromMain(slowServer: SlowServer) async -> String {
+// CHECK:  [[RESULT_BUF:%.*]] = alloc_stack $String
+// CHECK:  [[STRING_ARG:%.*]] = apply {{%.*}}({{%.*}}) : $@convention(method) (@guaranteed String) -> @owned NSString
+// CHECK:  [[METH:%.*]] = objc_method {{%.*}} : $SlowServer, #SlowServer.doSomethingDangerous!foreign
+// CHECK:  [[RAW_CONT:%.*]] = get_async_continuation_addr [throws] String, [[RESULT_BUF]] : $*String
+// CHECK:  [[CONT:%.*]] = struct $UnsafeContinuation<String, any Error> ([[RAW_CONT]] : $Builtin.RawUnsafeContinuation)
+// CHECK:  [[STORE_ALLOC:%.*]] = alloc_stack $@block_storage Any
+// CHECK:  [[PROJECTED:%.*]] = project_block_storage [[STORE_ALLOC]] : $*@block_storage
+// CHECK:  [[CHECKED_CONT_SLOT:%.*]] = init_existential_addr [[PROJECTED]] : $*Any, $CheckedContinuation<String, any Error>
+// CHECK:  [[CHECKED_CONT_INIT_FN:%.*]] = function_ref @$ss34_createCheckedThrowingContinuationyScCyxs5Error_pGSccyxsAB_pGnlF : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
+// CHECK:  [[CHECKED_CONT:%.*]] = alloc_stack $CheckedContinuation<String, any Error>
+// CHECK:  {{.*}} = apply [[CHECKED_CONT_INIT_FN]]<String>([[CHECKED_CONT]], [[CONT]]) : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
+// CHECK:  copy_addr [take] [[CHECKED_CONT]] to [init] [[CHECKED_CONT_SLOT]] : $*CheckedContinuation<String, any Error>
+// CHECK:  [[INVOKER:%.*]] = function_ref @$sSo8NSStringCSgSo7NSErrorCSgIeyByy_SSTz_
+// CHECK:  [[BLOCK:%.*]] = init_block_storage_header [[STORE_ALLOC]] {{.*}}, invoke [[INVOKER]]
+// CHECK:  [[OPTIONAL_BLK:%.*]] = enum {{.*}}, #Optional.some!enumelt, [[BLOCK]]
+// CHECK:  {{.*}} = apply [[METH]]([[STRING_ARG]], [[OPTIONAL_BLK]], {{%.*}}) : $@convention(objc_method) (NSString, Optional<@convention(block) (Optional<NSString>, Optional<NSError>) -> ()>, SlowServer) -> ()
+// CHECK:  [[STRING_ARG_COPY:%.*]] = copy_value [[STRING_ARG]] : $NSString
+// CHECK:  dealloc_stack [[CHECKED_CONT]] : $*CheckedContinuation<String, any Error>
+// CHECK:  dealloc_stack [[STORE_ALLOC]] : $*@block_storage Any
+// CHECK:  destroy_value [[STRING_ARG]] : $NSString
+// CHECK:  await_async_continuation [[RAW_CONT]] : $Builtin.RawUnsafeContinuation, resume [[RESUME:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+
+// CHECK: [[RESUME]]
+// CHECK:   hop_to_executor {{%.*}} : $MainActor
+// CHECK:   {{.*}} = load [take] [[RESULT_BUF]] : $*String
+// CHECK:   fix_lifetime [[STRING_ARG_COPY]] : $NSString
+// CHECK:   destroy_value [[STRING_ARG_COPY]] : $NSString
+// CHECK:   dealloc_stack [[RESULT_BUF]] : $*String
+
+// CHECK: [[ERROR]]
+// CHECK:   hop_to_executor {{%.*}} : $MainActor
+// CHECK:   fix_lifetime [[STRING_ARG_COPY]] : $NSString
+// CHECK:   destroy_value [[STRING_ARG_COPY]] : $NSString
+// CHECK:   dealloc_stack [[RESULT_BUF]] : $*String
+
+  do {
+    return try await slowServer.doSomethingDangerous("run-with-scissors")
+  } catch {
+    return "none"
+  }
+}
+
+// rdar://91502776
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}21checkCostcoMembershipSbyYaF : $@convention(thin) @async () -> Bool {
+// CHECK:    bb0:
+// CHECK:        hop_to_executor {{%.*}} : $Optional<Builtin.Executor>
+// CHECK:        [[FINAL_BUF:%.*]] = alloc_stack $Bool
+// CHECK:        [[RESULT_BUF:%.*]] = alloc_stack $NSObject
+// CHECK:        [[METH:%.*]] = objc_method {{%.*}} : $@objc_metatype Person.Type, #Person.asCustomer!foreign
+// CHECK:        get_async_continuation_addr NSObject, [[RESULT_BUF]] : $*NSObject
+// CHECK:        = apply [[METH]]
+// CHECK:        dealloc_stack {{%.*}} : $*@block_storage
+// CHECK:        await_async_continuation {{%.*}} : $Builtin.RawUnsafeContinuation, resume bb1
+// CHECK:    bb1:
+// CHECK:        hop_to_executor {{%.*}} : $Optional<Builtin.Executor>
+// CHECK:        [[RESULT:%.*]] = load [take] [[RESULT_BUF]] : $*NSObject
+// CHECK:        objc_method {{%.*}} : $CostcoManager, #CostcoManager.isCustomerEnrolled!foreign
+// CHECK:        get_async_continuation_addr Bool, [[FINAL_BUF]] : $*Bool
+// CHECK:        [[BLOCK_ARG:%.*]] = init_block_storage_header [[BLOCK_STORAGE:%.*]] : $*@block_storage
+// CHECK:        = apply {{%.*}}([[RESULT]], [[BLOCK_ARG]], [[MANAGER:%.*]]) : $@convention(objc_method)
+// CHECK:        [[EXTEND1:%.*]] = copy_value [[RESULT]] : $NSObject
+// CHECK:        [[EXTEND2:%.*]] = copy_value [[MANAGER]] : $CostcoManager
+// CHECK:        dealloc_stack [[BLOCK_STORAGE]] : $*@block_storage
+// CHECK:        await_async_continuation {{%.*}} : $Builtin.RawUnsafeContinuation, resume bb2
+// CHECK:    bb2:
+// CHECK:        hop_to_executor {{%.*}} : $Optional<Builtin.Executor>
+// CHECK:        [[ANSWER:%.*]] = load [trivial] [[FINAL_BUF]] : $*Bool
+// CHECK:        fix_lifetime [[EXTEND2]] : $CostcoManager
+// CHECK:        destroy_value [[EXTEND2]] : $CostcoManager
+// CHECK:        fix_lifetime [[EXTEND1]] : $NSObject
+// CHECK:        destroy_value [[EXTEND1]] : $NSObject
+// CHECK:        return [[ANSWER]] : $Bool
+// CHECK:  }
+func checkCostcoMembership() async -> Bool {
+  return await CostcoManager.shared().isCustomerEnrolled(inExecutiveProgram: Person.asCustomer())
+}

--- a/test/SILGen/objc_effectful_properties.swift
+++ b/test/SILGen/objc_effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -disable-availability-checking -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -checked-async-objc-bridging=off -disable-availability-checking -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_effectful_properties_checked.swift
+++ b/test/SILGen/objc_effectful_properties_checked.swift
@@ -1,0 +1,75 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -checked-async-objc-bridging=on -disable-availability-checking -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+import Foundation
+import EffectfulProperties
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}13testJustAsync
+func testJustAsync(eff : EffProps) async {
+  // CHECK: [[RESUME_BUF:%.*]] = alloc_stack $NSObject
+  // CHECK: [[METHOD:%.*]] = objc_method {{.*}} $@convention(objc_method) (@convention(block) (NSObject) -> (), EffProps) -> ()
+  // CHECK: [[CONT:%.*]] = get_async_continuation_addr NSObject, [[RESUME_BUF]]
+  // CHECK: [[WRAPPED:%.*]] = struct $UnsafeContinuation<NSObject, Never> ([[CONT]] : $Builtin.RawUnsafeContinuation)
+  // CHECK: [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage Any
+  // CHECK: [[CONT_SLOT:%.*]] = project_block_storage [[BLOCK_STORAGE]]
+  // CHECK: [[CHECKED_CONT_SLOT:%.*]] = init_existential_addr [[CONT_SLOT]] : $*Any, $CheckedContinuation<NSObject, Never>
+  // CHECK: [[CHECKED_CONT_INIT_FN:%.*]] = function_ref @$ss26_createCheckedContinuationyScCyxs5NeverOGSccyxACGnlF : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, Never>) -> @out CheckedContinuation<τ_0_0, Never>
+  // CHECK: [[CHECKED_CONT:%.*]] = alloc_stack $CheckedContinuation<NSObject, Never>
+  // CHECK: {{.*}} = apply [[CHECKED_CONT_INIT_FN]]<NSObject>([[CHECKED_CONT]], [[WRAPPED]]) : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, Never>) -> @out CheckedContinuation<τ_0_0, Never>
+  // CHECK: copy_addr [take] [[CHECKED_CONT]] to [init] [[CHECKED_CONT_SLOT]] : $*CheckedContinuation<NSObject, Never>
+  // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[NSO_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, NSObject) -> ()
+  // CHECK: [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] {{.*}}, invoke [[BLOCK_IMPL]]
+  // CHECK: apply [[METHOD]]([[BLOCK]], %0)
+  // CHECK: await_async_continuation [[CONT]] {{.*}}, resume [[RESUME:bb[0-9]+]]
+
+  // CHECK: [[RESUME]]:
+  // CHECK: [[RESULT:%.*]] = load [take] [[RESUME_BUF]]
+  // CHECK: dealloc_stack [[RESUME_BUF]]
+  let _ = await eff.doggo
+}
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}15testAsyncThrows
+func testAsyncThrows(eff : EffProps) async {
+  // CHECK: [[RESUME_BUF:%.*]] = alloc_stack $Optional<NSObject>
+  // CHECK: [[METHOD:%.*]] = objc_method {{.*}} $@convention(objc_method) (@convention(block) (Optional<NSObject>, Optional<NSError>) -> (), EffProps) -> ()
+  // CHECK: [[CONT:%.*]] = get_async_continuation_addr [throws] Optional<NSObject>, [[RESUME_BUF]]
+  // CHECK: [[WRAPPED:%.*]] = struct $UnsafeContinuation<Optional<NSObject>, any Error> ([[CONT]] : $Builtin.RawUnsafeContinuation)
+  // CHECK: [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage Any
+  // CHECK: [[CONT_SLOT:%.*]] = project_block_storage [[BLOCK_STORAGE]]
+  // CHECK: [[CHECKED_CONT_SLOT:%.*]] = init_existential_addr [[CONT_SLOT]] : $*Any, $CheckedContinuation<Optional<NSObject>, any Error>
+  // CHECK: [[CHECKED_CONT_INIT_FN:%.*]] = function_ref @$ss34_createCheckedThrowingContinuationyScCyxs5Error_pGSccyxsAB_pGnlF : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
+  // CHECK: [[CHECKED_CONT:%.*]] = alloc_stack $CheckedContinuation<Optional<NSObject>, any Error>
+  // CHECK: {{.*}} = apply [[CHECKED_CONT_INIT_FN:%.*]]<Optional<NSObject>>([[CHECKED_CONT]], [[WRAPPED]]) : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
+  // CHECK: copy_addr [take] [[CHECKED_CONT]] to [init] [[CHECKED_CONT_SLOT]] : $*CheckedContinuation<Optional<NSObject>, any Error>
+  // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[NSO_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage Any, Optional<NSObject>, Optional<NSError>) -> ()
+  // CHECK: [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] {{.*}}, invoke [[BLOCK_IMPL]]
+  // CHECK: apply [[METHOD]]([[BLOCK]], %0)
+  // CHECK: await_async_continuation [[CONT]] {{.*}}, resume [[RESUME:bb[0-9]+]], error [[RESUME_ERROR:bb[0-9]+]]
+
+  // CHECK: [[RESUME]]:
+  // CHECK: [[RESULT:%.*]] = load [take] [[RESUME_BUF]]
+  // CHECK: dealloc_stack [[RESUME_BUF]]
+
+  // CHECK: [[RESUME_ERROR]]([[ERROR_VAL:%[0-9]+]] : @owned $any Error):
+  // CHECK: dealloc_stack [[RESUME_BUF]]
+  let _ = try? await eff.catto
+}
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}17testMainActorProp
+func testMainActorProp(eff : EffProps) async {
+  // CHECK:         [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
+  // CHECK-NEXT:    hop_to_executor [[GENERIC_EXEC]] :
+  // CHECK:         hop_to_executor [[GENERIC_EXEC]] :
+  // CHECK: } // end sil function '${{.*}}17testMainActorProp
+  let _ = await eff.mainDogProp
+}
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}19testMainActorMethod
+func testMainActorMethod(eff : EffProps) async {
+  // CHECK:         [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
+  // CHECK-NEXT:    hop_to_executor [[GENERIC_EXEC]] :
+  // CHECK:         hop_to_executor [[GENERIC_EXEC]] :
+  // CHECK: } // end sil function '${{.*}}19testMainActorMethod
+  let _ = await eff.regularMainDog()
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68390

---

- Explanation:

To provide enhanced debugging and runtime checking for the correct usage
of continuations passed in a call to ObjC from Swift, this PR introduces a flag
for the `swift-frontend` that uses a `CheckedContinuation` when calling an
async ObjC function from Swift. When enabled, the underlying block value 
passed as a completion-handler is created using `CheckedContinuation` 
instead of just an `UnsafeContinuation`, which was what was used previously.
The checked continuation ensures that the block is only invoked once.

As of now, the `swift-frontend` flag is `-checked-async-objc-bridging={on, off}`

- Scope: Calls to ObjC with async handlers.

- Main Branch PR: https://github.com/apple/swift/pull/68390

- Resolves: rdar://89930501

- Risk: Low

- Reviewed By: @ktoso @jckarter 

- Testing: added test-cases to the test suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
