### PR TITLE
Options: Make -experimental-lazy-typecheck a driver option

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -444,9 +444,6 @@ def debug_forbid_typecheck_prefix : Separate<["-"], "debug-forbid-typecheck-pref
   HelpText<"Triggers llvm fatal_error if typechecker tries to typecheck a decl "
            "with the provided prefix name">;
 
-def experimental_lazy_typecheck : Flag<["-"], "experimental-lazy-typecheck">,
-  HelpText<"Type-check lazily as needed to produce requested outputs">;
-
 def debug_emit_invalid_swiftinterface_syntax : Flag<["-"], "debug-emit-invalid-swiftinterface-syntax">,
   HelpText<"Write an invalid declaration into swiftinterface files">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1887,6 +1887,11 @@ def cache_replay_prefix_map: Separate<["-"], "cache-replay-prefix-map">,
   Flags<[FrontendOption, NoDriverOption, CacheInvariant]>,
   HelpText<"Remap paths when replaying outputs from cache">, MetaVarName<"<prefix=replacement>">;
 
+def experimental_lazy_typecheck :
+  Flag<["-"], "experimental-lazy-typecheck">,
+  Flags<[FrontendOption, NewDriverOnlyOption, HelpHidden]>,
+  HelpText<"Type-check lazily as needed to produce requested outputs">;
+
 // END ONLY SUPPORTED IN NEW DRIVER
 
 


### PR DESCRIPTION
It should not just be a frontend option.

Partially resolves rdar://117168788.
