### PR TITLE
[CSBindings] Delay inference through OptionalObject if "object" is l-…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1429,6 +1429,26 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
 /// those types should be opened.
 void PotentialBindings::infer(Constraint *constraint) {
   switch (constraint->getKind()) {
+  case ConstraintKind::OptionalObject: {
+    // Inference through optional object is allowed if
+    // one of the types is resolved or "optional" type variable
+    // cannot be bound to l-value, otherwise there is a
+    // risk of binding "optional" to an optional type (inferred from
+    // the "object") and discovering an l-value binding for it later.
+    auto optionalType = constraint->getFirstType();
+
+    if (auto *optionalVar = optionalType->getAs<TypeVariableType>()) {
+      if (optionalVar->getImpl().canBindToLValue()) {
+        auto objectType =
+            constraint->getSecondType()->lookThroughAllOptionalTypes();
+        if (objectType->isTypeVariableOrMember())
+          return;
+      }
+    }
+
+    LLVM_FALLTHROUGH;
+  }
+
   case ConstraintKind::Bind:
   case ConstraintKind::Equal:
   case ConstraintKind::BindParam:
@@ -1438,7 +1458,6 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::Conversion:
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::OperatorArgumentConversion:
-  case ConstraintKind::OptionalObject:
   case ConstraintKind::UnresolvedMemberChainBase: {
     auto binding = inferFromRelational(constraint);
     if (!binding)

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1121,9 +1121,11 @@ func rdar17170728() {
   var j: Int?
   var k: Int? = 2
 
-  let _ = [i, j, k].reduce(0 as Int?) {
+  let _ = [i, j, k].reduce(0 as Int?) {  // expected-error {{missing argument label 'into:' in call}}
+    // expected-error@-1 {{cannot convert value of type 'Int?' to expected argument type '(inout @escaping (Bool, Bool) -> Bool?, Int?) throws -> ()'}}
     $0 && $1 ? $0! + $1! : ($0 ? $0! : ($1 ? $1! : nil))
-    // expected-error@-1 4 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
+    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
+    // expected-error@-2 4 {{cannot force unwrap value of non-optional type 'Bool'}}
   }
 
   let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{missing argument label 'into:' in call}}
@@ -1553,18 +1555,18 @@ func testNilCoalescingOperatorRemoveFix() {
   let _ = "" /* This is a comment */ ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{13-43=}}
 
   let _ = "" // This is a comment
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1555:13-1556:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1557:13-1558:10=}}
 
   let _ = "" // This is a comment
     /*
      * The blank line below is part of the test case, do not delete it
      */
 
-    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1558:13-1563:10=}}
+    ?? "" // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1560:13-1565:10=}}
 
-  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1566:9=}}
+  if ("" ?? // This is a comment // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{9-1568:9=}}
       "").isEmpty {}
 
   if ("" // This is a comment
-      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1568:9-1569:12=}}
+      ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{1570:9-1571:12=}}
 }

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -598,3 +598,19 @@ do {
   test(x!) // expected-error {{no exact matches in call to local function 'test'}}
   // expected-error@-1 {{cannot force unwrap value of non-optional type 'Double'}}
 }
+
+// Diagnose cases of invalid chaining when parameter is not optional based on context.
+do {
+  class Test {
+    var value: Int = 42
+  }
+
+  class Container {
+    let test: Test = Test()
+
+    func loop() {
+      [test].forEach { $0?.value = 42 }
+      // expected-error@-1 {{cannot use optional chaining on non-optional value of type 'Test'}}
+    }
+  }
+}


### PR DESCRIPTION
…value capable

Inference cannot be allowed in cases where both sides are type
variables and optional type is l-value capable because it results
in binding "optional" to an optional type and later discovering
a contextual type that is l-value optional i.e. if "optional type"
is resolved by selecting subscript overload.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
