### PR TITLE
[embedded] Use Builtin.RawPointer as the argument type on swift_release_n

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -154,12 +154,18 @@ func swift_retain_n_(object: UnsafeMutablePointer<HeapObject>, n: UInt32) -> Uns
 }
 
 @_silgen_name("swift_release")
-public func swift_release(object: UnsafeMutablePointer<HeapObject>?) {
+public func swift_release(object: Builtin.RawPointer) {
   swift_release_n(object: object, n: 1)
 }
 
 @_silgen_name("swift_release_n")
-public func swift_release_n(object: UnsafeMutablePointer<HeapObject>?, n: UInt32) {
+public func swift_release_n(object: Builtin.RawPointer, n: UInt32) {
+  if Int(Builtin.ptrtoint_Word(object)) == 0 { return }
+  let o = UnsafeMutablePointer<HeapObject>(object)
+  swift_release_n_(object: o, n: n)
+}
+
+public func swift_release_n_(object: UnsafeMutablePointer<HeapObject>?, n: UInt32) {
   guard let object else {
     return
   }

--- a/test/embedded/runtime-release.swift
+++ b/test/embedded/runtime-release.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+@main
+struct Main {
+    static func main() {
+        test()
+        print("Okay!")
+        // CHECK: Okay!
+    }
+}
+
+func test() -> [Int] {
+    var s: [Int] = []
+    s += []
+    return s
+}


### PR DESCRIPTION
The added test triggers a call to swift_release_n, which currently ends up causing an LLVM IR verification failure because swift_release_n is, at the IR level, expected to have a `ptr` argument, but `UnsafePointer?` in Swift code ends up lowering as `i64`. Let's avoid using it and instead use `Builtin.RawPointer` as the argument type, like we do in the other runtime refcounting functions.