### PR TITLE
Introduce `@extern(c)` to declare C function without Clang module

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -449,6 +449,20 @@ through WebAssembly's import interface.
 
 It's the equivalent of clang's `__attribute__((import_module("module"), import_name("field")))`.
 
+### `@_extern(c, [, <"cName">])`
+
+Indicates that a particular declaration should refer to a
+C declaration with the given name. If the optional "cName"
+string is not specified, the mangled Swift name will be used.
+
+Similar to `@_cdecl`, but this attribute is used to reference
+C declarations from Swift, while `@_cdecl` is used to define
+Swift functions that can be referenced from C.
+
+Also similar to `@_silgen_name`, but a function declared with
+`@_extern(c)` is assumed to use the C ABI, while `@_silgen_name`
+assumes the Swift ABI.
+
 ## `@_fixed_layout`
 
 Same as `@frozen` but also works for classes.

--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -453,7 +453,9 @@ It's the equivalent of clang's `__attribute__((import_module("module"), import_n
 
 Indicates that a particular declaration should refer to a
 C declaration with the given name. If the optional "cName"
-string is not specified, the mangled Swift name will be used.
+string is not specified, the Swift function name is used
+without Swift name mangling. Platform-specific mangling
+rules (leading underscore on Darwin) are still applied.
 
 Similar to `@_cdecl`, but this attribute is used to reference
 C declarations from Swift, while `@_cdecl` is used to define

--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -437,19 +437,19 @@ the export name.
 
 It's the equivalent of clang's `__attribute__((export_name))`.
 
-## `@_extern(<language>)`
+## `@extern(<language>)`
 
 Indicates that a particular declaration should be imported
 from the external environment.
 
-### `@_extern(wasm, module: <"moduleName">, name: <"fieldName">)`
+### `@extern(wasm, module: <"moduleName">, name: <"fieldName">)`
 
 Indicates that a particular declaration should be imported
 through WebAssembly's import interface.
 
 It's the equivalent of clang's `__attribute__((import_module("module"), import_name("field")))`.
 
-### `@_extern(c, [, <"cName">])`
+### `@extern(c, [, <"cName">])`
 
 Indicates that a particular declaration should refer to a
 C declaration with the given name. If the optional "cName"
@@ -462,7 +462,7 @@ C declarations from Swift, while `@_cdecl` is used to define
 Swift functions that can be referenced from C.
 
 Also similar to `@_silgen_name`, but a function declared with
-`@_extern(c)` is assumed to use the C ABI, while `@_silgen_name`
+`@extern(c)` is assumed to use the C ABI, while `@_silgen_name`
 assumes the Swift ABI.
 
 ## `@_fixed_layout`

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -421,7 +421,7 @@ DECL_ATTR(_rawLayout, RawLayout,
   OnStruct | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   146)
 DECL_ATTR(_extern, Extern,
-  OnFunc | ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
+  OnFunc | AllowMultipleAttributes | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   147)
 SIMPLE_DECL_ATTR(_nonEscapable, NonEscapable,
   OnNominalType | UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -420,7 +420,7 @@ DECL_ATTR(_section, Section,
 DECL_ATTR(_rawLayout, RawLayout,
   OnStruct | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   146)
-DECL_ATTR(_extern, Extern,
+DECL_ATTR(extern, Extern,
   OnFunc | AllowMultipleAttributes | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   147)
 SIMPLE_DECL_ATTR(_nonEscapable, NonEscapable,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2368,6 +2368,10 @@ public:
     return static_cast<ExternKind>(Bits.ExternAttr.kind);
   }
 
+  /// Returns the C name of the given declaration.
+  /// \p forDecl is the func decl that the attribute belongs to.
+  StringRef getCName(const FuncDecl *forDecl) const;
+
   /// Find an ExternAttr with the given kind in the given DeclAttributes.
   static ExternAttr *find(DeclAttributes &attrs, ExternKind kind);
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2343,25 +2343,25 @@ public:
 /// the specified way to interoperate with Swift.
 class ExternAttr : public DeclAttribute {
 public:
-  ExternAttr(std::optional<StringRef> ModuleName, std::optional<StringRef> Name,
+  ExternAttr(llvm::Optional<StringRef> ModuleName, llvm::Optional<StringRef> Name,
              SourceLoc AtLoc, SourceRange Range, ExternKind Kind, bool Implicit)
       : DeclAttribute(DAK_Extern, AtLoc, Range, Implicit),
         ModuleName(ModuleName), Name(Name) {
     Bits.ExternAttr.kind = static_cast<unsigned>(Kind);
   }
 
-  ExternAttr(std::optional<StringRef> ModuleName, std::optional<StringRef> Name,
+  ExternAttr(llvm::Optional<StringRef> ModuleName, llvm::Optional<StringRef> Name,
              ExternKind Kind, bool Implicit)
       : ExternAttr(ModuleName, Name, SourceLoc(), SourceRange(), Kind,
                    Implicit) {}
 
   /// The module name to import the named declaration in it
   /// Used for Wasm import declaration.
-  const std::optional<StringRef> ModuleName;
+  const llvm::Optional<StringRef> ModuleName;
 
   /// The declaration name to import
   /// std::nullopt if the declaration name is not specified with @_extern(c)
-  const std::optional<StringRef> Name;
+  const llvm::Optional<StringRef> Name;
 
   /// Returns the kind of extern.
   ExternKind getExternKind() const {

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2339,7 +2339,7 @@ public:
   }
 };
 
-/// Define the `@_extern` attribute, used to import external declarations in
+/// Define the `@extern` attribute, used to import external declarations in
 /// the specified way to interoperate with Swift.
 class ExternAttr : public DeclAttribute {
   SourceLoc LParenLoc, RParenLoc;
@@ -2364,7 +2364,7 @@ public:
   const llvm::Optional<StringRef> ModuleName;
 
   /// The declaration name to import
-  /// std::nullopt if the declaration name is not specified with @_extern(c)
+  /// std::nullopt if the declaration name is not specified with @extern(c)
   const llvm::Optional<StringRef> Name;
 
   SourceLoc getLParenLoc() const { return LParenLoc; }

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2342,18 +2342,22 @@ public:
 /// Define the `@_extern` attribute, used to import external declarations in
 /// the specified way to interoperate with Swift.
 class ExternAttr : public DeclAttribute {
+  SourceLoc LParenLoc, RParenLoc;
+
 public:
-  ExternAttr(llvm::Optional<StringRef> ModuleName, llvm::Optional<StringRef> Name,
-             SourceLoc AtLoc, SourceRange Range, ExternKind Kind, bool Implicit)
-      : DeclAttribute(DAK_Extern, AtLoc, Range, Implicit),
-        ModuleName(ModuleName), Name(Name) {
+  ExternAttr(llvm::Optional<StringRef> ModuleName,
+             llvm::Optional<StringRef> Name, SourceLoc AtLoc,
+             SourceLoc LParenLoc, SourceLoc RParenLoc, SourceRange Range,
+             ExternKind Kind, bool Implicit)
+      : DeclAttribute(DAK_Extern, AtLoc, Range, Implicit), LParenLoc(LParenLoc),
+        RParenLoc(RParenLoc), ModuleName(ModuleName), Name(Name) {
     Bits.ExternAttr.kind = static_cast<unsigned>(Kind);
   }
 
-  ExternAttr(llvm::Optional<StringRef> ModuleName, llvm::Optional<StringRef> Name,
-             ExternKind Kind, bool Implicit)
-      : ExternAttr(ModuleName, Name, SourceLoc(), SourceRange(), Kind,
-                   Implicit) {}
+  ExternAttr(llvm::Optional<StringRef> ModuleName,
+             llvm::Optional<StringRef> Name, ExternKind Kind, bool Implicit)
+      : ExternAttr(ModuleName, Name, SourceLoc(), SourceLoc(), SourceLoc(),
+                   SourceRange(), Kind, Implicit) {}
 
   /// The module name to import the named declaration in it
   /// Used for Wasm import declaration.
@@ -2362,6 +2366,9 @@ public:
   /// The declaration name to import
   /// std::nullopt if the declaration name is not specified with @_extern(c)
   const llvm::Optional<StringRef> Name;
+
+  SourceLoc getLParenLoc() const { return LParenLoc; }
+  SourceLoc getRParenLoc() const { return RParenLoc; }
 
   /// Returns the kind of extern.
   ExternKind getExternKind() const {

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -112,6 +112,24 @@ enum class ExposureKind: uint8_t {
 enum : unsigned { NumExposureKindBits =
   countBitsUsed(static_cast<unsigned>(ExposureKind::Last_ExposureKind)) };
   
+/// This enum represents the possible values of the @_extern attribute.
+enum class ExternKind: uint8_t {
+  /// Reference an externally defined C function.
+  /// The imported function has C function pointer representation,
+  /// and is called using the C calling convention.
+  C,
+  /// Reference an externally defined function through WebAssembly's
+  /// import mechanism.
+  /// This does not specify the calling convention and can be used
+  /// with other extern kinds together.
+  /// Effectively, this is no-op on non-WebAssembly targets.
+  Wasm,
+  Last_ExternKind = Wasm
+};
+
+enum : unsigned { NumExternKindBits =
+  countBitsUsed(static_cast<unsigned>(ExternKind::Last_ExternKind)) };
+
 enum DeclAttrKind : unsigned {
 #define DECL_ATTR(_, NAME, ...) DAK_##NAME,
 #include "swift/AST/Attr.def"

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -112,7 +112,7 @@ enum class ExposureKind: uint8_t {
 enum : unsigned { NumExposureKindBits =
   countBitsUsed(static_cast<unsigned>(ExposureKind::Last_ExposureKind)) };
   
-/// This enum represents the possible values of the @_extern attribute.
+/// This enum represents the possible values of the @extern attribute.
 enum class ExternKind: uint8_t {
   /// Reference an externally defined C function.
   /// The imported function has C function pointer representation,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1868,7 +1868,7 @@ ERROR(attr_rawlayout_expected_params,none,
       "expected %1 argument after %0 argument in @_rawLayout attribute", (StringRef, StringRef))
 
 ERROR(attr_extern_expected_label,none,
-      "expected %0 argument to @_extern attribute", (StringRef))
+      "expected %0 argument to @extern attribute", (StringRef))
 //------------------------------------------------------------------------------
 // MARK: Generics parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1874,6 +1874,22 @@ ERROR(section_empty_name,none,
 // @_extern
 ERROR(extern_not_at_top_level_func,none,
       "@_extern attribute can only be applied to global functions", ())
+ERROR(extern_empty_c_name,none,
+      "expected non-empty C name in @_extern attribute", ())
+ERROR(extern_only_non_other_attr,none,
+      "@_extern attribute cannot be applied to an '%0' declaration", (StringRef))
+ERROR(c_func_variadic, none,
+      "cannot declare variadic argument %0 in %kind1",
+      (DeclName, const ValueDecl *))
+ERROR(c_func_unsupported_specifier, none,
+      "cannot declare '%0' argument %1 in %kind2",
+      (StringRef, DeclName, const ValueDecl *))
+ERROR(c_func_unsupported_type, none, "%0 cannot be represented in C",
+      (Type))
+ERROR(c_func_async,none,
+      "async functions cannot be represented in C", ())
+ERROR(c_func_throws,none,
+      "raising errors from C functions is not supported", ())
 
 ERROR(expose_wasm_not_at_top_level_func,none,
       "@_expose attribute with 'wasm' can only be applied to global functions", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1877,7 +1877,7 @@ ERROR(extern_not_at_top_level_func,none,
 ERROR(extern_empty_c_name,none,
       "expected non-empty C name in @_extern attribute", ())
 ERROR(extern_only_non_other_attr,none,
-      "@_extern attribute cannot be applied to an '%0' declaration", (StringRef))
+      "@_extern attribute cannot be applied to an '@%0' declaration", (StringRef))
 ERROR(c_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1872,6 +1872,8 @@ ERROR(section_empty_name,none,
       "@_section section name cannot be empty", ())
 
 // @_extern
+ERROR(attr_extern_experimental,none,
+      "@_extern requires '-enable-experimental-feature Extern'", ())
 ERROR(extern_not_at_top_level_func,none,
       "@_extern attribute can only be applied to global functions", ())
 ERROR(extern_empty_c_name,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1878,6 +1878,8 @@ ERROR(extern_empty_c_name,none,
       "expected non-empty C name in @_extern attribute", ())
 ERROR(extern_only_non_other_attr,none,
       "@_extern attribute cannot be applied to an '@%0' declaration", (StringRef))
+ERROR(extern_c_invalid_name, none,
+      "@_extern attribute has invalid C name '%0'", (StringRef))
 ERROR(c_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1871,17 +1871,17 @@ ERROR(section_not_at_top_level,none,
 ERROR(section_empty_name,none,
       "@_section section name cannot be empty", ())
 
-// @_extern
+// @extern
 ERROR(attr_extern_experimental,none,
-      "@_extern requires '-enable-experimental-feature Extern'", ())
+      "@extern requires '-enable-experimental-feature Extern'", ())
 ERROR(extern_not_at_top_level_func,none,
-      "@_extern attribute can only be applied to global functions", ())
+      "@extern attribute can only be applied to global functions", ())
 ERROR(extern_empty_c_name,none,
-      "expected non-empty C name in @_extern attribute", ())
+      "expected non-empty C name in @extern attribute", ())
 ERROR(extern_only_non_other_attr,none,
-      "@_extern attribute cannot be applied to an '@%0' declaration", (StringRef))
+      "@extern attribute cannot be applied to an '@%0' declaration", (StringRef))
 WARNING(extern_c_maybe_invalid_name, none,
-        "C name '%0' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning",
+        "C name '%0' may be invalid; explicitly specify the name in @extern(c) to suppress this warning",
         (StringRef))
 
 ERROR(c_func_variadic, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1878,8 +1878,10 @@ ERROR(extern_empty_c_name,none,
       "expected non-empty C name in @_extern attribute", ())
 ERROR(extern_only_non_other_attr,none,
       "@_extern attribute cannot be applied to an '@%0' declaration", (StringRef))
-ERROR(extern_c_invalid_name, none,
-      "@_extern attribute has invalid C name '%0'", (StringRef))
+WARNING(extern_c_maybe_invalid_name, none,
+        "C name '%0' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning",
+        (StringRef))
+
 ERROR(c_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -205,6 +205,26 @@ public:
   void cacheResult(bool value) const;
 };
 
+/// Determine whether the given declaration has
+/// a C-compatible interface.
+class IsCCompatibleFuncDeclRequest :
+    public SimpleRequest<IsCCompatibleFuncDeclRequest,
+                         bool(FuncDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  bool evaluate(Evaluator &evaluator, FuncDecl *decl) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, CtorInitializerKind initKind);
 
 /// Computes the kind of initializer for a given \c ConstructorDecl

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -520,3 +520,6 @@ SWIFT_REQUEST(TypeChecker, SerializeAttrGenericSignatureRequest,
 SWIFT_REQUEST(TypeChecker, IsFunctionBodySkippedRequest,
               bool(const AbstractFunctionDecl *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsCCompatibleFuncDeclRequest,
+              bool(const FuncDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -256,6 +256,9 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 /// lifetime-dependent results.
 EXPERIMENTAL_FEATURE(NonEscapableTypes, false)
 
+/// Enable the `@_extern` attribute.
+EXPERIMENTAL_FEATURE(Extern, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -256,7 +256,7 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 /// lifetime-dependent results.
 EXPERIMENTAL_FEATURE(NonEscapableTypes, false)
 
-/// Enable the `@_extern` attribute.
+/// Enable the `@extern` attribute.
 EXPERIMENTAL_FEATURE(Extern, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1095,7 +1095,7 @@ public:
   ParserResult<DifferentiableAttr> parseDifferentiableAttribute(SourceLoc AtLoc,
                                                                 SourceLoc Loc);
 
-  /// Parse the @_extern attribute.
+  /// Parse the @extern attribute.
   bool parseExternAttribute(DeclAttributes &Attributes, bool &DiscardAttribute,
                             StringRef AttrName, SourceLoc AtLoc, SourceLoc Loc);
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -303,7 +303,7 @@ private:
   /// empty.
   StringRef WasmExportName;
 
-  /// Name of a Wasm import module and field if @_extern(wasm) attribute
+  /// Name of a Wasm import module and field if @extern(wasm) attribute
   llvm::Optional<std::pair<StringRef, StringRef>> WasmImportModuleAndField;
 
   /// Has value if there's a profile for this function
@@ -1293,14 +1293,14 @@ public:
   StringRef wasmExportName() const { return WasmExportName; }
   void setWasmExportName(StringRef value) { WasmExportName = value; }
 
-  /// Return Wasm import module name if @_extern(wasm) was used otherwise empty
+  /// Return Wasm import module name if @extern(wasm) was used otherwise empty
   StringRef wasmImportModuleName() const {
     if (WasmImportModuleAndField)
       return WasmImportModuleAndField->first;
     return StringRef();
   }
 
-  /// Return Wasm import field name if @_extern(wasm) was used otherwise empty
+  /// Return Wasm import field name if @extern(wasm) was used otherwise empty
   StringRef wasmImportFieldName() const {
     if (WasmImportModuleAndField)
       return WasmImportModuleAndField->second;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3589,6 +3589,10 @@ static bool usesFeatureTypedThrows(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureExtern(Decl *decl) {
+  return decl->getAttrs().hasAttribute<ExternAttr>();
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2651,6 +2651,14 @@ bool MacroRoleAttr::hasNameKind(MacroIntroducedDeclNameKind kind) const {
   }) != getNames().end();
 }
 
+StringRef ExternAttr::getCName(const FuncDecl *D) const {
+  if (auto cName = this->Name)
+    return cName.value();
+  // If no name was specified, fall back on the Swift base name without mangling.
+  // Base name is always available and non-empty for FuncDecl.
+  return D->getBaseIdentifier().str();
+}
+
 ExternAttr *ExternAttr::find(DeclAttributes &attrs, ExternKind kind) {
   for (DeclAttribute *attr : attrs) {
     if (auto *externAttr = dyn_cast<ExternAttr>(attr)) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1141,7 +1141,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DAK_Extern: {
     auto *Attr = cast<ExternAttr>(this);
-    Printer.printAttrName("@_extern");
+    Printer.printAttrName("@extern");
     Printer << "(";
     switch (Attr->getExternKind()) {
     case ExternKind::C:
@@ -1152,7 +1152,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
       break;
     case ExternKind::Wasm:
       Printer << "wasm";
-      // @_extern(wasm) always has names.
+      // @extern(wasm) always has names.
       Printer << ", module: \"" << *Attr->ModuleName << "\"";
       Printer << ", name: \"" << *Attr->Name << "\")";
       break;
@@ -1731,7 +1731,7 @@ StringRef DeclAttribute::getAttrName() const {
   case DAK_RawLayout:
     return "_rawLayout";
   case DAK_Extern:
-    return "_extern";
+    return "extern";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1450,7 +1450,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
   }
 
   auto parseStringLiteralArgument =
-      [&](std::optional<StringRef> fieldName) -> std::optional<StringRef> {
+      [&](std::optional<StringRef> fieldName) -> llvm::Optional<StringRef> {
     if (!consumeIf(tok::comma)) {
       diagnose(Loc, diag::attr_expected_comma, AttrName,
                DeclAttribute::isDeclModifier(DAK_Extern));
@@ -1489,7 +1489,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
 
   // Parse @_extern(wasm, module: "x", name: "y") or @_extern(c[, "x"])
   ExternKind kind;
-  std::optional<StringRef> importModuleName, importName;
+  llvm::Optional<StringRef> importModuleName, importName;
 
   if (kindTok.getText() == "wasm") {
     kind = ExternKind::Wasm;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1436,7 +1436,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
                                   SourceLoc AtLoc, SourceLoc Loc) {
   SourceLoc lParenLoc = Tok.getLoc(), rParenLoc;
 
-  // Parse @_extern(<language>, ...)
+  // Parse @extern(<language>, ...)
   if (!consumeIf(tok::l_paren)) {
     diagnose(Loc, diag::attr_expected_lparen, AttrName,
              DeclAttribute::isDeclModifier(DAK_Extern));
@@ -1488,7 +1488,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
   auto kindTok = Tok;
   consumeToken(tok::identifier);
 
-  // Parse @_extern(wasm, module: "x", name: "y") or @_extern(c[, "x"])
+  // Parse @extern(wasm, module: "x", name: "y") or @extern(c[, "x"])
   ExternKind kind;
   llvm::Optional<StringRef> importModuleName, importName;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1434,6 +1434,7 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
 bool Parser::parseExternAttribute(DeclAttributes &Attributes,
                                   bool &DiscardAttribute, StringRef AttrName,
                                   SourceLoc AtLoc, SourceLoc Loc) {
+  SourceLoc lParenLoc = Tok.getLoc(), rParenLoc;
 
   // Parse @_extern(<language>, ...)
   if (!consumeIf(tok::l_paren)) {
@@ -1512,6 +1513,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
     }
   }
 
+  rParenLoc = Tok.getLoc();
   if (!consumeIf(tok::r_paren)) {
     diagnose(Loc, diag::attr_expected_rparen, AttrName,
              DeclAttribute::isDeclModifier(DAK_Extern));
@@ -1527,9 +1529,10 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
   }
 
   if (!DiscardAttribute) {
-    Attributes.add(new (Context) ExternAttr(importModuleName, importName, AtLoc,
-                                            AttrRange, kind,
-                                            /*Implicit=*/false));
+    Attributes.add(new (Context)
+                       ExternAttr(importModuleName, importName, AtLoc,
+                                  lParenLoc, rParenLoc, AttrRange, kind,
+                                  /*Implicit=*/false));
   }
   return false;
 }

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1149,12 +1149,8 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
       }
 
     if (auto *ExternA = ExternAttr::find(getDecl()->getAttrs(), ExternKind::C)) {
-      if (auto cName = ExternA->Name)
-        return cName->str();
-      // If no name was specified, fall back on the Swift base name without mangling.
       assert(isa<FuncDecl>(getDecl()) && "non-FuncDecl with @_extern should be rejected by typechecker");
-      // Base name is always available and non-empty for FuncDecl.
-      return getDecl()->getBaseIdentifier().str().str();
+      return ExternA->getCName(cast<FuncDecl>(getDecl())).str();
     }
 
     // Use a given cdecl name for native-to-foreign thunks.

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1004,6 +1004,9 @@ bool SILDeclRef::isNativeToForeignThunk() const {
     // onto.
     if (getDecl()->hasClangNode())
       return false;
+    // No thunk is required if the decl directly references an external decl.
+    if (getDecl()->getAttrs().hasAttribute<ExternAttr>())
+      return false;
 
     // Only certain kinds of SILDeclRef can expose native-to-foreign thunks.
     return kind == Kind::Func || kind == Kind::Initializer ||
@@ -1144,7 +1147,12 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
       if (!NameA->Name.empty() && !isThunk()) {
         return NameA->Name.str();
       }
-      
+
+    if (auto *ExternA = ExternAttr::find(getDecl()->getAttrs(), ExternKind::C)) {
+      if (auto cName = ExternA->Name)
+        return cName->str();
+    }
+
     // Use a given cdecl name for native-to-foreign thunks.
     if (auto CDeclA = getDecl()->getAttrs().getAttribute<CDeclAttr>())
       if (isNativeToForeignThunk()) {

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1149,7 +1149,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
       }
 
     if (auto *ExternA = ExternAttr::find(getDecl()->getAttrs(), ExternKind::C)) {
-      assert(isa<FuncDecl>(getDecl()) && "non-FuncDecl with @_extern should be rejected by typechecker");
+      assert(isa<FuncDecl>(getDecl()) && "non-FuncDecl with @extern should be rejected by typechecker");
       return ExternA->getCName(cast<FuncDecl>(getDecl())).str();
     }
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1151,6 +1151,10 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     if (auto *ExternA = ExternAttr::find(getDecl()->getAttrs(), ExternKind::C)) {
       if (auto cName = ExternA->Name)
         return cName->str();
+      // If no name was specified, fall back on the Swift base name without mangling.
+      assert(isa<FuncDecl>(getDecl()) && "non-FuncDecl with @_extern should be rejected by typechecker");
+      // Base name is always available and non-empty for FuncDecl.
+      return getDecl()->getBaseIdentifier().str().str();
     }
 
     // Use a given cdecl name for native-to-foreign thunks.

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -180,8 +180,9 @@ void SILFunctionBuilder::addFunctionAttributes(
     }
   }
 
-  if (auto *EA = Attrs.getAttribute<ExternAttr>()) {
-    F->setWasmImportModuleAndField(EA->ModuleName, EA->Name);
+  if (auto *EA = ExternAttr::find(Attrs, ExternKind::Wasm)) {
+    // @_extern(wasm) always has explicit names
+    F->setWasmImportModuleAndField(*EA->ModuleName, *EA->Name);
   }
 
   if (Attrs.hasAttribute<UsedAttr>())

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -181,7 +181,7 @@ void SILFunctionBuilder::addFunctionAttributes(
   }
 
   if (auto *EA = ExternAttr::find(Attrs, ExternKind::Wasm)) {
-    // @_extern(wasm) always has explicit names
+    // @extern(wasm) always has explicit names
     F->setWasmImportModuleAndField(*EA->ModuleName, *EA->Name);
   }
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4081,6 +4081,8 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
     case SILDeclRef::Kind::Func:
       if (c.getDecl()->getDeclContext()->isTypeContext())
         return SILFunctionTypeRepresentation::Method;
+      if (ExternAttr::find(c.getDecl()->getAttrs(), ExternKind::C))
+        return SILFunctionTypeRepresentation::CFunctionPointer;
       return SILFunctionTypeRepresentation::Thin;
 
     case SILDeclRef::Kind::Destroyer:

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2157,7 +2157,7 @@ void AttributeChecker::visitExternAttr(ExternAttr *attr) {
   }
 
   for (auto *otherAttr : D->getAttrs()) {
-    // @_cdecl cannot be mixed with @_extern since @_cdecl is for definitions
+    // @_cdecl cannot be mixed with @extern since @_cdecl is for definitions
     // @_silgen_name cannot be mixed to avoid SIL-level name ambiguity
     if (isa<CDeclAttr>(otherAttr) || isa<SILGenNameAttr>(otherAttr)) {
       diagnose(attr->getLocation(), diag::extern_only_non_other_attr,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2135,16 +2135,18 @@ void AttributeChecker::visitExternAttr(ExternAttr *attr) {
       if (cName->empty())
         diagnose(attr->getLocation(), diag::extern_empty_c_name);
     }
+
+    // Ensure the decl has C compatible interface. Otherwise it produces diagnostics.
+    if (!isCCompatibleFuncDecl(FD)) {
+      attr->setInvalid();
+      // Mark the decl itself invalid not to require body even with invalid ExternAttr.
+      FD->setInvalid();
+    }
   }
 
   // @_cdecl cannot be mixed with @_extern since @_cdecl is for definitions
   if (D->getAttrs().hasAttribute<CDeclAttr>())
     diagnose(attr->getLocation(), diag::extern_only_non_other_attr, "@_cdecl");
-
-  if (!isCCompatibleFuncDecl(FD)) {
-    attr->setInvalid();
-    FD->setInvalid();
-  }
 }
 
 void AttributeChecker::visitUsedAttr(UsedAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2123,6 +2123,10 @@ static bool isCCompatibleFuncDecl(FuncDecl *FD) {
 }
 
 void AttributeChecker::visitExternAttr(ExternAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::Extern)) {
+    diagnoseAndRemoveAttr(attr, diag::attr_extern_experimental);
+    return;
+  }
   // Only top-level func or static func decls are currently supported.
   auto *FD = dyn_cast<FuncDecl>(D);
   if (!FD || (FD->getDeclContext()->isTypeContext() && !FD->isStatic())) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2144,9 +2144,14 @@ void AttributeChecker::visitExternAttr(ExternAttr *attr) {
     }
   }
 
-  // @_cdecl cannot be mixed with @_extern since @_cdecl is for definitions
-  if (D->getAttrs().hasAttribute<CDeclAttr>())
-    diagnose(attr->getLocation(), diag::extern_only_non_other_attr, "@_cdecl");
+  for (auto *otherAttr : D->getAttrs()) {
+    // @_cdecl cannot be mixed with @_extern since @_cdecl is for definitions
+    // @_silgen_name cannot be mixed to avoid SIL-level name ambiguity
+    if (isa<CDeclAttr>(otherAttr) || isa<SILGenNameAttr>(otherAttr)) {
+      diagnose(attr->getLocation(), diag::extern_only_non_other_attr,
+               otherAttr->getAttrName());
+    }
+  }
 }
 
 void AttributeChecker::visitUsedAttr(UsedAttr *attr) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3205,7 +3205,7 @@ public:
   /// Determine whether the given declaration should not have a definition.
   static bool requiresNoDefinition(Decl *decl) {
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      // Function with @_extern should not have a body.
+      // Function with @extern should not have a body.
       return func->getAttrs().hasAttribute<ExternAttr>();
     }
     // Everything else can have a definition.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5864,7 +5864,7 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
             scratch, isImplicit, rawKind, moduleNameSize, declNameSize);
 
         ExternKind kind = (ExternKind)rawKind;
-        std::optional<StringRef> moduleName, declName;
+        llvm::Optional<StringRef> moduleName, declName;
 
         switch (kind) {
         case ExternKind::C: {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5857,14 +5857,31 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
       }
 
       case decls_block::Extern_DECL_ATTR: {
+        unsigned rawKind;
         bool isImplicit;
         unsigned moduleNameSize, declNameSize;
         serialization::decls_block::ExternDeclAttrLayout::readRecord(
-            scratch, isImplicit, moduleNameSize, declNameSize);
-        StringRef moduleName = blobData.substr(0, moduleNameSize);
-        blobData = blobData.substr(moduleNameSize);
-        StringRef declName = blobData.substr(0, declNameSize);
-        Attr = new (ctx) ExternAttr(moduleName, declName, isImplicit);
+            scratch, isImplicit, rawKind, moduleNameSize, declNameSize);
+
+        ExternKind kind = (ExternKind)rawKind;
+        std::optional<StringRef> moduleName, declName;
+
+        switch (kind) {
+        case ExternKind::C: {
+          // Empty C name is rejected by typecheck, so serialized zero-length
+          // name is treated as no decl name.
+          if (declNameSize > 0)
+            declName = blobData.substr(0, declNameSize);
+          break;
+        }
+        case ExternKind::Wasm: {
+          moduleName = blobData.substr(0, moduleNameSize);
+          blobData = blobData.substr(moduleNameSize);
+          declName = blobData.substr(0, declNameSize);
+          break;
+        }
+        }
+        Attr = new (ctx) ExternAttr(moduleName, declName, (ExternKind)rawKind, isImplicit);
         break;
       }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 813; // VTable bit redefinition
+const uint16_t SWIFTMODULE_VERSION_MINOR = 814; // @_extern(c)
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2342,6 +2342,7 @@ namespace decls_block {
 
   using ExternDeclAttrLayout = BCRecordLayout<Extern_DECL_ATTR,
                                               BCFixed<1>, // implicit flag
+                                              BCFixed<1>, // extern kind
                                               BCVBR<4>,   // number of bytes in module name
                                               BCVBR<4>,   // number of bytes in name
                                               BCBlob      // module name and declaration name

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 814; // @_extern(c)
+const uint16_t SWIFTMODULE_VERSION_MINOR = 814; // @extern(c)
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3134,11 +3134,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto *theAttr = cast<ExternAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[ExternDeclAttrLayout::Code];
       llvm::SmallString<32> blob;
-      blob.append(theAttr->ModuleName);
-      blob.append(theAttr->Name);
+      auto moduleName = theAttr->ModuleName.value_or(StringRef());
+      auto name = theAttr->Name.value_or(StringRef());
+      blob.append(moduleName);
+      blob.append(name);
       ExternDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(),
-          theAttr->ModuleName.size(), theAttr->Name.size(), blob);
+          (unsigned)theAttr->getExternKind(),
+          moduleName.size(), name.size(), blob);
       return;
     }
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -109,6 +109,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD2-NEXT:             Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // KEYWORD2-NEXT:             Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // KEYWORD2-NEXT:             Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
+// KEYWORD2-NEXT:             Keyword/None:                       extern[#Func Attribute#]; name=extern
 // KEYWORD2-NOT:              Keyword
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -248,6 +249,7 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
 // ON_METHOD-DAG: Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // ON_METHOD-DAG: Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
+// ON_METHOD-DAG: Keyword/None:                       extern[#Func Attribute#]; name=extern
 // ON_METHOD-NOT: Keyword
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper

--- a/test/IRGen/extern_c.swift
+++ b/test/IRGen/extern_c.swift
@@ -1,28 +1,10 @@
-// RUN: %empty-directory(%t)
-// RUN: split-file %s %t
-// RUN: %target-swift-frontend -emit-ir %t/extern_c.swift -I%t | %FileCheck %s
-
-//--- c_types.h
-struct c_struct {
-  int field;
-};
-
-//--- module.modulemap
-module c_types {
-  header "c_types.h"
-}
-
-//--- extern_c.swift
-import c_types
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 func test() {
   // CHECK: call void @explicit_extern_c()
   explicit_extern_c()
   // CHECK: call void @implicit_extern_c()
   implicit_extern_c()
-
-  // CHECK: call i32 @"+"({{.*}})
-  _ = c_struct(field: 1) + c_struct(field: 2)
 }
 
 test()
@@ -32,6 +14,3 @@ test()
 
 // CHECK: declare void @implicit_extern_c()
 @_extern(c) func implicit_extern_c()
-
-// CHECK: declare i32 @"+"({{.*}})
-@_extern(c) func +(a: c_struct, b: c_struct) -> c_struct

--- a/test/IRGen/extern_c.swift
+++ b/test/IRGen/extern_c.swift
@@ -5,6 +5,11 @@ func test() {
   explicit_extern_c()
   // CHECK: call void @implicit_extern_c()
   implicit_extern_c()
+  // CHECK: [[DEFAULT_ARG:%[0-9]+]] = call swiftcc i32 @"$s8extern_c17default_arg_valueyys5Int32VFfA_"()
+  // CHECK: call void @default_arg_value(i32 [[DEFAULT_ARG]])
+  default_arg_value()
+  // CHECK: call void @default_arg_value(i32 24)
+  default_arg_value(24)
 }
 
 test()
@@ -14,3 +19,6 @@ test()
 
 // CHECK: declare void @implicit_extern_c()
 @_extern(c) func implicit_extern_c()
+
+// CHECK: declare void @default_arg_value(i32)
+@_extern(c) func default_arg_value(_: Int32 = 42)

--- a/test/IRGen/extern_c.swift
+++ b/test/IRGen/extern_c.swift
@@ -15,10 +15,10 @@ func test() {
 test()
 
 // CHECK: declare void @explicit_extern_c()
-@_extern(c, "explicit_extern_c") func explicit_extern_c()
+@extern(c, "explicit_extern_c") func explicit_extern_c()
 
 // CHECK: declare void @implicit_extern_c()
-@_extern(c) func implicit_extern_c()
+@extern(c) func implicit_extern_c()
 
 // CHECK: declare void @default_arg_value(i32)
-@_extern(c) func default_arg_value(_: Int32 = 42)
+@extern(c) func default_arg_value(_: Int32 = 42)

--- a/test/IRGen/extern_c.swift
+++ b/test/IRGen/extern_c.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+func test() {
+  // CHECK: call void @explicit_extern_c()
+  explicit_extern_c()
+  // CHECK: call void @"$s8extern_c09implicit_A2_cyyF"()
+  implicit_extern_c()
+}
+
+test()
+
+// CHECK: declare void @explicit_extern_c()
+@_extern(c, "explicit_extern_c") func explicit_extern_c()
+
+// CHECK: declare void @"$s8extern_c09implicit_A2_cyyF"()
+@_extern(c) func implicit_extern_c()

--- a/test/IRGen/extern_c.swift
+++ b/test/IRGen/extern_c.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-experimental-feature Extern %s | %FileCheck %s
 
 func test() {
   // CHECK: call void @explicit_extern_c()

--- a/test/IRGen/extern_c.swift
+++ b/test/IRGen/extern_c.swift
@@ -1,10 +1,28 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-ir %t/extern_c.swift -I%t | %FileCheck %s
+
+//--- c_types.h
+struct c_struct {
+  int field;
+};
+
+//--- module.modulemap
+module c_types {
+  header "c_types.h"
+}
+
+//--- extern_c.swift
+import c_types
 
 func test() {
   // CHECK: call void @explicit_extern_c()
   explicit_extern_c()
-  // CHECK: call void @"$s8extern_c09implicit_A2_cyyF"()
+  // CHECK: call void @implicit_extern_c()
   implicit_extern_c()
+
+  // CHECK: call i32 @"+"({{.*}})
+  _ = c_struct(field: 1) + c_struct(field: 2)
 }
 
 test()
@@ -12,5 +30,8 @@ test()
 // CHECK: declare void @explicit_extern_c()
 @_extern(c, "explicit_extern_c") func explicit_extern_c()
 
-// CHECK: declare void @"$s8extern_c09implicit_A2_cyyF"()
+// CHECK: declare void @implicit_extern_c()
 @_extern(c) func implicit_extern_c()
+
+// CHECK: declare i32 @"+"({{.*}})
+@_extern(c) func +(a: c_struct, b: c_struct) -> c_struct

--- a/test/IRGen/extern_c_abitypes.swift
+++ b/test/IRGen/extern_c_abitypes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -emit-ir %t/extern_c.swift -I%t | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-experimental-feature Extern %t/extern_c.swift -I%t | %FileCheck %s
 
 //--- c_abi_types.h
 #include <stdbool.h>

--- a/test/IRGen/extern_c_abitypes.swift
+++ b/test/IRGen/extern_c_abitypes.swift
@@ -34,25 +34,25 @@ module c_abi_types {
 
 import c_abi_types
 
-@_extern(c, "swift_roundtrip_void")
+@extern(c, "swift_roundtrip_void")
 func swift_roundtrip_void()
-@_extern(c, "swift_roundtrip_bool")
+@extern(c, "swift_roundtrip_bool")
 func swift_roundtrip_bool(_: Bool) -> Bool
-@_extern(c, "swift_roundtrip_char")
+@extern(c, "swift_roundtrip_char")
 func swift_roundtrip_char(_: CChar) -> CChar
-@_extern(c, "swift_roundtrip_int")
+@extern(c, "swift_roundtrip_int")
 func swift_roundtrip_int(_: CInt) -> CInt
-@_extern(c, "swift_roundtrip_float")
+@extern(c, "swift_roundtrip_float")
 func swift_roundtrip_float(_: CFloat) -> CFloat
-@_extern(c, "swift_roundtrip_double")
+@extern(c, "swift_roundtrip_double")
 func swift_roundtrip_double(_: CDouble) -> CDouble
-@_extern(c, "swift_roundtrip_opaque_ptr")
+@extern(c, "swift_roundtrip_opaque_ptr")
 func swift_roundtrip_opaque_ptr(_: OpaquePointer!) -> OpaquePointer!
-@_extern(c, "swift_roundtrip_void_star")
+@extern(c, "swift_roundtrip_void_star")
 func swift_roundtrip_void_star(_: UnsafeMutableRawPointer!) -> UnsafeMutableRawPointer!
-@_extern(c, "swift_roundtrip_c_struct")
+@extern(c, "swift_roundtrip_c_struct")
 func swift_roundtrip_c_struct(_: c_struct) -> c_struct
-@_extern(c, "swift_roundtrip_c_struct_ptr")
+@extern(c, "swift_roundtrip_c_struct_ptr")
 func swift_roundtrip_c_struct_ptr(_: UnsafeMutablePointer<c_struct>!) -> UnsafeMutablePointer<c_struct>!
 
 func test() {

--- a/test/IRGen/extern_c_abitypes.swift
+++ b/test/IRGen/extern_c_abitypes.swift
@@ -1,0 +1,120 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-ir %t/extern_c.swift -I%t | %FileCheck %s --check-prefixes CHECK,%target-cpu
+
+//--- c_abi_types.h
+#include <stdbool.h>
+
+void c_roundtrip_void(void);
+bool c_roundtrip_bool(bool);
+char c_roundtrip_char(char);
+int c_roundtrip_int(int);
+float c_roundtrip_float(float);
+double c_roundtrip_double(double);
+struct incomplete_ty;
+struct incomplete_ty *c_roundtrip_opaque_ptr(struct incomplete_ty *);
+void *c_roundtrip_void_star(void *);
+
+struct c_struct {
+  int foo;
+  long bar;
+  char baz;
+  // with tail pad
+};
+struct c_struct c_roundtrip_c_struct(struct c_struct);
+struct c_struct *c_roundtrip_c_struct_ptr(struct c_struct*);
+
+//--- module.modulemap
+
+module c_abi_types {
+  header "c_abi_types.h"
+}
+
+//--- extern_c.swift
+
+import c_abi_types
+
+@_extern(c, "swift_roundtrip_void")
+func swift_roundtrip_void()
+@_extern(c, "swift_roundtrip_bool")
+func swift_roundtrip_bool(_: Bool) -> Bool
+@_extern(c, "swift_roundtrip_char")
+func swift_roundtrip_char(_: CChar) -> CChar
+@_extern(c, "swift_roundtrip_int")
+func swift_roundtrip_int(_: CInt) -> CInt
+@_extern(c, "swift_roundtrip_float")
+func swift_roundtrip_float(_: CFloat) -> CFloat
+@_extern(c, "swift_roundtrip_double")
+func swift_roundtrip_double(_: CDouble) -> CDouble
+@_extern(c, "swift_roundtrip_opaque_ptr")
+func swift_roundtrip_opaque_ptr(_: OpaquePointer!) -> OpaquePointer!
+@_extern(c, "swift_roundtrip_void_star")
+func swift_roundtrip_void_star(_: UnsafeMutableRawPointer!) -> UnsafeMutableRawPointer!
+@_extern(c, "swift_roundtrip_c_struct")
+func swift_roundtrip_c_struct(_: c_struct) -> c_struct
+@_extern(c, "swift_roundtrip_c_struct_ptr")
+func swift_roundtrip_c_struct_ptr(_: UnsafeMutablePointer<c_struct>!) -> UnsafeMutablePointer<c_struct>!
+
+func test() {
+  // CHECK: call void @c_roundtrip_void()
+  // CHECK: call void @swift_roundtrip_void()
+  c_roundtrip_void()
+  swift_roundtrip_void()
+
+  // CHECK: call [[BOOL_TYPE:.+]]  @c_roundtrip_bool([[BOOL_TRUE:.+]])
+  // CHECK: call [[BOOL_TYPE]] @swift_roundtrip_bool([[BOOL_TRUE]])
+  _ = c_roundtrip_bool(true)
+  _ = swift_roundtrip_bool(true)
+
+  // CHECK: call [[CCHAR_TYPE:.+]]  @c_roundtrip_char([[CCHAR_VALUE:.+]])
+  // CHECK: call [[CCHAR_TYPE]] @swift_roundtrip_char([[CCHAR_VALUE]])
+  _ = c_roundtrip_char(0x61)
+  _ = swift_roundtrip_char(0x61)
+
+  // CHECK: call [[CINT_TYPE:.+]]  @c_roundtrip_int([[CINT_VALUE:.+]])
+  // CHECK: call [[CINT_TYPE]] @swift_roundtrip_int([[CINT_VALUE]])
+  _ = c_roundtrip_int(42)
+  _ = swift_roundtrip_int(42)
+
+  // CHECK: call [[CFLOAT_TYPE:.+]]  @c_roundtrip_float([[CFLOAT_VALUE:.+]])
+  // CHECK: call [[CFLOAT_TYPE]] @swift_roundtrip_float([[CFLOAT_VALUE]])
+  _ = c_roundtrip_float(3.14)
+  _ = swift_roundtrip_float(3.14)
+
+  // CHECK: call [[CDOUBLE_TYPE:.+]]  @c_roundtrip_double([[CDOUBLE_VALUE:.+]])
+  // CHECK: call [[CDOUBLE_TYPE]] @swift_roundtrip_double([[CDOUBLE_VALUE]])
+  _ = c_roundtrip_double(3.1415)
+  _ = swift_roundtrip_double(3.1415)
+
+  // CHECK: call [[OPAQUE_PTR_TYPE:.+]]  @c_roundtrip_opaque_ptr([[OPAQUE_PTR_VALUE:.+]])
+  // CHECK: call [[OPAQUE_PTR_TYPE]] @swift_roundtrip_opaque_ptr([[OPAQUE_PTR_VALUE]])
+  _ = c_roundtrip_opaque_ptr(nil)
+  _ = swift_roundtrip_opaque_ptr(nil)
+
+  // CHECK: call [[VOID_STAR_TYPE:.+]]  @c_roundtrip_void_star([[VOID_STAR_TYPE]] {{.*}})
+  // CHECK: call [[VOID_STAR_TYPE]] @swift_roundtrip_void_star([[VOID_STAR_TYPE]] {{.*}})
+  let nonNullPtr = UnsafeMutableRawPointer(bitPattern: 0xbeef)!
+  _ = c_roundtrip_void_star(nonNullPtr)
+  _ = swift_roundtrip_void_star(nonNullPtr)
+
+  // assume %struct.c_struct and %TSo8c_structV have compatible layout
+  //
+  // x86_64: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr byval(%struct.c_struct) align 8 {{.*}})
+  // x86_64: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr byval(%TSo8c_structV)   align 8 {{.*}})
+  // arm64:  call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr {{.*}})
+  // arm64:  call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr {{.*}})
+  // wasm32: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr byval(%struct.c_struct) align 4 {{.*}})
+  // wasm32: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr byval(%TSo8c_structV)   align 4 {{.*}})
+  var c_struct_val = c_struct(foo: 496, bar: 28, baz: 8)
+  _ = c_roundtrip_c_struct(c_struct_val)
+  _ = swift_roundtrip_c_struct(c_struct_val)
+
+  withUnsafeMutablePointer(to: &c_struct_val) { c_struct_ptr in
+    // CHECK: call [[C_STRUCT_PTR_TYPE:.+]]  @c_roundtrip_c_struct_ptr([[C_STRUCT_PTR_TYPE]] {{.*}})
+    // CHECK: call [[C_STRUCT_PTR_TYPE]] @swift_roundtrip_c_struct_ptr([[C_STRUCT_PTR_TYPE]] {{.*}})
+    _ = c_roundtrip_c_struct_ptr(c_struct_ptr)
+    _ = swift_roundtrip_c_struct_ptr(c_struct_ptr)
+  }
+}
+
+test()

--- a/test/IRGen/extern_c_abitypes.swift
+++ b/test/IRGen/extern_c_abitypes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -emit-ir %t/extern_c.swift -I%t | %FileCheck %s --check-prefixes CHECK,%target-cpu
+// RUN: %target-swift-frontend -emit-ir %t/extern_c.swift -I%t | %FileCheck %s
 
 //--- c_abi_types.h
 #include <stdbool.h>
@@ -99,12 +99,8 @@ func test() {
 
   // assume %struct.c_struct and %TSo8c_structV have compatible layout
   //
-  // x86_64: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr byval(%struct.c_struct) align 8 {{.*}})
-  // x86_64: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr byval(%TSo8c_structV)   align 8 {{.*}})
-  // arm64:  call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr {{.*}})
-  // arm64:  call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr {{.*}})
-  // wasm32: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr byval(%struct.c_struct) align 4 {{.*}})
-  // wasm32: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr byval(%TSo8c_structV)   align 4 {{.*}})
+  // CHECK: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
   var c_struct_val = c_struct(foo: 496, bar: 28, baz: 8)
   _ = c_roundtrip_c_struct(c_struct_val)
   _ = swift_roundtrip_c_struct(c_struct_val)

--- a/test/Interop/WebAssembly/extern-wasm-cdecls.swift
+++ b/test/Interop/WebAssembly/extern-wasm-cdecls.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -emit-ir -module-name Extern | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -enable-experimental-feature Extern -module-name Extern | %FileCheck %s
 
 // CHECK: declare void @import1() [[EA1:#[0-9]+]]
 @_extern(c)

--- a/test/Interop/WebAssembly/extern-wasm-cdecls.swift
+++ b/test/Interop/WebAssembly/extern-wasm-cdecls.swift
@@ -2,23 +2,23 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-experimental-feature Extern -module-name Extern | %FileCheck %s
 
 // CHECK: declare void @import1() [[EA1:#[0-9]+]]
-@_extern(c)
-@_extern(wasm, module: "m0", name: "import1")
+@extern(c)
+@extern(wasm, module: "m0", name: "import1")
 func import1()
 
 // CHECK: declare i32 @import2WithReturnInt() [[EA2:#[0-9]+]]
-@_extern(c)
-@_extern(wasm, module: "m0", name: "import2")
+@extern(c)
+@extern(wasm, module: "m0", name: "import2")
 func import2WithReturnInt() -> Int32
 
 // CHECK: declare void @import3TakingInt(i32) [[EA3:#[0-9]+]]
-@_extern(c)
-@_extern(wasm, module: "m0", name: "import3")
+@extern(c)
+@extern(wasm, module: "m0", name: "import3")
 func import3TakingInt(_: Int32)
 
 // CHECK: declare void @c_import4() [[EA4:#[0-9]+]]
-@_extern(c, "c_import4")
-@_extern(wasm, module: "m0", name: "import4")
+@extern(c, "c_import4")
+@extern(wasm, module: "m0", name: "import4")
 func import4()
 
 func test() {

--- a/test/Interop/WebAssembly/extern-wasm-cdecls.swift
+++ b/test/Interop/WebAssembly/extern-wasm-cdecls.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -emit-ir -module-name Extern | %FileCheck %s
+
+// CHECK: declare void @"$s6Extern7import1yyF"() [[EA1:#[0-9]+]]
+@_extern(c)
+@_extern(wasm, module: "m0", name: "import1")
+func import1()
+
+// CHECK: declare i32 @"$s6Extern20import2WithReturnInts5Int32VyF"() [[EA2:#[0-9]+]]
+@_extern(c)
+@_extern(wasm, module: "m0", name: "import2")
+func import2WithReturnInt() -> Int32
+
+// CHECK: declare void @"$s6Extern16import3TakingIntyys5Int32VF"(i32) [[EA3:#[0-9]+]]
+@_extern(c)
+@_extern(wasm, module: "m0", name: "import3")
+func import3TakingInt(_: Int32)
+
+// CHECK: declare void @c_import4() [[EA4:#[0-9]+]]
+@_extern(c, "c_import4")
+@_extern(wasm, module: "m0", name: "import4")
+func import4()
+
+func test() {
+    import1()
+    _ = import2WithReturnInt()
+    import3TakingInt(0)
+    import4()
+}
+
+test()
+
+// CHECK: attributes [[EA1]] = {{{.*}} "wasm-import-module"="m0" "wasm-import-name"="import1" {{.*}}}
+// CHECK: attributes [[EA2]] = {{{.*}} "wasm-import-module"="m0" "wasm-import-name"="import2" {{.*}}}
+// CHECK: attributes [[EA3]] = {{{.*}} "wasm-import-module"="m0" "wasm-import-name"="import3" {{.*}}}
+// CHECK: attributes [[EA4]] = {{{.*}} "wasm-import-module"="m0" "wasm-import-name"="import4" {{.*}}}

--- a/test/Interop/WebAssembly/extern-wasm-cdecls.swift
+++ b/test/Interop/WebAssembly/extern-wasm-cdecls.swift
@@ -1,17 +1,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-ir -module-name Extern | %FileCheck %s
 
-// CHECK: declare void @"$s6Extern7import1yyF"() [[EA1:#[0-9]+]]
+// CHECK: declare void @import1() [[EA1:#[0-9]+]]
 @_extern(c)
 @_extern(wasm, module: "m0", name: "import1")
 func import1()
 
-// CHECK: declare i32 @"$s6Extern20import2WithReturnInts5Int32VyF"() [[EA2:#[0-9]+]]
+// CHECK: declare i32 @import2WithReturnInt() [[EA2:#[0-9]+]]
 @_extern(c)
 @_extern(wasm, module: "m0", name: "import2")
 func import2WithReturnInt() -> Int32
 
-// CHECK: declare void @"$s6Extern16import3TakingIntyys5Int32VF"(i32) [[EA3:#[0-9]+]]
+// CHECK: declare void @import3TakingInt(i32) [[EA3:#[0-9]+]]
 @_extern(c)
 @_extern(wasm, module: "m0", name: "import3")
 func import3TakingInt(_: Int32)

--- a/test/Interop/WebAssembly/extern-wasm-decls-to-swift.swift
+++ b/test/Interop/WebAssembly/extern-wasm-decls-to-swift.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -emit-ir -module-name Extern | %FileCheck %s
+// RUN: %target-swift-frontend %s -enable-experimental-feature Extern -emit-ir -module-name Extern | %FileCheck %s
 
 // CHECK: declare {{.*}} void @"$s6Extern7import1yyF"() [[EA1:#[0-9]+]]
 @_extern(wasm, module: "m0", name: "import1")

--- a/test/Interop/WebAssembly/extern-wasm-decls-to-swift.swift
+++ b/test/Interop/WebAssembly/extern-wasm-decls-to-swift.swift
@@ -2,15 +2,15 @@
 // RUN: %target-swift-frontend %s -enable-experimental-feature Extern -emit-ir -module-name Extern | %FileCheck %s
 
 // CHECK: declare {{.*}} void @"$s6Extern7import1yyF"() [[EA1:#[0-9]+]]
-@_extern(wasm, module: "m0", name: "import1")
+@extern(wasm, module: "m0", name: "import1")
 func import1()
 
 // CHECK: declare {{.*}} i32 @"$s6Extern20import2WithReturnInts5Int32VyF"() [[EA2:#[0-9]+]]
-@_extern(wasm, module: "m0", name: "import2")
+@extern(wasm, module: "m0", name: "import2")
 func import2WithReturnInt() -> Int32
 
 // CHECK: declare {{.*}} void @"$s6Extern16import3TakingIntyys5Int32VF"(i32) [[EA3:#[0-9]+]]
-@_extern(wasm, module: "m0", name: "import3")
+@extern(wasm, module: "m0", name: "import3")
 func import3TakingInt(_: Int32)
 
 func test() {

--- a/test/SILGen/extern_c.swift
+++ b/test/SILGen/extern_c.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature Extern %s | %FileCheck %s
 
 // CHECK-DAG: sil hidden_external @my_c_name : $@convention(c) (Int) -> Int
 @_extern(c, "my_c_name")

--- a/test/SILGen/extern_c.swift
+++ b/test/SILGen/extern_c.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// CHECK-DAG: sil hidden_external @my_c_name : $@convention(c) (Int) -> Int
+@_extern(c, "my_c_name")
+func withCName(_ x: Int) -> Int
+
+// CHECK-DAG: sil hidden_external @take_c_func_ptr : $@convention(c) (@convention(c) (Int) -> Int) -> ()
+@_extern(c, "take_c_func_ptr")
+func takeCFuncPtr(_ f: @convention(c) (Int) -> Int)
+
+// CHECK-DAG: sil @public_visible : $@convention(c) (Int) -> Int
+@_extern(c, "public_visible")
+public func publicVisibility(_ x: Int) -> Int
+
+// CHECK-DAG: sil @private_visible : $@convention(c) (Int) -> Int
+@_extern(c, "private_visible")
+private func privateVisiblity(_ x: Int) -> Int
+
+// CHECK-DAG: sil hidden_external @$s8extern_c12withoutCNameSiyF : $@convention(c) () -> Int
+@_extern(c)
+func withoutCName() -> Int
+
+// CHECK-DAG: sil hidden [ossa] @$s8extern_c10defaultArgyySiFfA_ : $@convention(thin) () -> Int {
+// CHECK-DAG: sil hidden_external @default_arg : $@convention(c) (Int) -> ()
+@_extern(c, "default_arg")
+func defaultArg(_ x: Int = 42)
+
+func main() {
+  // CHECK-DAG: [[F1:%.+]] = function_ref @my_c_name : $@convention(c) (Int) -> Int
+  // CHECK-DAG: [[F2:%.+]] = function_ref @take_c_func_ptr : $@convention(c) (@convention(c) (Int) -> Int) -> ()
+  // CHECK-DAG: apply [[F2]]([[F1]]) : $@convention(c) (@convention(c) (Int) -> Int) -> ()
+  takeCFuncPtr(withCName)
+  // CHECK-DAG: [[F3:%.+]] = function_ref @public_visible : $@convention(c) (Int) -> Int
+  // CHECK-DAG: apply [[F3]]({{.*}}) : $@convention(c) (Int) -> Int
+  _ = publicVisibility(42)
+  // CHECK-DAG: [[F4:%.+]] = function_ref @private_visible : $@convention(c) (Int) -> Int
+  // CHECK-DAG: apply [[F4]]({{.*}}) : $@convention(c) (Int) -> Int
+  _ = privateVisiblity(24)
+  // CHECK-DAG: [[F5:%.+]] = function_ref @$s8extern_c12withoutCNameSiyF : $@convention(c) () -> Int
+  // CHECK-DAG: apply [[F5]]() : $@convention(c) () -> Int
+  _ = withoutCName()
+  // CHECK-DAG: [[F6:%.+]] = function_ref @$s8extern_c10defaultArgyySiFfA_ : $@convention(thin) () -> Int
+  // CHECK-DAG: [[DEFAULT_V:%.+]] = apply [[F6]]() : $@convention(thin) () -> Int
+  // CHECK-DAG: [[F7:%.+]] = function_ref @default_arg : $@convention(c) (Int) -> () // user: %20
+  // CHECK-DAG: apply [[F7]]([[DEFAULT_V]]) : $@convention(c) (Int) -> ()
+  defaultArg()
+}
+
+main()

--- a/test/SILGen/extern_c.swift
+++ b/test/SILGen/extern_c.swift
@@ -1,28 +1,28 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature Extern %s | %FileCheck %s
 
 // CHECK-DAG: sil hidden_external @my_c_name : $@convention(c) (Int) -> Int
-@_extern(c, "my_c_name")
+@extern(c, "my_c_name")
 func withCName(_ x: Int) -> Int
 
 // CHECK-DAG: sil hidden_external @take_c_func_ptr : $@convention(c) (@convention(c) (Int) -> Int) -> ()
-@_extern(c, "take_c_func_ptr")
+@extern(c, "take_c_func_ptr")
 func takeCFuncPtr(_ f: @convention(c) (Int) -> Int)
 
 // CHECK-DAG: sil @public_visible : $@convention(c) (Int) -> Int
-@_extern(c, "public_visible")
+@extern(c, "public_visible")
 public func publicVisibility(_ x: Int) -> Int
 
 // CHECK-DAG: sil @private_visible : $@convention(c) (Int) -> Int
-@_extern(c, "private_visible")
+@extern(c, "private_visible")
 private func privateVisiblity(_ x: Int) -> Int
 
 // CHECK-DAG: sil hidden_external @withoutCName : $@convention(c) () -> Int
-@_extern(c)
+@extern(c)
 func withoutCName() -> Int
 
 // CHECK-DAG: sil hidden [ossa] @$s8extern_c10defaultArgyySiFfA_ : $@convention(thin) () -> Int {
 // CHECK-DAG: sil hidden_external @default_arg : $@convention(c) (Int) -> ()
-@_extern(c, "default_arg")
+@extern(c, "default_arg")
 func defaultArg(_ x: Int = 42)
 
 func main() {

--- a/test/SILGen/extern_c.swift
+++ b/test/SILGen/extern_c.swift
@@ -16,7 +16,7 @@ public func publicVisibility(_ x: Int) -> Int
 @_extern(c, "private_visible")
 private func privateVisiblity(_ x: Int) -> Int
 
-// CHECK-DAG: sil hidden_external @$s8extern_c12withoutCNameSiyF : $@convention(c) () -> Int
+// CHECK-DAG: sil hidden_external @withoutCName : $@convention(c) () -> Int
 @_extern(c)
 func withoutCName() -> Int
 
@@ -36,7 +36,7 @@ func main() {
   // CHECK-DAG: [[F4:%.+]] = function_ref @private_visible : $@convention(c) (Int) -> Int
   // CHECK-DAG: apply [[F4]]({{.*}}) : $@convention(c) (Int) -> Int
   _ = privateVisiblity(24)
-  // CHECK-DAG: [[F5:%.+]] = function_ref @$s8extern_c12withoutCNameSiyF : $@convention(c) () -> Int
+  // CHECK-DAG: [[F5:%.+]] = function_ref @withoutCName : $@convention(c) () -> Int
   // CHECK-DAG: apply [[F5]]() : $@convention(c) () -> Int
   _ = withoutCName()
   // CHECK-DAG: [[F6:%.+]] = function_ref @$s8extern_c10defaultArgyySiFfA_ : $@convention(thin) () -> Int

--- a/test/Serialization/attr-extern.swift
+++ b/test/Serialization/attr-extern.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: %target-swift-frontend -enable-experimental-feature Extern -emit-module-path %t/a.swiftmodule -module-name a %s
 // RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s
 // RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck --check-prefix MODULE-CHECK %s
 

--- a/test/Serialization/attr-extern.swift
+++ b/test/Serialization/attr-extern.swift
@@ -5,6 +5,6 @@
 
 // BC-CHECK: <Extern_DECL_ATTR
 
-// MODULE-CHECK: @_extern(wasm, module: "m0", name: "import1") func import1()
-@_extern(wasm, module: "m0", name: "import1")
+// MODULE-CHECK: @extern(wasm, module: "m0", name: "import1") func import1()
+@extern(wasm, module: "m0", name: "import1")
 func import1()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -disable-availability-checking
 
 @_extern(wasm, module: "m1", name: "f1")
 func f1(x: Int) -> Int

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -115,6 +115,11 @@ func nonCParamTypesWasm(_: Int, _: NonC)
 @_extern(wasm, module: "non-c", name: "param_mixed")
 func nonCParamTypesMixed(_: Int, _: NonC) // expected-error {{'NonC' cannot be represented in C}}
 
+@_extern(c)
+func defaultArgValue_C(_: Int = 42)
+
+@_extern(wasm, module: "", name: "")
+func defaultArgValue_Wasm(_: Int = 24)
 
 @_extern(c)
 func asyncFuncC() async // expected-error {{async functions cannot be represented in C}}

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -49,11 +49,15 @@ func underscoredValid()
 @_extern(c, "") // expected-error {{expected non-empty C name in @_extern attribute}}
 func emptyCName()
 
-@_extern(c, "0start_with_digit") // expected-error {{@_extern attribute has invalid C name '0start_with_digit'}}
-func digitPrefixed()
+// Allow specifying any identifier explicitly
+@_extern(c, "0start_with_digit")
+func explicitDigitPrefixed()
 
-@_extern(c) // expected-error {{@_extern attribute has invalid C name '+'}}
+@_extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
 func +(a: Int, b: Bool) -> Bool
+
+@_extern(c) // expected-warning {{C name '🥸_implicitInvalid' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
+func 🥸_implicitInvalid()
 
 @_extern(c)
 func omitCName()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -12,16 +12,16 @@ func f3ErrorOnMissingNameColon(x: Int) -> Int // expected-error{{expected '{' in
 @_extern(wasm, module: "m4",) // expected-error  {{expected name argument to @_extern attribute}}
 func f4ErrorOnMissingNameLabel(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module: "m5") // expected-error {{expected name argument to @_extern attribute}}
+@_extern(wasm, module: "m5") // expected-error {{expected ',' in '_extern' attribute}}
 func f5ErrorOnMissingName(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module: ) // expected-error {{expected string literal in '_extern' attribute}} expected-error {{expected name argument to @_extern attribute}}
+@_extern(wasm, module: ) // expected-error {{expected string literal in '_extern' attribute}} expected-error {{expected ',' in '_extern' attribute}}
 func f6ErrorOnMissingModuleLiteral(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module) // expected-error {{expected ':' after label 'module'}} expected-error {{expected name argument to @_extern attribute}}
+@_extern(wasm, module) // expected-error {{expected ':' after label 'module'}} expected-error {{expected ',' in '_extern' attribute}}
 func f7ErrorOnMissingModuleColon(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm,) // expected-error {{expected module argument to @_extern attribute}} expected-error {{expected name argument to @_extern attribute}}
+@_extern(wasm,) // expected-error {{expected module argument to @_extern attribute}} expected-error {{expected ',' in '_extern' attribute}}
 func f8ErrorOnMissingModuleLabel(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
 @_extern(wasm, module: "m9", name: "f9")
@@ -37,5 +37,71 @@ func f11Scope() {
     func f11Inner()
 }
 
-@_extern(invalid, module: "m12", name: "f12") // expected-error {{expected '_extern' option such as 'wasm'}}
+@_extern(invalid, module: "m12", name: "f12") // expected-error {{expected '_extern' option such as 'c'}}
 func f12InvalidLang() // expected-error {{expected '{' in body of function declaration}}
+
+@_extern(c, "valid")
+func externCValid()
+
+@_extern(c, "") // expected-error {{expected non-empty C name in @_extern attribute}}
+func emptyCName()
+
+@_extern(c)
+func omitCName()
+
+@_extern(c, ) // expected-error {{expected string literal in '_extern' attribute}}
+func editingCName() // expected-error {{expected '{' in body of function declaration}}
+
+struct StructScopeC {
+    @_extern(c, "member_decl") // expected-error {{@_extern attribute can only be applied to global functions}}
+    func memberDecl()
+
+    @_extern(c, "static_member_decl")
+    static func staticMemberDecl()
+}
+
+func funcScopeC() {
+    @_extern(c, "func_scope_inner")
+    func inner()
+}
+
+@_extern(c, "c_value") // expected-error {{@_extern may only be used on 'func' declarations}}
+var nonFunc: Int = 0
+
+@_extern(c, "with_body")
+func withInvalidBody() {} // expected-error {{unexpected body of function declaration}}
+
+@_extern(c, "duplicate_attr_c_1")
+@_extern(c, "duplicate_attr_c_2") // expected-error {{duplicate attribute}}
+func duplicateAttrsC()
+
+@_extern(wasm, module: "dup", name: "duplicate_attr_wasm_1")
+@_extern(wasm, module: "dup", name: "duplicate_attr_wasm_2") // expected-error {{duplicate attribute}}
+func duplicateAttrsWasm()
+
+@_extern(c, "mixed_attr_c")
+@_extern(wasm, module: "mixed", name: "mixed_attr_wasm")
+func mixedAttrs_C_Wasm()
+
+class NonC {}
+@_extern(c)
+func nonCReturnTypes() -> NonC // expected-error {{'NonC' cannot be represented in C}}
+@_extern(c)
+func nonCParamTypes(_: Int, _: NonC) // expected-error {{'NonC' cannot be represented in C}}
+
+@_extern(c)
+func asyncFuncC() async // expected-error {{async functions cannot be represented in C}}
+
+@_extern(c)
+func throwsFuncC() throws // expected-error {{raising errors from C functions is not supported}}
+
+@_extern(c)
+func genericFuncC<T>(_: T) // expected-error {{'T' cannot be represented in C}}
+
+@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_cdecl("another_c_name")
+func withAtCDecl_C()
+
+@_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_cdecl("another_c_name")
+func withAtCDecl_Wasm()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -86,8 +86,22 @@ func mixedAttrs_C_Wasm()
 class NonC {}
 @_extern(c)
 func nonCReturnTypes() -> NonC // expected-error {{'NonC' cannot be represented in C}}
+// @_extern(wasm) have no interface limitation
+@_extern(wasm, module: "non-c", name: "return_wasm")
+func nonCReturnTypesWasm() -> NonC
+@_extern(c)
+@_extern(wasm, module: "non-c", name: "return_mixed")
+func nonCReturnTypesMixed() -> NonC // expected-error {{'NonC' cannot be represented in C}}
+
 @_extern(c)
 func nonCParamTypes(_: Int, _: NonC) // expected-error {{'NonC' cannot be represented in C}}
+@_extern(wasm, module: "non-c", name: "param_wasm")
+func nonCParamTypesWasm(_: Int, _: NonC)
+
+@_extern(c)
+@_extern(wasm, module: "non-c", name: "param_mixed")
+func nonCParamTypesMixed(_: Int, _: NonC) // expected-error {{'NonC' cannot be represented in C}}
+
 
 @_extern(c)
 func asyncFuncC() async // expected-error {{async functions cannot be represented in C}}

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -1,152 +1,152 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -disable-availability-checking
 
-@_extern(wasm, module: "m1", name: "f1")
+@extern(wasm, module: "m1", name: "f1")
 func f1(x: Int) -> Int
 
-@_extern(wasm, module: "m2", name: ) // expected-error  {{expected string literal in '_extern' attribute}}
+@extern(wasm, module: "m2", name: ) // expected-error  {{expected string literal in 'extern' attribute}}
 func f2ErrorOnMissingNameLiteral(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module: "m3", name) // expected-error  {{expected ':' after label 'name'}}
+@extern(wasm, module: "m3", name) // expected-error  {{expected ':' after label 'name'}}
 func f3ErrorOnMissingNameColon(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module: "m4",) // expected-error  {{expected name argument to @_extern attribute}}
+@extern(wasm, module: "m4",) // expected-error  {{expected name argument to @extern attribute}}
 func f4ErrorOnMissingNameLabel(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module: "m5") // expected-error {{expected ',' in '_extern' attribute}}
+@extern(wasm, module: "m5") // expected-error {{expected ',' in 'extern' attribute}}
 func f5ErrorOnMissingName(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module: ) // expected-error {{expected string literal in '_extern' attribute}} expected-error {{expected ',' in '_extern' attribute}}
+@extern(wasm, module: ) // expected-error {{expected string literal in 'extern' attribute}} expected-error {{expected ',' in 'extern' attribute}}
 func f6ErrorOnMissingModuleLiteral(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module) // expected-error {{expected ':' after label 'module'}} expected-error {{expected ',' in '_extern' attribute}}
+@extern(wasm, module) // expected-error {{expected ':' after label 'module'}} expected-error {{expected ',' in 'extern' attribute}}
 func f7ErrorOnMissingModuleColon(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm,) // expected-error {{expected module argument to @_extern attribute}} expected-error {{expected ',' in '_extern' attribute}}
+@extern(wasm,) // expected-error {{expected module argument to @extern attribute}} expected-error {{expected ',' in 'extern' attribute}}
 func f8ErrorOnMissingModuleLabel(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@_extern(wasm, module: "m9", name: "f9")
+@extern(wasm, module: "m9", name: "f9")
 func f9WithBody() {} // expected-error {{unexpected body of function declaration}}
 
 struct S {
-    @_extern(wasm, module: "m10", name: "f10") // expected-error {{@_extern attribute can only be applied to global functions}}
+    @extern(wasm, module: "m10", name: "f10") // expected-error {{@extern attribute can only be applied to global functions}}
     func f10Member()
 }
 
 func f11Scope() {
-    @_extern(wasm, module: "m11", name: "f11")
+    @extern(wasm, module: "m11", name: "f11")
     func f11Inner()
 }
 
-@_extern(invalid, module: "m12", name: "f12") // expected-error {{expected '_extern' option such as 'c'}}
+@extern(invalid, module: "m12", name: "f12") // expected-error {{expected 'extern' option such as 'c'}}
 func f12InvalidLang() // expected-error {{expected '{' in body of function declaration}}
 
-@_extern(c, "valid")
+@extern(c, "valid")
 func externCValid()
 
-@_extern(c, "_start_with_underscore")
+@extern(c, "_start_with_underscore")
 func underscoredValid()
 
-@_extern(c, "") // expected-error {{expected non-empty C name in @_extern attribute}}
+@extern(c, "") // expected-error {{expected non-empty C name in @extern attribute}}
 func emptyCName()
 
 // Allow specifying any identifier explicitly
-@_extern(c, "0start_with_digit")
+@extern(c, "0start_with_digit")
 func explicitDigitPrefixed()
 
-@_extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
+@extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @extern(c) to suppress this warning}}
 func +(a: Int, b: Bool) -> Bool
 
-@_extern(c) // expected-warning {{C name '🥸_implicitInvalid' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
+@extern(c) // expected-warning {{C name '🥸_implicitInvalid' may be invalid; explicitly specify the name in @extern(c) to suppress this warning}}
 func 🥸_implicitInvalid()
 
-@_extern(c)
+@extern(c)
 func omitCName()
 
-@_extern(c, ) // expected-error {{expected string literal in '_extern' attribute}}
+@extern(c, ) // expected-error {{expected string literal in 'extern' attribute}}
 func editingCName() // expected-error {{expected '{' in body of function declaration}}
 
 struct StructScopeC {
-    @_extern(c, "member_decl") // expected-error {{@_extern attribute can only be applied to global functions}}
+    @extern(c, "member_decl") // expected-error {{@extern attribute can only be applied to global functions}}
     func memberDecl()
 
-    @_extern(c, "static_member_decl")
+    @extern(c, "static_member_decl")
     static func staticMemberDecl()
 }
 
 func funcScopeC() {
-    @_extern(c, "func_scope_inner")
+    @extern(c, "func_scope_inner")
     func inner()
 }
 
-@_extern(c, "c_value") // expected-error {{@_extern may only be used on 'func' declarations}}
+@extern(c, "c_value") // expected-error {{@extern may only be used on 'func' declarations}}
 var nonFunc: Int = 0
 
-@_extern(c, "with_body")
+@extern(c, "with_body")
 func withInvalidBody() {} // expected-error {{unexpected body of function declaration}}
 
-@_extern(c, "duplicate_attr_c_1")
-@_extern(c, "duplicate_attr_c_2") // expected-error {{duplicate attribute}}
+@extern(c, "duplicate_attr_c_1")
+@extern(c, "duplicate_attr_c_2") // expected-error {{duplicate attribute}}
 func duplicateAttrsC()
 
-@_extern(wasm, module: "dup", name: "duplicate_attr_wasm_1")
-@_extern(wasm, module: "dup", name: "duplicate_attr_wasm_2") // expected-error {{duplicate attribute}}
+@extern(wasm, module: "dup", name: "duplicate_attr_wasm_1")
+@extern(wasm, module: "dup", name: "duplicate_attr_wasm_2") // expected-error {{duplicate attribute}}
 func duplicateAttrsWasm()
 
-@_extern(c, "mixed_attr_c")
-@_extern(wasm, module: "mixed", name: "mixed_attr_wasm")
+@extern(c, "mixed_attr_c")
+@extern(wasm, module: "mixed", name: "mixed_attr_wasm")
 func mixedAttrs_C_Wasm()
 
 class NonC {}
-@_extern(c)
+@extern(c)
 func nonCReturnTypes() -> NonC // expected-error {{'NonC' cannot be represented in C}}
-// @_extern(wasm) have no interface limitation
-@_extern(wasm, module: "non-c", name: "return_wasm")
+// @extern(wasm) have no interface limitation
+@extern(wasm, module: "non-c", name: "return_wasm")
 func nonCReturnTypesWasm() -> NonC
-@_extern(c)
-@_extern(wasm, module: "non-c", name: "return_mixed")
+@extern(c)
+@extern(wasm, module: "non-c", name: "return_mixed")
 func nonCReturnTypesMixed() -> NonC // expected-error {{'NonC' cannot be represented in C}}
 
-@_extern(c)
+@extern(c)
 func nonCParamTypes(_: Int, _: NonC) // expected-error {{'NonC' cannot be represented in C}}
-@_extern(wasm, module: "non-c", name: "param_wasm")
+@extern(wasm, module: "non-c", name: "param_wasm")
 func nonCParamTypesWasm(_: Int, _: NonC)
 
-@_extern(c)
-@_extern(wasm, module: "non-c", name: "param_mixed")
+@extern(c)
+@extern(wasm, module: "non-c", name: "param_mixed")
 func nonCParamTypesMixed(_: Int, _: NonC) // expected-error {{'NonC' cannot be represented in C}}
 
-@_extern(c)
+@extern(c)
 func defaultArgValue_C(_: Int = 42)
 
-@_extern(wasm, module: "", name: "")
+@extern(wasm, module: "", name: "")
 func defaultArgValue_Wasm(_: Int = 24)
 
-@_extern(c)
+@extern(c)
 func asyncFuncC() async // expected-error {{async functions cannot be represented in C}}
 
-@_extern(c)
+@extern(c)
 func throwsFuncC() throws // expected-error {{raising errors from C functions is not supported}}
 
-@_extern(c)
+@extern(c)
 func genericFuncC<T>(_: T) // expected-error {{'T' cannot be represented in C}}
 
-@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@extern(c) // expected-error {{@extern attribute cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_C()
 
-@_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@extern(wasm, module: "", name: "") // expected-error {{@extern attribute cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_Wasm()
 
-@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}}
+@extern(c) // expected-error {{@extern attribute cannot be applied to an '@_silgen_name' declaration}}
 @_silgen_name("another_sil_name")
 func withAtSILGenName_C()
 
-@_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}}
+@extern(wasm, module: "", name: "") // expected-error {{@extern attribute cannot be applied to an '@_silgen_name' declaration}}
 @_silgen_name("another_sil_name")
 func withAtSILGenName_Wasm()
 
-@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}} expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@extern(c) // expected-error {{@extern attribute cannot be applied to an '@_silgen_name' declaration}} expected-error {{@extern attribute cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 @_silgen_name("another_sil_name")
 func withAtSILGenName_CDecl_C()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -43,8 +43,17 @@ func f12InvalidLang() // expected-error {{expected '{' in body of function decla
 @_extern(c, "valid")
 func externCValid()
 
+@_extern(c, "_start_with_underscore")
+func underscoredValid()
+
 @_extern(c, "") // expected-error {{expected non-empty C name in @_extern attribute}}
 func emptyCName()
+
+@_extern(c, "0start_with_digit") // expected-error {{@_extern attribute has invalid C name '0start_with_digit'}}
+func digitPrefixed()
+
+@_extern(c) // expected-error {{@_extern attribute has invalid C name '+'}}
+func +(a: Int, b: Bool) -> Bool
 
 @_extern(c)
 func omitCName()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -119,3 +119,16 @@ func withAtCDecl_C()
 @_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_Wasm()
+
+@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}}
+@_silgen_name("another_sil_name")
+func withAtSILGenName_C()
+
+@_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}}
+@_silgen_name("another_sil_name")
+func withAtSILGenName_Wasm()
+
+@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}} expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_cdecl("another_c_name")
+@_silgen_name("another_sil_name")
+func withAtSILGenName_CDecl_C()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 @_extern(wasm, module: "m1", name: "f1")
 func f1(x: Int) -> Int

--- a/test/attr/attr_extern_fixit.swift
+++ b/test/attr/attr_extern_fixit.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
 // RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
-@_extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
+@extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @extern(c) to suppress this warning}}
 func +(a: Int, b: Bool) -> Bool

--- a/test/attr/attr_extern_fixit.swift
+++ b/test/attr/attr_extern_fixit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
 // RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
 @_extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}

--- a/test/attr/attr_extern_fixit.swift
+++ b/test/attr/attr_extern_fixit.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
+// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+
+@_extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
+func +(a: Int, b: Bool) -> Bool

--- a/test/attr/attr_extern_fixit.swift.result
+++ b/test/attr/attr_extern_fixit.swift.result
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
+// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+
+@_extern(c, "+") // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
+func +(a: Int, b: Bool) -> Bool

--- a/test/attr/attr_extern_fixit.swift.result
+++ b/test/attr/attr_extern_fixit.swift.result
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
 // RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
 @_extern(c, "+") // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}

--- a/test/attr/attr_extern_fixit.swift.result
+++ b/test/attr/attr_extern_fixit.swift.result
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
 // RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
-@_extern(c, "+") // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
+@extern(c, "+") // expected-warning {{C name '+' may be invalid; explicitly specify the name in @extern(c) to suppress this warning}}
 func +(a: Int, b: Bool) -> Bool


### PR DESCRIPTION
## Motivation

Currently the only **proper** way to reference a C function from Swift is by importing it through Clang module.
However there are a number of places using the incorrect `@_silgen_name` way to reference C function. (The attribute expects Swift calling convention and it causes calling convention mismatch.)
These incorrect references happened because defining a new Clang module requires non-trivial work mostly around the build system. (Also there is a very complex issue, which is not easy to solve with Clang module approach https://github.com/apple/swift/pull/67853#issuecomment-1760710859)

So this PR adds a new variant of `@extern` for C function declaration. Also this unlocks a way to declare a function with C calling convention imported through Wasm’s import mechanism by mixing with [`@extern(wasm)`](https://github.com/apple/swift/pull/69107)

The attribute is now gated by `-enable-experimental-feature Extern`

## Description

The new attribute unlocks declaring a C function in Swift source code. The declared function interfaces are limited to be C-compatible, so no async, no throws, and no ref counted types are allowed. (We might be able to unlock the use of ref counted type in theory but it introduces a lot of complexities)

Examples:

```swift
@extern(c)
func malloc(size: Int) -> UnsafeMutableRawPointer!

