### PR TITLE
[CMake] add option to generate API descriptors for the standard library

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -95,6 +95,10 @@ option(SWIFT_ENABLE_MODULE_INTERFACES
        "Generate .swiftinterface files alongside .swiftmodule files"
        "${SWIFT_STDLIB_STABLE_ABI}")
 
+option(SWIFT_STDLIB_EMIT_API_DESCRIPTORS
+        "Emit api descriptors for the standard library"
+        FALSE)
+
 if("${SWIFT_HOST_VARIANT_SDK}" IN_LIST SWIFT_DARWIN_PLATFORMS)
   set(SWIFT_STDLIB_ENABLE_PRESPECIALIZATION_default TRUE)
 elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -656,6 +656,12 @@ function(_compile_swift_files
            "-emit-private-module-interface-path" "${private_interface_file}")
     endif()
 
+    if(SWIFT_STDLIB_EMIT_API_DESCRIPTORS AND NOT SWIFTFILE_IS_FRAGILE)
+      set(api_descriptor_file "${module_base}.api.json")
+      list(APPEND swift_module_flags
+            "-emit-api-descriptor-path" "${api_descriptor_file}")
+    endif()
+
     if (NOT SWIFTFILE_IS_STDLIB_CORE)
       list(APPEND swift_module_flags
            "-Xfrontend" "-experimental-skip-non-inlinable-function-bodies")
@@ -714,6 +720,13 @@ function(_compile_swift_files
         set(maccatalyst_private_interface_file)
       endif()
 
+      if(SWIFT_STDLIB_EMIT_API_DESCRIPTORS AND NOT SWIFTFILE_IS_FRAGILE)
+        set(maccatalyst_api_descriptor_file "${maccatalyst_module_base}.api.json")
+        list(APPEND maccatalyst_module_outputs "${maccatalyst_api_descriptor_file}")
+      else()
+        set(maccatalyst_api_descriptor_file)
+      endif()
+
       swift_install_in_component(DIRECTORY ${maccatalyst_specific_module_dir}
                                  DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${maccatalyst_library_subdir}"
                                  COMPONENT "${SWIFTFILE_INSTALL_IN_COMPONENT}"
@@ -736,6 +749,9 @@ function(_compile_swift_files
   if(interface_file)
     list(APPEND module_outputs "${interface_file}" "${private_interface_file}")
     list(APPEND module_outputs_static "${interface_file_static}" "${private_interface_file_static}")
+  endif()
+  if(api_descriptor_file)
+      list(APPEND module_outputs "${api_descriptor_file}")
   endif()
 
   swift_install_in_component(DIRECTORY "${specific_module_dir}"
@@ -854,6 +870,14 @@ function(_compile_swift_files
       list(INSERT maccatalyst_swift_module_flags ${private_interface_file_index} "${maccatalyst_private_interface_file}")
       math(EXPR old_interface_file_index "${private_interface_file_index} + 1")
       list(REMOVE_AT maccatalyst_swift_module_flags ${old_interface_file_index})
+    endif()
+
+    # Remove original api descriptor
+    list(FIND maccatalyst_swift_module_flags "${api_descriptor_file}" api_descriptor_file_index)
+    if(NOT api_descriptor_file_index EQUAL -1)
+      list(INSERT maccatalyst_swift_module_flags ${api_descriptor_file_index} "${maccatalyst_api_descriptor_file}")
+      math(EXPR old_api_descriptor_file_index "${api_descriptor_file_index} + 1")
+      list(REMOVE_AT maccatalyst_swift_module_flags ${old_api_descriptor_file_index})
     endif()
 
     # We still need to change the main swift flags


### PR DESCRIPTION
This would be needed to stop using `swift-api-extract` in some internal configurations.

Given the limited scope, only add this as a CMake flag.

Addresses rdar://117019309