### PR TITLE
Add `-Runused-modules` to emit remarks for imported modules which go un-used

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1152,6 +1152,9 @@ REMARK(module_api_import_aliases,none,
        "typealias underlying type %kind0 is imported via %1"
        "%select{, which reexports definition from %2|}3",
        (const Decl *, ModuleDecl *, ModuleDecl *, bool))
+REMARK(potentially_unused_import,none,
+       "import of %0 unused during compilation",
+       (Identifier))
 
 REMARK(macro_loaded,none,
        "loaded macro implementation module %0 from "

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -371,7 +371,7 @@ public:
 
   /// Return the highest access level of the declarations referencing
   /// this import in signature or inlinable code.
-  AccessLevel
+  llvm::Optional<AccessLevel>
   getMaxAccessLevelUsingImport(AttributedImport<ImportedModule> import) const;
 
   /// Register the use of \p import from an API with \p accessLevel.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -249,6 +249,9 @@ namespace swift {
     /// Emit remarks about the source of each element exposed by the module API.
     bool EnableModuleApiImportRemarks = false;
 
+    /// Emit remarks about potentially-unused module imports
+    bool EnableUnusedModuleImportRemarks = false;
+
      /// Emit a remark after loading a macro implementation.
     bool EnableMacroLoadingRemarks = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -403,6 +403,10 @@ def remark_module_recovery : Flag<["-"], "Rmodule-recovery">,
 def remark_module_api_import : Flag<["-"], "Rmodule-api-import">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit remarks about the import briging in each element composing the API">;
+def remark_unused_module_import : Flag<["-"], "Runused-module">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit remarks about unused module imports">;
+
 
 def remark_macro_loading : Flag<["-"], "Rmacro-loading">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3087,12 +3087,12 @@ void SourceFile::setImportUsedPreconcurrency(
   PreconcurrencyImportsUsed.insert(import);
 }
 
-AccessLevel
+llvm::Optional<AccessLevel>
 SourceFile::getMaxAccessLevelUsingImport(
     AttributedImport<ImportedModule> import) const {
   auto known = ImportsUseAccessLevel.find(import);
   if (known == ImportsUseAccessLevel.end())
-    return AccessLevel::Internal;
+    return llvm::Optional<AccessLevel>();
   return known->second;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1027,6 +1027,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
   Opts.EnableModuleRecoveryRemarks = Args.hasArg(OPT_remark_module_recovery);
   Opts.EnableModuleApiImportRemarks = Args.hasArg(OPT_remark_module_api_import);
+  Opts.EnableUnusedModuleImportRemarks = Args.hasArg(OPT_remark_unused_module_import);
   Opts.EnableMacroLoadingRemarks = Args.hasArg(OPT_remark_macro_loading);
   Opts.EnableIndexingSystemModuleRemarks = Args.hasArg(OPT_remark_indexing_system_module);
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -304,6 +304,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
 
   diagnoseUnnecessaryPreconcurrencyImports(*SF);
   diagnoseUnnecessaryPublicImports(*SF);
+  diagnoseUnusedImports(*SF);
 
   // Check to see if there are any inconsistent imports.
   evaluateOrDefault(

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1561,6 +1561,8 @@ public:
 /// Report imports that are marked public but are not used in API.
 void diagnoseUnnecessaryPublicImports(SourceFile &SF);
 
+/// Report imports that did not result in any imported types/decls.
+void diagnoseUnusedImports(SourceFile &SF);
 } // end namespace swift
 
 #endif

--- a/test/Sema/unused-import.swift
+++ b/test/Sema/unused-import.swift
@@ -1,0 +1,92 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+/// Build the libraries.
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t -enable-library-evolution
+
+/// Check diagnostics.
+// RUN: %target-swift-frontend -typecheck %t/UnusedImportClient.swift -I %t -verify -Runused-module
+// RUN: %target-swift-frontend -typecheck %t/UsedImportClient1.swift -I %t -verify -Runused-module
+// RUN: %target-swift-frontend -typecheck %t/UsedImportClient2.swift -I %t -verify -Runused-module
+// RUN: %target-swift-frontend -typecheck %t/UsedImportClient3.swift -I %t -verify -Runused-module
+// RUN: %target-swift-frontend -typecheck %t/UsedImportClient4.swift -I %t -verify -Runused-module
+// RUN: %target-swift-frontend -typecheck %t/UsedImportClient5.swift -I %t -verify -Runused-module
+// RUN: %target-swift-frontend -typecheck %t/UsedImportClient6.swift -I %t -verify -Runused-module
+// RUN: %target-swift-frontend -typecheck %t/UsedImportClient7.swift -I %t -verify -Runused-module
+
+//--- PublicLib.swift
+public let PublicLibConstant: Int = 42
+public protocol PublicImportProto {
+    associatedtype T
+}
+public struct PublicImportType {
+    public init() {}
+}
+open class PublicImportClass {}
+
+@propertyWrapper
+public struct PublicLibWrapper<T> {
+  public var wrappedValue: T
+  public init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+extension Float: ExpressibleByArrayLiteral {
+    public init(arrayLiteral: Float...) {
+        self.init()
+        var sum: Float = 0
+        for element in arrayLiteral {
+            sum = sum + element
+        }
+        self = sum
+    }
+}
+
+extension Int {
+    public static var theBestInt: Int {
+        return 42
+    }
+}
+
+/// Short test to demonstrate unused import remark
+//--- UnusedImportClient.swift
+import PublicLib // expected-remark {{import of 'PublicLib' unused during compilation}}
+
+//--- UsedImportClient1.swift
+import PublicLib
+public struct PublicLibClientStruct {
+    let sp1: PublicImportType
+}
+
+//--- UsedImportClient2.swift
+import PublicLib
+public protocol PublicLibClientProtocol : PublicImportProto {}
+
+//--- UsedImportClient3.swift
+import PublicLib
+public class PublicLibClientSubclass : PublicImportClass {}
+
+//--- UsedImportClient4.swift
+import PublicLib
+public struct PublicLibClientStruct {
+    @PublicLibWrapper
+    var wp1: Int
+}
+
+//--- UsedImportClient5.swift
+import PublicLib
+public let PublicLibClientConstant: Int = 84 - PublicLibConstant
+
+//--- UsedImportClient6.swift
+import PublicLib
+func foo() {
+    let _: Float = [1.0, 2.0, 3.0]
+}
+
+//--- UsedImportClient7.swift
+import PublicLib
+func foo() {
+    print(Int.theBestInt)
+}
+


### PR DESCRIPTION
To-Do:
---------------------------------
- [ ] References to non-type imported decls (e.g. `UsedImportClient5.swift`)
- [ ] Usage of imported conformances (e.g. `UsedImportClient6.swift`)
- [ ] Usage of members of extensions defined in the imported module (e.g. `UsedImportClient7.swift`)