### PR TITLE
[NFC] Correct AFD::needsNewVTableEntry()

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1051,10 +1051,8 @@ NeedsNewVTableEntryRequest::evaluate(Evaluator &evaluator,
                                      AbstractFunctionDecl *decl) const {
   auto *dc = decl->getDeclContext();
 
-  // FIXME: This is mysterious and seems wrong. However, changing it to return
-  // false (as it seems like it should) breaks a couple Serialization tests.
   if (!isa<ClassDecl>(dc))
-    return true;
+    return false;
 
   // Destructors always use a fixed vtable entry.
   if (isa<DestructorDecl>(decl))

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -269,7 +269,7 @@ public:
 protected:
   DeclName name;
   Flags flags;
-  uint8_t numVTableEntries = 0;
+  uint8_t numTableEntries = 0;
 
 public:
   DeclName getName() const {
@@ -279,8 +279,8 @@ public:
   bool isDesignatedInitializer() const {
     return flags.contains(Flag::DesignatedInitializer);
   }
-  unsigned getNumberOfVTableEntries() const {
-    return numVTableEntries;
+  unsigned getNumberOfTableEntries() const {
+    return numTableEntries;
   }
   bool needsFieldOffsetVectorEntry() const {
     return flags.contains(Flag::NeedsFieldOffsetVectorEntry);
@@ -424,10 +424,10 @@ private:
 
 public:
   explicit OverrideError(DeclName name,
-                         Flags flags={}, unsigned numVTableEntries=0) {
+                         Flags flags={}, unsigned numTableEntries=0) {
     this->name = name;
     this->flags = flags;
-    this->numVTableEntries = numVTableEntries;
+    this->numTableEntries = numTableEntries;
   }
 
   void log(raw_ostream &OS) const override {
@@ -489,11 +489,11 @@ class TypeError : public llvm::ErrorInfo<TypeError, DeclDeserializationError>,
 
 public:
   explicit TypeError(DeclName name, std::unique_ptr<ErrorInfoBase> reason,
-                     Flags flags={}, unsigned numVTableEntries=0)
+                     Flags flags={}, unsigned numTableEntries=0)
       : ErrorWithUnderlyingReason(std::move(reason)) {
     this->name = name;
     this->flags = flags;
-    this->numVTableEntries = numVTableEntries;
+    this->numTableEntries = numTableEntries;
   }
 
   void diagnose(const ModuleFile *MF) const;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 812; // @_extern(wasm)
+const uint16_t SWIFTMODULE_VERSION_MINOR = 813; // VTable bit redefinition
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1524,7 +1524,7 @@ namespace decls_block {
     DeclIDField, // overridden decl
     BCFixed<1>,   // whether the overridden decl affects ABI
     AccessLevelField, // access level
-    BCFixed<1>,   // requires a new vtable slot
+    BCFixed<1>,   // requires a new vtable/witness table slot
     BCFixed<1>,   // 'required' but overridden is not (used for recovery)
     BCVBR<5>,     // number of parameter name components
     BCArray<IdentifierIDField> // name components,
@@ -1561,7 +1561,7 @@ namespace decls_block {
     AccessLevelField, // setter access, if applicable
     DeclIDField, // opaque return type decl
     BCFixed<2>,  // # of property wrapper backing properties
-    BCVBR<4>,    // total number of vtable entries introduced by all accessors
+    BCVBR<4>,    // total number of vtable/witness table entries introduced by all accessors
     BCArray<TypeIDField> // accessors, backing properties, and dependencies
   >;
 
@@ -1605,7 +1605,7 @@ namespace decls_block {
     BCVBR<5>,     // 0 for a simple name, otherwise the number of parameter name
                   // components plus one
     AccessLevelField, // access level
-    BCFixed<1>,   // requires a new vtable slot
+    BCFixed<1>,   // requires a new vtable/witness table slot
     DeclIDField,  // opaque result type decl
     BCFixed<1>,   // isUserAccessible?
     BCFixed<1>,   // is distributed thunk
@@ -1666,7 +1666,7 @@ namespace decls_block {
     DeclIDField,  // AccessorStorageDecl
     AccessorKindField, // accessor kind
     AccessLevelField, // access level
-    BCFixed<1>,   // requires a new vtable slot
+    BCFixed<1>,   // requires a new vtable/witness table slot
     BCFixed<1>,   // is transparent
     BCFixed<1>,   // is distributed thunk
     BCArray<IdentifierIDField> // name components,
@@ -1754,7 +1754,7 @@ namespace decls_block {
     StaticSpellingKindField,    // is subscript static?
     BCVBR<5>,    // number of parameter name components
     DeclIDField, // opaque return type decl
-    BCVBR<4>,    // total number of vtable entries introduced by all accessors
+    BCVBR<4>,    // total number of vtable/witness table entries introduced by all accessors
     BCArray<IdentifierIDField> // name components,
                                // followed by DeclID accessors,
                                // followed by TypeID dependencies

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3688,11 +3688,17 @@ private:
     InlinableBodyTextLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode, body);
   }
 
-  unsigned getNumberOfRequiredVTableEntries(
+  static bool getNeedsNewTableEntry(const AbstractFunctionDecl *func) {
+    if (isa_and_nonnull<ProtocolDecl>(func->getDeclContext()))
+      return func->requiresNewWitnessTableEntry();
+    return func->needsNewVTableEntry();
+  }
+
+  unsigned getNumberOfRequiredTableEntries(
       const AbstractStorageDecl *storage) const {
     unsigned count = 0;
     for (auto *accessor : storage->getAllAccessors()) {
-      if (accessor->needsNewVTableEntry())
+      if (getNeedsNewTableEntry(accessor))
         count++;
     }
     return count;
@@ -4296,7 +4302,7 @@ public:
 
     auto rawIntroducer = getRawStableVarDeclIntroducer(var->getIntroducer());
 
-    unsigned numVTableEntries = getNumberOfRequiredVTableEntries(var);
+    unsigned numTableEntries = getNumberOfRequiredTableEntries(var);
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[VarLayout::Code];
     VarLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -4322,7 +4328,7 @@ public:
                           rawAccessLevel, rawSetterAccessLevel,
                           S.addDeclRef(var->getOpaqueResultTypeDecl()),
                           numBackingProperties,
-                          numVTableEntries,
+                          numTableEntries,
                           arrayFields);
   }
 
@@ -4422,7 +4428,7 @@ public:
                            fn->getName().getArgumentNames().size() +
                              fn->getName().isCompoundName(),
                            rawAccessLevel,
-                           fn->needsNewVTableEntry(),
+                           getNeedsNewTableEntry(fn),
                            S.addDeclRef(fn->getOpaqueResultTypeDecl()),
                            fn->isUserAccessible(),
                            fn->isDistributedThunk(),
@@ -4539,7 +4545,7 @@ public:
                                S.addDeclRef(fn->getStorage()),
                                rawAccessorKind,
                                rawAccessLevel,
-                               fn->needsNewVTableEntry(),
+                               getNeedsNewTableEntry(fn),
                                fn->isTransparent(),
                                fn->isDistributedThunk(),
                                dependencies);
@@ -4630,7 +4636,7 @@ public:
     uint8_t rawStaticSpelling =
       uint8_t(getStableStaticSpelling(subscript->getStaticSpelling()));
 
-    unsigned numVTableEntries = getNumberOfRequiredVTableEntries(subscript);
+    unsigned numTableEntries = getNumberOfRequiredTableEntries(subscript);
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[SubscriptLayout::Code];
     SubscriptLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -4654,7 +4660,7 @@ public:
                                 rawStaticSpelling,
                                 subscript->getName().getArgumentNames().size(),
                                 S.addDeclRef(subscript->getOpaqueResultTypeDecl()),
-                                numVTableEntries,
+                                numTableEntries,
                                 nameComponentsAndDependencies);
 
     writeGenericParams(subscript->getGenericParams());
@@ -4703,7 +4709,7 @@ public:
                                   S.addDeclRef(overridden),
                                   overriddenAffectsABI,
                                   rawAccessLevel,
-                                  ctor->needsNewVTableEntry(),
+                                  getNeedsNewTableEntry(ctor),
                                   firstTimeRequired,
                                   ctor->getName().getArgumentNames().size(),
                                   nameComponentsAndDependencies);


### PR DESCRIPTION
Serialization depended on a longstanding bug in NeedsNewVTableEntryRequest: For a member of a non-class, it always returned `true`, not `false`. It turns out this was because serialization was conflating the concepts of vtable entries and witness table entries, so it needed NeedsNewVTableEntryRequest to return true for members of protocols. Untangle this logic so that NeedsNewVTableEntryRequest can be given the logical behavior.