### PR TITLE
[5.10] tests: fix AutoDiff/stdlib/callee_differential_not_leaked_in_func_with_loops.swift for 32 bit architectures

### DIFF
--- a/test/AutoDiff/stdlib/callee_differential_not_leaked_in_func_with_loops.swift
+++ b/test/AutoDiff/stdlib/callee_differential_not_leaked_in_func_with_loops.swift
@@ -44,14 +44,14 @@ extension LifetimeTracked {
 func f(ltti: LifetimeTracked) -> Float {
     for _ in 0..<1 {
     }
-    return ltti.callee(0xDEADBEEF)
+    return ltti.callee(0xDEADBEE)
 }
 
 var Tests = TestSuite("CalleeDifferentialLeakTest")
 
 Tests.test("dontLeakCalleeDifferential") {
   do {
-    let ltti = LifetimeTracked(0xDEADBEEF)
+    let ltti = LifetimeTracked(0xDEADBEE)
     let _ = valueWithPullback(at: ltti, of: f)
   }
   expectEqual(0, LifetimeTracked.instances)


### PR DESCRIPTION
* **Explanation**: This fixes an auto-diff test failure on CI for 32-bit architectures. The test fails because the constant overflows a signed 32 bit integer.

* **Issue**: rdar://117213786

* **Risk**: zero

* **Reviewer**: @aschwaighofer

* **Main branch PR**: https://github.com/apple/swift/pull/68795
