### PR TITLE
SIL: Treat store_borrow as borrowing its source, and have the move-only checker account for borrow scopes.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -254,6 +254,7 @@ public:
   enum Kind : uint8_t {
     Invalid = 0,
     BeginBorrow,
+    StoreBorrow,
     BeginApply,
     Branch,
     Apply,
@@ -277,6 +278,8 @@ public:
       return Kind::Invalid;
     case SILInstructionKind::BeginBorrowInst:
       return Kind::BeginBorrow;
+    case SILInstructionKind::StoreBorrowInst:
+      return Kind::StoreBorrow;
     case SILInstructionKind::BeginApplyInst:
       return Kind::BeginApply;
     case SILInstructionKind::BranchInst:
@@ -386,6 +389,7 @@ struct BorrowingOperand {
     case BorrowingOperandKind::Invalid:
       llvm_unreachable("Using invalid case?!");
     case BorrowingOperandKind::BeginBorrow:
+    case BorrowingOperandKind::StoreBorrow:
     case BorrowingOperandKind::BeginApply:
     case BorrowingOperandKind::Apply:
     case BorrowingOperandKind::TryApply:
@@ -418,6 +422,7 @@ struct BorrowingOperand {
     case BorrowingOperandKind::BeginBorrow:
     case BorrowingOperandKind::Branch:
       return true;
+    case BorrowingOperandKind::StoreBorrow:
     case BorrowingOperandKind::BeginApply:
     case BorrowingOperandKind::Apply:
     case BorrowingOperandKind::TryApply:
@@ -790,7 +795,6 @@ public:
     RefTailAddr,
     OpenExistentialBox,
     ProjectBox,
-    StoreBorrow,
   };
 
 private:
@@ -819,8 +823,6 @@ public:
       return Kind::OpenExistentialBox;
     case SILInstructionKind::ProjectBoxInst:
       return Kind::ProjectBox;
-    case SILInstructionKind::StoreBorrowInst:
-      return Kind::StoreBorrow;
     }
   }
 
@@ -839,8 +841,6 @@ public:
       return Kind::OpenExistentialBox;
     case ValueKind::ProjectBoxInst:
       return Kind::ProjectBox;
-    case ValueKind::StoreBorrowInst:
-      return Kind::StoreBorrow;
     }
   }
 
