### PR TITLE
Support overrides of unavailable inits in objcImpl

### DIFF
--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -2,6 +2,7 @@
 
 @interface ObjCBaseClass
 
+- (instancetype)init __attribute__((unavailable));
 
 // Need two initializers to reproduce certain conflict bugs.
 - (instancetype)initFromSuperclass:(int)param  __attribute__((objc_designated_initializer));
@@ -158,6 +159,12 @@
 @end
 
 @interface ObjCImplSubclass : ObjCClass
+
+@end
+
+@interface ObjCBasicInitClass : ObjCBaseClass
+
+- (nonnull instancetype)init __attribute__((objc_designated_initializer));
 
 @end
 

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -393,6 +393,12 @@ protocol EmptySwiftProto {}
     }
 }
 
+@_objcImplementation extension ObjCBasicInitClass {
+  init() {
+    // OK
+  }
+}
+
 @_objcImplementation extension ObjCClass {}
 // expected-error@-1 {{duplicate implementation of Objective-C class 'ObjCClass'}}
 


### PR DESCRIPTION
Suppose a superclass declares an initializer unavailable and then a subclass wants to redeclare and use it. Formally, the subclass declaration overrides the superclass one; however, Swift will not actually require the subclass to use the `override` keyword. As currently implemented, this means that the requirement will be skipped as an override, but the candidate will be included as a member implementation. Result: a “candidate does not match any requirement” diagnostic.

Fix this by skipping requirements that are overrides *only* if the declaration they override is not unavailable.

Fixes rdar://109541045.