### PR TITLE
Emit extra inhabitants in debug info for basic types

### DIFF
--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -45,6 +45,7 @@ protected:
   /// the storage type for undefined variables.
   llvm::Type *FragmentStorageType = nullptr;
   llvm::Optional<Size::int_type> SizeInBits;
+  std::optional<uint32_t> NumExtraInhabitants;
   Alignment Align;
   bool DefaultAlignment = true;
   bool IsMetadataType = false;
@@ -57,7 +58,8 @@ public:
                 llvm::Optional<Size::int_type> SizeInBits = {},
                 Alignment AlignInBytes = Alignment(1),
                 bool HasDefaultAlignment = true, bool IsMetadataType = false,
-                bool IsFragmentTypeInfo = false, bool IsFixedBuffer = false);
+                bool IsFragmentTypeInfo = false, bool IsFixedBuffer = false,
+                std::optional<uint32_t> NumExtraInhabitants = {});
 
   /// Create type for a local variable.
   static DebugTypeInfo getLocalVariable(VarDecl *Decl, swift::Type Ty,
@@ -119,6 +121,9 @@ public:
   bool hasDefaultAlignment() const { return DefaultAlignment; }
   bool isSizeFragmentSize() const { return SizeIsFragmentSize; }
   bool isFixedBuffer() const { return IsFixedBuffer; }
+  std::optional<uint32_t> getNumExtraInhabitants() const {
+    return NumExtraInhabitants;
+  }
 
   bool operator==(DebugTypeInfo T) const;
   bool operator!=(DebugTypeInfo T) const;

--- a/test/DebugInfo/bool.swift
+++ b/test/DebugInfo/bool.swift
@@ -5,7 +5,7 @@
 func markUsed<T>(_ t: T) {}
 
 // Int1 uses 1 bit, but is aligned at 8 bits.
-// CHECK: !DIBasicType(name: "$sBi1_D", size: 1, encoding: DW_ATE_unsigned)
+// CHECK: !DIBasicType(name: "$sBi1_D", size: 1, encoding: DW_ATE_unsigned, num_extra_inhabitants: 254)
 // Bool has a fixed layout with a storage size of 1 byte and 7 "spare" bits.
 // CHECK_G: !DICompositeType(tag: DW_TAG_structure_type, name: "Bool",
 // CHECK_G-SAME:             size: 8


### PR DESCRIPTION
To support debugging embedded Swift, we will need to store information that previously we searched in metadata. Extra inhabitants is one of those.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