@extern(c, "swift_demangle")
public func _stdlib_demangleImpl(
  mangledName: UnsafePointer<CChar>?,
  mangledNameLength: UInt,
  outputBuffer: UnsafeMutablePointer<CChar>?,
  outputBufferSize: UnsafeMutablePointer<UInt>?,
  flags: UInt32
) -> UnsafeMutablePointer<CChar>?

@extern(wasm, module: "wasi_snapshot_preview1", name: "random_get")
@extern(c) // NOTE: Just for calling it with C calling convention
func wasi_random_get(
  buffer: UnsafeMutablePointer<UInt8>,
  count: UInt32
) -> Int32
```

Resolves rdar://115802180 and unblock https://github.com/apple/swift/pull/67853

<details>
<summary>Alternative consideration: Allow @_cdecl without body</summary>

We initially planned this approach, but didn’t take it for the following reason

* The current semantics of `@_cdecl` is “expose the Swift declaration to C/Objective-C world” and it allows having Objective-C types in its interface.
    * Thus it requires a native-to-foreign thunk to be emitted within the module, which defines the `@_cdecl` function.
* The new mode (without body) would add a semantics: “if no function body is defined, reference a C function corresponding to the Swift function declaration”.
    * This requires a foreign-to-native thunk to be emitted within the module, which *declare* the `@_cdecl` function.
* The problem here is we have to determine if a function with @_cdecl requires foreign-to-native thunk based on where function declarations come from because a @_cdecl function without body declared within a compiling module and imported @_cdecl function both do not have body.

</details>