### PR TITLE
[ASTGen] Null-terminate error messsages from ASTGen

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -40,24 +40,21 @@ extension String {
   }
 }
 
-/// Allocate a copy of the given string as a UTF-8 string.
+/// Allocate a copy of the given string as a null-terminated UTF-8 string.
 func allocateBridgedString(
-  _ string: String,
-  nullTerminated: Bool = false
+  _ string: String
 ) -> BridgedString {
   var string = string
   return string.withUTF8 { utf8 in
-    let capacity = utf8.count + (nullTerminated ? 1 : 0)
     let ptr = UnsafeMutablePointer<UInt8>.allocate(
-      capacity: capacity
+      capacity: utf8.count + 1
     )
     if let baseAddress = utf8.baseAddress {
       ptr.initialize(from: baseAddress, count: utf8.count)
     }
 
-    if nullTerminated {
-      ptr[utf8.count] = 0
-    }
+    // null terminate, for client's convenience.
+    ptr[utf8.count] = 0
 
     return BridgedString(data: ptr, length: utf8.count)
   }

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -265,7 +265,7 @@ func checkMacroDefinition(
 
       // Form the "ModuleName.TypeName" result string.
       externalMacroOutPtr.pointee =
-        allocateBridgedString("\(module).\(type)", nullTerminated: true)
+        allocateBridgedString("\(module).\(type)")
 
       // Translate this into a use of #externalMacro.
       let expansionSourceSyntax: ExprSyntax =
@@ -329,14 +329,13 @@ func checkMacroDefinition(
 
       // Form the "ModuleName.TypeName" result string.
       externalMacroOutPtr.pointee =
-        allocateBridgedString("\(module).\(type)", nullTerminated: true)
+        allocateBridgedString("\(module).\(type)")
       return Int(BridgedMacroDefinitionKind.externalMacro.rawValue)
 
     case let .expansion(expansionSyntax, replacements: replacements):
       // Provide the expansion syntax.
       externalMacroOutPtr.pointee =
-        allocateBridgedString(expansionSyntax.trimmedDescription,
-                              nullTerminated: true)
+        allocateBridgedString(expansionSyntax.trimmedDescription)
 
 
       // If there are no replacements, we're done.
@@ -395,7 +394,7 @@ func makeExpansionOutputResult(
     outputPointer.pointee = BridgedString()
     return -1
   }
-  outputPointer.pointee = allocateBridgedString(expandedSource, nullTerminated: true)
+  outputPointer.pointee = allocateBridgedString(expandedSource)
   return 0
 }
 


### PR DESCRIPTION
Always null-terminate `BridgedString` by  `allocateBridgedString()`. It had `nullTerminated: Bool` option, but allocating one extra byte doesn't harm anything. Always null-terminate the string for client's convenience.

This fixes ASAN failure `heap-buffer-overflow` where error string by `allocateBridgedString()` was read as a C-string. Since it _was_ not null-terminated, it used to read past the end.

rdar://117205829
