### PR TITLE
[5.10][Concurrency] Hide `async_Main` from other object files

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -538,8 +538,13 @@ SILLinkage SILDeclRef::getDefinitionLinkage() const {
   // The main entry-point is public.
   if (kind == Kind::EntryPoint)
     return SILLinkage::Public;
-  if (kind == Kind::AsyncEntryPoint)
-    return SILLinkage::Hidden;
+  if (kind == Kind::AsyncEntryPoint) {
+    // async main entrypoint is referenced only from @main and
+    // they are in the same SIL module. Hiding this entrypoint
+    // from other object file makes it possible to link multiple
+    // executable targets for SwiftPM testing with -entry-point-function-name
+    return SILLinkage::Private;
+  }
 
   // Calling convention thunks have shared linkage.
   if (isForeignToNativeThunk())

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -40,7 +40,7 @@ func asyncFunc() async {
 
 
 // async_Main
-// CHECK-SIL-LABEL: sil hidden @async_Main : $@convention(thin) @async () -> () {
+// CHECK-SIL-LABEL: sil private @async_Main : $@convention(thin) @async () -> () {
 // call main
 // CHECK-SIL:  %0 = metatype $@thin MyProgram.Type             // user: %2
 // CHECK-SIL-NEXT:  // function_ref static MyProgram.$main()

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -3,7 +3,7 @@
 // a
 // CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1aSivp : $Int
 
-// CHECK-LABEL: sil hidden [ossa] @async_Main
+// CHECK-LABEL: sil private [ossa] @async_Main
 // CHECK: bb0:
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[GET_MAIN:%.*]] = function_ref @swift_task_getMainExecutor


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/69113 to repair release/5.10 CI https://github.com/apple/swift/pull/69113#issuecomment-1763460044

---

**Explanation**: Hide compiler emitted `async_Main` symbol from other object files to allow testing multiple async executable modules in SwiftPM.
**Original PR**: https://github.com/apple/swift/pull/69113
**Reviewed by**: @neonichu @etcwilde 
**Resolves**: 
**Tests**: Tests added in the main of SwiftPM has been auto-merged in advance. https://github.com/apple/swift-package-manager/commit/f258cd551d6508acb2ef89588485659d4cf76729