### PR TITLE
build: bundle the VC redist in the installer

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -973,7 +973,7 @@ msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bundle\installer.
   -p:BaseReleaseDownloadUrl=https://download.swift.org/development/windows ^
   -p:Configuration=Release ^
   -p:BaseOutputPath=%PackageRoot%\online\ ^
-  -p:VCRedistInstaller=%VCToolsRedistDir%\vc_redist.%VSCMD_ARG_TGT_ARCH%.exe ^
+  -p:VCRedistInstaller="%VCToolsRedistDir%\vc_redist.%VSCMD_ARG_TGT_ARCH%.exe" ^
   -p:VSVersion=%VSCMD_VER% ^
   -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
@@ -989,7 +989,7 @@ msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bundle\installer.
   -p:BundleFlavor=offline ^
   -p:Configuration=Release ^
   -p:BaseOutputPath=%PackageRoot%\offline\ ^
-  -p:VCRedistInstaller=%VCToolsRedistDir%\vc_redist.%VSCMD_ARG_TGT_ARCH%.exe ^
+  -p:VCRedistInstaller="%VCToolsRedistDir%\vc_redist.%VSCMD_ARG_TGT_ARCH%.exe" ^
   -p:VSVersion=%VSCMD_VER% ^
   -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -973,6 +973,8 @@ msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bundle\installer.
   -p:BaseReleaseDownloadUrl=https://download.swift.org/development/windows ^
   -p:Configuration=Release ^
   -p:BaseOutputPath=%PackageRoot%\online\ ^
+  -p:VCRedistInstaller=%VCToolsRedistDir%\vc_redist.%VSCMD_ARG_TGT_ARCH%.exe ^
+  -p:VSVersion=%VSCMD_VER% ^
   -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:PLATFORM_ROOT=%PlatformRoot%\ ^
@@ -987,6 +989,8 @@ msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\bundle\installer.
   -p:BundleFlavor=offline ^
   -p:Configuration=Release ^
   -p:BaseOutputPath=%PackageRoot%\offline\ ^
+  -p:VCRedistInstaller=%VCToolsRedistDir%\vc_redist.%VSCMD_ARG_TGT_ARCH%.exe ^
+  -p:VSVersion=%VSCMD_VER% ^
   -p:DEVTOOLS_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:TOOLCHAIN_ROOT=%BuildRoot%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain ^
   -p:PLATFORM_ROOT=%PlatformRoot%\ ^


### PR DESCRIPTION
With the work to enable ARM64, we need to package the redistributable into the toolchain to allow distribution via winget.  This is also important to make the runtime work without additional packaging.