### PR TITLE
[ASTGen] Introduce nullable variants of bridging wrappers

### DIFF
--- a/include/swift/AST/ASTBridgingWrappers.def
+++ b/include/swift/AST/ASTBridgingWrappers.def
@@ -19,15 +19,14 @@
 ///   The default macro to define a bridging wrapper type.
 
 /// AST_BRIDGING_WRAPPER_NULLABLE(Name)
-///   Specifies that the given bridging wrapper should have a
-///   nullable raw value.
+///   Specifies that both a nullable and non-null variant of the wrapper should
+///   be created.
 #ifndef AST_BRIDGING_WRAPPER_NULLABLE
 #define AST_BRIDGING_WRAPPER_NULLABLE(Name) AST_BRIDGING_WRAPPER(Name)
 #endif
 
 /// AST_BRIDGING_WRAPPER_NONNULL(Name)
-///   Specifies that the given bridging wrapper should have a
-///   non-null raw value.
+///   Specifies that only a non-null variant of the wrapper should be created.
 #ifndef AST_BRIDGING_WRAPPER_NONNULL
 #define AST_BRIDGING_WRAPPER_NONNULL(Name) AST_BRIDGING_WRAPPER(Name)
 #endif

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -38,9 +38,14 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
     void *_Nonnull raw;                                                        \
   } Bridged##Name;
 
+// For nullable nodes, define both a nullable and non-null variant.
 #define AST_BRIDGING_WRAPPER_NULLABLE(Name)                                    \
   typedef struct {                                                             \
     void *_Nullable raw;                                                       \
+  } BridgedNullable##Name;                                                     \
+                                                                               \
+  typedef struct {                                                             \
+    void *_Nonnull raw;                                                        \
   } Bridged##Name;
 
 #include "swift/AST/ASTBridgingWrappers.def"
@@ -340,7 +345,7 @@ TopLevelCodeDecl_createExpr(BridgedASTContext cContext,
 SWIFT_NAME("BridgedReturnStmt.createParsed(_:returnKeywordLoc:expr:)")
 BridgedReturnStmt ReturnStmt_createParsed(BridgedASTContext cContext,
                                           BridgedSourceLoc cLoc,
-                                          BridgedExpr expr);
+                                          BridgedNullableExpr expr);
 
 SWIFT_NAME("BridgedSequenceExpr.createParsed(_:exprs:)")
 BridgedSequenceExpr SequenceExpr_createParsed(BridgedASTContext cContext,
@@ -411,7 +416,7 @@ SWIFT_NAME("BridgedIfStmt.createParsed(_:ifKeywordLoc:condition:thenStmt:"
 BridgedIfStmt IfStmt_createParsed(BridgedASTContext cContext,
                                   BridgedSourceLoc cIfLoc, BridgedExpr cond,
                                   BridgedStmt then, BridgedSourceLoc cElseLoc,
-                                  BridgedStmt elseStmt);
+                                  BridgedNullableStmt elseStmt);
 
 SWIFT_NAME("BridgedBraceStmt.createParsed(_:lBraceLoc:elements:rBraceLoc:)")
 BridgedBraceStmt BraceStmt_createParsed(BridgedASTContext cContext,
@@ -425,8 +430,8 @@ BridgedParamDecl ParamDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cSpecifierLoc, BridgedIdentifier cFirstName,
     BridgedSourceLoc cFirstNameLoc, BridgedIdentifier cSecondName,
-    BridgedSourceLoc cSecondNameLoc, BridgedTypeRepr type,
-    BridgedExpr defaultValue);
+    BridgedSourceLoc cSecondNameLoc, BridgedNullableTypeRepr type,
+    BridgedNullableExpr defaultValue);
 
 SWIFT_NAME("BridgedConstructorDecl.setParsedBody(self:_:)")
 void ConstructorDecl_setParsedBody(BridgedConstructorDecl decl,
@@ -447,11 +452,11 @@ BridgedFuncDecl FuncDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cStaticLoc, BridgedSourceLoc cFuncKeywordLoc,
     BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
-    BridgedGenericParamList genericParamList,
+    BridgedNullableGenericParamList genericParamList,
     BridgedParameterList parameterList, BridgedSourceLoc cAsyncLoc,
-    BridgedSourceLoc cThrowsLoc, BridgedTypeRepr thrownType,
-    BridgedTypeRepr returnType,
-    BridgedTrailingWhereClause opaqueGenericWhereClause);
+    BridgedSourceLoc cThrowsLoc, BridgedNullableTypeRepr thrownType,
+    BridgedNullableTypeRepr returnType,
+    BridgedNullableTrailingWhereClause opaqueGenericWhereClause);
 
 SWIFT_NAME(
     "BridgedConstructorDecl.createParsed(_:declContext:initKeywordLoc:"
@@ -460,10 +465,10 @@ SWIFT_NAME(
 BridgedConstructorDecl ConstructorDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cInitKeywordLoc, BridgedSourceLoc cFailabilityMarkLoc,
-    _Bool isIUO, BridgedGenericParamList genericParams,
+    _Bool isIUO, BridgedNullableGenericParamList genericParams,
     BridgedParameterList parameterList, BridgedSourceLoc cAsyncLoc,
-    BridgedSourceLoc cThrowsLoc, BridgedTypeRepr thrownType,
-    BridgedTrailingWhereClause genericWhereClause);
+    BridgedSourceLoc cThrowsLoc, BridgedNullableTypeRepr thrownType,
+    BridgedNullableTrailingWhereClause genericWhereClause);
 
 SWIFT_NAME(
     "BridgedDestructorDecl.createParsed(_:declContext:deinitKeywordLoc:)")
