### PR TITLE
[AddressLowering] Fixed single arg phi edge case.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PhiStorageOptimizer.cpp
+++ b/lib/SILOptimizer/Mandatory/PhiStorageOptimizer.cpp
@@ -168,7 +168,14 @@ void CoalescedPhi::coalesce(PhiValue phi,
 void PhiStorageOptimizer::optimize() {
   // The single incoming value case always projects storage.
   if (auto *predecessor = phi.phiBlock->getSinglePredecessorBlock()) {
-    coalescedPhi.coalescedOperands.push_back(phi.getOperand(predecessor));
+    if (canCoalesceValue(phi.getValue()->getIncomingPhiValue(predecessor))) {
+      // Storage will always be allocated for the phi.  The optimization
+      // attempts to let incoming values reuse the phi's storage.  This isn't
+      // always possible, even in the single incoming value case.  For example,
+      // it isn't possible when the incoming value is a function argument or
+      // when the incoming value is already a projection.
+      coalescedPhi.coalescedOperands.push_back(phi.getOperand(predecessor));
+    }
     return;
   }
   for (auto *incomingPred : phi.phiBlock->getPredecessorBlocks()) {

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1427,8 +1427,10 @@ nopers(%error : @owned $any Error):
 
 // CHECK-LABEL: sil [ossa] @f262_testTryApplyIntoPhi : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
-// CHECK:         try_apply undef<R>([[ADDR]]) {{.*}}, normal [[NORMAL:bb[0-9]+]]
-// CHECK:       [[NORMAL]](%2 : $()):                                    
+// CHECK:         [[STACK:%[^,]+]] = alloc_stack
+// CHECK:         try_apply undef<R>([[STACK]]) {{.*}}, normal [[NORMAL:bb[0-9]+]]
+// CHECK:       [[NORMAL]]({{%[^,]+}} : $()):
+// CHECK:         copy_addr [take] [[STACK]] to [init] [[ADDR]]
 // CHECK:         br [[EXIT:bb[0-9]+]]                                          
 // CHECK:       [[EXIT]]:                                              
 // CHECK:         return {{%[^,]+}} : $()                                 

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -30,6 +30,10 @@ enum OuterEnum<T> {
   case inner(InnerEnum<T>, AnyObject)
 }
 
+struct Box<T> {
+  var t: T
+}
+
 struct InnerStruct<T> {
   var t: T
   var object: AnyObject
@@ -533,6 +537,65 @@ right:
   br exit(%instance : $T, %s : $S)
 exit(%instance_2 : @owned $T, %s_2 : $S):
   destroy_value %instance_2 : $T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Check behavior of non-coalesceable single incoming phi.
+// CHECK-LABEL: sil [ossa] @f120_single_phi_argument_forwarded_function_argument : {{.*}} {
+// CHECK:       bb0([[T:%[^,]+]] :
+// CHECK:         [[STORAGE:%[^,]+]] = alloc_stack
+// CHECK:         copy_addr [take] [[T]] to [init] [[STORAGE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_addr [[STORAGE]]
+// CHECK:         dealloc_stack [[STORAGE]]
+// CHECK-LABEL: } // end sil function 'f120_single_phi_argument_forwarded_function_argument'
+sil [ossa]@f120_single_phi_argument_forwarded_function_argument : $@convention(thin) <T> (@in T) -> () {
+entry(%t : @owned $T):
+  br exit(%t : $T)
+
+exit(%t2 : @owned $T):
+  destroy_value %t2 : $T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @f121_single_phi_argument_forwarded_function_argument_returned : {{.*}} {
+// CHECK:       bb0([[OUT:%[^,]+]] :
+// CHECK-SAME:      [[IN:%[^,]+]] :
+// CHECK:         copy_addr [take] [[IN]] to [init] [[OUT]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'f121_single_phi_argument_forwarded_function_argument_returned'
+sil [ossa]@f121_single_phi_argument_forwarded_function_argument_returned : $@convention(thin) <T> (@in T) -> @out T {
+entry(%t : @owned $T):
+  br exit(%t : $T)
+
+exit(%t2 : @owned $T):
+  return %t2 : $T
+}
+
+// CHECK-LABEL: sil [ossa] @f122_single_phi_argument_destructure : $@convention(thin) <T> () -> () {
+// CHECK:         [[PHI_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         [[BOX_ADDR:%[^,]+]] = alloc_stack $Box<T>
+// CHECK:         apply undef<T>([[BOX_ADDR]])
+// CHECK:         [[T_ADDR:%[^,]+]] = struct_element_addr [[BOX_ADDR]] : $*Box<T>, #Box.t
+// CHECK:         copy_addr [take] [[T_ADDR]] to [init] [[PHI_ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_addr [[PHI_ADDR]]
+// CHECK:         dealloc_stack [[BOX_ADDR]]
+// CHECK:         dealloc_stack [[PHI_ADDR]]
+// CHECK-LABEL: } // end sil function 'f122_single_phi_argument_destructure'
+sil [ossa]@f122_single_phi_argument_destructure : $@convention(thin) <T> () -> () {
+entry:
+  %box = apply undef<T>() : $@convention(thin) <T> () -> (@out Box<T>)
+  %t = destructure_struct %box : $Box<T>
+  br exit(%t : $T)
+
+exit(%t2 : @owned $T):
+  destroy_value %t2 : $T
   %retval = tuple ()
   return %retval : $()
 }


### PR DESCRIPTION
Not every phi with a single incoming value can be coalesced.  Explicitly check whether it is coalesceable and only coalesce it if so.
