### PR TITLE
[5.10] Reduce rebuilds when running buildbot_incremental presets in succession

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2166,6 +2166,13 @@ build-ninja
 build-swift-stdlib-unittest-extra
 skip-build-benchmarks
 
+# This is needed to avoid needless rebuild
+# (in particolar compiler-rt) if we run
+# presets focused on testing like
+# buildbot_incremental,*,test=*
+# after buildbot_incremental,*,build
+lit-args=-v
+
 [preset: mixin_buildbot_incremental,test=macOS,type=device]
 
 test


### PR DESCRIPTION
**Explanation:** explicitly set `lit-args` for `buildbot_incremental,*,build` presets, so that when we run matching `buildbot_incremental,*,test=` on the same build folder we don't have any unnecessary rebuilds in LLVM
**Radar:** rdar://116922016
**Scope:** `buildbot_incremental,*,build` presets
**Risk:** low
* `buildbot_incremental,*,test` presets are currently specifying the same value for `lit-args`
* at worst build times will remain the same instead of descreasing

**Testing:** run at desk a build of `buildbot_incremental,tools=RA,stdlib=RD,build`  followed by `buildbot_incremental,tools=RA,stdlib=RD,test=macOS,type=device`, and checked there is no rebuild of compiler-rt
**Reviewed by:**

(cherry picked from commit 6cf157e181c3692e2e8b020222223895f45fa429)