### PR TITLE
[Embedded] add provisional support for building armv6(m) eabi embedded targets

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -277,6 +277,15 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
   SmallString<128> SharedResourceDirPath;
   getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
 
+  bool embeddedEnabled = false;
+  for (const Arg *A : context.Args.filtered(options::OPT_enable_experimental_feature)) {
+    StringRef value = A->getValue();
+    if (value == "Embedded") {
+      embeddedEnabled = true;
+      break;
+    }
+  }
+
   SmallString<128> swiftrtPath = SharedResourceDirPath;
   llvm::sys::path::append(swiftrtPath,
                           swift::getMajorArchitectureName(getTriple()));
@@ -341,6 +350,8 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
     llvm::sys::path::append(linkFilePath, "static-executable-args.lnk");
   } else if (staticStdlib) {
     llvm::sys::path::append(linkFilePath, "static-stdlib-args.lnk");
+  } else if (embeddedEnabled) {
+    linkFilePath.clear();
   } else {
     linkFilePath.clear();
     Arguments.push_back("-lswiftCore");

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -146,6 +146,9 @@ if(SWIFT_BUILD_STDLIB)
 
   set(EMBEDDED_STDLIB_TARGET_TRIPLES
     # arch    module_name               target triple
+    "armv6    armv6-none-none-eabi      armv6-none-none-eabi"
+    "armv7    armv7-none-none-eabi      armv7-none-none-eabi"
+    "armv6    armv6-apple-none-macho    armv6-apple-none-macho"
     "armv7    armv7-apple-none-macho    armv7-apple-none-macho"
     "arm64    arm64-apple-none-macho    arm64-apple-none-macho"
     "x86_64   x86_64-apple-macos        x86_64-apple-macos10.13"

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -262,6 +262,7 @@ class StdlibDeploymentTarget(object):
     # to build the stdlib as standalone and/or statically linked.
     Freestanding = Platform("freestanding", archs=[
         "i386", "x86_64",
+        "armv6", "armv6m",
         "armv7", "armv7s", "armv7k", "armv7m", "armv7em",
         "arm64", "arm64e", "arm64_32"])
 


### PR DESCRIPTION
This allows a compiler to be built that supports emitting code for armv6-none-none-eabi targets (which are commonly used for systems like RP2040, Arduino Uno R4 and others). 

This does not provide a standard library, libc, compiler c runtime, linker, assembler, or librarian. 

This does provide the knowledge to the compiler that target triple exists.