### PR TITLE
ModuleInterface: Always ignore export-as for printing references in private swiftinterfaces

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -147,7 +147,6 @@ EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, true)
 
-EXPERIMENTAL_FEATURE(ModuleInterfaceExportAs, true)
 EXPERIMENTAL_FEATURE(AccessLevelOnImport, true)
 
 /// Whether to enable experimental layout string value witnesses

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3312,10 +3312,6 @@ static bool usesFeatureLayoutStringValueWitnessesInstantiation(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureModuleInterfaceExportAs(Decl *decl) {
-  return false;
-}
-
 static bool usesFeatureAccessLevelOnImport(Decl *decl) {
   return false;
 }

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -821,13 +821,7 @@ bool swift::emitSwiftInterface(raw_ostream &out,
 
   printImports(out, Opts, M, aliasModuleNamesTargets);
 
-  static bool forceUseExportedModuleNameInPublicOnly =
-    getenv("SWIFT_DEBUG_USE_EXPORTED_MODULE_NAME_IN_PUBLIC_ONLY");
-  bool useExportedModuleNameInPublicOnly =
-    M->getASTContext().LangOpts.hasFeature(Feature::ModuleInterfaceExportAs) ||
-    forceUseExportedModuleNameInPublicOnly;
-  bool useExportedModuleNames = !(useExportedModuleNameInPublicOnly &&
-                                  Opts.PrintPrivateInterfaceContent);
+  bool useExportedModuleNames = !Opts.PrintPrivateInterfaceContent;
 
   const PrintOptions printOptions = PrintOptions::printSwiftInterfaceFile(
       M, Opts.PreserveTypesAsWritten, Opts.PrintFullConvention,

--- a/test/ModuleInterface/export-as-in-swiftinterfaces.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces.swift
@@ -21,7 +21,6 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Exported.swiftinterface) -I %t -module-name Exporter
 
 /// Build lib with an @exported import of the exported one.
-/// Default/old behavior.
 // RUN: %target-swift-frontend -emit-module %t/Exporter.swift \
 // RUN:   -module-name Exporter -swift-version 5 -I %t \
 // RUN:   -enable-library-evolution \
@@ -31,26 +30,10 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.swiftinterface) -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.private.swiftinterface) -module-name Exporter -I %t
 // RUN: cat %t/Exporter.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
-// RUN: cat %t/Exporter.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
-
-/// Build lib with an @exported import of the exported one.
-/// New behavior via flag.
-// RUN: %target-swift-frontend -emit-module %t/Exporter.swift \
-// RUN:   -module-name Exporter -swift-version 5 -I %t \
-// RUN:   -enable-library-evolution \
-// RUN:   -emit-module-path %t/Exporter.swiftmodule \
-// RUN:   -emit-module-interface-path %t/Exporter.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/Exporter.private.swiftinterface \
-// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
-// RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.swiftinterface) -I %t
-// RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.private.swiftinterface) -module-name Exporter -I %t
-// RUN: cat %t/Exporter.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
 // RUN: cat %t/Exporter.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTED %s
 
 /// Build lib with an @exported import of the exported one.
-/// New behavior via env var.
-// RUN: env SWIFT_DEBUG_USE_EXPORTED_MODULE_NAME_IN_PUBLIC_ONLY=1 \
-// RUN:   %target-swift-frontend -emit-module %t/Exporter.swift \
+// RUN: %target-swift-frontend -emit-module %t/Exporter.swift \
 // RUN:   -module-name Exporter -swift-version 5 -I %t \
 // RUN:   -enable-library-evolution \
 // RUN:   -emit-module-path %t/Exporter.swiftmodule \
@@ -67,22 +50,20 @@
 // RUN:   -enable-library-evolution \
 // RUN:   -emit-module-path %t/Client.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Client.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface \
-// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I %t
 // RUN: cat %t/Client.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
 // RUN: cat %t/Client.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTED %s
 
-/// Build a client of the exporter lib.
+/// Build a client of the exporter lib against the public swiftinterface.
 // RUN: rm %t/Exporter.private.swiftinterface %t/Exporter.swiftmodule
 // RUN: %target-swift-frontend -emit-module %t/Client.swift \
 // RUN:   -module-name Client -swift-version 5 -I %t \
 // RUN:   -enable-library-evolution \
 // RUN:   -emit-module-path %t/Client.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Client.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface \
-// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I %t
 // RUN: cat %t/Client.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s

--- a/test/ModuleInterface/export-as-in-swiftinterfaces.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces.swift
@@ -10,8 +10,7 @@
 // RUN:   -enable-library-evolution \
 // RUN:   -emit-module-path %t/Exported.swiftmodule \
 // RUN:   -emit-module-interface-path %t/Exported.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/Exported.private.swiftinterface \
-// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+// RUN:   -emit-private-module-interface-path %t/Exported.private.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t/Exported.private.swiftinterface) -module-name Exported -I %t
 // RUN: cat %t/Exported.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
 // RUN: cat %t/Exported.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTED %s

--- a/test/ModuleInterface/swift-export-as.swift
+++ b/test/ModuleInterface/swift-export-as.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+/// Build exportee.
 // RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift \
 // RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -export-as PublicLib \
