### PR TITLE
[5.10] Optimizer: fix compiler crashes caused by certain types of statically initialized global variables

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2700,11 +2700,6 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
   if (gvar) {
     if (forDefinition) {
       updateLinkageForDefinition(*this, gvar, entity);
-
-      if (var->getStaticInitializerValue()) {
-        assert(gvar->hasInitializer() &&
-               "global variable referenced before created");
-      }
     }
     if (forDefinition && !gvar->hasInitializer())
       initVal = getGlobalInitValue(var, storageType, fixedAlignment);

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -212,6 +212,8 @@ class DeadFunctionAndGlobalElimination {
     for (const SILInstruction &initInst : *global) {
       if (auto *fRef = dyn_cast<FunctionRefInst>(&initInst))
         ensureAlive(fRef->getReferencedFunction());
+      if (auto *gRef = dyn_cast<GlobalAddrInst>(&initInst))
+        ensureAlive(gRef->getReferencedGlobal());
     }
   }
 

--- a/test/IRGen/referenced_global.swift
+++ b/test/IRGen/referenced_global.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -parse-as-library -primary-file %s -O -emit-ir -o - | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// Check that IRGen doesn't crash when a global variable reference another private global.
+
+// CHECK-LABEL: @"$s17referenced_global1bSPySiGvp" ={{.*}} global {{.*}} ptr @"$s17referenced_global1x{{.*}}"
+public var b = UnsafePointer(&x)
+private var x = 1

--- a/test/SILOptimizer/dead_function_elimination.swift
+++ b/test/SILOptimizer/dead_function_elimination.swift
@@ -1,6 +1,11 @@
 // RUN: %target-swift-frontend %s -O -emit-sil | %FileCheck %s
 // RUN: %target-swift-frontend %s -O -emit-sil -enable-testing | %FileCheck -check-prefix=CHECK-TESTING %s
 
+// Check if a private global is kept alive if it's only reference from another global variable.
+
+private var g1 = 27
+let g2 = UnsafePointer(&g1)
+
 // Check if cycles are removed.
 
 @inline(never)
@@ -183,6 +188,8 @@ struct GFStr {
 public func keepPtrAlive() {
   GFStr.aliveFuncPtr()
 }
+
+// CHECK-LABEL: sil_global private @$s25dead_function_elimination2g1{{.*}}
 
 // CHECK-NOT: sil {{.*}}inCycleA
 // CHECK-NOT: sil {{.*}}inCycleB

--- a/test/SILOptimizer/init_static_globals.sil
+++ b/test/SILOptimizer/init_static_globals.sil
@@ -98,6 +98,10 @@ sil_global [let] @g7 : $TwoFields
 // CHECK-NEXT:  }
 sil_global [let] @g8 : $UnsafePointer<Int32>
 
+sil_global [let] @g9 : $TwoFields
+
+sil @unknownfunc : $@convention(thin) () -> ()
+
 // CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_trivialglobal_func :
 // CHECK-NOT:     alloc_global
 // CHECK-NOT:     store
@@ -229,6 +233,34 @@ bb0:
   %7 = struct $Int32 (%6 : $Builtin.Int32)
   %8 = struct_element_addr %1 : $*TwoFields, #TwoFields.a
   store %7 to [trivial] %8 : $*Int32
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil [global_init_once_fn] [ossa] @merge_stores_but_no_global_init :
+// CHECK:         [[GA:%.*]] = global_addr @g9 : $*TwoFields
+// CHECK:         [[L10:%.*]] = integer_literal $Builtin.Int32, 10
+// CHECK:         [[I10:%.*]] = struct $Int32 ([[L10]] : $Builtin.Int32)
+// CHECK:         [[L11:%.*]] = integer_literal $Builtin.Int32, 11
+// CHECK:         [[I11:%.*]] = struct $Int32 ([[L11]] : $Builtin.Int32)
+// CHECK:         [[TF:%.*]] = struct $TwoFields ([[I11]] : $Int32, [[I10]] : $Int32)
+// CHECK:         store [[TF]] to [trivial] [[GA]]
+// CHECK:         function_ref
+// CHECK:       } // end sil function 'merge_stores_but_no_global_init'
+sil [global_init_once_fn] [ossa] @merge_stores_but_no_global_init : $@convention(c) () -> () {
+bb0:
+  alloc_global @g9
+  %1 = global_addr @g9 : $*TwoFields
+  %2 = integer_literal $Builtin.Int32, 10
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  %4 = struct_element_addr %1 : $*TwoFields, #TwoFields.b
+  store %3 to [trivial] %4 : $*Int32
+  %6 = integer_literal $Builtin.Int32, 11
+  %7 = struct $Int32 (%6 : $Builtin.Int32)
+  %8 = struct_element_addr %1 : $*TwoFields, #TwoFields.a
+  store %7 to [trivial] %8 : $*Int32
+  %f = function_ref @unknownfunc : $@convention(thin) () -> ()
+  %a = apply %f() : $@convention(thin) () -> ()
   %10 = tuple ()
   return %10 : $()
 }

--- a/test/SILOptimizer/remove_unused_func.sil
+++ b/test/SILOptimizer/remove_unused_func.sil
@@ -25,6 +25,30 @@ sil_global @globalFunctionPointer : $@callee_guaranteed () -> () = {
   %initval = thin_to_thick_function %0 : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
 }
 
+// CHECK-LABEL: sil_global private @self_referencing_private_global
+sil_global private @self_referencing_private_global : $Builtin.RawPointer = {
+  %0 = global_addr @self_referencing_private_global : $*Builtin.RawPointer
+  %initval = address_to_pointer %0 : $*Builtin.RawPointer to $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil_global private @referencing_other_private_global
+sil_global private @referencing_other_private_global : $Builtin.RawPointer = {
+  %0 = global_addr @self_referencing_private_global : $*Builtin.RawPointer
+  %initval = address_to_pointer %0 : $*Builtin.RawPointer to $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil_global @referencing_private_globals
+sil_global @referencing_private_globals : $Builtin.RawPointer = {
+  %0 = global_addr @referencing_other_private_global : $*Builtin.RawPointer
+  %initval = address_to_pointer %0 : $*Builtin.RawPointer to $Builtin.RawPointer
+}
+
+// KEEP-NOT: @dead_self_referencing_private_global
+sil_global private @dead_self_referencing_private_global : $Builtin.RawPointer = {
+  %0 = global_addr @dead_self_referencing_private_global : $*Builtin.RawPointer
+  %initval = address_to_pointer %0 : $*Builtin.RawPointer to $Builtin.RawPointer
+}
+
 // CHECK-LABEL: sil private @alivePrivateFunc
 sil private @alivePrivateFunc : $@convention(thin) () -> () {
 bb0:


### PR DESCRIPTION
* **Explanation**: This fixes three problems which can cause compiler crashes for certain rare cases of statically initialized global variables.

1. DeadFunctionElimination doesn't keep global variables alive which are referenced from another global, for example:

```
private var g1 = 27
let g2 = UnsafePointer(&g1)
```

2.  When InitializeStaticGlobals merges stores in a global initializer, it's possible that the resulting store is inserted at the wrong location which causes a SIL verifier error. The resulting store must be inserted _after_ all other stores. Instead it's inserted after the store of the last property. Now, if properties are _not_ initialized in the order they are declared, this problem can show up.

3. IRGen has a wrong assert for global variable initialization: in case a global variable reference another global variable, it can be the case that the other variable is first generated as declaration and then "converted" to a definition by adding the constant initializer.

* **Issue**: rdar://117189962

* **Risk**: Low. The fixes are pretty trivial and only affect certain rare types of statically initialized global variables.

* **Testing**: With regression tests

* **Reviewer**: @atrick

* **Main branch PR**: https://github.com/apple/swift/pull/69271
