### PR TITLE
Add a temporary @_nonEscapable and @_hasUnsafeNonEscapableResult attribute

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -116,6 +116,10 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     }
   }
 
+  public var hasUnsafeNonEscapableResult: Bool {
+    return bridged.hasUnsafeNonEscapableResult()
+  }
+
   /// True if the callee function is annotated with @_semantics("programtermination_point").
   /// This means that the function terminates the program.
   public var isProgramTerminationPoint: Bool { hasSemanticsAttribute("programtermination_point") }

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -58,6 +58,7 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
   public var isMetatype: Bool { bridged.isMetatype() }
   public var isNoEscapeFunction: Bool { bridged.isNoEscapeFunction() }
   public var isAsyncFunction: Bool { bridged.isAsyncFunction() }
+  public var isEscapable: Bool { bridged.isEscapable() }
 
   public var canBeClass: BridgedType.TraitResult { bridged.canBeClass() }
 

--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -625,6 +625,15 @@ This is the default behavior, unless the type annotated is an aggregate that
 consists entirely of `@_eagerMove` or trivial values, in which case the
 attribute overrides the inferred type-level annotation.
 
+## `@_nonEscapable`
+
+Indicates that a type is non-escapable. All instances of this type are
+non-escaping values. A non-escaping value's lifetime must be confined
+to another "parent" lifetime.
+
+This is temporary until ~Escapable syntax is supported, which will
+also work as a generic type constraint.
+
 ## `@_marker`
 
 Indicates that a protocol is a marker protocol. Marker protocols represent some

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -423,6 +423,9 @@ DECL_ATTR(_rawLayout, RawLayout,
 DECL_ATTR(_extern, Extern,
   OnFunc | ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   147)
+SIMPLE_DECL_ATTR(_nonEscapable, NonEscapable,
+  OnNominalType | UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  148)
 CONTEXTUAL_SIMPLE_DECL_ATTR(final, Final,
   OnClass | OnFunc | OnAccessor | OnVar | OnSubscript | DeclModifier | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   2)

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -426,6 +426,9 @@ DECL_ATTR(_extern, Extern,
 SIMPLE_DECL_ATTR(_nonEscapable, NonEscapable,
   OnNominalType | UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   148)
+SIMPLE_DECL_ATTR(_unsafeNonEscapableResult, UnsafeNonEscapableResult,
+  OnAbstractFunction | OnSubscript | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIBreakingToRemove,
+  149)
 CONTEXTUAL_SIMPLE_DECL_ATTR(final, Final,
   OnClass | OnFunc | OnAccessor | OnVar | OnSubscript | DeclModifier | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   2)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2611,6 +2611,12 @@ private:
 
     /// Whether this declaration can not be copied and thus is move only.
     unsigned isMoveOnly : 1;
+
+    /// Whether the "isEscapable" bit has been computed yet.
+    unsigned isEscapable : 1;
+
+    /// Whether this declaration is escapable.
+    unsigned isEscapableComputed : 1;
   } LazySemanticInfo = { };
 
   friend class DynamicallyReplacedDeclRequest;
@@ -2618,6 +2624,7 @@ private:
   friend class IsObjCRequest;
   friend class IsFinalRequest;
   friend class IsMoveOnlyRequest;
+  friend class IsEscapableRequest;
   friend class IsDynamicRequest;
   friend class IsImplicitlyUnwrappedOptionalRequest;
   friend class InterfaceTypeRequest;
@@ -2922,6 +2929,9 @@ public:
 
   /// Is this declaration 'moveOnly'?
   bool isMoveOnly() const;
+
+  /// Is this declaration escapable?
+  bool isEscapable() const;
 
   /// Is this declaration marked with 'dynamic'?
   bool isDynamic() const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7536,6 +7536,9 @@ ERROR(noncopyable_cannot_have_read_set_accessor,none,
       "noncopyable %select{variable|subscript}0 cannot provide a read and set accessor",
       (unsigned))
 
+ERROR(nonescapable_types_attr_disabled,none,
+      "attribute requires '-enable-experimental-feature NonEscapableTypes'", ())
+
 //------------------------------------------------------------------------------
 // MARK: Init accessors
 //------------------------------------------------------------------------------

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -427,6 +427,27 @@ public:
   void cacheResult(bool value) const;
 };
 
