### PR TITLE
[embedded] Make ExpressibleByStringInterpolation available in embedded Swift

### DIFF
--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -762,10 +762,10 @@ public protocol ExpressibleByDictionaryLiteral {
 /// `StringInterpolationProtocol` and have a matching `StringLiteralType`.
 ///
 /// For more information, see the `StringInterpolationProtocol` documentation.
-@_unavailableInEmbedded
 public protocol ExpressibleByStringInterpolation
   : ExpressibleByStringLiteral {
   
+#if !$Embedded
   /// The type each segment of a string literal containing interpolations
   /// should be appended to.
   ///
@@ -774,6 +774,10 @@ public protocol ExpressibleByStringInterpolation
   associatedtype StringInterpolation: StringInterpolationProtocol
     = DefaultStringInterpolation
     where StringInterpolation.StringLiteralType == StringLiteralType
+#else
+  associatedtype StringInterpolation: StringInterpolationProtocol
+    where StringInterpolation.StringLiteralType == StringLiteralType
+#endif
 
   /// Creates an instance from a string interpolation.
   /// 
@@ -788,7 +792,7 @@ public protocol ExpressibleByStringInterpolation
   init(stringInterpolation: StringInterpolation)
 }
 
-@_unavailableInEmbedded
+#if !$Embedded
 extension ExpressibleByStringInterpolation
   where StringInterpolation == DefaultStringInterpolation {
   
@@ -811,6 +815,7 @@ extension ExpressibleByStringInterpolation
     self.init(stringLiteral: stringInterpolation.make())
   }
 }
+#endif
 
 /// Represents the contents of a string literal with interpolations while it's
 /// being built up.

--- a/test/embedded/Inputs/print.swift
+++ b/test/embedded/Inputs/print.swift
@@ -1,7 +1,7 @@
 @_silgen_name("putchar")
 func putchar(_: UInt8)
 
-public func print(_ s: StaticString, terminator: StaticString = "\n") {
+func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
     putchar(p.pointee)
@@ -12,4 +12,55 @@ public func print(_ s: StaticString, terminator: StaticString = "\n") {
     putchar(p.pointee)
     p += 1
   }
+}
+
+func printCharacters(_ buf: UnsafeRawBufferPointer) {
+  for c in buf {
+    putchar(c)
+  }
+}
+
+func printCharacters(_ buf: UnsafeBufferPointer<UInt8>) {
+  printCharacters(UnsafeRawBufferPointer(buf))
+}
+
+extension BinaryInteger {
+  func writeToStdout(radix: Int = 10) {
+    if self == (0 as Self) {
+      print("0", terminator: "")
+      return
+    }
+    
+    func _ascii(_ digit: UInt8) -> UInt8 {
+      if digit < 10 {
+        UInt8(("0" as Unicode.Scalar).value) + digit
+      } else {
+        UInt8(("a" as Unicode.Scalar).value) + (digit - 10)
+      }
+    }
+    let isNegative = Self.isSigned && self < (0 as Self)
+    var value = magnitude
+    withUnsafeTemporaryAllocation(byteCount: 64, alignment: 1) { buffer in
+      var index = buffer.count - 1
+      while value != 0 {
+        let (quotient, remainder) = value.quotientAndRemainder(dividingBy: Magnitude(radix))
+        buffer[index] = _ascii(UInt8(truncatingIfNeeded: remainder))
+        index -= 1
+        value = quotient
+      }
+      if isNegative {
+        buffer[index] = UInt8(("-" as Unicode.Scalar).value)
+        index -= 1
+      }
+      let start = index + 1
+      let end = buffer.count - 1
+      let count = end - start + 1
+      printCharacters(UnsafeBufferPointer(start: buffer.baseAddress?.advanced(by: start).assumingMemoryBound(to: UInt8.self), count: count))
+    }
+  }
+}
+
+func print(_ n: some BinaryInteger, terminator: StaticString = "\n") {
+  n.writeToStdout()
+  print("", terminator: terminator)
 }

--- a/test/embedded/static-string-interpolation.swift
+++ b/test/embedded/static-string-interpolation.swift
@@ -1,0 +1,58 @@
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -Xfrontend -throws-as-traps -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public struct MyInterpolation : StringInterpolationProtocol {
+    public typealias StringLiteralType = StaticString
+    public init(literalCapacity: Int, interpolationCount: Int) {}
+    
+    var literalCount = 0
+    var interpolationCount = 0
+    
+    public mutating func appendLiteral(_ literal: StaticString) {
+        print("appendLiteral")
+        literalCount += 1
+    }
+    
+    public mutating func appendInterpolation<T>(_ value: @autoclosure @escaping () -> T) {
+        print("appendInterpolation<T>")
+        interpolationCount += 1
+    }
+}
+
+public struct MyMessage : ExpressibleByStringInterpolation {
+    public typealias StringInterpolation = MyInterpolation
+    var interpolation: MyInterpolation
+    
+    public init(stringInterpolation: MyInterpolation) {
+        self.interpolation = stringInterpolation
+    }
+    
+    public init(stringLiteral value: StaticString) {
+        self.interpolation = MyInterpolation(literalCapacity: 0, interpolationCount: 0)
+        self.interpolation.appendLiteral(value)
+    }
+}
+
+public func print_interpolation(_ message: MyMessage) {
+    print(message.interpolation.literalCount)
+    print(message.interpolation.interpolationCount)
+}
+
+@main
+struct Main {
+    static func main() {
+        print_interpolation("hello \(42) \(123) abc")
+    }
+}
+
+// CHECK: appendLiteral
+// CHECK: appendInterpolation<T>
+// CHECK: appendLiteral
+// CHECK: appendInterpolation<T>
+// CHECK: appendLiteral
+// CHECK: 3
+// CHECK: 2


### PR DESCRIPTION
This only makes ExpressibleByStringInterpolation available, but does not provide any concrete implementations of ExpressibleByStringInterpolation. But it should make it possible for users to write their own string interpolation implementations. See the attached test showcasing that.