### PR TITLE
Add %target-codesign to IRGen/typed_throws_exec.swift

### DIFF
--- a/test/IRGen/typed_throws_exec.swift
+++ b/test/IRGen/typed_throws_exec.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -module-name=test -enable-experimental-feature TypedThrows %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 


### PR DESCRIPTION
This is (apparently) needed to make executable tests work in some CI configurations.