### PR TITLE
[embedded] Make -parse-as-library the default mode in embedded Swift

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3145,6 +3145,9 @@ bool CompilerInvocation::parseArgs(
     SILOpts.SkipFunctionBodies = FunctionBodySkipping::None;
     SILOpts.CMOMode = CrossModuleOptimizationMode::Everything;
     SILOpts.EmbeddedSwift = true;
+    if (FrontendOpts.InputMode == FrontendOptions::ParseInputMode::Swift) {
+      FrontendOpts.InputMode = FrontendOptions::ParseInputMode::SwiftLibrary;
+    }
   }
 
   return false;

--- a/test/embedded/array-to-pointer.swift
+++ b/test/embedded/array-to-pointer.swift
@@ -71,4 +71,9 @@ func test() {
   // CHECK-NEXT: [42, 2, 3, 4, 5]
 }
 
-test()
+@main
+struct Main {
+  static func main() {
+    test()
+  }
+}

--- a/test/embedded/arrays.swift
+++ b/test/embedded/arrays.swift
@@ -52,4 +52,9 @@ func test() {
   print(c) // CHECK: [8, 4, 2]
 }
 
-test()
+@main
+struct Main {
+  static func main() {
+    test()
+  }
+}

--- a/test/embedded/basic-modules-generics-no-stdlib.swift
+++ b/test/embedded/basic-modules-generics-no-stdlib.swift
@@ -42,7 +42,7 @@ extension Bool: Protocol {}
 
 extension GenericType: Protocol {}
 
