### PR TITLE
[CMake] [Darwin] Don't add the Darwin overlay as a dependency if the overlays aren't being built

### DIFF
--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(swift_oslog_darwin_dependencies "")
+if(SWIFT_BUILD_SDK_OVERLAY)
+    list(APPEND swift_oslog_darwin_dependencies "Darwin")
+endif()
 if (SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
     list(APPEND swift_oslog_darwin_dependencies "_Concurrency")
 endif()
@@ -22,11 +25,11 @@ add_swift_target_library(swiftOSLogTestHelper
   OSLogPrivacy.swift
   OSLogFloatFormatting.swift
 
-  SWIFT_MODULE_DEPENDS_IOS Darwin ${swift_oslog_darwin_dependencies}
-  SWIFT_MODULE_DEPENDS_OSX Darwin ${swift_oslog_darwin_dependencies}
-  SWIFT_MODULE_DEPENDS_TVOS Darwin ${swift_oslog_darwin_dependencies}
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin ${swift_oslog_darwin_dependencies}
-  SWIFT_MODULE_DEPENDS_MACCATALYST Darwin ${swift_oslog_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_IOS ${swift_oslog_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_oslog_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_oslog_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_oslog_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_oslog_darwin_dependencies}
   TARGET_SDKS ALL_APPLE_PLATFORMS
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install

--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(SWIFT_BUILD_SDK_OVERLAY)
+set(swift_stdlib_unittest_darwin_dependencies Darwin)
+else()
+set(swift_stdlib_unittest_darwin_dependencies)
+endif()
 
 set(swift_stdlib_unittest_compile_flags
   "-Xfrontend" "-disable-objc-attr-requires-foundation-module")
@@ -50,11 +55,11 @@ add_swift_target_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
   TypeIndexed.swift
 
   SWIFT_MODULE_DEPENDS SwiftPrivate SwiftPrivateThreadExtras SwiftPrivateLibcExtras ${swift_stdlib_unittest_modules}
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-  SWIFT_MODULE_DEPENDS_MACCATALYST Darwin
+  SWIFT_MODULE_DEPENDS_IOS ${swift_stdlib_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_stdlib_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_stdlib_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_stdlib_unittest_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_stdlib_unittest_darwin_dependencies}
   SWIFT_MODULE_DEPENDS_FREESTANDING "${SWIFT_FREESTANDING_TEST_DEPENDENCIES}"
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc

--- a/stdlib/private/SwiftPrivate/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivate/CMakeLists.txt
@@ -2,6 +2,12 @@ set(swift_swiftprivate_compile_flags
     "-parse-stdlib"
     "-Xfrontend" "-disable-access-control")
 
+if(SWIFT_BUILD_SDK_OVERLAY)
+set(swift_swiftprivate_darwin_depencencies Darwin)
+else()
+set(swift_swiftprivate_darwin_depencencies)
+endif()
+
 add_swift_target_library(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
@@ -15,11 +21,11 @@ add_swift_target_library(swiftSwiftPrivate ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   GYB_SOURCES
     AtomicInt.swift.gyb
 
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-  SWIFT_MODULE_DEPENDS_MACCATALYST Darwin
+  SWIFT_MODULE_DEPENDS_OSX ${swift_swiftprivate_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_IOS ${swift_swiftprivate_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_swiftprivate_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_swiftprivate_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_swiftprivate_darwin_depencencies}
   SWIFT_MODULE_DEPENDS_FREESTANDING "${SWIFT_FREESTANDING_TEST_DEPENDENCIES}"
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc

--- a/stdlib/private/SwiftPrivateLibcExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivateLibcExtras/CMakeLists.txt
@@ -14,6 +14,12 @@ else()
   set(swift_private_libc_extras_incorporate_object_libraries "swiftCommandLineSupport")
 endif()
 
+if(SWIFT_BUILD_SDK_OVERLAY)
+set(swift_private_libc_extras_darwin_depencencies Darwin)
+else()
+set(swift_private_libc_extras_darwin_depencencies)
+endif()
+
 add_swift_target_library(swiftSwiftPrivateLibcExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
@@ -25,11 +31,11 @@ add_swift_target_library(swiftSwiftPrivateLibcExtras ${SWIFT_STDLIB_LIBRARY_BUIL
 
   SWIFT_MODULE_DEPENDS SwiftPrivate
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS} ${swift_private_libc_extras_flags}
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-  SWIFT_MODULE_DEPENDS_MACCATALYST Darwin
+  SWIFT_MODULE_DEPENDS_OSX ${swift_private_libc_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_IOS ${swift_private_libc_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_private_libc_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_private_libc_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_private_libc_extras_darwin_depencencies}
   SWIFT_MODULE_DEPENDS_FREESTANDING "${SWIFT_FREESTANDING_TEST_DEPENDENCIES}"
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc

--- a/stdlib/private/SwiftPrivateThreadExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivateThreadExtras/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(SWIFT_BUILD_SDK_OVERLAY)
+set(swift_private_thread_extras_darwin_depencencies Darwin)
+else()
+set(swift_private_thread_extras_darwin_depencencies)
+endif()
+
 add_swift_target_library(swiftSwiftPrivateThreadExtras ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
@@ -6,11 +12,11 @@ add_swift_target_library(swiftSwiftPrivateThreadExtras ${SWIFT_STDLIB_LIBRARY_BU
 
   "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-  SWIFT_MODULE_DEPENDS_MACCATALYST Darwin
+  SWIFT_MODULE_DEPENDS_IOS ${swift_private_thread_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_private_thread_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_private_thread_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_private_thread_extras_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swift_private_thread_extras_darwin_depencencies}
   SWIFT_MODULE_DEPENDS_FREESTANDING "${SWIFT_FREESTANDING_TEST_DEPENDENCIES}"
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc

--- a/stdlib/private/SwiftReflectionTest/CMakeLists.txt
+++ b/stdlib/private/SwiftReflectionTest/CMakeLists.txt
@@ -1,13 +1,18 @@
+if(SWIFT_BUILD_SDK_OVERLAY)
+set(swift_reflection_test_darwin_depencencies Darwin)
+else()
+set(swift_reflection_test_darwin_depencencies)
+endif()
 
 if (SWIFT_INCLUDE_TESTS AND SWIFT_BUILD_DYNAMIC_STDLIB)
   add_swift_target_library(swiftSwiftReflectionTest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
     SwiftReflectionTest.swift
     SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     SWIFT_COMPILE_FLAGS_LINUX -Xcc -D_GNU_SOURCE
-    SWIFT_MODULE_DEPENDS_OSX Darwin
-    SWIFT_MODULE_DEPENDS_IOS Darwin
-    SWIFT_MODULE_DEPENDS_TVOS Darwin
-    SWIFT_MODULE_DEPENDS_WATCHOS Darwin
+    SWIFT_MODULE_DEPENDS_OSX ${swift_reflection_test_darwin_depencencies}
+    SWIFT_MODULE_DEPENDS_IOS ${swift_reflection_test_darwin_depencencies}
+    SWIFT_MODULE_DEPENDS_TVOS ${swift_reflection_test_darwin_depencencies}
+    SWIFT_MODULE_DEPENDS_WATCHOS ${swift_reflection_test_darwin_depencencies}
     SWIFT_MODULE_DEPENDS_LINUX Glibc
     SWIFT_MODULE_DEPENDS_FREEBSD Glibc
     SWIFT_MODULE_DEPENDS_OPENBSD Glibc

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -24,7 +24,7 @@ add_dependencies(compiler CxxStdlib-apinotes)
 # is built with a different (older) version of the compiler. To workaround this,
 # declare the Darwin overlay as a dependency of CxxStdlib.
 set(swift_cxxstdlib_darwin_dependencies)
-if(SWIFT_BUILD_STDLIB AND (SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_TEST_SUPPORT_MODULES))
+if(SWIFT_BUILD_STDLIB AND SWIFT_BUILD_SDK_OVERLAY)
   set(swift_cxxstdlib_darwin_dependencies Darwin)
 endif()
 

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -16,6 +16,12 @@ else()
 set(swiftDifferentiationSIMDFiles)
 endif()
 
+if(SWIFT_BUILD_SDK_OVERLAY)
+set(swiftDifferentiationDarwinDependencies Darwin)
+else()
+set(swiftDifferentiationDarwinDependencies)
+endif()
+
 add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   Differentiable.swift
   DifferentialOperators.swift
@@ -31,10 +37,10 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
     TgmathDerivatives.swift.gyb
     ${swiftDifferentiationSIMDFiles}
 
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
+  SWIFT_MODULE_DEPENDS_OSX ${swiftDifferentiationDarwinDependencies}
+  SWIFT_MODULE_DEPENDS_IOS ${swiftDifferentiationDarwinDependencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swiftDifferentiationDarwinDependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swiftDifferentiationDarwinDependencies}
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc
   SWIFT_MODULE_DEPENDS_OPENBSD Glibc
@@ -50,5 +56,5 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
     -parse-stdlib
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib
-  SWIFT_MODULE_DEPENDS_MACCATALYST Darwin
+  SWIFT_MODULE_DEPENDS_MACCATALYST ${swiftDifferentiationDarwinDependencies}
   MACCATALYST_BUILD_FLAVOR "zippered")

--- a/stdlib/public/Distributed/CMakeLists.txt
+++ b/stdlib/public/Distributed/CMakeLists.txt
@@ -10,6 +10,12 @@
 #
 #===----------------------------------------------------------------------===#
 
+if(SWIFT_BUILD_SDK_OVERLAY)
+set(swift_distributed_darwin_depencencies Darwin)
+else()
+set(swift_distributed_darwin_depencencies)
+endif()
+
 set(swift_distributed_link_libraries
   swiftCore)
 
@@ -23,10 +29,10 @@ add_swift_target_library(swiftDistributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
   DistributedMetadata.swift
   LocalTestingDistributedActorSystem.swift
 
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
+  SWIFT_MODULE_DEPENDS_IOS ${swift_distributed_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_OSX ${swift_distributed_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_TVOS ${swift_distributed_darwin_depencencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS ${swift_distributed_darwin_depencencies}
   SWIFT_MODULE_DEPENDS_LINUX Glibc
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc
   SWIFT_MODULE_DEPENDS_OPENBSD Glibc


### PR DESCRIPTION
Allow for the overlays to not be built in Darwin by respecting SWIFT_BUILD_SDK_OVERLAY.