### PR TITLE
[NFC][In Both Senses] Use _NormData type instead of performing a lookup directly

### DIFF
--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftShims
-
 extension Unicode.Scalar {
   // Normalization boundary - a place in a string where everything left of the
   // boundary can be normalized independently from everything right of the

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -27,17 +27,8 @@ extension Unicode.Scalar {
   internal var _isNFCStarter: Bool {
     // Fast path: All scalars up to U+300 are NFC_QC and have boundaries
     // before them.
-    if value < 0x300 {
-      return true
-    }
-
-    // Any scalar who has CCC of 0 has a normalization boundary before it AND
-    // any scalar who is also NFC_QC is considered an NFC starter.
-    let normData = _swift_stdlib_getNormData(value)
-    let ccc = normData >> 3
-    let isNFCQC = normData & 0x6 == 0
-
-    return ccc == 0 && isNFCQC
+    let normData = Unicode._NormData(self, fastUpperbound: 0x300)
+    return normData.ccc == 0 && normData.isNFCQC
   }
 }
 


### PR DESCRIPTION
Very tiny cleanup. 

It's cleaner to use the type and its accessors rather than manually performing a lookup and duplicating the bit-shifting and masking code.

@Azoy could you review?
