### PR TITLE
[ASTGen] Introduce wrapper types for AST nodes

### DIFF
--- a/include/swift/AST/ASTBridgingWrappers.def
+++ b/include/swift/AST/ASTBridgingWrappers.def
@@ -57,9 +57,10 @@
 #define ABSTRACT_TYPEREPR(Id, Parent) TYPEREPR(Id, Parent)
 #include "swift/AST/TypeReprNodes.def"
 
-// Most of the base classes need to be nullable to allow them to be used as
+// Some of the base classes need to be nullable to allow them to be used as
 // optional parameters.
 AST_BRIDGING_WRAPPER_NONNULL(Decl)
+AST_BRIDGING_WRAPPER_NONNULL(DeclContext)
 AST_BRIDGING_WRAPPER_NULLABLE(Stmt)
 AST_BRIDGING_WRAPPER_NULLABLE(Expr)
 AST_BRIDGING_WRAPPER_NULLABLE(TypeRepr)

--- a/include/swift/AST/ASTBridgingWrappers.def
+++ b/include/swift/AST/ASTBridgingWrappers.def
@@ -1,0 +1,74 @@
+//===--- ASTBridgingWrappers.def - Swift AST Metaprogramming ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines macros used for bridging macro-metaprogramming with AST
+// nodes.
+//
+//===----------------------------------------------------------------------===//
+
+/// AST_BRIDGING_WRAPPER(Name)
+///   The default macro to define a bridging wrapper type.
+
+/// AST_BRIDGING_WRAPPER_NULLABLE(Name)
+///   Specifies that the given bridging wrapper should have a
+///   nullable raw value.
+#ifndef AST_BRIDGING_WRAPPER_NULLABLE
+#define AST_BRIDGING_WRAPPER_NULLABLE(Name) AST_BRIDGING_WRAPPER(Name)
+#endif
+
+/// AST_BRIDGING_WRAPPER_NONNULL(Name)
+///   Specifies that the given bridging wrapper should have a
+///   non-null raw value.
+#ifndef AST_BRIDGING_WRAPPER_NONNULL
+#define AST_BRIDGING_WRAPPER_NONNULL(Name) AST_BRIDGING_WRAPPER(Name)
+#endif
+
+// Each AST node subclass stores a non-null raw value.
+#ifndef DECL
+#define DECL(Id, Parent) AST_BRIDGING_WRAPPER_NONNULL(Id##Decl)
+#endif
+#define ABSTRACT_DECL(Id, Parent) DECL(Id, Parent)
+#include "swift/AST/DeclNodes.def"
+
+#ifndef EXPR
+#define EXPR(Id, Parent) AST_BRIDGING_WRAPPER_NONNULL(Id##Expr)
+#endif
+#define ABSTRACT_EXPR(Id, Parent) EXPR(Id, Parent)
+#include "swift/AST/ExprNodes.def"
+
+#ifndef STMT
+#define STMT(Id, Parent) AST_BRIDGING_WRAPPER_NONNULL(Id##Stmt)
+#endif
+#define ABSTRACT_STMT(Id, Parent) STMT(Id, Parent)
+#include "swift/AST/StmtNodes.def"
+
+#ifndef TYPEREPR
+#define TYPEREPR(Id, Parent) AST_BRIDGING_WRAPPER_NONNULL(Id##TypeRepr)
+#endif
+#define ABSTRACT_TYPEREPR(Id, Parent) TYPEREPR(Id, Parent)
+#include "swift/AST/TypeReprNodes.def"
+
+// Most of the base classes need to be nullable to allow them to be used as
+// optional parameters.
+AST_BRIDGING_WRAPPER_NONNULL(Decl)
+AST_BRIDGING_WRAPPER_NULLABLE(Stmt)
+AST_BRIDGING_WRAPPER_NULLABLE(Expr)
+AST_BRIDGING_WRAPPER_NULLABLE(TypeRepr)
+
+// Misc AST types to generate wrappers for.
+AST_BRIDGING_WRAPPER_NULLABLE(GenericParamList)
+AST_BRIDGING_WRAPPER_NULLABLE(TrailingWhereClause)
+AST_BRIDGING_WRAPPER_NULLABLE(ParameterList)
+
+#undef AST_BRIDGING_WRAPPER_NONNULL
+#undef AST_BRIDGING_WRAPPER_NULLABLE
+#undef AST_BRIDGING_WRAPPER

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -31,6 +31,69 @@
 #endif
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+typedef struct BridgedDeclContext {
+  void *_Nonnull raw;
+} BridgedDeclContext;
+
+// Define the bridging wrappers for each AST node.
+#define AST_BRIDGING_WRAPPER_NONNULL(Name)                                     \
+  typedef struct {                                                             \
+    void *_Nonnull raw;                                                        \
+  } Bridged##Name;
+
+#define AST_BRIDGING_WRAPPER_NULLABLE(Name)                                    \
+  typedef struct {                                                             \
+    void *_Nullable raw;                                                       \
+  } Bridged##Name;
+
+#include "swift/AST/ASTBridgingWrappers.def"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Declare `.asDecl` on each BridgedXXXDecl type.
+#define DECL(Id, Parent)                                                       \
+  SWIFT_NAME("getter:Bridged" #Id "Decl.asDecl(self:)")                        \
+  BridgedDecl Id##Decl_asDecl(Bridged##Id##Decl decl);
+#define ABSTRACT_DECL(Id, Parent) DECL(Id, Parent)
+#include "swift/AST/DeclNodes.def"
+
+// Declare `.asDeclContext` on each BridgedXXXDecl type that's also a
+// DeclContext.
+#define DECL(Id, Parent)
+#define CONTEXT_DECL(Id, Parent)                                               \
+  SWIFT_NAME("getter:Bridged" #Id "Decl.asDeclContext(self:)")                 \
+  BridgedDeclContext Id##Decl_asDeclContext(Bridged##Id##Decl decl);
+#define ABSTRACT_CONTEXT_DECL(Id, Parent) CONTEXT_DECL(Id, Parent)
+#include "swift/AST/DeclNodes.def"
+
+// Declare `.asStmt` on each BridgedXXXStmt type.
+#define STMT(Id, Parent)                                                       \
+  SWIFT_NAME("getter:Bridged" #Id "Stmt.asStmt(self:)")                        \
+  BridgedStmt Id##Stmt_asStmt(Bridged##Id##Stmt stmt);
+#define ABSTRACT_STMT(Id, Parent) STMT(Id, Parent)
+#include "swift/AST/StmtNodes.def"
+
+// Declare `.asExpr` on each BridgedXXXExpr type.
+#define EXPR(Id, Parent)                                                       \
+  SWIFT_NAME("getter:Bridged" #Id "Expr.asExpr(self:)")                        \
+  BridgedExpr Id##Expr_asExpr(Bridged##Id##Expr expr);
+#define ABSTRACT_EXPR(Id, Parent) EXPR(Id, Parent)
+#include "swift/AST/ExprNodes.def"
+
+// Declare `.asTypeRepr` on each BridgedXXXTypeRepr type.
+#define TYPEREPR(Id, Parent)                                                   \
+  SWIFT_NAME("getter:Bridged" #Id "TypeRepr.asTypeRepr(self:)")                \
+  BridgedTypeRepr Id##TypeRepr_asTypeRepr(Bridged##Id##TypeRepr typeRepr);
+#define ABSTRACT_TYPEREPR(Id, Parent) TYPEREPR(Id, Parent)
+#include "swift/AST/TypeReprNodes.def"
+
+#ifdef __cplusplus
+}
+#endif
+
 SWIFT_BEGIN_ASSUME_NONNULL
 
 typedef struct {
@@ -46,10 +109,6 @@ typedef struct {
 typedef struct BridgedASTContext {
   void *raw;
 } BridgedASTContext;
-
-typedef struct BridgedDeclContext {
-  void *raw;
-} BridgedDeclContext;
 
 typedef struct BridgedSourceLoc {
   const void *_Nullable raw;
@@ -76,7 +135,7 @@ typedef struct {
   BridgedSourceLoc SecondNameLoc;
   BridgedSourceLoc UnderscoreLoc;
   BridgedSourceLoc ColonLoc;
-  void *Type;
+  BridgedTypeRepr Type;
   BridgedSourceLoc TrailingCommaLoc;
 } BridgedTupleTypeElement;
 
@@ -101,8 +160,8 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedRequirementReprKind : size_t {
 typedef struct {
   BridgedSourceLoc SeparatorLoc;
   BridgedRequirementReprKind Kind;
-  void *FirstType;
-  void *SecondType;
+  BridgedTypeRepr FirstType;
+  BridgedTypeRepr SecondType;
   // FIXME: Handle Layout Requirements
 } BridgedRequirementRepr;
 
@@ -210,17 +269,6 @@ typedef struct BridgedASTNode {
   ASTNodeKind kind;
 } BridgedASTNode;
 
-typedef struct BridgedFuncDecl {
-  BridgedDeclContext declContext;
-  void *funcDecl;
-  void *decl;
-} BridgedFuncDecl;
-
-typedef struct BridgedDeclContextAndDecl {
-  BridgedDeclContext asDeclContext;
-  void *asDecl;
-} BridgedDeclContextAndDecl;
-
 typedef struct BridgedTypeAttributes {
   void *raw;
 } BridgedTypeAttributes;
@@ -266,210 +314,267 @@ BridgedIdentifier ASTContext_getIdentifier(BridgedASTContext cContext,
 _Bool ASTContext_langOptsHasFeature(BridgedASTContext cContext,
                                     BridgedFeature feature);
 
-SWIFT_NAME("TopLevelCodeDecl_createStmt(astContext:declContext:startLoc:"
-           "statement:endLoc:)")
-void *TopLevelCodeDecl_createStmt(BridgedASTContext cContext,
-                                  BridgedDeclContext cDeclContext,
-                                  BridgedSourceLoc cStartLoc, void *statement,
-                                  BridgedSourceLoc cEndLoc);
+SWIFT_NAME(
+    "BridgedTopLevelCodeDecl.createParsed(_:declContext:startLoc:stmt:endLoc:)")
+BridgedTopLevelCodeDecl
+TopLevelCodeDecl_createStmt(BridgedASTContext cContext,
+                            BridgedDeclContext cDeclContext,
+                            BridgedSourceLoc cStartLoc, BridgedStmt statement,
+                            BridgedSourceLoc cEndLoc);
 
-SWIFT_NAME("TopLevelCodeDecl_createExpr(astContext:declContext:startLoc:"
-           "expression:endLoc:)")
-void *TopLevelCodeDecl_createExpr(BridgedASTContext cContext,
-                                  BridgedDeclContext cDeclContext,
-                                  BridgedSourceLoc cStartLoc, void *expression,
-                                  BridgedSourceLoc cEndLoc);
+SWIFT_NAME(
+    "BridgedTopLevelCodeDecl.createParsed(_:declContext:startLoc:expr:endLoc:)")
+BridgedTopLevelCodeDecl
+TopLevelCodeDecl_createExpr(BridgedASTContext cContext,
+                            BridgedDeclContext cDeclContext,
+                            BridgedSourceLoc cStartLoc, BridgedExpr expression,
+                            BridgedSourceLoc cEndLoc);
 
-void *ReturnStmt_create(BridgedASTContext cContext, BridgedSourceLoc cLoc,
-                        void *_Nullable expr);
+SWIFT_NAME("BridgedReturnStmt.createParsed(_:returnKeywordLoc:expr:)")
+BridgedReturnStmt ReturnStmt_createParsed(BridgedASTContext cContext,
+                                          BridgedSourceLoc cLoc,
+                                          BridgedExpr expr);
 
-void *SequenceExpr_create(BridgedASTContext cContext, BridgedArrayRef exprs);
-
-void *TupleExpr_create(BridgedASTContext cContext, BridgedSourceLoc cLParen,
-                       BridgedArrayRef subs, BridgedArrayRef names,
-                       BridgedArrayRef cNameLocs, BridgedSourceLoc cRParen);
-
-void *FunctionCallExpr_create(BridgedASTContext cContext, void *fn, void *args);
-
-void *IdentifierExpr_create(BridgedASTContext cContext, BridgedIdentifier base,
-                            BridgedSourceLoc cLoc);
-
-void *StringLiteralExpr_create(BridgedASTContext cContext, BridgedString cStr,
-                               BridgedSourceLoc cTokenLoc);
-
-void *IntegerLiteralExpr_create(BridgedASTContext cContext, BridgedString cStr,
-                                BridgedSourceLoc cTokenLoc);
-
-void *BooleanLiteralExpr_create(BridgedASTContext cContext, _Bool value,
-                                BridgedSourceLoc cTokenLoc);
-
-SWIFT_NAME("NilLiteralExpr_create(astContext:nilKeywordLoc:)")
-void *NilLiteralExpr_create(BridgedASTContext cContext,
-                            BridgedSourceLoc cNilKeywordLoc);
-
-void *ArrayExpr_create(BridgedASTContext cContext, BridgedSourceLoc cLLoc,
-                       BridgedArrayRef elements, BridgedArrayRef commas,
-                       BridgedSourceLoc cRLoc);
-
-SWIFT_NAME("VarDecl_create(astContext:declContext:bindingKeywordLoc:nameExpr:"
-           "initializer:isStatic:isLet:)")
-void *VarDecl_create(BridgedASTContext cContext,
-                     BridgedDeclContext cDeclContext,
-                     BridgedSourceLoc cBindingKeywordLoc, void *opaqueNameExpr,
-                     void *opaqueInitExpr, _Bool isStatic, _Bool isLet);
-
-void *SingleValueStmtExpr_createWithWrappedBranches(
-    BridgedASTContext cContext, void *S, BridgedDeclContext cDeclContext,
-    _Bool mustBeExpr);
-
-void *IfStmt_create(BridgedASTContext cContext, BridgedSourceLoc cIfLoc,
-                    void *cond, void *_Nullable then, BridgedSourceLoc cElseLoc,
-                    void *_Nullable elseStmt);
-
-void *BraceStmt_create(BridgedASTContext cContext, BridgedSourceLoc cLBLoc,
-                       BridgedArrayRef elements, BridgedSourceLoc cRBLoc);
+SWIFT_NAME("BridgedSequenceExpr.createParsed(_:exprs:)")
+BridgedSequenceExpr SequenceExpr_createParsed(BridgedASTContext cContext,
+                                              BridgedArrayRef exprs);
 
 BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, size_t len);
 
-SWIFT_NAME("ParamDecl_create(astContext:declContext:specifierLoc:firstName:"
+SWIFT_NAME("BridgedTupleExpr.createParsed(_:leftParenLoc:exprs:labels:"
+           "labelLocs:rightParenLoc:)")
+BridgedTupleExpr
+TupleExpr_createParsed(BridgedASTContext cContext, BridgedSourceLoc cLParen,
+                       BridgedArrayRef subs, BridgedArrayRef names,
+                       BridgedArrayRef cNameLocs, BridgedSourceLoc cRParen);
+
+SWIFT_NAME("BridgedCallExpr.createParsed(_:fn:args:)")
+BridgedCallExpr CallExpr_createParsed(BridgedASTContext cContext,
+                                      BridgedExpr fn, BridgedTupleExpr args);
+
+SWIFT_NAME("BridgedUnresolvedDeclRefExpr.createParsed(_:base:loc:)")
+BridgedUnresolvedDeclRefExpr UnresolvedDeclRefExpr_createParsed(
+    BridgedASTContext cContext, BridgedIdentifier base, BridgedSourceLoc cLoc);
+
+SWIFT_NAME("BridgedStringLiteralExpr.createParsed(_:value:loc:)")
+BridgedStringLiteralExpr
+StringLiteralExpr_createParsed(BridgedASTContext cContext, BridgedString cStr,
+                               BridgedSourceLoc cTokenLoc);
+
+SWIFT_NAME("BridgedIntegerLiteralExpr.createParsed(_:value:loc:)")
+BridgedIntegerLiteralExpr
+IntegerLiteralExpr_createParsed(BridgedASTContext cContext, BridgedString cStr,
+                                BridgedSourceLoc cTokenLoc);
+
+SWIFT_NAME("BridgedBooleanLiteralExpr.createParsed(_:value:loc:)")
+BridgedBooleanLiteralExpr
+BooleanLiteralExpr_createParsed(BridgedASTContext cContext, _Bool value,
+                                BridgedSourceLoc cTokenLoc);
+
+SWIFT_NAME("BridgedNilLiteralExpr.createParsed(_:nilKeywordLoc:)")
+BridgedNilLiteralExpr
+NilLiteralExpr_createParsed(BridgedASTContext cContext,
+                            BridgedSourceLoc cNilKeywordLoc);
+
+SWIFT_NAME("BridgedArrayExpr.createParsed(_:lSquareLoc:elements:commaLocs:"
+           "rSquareLoc:)")
+BridgedArrayExpr ArrayExpr_createParsed(BridgedASTContext cContext,
+                                        BridgedSourceLoc cLLoc,
+                                        BridgedArrayRef elements,
+                                        BridgedArrayRef commas,
+                                        BridgedSourceLoc cRLoc);
+
+SWIFT_NAME(
+    "BridgedPatternBindingDecl.createParsed(_:declContext:bindingKeywordLoc:"
+    "nameExpr:initializer:isStatic:isLet:)")
+BridgedPatternBindingDecl PatternBindingDecl_createParsed(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedSourceLoc cBindingKeywordLoc, BridgedExpr opaqueNameExpr,
+    BridgedExpr opaqueInitExpr, _Bool isStatic, _Bool isLet);
+
+SWIFT_NAME("BridgedSingleValueStmtExpr.createWithWrappedBranches(_:stmt:"
+           "declContext:mustBeExpr:)")
+BridgedSingleValueStmtExpr SingleValueStmtExpr_createWithWrappedBranches(
+    BridgedASTContext cContext, BridgedStmt S, BridgedDeclContext cDeclContext,
+    _Bool mustBeExpr);
+
+SWIFT_NAME("BridgedIfStmt.createParsed(_:ifKeywordLoc:condition:thenStmt:"
+           "elseLoc:elseStmt:)")
+BridgedIfStmt IfStmt_createParsed(BridgedASTContext cContext,
+                                  BridgedSourceLoc cIfLoc, BridgedExpr cond,
+                                  BridgedStmt then, BridgedSourceLoc cElseLoc,
+                                  BridgedStmt elseStmt);
+
+SWIFT_NAME("BridgedBraceStmt.createParsed(_:lBraceLoc:elements:rBraceLoc:)")
+BridgedBraceStmt BraceStmt_createParsed(BridgedASTContext cContext,
+                                        BridgedSourceLoc cLBLoc,
+                                        BridgedArrayRef elements,
+                                        BridgedSourceLoc cRBLoc);
+
+SWIFT_NAME("BridgedParamDecl.createParsed(_:declContext:specifierLoc:firstName:"
            "firstNameLoc:secondName:secondNameLoc:type:defaultValue:)")
-void *
-ParamDecl_create(BridgedASTContext cContext, BridgedDeclContext cDeclContext,
-                 BridgedSourceLoc cSpecifierLoc, BridgedIdentifier cFirstName,
-                 BridgedSourceLoc cFirstNameLoc, BridgedIdentifier cSecondName,
-                 BridgedSourceLoc cSecondNameLoc, void *_Nullable opaqueType,
-                 void *_Nullable opaqueDefaultValue);
+BridgedParamDecl ParamDecl_createParsed(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedSourceLoc cSpecifierLoc, BridgedIdentifier cFirstName,
+    BridgedSourceLoc cFirstNameLoc, BridgedIdentifier cSecondName,
+    BridgedSourceLoc cSecondNameLoc, BridgedTypeRepr type,
+    BridgedExpr defaultValue);
 
-SWIFT_NAME("AbstractFunctionDecl_setBody(_:ofDecl:)")
-void AbstractFunctionDecl_setBody(void *opaqueBody, void *opaqueDecl);
+SWIFT_NAME("BridgedConstructorDecl.setParsedBody(self:_:)")
+void ConstructorDecl_setParsedBody(BridgedConstructorDecl decl,
+                                   BridgedBraceStmt body);
 
-SWIFT_NAME("FuncDecl_create(astContext:declContext:staticLoc:funcKeywordLoc:"
-           "name:nameLoc:genericParamList:parameterList:asyncSpecifierLoc:"
-           "throwsSpecifierLoc:thrownType:returnType:genericWhereClause:)")
-struct BridgedDeclContextAndDecl
-FuncDecl_create(BridgedASTContext cContext, BridgedDeclContext cDeclContext,
-                BridgedSourceLoc cStaticLoc, BridgedSourceLoc cFuncKeywordLoc,
-                BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
-                void *_Nullable opaqueGenericParamList,
-                void *opaqueParameterList, BridgedSourceLoc cAsyncLoc,
-                BridgedSourceLoc cThrowsLoc, void *_Nullable opaqueThrownType,
-                void *_Nullable opaqueReturnType,
-                void *_Nullable opaqueGenericWhereClause);
+SWIFT_NAME("BridgedFuncDecl.setParsedBody(self:_:)")
+void FuncDecl_setParsedBody(BridgedFuncDecl decl, BridgedBraceStmt body);
 
-SWIFT_NAME("ConstructorDecl_create(astContext:declContext:initKeywordLoc:"
-           "failabilityMarkLoc:isIUO:genericParamList:parameterList:"
-           "asyncSpecifierLoc:throwsSpecifierLoc:thrownType:genericWhereClause:)")
-BridgedDeclContextAndDecl ConstructorDecl_create(
+SWIFT_NAME("BridgedDestructorDecl.setParsedBody(self:_:)")
+void DestructorDecl_setParsedBody(BridgedDestructorDecl decl,
+                                  BridgedBraceStmt body);
+
+SWIFT_NAME(
+    "BridgedFuncDecl.createParsed(_:declContext:staticLoc:funcKeywordLoc:"
+    "name:nameLoc:genericParamList:parameterList:asyncSpecifierLoc:"
+    "throwsSpecifierLoc:thrownType:returnType:genericWhereClause:)")
+BridgedFuncDecl FuncDecl_createParsed(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedSourceLoc cStaticLoc, BridgedSourceLoc cFuncKeywordLoc,
+    BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
+    BridgedGenericParamList genericParamList,
+    BridgedParameterList parameterList, BridgedSourceLoc cAsyncLoc,
+    BridgedSourceLoc cThrowsLoc, BridgedTypeRepr thrownType,
+    BridgedTypeRepr returnType,
+    BridgedTrailingWhereClause opaqueGenericWhereClause);
+
+SWIFT_NAME(
+    "BridgedConstructorDecl.createParsed(_:declContext:initKeywordLoc:"
+    "failabilityMarkLoc:isIUO:genericParamList:parameterList:"
+    "asyncSpecifierLoc:throwsSpecifierLoc:thrownType:genericWhereClause:)")
+BridgedConstructorDecl ConstructorDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cInitKeywordLoc, BridgedSourceLoc cFailabilityMarkLoc,
-    _Bool isIUO, void *_Nullable opaqueGenericParams, void *opaqueParameterList,
-    BridgedSourceLoc cAsyncLoc, BridgedSourceLoc cThrowsLoc,
-    void *_Nullable opaqueThrownType,
-    void *_Nullable opaqueGenericWhereClause);
+    _Bool isIUO, BridgedGenericParamList genericParams,
+    BridgedParameterList parameterList, BridgedSourceLoc cAsyncLoc,
+    BridgedSourceLoc cThrowsLoc, BridgedTypeRepr thrownType,
+    BridgedTrailingWhereClause genericWhereClause);
 
-SWIFT_NAME("DestructorDecl_create(astContext:declContext:deinitKeywordLoc:)")
-BridgedDeclContextAndDecl
-DestructorDecl_create(BridgedASTContext cContext,
-                      BridgedDeclContext cDeclContext,
-                      BridgedSourceLoc cDeinitKeywordLoc);
+SWIFT_NAME(
+    "BridgedDestructorDecl.createParsed(_:declContext:deinitKeywordLoc:)")
+BridgedDestructorDecl
+DestructorDecl_createParsed(BridgedASTContext cContext,
+                            BridgedDeclContext cDeclContext,
+                            BridgedSourceLoc cDeinitKeywordLoc);
 
-void *SimpleIdentTypeRepr_create(BridgedASTContext cContext,
-                                 BridgedSourceLoc cLoc, BridgedIdentifier id);
+SWIFT_NAME("BridgedSimpleIdentTypeRepr.createParsed(_:loc:name:)")
+BridgedTypeRepr SimpleIdentTypeRepr_createParsed(BridgedASTContext cContext,
+                                                 BridgedSourceLoc cLoc,
+                                                 BridgedIdentifier id);
 
-void *UnresolvedDotExpr_create(BridgedASTContext cContext, void *base,
+SWIFT_NAME("BridgedUnresolvedDotExpr.createParsed(_:base:dotLoc:name:nameLoc:)")
+BridgedUnresolvedDotExpr
+UnresolvedDotExpr_createParsed(BridgedASTContext cContext, BridgedExpr base,
                                BridgedSourceLoc cDotLoc, BridgedIdentifier name,
                                BridgedSourceLoc cNameLoc);
 
-void *ClosureExpr_create(BridgedASTContext cContext, void *body,
-                         BridgedDeclContext cDeclContext);
+SWIFT_NAME("BridgedClosureExpr.createParsed(_:declContext:body:)")
+BridgedClosureExpr ClosureExpr_createParsed(BridgedASTContext cContext,
+                                            BridgedDeclContext cDeclContext,
+                                            BridgedBraceStmt body);
 
 SWIFT_NAME(
-    "TypeAliasDecl_create(astContext:declContext:typealiasKeywordLoc:name:"
+    "BridgedTypeAliasDecl.createParsed(_:declContext:typealiasKeywordLoc:name:"
     "nameLoc:genericParamList:equalLoc:underlyingType:genericWhereClause:)")
-void *TypeAliasDecl_create(BridgedASTContext cContext,
-                           BridgedDeclContext cDeclContext,
-                           BridgedSourceLoc cAliasKeywordLoc,
-                           BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
-                           void *_Nullable opaqueGenericParamList,
-                           BridgedSourceLoc cEqualLoc,
-                           void *opaqueUnderlyingType,
-                           void *_Nullable opaqueGenericWhereClause);
+BridgedTypeAliasDecl TypeAliasDecl_createParsed(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedSourceLoc cAliasKeywordLoc, BridgedIdentifier cName,
+    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cEqualLoc, BridgedTypeRepr underlyingType,
+    BridgedTrailingWhereClause genericWhereClause);
 
-SWIFT_NAME("IterableDeclContext_setParsedMembers(_:ofDecl:)")
-void IterableDeclContext_setParsedMembers(BridgedArrayRef members,
-                                          void *opaqueDecl);
+SWIFT_NAME("BridgedNominalTypeDecl.setParsedMembers(self:_:)")
+void NominalTypeDecl_setParsedMembers(BridgedNominalTypeDecl decl,
+                                      BridgedArrayRef members);
 
-SWIFT_NAME("EnumDecl_create(astContext:declContext:enumKeywordLoc:name:nameLoc:"
-           "genericParamList:inheritedTypes:genericWhereClause:braceRange:)")
-BridgedDeclContextAndDecl EnumDecl_create(
+SWIFT_NAME("BridgedExtensionDecl.setParsedMembers(self:_:)")
+void ExtensionDecl_setParsedMembers(BridgedExtensionDecl decl,
+                                    BridgedArrayRef members);
+
+SWIFT_NAME(
+    "BridgedEnumDecl.createParsed(_:declContext:enumKeywordLoc:name:nameLoc:"
+    "genericParamList:inheritedTypes:genericWhereClause:braceRange:)")
+BridgedNominalTypeDecl EnumDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cEnumKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, void *_Nullable opaqueGenericParamList,
-    BridgedArrayRef cInheritedTypes, void *_Nullable opaqueGenericWhereClause,
+    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedArrayRef cInheritedTypes,
+    BridgedTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
-SWIFT_NAME("EnumCaseDecl_create(declContext:caseKeywordLoc:elements:)")
-void *EnumCaseDecl_create(BridgedDeclContext cDeclContext,
-                          BridgedSourceLoc cCaseKeywordLoc,
-                          BridgedArrayRef cElements);
-
-SWIFT_NAME("EnumElementDecl_create(astContext:declContext:name:nameLoc:"
-           "parameterList:equalsLoc:rawValue:)")
-void *EnumElementDecl_create(BridgedASTContext cContext,
-                             BridgedDeclContext cDeclContext,
-                             BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
-                             void *_Nullable opaqueParameterList,
-                             BridgedSourceLoc cEqualsLoc,
-                             void *_Nullable opaqueRawValue);
-
 SWIFT_NAME(
-    "StructDecl_create(astContext:declContext:structKeywordLoc:name:nameLoc:"
-    "genericParamList:inheritedTypes:genericWhereClause:braceRange:)")
-BridgedDeclContextAndDecl StructDecl_create(
+    "BridgedEnumCaseDecl.createParsed(declContext:caseKeywordLoc:elements:)")
+BridgedEnumCaseDecl EnumCaseDecl_createParsed(BridgedDeclContext cDeclContext,
+                                              BridgedSourceLoc cCaseKeywordLoc,
+                                              BridgedArrayRef cElements);
+
+SWIFT_NAME("BridgedEnumElementDecl.createParsed(_:declContext:name:nameLoc:"
+           "parameterList:equalsLoc:rawValue:)")
+BridgedEnumElementDecl EnumElementDecl_createParsed(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
+    BridgedParameterList parameterList, BridgedSourceLoc cEqualsLoc,
+    BridgedExpr opaqueRawValue);
+
+SWIFT_NAME("BridgedStructDecl.createParsed(_:declContext:structKeywordLoc:name:"
+           "nameLoc:genericParamList:inheritedTypes:genericWhereClause:"
+           "braceRange:)")
+BridgedNominalTypeDecl StructDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cStructKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, void *_Nullable opaqueGenericParamList,
-    BridgedArrayRef cInheritedTypes, void *_Nullable opaqueGenericWhereClause,
+    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedArrayRef cInheritedTypes,
+    BridgedTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
 SWIFT_NAME(
-    "ClassDecl_create(astContext:declContext:classKeywordLoc:name:nameLoc:"
+    "BridgedClassDecl.createParsed(_:declContext:classKeywordLoc:name:nameLoc:"
     "genericParamList:inheritedTypes:genericWhereClause:braceRange:isActor:)")
-BridgedDeclContextAndDecl ClassDecl_create(
+BridgedNominalTypeDecl ClassDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cClassKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, void *_Nullable opaqueGenericParamList,
-    BridgedArrayRef cInheritedTypes, void *_Nullable opaqueGenericWhereClause,
+    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedArrayRef cInheritedTypes,
+    BridgedTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange, _Bool isActor);
 
-SWIFT_NAME("ProtocolDecl_create(astContext:declContext:protocolKeywordLoc:name:"
-           "nameLoc:primaryAssociatedTypeNames:inheritedTypes:"
-           "genericWhereClause:braceRange:)")
-BridgedDeclContextAndDecl ProtocolDecl_create(
+SWIFT_NAME(
+    "BridgedProtocolDecl.createParsed(_:declContext:protocolKeywordLoc:name:"
+    "nameLoc:primaryAssociatedTypeNames:inheritedTypes:"
+    "genericWhereClause:braceRange:)")
+BridgedNominalTypeDecl ProtocolDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cProtocolKeywordLoc, BridgedIdentifier cName,
     BridgedSourceLoc cNameLoc, BridgedArrayRef cPrimaryAssociatedTypeNames,
-    BridgedArrayRef cInheritedTypes, void *_Nullable opaqueGenericWhereClause,
+    BridgedArrayRef cInheritedTypes,
+    BridgedTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
-SWIFT_NAME(
-    "AssociatedTypeDecl_create(astContext:declContext:associatedtypeKeywordLoc:"
-    "name:nameLoc:inheritedTypes:defaultType:genericWhereClause:)")
-void *AssociatedTypeDecl_create(BridgedASTContext cContext,
-                                BridgedDeclContext cDeclContext,
-                                BridgedSourceLoc cAssociatedtypeKeywordLoc,
-                                BridgedIdentifier cName,
-                                BridgedSourceLoc cNameLoc,
-                                BridgedArrayRef cInheritedTypes,
-                                void *_Nullable opaqueDefaultType,
-                                void *_Nullable opaqueGenericWhereClause);
-
-SWIFT_NAME("ExtensionDecl_create(astContext:declContext:extensionKeywordLoc:"
-           "extendedType:inheritedTypes:genericWhereClause:braceRange:)")
-BridgedDeclContextAndDecl ExtensionDecl_create(
+SWIFT_NAME("BridgedAssociatedTypeDecl.createParsed(_:declContext:"
+           "associatedtypeKeywordLoc:name:nameLoc:inheritedTypes:defaultType:"
+           "genericWhereClause:)")
+BridgedAssociatedTypeDecl AssociatedTypeDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
-    BridgedSourceLoc cExtensionKeywordLoc, void *opaqueExtendedType,
-    BridgedArrayRef cInheritedTypes, void *_Nullable opaqueGenericWhereClause,
+    BridgedSourceLoc cAssociatedtypeKeywordLoc, BridgedIdentifier cName,
+    BridgedSourceLoc cNameLoc, BridgedArrayRef cInheritedTypes,
+    BridgedTypeRepr opaqueDefaultType,
+    BridgedTrailingWhereClause genericWhereClause);
+
+SWIFT_NAME(
+    "BridgedExtensionDecl.createParsed(_:declContext:extensionKeywordLoc:"
+    "extendedType:inheritedTypes:genericWhereClause:braceRange:)")
+BridgedExtensionDecl ExtensionDecl_createParsed(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedSourceLoc cExtensionKeywordLoc, BridgedTypeRepr opaqueExtendedType,
+    BridgedArrayRef cInheritedTypes,
+    BridgedTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
 typedef enum ENUM_EXTENSIBILITY_ATTR(closed) {
@@ -478,17 +583,15 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(closed) {
   BridgedOperatorFixityPostfix,
 } BridgedOperatorFixity;
 
-SWIFT_NAME(
-    "OperatorDecl_create(astContext:declContext:fixity:operatorKeywordLoc:name:"
-    "nameLoc:colonLoc:precedenceGroupName:PrecedenceGroupLoc:)")
-void *OperatorDecl_create(BridgedASTContext cContext,
-                          BridgedDeclContext cDeclContext,
-                          BridgedOperatorFixity cFixity,
-                          BridgedSourceLoc cOperatorKeywordLoc,
-                          BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
-                          BridgedSourceLoc cColonLoc,
-                          BridgedIdentifier cPrecedenceGroupName,
-                          BridgedSourceLoc cPrecedenceGroupLoc);
+SWIFT_NAME("BridgedOperatorDecl.createParsed(_:declContext:fixity:"
+           "operatorKeywordLoc:name:nameLoc:colonLoc:precedenceGroupName:"
+           "precedenceGroupLoc:)")
+BridgedOperatorDecl OperatorDecl_createParsed(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedOperatorFixity cFixity, BridgedSourceLoc cOperatorKeywordLoc,
+    BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
+    BridgedSourceLoc cColonLoc, BridgedIdentifier cPrecedenceGroupName,
+    BridgedSourceLoc cPrecedenceGroupLoc);
 
 typedef enum ENUM_EXTENSIBILITY_ATTR(closed) {
   BridgedAssociativityNone,
@@ -496,12 +599,13 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(closed) {
   BridgedAssociativityRight,
 } BridgedAssociativity;
 
-SWIFT_NAME("PrecedenceGroupDecl_create(declContext:precedencegroupKeywordLoc:"
-           "name:nameLoc:leftBraceLoc:associativityLabelLoc:"
-           "associativityValueLoc:associativity:assignmentLabelLoc:"
-           "assignmentValueLoc:isAssignment:higherThanKeywordLoc:"
-           "higherThanNames:lowerThanKeywordLoc:lowerThanNames:rightBraceLoc:)")
-void *PrecedenceGroupDecl_create(
+SWIFT_NAME("BridgedPrecedenceGroupDecl.createParsed(declContext:"
+           "precedencegroupKeywordLoc:name:nameLoc:leftBraceLoc:"
+           "associativityLabelLoc:associativityValueLoc:associativity:"
+           "assignmentLabelLoc:assignmentValueLoc:isAssignment:"
+           "higherThanKeywordLoc:higherThanNames:lowerThanKeywordLoc:"
+           "lowerThanNames:rightBraceLoc:)")
+BridgedPrecedenceGroupDecl PrecedenceGroupDecl_createParsed(
     BridgedDeclContext cDeclContext,
     BridgedSourceLoc cPrecedencegroupKeywordLoc, BridgedIdentifier cName,
     BridgedSourceLoc cNameLoc, BridgedSourceLoc cLeftBraceLoc,
@@ -524,45 +628,43 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) {
   BridgedImportKindFunc,
 } BridgedImportKind;
 
-SWIFT_NAME("ImportDecl_create(astContext:declContext:importKeywordLoc:"
+SWIFT_NAME("BridgedImportDecl.createParsed(_:declContext:importKeywordLoc:"
            "importKind:importKindLoc:path:)")
-void *ImportDecl_create(BridgedASTContext cContext,
-                        BridgedDeclContext cDeclContext,
-                        BridgedSourceLoc cImportKeywordLoc,
-                        BridgedImportKind cImportKind,
-                        BridgedSourceLoc cImportKindLoc,
-                        BridgedArrayRef cImportPathElements);
+BridgedImportDecl ImportDecl_createParsed(BridgedASTContext cContext,
+                                          BridgedDeclContext cDeclContext,
+                                          BridgedSourceLoc cImportKeywordLoc,
+                                          BridgedImportKind cImportKind,
+                                          BridgedSourceLoc cImportKindLoc,
+                                          BridgedArrayRef cImportPathElements);
 
-SWIFT_NAME("GenericParamList_create(astContext:leftAngleLoc:parameters:"
+SWIFT_NAME("BridgedGenericParamList.createParsed(_:leftAngleLoc:parameters:"
            "genericWhereClause:rightAngleLoc:)")
-void *GenericParamList_create(BridgedASTContext cContext,
-                              BridgedSourceLoc cLeftAngleLoc,
-                              BridgedArrayRef cParameters,
-                              void *_Nullable opaqueGenericWhereClause,
-                              BridgedSourceLoc cRightAngleLoc);
-
-SWIFT_NAME("GenericTypeParamDecl_create(astContext:declContext:eachKeywordLoc:"
-           "name:nameLoc:inheritedType:index:)")
-void *GenericTypeParamDecl_create(BridgedASTContext cContext,
-                                  BridgedDeclContext cDeclContext,
-                                  BridgedSourceLoc cEachLoc,
-                                  BridgedIdentifier cName,
-                                  BridgedSourceLoc cNameLoc,
-                                  void *_Nullable opaqueInheritedType,
-                                  size_t index);
+BridgedGenericParamList GenericParamList_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cLeftAngleLoc,
+    BridgedArrayRef cParameters, BridgedTrailingWhereClause genericWhereClause,
+    BridgedSourceLoc cRightAngleLoc);
 
 SWIFT_NAME(
-    "TrailingWhereClause_create(astContext:whereKeywordLoc:requirements:)")
-void *TrailingWhereClause_create(BridgedASTContext cContext,
+    "BridgedGenericTypeParamDecl.createParsed(_:declContext:eachKeywordLoc:"
+    "name:nameLoc:inheritedType:index:)")
+BridgedGenericTypeParamDecl GenericTypeParamDecl_createParsed(
+    BridgedASTContext cContext, BridgedDeclContext cDeclContext,
+    BridgedSourceLoc cEachLoc, BridgedIdentifier cName,
+    BridgedSourceLoc cNameLoc, BridgedTypeRepr opaqueInheritedType,
+    size_t index);
+
+SWIFT_NAME(
+    "BridgedTrailingWhereClause.createParsed(_:whereKeywordLoc:requirements:)")
+BridgedTrailingWhereClause
+TrailingWhereClause_createParsed(BridgedASTContext cContext,
                                  BridgedSourceLoc cWhereKeywordLoc,
                                  BridgedArrayRef cRequirements);
 
-SWIFT_NAME(
-    "ParameterList_create(astContext:leftParenLoc:parameters:rightParenLoc:)")
-void *ParameterList_create(BridgedASTContext cContext,
-                           BridgedSourceLoc cLeftParenLoc,
-                           BridgedArrayRef cParameters,
-                           BridgedSourceLoc cRightParenLoc);
+SWIFT_NAME("BridgedParameterList.createParsed(_:leftParenLoc:parameters:"
+           "rightParenLoc:)")
+BridgedParameterList ParameterList_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cLeftParenLoc,
+    BridgedArrayRef cParameters, BridgedSourceLoc cRightParenLoc);
 
 BridgedTypeAttrKind TypeAttrKind_fromString(BridgedString cStr);
 BridgedTypeAttributes TypeAttributes_create(void);
@@ -571,65 +673,137 @@ void TypeAttributes_addSimpleAttr(BridgedTypeAttributes cAttributes,
                                   BridgedSourceLoc cAtLoc,
                                   BridgedSourceLoc cAttrLoc);
 
-void *ArrayTypeRepr_create(BridgedASTContext cContext, void *base,
-                           BridgedSourceLoc cLSquareLoc,
-                           BridgedSourceLoc cRSquareLoc);
-void *AttributedTypeRepr_create(BridgedASTContext cContext, void *base,
-                                BridgedTypeAttributes cAttributes);
-void *
-AttributedTypeSpecifierRepr_create(BridgedASTContext cContext, void *base,
-                                   BridgedAttributedTypeSpecifier specifier,
-                                   BridgedSourceLoc cSpecifierLoc);
-void *CompositionTypeRepr_create(BridgedASTContext cContext,
-                                 BridgedArrayRef types,
-                                 BridgedSourceLoc cFirstTypeLoc,
-                                 BridgedSourceLoc cFirstAmpLoc);
-void *DictionaryTypeRepr_create(BridgedASTContext cContext, void *keyType,
-                                void *valueType, BridgedSourceLoc cLSquareLoc,
-                                BridgedSourceLoc cColonloc,
-                                BridgedSourceLoc cRSquareLoc);
-void *EmptyCompositionTypeRepr_create(BridgedASTContext cContext,
-                                      BridgedSourceLoc cAnyLoc);
-void *FunctionTypeRepr_create(BridgedASTContext cContext, void *argsTy,
-                              BridgedSourceLoc cAsyncLoc,
-                              BridgedSourceLoc cThrowsLoc,
-                              void * _Nullable thrownType,
-                              BridgedSourceLoc cArrowLoc, void *returnType);
-void *GenericIdentTypeRepr_create(BridgedASTContext cContext,
-                                  BridgedIdentifier name,
-                                  BridgedSourceLoc cNameLoc,
-                                  BridgedArrayRef genericArgs,
-                                  BridgedSourceLoc cLAngleLoc,
-                                  BridgedSourceLoc cRAngleLoc);
-void *OptionalTypeRepr_create(BridgedASTContext cContext, void *base,
-                              BridgedSourceLoc cQuestionLoc);
-void *ImplicitlyUnwrappedOptionalTypeRepr_create(
-    BridgedASTContext cContext, void *base, BridgedSourceLoc cExclamationLoc);
-void *MemberTypeRepr_create(BridgedASTContext cContext, void *baseComponent,
-                            BridgedArrayRef bridgedMemberComponents);
-void *MetatypeTypeRepr_create(BridgedASTContext cContext, void *baseType,
-                              BridgedSourceLoc cTypeLoc);
-void *ProtocolTypeRepr_create(BridgedASTContext cContext, void *baseType,
-                              BridgedSourceLoc cProtoLoc);
-void *PackExpansionTypeRepr_create(BridgedASTContext cContext, void *base,
-                                   BridgedSourceLoc cRepeatLoc);
-void *TupleTypeRepr_create(BridgedASTContext cContext, BridgedArrayRef elements,
-                           BridgedSourceLoc cLParenLoc,
-                           BridgedSourceLoc cRParenLoc);
-void *NamedOpaqueReturnTypeRepr_create(BridgedASTContext cContext,
-                                       void *baseTy);
-void *OpaqueReturnTypeRepr_create(BridgedASTContext cContext,
-                                  BridgedSourceLoc cOpaqueLoc, void *baseTy);
-void *ExistentialTypeRepr_create(BridgedASTContext cContext,
-                                 BridgedSourceLoc cAnyLoc, void *baseTy);
-void *VarargTypeRepr_create(BridgedASTContext cContext, void *base,
-                            BridgedSourceLoc cEllipsisLoc);
+SWIFT_NAME(
+    "BridgedArrayTypeRepr.createParsed(_:base:leftSquareLoc:rightSquareLoc:)")
+BridgedTypeRepr ArrayTypeRepr_createParsed(BridgedASTContext cContext,
+                                           BridgedTypeRepr base,
+                                           BridgedSourceLoc cLSquareLoc,
+                                           BridgedSourceLoc cRSquareLoc);
 
-void TopLevelCodeDecl_dump(void *decl);
-void Expr_dump(void *expr);
-void Decl_dump(void *decl);
-void Stmt_dump(void *statement);
-void Type_dump(void *type);
+SWIFT_NAME("BridgedAttributedTypeRepr.createParsed(_:base:attributes:)")
+BridgedTypeRepr
+AttributedTypeRepr_createParsed(BridgedASTContext cContext,
+                                BridgedTypeRepr base,
+                                BridgedTypeAttributes cAttributes);
+
+SWIFT_NAME(
+    "BridgedSpecifierTypeRepr.createParsed(_:base:specifier:specifierLoc:)")
+BridgedTypeRepr
+SpecifierTypeRepr_createParsed(BridgedASTContext cContext, BridgedTypeRepr base,
+                               BridgedAttributedTypeSpecifier specifier,
+                               BridgedSourceLoc cSpecifierLoc);
+
+SWIFT_NAME("BridgedCompositionTypeRepr.createEmpty(_:anyKeywordLoc:)")
+BridgedTypeRepr CompositionTypeRepr_createEmpty(BridgedASTContext cContext,
+                                                BridgedSourceLoc cAnyLoc);
+
+SWIFT_NAME("BridgedCompositionTypeRepr.createParsed(_:types:ampersandLoc:)")
+BridgedTypeRepr CompositionTypeRepr_createParsed(BridgedASTContext cContext,
+                                                 BridgedArrayRef types,
+                                                 BridgedSourceLoc cFirstAmpLoc);
+
+SWIFT_NAME("BridgedDictionaryTypeRepr.createParsed(_:leftSquareLoc:keyType:"
+           "colonLoc:valueType:rightSquareLoc:)")
+BridgedTypeRepr DictionaryTypeRepr_createParsed(BridgedASTContext cContext,
+                                                BridgedSourceLoc cLSquareLoc,
+                                                BridgedTypeRepr keyType,
+                                                BridgedSourceLoc cColonloc,
+                                                BridgedTypeRepr valueType,
+                                                BridgedSourceLoc cRSquareLoc);
+
+SWIFT_NAME("BridgedFunctionTypeRepr.createParsed(_:argsType:asyncLoc:throwsLoc:"
+           "thrownType:arrowLoc:resultType:)")
+BridgedTypeRepr FunctionTypeRepr_createParsed(BridgedASTContext cContext,
+                                              BridgedTypeRepr argsTy,
+                                              BridgedSourceLoc cAsyncLoc,
+                                              BridgedSourceLoc cThrowsLoc,
+                                              BridgedTypeRepr thrownType,
+                                              BridgedSourceLoc cArrowLoc,
+                                              BridgedTypeRepr resultType);
+
+SWIFT_NAME("BridgedGenericIdentTypeRepr.createParsed(_:name:nameLoc:"
+           "genericArgs:leftAngleLoc:rightAngleLoc:)")
+BridgedTypeRepr GenericIdentTypeRepr_createParsed(BridgedASTContext cContext,
+                                                  BridgedIdentifier name,
+                                                  BridgedSourceLoc cNameLoc,
+                                                  BridgedArrayRef genericArgs,
+                                                  BridgedSourceLoc cLAngleLoc,
+                                                  BridgedSourceLoc cRAngleLoc);
+
+SWIFT_NAME("BridgedOptionalTypeRepr.createParsed(_:base:questionLoc:)")
+BridgedTypeRepr OptionalTypeRepr_createParsed(BridgedASTContext cContext,
+                                              BridgedTypeRepr base,
+                                              BridgedSourceLoc cQuestionLoc);
+
+SWIFT_NAME("BridgedImplicitlyUnwrappedOptionalTypeRepr.createParsed(_:base:"
+           "exclaimLoc:)")
+BridgedTypeRepr ImplicitlyUnwrappedOptionalTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedTypeRepr base,
+    BridgedSourceLoc cExclamationLoc);
+
+SWIFT_NAME("BridgedMemberTypeRepr.createParsed(_:base:members:)")
+BridgedTypeRepr
+MemberTypeRepr_createParsed(BridgedASTContext cContext,
+                            BridgedTypeRepr baseComponent,
+                            BridgedArrayRef bridgedMemberComponents);
+
+SWIFT_NAME("BridgedMetatypeTypeRepr.createParsed(_:base:typeKeywordLoc:)")
+BridgedTypeRepr MetatypeTypeRepr_createParsed(BridgedASTContext cContext,
+                                              BridgedTypeRepr baseType,
+                                              BridgedSourceLoc cTypeLoc);
+
+SWIFT_NAME("BridgedProtocolTypeRepr.createParsed(_:base:protocolKeywordLoc:)")
+BridgedTypeRepr ProtocolTypeRepr_createParsed(BridgedASTContext cContext,
+                                              BridgedTypeRepr baseType,
+                                              BridgedSourceLoc cProtoLoc);
+
+SWIFT_NAME(
+    "BridgedPackExpansionTypeRepr.createParsed(_:base:repeatKeywordLoc:)")
+BridgedTypeRepr PackExpansionTypeRepr_createParsed(BridgedASTContext cContext,
+                                                   BridgedTypeRepr base,
+                                                   BridgedSourceLoc cRepeatLoc);
+
+SWIFT_NAME(
+    "BridgedTupleTypeRepr.createParsed(_:elements:leftParenLoc:rightParenLoc:)")
+BridgedTypeRepr TupleTypeRepr_createParsed(BridgedASTContext cContext,
+                                           BridgedArrayRef elements,
+                                           BridgedSourceLoc cLParenLoc,
+                                           BridgedSourceLoc cRParenLoc);
+
+SWIFT_NAME("BridgedNamedOpaqueReturnTypeRepr.createParsed(_:base:)")
+BridgedTypeRepr
+NamedOpaqueReturnTypeRepr_createParsed(BridgedASTContext cContext,
+                                       BridgedTypeRepr baseTy);
+
+SWIFT_NAME("BridgedOpaqueReturnTypeRepr.createParsed(_:someKeywordLoc:base:)")
+BridgedTypeRepr OpaqueReturnTypeRepr_createParsed(BridgedASTContext cContext,
+                                                  BridgedSourceLoc cOpaqueLoc,
+                                                  BridgedTypeRepr baseTy);
+
+SWIFT_NAME("BridgedExistentialTypeRepr.createParsed(_:anyKeywordLoc:base:)")
+BridgedTypeRepr ExistentialTypeRepr_createParsed(BridgedASTContext cContext,
+                                                 BridgedSourceLoc cAnyLoc,
+                                                 BridgedTypeRepr baseTy);
+
+SWIFT_NAME("BridgedVarargTypeRepr.createParsed(_:base:ellipsisLoc:)")
+BridgedTypeRepr VarargTypeRepr_createParsed(BridgedASTContext cContext,
+                                            BridgedTypeRepr base,
+                                            BridgedSourceLoc cEllipsisLoc);
+
+SWIFT_NAME("BridgedTopLevelCodeDecl.dump(self:)")
+void TopLevelCodeDecl_dump(BridgedTopLevelCodeDecl decl);
+
+SWIFT_NAME("BridgedExpr.dump(self:)")
+void Expr_dump(BridgedExpr expr);
+
+SWIFT_NAME("BridgedDecl.dump(self:)")
+void Decl_dump(BridgedDecl decl);
+
+SWIFT_NAME("BridgedStmt.dump(self:)")
+void Stmt_dump(BridgedStmt statement);
+
+SWIFT_NAME("BridgedTypeRepr.dump(self:)")
+void TypeRepr_dump(BridgedTypeRepr type);
 
 //===----------------------------------------------------------------------===//
 // Plugins

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -291,26 +291,32 @@ extern "C" {
 ///
 /// \returns a diagnostic instance that can be extended with additional
 /// information and then must be finished via \c SwiftDiagnostic_finish.
-BridgedDiagnostic Diagnostic_create(BridgedDiagnosticEngine cDiags,
+SWIFT_NAME("BridgedDiagnostic.init(at:message:severity:engine:)")
+BridgedDiagnostic Diagnostic_create(BridgedSourceLoc cLoc, BridgedString cText,
                                     BridgedDiagnosticSeverity severity,
-                                    BridgedSourceLoc cLoc, BridgedString cText);
+                                    BridgedDiagnosticEngine cDiags);
 
 /// Highlight a source range as part of the diagnostic.
+SWIFT_NAME("BridgedDiagnostic.highlight(self:start:end:)")
 void Diagnostic_highlight(BridgedDiagnostic cDiag, BridgedSourceLoc cStartLoc,
                           BridgedSourceLoc cEndLoc);
 
 /// Add a Fix-It to replace a source range as part of the diagnostic.
+SWIFT_NAME("BridgedDiagnostic.fixItReplace(self:start:end:replacement:)")
 void Diagnostic_fixItReplace(BridgedDiagnostic cDiag,
                              BridgedSourceLoc cStartLoc,
                              BridgedSourceLoc cEndLoc,
                              BridgedString cReplaceText);
 
 /// Finish the given diagnostic and emit it.
+SWIFT_NAME("BridgedDiagnostic.finish(self:)")
 void Diagnostic_finish(BridgedDiagnostic cDiag);
 
+SWIFT_NAME("BridgedASTContext.getIdentifier(self:_:)")
 BridgedIdentifier ASTContext_getIdentifier(BridgedASTContext cContext,
                                            BridgedString cStr);
 
+SWIFT_NAME("BridgedASTContext.langOptsHasFeature(self:_:)")
 _Bool ASTContext_langOptsHasFeature(BridgedASTContext cContext,
                                     BridgedFeature feature);
 
@@ -339,6 +345,7 @@ SWIFT_NAME("BridgedSequenceExpr.createParsed(_:exprs:)")
 BridgedSequenceExpr SequenceExpr_createParsed(BridgedASTContext cContext,
                                               BridgedArrayRef exprs);
 
+SWIFT_NAME("BridgedSourceLoc.advanced(self:by:)")
 BridgedSourceLoc SourceLoc_advanced(BridgedSourceLoc cLoc, size_t len);
 
 SWIFT_NAME("BridgedTupleExpr.createParsed(_:leftParenLoc:exprs:labels:"

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -32,10 +32,6 @@
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
-typedef struct BridgedDeclContext {
-  void *_Nonnull raw;
-} BridgedDeclContext;
-
 // Define the bridging wrappers for each AST node.
 #define AST_BRIDGING_WRAPPER_NONNULL(Name)                                     \
   typedef struct {                                                             \
@@ -53,7 +49,8 @@ typedef struct BridgedDeclContext {
 extern "C" {
 #endif
 
-// Declare `.asDecl` on each BridgedXXXDecl type.
+// Declare `.asDecl` on each BridgedXXXDecl type, which upcasts a wrapper for
+// a Decl subclass to a BridgedDecl.
 #define DECL(Id, Parent)                                                       \
   SWIFT_NAME("getter:Bridged" #Id "Decl.asDecl(self:)")                        \
   BridgedDecl Id##Decl_asDecl(Bridged##Id##Decl decl);
@@ -69,21 +66,24 @@ extern "C" {
 #define ABSTRACT_CONTEXT_DECL(Id, Parent) CONTEXT_DECL(Id, Parent)
 #include "swift/AST/DeclNodes.def"
 
-// Declare `.asStmt` on each BridgedXXXStmt type.
+// Declare `.asStmt` on each BridgedXXXStmt type, which upcasts a wrapper for
+// a Stmt subclass to a BridgedStmt.
 #define STMT(Id, Parent)                                                       \
   SWIFT_NAME("getter:Bridged" #Id "Stmt.asStmt(self:)")                        \
   BridgedStmt Id##Stmt_asStmt(Bridged##Id##Stmt stmt);
 #define ABSTRACT_STMT(Id, Parent) STMT(Id, Parent)
 #include "swift/AST/StmtNodes.def"
 
-// Declare `.asExpr` on each BridgedXXXExpr type.
+// Declare `.asExpr` on each BridgedXXXExpr type, which upcasts a wrapper for
+// a Expr subclass to a BridgedExpr.
 #define EXPR(Id, Parent)                                                       \
   SWIFT_NAME("getter:Bridged" #Id "Expr.asExpr(self:)")                        \
   BridgedExpr Id##Expr_asExpr(Bridged##Id##Expr expr);
 #define ABSTRACT_EXPR(Id, Parent) EXPR(Id, Parent)
 #include "swift/AST/ExprNodes.def"
 
-// Declare `.asTypeRepr` on each BridgedXXXTypeRepr type.
+// Declare `.asTypeRepr` on each BridgedXXXTypeRepr type, which upcasts a
+// wrapper for a TypeRepr subclass to a BridgedTypeRepr.
 #define TYPEREPR(Id, Parent)                                                   \
   SWIFT_NAME("getter:Bridged" #Id "TypeRepr.asTypeRepr(self:)")                \
   BridgedTypeRepr Id##TypeRepr_asTypeRepr(Bridged##Id##TypeRepr typeRepr);

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -38,6 +38,13 @@
 #define CONTEXT_DECL(Id, Parent) DECL(Id, Parent)
 #endif
 
+/// ABSTRACT_CONTEXT_DECL(Id, Parent)
+///   Used for abstract Decls that are also DeclContexts.
+///
+#ifndef ABSTRACT_CONTEXT_DECL
+#define ABSTRACT_CONTEXT_DECL(Id, Parent) ABSTRACT_DECL(Id, Parent)
+#endif
+
 /// ITERABLE_NONGENERIC_DECL(Id, Parent)
 ///   Used for Decls that are also IterableDeclContexts and DeclContexts. The
 ///   default behavior is to do the same as for CONTEXT_DECL. This combination
@@ -145,8 +152,8 @@
 
 ABSTRACT_DECL(Value, Decl)
   ABSTRACT_DECL(Type, ValueDecl)
-    ABSTRACT_DECL(GenericType, TypeDecl)
-      ABSTRACT_DECL(NominalType, GenericTypeDecl)
+    ABSTRACT_CONTEXT_DECL(GenericType, TypeDecl)
+      ABSTRACT_CONTEXT_DECL(NominalType, GenericTypeDecl)
         NOMINAL_TYPE_DECL(Enum, NominalTypeDecl)
         NOMINAL_TYPE_DECL(Struct, NominalTypeDecl)
         NOMINAL_TYPE_DECL(Class, NominalTypeDecl)
@@ -165,7 +172,7 @@ ABSTRACT_DECL(Value, Decl)
       VALUE_DECL(Param, VarDecl)
     GENERIC_VALUE_DECL(Subscript, AbstractStorageDecl)
     DECL_RANGE(AbstractStorage, Var, Subscript)
-  ABSTRACT_DECL(AbstractFunction, ValueDecl)
+  ABSTRACT_CONTEXT_DECL(AbstractFunction, ValueDecl)
     ABSTRACT_FUNCTION_DECL(Constructor, AbstractFunctionDecl)
     ABSTRACT_FUNCTION_DECL(Destructor, AbstractFunctionDecl)
     ABSTRACT_FUNCTION_DECL(Func, AbstractFunctionDecl)
@@ -208,6 +215,7 @@ LAST_DECL(MacroExpansion)
 #undef ABSTRACT_FUNCTION_DECL
 #undef VALUE_DECL
 #undef DECL_RANGE
+#undef ABSTRACT_CONTEXT_DECL
 #undef ABSTRACT_DECL
 #undef OPERATOR_DECL
 #undef DECL

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -167,10 +167,9 @@ static TypeAttrKind convertTypeAttrKind(BridgedTypeAttrKind kind) {
   }
 }
 
-BridgedDiagnostic Diagnostic_create(BridgedDiagnosticEngine cDiags,
+BridgedDiagnostic Diagnostic_create(BridgedSourceLoc cLoc, BridgedString cText,
                                     BridgedDiagnosticSeverity severity,
-                                    BridgedSourceLoc cLoc,
-                                    BridgedString cText) {
+                                    BridgedDiagnosticEngine cDiags) {
   StringRef origText = convertString(cText);
   BridgedDiagnosticImpl::Allocator alloc;
   StringRef text = origText.copy(alloc);

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -13,35 +13,47 @@ extension UnsafePointer {
 }
 
 enum ASTNode {
-  case decl(UnsafeMutableRawPointer)
-  case stmt(UnsafeMutableRawPointer)
-  case expr(UnsafeMutableRawPointer)
-  case type(UnsafeMutableRawPointer)
-  case misc(UnsafeMutableRawPointer)
+  case decl(BridgedDecl)
+  case stmt(BridgedStmt)
+  case expr(BridgedExpr)
+  case type(BridgedTypeRepr)
 
-  var rawValue: UnsafeMutableRawPointer {
-    switch self {
-    case .decl(let ptr):
-      return ptr
-    case .stmt(let ptr):
-      return ptr
-    case .expr(let ptr):
-      return ptr
-    case .type(let ptr):
-      return ptr
-    case .misc(let ptr):
-      return ptr
+  var castToExpr: BridgedExpr {
+    guard case .expr(let bridged) = self else {
+      fatalError("Expected an expr")
     }
+    return bridged
+  }
+
+  var castToStmt: BridgedStmt {
+    guard case .stmt(let bridged) = self else {
+      fatalError("Expected a stmt")
+    }
+    return bridged
+  }
+
+  var castToDecl: BridgedDecl {
+    guard case .decl(let bridged) = self else {
+      fatalError("Expected a decl")
+    }
+    return bridged
+  }
+
+  var castToType: BridgedTypeRepr {
+    guard case .type(let bridged) = self else {
+      fatalError("Expected a type")
+    }
+    return bridged
   }
 
   var bridged: BridgedASTNode {
     switch self {
     case .expr(let e):
-      return BridgedASTNode(ptr: e, kind: .expr)
+      return BridgedASTNode(ptr: e.raw!, kind: .expr)
     case .stmt(let s):
-      return BridgedASTNode(ptr: s, kind: .stmt)
+      return BridgedASTNode(ptr: s.raw!, kind: .stmt)
     case .decl(let d):
-      return BridgedASTNode(ptr: d, kind: .decl)
+      return BridgedASTNode(ptr: d.raw, kind: .decl)
     default:
       fatalError("Must be expr, stmt, or decl.")
     }
@@ -92,11 +104,19 @@ struct ASTGenVisitor {
       let swiftASTNodes = generate(element)
       switch swiftASTNodes {
       case .decl(let d):
-        out.append(d)
+        out.append(d.raw)
       case .stmt(let s):
-        out.append(TopLevelCodeDecl_createStmt(astContext: self.ctx, declContext: self.declContext, startLoc: loc, statement: s, endLoc: loc))
+        let topLevelDecl = BridgedTopLevelCodeDecl.createParsed(
+          self.ctx, declContext: self.declContext, startLoc: loc, stmt: s, 
+          endLoc: loc
+        )
+        out.append(topLevelDecl.raw)
       case .expr(let e):
-        out.append(TopLevelCodeDecl_createExpr(astContext: self.ctx, declContext: self.declContext, startLoc: loc, expression: e, endLoc: loc))
+        let topLevelDecl = BridgedTopLevelCodeDecl.createParsed(
+          self.ctx, declContext: self.declContext, startLoc: loc, expr: e,
+          endLoc: loc
+        )
+        out.append(topLevelDecl.raw)
       default:
         fatalError("Top level nodes must be decls, stmts, or exprs.")
       }
@@ -131,24 +151,24 @@ extension ASTGenVisitor {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: DeclSyntax) -> ASTNode {
-    return generate(Syntax(node))
+  func generate(_ node: DeclSyntax) -> BridgedDecl {
+    return generate(Syntax(node)).castToDecl
   }
 
-  func generate(_ node: ExprSyntax) -> ASTNode {
-    return generate(Syntax(node))
+  func generate(_ node: ExprSyntax) -> BridgedExpr {
+    return generate(Syntax(node)).castToExpr
   }
 
   func generate(_ node: PatternSyntax) -> ASTNode {
     return generate(Syntax(node))
   }
 
-  func generate(_ node: StmtSyntax) -> ASTNode {
-    return generate(Syntax(node))
+  func generate(_ node: StmtSyntax) -> BridgedStmt {
+    return generate(Syntax(node)).castToStmt
   }
 
-  func generate(_ node: TypeSyntax) -> ASTNode {
-    return generate(Syntax(node))
+  func generate(_ node: TypeSyntax) -> BridgedTypeRepr {
+    return generate(Syntax(node)).castToType
   }
 
   func generate(_ node: some SyntaxChildChoices) -> ASTNode {
@@ -158,123 +178,107 @@ extension ASTGenVisitor {
   func generate(_ node: Syntax) -> ASTNode {
     switch node.as(SyntaxEnum.self) {
     case .actorDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .arrayElement(let node):
-      return generate(node)
+      return .expr(generate(node))
     case .arrayExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .arrayType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .associatedTypeDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .attributedType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .booleanLiteralExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .classDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .closureExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .codeBlock(let node):
-      return generate(node)
+      return .stmt(generate(node).asStmt)
     case .codeBlockItem(let node):
       return generate(node)
     case .compositionType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .conditionElement(let node):
       return generate(node)
     case .declReferenceExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .deinitializerDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .dictionaryType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .enumCaseDecl(let node):
-      return generate(node)
-    case .enumCaseElement(let node):
-      return generate(node)
-    case .enumCaseParameter(let node):
-      return generate(node)
-    case .enumCaseParameterClause(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .enumDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .expressionStmt(let node):
-     return generate(node)
+      return .stmt(generate(node))
     case .extensionDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .functionCallExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .functionDecl(let node):
-      return generate(node)
-    case .functionParameter(let node):
-      return generate(node)
-    case .functionParameterClause(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .functionType(let node):
-      return generate(node)
-    case .genericParameter(let node):
-      return generate(node)
-    case .genericParameterClause(let node):
-      return generate(node)
-    case .genericWhereClause(let node):
-      return generate(node)
+      return .type(generate(node))
     case .identifierPattern(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .identifierType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .ifExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .implicitlyUnwrappedOptionalType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .importDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .initializerClause(let node):
-      return generate(node)
+      return .expr(generate(node))
     case .initializerDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .integerLiteralExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .labeledExprList:
       fatalError("case does not correspond to an ASTNode")
     case .memberAccessExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .memberBlockItem(let node):
-      return generate(node)
+      return .decl(generate(node))
     case .memberType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .metatypeType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .namedOpaqueReturnType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .nilLiteralExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .operatorDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .optionalType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .packExpansionType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .precedenceGroupDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .protocolDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .returnStmt(let node):
-      return generate(node)
+      return .stmt(generate(node).asStmt)
     case .someOrAnyType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .stringLiteralExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .structDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .tupleExpr(let node):
-      return generate(node)
+      return .expr(generate(node).asExpr)
     case .tupleType(let node):
-      return generate(node)
+      return .type(generate(node))
     case .typeAliasDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     case .variableDecl(let node):
-      return generate(node)
+      return .decl(generate(node).asDecl)
     default:
       fatalError("not implemented")
     }
@@ -284,11 +288,11 @@ extension ASTGenVisitor {
 // Misc visits.
 // TODO: Some of these are called within a single file/method; we may want to move them to the respective files.
 extension ASTGenVisitor {
-  public func generate(_ node: MemberBlockItemSyntax) -> ASTNode {
+  public func generate(_ node: MemberBlockItemSyntax) -> BridgedDecl {
     generate(node.decl)
   }
 
-  public func generate(_ node: InitializerClauseSyntax) -> ASTNode {
+  public func generate(_ node: InitializerClauseSyntax) -> BridgedExpr {
     generate(node.value)
   }
 
@@ -300,7 +304,7 @@ extension ASTGenVisitor {
     generate(node.item)
   }
 
-  public func generate(_ node: ArrayElementSyntax) -> ASTNode {
+  public func generate(_ node: ArrayElementSyntax) -> BridgedExpr {
     generate(node.expression)
   }
 
@@ -314,18 +318,18 @@ extension ASTGenVisitor {
 // 'self.visit(<expr>)' recursion pattern between optional and non-optional inputs.
 extension ASTGenVisitor {
   @inline(__always)
-  func generate(_ node: TypeSyntax?) -> ASTNode? {
+  func generate(_ node: TypeSyntax?) -> BridgedTypeRepr {
     guard let node else {
-      return nil
+      return .init(raw: nil)
     }
 
     return self.generate(node)
   }
 
   @inline(__always)
-  func generate(_ node: ExprSyntax?) -> ASTNode? {
+  func generate(_ node: ExprSyntax?) -> BridgedExpr {
     guard let node else {
-      return nil
+      return .init(raw: nil)
     }
 
     return self.generate(node)
@@ -342,27 +346,27 @@ extension ASTGenVisitor {
   }
 
   @inline(__always)
-  func generate(_ node: GenericParameterClauseSyntax?) -> ASTNode? {
+  func generate(_ node: GenericParameterClauseSyntax?) -> BridgedGenericParamList {
     guard let node else {
-      return nil
+      return .init(raw: nil)
     }
 
     return self.generate(node)
   }
 
   @inline(__always)
-  func generate(_ node: GenericWhereClauseSyntax?) -> ASTNode? {
+  func generate(_ node: GenericWhereClauseSyntax?) -> BridgedTrailingWhereClause {
     guard let node else {
-      return nil
+      return .init(raw: nil)
     }
 
     return self.generate(node)
   }
 
   @inline(__always)
-  func generate(_ node: EnumCaseParameterClauseSyntax?) -> ASTNode? {
+  func generate(_ node: EnumCaseParameterClauseSyntax?) -> BridgedParameterList {
     guard let node else {
-      return nil
+      return .init(raw: nil)
     }
 
     return self.generate(node)

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -320,7 +320,7 @@ extension ASTGenVisitor {
   @inline(__always)
   func generate(_ node: TypeSyntax?) -> BridgedTypeRepr {
     guard let node else {
-      return .init(raw: nil)
+      return BridgedTypeRepr(raw: nil)
     }
 
     return self.generate(node)
@@ -329,7 +329,7 @@ extension ASTGenVisitor {
   @inline(__always)
   func generate(_ node: ExprSyntax?) -> BridgedExpr {
     guard let node else {
-      return .init(raw: nil)
+      return BridgedExpr(raw: nil)
     }
 
     return self.generate(node)
@@ -348,7 +348,7 @@ extension ASTGenVisitor {
   @inline(__always)
   func generate(_ node: GenericParameterClauseSyntax?) -> BridgedGenericParamList {
     guard let node else {
-      return .init(raw: nil)
+      return BridgedGenericParamList(raw: nil)
     }
 
     return self.generate(node)
@@ -357,7 +357,7 @@ extension ASTGenVisitor {
   @inline(__always)
   func generate(_ node: GenericWhereClauseSyntax?) -> BridgedTrailingWhereClause {
     guard let node else {
-      return .init(raw: nil)
+      return BridgedTrailingWhereClause(raw: nil)
     }
 
     return self.generate(node)
@@ -366,7 +366,7 @@ extension ASTGenVisitor {
   @inline(__always)
   func generate(_ node: EnumCaseParameterClauseSyntax?) -> BridgedParameterList {
     guard let node else {
-      return .init(raw: nil)
+      return BridgedParameterList(raw: nil)
     }
 
     return self.generate(node)

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -21,7 +21,7 @@ extension BridgedSourceLoc {
     in buffer: UnsafeBufferPointer<UInt8>
   ) {
     precondition(position.utf8Offset >= 0 && position.utf8Offset <= buffer.count)
-    self = SourceLoc_advanced(BridgedSourceLoc(raw: buffer.baseAddress!), position.utf8Offset)
+    self = BridgedSourceLoc(raw: buffer.baseAddress!).advanced(by: position.utf8Offset)
   }
 }
 
@@ -103,7 +103,7 @@ extension TokenSyntax {
   func bridgedIdentifier(in astgen: ASTGenVisitor) -> BridgedIdentifier {
     var text = self.text
     return text.withBridgedString { bridged in
-      ASTContext_getIdentifier(astgen.ctx, bridged)
+      astgen.ctx.getIdentifier(bridged)
     }
   }
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -7,153 +7,169 @@ import SwiftDiagnostics
 // MARK: - TypeDecl
 
 extension ASTGenVisitor {
-  public func generate(_ node: TypeAliasDeclSyntax) -> ASTNode {
+  public func generate(_ node: TypeAliasDeclSyntax) -> BridgedTypeAliasDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
-    return .decl(
-      TypeAliasDecl_create(
-        astContext: self.ctx,
-        declContext: self.declContext,
-        typealiasKeywordLoc: node.typealiasKeyword.bridgedSourceLoc(in: self),
-        name: name,
-        nameLoc: nameLoc,
-        genericParamList: self.generate(node.genericParameterClause)?.rawValue,
-        equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
-        underlyingType: self.generate(node.initializer.value).rawValue,
-        genericWhereClause: self.generate(node.genericWhereClause)?.rawValue
-      )
+    return .createParsed(
+      self.ctx,
+      declContext: self.declContext,
+      typealiasKeywordLoc: node.typealiasKeyword.bridgedSourceLoc(in: self),
+      name: name,
+      nameLoc: nameLoc,
+      genericParamList: self.generate(node.genericParameterClause),
+      equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
+      underlyingType: self.generate(node.initializer.value),
+      genericWhereClause: self.generate(node.genericWhereClause)
     )
   }
 
-  public func generate(_ node: EnumDeclSyntax) -> ASTNode {
+  public func generate(_ node: EnumDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
-    let decl = EnumDecl_create(
-      astContext: self.ctx,
+    let decl = BridgedEnumDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       enumKeywordLoc: node.enumKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      genericParamList: self.generate(node.genericParameterClause),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
-      braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self)
+      genericWhereClause: self.generate(node.genericWhereClause),
+      braceRange: BridgedSourceRange(
+        startToken: node.memberBlock.leftBrace,
+        endToken: node.memberBlock.rightBrace, 
+        in: self
+      )
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
+      decl.setParsedMembers(self.generate(node.memberBlock.members))
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 
-  public func generate(_ node: StructDeclSyntax) -> ASTNode {
+  public func generate(_ node: StructDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
-    let decl = StructDecl_create(
-      astContext: self.ctx,
+    let decl = BridgedStructDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       structKeywordLoc: node.structKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      genericParamList: self.generate(node.genericParameterClause),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
-      braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self)
+      genericWhereClause: self.generate(node.genericWhereClause),
+      braceRange: BridgedSourceRange(
+        startToken: node.memberBlock.leftBrace,
+        endToken: node.memberBlock.rightBrace, 
+        in: self
+      )
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
+      decl.setParsedMembers(self.generate(node.memberBlock.members))
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 
-  public func generate(_ node: ClassDeclSyntax) -> ASTNode {
+  public func generate(_ node: ClassDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
-    let decl = ClassDecl_create(
-      astContext: self.ctx,
+    let decl = BridgedClassDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       classKeywordLoc: node.classKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      genericParamList: self.generate(node.genericParameterClause),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
-      braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self),
+      genericWhereClause: self.generate(node.genericWhereClause),
+      braceRange: BridgedSourceRange(
+        startToken: node.memberBlock.leftBrace,
+        endToken: node.memberBlock.rightBrace,
+        in: self
+      ),
       isActor: false
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
+      decl.setParsedMembers(self.generate(node.memberBlock.members))
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 
-  public func generate(_ node: ActorDeclSyntax) -> ASTNode {
+  public func generate(_ node: ActorDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
-    let decl = ClassDecl_create(
-      astContext: self.ctx,
+    let decl = BridgedClassDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       classKeywordLoc: node.actorKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
+      genericParamList: self.generate(node.genericParameterClause),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
-      braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self),
+      genericWhereClause: self.generate(node.genericWhereClause),
+      braceRange: BridgedSourceRange(
+        startToken: node.memberBlock.leftBrace,
+        endToken: node.memberBlock.rightBrace,
+        in: self
+      ),
       isActor: true
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
+      decl.setParsedMembers(self.generate(node.memberBlock.members))
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 
-  func generate(_ node: ProtocolDeclSyntax) -> ASTNode {
+  func generate(_ node: ProtocolDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
     let primaryAssociatedTypeNames = node.primaryAssociatedTypeClause?.primaryAssociatedTypes.lazy.map {
       $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
     }
 
-    let decl = ProtocolDecl_create(
-      astContext: self.ctx,
+    let decl = BridgedProtocolDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       protocolKeywordLoc: node.protocolKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
       primaryAssociatedTypeNames: primaryAssociatedTypeNames.bridgedArray(in: self),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
-      braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self)
+      genericWhereClause: self.generate(node.genericWhereClause),
+      braceRange: BridgedSourceRange(
+        startToken: node.memberBlock.leftBrace,
+        endToken: node.memberBlock.rightBrace,
+        in: self
+      )
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
+      decl.setParsedMembers(self.generate(node.memberBlock.members))
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 
-  func generate(_ node: AssociatedTypeDeclSyntax) -> ASTNode {
+  func generate(_ node: AssociatedTypeDeclSyntax) -> BridgedAssociatedTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
-    return .decl(
-      AssociatedTypeDecl_create(
-        astContext: self.ctx,
-        declContext: self.declContext,
-        associatedtypeKeywordLoc: node.associatedtypeKeyword.bridgedSourceLoc(in: self),
-        name: name,
-        nameLoc: nameLoc,
-        inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-        defaultType: self.generate(node.initializer?.value)?.rawValue,
-        genericWhereClause: self.generate(node.genericWhereClause)?.rawValue
-      )
+    return .createParsed(
+      self.ctx,
+      declContext: self.declContext,
+      associatedtypeKeywordLoc: node.associatedtypeKeyword.bridgedSourceLoc(in: self),
+      name: name,
+      nameLoc: nameLoc,
+      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
+      defaultType: self.generate(node.initializer?.value),
+      genericWhereClause: self.generate(node.genericWhereClause)
     )
   }
 }
@@ -161,51 +177,51 @@ extension ASTGenVisitor {
 // MARK: - ExtensionDecl
 
 extension ASTGenVisitor {
-  func generate(_ node: ExtensionDeclSyntax) -> ASTNode {
-    let decl = ExtensionDecl_create(
-      astContext: self.ctx,
+  func generate(_ node: ExtensionDeclSyntax) -> BridgedExtensionDecl {
+    let decl = BridgedExtensionDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       extensionKeywordLoc: node.extensionKeyword.bridgedSourceLoc(in: self),
-      extendedType: self.generate(node.extendedType).rawValue,
+      extendedType: self.generate(node.extendedType),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
-      braceRange: BridgedSourceRange(startToken: node.memberBlock.leftBrace, endToken: node.memberBlock.rightBrace, in: self)
+      genericWhereClause: self.generate(node.genericWhereClause),
+      braceRange: BridgedSourceRange(
+        startToken: node.memberBlock.leftBrace,
+        endToken: node.memberBlock.rightBrace,
+        in: self
+      )
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      IterableDeclContext_setParsedMembers(self.generate(node.memberBlock.members), ofDecl: decl.asDecl)
+      decl.setParsedMembers(self.generate(node.memberBlock.members))
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 }
 
 // MARK: - EnumCaseDecl
 
 extension ASTGenVisitor {
-  func generate(_ node: EnumCaseElementSyntax) -> ASTNode {
+  func generate(_ node: EnumCaseElementSyntax) -> BridgedEnumElementDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
-    return .decl(
-      EnumElementDecl_create(
-        astContext: self.ctx,
-        declContext: self.declContext,
-        name: name,
-        nameLoc: nameLoc,
-        parameterList: self.generate(node.parameterClause)?.rawValue,
-        equalsLoc: (node.rawValue?.equal).bridgedSourceLoc(in: self),
-        rawValue: self.generate(node.rawValue?.value)?.rawValue
-      )
+    return .createParsed(
+      self.ctx,
+      declContext: self.declContext,
+      name: name,
+      nameLoc: nameLoc,
+      parameterList: self.generate(node.parameterClause),
+      equalsLoc: (node.rawValue?.equal).bridgedSourceLoc(in: self),
+      rawValue: self.generate(node.rawValue?.value)
     )
   }
 
-  func generate(_ node: EnumCaseDeclSyntax) -> ASTNode {
-    .decl(
-      EnumCaseDecl_create(
-        declContext: self.declContext,
-        caseKeywordLoc: node.caseKeyword.bridgedSourceLoc(in: self),
-        elements: node.elements.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self)
-      )
+  func generate(_ node: EnumCaseDeclSyntax) -> BridgedEnumCaseDecl {
+    .createParsed(
+      declContext: self.declContext,
+      caseKeywordLoc: node.caseKeyword.bridgedSourceLoc(in: self),
+      elements: node.elements.lazy.map(self.generate).bridgedArray(in: self)
     )
   }
 }
@@ -213,23 +229,21 @@ extension ASTGenVisitor {
 // MARK: - AbstractStorageDecl
 
 extension ASTGenVisitor {
-  public func generate(_ node: VariableDeclSyntax) -> ASTNode {
-    let pattern = generate(node.bindings.first!.pattern).rawValue
-    let initializer = generate(node.bindings.first!.initializer!).rawValue
+  public func generate(_ node: VariableDeclSyntax) -> BridgedPatternBindingDecl {
+    let pattern = generate(node.bindings.first!.pattern)
+    let initializer = generate(node.bindings.first!.initializer!)
 
     let isStatic = false  // TODO: compute this
     let isLet = node.bindingSpecifier.tokenKind == .keyword(.let)
 
-    return .decl(
-      VarDecl_create(
-        astContext: self.ctx,
-        declContext: self.declContext,
-        bindingKeywordLoc: node.bindingSpecifier.bridgedSourceLoc(in: self),
-        nameExpr: pattern,
-        initializer: initializer,
-        isStatic: isStatic,
-        isLet: isLet
-      )
+    return .createParsed(
+      self.ctx,
+      declContext: self.declContext,
+      bindingKeywordLoc: node.bindingSpecifier.bridgedSourceLoc(in: self),
+      nameExpr: pattern.castToExpr,
+      initializer: initializer,
+      isStatic: isStatic,
+      isLet: isLet
     )
   }
 }
@@ -237,75 +251,75 @@ extension ASTGenVisitor {
 // MARK: - AbstractFunctionDecl
 
 extension ASTGenVisitor {
-  public func generate(_ node: FunctionDeclSyntax) -> ASTNode {
+  public func generate(_ node: FunctionDeclSyntax) -> BridgedFuncDecl {
     // FIXME: Compute this location
     let staticLoc: BridgedSourceLoc = nil
 
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
-    let decl = FuncDecl_create(
-      astContext: self.ctx,
+    let decl = BridgedFuncDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       staticLoc: staticLoc,
       funcKeywordLoc: node.funcKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
-      parameterList: self.generate(node.signature.parameterClause).rawValue,
+      genericParamList: self.generate(node.genericParameterClause),
+      parameterList: self.generate(node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type)?.rawValue,
-      returnType: self.generate(node.signature.returnClause?.type)?.rawValue,
-      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue
+      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type),
+      returnType: self.generate(node.signature.returnClause?.type),
+      genericWhereClause: self.generate(node.genericWhereClause)
     )
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        AbstractFunctionDecl_setBody(self.generate(body).rawValue, ofDecl: decl.asDecl)
+        decl.setParsedBody(self.generate(body))
       }
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 
-  func generate(_ node: InitializerDeclSyntax) -> ASTNode {
-    let decl = ConstructorDecl_create(
-      astContext: self.ctx,
+  func generate(_ node: InitializerDeclSyntax) -> BridgedConstructorDecl {
+    let decl = BridgedConstructorDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       initKeywordLoc: node.initKeyword.bridgedSourceLoc(in: self),
       failabilityMarkLoc: node.optionalMark.bridgedSourceLoc(in: self),
       isIUO: node.optionalMark?.tokenKind == .exclamationMark,
-      genericParamList: self.generate(node.genericParameterClause)?.rawValue,
-      parameterList: self.generate(node.signature.parameterClause).rawValue,
+      genericParamList: self.generate(node.genericParameterClause),
+      parameterList: self.generate(node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type)?.rawValue,
-      genericWhereClause: self.generate(node.genericWhereClause)?.rawValue
+      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type),
+      genericWhereClause: self.generate(node.genericWhereClause)
     )
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        AbstractFunctionDecl_setBody(self.generate(body).rawValue, ofDecl: decl.asDecl)
+        decl.setParsedBody(self.generate(body))
       }
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 
-  func generate(_ node: DeinitializerDeclSyntax) -> ASTNode {
-    let decl = DestructorDecl_create(
-      astContext: self.ctx,
+  func generate(_ node: DeinitializerDeclSyntax) -> BridgedDestructorDecl {
+    let decl = BridgedDestructorDecl.createParsed(
+      self.ctx,
       declContext: self.declContext,
       deinitKeywordLoc: node.deinitKeyword.bridgedSourceLoc(in: self)
     )
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        AbstractFunctionDecl_setBody(self.generate(body).rawValue, ofDecl: decl.asDecl)
+        decl.setParsedBody(self.generate(body))
       }
     }
 
-    return .decl(decl.asDecl)
+    return decl
   }
 }
 
@@ -323,7 +337,7 @@ extension BridgedOperatorFixity {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: OperatorDeclSyntax) -> ASTNode {
+  func generate(_ node: OperatorDeclSyntax) -> BridgedOperatorDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
     let (precedenceGroupName, precedenceGroupLoc) = (node.operatorPrecedenceAndTypes?.precedenceGroup).bridgedIdentifierAndSourceLoc(in: self)
 
@@ -335,18 +349,16 @@ extension ASTGenVisitor {
       self.diagnose(Diagnostic(node: node.fixitySpecifier, message: UnexpectedTokenKindError(token: node.fixitySpecifier)))
     }
 
-    return .decl(
-      OperatorDecl_create(
-        astContext: self.ctx,
-        declContext: self.declContext,
-        fixity: fixity,
-        operatorKeywordLoc: node.operatorKeyword.bridgedSourceLoc(in: self),
-        name: name,
-        nameLoc: nameLoc,
-        colonLoc: (node.operatorPrecedenceAndTypes?.colon).bridgedSourceLoc(in: self),
-        precedenceGroupName: precedenceGroupName,
-        PrecedenceGroupLoc: precedenceGroupLoc
-      )
+    return .createParsed(
+      self.ctx,
+      declContext: self.declContext,
+      fixity: fixity,
+      operatorKeywordLoc: node.operatorKeyword.bridgedSourceLoc(in: self),
+      name: name,
+      nameLoc: nameLoc,
+      colonLoc: (node.operatorPrecedenceAndTypes?.colon).bridgedSourceLoc(in: self),
+      precedenceGroupName: precedenceGroupName,
+      precedenceGroupLoc: precedenceGroupLoc
     )
   }
 }
@@ -365,7 +377,7 @@ extension BridgedAssociativity {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: PrecedenceGroupDeclSyntax) -> ASTNode {
+  func generate(_ node: PrecedenceGroupDeclSyntax) -> BridgedPrecedenceGroupDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     struct PrecedenceGroupBody {
@@ -438,25 +450,23 @@ extension ASTGenVisitor {
       assignmentValue = false
     }
 
-    return .decl(
-      PrecedenceGroupDecl_create(
-        declContext: self.declContext,
-        precedencegroupKeywordLoc: node.precedencegroupKeyword.bridgedSourceLoc(in: self),
-        name: name,
-        nameLoc: nameLoc,
-        leftBraceLoc: node.leftBrace.bridgedSourceLoc(in: self),
-        associativityLabelLoc: (body.associativity?.associativityLabel).bridgedSourceLoc(in: self),
-        associativityValueLoc: (body.associativity?.value).bridgedSourceLoc(in: self),
-        associativity: associativityValue,
-        assignmentLabelLoc: (body.assignment?.assignmentLabel).bridgedSourceLoc(in: self),
-        assignmentValueLoc: (body.assignment?.value).bridgedSourceLoc(in: self),
-        isAssignment: assignmentValue,
-        higherThanKeywordLoc: (body.higherThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-        higherThanNames: self.generate(body.higherThanRelation?.precedenceGroups),
-        lowerThanKeywordLoc: (body.lowerThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-        lowerThanNames: self.generate(body.lowerThanRelation?.precedenceGroups),
-        rightBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
-      )
+    return .createParsed(
+      declContext: self.declContext,
+      precedencegroupKeywordLoc: node.precedencegroupKeyword.bridgedSourceLoc(in: self),
+      name: name,
+      nameLoc: nameLoc,
+      leftBraceLoc: node.leftBrace.bridgedSourceLoc(in: self),
+      associativityLabelLoc: (body.associativity?.associativityLabel).bridgedSourceLoc(in: self),
+      associativityValueLoc: (body.associativity?.value).bridgedSourceLoc(in: self),
+      associativity: associativityValue,
+      assignmentLabelLoc: (body.assignment?.assignmentLabel).bridgedSourceLoc(in: self),
+      assignmentValueLoc: (body.assignment?.value).bridgedSourceLoc(in: self),
+      isAssignment: assignmentValue,
+      higherThanKeywordLoc: (body.higherThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
+      higherThanNames: self.generate(body.higherThanRelation?.precedenceGroups),
+      lowerThanKeywordLoc: (body.lowerThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
+      lowerThanNames: self.generate(body.lowerThanRelation?.precedenceGroups),
+      rightBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
     )
   }
 }
@@ -479,7 +489,7 @@ extension BridgedImportKind {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: ImportDeclSyntax) -> ASTNode {
+  func generate(_ node: ImportDeclSyntax) -> BridgedImportDecl {
     let importKind: BridgedImportKind
     if let specifier = node.importKindSpecifier {
       if let value = BridgedImportKind(from: specifier.tokenKind) {
@@ -492,17 +502,15 @@ extension ASTGenVisitor {
       importKind = .module
     }
 
-    return .decl(
-      ImportDecl_create(
-        astContext: self.ctx,
-        declContext: self.declContext,
-        importKeywordLoc: node.importKeyword.bridgedSourceLoc(in: self),
-        importKind: importKind,
-        importKindLoc: node.importKindSpecifier.bridgedSourceLoc(in: self),
-        path: node.path.lazy.map {
-          $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
-        }.bridgedArray(in: self)
-      )
+    return .createParsed(
+      self.ctx,
+      declContext: self.declContext,
+      importKeywordLoc: node.importKeyword.bridgedSourceLoc(in: self),
+      importKind: importKind,
+      importKindLoc: node.importKindSpecifier.bridgedSourceLoc(in: self),
+      path: node.path.lazy.map {
+        $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
+      }.bridgedArray(in: self)
     )
   }
 }
@@ -510,12 +518,12 @@ extension ASTGenVisitor {
 extension ASTGenVisitor {
   @inline(__always)
   func generate(_ node: MemberBlockItemListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self)
+    node.lazy.map(self.generate).bridgedArray(in: self)
   }
 
   @inline(__always)
   func generate(_ node: InheritedTypeListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.generate($0.type).rawValue }.bridgedArray(in: self)
+    node.lazy.map { self.generate($0.type) }.bridgedArray(in: self)
   }
 
   @inline(__always)

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -21,17 +21,19 @@ fileprivate func emitDiagnosticParts(
   // Emit the diagnostic
   var mutableMessage = message
   let diag = mutableMessage.withBridgedString { bridgedMessage in
-    Diagnostic_create(
-      diagnosticEngine, bridgedSeverity, bridgedSourceLoc(at: position),
-      bridgedMessage
+    BridgedDiagnostic(
+      at: bridgedSourceLoc(at: position),
+      message: bridgedMessage,
+      severity: bridgedSeverity,
+      engine: diagnosticEngine
     )
   }
 
   // Emit highlights
   for highlight in highlights {
-    Diagnostic_highlight(
-      diag, bridgedSourceLoc(at: highlight.positionAfterSkippingLeadingTrivia),
-      bridgedSourceLoc(at: highlight.endPositionBeforeTrailingTrivia)
+    diag.highlight(
+      start: bridgedSourceLoc(at: highlight.positionAfterSkippingLeadingTrivia),
+      end: bridgedSourceLoc(at: highlight.endPositionBeforeTrailingTrivia)
     )
   }
 
@@ -60,14 +62,14 @@ fileprivate func emitDiagnosticParts(
     }
 
     newText.withBridgedString { bridgedMessage in
-      Diagnostic_fixItReplace(
-        diag, replaceStartLoc, replaceEndLoc,
-        bridgedMessage
+      diag.fixItReplace(
+        start: replaceStartLoc, end: replaceEndLoc,
+        replacement: bridgedMessage
       )
     }
   }
 
-  Diagnostic_finish(diag);
+  diag.finish();
 }
 
 /// Emit the given diagnostic via the diagnostic engine.
@@ -139,19 +141,19 @@ extension SourceManager {
     // Emit the diagnostic
     var mutableMessage = message
     let diag = mutableMessage.withBridgedString { bridgedMessage in
-      Diagnostic_create(
-        bridgedDiagEngine, bridgedSeverity,
-        bridgedSourceLoc(for: node, at: position),
-        bridgedMessage
+      BridgedDiagnostic(
+        at: bridgedSourceLoc(for: node, at: position),
+        message: bridgedMessage,
+        severity: bridgedSeverity,
+        engine: bridgedDiagEngine
       )
     }
 
     // Emit highlights
     for highlight in highlights {
-      Diagnostic_highlight(
-        diag,
-        bridgedSourceLoc(for: highlight, at: highlight.positionAfterSkippingLeadingTrivia),
-        bridgedSourceLoc(for: highlight, at: highlight.endPositionBeforeTrailingTrivia)
+      diag.highlight(
+        start: bridgedSourceLoc(for: highlight, at: highlight.positionAfterSkippingLeadingTrivia),
+        end: bridgedSourceLoc(for: highlight, at: highlight.endPositionBeforeTrailingTrivia)
       )
     }
 
@@ -193,14 +195,14 @@ extension SourceManager {
       }
 
       newText.withBridgedString { bridgedMessage in
-        Diagnostic_fixItReplace(
-          diag, replaceStartLoc, replaceEndLoc,
-          bridgedMessage
+        diag.fixItReplace(
+          start: replaceStartLoc, end: replaceEndLoc,
+          replacement: bridgedMessage
         )
       }
     }
 
-    Diagnostic_finish(diag);
+    diag.finish();
   }
 
   /// Emit a diagnostic via the C++ diagnostic engine.

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -3,19 +3,19 @@ import SwiftSyntax
 import SwiftDiagnostics
 
 extension ASTGenVisitor {
-  public func generate(_ node: ClosureExprSyntax) -> ASTNode {
-    let body = BraceStmt_create(
+  public func generate(_ node: ClosureExprSyntax) -> BridgedClosureExpr {
+    let body = BridgedBraceStmt.createParsed(
       self.ctx,
-      node.leftBrace.bridgedSourceLoc(in: self),
-      self.generate(node.statements),
-      node.rightBrace.bridgedSourceLoc(in: self)
+      lBraceLoc: node.leftBrace.bridgedSourceLoc(in: self),
+      elements: self.generate(node.statements),
+      rBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
     )
 
     // FIXME: Translate the signature, capture list, 'in' location, etc.
-    return .expr(ClosureExpr_create(self.ctx, body, self.declContext))
+    return .createParsed(self.ctx, declContext: self.declContext, body: body)
   }
 
-  public func generate(_ node: FunctionCallExprSyntax) -> ASTNode {
+  public func generate(_ node: FunctionCallExprSyntax) -> BridgedCallExpr {
     if !node.arguments.isEmpty || node.trailingClosure == nil {
       if node.leftParen == nil {
         self.diagnose(Diagnostic(node: node, message: MissingChildTokenError(parent: node, kindOfTokenMissing: .leftParen)))
@@ -36,52 +36,53 @@ extension ASTGenVisitor {
       node.trailingClosure = nil
     }
 
-    let argumentTuple = self.generate(node.arguments, leftParen: node.leftParen, rightParen: node.rightParen)
-      .rawValue
-    let callee = generate(node.calledExpression).rawValue
+    let argumentTuple = self.generate(
+      node.arguments, leftParen: node.leftParen, rightParen: node.rightParen
+    )
+    let callee = generate(node.calledExpression)
 
-    return .expr(FunctionCallExpr_create(self.ctx, callee, argumentTuple))
+    return .createParsed(self.ctx, fn: callee, args: argumentTuple)
   }
 
-  public func generate(_ node: DeclReferenceExprSyntax) -> ASTNode {
+  public func generate(_ node: DeclReferenceExprSyntax) -> BridgedUnresolvedDeclRefExpr {
     let (name, nameLoc) = node.baseName.bridgedIdentifierAndSourceLoc(in: self)
 
-    return .expr(IdentifierExpr_create(self.ctx, name, nameLoc))
+    return .createParsed(self.ctx, base: name, loc: nameLoc)
   }
 
-  public func generate(_ node: IdentifierPatternSyntax) -> ASTNode {
+  public func generate(_ node: IdentifierPatternSyntax) -> BridgedUnresolvedDeclRefExpr {
     let (name, nameLoc) = node.identifier.bridgedIdentifierAndSourceLoc(in: self)
 
-    return .expr(IdentifierExpr_create(self.ctx, name, nameLoc))
+    return .createParsed(self.ctx, base: name, loc: nameLoc)
   }
 
-  public func generate(_ node: MemberAccessExprSyntax) -> ASTNode {
+  public func generate(_ node: MemberAccessExprSyntax) -> BridgedUnresolvedDotExpr {
     let loc = node.bridgedSourceLoc(in: self)
-    let base = generate(node.base!).rawValue
+    let base = generate(node.base!)
     let name = node.declName.baseName.bridgedIdentifier(in: self)
 
-    return .expr(UnresolvedDotExpr_create(ctx, base, loc, name, loc))
+    return .createParsed(ctx, base: base, dotLoc: loc, name: name, nameLoc: loc)
   }
 
-  public func generate(_ node: IfExprSyntax) -> ASTNode {
-    let stmt = makeIfStmt(node).rawValue
+  public func generate(_ node: IfExprSyntax) -> BridgedSingleValueStmtExpr {
+    let stmt = makeIfStmt(node).asStmt
 
     // Wrap in a SingleValueStmtExpr to embed as an expression.
-    let sve = SingleValueStmtExpr_createWithWrappedBranches(
-      ctx, stmt, declContext, /*mustBeExpr*/ true)
-    return .expr(sve)
+    return .createWithWrappedBranches(
+      ctx, stmt: stmt, declContext: declContext, mustBeExpr: true
+    )
   }
 
-  public func generate(_ node: TupleExprSyntax) -> ASTNode {
+  public func generate(_ node: TupleExprSyntax) -> BridgedTupleExpr {
     self.generate(node.elements, leftParen: node.leftParen, rightParen: node.rightParen)
   }
 }
 
 extension ASTGenVisitor {
   /// Generate a tuple expression from a ``LabeledExprListSyntax`` and parentheses.
-  func generate(_ node: LabeledExprListSyntax, leftParen: TokenSyntax?, rightParen: TokenSyntax?) -> ASTNode {
+  func generate(_ node: LabeledExprListSyntax, leftParen: TokenSyntax?, rightParen: TokenSyntax?) -> BridgedTupleExpr {
     let expressions = node.lazy.map {
-      self.generate($0.expression).rawValue
+      self.generate($0.expression)
     }
     let labels = node.lazy.map {
       $0.label.bridgedIdentifier(in: self)
@@ -93,16 +94,14 @@ extension ASTGenVisitor {
 
       return $0.bridgedSourceLoc(in: self)
     }
-
-    return .expr(
-      TupleExpr_create(
-        self.ctx,
-        leftParen.bridgedSourceLoc(in: self),
-        expressions.bridgedArray(in: self),
-        labels.bridgedArray(in: self),
-        labelLocations.bridgedArray(in: self),
-        rightParen.bridgedSourceLoc(in: self)
-      )
+    
+    return BridgedTupleExpr.createParsed(
+      self.ctx,
+      leftParenLoc: leftParen.bridgedSourceLoc(in: self),
+      exprs: expressions.bridgedArray(in: self),
+      labels: labels.bridgedArray(in: self),
+      labelLocs: labelLocations.bridgedArray(in: self),
+      rightParenLoc: rightParen.bridgedSourceLoc(in: self)
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -3,19 +3,17 @@ import CBasicBridging
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  func generate(_ node: GenericParameterClauseSyntax) -> ASTNode {
-    .misc(
-      GenericParamList_create(
-        astContext: self.ctx,
-        leftAngleLoc: node.leftAngle.bridgedSourceLoc(in: self),
-        parameters: node.parameters.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self),
-        genericWhereClause: self.generate(node.genericWhereClause)?.rawValue,
-        rightAngleLoc: node.rightAngle.bridgedSourceLoc(in: self)
-      )
+  func generate(_ node: GenericParameterClauseSyntax) -> BridgedGenericParamList {
+    .createParsed(
+      self.ctx,
+      leftAngleLoc: node.leftAngle.bridgedSourceLoc(in: self),
+      parameters: node.parameters.lazy.map(self.generate).bridgedArray(in: self),
+      genericWhereClause: self.generate(node.genericWhereClause),
+      rightAngleLoc: node.rightAngle.bridgedSourceLoc(in: self)
     )
   }
 
-  func generate(_ node: GenericParameterSyntax) -> ASTNode {
+  func generate(_ node: GenericParameterSyntax) -> BridgedGenericTypeParamDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     var genericParameterIndex: Int?
@@ -29,35 +27,33 @@ extension ASTGenVisitor {
       preconditionFailure("Node not part of the parent?")
     }
 
-    return .decl(
-      GenericTypeParamDecl_create(
-        astContext: self.ctx,
-        declContext: self.declContext,
-        eachKeywordLoc: node.eachKeyword.bridgedSourceLoc(in: self),
-        name: name,
-        nameLoc: nameLoc,
-        inheritedType: self.generate(node.inheritedType)?.rawValue,
-        index: genericParameterIndex
-      )
+    return .createParsed(
+      self.ctx,
+      declContext: self.declContext,
+      eachKeywordLoc: node.eachKeyword.bridgedSourceLoc(in: self),
+      name: name,
+      nameLoc: nameLoc,
+      inheritedType: self.generate(node.inheritedType),
+      index: genericParameterIndex
     )
   }
 
-  func generate(_ node: GenericWhereClauseSyntax) -> ASTNode {
+  func generate(_ node: GenericWhereClauseSyntax) -> BridgedTrailingWhereClause {
     let requirements = node.requirements.lazy.map {
       switch $0.requirement {
       case .conformanceRequirement(let conformance):
         return BridgedRequirementRepr(
           SeparatorLoc: conformance.colon.bridgedSourceLoc(in: self),
           Kind: .typeConstraint,
-          FirstType: self.generate(conformance.leftType).rawValue,
-          SecondType: self.generate(conformance.rightType).rawValue
+          FirstType: self.generate(conformance.leftType),
+          SecondType: self.generate(conformance.rightType)
         )
       case .sameTypeRequirement(let sameType):
         return BridgedRequirementRepr(
           SeparatorLoc: sameType.equal.bridgedSourceLoc(in: self),
           Kind: .sameType,
-          FirstType: self.generate(sameType.leftType).rawValue,
-          SecondType: self.generate(sameType.rightType).rawValue
+          FirstType: self.generate(sameType.leftType),
+          SecondType: self.generate(sameType.rightType)
         )
       case .layoutRequirement(_):
         // FIXME: Implement layout requirement translation.
@@ -65,12 +61,10 @@ extension ASTGenVisitor {
       }
     }
 
-    return .misc(
-      TrailingWhereClause_create(
-        astContext: self.ctx,
-        whereKeywordLoc: node.whereKeyword.bridgedSourceLoc(in: self),
-        requirements: requirements.bridgedArray(in: self)
-      )
+    return BridgedTrailingWhereClause.createParsed(
+      self.ctx,
+      whereKeywordLoc: node.whereKeyword.bridgedSourceLoc(in: self),
+      requirements: requirements.bridgedArray(in: self)
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -2,53 +2,45 @@ import CASTBridging
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func generate(_ node: StringLiteralExprSyntax) -> ASTNode {
+  public func generate(_ node: StringLiteralExprSyntax) -> BridgedStringLiteralExpr {
     let openDelimiterOrQuoteLoc = (node.openingPounds ?? node.openingQuote).bridgedSourceLoc(in: self)
 
     // FIXME: Handle interpolated strings.
     var segment = node.segments.first!.as(StringSegmentSyntax.self)!.content.text
-    return .expr(
-      segment.withBridgedString { bridgedSegment in
-        return StringLiteralExpr_create(self.ctx, bridgedSegment, openDelimiterOrQuoteLoc)
-      }
-    )
-  }
-
-  public func generate(_ node: IntegerLiteralExprSyntax) -> ASTNode {
-    var segment = node.literal.text
-    return .expr(
-      segment.withBridgedString { bridgedSegment in
-        return IntegerLiteralExpr_create(ctx, bridgedSegment, node.literal.bridgedSourceLoc(in: self))
-      }
-    )
-  }
-
-  public func generate(_ node: BooleanLiteralExprSyntax) -> ASTNode {
-    let value = node.literal.tokenKind == .keyword(.true)
-    return .expr(BooleanLiteralExpr_create(ctx, value, node.literal.bridgedSourceLoc(in: self)))
-  }
-
-  public func generate(_ node: ArrayExprSyntax) -> ASTNode {
-    let expressions = node.elements.lazy.map {
-      self.generate($0).rawValue
+    return segment.withBridgedString { bridgedSegment in
+      return .createParsed(self.ctx, value: bridgedSegment, loc: openDelimiterOrQuoteLoc)
     }
+  }
+
+  public func generate(_ node: IntegerLiteralExprSyntax) -> BridgedIntegerLiteralExpr {
+    var segment = node.literal.text
+    return segment.withBridgedString { bridgedSegment in
+      return .createParsed(ctx, value: bridgedSegment, loc: node.literal.bridgedSourceLoc(in: self))
+    }
+  }
+
+  public func generate(_ node: BooleanLiteralExprSyntax) -> BridgedBooleanLiteralExpr {
+    let value = node.literal.tokenKind == .keyword(.true)
+    return .createParsed(ctx, value: value, loc: node.literal.bridgedSourceLoc(in: self))
+  }
+
+  public func generate(_ node: ArrayExprSyntax) -> BridgedArrayExpr {
+    let expressions = node.elements.lazy.map(self.generate)
 
     let commaLocations = node.elements.compactMap(in: self) {
       $0.trailingComma.bridgedSourceLoc(in: self)
     }
 
-    return .expr(
-      ArrayExpr_create(
-        self.ctx,
-        node.leftSquare.bridgedSourceLoc(in: self),
-        expressions.bridgedArray(in: self),
-        commaLocations,
-        node.rightSquare.bridgedSourceLoc(in: self)
-      )
+    return .createParsed(
+      self.ctx,
+      lSquareLoc: node.leftSquare.bridgedSourceLoc(in: self),
+      elements: expressions.bridgedArray(in: self),
+      commaLocs: commaLocations,
+      rSquareLoc: node.rightSquare.bridgedSourceLoc(in: self)
     )
   }
 
-  func generate(_ node: NilLiteralExprSyntax) -> ASTNode {
-    .expr(NilLiteralExpr_create(astContext: self.ctx, nilKeywordLoc: node.nilKeyword.bridgedSourceLoc(in: self)))
+  func generate(_ node: NilLiteralExprSyntax) -> BridgedNilLiteralExpr {
+    .createParsed(self.ctx, nilKeywordLoc: node.nilKeyword.bridgedSourceLoc(in: self))
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
+++ b/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
@@ -54,15 +54,15 @@ extension EnumCaseParameterSyntax: ValueParameterSyntax {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: FunctionParameterSyntax) -> ASTNode {
+  func generate(_ node: FunctionParameterSyntax) -> BridgedParamDecl {
     self.makeParamDecl(node)
   }
 
-  func generate(_ node: EnumCaseParameterSyntax) -> ASTNode {
+  func generate(_ node: EnumCaseParameterSyntax) -> BridgedParamDecl {
     self.makeParamDecl(node)
   }
 
-  private func makeParamDecl(_ node: some ValueParameterSyntax) -> ASTNode {
+  private func makeParamDecl(_ node: some ValueParameterSyntax) -> BridgedParamDecl {
     // FIXME: This location should be derived from the type repr.
     let specifierLoc: BridgedSourceLoc = nil
 
@@ -76,18 +76,16 @@ extension ASTGenVisitor {
 
     let (secondName, secondNameLoc) = node.secondName.bridgedIdentifierAndSourceLoc(in: self)
 
-    return .decl(
-      ParamDecl_create(
-        astContext: self.ctx,
-        declContext: self.declContext,
-        specifierLoc: specifierLoc,
-        firstName: firstName,
-        firstNameLoc: node.optionalFirstName.bridgedSourceLoc(in: self),
-        secondName: secondName,
-        secondNameLoc: secondNameLoc,
-        type: self.generate(node.optionalType)?.rawValue,
-        defaultValue: self.generate(node.defaultValue?.value)?.rawValue
-      )
+    return BridgedParamDecl.createParsed(
+      self.ctx,
+      declContext: self.declContext,
+      specifierLoc: specifierLoc,
+      firstName: firstName,
+      firstNameLoc: node.optionalFirstName.bridgedSourceLoc(in: self),
+      secondName: secondName,
+      secondNameLoc: secondNameLoc,
+      type: self.generate(node.optionalType),
+      defaultValue: self.generate(node.defaultValue?.value)
     )
   }
 }
@@ -95,25 +93,21 @@ extension ASTGenVisitor {
 // MARK: - ParameterList
 
 extension ASTGenVisitor {
-  func generate(_ node: FunctionParameterClauseSyntax) -> ASTNode {
-    .misc(
-      ParameterList_create(
-        astContext: self.ctx,
-        leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
-        parameters: self.generate(node.parameters),
-        rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
-      )
+  func generate(_ node: FunctionParameterClauseSyntax) -> BridgedParameterList {
+    BridgedParameterList.createParsed(
+      self.ctx,
+      leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
+      parameters: self.generate(node.parameters),
+      rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
     )
   }
 
-  func generate(_ node: EnumCaseParameterClauseSyntax) -> ASTNode {
-    .misc(
-      ParameterList_create(
-        astContext: self.ctx,
-        leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
-        parameters: node.parameters.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self),
-        rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
-      )
+  func generate(_ node: EnumCaseParameterClauseSyntax) -> BridgedParameterList {
+    BridgedParameterList.createParsed(
+      self.ctx,
+      leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
+      parameters: node.parameters.lazy.map(self.generate).bridgedArray(in: self),
+      rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
     )
   }
 }
@@ -121,6 +115,6 @@ extension ASTGenVisitor {
 extension ASTGenVisitor {
   @inline(__always)
   func generate(_ node: FunctionParameterListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.generate($0).rawValue }.bridgedArray(in: self)
+    node.lazy.map(self.generate).bridgedArray(in: self)
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -31,7 +31,7 @@ extension Parser.ExperimentalFeatures {
     guard let context = context else { return }
 
     func mapFeature(_ bridged: BridgedFeature, to feature: Self) {
-      if ASTContext_langOptsHasFeature(context, bridged) {
+      if context.langOptsHasFeature(bridged) {
         insert(feature)
       }
     }

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -2,49 +2,43 @@ import CASTBridging
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func generate(_ node: CodeBlockSyntax) -> ASTNode {
-    .stmt(
-      BraceStmt_create(
-        self.ctx,
-        node.leftBrace.bridgedSourceLoc(in: self),
-        self.generate(node.statements),
-        node.rightBrace.bridgedSourceLoc(in: self)
-      )
+  public func generate(_ node: CodeBlockSyntax) -> BridgedBraceStmt {
+    BridgedBraceStmt.createParsed(
+      self.ctx,
+      lBraceLoc: node.leftBrace.bridgedSourceLoc(in: self),
+      elements: self.generate(node.statements),
+      rBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
     )
   }
 
-  func makeIfStmt(_ node: IfExprSyntax) -> ASTNode {
-    let conditions = node.conditions.map { self.generate($0).rawValue }
+  func makeIfStmt(_ node: IfExprSyntax) -> BridgedIfStmt {
+    let conditions = node.conditions.map(self.generate)
     assert(conditions.count == 1)  // TODO: handle multiple conditions.
 
-    return .stmt(
-      IfStmt_create(
-        self.ctx,
-        node.ifKeyword.bridgedSourceLoc(in: self),
-        conditions.first!,
-        self.generate(node.body).rawValue,
-        node.elseKeyword.bridgedSourceLoc(in: self),
-        self.generate(node.elseBody)?.rawValue
-      )
+    return .createParsed(
+      self.ctx,
+      ifKeywordLoc: node.ifKeyword.bridgedSourceLoc(in: self),
+      condition: conditions.first!.castToExpr,
+      thenStmt: self.generate(node.body).asStmt,
+      elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
+      elseStmt: self.generate(node.elseBody)?.castToStmt ?? .init(raw: nil)
     )
   }
 
-  public func generate(_ node: ExpressionStmtSyntax) -> ASTNode {
+  public func generate(_ node: ExpressionStmtSyntax) -> BridgedStmt {
     switch Syntax(node.expression).as(SyntaxEnum.self) {
     case .ifExpr(let e):
-      return makeIfStmt(e)
+      return makeIfStmt(e).asStmt
     default:
       fatalError("Unhandled case!")
     }
   }
 
-  public func generate(_ node: ReturnStmtSyntax) -> ASTNode {
-    .stmt(
-      ReturnStmt_create(
-        self.ctx,
-        node.returnKeyword.bridgedSourceLoc(in: self),
-        self.generate(node.expression)?.rawValue
-      )
+  public func generate(_ node: ReturnStmtSyntax) -> BridgedReturnStmt {
+    .createParsed(
+      self.ctx,
+      returnKeywordLoc: node.returnKeyword.bridgedSourceLoc(in: self),
+      expr: self.generate(node.expression)
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -5,179 +5,193 @@ import SwiftSyntax
 import SwiftDiagnostics
 
 extension ASTGenVisitor {
-  public func generate(_ node: IdentifierTypeSyntax) -> ASTNode {
+  public func generate(_ node: IdentifierTypeSyntax) -> BridgedTypeRepr {
     let loc = node.bridgedSourceLoc(in: self)
 
     // If this is the bare 'Any' keyword, produce an empty composition type.
     if node.name.tokenKind == .keyword(.Any) && node.genericArgumentClause == nil {
-      return .type(EmptyCompositionTypeRepr_create(self.ctx, loc))
+      return BridgedCompositionTypeRepr.createEmpty(self.ctx, anyKeywordLoc: loc)
     }
 
     let id = node.name.bridgedIdentifier(in: self)
 
     guard let generics = node.genericArgumentClause else {
-      return .type(SimpleIdentTypeRepr_create(ctx, loc, id))
+      return BridgedSimpleIdentTypeRepr.createParsed(ctx, loc: loc, name: id)
     }
 
     let genericArguments = generics.arguments.lazy.map {
-      self.generate($0.argument).rawValue
+      self.generate($0.argument)
     }
 
-    return .type(
-      GenericIdentTypeRepr_create(
-        self.ctx,
-        id,
-        loc,
-        genericArguments.bridgedArray(in: self),
-        generics.leftAngle.bridgedSourceLoc(in: self),
-        generics.rightAngle.bridgedSourceLoc(in: self)
-      )
+    return BridgedGenericIdentTypeRepr.createParsed(
+      self.ctx,
+      name: id,
+      nameLoc: loc,
+      genericArgs: genericArguments.bridgedArray(in: self),
+      leftAngleLoc: generics.leftAngle.bridgedSourceLoc(in: self),
+      rightAngleLoc: generics.rightAngle.bridgedSourceLoc(in: self)
     )
   }
 
-  public func generate(_ node: MemberTypeSyntax) -> ASTNode {
+  public func generate(_ node: MemberTypeSyntax) -> BridgedTypeRepr {
     // Gather the member components, in decreasing depth order.
-    var reverseMemberComponents = [UnsafeMutableRawPointer]()
+    var reverseMemberComponents = [BridgedTypeRepr]()
 
-    var baseType = Syntax(node)
+    var baseType = TypeSyntax(node)
     while let memberType = baseType.as(MemberTypeSyntax.self) {
       let (name, nameLoc) = memberType.name.bridgedIdentifierAndSourceLoc(in: self)
 
       if let generics = memberType.genericArgumentClause {
         let genericArguments = generics.arguments.lazy.map {
-          self.generate($0.argument).rawValue
+          self.generate($0.argument)
         }
 
         reverseMemberComponents.append(
-          GenericIdentTypeRepr_create(
+          BridgedGenericIdentTypeRepr.createParsed(
             self.ctx,
-            name,
-            nameLoc,
-            genericArguments.bridgedArray(in: self),
-            generics.leftAngle.bridgedSourceLoc(in: self),
-            generics.rightAngle.bridgedSourceLoc(in: self)
+            name: name,
+            nameLoc: nameLoc,
+            genericArgs: genericArguments.bridgedArray(in: self),
+            leftAngleLoc: generics.leftAngle.bridgedSourceLoc(in: self),
+            rightAngleLoc: generics.rightAngle.bridgedSourceLoc(in: self)
           )
         )
       } else {
-        reverseMemberComponents.append(SimpleIdentTypeRepr_create(self.ctx, nameLoc, name))
+        reverseMemberComponents.append(
+          BridgedSimpleIdentTypeRepr.createParsed(self.ctx, loc: nameLoc, name: name)
+        )
       }
 
-      baseType = Syntax(memberType.baseType)
+      baseType = memberType.baseType
     }
 
-    let baseComponent = generate(baseType).rawValue
+    let baseComponent = generate(baseType)
     let memberComponents = reverseMemberComponents.reversed().bridgedArray(in: self)
 
-    return .type(MemberTypeRepr_create(self.ctx, baseComponent, memberComponents))
+    return BridgedMemberTypeRepr.createParsed(
+      self.ctx, base: baseComponent, members: memberComponents
+    )
   }
 
-  public func generate(_ node: ArrayTypeSyntax) -> ASTNode {
-    let elementType = generate(node.element).rawValue
+  public func generate(_ node: ArrayTypeSyntax) -> BridgedTypeRepr {
+    let elementType = generate(node.element)
     let lSquareLoc = node.leftSquare.bridgedSourceLoc(in: self)
     let rSquareLoc = node.rightSquare.bridgedSourceLoc(in: self)
-    return .type(ArrayTypeRepr_create(self.ctx, elementType, lSquareLoc, rSquareLoc))
+    return BridgedArrayTypeRepr.createParsed(
+      self.ctx, base: elementType, leftSquareLoc: lSquareLoc, 
+      rightSquareLoc: rSquareLoc
+    )
   }
 
-  public func generate(_ node: DictionaryTypeSyntax) -> ASTNode {
-    let keyType = generate(node.key).rawValue
-    let valueType = generate(node.value).rawValue
+  public func generate(_ node: DictionaryTypeSyntax) -> BridgedTypeRepr {
+    let keyType = generate(node.key)
+    let valueType = generate(node.value)
     let colonLoc = node.colon.bridgedSourceLoc(in: self)
     let lSquareLoc = node.leftSquare.bridgedSourceLoc(in: self)
     let rSquareLoc = node.rightSquare.bridgedSourceLoc(in: self)
-    return .type(
-      DictionaryTypeRepr_create(self.ctx, keyType, valueType, colonLoc, lSquareLoc, rSquareLoc))
-  }
-
-  public func generate(_ node: MetatypeTypeSyntax) -> ASTNode {
-    let baseType = generate(node.baseType).rawValue
-    let tyLoc = node.metatypeSpecifier.bridgedSourceLoc(in: self)
-    if node.metatypeSpecifier.text == "Type" {
-      return .type(MetatypeTypeRepr_create(self.ctx, baseType, tyLoc))
-    } else {
-      assert(node.metatypeSpecifier.text == "Protocol")
-      return .type(ProtocolTypeRepr_create(self.ctx, baseType, tyLoc))
-    }
-  }
-
-  public func generate(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) -> ASTNode {
-    let base = generate(node.wrappedType).rawValue
-    let exclaimLoc = node.exclamationMark.bridgedSourceLoc(in: self)
-    return .type(ImplicitlyUnwrappedOptionalTypeRepr_create(self.ctx, base, exclaimLoc))
-  }
-
-  public func generate(_ node: OptionalTypeSyntax) -> ASTNode {
-    let base = generate(node.wrappedType).rawValue
-    let questionLoc = node.questionMark.bridgedSourceLoc(in: self)
-    return .type(OptionalTypeRepr_create(self.ctx, base, questionLoc))
-  }
-
-  public func generate(_ node: PackExpansionTypeSyntax) -> ASTNode {
-    let base = generate(node.repetitionPattern).rawValue
-    let repeatLoc = node.repeatKeyword.bridgedSourceLoc(in: self)
-    return .type(PackExpansionTypeRepr_create(self.ctx, base, repeatLoc))
-  }
-
-  public func generate(_ node: TupleTypeSyntax) -> ASTNode {
-    .type(
-      TupleTypeRepr_create(
-        self.ctx,
-        self.generate(node.elements),
-        node.leftParen.bridgedSourceLoc(in: self),
-        node.rightParen.bridgedSourceLoc(in: self)
-      )
+    return BridgedDictionaryTypeRepr.createParsed(
+      self.ctx, leftSquareLoc: lSquareLoc, keyType: keyType, colonLoc: colonLoc,
+      valueType: valueType, rightSquareLoc: rSquareLoc
     )
   }
 
-  public func generate(_ node: CompositionTypeSyntax) -> ASTNode {
+  public func generate(_ node: MetatypeTypeSyntax) -> BridgedTypeRepr {
+    let baseType = generate(node.baseType)
+    let tyLoc = node.metatypeSpecifier.bridgedSourceLoc(in: self)
+    if node.metatypeSpecifier.text == "Type" {
+      return BridgedMetatypeTypeRepr.createParsed(
+        self.ctx, base: baseType, typeKeywordLoc: tyLoc
+      )
+    } else {
+      assert(node.metatypeSpecifier.text == "Protocol")
+      return BridgedProtocolTypeRepr.createParsed(
+        self.ctx, base: baseType, protocolKeywordLoc: tyLoc
+      )
+    }
+  }
+
+  public func generate(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) -> BridgedTypeRepr {
+    let base = generate(node.wrappedType)
+    let exclaimLoc = node.exclamationMark.bridgedSourceLoc(in: self)
+    return BridgedImplicitlyUnwrappedOptionalTypeRepr.createParsed(
+      self.ctx, base: base, exclaimLoc: exclaimLoc
+    )
+  }
+
+  public func generate(_ node: OptionalTypeSyntax) -> BridgedTypeRepr {
+    let base = generate(node.wrappedType)
+    let questionLoc = node.questionMark.bridgedSourceLoc(in: self)
+    return BridgedOptionalTypeRepr.createParsed(
+      self.ctx, base: base, questionLoc: questionLoc
+    )
+  }
+
+  public func generate(_ node: PackExpansionTypeSyntax) -> BridgedTypeRepr {
+    let base = generate(node.repetitionPattern)
+    let repeatLoc = node.repeatKeyword.bridgedSourceLoc(in: self)
+    return BridgedPackExpansionTypeRepr.createParsed(
+      self.ctx, base: base, repeatKeywordLoc: repeatLoc
+    )
+  }
+
+  public func generate(_ node: TupleTypeSyntax) -> BridgedTypeRepr {
+    BridgedTupleTypeRepr.createParsed(
+      self.ctx,
+      elements: self.generate(node.elements),
+      leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
+      rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
+    )
+  }
+
+  public func generate(_ node: CompositionTypeSyntax) -> BridgedTypeRepr {
     assert(node.elements.count > 1)
 
     let types = node.elements.lazy.map {
-      generate($0.type).rawValue
+      generate($0.type)
     }
 
-    return .type(
-      CompositionTypeRepr_create(
-        self.ctx,
-        types.bridgedArray(in: self),
-        (node.elements.first?.type).bridgedSourceLoc(in: self),
-        (node.elements.first?.ampersand).bridgedSourceLoc(in: self)
-      )
+    return BridgedCompositionTypeRepr.createParsed(
+      self.ctx,
+      types: types.bridgedArray(in: self),
+      ampersandLoc: (node.elements.first?.ampersand).bridgedSourceLoc(in: self)
     )
   }
 
-  public func generate(_ node: FunctionTypeSyntax) -> ASTNode {
-    .type(
-      FunctionTypeRepr_create(
+  public func generate(_ node: FunctionTypeSyntax) -> BridgedTypeRepr {
+    BridgedFunctionTypeRepr.createParsed(
+      self.ctx,
+      // FIXME: Why does `FunctionTypeSyntax` not have a `TupleTypeSyntax` child?
+      argsType: BridgedTupleTypeRepr.createParsed(
         self.ctx,
-        // FIXME: Why does `FunctionTypeSyntax` not have a `TupleTypeSyntax` child?
-        TupleTypeRepr_create(
-          self.ctx,
-          self.generate(node.parameters),
-          node.leftParen.bridgedSourceLoc(in: self),
-          node.rightParen.bridgedSourceLoc(in: self)
-        ),
-        (node.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
-        (node.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-        self.generate(node.effectSpecifiers?.thrownError?.type)?.rawValue,
-        node.returnClause.arrow.bridgedSourceLoc(in: self),
-        generate(node.returnClause.type).rawValue
-      )
+        elements: self.generate(node.parameters),
+        leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
+        rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
+      ),
+      asyncLoc: (node.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
+      throwsLoc: (node.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
+      thrownType: self.generate(node.effectSpecifiers?.thrownError?.type),
+      arrowLoc: node.returnClause.arrow.bridgedSourceLoc(in: self),
+      resultType: generate(node.returnClause.type)
     )
   }
 
-  public func generate(_ node: NamedOpaqueReturnTypeSyntax) -> ASTNode {
-    let baseTy = generate(node.type).rawValue
-    return .type(NamedOpaqueReturnTypeRepr_create(self.ctx, baseTy))
+  public func generate(_ node: NamedOpaqueReturnTypeSyntax) -> BridgedTypeRepr {
+    let baseTy = generate(node.type)
+    return BridgedNamedOpaqueReturnTypeRepr.createParsed(self.ctx, base: baseTy)
   }
 
-  public func generate(_ node: SomeOrAnyTypeSyntax) -> ASTNode {
+  public func generate(_ node: SomeOrAnyTypeSyntax) -> BridgedTypeRepr {
     let someOrAnyLoc = node.someOrAnySpecifier.bridgedSourceLoc(in: self)
-    let baseTy = generate(node.constraint).rawValue
+    let baseTy = generate(node.constraint)
     if node.someOrAnySpecifier.text == "some" {
-      return .type(OpaqueReturnTypeRepr_create(self.ctx, someOrAnyLoc, baseTy))
+      return BridgedOpaqueReturnTypeRepr.createParsed(
+        self.ctx, someKeywordLoc: someOrAnyLoc, base: baseTy
+      )
     } else {
       assert(node.someOrAnySpecifier.text == "any")
-      return .type(ExistentialTypeRepr_create(self.ctx, someOrAnyLoc, baseTy))
+      return BridgedExistentialTypeRepr.createParsed(
+        self.ctx, anyKeywordLoc: someOrAnyLoc, base: baseTy
+      )
     }
   }
 }
@@ -200,13 +214,16 @@ extension BridgedAttributedTypeSpecifier {
 }
 
 extension ASTGenVisitor {
-  public func generate(_ node: AttributedTypeSyntax) -> ASTNode {
+  public func generate(_ node: AttributedTypeSyntax) -> BridgedTypeRepr {
     var type = generate(node.baseType)
 
     // Handle specifiers.
     if let specifier = node.specifier {
       if let kind = BridgedAttributedTypeSpecifier(from: specifier.tokenKind) {
-        type = .type(AttributedTypeSpecifierRepr_create(self.ctx, type.rawValue, kind, specifier.bridgedSourceLoc(in: self)))
+        type = BridgedSpecifierTypeRepr.createParsed(
+          self.ctx, base: type, specifier: kind, 
+          specifierLoc: specifier.bridgedSourceLoc(in: self)
+        )
       } else {
         self.diagnose(Diagnostic(node: specifier, message: UnexpectedTokenKindError(token: specifier)))
       }
@@ -260,7 +277,9 @@ extension ASTGenVisitor {
         }
       }
 
-      type = .type(AttributedTypeRepr_create(self.ctx, type.rawValue, typeAttributes))
+      type = BridgedAttributedTypeRepr.createParsed(
+        self.ctx, base: type, attributes: typeAttributes
+      )
     }
 
     return type
@@ -272,9 +291,11 @@ extension ASTGenVisitor {
     node.lazy.map { element in
       let (firstName, firstNameLoc) = element.firstName.bridgedIdentifierAndSourceLoc(in: self)
       let (secondName, secondNameLoc) = element.secondName.bridgedIdentifierAndSourceLoc(in: self)
-      var type = generate(element.type).rawValue
+      var type = generate(element.type)
       if let ellipsis = element.ellipsis {
-        type = VarargTypeRepr_create(self.ctx, type, ellipsis.bridgedSourceLoc(in: self))
+        type = BridgedVarargTypeRepr.createParsed(
+          self.ctx, base: type, ellipsisLoc: ellipsis.bridgedSourceLoc(in: self)
+        )
       }
 
       return BridgedTupleTypeElement(
@@ -325,5 +346,5 @@ func buildTypeRepr(
     sourceBuffer: sourceFile.pointee.buffer,
     declContext: BridgedDeclContext(raw: dc),
     astContext: BridgedASTContext(raw: ctx)
-  ).generate(typeSyntax).rawValue
+  ).generate(typeSyntax).raw
 }


### PR DESCRIPTION
Stamp out wrapper types for all the AST nodes, and use them for ASTGen, with members being imported on those types.

Resolves #68346
Resolves #68348
rdar://117159010