### PR TITLE
[5.10] Optimizer: better handling of the complexity budget in redundant-load-elimination and dead-store-elimination

### DIFF
--- a/validation-test/SILOptimizer/rle_dse_complexity.swift
+++ b/validation-test/SILOptimizer/rle_dse_complexity.swift
@@ -1,0 +1,26 @@
+
+// The compiler should finish in about 5 seconds. To give some slack,
+// specify a timeout of 60 seconds
+// If the compiler needs more than 60 seconds, there is probably a real problem.
+// So please don't just increase the timeout in case this test fails.
+
+// RUN: %{python} %S/../../test/Inputs/timeout.py 60 %target-swift-frontend -O -parse-as-library -sil-verify-none -emit-sil %s | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=aarch64
+// REQUIRES: OS=macosx
+
+import Darwin
+
+// Check that redundant-load-elimination and dead-store-elimination don't take
+// extermely long when optimizing statfs, which contains a 1023-element tuple.
+
+// CHECK-LABEL: test_rle_dse_compile_time
+public func test_rle_dse_compile_time(_ s: statfs) {
+  withUnsafePointer(to: s.f_mntonname) {
+    $0.withMemoryRebound(to: UInt8.self, capacity: Int(MAXPATHLEN)) { (str) in
+      print(str)
+    }
+  }
+}
+


### PR DESCRIPTION
* **Explanation**: This fixes a compile time problem which occurs when using large C arrays, like the 1023-character path array in `statfs`.  C-arrays are imported as tuples and cause the size of the SIL to explode if such arrays are large. Both, redundant-load-elimination and dead-store-elimination, already had a protection against quadratic complexity when processing huge SIL functions, but only per single `load` and `store` operation. The fix for this problem is to have a complexity budget for the whole function. This catches cases where generated SIL contains a very large number of `load` and `store` instructions.

* **Issue**: rdar://116877696

* **Risk**: Low. The risk is not so much on functional correctness, because this change only affects when the optimization bails out. The risk is more about potential performance regressions. But the complexity limits are pretty large and should only trigger in rare cases.

* **Testing**: With a regression test

* **Reviewer**: @atrick

* **Main branch PR**: https://github.com/apple/swift/pull/69199
