### PR TITLE
[embedded] Allow metadata for DynamicSelfType to support using Self in classes

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -90,7 +90,8 @@ inline bool isEmbedded(CanType t) {
 }
 
 inline bool isMetadataAllowedInEmbedded(CanType t) {
-  return isa<ClassType>(t) || isa<BoundGenericClassType>(t);
+  return isa<ClassType>(t) || isa<BoundGenericClassType>(t) ||
+         isa<DynamicSelfType>(t);
 }
 
 inline bool isEmbedded(Decl *d) {

--- a/test/embedded/dynamic-self.swift
+++ b/test/embedded/dynamic-self.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+class MyClass {
+     init() {
+          Self.static_foo()
+     }
+
+     static func static_foo() {}
+}
+
+@main
+struct Main {
+     static func main() {
+          _ = MyClass()
+     }
+}
+
+// CHECK: define {{.*}}@main(

--- a/test/embedded/dynamic-self.swift
+++ b/test/embedded/dynamic-self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -parse-as-library -module-name main | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: VENDOR=apple


### PR DESCRIPTION
Looking for some guidance on this :) The immediate problem I observed is that in a class method, using Self ends up emitting a thick metadata instruction for the dynamic self type and that fails the current assert we have for embedded Swift. This particular case seems to be fixable by just allowing metadata emission on DynamicSelfType in IRGen, but I'm wondering if there's any other considerations for dynamic self we need to take into look into :)

Fixes rdar://117174867