### PR TITLE
[5.10] Fix deserialization to avoid invoking a pass N times per function

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -390,6 +390,10 @@ private:
   /// This gets set in OwnershipModelEliminator pass.
   bool regDeserializationNotificationHandlerForAllFuncOME;
 
+  // True if a DeserializationNotificationHandler is set for
+  // AccessMarkerElimination.
+  bool hasAccessMarkerHandler;
+
   bool prespecializedFunctionDeclsImported;
 
   /// Action to be executed for serializing the SILModule.
@@ -440,6 +444,13 @@ public:
   }
   void setRegisteredDeserializationNotificationHandlerForAllFuncOME() {
     regDeserializationNotificationHandlerForAllFuncOME = true;
+  }
+
+  bool checkHasAccessMarkerHandler() {
+    return hasAccessMarkerHandler;
+  }
+  void setHasAccessMarkerHandler() {
+    hasAccessMarkerHandler = true;
   }
 
   /// Returns the instruction which defines the given root local archetype,

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -100,6 +100,7 @@ SILModule::SILModule(llvm::PointerUnion<FileUnit *, ModuleDecl *> context,
       irgenOptions(irgenOptions), serialized(false),
       regDeserializationNotificationHandlerForNonTransparentFuncOME(false),
       regDeserializationNotificationHandlerForAllFuncOME(false),
+      hasAccessMarkerHandler(false),
       prespecializedFunctionDeclsImported(false), SerializeSILAction(),
       Types(TC) {
   assert(!context.isNull());

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -183,16 +183,16 @@ struct AccessMarkerEliminationPass : SILModuleTransform {
         auto InvalidKind = SILAnalysis::InvalidationKind::Instructions;
         invalidateAnalysis(&F, InvalidKind);
       }
-
-      // Markers from all current SIL functions are stripped. Register a
-      // callback to strip an subsequently loaded functions on-the-fly.
-      if (!EnableOptimizedAccessMarkers) {
-        using NotificationHandlerTy =
-            FunctionBodyDeserializationNotificationHandler;
-        auto *n = new NotificationHandlerTy(prepareSILFunctionForOptimization);
-        std::unique_ptr<DeserializationNotificationHandler> ptr(n);
-        M.registerDeserializationNotificationHandler(std::move(ptr));
-      }
+    }
+    // Markers from all current SIL functions are stripped. Register a
+    // callback to strip an subsequently loaded functions on-the-fly.
+    if (!EnableOptimizedAccessMarkers && !M.checkHasAccessMarkerHandler()) {
+      using NotificationHandlerTy =
+        FunctionBodyDeserializationNotificationHandler;
+      auto *n = new NotificationHandlerTy(prepareSILFunctionForOptimization);
+      std::unique_ptr<DeserializationNotificationHandler> ptr(n);
+      M.registerDeserializationNotificationHandler(std::move(ptr));
+      M.setHasAccessMarkerHandler();
     }
   }
 };


### PR DESCRIPTION
Deserialization is calling AccessMarkerElimination repeatedly on the same function.

The bug was introduced here:

commit 872bf40e17adc19c0e17bf587f2a27e90667746d
Date:   Mon Aug 13 10:24:20 2018

    [sil-optimizer] Centralize how we send out serialization notifications.

Where the code that uniques the deserialization callbacks was simply removed!

As a result, this pass was being invoked a number of times equal to the number of functions in the module *multiplied* by the number of functions being deserialized.

Issue: Fixes rdar://117141871 (Building spends most of its time in AccessMarkerElimination)

Risk: Low. The fix is a trivial flag to avoid registering a callback more than once.

Testing: build time for an app decreased by 20% from 34s to 27s

Reviewer: @eeckstein 

Main branch PR: https://github.com/apple/swift/pull/69250
