### PR TITLE
[5.10][Concurrency] Allow default arguments to require actor isolation.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1955,6 +1955,15 @@ private:
   SourceRange getOriginalInitRange() const;
   void setInit(Expr *E);
 
+  /// Get the required actor isolation for evaluating the initializer
+  /// expression synchronously (if there is one). 
+  ///
+  /// If this pattern binding entry is for a stored instance property, the
+  /// initializer can only be used in an `init` that meets the required
+  /// isolation; otherwise, the property must be explicitly initialized in
+  /// the `init`.
+  ActorIsolation getInitializerIsolation() const;
+
   /// Gets the text of the initializer expression, stripping out inactive
   /// branches of any #ifs inside the expression.
   StringRef getInitStringRepresentation(SmallVectorImpl<char> &scratch) const;
@@ -2201,6 +2210,10 @@ public:
 
   void setOriginalInit(unsigned i, Expr *E) {
     getMutablePatternList()[i].setOriginalInit(E);
+  }
+
+  ActorIsolation getInitializerIsolation(unsigned i) const {
+    return getPatternList()[i].getInitializerIsolation();
   }
 
   Pattern *getPattern(unsigned i) const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1955,15 +1955,6 @@ private:
   SourceRange getOriginalInitRange() const;
   void setInit(Expr *E);
 
-  /// Get the required actor isolation for evaluating the initializer
-  /// expression synchronously (if there is one). 
-  ///
-  /// If this pattern binding entry is for a stored instance property, the
-  /// initializer can only be used in an `init` that meets the required
-  /// isolation; otherwise, the property must be explicitly initialized in
-  /// the `init`.
-  ActorIsolation getInitializerIsolation() const;
-
   /// Gets the text of the initializer expression, stripping out inactive
   /// branches of any #ifs inside the expression.
   StringRef getInitStringRepresentation(SmallVectorImpl<char> &scratch) const;
@@ -2210,10 +2201,6 @@ public:
 
   void setOriginalInit(unsigned i, Expr *E) {
     getMutablePatternList()[i].setOriginalInit(E);
-  }
-
-  ActorIsolation getInitializerIsolation(unsigned i) const {
-    return getPatternList()[i].getInitializerIsolation();
   }
 
   Pattern *getPattern(unsigned i) const {
@@ -5948,6 +5935,19 @@ public:
     return getParentExecutableInitializer() != nullptr;
   }
 
+  /// Get the required actor isolation for evaluating the initializer
+  /// expression synchronously (if there is one).
+  ///
+  /// If this VarDecl is a stored instance property, the initializer
+  /// can only be used in an `init` that meets the required isolation.
+  /// Otherwise, the property must be explicitly initialized in the `init`.
+  ///
+  /// If this is a ParamDecl, the initializer isolation is required at
+  /// the call-site in order to use the default argument for this parameter.
+  /// If the required isolation is not met, an argument must be written
+  /// explicitly at the call-site.
+  ActorIsolation getInitializerIsolation() const;
+
   // Return whether this VarDecl has an initial value, either by checking
   // if it has an initializer in its parent pattern binding or if it has
   // the @_hasInitialValue attribute.
@@ -6389,11 +6389,6 @@ public:
   /// check whether the code is valid. Such default arguments get re-created
   /// at the call site in order to have the correct context information.
   Expr *getTypeCheckedDefaultExpr() const;
-
-  /// The actor isolation required of the caller in order to use the
-  /// default argument for this parameter. If the required isolation is
-  /// not met, an argument must be written explicitly at the call-site.
-  ActorIsolation getDefaultArgumentIsolation() const;
 
   /// Retrieve the potentially un-type-checked default argument expression for
   /// this parameter, which can be queried for information such as its source

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2250,7 +2250,9 @@ public:
   void setInitializerSubsumed(unsigned i) {
     getMutablePatternList()[i].setInitializerSubsumed();
   }
-  
+
+  ActorIsolation getInitializerIsolation(unsigned i) const;
+
   /// Does this binding declare something that requires storage?
   bool hasStorage() const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6377,6 +6377,11 @@ public:
   /// at the call site in order to have the correct context information.
   Expr *getTypeCheckedDefaultExpr() const;
 
+  /// The actor isolation required of the caller in order to use the
+  /// default argument for this parameter. If the required isolation is
+  /// not met, an argument must be written explicitly at the call-site.
+  ActorIsolation getDefaultArgumentIsolation() const;
+
   /// Retrieve the potentially un-type-checked default argument expression for
   /// this parameter, which can be queried for information such as its source
   /// range and textual representation. Returns \c nullptr if there is no

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5196,6 +5196,9 @@ ERROR(isolated_default_argument,none,
       "%0 default argument cannot be synchronously evaluated from a "
       "%1 context",
       (ActorIsolation, ActorIsolation))
+ERROR(conflicting_default_argument_isolation,none,
+      "default argument cannot be both %0 and %1",
+      (ActorIsolation, ActorIsolation))
 ERROR(distributed_actor_needs_explicit_distributed_import,none,
       "'Distributed' module not imported, required for 'distributed actor'",
       ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5192,6 +5192,10 @@ ERROR(distributed_actor_isolated_non_self_reference,none,
       "distributed actor-isolated %kind0 can not be accessed from a "
       "non-isolated context",
       (const ValueDecl *))
+ERROR(isolated_default_argument,none,
+      "%0 default argument cannot be synchronously evaluated from a "
+      "%1 context",
+      (ActorIsolation, ActorIsolation))
 ERROR(distributed_actor_needs_explicit_distributed_import,none,
       "'Distributed' module not imported, required for 'distributed actor'",
       ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4538,6 +4538,11 @@ public:
   /// expression within the context of the call site.
   Expr *getCallerSideDefaultExpr() const;
 
+  /// Get the required actor isolation for evaluating this default argument
+  /// synchronously. If the caller does not meet the required isolation, the
+  /// argument must be written explicitly at the call-site.
+  ActorIsolation getRequiredIsolation() const;
+
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::DefaultArgument;
   }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2911,6 +2911,24 @@ public:
   void cacheResult(Type type) const;
 };
 
+/// Compute the actor isolation needed to synchronously evaluate the
+/// default argument for the given parameter.
+class DefaultArgumentIsolation
+    : public SimpleRequest<DefaultArgumentIsolation,
+                           ActorIsolation(ParamDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ActorIsolation evaluate(Evaluator &evaluator, ParamDecl *param) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Computes the fully type-checked caller-side default argument within the
 /// context of the call site that it will be inserted into.
 class CallerSideDefaultArgExprRequest

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2912,10 +2912,10 @@ public:
 };
 
 /// Compute the actor isolation needed to synchronously evaluate the
