### PR TITLE
[embedded] Fix an LLVMARCOpts crash by avoiding direct calls to swift_retain/swift_release

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -131,7 +131,9 @@ public func swift_isUniquelyReferenced_nonNull_native(object: UnsafeMutablePoint
 
 @_silgen_name("swift_retain")
 public func swift_retain(object: Builtin.RawPointer) -> Builtin.RawPointer {
-  return swift_retain_n(object: object, n: 1)
+  if Int(Builtin.ptrtoint_Word(object)) == 0 { return object }
+  let o = UnsafeMutablePointer<HeapObject>(object)
+  return swift_retain_n_(object: o, n: 1)._rawValue
 }
 
 // Cannot use UnsafeMutablePointer<HeapObject>? directly in the function argument or return value as it causes IRGen crashes
@@ -155,7 +157,9 @@ func swift_retain_n_(object: UnsafeMutablePointer<HeapObject>, n: UInt32) -> Uns
 
 @_silgen_name("swift_release")
 public func swift_release(object: Builtin.RawPointer) {
-  swift_release_n(object: object, n: 1)
+  if Int(Builtin.ptrtoint_Word(object)) == 0 { return }
+  let o = UnsafeMutablePointer<HeapObject>(object)
+  swift_release_n_(object: o, n: 1)
 }
 
 @_silgen_name("swift_release_n")

--- a/test/embedded/arc-crash.swift
+++ b/test/embedded/arc-crash.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -assert-config Debug -Osize -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: optimized_stdlib
+
+public func test() {}
+test()
+
+// CHECK: define {{.*}}i32 @main

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -1,3 +1,8 @@
+// Regression test for a "Ouroboros Bug": The ARC optimizer doesn't like the
+// presense of a direct call to swift_retain and swift_release in any Swift
+// code, but in the embedded Swift's runtime that's somewhat reasonable thing
+// to do (but is to be avoided because of this).
+
 // RUN: %target-swift-frontend -target armv7-apple-none-macho -assert-config Debug -Osize -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 


### PR DESCRIPTION
The attached testcase causes a compiler crash (by using `-assert-config Debug -Osize` compilation flags). Turns out that the ARC optimizer doesn't like the presense of a direct call to swift_retain and swift_release in any Swift code, which is present in embedded runtime (EmbeddedRuntime.swift). Let's simply avoid that.

```
These are only created by LLVMARCContract !
UNREACHABLE executed at /Users/kuba/swift-github-main/swift/lib/LLVMPasses/LLVMARCOpts.cpp:99!
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
7  swift-frontend           0x0000000104dda3b4 runSwiftARCOpts(llvm::Function&, swift::SwiftRCIdentity&) + 7880
8  swift-frontend           0x0000000104dda480 swift::SwiftARCOptPass::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) + 48
9  swift-frontend           0x00000001092bf0d4 llvm::PassManager<llvm::Function, llvm::AnalysisManager<llvm::Function>>::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) + 308
10 swift-frontend           0x0000000108d5fa20 llvm::CGSCCToFunctionPassAdaptor::run(llvm::LazyCallGraph::SCC&, llvm::AnalysisManager<llvm::LazyCallGraph::SCC, llvm::LazyCallGraph&>&, llvm::LazyCallGraph&, llvm::CGSCCUpdateResult&) + 984
11 swift-frontend           0x0000000108d5bec4 llvm::PassManager<llvm::LazyCallGraph::SCC, llvm::AnalysisManager<llvm::LazyCallGraph::SCC, llvm::LazyCallGraph&>, llvm::LazyCallGraph&, llvm::CGSCCUpdateResult&>::run(llvm::LazyCallGraph::SCC&, llvm::AnalysisManager<llvm::LazyCallGraph::SCC, llvm::LazyCallGraph&>&, llvm::LazyCallGraph&, llvm::CGSCCUpdateResult&) + 376
```

Fixes rdar://117162118.