### PR TITLE
[ASTGen] Cleanup string bridging

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -40,6 +40,40 @@ extension String {
   }
 }
 
+/// Allocate a copy of the given string as a UTF-8 string.
+func allocateBridgedString(
+  _ string: String,
+  nullTerminated: Bool = false
+) -> BridgedString {
+  var string = string
+  return string.withUTF8 { utf8 in
+    let capacity = utf8.count + (nullTerminated ? 1 : 0)
+    let ptr = UnsafeMutablePointer<UInt8>.allocate(
+      capacity: capacity
+    )
+    if let baseAddress = utf8.baseAddress {
+      ptr.initialize(from: baseAddress, count: utf8.count)
+    }
+
+    if nullTerminated {
+      ptr[utf8.count] = 0
+    }
+
+    return BridgedString(data: ptr, length: utf8.count)
+  }
+}
+
+@_cdecl("swift_ASTGen_freeBridgedString")
+public func freeBridgedString(bridged: BridgedString) {
+  bridged.data?.deallocate()
+}
+
+extension BridgedString {
+  var isEmptyInitialized: Bool {
+    return self.data == nil && self.length == 0
+  }
+}
+
 extension SyntaxProtocol {
   /// Obtains the bridged start location of the node excluding leading trivia in the source buffer provided by `astgen`
   ///

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -28,7 +28,7 @@ enum PluginError: String, Error, CustomStringConvertible {
 @_cdecl("swift_ASTGen_initializePlugin")
 public func _initializePlugin(
   opaqueHandle: UnsafeMutableRawPointer,
-  cxxDiagnosticEngine: UnsafeMutablePointer<UInt8>?
+  cxxDiagnosticEngine: UnsafeMutableRawPointer?
 ) -> Bool {
   let plugin = CompilerPlugin(opaqueHandle: opaqueHandle)
   let diagEngine = PluginDiagnosticsEngine(cxxDiagnosticEngine: cxxDiagnosticEngine)
@@ -57,9 +57,9 @@ public func _deinitializePlugin(
 @_cdecl("swift_ASTGen_pluginServerLoadLibraryPlugin")
 func swift_ASTGen_pluginServerLoadLibraryPlugin(
   opaqueHandle: UnsafeMutableRawPointer,
-  libraryPath: UnsafePointer<Int8>,
-  moduleName: UnsafePointer<Int8>,
-  cxxDiagnosticEngine: UnsafeMutablePointer<UInt8>?
+  libraryPath: UnsafePointer<CChar>,
+  moduleName: UnsafePointer<CChar>,
+  cxxDiagnosticEngine: UnsafeMutableRawPointer?
 ) -> Bool {
   let plugin =  CompilerPlugin(opaqueHandle: opaqueHandle)
   let diagEngine = PluginDiagnosticsEngine(cxxDiagnosticEngine: cxxDiagnosticEngine)
@@ -206,12 +206,12 @@ class PluginDiagnosticsEngine {
   private let bridgedDiagEngine: BridgedDiagnosticEngine
   private var exportedSourceFileByName: [String: UnsafePointer<ExportedSourceFile>] = [:]
 
-  init(cxxDiagnosticEngine: UnsafeMutablePointer<UInt8>) {
+  init(cxxDiagnosticEngine: UnsafeMutableRawPointer) {
     self.bridgedDiagEngine = BridgedDiagnosticEngine(raw: cxxDiagnosticEngine)
   }
 
   /// Failable convenience initializer for optional cxx engine pointer.
-  convenience init?(cxxDiagnosticEngine: UnsafeMutablePointer<UInt8>?) {
+  convenience init?(cxxDiagnosticEngine: UnsafeMutableRawPointer?) {
     guard let cxxDiagnosticEngine = cxxDiagnosticEngine else {
       return nil
     }

--- a/lib/ASTGen/Sources/ASTGen/SourceManager.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager.swift
@@ -5,7 +5,7 @@ import SwiftSyntaxMacros
 
 /// A source manager that keeps track of the source files in the program.
 class SourceManager {
-  init(cxxDiagnosticEngine: UnsafeMutablePointer<UInt8>) {
+  init(cxxDiagnosticEngine: UnsafeMutableRawPointer) {
     self.bridgedDiagEngine = BridgedDiagnosticEngine(raw: cxxDiagnosticEngine)
   }
 


### PR DESCRIPTION
* Use `BridgedString` for ASTGen -> C++ string returnings - because why not
* Use null terminated C-strings for C++ -> ASTGen string arguments - As long as it's null-terminated and doesn't contain null byte in the string, there's no benefit to pass the length.
* Use `UnsafeMutableRawPointer` for C++ -> ASTGen diagnostic engine arguments - In C++, it's passed as `void *` swift side should use raw pointers.
