### PR TITLE
[Runtime] NFC: Use `std::invoke_result` instead of deprecated `std::result_of`

### DIFF
--- a/include/swift/ABI/CompactFunctionPointer.h
+++ b/include/swift/ABI/CompactFunctionPointer.h
@@ -48,7 +48,7 @@ public:
   }
 
   template <typename... ArgTy>
-  typename std::result_of<T *(ArgTy...)>::type operator()(ArgTy... arg) const {
+  typename std::invoke_result<T *(ArgTy...)>::type operator()(ArgTy... arg) const {
     static_assert(std::is_function<T>::value,
                   "T must be an explicit function type");
     return this->get()(std::forward<ArgTy>(arg)...);


### PR DESCRIPTION
Just resolve deprecated warnings while building stdlib for WebAssembly