-/// default argument for the given parameter.
-class DefaultArgumentIsolation
-    : public SimpleRequest<DefaultArgumentIsolation,
-                           ActorIsolation(ParamDecl *),
+/// default initializer expression.
+class DefaultInitializerIsolation
+    : public SimpleRequest<DefaultInitializerIsolation,
+                           ActorIsolation(Initializer *, Expr *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2923,11 +2923,15 @@ public:
 private:
   friend SimpleRequest;
 
-  ActorIsolation evaluate(Evaluator &evaluator, ParamDecl *param) const;
+  ActorIsolation evaluate(Evaluator &evaluator, 
+                          Initializer *init,
+                          Expr *initExpr) const;
 
 public:
   bool isCached() const { return true; }
 };
+
+void simple_display(llvm::raw_ostream &out, Initializer *init);
 
 /// Computes the fully type-checked caller-side default argument within the
 /// context of the call site that it will be inserted into.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2915,7 +2915,7 @@ public:
 /// default initializer expression.
 class DefaultInitializerIsolation
     : public SimpleRequest<DefaultInitializerIsolation,
-                           ActorIsolation(Initializer *, Expr *),
+                           ActorIsolation(VarDecl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2924,8 +2924,7 @@ private:
   friend SimpleRequest;
 
   ActorIsolation evaluate(Evaluator &evaluator, 
-                          Initializer *init,
-                          Expr *initExpr) const;
+                          VarDecl *) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -62,8 +62,9 @@ SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
               Expr *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentTypeRequest,
               Type(ParamDecl *), SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, DefaultArgumentIsolation,
