### PR TITLE
[5.9][Macros] Improve visitation of auxiliary decls

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -951,6 +951,10 @@ public:
   /// The order of the results is not guaranteed to be meaningful.
   void getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const;
 
+  /// Finds all top-level decls of this module including auxiliary decls.
+  void
+  getTopLevelDeclsWithAuxiliaryDecls(SmallVectorImpl<Decl *> &Results) const;
+
   void getExportedPrespecializations(SmallVectorImpl<Decl *> &results) const;
 
   /// Finds top-level decls of this module filtered by their attributes.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1329,6 +1329,11 @@ void ModuleDecl::getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const {
   FORWARD(getTopLevelDecls, (Results));
 }
 
+void ModuleDecl::getTopLevelDeclsWithAuxiliaryDecls(
+    SmallVectorImpl<Decl *> &Results) const {
+  FORWARD(getTopLevelDeclsWithAuxiliaryDecls, (Results));
+}
+
 void ModuleDecl::dumpDisplayDecls() const {
   SmallVector<Decl *, 32> Decls;
   getDisplayDecls(Decls);
@@ -3132,7 +3137,9 @@ void SourceFile::print(raw_ostream &OS, const PrintOptions &PO) {
 void SourceFile::print(ASTPrinter &Printer, const PrintOptions &PO) {
   std::set<DeclKind> MajorDeclKinds = {DeclKind::Class, DeclKind::Enum,
     DeclKind::Extension, DeclKind::Protocol, DeclKind::Struct};
-  for (auto decl : getTopLevelDecls()) {
+  SmallVector<Decl *> topLevelDecls;
+  getTopLevelDeclsWithAuxiliaryDecls(topLevelDecls);
+  for (auto decl : topLevelDecls) {
     if (!decl->shouldPrintInContext(PO))
       continue;
     // For a major decl, we print an empty line before it.
@@ -4179,14 +4186,18 @@ void FileUnit::getTopLevelDeclsWhereAttributesMatch(
 
 void FileUnit::getTopLevelDeclsWithAuxiliaryDecls(
     SmallVectorImpl<Decl*> &results) const {
+
+  std::function<void(Decl *)> addResult;
+  addResult = [&](Decl *decl) {
+    results.push_back(decl);
+    decl->visitAuxiliaryDecls(addResult);
+  };
+
   SmallVector<Decl *, 32> nonExpandedDecls;
   nonExpandedDecls.reserve(results.capacity());
   getTopLevelDecls(nonExpandedDecls);
   for (auto *decl : nonExpandedDecls) {
-    decl->visitAuxiliaryDecls([&](Decl *auxDecl) {
-      results.push_back(auxDecl);
-    });
-    results.push_back(decl);
+    addResult(decl);
   }
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3939,16 +3939,12 @@ void FindLocalVal::visitBraceStmt(BraceStmt *S, bool isTopLevelCode) {
     }
   }
 
-  auto visitDecl = [&](Decl *D) {
+  std::function<void(Decl *)> visitDecl;
+  visitDecl = [&](Decl *D) {
     if (auto *VD = dyn_cast<ValueDecl>(D))
       checkValueDecl(VD, DeclVisibilityKind::LocalVariable);
-    D->visitAuxiliaryDecls([&](Decl *D) {
-      if (auto *VD = dyn_cast<ValueDecl>(D))
-        checkValueDecl(VD, DeclVisibilityKind::LocalVariable);
-      // FIXME: Recursively call `visitDecl` to handle nested macros.
-    });
+    D->visitAuxiliaryDecls(visitDecl);
   };
-
   for (auto elem : S->getElements()) {
     if (auto *E = elem.dyn_cast<Expr *>()) {
       // 'MacroExpansionExpr' at code-item position may introduce value decls.

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -833,7 +833,7 @@ bool swift::emitSwiftInterface(raw_ostream &out,
   InheritedProtocolCollector::PerTypeMap inheritedProtocolMap;
 
   SmallVector<Decl *, 16> topLevelDecls;
-  M->getTopLevelDecls(topLevelDecls);
+  M->getTopLevelDeclsWithAuxiliaryDecls(topLevelDecls);
   for (const Decl *D : topLevelDecls) {
     InheritedProtocolCollector::collectProtocols(inheritedProtocolMap, D);
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -217,24 +217,17 @@ static void collectVisibleMemberDecls(const DeclContext *CurrDC, LookupState LS,
                                       Type BaseType,
                                       IterableDeclContext *Parent,
                                       SmallVectorImpl<ValueDecl *> &FoundDecls) {
-  auto check = [&](Decl *decl) {
-    auto *VD = dyn_cast<ValueDecl>(decl);
+  for (auto Member : Parent->getAllMembers()) {
+    auto *VD = dyn_cast<ValueDecl>(Member);
     if (!VD)
-      return;
+      continue;
     if (!isDeclVisibleInLookupMode(VD, LS, CurrDC))
-      return;
+      continue;
     if (!evaluateOrDefault(CurrDC->getASTContext().evaluator,
         IsDeclApplicableRequest(DeclApplicabilityOwner(CurrDC, BaseType, VD)),
                            false))
-      return;
+      continue;
     FoundDecls.push_back(VD);
-  };
-
-  for (auto Member : Parent->getAllMembers()) {
-    check(Member);
-    Member->visitAuxiliaryDecls([&](Decl *d) {
-      check(d);
-    });
   }
 }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1928,7 +1928,7 @@ public struct AddPeerStoredPropertyMacro: PeerMacro, Sendable {
     return [
       """
 
-      private var _foo: Int = 100
+      public var _foo: Int = 100
       """
     ]
   }

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -64,8 +64,35 @@ macro structWithUnqualifiedLookup() = #externalMacro(module: "MacroDefinition", 
 
 let world = 17
 
-// CHECK-NOT: structWithUnqualifiedLookup
 public
 #structWithUnqualifiedLookup
-
+// CHECK-NOT: structWithUnqualifiedLookup
+// CHECK-NOT: struct StructWithUnqualifiedLookup
 // CHECK: struct StructWithUnqualifiedLookup
+// CHECK-NOT: struct StructWithUnqualifiedLookup
+
+@attached(peer, names: named(_foo))
+macro AddPeerStoredProperty() = #externalMacro(module: "MacroDefinition", type: "AddPeerStoredPropertyMacro")
+
+@AddPeerStoredProperty
+public var test: Int = 10
+// CHECK: var test
+// CHECK-NOT: var _foo
+// CHECK: var _foo
+// CHECK-NOT: var _foo
+
+// CHECK: struct TestStruct {
+public struct TestStruct {
+  public #structWithUnqualifiedLookup
+  // CHECK-NOT: structWithUnqualifiedLookup
+  // CHECK-NOT: struct StructWithUnqualifiedLookup
+  // CHECK: struct StructWithUnqualifiedLookup
+  // CHECK-NOT: struct StructWithUnqualifiedLookup
+
+  @AddPeerStoredProperty
+  public var test: Int = 10
+  // CHECK: var test
+  // CHECK-NOT: var _foo
+  // CHECK: var _foo
+  // CHECK-NOT: var _foo
+}

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -60,6 +60,13 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 @freestanding(expression) macro assert(_: String) = #externalMacro(module: "MacroDefinition", type: "AssertMacro")
 #assert("foobar")
 
+@attached(peer, names: named(_foo))
+macro AddPeerStoredProperty() = #externalMacro(module: "MacroDefinition", type: "AddPeerStoredPropertyMacro")
+struct S5 {
+  @AddPeerStoredProperty
+  var test: Int = 10
+}
+
 // REQUIRES: swift_swift_parser, executable_test, shell
 
 // RUN: %empty-directory(%t)
@@ -284,3 +291,8 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 //##-- Expansion on "fails to typecheck" macro expression
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=61:2 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ERRONEOUS_EXPAND %s
 // ERRONEOUS_EXPAND: 61:1-61:18 (@__swiftmacro_{{.+}}.swift) "assert("foobar")"
+
+//##-- Cursor-info on a decl where a peer macro attached.
+// RUN: %sourcekitd-test -req=cursor -pos=67:7 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=CURSOR_ON_DECL_WITH_PEER %s
+// CURSOR_ON_DECL_WITH_PEER: <decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>test</decl.name>: <decl.var.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.type></decl.var.instance>
+// CURSOR_ON_DECL_WITH_PEER-NOT: _foo


### PR DESCRIPTION
Cherry-pick #69340 into release/5.9

* **Explanation**: Previously, there was a case where macro expanded member declarations in types were printed twice in `.swiftinterface`.
* **Scope**: AST declaration printing
* **Risk**: Low, although this affect every declaration printing, I think it's fairly safe
* **Testing**: Added regression tests
* **Issues**: rdar://117374821 rdar://117374966
* **Reviewers**: Doug Gregor (@DougGregor)