### PR TITLE
nonisolated(unsafe) to opt out of strict concurrency static checking for global variables

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -60,6 +60,9 @@ public:
     /// meaning that it can be used from any actor but is also unable to
     /// refer to the isolated state of any given actor.
     Nonisolated,
+    /// The declaration is explicitly specified to be not isolated and with the
+    /// "unsafe" annotation, which means that we do not enforce isolation.
+    NonisolatedUnsafe,
     /// The declaration is isolated to a global actor. It can refer to other
     /// entities with the same global actor.
     GlobalActor,
@@ -97,8 +100,8 @@ public:
     return ActorIsolation(Unspecified, nullptr);
   }
 
-  static ActorIsolation forNonisolated() {
-    return ActorIsolation(Nonisolated, nullptr);
+  static ActorIsolation forNonisolated(bool unsafe) {
+    return ActorIsolation(unsafe ? NonisolatedUnsafe : Nonisolated, nullptr);
   }
 
   static ActorIsolation forActorInstanceSelf(NominalTypeDecl *actor) {
@@ -124,8 +127,10 @@ public:
   operator Kind() const { return getKind(); }
 
   bool isUnspecified() const { return kind == Unspecified; }
-  
-  bool isNonisolated() const { return kind == Nonisolated; }
+
+  bool isNonisolated() const {
+    return (kind == Nonisolated) || (kind == NonisolatedUnsafe);
+  }
 
   /// Retrieve the parameter to which actor-instance isolation applies.
   ///
@@ -144,6 +149,7 @@ public:
 
     case Unspecified:
     case Nonisolated:
+    case NonisolatedUnsafe:
       return false;
     }
   }
@@ -192,6 +198,7 @@ public:
 
     switch (lhs.getKind()) {
     case Nonisolated:
+    case NonisolatedUnsafe:
     case Unspecified:
       return true;
 

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -499,7 +499,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(async, Async,
 SIMPLE_DECL_ATTR(reasync, Reasync,
   OnFunc | OnConstructor | RejectByParser | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   109)
-CONTEXTUAL_SIMPLE_DECL_ATTR(nonisolated, Nonisolated,
+CONTEXTUAL_DECL_ATTR(nonisolated, Nonisolated,
   DeclModifier | OnFunc | OnConstructor | OnVar | OnSubscript | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   112)
 CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -187,6 +187,10 @@ protected:
     SWIFT_INLINE_BITFIELD(ObjCImplementationAttr, DeclAttribute, 1,
       isCategoryNameInvalid : 1
     );
+
+    SWIFT_INLINE_BITFIELD(NonisolatedAttr, DeclAttribute, 1,
+      isUnsafe : 1
+    );
   } Bits;
   // clang-format on
 
@@ -2431,6 +2435,26 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_ObjCImplementation;
+  }
+};
+
+/// Represents nonisolated modifier.
+class NonisolatedAttr final : public DeclAttribute {
+public:
+  NonisolatedAttr(SourceLoc atLoc, SourceRange range, bool unsafe,
+                  bool implicit)
+      : DeclAttribute(DAK_Nonisolated, atLoc, range, implicit) {
+    Bits.NonisolatedAttr.isUnsafe = unsafe;
+    assert((isUnsafe() == unsafe) && "not enough bits for unsafe state");
+  }
+
+  NonisolatedAttr(bool unsafe, bool implicit)
+      : NonisolatedAttr({}, {}, unsafe, implicit) {}
+
+  bool isUnsafe() const { return Bits.NonisolatedAttr.isUnsafe; }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_Nonisolated;
   }
 };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6128,7 +6128,10 @@ public:
   /// True if this is a top-level global variable from the main source file.
   bool isTopLevelGlobal() const { return Bits.VarDecl.IsTopLevelGlobal; }
   void setTopLevelGlobal(bool b) { Bits.VarDecl.IsTopLevelGlobal = b; }
-  
+
+  /// True if this is any storage of static duration (global scope or static).
+  bool isGlobalStorage() const;
+
   /// Retrieve the custom attributes that attach property wrappers to this
   /// property. The returned list contains all of the attached property wrapper
   /// attributes in source order, which means the outermost wrapper attribute

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1456,8 +1456,10 @@ namespace {
         });
       }
 
