### PR TITLE
[ConstraintSystem] Bring back one-way pattern solving for for-in stat…

### DIFF
--- a/include/swift/Sema/SyntacticElementTarget.h
+++ b/include/swift/Sema/SyntacticElementTarget.h
@@ -469,6 +469,8 @@ public:
   bool shouldBindPatternVarsOneWay() const {
     if (kind == Kind::expression)
       return expression.bindPatternVarsOneWay;
+    if (kind == Kind::forEachStmt)
+      return !ignoreForEachWhereClause() && forEachStmt.stmt->getWhere();
     return false;
   }
 

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -295,3 +295,24 @@ do {
     }
   }
 }
+
+// rdar://117220710 - The compiler incorrectly infers `v` pattern to be optional.
+do {
+  struct S {
+    var test: Int
+  }
+
+  func check(_: S?, _: S?) -> Bool { false }
+
+  func test(data: [S]?, exclusion: S?) {
+    for v in data ?? [] where check(v, exclusion) {
+      _ = v.test // Ok
+    }
+  }
+
+  let _ = { (data: [S]?, exclusion: S?) in
+    for v in data ?? [] where check(v, exclusion) {
+      _ = v.test // Ok
+    }
+  }
+}


### PR DESCRIPTION
…ements (outside closures)

Type-checker separates `where` clause from `for-in` statement's pattern/sequence in closure contexts
which works as a natural barrier for inference, but for-in statements in i.e. function bodies still type-check
all of the for-in statement components together, so we need to make sure that where clause cannot be 
used to infer a type of the pattern before its sequence expression.

Resolves: rdar://117220710


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
