### PR TITLE
[CSDiagnostics] Adjust how requirement failures anchor type is computed

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -216,8 +216,7 @@ bool FailureDiagnostic::conformsToKnownProtocol(
 }
 
 Type RequirementFailure::getOwnerType() const {
-  auto anchor = getRawAnchor();
-
+  auto anchor = getAnchor();
   // If diagnostic is anchored at assignment expression
   // it means that requirement failure happened while trying
   // to convert source to destination, which means that

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5729,6 +5729,13 @@ void constraints::simplifyLocator(ASTNode &anchor,
       // Extract tuple element.
       auto elt = path[0].castTo<LocatorPathElt::AnyTupleElement>();
       unsigned index = elt.getIndex();
+
+      if (auto *AE = getAsExpr<AssignExpr>(anchor)) {
+        if (isa<TupleExpr>(AE->getSrc())) {
+          anchor = AE->getSrc();
+        }
+      }
+
       if (auto tupleExpr = getAsExpr<TupleExpr>(anchor)) {
         if (index < tupleExpr->getNumElements()) {
           anchor = tupleExpr->getElement(index);
@@ -5744,6 +5751,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
           continue;
         }
       }
+
       break;
     }
 

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -353,7 +353,7 @@ func existential_good<T: P1>(_: T.Type) {
 }
 
 func existential_bad<T>(_: T.Type) {
-  _ = Free<T>() as P2 // expected-error{{protocol 'P2' requires that 'T' conform to 'P1'}}
+  _ = Free<T>() as P2 // expected-error{{generic struct 'Free' requires that 'T' conform to 'P1'}}
 }
 
 // rdar://problem/35837054

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -45,7 +45,7 @@ func arraySameType() {
 
     let _: SameType = arrayWorks as SameType
     let _: SameType = arrayFails as SameType
-    // expected-error@-1 {{protocol 'SameType' requires the types 'Fails' and 'Works' be equivalent}}
+    // expected-error@-1 {{generic struct 'Array' requires the types 'Fails' and 'Works' be equivalent}}
 }
 
 func dictionarySameType() {
@@ -70,7 +70,7 @@ func dictionarySameType() {
 
     let _: SameType = dictWorks as SameType
     let _: SameType = dictFails as SameType
-    // expected-error@-1 {{protocol 'SameType' requires the types 'Fails' and 'Works' be equivalent}}
+    // expected-error@-1 {{generic struct 'Dictionary' requires the types 'Fails' and 'Works' be equivalent}}
 }
 
 func arrayConforms() {
@@ -91,11 +91,11 @@ func arrayConforms() {
 
     let _: Conforms = [works] as Conforms
     let _: Conforms = [fails] as Conforms
-    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{generic struct 'Array' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = arrayWorks as Conforms
     let _: Conforms = arrayFails as Conforms
-    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{generic struct 'Array' requires that 'Fails' conform to 'Conforms'}}
 }
 
 func dictionaryConforms() {
@@ -116,11 +116,11 @@ func dictionaryConforms() {
 
     let _: Conforms = [0 : works] as Conforms
     let _: Conforms = [0 : fails] as Conforms
-    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
 
     let _: Conforms = dictWorks as Conforms
     let _: Conforms = dictFails as Conforms
-    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
 }
 
 func combined() {
@@ -133,6 +133,6 @@ func combined() {
     // expected-error@-1 {{type 'any Conforms' cannot conform to 'Conforms'}} expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
 
     let _: Conforms = [[0: [1 : [fails]] as Conforms]]
-    // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
+    // expected-error@-1 {{generic struct 'Dictionary' requires that 'Fails' conform to 'Conforms'}}
     // expected-error@-2 {{type 'any Conforms' cannot conform to 'Conforms'}} expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
 }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
@@ -14,6 +14,7 @@ struct Test {
 
   mutating func test<T>(v: Value<T>) {
     _ = {
+      // FIXME(diagnostics): We need to figure out how to avoid mentioning <<error type>> in the second diagnostic
       self.tuple = (v, 42)
       // expected-error@-1 {{cannot assign value of type '(Value<T>, Int)' to type '(value: any AnyValue, id: Int)'}}
       // expected-error@-2 {{generic struct 'Value' requires the types 'T' and '<<error type>>' be equivalent}}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar116122902.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol AnyValue {
+}
+
+struct Value<T> {}
+
+extension Value: AnyValue where T = { // expected-error {{use '==' for same-type requirements rather than '='}} expected-error {{expected type}}
+// expected-note@-1 {{requirement from conditional conformance of 'Value<T>' to 'AnyValue'}}
+}
+
+struct Test {
+  var tuple: (value: any AnyValue, id: Int)?
+
+  mutating func test<T>(v: Value<T>) {
+    _ = {
+      self.tuple = (v, 42)
+      // expected-error@-1 {{cannot assign value of type '(Value<T>, Int)' to type '(value: any AnyValue, id: Int)'}}
+      // expected-error@-2 {{generic struct 'Value' requires the types 'T' and '<<error type>>' be equivalent}}
+      return 0
+    }
+  }
+}


### PR DESCRIPTION
- Add a missing case to locator simplification

If tuple element is anchored on an assignment, we need to look
at the source of the assignment to find tuple expression the
element belongs to.

- Use simplified locator to find owner type of a requirement failure

Only simplified locator points to the right underlying expression.

Resolves: rdar://116122902

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