-public func main() {
+func test() {
   nonGenericFunc()
   _ = genericFunc(Bool())
   _ = NonGenericType()
@@ -51,12 +51,18 @@ public func main() {
   protocolBoundFunc(GenericType<Bool>(Bool()))
 }
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+@main
+struct Main {
+  static func main() {
+    test()
+  }
+}
+
 // CHECK: define {{.*}}void @"$s4Main4BoolVACycfC"()
-// CHECK: define {{.*}}void @"$s4Main4mainyyF"()
 // CHECK: define {{.*}}void @"$s8MyModule14nonGenericFuncyyF"()
 // CHECK: define {{.*}}void @"$s8MyModule11genericFuncyxxlF4Main4BoolV_Tg5"()
 // CHECK: define {{.*}}void @"$s8MyModule14NonGenericTypeVACycfC"()
 // CHECK: define {{.*}}void @"$s8MyModule11GenericTypeVyACyxGxcfC4Main4BoolV_Tgm5"()
 // CHECK: define {{.*}}void @"$s8MyModule17protocolBoundFuncyyxAA8ProtocolRzlF4Main4BoolV_Tg5"()
 // CHECK: define {{.*}}void @"$s8MyModule17protocolBoundFuncyyxAA8ProtocolRzlFAA11GenericTypeVy4Main4BoolVG_Tg5"()
+// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)

--- a/test/embedded/basic-modules-no-stdlib.swift
+++ b/test/embedded/basic-modules-no-stdlib.swift
@@ -37,7 +37,6 @@ public func main() {
   moduleMain()
 }
 
-// CHECK: define {{.*}}@main{{.*}} {
 // CHECK: define {{.*}}void @"$s4Main4mainyyF"{{.*}} {
 // CHECK: define {{.*}}void @"$s8MyModule10moduleMainyyF"{{.*}} {
 // CHECK: define {{.*}}void @"$s8MyModule8ConcreteVACycfC"{{.*}} {

--- a/test/embedded/collection.swift
+++ b/test/embedded/collection.swift
@@ -87,4 +87,9 @@ func foo() {
     print(bytes.min()!) // CHECK: -1
 }
 
-foo()
+@main
+struct Main {
+  static func main() {
+    foo()
+  }
+}

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s %S/Inputs/print.swift -c -o %t/a.o
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded %s %S/Inputs/print.swift -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -23,5 +23,11 @@ public func print(_ s: StaticString, terminator: StaticString = "\n") {
   }
 }
 
-print("Hello, Embedded Swift!")
+@main
+struct Main {
+  static func main() {
+    print("Hello, Embedded Swift!")
+  }
+}
+
 // CHECK: Hello, Embedded Swift!

--- a/test/embedded/extensions.swift
+++ b/test/embedded/extensions.swift
@@ -18,6 +18,8 @@ struct MyStruct {}
 
 extension MyStruct: MyProtocol {}
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+public func test() {}
+
+// CHECK: define {{.*}}@"$s4Main4testyyF"()
 // CHECK-NOT: MyStruct
 // CHECK-NOT: MyProtocol

--- a/test/embedded/globals.swift
+++ b/test/embedded/globals.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-ir -target armv7-apple-none-macho -parse-stdlib -module-name Swift %s -enable-experimental-feature Embedded -wmo -parse-as-library | %FileCheck %s --check-prefix CHECK --check-prefix CHECK-NONOPT
-// RUN: %target-swift-emit-ir -target armv7-apple-none-macho -parse-stdlib -module-name Swift %s -enable-experimental-feature Embedded -wmo -parse-as-library -O | %FileCheck %s
+// RUN: %target-swift-emit-ir -target armv7-apple-none-macho -parse-stdlib -module-name Swift %s -enable-experimental-feature Embedded -wmo | %FileCheck %s --check-prefix CHECK --check-prefix CHECK-NONOPT
+// RUN: %target-swift-emit-ir -target armv7-apple-none-macho -parse-stdlib -module-name Swift %s -enable-experimental-feature Embedded -wmo -O | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 

--- a/test/embedded/internalize-no-stdlib.swift
+++ b/test/embedded/internalize-no-stdlib.swift
@@ -25,13 +25,11 @@ public func main() {
   start(p: Concrete())
 }
 
-// CHECK-ELF: @"\01l_entry_point" =
 // CHECK-ELF: @__swift_reflection_version =
 // CHECK-ELF: @_swift1_autolink_entries =
-// CHECK-ELF: @llvm.compiler.used = appending global [3 x ptr] [ptr @"\01l_entry_point", ptr @__swift_reflection_version, ptr @_swift1_autolink_entries], section "llvm.metadata"
+// CHECK-ELF: @llvm.compiler.used = appending global [2 x ptr] [ptr @__swift_reflection_version, ptr @_swift1_autolink_entries], section "llvm.metadata"
 // CHECK-ELF-NOT: @llvm.used
 
-// CHECK-MACHO: @"\01l_entry_point" =
 // CHECK-MACHO: @__swift_reflection_version =
 // CHECK-MACHO-NOT: @llvm.compiler.used
-// CHECK-MACHO: @llvm.used = appending global [2 x ptr] [ptr @"\01l_entry_point", ptr @__swift_reflection_version], section "llvm.metadata"
+// CHECK-MACHO: @llvm.used = appending global [1 x ptr] [ptr @__swift_reflection_version], section "llvm.metadata"

--- a/test/embedded/lto.swift
+++ b/test/embedded/lto.swift
@@ -28,5 +28,11 @@ public func print(_ s: StaticString, terminator: StaticString = "\n") {
   }
 }
 
-print("Hello, Embedded Swift!")
+@main
+struct Main {
+  static func main() {
+    print("Hello, Embedded Swift!")
+  }
+}
+
 // CHECK: Hello, Embedded Swift!

--- a/test/embedded/modules-classes.swift
+++ b/test/embedded/modules-classes.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift %S/Inputs/print.swift -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
@@ -34,6 +34,11 @@ func test() {
   foo()
 }
 
-test()
+@main
+struct Main {
+  static func main() {
+    test()
+  }
+}
 
 // CHECK: MyClass.foo

