### PR TITLE
[Typed throws] Add upcoming feature FullTypedThrows

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -118,6 +118,7 @@ UPCOMING_FEATURE(ExistentialAny, 335, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
 UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 6)
+UPCOMING_FEATURE(FullTypedThrows, 410, 6)
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3575,6 +3575,10 @@ static bool usesFeatureNewCxxMethodSafetyHeuristics(Decl *decl) {
   return decl->hasClangNode();
 }
 
+static bool usesFeatureFullTypedThrows(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureTypedThrows(Decl *decl) {
   if (auto func = dyn_cast<AbstractFunctionDecl>(decl))
     return func->getThrownTypeRepr() != nullptr;

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature TypedThrows
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TypedThrows -enable-upcoming-feature FullTypedThrows
 
 enum MyError: Error {
 case failed
@@ -15,16 +15,23 @@ func processMyError(_: MyError) { }
 func doSomething() throws(MyError) { }
 func doHomework() throws(HomeworkError) { }
 
-func testDoCatchErrorTyped() {
-  #if false
-  // FIXME: Deal with throws directly in the do...catch blocks.
+func testDoCatchErrorTyped(cond: Bool) {
   do {
     throw MyError.failed
   } catch {
     assert(error == .failed)
     processMyError(error)
   }
-  #endif
+
+  do {
+    if cond {
+      throw MyError.failed
+    } else {
+      throw HomeworkError.dogAteIt
+    }
+  } catch {
+    processMyError(error) // expected-error{{cannot convert value of type 'any Error' to expected argument type 'MyError'}}
+  }
 
   // Throwing a typed error in a do...catch catches the error with that type.
   do {


### PR DESCRIPTION
Introduce the upcoming feature `FullTypedThrows`. When enabled, infer the error type of a `throw` statement based on its original type, instead of always being `any Error`. This is technically a source-breaking change, hence the upcoming feature flag.
