### PR TITLE
[Test][Backtracing] Disable FatalError test for macOS.

### DIFF
--- a/test/Backtracing/FatalError.swift
+++ b/test/Backtracing/FatalError.swift
@@ -8,8 +8,7 @@
 // UNSUPPORTED: asan
 // REQUIRES: executable_test
 // REQUIRES: backtracing
-// REQUIRES: OS=macosx || OS=linux-gnu
-// REQUIRES: rdar116790881
+// REQUIRES: OS=linux-gnu
 
 func level1() {
   level2()

--- a/test/Backtracing/FatalError.swift
+++ b/test/Backtracing/FatalError.swift
@@ -9,6 +9,7 @@
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: rdar116790881
 
 func level1() {
   level2()


### PR DESCRIPTION
Temporarily disable the FatalError backtracing test for macOS only; some CI nodes need a software update before the test will pass.