### PR TITLE
[embedded] Start diagnosing metatype/value_metatype instructions in embedded Swift

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -356,6 +356,10 @@ ERROR(embedded_swift_existential_type,none,
       "cannot use a value of protocol type %0 in embedded Swift", (Type))
 ERROR(embedded_swift_existential,none,
       "cannot use a value of protocol type in embedded Swift", ())
+ERROR(embedded_swift_metatype_type,none,
+      "cannot use metatype %0 in embedded Swift", (Type))
+ERROR(embedded_swift_metatype,none,
+      "cannot use metatype in embedded Swift", ())
 NOTE(performance_called_from,none,
       "called from here", ())
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -357,7 +357,7 @@ ERROR(embedded_swift_existential_type,none,
 ERROR(embedded_swift_existential,none,
       "cannot use a value of protocol type in embedded Swift", ())
 ERROR(embedded_swift_metatype_type,none,
-      "cannot use metatype %0 in embedded Swift", (Type))
+      "cannot use metatype of type %0 in embedded Swift", (Type))
 ERROR(embedded_swift_metatype,none,
       "cannot use metatype in embedded Swift", ())
 NOTE(performance_called_from,none,

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -302,14 +302,13 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
       self = _ContiguousArrayBuffer<Element>()
     }
     else {
-      let storageType: _ContiguousArrayStorage<Element>.Type
       #if !$Embedded
-      storageType = getContiguousArrayStorageType(for: Element.self)
-      #else
-      storageType = _ContiguousArrayStorage<Element>.self
-      #endif
       _storage = Builtin.allocWithTailElems_1(
-         storageType, realMinimumCapacity._builtinWordValue, Element.self)
+         getContiguousArrayStorageType(for: Element.self), realMinimumCapacity._builtinWordValue, Element.self)
+      #else
+      _storage = Builtin.allocWithTailElems_1(
+         _ContiguousArrayStorage<Element>.self, realMinimumCapacity._builtinWordValue, Element.self)
+      #endif
 
       let storageAddr = UnsafeMutableRawPointer(Builtin.bridgeToRawPointer(_storage))
       let allocSize: Int?

--- a/test/embedded/metatypes.swift
+++ b/test/embedded/metatypes.swift
@@ -8,7 +8,7 @@ public func sink<T>(t: T) {}
 
 public func test() -> Int {
   let metatype = Int.self
-  sink(t: metatype) // expected-error {{cannot use metatype 'Int' in embedded Swift}}
+  sink(t: metatype) // expected-error {{cannot use metatype of type 'Int' in embedded Swift}}
   // expected-note@-1 {{called from here}}
   return 42
 }

--- a/test/embedded/metatypes.swift
+++ b/test/embedded/metatypes.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-ir -verify %s -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public func sink<T>(t: T) {}
+
+public func test() -> Int {
+  let metatype = Int.self
+  sink(t: metatype) // expected-error {{cannot use metatype 'Int' in embedded Swift}}
+  // expected-note@-1 {{called from here}}
+  return 42
+}

--- a/test/embedded/typeof.swift
+++ b/test/embedded/typeof.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-ir -verify %s -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public func unsafeWriteArray<T, R>(_ elementType: R.Type, array: inout T, index n: Int, value: R) {
+  precondition(_isPOD(elementType))
+  precondition(_isPOD(type(of: array))) // expected-error {{cannot use metatype '(Int, Int, Int, Int)' in embedded Swift}}
+  // expected-note@-1 {{called from here}}
+
+  return withUnsafeMutableBytes(of: &array) { ptr in
+    let buffer = ptr.bindMemory(to: R.self)
+    precondition(n >= 0)
+    precondition(n < buffer.count)
+    buffer[n] = value
+  }
+}
+
+public func test() {
+  var args: (Int, Int, Int, Int) = (0, 0, 0, 0)
+  let n = 2
+  let value = 42
+  unsafeWriteArray(type(of: args.0), array: &args, index: n, value: value)
+}

--- a/test/embedded/typeof.swift
+++ b/test/embedded/typeof.swift
@@ -6,7 +6,7 @@
 
 public func unsafeWriteArray<T, R>(_ elementType: R.Type, array: inout T, index n: Int, value: R) {
   precondition(_isPOD(elementType))
-  precondition(_isPOD(type(of: array))) // expected-error {{cannot use metatype '(Int, Int, Int, Int)' in embedded Swift}}
+  precondition(_isPOD(type(of: array))) // expected-error {{cannot use metatype of type '(Int, Int, Int, Int)' in embedded Swift}}
   // expected-note@-1 {{called from here}}
 
   return withUnsafeMutableBytes(of: &array) { ptr in


### PR DESCRIPTION
Currently, PerformanceDiagnostics are used in embedded Swift to flag uses of existentials in SIL (instructions that have RuntimeEffect::Existential). We should also diagnose RuntimeEffect::MetaData, but that is today overly conservative, so let's start with ValueMetatypeInst + MetatypeInst instructions only (which in IRGen directly emit a metadata reference, so we know they are not going to work).

Adding a simple test of directly using a metatype, and a more complex test where type(of:) is used which produces a metatype.