### PR TITLE
SILGen: Introduce option to skip non-exportable declarations

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -957,6 +957,10 @@ public:
   unsigned getAttachedMacroDiscriminator(DeclBaseName macroName, MacroRole role,
                                          const CustomAttr *attr) const;
 
+  /// Determines if this declaration is exposed to clients of the module it is
+  /// defined in. For example, `public` declarations are exposed to clients.
+  bool isExposedToClients() const;
+
   /// Returns the innermost enclosing decl with an availability annotation.
   const Decl *getInnermostDeclWithAvailability() const;
 

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -877,15 +877,6 @@ public:
   /// The resulting list of members will be stable across translation units.
   ArrayRef<Decl *> getABIMembers() const;
 
-  using DeclsForLowering =
-      OptionalTransformRange<ArrayRef<Decl *>,
-                             AvailableDuringLoweringDeclFilter<Decl>>;
-
-  /// Get all of the members within this context that should be included when
-  /// lowering to SIL/IR, including any implicitly-synthesized members. The
-  /// decls returned by \c getABIMembers() are a superset of these decls.
-  DeclsForLowering getMembersForLowering() const;
-
   /// Get all of the members within this context, including any
   /// implicitly-synthesized members.
   ///

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -105,6 +105,9 @@ template <class T> class SILVTableVisitor {
   }
 
   void maybeAddMember(Decl *member) {
+    if (!member->isAvailableDuringLowering())
+      return;
+
     if (isa<AccessorDecl>(member))
       /* handled as part of its storage */;
     else if (auto *fd = dyn_cast<FuncDecl>(member))
@@ -141,7 +144,7 @@ protected:
     if (!theClass->hasKnownSwiftImplementation())
       return;
 
-    for (Decl *member : theClass->getMembersForLowering()) {
+    for (Decl *member : theClass->getABIMembers()) {
       maybeAddMember(member);
     }
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/CaptureInfo.h"
+#include "swift/AST/DeclExportabilityVisitor.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -490,6 +491,10 @@ unsigned Decl::getAttachedMacroDiscriminator(DeclBaseName macroName,
   return ctx.getNextMacroDiscriminator(
       MacroDiscriminatorContext::getParentOf(getLoc(), getDeclContext()),
       macroName);
+}
+
+bool Decl::isExposedToClients() const {
+  return DeclExportabilityVisitor().visit(this);
 }
 
 const Decl *Decl::getInnermostDeclWithAvailability() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -914,12 +914,6 @@ ArrayRef<Decl *> IterableDeclContext::getABIMembers() const {
       ArrayRef<Decl *>());
 }
 
