### PR TITLE
[5.10] Options: Make -experimental-lazy-typecheck a driver option

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -448,9 +448,6 @@ def debug_forbid_typecheck_prefix : Separate<["-"], "debug-forbid-typecheck-pref
   HelpText<"Triggers llvm fatal_error if typechecker tries to typecheck a decl "
            "with the provided prefix name">;
 
-def experimental_lazy_typecheck : Flag<["-"], "experimental-lazy-typecheck">,
-  HelpText<"Type-check lazily as needed to produce requested outputs">;
-
 def debug_emit_invalid_swiftinterface_syntax : Flag<["-"], "debug-emit-invalid-swiftinterface-syntax">,
   HelpText<"Write an invalid declaration into swiftinterface files">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1853,6 +1853,11 @@ def clang_scanner_module_cache_path : Separate<["-"], "clang-scanner-module-cach
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Specifies the Clang dependency scanner module cache path">;
 
+def experimental_lazy_typecheck :
+  Flag<["-"], "experimental-lazy-typecheck">,
+  Flags<[FrontendOption, NewDriverOnlyOption, HelpHidden]>,
+  HelpText<"Type-check lazily as needed to produce requested outputs">;
+
 // END ONLY SUPPORTED IN NEW DRIVER
 
 


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/69259.

It should not just be a frontend option.

Partially resolves rdar://117168788.
