### PR TITLE
Reduce rebuilds when running buildbot_incremental presets in succession

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2154,6 +2154,13 @@ build-ninja
 build-swift-stdlib-unittest-extra
 skip-build-benchmarks
 
+# This is needed to avoid needless rebuild
+# (in particolar compiler-rt) if we run
+# presets focused on testing like
+# buildbot_incremental,*,test=*
+# after buildbot_incremental,*,build
+lit-args=-v
+
 [preset: mixin_buildbot_incremental,test=macOS,type=device]
 
 test


### PR DESCRIPTION
We have some configurations in which we run a preset that only builds the compiler, and then a few ones to tests such binary, e.g.

```
buildbot_incremental,tools=RA,stdlib=RD,build
buildbot_incremental,tools=RA,stdlib=RD,test=macOS,type=device
buildbot_incremental,tools=RA,stdlib=RD,test=iOS,type=simulator
buildbot_incremental,tools=RA,stdlib=RD,test=watchOS,type=simulator
```

Contrary to the other presets, in the first preset we did not specify "--lit-args" since it is not necessary -- however that plays a part in the configuration of compiler-rt, causing an unwanted rebuild when that parameter is specified in the following preset.

Addresses rdar://116922016