### PR TITLE
[embedded] Avoid building the embedded stdlib when BOOTSTRAPPING=OFF

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -144,6 +144,8 @@ elseif(NOT SWIFT_INCLUDE_TOOLS)
   # Temporarily, only build embedded stdlib when building the compiler, to
   # unblock CI jobs that run against old(er) toolchains.
   set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
+elseif(BOOTSTRAPPING_MODE STREQUAL "OFF")
+  set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
 endif()
 
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)


### PR DESCRIPTION
Embedded stdlib needs SIL optimization passes from SwiftCompilerSources. Let's just not build it under BOOTSTRAPPING=OFF.