### PR TITLE
Rewrite `SimpleDidSetRequest` to not require a typechecked body

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -957,14 +957,6 @@ Type AbstractFunctionDecl::getThrownInterfaceType() const {
 
 llvm::Optional<Type> 
 AbstractFunctionDecl::getEffectiveThrownErrorType() const {
-  // FIXME: Only getters can have thrown error types right now, and DidSet
-  // has a cyclic reference if we try to get its interface type here. Find a
-  // better way to express this.
-  if (auto accessor = dyn_cast<AccessorDecl>(this)) {
-    if (accessor->getAccessorKind() != AccessorKind::Get)
-      return llvm::None;
-  }
-
   Type interfaceType = getInterfaceType();
   if (hasImplicitSelfDecl()) {
     if (auto fnType = interfaceType->getAs<AnyFunctionType>())

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1199,7 +1199,7 @@ void TypeChecker::buildTypeRefinementContextHierarchyDelayed(SourceFile &SF, Abs
   if(!RootTRC)
     return;
 
-  if (AFD->getBodyKind() != AbstractFunctionDecl::BodyKind::Unparsed)
+  if (AFD->getLoc().isInvalid())
     return;
 
   // Parse the function body.


### PR DESCRIPTION
SimpleDidSetRequest's implementation was depending on type-checking the body of the observer, meaning that computing the interface type of a `didSet` would require type-checking the body first. This triggers some request cycles, and is unnecessarily complicated.

Rewrite the implementation to work on a non-type-checked body, by using name lookup to establish when the `oldValue` parameter is referenced from the body.
