### PR TITLE
[embedded] Move _CustomStringConvertibleOrNone/_LosslessStringConvertibleOrNone to avoid detaching doccomments from their declarations

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -406,6 +406,12 @@ extension AdditiveArithmetic {
   }
 }
 
+#if !$Embedded
+public typealias _CustomStringConvertibleOrNone = CustomStringConvertible
+#else
+public typealias _CustomStringConvertibleOrNone = Any
+#endif
+
 //===----------------------------------------------------------------------===//
 //===--- BinaryInteger ----------------------------------------------------===//
 //===----------------------------------------------------------------------===//
@@ -566,13 +572,6 @@ extension AdditiveArithmetic {
 ///         print("\(z) is greater than \(x).")
 ///     }
 ///     // Prints "23 is greater than -23."
-
-#if !$Embedded
-public typealias _CustomStringConvertibleOrNone = CustomStringConvertible
-#else
-public typealias _CustomStringConvertibleOrNone = Any
-#endif
-
 public protocol BinaryInteger :
   Hashable, Numeric, _CustomStringConvertibleOrNone, Strideable
   where Magnitude: BinaryInteger, Magnitude.Magnitude == Magnitude
@@ -1831,6 +1830,12 @@ extension BinaryInteger {
   }
 }
 
+#if !$Embedded
+public typealias _LosslessStringConvertibleOrNone = LosslessStringConvertible
+#else
+public protocol _LosslessStringConvertibleOrNone {}
+#endif
+
 //===----------------------------------------------------------------------===//
 //===--- FixedWidthInteger ------------------------------------------------===//
 //===----------------------------------------------------------------------===//
@@ -1899,13 +1904,6 @@ extension BinaryInteger {
 /// customization points for arithmetic operations. When you provide just those
 /// methods, the standard library provides default implementations for all
 /// other arithmetic methods and operators.
-
-#if !$Embedded
-public typealias _LosslessStringConvertibleOrNone = LosslessStringConvertible
-#else
-public protocol _LosslessStringConvertibleOrNone {}
-#endif
-
 public protocol FixedWidthInteger: BinaryInteger, _LosslessStringConvertibleOrNone
 where Magnitude: FixedWidthInteger & UnsignedInteger,
       Stride: FixedWidthInteger & SignedInteger {

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !$Embedded
+
 /// A unique identifier for a class instance or metatype.
 ///
 /// This unique identifier is only valid for comparisons during the lifetime
@@ -50,32 +52,39 @@ public struct ObjectIdentifier: Sendable {
   ///     // Prints "false"
   ///
   /// - Parameter x: An instance of a class.
-#if $Embedded
-  @inlinable // trivial-implementation
-  public init<Object: AnyObject>(_ x: Object) {
-    self._value = Builtin.bridgeToRawPointer(x)
-  }
-#else
   @inlinable // trivial-implementation
   public init(_ x: AnyObject) {
     self._value = Builtin.bridgeToRawPointer(x)
   }
-#endif
+
   /// Creates an instance that uniquely identifies the given metatype.
   ///
   /// - Parameter: A metatype.
-#if $Embedded
-  @inlinable // trivial-implementation
-  public init<Object>(_ x: Object.Type) {
-    self._value = unsafeBitCast(x, to: Builtin.RawPointer.self)
-  }
-#else
   @inlinable // trivial-implementation
   public init(_ x: Any.Type) {
     self._value = unsafeBitCast(x, to: Builtin.RawPointer.self)
   }
-#endif
 }
+
+#else
+
+@frozen // trivial-implementation
+public struct ObjectIdentifier: Sendable {
+  @usableFromInline // trivial-implementation
+  internal let _value: Builtin.RawPointer
+
+  @inlinable // trivial-implementation
+  public init<Object: AnyObject>(_ x: Object) {
+    self._value = Builtin.bridgeToRawPointer(x)
+  }
+
+  @inlinable // trivial-implementation
+  public init<Object>(_ x: Object.Type) {
+    self._value = unsafeBitCast(x, to: Builtin.RawPointer.self)
+  }
+}
+
+#endif
 
 @_unavailableInEmbedded
 extension ObjectIdentifier: CustomDebugStringConvertible {


### PR DESCRIPTION
It turns out that the addition of the _CustomStringConvertibleOrNone/_LosslessStringConvertibleOrNone typealiases happened at a very unfortunate source code location that causes the doccomments to get detached from their declarations. Let's fix that.