@@ -897,8 +897,7 @@ struct InteriorPointerOperand {
     case InteriorPointerOperandKind::RefElementAddr:
     case InteriorPointerOperandKind::RefTailAddr:
     case InteriorPointerOperandKind::OpenExistentialBox:
-    case InteriorPointerOperandKind::ProjectBox:
-    case InteriorPointerOperandKind::StoreBorrow: {
+    case InteriorPointerOperandKind::ProjectBox: {
       // Ok, we have a valid instruction. Return the relevant operand.
       auto *op =
           &cast<SingleValueInstruction>(resultValue)->getAllOperands()[0];
@@ -941,8 +940,6 @@ struct InteriorPointerOperand {
       return cast<OpenExistentialBoxInst>(operand->getUser());
     case InteriorPointerOperandKind::ProjectBox:
       return cast<ProjectBoxInst>(operand->getUser());
-    case InteriorPointerOperandKind::StoreBorrow:
-      return cast<StoreBorrowInst>(operand->getUser());
     }
     llvm_unreachable("Covered switch isn't covered?!");
   }

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -452,7 +452,7 @@ OperandOwnership OperandOwnershipClassifier::visitBranchInst(BranchInst *bi) {
 OperandOwnership
 OperandOwnershipClassifier::visitStoreBorrowInst(StoreBorrowInst *i) {
   if (getValue() == i->getSrc()) {
-    return OperandOwnership::InteriorPointer;
+    return OperandOwnership::Borrow;
   }
   return OperandOwnership::TrivialUse;
 }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -437,6 +437,17 @@ bool Implementation::gatherUses(SILValue value) {
                             false /*is lifetime ending*/}});
       liveness.updateForUse(nextUse->getUser(), *leafRange,
                             false /*is lifetime ending*/);
+      // The liveness extends to the scope-ending uses of the borrow.
+      BorrowingOperand(nextUse).visitScopeEndingUses([&](Operand *end) -> bool {
+        if (end->getOperandOwnership() == OperandOwnership::Reborrow) {
+          return false;
+        }
+        LLVM_DEBUG(llvm::dbgs() << "        ++ Scope-ending use: ";
+                   end->getUser()->print(llvm::dbgs()));
+        liveness.updateForUse(end->getUser(), *leafRange,
+                              false /*is lifetime ending*/);
+        return true;
+      });
       instToInterestingOperandIndexMap.insert(nextUse->getUser(), nextUse);
 
       continue;
@@ -1001,6 +1012,48 @@ dumpIntervalMap(IntervalMapAllocator::Map &map) {
 }
 #endif
 
+// Helper to insert end_borrows after the end of a non-consuming use. If the
+// use is momentary, one end_borrow is inserted after the use. If it is an
+// interior pointer projection or nested borrow, then end_borrows are inserted
+// after every scope-ending instruction for the use.
+static void insertEndBorrowsForNonConsumingUse(Operand *op,
+                                               SILValue borrow) {
+  if (auto iOp = InteriorPointerOperand::get(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "    -- Ending borrow after interior pointer scope:\n"
+                               "    ";
+               op->getUser()->print(llvm::dbgs()));
+    iOp.visitBaseValueScopeEndingUses([&](Operand *endScope) -> bool {
+      auto *endScopeInst = endScope->getUser();
+      LLVM_DEBUG(llvm::dbgs() << "       ";
+                 endScopeInst->print(llvm::dbgs()));
+      SILBuilderWithScope endBuilder(endScopeInst);
+      endBuilder.createEndBorrow(getSafeLoc(endScopeInst), borrow);
+      return true;
+    });
+  } else if (auto bOp = BorrowingOperand(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "    -- Ending borrow after borrow scope:\n"
+                               "    ";
+               op->getUser()->print(llvm::dbgs()));
+    bOp.visitScopeEndingUses([&](Operand *endScope) -> bool {
+      auto *endScopeInst = endScope->getUser();
+      LLVM_DEBUG(llvm::dbgs() << "       ";
+                 endScopeInst->print(llvm::dbgs()));
+      auto afterScopeInst = endScopeInst->getNextInstruction();
+      SILBuilderWithScope endBuilder(afterScopeInst);
+      endBuilder.createEndBorrow(getSafeLoc(afterScopeInst),
+                                 borrow);
+      return true;
+    });
+  } else {
+    auto *nextInst = op->getUser()->getNextInstruction();
+    LLVM_DEBUG(llvm::dbgs() << "    -- Ending borrow after momentary use at: ";
+               nextInst->print(llvm::dbgs()));
+    SILBuilderWithScope endBuilder(nextInst);
+    endBuilder.createEndBorrow(getSafeLoc(nextInst), borrow);
+  }
+  
+}
+
 void Implementation::rewriteUses(InstructionDeleter *deleter) {
   blocksToUses.setFrozen();
 
@@ -1129,6 +1182,8 @@ void Implementation::rewriteUses(InstructionDeleter *deleter) {
           }
 
           // Otherwise, we need to insert a borrow.
+          LLVM_DEBUG(llvm::dbgs() << "    Inserting borrow for: ";
+                     inst->print(llvm::dbgs()));
           SILBuilderWithScope borrowBuilder(inst);
           SILValue borrow =
               borrowBuilder.createBeginBorrow(getSafeLoc(inst), first);
@@ -1138,21 +1193,10 @@ void Implementation::rewriteUses(InstructionDeleter *deleter) {
                 borrowBuilder.createGuaranteedMoveOnlyWrapperToCopyableValue(
                     getSafeLoc(inst), innerValue);
           }
+          
+          insertEndBorrowsForNonConsumingUse(&operand, borrow);
 
-          if (auto op = InteriorPointerOperand::get(&operand)) {
-            op.visitBaseValueScopeEndingUses([&](Operand *endScope) -> bool {
-              auto *endScopeInst = endScope->getUser();
-              SILBuilderWithScope endBuilder(endScopeInst);
-              endBuilder.createEndBorrow(getSafeLoc(endScopeInst), borrow);
-              return true;
-            });
-          } else {
-            auto *nextInst = inst->getNextInstruction();
-            SILBuilderWithScope endBuilder(nextInst);
-            endBuilder.createEndBorrow(getSafeLoc(nextInst), borrow);
-          }
-
-          // NOTE: This needs to be /after/the interior pointer operand usage
+          // NOTE: This needs to be /after/ the interior pointer operand usage
           // above so that we can use the end scope of our interior pointer base
           // value.
           // NOTE: oldInst may be nullptr if our operand is a SILArgument
@@ -1245,9 +1289,7 @@ void Implementation::rewriteUses(InstructionDeleter *deleter) {
             }
           }
 
-          auto *nextInst = inst->getNextInstruction();
-          SILBuilderWithScope endBuilder(nextInst);
-          endBuilder.createEndBorrow(getSafeLoc(nextInst), borrow);
+          insertEndBorrowsForNonConsumingUse(&operand, borrow);
           continue;
         }
 
