### PR TITLE
Add initial support for  _resultDependsOnSelf

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -527,6 +527,9 @@ DECL_ATTR(storageRestrictions, StorageRestrictions,
 CONTEXTUAL_SIMPLE_DECL_ATTR(actor, Actor,
   DeclModifier | OnClass | ConcurrencyOnly | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   102)
+CONTEXTUAL_SIMPLE_DECL_ATTR(_resultDependsOnSelf, ResultDependsOnSelf,
+  OnFunc | DeclModifier | UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  150)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -241,7 +241,8 @@ enum class SelfAccessKind : uint8_t {
   LegacyConsuming,
   Consuming,
   Borrowing,
-  LastSelfAccessKind = Borrowing,
+  ResultDependsOnSelf,
+  LastSelfAccessKind = ResultDependsOnSelf,
 };
 enum : unsigned {
   NumSelfAccessKindBits =

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2166,5 +2166,10 @@ ERROR(duplicate_storage_restrictions_attr_label,none,
 ERROR(storage_restrictions_attr_expected_name,none,
       "expected property name in @storageRestrictions list", ())
 
+ERROR(requires_non_escapable_types, none,
+      "'%0' %select{attribute|parameter specifier}1 is only valid when experimental "
+      "NonEscapableTypes is enabled",
+      (StringRef, bool))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7701,5 +7701,12 @@ ERROR(referencebindings_binding_must_have_initial_value,none,
 ERROR(referencebindings_binding_must_be_to_lvalue,none,
       "%0 bindings must be bound to an lvalue", (StringRef))
 
+//------------------------------------------------------------------------------
+// MARK: resultDependsOn Errors
+//------------------------------------------------------------------------------
+
+ERROR(result_depends_on_no_result,none,
+      "Incorrect use of %0 with no result", (StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1559,6 +1559,9 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, ValueDecl *VD)
     case SelfAccessKind::Borrowing:
       FuncSelfKind = "Borrowing";
       break;
+    case SelfAccessKind::ResultDependsOnSelf:
+      FuncSelfKind = "ResultDependsOnSelf";
+      break;
     }
   }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3455,6 +3455,8 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
   case SelfAccessKind::NonMutating:
     // The default flagless state.
     break;
+  case SelfAccessKind::ResultDependsOnSelf:
+    break;
   }
 
   return AnyFunctionType::Param(selfTy, Identifier(), flags);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -604,6 +604,8 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
   case SelfAccessKind::LegacyConsuming: return OS << "'__consuming'";
   case SelfAccessKind::Consuming: return OS << "'consuming'";
   case SelfAccessKind::Borrowing: return OS << "'borrowing'";
+  case SelfAccessKind::ResultDependsOnSelf:
+    return OS << "'resultDependsOnSelf'";
   }
   llvm_unreachable("Unknown SelfAccessKind");
 }

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -34,6 +34,7 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.ThenStatements, to: .thenStatements)
     mapFeature(.TypedThrows, to: .typedThrows)
     mapFeature(.DoExpressions, to: .doExpressions)
+    mapFeature(.NonEscapableTypes, to: .nonEscapableTypes)
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -217,7 +217,7 @@ extension ASTGenVisitor {
   }
 }
 
-// MARK: - SpecifierTypeRepr/AttrubutedTypeRepr
+// MARK: - SpecifierTypeRepr/AttributedTypeRepr
 
 extension BridgedAttributedTypeSpecifier {
   fileprivate init?(from tokenKind: TokenKind) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2900,6 +2900,12 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
   }
 
