### PR TITLE
Update Windows-x86_64.cmake

### DIFF
--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -152,6 +152,7 @@ set(SWIFT_INSTALL_COMPONENTS
       sourcekit-inproc
       swift-remote-mirror
       swift-remote-mirror-headers
+      swift-syntax-lib
     CACHE STRING "")
 
 set(LLVM_DISTRIBUTION_COMPONENTS


### PR DESCRIPTION
Add `swift-syntax-lib` component to the distribution set.