### PR TITLE
[Concurrency] Close a hole that allowed non-`Sendable` types to cross isolation boundaries in initializers.

### DIFF
--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -824,6 +824,7 @@ actor SomeActorWithInits {
   // expected-note@+1 3 {{mutation of this property is only permitted within the actor}}
   var mutableState: Int = 17
   var otherMutableState: Int
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
   let nonSendable: SomeClass
 
   // Sema should not complain about referencing non-sendable members
@@ -887,7 +888,7 @@ actor SomeActorWithInits {
   @MainActor init(i5 x: SomeClass) {
     self.mutableState = 42
     self.otherMutableState = 17
-    self.nonSendable = x
+    self.nonSendable = x // expected-warning {{actor-isolated property 'nonSendable' can not be mutated from the main actor; this is an error in Swift 6}}
 
     self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from the main actor; this is an error in Swift 6}}
     self.nonisolated()

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -324,17 +324,30 @@ struct WrapperOnActor<Wrapped: Sendable> {
 public struct WrapperOnMainActor<Wrapped> {
   // Make sure inference of @MainActor on wrappedValue doesn't crash.
   
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
   public var wrappedValue: Wrapped
 
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
+    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context; this is an error in Swift 6}}
     self.wrappedValue = wrappedValue
   }
 }
 
 @propertyWrapper
-public struct WrapperOnMainActor2<Wrapped> {
+public struct WrapperOnMainActorNonSendable<Wrapped> {
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
+  @MainActor public var wrappedValue: Wrapped
+
+  public init(wrappedValue: Wrapped) {
+    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+    self.wrappedValue = wrappedValue
+  }
+}
+
+@propertyWrapper
+public struct WrapperOnMainActorSendable<Wrapped: Sendable> {
   @MainActor public var wrappedValue: Wrapped
 
   public init(wrappedValue: Wrapped) {

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -69,11 +69,13 @@ struct WrapperOnActor<Wrapped: Sendable> {
 public struct WrapperOnMainActor<Wrapped> {
   // Make sure inference of @MainActor on wrappedValue doesn't crash.
 
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
   public var wrappedValue: Wrapped // expected-note {{property declared here}}
 
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
+    // expected-error@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context}}
     self.wrappedValue = wrappedValue
   }
 }


### PR DESCRIPTION
Initializing a global actor isolated stored property with a non-`Sendable` value is effectively passing that non-`Sendable` value into a global actor isolated context. It is invalid for the initialization to happen from outside the actor, e.g. in a `nonisolated init`. However, this code is currently accepted

```swift
class NonSendable {}

class C {
  @MainActor var ns: NonSendable

  init(ns: NonSendable) {
    self.ns = ns
  }
}
```

This code passed the actor isolation checker due to the carve outs for diagnostics that are deferred to the flow-sensitive isolation pass, which also doesn't handle non-`Sendable` types crossing isolation boundaries via stored property initialization. The solution is to only allow those carve outs for `Sendable` stored property types.

Resolves rdar://91257332