-IterableDeclContext::DeclsForLowering
-IterableDeclContext::getMembersForLowering() const {
-  return DeclsForLowering(getABIMembers(),
-                          AvailableDuringLoweringDeclFilter<Decl>());
-}
-
 ArrayRef<Decl *> IterableDeclContext::getAllMembers() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1425,11 +1425,6 @@ bool CompilerInstance::performParseAndResolveImportsOnly() {
 void CompilerInstance::performSema() {
   performParseAndResolveImportsOnly();
 
-  // Skip eager type checking. Instead, let later stages of compilation drive
-  // type checking as needed through request evaluation.
-  if (getASTContext().TypeCheckerOpts.EnableLazyTypecheck)
-    return;
-
   FrontendStatsTracer tracer(getStatsReporter(), "perform-sema");
 
   forEachFileToTypeCheck([&](SourceFile &SF) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -801,6 +801,10 @@ bool SILGenModule::shouldSkipDecl(Decl *D) {
   if (!D->isAvailableDuringLowering())
     return true;
 
+  if (getASTContext().SILOpts.SkipNonExportableDecls &&
+      !D->isExposedToClients())
+    return true;
+
   return false;
 }
 
@@ -1419,6 +1423,8 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
 }
 
 void SILGenModule::emitFunction(FuncDecl *fd) {
+  assert(!shouldSkipDecl(fd));
+
   Types.setCaptureTypeExpansionContext(SILDeclRef(fd), M);
 
   SILDeclRef::Loc decl = fd;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -797,8 +797,15 @@ bool SILGenModule::hasFunction(SILDeclRef constant) {
   return emittedFunctions.count(constant);
 }
 
-void SILGenModule::visit(Decl *D) {
+bool SILGenModule::shouldSkipDecl(Decl *D) {
   if (!D->isAvailableDuringLowering())
+    return true;
+
+  return false;
+}
+
+void SILGenModule::visit(Decl *D) {
+  if (shouldSkipDecl(D))
     return;
 
   ASTVisitor::visit(D);

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -264,6 +264,9 @@ public:
   // Visitors for top-level forms
   //===--------------------------------------------------------------------===//
 
+  /// Returns true if SILGen should be skipped for the given decl.
+  bool shouldSkipDecl(Decl *d);
+
   void visit(Decl *D);
 
   // These are either not allowed at global scope or don't require

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -294,9 +294,16 @@ void SILGenTopLevel::visitTopLevelCodeDecl(TopLevelCodeDecl *TD) {
 SILGenTopLevel::TypeVisitor::TypeVisitor(SILGenFunction &SGF) : SGF(SGF) {}
 
 void SILGenTopLevel::TypeVisitor::emit(IterableDeclContext *Ctx) {
-  for (auto *Member : Ctx->getMembersForLowering()) {
+  for (auto *Member : Ctx->getABIMembers()) {
     visit(Member);
   }
+}
+
+void SILGenTopLevel::TypeVisitor::visit(Decl *D) {
+  if (SGF.SGM.shouldSkipDecl(D))
+    return;
+
+  TypeMemberVisitor::visit(D);
 }
 
 void SILGenTopLevel::TypeVisitor::visitPatternBindingDecl(

--- a/lib/SILGen/SILGenTopLevel.h
+++ b/lib/SILGen/SILGenTopLevel.h
@@ -49,6 +49,7 @@ private:
     /// Emit `mark_function_escape` SIL instructions into `SGF` for encountered
     /// escape points.
     TypeVisitor(SILGenFunction &SGF);
+    void visit(Decl *D);
     void visitDecl(Decl *D) {}
     void emit(IterableDeclContext *Ctx);
     virtual void visitPatternBindingDecl(PatternBindingDecl *PD);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -47,6 +47,9 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass, SILDeclRef derived,
   auto *baseDecl = cast<AbstractFunctionDecl>(base.getDecl());
   auto *derivedDecl = cast<AbstractFunctionDecl>(derived.getDecl());
 
+  if (shouldSkipDecl(baseDecl))
+    return llvm::None;
+
   // Note: We intentionally don't support extension members here.
   //
   // Once extensions can override or introduce new vtable entries, this will

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1098,7 +1098,7 @@ public:
   void emitType() {
     SGM.emitLazyConformancesForType(theType);
 
-    for (Decl *member : theType->getMembersForLowering()) {
+    for (Decl *member : theType->getABIMembers()) {
       visit(member);
     }
 
@@ -1141,6 +1141,13 @@ public:
   //===--------------------------------------------------------------------===//
   // Visitors for subdeclarations
   //===--------------------------------------------------------------------===//
+  void visit(Decl *D) {
+    if (SGM.shouldSkipDecl(D))
+      return;
+
+    TypeMemberVisitor::visit(D);
+  }
+
   void visitTypeAliasDecl(TypeAliasDecl *tad) {}
   void visitOpaqueTypeDecl(OpaqueTypeDecl *otd) {}
   void visitGenericTypeParamDecl(GenericTypeParamDecl *d) {}
@@ -1273,7 +1280,7 @@ public:
     // @_objcImplementation extension, but we don't actually need to do any of
     // the stuff that it currently does.
 
-    for (Decl *member : e->getMembersForLowering()) {
+    for (Decl *member : e->getABIMembers()) {
       visit(member);
     }
 
@@ -1300,6 +1307,13 @@ public:
   //===--------------------------------------------------------------------===//
   // Visitors for subdeclarations
   //===--------------------------------------------------------------------===//
+  void visit(Decl *D) {
+    if (SGM.shouldSkipDecl(D))
+      return;
+
+    TypeMemberVisitor::visit(D);
+  }
+
   void visitTypeAliasDecl(TypeAliasDecl *tad) {}
   void visitOpaqueTypeDecl(OpaqueTypeDecl *tad) {}
   void visitGenericTypeParamDecl(GenericTypeParamDecl *d) {}

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -242,6 +242,12 @@ void swift::bindExtensions(ModuleDecl &mod) {
 }
 
 void swift::performTypeChecking(SourceFile &SF) {
+  if (SF.getASTContext().TypeCheckerOpts.EnableLazyTypecheck) {
+    // Skip eager type checking. Instead, let later stages of compilation drive
+    // type checking as needed through request evaluation.
+    return;
+  }
+
   return (void)evaluateOrDefault(SF.getASTContext().evaluator,
                                  TypeCheckSourceFileRequest{&SF}, {});
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -16,7 +16,6 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/AutoDiff.h"
-#include "swift/AST/DeclExportabilityVisitor.h"
 #include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/FileSystem.h"
@@ -3306,7 +3305,7 @@ public:
   /// it, but at the same time keep the safety checks precise to avoid
   /// XRef errors and such.
   static bool isDeserializationSafe(const Decl *decl) {
-    return DeclExportabilityVisitor().visit(decl);
+    return decl->isExposedToClients();
   }
 
 private:

--- a/test/SILGen/skip-non-exportable-decls.swift
+++ b/test/SILGen/skip-non-exportable-decls.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -module-name Test | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-SKIP
+// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -module-name Test -experimental-skip-non-exportable-decls | %FileCheck %s --check-prefixes=CHECK,CHECK-SKIP
+
+// CHECK-NO-SKIP: sil private{{.*}} @$s4Test11privateFunc33_E3F0E1C7B46D05C8067CB98677DE566CLLyyF : $@convention(thin) () -> () {
+// CHECK-SKIP-NOT: s4Test11privateFunc33_E3F0E1C7B46D05C8067CB98677DE566CLLyyF
+private func privateFunc() {}
+
+// CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test12internalFuncyyF : $@convention(thin) () -> () {
+// CHECK-SKIP-NOT: s4Test12internalFuncyyF
+internal func internalFunc() {}
+
+// CHECK: sil{{.*}} @$s4Test10publicFuncyyF : $@convention(thin) () -> () {
+public func publicFunc() {}
+
+private class PrivateClass {
+  // CHECK-NO-SKIP: sil private{{.*}} @$s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCfd : $@convention(method) (@guaranteed PrivateClass) -> @owned Builtin.NativeObject {
+  // CHECK-SKIP-NOT: s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCfd
+
+  // CHECK-NO-SKIP: sil private{{.*}} @$s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCfD : $@convention(method) (@owned PrivateClass) -> () {
+  // CHECK-SKIP-NOT: s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCfD
+
+  // CHECK-NO-SKIP: sil private{{.*}} @$s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCADycfC : $@convention(method) (@thick PrivateClass.Type) -> @owned PrivateClass {
+  // CHECK-SKIP-NOT: s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCADycfC
+
+  // CHECK-NO-SKIP: sil private{{.*}} @$s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCADycfc : $@convention(method) (@owned PrivateClass) -> @owned PrivateClass {
+  // CHECK-SKIP-NOT: s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCADycfc
+}
+
+public class PublicClass {
+  // CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test11PublicClassC14internalMethodyyF : $@convention(method) (@guaranteed PublicClass) -> () {
+  // CHECK-SKIP-NOT: s4Test11PublicClassC14internalMethodyyF
+  internal func internalMethod() {}
+
+  // CHECK: sil{{.*}} @$s4Test11PublicClassCfd : $@convention(method) (@guaranteed PublicClass) -> @owned Builtin.NativeObject {
+
+  // CHECK: sil{{.*}} @$s4Test11PublicClassCfD : $@convention(method) (@owned PublicClass) -> () {
+
+  // CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test11PublicClassCACycfC : $@convention(method) (@thick PublicClass.Type) -> @owned PublicClass {
+  // CHECK-SKIP-NOT: s4Test11PublicClassCACycfC
+
+  // CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test11PublicClassCACycfc : $@convention(method) (@owned PublicClass) -> @owned PublicClass {
+  // CHECK-SKIP-NOT: s4Test11PublicClassCACycfc
+}
+
+extension PublicClass {
+  // CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test11PublicClassC25internalMethodInExtensionyyF : $@convention(method) (@guaranteed PublicClass) -> () {
+  // CHECK-SKIP-NOT: s4Test11PublicClassC25internalMethodInExtensionyyF
+  internal func internalMethodInExtension() {}
+}
+
+// CHECK-NO-SKIP-LABEL: sil_vtable PrivateClass {
+// CHECK-NO-SKIP-NEXT:    #PrivateClass.init!allocator
+// CHECK-NO-SKIP-NEXT:    #PrivateClass.deinit!deallocator
+// CHECK-NO-SKIP-NEXT:  }
+// CHECK-SKIP-NOT:      sil_vtable PrivateClass
+
+// CHECK-LABEL:         sil_vtable [serialized] PublicClass {
+// CHECK-NO-SKIP-NEXT:    #PublicClass.internalMethod
+// CHECK-SKIP-NOT:        #PublicClass.internalMethod
+// CHECK-NO-SKIP-NEXT:    #PublicClass.init!allocator
+// CHECK-SKIP-NOT:        #PublicClass.init!allocator
+// CHECK-NEXT:            #PublicClass.deinit!deallocator
+// CHECK-NEXT:          }


### PR DESCRIPTION
When `-experimental-skip-non-exportable-decls` is specified, only emit SIL for declarations that are exposed to clients.
    
Resolves rdar://116774565