### PR TITLE
[AddressLowering] Allow use-projection into phi.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -4361,6 +4361,8 @@ The following types of test arguments are supported:
          Example: @function[foo].block[2]
 - trace: @trace <-- the first ``debug_value [trace]`` in the current function
          @trace[uint] <-- the ``debug_value [trace]`` at index ``uint``
+- value: @{instruction}.result <-- the first result of the instruction
+         @{instruction}.result[uint] <-- the result at index ``uint`` produced by the instruction
          @{function}.{trace} <-- the indicated trace in the indicated function
          Example: @function[bar].trace
 - argument: @argument <-_ the first argument of the current block

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1446,7 +1446,7 @@ void OpaqueStorageAllocation::allocatePhi(PhiValue phi) {
   // The phi operand projections are computed first to give them priority. Then
   // we determine if the phi itself can share storage with one of its users.
   CoalescedPhi coalescedPhi;
-  coalescedPhi.coalesce(phi, pass.valueStorageMap);
+  coalescedPhi.coalesce(phi, pass.valueStorageMap, pass.domInfo);
 
   SmallVector<SILValue, 4> coalescedValues;
   coalescedValues.reserve(coalescedPhi.getCoalescedOperands().size());

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -433,51 +433,58 @@ void ValueStorageMap::replaceValue(SILValue oldValue, SILValue newValue) {
 }
 
 #ifndef NDEBUG
-void ValueStorage::dump() const {
-  llvm::dbgs() << "projectedStorageID: " << projectedStorageID << "\n";
-  llvm::dbgs() << "projectedOperandNum: " << projectedOperandNum << "\n";
-  llvm::dbgs() << "isDefProjection: " << isDefProjection << "\n";
-  llvm::dbgs() << "isUseProjection: " << isUseProjection << "\n";
-  llvm::dbgs() << "isRewritten: " << isRewritten << "\n";
-  llvm::dbgs() << "initializes: " << initializes << "\n";
+void ValueStorage::print(llvm::raw_ostream &OS) const {
+  OS << "projectedStorageID: " << projectedStorageID << "\n";
+  OS << "projectedOperandNum: " << projectedOperandNum << "\n";
+  OS << "isDefProjection: " << isDefProjection << "\n";
+  OS << "isUseProjection: " << isUseProjection << "\n";
+  OS << "isRewritten: " << isRewritten << "\n";
+  OS << "initializes: " << initializes << "\n";
 }
-void ValueStorageMap::ValueStoragePair::dump() const {
-  llvm::dbgs() << "value: ";
-  value->dump();
-  llvm::dbgs() << "address:  ";
+void ValueStorage::dump() const { print(llvm::dbgs()); }
+void ValueStorageMap::ValueStoragePair::print(llvm::raw_ostream &OS) const {
+  OS << "value: ";
+  value->print(OS);
+  OS << "address:  ";
   if (storage.storageAddress)
-    storage.storageAddress->dump();
+    storage.storageAddress->print(OS);
   else
-    llvm::dbgs() << "UNKNOWN!\n";
-  storage.dump();
+    OS << "UNKNOWN!\n";
+  storage.print(OS);
+}
+void ValueStorageMap::ValueStoragePair::dump() const { print(llvm::dbgs()); }
+void ValueStorageMap::printProjections(SILValue value,
+                                       llvm::raw_ostream &OS) const {
+  for (auto *pair : getProjections(value)) {
+    pair->print(OS);
+  }
 }
 void ValueStorageMap::dumpProjections(SILValue value) const {
-  for (auto *pair : getProjections(value)) {
-    pair->dump();
-  }
+  printProjections(value, llvm::dbgs());
 }
-void ValueStorageMap::dump() const {
-  llvm::dbgs() << "ValueStorageMap:\n";
+void ValueStorageMap::print(llvm::raw_ostream &OS) const {
+  OS << "ValueStorageMap:\n";
   for (unsigned ordinal : indices(valueVector)) {
     auto &valStoragePair = valueVector[ordinal];
-    llvm::dbgs() << "value: ";
-    valStoragePair.value->dump();
+    OS << "value: ";
+    valStoragePair.value->print(OS);
     auto &storage = valStoragePair.storage;
     if (storage.isUseProjection) {
-      llvm::dbgs() << "  use projection: ";
+      OS << "  use projection: ";
       if (!storage.isRewritten)
-        valueVector[storage.projectedStorageID].value->dump();
+        valueVector[storage.projectedStorageID].value->print(OS);
     } else if (storage.isDefProjection) {
-      llvm::dbgs() << "  def projection: ";
+      OS << "  def projection: ";
       if (!storage.isRewritten)
-        valueVector[storage.projectedStorageID].value->dump();
+        valueVector[storage.projectedStorageID].value->print(OS);
     }
     if (storage.storageAddress) {
-      llvm::dbgs() << "  storage: ";
-      storage.storageAddress->dump();
+      OS << "  storage: ";
+      storage.storageAddress->print(OS);
     }
   }
 }
+void ValueStorageMap::dump() const { print(llvm::dbgs()); }
 #endif
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/AddressLowering.h
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.h
@@ -17,6 +17,10 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace swift {
 
 /// Track an opaque value's storage. An opaque value is a SILValue with
@@ -199,6 +203,7 @@ struct ValueStorage {
   }
 
 #ifndef NDEBUG
+  void print(llvm::raw_ostream &OS) const;
   void dump() const;
 #endif
 };
@@ -215,6 +220,7 @@ public:
     ValueStorage storage;
     ValueStoragePair(SILValue v, ValueStorage s) : value(v), storage(s) {}
 #ifndef NDEBUG
+    void print(llvm::raw_ostream &OS) const;
     void dump() const;
 #endif
   };
@@ -396,7 +402,9 @@ public:
   bool isComposingUseProjection(Operand *oper) const;
 
 #ifndef NDEBUG
+  void printProjections(SILValue value, llvm::raw_ostream &OS) const;
   void dumpProjections(SILValue value) const;
+  void print(llvm::raw_ostream &OS) const;
   void dump() const;
 #endif
 };

--- a/lib/SILOptimizer/Mandatory/PhiStorageOptimizer.cpp
+++ b/lib/SILOptimizer/Mandatory/PhiStorageOptimizer.cpp
@@ -87,6 +87,8 @@
 
 #include "PhiStorageOptimizer.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/Dominance.h"
+#include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILInstruction.h"
 
@@ -101,6 +103,7 @@ namespace swift {
 class PhiStorageOptimizer {
   PhiValue phi;
   const ValueStorageMap &valueStorageMap;
+  DominanceInfo *domInfo;
 
   CoalescedPhi &coalescedPhi;
 
@@ -108,28 +111,37 @@ class PhiStorageOptimizer {
 
 public:
   PhiStorageOptimizer(PhiValue phi, const ValueStorageMap &valueStorageMap,
-                      CoalescedPhi &coalescedPhi)
-      : phi(phi), valueStorageMap(valueStorageMap), coalescedPhi(coalescedPhi),
-        occupiedBlocks(getFunction()) {}
+                      CoalescedPhi &coalescedPhi, DominanceInfo *domInfo)
+      : phi(phi), valueStorageMap(valueStorageMap), domInfo(domInfo),
+        coalescedPhi(coalescedPhi), occupiedBlocks(getFunction()) {}
 
   SILFunction *getFunction() const { return phi.phiBlock->getParent(); }
 
   void optimize();
 
 protected:
-  bool hasUseProjection(SILInstruction *defInst);
-  bool canCoalesceValue(SILValue incomingVal);
+  using ProjectedValues = StackList<SILValue>;
+  bool findUseProjections(SILValue value, SmallVectorImpl<Operand *> &operands);
+  bool findDefProjections(SILValue value,
+                          SmallVectorImpl<SILValue> *projecteds);
+  SILBasicBlock *canCoalesceValue(SILValue incomingVal,
+                                  ProjectedValues *projectedValues);
   void tryCoalesceOperand(SILBasicBlock *incomingPred);
-  bool recordUseLiveness(SILValue incomingVal, BasicBlockSetVector &liveBlocks);
+  bool recordUseLiveness(ProjectedValues &incomingVals,
+                         SILBasicBlock *dominatingBlock,
+                         BasicBlockSetVector &liveBlocks);
+  SILBasicBlock *getDominatingBlock(SILValue incomingVal,
+                                    ProjectedValues *projectedValues);
 };
 
 } // namespace swift
 
 void CoalescedPhi::coalesce(PhiValue phi,
-                            const ValueStorageMap &valueStorageMap) {
+                            const ValueStorageMap &valueStorageMap,
+                            DominanceInfo *domInfo) {
   assert(empty() && "attempt to recoalesce the same phi");
 
-  PhiStorageOptimizer(phi, valueStorageMap, *this).optimize();
+  PhiStorageOptimizer(phi, valueStorageMap, *this, domInfo).optimize();
 }
 
 /// Optimize phi storage by coalescing phi operands.
@@ -168,7 +180,8 @@ void CoalescedPhi::coalesce(PhiValue phi,
 void PhiStorageOptimizer::optimize() {
   // The single incoming value case always projects storage.
   if (auto *predecessor = phi.phiBlock->getSinglePredecessorBlock()) {
-    if (canCoalesceValue(phi.getValue()->getIncomingPhiValue(predecessor))) {
+    if (canCoalesceValue(phi.getValue()->getIncomingPhiValue(predecessor),
+                         /*projectedValues=*/nullptr)) {
       // Storage will always be allocated for the phi.  The optimization
       // attempts to let incoming values reuse the phi's storage.  This isn't
       // always possible, even in the single incoming value case.  For example,
@@ -183,21 +196,52 @@ void PhiStorageOptimizer::optimize() {
   }
 }
 
-// Return true if any of \p defInst's operands are composing use projections
-// into \p defInst's storage.
-bool PhiStorageOptimizer::hasUseProjection(SILInstruction *defInst) {
+/// Return \p value's defining instruction's operand which is a composing use
+/// projection into \p defInst's storage, or nullptr if none exists.
+///
+/// Precondition: \p value is defined by an instruction.
+bool PhiStorageOptimizer::findUseProjections(
+    SILValue value, SmallVectorImpl<Operand *> &operands) {
+  auto *defInst = value->getDefiningInstruction();
+  auto ordinal = valueStorageMap.getOrdinal(value);
+  bool found = false;
   for (Operand &oper : defInst->getAllOperands()) {
-    if (valueStorageMap.isComposingUseProjection(&oper))
-      return true;
+    if (valueStorageMap.isComposingUseProjection(&oper) &&
+        valueStorageMap.getStorage(oper.get()).projectedStorageID == ordinal) {
+      found = true;
+      operands.push_back(&oper);
+    }
   }
-  return false;
+  return found;
 }
 
-// Return true in \p incomingVal can be coalesced with this phi ignoring
-// possible interference. Simply determine whether storage reuse is possible.
+bool PhiStorageOptimizer::findDefProjections(
+    SILValue value, SmallVectorImpl<SILValue> *projecteds) {
+  bool found = false;
+  for (auto user : value->getUsers()) {
+    for (auto result : user->getResults()) {
+      auto *storage = valueStorageMap.getStorageOrNull(result);
+      if (!storage)
+        continue;
+      if (storage->isDefProjection) {
+        assert(storage->projectedStorageID ==
+               valueStorageMap.getOrdinal(value));
+        projecteds->push_back(result);
+        found = true;
+      }
+    }
+  }
+  return found;
+}
+
+// Determine whether storage reuse is possible with \p incomingVal.  Ignore
+// possible interference.  If reuse is possible, return the block which
+// dominates all defs whose storage is projected out of incomingVal.
 //
 // Precondition: \p incomingVal is an operand of this phi.
-bool PhiStorageOptimizer::canCoalesceValue(SILValue incomingVal) {
+SILBasicBlock *
+PhiStorageOptimizer::canCoalesceValue(SILValue incomingVal,
+                                      ProjectedValues *projectedValues) {
   // A Phi must not project from storage that was initialized on a path that
   // reaches the phi because other uses of the storage may interfere with the
   // phi. A phi may, however, be a composing use projection.
@@ -215,31 +259,20 @@ bool PhiStorageOptimizer::canCoalesceValue(SILValue incomingVal) {
   // could be handled, but would require by recursively following uses across
   // projections when computing liveness.
   if (!incomingStorage.isAllocated() || incomingStorage.isProjection())
-    return false;
+    return nullptr;
 
-  auto *defInst = incomingVal->getDefiningInstruction();
-  if (!defInst) {
-    // Indirect function arguments were replaced by loads.
-    assert(!isa<SILFunctionArgument>(incomingVal));
+  if (PhiValue(incomingVal)) {
     // Do not coalesce a phi with other phis. This would require liveness
     // analysis of the whole phi web before coalescing phi operands.
-    return false;
+    return nullptr;
   }
 
   // Don't coalesce an incoming value unless it's storage is from a stack
   // allocation, which can be replaced with another alloc_stack.
   if (!isa<AllocStackInst>(incomingStorage.storageAddress))
-    return false;
+    return nullptr;
 
-  // Make sure that the incomingVal is not coalesced with any of its operands.
-  //
-  // Handling incomingValues whose operands project into them would require by
-  // recursively finding the set of value definitions and their dominating defBB
-  // instead of simply incomingVal->getParentBlock().
-  if (hasUseProjection(defInst))
-    return false;
-
-  return true;
+  return getDominatingBlock(incomingVal, projectedValues);
 }
 
 // Process a single incoming phi operand. Compute the value's liveness while
@@ -248,11 +281,13 @@ void PhiStorageOptimizer::tryCoalesceOperand(SILBasicBlock *incomingPred) {
   Operand *incomingOper = phi.getOperand(incomingPred);
   SILValue incomingVal = incomingOper->get();
 
-  if (!canCoalesceValue(incomingVal))
+  ProjectedValues projectedValues(incomingPred->getFunction());
+  auto *dominatingBlock = canCoalesceValue(incomingVal, &projectedValues);
+  if (!dominatingBlock)
     return;
 
   BasicBlockSetVector liveBlocks(getFunction());
-  if (!recordUseLiveness(incomingVal, liveBlocks))
+  if (!recordUseLiveness(projectedValues, dominatingBlock, liveBlocks))
     return;
 
   for (auto *block : liveBlocks) {
@@ -262,39 +297,103 @@ void PhiStorageOptimizer::tryCoalesceOperand(SILBasicBlock *incomingPred) {
   coalescedPhi.coalescedOperands.push_back(incomingOper);
 }
 
-// Record liveness generated by uses of \p incomingVal.
+/// The block which dominates all the defs whose storage is projected out of the
+/// storage for \p incomingVal.
+///
+/// Populates \p projectedValues with the values whose storage is recursively
+/// projected out of the storage for incomingVal.
+SILBasicBlock *
+PhiStorageOptimizer::getDominatingBlock(SILValue incomingVal,
+                                        ProjectedValues *projectedValues) {
+  assert(domInfo);
+
+  // Recursively find the set of value definitions and the dominating LCA.
+  ValueWorklist values(incomingVal->getFunction());
+
+  values.push(incomingVal);
+
+  SILBasicBlock *lca = incomingVal->getParentBlock();
+  auto updateLCA = [&](SILBasicBlock *other) {
+    lca = domInfo->findNearestCommonDominator(lca, other);
+  };
+
+  while (auto value = values.pop()) {
+    if (projectedValues)
+      projectedValues->push_back(value);
+    auto *defInst = value->getDefiningInstruction();
+    if (!defInst) {
+      assert(!PhiValue(value));
+      updateLCA(value->getParentBlock());
+      continue;
+    }
+    SmallVector<Operand *, 2> operands;
+    if (findUseProjections(value, operands)) {
+      assert(operands.size() > 0);
+      // Any operand whose storage is a use-projection out of `value`'s storage
+      // dominates `value` (i.e. `defInst`), so skip updating the LCA here.
+      for (auto *operand : operands) {
+        values.pushIfNotVisited(operand->get());
+      }
+      continue;
+    }
+    SmallVector<SILValue, 2> projecteds;
+    if (findDefProjections(value, &projecteds)) {
+      assert(projecteds.size() > 0);
+      // Walking up the storage projection chain from this point, every
+      // subsequent projection must be a def projection
+      // [projection_chain_structure]. Every such projection is dominated by
+      // `value` (i.e. defInst).
+      //
+      // If the walk were only updating the LCA, it could stop here.
+      //
+      // It is also collecting values whose storage is projected out of the
+      // phi, however, so the walk must continue.
+      updateLCA(defInst->getParent());
+      for (auto projected : projecteds) {
+        values.pushIfNotVisited(projected);
+      }
+      continue;
+    }
+    updateLCA(defInst->getParent());
+  }
+  return lca;
+}
+
+// Record liveness generated by uses of \p projectedVals.
 //
 // Return true if no interference was detected along the way.
-bool PhiStorageOptimizer::recordUseLiveness(SILValue incomingVal,
+bool PhiStorageOptimizer::recordUseLiveness(ProjectedValues &projectedVals,
+                                            SILBasicBlock *dominatingBlock,
                                             BasicBlockSetVector &liveBlocks) {
   assert(liveBlocks.empty());
 
-  // Stop liveness traversal at defBB.
-  SILBasicBlock *defBB = incomingVal->getParentBlock();
-  for (auto *use : incomingVal->getUses()) {
-    StackList<SILBasicBlock *> liveBBWorklist(getFunction());
+  for (auto projectedVal : projectedVals) {
+    for (auto *use : projectedVal->getUses()) {
+      StackList<SILBasicBlock *> liveBBWorklist(getFunction());
 
-    // If \p liveBB is already occupied by another value, return
-    // false. Otherwise, mark \p liveBB live and push it onto liveBBWorklist.
-    auto visitLiveBlock = [&](SILBasicBlock *liveBB) {
-      assert(liveBB != phi.phiBlock && "phi operands are consumed");
+      // If \p liveBB is already occupied by another value, return
+      // false. Otherwise, mark \p liveBB live and push it onto liveBBWorklist.
+      auto visitLiveBlock = [&](SILBasicBlock *liveBB) {
+        assert(liveBB != phi.phiBlock && "phi operands are consumed");
 
-      if (occupiedBlocks.contains(liveBB))
+        if (occupiedBlocks.contains(liveBB))
+          return false;
+
+        // Stop liveness traversal at dominatingBlock.
+        if (liveBlocks.insert(liveBB) && liveBB != dominatingBlock) {
+          liveBBWorklist.push_back(liveBB);
+        }
+        return true;
+      };
+      if (!visitLiveBlock(use->getUser()->getParent()))
         return false;
 
-      if (liveBlocks.insert(liveBB) && liveBB != defBB) {
-        liveBBWorklist.push_back(liveBB);
-      }
-      return true;
-    };
-    if (!visitLiveBlock(use->getUser()->getParent()))
-      return false;
-
-    while (!liveBBWorklist.empty()) {
-      auto *succBB = liveBBWorklist.pop_back_val();
-      for (auto *predBB : succBB->getPredecessorBlocks()) {
-        if (!visitLiveBlock(predBB))
-          return false;
+      while (!liveBBWorklist.empty()) {
+        auto *succBB = liveBBWorklist.pop_back_val();
+        for (auto *predBB : succBB->getPredecessorBlocks()) {
+          if (!visitLiveBlock(predBB))
+            return false;
+        }
       }
     }
   }

--- a/lib/SILOptimizer/Mandatory/PhiStorageOptimizer.h
+++ b/lib/SILOptimizer/Mandatory/PhiStorageOptimizer.h
@@ -24,6 +24,8 @@
 
 namespace swift {
 
+class DominanceInfo;
+
 class CoalescedPhi {
   friend class PhiStorageOptimizer;
 
@@ -37,7 +39,8 @@ public:
   CoalescedPhi(CoalescedPhi &&) = default;
   CoalescedPhi &operator=(CoalescedPhi &&) = default;
 
-  void coalesce(PhiValue phi, const ValueStorageMap &valueStorageMap);
+  void coalesce(PhiValue phi, const ValueStorageMap &valueStorageMap,
+                DominanceInfo *domInfo);
 
   bool empty() const { return coalescedOperands.empty(); }
 

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1431,10 +1431,8 @@ nopers(%error : @owned $any Error):
 
 // CHECK-LABEL: sil [ossa] @f262_testTryApplyIntoPhi : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
-// CHECK:         [[STACK:%[^,]+]] = alloc_stack
-// CHECK:         try_apply undef<R>([[STACK]]) {{.*}}, normal [[NORMAL:bb[0-9]+]]
+// CHECK:         try_apply undef<R>([[ADDR]]) {{.*}}, normal [[NORMAL:bb[0-9]+]]
 // CHECK:       [[NORMAL]]({{%[^,]+}} : $()):
-// CHECK:         copy_addr [take] [[STACK]] to [init] [[ADDR]]
 // CHECK:         br [[EXIT:bb[0-9]+]]                                          
 // CHECK:       [[EXIT]]:                                              
 // CHECK:         return {{%[^,]+}} : $()                                 
@@ -2268,15 +2266,13 @@ bb3:
 // Test the result being stored into an @out enum.
 // CHECK-LABEL: sil [ossa] @test_checked_cast_br4 : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*Optional<T>, [[INSTANCE:%[^,]+]] : @owned $TestGeneric<Element>):
-// CHECK:         [[TEMP:%[^,]+]] = alloc_stack $Optional<T>
 // CHECK:         [[CAST_SOURCE_ADDR:%[^,]+]] = alloc_stack $TestGeneric<Element>
 // CHECK:         store [[INSTANCE]] to [init] [[CAST_SOURCE_ADDR]]
-// CHECK:         [[CAST_DEST_ADDR:%[^,]+]] = init_enum_data_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt
+// CHECK:         [[CAST_DEST_ADDR:%[^,]+]] = init_enum_data_addr [[OUT_ADDR]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK:         checked_cast_addr_br take_on_success TestGeneric<Element> in [[CAST_SOURCE_ADDR]] : $*TestGeneric<Element> to T in [[CAST_DEST_ADDR]] : $*T, [[SUCCESS:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         dealloc_stack [[CAST_SOURCE_ADDR]]
-// CHECK:         inject_enum_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt
-// CHECK:         copy_addr [take] [[TEMP]] to [init] [[OUT_ADDR]]
+// CHECK:         inject_enum_addr [[OUT_ADDR]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK-LABEL: } // end sil function 'test_checked_cast_br4'
 sil [ossa] @test_checked_cast_br4 : $@convention(method) <Element><T> (@owned TestGeneric<Element>) -> @out Optional<T> {
 bb0(%3 : @owned $TestGeneric<Element>):

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -6,6 +6,8 @@ import Builtin
 
 sil_stage raw
 
+protocol Error {}
+
 typealias AnyObject = Builtin.AnyObject
 typealias Int = Builtin.Int64
 typealias Bool = Builtin.Int1
@@ -43,6 +45,11 @@ struct OuterStruct<T> {
   var object: AnyObject
 }
 
+struct Pair<T> {
+  var x: T
+  var y: T
+}
+
 sil [ossa] @getOut : $@convention(thin) <T> () -> @out T
 
 // Test BBArgs allocation.
@@ -78,6 +85,129 @@ bb2:
 // %15
 bb3(%15 : @owned $T):
   return %15 : $T
+}
+
+// Double use projection without interference.
+// CHECK-LABEL: sil [ossa] @f011_testBBArgSelect_useProjection : $@convention(thin) <T> () -> () {
+// CHECK:         [[STACK:%[^,]+]] = alloc_stack $Optional<T>
+// CHECK:         cond_br undef, [[RIGHT:bb[0-9]+]], [[LEFT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[LEFT_ADDR:%[^,]+]] = init_enum_data_addr [[STACK]]
+// CHECK:         apply {{%[^,]+}}<T>([[LEFT_ADDR]])
+// CHECK:         inject_enum_addr [[STACK]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[RIGHT_ADDR:%[^,]+]] = init_enum_data_addr [[STACK]]
+// CHECK:         apply {{%[^,]+}}<T>([[RIGHT_ADDR]])
+// CHECK:         inject_enum_addr [[STACK]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_addr [[STACK]]
+// CHECK:         dealloc_stack [[STACK]]
+// CHECK-LABEL: } // end sil function 'f011_testBBArgSelect_useProjection'
+sil [ossa] @f011_testBBArgSelect_useProjection : $@convention(thin) <T> () -> () {
+entry:
+  %get = function_ref @getOut : $@convention(thin) <τ_0_0>() -> @out τ_0_0
+  cond_br undef, left, right
+left:
+  %left = apply %get<T>() : $@convention(thin) <T> () -> (@out T)
+  %forward = enum $Optional<T>, #Optional.some, %left : $T
+  br exit(%forward : $Optional<T>)
+right:
+  %right = apply %get<T>() : $@convention(thin) <T> () -> (@out T)
+  %backward = enum $Optional<T>, #Optional.some, %right : $T
+  br exit(%backward : $Optional<T>)
+exit(%box : @owned $Optional<T>):
+  destroy_value %box : $Optional<T>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Double use projection + interference.
+// CHECK-LABEL: sil [ossa] @f012_testBBArgSelect_useProjection_oneInterference : $@convention(thin) <T> () -> () {
+// CHECK:         [[LEFT_OUTER:%[^,]+]] = alloc_stack $Optional<T>
+// CHECK:         [[LEFT_ADDR:%[^,]+]] = init_enum_data_addr [[LEFT_OUTER]]
+// CHECK:         apply {{%[^,]+}}<T>([[LEFT_ADDR]])
+// CHECK:         [[PHI_ADDR:%[^,]+]] = alloc_stack $Optional<T>
+// CHECK:         [[RIGHT_ADDR:%[^,]+]] = init_enum_data_addr [[PHI_ADDR]]
+// CHECK:         apply {{%[^,]+}}<T>([[RIGHT_ADDR]])
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         destroy_addr [[LEFT_ADDR]]
+// CHECK:         inject_enum_addr [[PHI_ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_addr [[RIGHT_ADDR]]
+// CHECK:         inject_enum_addr [[LEFT_OUTER]]
+// CHECK:         copy_addr [take] [[LEFT_OUTER]] to [init] [[PHI_ADDR]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_addr [[PHI_ADDR]]
+// CHECK:         dealloc_stack [[PHI_ADDR]]
+// CHECK:         dealloc_stack [[LEFT_OUTER]]
+// CHECK-LABEL: } // end sil function 'f012_testBBArgSelect_useProjection_oneInterference'
+sil [ossa] @f012_testBBArgSelect_useProjection_oneInterference : $@convention(thin) <T> () -> () {
+entry:
+  %get = function_ref @getOut : $@convention(thin) <τ_0_0>() -> @out τ_0_0
+  %left = apply %get<T>() : $@convention(thin) <T> () -> (@out T)
+  %right = apply %get<T>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, left, right
+left:
+  destroy_value %right : $T
+  %forward = enum $Optional<T>, #Optional.some, %left : $T
+  br exit(%forward : $Optional<T>)
+right:
+  destroy_value %left : $T
+  %backward = enum $Optional<T>, #Optional.some, %right : $T
+  br exit(%backward : $Optional<T>)
+exit(%box : @owned $Optional<T>):
+  destroy_value %box : $Optional<T>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @f013_testBBArgSelect_useProjections_interference : {{.*}} {
+// CHECK:         [[S2_ADDR:%[^,]+]] = alloc_stack $Box<T>
+// CHECK:         [[PHI_ADDR:%[^,]+]] = alloc_stack $Box<T>
+// CHECK:         [[T_ADDR:%[^,]+]] = struct_element_addr [[PHI_ADDR]] : $*Box<T>, #Box.t
+// CHECK:         apply undef<T>([[T_ADDR]])
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         br [[MERGE:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[S2_FIELD_ADDR:%[^,]+]] = struct_element_addr [[S2_ADDR]] : $*Box<T>, #Box.t
+// CHECK:         copy_addr [take] [[T_ADDR]] to [init] [[S2_FIELD_ADDR]]
+// CHECK:         copy_addr [take] [[S2_ADDR]] to [init] [[PHI_ADDR]]
+// CHECK:         br [[MERGE]]
+// CHECK:       [[MERGE]]:
+// CHECK:         apply undef<Box<T>>([[PHI_ADDR]])
+// CHECK:         destroy_addr [[PHI_ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         dealloc_stack [[PHI_ADDR]]
+// CHECK:         dealloc_stack [[S2_ADDR]]
+// CHECK-LABEL: } // end sil function 'f013_testBBArgSelect_useProjections_interference'
+sil [ossa] @f013_testBBArgSelect_useProjections_interference : $@convention(thin) <T> () -> () {
+entry:
+  %t = apply undef<T>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, left, right
+
+left:
+  %s2 = struct $Box<T>(%t : $T)
+  br merge(%s2 : $Box<T>)
+
+right:
+  %s = struct $Box<T>(%t : $T)
+  br merge(%s : $Box<T>)
+
+merge(%tb : @owned $Box<T>):
+  apply undef<Box<T>>(%tb) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  destroy_value %tb : $Box<T>
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
 }
 
 // One projection from incoming values. One interference.
@@ -336,7 +466,6 @@ bb3(%phio0 : @owned $AnyObject, %phio1 : @owned $AnyObject, %phie0 : @owned $T, 
 // CHECK:   [[TUPLE1_1:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 1
 // CHECK:   store %3 to [init] [[TUPLE1_1]] : $*AnyObject
 // CHECK:   inject_enum_addr [[INNER1]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
-// CHECK:   copy_addr [take] [[INNER1]] to [init] [[PHI6:%.*]] : $*InnerEnum<T>
 // CHECK:   br bb6
 // CHECK: bb2:
 // CHECK:   cond_br undef, bb4, bb3
@@ -355,12 +484,11 @@ bb3(%phio0 : @owned $AnyObject, %phio1 : @owned $AnyObject, %phie0 : @owned $T, 
 // CHECK:   [[TUPLE5_1:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 1
 // CHECK:   store %3 to [init] [[TUPLE5_1]] : $*AnyObject
 // CHECK:   inject_enum_addr [[INNER5]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
-// CHECK:   copy_addr [take] [[INNER5]] to [init] [[PHI6:%.*]] : $*InnerEnum<T>
 // CHECK:   br bb6
 // CHECK: bb6:
 // CHECK:   [[TUPLE6:%.*]] = init_enum_data_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
 // CHECK:   [[TUPLE6_0:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 0
-// CHECK:   copy_addr [take] [[PHI6]] to [init] [[TUPLE6_0]] : $*InnerEnum<T>
+// CHECK:   copy_addr [take] [[INNER1]] to [init] [[TUPLE6_0]] : $*InnerEnum<T>
 // CHECK:   [[TUPLE6_1:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 1
 // CHECK:   store %4 to [init] [[TUPLE6_1]] : $*AnyObject
 // CHECK:   inject_enum_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
@@ -596,6 +724,434 @@ entry:
 
 exit(%t2 : @owned $T):
   destroy_value %t2 : $T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @f130_single_phi_use_of_phi {{.*}} {
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $Box<T>
+// CHECK:         [[T_ADDR:%[^,]+]] = struct_element_addr [[ADDR]] : $*Box<T>, #Box.t
+// CHECK:         apply undef<T>([[T_ADDR]])
+// CHECK:         br [[FAKE_MERGE1:bb[0-9]+]]
+// CHECK:       [[FAKE_MERGE1]]:
+// CHECK:         [[T_ADDR_2:%[^,]+]] = struct_element_addr [[ADDR]] : $*Box<T>, #Box.t
+// CHECK:         apply undef<T>([[T_ADDR_2]])
+// CHECK:         br [[FAKE_MERGE2:bb[0-9]+]]
+// CHECK:       [[FAKE_MERGE2]]:
+// CHECK:         apply undef<Box<T>>([[ADDR]])
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK-LABEL: } // end sil function 'f130_single_phi_use_of_phi'
+sil [ossa] @f130_single_phi_use_of_phi : $@convention(thin) <T> () -> () {
+entry:
+  %t = apply undef<T>() : $@convention(thin) <T> () -> (@out T)
+  br fakeMerge1(%t : $T)
+
+fakeMerge1(%tp : @owned $T):
+  apply undef<T>(%tp) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %box = struct $Box<T>(%tp : $T)
+  br fakeMerge2(%box : $Box<T>)
+
+fakeMerge2(%boxp : @owned $Box<T>):
+  apply undef<Box<T>>(%boxp) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  destroy_value %boxp : $Box<T>
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @f131_single_phi_use_of_phi_interference : {{.*}} {
+// CHECK:         [[BOXP_ADDR:%[^,]+]] = alloc_stack $Box<T>
+// CHECK:         [[T_ADDR:%[^,]+]] = struct_element_addr [[BOXP_ADDR]] : $*Box<T>, #Box.t
+// CHECK:         apply undef<T>([[T_ADDR]])
+// CHECK:         br [[FAKE_MERGE:bb[0-9]+]]
+// CHECK:       [[FAKE_MERGE]]:
+// CHECK:         [[T_ADDR_2:%[^,]+]] = struct_element_addr [[BOXP_ADDR]] : $*Box<T>, #Box.t
+// CHECK:         apply undef<T>([[T_ADDR_2]])
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[BOX_2_ADDR:%[^,]+]] = alloc_stack $Box<T>
+// CHECK:         apply undef<Box<T>>([[BOX_2_ADDR]])
+// CHECK:         destroy_addr [[BOXP_ADDR]]
+// CHECK:         copy_addr [take] [[BOX_2_ADDR]] to [init] [[BOXP_ADDR]]
+// CHECK:         dealloc_stack [[BOX_2_ADDR]]
+// CHECK:         br [[MERGE:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         br [[MERGE]]
+// CHECK:       [[MERGE]]:
+// CHECK:         apply undef<Box<T>>([[BOXP_ADDR]])
+// CHECK:         destroy_addr [[BOXP_ADDR]]
+// CHECK:         dealloc_stack [[BOXP_ADDR]]
+// CHECK-LABEL: } // end sil function 'f131_single_phi_use_of_phi_interference'
+sil [ossa] @f131_single_phi_use_of_phi_interference : $@convention(thin) <T> () -> () {
+entry:
+  %t = apply undef<T>() : $@convention(thin) <T> () -> (@out T)
+  br fakeMerge1(%t : $T)
+
+fakeMerge1(%tp : @owned $T):
+  apply undef<T>(%tp) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %box = struct $Box<T>(%tp : $T)
+  cond_br undef, left, right
+
+right:
+  %box2 = apply undef<Box<T>>() : $@convention(thin) <T> () -> (@out T)
+  destroy_value %box : $Box<T>
+  br merge2(%box2 : $Box<T>)
+
+left:
+  br merge2(%box : $Box<T>)
+
+merge2(%boxp : @owned $Box<T>):
+  apply undef<Box<T>>(%boxp) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  destroy_value %boxp : $Box<T>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @f140_interfering_use_projection : {{.*}} {
+// CHECK:         [[S2_ADDR:%[^,]+]] = alloc_stack $Pair<T>
+// CHECK:         [[T2_ADDR:%[^,]+]] = struct_element_addr [[S2_ADDR]] : $*Pair<T>, #Pair.y
+// CHECK:         apply undef<T>([[T2_ADDR]])
+// CHECK:         [[PHI_ADDR:%[^,]+]] = alloc_stack $Pair<T>
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply undef<Pair<T>>([[PHI_ADDR]])
+// CHECK:         destroy_addr [[T2_ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[T1_ADDR:%[^,]+]] = struct_element_addr [[S2_ADDR]] : $*Pair<T>, #Pair.x
+// CHECK:         apply undef<T>([[T1_ADDR]])
+// CHECK:         copy_addr [take] [[S2_ADDR]] to [init] [[PHI_ADDR]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_addr [[PHI_ADDR]]
+// CHECK:         dealloc_stack [[PHI_ADDR]]
+// CHECK:         dealloc_stack [[S2_ADDR]]
+// CHECK-LABEL: } // end sil function 'f140_interfering_use_projection'
+sil [ossa] @f140_interfering_use_projection : $@convention(thin) <T> () -> () {
+entry:
+  %t2 = apply undef<T>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, left, right
+
+left:
+  %t1 = apply undef<T>() : $@convention(thin) <T> () -> (@out T)
+  %s2 = struct $Pair<T>(%t1 : $T, %t2 : $T)
+  br merge(%s2 : $Pair<T>)
+
+right:
+  %s1 = apply undef<Pair<T>>() : $@convention(thin) <T> () -> (@out T)
+  destroy_value %t2 : $T
+  br merge(%s1 : $Pair<T>)
+
+merge(%sp : @owned $Pair<T>):
+  destroy_value %sp : $Pair<T>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Incoming value is the root of a chain of projections: 
+//     storage <- use <- use <- def
+//                ^^^    ^^^    ^^^
+//                %s projects out of %s2's storage
+//                       ^^^    ^^^
+//                       %box projects out of %s's strorage
+//                              ^^^
+//                              %t projects out of %box's storage
+// There is no interference (and only one incoming phi.)
+// CHECK-LABEL: sil [ossa] @f150_incoming_use_use_def_no_interference : {{.*}} {
+// CHECK:         [[PHI_ADDR:%[^,]+]] = alloc_stack $Box<Box<Box<T>>>
+// CHECK:         [[S_ADDR:%[^,]+]] = struct_element_addr [[PHI_ADDR]] : $*Box<Box<Box<T>>>, #Box.t
+// CHECK:         [[BOX_ADDR:%[^,]+]] = struct_element_addr [[S_ADDR]] : $*Box<Box<T>>, #Box.t
+// CHECK:         apply undef<Box<T>>([[BOX_ADDR]])
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         br [[FAKE_MERGE:bb[0-9]+]]
+// CHECK:       [[FAKE_MERGE]]:
+// CHECK:         apply undef<Box<Box<Box<T>>>>([[PHI_ADDR]])
+// CHECK:         destroy_addr [[PHI_ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[T_ADDR:%[^,]+]] = struct_element_addr [[BOX_ADDR]] : $*Box<T>, #Box.t
+// CHECK:         destroy_addr [[T_ADDR]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         dealloc_stack [[PHI_ADDR]]
+// CHECK-LABEL: } // end sil function 'f150_incoming_use_use_def_no_interference'
+sil [ossa] @f150_incoming_use_use_def_no_interference : $@convention(thin) <T> () -> () {
+entry:
+  %box = apply undef<Box<T>>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, left, right
+
+left:
+  %t = destructure_struct %box : $Box<T>
+  destroy_value %t : $T
+  br exit
+
+right:
+  %s = struct $Box<Box<T>>(%box : $Box<T>)
+  %s2 = struct $Box<Box<Box<T>>>(%s : $Box<Box<T>>)
+  br fakeMerge(%s2 : $Box<Box<Box<T>>>)
+
+fakeMerge(%tb : @owned $Box<Box<Box<T>>>):
+  apply undef<Box<Box<Box<T>>>>(%tb) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  destroy_value %tb : $Box<Box<Box<T>>>
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Incoming value is the root of a chain of projections: 
+//     storage <- use <- use <- def
+//                ^^^    ^^^    ^^^
+//                %s projects out of %s2's storage
+//                       ^^^    ^^^
+//                       %box projects out of %s's strorage
+//                              ^^^
+//                              %t projects out of %box's storage
+// There is interference of the _def_ projection (which can only be detected by
+// adding its uses to liveness:
+//   %t is destroyed in ^left2
+//   %s3 is defined in ^left2
+// TODO: When doing per-instruction rather than per-block liveness, this test
+//       will no longer have interference.  At that point, move the
+//       destroy_value %t below the subsequent apply to reintroduce interference
+//       and duplicate this test.
+// CHECK-LABEL: sil [ossa] @f160_incoming_use_use_def_interference : {{.*}} {
+// CHECK:         [[PHI_ADDR:%[^,]+]] = alloc_stack $Box<Box<Box<T>>>
+// CHECK:         [[S_ADDR:%[^,]+]] = struct_element_addr [[PHI_ADDR]] : $*Box<Box<Box<T>>>, #Box.t
+// CHECK:         [[BOX_ADDR:%[^,]+]] = struct_element_addr [[S_ADDR]] : $*Box<Box<T>>, #Box.t
+// CHECK:         apply undef<Box<T>>([[BOX_ADDR]])
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         br [[MERGE:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         br [[LEFT2:bb[0-9]+]]
+// CHECK:       [[LEFT2]]:
+// CHECK:         [[S3_ADDR:%[^,]+]] = alloc_stack $Box<Box<Box<T>>>
+// CHECK:         [[T_ADDR:%[^,]+]] = struct_element_addr [[BOX_ADDR]] : $*Box<T>, #Box.t
+// CHECK:         destroy_addr [[T_ADDR]]
+// CHECK:         apply undef<Box<Box<Box<T>>>>([[S3_ADDR]])
+// CHECK:         copy_addr [take] [[S3_ADDR]] to [init] [[PHI_ADDR]] : $*Box<Box<Box<T>>>
+// CHECK:         dealloc_stack [[S3_ADDR]]
+// CHECK:         br [[MERGE:bb[0-9]+]]
+// CHECK:       [[MERGE]]:
+// CHECK:         apply undef<Box<Box<Box<T>>>>([[PHI_ADDR]])
+// CHECK:         destroy_addr [[PHI_ADDR]]
+// CHECK:         dealloc_stack [[PHI_ADDR]]
+// CHECK-LABEL: } // end sil function 'f160_incoming_use_use_def_interference'
+sil [ossa] @f160_incoming_use_use_def_interference : $@convention(thin) <T> () -> () {
+entry:
+  %box = apply undef<Box<T>>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, left, right
+
+left:
+  %t = destructure_struct %box : $Box<T>
+  br left2
+
+left2:
+  destroy_value %t : $T
+  %s3 = apply undef<Box<Box<Box<T>>>>() : $@convention(thin) <T> () -> (@out T)
+  br merge(%s3 : $Box<Box<Box<T>>>)
+
+right:
+  %s = struct $Box<Box<T>>(%box : $Box<T>)
+  %s2 = struct $Box<Box<Box<T>>>(%s : $Box<Box<T>>)
+  br merge(%s2 : $Box<Box<Box<T>>>)
+
+merge(%tb : @owned $Box<Box<Box<T>>>):
+  apply undef<Box<Box<Box<T>>>>(%tb) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  destroy_value %tb : $Box<Box<Box<T>>>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Incoming phi.
+// TODO: Coalesce in this case.
+// CHECK-LABEL: sil [ossa] @f170_incoming_phi_no_interference : {{.*}} {
+// CHECK:         [[T_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         apply undef<T>([[T_ADDR]])
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         br [[FAKE_MERGE_1:bb[0-9]+]]
+// CHECK:       [[FAKE_MERGE_1]]:
+// CHECK:         [[TP_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         apply undef<T>([[T_ADDR]])
+// CHECK:         copy_addr [take] [[T_ADDR]] to [init] [[TP_ADDR]]
+// CHECK:         br [[FAKE_MERGE_2:bb[0-9]+]]
+// CHECK:       [[FAKE_MERGE_2]]:
+// CHECK:         apply undef<T>([[TP_ADDR]])
+// CHECK:         destroy_addr [[TP_ADDR]]
+// CHECK:         dealloc_stack [[TP_ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_addr [[T_ADDR]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         dealloc_stack [[T_ADDR]]
+// CHECK-LABEL: } // end sil function 'f170_incoming_phi_no_interference'
+sil [ossa] @f170_incoming_phi_no_interference : $@convention(thin) <T> () -> () {
+entry:
+  %t = apply undef<T>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, left, right
+
+left:
+  destroy_value %t : $T
+  br exit
+
+right:
+  br fakeMerge1(%t : $T)
+
+fakeMerge1(%tp : @owned $T):
+  apply undef<T>(%tp) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  br fakeMerge2(%tp : $T)
+
+fakeMerge2(%tpp : @owned $T):
+  apply undef<T>(%tpp) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  destroy_value %tpp : $T
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @f180_incoming_terminator_results : {{.*}} {
+// CHECK:       bb0(%0 :
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         try_apply undef<T>(%0)
+// CHECK-SAME:        normal [[RIGHT_SUCCESS:bb[0-9]+]], error [[RIGHT_FAILURE:bb[0-9]+]]
+// CHECK:       [[RIGHT_FAILURE]]({{%[^,]+}} : @owned $any Error):
+// CHECK:         unreachable
+// CHECK:       [[RIGHT_SUCCESS]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         try_apply undef<T>(%0)
+// CHECK-SAME:        normal [[LEFT_SUCCESS:bb[0-9]+]], error [[LEFT_FAILURE:bb[0-9]+]]
+// CHECK:       [[LEFT_FAILURE]]({{%[^,]+}} : @owned $any Error):
+// CHECK:         unreachable
+// CHECK:       [[LEFT_SUCCESS]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'f180_incoming_terminator_results'
+sil [ossa] @f180_incoming_terminator_results : $@convention(thin) <T> () -> (@out T) {
+entry:
+  cond_br undef, left, right
+
+left:
+  try_apply undef<T>() : $@convention(thin) <T> () -> (@out T, @error any Error), normal left_success, error left_failure
+
+left_success(%lt : @owned $T):
+  br exit(%lt : $T)
+
+left_failure(%lerror : @owned $any Error):
+  unreachable
+
+right:
+  try_apply undef<T>() : $@convention(thin) <T> () -> (@out T, @error any Error), normal right_success, error right_failure
+
+right_success(%rt : @owned $T):
+  br exit(%rt : $T)
+
+exit(%tp : @owned $T):
+  return %tp : $T
+
+right_failure(%rerror : @owned $any Error):
+  unreachable
+}
+
+// Verify that LCA for `%agg` is correctly determined to be `parent` so that the
+// backwards walk when determining the liveness contribution from `%v` stops at
+// `%trouble2`, that there is only a single `alloc_stack`.
+// CHECK-LABEL: sil [ossa] @f190_vexing_incoming_def_projection : {{.*}} {
+// CHECK:         [[P_ADDR:%[^,]+]] = alloc_stack $Box<Box<T>>
+// CHECK-NOT:     alloc_stack
+// CHECK:         apply undef<Box<Box<T>>>([[P_ADDR]])
+// CHECK:         cond_br undef, [[OKAY:bb[0-9]+]], [[TROUBLE:bb[0-9]+]]
+// CHECK:       [[TROUBLE]]:
+// CHECK:         destroy_addr [[P_ADDR]]
+// CHECK:         br [[TROUBLE2:bb[0-9]+]]
+// CHECK:       [[TROUBLE2]]:
+// CHECK:         [[V_ADDR:%[^,]+]] = struct_element_addr [[P_ADDR]]
+// CHECK:         apply undef<Box<T>>([[V_ADDR]])
+// CHECK:         cond_br undef, [[PARENT:bb[0-9]+]], [[OTHER:bb[0-9]+]]
+// CHECK:       [[OTHER]]:
+// CHECK:         destroy_addr [[V_ADDR]]
+// CHECK:         br [[OTHER2:bb[0-9]+]]
+// CHECK:       [[OTHER2]]:
+// CHECK:         apply undef<Box<Box<T>>>([[P_ADDR]])
+// CHECK:         br [[MERGE:bb[0-9]+]]
+// CHECK:       [[PARENT]]:
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         br [[MERGE]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[T_ADDR:%[^,]+]] = struct_element_addr [[V_ADDR]]
+// CHECK:         destroy_addr [[T_ADDR]]
+// CHECK:         br [[LEFT2:bb[0-9]+]]
+// CHECK:       [[LEFT2]]:
+// CHECK:         apply undef<Box<Box<T>>>([[P_ADDR]])
+// CHECK:         br [[MERGE]]
+// CHECK:       [[OKAY]]:
+// CHECK:         br [[MERGE]]
+// CHECK:       [[MERGE]]:
+// CHECK:         destroy_addr [[P_ADDR]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         dealloc_stack [[P_ADDR]]
+// CHECK-LABEL: } // end sil function 'f190_vexing_incoming_def_projection'
+sil [ossa] @f190_vexing_incoming_def_projection : $@convention(thin) <T> () -> () {
+entry:
+  %agg4 = apply undef<Box<Box<T>>>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, okay, trouble
+
+okay:
+  br merge(%agg4 : $Box<Box<T>>)
+
+
+trouble:
+  destroy_value %agg4 : $Box<Box<T>>
+  br trouble2
+
+trouble2:
+  %v = apply undef<Box<T>>() : $@convention(thin) <T> () -> (@out T)
+  cond_br undef, parent, other
+
+parent:
+  cond_br undef, left, right
+
+left:
+  %t = destructure_struct %v : $Box<T>
+  destroy_value %t : $T
+  br left2
+
+left2:
+  %agg2 = apply undef<Box<Box<T>>>() : $@convention(thin) <T> () -> (@out T)
+  br merge(%agg2 : $Box<Box<T>>)
+
+right:
+  %agg = struct $Box<Box<T>>(%v : $Box<T>)
+  br merge(%agg : $Box<Box<T>>)
+
+other:
+  destroy_value %v : $Box<T>
+  br other2
+
+other2:
+  %agg3 = apply undef<Box<Box<T>>>() : $@convention(thin) <T> () -> (@out T)
+  br merge(%agg3 : $Box<Box<T>>)
+
+merge(%p : @owned $Box<Box<T>>):
+  destroy_value %p : $Box<Box<T>>
+  br exit
+
+exit:
   %retval = tuple ()
   return %retval : $()
 }


### PR DESCRIPTION
Resolves numerous regressions when enabling AddressLowering early in the pipeline.

Previously, if a value incoming into a phi had storage which itself was a use-projection out of some other storage, PhiStorageOptimizer bailed out.  The result was unnecessary "moves" (i.e. `copy_addr [take] [init]` instructions).

Here, this bailout is removed.  In order to do this, it is necessary to find (1) all values whose storage recursively project out of an incoming value (such a value may have storage which is either a use _or_ a def projection) and (2) the block which dominates the defs of all these values.

Together, these values are used to compute liveness to determine interference.  Previously, the live region was that between the uses of an incoming value and its defining block.  Now, it is that between the uses of any of the values found in (1) and the dominating block found in (2).
