### PR TITLE
[5.10][Concurrency] Disallow Sendable annotation on methods of non-Sendable…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5248,6 +5248,9 @@ ERROR(local_function_executed_concurrently,none,
 ERROR(sendable_isolated_sync_function,none,
       "%0 synchronous %kind1 cannot be marked as '@Sendable'",
       (ActorIsolation, const ValueDecl *))
+ERROR(nonsendable_instance_method,none,
+      "instance methods of non-Sendable types cannot be marked as '@Sendable'",
+      ())
 ERROR(concurrent_access_of_local_capture,none,
       "%select{mutation of|reference to}0 captured %kind1 in "
       "concurrently-executing code",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6560,6 +6560,8 @@ void AttributeChecker::visitKnownToBeLocalAttr(KnownToBeLocalAttr *attr) {
 
 void AttributeChecker::visitSendableAttr(SendableAttr *attr) {
 
+  auto dc = D->getDeclContext();
+
   if ((isa<AbstractFunctionDecl>(D) || isa<AbstractStorageDecl>(D)) &&
       !isAsyncDecl(cast<ValueDecl>(D))) {
     auto value = cast<ValueDecl>(D);
@@ -6569,6 +6571,15 @@ void AttributeChecker::visitSendableAttr(SendableAttr *attr) {
           attr, diag::sendable_isolated_sync_function,
           isolation, value)
         .warnUntilSwiftVersion(6);
+    }
+  }
+  // Prevent Sendable Attr from being added to methods of non-sendable types
+  if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(D)) {
+    if (auto selfdecl = funcDecl->getImplicitSelfDecl()) {
+      if (!isSendableType(dc->getParentModule(), selfdecl->getTypeInContext())) {
+        diagnose(attr->getLocation(), diag::nonsendable_instance_method)
+        .warnUntilSwiftVersion(6);
+      }
     }
   }
 }

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -23,6 +23,24 @@ actor A {
   }
 }
 
+class NonSendableC {
+    var x: Int = 0
+
+    @Sendable func inc() { // expected-warning{{instance methods of non-Sendable types cannot be marked as '@Sendable'}}
+        x += 1
+    }
+}
+
+struct S<T> {
+  let t: T
+
+  @Sendable func test() {} // expected-warning{{instance methods of non-Sendable types cannot be marked as '@Sendable'}}
+}
+
+extension S: Sendable where T: Sendable {
+  @Sendable func test2() {}
+}
+
 @available(SwiftStdlib 5.1, *)
 @MainActor @Sendable func globalActorFunc() { } // expected-warning{{main actor-isolated synchronous global function 'globalActorFunc()' cannot be marked as '@Sendable'}}
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/69177 into release/5.10

**Explanation**:  Diagnose Sendable annotation on methods of non-Sendable types. This will be an error in Swift 6.
**Risk**: Low, diagnostic
**Testing**: Passes current test-suite
**Reviewer**: @hborla @slavapestov 