### PR TITLE
Check thrown error types of for applications/subscripts/property access

### DIFF
--- a/include/swift/AST/CatchNode.h
+++ b/include/swift/AST/CatchNode.h
@@ -1,0 +1,43 @@
+//===--- CatchNode.h - An AST node that catches errors -----------*- C++-*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_CATCHNODE_H
+#define SWIFT_AST_CATCHNODE_H
+
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/PointerUnion.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Stmt.h"
+
+namespace swift {
+
+/// An AST node that represents a point where a thrown error can be caught and
+/// or rethrown, which includes functions do...catch statements.
+class CatchNode: public llvm::PointerUnion<
+    AbstractFunctionDecl *, AbstractClosureExpr *, DoCatchStmt *
+  > {
+public:
+  using PointerUnion::PointerUnion;
+
+  /// Determine the thrown error type within the region of this catch node
+  /// where it will catch (and possibly rethrow) errors. All of the errors
+  /// thrown from within that region will be converted to this error type.
+  ///
+  /// Returns the thrown error type for a throwing context, or \c llvm::None
+  /// if this is a non-throwing context.
+  llvm::Optional<Type> getThrownErrorTypeInContext(ASTContext &ctx) const;
+};
+
+} // end namespace swift
+
+#endif // SWIFT_AST_CATCHNODE_H

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -18,6 +18,7 @@
 #define SWIFT_AST_NAME_LOOKUP_H
 
 #include "swift/AST/ASTVisitor.h"
+#include "swift/AST/CatchNode.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Module.h"
@@ -832,6 +833,25 @@ public:
   static void lookupEnclosingMacroScope(
       SourceFile *sourceFile, SourceLoc loc,
       llvm::function_ref<bool(PotentialMacro macro)> consume);
+
+  /// Look up the scope tree for the nearest point at which an error thrown from
+  /// this location can be caught or rethrown.
+  ///
+  /// For example, given this code:
+  ///
+  /// \code
+  /// func f() throws {
+  ///   do {
+  ///     try g() // A
+  ///   } catch {
+  ///     throw ErrorWrapper(error) // B
+  ///   }
+  /// }
+  /// \endcode
+  ///
+  /// At the point marked A, the catch node is the enclosing do...catch
+  /// statement. At the point marked B, the catch node is the function itself.
+  static CatchNode lookupCatchNode(ModuleDecl *module, SourceLoc loc);
 
   SWIFT_DEBUG_DUMP;
   void print(llvm::raw_ostream &) const;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -963,8 +963,10 @@ AbstractFunctionDecl::getEffectiveThrownErrorType() const {
       interfaceType = fnType->getResult();
   }
 
