### PR TITLE
[Concurrency] Disallow Sendable annotation on methods of non-Sendable types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5302,6 +5302,9 @@ ERROR(local_function_executed_concurrently,none,
 ERROR(sendable_isolated_sync_function,none,
       "%0 synchronous %kind1 cannot be marked as '@Sendable'",
       (ActorIsolation, const ValueDecl *))
+ERROR(nonsendable_instance_method,none,
+      "instance methods of non-Sendable types cannot be marked as '@Sendable'",
+      ())
 ERROR(concurrent_access_of_local_capture,none,
       "%select{mutation of|reference to}0 captured %kind1 in "
       "concurrently-executing code",

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -23,6 +23,24 @@ actor A {
   }
 }
 
+class NonSendableC {
+    var x: Int = 0
+
+    @Sendable func inc() { // expected-warning{{instance methods of non-Sendable types cannot be marked as '@Sendable'}}
+        x += 1
+    }
+}
+
+struct S<T> {
+  let t: T
+
+  @Sendable func test() {} // expected-warning{{instance methods of non-Sendable types cannot be marked as '@Sendable'}}
+}
+
+extension S: Sendable where T: Sendable {
+  @Sendable func test2() {}
+}
+
 @available(SwiftStdlib 5.1, *)
 @MainActor @Sendable func globalActorFunc() { } // expected-warning{{main actor-isolated synchronous global function 'globalActorFunc()' cannot be marked as '@Sendable'}}
 


### PR DESCRIPTION
Disallow Sendable annotation on methods of non-Sendable types.