@@ -1333,6 +1375,13 @@ void Implementation::rewriteUses(InstructionDeleter *deleter) {
 }
 
 void Implementation::cleanup() {
+  LLVM_DEBUG(llvm::dbgs()
+             << "Performing BorrowToDestructureTransform::cleanup()!\n");
+  SWIFT_DEFER {
+    LLVM_DEBUG(llvm::dbgs() << "Function after cleanup!\n";
+               getMarkedValue()->getFunction()->dump());
+  };
+
   // Then add destroys for any destructure elements that we inserted that we did
   // not actually completely consume.
   auto *fn = getMarkedValue()->getFunction();
@@ -1793,11 +1842,15 @@ bool BorrowToDestructureTransform::transform() {
   // Then clean up all of our borrows/copies/struct_extracts which no longer
   // have any uses...
   {
+    LLVM_DEBUG(llvm::dbgs() << "Deleting dead instructions!\n");
+
     InstructionDeleter deleter;
     while (!borrowWorklist.empty()) {
       deleter.recursivelyForceDeleteUsersAndFixLifetimes(
           borrowWorklist.pop_back_val());
     }
+    LLVM_DEBUG(llvm::dbgs() << "Function after deletion!\n";
+               impl.getMarkedValue()->getFunction()->dump());
   }
 
   return true;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -162,7 +162,6 @@ SILCombiner::optimizeBuiltinCOWBufferForReadingOSSA(BuiltinInst *bi) {
             return;
           case InteriorPointerOperandKind::OpenExistentialBox:
           case InteriorPointerOperandKind::ProjectBox:
-          case InteriorPointerOperandKind::StoreBorrow:
             // Can not mark this immutable.
             return;
           }

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -129,6 +129,8 @@ static bool isDestroyOfCopyOf(SILInstruction *instruction, SILValue def) {
 //===----------------------------------------------------------------------===//
 
 bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
+  LLVM_DEBUG(llvm::dbgs() << "Computing canonical liveness from:\n";
+             getCurrentDef()->print(llvm::dbgs()));
   defUseWorklist.initialize(getCurrentDef());
   // Only the first level of reborrows need to be consider. All nested inner
   // adjacent reborrows and phis are encapsulated within their lifetimes.
@@ -140,7 +142,13 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
     });
   }
   while (SILValue value = defUseWorklist.pop()) {
+    LLVM_DEBUG(llvm::dbgs() << "  Uses of value:\n";
+               value->print(llvm::dbgs()));
+
     for (Operand *use : value->getUses()) {
+      LLVM_DEBUG(llvm::dbgs() << "    Use:\n";
+                 use->getUser()->print(llvm::dbgs()));
+      
       auto *user = use->getUser();
       // Recurse through copies.
       if (auto *copy = dyn_cast<CopyValueInst>(user)) {
@@ -169,6 +177,7 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
       // escape. Is it legal to canonicalize ForwardingUnowned?
       case OperandOwnership::ForwardingUnowned:
       case OperandOwnership::PointerEscape:
+        LLVM_DEBUG(llvm::dbgs() << "      Value escaped! Giving up\n");
         return false;
       case OperandOwnership::InstantaneousUse:
       case OperandOwnership::UnownedInstantaneousUse:
@@ -197,7 +206,8 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
         break;
       case OperandOwnership::Borrow:
         if (liveness->updateForBorrowingOperand(use)
-            != InnerBorrowKind::Contained) {
+              != InnerBorrowKind::Contained) {
+          LLVM_DEBUG(llvm::dbgs() << "      Inner borrow can't be contained! Giving up\n");
           return false;
         }
         break;
@@ -1133,10 +1143,12 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
 //===----------------------------------------------------------------------===//
 
 bool CanonicalizeOSSALifetime::computeLiveness() {
-  if (currentDef->getOwnershipKind() != OwnershipKind::Owned)
-    return false;
-
   LLVM_DEBUG(llvm::dbgs() << "  Canonicalizing: " << currentDef);
+
+  if (currentDef->getOwnershipKind() != OwnershipKind::Owned) {
+    LLVM_DEBUG(llvm::dbgs() << "  not owned, never mind\n");
+    return false;
+  }
 
   // Note: There is no need to register callbacks with this utility. 'onDelete'
   // is the only one in use to handle dangling pointers, which could be done
@@ -1154,7 +1166,7 @@ bool CanonicalizeOSSALifetime::computeLiveness() {
 
   // Step 1: compute liveness
   if (!computeCanonicalLiveness()) {
-    LLVM_DEBUG(llvm::errs() << "Failed to compute canonical liveness?!\n");
+    LLVM_DEBUG(llvm::dbgs() << "Failed to compute canonical liveness?!\n");
     clear();
     return false;
   }

--- a/test/SILOptimizer/OSLogMandatoryOptTest.swift
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.swift
@@ -46,9 +46,8 @@ func testSimpleInterpolation() {
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
   // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
+  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
   // We need to wade through some borrows and copy values here.
-  // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
@@ -93,8 +92,7 @@ func testInterpolationWithFormatOptions() {
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
   // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
-  // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
+  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
@@ -141,8 +139,7 @@ func testInterpolationWithFormatOptionsAndPrivacy() {
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
   // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
-  // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
+  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
@@ -195,9 +192,8 @@ func testInterpolationWithMultipleArguments() {
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
   // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
+  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAYADDR]] = alloc_stack $Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>
-  // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
@@ -246,8 +242,7 @@ func testLogMessageWithoutData() {
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
   // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to {{.*}} 
-  // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
+  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to {{.*}} 
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[ARGSARRAY:%[0-9]+]]
   // CHECK-DAG: ([[ARGSARRAY]], {{%.*}}) = destructure_tuple [[ARRAYINITRES:%[0-9]+]]
@@ -319,8 +314,7 @@ func testMessageWithTooManyArguments() {
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
   // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
-  // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
+  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
@@ -404,8 +398,7 @@ func testDynamicStringArguments() {
 
   // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
   // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
-  // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
+  // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
   // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
   // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
@@ -457,8 +450,7 @@ func testNSObjectInterpolation() {
 
     // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
     // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-    // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
-    // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
+    // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
     // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
     // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
     // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
@@ -505,8 +497,7 @@ func testDoubleInterpolation() {
 
     // CHECK-DAG: [[FOREACH:%[0-9]+]] = function_ref @$sSTsE7forEachyyy7ElementQzKXEKF
     // CHECK-DAG: try_apply [[FOREACH]]<Array<(inout UnsafeMutablePointer<UInt8>, inout Optional<UnsafeMutablePointer<NSObject>>, inout Optional<UnsafeMutablePointer<Any>>) -> ()>>({{%.*}}, [[SB:%[0-9]+]])
-    // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY2:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
-    // CHECK-DAG: [[ARGSARRAY2]] = begin_borrow [[ARGSARRAY3:%[0-9]+]]
+    // CHECK-DAG: [[SB]] = store_borrow [[ARGSARRAY3:%[0-9]+]] to [[ARGSARRAYADDR:%[0-9]+]]
     // CHECK-DAG: [[ARGSARRAY3]] = copy_value [[ARGSARRAY4:%[0-9]+]]
     // CHECK-DAG: [[ARGSARRAY4]] = begin_borrow [[FINARR:%[0-9]+]]
     // CHECK-DAG: [[FINARRFUNC:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF

--- a/test/SILOptimizer/moveonly_resilient_property_reader.swift
+++ b/test/SILOptimizer/moveonly_resilient_property_reader.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -enable-experimental-feature MoveOnlyResilientTypes -enable-library-evolution -emit-sil %s | %FileCheck %s
+
+public struct ResilientMemberC {}
+public struct ResilientMemberNC: ~Copyable {}
+
+public struct Resilient: ~Copyable {
+    // CHECK-LABEL: sil @${{.*}}9pubPropNC{{.*}}vr :
+    // CHECK:         [[BASE:%.*]] = load {{.*}} : $*Resilient
+    // CHECK:         [[PROJ_BUF:%.*]] = alloc_stack $ResilientMemberNC
+    // CHECK:         [[PROJ:%.*]] = struct_extract [[BASE]]
+    // CHECK:         store [[PROJ]] to [[PROJ_BUF]]
+    // CHECK:         yield [[PROJ_BUF]]
+    public var pubPropNC: ResilientMemberNC = ResilientMemberNC()
+}
+


### PR DESCRIPTION
When rewriting uses of a noncopyable value, the move-only checker failed to take into account the scope of borrowing uses when establishing the final lifetimes of values. One way this manifested was when borrowed values get reabstracted from value to in-memory representations, using a store_borrow instruction, the lifetime of the original borrow would be ended immediately after the store_borrow begins rather than after the matching end_borrow. Fix this by, first, changing `store_borrow` to be treated as a borrowing use of its source rather than an interior-pointer use; this should be more accurate overall since `store_borrow` borrows the entire source value for a well-scoped duration balanced by `end_borrow` instructions. That done, change MoveOnlyBorrowToDestructureUtils so that when it sees a borrow use, it ends the borrow at the end(s) of the use's borrow scope, instead of immediately after the beginning of the use.