+
+/// Determine whether the given declaration is escapable.
+class IsEscapableRequest
+    : public SimpleRequest<IsEscapableRequest, bool(ValueDecl *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  bool evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  llvm::Optional<bool> getCachedResult() const;
+  void cacheResult(bool value) const;
+};
+
 /// Determine whether the given declaration is 'dynamic''.
 class IsDynamicRequest :
     public SimpleRequest<IsDynamicRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -212,6 +212,8 @@ SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsMoveOnlyRequest, bool(ValueDecl *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsEscapableRequest, bool(ValueDecl *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsGetterMutatingRequest, bool(AbstractStorageDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsImplicitlyUnwrappedOptionalRequest,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -252,6 +252,10 @@ EXPERIMENTAL_FEATURE(TypedThrows, true)
 /// Allow destructuring stored `let` bindings in structs.
 EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 
+/// Enable non-escapable type attributes and function attributes that support
+/// lifetime-dependent results.
+EXPERIMENTAL_FEATURE(NonEscapableTypes, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -329,6 +329,7 @@ struct BridgedFunction {
   BRIDGED_INLINE bool isDestructor() const;
   BRIDGED_INLINE bool isGenericFunction() const;
   BRIDGED_INLINE bool hasSemanticsAttr(BridgedStringRef attrName) const;
+  BRIDGED_INLINE bool hasUnsafeNonEscapableResult() const;
   BRIDGED_INLINE EffectsKind getEffectAttribute() const;
   BRIDGED_INLINE PerformanceConstraints getPerformanceConstraints() const;
   BRIDGED_INLINE InlineStrategy getInlineStrategy() const;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -110,6 +110,7 @@ struct BridgedType {
   BRIDGED_INLINE bool isAsyncFunction() const;
   BRIDGED_INLINE TraitResult canBeClass() const;
   BRIDGED_INLINE bool isMoveOnly() const;
+  BRIDGED_INLINE bool isEscapable() const;
   BRIDGED_INLINE bool isOrContainsObjectiveCClass() const;
   BRIDGED_INLINE bool isBuiltinInteger() const;
   BRIDGED_INLINE bool isBuiltinFloat() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -498,6 +498,10 @@ bool BridgedFunction::hasSemanticsAttr(BridgedStringRef attrName) const {
   return getFunction()->hasSemanticsAttr(attrName.get());
 }
 
+bool BridgedFunction::hasUnsafeNonEscapableResult() const {
+  return getFunction()->hasUnsafeNonEscapableResult();
+}
+
 BridgedFunction::EffectsKind BridgedFunction::getEffectAttribute() const {
   return (EffectsKind)getFunction()->getEffectsKind();
 }

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -140,6 +140,10 @@ bool BridgedType::isMoveOnly() const {
   return get().isMoveOnly();
 }
 
+bool BridgedType::isEscapable() const {
+  return get().isEscapable();
+}
+
 bool BridgedType::isOrContainsObjectiveCClass() const {
   return get().isOrContainsObjectiveCClass();
 }

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -434,6 +434,10 @@ private:
   /// from running with pack metadata markers in place.
   unsigned UseStackForPackMetadata : 1;
 
+  /// If true, the function returns a non-escapable value without any
+  /// lifetime-dependence on an argument.
+  unsigned HasUnsafeNonEscapableResult : 1;
+
   static void
   validateSubclassScope(SubclassScope scope, IsThunk_t isThunk,
                         const GenericSpecializationInformation *genericInfo) {
@@ -714,6 +718,14 @@ public:
 
   void setUseStackForPackMetadata(UseStackForPackMetadata_t value) {
     UseStackForPackMetadata = value;
+  }
+
+  bool hasUnsafeNonEscapableResult() const {
+    return HasUnsafeNonEscapableResult;
+  }
+
+  void setHasUnsafeNonEscapableResult(bool value) {
+    HasUnsafeNonEscapableResult = value;
   }
 
   /// Returns true if this is a reabstraction thunk of escaping function type

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -881,6 +881,10 @@ public:
   ProtocolConformanceRef conformsToProtocol(SILFunction *fn,
                                             ProtocolDecl *protocol) const;
 
+  /// False if SILValues of this type cannot be used outside the scope of their
+  /// lifetime dependence.
+  bool isEscapable() const;
+
   //
   // Accessors for types used in SIL instructions:
   //

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3512,6 +3512,11 @@ static bool usesFeatureStructLetDestructuring(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureNonEscapableTypes(Decl *decl) {
+  return decl->getAttrs().hasAttribute<NonEscapableAttr>()
+    || decl->getAttrs().hasAttribute<UnsafeNonEscapableResultAttr>();
+}
+
 static bool hasParameterPacks(Decl *decl) {
   if (auto genericContext = decl->getAsGenericContext()) {
     auto sig = genericContext->getGenericSignature();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3562,6 +3562,12 @@ bool ValueDecl::isMoveOnly() const {
                            getAttrs().hasAttribute<MoveOnlyAttr>());
 }
 
+bool ValueDecl::isEscapable() const {
+  return evaluateOrDefault(getASTContext().evaluator,
+                           IsEscapableRequest{const_cast<ValueDecl *>(this)},
+                           !getAttrs().hasAttribute<NonEscapableAttr>());
+}
+
 bool ValueDecl::isDynamic() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -337,6 +337,29 @@ void IsMoveOnlyRequest::cacheResult(bool value) const {
 }
 
 //----------------------------------------------------------------------------//
+// isEscapable computation.
+//----------------------------------------------------------------------------//
+
+llvm::Optional<bool> IsEscapableRequest::getCachedResult() const {
+  auto decl = std::get<0>(getStorage());
+  if (decl->LazySemanticInfo.isEscapableComputed)
+    return decl->LazySemanticInfo.isEscapable;
+
+  return llvm::None;
+}
+
+void IsEscapableRequest::cacheResult(bool value) const {
+  auto decl = std::get<0>(getStorage());
+  decl->LazySemanticInfo.isEscapableComputed = true;
+  decl->LazySemanticInfo.isEscapable = value;
+
+  // Add an attribute for printing
+  if (!value && !decl->getAttrs().hasAttribute<NonEscapableAttr>())
+    decl->getAttrs().add(new (decl->getASTContext())
+                             NonEscapableAttr(/*Implicit=*/true));
+}
+
+//----------------------------------------------------------------------------//
 // isDynamic computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -208,6 +208,7 @@ void SILFunction::init(
   this->IsRuntimeAccessible = isRuntimeAccessible;
   this->ForceEnableLexicalLifetimes = DoNotForceEnableLexicalLifetimes;
   this->UseStackForPackMetadata = DoUseStackForPackMetadata;
+  this->HasUnsafeNonEscapableResult = false;
   this->stackProtection = false;
   this->Inlined = false;
   this->Zombie = false;

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -197,6 +197,10 @@ void SILFunctionBuilder::addFunctionAttributes(
     F->setForceEnableLexicalLifetimes(DoForceEnableLexicalLifetimes);
   }
 
+  if (Attrs.hasAttribute<UnsafeNonEscapableResultAttr>()) {
+    F->setHasUnsafeNonEscapableResult(true);
+  }
+
   // Validate `@differentiable` attributes by calling `getParameterIndices`.
   // This is important for:
   // - Skipping invalid `@differentiable` attributes in non-primary files.

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3245,6 +3245,9 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   if (!useStackForPackMetadata()) {
     OS << "[no_onstack_pack_metadata] ";
   }
+  if (hasUnsafeNonEscapableResult()) {
+    OS << "[unsafe_nonescapable_result] ";
+  }
 
   if (isExactSelfClass()) {
     OS << "[exact_self_class] ";

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1130,6 +1130,13 @@ bool SILType::isMarkedAsImmortal() const {
   return false;
 }
 
+bool SILType::isEscapable() const {
+  if (auto *nom = getASTType().getAnyNominal())
+    return nom->isEscapable();
+
+  return true;
+}
+
 intptr_t SILType::getFieldIdxOfNominalType(StringRef fieldName) const {
   auto *nominal = getNominalOrBoundGenericNominal();
   if (!nominal)

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2411,7 +2411,9 @@ namespace {
         return new (TC) MoveOnlyLoadableStructTypeLowering(
             structType, properties, Expansion);
       }
-
+      if (!D->isEscapable()) {
+        properties.setNonTrivial();
+      }
       return handleAggregateByProperties<LoadableStructTypeLowering>(structType,
                                                                     properties);
     }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -7477,9 +7477,9 @@ bool SILParserState::parseSILGlobal(Parser &P) {
       parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, &isLet, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, &isLet, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           State, M) ||
+                           nullptr, State, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
       P.parseIdentifier(GlobalName, NameLoc, /*diagnoseDollarPrefix=*/false,
                         diag::expected_sil_value_name) ||
@@ -7531,7 +7531,7 @@ bool SILParserState::parseSILProperty(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           SP, M))
+                           nullptr, SP, M))
     return true;
   
   ValueDecl *VD;
@@ -7601,7 +7601,7 @@ bool SILParserState::parseSILVTable(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           VTableState, M))
+                           nullptr, VTableState, M))
     return true;
 
   // Parse the class name.
@@ -7712,7 +7712,7 @@ bool SILParserState::parseSILMoveOnlyDeinit(Parser &parser) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           moveOnlyDeinitTableState, M))
+                           nullptr, moveOnlyDeinitTableState, M))
     return true;
 
   // Parse the class name.
