### PR TITLE
Nested do-catch does not preserve rethrowing

### DIFF
--- a/test/expr/unary/do_expr.swift
+++ b/test/expr/unary/do_expr.swift
@@ -376,7 +376,6 @@ func tryDo29(_ fn: () throws -> Int) rethrows -> Int {
 }
 
 func tryDo30(_ fn: () throws -> Int) rethrows -> Int {
-  // FIXME: This ought to work (https://github.com/apple/swift/issues/68824)
   do {
     let x = do { try fn() } catch { throw error }
     return x


### PR DESCRIPTION
I believe this error is expected and this is not a compiler's bug.

This is expected because you have 2 `throw` statements in the code and by the time the compiler hits the second `throw`, it knows that the error thrown by the function passed in the parameter has already been handled, so it's a new error that can't be thrown:

``` swift
func bar(_ fn: () throws -> Void) rethrows {
  do {
    do { try fn() } catch { throw error } // the error thrown by fn() is rethrown here
  } catch {
    throw error // the error caught here was NOT thrown by fn() and therefore the diagnosis is expected
  }
}
```

The following example is OK because even though `do`s are nested, there's only one `throw`:
``` swift
func bar(_ fn: () throws -> Void) rethrows {
  do {
    do { try fn() } // no catch here
  } catch {
    throw error // the error caught here was thrown by fn() and therefore this code is valid
  }
}
```

Resolves #68824 