@@ -13,6 +14,7 @@
 // RUN: cat %t/PrivateLib.swiftinterface | %FileCheck --check-prefixes=PRIVATELIB-PUBLIC %s
 // RUN: cat %t/PrivateLib.private.swiftinterface | %FileCheck --check-prefixes=PRIVATELIB-PUBLIC %s
 
+/// Build exporter.
 // RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -I %t \
 // RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -o %t/PublicLib.swiftmodule \
@@ -22,42 +24,40 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/PublicLib.private.swiftinterface) -I %t \
 // RUN:   -module-name PublicLib
 // RUN: cat %t/PublicLib.swiftinterface | %FileCheck --check-prefixes=PUBLICLIB-PUBLIC %s
-// RUN: cat %t/PublicLib.private.swiftinterface | %FileCheck --check-prefixes=PUBLICLIB-PUBLIC %s
+// RUN: cat %t/PublicLib.private.swiftinterface | %FileCheck --check-prefixes=PUBLICLIB-PRIVATE %s
 
-/// Default logic applying export-as in both swiftinterface.
+/// Build client.
 // RUN: %target-swift-frontend -emit-module %t/ClientLib.swift -I %t \
 // RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -o %t/ClientLib.swiftmodule \
 // RUN:   -emit-module-interface-path %t/ClientLib.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/ClientLib.private.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.swiftinterface) -I %t
-// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.private.swiftinterface) -I %t
-// RUN: cat %t/ClientLib.swiftinterface | %FileCheck --check-prefixes=CLIENT-PUBLIC %s
-// RUN: cat %t/ClientLib.private.swiftinterface | %FileCheck --check-prefixes=CLIENT-PUBLIC %s
-
-/// New logic applying export-as only in the public swiftinterface with
-/// `-enable-experimental-feature ModuleInterfaceExportAs`.
-// RUN: %target-swift-frontend -emit-module %t/ClientLib.swift -I %t \
-// RUN:   -swift-version 5 -enable-library-evolution \
-// RUN:   -o %t/ClientLib.swiftmodule \
-// RUN:   -emit-module-interface-path %t/ClientLib.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/ClientLib.private.swiftinterface \
-// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
-// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.swiftinterface) -I %t
-// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.private.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.private.swiftinterface) -I %t -module-name ClientLib
 // RUN: cat %t/ClientLib.swiftinterface | %FileCheck --check-prefixes=CLIENT-PUBLIC %s
 // RUN: cat %t/ClientLib.private.swiftinterface | %FileCheck --check-prefixes=CLIENT-PRIVATE %s
 
-/// Check that we get the same behavior using swiftinterfaces only.
+/// Build client against private swiftinterfaces.
 // RUN: rm -f %t/PrivateLib.swiftmodule %t/PublicLib.swiftmodule
 // RUN: %target-swift-frontend -emit-module %t/ClientLib.swift -I %t \
 // RUN:   -swift-version 5 -enable-library-evolution \
 // RUN:   -o %t/ClientLib.swiftmodule \
 // RUN:   -emit-module-interface-path %t/ClientLib.swiftinterface \
-// RUN:   -emit-private-module-interface-path %t/ClientLib.private.swiftinterface \
-// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+// RUN:   -emit-private-module-interface-path %t/ClientLib.private.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.swiftinterface) -I %t
-// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.private.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.private.swiftinterface) -I %t -module-name ClientLib
+// RUN: cat %t/ClientLib.swiftinterface | %FileCheck --check-prefixes=CLIENT-PUBLIC %s
+// RUN: cat %t/ClientLib.private.swiftinterface | %FileCheck --check-prefixes=CLIENT-PRIVATE %s
+
+/// Build client against public swiftinterfaces, for the same result.
+// RUN: rm -f %t/PrivateLib.private.swiftinterface %t/PublicLib.private.swiftinterface
+// RUN: %target-swift-frontend -emit-module %t/ClientLib.swift -I %t \
+// RUN:   -swift-version 5 -enable-library-evolution \
+// RUN:   -o %t/ClientLib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/ClientLib.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/ClientLib.private.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/ClientLib.private.swiftinterface) -I %t -module-name ClientLib
 // RUN: cat %t/ClientLib.swiftinterface | %FileCheck --check-prefixes=CLIENT-PUBLIC %s
 // RUN: cat %t/ClientLib.private.swiftinterface | %FileCheck --check-prefixes=CLIENT-PRIVATE %s
 
@@ -76,6 +76,7 @@ public struct PublicNameStruct {}
 
 public func publicLibUser(_ arg: PrivateNameStruct) {}
 // PUBLICLIB-PUBLIC: arg: PublicLib.PrivateNameStruct
+// PUBLICLIB-PRIVATE: arg: PrivateLib.PrivateNameStruct
 
 //--- ClientLib.swift
 

--- a/test/ModuleInterface/swift-export-as.swift
+++ b/test/ModuleInterface/swift-export-as.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+/// Make sure the flag `ModuleInterfaceExportAs` doesn't raise an error.
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift \
+// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+
 /// Build exportee.
 // RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift \
 // RUN:   -swift-version 5 -enable-library-evolution \


### PR DESCRIPTION
Always print the real module name for references in private swiftinterfaces, ignoring export-as declarations. Keep using the export-as name for the public swiftinterface only.

The flag `ModuleInterfaceExportAs` used to enable this behavior and we're removing it to make it the default.

rdar://115922907