### PR TITLE
[AddressLowering] Move into secondary use.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -451,12 +451,12 @@ void ValueStorageMap::ValueStoragePair::dump() const {
     llvm::dbgs() << "UNKNOWN!\n";
   storage.dump();
 }
-void ValueStorageMap::dumpProjections(SILValue value) {
+void ValueStorageMap::dumpProjections(SILValue value) const {
   for (auto *pair : getProjections(value)) {
     pair->dump();
   }
 }
-void ValueStorageMap::dump() {
+void ValueStorageMap::dump() const {
   llvm::dbgs() << "ValueStorageMap:\n";
   for (unsigned ordinal : indices(valueVector)) {
     auto &valStoragePair = valueVector[ordinal];

--- a/lib/SILOptimizer/Mandatory/AddressLowering.h
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.h
@@ -396,8 +396,8 @@ public:
   bool isComposingUseProjection(Operand *oper) const;
 
 #ifndef NDEBUG
-  void dumpProjections(SILValue value);
-  void dump();
+  void dumpProjections(SILValue value) const;
+  void dump() const;
 #endif
 };
 

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -60,6 +60,10 @@ struct Pair<T> {
   var y : T
 }
 
+struct Box<T> {
+  var t: T
+}
+
 struct Box2<T, U> {
     var v1: T
     var v2: U
@@ -2708,6 +2712,44 @@ entry:
   end_borrow %lifetime : $T
   dealloc_stack %addr : $*T
   destroy_value %instance : $T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_struct_1_two_use_projections : {{.*}} {
+// CHECK:         [[S_ADDR:%[^,]+]] = alloc_stack $Box<T>                        
+// CHECK:         [[S2_ADDR:%[^,]+]] = alloc_stack $Box<T>                        
+// CHECK:         [[S_FIELD_ADDR:%[^,]+]] = struct_element_addr [[S_ADDR]] : $*Box<T>, #Box.t  
+// CHECK:         apply undef<T>([[S_FIELD_ADDR]])
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]                         
+// CHECK:       [[RIGHT]]:                                              
+// CHECK:         destroy_addr [[S_ADDR]] : $*Box<T>                      
+// CHECK:         br [[EXIT:bb[0-9]+]]                                          
+// CHECK:       [[LEFT]]:                                              
+// CHECK:         [[S2_FIELD_ADDR:%[^,]+]] = struct_element_addr [[S2_ADDR]] : $*Box<T>, #Box.t  
+// CHECK:         copy_addr [take] [[S_FIELD_ADDR]] to [init] [[S2_FIELD_ADDR]]
+// CHECK:         destroy_addr [[S2_ADDR]] : $*Box<T>                      
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[EXIT]]:                                              
+// CHECK:         dealloc_stack [[S2_ADDR]] : $*Box<T>                     
+// CHECK:         dealloc_stack [[S_ADDR]] : $*Box<T>                     
+// CHECK-LABEL: } // end sil function 'test_struct_1_two_use_projections'
+sil [ossa] @test_struct_1_two_use_projections : $@convention(thin) <T> () -> () {
+entry:
+  %box = apply undef<T>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, left, right
+
+left:
+  %s2 = struct $Box<T>(%box : $T)
+  destroy_value %s2 : $Box<T>
+  br exit
+
+right:
+  %s = struct $Box<T>(%box : $T)
+  destroy_value %s : $Box<T>
+  br exit
+
+exit:
   %retval = tuple ()
   return %retval : $()
 }


### PR DESCRIPTION
If a value's storage is a use projection out of some use, AddressLowering correctly does not move into that storage when initializing the composing use of the operand for the user into whose storage it projects.

Previously, however, it was only checked that the value's storage was a use projection at all.  When initializing the composing use of the operand of some _other_ user of the value (i.e. a user into whose storage it does _not_ project), the result was a missing move.

Here, this is fixed by only skipping the move when the value's storage is a projection _and_ it projects into the storage of the user of the operand at hand.