-      printFlag(D->getAttrs().hasAttribute<NonisolatedAttr>(), "nonisolated",
-                ExprModifierColor);
+      if (auto *attr = D->getAttrs().getAttribute<NonisolatedAttr>()) {
+        printFlag(attr->isUnsafe() ? "nonisolated(unsafe)" : "nonisolated",
+                  ExprModifierColor);
+      }
       printFlag(D->isDistributed(), "distributed", ExprModifierColor);
       printFlag(D->isDistributedThunk(), "distributed_thunk",ExprModifierColor);
     }
@@ -2735,6 +2737,7 @@ public:
     switch (auto isolation = E->getActorIsolation()) {
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
       break;
 
     case ActorIsolation::ActorInstance:

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1401,6 +1401,14 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_Nonisolated: {
+    Printer.printAttrName("nonisolated");
+    if (cast<NonisolatedAttr>(this)->isUnsafe()) {
+      Printer << "(unsafe)";
+    }
+    break;
+  }
+
   case DAK_MacroRole: {
     auto Attr = cast<MacroRoleAttr>(this);
 
@@ -1721,6 +1729,12 @@ StringRef DeclAttribute::getAttrName() const {
     return "_section";
   case DAK_Documentation:
     return "_documentation";
+  case DAK_Nonisolated:
+    if (cast<NonisolatedAttr>(this)->isUnsafe()) {
+        return "nonisolated(unsafe)";
+    } else {
+        return "nonisolated";
+    }
   case DAK_MacroRole:
     switch (cast<MacroRoleAttr>(this)->getMacroSyntax()) {
     case MacroSyntax::Freestanding:

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -921,8 +921,12 @@ static void formatDiagnosticArgument(StringRef Modifier,
     }
 
     case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
     case ActorIsolation::Unspecified:
       Out << "nonisolated";
+      if (isolation == ActorIsolation::NonisolatedUnsafe) {
+        Out << "(unsafe)";
+      }
       break;
     }
     break;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1741,7 +1741,11 @@ void swift::simple_display(
       break;
 
     case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
       out << "nonisolated";
+      if (state == ActorIsolation::NonisolatedUnsafe) {
+        out << "(unsafe)";
+      }
       break;
 
     case ActorIsolation::Unspecified:

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7844,7 +7844,8 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
       // Hard-code @actorIndependent, until Objective-C clients start
       // using nonisolated.
       if (swiftAttr->getAttribute() == "@actorIndependent") {
-        auto attr = new (SwiftContext) NonisolatedAttr(/*isImplicit=*/true);
+        auto attr = new (SwiftContext)
+            NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true);
         MappedDecl->getAttrs().add(attr);
         continue;
       }

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -422,7 +422,8 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(
 
   // Mark the function transparent so that we inline it away completely.
   func->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
-  auto nonisolatedAttr = new (C) NonisolatedAttr(/*IsImplicit=*/true);
+  auto nonisolatedAttr =
+      new (C) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true);
   var->getAttrs().add(nonisolatedAttr);
 
   // Set the function up as the getter.

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -789,6 +789,7 @@ void CompletionLookup::analyzeActorIsolation(
   }
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
+  case ActorIsolation::NonisolatedUnsafe:
     return;
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3839,6 +3839,20 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       return makeParserSuccess();
     break;
   }
+  case DAK_Nonisolated: {
+    auto isUnsafe =
+        parseSingleAttrOption<bool>(*this, Loc, AttrRange, AttrName, DK,
+                                    {{Context.Id_unsafe, true}}, false);
+    if (!isUnsafe) {
+      return makeParserSuccess();
+    }
+
+    if (!DiscardAttribute) {
+      Attributes.add(new (Context) NonisolatedAttr(AtLoc, AttrRange, *isUnsafe,
+                                                   /*implicit*/ false));
+    }
+    break;
+  }
   case DAK_MacroRole: {
     auto syntax = (AttrName == "freestanding" ? MacroSyntax::Freestanding
                                               : MacroSyntax::Attached);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5521,6 +5521,7 @@ RValue SILGenFunction::emitApply(
 
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
       llvm_unreachable("Not isolated");
       break;
     }

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -610,6 +610,7 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
 
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
       return false;
@@ -1554,6 +1555,7 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     // 'nonisolated' expressions can be evaluated from anywhere
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
       break;
 
     case ActorIsolation::GlobalActor:

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1281,6 +1281,7 @@ void SILGenFunction::emitProlog(
           return false;
 
         case ActorIsolation::Nonisolated:
+        case ActorIsolation::NonisolatedUnsafe:
         case ActorIsolation::Unspecified:
           return false;
         }
@@ -1332,6 +1333,7 @@ void SILGenFunction::emitProlog(
     switch (actorIsolation.getKind()) {
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
       break;
 
     case ActorIsolation::ActorInstance: {
@@ -1384,6 +1386,7 @@ void SILGenFunction::emitProlog(
     switch (actorIsolation.getKind()) {
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
       break;
 
     case ActorIsolation::ActorInstance: {
@@ -1572,6 +1575,7 @@ SILGenFunction::emitExecutor(SILLocation loc, ActorIsolation isolation,
   switch (isolation.getKind()) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
+  case ActorIsolation::NonisolatedUnsafe:
     return llvm::None;
 
   case ActorIsolation::ActorInstance: {
@@ -1597,8 +1601,9 @@ void SILGenFunction::emitHopToActorValue(SILLocation loc, ManagedValue actor) {
       getActorIsolationOfContext(FunctionDC, [](AbstractClosureExpr *CE) {
         return CE->getActorIsolation();
       });
-  if (isolation != ActorIsolation::Nonisolated
-      && isolation != ActorIsolation::Unspecified) {
+  if (isolation != ActorIsolation::Nonisolated &&
+      isolation != ActorIsolation::NonisolatedUnsafe &&
+      isolation != ActorIsolation::Unspecified) {
     // TODO: Explicit hop with no hop-back should only be allowed in nonisolated
     // async functions. But it needs work for any closure passed to
     // Task.detached, which currently has unspecified isolation.

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1046,6 +1046,7 @@ void LifetimeChecker::injectActorHops() {
 
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
+  case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::GlobalActorUnsafe:
   case ActorIsolation::GlobalActor:
     return;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1634,7 +1634,8 @@ bool swift::addNonIsolatedToSynthesized(NominalTypeDecl *nominal,
     return false;
 
   ASTContext &ctx = nominal->getASTContext();
-  value->getAttrs().add(new (ctx) NonisolatedAttr(/*isImplicit=*/true));
+  value->getAttrs().add(
+      new (ctx) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
   return true;
 }
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -108,7 +108,7 @@ static VarDecl *addImplicitDistributedActorIDProperty(
 
   // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(
-      new (C) NonisolatedAttr(/*IsImplicit=*/true));
+      new (C) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
   // mark as @_compilerInitialized, since we synthesize the initializing
   // assignment during SILGen.
   propDecl->getAttrs().add(
@@ -158,7 +158,7 @@ static VarDecl *addImplicitDistributedActorActorSystemProperty(
 
   // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(
-      new (C) NonisolatedAttr(/*IsImplicit=*/true));
+      new (C) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
 
   auto idProperty = nominal->getDistributedActorIDProperty();
   // If the id was not yet synthesized, we need to ensure that eventually
@@ -735,7 +735,8 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
 
   thunk->setSynthesized(true);
   thunk->setDistributedThunk(true);
-  thunk->getAttrs().add(new (C) NonisolatedAttr(/*isImplicit=*/true));
+  thunk->getAttrs().add(
+      new (C) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
 
   if (isa<ClassDecl>(DC))
     thunk->getAttrs().add(new (C) FinalAttr(/*isImplicit=*/true));

--- a/lib/Sema/DerivedConformanceActor.cpp
+++ b/lib/Sema/DerivedConformanceActor.cpp
@@ -147,7 +147,8 @@ static ValueDecl *deriveActor_unownedExecutor(DerivedConformance &derived) {
   property->getAttrs().add(new (ctx) SemanticsAttr(SEMANTICS_DEFAULT_ACTOR,
                                                    SourceLoc(), SourceRange(),
                                                    /*implicit*/ true));
-  property->getAttrs().add(new (ctx) NonisolatedAttr(/*IsImplicit=*/true));
+  property->getAttrs().add(
+      new (ctx) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
 
   // Make the property implicitly final.
   property->getAttrs().add(new (ctx) FinalAttr(/*IsImplicit=*/true));

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -455,7 +455,7 @@ static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
 
   // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(
-      new (C) NonisolatedAttr(/*IsImplicit=*/true));
+      new (C) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
 
   derived.addMemberToConformanceContext(pbDecl, /*insertAtHead=*/true);
   derived.addMemberToConformanceContext(propDecl, /*insertAtHead=*/true);
@@ -484,7 +484,7 @@ static ValueDecl *deriveDistributedActor_actorSystem(
 
   // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(
-      new (C) NonisolatedAttr(/*IsImplicit=*/true));
+      new (C) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
 
   // IMPORTANT: `id` MUST be the first field of a distributed actor, and
   // `actorSystem` MUST be the second field, because for a remote instance
@@ -782,7 +782,8 @@ static ValueDecl *deriveDistributedActor_unownedExecutor(DerivedConformance &der
   property->getAttrs().add(new (ctx) SemanticsAttr(SEMANTICS_DEFAULT_ACTOR,
                                                    SourceLoc(), SourceRange(),
                                                    /*implicit*/ true));
-  property->getAttrs().add(new (ctx) NonisolatedAttr(/*IsImplicit=*/true));
+  property->getAttrs().add(
+      new (ctx) NonisolatedAttr(/*unsafe=*/false, /*implicit=*/true));
 
   // Make the property implicitly final.
   property->getAttrs().add(new (ctx) FinalAttr(/*IsImplicit=*/true));

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -563,7 +563,8 @@ deriveHashable_hashInto(
   // The derived hash(into:) for an actor must be non-isolated.
   if (!addNonIsolatedToSynthesized(derived.Nominal, hashDecl) &&
       derived.Nominal->isActor())
-    hashDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/ true));
+    hashDecl->getAttrs().add(
+        new (C) NonisolatedAttr(/*unsafe*/ false, /*implicit*/ true));
 
   derived.addMembersToConformanceContext({hashDecl});
 
@@ -928,7 +929,8 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   // The derived hashValue of an actor must be nonisolated.
   if (!addNonIsolatedToSynthesized(derived.Nominal, hashValueDecl) &&
       derived.Nominal->isActor())
-    hashValueDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/ true));
+    hashValueDecl->getAttrs().add(
+        new (C) NonisolatedAttr(/*unsafe*/ false, /*implicit*/ true));
 
   Pattern *hashValuePat =
       NamedPattern::createImplicit(C, hashValueDecl, intType);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6777,9 +6777,10 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
   if (auto var = dyn_cast<VarDecl>(D)) {
     // stored properties have limitations as to when they can be nonisolated.
     if (var->hasStorage()) {
+      const bool isUnsafeGlobal = attr->isUnsafe() && var->isGlobalStorage();
 
       // 'nonisolated' can not be applied to mutable stored properties.
-      if (var->supportsMutation()) {
+      if (var->supportsMutation() && !isUnsafeGlobal) {
         diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage);
         return;
       }
@@ -6833,8 +6834,8 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       return;
     }
   }
-  
-  // `nonisolated` on non-async actor initializers is invalid
+
+  // `nonisolated` on non-async actor initializers is invalid.
   // the reasoning is that there is a "little bit" of isolation,
   // as afforded by flow-isolation.
   if (auto ctor = dyn_cast<ConstructorDecl>(D)) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -492,6 +492,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD, ObjCReason Reason) {
     return false;
 
   case ActorIsolation::Nonisolated:
+  case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Unspecified:
     return false;
   }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -98,6 +98,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   case ActorIsolation::GlobalActor:
   case ActorIsolation::GlobalActorUnsafe:
   case ActorIsolation::Nonisolated:
+  case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Unspecified:
     break;
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -464,6 +464,7 @@ getActualActorIsolationKind(uint8_t raw) {
   CASE(Unspecified)
   CASE(ActorInstance)
   CASE(Nonisolated)
+  CASE(NonisolatedUnsafe)
   CASE(GlobalActor)
   CASE(GlobalActorUnsafe)
 #undef CASE
@@ -3841,6 +3842,7 @@ public:
       switch (isoKind) {
       case ActorIsolation::Unspecified:
       case ActorIsolation::Nonisolated:
+      case ActorIsolation::NonisolatedUnsafe:
         isolation = ActorIsolation::forUnspecified();
         break;
 
@@ -5912,6 +5914,15 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         Attr = new (ctx) ObjCImplementationAttr(categoryName, SourceLoc(),
                                                 SourceRange(), isImplicit,
                                                 isCategoryNameInvalid);
+        break;
+      }
+
+      case decls_block::Nonisolated_DECL_ATTR: {
+        bool isUnsafe{};
+        bool isImplicit{};
+        serialization::decls_block::NonisolatedDeclAttrLayout::readRecord(
+            scratch, isUnsafe, isImplicit);
+        Attr = new (ctx) NonisolatedAttr(isUnsafe, isImplicit);
         break;
       }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 814; // @extern(c)
+const uint16_t SWIFTMODULE_VERSION_MINOR = 815; // nonisolated(unsafe)
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -532,6 +532,7 @@ enum class ActorIsolation : uint8_t {
   Unspecified = 0,
   ActorInstance,
   Nonisolated,
+  NonisolatedUnsafe,
   GlobalActor,
   GlobalActorUnsafe
 };
@@ -2355,6 +2356,12 @@ namespace decls_block {
     BCFixed<1>,         // has visibility
     AccessLevelField    // visibility
   >;
+
+  using NonisolatedDeclAttrLayout =
+      BCRecordLayout<Nonisolated_DECL_ATTR,
+                     BCFixed<1>, // is the argument (unsafe)
+                     BCFixed<1>  // implicit flag
+                     >;
 
   using MacroRoleDeclAttrLayout = BCRecordLayout<
     MacroRole_DECL_ATTR,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1417,6 +1417,7 @@ getRawStableActorIsolationKind(swift::ActorIsolation::Kind kind) {
   CASE(Unspecified)
   CASE(ActorInstance)
   CASE(Nonisolated)
+  CASE(NonisolatedUnsafe)
   CASE(GlobalActor)
   CASE(GlobalActorUnsafe)
 #undef CASE
@@ -3169,6 +3170,15 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       DocumentationDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(),
           metadataIDPair.second, hasVisibility, visibility);
+      return;
+    }
+
+    case DAK_Nonisolated: {
+      auto *theAttr = cast<NonisolatedAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[NonisolatedDeclAttrLayout::Code];
+      NonisolatedDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                            theAttr->isUnsafe(),
+                                            theAttr->isImplicit());
       return;
     }
 

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -45,18 +45,31 @@ final class TestNonsendable {
   init() {}
 }
 
-struct A {
+@propertyWrapper
+public struct TestWrapper {
+  public init() {}
+  public var wrappedValue: Int {
+    return 0
+  }
+}
+
+struct TestStatics {
   static let immutableExplicitSendable = TestSendable()
-  static let immutableNonsendableGlobal = TestNonsendable() // expected-warning{{static property 'immutableNonsendableGlobal' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor}}
+  static let immutableNonsendable = TestNonsendable() // expected-warning{{static property 'immutableNonsendable' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor}}
+  static nonisolated(unsafe) let immutableNonisolatedUnsafe = TestNonsendable()
+  static nonisolated let immutableNonisolated = TestNonsendable() // expected-warning{{static property 'immutableNonisolated' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor}}
   static let immutableInferredSendable = 0
   static var mutable = 0 // expected-warning{{static property 'mutable' is not concurrency-safe because it is non-isolated global shared mutable state}}
   // expected-note@-1{{isolate 'mutable' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
   // expected-note@-2{{static property declared here}}
+  static var computedProperty: Int { 0 } // computed property that, though static, has no storage so is not a global
+  @TestWrapper static var wrapped: Int // expected-warning{{static property 'wrapped' is not concurrency-safe because it is non-isolated global shared mutable state}}
+  // expected-note@-1{{isolate 'wrapped' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 }
 
 @TestGlobalActor
 func f() {
-  print(A.immutableExplicitSendable)
-  print(A.immutableInferredSendable)
-  print(A.mutable) // expected-warning{{reference to static property 'mutable' is not concurrency-safe because it involves shared mutable state}}
+  print(TestStatics.immutableExplicitSendable)
+  print(TestStatics.immutableInferredSendable)
+  print(TestStatics.mutable) // expected-warning{{reference to static property 'mutable' is not concurrency-safe because it involves shared mutable state}}
 }

--- a/test/Serialization/attr-nonisolated.swift
+++ b/test/Serialization/attr-nonisolated.swift
@@ -19,7 +19,7 @@
 
 // and look for nonisolated
 
-// BC-CHECK: <Nonisolated_DECL_ATTR abbrevid={{[0-9]+}} op0=0/>
+// BC-CHECK: <Nonisolated_DECL_ATTR abbrevid={{[0-9]+}} op0=0 op1=0/>
 
 
 actor UnsafeCounter {


### PR DESCRIPTION
This is a follow-up based on feedback from the pitch for strict concurrency for global variables that there is need for an opt-out mechanism when thread-safety is manually managed.