### PR TITLE
[rebranch] Move `SILBuilder::substituteAnonymousArgs` out of the header

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -396,20 +396,7 @@ public:
   llvm::Optional<SILDebugVariable>
   substituteAnonymousArgs(llvm::SmallString<4> Name,
                           llvm::Optional<SILDebugVariable> Var,
-                          SILLocation Loc) {
-    if (Var && shouldDropVariable(*Var, Loc))
-      return {};
-    if (!Var || !Var->ArgNo || !Var->Name.empty())
-      return Var;
-
-    auto *VD = Loc.getAsASTNode<VarDecl>();
-    if (VD && !VD->getName().empty())
-      return Var;
-
-    llvm::raw_svector_ostream(Name) << '_' << (Var->ArgNo - 1);
-    Var->Name = Name;
-    return Var;
-  }
+                          SILLocation Loc);
 
   AllocStackInst *
   createAllocStack(SILLocation Loc, SILType elementType,


### PR DESCRIPTION
An attempt to fix an undefined reference to `std::_Construct` that we're hitting on Ubuntu 22.04 and UBI 9.