### PR TITLE
[TypeChecker] Make `couldDynamicallyConformToProtocol` more leanient

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5904,7 +5904,8 @@ TypeChecker::couldDynamicallyConformToProtocol(Type type, ProtocolDecl *Proto,
   // as an intermediate collection cast can dynamically change if the conditions
   // are met or not.
   if (type->isKnownStdlibCollectionType())
-    return !M->lookupConformance(type, Proto).isInvalid();
+    return !M->lookupConformance(type, Proto, /*allowMissing=*/true)
+                .isInvalid();
   return !conformsToProtocol(type, Proto, M).isInvalid();
 }
 

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -751,3 +751,10 @@ do {
     _ = a is String // OK
   }
 }
+
+// rdar://115603144 - casting `any Sendable` to a collection warns about cast failure although the cast could succeed at runtime
+func test_existential_sendable_cast(v: any Sendable) {
+  let _ = v as! [Any] // Ok
+  let _ = v as! [String: Any] // Ok
+  let _ = v as! Set<Int> // Ok
+}


### PR DESCRIPTION
Current check is too strict for stdlib collection types because it checks conditional conformances which leads to erroneous warnings.

To determine whether a type dynamically conforms to a protocol, for stdlib collection types, 
the method is employing `Module::lookupConformance` check which has `allowMissing` 
conformances set to `false` by default. That directly contradicts the comment which states
that the conditional conformances are to be skipped and doesn't fit well with 
`TypeChecker::conformsToProtocol` check below it that defaults `allowMissing` to `true`.

Resolves: rdar://115603144

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
