### PR TITLE
ClosureLifetimeFixup: Fix parameter indexing issue.

### DIFF
--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -725,6 +725,9 @@ static SILValue tryRewriteToPartialApplyStack(
   
   SmallSetVector<SILValue, 4> borrowedOriginals;
   
+  unsigned appliedArgStartIdx =
+        newPA->getOrigCalleeType()->getNumParameters() - newPA->getNumArguments();
+
   for (unsigned i : indices(newPA->getArgumentOperands())) {
     auto &arg = newPA->getArgumentOperands()[i];
     SILValue copy = arg.get();
@@ -747,11 +750,12 @@ static SILValue tryRewriteToPartialApplyStack(
     }
     
     // Is the capture a borrow?
-    auto paramIndex = newPA
-      ->getArgumentIndexForOperandIndex(i + newPA->getArgumentOperandNumber())
-      .value();
-    if (!newPA->getOrigCalleeType()->getParameters()[paramIndex]
-          .isIndirectInGuaranteed()) {
+
+    auto paramIndex = i + appliedArgStartIdx;
+    auto param = newPA->getOrigCalleeType()->getParameters()[paramIndex];
+    LLVM_DEBUG(param.print(llvm::dbgs());
+               llvm::dbgs() << '\n');
+    if (!param.isIndirectInGuaranteed()) {
       LLVM_DEBUG(llvm::dbgs() << "-- not an in_guaranteed parameter\n";
                  newPA->getOrigCalleeType()->getParameters()[paramIndex]
                    .print(llvm::dbgs());

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -17,6 +17,8 @@ struct M {
 #else
     private var x: Int = 0
 #endif
+
+    borrowing func borrow() {}
 }
 
 func borrow(_: borrowing M) {}
@@ -154,6 +156,18 @@ func p(x: inout M) {
     x = M()
 
     clodger({ consume(x); x = M() })
+}
+
+func takesClosureWithArg(_: (Int) -> ()) {}
+
+func invokesWithClosureWithArg() {
+    let m = M()
+
+    takesClosureWithArg { _ in
+      m.borrow()
+    }
+
+    m.borrow()
 }
 
 // need test cases for:


### PR DESCRIPTION
When deciding whether to clean up copies of noncopyable captures, I got the parameter indexing wrong when the closure has non-capture arguments. Fixing this allows noncopyable captures to work in more general circumstances.