### PR TITLE
[region-based-isolation] Stack of smaller fixes before a larger fix

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -877,12 +877,12 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 
 // Warnings arising from the flow-sensitive checking of Sendability of
 // non-Sendable values
-WARNING(arg_region_consumed, none,
+WARNING(arg_region_transferred, none,
         "call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller", ())
-WARNING(consumption_yields_race, none,
+WARNING(transfer_yields_race, none,
         "non-sendable value sent across isolation domains that could be concurrently accessed later in this function (%0 access site%select{|s}1 displayed%select{|, %3 more hidden}2)",
         (unsigned, bool, bool, unsigned))
-WARNING(call_site_consumption_yields_race, none,
+WARNING(call_site_transfer_yields_race, none,
         "passing argument of non-sendable type %0 from %1 context to %2 context at this call site could yield a race with accesses later in this function (%3 access site%select{|s}4 displayed%select{|, %6 more hidden}5)",
         (Type, ActorIsolation, ActorIsolation, unsigned, bool, bool, unsigned))
 NOTE(possible_racy_access_site, none,

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -878,6 +878,8 @@ public:
 
   bool isMarkedAsImmortal() const;
 
+  bool isActor() const { return getASTType()->isActorType(); }
+
   ProtocolConformanceRef conformsToProtocol(SILFunction *fn,
                                             ProtocolDecl *protocol) const;
 

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -322,7 +322,7 @@ public:
   // so set to false to begin with
   Partition(bool canonical) : labels({}), canonical(canonical) {}
 
-  static Partition singleRegion(std::vector<Element> indices) {
+  static Partition singleRegion(ArrayRef<Element> indices) {
     Partition p;
     if (!indices.empty()) {
       Region min_index =

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -49,9 +49,9 @@ struct Region {
 
   operator signed() const { return num; }
 
-  bool isConsumed() const { return num < 0; }
+  bool isTransferred() const { return num < 0; }
 
-  static Region consumed() { return Region(-1); }
+  static Region transferred() { return Region(-1); }
 };
 }
 
@@ -61,20 +61,20 @@ using namespace PartitionPrimitives;
 /// SILInstructions can be translated to
 enum class PartitionOpKind : uint8_t {
   /// Assign one value to the region of another, takes two args, second arg
-  /// must already be tracked with a non-consumed region
+  /// must already be tracked with a non-transferred region
   Assign,
 
   /// Assign one value to a fresh region, takes one arg.
   AssignFresh,
 
   /// Merge the regions of two values, takes two args, both must be from
-  /// non-consumed regions.
+  /// non-transferred regions.
   Merge,
 
-  /// Consume the region of a value if not already consumed, takes one arg.
+  /// Consume the region of a value if not already transferred, takes one arg.
   Transfer,
 
-  /// Require the region of a value to be non-consumed, takes one arg.
+  /// Require the region of a value to be non-transferred, takes one arg.
   Require,
 };
 
@@ -92,7 +92,8 @@ private:
   SILInstruction *sourceInst;
 
   // Record an AST expression corresponding to this PartitionOp, currently
-  // populated only for Consume expressions to indicate the value being consumed
+  // populated only for Consume expressions to indicate the value being
+  // transferred
   Expr *sourceExpr;
 
   // TODO: can the following declarations be merged?
@@ -176,7 +177,7 @@ public:
       os << "assign_fresh %%" << OpArgs[0] << "\n";
       break;
     case PartitionOpKind::Transfer:
-      os << "consume %%" << OpArgs[0] << "\n";
+      os << "transfer %%" << OpArgs[0] << "\n";
       break;
     case PartitionOpKind::Merge:
       os << "merge %%" << OpArgs[0] << " with %%" << OpArgs[1] << "\n";
@@ -213,8 +214,8 @@ static void horizontalUpdate(std::map<Element, Region> &map, Element key,
 class Partition {
 private:
   // Label each index with a non-negative (unsigned) label if it is associated
-  // with a valid region, and with -1 if it is associated with a consumed region
-  // in-order traversal relied upon.
+  // with a valid region, and with -1 if it is associated with a transferred
+  // region in-order traversal relied upon.
   std::map<Element, Region> labels;
 
   // Track a label that is guaranteed to be strictly larger than all in use,
@@ -240,8 +241,8 @@ private:
     };
 
     for (auto &[i, label] : labels) {
-      // correctness vacuous at consumed indices
-      if (label.isConsumed())
+      // correctness vacuous at transferred indices
+      if (label.isTransferred())
         continue;
 
       // this label should not exceed fresh_label
@@ -266,7 +267,7 @@ private:
 
   // linear time - For each region label that occurs, find the first index
   // at which it occurs and relabel all instances of it to that index.
-  // This excludes the -1 label for consumed regions.
+  // This excludes the -1 label for transferred regions.
   void canonicalize() {
     if (canonical)
       return;
@@ -276,8 +277,8 @@ private:
 
     // relies on in-order traversal of labels
     for (auto &[i, label] : labels) {
-      // leave -1 (consumed region) as is
-      if (label.isConsumed())
+      // leave -1 (transferred region) as is
+      if (label.isTransferred())
         continue;
 
       if (!relabel.count(label)) {
@@ -348,8 +349,8 @@ public:
 
   bool isTracked(Element val) const { return labels.count(val); }
 
-  bool isConsumed(Element val) const {
-    return isTracked(val) && labels.at(val).isConsumed();
+  bool isTransferred(Element val) const {
+    return isTracked(val) && labels.at(val).isTransferred();
   }
 
   // quadratic time - Construct the partition corresponding to the join of the
@@ -374,9 +375,10 @@ public:
     // of indices that are in the same region in snd are also in the same region
     // in fst - the desired property
     for (const auto [i, snd_label] : snd_reduced.labels) {
-      if (snd_label.isConsumed())
-        // if snd says that the region has been consumed, mark it consumed in fst
-        horizontalUpdate(fst_reduced.labels, i, Region::consumed());
+      if (snd_label.isTransferred())
+        // if snd says that the region has been transferred, mark it transferred
+        // in fst
+        horizontalUpdate(fst_reduced.labels, i, Region::transferred());
       else
         fst_reduced.merge(i, Element(snd_label));
     }
@@ -394,12 +396,12 @@ public:
 
   // Apply the passed PartitionOp to this partition, performing its action.
   // A `handleFailure` closure can optionally be passed in that will be called
-  // if a consumed region is required. The closure is given the PartitionOp that
-  // failed, and the index of the SIL value that was required but consumed.
-  // Additionally, a list of "nonconsumable" indices can be passed in along with
-  // a handleConsumeNonConsumable closure. In the event that a region containing
-  // one of the nonconsumable indices is consumed, the closure will be called
-  // with the offending Consume.
+  // if a transferred region is required. The closure is given the PartitionOp
+  // that failed, and the index of the SIL value that was required but
+  // transferred. Additionally, a list of "nonconsumable" indices can be passed
+  // in along with a handleConsumeNonConsumable closure. In the event that a
+  // region containing one of the nonconsumable indices is transferred, the
+  // closure will be called with the offending Consume.
   void apply(
       PartitionOp op,
       llvm::function_ref<void(const PartitionOp &, Element)> handleFailure =
@@ -422,7 +424,7 @@ public:
       assert(labels.count(op.OpArgs[1]) &&
              "Assign PartitionOp's source argument should be already tracked");
       // if assigning to a missing region, handle the failure
-      if (isConsumed(op.OpArgs[1]))
+      if (isTransferred(op.OpArgs[1]))
         handleFailure(op, op.OpArgs[1]);
 
       labels.insert_or_assign(op.OpArgs[0], labels.at(op.OpArgs[1]));
@@ -448,25 +450,24 @@ public:
       assert(labels.count(op.OpArgs[0]) &&
              "Consume PartitionOp's argument should already be tracked");
 
-      // check if any nonconsumables are consumed here, and handle the failure if so
+      // check if any nonconsumables are transferred here, and handle the
+      // failure if so
       for (Element nonconsumable : nonconsumables) {
         assert(labels.count(nonconsumable) &&
                "nonconsumables should be function args and self, and therefore"
                "always present in the label map because of initialization at "
                "entry");
-        if (!isConsumed(nonconsumable) &&
+        if (!isTransferred(nonconsumable) &&
             labels.at(nonconsumable) == labels.at(op.OpArgs[0])) {
           handleConsumeNonConsumable(op, nonconsumable);
           break;
         }
       }
 
-      // ensure region is consumed
-      if (!isConsumed(op.OpArgs[0]))
-        // mark region as consumed
-        horizontalUpdate(labels, op.OpArgs[0], Region::consumed());
-
-
+      // ensure region is transferred
+      if (!isTransferred(op.OpArgs[0]))
+        // mark region as transferred
+        horizontalUpdate(labels, op.OpArgs[0], Region::transferred());
 
       break;
     case PartitionOpKind::Merge:
@@ -475,10 +476,10 @@ public:
       assert(labels.count(op.OpArgs[0]) && labels.count(op.OpArgs[1]) &&
              "Merge PartitionOp's arguments should already be tracked");
 
-      // if attempting to merge a consumed region, handle the failure
-      if (isConsumed(op.OpArgs[0]))
+      // if attempting to merge a transferred region, handle the failure
+      if (isTransferred(op.OpArgs[0]))
         handleFailure(op, op.OpArgs[0]);
-      if (isConsumed(op.OpArgs[1]))
+      if (isTransferred(op.OpArgs[1]))
         handleFailure(op, op.OpArgs[1]);
 
       merge(op.OpArgs[0], op.OpArgs[1]);
@@ -488,26 +489,26 @@ public:
              "Require PartitionOp should be passed 1 argument");
       assert(labels.count(op.OpArgs[0]) &&
              "Require PartitionOp's argument should already be tracked");
-      if (isConsumed(op.OpArgs[0]))
+      if (isTransferred(op.OpArgs[0]))
         handleFailure(op, op.OpArgs[0]);
     }
 
     assert(is_canonical_correct());
   }
 
-  // return a vector of the consumed values in this partition
-  std::vector<Element> getConsumedVals() const {
+  // return a vector of the transferred values in this partition
+  std::vector<Element> getTransferredVals() const {
     // for effeciency, this could return an iterator not a vector
-    std::vector<Element> consumedVals;
+    std::vector<Element> transferredVals;
     for (auto [i, _] : labels)
-      if (isConsumed(i))
-        consumedVals.push_back(i);
-    return consumedVals;
+      if (isTransferred(i))
+        transferredVals.push_back(i);
+    return transferredVals;
   }
 
-  // return a vector of the non-consumed regions in this partition, each
+  // return a vector of the non-transferred regions in this partition, each
   // represented as a vector of values
-  std::vector<std::vector<Element>> getNonConsumedRegions() const {
+  std::vector<std::vector<Element>> getNonTransferredRegions() const {
     // for effeciency, this could return an iterator not a vector
     std::map<Region, std::vector<Element>> buckets;
 
@@ -542,12 +543,12 @@ public:
 
     os << "[";
     for (auto [label, indices] : buckets) {
-      os << (label.isConsumed() ? "{" : "(");
+      os << (label.isTransferred() ? "{" : "(");
       int j = 0;
       for (Element i : indices) {
         os << (j++ ? " " : "") << i;
       }
-      os << (label.isConsumed() ? "}" : ")");
+      os << (label.isTransferred() ? "}" : ")");
     }
     os << "]\n";
   }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -49,16 +49,12 @@ static bool SILApplyCrossesIsolation(const SILInstruction *inst) {
   return false;
 }
 
-static bool isAddress(SILValue val) {
-  return val->getType() && val->getType().isAddress();
-}
-
 static bool isApplyInst(SILInstruction &inst) {
   return ApplySite::isa(&inst) || isa<BuiltinInst>(inst);
 }
 
 static AccessStorage getAccessStorageFromAddr(SILValue value) {
-  assert(isAddress(value));
+  assert(value->getType().isAddress());
   auto accessStorage = AccessStorage::compute(value);
   if (accessStorage && accessStorage.getRoot()) {
     if (auto definingInst = accessStorage.getRoot().getDefiningInstruction()) {
@@ -72,7 +68,7 @@ static AccessStorage getAccessStorageFromAddr(SILValue value) {
 }
 
 static SILValue getUnderlyingTrackedValue(SILValue value) {
-  if (!isAddress(value)) {
+  if (!value->getType().isAddress()) {
     return getUnderlyingObject(value);
   }
 
@@ -355,9 +351,9 @@ class PartitionOpTranslator {
     self->stateIndexToEquivalenceClass[iter.first->second.getID()] = value;
 #endif
 
-    // Otherwise, we need to compute our true aliased and sendable values. Begi
-    // by seeing if we have a value that we can prove is not aliased.
-    if (isAddress(value)) {
+    // Otherwise, we need to compute our flags. Begin by seeing if we have a
+    // value that we can prove is not aliased.
+    if (value->getType().isAddress()) {
       if (auto accessStorage = AccessStorage::compute(value))
         if (accessStorage.isUniquelyIdentified() &&
             !capturedUIValues.count(value))

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1381,7 +1381,6 @@ class RaceTracer {
       SILBasicBlock * SILBlock, TrackableValueID consumedVal,
       ConsumedReason &consumedReason, unsigned distance,
       std::optional<PartitionOp> targetOp = {}) {
-    assert(blockStates[SILBlock].getExitPartition().isConsumed(consumedVal));
     LocalConsumedReason localReason
         = findLocalConsumedReason(SILBlock, consumedVal, targetOp);
     switch (localReason.kind) {

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -385,7 +385,7 @@ class PartitionOpTranslator {
       auto *svi = cast<SingleValueInstruction>(iter.first->first);
       auto storage = AccessStorageWithBase::compute(svi->getOperand(0));
       if (storage.storage && isa<RefElementAddrInst>(storage.base)) {
-        if (storage.storage.getRoot()->getType().getASTType()->isActorType()) {
+        if (storage.storage.getRoot()->getType().isActor()) {
           self->neverConsumedValueIDs.push_back(iter.first->second.getID());
         }
       }
@@ -606,7 +606,7 @@ public:
       if (auto fas = FullApplySite::isa(applyInst)) {
         if (fas.hasSelfArgument()) {
           if (auto self = fas.getSelfArgument()) {
-            hasActorSelf = self->getType().getASTType()->isActorType();
+            hasActorSelf = self->getType().isActor();
           }
         }
       }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -246,7 +246,7 @@ struct PartitionOpBuilder {
 
   void addTransfer(SILValue value, Expr *sourceExpr = nullptr) {
     assert(valueHasID(value) &&
-           "consumed value should already have been encountered");
+           "transfered value should already have been encountered");
 
     currentInstPartitionOps.emplace_back(
         PartitionOp::Transfer(lookupValueID(value), currentInst, sourceExpr));
@@ -323,11 +323,11 @@ class PartitionOpTranslator {
   //       utilities would make it easier than handrolling
   llvm::DenseSet<SILValue> capturedUIValues;
 
-  /// A list of values that can never be consumed.
+  /// A list of values that can never be transferred.
   ///
   /// This includes all function arguments as well as ref_element_addr from
   /// actors.
-  std::vector<TrackableValueID> neverConsumedValueIDs;
+  std::vector<TrackableValueID> neverTransferredValueIDs;
 
   /// A cache of argument IDs.
   SmallVector<TrackableValueID> argIDs;
@@ -385,19 +385,19 @@ class PartitionOpTranslator {
       iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
 
     // Check if our base is a ref_element_addr from an actor value. In such a
-    // case, add this id to the neverConsumedValueIDs.
+    // case, add this id to the neverTransferredValueIDs.
     if (isa<LoadInst, LoadBorrowInst>(iter.first->first)) {
       auto *svi = cast<SingleValueInstruction>(iter.first->first);
       auto storage = AccessStorageWithBase::compute(svi->getOperand(0));
       if (storage.storage && isa<RefElementAddrInst>(storage.base)) {
         if (storage.storage.getRoot()->getType().isActor()) {
-          self->neverConsumedValueIDs.push_back(iter.first->second.getID());
+          self->neverTransferredValueIDs.push_back(iter.first->second.getID());
         }
       }
     }
 
     // If our access storage is from a class, then see if we have an actor. In
-    // such a case, we need to add this id to the neverConsumed set.
+    // such a case, we need to add this id to the neverTransferred set.
 
     return {iter.first->first, iter.first->second};
   }
@@ -491,7 +491,7 @@ private:
       auto *self = const_cast<PartitionOpTranslator *>(this);
       for (SILArgument *arg : functionArguments) {
         if (auto state = trackIfNonSendable(arg)) {
-          self->neverConsumedValueIDs.push_back(state->getID());
+          self->neverTransferredValueIDs.push_back(state->getID());
           self->argIDs.push_back(state->getID());
         }
       }
@@ -509,16 +509,16 @@ public:
     return Partition::singleRegion(getArgIDs());
   }
 
-  // Get the vector of IDs that cannot be legally consumed at any point in
+  // Get the vector of IDs that cannot be legally transferred at any point in
   // this function. Since we place all args and self in a single region right
   // now, it is only necessary to choose a single representative of the set.
-  ArrayRef<TrackableValueID> getNeverConsumedValues() const {
-    return llvm::makeArrayRef(neverConsumedValueIDs);
+  ArrayRef<TrackableValueID> getNeverTransferredValues() const {
+    return llvm::makeArrayRef(neverTransferredValueIDs);
   }
 
-  void sortUniqueNeverConsumedValues() {
+  void sortUniqueNeverTransferredValues() {
     // TODO: Make a FrozenSetVector.
-    sortUnique(neverConsumedValueIDs);
+    sortUnique(neverTransferredValueIDs);
   }
 
   // get the results of an apply instruction. This is the single result value
@@ -584,10 +584,8 @@ public:
                         nonSendableOperands.front());
     }
 
-    // If our results are actor isolated (and thus cannot be consumed)... add
-    // them to the neverConsumedValueID array.
     if (resultsActorIsolated) {
-      neverConsumedValueIDs.push_back(
+      neverTransferredValueIDs.push_back(
           lookupValueID(nonSendableResults.front()));
     }
 
@@ -595,16 +593,15 @@ public:
     for (unsigned i = 1; i < nonSendableResults.size(); i++) {
       builder.addAssign(nonSendableResults[i], nonSendableResults.front());
 
-      // If our results are actor isolated (and thus cannot be consumed)... add
-      // them to the neverConsumedValueID array.
       if (resultsActorIsolated)
-        neverConsumedValueIDs.push_back(lookupValueID(nonSendableResults[i]));
+        neverTransferredValueIDs.push_back(
+            lookupValueID(nonSendableResults[i]));
     }
   }
 
   void translateSILApply(SILInstruction *applyInst) {
     // if this apply does not cross isolation domains, it has normal,
-    // non-consuming multi-assignment semantics
+    // non-transferring multi-assignment semantics
     if (!SILApplyCrossesIsolation(applyInst)) {
       // TODO: How do we handle partial_apply here.
       bool hasActorSelf = false;
@@ -633,7 +630,7 @@ public:
   }
 
   // handles the semantics for SIL applies that cross isolation
-  // in particular, all arguments are consumed
+  // in particular, all arguments are transferred.
   void translateIsolationCrossingSILApply(ApplySite applySite) {
     ApplyExpr *sourceApply = applySite.getLoc().getAsASTNode<ApplyExpr>();
     assert(sourceApply && "only ApplyExpr's should cross isolation domains");
@@ -896,7 +893,7 @@ public:
           TinyPtrVector<SILValue>(inst->getResult(0)),
           inst->getOperandValues());
 
-    // Handle returns and throws - require the operand to be non-consumed
+    // Handle returns and throws - require the operand to be non-transferred
     case SILInstructionKind::ReturnInst:
     case SILInstructionKind::ThrowInst:
       return translateSILRequire(inst->getOperand(0));
@@ -1133,15 +1130,15 @@ class BlockPartitionState {
   // but this time pass in a handleFailure closure that can be used
   // to diagnose any failures
   void diagnoseFailures(
-      llvm::function_ref<void(const PartitionOp&, TrackableValueID)>
+      llvm::function_ref<void(const PartitionOp &, TrackableValueID)>
           handleFailure,
-      llvm::function_ref<void(const PartitionOp&, TrackableValueID)>
-          handleConsumeNonConsumable) {
+      llvm::function_ref<void(const PartitionOp &, TrackableValueID)>
+          handleTransferNonTransferable) {
     Partition workingPartition = entryPartition;
     for (auto &partitionOp : blockPartitionOps) {
       workingPartition.apply(partitionOp, handleFailure,
-                             translator.getNeverConsumedValues(),
-                             handleConsumeNonConsumable);
+                             translator.getNeverTransferredValues(),
+                             handleTransferNonTransferable);
     }
   }
 
@@ -1190,60 +1187,62 @@ public:
   }
 };
 
-enum class LocalConsumedReasonKind {
-  LocalConsumeInst,
-  LocalNonConsumeInst,
+enum class LocalTransferredReasonKind {
+  LocalTransferInst,
+  LocalNonTransferInst,
   NonLocal
 };
 
-// Why was a value consumed, without looking across blocks?
-// kind == LocalConsumeInst: a consume instruction in this block
-// kind == LocalNonConsumeInst: an instruction besides a consume instruction
+// Why was a value transferred, without looking across blocks?
+// kind == LocalTransferInst: a transfer instruction in this block
+// kind == LocalNonTransferInst: an instruction besides a transfer instruction
 //                              in this block
 // kind == NonLocal: an instruction outside this block
-struct LocalConsumedReason {
-  LocalConsumedReasonKind kind;
+struct LocalTransferredReason {
+  LocalTransferredReasonKind kind;
   std::optional<PartitionOp> localInst;
 
-  static LocalConsumedReason ConsumeInst(PartitionOp localInst) {
+  static LocalTransferredReason TransferInst(PartitionOp localInst) {
     assert(localInst.getKind() == PartitionOpKind::Transfer);
-    return LocalConsumedReason(LocalConsumedReasonKind::LocalConsumeInst, localInst);
+    return LocalTransferredReason(LocalTransferredReasonKind::LocalTransferInst,
+                                  localInst);
   }
 
-  static LocalConsumedReason NonConsumeInst() {
-    return LocalConsumedReason(LocalConsumedReasonKind::LocalNonConsumeInst);
+  static LocalTransferredReason NonTransferInst() {
+    return LocalTransferredReason(
+        LocalTransferredReasonKind::LocalNonTransferInst);
   }
 
-  static LocalConsumedReason NonLocal() {
-    return LocalConsumedReason(LocalConsumedReasonKind::NonLocal);
+  static LocalTransferredReason NonLocal() {
+    return LocalTransferredReason(LocalTransferredReasonKind::NonLocal);
   }
 
   // 0-ary constructor only used in maps, where it's immediately overridden
-  LocalConsumedReason() : kind(LocalConsumedReasonKind::NonLocal) {}
+  LocalTransferredReason() : kind(LocalTransferredReasonKind::NonLocal) {}
 
 private:
-  LocalConsumedReason(LocalConsumedReasonKind kind,
-                 std::optional<PartitionOp> localInst = {})
+  LocalTransferredReason(LocalTransferredReasonKind kind,
+                         std::optional<PartitionOp> localInst = {})
       : kind(kind), localInst(localInst) {}
 };
 
 // This class captures all available information about why a value's region was
-// consumed. In particular, it contains a map `consumeOps` whose keys are
-// "distances" and whose values are Consume PartitionOps that cause the target
-// region to be consumed. Distances are (roughly) the number of times
+// transferred. In particular, it contains a map `transferOps` whose keys are
+// "distances" and whose values are Transfer PartitionOps that cause the target
+// region to be transferred. Distances are (roughly) the number of times
 // two different predecessor blocks had to have their exit partitions joined
-// together to actually cause the target region to be consumed. If a Consume
+// together to actually cause the target region to be transferred. If a Transfer
 // op only causes a target access to be invalid because of merging/joining
 // that spans many different blocks worth of control flow, it is less likely
 // to be informative, so distance is used as a heuristic to choose which
 // access sites to display in diagnostics given a racy consumption.
-class ConsumedReason {
-  std::map<unsigned, std::vector<PartitionOp>> consumeOps;
+class TransferredReason {
+  std::map<unsigned, std::vector<PartitionOp>> transferOps;
 
-  friend class ConsumeRequireAccumulator;
+  friend class TransferRequireAccumulator;
 
   bool containsOp(const PartitionOp& op) {
-    for (auto [_, vec] : consumeOps)
+    for (auto [_, vec] : transferOps)
       for (auto vecOp : vec)
         if (op == vecOp)
           return true;
@@ -1251,45 +1250,49 @@ class ConsumedReason {
   }
 
 public:
-  // a ConsumedReason is valid if it contains at least one consume instruction
+  // a TransferredReason is valid if it contains at least one transfer
+  // instruction
   bool isValid() {
-    for (auto [_, vec] : consumeOps)
+    for (auto [_, vec] : transferOps)
       if (!vec.empty())
         return true;
     return false;
   }
 
-  ConsumedReason() {}
+  TransferredReason() {}
 
-  ConsumedReason(LocalConsumedReason localReason) {
-    assert(localReason.kind == LocalConsumedReasonKind::LocalConsumeInst);
-    consumeOps[0] = {localReason.localInst.value()};
+  TransferredReason(LocalTransferredReason localReason) {
+    assert(localReason.kind == LocalTransferredReasonKind::LocalTransferInst);
+    transferOps[0] = {localReason.localInst.value()};
   }
 
-  void addConsumeOp(PartitionOp consumeOp, unsigned distance) {
-    assert(consumeOp.getKind() == PartitionOpKind::Transfer);
+  void addTransferOp(PartitionOp transferOp, unsigned distance) {
+    assert(transferOp.getKind() == PartitionOpKind::Transfer);
     // duplicates should not arise
-    if (!containsOp(consumeOp))
-      consumeOps[distance].push_back(consumeOp);
+    if (!containsOp(transferOp))
+      transferOps[distance].push_back(transferOp);
   }
 
-  // merge in another consumedReason, adding the specified distane to all its ops
-  void addOtherReasonAtDistance(const ConsumedReason &otherReason, unsigned distance) {
-    for (auto &[otherDistance, otherConsumeOpsAtDistance] : otherReason.consumeOps)
-      for (auto otherConsumeOp : otherConsumeOpsAtDistance)
-        addConsumeOp(otherConsumeOp, distance + otherDistance);
+  // merge in another transferredReason, adding the specified distane to all its
+  // ops
+  void addOtherReasonAtDistance(const TransferredReason &otherReason,
+                                unsigned distance) {
+    for (auto &[otherDistance, otherTransferOpsAtDistance] :
+         otherReason.transferOps)
+      for (auto otherTransferOp : otherTransferOpsAtDistance)
+        addTransferOp(otherTransferOp, distance + otherDistance);
   }
 };
 
-// This class is the "inverse" of a ConsumedReason: instead of associating
+// This class is the "inverse" of a TransferredReason: instead of associating
 // accessing PartitionOps with their consumption sites, it associates
-// consumption site Consume PartitionOps with the corresponding accesses.
-// It is built up by repeatedly calling accumulateConsumedReason on
-// ConsumedReasons, which "inverts" the contents of that reason and adds it to
-// this class's tracking. Instead of a two-level map, we store a set that
+// consumption site Transfer PartitionOps with the corresponding accesses.
+// It is built up by repeatedly calling accumulateTransferredReason on
+// TransferredReasons, which "inverts" the contents of that reason and adds it
+// to this class's tracking. Instead of a two-level map, we store a set that
 // join together distances and access partitionOps so that we can use the
 // ordering by lowest diagnostics for prioritized output
-class ConsumeRequireAccumulator {
+class TransferRequireAccumulator {
   struct PartitionOpAtDistance {
     PartitionOp partitionOp;
     unsigned distance;
@@ -1307,44 +1310,46 @@ class ConsumeRequireAccumulator {
   // map consumptions to sets of requirements for that consumption, ordered so
   // that requirements at a smaller distance from the consumption come first
   std::map<PartitionOp, std::set<PartitionOpAtDistance>>
-      requirementsForConsumptions;
+      requirementsForTransfers;
 
   SILFunction *fn;
 
 public:
-  ConsumeRequireAccumulator(SILFunction *fn) : fn(fn) {}
+  TransferRequireAccumulator(SILFunction *fn) : fn(fn) {}
 
-  void accumulateConsumedReason(PartitionOp requireOp, const ConsumedReason &consumedReason) {
-    for (auto [distance, consumeOps] : consumedReason.consumeOps)
-      for (auto consumeOp : consumeOps)
-        requirementsForConsumptions[consumeOp].insert({requireOp, distance});
+  void accumulateTransferredReason(PartitionOp requireOp,
+                                   const TransferredReason &transferredReason) {
+    for (auto [distance, transferOps] : transferredReason.transferOps)
+      for (auto transferOp : transferOps)
+        requirementsForTransfers[transferOp].insert({requireOp, distance});
   }
 
-  void
-  emitErrorsForConsumeRequire(unsigned numRequiresPerConsume = UINT_MAX) const {
-    for (auto [consumeOp, requireOps] : requirementsForConsumptions) {
-      unsigned numProcessed = std::min({(unsigned) requireOps.size(),
-                                        (unsigned) numRequiresPerConsume});
+  void emitErrorsForTransferRequire(
+      unsigned numRequiresPerTransfer = UINT_MAX) const {
+    for (auto [transferOp, requireOps] : requirementsForTransfers) {
+      unsigned numProcessed = std::min(
+          {(unsigned)requireOps.size(), (unsigned)numRequiresPerTransfer});
 
-      // First process our consume ops.
+      // First process our transfer ops.
       unsigned numDisplayed = numProcessed;
       unsigned numHidden = requireOps.size() - numProcessed;
-      if (!tryDiagnoseAsCallSite(consumeOp, numDisplayed, numHidden)) {
+      if (!tryDiagnoseAsCallSite(transferOp, numDisplayed, numHidden)) {
         assert(false && "no consumptions besides callsites implemented yet");
 
         // default to more generic diagnostic
-        auto expr = getExprForPartitionOp(consumeOp);
+        auto expr = getExprForPartitionOp(transferOp);
         auto diag = fn->getASTContext().Diags.diagnose(
-            expr->getLoc(), diag::consumption_yields_race, numDisplayed,
+            expr->getLoc(), diag::transfer_yields_race, numDisplayed,
             numDisplayed != 1, numHidden > 0, numHidden);
-        if (auto sourceExpr = consumeOp.getSourceExpr())
+        if (auto sourceExpr = transferOp.getSourceExpr())
           diag.highlight(sourceExpr->getSourceRange());
         return;
       }
 
-      unsigned numRequiresToProcess = numRequiresPerConsume;
+      unsigned numRequiresToProcess = numRequiresPerTransfer;
       for (auto [requireOp, _] : requireOps) {
-        // ensures at most numRequiresPerConsume requires are processed per consume
+        // ensures at most numRequiresPerTransfer requires are processed per
+        // transfer
         if (numRequiresToProcess-- == 0)
           break;
         auto expr = getExprForPartitionOp(requireOp);
@@ -1358,9 +1363,9 @@ public:
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 
   void print(llvm::raw_ostream &os) const {
-    for (auto [consumeOp, requireOps] : requirementsForConsumptions) {
-      os << " ┌──╼ CONSUME: ";
-      consumeOp.print(os);
+    for (auto [transferOp, requireOps] : requirementsForTransfers) {
+      os << " ┌──╼ TRANSFER: ";
+      transferOp.print(os);
 
       for (auto &[requireOp, _] : requireOps) {
         os << " ├╼ REQUIRE: ";
@@ -1370,24 +1375,24 @@ public:
   }
 
 private:
-  /// Try to interpret this consumeOp as a source-level callsite (ApplyExpr),
+  /// Try to interpret this transferOp as a source-level callsite (ApplyExpr),
   /// and report a diagnostic including actor isolation crossing information
   /// returns true iff one was succesfully formed and emitted.
-  bool tryDiagnoseAsCallSite(const PartitionOp &consumeOp,
+  bool tryDiagnoseAsCallSite(const PartitionOp &transferOp,
                              unsigned numDisplayed, unsigned numHidden) const {
     SILInstruction *sourceInst =
-        consumeOp.getSourceInst(/*assertNonNull=*/true);
+        transferOp.getSourceInst(/*assertNonNull=*/true);
     ApplyExpr *apply = sourceInst->getLoc().getAsASTNode<ApplyExpr>();
     if (!apply)
       // consumption does not correspond to an apply expression
       return false;
     auto isolationCrossing = apply->getIsolationCrossing();
     if (!isolationCrossing) {
-      assert(false && "ApplyExprs should be consuming only if"
+      assert(false && "ApplyExprs should be transferring only if"
                       " they are isolation crossing");
       return false;
     }
-    auto argExpr = consumeOp.getSourceExpr();
+    auto argExpr = transferOp.getSourceExpr();
     if (!argExpr)
       assert(false &&
              "sourceExpr should be populated for ApplyExpr consumptions");
@@ -1395,7 +1400,7 @@ private:
     sourceInst->getFunction()
         ->getASTContext()
         .Diags
-        .diagnose(argExpr->getLoc(), diag::call_site_consumption_yields_race,
+        .diagnose(argExpr->getLoc(), diag::call_site_transfer_yields_race,
                   argExpr->findOriginalType(),
                   isolationCrossing.value().getCallerIsolation(),
                   isolationCrossing.value().getCalleeIsolation(), numDisplayed,
@@ -1407,76 +1412,81 @@ private:
 
 // A RaceTracer is used to accumulate the facts that the main phase of
 // PartitionAnalysis generates - that certain values were required at certain
-// points but were in consumed regions and thus should yield diagnostics -
-// and traces those facts to the Consume operations that could have been
+// points but were in transferred regions and thus should yield diagnostics -
+// and traces those facts to the Transfer operations that could have been
 // responsible.
 class RaceTracer {
   const BasicBlockData<BlockPartitionState>& blockStates;
 
-  std::map<std::pair<SILBasicBlock *, TrackableValueID>, ConsumedReason>
-      consumedAtEntryReasons;
+  std::map<std::pair<SILBasicBlock *, TrackableValueID>, TransferredReason>
+      transferredAtEntryReasons;
 
-  // caches the reasons why consumedVals were consumed at the exit to basic blocks
-  std::map<std::pair<SILBasicBlock *, TrackableValueID>, LocalConsumedReason>
-      consumedAtExitReasons;
+  // caches the reasons why transferredVals were transferred at the exit to
+  // basic blocks
+  std::map<std::pair<SILBasicBlock *, TrackableValueID>, LocalTransferredReason>
+      transferredAtExitReasons;
 
-  ConsumeRequireAccumulator accumulator;
+  TransferRequireAccumulator accumulator;
 
-  ConsumedReason findConsumedAtOpReason(TrackableValueID consumedVal, PartitionOp op) {
-    ConsumedReason consumedReason;
-    findAndAddConsumedReasons(op.getSourceInst(true)->getParent(), consumedVal,
-                              consumedReason, 0, op);
-    return consumedReason;
+  TransferredReason findTransferredAtOpReason(TrackableValueID transferredVal,
+                                              PartitionOp op) {
+    TransferredReason transferredReason;
+    findAndAddTransferredReasons(op.getSourceInst(true)->getParent(),
+                                 transferredVal, transferredReason, 0, op);
+    return transferredReason;
   }
 
-  void findAndAddConsumedReasons(
-      SILBasicBlock * SILBlock, TrackableValueID consumedVal,
-      ConsumedReason &consumedReason, unsigned distance,
-      std::optional<PartitionOp> targetOp = {}) {
-    LocalConsumedReason localReason
-        = findLocalConsumedReason(SILBlock, consumedVal, targetOp);
+  void findAndAddTransferredReasons(SILBasicBlock *SILBlock,
+                                    TrackableValueID transferredVal,
+                                    TransferredReason &transferredReason,
+                                    unsigned distance,
+                                    std::optional<PartitionOp> targetOp = {}) {
+    LocalTransferredReason localReason =
+        findLocalTransferredReason(SILBlock, transferredVal, targetOp);
     switch (localReason.kind) {
-    case LocalConsumedReasonKind::LocalConsumeInst:
-      // there is a local consume in the pred block
-      consumedReason.addConsumeOp(localReason.localInst.value(), distance);
+    case LocalTransferredReasonKind::LocalTransferInst:
+      // there is a local transfer in the pred block
+      transferredReason.addTransferOp(localReason.localInst.value(), distance);
       break;
-    case LocalConsumedReasonKind::LocalNonConsumeInst:
+    case LocalTransferredReasonKind::LocalNonTransferInst:
       // ignore this case, that instruction will initiate its own search
-      // for a consume op
+      // for a transfer op
       break;
-    case LocalConsumedReasonKind::NonLocal:
-      consumedReason.addOtherReasonAtDistance(
+    case LocalTransferredReasonKind::NonLocal:
+      transferredReason.addOtherReasonAtDistance(
           // recursive call
-          findConsumedAtEntryReason(SILBlock, consumedVal), distance);
+          findTransferredAtEntryReason(SILBlock, transferredVal), distance);
     }
   }
 
-  // find the reason why a value was consumed at entry to a block
-  const ConsumedReason &findConsumedAtEntryReason(
-      SILBasicBlock *SILBlock, TrackableValueID consumedVal) {
+  // find the reason why a value was transferred at entry to a block
+  const TransferredReason &
+  findTransferredAtEntryReason(SILBasicBlock *SILBlock,
+                               TrackableValueID transferredVal) {
     const BlockPartitionState &block = blockStates[SILBlock];
-    assert(block.getEntryPartition().isConsumed(consumedVal));
+    assert(block.getEntryPartition().isTransferred(transferredVal));
 
     // check the cache
-    if (consumedAtEntryReasons.count({SILBlock, consumedVal}))
-      return consumedAtEntryReasons.at({SILBlock, consumedVal});
+    if (transferredAtEntryReasons.count({SILBlock, transferredVal}))
+      return transferredAtEntryReasons.at({SILBlock, transferredVal});
 
     // enter a dummy value in the cache to prevent circular call dependencies
-    consumedAtEntryReasons[{SILBlock, consumedVal}] = ConsumedReason();
+    transferredAtEntryReasons[{SILBlock, transferredVal}] = TransferredReason();
 
     auto entryTracks = [&](TrackableValueID val) {
       return block.getEntryPartition().isTracked(val);
     };
 
     // this gets populated with all the tracked values at entry to this block
-    // that are consumed at the exit to some predecessor block, associated
-    // with the blocks that consume them
-    std::map<TrackableValueID, std::vector<SILBasicBlock *>> consumedInSomePred;
+    // that are transferred at the exit to some predecessor block, associated
+    // with the blocks that transfer them
+    std::map<TrackableValueID, std::vector<SILBasicBlock *>>
+        transferredInSomePred;
     for (SILBasicBlock *pred : SILBlock->getPredecessorBlocks())
-      for (TrackableValueID consumedVal
-          : blockStates[pred].getExitPartition().getConsumedVals())
-        if (entryTracks(consumedVal))
-          consumedInSomePred[consumedVal].push_back(pred);
+      for (TrackableValueID transferredVal :
+           blockStates[pred].getExitPartition().getTransferredVals())
+        if (entryTracks(transferredVal))
+          transferredInSomePred[transferredVal].push_back(pred);
 
     // this gets populated with all the multi-edges between values tracked
     // at entry to this block that will be merged because of common regionality
@@ -1484,24 +1494,24 @@ class RaceTracer {
     // because we want to count how many steps transitive merges require
     std::map<TrackableValueID, std::set<TrackableValueID>> singleStepJoins;
     for (SILBasicBlock *pred : SILBlock->getPredecessorBlocks())
-      for (std::vector<TrackableValueID> region
-          : blockStates[pred].getExitPartition().getNonConsumedRegions()) {
+      for (std::vector<TrackableValueID> region :
+           blockStates[pred].getExitPartition().getNonTransferredRegions()) {
         for (TrackableValueID fst : region) for (TrackableValueID snd : region)
             if (fst != snd && entryTracks(fst) && entryTracks(snd))
               singleStepJoins[fst].insert(snd);
       }
 
     // this gets populated with the distance, in terms of single step joins,
-    // from the target consumedVal to other values that will get merged with it
-    // because of the join at entry to this basic block
+    // from the target transferredVal to other values that will get merged with
+    // it because of the join at entry to this basic block
     std::map<TrackableValueID, unsigned> distancesFromTarget;
 
     // perform BFS
     // an entry of `{val, dist}` in the `processValues` deque indicates that
-    // `val` is known to be merged with `consumedVal` (the target of this find)
-    // at a distance of `dist` single-step joins
+    // `val` is known to be merged with `transferredVal` (the target of this
+    // find) at a distance of `dist` single-step joins
     std::deque<std::pair<TrackableValueID, unsigned>> processValues;
-    processValues.push_back({consumedVal, 0});
+    processValues.push_back({transferredVal, 0});
     while (!processValues.empty()) {
       auto [currentTarget, currentDistance] = processValues.front();
       processValues.pop_front();
@@ -1511,91 +1521,97 @@ class RaceTracer {
           processValues.push_back({nextTarget, currentDistance + 1});
     }
 
-    ConsumedReason consumedReason;
+    TransferredReason transferredReason;
 
     for (auto [predVal, distanceFromTarget] : distancesFromTarget) {
-      for (SILBasicBlock *predBlock : consumedInSomePred[predVal]) {
-        // one reason that our target consumedVal is consumed is that
-        // predConsumedVal was consumed at exit of predBlock, and
+      for (SILBasicBlock *predBlock : transferredInSomePred[predVal]) {
+        // one reason that our target transferredVal is transferred is that
+        // predTransferredVal was transferred at exit of predBlock, and
         // distanceFromTarget merges had to be performed to make that
-        // be a reason. Use this to build a ConsumedReason for consumedVal.
-        findAndAddConsumedReasons(predBlock, predVal, consumedReason, distanceFromTarget);
+        // be a reason. Use this to build a TransferredReason for
+        // transferredVal.
+        findAndAddTransferredReasons(predBlock, predVal, transferredReason,
+                                     distanceFromTarget);
       }
     }
 
-    consumedAtEntryReasons[{SILBlock, consumedVal}] = std::move(consumedReason);
+    transferredAtEntryReasons[{SILBlock, transferredVal}] =
+        std::move(transferredReason);
 
-    return consumedAtEntryReasons[{SILBlock, consumedVal}];
+    return transferredAtEntryReasons[{SILBlock, transferredVal}];
   }
 
-  // assuming that consumedVal is consumed at the point of targetOp within
+  // assuming that transferredVal is transferred at the point of targetOp within
   // SILBlock (or block exit if targetOp = {}), find the reason why it was
-  // consumed, possibly local or nonlocal. Return the reason.
-  LocalConsumedReason findLocalConsumedReason(
-      SILBasicBlock * SILBlock, TrackableValueID consumedVal,
-      std::optional<PartitionOp> targetOp = {}) {
+  // transferred, possibly local or nonlocal. Return the reason.
+  LocalTransferredReason
+  findLocalTransferredReason(SILBasicBlock *SILBlock,
+                             TrackableValueID transferredVal,
+                             std::optional<PartitionOp> targetOp = {}) {
     // if this is a query for consumption reason at block exit, check the cache
-    if (!targetOp && consumedAtExitReasons.count({SILBlock, consumedVal}))
-      return consumedAtExitReasons.at({SILBlock, consumedVal});
+    if (!targetOp && transferredAtExitReasons.count({SILBlock, transferredVal}))
+      return transferredAtExitReasons.at({SILBlock, transferredVal});
 
     const BlockPartitionState &block = blockStates[SILBlock];
 
-    // if targetOp is null, we're checking why the value is consumed at exit,
-    // so assert that it's actually consumed at exit
-    assert(targetOp || block.getExitPartition().isConsumed(consumedVal));
+    // if targetOp is null, we're checking why the value is transferred at exit,
+    // so assert that it's actually transferred at exit
+    assert(targetOp || block.getExitPartition().isTransferred(transferredVal));
 
-    std::optional<LocalConsumedReason> consumedReason;
+    std::optional<LocalTransferredReason> transferredReason;
 
     Partition workingPartition = block.getEntryPartition();
 
-    // we're looking for a local reason, so if the value is consumed at entry,
-    // revive it for the sake of this search
-    if (workingPartition.isConsumed(consumedVal))
-      workingPartition.apply(PartitionOp::AssignFresh(consumedVal));
+    // we're looking for a local reason, so if the value is transferred at
+    // entry, revive it for the sake of this search
+    if (workingPartition.isTransferred(transferredVal))
+      workingPartition.apply(PartitionOp::AssignFresh(transferredVal));
 
     int i = 0;
     block.forEachPartitionOp([&](const PartitionOp& partitionOp) {
       if (targetOp == partitionOp)
         return false; //break
       workingPartition.apply(partitionOp);
-      if (workingPartition.isConsumed(consumedVal) && !consumedReason) {
-        // this partitionOp consumes the target value
+      if (workingPartition.isTransferred(transferredVal) &&
+          !transferredReason) {
+        // this partitionOp transfers the target value
         if (partitionOp.getKind() == PartitionOpKind::Transfer)
-          consumedReason = LocalConsumedReason::ConsumeInst(partitionOp);
+          transferredReason = LocalTransferredReason::TransferInst(partitionOp);
         else
           // a merge or assignment invalidated this, but that will be a separate
           // failure to diagnose, so we don't worry about it here
-          consumedReason = LocalConsumedReason::NonConsumeInst();
+          transferredReason = LocalTransferredReason::NonTransferInst();
       }
-      if (!workingPartition.isConsumed(consumedVal) && consumedReason)
-        // value is no longer consumed - e.g. reassigned or assigned fresh
-        consumedReason = llvm::None;
+      if (!workingPartition.isTransferred(transferredVal) && transferredReason)
+        // value is no longer transferred - e.g. reassigned or assigned fresh
+        transferredReason = llvm::None;
 
       // continue walking block
       i++;
       return true;
     });
 
-    // if we failed to find a local consume reason, but the value was consumed
-    // at entry to the block, then the reason is "NonLocal"
-    if (!consumedReason && block.getEntryPartition().isConsumed(consumedVal))
-      consumedReason = LocalConsumedReason::NonLocal();
+    // if we failed to find a local transfer reason, but the value was
+    // transferred at entry to the block, then the reason is "NonLocal"
+    if (!transferredReason &&
+        block.getEntryPartition().isTransferred(transferredVal))
+      transferredReason = LocalTransferredReason::NonLocal();
 
-    // if consumedReason is none, then consumedVal was not actually consumed
-    assert(consumedReason
-           || dumpBlockSearch(SILBlock, consumedVal)
-           && " no consumption was found"
-    );
+    // if transferredReason is none, then transferredVal was not actually
+    // transferred
+    assert(transferredReason || dumpBlockSearch(SILBlock, transferredVal) &&
+                                    " no consumption was found");
 
     // if this is a query for consumption reason at block exit, update the cache
     if (!targetOp)
-      return consumedAtExitReasons[std::pair{SILBlock, consumedVal}]
-                 = consumedReason.value();
+      return transferredAtExitReasons[std::pair{SILBlock, transferredVal}] =
+                 transferredReason.value();
 
-    return consumedReason.value();
+    return transferredReason.value();
   }
 
-  bool dumpBlockSearch(SILBasicBlock * SILBlock, TrackableValueID consumedVal) {
+  bool dumpBlockSearch(SILBasicBlock *SILBlock,
+                       TrackableValueID transferredVal) {
     LLVM_DEBUG(unsigned i = 0;
                const BlockPartitionState &block = blockStates[SILBlock];
                Partition working = block.getEntryPartition();
@@ -1605,8 +1621,8 @@ class RaceTracer {
                  op.print(llvm::dbgs());
                  working.apply(op);
                  llvm::dbgs() << "│ ";
-                 if (working.isConsumed(consumedVal)) {
-                   llvm::dbgs() << "(" << consumedVal << " CONSUMED) ";
+                 if (working.isTransferred(transferredVal)) {
+                   llvm::dbgs() << "(" << transferredVal << " TRANSFERRED) ";
                  }
                  working.print(llvm::dbgs());
                  return true;
@@ -1620,14 +1636,13 @@ public:
              const BasicBlockData<BlockPartitionState> &blockStates)
       : blockStates(blockStates), accumulator(fn) {}
 
-  void traceUseOfConsumedValue(PartitionOp use, TrackableValueID consumedVal) {
-    accumulator.accumulateConsumedReason(
-        use, findConsumedAtOpReason(consumedVal, use));
+  void traceUseOfTransferredValue(PartitionOp use,
+                                  TrackableValueID transferredVal) {
+    accumulator.accumulateTransferredReason(
+        use, findTransferredAtOpReason(transferredVal, use));
   }
 
-  const ConsumeRequireAccumulator &getAccumulator() {
-    return accumulator;
-  }
+  const TransferRequireAccumulator &getAccumulator() { return accumulator; }
 };
 
 // Instances of PartitionAnalysis perform the region-based Sendable checking.
@@ -1729,8 +1744,9 @@ class PartitionAnalysis {
       }
     }
 
-    // Now that we have finished processing, sort/unique our non consumed array.
-    translator.sortUniqueNeverConsumedValues();
+    // Now that we have finished processing, sort/unique our non transferred
+    // array.
+    translator.sortUniqueNeverTransferredValues();
   }
 
   // track the AST exprs that have already had diagnostics emitted about
@@ -1748,7 +1764,7 @@ class PartitionAnalysis {
   }
 
   // once the fixpoint has been solved for, run one more pass over each basic
-  // block, reporting any failures due to requiring consumed regions in the
+  // block, reporting any failures due to requiring transferred regions in the
   // fixpoint state
   void diagnose() {
     assert(solved && "diagnose should not be called before solve");
@@ -1759,25 +1775,26 @@ class PartitionAnalysis {
     RaceTracer tracer(function, blockStates);
 
     for (auto [_, blockState] : blockStates) {
-      // populate the raceTracer with all requires of consumed valued found
+      // populate the raceTracer with all requires of transferred valued found
       // throughout the CFG
       blockState.diagnoseFailures(
           /*handleFailure=*/
-          [&](const PartitionOp& partitionOp, TrackableValueID consumedVal) {
+          [&](const PartitionOp &partitionOp, TrackableValueID transferredVal) {
             auto expr = getExprForPartitionOp(partitionOp);
 
             // ensure that multiple consumptions at the same AST node are only
             // entered once into the race tracer
-            if (hasBeenEmitted(expr)) return;
+            if (hasBeenEmitted(expr))
+              return;
 
-            raceTracer.traceUseOfConsumedValue(partitionOp, consumedVal);
+            raceTracer.traceUseOfTransferredValue(partitionOp, transferredVal);
           },
 
-          /*handleConsumeNonConsumable=*/
-          [&](const PartitionOp& partitionOp, TrackableValueID consumedVal) {
+          /*handleTransferNonConsumable=*/
+          [&](const PartitionOp &partitionOp, TrackableValueID transferredVal) {
             auto expr = getExprForPartitionOp(partitionOp);
             function->getASTContext().Diags.diagnose(
-                expr->getLoc(), diag::arg_region_consumed);
+                expr->getLoc(), diag::arg_region_transferred);
           });
     }
 
@@ -1786,30 +1803,31 @@ class PartitionAnalysis {
 
     // Ask the raceTracer to report diagnostics at the consumption sites for all
     // the racy requirement sites entered into it above.
-    raceTracer.getAccumulator().emitErrorsForConsumeRequire(
+    raceTracer.getAccumulator().emitErrorsForTransferRequire(
         NUM_REQUIREMENTS_TO_DIAGNOSE);
   }
 
-  bool tryDiagnoseAsCallSite(
-      const PartitionOp& consumeOp, unsigned numDisplayed, unsigned numHidden) {
-    SILInstruction *sourceInst = consumeOp.getSourceInst(/*assertNonNull=*/true);
+  bool tryDiagnoseAsCallSite(const PartitionOp &transferOp,
+                             unsigned numDisplayed, unsigned numHidden) {
+    SILInstruction *sourceInst =
+        transferOp.getSourceInst(/*assertNonNull=*/true);
     ApplyExpr *apply = sourceInst->getLoc().getAsASTNode<ApplyExpr>();
     if (!apply)
       // consumption does not correspond to an apply expression
       return false;
     auto isolationCrossing = apply->getIsolationCrossing();
     if (!isolationCrossing) {
-      assert(false && "ApplyExprs should be consuming only if"
+      assert(false && "ApplyExprs should be transferring only if"
                       " they are isolation crossing");
       return false;
     }
-    auto argExpr = consumeOp.getSourceExpr();
+    auto argExpr = transferOp.getSourceExpr();
     if (!argExpr)
       assert(false && "sourceExpr should be populated for ApplyExpr consumptions");
 
     function->getASTContext()
         .Diags
-        .diagnose(argExpr->getLoc(), diag::call_site_consumption_yields_race,
+        .diagnose(argExpr->getLoc(), diag::call_site_transfer_yields_race,
                   argExpr->findOriginalType(),
                   isolationCrossing.value().getCallerIsolation(),
                   isolationCrossing.value().getCalleeIsolation(), numDisplayed,

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(swiftSILOptimizer PRIVATE
   LoopUtils.cpp
   OptimizerStatsUtils.cpp
   PartialApplyCombiner.cpp
+  PartitionUtils.cpp
   PerformanceInlinerUtils.cpp
   ShrinkBorrowScope.cpp
   SILInliner.cpp

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -1,0 +1,29 @@
+//===--- PartitionUtils.cpp -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Utils/PartitionUtils.h"
+#include "llvm/Support/CommandLine.h"
+
+#ifndef NDEBUG
+
+bool swift::PartitionPrimitives::REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING;
+
+static llvm::cl::opt<bool, true> // The parser
+    RegionBasedIsolationVerboseLog(
+        "sil-regionbasedisolation-verbose-log",
+        llvm::cl::desc("Enable verbose logging for SIL region based isolation "
+                       "diagnostics"),
+        llvm::cl::Hidden,
+        llvm::cl::location(swift::PartitionPrimitives::
+                               REGIONBASEDISOLATION_ENABLE_VERBOSE_LOGGING));
+
+#endif

--- a/unittests/SIL/CMakeLists.txt
+++ b/unittests/SIL/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_swift_unittest(SwiftSILTests
-  PartitionUtilsTest.cpp
   SILBitfieldTest.cpp
 )
 

--- a/unittests/SILOptimizer/CMakeLists.txt
+++ b/unittests/SILOptimizer/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_swift_unittest(SwiftSILOptimizerTests
+  PartitionUtilsTest.cpp
+)
+
+target_link_libraries(SwiftSILOptimizerTests
+   PRIVATE
+   swiftSILOptimizer
+)

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -1,6 +1,18 @@
-#include "gtest/gtest.h"
+//===--- PartitionUtilsTest.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 
 #include "swift/SILOptimizer/Utils/PartitionUtils.h"
+
+#include "gtest/gtest.h"
 
 using namespace swift;
 
@@ -109,7 +121,9 @@ TEST(PartitionUtilsTest, TestAssign) {
   p3.apply(PartitionOp::AssignFresh(Element(2)));
   p3.apply(PartitionOp::AssignFresh(Element(3)));
 
-  //expected: p1: ((Element(0)) (Element(1)) (Element(2)) (Element(3))), p2: ((Element(0)) (Element(1)) (Element(2)) (Element(3))), p3: ((Element(0)) (Element(1)) (Element(2)) (Element(3)))
+  // expected: p1: ((Element(0)) (Element(1)) (Element(2)) (Element(3))), p2:
+  // ((Element(0)) (Element(1)) (Element(2)) (Element(3))), p3: ((Element(0))
+  // (Element(1)) (Element(2)) (Element(3)))
 
   EXPECT_TRUE(Partition::equals(p1, p2));
   EXPECT_TRUE(Partition::equals(p2, p3));
@@ -119,7 +133,8 @@ TEST(PartitionUtilsTest, TestAssign) {
   p2.apply(PartitionOp::Assign(Element(1), Element(0)));
   p3.apply(PartitionOp::Assign(Element(2), Element(1)));
 
-  //expected: p1: ((0 1) (Element(2)) (Element(3))), p2: ((0 1) (Element(2)) (Element(3))), p3: ((Element(0)) (1 2) (Element(3)))
+  // expected: p1: ((0 1) (Element(2)) (Element(3))), p2: ((0 1) (Element(2))
+  // (Element(3))), p3: ((Element(0)) (1 2) (Element(3)))
 
   EXPECT_TRUE(Partition::equals(p1, p2));
   EXPECT_FALSE(Partition::equals(p2, p3));
@@ -129,7 +144,8 @@ TEST(PartitionUtilsTest, TestAssign) {
   p2.apply(PartitionOp::Assign(Element(2), Element(1)));
   p3.apply(PartitionOp::Assign(Element(0), Element(2)));
 
-  //expected: p1: ((0 1 2) (Element(3))), p2: ((0 1 2) (Element(3))), p3: ((0 1 2) (Element(3)))
+  // expected: p1: ((0 1 2) (Element(3))), p2: ((0 1 2) (Element(3))), p3: ((0 1
+  // 2) (Element(3)))
 
   EXPECT_TRUE(Partition::equals(p1, p2));
   EXPECT_TRUE(Partition::equals(p2, p3));
@@ -139,7 +155,7 @@ TEST(PartitionUtilsTest, TestAssign) {
   p2.apply(PartitionOp::Assign(Element(1), Element(3)));
   p3.apply(PartitionOp::Assign(Element(2), Element(3)));
 
-  //expected: p1: ((1 2) (0 3)), p2: ((0 2) (1 3)), p3: ((0 1) (2 3))
+  // expected: p1: ((1 2) (0 3)), p2: ((0 2) (1 3)), p3: ((0 1) (2 3))
 
   EXPECT_FALSE(Partition::equals(p1, p2));
   EXPECT_FALSE(Partition::equals(p2, p3));
@@ -149,7 +165,8 @@ TEST(PartitionUtilsTest, TestAssign) {
   p2.apply(PartitionOp::Assign(Element(2), Element(1)));
   p3.apply(PartitionOp::Assign(Element(0), Element(2)));
 
-  //expected: p1: ((Element(2)) (0 1 3)), p2: ((Element(0)) (1 2 3)), p3: ((Element(1)) (0 2 3))
+  // expected: p1: ((Element(2)) (0 1 3)), p2: ((Element(0)) (1 2 3)), p3:
+  // ((Element(1)) (0 2 3))
 
   EXPECT_FALSE(Partition::equals(p1, p2));
   EXPECT_FALSE(Partition::equals(p2, p3));
@@ -159,7 +176,7 @@ TEST(PartitionUtilsTest, TestAssign) {
   p2.apply(PartitionOp::Assign(Element(0), Element(3)));
   p3.apply(PartitionOp::Assign(Element(1), Element(3)));
 
-  //expected: p1: ((0 1 2 3)), p2: ((0 1 2 3)), p3: ((0 1 2 3))
+  // expected: p1: ((0 1 2 3)), p2: ((0 1 2 3)), p3: ((0 1 2 3))
 
   EXPECT_TRUE(Partition::equals(p1, p2));
   EXPECT_TRUE(Partition::equals(p2, p3));
@@ -192,7 +209,7 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
   p.apply(PartitionOp::Assign(Element(7), Element(6)));
   p.apply(PartitionOp::Assign(Element(9), Element(8)));
 
-  //expected: p: ((0 1 2) (3 4 5) (6 7) (8 9) (Element(10)) (Element(11)))
+  // expected: p: ((0 1 2) (3 4 5) (6 7) (8 9) (Element(10)) (Element(11)))
 
   p.apply(PartitionOp::Transfer(Element(2)));
   p.apply(PartitionOp::Transfer(Element(7)));
@@ -200,15 +217,13 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
 
   // expected: p: ({0 1 2 6 7 10} (3 4 5) (8 9) (Element(11)))
 
-  auto never_called = [](const PartitionOp &, unsigned) {
-      EXPECT_TRUE(false);
-  };
+  auto never_called = [](const PartitionOp &, unsigned) { EXPECT_TRUE(false); };
 
   int times_called = 0;
   int expected_times_called = 0;
   auto increment_times_called = [&](const PartitionOp &, unsigned) {
-        times_called++;
-      };
+    times_called++;
+  };
   auto get_increment_times_called = [&]() {
     expected_times_called++;
     return increment_times_called;
@@ -238,12 +253,10 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
   Partition p2 = p1;
   p1.apply(PartitionOp::Transfer(Element(0)));
   bool failure = false;
-  p1.apply(PartitionOp::Require(Element(0)), [&](const PartitionOp &, unsigned) {
-      failure = true;
-    });
+  p1.apply(PartitionOp::Require(Element(0)),
+           [&](const PartitionOp &, unsigned) { failure = true; });
   EXPECT_TRUE(failure);
 
-  p2.apply(PartitionOp::Require(Element(0)), [](const PartitionOp &, unsigned) {
-    EXPECT_TRUE(false);
-  });
+  p2.apply(PartitionOp::Require(Element(0)),
+           [](const PartitionOp &, unsigned) { EXPECT_TRUE(false); });
 }


### PR DESCRIPTION
This PR contains a small set of fixes that are chopped off a larger PR. Most are NFC or small performance fixes. I am chopping it off to make reviewing the other PR easier.

The specific PRs are:

1. I added a new helper API to SILType to check if a SILType is an actor. This prevents us from needing to get at the ASTType to get that information.
2. I added new verbose logging to PartitionUtils.h so that as the partition utils walks the blocks, one can see how it changes the regions. Otherwise the only information one gets from the logging are the exiting regions at the bottom of the block which is not always the information one needs. Since this is significantly more verbose, I put it behind a flag.
3. Since I added the flag from 2, I needed to add a new .cpp file for PartitionUtils. Since PartitionUtils is in SILOptimizer, I had to also create that .cpp file in SILOptimizer. This required me to move the unit tests for PartitionUtils from the SIL unittest folder to the SILOptimizer unittest folder so that we link against the appropriate library.
4. I found another case of a std::vector being used as an argument where we could just use an ArrayRef since we are never writing into the vector. Eliminating unnecessary heap allocations are good.
5. I deleted an incorrect assert. The assert was validating that if we transferred a value within the block, we always had the value as transferred at the end of the block. This isn't true if we reinitialize the value within the block.
6. I removed an unnecessary helper that checked if a value has an address type. 
7. I changed the ConsumeRequireAccumulator to just emit errors directly rather than use callbacks. I did this since it seemed like a premature optimization.
8. I finally changed the rest of the usages of Consume -> Transferred since that is the terminology we are using.