-  return interfaceType->castTo<AnyFunctionType>()
-      ->getEffectiveThrownErrorType();
+  if (auto fnType = interfaceType->getAs<AnyFunctionType>())
+    return fnType->getEffectiveThrownErrorType();
+
+  return llvm::None;
 }
 
 Expr *AbstractFunctionDecl::getSingleExpressionBody() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -957,6 +957,14 @@ Type AbstractFunctionDecl::getThrownInterfaceType() const {
 
 llvm::Optional<Type> 
 AbstractFunctionDecl::getEffectiveThrownErrorType() const {
+  // FIXME: Only getters can have thrown error types right now, and DidSet
+  // has a cyclic reference if we try to get its interface type here. Find a
+  // better way to express this.
+  if (auto accessor = dyn_cast<AccessorDecl>(this)) {
+    if (accessor->getAccessorKind() != AccessorKind::Get)
+      return llvm::None;
+  }
+
   Type interfaceType = getInterfaceType();
   if (hasImplicitSelfDecl()) {
     if (auto fnType = interfaceType->getAs<AnyFunctionType>())

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -599,7 +599,7 @@ struct InferRequirementsWalker : public TypeWalker {
                                      DifferentiabilityKind::Linear);
       }
 
-      // Infer that the thrown error type conforms to Error.
+      // Infer that the thrown error type of a function type conforms to Error.
       if (auto thrownError = fnTy->getThrownError()) {
         if (auto errorProtocol = ctx.getErrorDecl()) {
           addConformanceConstraint(thrownError, errorProtocol);

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -473,12 +473,15 @@ bool DoCatchStmt::isSyntacticallyExhaustive() const {
 }
 
 Type DoCatchStmt::getCaughtErrorType() const {
-  return getCatches()
+  auto firstPattern = getCatches()
     .front()
     ->getCaseLabelItems()
     .front()
-    .getPattern()
-    ->getType();
+    .getPattern();
+  if (firstPattern->hasType())
+    return firstPattern->getType();
+
+  return Type();
 }
 
 void LabeledConditionalStmt::setCond(StmtCondition e) {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1718,14 +1718,15 @@ public:
 private:
   static Context getContextForPatternBinding(PatternBindingDecl *pbd) {
     if (!pbd->isStatic() && pbd->getDeclContext()->isTypeContext()) {
-      return Context(Kind::IVarInitializer);
+      return Context(Kind::IVarInitializer, pbd->getDeclContext());
     } else {
-      return Context(Kind::GlobalVarInitializer);
+      return Context(Kind::GlobalVarInitializer, pbd->getDeclContext());
     }
   }
 
   Kind TheKind;
   llvm::Optional<AnyFunctionRef> Function;
+  DeclContext *DC;
   bool HandlesErrors = false;
   bool HandlesAsync = false;
 
@@ -1736,14 +1737,15 @@ private:
   bool DiagnoseErrorOnTry = false;
   InterpolatedStringLiteralExpr *InterpolatedString = nullptr;
 
-  explicit Context(Kind kind)
-      : TheKind(kind), Function(llvm::None), HandlesErrors(false) {
+  explicit Context(Kind kind, DeclContext *dc)
+      : TheKind(kind), Function(llvm::None), DC(dc), HandlesErrors(false) {
     assert(TheKind != Kind::PotentiallyHandled);
   }
 
   explicit Context(bool handlesErrors, bool handlesAsync,
-                   llvm::Optional<AnyFunctionRef> function)
-      : TheKind(Kind::PotentiallyHandled), Function(function),
+                   llvm::Optional<AnyFunctionRef> function,
+                   DeclContext *dc)
+      : TheKind(Kind::PotentiallyHandled), Function(function), DC(dc),
         HandlesErrors(handlesErrors), HandlesAsync(handlesAsync) {}
 
 public:
@@ -1820,7 +1822,7 @@ public:
   static Context forTopLevelCode(TopLevelCodeDecl *D) {
     // Top-level code implicitly handles errors.
     return Context(/*handlesErrors=*/true,
-                   /*handlesAsync=*/D->isAsyncContext(), llvm::None);
+                   /*handlesAsync=*/D->isAsyncContext(), llvm::None, D);
   }
 
   static Context forFunction(AbstractFunctionDecl *D) {
@@ -1840,20 +1842,20 @@ public:
       }
     }
 
-    return Context(D->hasThrows(), D->isAsyncContext(), AnyFunctionRef(D));
+    return Context(D->hasThrows(), D->isAsyncContext(), AnyFunctionRef(D), D);
   }
 
-  static Context forDeferBody() {
-    return Context(Kind::DeferBody);
+  static Context forDeferBody(DeclContext *dc) {
+    return Context(Kind::DeferBody, dc);
   }
 
   static Context forInitializer(Initializer *init) {
     if (isa<DefaultArgumentInitializer>(init)) {
-      return Context(Kind::DefaultArgument);
+      return Context(Kind::DefaultArgument, init);
     }
 
     if (isa<PropertyWrapperInitializer>(init)) {
-      return Context(Kind::PropertyWrapper);
+      return Context(Kind::PropertyWrapper, init);
     }
 
     auto *binding = cast<PatternBindingInitializer>(init)->getBinding();
@@ -1863,7 +1865,7 @@ public:
   }
 
   static Context forEnumElementInitializer(EnumElementDecl *elt) {
-    return Context(Kind::EnumElementInitializer);
+    return Context(Kind::EnumElementInitializer, elt);
   }
 
   static Context forClosure(AbstractClosureExpr *E) {
@@ -1877,15 +1879,15 @@ public:
       }
     }
 
-    return Context(closureTypeThrows, closureTypeIsAsync, AnyFunctionRef(E));
+    return Context(closureTypeThrows, closureTypeIsAsync, AnyFunctionRef(E), E);
   }
 
-  static Context forCatchPattern(CaseStmt *S) {
-    return Context(Kind::CatchPattern);
+  static Context forCatchPattern(CaseStmt *S, DeclContext *dc) {
+    return Context(Kind::CatchPattern, dc);
   }
 
-  static Context forCatchGuard(CaseStmt *S) {
-    return Context(Kind::CatchGuard);
+  static Context forCatchGuard(CaseStmt *S, DeclContext *dc) {
+    return Context(Kind::CatchGuard, dc);
   }
 
   static Context forPatternBinding(PatternBindingDecl *binding) {
@@ -1908,6 +1910,8 @@ public:
   }
 
   Kind getKind() const { return TheKind; }
+
+  DeclContext *getDeclContext() const { return DC; }
 
   bool handlesThrows(ConditionalEffectKind errorKind) const {
     switch (errorKind) {
@@ -2587,6 +2591,19 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
     }
   };
 
+  /// Retrieve the type of the error that can be caught when an error is
+  /// thrown from the given location.
+  Type getCaughtErrorTypeAt(SourceLoc loc) {
+    auto module = CurContext.getDeclContext()->getParentModule();
+    if (CatchNode catchNode = ASTScope::lookupCatchNode(module, loc)) {
+      if (auto caughtType = catchNode.getThrownErrorTypeInContext(Ctx))
+        return *caughtType;
+    }
+
+    // Fall back to the error existential.
+    return Ctx.getErrorExistentialType();
+  }
+
 public:
   CheckEffectsCoverage(ASTContext &ctx, Context initialContext)
     : Ctx(ctx), CurContext(initialContext),
@@ -2706,6 +2723,11 @@ private:
     // specialized diagnostic about non-exhaustive catches.
     if (!CurContext.handlesThrows(ConditionalEffectKind::Conditional)) {
       CurContext.setNonExhaustiveCatch(true);
+    } else if (Type rethrownErrorType = S->getCaughtErrorType()) {
+      // We're implicitly rethrowing the error out of this do..catch, so make
+      // sure that we can throw an error of this type out of this context.
+      auto catches = S->getCatches();
+      checkThrownErrorType(catches.back()->getEndLoc(), rethrownErrorType);
     }
 
     S->getBody()->walk(*this);
@@ -2727,14 +2749,15 @@ private:
   }
 
   void checkCatch(CaseStmt *S, ConditionalEffectKind doThrowingKind) {
+    auto dc = CurContext.getDeclContext();
     for (auto &LabelItem : S->getMutableCaseLabelItems()) {
       // The pattern and guard aren't allowed to throw.
       {
-        ContextScope scope(*this, Context::forCatchPattern(S));
+        ContextScope scope(*this, Context::forCatchPattern(S, dc));
         LabelItem.getPattern()->walk(*this);
       }
       if (auto guard = LabelItem.getGuardExpr()) {
-        ContextScope scope(*this, Context::forCatchGuard(S));
+        ContextScope scope(*this, Context::forCatchGuard(S, dc));
         guard->walk(*this);
       }
     }
@@ -2943,9 +2966,25 @@ private:
       } else if (!isTryCovered) {
         CurContext.diagnoseUncoveredThrowSite(Ctx, E, // we want this one to trigger
                                               classification.getThrowReason());
+      } else {
+        checkThrownErrorType(E.getStartLoc(), classification.getThrownError());
       }
       break;
     }
+  }
+
+  /// Check the thrown error type against the type that can be caught or
+  /// rethrown by the context.
+  void checkThrownErrorType(SourceLoc loc, Type thrownErrorType) {
+    Type caughtErrorType = getCaughtErrorTypeAt(loc);
+    if (caughtErrorType->isEqual(thrownErrorType))
+      return;
+
+    OpaqueValueExpr *opaque = new (Ctx) OpaqueValueExpr(loc, thrownErrorType);
+    Expr *rethrowExpr = opaque;
+    TypeChecker::typeCheckExpression(
+        rethrowExpr, CurContext.getDeclContext(),
+        {caughtErrorType, /*FIXME:*/CTP_ThrowStmt});
   }
 
   ShouldRecurse_t checkAwait(AwaitExpr *E) {
@@ -3206,7 +3245,7 @@ void TypeChecker::checkFunctionEffects(AbstractFunctionDecl *fn) {
 
   auto isDeferBody = isa<FuncDecl>(fn) && cast<FuncDecl>(fn)->isDeferBody();
   auto context =
-      isDeferBody ? Context::forDeferBody() : Context::forFunction(fn);
+      isDeferBody ? Context::forDeferBody(fn) : Context::forFunction(fn);
   auto &ctx = fn->getASTContext();
   CheckEffectsCoverage checker(ctx, context);
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -918,12 +918,15 @@ public:
 
   Classification classifyConformance(ProtocolConformanceRef conformanceRef,
                                      EffectKind kind) {
+    if (conformanceRef.isInvalid())
+      return Classification::forInvalidCode();
+
     if (conformanceRef.hasEffect(kind)) {
       assert(kind == EffectKind::Throws); // there is no async
       ASTContext &ctx = conformanceRef.getRequirement()->getASTContext();
       // FIXME: typed throws, if it becomes a thing for conformances
       return Classification::forThrows(
-          ctx.getAnyExistentialType(),
+          ctx.getErrorExistentialType(),
           ConditionalEffectKind::Conditional,
           PotentialEffectReason::forConformance());
     }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1689,21 +1689,6 @@ public:
                           CaseParentKind::DoCatch, limitExhaustivityChecks,
                           caughtErrorType);
 
-    if (!S->isSyntacticallyExhaustive()) {
-      // If we're implicitly rethrowing the error out of this do..catch, make
-      // sure that we can throw an error of this type out of this context.
-      // FIXME: Unify this lookup of the type with that from ThrowStmt.
-      if (auto TheFunc = AnyFunctionRef::fromDeclContext(DC)) {
-        if (Type expectedErrorType = TheFunc->getThrownErrorType()) {
-          OpaqueValueExpr *opaque = new (Ctx) OpaqueValueExpr(
-              catches.back()->getEndLoc(), caughtErrorType);
-          Expr *rethrowExpr = opaque;
-          TypeChecker::typeCheckExpression(
-              rethrowExpr, DC, {expectedErrorType, CTP_ThrowStmt});
-        }
-      }
-    }
-
     return S;
   }
 

--- a/test/Concurrency/typed_throws.swift
+++ b/test/Concurrency/typed_throws.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TypedThrows
+
+// REQUIRES: concurrency
+
+enum MyError: Error {
+  case failed
+  case epicFailed
+}
+
+
+@available(SwiftStdlib 5.1, *)
+func testAsyncFor<S: AsyncSequence>(seq: S) async throws(MyError) {
+  // expected-error@+1{{thrown expression type 'any Error' cannot be converted to error type 'MyError'}}
+  for try await _ in seq {
+  }
+}

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -117,7 +117,7 @@ func testDoCatchRethrowsTyped() throws(HomeworkError) {
 func testTryIncompatibleTyped(cond: Bool) throws(HomeworkError) {
   try doHomework() // okay
 
-  try doSomething() // FIXME: should error
+  try doSomething() // expected-error{{thrown expression type 'MyError' cannot be converted to error type 'HomeworkError'}}
 
   do {
     if cond {

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -74,10 +74,10 @@ func testDoCatchMultiErrorType() {
     try doSomething()
     try doHomework()
   } catch .failed { // expected-error{{type 'any Error' has no member 'failed'}}
-    
+
   } catch {
     let _: Int = error // expected-error{{cannot convert value of type 'any Error' to specified type 'Int'}}
-  }  
+  }
 }
 
 func testDoCatchRethrowsUntyped() throws {
@@ -96,7 +96,7 @@ func testDoCatchRethrowsTyped() throws(HomeworkError) {
   do {
     try doSomething()
   } catch .failed {
-    
+
   } // expected-error{{thrown expression type 'MyError' cannot be converted to error type 'HomeworkError'}}
 
   do {
@@ -114,8 +114,20 @@ func testDoCatchRethrowsTyped() throws(HomeworkError) {
   } // okay, the thrown 'any Error' has been caught
 }
 
-func testTryIncompatibleTyped() throws(HomeworkError) {
+func testTryIncompatibleTyped(cond: Bool) throws(HomeworkError) {
   try doHomework() // okay
 
   try doSomething() // FIXME: should error
+
+  do {
+    if cond {
+      throw .dogAteIt // expected-error{{type 'any Error' has no member 'dogAteIt'}}
+    } else {
+      try doSomething()
+    }
+  } catch let error as Never {
+    // expected-warning@-1{{'catch' block is unreachable because no errors are thrown in 'do' block}}
+    // expected-warning@-2{{'as' test is always true}}
+    throw .forgot
+  }
 }


### PR DESCRIPTION
Whenever there is a throwing operation such as a call, subscript, or
property access, check that the error type thrown from that operation
can be caught/rethrown from the current context.

To do this, introduce a new API to find the AST node that catches or rethrows an
error thrown from the given source location.