### PR TITLE
Move llvm:Error types

### DIFF
--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -90,7 +90,7 @@ Expected<bool> cas::CachedResultLoader::replay(CallbackTy Callback) {
               [&](swift::cas::CompileJobCacheResult::Output Output) -> Error {
                 return Callback(Output.Kind, Output.Object);
               }))
-        return Err;
+        return std::move(Err);
 
       return true;
     }
@@ -120,7 +120,7 @@ Expected<bool> cas::CachedResultLoader::replay(CallbackTy Callback) {
                    "Unexpected output kind in clang cached result");
             return Callback(OutputKind, Output.Object);
           }))
-        return Err;
+        return std::move(Err);
 
       return true;
     }


### PR DESCRIPTION
Older compilers don't have the copy-elision rule of newer C++ compilers, resulting in an error message when returning a non-copyable type. Move llvm::Error instead of copying it.

```
/home/ewilde/work/swift-project/swift/lib/Frontend/CachingUtils.cpp:93:16: error: call to deleted constructor of 'llvm::Error'
        return Err;
               ^~~
/home/ewilde/work/swift-project/llvm-project/llvm/include/llvm/Support/Error.h:184:3: note: 'Error' has been explicitly marked deleted here
  Error(const Error &Other) = delete;
  ^
/home/ewilde/work/swift-project/llvm-project/llvm/include/llvm/Support/Error.h:491:18: note: passing argument to parameter 'Err' here
  Expected(Error Err)
                 ^
/home/ewilde/work/swift-project/swift/lib/Frontend/CachingUtils.cpp:123:16: error: call to deleted constructor of 'llvm::Error'
        return Err;
               ^~~
/home/ewilde/work/swift-project/llvm-project/llvm/include/llvm/Support/Error.h:184:3: note: 'Error' has been explicitly marked deleted here
  Error(const Error &Other) = delete;
  ^
/home/ewilde/work/swift-project/llvm-project/llvm/include/llvm/Support/Error.h:491:18: note: passing argument to parameter 'Err' here
  Expected(Error Err)
                 ^
```