--- a/test/embedded/modules-globals-exec.swift
+++ b/test/embedded/modules-globals-exec.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
@@ -57,4 +57,9 @@ func test() {
   print(global_in_module_unused_in_module) // CHECK-NEXT: 0
 }
 
-test()
+@main
+struct Main {
+  static func main() {
+    test()
+  }
+}

--- a/test/embedded/modules-globals-many.swift
+++ b/test/embedded/modules-globals-many.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleA.swiftmodule %t/MyModuleA.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleB.swiftmodule %t/MyModuleB.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleC.swiftmodule %t/MyModuleC.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleA.swiftmodule %t/MyModuleA.swift -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleB.swiftmodule %t/MyModuleB.swift -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleC.swiftmodule %t/MyModuleC.swift -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: VENDOR=apple

--- a/test/embedded/modules-globals.swift
+++ b/test/embedded/modules-globals.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: VENDOR=apple

--- a/test/embedded/modules-print-exec.swift
+++ b/test/embedded/modules-print-exec.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
@@ -46,4 +46,9 @@ func test() {
   print(42, terminator: "\n") // CHECK-NEXT: 42
 }
 
-test()
+@main
+struct Main {
+  static func main() {
+    test()
+  }
+}

--- a/test/embedded/once.swift
+++ b/test/embedded/once.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -lto=llvm-full %lto_flags %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -lto=llvm-full %lto_flags %S/Inputs/print.swift -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib

--- a/test/embedded/osize-genericspecializer.swift
+++ b/test/embedded/osize-genericspecializer.swift
@@ -16,4 +16,4 @@ public func baz<T>(n: T) {
     let x: ContiguousArray<Int> = .init(repeating: 0, count: 1)
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: !llvm.module.flags =

--- a/test/embedded/osize-releasedevirt.swift
+++ b/test/embedded/osize-releasedevirt.swift
@@ -12,4 +12,4 @@ public func foo() {
 func bar(_: UnsafePointer<UInt?>) {
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: !llvm.module.flags =

--- a/test/embedded/runtime.swift
+++ b/test/embedded/runtime.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib

--- a/test/embedded/static-object.swift
+++ b/test/embedded/static-object.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -O -emit-irgen %s %S/Inputs/print.swift -module-name main -parse-as-library -enable-experimental-feature Embedded | %FileCheck %s --check-prefix CHECK-IR
-// RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-irgen %s %S/Inputs/print.swift -module-name main -enable-experimental-feature Embedded | %FileCheck %s --check-prefix CHECK-IR
+// RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -35,7 +35,6 @@ public func checks(n: Int) {
   if n < 0 { assertionFailure("with message") }
 }
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
 // CHECK: define {{.*}}i1 @"$s4main4boolSbyF"()
 // CHECK: define {{.*}}i1 @"$sSb22_builtinBooleanLiteralSbBi1__tcfC"(i1 %0)
 // CHECK: define {{.*}}{{i32|i64}} @"$s4main3intSiyF"()

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -38,6 +38,4 @@ public func test() {
   let o = unmanaged2.takeUnretainedValue()
 }
 
-test()
-
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}@"$s4main4testyyF"()

--- a/test/embedded/throw-typed.swift
+++ b/test/embedded/throw-typed.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -enable-experimental-feature TypedThrows -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -O -enable-experimental-feature Embedded -enable-experimental-feature TypedThrows -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -Osize -enable-experimental-feature Embedded -enable-experimental-feature TypedThrows -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -enable-experimental-feature TypedThrows -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -O -enable-experimental-feature Embedded -enable-experimental-feature TypedThrows -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -Osize -enable-experimental-feature Embedded -enable-experimental-feature TypedThrows -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib


### PR DESCRIPTION
Top-level mode (script mode) doesn't seem to be useful to embedded Swift usecases, and can cause subtle problems (global variables in top-level mode have often unexpected semantics). Let's make -parse-as-library be the default in embedded Swift.