### PR TITLE
TDBGen: amend file type for SwiftAPIDescriptor

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -98,7 +98,7 @@ TYPE("pch",                 PCH,                       "pch",             "")
 TYPE("none",                Nothing,                   "",                "")
 
 TYPE("abi-baseline-json",   SwiftABIDescriptor,        "abi.json",        "")
-TYPE("api-json",            SwiftAPIDescriptor,        "",                "")
+TYPE("api-descriptor-json", SwiftAPIDescriptor,        "",                "")
 TYPE("fixit",               SwiftFixIt,                "",                "")
 TYPE("module-semantic-info", ModuleSemanticInfo,       "",                "")
 TYPE("cached-diagnostics",  CachedDiagnostics,         "",                "")

--- a/test/Frontend/emit-module-api-descriptor.swift
+++ b/test/Frontend/emit-module-api-descriptor.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: echo 'print("Hello, World!")' >%t/main.swift
+// RUN: cd %t
+
+// RUN: %target-swift-frontend -emit-module -emit-api-descriptor-path %t/main.api.json %t/main.swift
+// RUN: test -f %t/main.api.json
+
+// RUN: echo '"%/t/main.swift": { api-descriptor-json: "%/t/foo.api.json" }' > %/t/filemap.yaml
+// RUN: %target-swift-frontend -emit-module -supplementary-output-file-map %/t/filemap.yaml %/t/main.swift
+// RUN: test -f %t/foo.api.json


### PR DESCRIPTION
This is to match the one SwiftDriver expects, so that we generate API descriptors when they are specified in supplementary output files.

Addresses rdar://116809713