### PR TITLE
[embedded] When linking SIL vtables, also link superclass vtables

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -189,6 +189,10 @@ void SILLinkerVisitor::linkInVTable(ClassDecl *D) {
       maybeAddFunctionToWorklist(impl, Vtbl->isSerialized());
     }
   }
+
+  if (auto *S = D->getSuperclassDecl()) {
+    linkInVTable(S);
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/embedded/deserialize-vtables.swift
+++ b/test/embedded/deserialize-vtables.swift
@@ -1,0 +1,34 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+@main
+struct Main {
+    static func main() {
+        StaticString("Hello, World!").asUTF8Array.print()
+        // CHECK: Hello, World!
+    }
+}
+
+extension StaticString {
+    var asUTF8Array: [UInt8] {
+        Array(UnsafeBufferPointer(start: utf8Start, count: utf8CodeUnitCount))
+    }
+}
+
+@_silgen_name("putchar")
+func putchar(_: UInt8)
+
+extension Array<UInt8> {
+    func print() {
+        for byte in self {
+            putchar(byte)
+        }
+        putchar(10)
+    }
+}


### PR DESCRIPTION
The attached testcase demonstrates the problem, where the resulting program ends up referencing missing symbols at link time:
```
ld: Undefined symbols:
  _$ss28__ContiguousArrayStorageBaseC012_doNotCallMeD0AByt_tcfC, referenced from:
      _$ss28__ContiguousArrayStorageBaseCN in main-86e491.o
  _$ss28__ContiguousArrayStorageBaseC16canStoreElements13ofDynamicTypeSbypXp_tF, referenced from:
      _$ss28__ContiguousArrayStorageBaseCN in main-86e491.o
  _$ss28__ContiguousArrayStorageBaseCfD, referenced from:
      _$ss28__ContiguousArrayStorageBaseCN in main-86e491.o
  _$ss41__SwiftNativeNSArrayWithContiguousStorageCABycfC, referenced from:
      _$ss41__SwiftNativeNSArrayWithContiguousStorageCN in main-86e491.o
  _$ss41__SwiftNativeNSArrayWithContiguousStorageCfD, referenced from:
      _$ss41__SwiftNativeNSArrayWithContiguousStorageCN in main-86e491.o
```
These are all vtable methods referenced from a superclass of an array class that's actually allocated in the program. Because the current logic `SILLinkerVisitor::linkInVTable` only deserializes the one vtable that is being used, we end up with the methods from the superclass missing.