### PR TITLE
[5.9][build-script] Add module ABI name prefix to swift-syntax libraries

### DIFF
--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -17,14 +17,14 @@
 
 // CHECK: ->(plugin:[[#PID1:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION:]]}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":6,"offset":[[#]]},"source":"#fooMacro(1)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":7,"offset":[[#]]},"source":"#fooMacro(1)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID1]]) {"invalidResponse":{}}
-// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":8,"offset":[[#]]},"source":"#fooMacro(2)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":9,"offset":[[#]]},"source":"#fooMacro(2)"}}}
 // ^ This messages causes the mock plugin exit because there's no matching expected message.
 
 // CHECK: ->(plugin:[[#PID2:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION]]}}}
 // CHECK-NEXT: <-(plugin:[[#PID2]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
-// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":10,"offset":[[#]]},"source":"#fooMacro(3)"}}}
+// CHECK-NEXT: ->(plugin:[[#PID2]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"macroRole":"expression","syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"{{.+}}test.swift","line":11,"offset":[[#]]},"source":"#fooMacro(3)"}}}
 // CHECK-NEXT: <-(plugin:[[#PID2:]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"3.description"}}
 
 //--- test.swift
@@ -32,9 +32,10 @@
 
 func test() {
   // FIXME: Should be more user friendly message.
+  // FIXME: -module-abi-name ABI name is leaking.
 
   let _: String = #fooMacro(1)
-  // expected-error @-1 {{typeMismatch(SwiftCompilerPluginMessageHandling.PluginToHostMessage}}
+  // expected-error @-1 {{typeMismatch(CompilerSwiftCompilerPluginMessageHandling.PluginToHostMessage}}
   let _: String = #fooMacro(2)
   // expected-error @-1 {{failed to receive result from plugin (from macro 'fooMacro')}}
   let _: String = #fooMacro(3)

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -214,6 +214,8 @@ cmake ^
 
   -D CMAKE_INSTALL_PREFIX="%InstallRoot%" ^
 
+  -D SWIFT_MODULE_ABI_NAME_PREFIX="Compiler" ^
+
   -G Ninja ^
   -S %SourceRoot%\swift-syntax || (exit /b)
 cmake --build %BuildRoot%\99 || (exit /b)

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -63,6 +63,7 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
         self.cmake_options.define('CMAKE_INSTALL_PREFIX:PATH', self.args.install_prefix)
         self.cmake_options.define('SWIFTSYNTAX_ENABLE_ASSERTIONS:BOOL',
                                   self.args.assertions)
+        self.cmake_options.define('SWIFT_MODULE_ABI_NAME_PREFIX:STRING', 'Compiler')
         self.build_with_cmake(["all"], self.args.swift_build_variant, [])
 
     def should_test(self, host_target):


### PR DESCRIPTION
release/5.9 version of #69188 

* **Explanation**: Add `SWIFT_MODULE_ABI_NAME_PREFIX` CMake variable to swift-syntax libraries. Without this, `(lib)sourcekitdInProc.{dylib|so|dll}` was unusable if the binary links with swift-syntax via SwiftPM dependency, because sourcekitdInProc's swift-syntax symbols conflict with them. By differentiating the ABI name of the compiler's swift-syntax libraries, it can avoids name conflicts.
* **Risk**: Low, no code change. `-module-abi-name` is a well-tested reliable option.
* **Testing**: Passes current test-suite
* **Issues**: rdar://116951101 , https://github.com/apple/swift/issues/68812
* **Reviewer**: Alex Hoppen (@ahoppen), Ben Barham (@bnbarham)