### PR TITLE
[5.10 🍒][Dependency Scanning] On discovering cross-import overlays, do not add their discovered dependencies to the main module's direct dependencies

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -850,12 +850,22 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
   }
 
   // Update main module's dependencies to include these new overlays.
+  auto resolvedDummyDep =
+      *(cache.findDependency(dummyMainName, ModuleDependencyKind::SwiftSource)
+            .value());
   auto mainDep =
       *(cache.findDependency(mainModuleName, ModuleDependencyKind::SwiftSource)
             .value());
-  std::for_each(/* +1 to exclude dummy main*/ allModules.begin() + 1,
-                allModules.end(), [&](ModuleDependencyID dependencyID) {
-                  mainDep.addModuleDependency(dependencyID);
+  auto newOverlayDeps = resolvedDummyDep.getDirectModuleDependencies();
+  auto existingMainDeps = mainDep.getDirectModuleDependencies();
+  ModuleDependencyIDSet existingMainDepsSet(existingMainDeps.begin(),
+                                            existingMainDeps.end());
+  // Ensure we do not add cross-import overlay dependencies in case they
+  // were already explicitly imported
+  std::for_each(newOverlayDeps.begin(), newOverlayDeps.end(),
+                [&](ModuleDependencyID crossImportOverlayModID) {
+                  if (!existingMainDepsSet.count(crossImportOverlayModID))
+                    mainDep.addModuleDependency(crossImportOverlayModID);
                 });
   cache.updateDependency(
       {mainModuleName.str(), ModuleDependencyKind::SwiftSource}, mainDep);

--- a/test/ScanDependencies/Inputs/Swift/_cross_import_E.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/_cross_import_E.swiftinterface
@@ -3,4 +3,5 @@
 import Swift
 import E
 import SubE
+import X
 public func funcCrossImportE() {}

--- a/test/ScanDependencies/module_deps_cross_import_overlay.swift
+++ b/test/ScanDependencies/module_deps_cross_import_overlay.swift
@@ -24,4 +24,9 @@ import SubEWrapper
 // CHECK-DAG:   "swift": "_StringProcessing"
 // CHECK-DAG:   "swift": "_cross_import_E"
 // CHECK-DAG:   "clang": "_SwiftConcurrencyShims"
+// Ensure a transitive dependency via "_cross_import_E" is not a direct dep of main module
+// CHECK-NOT:   "clang": "X"
 // CHECK: ],
+
+// Ensure a transitive dependency via "_cross_import_E" is recorded in the graph still
+// CHECK:   "clang": "X"


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/69309
---------------------------------------
Instead, only add the overlay itself, and let it refer to its own dependencies, which will still get recorded in the overall output.

• Release: Swift 5.10
• Explanation: Prior refactoring of the dependency scanner caused it to add all discovered dependencies of discovered cross-import overlay modules to the list of main module dependencies. This resulted in the main module seemingly "directly" depending on what is actually its transitive dependencies via a cross-import overlay. Moreover, this caused duplicate entries in the list of main module direct dependencies. This change addresses this by only adding the cross-import overlay module itself to the list of main module direct dependencies.

• Scope of Issue: `swift-build-sdk-interfaces` tool attempts to build some modules more than once because they appear duplicated in main module dependency lists.
• Risk: Minimal, this change affects only code paths for explicit module builds and `swift-build-sdk-interfaces`, which are not yet default, and improves overall correctness of scanning results.
• Origination: Explicit Module Build feature development.

Resolves rdar://117010118
