### PR TITLE
[Macros] Update for CompilerPluginMessageListener

### DIFF
--- a/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
+++ b/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
@@ -40,11 +40,11 @@ final class SwiftPluginServer {
   /// @main entry point.
   static func main() throws {
     let connection = try PluginHostConnection()
-    let messageHandler = CompilerPluginMessageHandler(
+    let listener = CompilerPluginMessageListener(
       connection: connection,
       provider: self.init()
     )
-    try messageHandler.main()
+    try listener.main()
   }
 }
 


### PR DESCRIPTION
Update for https://github.com/apple/swift-syntax/pull/2301
Use `CompilerPluginMessageListener` instead of `CompilerPluginMessageHandler`