@@ -494,9 +499,9 @@ SWIFT_NAME(
 BridgedTypeAliasDecl TypeAliasDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cAliasKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedSourceLoc cEqualLoc, BridgedTypeRepr underlyingType,
-    BridgedTrailingWhereClause genericWhereClause);
+    BridgedNullableTrailingWhereClause genericWhereClause);
 
 SWIFT_NAME("BridgedNominalTypeDecl.setParsedMembers(self:_:)")
 void NominalTypeDecl_setParsedMembers(BridgedNominalTypeDecl decl,
@@ -512,9 +517,9 @@ SWIFT_NAME(
 BridgedNominalTypeDecl EnumDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cEnumKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
 SWIFT_NAME(
@@ -528,8 +533,8 @@ SWIFT_NAME("BridgedEnumElementDecl.createParsed(_:declContext:name:nameLoc:"
 BridgedEnumElementDecl EnumElementDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
-    BridgedParameterList parameterList, BridgedSourceLoc cEqualsLoc,
-    BridgedExpr opaqueRawValue);
+    BridgedNullableParameterList parameterList, BridgedSourceLoc cEqualsLoc,
+    BridgedNullableExpr opaqueRawValue);
 
 SWIFT_NAME("BridgedStructDecl.createParsed(_:declContext:structKeywordLoc:name:"
            "nameLoc:genericParamList:inheritedTypes:genericWhereClause:"
@@ -537,9 +542,9 @@ SWIFT_NAME("BridgedStructDecl.createParsed(_:declContext:structKeywordLoc:name:"
 BridgedNominalTypeDecl StructDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cStructKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
 SWIFT_NAME(
@@ -548,9 +553,9 @@ SWIFT_NAME(
 BridgedNominalTypeDecl ClassDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cClassKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange, _Bool isActor);
 
 SWIFT_NAME(
@@ -562,7 +567,7 @@ BridgedNominalTypeDecl ProtocolDecl_createParsed(
     BridgedSourceLoc cProtocolKeywordLoc, BridgedIdentifier cName,
     BridgedSourceLoc cNameLoc, BridgedArrayRef cPrimaryAssociatedTypeNames,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
 SWIFT_NAME("BridgedAssociatedTypeDecl.createParsed(_:declContext:"
@@ -572,8 +577,8 @@ BridgedAssociatedTypeDecl AssociatedTypeDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cAssociatedtypeKeywordLoc, BridgedIdentifier cName,
     BridgedSourceLoc cNameLoc, BridgedArrayRef cInheritedTypes,
-    BridgedTypeRepr opaqueDefaultType,
-    BridgedTrailingWhereClause genericWhereClause);
+    BridgedNullableTypeRepr opaqueDefaultType,
+    BridgedNullableTrailingWhereClause genericWhereClause);
 
 SWIFT_NAME(
     "BridgedExtensionDecl.createParsed(_:declContext:extensionKeywordLoc:"
@@ -582,7 +587,7 @@ BridgedExtensionDecl ExtensionDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cExtensionKeywordLoc, BridgedTypeRepr opaqueExtendedType,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange);
 
 typedef enum ENUM_EXTENSIBILITY_ATTR(closed) {
@@ -649,7 +654,8 @@ SWIFT_NAME("BridgedGenericParamList.createParsed(_:leftAngleLoc:parameters:"
            "genericWhereClause:rightAngleLoc:)")
 BridgedGenericParamList GenericParamList_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cLeftAngleLoc,
-    BridgedArrayRef cParameters, BridgedTrailingWhereClause genericWhereClause,
+    BridgedArrayRef cParameters,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceLoc cRightAngleLoc);
 
 SWIFT_NAME(
@@ -658,7 +664,7 @@ SWIFT_NAME(
 BridgedGenericTypeParamDecl GenericTypeParamDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cEachLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedTypeRepr opaqueInheritedType,
+    BridgedSourceLoc cNameLoc, BridgedNullableTypeRepr opaqueInheritedType,
     size_t index);
 
 SWIFT_NAME(
@@ -721,13 +727,11 @@ BridgedTypeRepr DictionaryTypeRepr_createParsed(BridgedASTContext cContext,
 
 SWIFT_NAME("BridgedFunctionTypeRepr.createParsed(_:argsType:asyncLoc:throwsLoc:"
            "thrownType:arrowLoc:resultType:)")
-BridgedTypeRepr FunctionTypeRepr_createParsed(BridgedASTContext cContext,
-                                              BridgedTypeRepr argsTy,
-                                              BridgedSourceLoc cAsyncLoc,
-                                              BridgedSourceLoc cThrowsLoc,
-                                              BridgedTypeRepr thrownType,
-                                              BridgedSourceLoc cArrowLoc,
-                                              BridgedTypeRepr resultType);
+BridgedTypeRepr FunctionTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedTypeRepr argsTy,
+    BridgedSourceLoc cAsyncLoc, BridgedSourceLoc cThrowsLoc,
+    BridgedNullableTypeRepr thrownType, BridgedSourceLoc cArrowLoc,
+    BridgedTypeRepr resultType);
 
 SWIFT_NAME("BridgedGenericIdentTypeRepr.createParsed(_:name:nameLoc:"
            "genericArgs:leftAngleLoc:rightAngleLoc:)")

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -57,10 +57,16 @@ struct BridgedDiagnosticImpl {
 
 // Define `unbridged` overloads for each AST node.
 #define AST_BRIDGING_WRAPPER(Name)                                             \
-  [[maybe_unused]]                                                             \
-  static Name *unbridged(Bridged##Name bridged) {                              \
+  [[maybe_unused]] static Name *unbridged(Bridged##Name bridged) {             \
     return static_cast<Name *>(bridged.raw);                                   \
   }
+#include "swift/AST/ASTBridgingWrappers.def"
+
+#define AST_BRIDGING_WRAPPER_NULLABLE(Name)                                    \
+  [[maybe_unused]] static Name *unbridged(BridgedNullable##Name bridged) {     \
+    return static_cast<Name *>(bridged.raw);                                   \
+  }
+#define AST_BRIDGING_WRAPPER_NONNULL(Name)
 #include "swift/AST/ASTBridgingWrappers.def"
 
 // Define `.asDecl` on each BridgedXXXDecl type.
@@ -399,7 +405,7 @@ BridgedSingleValueStmtExpr SingleValueStmtExpr_createWithWrappedBranches(
 BridgedIfStmt IfStmt_createParsed(BridgedASTContext cContext,
                                   BridgedSourceLoc cIfLoc, BridgedExpr cond,
                                   BridgedStmt then, BridgedSourceLoc cElseLoc,
-                                  BridgedStmt elseStmt) {
+                                  BridgedNullableStmt elseStmt) {
   ASTContext &context = unbridged(cContext);
   auto *IS = new (context)
       IfStmt(unbridged(cIfLoc), unbridged(cond), unbridged(then),
@@ -409,7 +415,7 @@ BridgedIfStmt IfStmt_createParsed(BridgedASTContext cContext,
 
 BridgedReturnStmt ReturnStmt_createParsed(BridgedASTContext cContext,
                                           BridgedSourceLoc cLoc,
-                                          BridgedExpr expr) {
+                                          BridgedNullableExpr expr) {
   ASTContext &context = unbridged(cContext);
   return bridged(new (context) ReturnStmt(unbridged(cLoc), unbridged(expr)));
 }
@@ -454,8 +460,8 @@ BridgedParamDecl ParamDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cSpecifierLoc, BridgedIdentifier cFirstName,
     BridgedSourceLoc cFirstNameLoc, BridgedIdentifier cSecondName,
-    BridgedSourceLoc cSecondNameLoc, BridgedTypeRepr opaqueType,
-    BridgedExpr opaqueDefaultValue) {
+    BridgedSourceLoc cSecondNameLoc, BridgedNullableTypeRepr opaqueType,
+    BridgedNullableExpr opaqueDefaultValue) {
   assert((bool)cSecondNameLoc.raw == (bool)cSecondName.raw);
   if (!cSecondName.raw) {
     cSecondName = cFirstName;
@@ -503,10 +509,11 @@ BridgedFuncDecl FuncDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cStaticLoc, BridgedSourceLoc cFuncKeywordLoc,
     BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
-    BridgedGenericParamList genericParamList,
+    BridgedNullableGenericParamList genericParamList,
     BridgedParameterList parameterList, BridgedSourceLoc cAsyncLoc,
-    BridgedSourceLoc cThrowsLoc, BridgedTypeRepr thrownType,
-    BridgedTypeRepr returnType, BridgedTrailingWhereClause genericWhereClause) {
+    BridgedSourceLoc cThrowsLoc, BridgedNullableTypeRepr thrownType,
+    BridgedNullableTypeRepr returnType,
+    BridgedNullableTrailingWhereClause genericWhereClause) {
   ASTContext &context = unbridged(cContext);
 
   auto *paramList = unbridged(parameterList);
@@ -529,10 +536,10 @@ BridgedFuncDecl FuncDecl_createParsed(
 BridgedConstructorDecl ConstructorDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cInitKeywordLoc, BridgedSourceLoc cFailabilityMarkLoc,
-    bool isIUO, BridgedGenericParamList genericParams,
+    bool isIUO, BridgedNullableGenericParamList genericParams,
     BridgedParameterList bridgedParameterList, BridgedSourceLoc cAsyncLoc,
-    BridgedSourceLoc cThrowsLoc, BridgedTypeRepr thrownType,
-    BridgedTrailingWhereClause genericWhereClause) {
+    BridgedSourceLoc cThrowsLoc, BridgedNullableTypeRepr thrownType,
+    BridgedNullableTrailingWhereClause genericWhereClause) {
   assert((bool)cFailabilityMarkLoc.raw || !isIUO);
 
   ASTContext &context = unbridged(cContext);
@@ -630,9 +637,9 @@ BridgedClosureExpr ClosureExpr_createParsed(BridgedASTContext cContext,
 BridgedTypeAliasDecl TypeAliasDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cAliasKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedSourceLoc cEqualLoc, BridgedTypeRepr opaqueUnderlyingType,
-    BridgedTrailingWhereClause genericWhereClause) {
+    BridgedNullableTrailingWhereClause genericWhereClause) {
   ASTContext &context = unbridged(cContext);
 
   auto *decl = new (context)
@@ -689,9 +696,9 @@ convertToInheritedEntries(BridgedArrayRef cInheritedTypes) {
 BridgedNominalTypeDecl EnumDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cEnumKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange) {
   ASTContext &context = unbridged(cContext);
 
@@ -718,8 +725,8 @@ BridgedEnumCaseDecl EnumCaseDecl_createParsed(BridgedDeclContext cDeclContext,
 BridgedEnumElementDecl EnumElementDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
-    BridgedParameterList bridgedParameterList, BridgedSourceLoc cEqualsLoc,
-    BridgedExpr rawValue) {
+    BridgedNullableParameterList bridgedParameterList,
+    BridgedSourceLoc cEqualsLoc, BridgedNullableExpr rawValue) {
   ASTContext &context = unbridged(cContext);
 
   auto *parameterList = unbridged(bridgedParameterList);
@@ -742,9 +749,9 @@ BridgedEnumElementDecl EnumElementDecl_createParsed(
 BridgedNominalTypeDecl StructDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cStructKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange) {
   ASTContext &context = unbridged(cContext);
 
@@ -761,9 +768,9 @@ BridgedNominalTypeDecl StructDecl_createParsed(
 BridgedNominalTypeDecl ClassDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cClassKeywordLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedGenericParamList genericParamList,
+    BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange, bool isActor) {
   ASTContext &context = unbridged(cContext);
 
@@ -782,7 +789,7 @@ BridgedNominalTypeDecl ProtocolDecl_createParsed(
     BridgedSourceLoc cProtocolKeywordLoc, BridgedIdentifier cName,
     BridgedSourceLoc cNameLoc, BridgedArrayRef cPrimaryAssociatedTypeNames,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange) {
   SmallVector<PrimaryAssociatedTypeName, 2> primaryAssociatedTypeNames;
   for (auto &pair : unbridgedArrayRef<BridgedIdentifierAndSourceLoc>(
@@ -807,8 +814,8 @@ BridgedAssociatedTypeDecl AssociatedTypeDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cAssociatedtypeKeywordLoc, BridgedIdentifier cName,
     BridgedSourceLoc cNameLoc, BridgedArrayRef cInheritedTypes,
-    BridgedTypeRepr defaultType,
-    BridgedTrailingWhereClause genericWhereClause) {
+    BridgedNullableTypeRepr defaultType,
+    BridgedNullableTrailingWhereClause genericWhereClause) {
   ASTContext &context = unbridged(cContext);
 
   auto *decl = AssociatedTypeDecl::createParsed(
@@ -825,7 +832,7 @@ BridgedExtensionDecl ExtensionDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cExtensionKeywordLoc, BridgedTypeRepr extendedType,
     BridgedArrayRef cInheritedTypes,
-    BridgedTrailingWhereClause genericWhereClause,
+    BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange) {
   ASTContext &context = unbridged(cContext);
 
@@ -1152,13 +1159,11 @@ CompositionTypeRepr_createParsed(BridgedASTContext cContext,
   return bridged(CT);
 }
 
-BridgedTypeRepr FunctionTypeRepr_createParsed(BridgedASTContext cContext,
-                                              BridgedTypeRepr argsTy,
-                                              BridgedSourceLoc cAsyncLoc,
-                                              BridgedSourceLoc cThrowsLoc,
-                                              BridgedTypeRepr thrownType,
-                                              BridgedSourceLoc cArrowLoc,
-                                              BridgedTypeRepr resultType) {
+BridgedTypeRepr FunctionTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedTypeRepr argsTy,
+    BridgedSourceLoc cAsyncLoc, BridgedSourceLoc cThrowsLoc,
+    BridgedNullableTypeRepr thrownType, BridgedSourceLoc cArrowLoc,
+    BridgedTypeRepr resultType) {
   ASTContext &context = unbridged(cContext);
   auto *FT = new (context) FunctionTypeRepr(
       nullptr, cast<TupleTypeRepr>(unbridged(argsTy)), unbridged(cAsyncLoc),
@@ -1196,7 +1201,7 @@ BridgedTypeRepr ExistentialTypeRepr_createParsed(BridgedASTContext cContext,
 BridgedGenericParamList GenericParamList_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cLeftAngleLoc,
     BridgedArrayRef cParameters,
-    BridgedTrailingWhereClause bridgedGenericWhereClause,
+    BridgedNullableTrailingWhereClause bridgedGenericWhereClause,
     BridgedSourceLoc cRightAngleLoc) {
   SourceLoc whereLoc;
   ArrayRef<RequirementRepr> requirements;
@@ -1215,7 +1220,7 @@ BridgedGenericParamList GenericParamList_createParsed(
 BridgedGenericTypeParamDecl GenericTypeParamDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cEachLoc, BridgedIdentifier cName,
-    BridgedSourceLoc cNameLoc, BridgedTypeRepr bridgedInheritedType,
+    BridgedSourceLoc cNameLoc, BridgedNullableTypeRepr bridgedInheritedType,
     size_t index) {
   auto eachLoc = unbridged(cEachLoc);
   auto *decl = GenericTypeParamDecl::createParsed(

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -48,9 +48,9 @@ enum ASTNode {
   var bridged: BridgedASTNode {
     switch self {
     case .expr(let e):
-      return BridgedASTNode(ptr: e.raw!, kind: .expr)
+      return BridgedASTNode(ptr: e.raw, kind: .expr)
     case .stmt(let s):
-      return BridgedASTNode(ptr: s.raw!, kind: .stmt)
+      return BridgedASTNode(ptr: s.raw, kind: .stmt)
     case .decl(let d):
       return BridgedASTNode(ptr: d.raw, kind: .decl)
     default:
@@ -323,18 +323,18 @@ extension ASTGenVisitor {
 // 'self.visit(<expr>)' recursion pattern between optional and non-optional inputs.
 extension ASTGenVisitor {
   @inline(__always)
-  func generate(_ node: TypeSyntax?) -> BridgedTypeRepr {
+  func generate(_ node: TypeSyntax?) -> BridgedTypeRepr? {
     guard let node else {
-      return BridgedTypeRepr(raw: nil)
+      return nil
     }
 
     return self.generate(node)
   }
 
   @inline(__always)
-  func generate(_ node: ExprSyntax?) -> BridgedExpr {
+  func generate(_ node: ExprSyntax?) -> BridgedExpr? {
     guard let node else {
-      return BridgedExpr(raw: nil)
+      return nil
     }
 
     return self.generate(node)
@@ -351,27 +351,27 @@ extension ASTGenVisitor {
   }
 
   @inline(__always)
-  func generate(_ node: GenericParameterClauseSyntax?) -> BridgedGenericParamList {
+  func generate(_ node: GenericParameterClauseSyntax?) -> BridgedGenericParamList? {
     guard let node else {
-      return BridgedGenericParamList(raw: nil)
+      return nil
     }
 
     return self.generate(node)
   }
 
   @inline(__always)
-  func generate(_ node: GenericWhereClauseSyntax?) -> BridgedTrailingWhereClause {
+  func generate(_ node: GenericWhereClauseSyntax?) -> BridgedTrailingWhereClause? {
     guard let node else {
-      return BridgedTrailingWhereClause(raw: nil)
+      return nil
     }
 
     return self.generate(node)
   }
 
   @inline(__always)
-  func generate(_ node: EnumCaseParameterClauseSyntax?) -> BridgedParameterList {
+  func generate(_ node: EnumCaseParameterClauseSyntax?) -> BridgedParameterList? {
     guard let node else {
-      return BridgedParameterList(raw: nil)
+      return nil
     }
 
     return self.generate(node)

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -14,6 +14,42 @@ extension BridgedIdentifier: ExpressibleByNilLiteral {
   }
 }
 
+extension BridgedStmt? {
+  var asNullable: BridgedNullableStmt {
+    .init(raw: self?.raw)
+  }
+}
+
+extension BridgedExpr? {
+  var asNullable: BridgedNullableExpr {
+    .init(raw: self?.raw)
+  }
+}
+
+extension BridgedTypeRepr? {
+  var asNullable: BridgedNullableTypeRepr {
+    .init(raw: self?.raw)
+  }
+}
+
+extension BridgedGenericParamList? {
+  var asNullable: BridgedNullableGenericParamList {
+    .init(raw: self?.raw)
+  }
+}
+
+extension BridgedTrailingWhereClause? {
+  var asNullable: BridgedNullableTrailingWhereClause {
+    .init(raw: self?.raw)
+  }
+}
+
+extension BridgedParameterList? {
+  var asNullable: BridgedNullableParameterList {
+    .init(raw: self?.raw)
+  }
+}
+
 extension BridgedSourceLoc {
   /// Form a source location at the given absolute position in `buffer`.
   init(

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -14,10 +14,10 @@ extension ASTGenVisitor {
       typealiasKeywordLoc: node.typealiasKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause),
+      genericParamList: self.generate(node.genericParameterClause).asNullable,
       equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
       underlyingType: self.generate(node.initializer.value),
-      genericWhereClause: self.generate(node.genericWhereClause)
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable
     )
   }
 
@@ -30,9 +30,9 @@ extension ASTGenVisitor {
       enumKeywordLoc: node.enumKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause),
+      genericParamList: self.generate(node.genericParameterClause).asNullable,
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause),
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -56,9 +56,9 @@ extension ASTGenVisitor {
       structKeywordLoc: node.structKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause),
+      genericParamList: self.generate(node.genericParameterClause).asNullable,
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause),
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -82,9 +82,9 @@ extension ASTGenVisitor {
       classKeywordLoc: node.classKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause),
+      genericParamList: self.generate(node.genericParameterClause).asNullable,
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause),
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -109,9 +109,9 @@ extension ASTGenVisitor {
       classKeywordLoc: node.actorKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause),
+      genericParamList: self.generate(node.genericParameterClause).asNullable,
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause),
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -141,7 +141,7 @@ extension ASTGenVisitor {
       nameLoc: nameLoc,
       primaryAssociatedTypeNames: primaryAssociatedTypeNames.bridgedArray(in: self),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause),
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -166,8 +166,8 @@ extension ASTGenVisitor {
       name: name,
       nameLoc: nameLoc,
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      defaultType: self.generate(node.initializer?.value),
-      genericWhereClause: self.generate(node.genericWhereClause)
+      defaultType: self.generate(node.initializer?.value).asNullable,
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable
     )
   }
 }
@@ -182,7 +182,7 @@ extension ASTGenVisitor {
       extensionKeywordLoc: node.extensionKeyword.bridgedSourceLoc(in: self),
       extendedType: self.generate(node.extendedType),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause),
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -209,9 +209,9 @@ extension ASTGenVisitor {
       declContext: self.declContext,
       name: name,
       nameLoc: nameLoc,
-      parameterList: self.generate(node.parameterClause),
+      parameterList: self.generate(node.parameterClause).asNullable,
       equalsLoc: (node.rawValue?.equal).bridgedSourceLoc(in: self),
-      rawValue: self.generate(node.rawValue?.value)
+      rawValue: self.generate(node.rawValue?.value).asNullable
     )
   }
 
@@ -262,13 +262,13 @@ extension ASTGenVisitor {
       funcKeywordLoc: node.funcKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause),
+      genericParamList: self.generate(node.genericParameterClause).asNullable,
       parameterList: self.generate(node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type),
-      returnType: self.generate(node.signature.returnClause?.type),
-      genericWhereClause: self.generate(node.genericWhereClause)
+      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type).asNullable,
+      returnType: self.generate(node.signature.returnClause?.type).asNullable,
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable
     )
 
     if let body = node.body {
@@ -287,12 +287,12 @@ extension ASTGenVisitor {
       initKeywordLoc: node.initKeyword.bridgedSourceLoc(in: self),
       failabilityMarkLoc: node.optionalMark.bridgedSourceLoc(in: self),
       isIUO: node.optionalMark?.tokenKind == .exclamationMark,
-      genericParamList: self.generate(node.genericParameterClause),
+      genericParamList: self.generate(node.genericParameterClause).asNullable,
       parameterList: self.generate(node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type),
-      genericWhereClause: self.generate(node.genericWhereClause)
+      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type).asNullable,
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable
     )
 
     if let body = node.body {

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -8,7 +8,7 @@ extension ASTGenVisitor {
       self.ctx,
       leftAngleLoc: node.leftAngle.bridgedSourceLoc(in: self),
       parameters: node.parameters.lazy.map(self.generate).bridgedArray(in: self),
-      genericWhereClause: self.generate(node.genericWhereClause),
+      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
       rightAngleLoc: node.rightAngle.bridgedSourceLoc(in: self)
     )
   }
@@ -33,7 +33,7 @@ extension ASTGenVisitor {
       eachKeywordLoc: node.eachKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      inheritedType: self.generate(node.inheritedType),
+      inheritedType: self.generate(node.inheritedType).asNullable,
       index: genericParameterIndex
     )
   }

--- a/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
+++ b/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
@@ -76,7 +76,7 @@ extension ASTGenVisitor {
 
     let (secondName, secondNameLoc) = node.secondName.bridgedIdentifierAndSourceLoc(in: self)
 
-    return BridgedParamDecl.createParsed(
+    return .createParsed(
       self.ctx,
       declContext: self.declContext,
       specifierLoc: specifierLoc,
@@ -84,8 +84,8 @@ extension ASTGenVisitor {
       firstNameLoc: node.optionalFirstName.bridgedSourceLoc(in: self),
       secondName: secondName,
       secondNameLoc: secondNameLoc,
-      type: self.generate(node.optionalType),
-      defaultValue: self.generate(node.defaultValue?.value)
+      type: self.generate(node.optionalType).asNullable,
+      defaultValue: self.generate(node.defaultValue?.value).asNullable
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -21,7 +21,7 @@ extension ASTGenVisitor {
       condition: conditions.first!.castToExpr,
       thenStmt: self.generate(node.body).asStmt,
       elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
-      elseStmt: self.generate(node.elseBody)?.castToStmt ?? .init(raw: nil)
+      elseStmt: (self.generate(node.elseBody)?.castToStmt).asNullable
     )
   }
 
@@ -38,7 +38,7 @@ extension ASTGenVisitor {
     .createParsed(
       self.ctx,
       returnKeywordLoc: node.returnKeyword.bridgedSourceLoc(in: self),
-      expr: self.generate(node.expression)
+      expr: self.generate(node.expression).asNullable
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -185,7 +185,7 @@ extension ASTGenVisitor {
       ),
       asyncLoc: (node.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsLoc: (node.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(node.effectSpecifiers?.thrownError?.type),
+      thrownType: self.generate(node.effectSpecifiers?.thrownError?.type).asNullable,
       arrowLoc: node.returnClause.arrow.bridgedSourceLoc(in: self),
       resultType: generate(node.returnClause.type)
     )


### PR DESCRIPTION
For nullable nodes, introduce both a non-null and nullable variant of the bridging wrapper. This allows us to annotate the necessary parameters as nullable, but keep the returns of the bridged `createParsed` methods non-null.