-              ActorIsolation(ParamDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DefaultInitializerIsolation,
+              ActorIsolation(Initializer *, Expr *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
               Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -63,7 +63,7 @@ SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
 SWIFT_REQUEST(TypeChecker, DefaultArgumentTypeRequest,
               Type(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultInitializerIsolation,
-              ActorIsolation(Initializer *, Expr *),
+              ActorIsolation(VarDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
               Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -62,6 +62,8 @@ SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
               Expr *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentTypeRequest,
               Type(ParamDecl *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DefaultArgumentIsolation,
+              ActorIsolation(ParamDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
               Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -222,6 +222,9 @@ EXPERIMENTAL_FEATURE(SendNonSendable, false)
 /// Within strict concurrency, narrow global variable isolation requirements.
 EXPERIMENTAL_FEATURE(GlobalConcurrency, false)
 
+/// Allow default arguments to require isolation at the call-site.
+EXPERIMENTAL_FEATURE(IsolatedDefaultArguments, false)
+
 /// Enable extended callbacks (with additional parameters) to be used when the
 /// "playground transform" is enabled.
 EXPERIMENTAL_FEATURE(PlaygroundExtendedCallbacks, true)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -222,8 +222,8 @@ EXPERIMENTAL_FEATURE(SendNonSendable, false)
 /// Within strict concurrency, narrow global variable isolation requirements.
 EXPERIMENTAL_FEATURE(GlobalConcurrency, false)
 
-/// Allow default arguments to require isolation at the call-site.
-EXPERIMENTAL_FEATURE(IsolatedDefaultArguments, false)
+/// Allow default values to require isolation at the call-site.
+EXPERIMENTAL_FEATURE(IsolatedDefaultValues, false)
 
 /// Enable extended callbacks (with additional parameters) to be used when the
 /// "playground transform" is enabled.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3502,6 +3502,10 @@ static bool usesFeatureSendNonSendable(Decl *decl) {
 
 static bool usesFeatureGlobalConcurrency(Decl *decl) { return false; }
 
+static bool usesFeatureIsolatedDefaultArguments(Decl *decl) {
+  return false;
+}
+
 static bool usesFeaturePlaygroundExtendedCallbacks(Decl *decl) {
   return false;
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3502,7 +3502,7 @@ static bool usesFeatureSendNonSendable(Decl *decl) {
 
 static bool usesFeatureGlobalConcurrency(Decl *decl) { return false; }
 
-static bool usesFeatureIsolatedDefaultArguments(Decl *decl) {
+static bool usesFeatureIsolatedDefaultValues(Decl *decl) {
   return false;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10293,7 +10293,7 @@ ActorIsolation swift::getActorIsolationOfContext(
   //     that meet the required isolation.
   if (auto *var = dcToUse->getNonLocalVarDecl()) {
     auto &ctx = dc->getASTContext();
-    if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultArguments) &&
+    if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues) &&
         var->isInstanceMember() &&
         !var->getAttrs().hasAttribute<LazyAttr>()) {
       return ActorIsolation::forNonisolated();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1953,20 +1953,6 @@ void PatternBindingEntry::setInit(Expr *E) {
                              PatternFlags::IsText);
 }
 
-ActorIsolation PatternBindingEntry::getInitializerIsolation() const {
-  if (!isInitialized())
-    return ActorIsolation::forUnspecified();
-
-  auto *dc = cast<Initializer>(getInitContext());
-  auto &ctx = dc->getASTContext();
-  auto *initExpr = getExecutableInit();
-
-  return evaluateOrDefault(
-      ctx.evaluator,
-      DefaultInitializerIsolation{dc, initExpr},
-      ActorIsolation::forNonisolated());
-}
-
 VarDecl *PatternBindingEntry::getAnchoringVarDecl() const {
   SmallVector<VarDecl *, 8> variables;
   getPattern()->collectVariables(variables);
@@ -7060,6 +7046,14 @@ Expr *VarDecl::getParentExecutableInitializer() const {
   return nullptr;
 }
 
+ActorIsolation VarDecl::getInitializerIsolation() const {
+  auto *mutableThis = const_cast<VarDecl *>(this);
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      DefaultInitializerIsolation{mutableThis},
+      ActorIsolation::forUnspecified());
+}
+
 SourceRange VarDecl::getSourceRange() const {
   if (auto Param = dyn_cast<ParamDecl>(this))
     return Param->getSourceRange();
@@ -8170,34 +8164,6 @@ Type ParamDecl::getTypeOfDefaultExpr() const {
   }
 
   return Type();
-}
-
-ActorIsolation ParamDecl::getDefaultArgumentIsolation() const {
-  // If this parameter corresponds to a stored property for a
-  // memberwise initializer, the default argument is the default
-  // initializer expression.
-  auto *var = getStoredProperty();
-  if (var && !var->isInvalid()) {
-    // FIXME: Force computation of property wrapper initializers.
-    if (auto *wrapped = var->getOriginalWrappedProperty())
-      (void)wrapped->getPropertyWrapperInitializerInfo();
-
-    auto *pbd = var->getParentPatternBinding();
-    auto i = pbd->getPatternEntryIndexForVarDecl(var);
-    return var->getParentPatternBinding()->getInitializerIsolation(i);
-  }
-
-  if (!hasDefaultExpr())
-    return ActorIsolation::forUnspecified();
-
-  auto &ctx = getASTContext();
-  auto *dc = getDefaultArgumentInitContext();
-  auto *initExpr = getTypeCheckedDefaultExpr();
-
-  return evaluateOrDefault(
-      ctx.evaluator,
-      DefaultInitializerIsolation{dc, initExpr},
-      ActorIsolation::forNonisolated());
 }
 
 void ParamDecl::setDefaultExpr(Expr *E, bool isTypeChecked) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8158,6 +8158,14 @@ Type ParamDecl::getTypeOfDefaultExpr() const {
   return Type();
 }
 
+ActorIsolation ParamDecl::getDefaultArgumentIsolation() const {
+  auto &ctx = getASTContext();
+  return evaluateOrDefault(
+      ctx.evaluator,
+      DefaultArgumentIsolation{const_cast<ParamDecl *>(this)},
+      ActorIsolation::forNonisolated());
+}
+
 void ParamDecl::setDefaultExpr(Expr *E, bool isTypeChecked) {
   if (!DefaultValueAndFlags.getPointer()) {
     if (!E) return;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2065,6 +2065,14 @@ bool PatternBindingDecl::isAsyncLet() const {
   return false;
 }
 
+ActorIsolation
+PatternBindingDecl::getInitializerIsolation(unsigned i) const {
+  auto *var = getPatternList()[i].getAnchoringVarDecl();
+  if (!var)
+    return ActorIsolation::forUnspecified();
+
+  return var->getInitializerIsolation();
+}
 
 bool PatternBindingDecl::hasStorage() const {
   // Walk the pattern, to check to see if any of the VarDecls included in it

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1953,6 +1953,20 @@ void PatternBindingEntry::setInit(Expr *E) {
                              PatternFlags::IsText);
 }
 
+ActorIsolation PatternBindingEntry::getInitializerIsolation() const {
+  if (!isInitialized())
+    return ActorIsolation::forUnspecified();
+
+  auto *dc = cast<Initializer>(getInitContext());
+  auto &ctx = dc->getASTContext();
+  auto *initExpr = getExecutableInit();
+
+  return evaluateOrDefault(
+      ctx.evaluator,
+      DefaultInitializerIsolation{dc, initExpr},
+      ActorIsolation::forNonisolated());
+}
+
 VarDecl *PatternBindingEntry::getAnchoringVarDecl() const {
   SmallVector<VarDecl *, 8> variables;
   getPattern()->collectVariables(variables);
@@ -8159,10 +8173,30 @@ Type ParamDecl::getTypeOfDefaultExpr() const {
 }
 
 ActorIsolation ParamDecl::getDefaultArgumentIsolation() const {
+  // If this parameter corresponds to a stored property for a
+  // memberwise initializer, the default argument is the default
+  // initializer expression.
+  auto *var = getStoredProperty();
+  if (var && !var->isInvalid()) {
+    // FIXME: Force computation of property wrapper initializers.
+    if (auto *wrapped = var->getOriginalWrappedProperty())
+      (void)wrapped->getPropertyWrapperInitializerInfo();
+
+    auto *pbd = var->getParentPatternBinding();
+    auto i = pbd->getPatternEntryIndexForVarDecl(var);
+    return var->getParentPatternBinding()->getInitializerIsolation(i);
+  }
+
+  if (!hasDefaultExpr())
+    return ActorIsolation::forUnspecified();
+
   auto &ctx = getASTContext();
+  auto *dc = getDefaultArgumentInitContext();
+  auto *initExpr = getTypeCheckedDefaultExpr();
+
   return evaluateOrDefault(
       ctx.evaluator,
-      DefaultArgumentIsolation{const_cast<ParamDecl *>(this)},
+      DefaultInitializerIsolation{dc, initExpr},
       ActorIsolation::forNonisolated());
 }
 
@@ -10274,8 +10308,25 @@ ActorIsolation swift::getActorIsolationOfContext(
   if (auto *vd = dyn_cast_or_null<ValueDecl>(dcToUse->getAsDecl()))
     return getActorIsolation(vd);
 
-  if (auto *var = dcToUse->getNonLocalVarDecl())
+  // In the context of the initializing or default-value expression of a
+  // stored property, the isolation varies between instance and type members:
+  //   - For a static stored property, the isolation matches the VarDecl.
+  //     Static properties are initialized upon first use, so the isolation
+  //     of the initializer must match the isolation required to access the
+  //     property.
+  //   - For a field of a nominal type, the expression can require a specific
+  //     actor isolation. That default expression may only be used from inits
+  //     that meet the required isolation.
+  if (auto *var = dcToUse->getNonLocalVarDecl()) {
+    auto &ctx = dc->getASTContext();
+    if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultArguments) &&
+        var->isInstanceMember() &&
+        !var->getAttrs().hasAttribute<LazyAttr>()) {
+      return ActorIsolation::forNonisolated();
+    }
+
     return getActorIsolation(var);
+  }
 
   if (auto *closure = dyn_cast<AbstractClosureExpr>(dcToUse)) {
     return getClosureActorIsolation(closure);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1601,6 +1601,12 @@ Expr *DefaultArgumentExpr::getCallerSideDefaultExpr() const {
                            new (ctx) ErrorExpr(getSourceRange(), getType()));
 }
 
+ActorIsolation
+DefaultArgumentExpr::getRequiredIsolation() const {
+  auto *param = getParamDecl();
+  return param->getDefaultArgumentIsolation();
+}
+
 ValueDecl *ApplyExpr::getCalledValue(bool skipFunctionConversions) const {
   return ::getCalledValue(Fn, skipFunctionConversions);
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1603,8 +1603,7 @@ Expr *DefaultArgumentExpr::getCallerSideDefaultExpr() const {
 
 ActorIsolation
 DefaultArgumentExpr::getRequiredIsolation() const {
-  auto *param = getParamDecl();
-  return param->getDefaultArgumentIsolation();
+  return getParamDecl()->getInitializerIsolation();
 }
 
 ValueDecl *ApplyExpr::getCalledValue(bool skipFunctionConversions) const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1271,6 +1271,24 @@ void DefaultArgumentTypeRequest::cacheResult(Type type) const {
 }
 
 //----------------------------------------------------------------------------//
+// DefaultInitializerIsolation computation.
+//----------------------------------------------------------------------------//
+
+void swift::simple_display(llvm::raw_ostream &out, Initializer *init) {
+  switch (init->getInitializerKind()) {
+  case InitializerKind::PatternBinding:
+    out << "pattern binding initializer";
+    break;
+  case InitializerKind::DefaultArgument:
+    out << "default argument initializer";
+    break;
+  case InitializerKind::PropertyWrapper:
+    out << "property wrapper initializer";
+    break;
+  }
+}
+
+//----------------------------------------------------------------------------//
 // CallerSideDefaultArgExprRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1531,7 +1531,8 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     // initializer from being evaluated synchronously (or propagating required
     // isolation through closure bodies), then the default value cannot be used
     // and the member must be explicitly initialized in the constructor.
-    auto requiredIsolation = field->getInitializerIsolation(i);
+    auto *var = field->getAnchoringVarDecl(i);
+    auto requiredIsolation = var->getInitializerIsolation();
     auto contextIsolation = getActorIsolationOfContext(dc);
     switch (requiredIsolation) {
     // 'nonisolated' expressions can be evaluated from anywhere

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1526,6 +1526,26 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     if (!init)
       continue;
 
+    // Member initializer expressions are only used in a constructor with
+    // matching actor isolation. If the isolation prohibits the member
+    // initializer from being evaluated synchronously (or propagating required
+    // isolation through closure bodies), then the default value cannot be used
+    // and the member must be explicitly initialized in the constructor.
+    auto requiredIsolation = field->getInitializerIsolation(i);
+    auto contextIsolation = getActorIsolationOfContext(dc);
+    switch (requiredIsolation) {
+    // 'nonisolated' expressions can be evaluated from anywhere
+    case ActorIsolation::Unspecified:
+    case ActorIsolation::Nonisolated:
+      break;
+
+    case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
+    case ActorIsolation::ActorInstance:
+      if (requiredIsolation != contextIsolation)
+        continue;
+    }
+
     auto *varPattern = field->getPattern(i);
 
     // Cleanup after this initialization.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3621,11 +3621,6 @@ void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
   }
 }
 
-void swift::checkInitializerActorIsolation(Initializer *init, Expr *expr) {
-  ActorIsolationChecker checker(init);
-  expr->walk(checker);
-}
-
 ActorIsolation 
 swift::computeRequiredIsolation(Initializer *init, Expr *expr) {
   ActorIsolationChecker checker(init);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1949,6 +1949,12 @@ namespace {
     llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation;
 
+    bool shouldRefineIsolation = false;
+
+    /// Used under the mode to compute required actor isolation for
+    /// an expression or function.
+    ActorIsolation requiredIsolation = ActorIsolation::forNonisolated();
+
     /// Keeps track of the capture context of variables that have been
     /// explicitly captured in closures.
     llvm::SmallDenseMap<VarDecl *, TinyPtrVector<const DeclContext *>>
@@ -2140,6 +2146,65 @@ namespace {
       }
     }
 
+    bool refineRequiredIsolation(ActorIsolation refinedIsolation) {
+      if (!shouldRefineIsolation)
+        return false;
+
+      if (auto *closure = dyn_cast<AbstractClosureExpr>(getDeclContext())) {
+        // We cannot infer a more specific actor isolation for a @Sendable
+        // closure. It is an error to cast away actor isolation from a function
+        // type, but this is okay for non-Sendable closures because they cannot
+        // leave the isolation domain they're created in anyway.
+        if (closure->isSendable())
+          return false;
+
+        if (closure->getActorIsolation().isActorIsolated())
+          return false;
+      }
+
+      // To refine the required isolation, the existing requirement
+      // must either be 'nonisolated' or exactly the same as the
+      // new refinement.
+      if (requiredIsolation == ActorIsolation::Nonisolated ||
+          requiredIsolation == refinedIsolation) {
+        requiredIsolation = refinedIsolation;
+        return true;
+      }
+
+      return false;
+    }
+
+    void checkDefaultArgument(DefaultArgumentExpr *expr) {
+      // Check the context isolation against the required isolation for
+      // evaluating the default argument synchronously. If the default
+      // argument must be evaluated asynchronously, it must be written
+      // explicitly in the argument list with 'await'.
+      auto requiredIsolation = expr->getRequiredIsolation();
+      auto contextIsolation = getInnermostIsolatedContext(
+          getDeclContext(), getClosureActorIsolation);
+
+      if (requiredIsolation == contextIsolation)
+        return;
+
+      switch (requiredIsolation) {
+      // Nonisolated is okay from any caller isolation because
+      // default arguments cannot have any async calls.
+      case ActorIsolation::Unspecified:
+      case ActorIsolation::Nonisolated:
+        return;
+
+      case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
+      case ActorIsolation::ActorInstance:
+        break;
+      }
+
+      auto &ctx = getDeclContext()->getASTContext();
+      ctx.Diags.diagnose(
+          expr->getLoc(), diag::isolated_default_argument,
+          requiredIsolation, contextIsolation);
+    }
+
     /// Check closure captures for Sendable violations.
     void checkLocalCaptures(AnyFunctionRef localFunc) {
       SmallVector<CapturedValue, 2> captures;
@@ -2195,6 +2260,16 @@ namespace {
         : ctx(dc->getASTContext()), getType(getType),
           getClosureActorIsolation(getClosureActorIsolation) {
       contextStack.push_back(dc);
+    }
+
+    ActorIsolation computeRequiredIsolation(Expr *expr) {
+      auto &ctx = getDeclContext()->getASTContext();
+
+      shouldRefineIsolation =
+          ctx.LangOpts.hasFeature(Feature::IsolatedDefaultArguments);
+      expr->walk(*this);
+      shouldRefineIsolation = false;
+      return requiredIsolation;
     }
 
     /// Searches the applyStack from back to front for the inner-most CallExpr
@@ -2396,6 +2471,10 @@ namespace {
       // The constraint solver may not have chosen legal casts.
       if (auto funcConv = dyn_cast<FunctionConversionExpr>(expr)) {
         checkFunctionConversion(funcConv);
+      }
+
+      if (auto *defaultArg = dyn_cast<DefaultArgumentExpr>(expr)) {
+        checkDefaultArgument(defaultArg);
       }
 
       return Action::Continue(expr);
@@ -2957,6 +3036,9 @@ namespace {
       if (!unsatisfiedIsolation)
         return false;
 
+      if (refineRequiredIsolation(*unsatisfiedIsolation))
+        return false;
+
       // At this point, we know a jump is made to the callee that yields
       // an isolation requirement unsatisfied by the calling context, so
       // set the unsatisfiedIsolationJump fields of the ApplyExpr appropriately
@@ -3294,6 +3376,14 @@ namespace {
 
       case AsyncMarkingResult::SyncContext:
       case AsyncMarkingResult::NotFound:
+        // If we found an implicitly async reference in a sync
+        // context and we're computing the required isolation for
+        // an expression, the calling context requires the isolation
+        // of the reference.
+        if (refineRequiredIsolation(result.isolation)) {
+          return false;
+        }
+
         // Complain about access outside of the isolation domain.
         auto useKind = static_cast<unsigned>(
             kindOfUsage(decl, context).value_or(VarRefUseEnv::Read));
@@ -3504,6 +3594,12 @@ void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
 void swift::checkInitializerActorIsolation(Initializer *init, Expr *expr) {
   ActorIsolationChecker checker(init);
   expr->walk(checker);
+}
+
+ActorIsolation 
+swift::computeRequiredIsolation(Initializer *init, Expr *expr) {
+  ActorIsolationChecker checker(init);
+  return checker.computeRequiredIsolation(expr);
 }
 
 void swift::checkEnumElementActorIsolation(

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3621,12 +3621,6 @@ void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
   }
 }
 
-ActorIsolation 
-swift::computeRequiredIsolation(Initializer *init, Expr *expr) {
-  ActorIsolationChecker checker(init);
-  return checker.computeRequiredIsolation(expr);
-}
-
 void swift::checkEnumElementActorIsolation(
     EnumElementDecl *element, Expr *expr) {
   ActorIsolationChecker checker(element);
@@ -4645,6 +4639,48 @@ bool HasIsolatedSelfRequest::evaluate(
   }
 
   return true;
+}
+
+ActorIsolation
+DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
+                                      VarDecl *var) const {
+  if (var->isInvalid())
+    return ActorIsolation::forUnspecified();
+
+  Initializer *dc = nullptr;
+  Expr *initExpr = nullptr;
+
+  if (auto *pbd = var->getParentPatternBinding()) {
+    if (!var->isParentInitialized())
+      return ActorIsolation::forUnspecified();
+
+    auto i = pbd->getPatternEntryIndexForVarDecl(var);
+    dc = cast<Initializer>(pbd->getInitContext(i));
+    initExpr = var->getParentInitializer();
+  } else if (auto *param = dyn_cast<ParamDecl>(var)) {
+    // If this parameter corresponds to a stored property for a
+    // memberwise initializer, the default argument is the default
+    // initializer expression.
+    if (auto *property = param->getStoredProperty()) {
+      // FIXME: Force computation of property wrapper initializers.
+      if (auto *wrapped = property->getOriginalWrappedProperty())
+        (void)property->getPropertyWrapperInitializerInfo();
+
+      return property->getInitializerIsolation();
+    }
+
+    if (!param->hasDefaultExpr())
+      return ActorIsolation::forUnspecified();
+
+    dc = param->getDefaultArgumentInitContext();
+    initExpr = param->getTypeCheckedDefaultExpr();
+  }
+
+  if (!dc || !initExpr)
+    return ActorIsolation::forUnspecified();
+
+  ActorIsolationChecker checker(dc);
+  return checker.computeRequiredIsolation(initExpr);
 }
 
 void swift::checkOverrideActorIsolation(ValueDecl *value) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1949,11 +1949,11 @@ namespace {
     llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation;
 
-    bool shouldRefineIsolation = false;
+    SourceLoc requiredIsolationLoc;
 
     /// Used under the mode to compute required actor isolation for
     /// an expression or function.
-    ActorIsolation requiredIsolation = ActorIsolation::forNonisolated();
+    llvm::SmallDenseMap<const DeclContext *, ActorIsolation> requiredIsolation;
 
     /// Keeps track of the capture context of variables that have been
     /// explicitly captured in closures.
@@ -2147,31 +2147,60 @@ namespace {
     }
 
     bool refineRequiredIsolation(ActorIsolation refinedIsolation) {
-      if (!shouldRefineIsolation)
+      if (requiredIsolationLoc.isInvalid())
         return false;
 
-      if (auto *closure = dyn_cast<AbstractClosureExpr>(getDeclContext())) {
-        // We cannot infer a more specific actor isolation for a @Sendable
-        // closure. It is an error to cast away actor isolation from a function
-        // type, but this is okay for non-Sendable closures because they cannot
-        // leave the isolation domain they're created in anyway.
-        if (closure->isSendable())
+      auto infersIsolationFromContext =
+          [](const DeclContext *dc) -> bool {
+            // Isolation for declarations is based solely on explicit 
+            // annotations; only infer isolation for initializer expressions
+            // and closures.
+            if (dc->getAsDecl())
+              return false;
+
+            if (auto *closure = dyn_cast<AbstractClosureExpr>(dc)) {
+              // We cannot infer a more specific actor isolation for a Sendable
+              // closure. It is an error to cast away actor isolation from a
+              // function type, but this is okay for non-Sendable closures
+              // because they cannot leave the isolation domain they're created
+              // in anyway.
+              if (closure->isSendable())
+                return false;
+
+              if (closure->getActorIsolation().isActorIsolated())
+                return false;
+            }
+
+            return true;
+          };
+
+      // For the call to require the given actor isolation, every DeclContext
+      // in the current context stack must require the same isolation. If
+      // along the way to the innermost context, we find a DeclContext that
+      // has a different isolation (e.g. it's a local function that does not
+      // recieve isolation from its decl context), then the expression cannot
+      // require a different isolation.
+      for (auto *dc : contextStack) {
+        if (!infersIsolationFromContext(dc))
           return false;
 
-        if (closure->getActorIsolation().isActorIsolated())
-          return false;
+        // To refine the required isolation, the existing requirement
+        // must either be 'nonisolated' or exactly the same as the
+        // new refinement.
+        auto isolation = requiredIsolation.find(dc);
+        if (isolation == requiredIsolation.end() ||
+            isolation->second == ActorIsolation::Nonisolated) {
+          requiredIsolation[dc] = refinedIsolation;
+        } else if (isolation->second != refinedIsolation) {
+          dc->getASTContext().Diags.diagnose(
+              requiredIsolationLoc,
+              diag::conflicting_default_argument_isolation,
+              isolation->second, refinedIsolation);
+          return true;
+        }
       }
 
-      // To refine the required isolation, the existing requirement
-      // must either be 'nonisolated' or exactly the same as the
-      // new refinement.
-      if (requiredIsolation == ActorIsolation::Nonisolated ||
-          requiredIsolation == refinedIsolation) {
-        requiredIsolation = refinedIsolation;
-        return true;
-      }
-
-      return false;
+      return true;
     }
 
     void checkDefaultArgument(DefaultArgumentExpr *expr) {
@@ -2265,11 +2294,12 @@ namespace {
     ActorIsolation computeRequiredIsolation(Expr *expr) {
       auto &ctx = getDeclContext()->getASTContext();
 
-      shouldRefineIsolation =
-          ctx.LangOpts.hasFeature(Feature::IsolatedDefaultArguments);
+      if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultArguments))
+        requiredIsolationLoc = expr->getLoc();
+
       expr->walk(*this);
-      shouldRefineIsolation = false;
-      return requiredIsolation;
+      requiredIsolationLoc = SourceLoc();
+      return requiredIsolation[getDeclContext()];
     }
 
     /// Searches the applyStack from back to front for the inner-most CallExpr

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2294,7 +2294,7 @@ namespace {
     ActorIsolation computeRequiredIsolation(Expr *expr) {
       auto &ctx = getDeclContext()->getASTContext();
 
-      if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultArguments))
+      if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues))
         requiredIsolationLoc = expr->getLoc();
 
       expr->walk(*this);

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -60,6 +60,10 @@ void checkInitializerActorIsolation(Initializer *init, Expr *expr);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
 void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 
+/// Compute the actor isolation required in order to evaluate the given
+/// initializer expression synchronously.
+ActorIsolation computeRequiredIsolation(Initializer *init, Expr *expr);
+
 /// States the reason for checking the Sendability of a given declaration.
 enum class SendableCheckReason {
   /// A reference to an actor from outside that actor.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -56,7 +56,6 @@ void addAsyncNotes(AbstractFunctionDecl const* func);
 /// Check actor isolation rules.
 void checkTopLevelActorIsolation(TopLevelCodeDecl *decl);
 void checkFunctionActorIsolation(AbstractFunctionDecl *decl);
-void checkInitializerActorIsolation(Initializer *init, Expr *expr);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
 void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -59,10 +59,6 @@ void checkFunctionActorIsolation(AbstractFunctionDecl *decl);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
 void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 
-/// Compute the actor isolation required in order to evaluate the given
-/// initializer expression synchronously.
-ActorIsolation computeRequiredIsolation(Initializer *init, Expr *expr);
-
 /// States the reason for checking the Sendability of a given declaration.
 enum class SendableCheckReason {
   /// A reference to an actor from outside that actor.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1157,14 +1157,13 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
 }
 
 ActorIsolation 
-DefaultArgumentIsolation::evaluate(Evaluator &evaluator,
-                                   ParamDecl *param) const {
-  if (!param->hasDefaultExpr())
+DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
+                                      Initializer *init,
+                                      Expr *initExpr) const {
+  if (!init || !initExpr)
     return ActorIsolation::forUnspecified();
 
-  auto *dc = param->getDefaultArgumentInitContext();
-  auto *initExpr = param->getTypeCheckedDefaultExpr();
-  return computeRequiredIsolation(dc, initExpr);
+  return computeRequiredIsolation(init, initExpr);
 }
 
 Type DefaultArgumentTypeRequest::evaluate(Evaluator &evaluator,
@@ -2477,7 +2476,7 @@ public:
               PBD->getInitContext(i));
           if (initContext) {
             TypeChecker::contextualizeInitializer(initContext, init);
-            checkInitializerActorIsolation(initContext, init);
+            (void)PBD->getInitializerIsolation(i);
             TypeChecker::checkInitializerEffects(initContext, init);
           }
         }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3210,7 +3210,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
   // synthesize a computed property for '$foo'.
   Expr *projectedValueInit = nullptr;
   if (auto *projection = var->getPropertyWrapperProjectionVar()) {
-    createPBD(projection);
+    auto *pbd = createPBD(projection);
 
     if (var->hasExternalPropertyWrapper()) {
       // Projected-value initialization is currently only supported for parameters.
@@ -3224,7 +3224,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
       // Check initializer effects.
       auto *initContext = new (ctx) PropertyWrapperInitializer(
           dc, param, PropertyWrapperInitializer::Kind::ProjectedValue);
-      checkInitializerActorIsolation(initContext, projectedValueInit);
+      (void)pbd->getInitializerIsolation(0);
       TypeChecker::checkInitializerEffects(initContext, projectedValueInit);
     }
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3210,7 +3210,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
   // synthesize a computed property for '$foo'.
   Expr *projectedValueInit = nullptr;
   if (auto *projection = var->getPropertyWrapperProjectionVar()) {
-    auto *pbd = createPBD(projection);
+    createPBD(projection);
 
     if (var->hasExternalPropertyWrapper()) {
       // Projected-value initialization is currently only supported for parameters.
@@ -3224,7 +3224,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
       // Check initializer effects.
       auto *initContext = new (ctx) PropertyWrapperInitializer(
           dc, param, PropertyWrapperInitializer::Kind::ProjectedValue);
-      (void)pbd->getInitializerIsolation(0);
+      (void)projection->getInitializerIsolation();
       TypeChecker::checkInitializerEffects(initContext, projectedValueInit);
     }
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -455,6 +455,22 @@ getActualDefaultArgKind(uint8_t raw) {
   return llvm::None;
 }
 
+static llvm::Optional<swift::ActorIsolation::Kind>
+getActualActorIsolationKind(uint8_t raw) {
+  switch (static_cast<serialization::ActorIsolation>(raw)) {
+#define CASE(X) \
+  case serialization::ActorIsolation::X: \
+    return swift::ActorIsolation::Kind::X;
+  CASE(Unspecified)
+  CASE(ActorInstance)
+  CASE(Nonisolated)
+  CASE(GlobalActor)
+  CASE(GlobalActorUnsafe)
+#undef CASE
+  }
+  return llvm::None;
+}
+
 static llvm::Optional<StableSerializationPath::ExternalPath::ComponentKind>
 getActualClangDeclPathComponentKind(uint64_t raw) {
   switch (static_cast<serialization::ClangDeclPathComponentKind>(raw)) {
@@ -3756,6 +3772,8 @@ public:
     bool isCompileTimeConst;
     uint8_t rawDefaultArg;
     TypeID defaultExprType;
+    uint8_t rawDefaultArgIsolation;
+    TypeID globalActorTypeID;
 
     decls_block::ParamLayout::readRecord(scratch, argNameID, paramNameID,
                                          contextID, rawSpecifier,
@@ -3763,7 +3781,9 @@ public:
                                          isAutoClosure, isIsolated,
                                          isCompileTimeConst,
                                          rawDefaultArg,
-                                         defaultExprType);
+                                         defaultExprType,
+                                         rawDefaultArgIsolation,
+                                         globalActorTypeID);
 
     auto argName = MF.getIdentifier(argNameID);
     auto paramName = MF.getIdentifier(paramNameID);
@@ -3807,6 +3827,29 @@ public:
 
       if (auto exprType = MF.getType(defaultExprType))
         param->setDefaultExprType(exprType);
+
+      auto isoKind = *getActualActorIsolationKind(rawDefaultArgIsolation);
+      auto globalActor = MF.getType(globalActorTypeID);
+      ActorIsolation isolation;
+      switch (isoKind) {
+      case ActorIsolation::Unspecified:
+      case ActorIsolation::Nonisolated:
+        isolation = ActorIsolation::forUnspecified();
+        break;
+
+      case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
+        isolation = ActorIsolation::forGlobalActor(
+            globalActor, isoKind == ActorIsolation::GlobalActorUnsafe);
+        break;
+
+      case ActorIsolation::ActorInstance:
+        llvm_unreachable("default arg cannot be actor instance isolated");
+      }
+
+      ctx.evaluator.cacheOutput(
+          DefaultInitializerIsolation{param},
+          std::move(isolation));
 
       if (!blobData.empty())
         param->setDefaultValueStringRepresentation(blobData);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 804; // embedded swift modules
+const uint16_t SWIFTMODULE_VERSION_MINOR = 805; // default argument isolation
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -521,6 +521,17 @@ enum class DefaultArgumentKind : uint8_t {
   StoredProperty,
 };
 using DefaultArgumentField = BCFixed<4>;
+
+/// These IDs must \em not be renumbered or reordered without incrementing
+/// the module version.
+enum class ActorIsolation : uint8_t {
+  Unspecified = 0,
+  ActorInstance,
+  Nonisolated,
+  GlobalActor,
+  GlobalActorUnsafe
+};
+using ActorIsolationField = BCFixed<3>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
@@ -1561,6 +1572,8 @@ namespace decls_block {
     BCFixed<1>,              // isCompileTimeConst?
     DefaultArgumentField,    // default argument kind
     TypeIDField,             // default argument type
+    ActorIsolationField,     // default argument isolation
+    TypeIDField,             // global actor isolation
     BCBlob                   // default argument text
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1391,6 +1391,22 @@ static uint8_t getRawStableDefaultArgumentKind(swift::DefaultArgumentKind kind) 
   llvm_unreachable("Unhandled DefaultArgumentKind in switch.");
 }
 
+static uint8_t 
+getRawStableActorIsolationKind(swift::ActorIsolation::Kind kind) {
+  switch (kind) {
+#define CASE(X) \
+  case swift::ActorIsolation::X: \
+    return static_cast<uint8_t>(serialization::ActorIsolation::X);
+  CASE(Unspecified)
+  CASE(ActorInstance)
+  CASE(Nonisolated)
+  CASE(GlobalActor)
+  CASE(GlobalActorUnsafe)
+#undef CASE
+  }
+  llvm_unreachable("bad actor isolation");
+}
+
 static uint8_t
 getRawStableMetatypeRepresentation(const AnyMetatypeType *metatype) {
   if (!metatype->hasRepresentation()) {
@@ -4365,6 +4381,11 @@ public:
       defaultExprType = param->getTypeOfDefaultExpr();
     }
 
+    auto isolation = param->getInitializerIsolation();
+    Type globalActorType;
+    if (isolation.isGlobalActor())
+      globalActorType = isolation.getGlobalActor();
+
     unsigned abbrCode = S.DeclTypeAbbrCodes[ParamLayout::Code];
     ParamLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
         S.addDeclBaseNameRef(param->getArgumentName()),
@@ -4379,6 +4400,8 @@ public:
         param->isCompileTimeConst(),
         getRawStableDefaultArgumentKind(argKind),
         S.addTypeRef(defaultExprType),
+        getRawStableActorIsolationKind(isolation.getKind()),
+        S.addTypeRef(globalActorType),
         defaultArgumentText);
 
     if (interfaceType->hasError() && !S.allowCompilerErrors()) {

--- a/test/Concurrency/Inputs/serialized_default_arguments.swift
+++ b/test/Concurrency/Inputs/serialized_default_arguments.swift
@@ -1,0 +1,11 @@
+
+@MainActor
+public func mainActorDefaultArg() -> Int { 0 }
+
+@MainActor
+public func useMainActorDefault(_ value: Int = mainActorDefaultArg()) {}
+
+public func nonisolatedDefaultArg() -> Int { 0 }
+
+@MainActor
+public func useNonisolatedDefault(_ value: Int = nonisolatedDefaultArg()) {}

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -124,3 +124,59 @@ func closureWithIsolatedParam(
     _ = requiresMainActor()
   }
 ) {}
+
+@MainActor
+struct S1 {
+  var required: Int
+
+  var x: Int = requiresMainActor()
+
+  lazy var y: Int = requiresMainActor()
+
+  static var z: Int = requiresMainActor()
+}
+
+@SomeGlobalActor
+struct S2 {
+  var required: Int
+
+  var x: Int = requiresSomeGlobalActor()
+
+  lazy var y: Int = requiresSomeGlobalActor()
+
+  static var z: Int = requiresSomeGlobalActor()
+}
+
+@MainActor
+func initializeFromMainActor() {
+  _ = S1(required: 10)
+
+  // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a main actor-isolated context}}
+  _ = S2(required: 10)
+}
+
+@SomeGlobalActor
+func initializeFromSomeGlobalActor() {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a global actor 'SomeGlobalActor'-isolated context}}
+  _ = S1(required: 10)
+
+  _ = S2(required: 10)
+}
+
+func initializeFromNonisolated() {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  _ = S1(required: 10)
+
+  // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  _ = S2(required: 10)
+}
+
+extension A {
+  func initializeFromActorInstance() {
+    // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a actor-isolated context}}
+    _ = S1(required: 10)
+
+    // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a actor-isolated context}}
+    _ = S2(required: 10)
+  }
+}

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -1,0 +1,108 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultArguments -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultArguments -enable-experimental-feature SendNonSendable %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@globalActor
+actor SomeGlobalActor {
+  static let shared = SomeGlobalActor()
+}
+
+@MainActor
+func requiresMainActor() -> Int { 0 }
+
+// expected-note@+2 2 {{calls to global function 'requiresSomeGlobalActor()' from outside of its actor context are implicitly asynchronous}}
+@SomeGlobalActor
+func requiresSomeGlobalActor() -> Int { 0 }
+
+func mainActorDefaultArg(value: Int = requiresMainActor()) {}
+
+func mainActorClosure(
+  closure: () -> Int = {
+    requiresMainActor()
+  }
+) {}
+
+func mainActorClosureCall(
+  closure: Int = {
+    requiresMainActor()
+  }()
+) {}
+
+@MainActor func mainActorCaller() {
+  mainActorDefaultArg()
+  mainActorClosure()
+  mainActorClosureCall()
+}
+
+func nonisolatedCaller() {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorDefaultArg()
+
+  // FIXME: confusing error message.
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorClosure()
+
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorClosureCall()
+}
+
+func nonisolatedAsyncCaller() async {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorDefaultArg()
+
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorClosure()
+
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  mainActorClosureCall()
+
+  await mainActorDefaultArg(value: requiresMainActor())
+
+  // 'await' doesn't help closures in default arguments; the calling context needs a matching
+  // actor isolation for that isolation to be inferred for the closure value.
+
+  // expected-error@+2 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-warning@+1 {{no 'async' operations occur within 'await' expression}}
+  await mainActorClosure()
+
+  // expected-error@+2 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-warning@+1 {{no 'async' operations occur within 'await' expression}}
+  await mainActorClosureCall()
+}
+
+func conflictingIsolationDefaultArg(
+  // expected-error@+1 {{call to global actor 'SomeGlobalActor'-isolated global function 'requiresSomeGlobalActor()' in a synchronous nonisolated context}}
+  value: (Int, Int) = (requiresMainActor(), requiresSomeGlobalActor())
+) {}
+
+func closureLosesIsolation(
+  closure: @Sendable () -> Void = {
+    // expected-note@+1 {{calls to local function 'f()' from outside of its actor context are implicitly asynchronous}}
+    @MainActor func f() {}
+    // expected-error@+1 {{call to main actor-isolated local function 'f()' in a synchronous nonisolated context}}
+    f()
+  }
+) {}
+
+func closureIsolationMismatch(
+  closure: @SomeGlobalActor () -> Void = {
+    // expected-note@+1 {{calls to local function 'f()' from outside of its actor context are implicitly asynchronous}}
+    @MainActor func f() {}
+    // expected-error@+1 {{call to main actor-isolated local function 'f()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
+    f()
+  }
+) {}
+
+func conflictingClosureIsolation(
+  closure: () -> Void = {
+    _ = requiresMainActor()
+    // expected-error@+1 {{call to global actor 'SomeGlobalActor'-isolated global function 'requiresSomeGlobalActor()' in a synchronous nonisolated context}}
+    _ = requiresSomeGlobalActor()
+  }
+) {}

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -147,6 +147,11 @@ struct S2 {
   static var z: Int = requiresSomeGlobalActor()
 }
 
+struct S3 {
+  // expected-error@+1 {{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+  var (x, y, z) = (requiresMainActor(), requiresSomeGlobalActor(), 10)
+}
+
 @MainActor
 func initializeFromMainActor() {
   _ = S1(required: 10)

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultArguments -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultArguments -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultArguments %S/Inputs/serialized_default_arguments.swift
+
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-experimental-feature IsolatedDefaultArguments
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+import SerializedDefaultArguments
+
+@MainActor 
+func mainActorCaller() {
+  useMainActorDefault()
+  useNonisolatedDefault()
+}
+
+func nonisolatedCaller() async {
+  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  await useMainActorDefault()
+
+  await useMainActorDefault(mainActorDefaultArg())
+
+  await useNonisolatedDefault()
+}

--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultArguments %S/Inputs/serialized_default_arguments.swift
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultValues %S/Inputs/serialized_default_arguments.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-experimental-feature IsolatedDefaultArguments
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-experimental-feature IsolatedDefaultValues
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultArguments -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultArguments -enable-experimental-feature SendNonSendable %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@globalActor
+actor SomeGlobalActor {
+  static let shared = SomeGlobalActor()
+}
+
+@MainActor
+func requiresMainActor() -> Int { 0 }
+
+@SomeGlobalActor
+func requiresSomeGlobalActor() -> Int { 0 }
+
+struct S1 {
+  // expected-note@+1 2 {{'self.x' not initialized}}
+  var x = requiresMainActor()
+  // expected-note@+1 2 {{'self.y' not initialized}}
+  var y = requiresSomeGlobalActor()
+  var z = 10
+
+  // expected-error@+1 {{return from initializer without initializing all stored properties}}
+  nonisolated init(a: Int) {}
+
+  // expected-error@+1 {{return from initializer without initializing all stored properties}}
+  @MainActor init(b: Int) {}
+
+  // expected-error@+1 {{return from initializer without initializing all stored properties}}
+  @SomeGlobalActor init(c: Int) {}
+}
+
+struct S2 {
+  var x = requiresMainActor()
+  var y = requiresSomeGlobalActor()
+  var z = 10
+
+  nonisolated init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  @MainActor init(y: Int) {
+    self.y = y
+  }
+
+  @SomeGlobalActor init(x: Int) {
+    self.x = x
+  }
+}
+

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultArguments -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultArguments -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts


### PR DESCRIPTION
* **Explanation**: This is the experimental implementation of allowing default arguments to call global-actor-isolated functions. Actor isolation checking is deferred to the caller; it is an error to use a default argument from across isolation domains. Though this is experimental, cherry-picking is useful to make cherry-picking other actor isolation checker bug fixes easier, and it leaves open the opportunity to close the data-race hole with global-actor-isolated instance properties in 5.10 if the feature is accepted.
* **Scope**: Limited to the actor isolation checker. The implementation is gated behind `-enable-experimental-feature IsolatedDefaultValues`, so it will not impact existing code.
* **Risk**: Low; the feature is not actually enabled.
* **Testing**: Added new tests.
* **Reviewer**: @xedin @ktoso
* **Issue**: rdar://101058224
* **Main branch PR**: https://github.com/apple/swift/pull/68794, https://github.com/apple/swift/pull/69030
