### PR TITLE
[SIL] Add explicit template instantiation for `std::_Construct`

### DIFF
--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -758,3 +758,7 @@ void SILBuilderWithScope::insertAfter(SILInstruction *inst,
     func(builder);
   }
 }
+
+// C++ interop workaround for Ubuntu 22.04 and UBI 9 due to undefined reference in
+// SILBuilder::substituteAnonymousArgs
+template void std::_Construct<SILDebugVariable, SILDebugVariable>(SILDebugVariable *, SILDebugVariable &&);


### PR DESCRIPTION
Not sure what the cause is here, but both Ubuntu 22.04 and UBI 9 have an undefined reference to `std::_Construct` from
`SILBuilder::substituteAnonymousArgs`. It's possible that may also be fixed by moving the implementation out of the header, but let's just instantiate the template explicitly for now (we needed a similar workaround in 5.9).