+  if (DK == DAK_ResultDependsOnSelf &&
+      !Context.LangOpts.hasFeature(Feature::NonEscapableTypes)) {
+    diagnose(Loc, diag::requires_non_escapable_types, AttrName, true);
+    DiscardAttribute = true;
+  }
+
   // Filled in during parsing.  If there is a duplicate
   // diagnostic this can be used for better error presentation.
   SourceRange AttrRange;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5348,6 +5348,7 @@ bool SILGenModule::shouldEmitSelfAsRValue(FuncDecl *fn, CanType selfType) {
   case SelfAccessKind::LegacyConsuming:
   case SelfAccessKind::Consuming:
   case SelfAccessKind::Borrowing:
+  case SelfAccessKind::ResultDependsOnSelf:
     return true;
   }
   llvm_unreachable("bad self-access kind");

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2392,6 +2392,7 @@ ParamSpecifierRequest::evaluate(Evaluator &evaluator,
       case SelfAccessKind::Mutating:
         return ParamSpecifier::InOut;
       case SelfAccessKind::NonMutating:
+      case SelfAccessKind::ResultDependsOnSelf:
         return ParamSpecifier::Default;
       }
       llvm_unreachable("nonexhaustive switch");

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1531,6 +1531,7 @@ namespace  {
     UNINTERESTING_ATTR(Override)
     UNINTERESTING_ATTR(RawDocComment)
     UNINTERESTING_ATTR(RawLayout)
+    UNINTERESTING_ATTR(ResultDependsOnSelf)
     UNINTERESTING_ATTR(Required)
     UNINTERESTING_ATTR(Convenience)
     UNINTERESTING_ATTR(Semantics)

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1348,6 +1348,7 @@ public:
         case SelfAccessKind::Borrowing:
         case SelfAccessKind::NonMutating:
         case SelfAccessKind::Mutating:
+        case SelfAccessKind::ResultDependsOnSelf:
           ctx.Diags.diagnose(DS->getDiscardLoc(),
                              diag::discard_wrong_context_nonconsuming,
                              fn->getDescriptiveKind());

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2837,6 +2837,8 @@ getActualSelfAccessKind(uint8_t raw) {
     return swift::SelfAccessKind::Consuming;
   case serialization::SelfAccessKind::Borrowing:
     return swift::SelfAccessKind::Borrowing;
+  case serialization::SelfAccessKind::ResultDependsOnSelf:
+    return swift::SelfAccessKind::ResultDependsOnSelf;
   }
   return llvm::None;
 }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 818; // tuple_addr_constructor
+const uint16_t SWIFTMODULE_VERSION_MINOR = 819; // _resultDependsOnSelf
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -428,7 +428,8 @@ enum class SelfAccessKind : uint8_t {
   Mutating,
   LegacyConsuming,
   Consuming,
-  Borrowing
+  Borrowing,
+  ResultDependsOnSelf,
 };
 using SelfAccessKindField = BCFixed<3>;
   

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2334,6 +2334,8 @@ getStableSelfAccessKind(swift::SelfAccessKind MM) {
     return serialization::SelfAccessKind::Consuming;
   case swift::SelfAccessKind::Borrowing:
     return serialization::SelfAccessKind::Borrowing;
+  case swift::SelfAccessKind::ResultDependsOnSelf:
+    return serialization::SelfAccessKind::ResultDependsOnSelf;
   }
 
   llvm_unreachable("Unhandled StaticSpellingKind in switch.");

--- a/test/Parse/result_depends_on.swift
+++ b/test/Parse/result_depends_on.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonEscapableTypes
+// REQUIRES: asserts
+
+import Builtin
+
+class Klass {}
+
+class MethodModifiers {
+    _resultDependsOnSelf func getDependentResult() -> Builtin.NativeObject {
+      return Builtin.unsafeCastToNativeObject(self)
+    }
+}

--- a/test/Parse/result_depends_on_contextual_tests1.swift
+++ b/test/Parse/result_depends_on_contextual_tests1.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonEscapableTypes
+// REQUIRES: asserts
+
+import Builtin
+
+class Klass {}
+
+var _resultDependsOn = 0
+var _resultDependsOnSelf = 100.9
+
+class MethodModifiers {
+    _resultDependsOnSelf func _resultDependsOnSelf() -> Builtin.NativeObject {
+      return Builtin.unsafeCastToNativeObject(self)
+    }
+}
+

--- a/test/Parse/result_depends_on_contextual_tests2.swift
+++ b/test/Parse/result_depends_on_contextual_tests2.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonEscapableTypes
+// REQUIRES: asserts
+
+import Builtin
+
+class Klass {}
+
+class borrowing {}
+
+class _resultDependsOnSelf {}
+
+class MethodModifiers {
+    func getNoOpReturn() -> _resultDependsOnSelf {
+      return _resultDependsOnSelf()
+    }
+}

--- a/test/Sema/result_depends_on_errors.swift
+++ b/test/Sema/result_depends_on_errors.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature  NonEscapableTypes
+// REQUIRES: asserts
+
+import Builtin
+
+class Klass {}
+class MethodModifiers {
+    _resultDependsOnSelf func testAttrOnMethod() { } // expected-error{{Incorrect use of _resultDependsOnSelf with no result}}
+}
+
+_resultDependsOnSelf func testAttrOnFunc () { } // expected-error{{'resultDependsOnSelf' is only valid on methods}}


### PR DESCRIPTION
These attributes are used to establish lifetime dependence between argument/self and the result.

Matching swift-syntax PR :  https://github.com/apple/swift-syntax/pull/2281

