### PR TITLE
[Dependency Scanning] On discovering cross-import overlays, do not add their discovered dependencies to the main module's direct dependencies

### DIFF
--- a/test/ScanDependencies/Inputs/Swift/_cross_import_E.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/_cross_import_E.swiftinterface
@@ -3,4 +3,5 @@
 import Swift
 import E
 import SubE
+import X
 public func funcCrossImportE() {}

--- a/test/ScanDependencies/module_deps_cross_import_overlay.swift
+++ b/test/ScanDependencies/module_deps_cross_import_overlay.swift
@@ -24,4 +24,9 @@ import SubEWrapper
 // CHECK-DAG:   "swift": "_StringProcessing"
 // CHECK-DAG:   "swift": "_cross_import_E"
 // CHECK-DAG:   "clang": "_SwiftConcurrencyShims"
+// Ensure a transitive dependency via "_cross_import_E" is not a direct dep of main module
+// CHECK-NOT:   "clang": "X"
 // CHECK: ],
+
+// Ensure a transitive dependency via "_cross_import_E" is recorded in the graph still
+// CHECK:   "clang": "X"


### PR DESCRIPTION
Instead, only add the overlay itself, and let it refer to its own dependencies, which will still get recorded in the overall output.

This does not impact Explicit Module Builds today because they de-duplicate dependency lists, but may impact `swift-build-sdk-interfaces` tool.

Resolves rdar://117010118
