### PR TITLE
A quick hack try to avoid the deserialized swiftmodule contains un-supported platform visionOS

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2762,7 +2762,6 @@ ModuleDecl *ModuleFile::getModule(ImportPath::Module name,
   return getContext().getLoadedModule(name);
 }
 
-
 /// Translate from the Serialization associativity enum values to the AST
 /// strongly-typed enum.
 ///
@@ -5280,6 +5279,11 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
       isPackageDescriptionVersionSpecific, isSPI, LIST_VER_TUPLE_PIECES(Introduced),
       LIST_VER_TUPLE_PIECES(Deprecated), LIST_VER_TUPLE_PIECES(Obsoleted),
       platform, renameDeclID, messageSize, renameSize);
+  
+  // Hack: Filter the un-supported platforms from swiftmodule
+  if (platform >= /*PlatformKind::visionOS*/13) {
+    return nullptr;
+  }
 
   ValueDecl *renameDecl = nullptr;
   if (renameDeclID) {
@@ -5513,6 +5517,7 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
 
       case decls_block::Available_DECL_ATTR: {
         Attr = readAvailable_DECL_ATTR(scratch, blobData);
+        if (!Attr) skipAttr = true;
         break;
       }
 
@@ -5625,9 +5630,19 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
           }
 
           auto attr = readAvailable_DECL_ATTR(scratch, blobData);
-          availabilityAttrs.push_back(attr);
+          if (attr) {
+            availabilityAttrs.push_back(attr);
+          }
           restoreOffset2.cancel();
           --numAvailabilityAttrs;
+        }
+        
+        // Hack: When deserialized from some un-supported @available attr decl, we should remove it
+        // @available (iOS, macOS, visionOS) -> @available (iOS, macOS)
+        if (availabilityAttrs.empty()) {
+          // If attr list is empty, then remove this attr
+          skipAttr = true;
+          break;
         }
 
         auto specializedSig = MF.getGenericSignature(specializedSigID);


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is the quick fix for non-visionOS build (like iOS) when seeing the `@available` decl

This is the hack before Apple fully release the visionOS support on LLVM / Swift compiler, which is beyond this topic.

The quick hack is used to allows to consume swiftmodule built for iOS which contains `@available (visionOS 1)` attrs. This is common for some third-party libraries who distribute the swiftmodule only instead of source code.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #67857, fix #68034

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

The code changes just make this happenes on serialized AST consuming when finding the unsupported `swift::PlatformKind` :

+ Available Atrribute

```swift
@avaiable (iOS 10, visionOS 1, *)
class Foobar {}
```

=>

```swift
@avaiable (iOS 10, *)
class Foobar {}
```