### PR TITLE
[test][IRGen] Disable dylib related tests on WebAssembly

### DIFF
--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -3,7 +3,7 @@
 
 // https://github.com/apple/swift/issues/54619
 // XFAIL: OS=linux-android, CPU=aarch64
-// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnu, CPU=wasm32
 
 // RUN: %target-swift-frontend %s -module-name main -S -o - | %FileCheck -check-prefix=%target-cpu -check-prefix=%target-cpu-%target-sdk-name %s
 

--- a/test/IRGen/pre_specialize.swift
+++ b/test/IRGen/pre_specialize.swift
@@ -168,3 +168,5 @@ public func testPrespecializedUse() {
 
   testSpecialization(AnotherThing())
 }
+// dynamic library with wasm is not supported yet
+// UNSUPPORTED: CPU=wasm32

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-evolution-1argument-1distinct_use-external_resilient-nonfrozen.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=wasm32
 
 import TestModule
 

--- a/test/IRGen/protocol_synthesized.swift
+++ b/test/IRGen/protocol_synthesized.swift
@@ -6,6 +6,7 @@
 // to emit a GenericWitnessTable in the ProtocolConformanceDescriptor so that
 // the initializer for the protocol witness table actually runs.
 // (see rdar://97290618)
+// UNSUPPORTED: CPU=wasm32
 
 import SynthesizedProtocol
 

--- a/test/IRGen/vtable_symbol_linkage.swift
+++ b/test/IRGen/vtable_symbol_linkage.swift
@@ -6,6 +6,8 @@
 // RUN: %target-build-swift %S/Inputs/vtable_symbol_linkage_base.swift -emit-module -emit-module-path=%t/BaseModule.swiftmodule -emit-library -module-name BaseModule -o %t/%target-library-name(BaseModule) -enable-library-evolution
 // RUN: %target-build-swift -I %t %s -o %t/a.out -L%t -lBaseModule
 
+// UNSUPPORTED: CPU=wasm32
+
 // Check if the program can be linked without undefined symbol errors.
 
 import BaseModule


### PR DESCRIPTION
Disable some tests that use `-emit-library` to emit dynamic library because dynamic library from Swift is not supported yet on Wasm. We will enable them after we will get better dylib support in the ecosystem.