@@ -8199,7 +8199,7 @@ bool SILParserState::parseSILWitnessTable(Parser &P) {
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           WitnessState, M))
+                           nullptr, WitnessState, M))
     return true;
 
   // Parse the protocol conformance.

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1044,6 +1044,7 @@ static bool parseDeclSILOptional(bool *isTransparent,
                                  IsRuntimeAccessible_t *isRuntimeAccessible,
                                  ForceEnableLexicalLifetimes_t *forceEnableLexicalLifetimes,
                                  UseStackForPackMetadata_t *useStackForPackMetadata,
+                                 bool *hasUnsafeNonEscapableResult,
                                  IsExactSelfClass_t *isExactSelfClass,
                                  SILFunction **dynamicallyReplacedFunction,
                                  SILFunction **usedAdHocRequirementWitness,
@@ -1089,6 +1090,9 @@ static bool parseDeclSILOptional(bool *isTransparent,
       *forceEnableLexicalLifetimes = DoForceEnableLexicalLifetimes;
     else if (useStackForPackMetadata &&
              SP.P.Tok.getText() == "no_onstack_pack_metadata")
+      *useStackForPackMetadata = DoNotUseStackForPackMetadata;
+    else if (hasUnsafeNonEscapableResult &&
+             SP.P.Tok.getText() == "unsafe_nonescapable_result")
       *useStackForPackMetadata = DoNotUseStackForPackMetadata;
     else if (isExactSelfClass && SP.P.Tok.getText() == "exact_self_class")
       *isExactSelfClass = IsExactSelfClass;
@@ -7201,6 +7205,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
   ForceEnableLexicalLifetimes_t forceEnableLexicalLifetimes =
       DoNotForceEnableLexicalLifetimes;
   UseStackForPackMetadata_t useStackForPackMetadata = DoUseStackForPackMetadata;
+  bool hasUnsafeNonEscapableResult = false;
   IsExactSelfClass_t isExactSelfClass = IsNotExactSelfClass;
   bool hasOwnershipSSA = false;
   IsThunk_t isThunk = IsNotThunk;
@@ -7226,6 +7231,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
           &isTransparent, &isSerialized, &isCanonical, &hasOwnershipSSA,
           &isThunk, &isDynamic, &isDistributed, &isRuntimeAccessible,
           &forceEnableLexicalLifetimes, &useStackForPackMetadata,
+          &hasUnsafeNonEscapableResult,
           &isExactSelfClass, &DynamicallyReplacedFunction,
           &AdHocWitnessFunction, &objCReplacementFor, &specialPurpose,
           &inlineStrategy, &optimizationMode, &perfConstr, &markedAsUsed,
@@ -7266,6 +7272,8 @@ bool SILParserState::parseDeclSIL(Parser &P) {
     FunctionState.F->setForceEnableLexicalLifetimes(
         forceEnableLexicalLifetimes);
     FunctionState.F->setUseStackForPackMetadata(useStackForPackMetadata);
+    FunctionState.F->setHasUnsafeNonEscapableResult(
+      hasUnsafeNonEscapableResult);
     FunctionState.F->setIsExactSelfClass(isExactSelfClass);
     FunctionState.F->setDynamicallyReplacedFunction(
         DynamicallyReplacedFunction);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -162,6 +162,7 @@ public:
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(LexicalLifetimes)
   IGNORED_ATTR(NonEscapable)
+  IGNORED_ATTR(UnsafeNonEscapableResult)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -161,6 +161,7 @@ public:
   IGNORED_ATTR(BackDeployed)
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(LexicalLifetimes)
+  IGNORED_ATTR(NonEscapable)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -161,8 +161,6 @@ public:
   IGNORED_ATTR(BackDeployed)
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(LexicalLifetimes)
-  IGNORED_ATTR(NonEscapable)
-  IGNORED_ATTR(UnsafeNonEscapableResult)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {
@@ -349,6 +347,9 @@ public:
   void visitMacroRoleAttr(MacroRoleAttr *attr);
   
   void visitRawLayoutAttr(RawLayoutAttr *attr);
+
+  void visitNonEscapableAttr(NonEscapableAttr *attr);
+  void visitUnsafeNonEscapableResultAttr(UnsafeNonEscapableResultAttr *attr);
 };
 
 } // end anonymous namespace
@@ -7058,6 +7059,19 @@ void AttributeChecker::visitRawLayoutAttr(RawLayoutAttr *attr) {
   
   // The storage is not directly referenceable by stored properties.
   sd->setHasUnreferenceableStorage(true);
+}
+
+void AttributeChecker::visitNonEscapableAttr(NonEscapableAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::NonEscapableTypes)) {
+    diagnoseAndRemoveAttr(attr, diag::nonescapable_types_attr_disabled);
+  }
+}
+
+void AttributeChecker::visitUnsafeNonEscapableResultAttr(
+  UnsafeNonEscapableResultAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::NonEscapableTypes)) {
+    diagnoseAndRemoveAttr(attr, diag::nonescapable_types_attr_disabled);
+  }
 }
 
 namespace {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -927,6 +927,13 @@ bool IsMoveOnlyRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   return false;
 }
 
