### PR TITLE
Frontend: Temporarily force decl skipping with -experimental-lazy-typecheck

### DIFF
--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -322,6 +322,8 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.SkipNonExportableDecls |=
       Args.hasArg(OPT_experimental_skip_non_exportable_decls);
+  // FIXME: Remove this with rdar://117020997
+  Opts.SkipNonExportableDecls |= Args.hasArg(OPT_experimental_lazy_typecheck);
   Opts.DebugPrefixSerializedDebuggingOptions |=
       Args.hasArg(OPT_prefix_serialized_debugging_options);
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -2,6 +2,10 @@
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -enable-library-evolution -parse-as-library -package-name Package -DFLAG -typecheck -verify
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path %t/lazy_typecheck.swiftmodule -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
 
+// Verify the module also builds without -experimental-skip-non-exportable-decls
+// FIXME: Remove with rdar://117020997
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies
+
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t
 
 // FIXME: Re-run the test with -experimental-skip-non-inlinable-function-bodies


### PR DESCRIPTION
Until a `swiftc` with https://github.com/apple/swift-driver/pull/1465 is available widely, enable `-experimental-skip-non-exportable-decls` whenever `-experimental-lazy-typecheck` is specified.

Resolves rdar://117020908
