### PR TITLE
[Concurrency] Downgrade `actor_isolated_mutating_func` to a warning in a narrow case that was previously accepted.

### DIFF
--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -307,3 +307,18 @@ actor ProtectArray {
     }
   }
 }
+
+extension Optional {
+  mutating func mutate() async {}
+}
+
+@available(SwiftStdlib 5.1, *)
+actor ProtectDictionary {
+  var dict: [Int: Int] = [:]
+
+  func invalid() async {
+    await dict[0].mutate()
+    // expected-warning@-1 {{cannot call mutating async function 'mutate()' on actor-isolated property 'dict'; this is an error in Swift 6}}
+    // expected-targeted-complete-warning@-2 {{passing argument of non-sendable type 'inout Optional<Int>' outside of actor-isolated context may introduce data races}}
+  }
+}


### PR DESCRIPTION
The following code is accepted by the Swift 5.9 compiler and below:

```swift
extension Optional {
    mutating func mutate() async {}
}

actor A {
  var dict: [Int: Int] = [:]

  func test() async {
    await dict[0]. mutate()
  }
}
```

This is invalid because an actor-isolated value is passed as `inout` to an `async` function. However, because this code was previously accepted as valid, this change downgrades the diagnostic to a warning prior to Swift 6.

Resolves rdar://117357457