### PR TITLE
[5.10][Distributed] Handle dispatch thunks and superclasses in ad-hoc witness for decodeNextArguent

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1469,7 +1469,11 @@ AbstractFunctionDecl *ASTContext::getOnReturnOnDistributedTargetInvocationResult
 
 FuncDecl *ASTContext::getDoneRecordingOnDistributedInvocationEncoder(
     NominalTypeDecl *nominal) const {
-  for (auto result : nominal->lookupDirect(Id_doneRecording)) {
+
+  llvm::SmallVector<ValueDecl *, 2> results;
+  nominal->lookupQualified(nominal, DeclNameRef(Id_doneRecording),
+                           SourceLoc(), NL_QualifiedDefault, results);
+  for (auto result : results) {
     auto *fd = dyn_cast<FuncDecl>(result);
     if (!fd)
       continue;

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -693,7 +693,7 @@ void DistributedAccessor::emit() {
   }
 
   // Add all of the substitutions to the explosion
-  if (Target->getGenericEnvironment()) {
+  if (Target->isGeneric()) {
     // swift.type **
     llvm::Value *substitutionBuffer =
         IGF.Builder.CreateBitCast(substitutions, IGM.TypeMetadataPtrPtrTy);

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -693,7 +693,7 @@ void DistributedAccessor::emit() {
   }
 
   // Add all of the substitutions to the explosion
-  if (Target->isGeneric()) {
+  if (auto *genericEnvironment = Target->getGenericEnvironment()) {
     // swift.type **
     llvm::Value *substitutionBuffer =
         IGF.Builder.CreateBitCast(substitutions, IGM.TypeMetadataPtrPtrTy);

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -843,7 +843,6 @@ ArgumentDecoderInfo DistributedAccessor::findArgumentDecoder(
     /// so we must use this instead of the decodeFn directly.
    if (classDecl->hasResilientMetadata()) {
       if (getMethodDispatch(decodeFn) == swift::MethodDispatch::Class) {
-        SILDeclRef(decodeFn).getOverriddenVTableEntry().getDecl()->getDeclContext()->dumpContext();
         fnPtr = IGM.getAddrOfDispatchThunk(SILDeclRef(decodeFn), NotForDefinition);
         usesDispatchThunk = true;
       }

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -524,6 +524,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
   {
     auto doneRecordingDecl =
         C.getDoneRecordingOnDistributedInvocationEncoder(invocationEncoderDecl);
+    assert(doneRecordingDecl && "Could not find 'doneRecording' ad-hoc requirement witness.");
     auto doneRecordingDeclRef =
         UnresolvedDeclRefExpr::createImplicit(C, doneRecordingDecl->getName());
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -71,7 +71,10 @@ static AbstractFunctionDecl *findDistributedAdHocRequirement(
     return nullptr;
   }
 
-  for (auto value : decl->lookupDirect(identifier)) {
+  llvm::SmallVector<ValueDecl *, 2> results;
+  decl->lookupQualified(decl, DeclNameRef(identifier),
+                        SourceLoc(), NL_QualifiedDefault, results);
+  for (auto value : results) {
     auto func = dyn_cast<AbstractFunctionDecl>(value);
     if (func && matchFn(func))
       return func;

--- a/test/Distributed/Runtime/distributed_actor_system_decoder_subclass.swift
+++ b/test/Distributed/Runtime/distributed_actor_system_decoder_subclass.swift
@@ -1,0 +1,157 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Distributed
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+distributed actor DA {
+  distributed func test() {}
+}
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  // CHECK: assign type:DA, address:ActorAddress(address: "xxx")
+  // CHECK: ready actor:main.DA, address:ActorAddress(address: "xxx")
+  let da = DA(actorSystem: system)
+  try await da.test()
+  // CHECK: resign address:ActorAddress(address: "xxx")
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}
+
+
+// ==== Fake Transport ---------------------------------------------------------
+
+struct ActorAddress: Hashable, Sendable, Codable {
+  let address: String
+  init(parse address : String) {
+    self.address = address
+  }
+
+  // Explicit implementations to make our TestEncoder/Decoder simpler
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.address = try container.decode(String.self)
+    print("decode ActorAddress -> \(self)")
+  }
+
+  func encode(to encoder: Encoder) throws {
+    print("encode \(self)")
+    var container = encoder.singleValueContainer()
+    try container.encode(self.address)
+  }
+}
+
+final class FakeActorSystem: DistributedActorSystem {
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocation
+  typealias InvocationEncoder = FakeInvocation
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type) throws -> Act?
+    where Act: DistributedActor,
+    Act.ID == ActorID  {
+    print("resolve type:\(actorType), address:\(id)")
+    return nil
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor, Act.ID == ActorID {
+    let address = ActorAddress(parse: "xxx")
+    print("assign type:\(actorType), address:\(address)")
+    return address
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+    print("ready actor:\(actor), address:\(actor.id)")
+  }
+
+  func resignID(_ id: ActorID) {
+    print("resign address:\(id)")
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+    .init()
+  }
+
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error,
+    Res: SerializationRequirement {
+    fatalError("not implemented: \(#function)")
+  }
+
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    fatalError("not implemented: \(#function)")
+  }
+
+}
+
+class EncoderBase: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = Codable
+
+  func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  func doneRecording() throws {}
+
+}
+
+class DecoderBase: EncoderBase, DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Codable
+
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
+}
+
+class FakeInvocation: DecoderBase {}
+
+@available(SwiftStdlib 5.5, *)
+public struct FakeResultHandler: DistributedTargetInvocationResultHandler {
+  public typealias SerializationRequirement = Codable
+
+  public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    fatalError("Not implemented: \(#function)")
+  }
+
+  public func onReturnVoid() async throws {
+    fatalError("Not implemented: \(#function)")
+  }
+
+  public func onThrow<Err: Error>(error: Err) async throws {
+    fatalError("Not implemented: \(#function)")
+  }
+}


### PR DESCRIPTION
**Description:** We did not properly find the method we need to refer to when a distributed actor system was built using module resilience. This fixes this issue, as well as a lookup problem when the witness comes from a superclass.
**Risk:** Low
**Review by:** @xedin @slavapestov 
**Testing:** added new tests and checked in real project 
**Original PR:** https://github.com/apple/swift/pull/69242
**Radar:** rdar://116812673