### PR TITLE
[wasm] Use `__main_argc_argv` as entry point name

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -177,7 +177,7 @@ namespace swift {
     llvm::VersionTuple MinimumInliningTargetVersion;
 
     /// The alternate name to use for the entry point instead of main.
-    std::string entryPointFunctionName = "main";
+    std::optional<std::string> entryPointFunctionName;
 
     ///
     /// Language features

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5906,7 +5906,14 @@ ASTContext::SILTransformCtors ASTContext::getIRGenSILTransforms() const {
 }
 
 std::string ASTContext::getEntryPointFunctionName() const {
-  return LangOpts.entryPointFunctionName;
+  // Set default entry point name
+  //
+  // Usually the main entrypoint is "main" but WebAssembly's C ABI uses
+  // "__main_argc_argv" for `int (int, char **)` signature and Swift's
+  // main entrypoint always takes argc/argv.
+  // See https://github.com/WebAssembly/tool-conventions/blob/main/BasicCABI.md
+  std::string defaultName = LangOpts.Target.isWasm() ? "__main_argc_argv" :  "main";
+  return LangOpts.entryPointFunctionName.value_or(defaultName);
 }
 
 SILLayout *SILLayout::get(ASTContext &C,

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -37,7 +37,7 @@ class OptionalInoutFuncType {
   }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i32 @main(i32 %0, ptr %1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i32 @{{main|__main_argc_argv}}(i32 %0, ptr %1)
 // CHECK: call void @llvm.lifetime.start
 // CHECK: call void @llvm.memcpy
 // CHECK: call void @llvm.lifetime.end

--- a/test/IRGen/default_function_ir_attributes.swift
+++ b/test/IRGen/default_function_ir_attributes.swift
@@ -37,7 +37,7 @@ struct StructHoldingOutlined<T> {
 }
 
 //   main
-// CHECK-LABEL: define {{.*}} @main(
+// CHECK-LABEL: define {{.*}} @{{main|__main_argc_argv}}(
 // CHECK-SAME: [[ATTRS_SIMPLE:#[0-9]+]]
 
 //   class deinit

--- a/test/IRGen/opaque-pointer-llvm.swift
+++ b/test/IRGen/opaque-pointer-llvm.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xcc -Xclang -Xcc -opaque-pointers -primary-file %s -emit-ir   | %FileCheck %s --check-prefix=CHECK
 // RUN: %target-swift-frontend -Xcc -Xclang -Xcc -no-opaque-pointers -primary-file %s -emit-ir   | %FileCheck %s --check-prefix=CHECK-NO
 
-// CHECK: define{{.*}} @main({{.*}} %0, ptr %1)
-// CHECK-NO: define{{.*}} @main({{.*}} %0, i8** %1)
+// CHECK: define{{.*}} @{{main|__main_argc_argv}}({{.*}} %0, ptr %1)
+// CHECK-NO: define{{.*}} @{{main|__main_argc_argv}}({{.*}} %0, i8** %1)
 public func test() {}

--- a/test/IRGen/wasm-absolute-func-ptr.swift
+++ b/test/IRGen/wasm-absolute-func-ptr.swift
@@ -2,5 +2,5 @@
 
 // REQUIRES: CODEGENERATOR=WebAssembly
 
-// CHECK: @"\01l_entry_point" = private constant { i32{{.*}} { i32 ptrtoint (ptr @main to i32){{.*}} }, section "swift5_entry", align 4
+// CHECK: @"\01l_entry_point" = private constant { i32{{.*}} { i32 ptrtoint (ptr @__main_argc_argv to i32){{.*}} }, section "swift5_entry", align 4
 


### PR DESCRIPTION
Wasm C ABI now uses `int __main_argc_argv(int argc, char *argv[])` as entry point signature[^1], and wasi-libc has removed backward compatibility with legacy "main"[^2], so we need to support the new name in compiler side.

[^1]: https://github.com/WebAssembly/tool-conventions/blob/main/BasicCABI.md
[^2]: https://github.com/WebAssembly/wasi-libc/commit/d8d00bcd5a839150f1950678ce6e6a9b80fbc140

Resolve rdar://116552600