+bool IsEscapableRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
+  if (isa<ClassDecl>(decl) || isa<StructDecl>(decl) || isa<EnumDecl>(decl)) {
+    return !decl->getAttrs().hasAttribute<NonEscapableAttr>();
+  }
+  return true;
+}
+
 bool
 IsStaticRequest::evaluate(Evaluator &evaluator, FuncDecl *decl) const {
   if (auto *accessor = dyn_cast<AccessorDecl>(decl))

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1626,6 +1626,7 @@ namespace  {
 
     UNINTERESTING_ATTR(MacroRole)
     UNINTERESTING_ATTR(LexicalLifetimes)
+    UNINTERESTING_ATTR(NonEscapable)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1627,6 +1627,7 @@ namespace  {
     UNINTERESTING_ATTR(MacroRole)
     UNINTERESTING_ATTR(LexicalLifetimes)
     UNINTERESTING_ATTR(NonEscapable)
+    UNINTERESTING_ATTR(UnsafeNonEscapableResult)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/test/SIL/Parser/attributes.sil
+++ b/test/SIL/Parser/attributes.sil
@@ -23,3 +23,9 @@ bb0:
 // Make sure we don't try to parse the Swift decl as '@owned() func baz()'.
 sil @bar : $@convention(thin) () -> @owned ()
 func baz()
+
+sil [unsafe_nonescapable_result] [ossa] @test_unsafe_nonescapable : $@convention(thin) () -> () {
+bb0:
+  %1 = tuple ()
+  return %1 : $()
+}

--- a/test/attr/attr_nonEscapable.swift
+++ b/test/attr/attr_nonEscapable.swift
@@ -1,5 +1,15 @@
 // RUN: %target-typecheck-verify-swift
 
-@_nonEscapable public struct S {
+@_nonEscapable public struct NES {
   let x: Int
+
+  @_unsafeNonEscapableResult
+  init() {
+    x = 0
+  }
+
+  @_unsafeNonEscapableResult
+  static func makeS() -> NES {
+    return NES()
+  }
 }

--- a/test/attr/attr_nonEscapable.swift
+++ b/test/attr/attr_nonEscapable.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+@_nonEscapable public struct S {
+  let x: Int
+}

--- a/test/attr/attr_nonEscapable.swift
+++ b/test/attr/attr_nonEscapable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonEscapableTypes
 
 @_nonEscapable public struct NES {
   let x: Int


### PR DESCRIPTION
@_nonEscapable type attribute is for testing compiler support until we have the ~Escapable syntax.

@_unsafeNonEscapableResult function attribute allows NonEscapable types to be returned from a function for testing non-escapable library development.