### PR TITLE
Frontend: Enable -unavailable-decl-optimization=stub by default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -197,7 +197,7 @@ namespace swift {
 
     /// Optimization mode for unavailable declarations.
     UnavailableDeclOptimization UnavailableDeclOptimizationMode =
-        UnavailableDeclOptimization::None;
+        UnavailableDeclOptimization::Stub;
 
     /// Causes the compiler to use weak linkage for symbols belonging to
     /// declarations introduced at the deployment target.

--- a/test/IRGen/float16_macos.swift
+++ b/test/IRGen/float16_macos.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-ir %s -target x86_64-apple-macos10.15 | %FileCheck %s
-// RUN: %target-swift-frontend -emit-ir %s -target x86_64-apple-macos11 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -unavailable-decl-optimization=none %s -target x86_64-apple-macos10.15 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -unavailable-decl-optimization=none %s -target x86_64-apple-macos11 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/unavailable_decl_optimization_complete_nested_type.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_nested_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=none %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
 
 // RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
 

--- a/test/IRGen/unavailable_decl_optimization_complete_struct.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_struct.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=none %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
 
 // RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
 

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.50 -emit-module -emit-module-path %t/weak_import_availability_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_availability_helper.swift -enable-library-evolution
 //
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-OLD
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.50 | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.60 | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx10.50 | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx10.60 | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
 
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.50 -weak-link-at-target | %FileCheck %s --check-prefixes=CHECK,CHECK-OLD
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.60 -weak-link-at-target | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx10.50 -weak-link-at-target | %FileCheck %s --check-prefixes=CHECK,CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -unavailable-decl-optimization=none -emit-ir -target %target-cpu-apple-macosx10.60 -weak-link-at-target | %FileCheck %s --check-prefixes=CHECK,CHECK-NEW
 
 // REQUIRES: OS=macosx
 

--- a/test/Interpreter/unavailable_decl_optimization_stub.swift
+++ b/test/Interpreter/unavailable_decl_optimization_stub.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -module-name main -Xfrontend -unavailable-decl-optimization=stub %s -o %t/a.out
+// RUN: %target-build-swift -module-name main %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out > %t/output 2>&1 || true
 // RUN: %FileCheck %s < %t/output


### PR DESCRIPTION
By default the compiler will now replace the bodies of unavailable functions with stubs that call `_diagnoseUnavailableCodeReached()` instead.

Resolves rdar://116019744
