### PR TITLE
Update build-windows-toolchain.bat

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -779,7 +779,7 @@ cmake --build %BuildRoot%\19 --target install || (exit /b)
 :: Create Configuration Files
 python -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'DEFAULT_USE_RUNTIME': 'MD' } }), encoding='utf-8'))" > %SDKInstallRoot%\SDKSettings.plist
 :: TODO(compnerd) match the XCTest installation name
-python -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'XCTEST_VERSION': 'development' } }), encoding='utf-8'))" > %PlatformRoot%\Info.plist
+python -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'XCTEST_VERSION': 'development', 'SWIFTC_FLAGS': ['-use-ld=lld'] } }), encoding='utf-8'))" > %PlatformRoot%\Info.plist
 
 IF NOT "%SKIP_PACKAGING%"=="1" call :PackageToolchain || (exit /b)
 


### PR DESCRIPTION
Backport the changes to select the default linker with SPM.  This is required to enable building without the VS developer shell by default.