### PR TITLE
[wasm][test] Remove unused argc/argv parameters from @main decl

### DIFF
--- a/test/IRGen/async/run-call-classinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-int64-to-void.sil
@@ -112,8 +112,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-void-to-void.sil
@@ -110,8 +110,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -88,8 +88,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -60,8 +60,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
+++ b/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
@@ -67,8 +67,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-int64-and-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-and-int64-to-void.sil
@@ -53,8 +53,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-to-void.sil
@@ -50,8 +50,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
@@ -89,8 +89,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
@@ -80,8 +80,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-resilient-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-resilient-classinstance-void-to-void.sil
@@ -47,8 +47,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-struct_five_bools-to-void.sil
+++ b/test/IRGen/async/run-call-struct_five_bools-to-void.sil
@@ -72,8 +72,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-structinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-structinstance-int64-to-void.sil
@@ -73,8 +73,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
@@ -134,8 +134,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
@@ -158,8 +158,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
@@ -145,8 +145,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
@@ -159,8 +159,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
@@ -145,8 +145,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -92,8 +92,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-void-to-int64-and-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64-and-int64.sil
@@ -55,8 +55,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call-void-to-struct_large.sil
+++ b/test/IRGen/async/run-call-void-to-struct_large.sil
@@ -143,8 +143,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -102,8 +102,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
@@ -89,8 +89,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-convertfunction-int64-to-void.sil
+++ b/test/IRGen/async/run-convertfunction-int64-to-void.sil
@@ -61,8 +61,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-class-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-class-to-void.sil
@@ -103,8 +103,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-classinstance-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-classinstance-to-void.sil
@@ -97,8 +97,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -93,8 +93,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -79,8 +79,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-throws-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-throws-to-int64.sil
@@ -90,8 +90,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
@@ -81,8 +81,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
@@ -72,8 +72,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
@@ -116,8 +116,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
@@ -110,8 +110,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
@@ -78,8 +78,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
@@ -83,8 +83,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
@@ -112,8 +112,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/async/run-thintothick-int64-to-void.sil
+++ b/test/IRGen/async/run-thintothick-int64-to-void.sil
@@ -57,8 +57,7 @@ bb0(%0 :$@async @callee_guaranteed () -> ()):
 }
 
 // main
-sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil @main : $@convention(c) () -> Int32 {
   %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
   %thick_test_case = thin_to_thick_function %test_case_nothrow : $@convention(thin) @async () -> () to $@callee_guaranteed @async () -> ()
   %thunk = function_ref @no_throw_to_throw_think : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> @error Error

--- a/test/IRGen/partial_apply_run_generic_method1.sil
+++ b/test/IRGen/partial_apply_run_generic_method1.sil
@@ -190,8 +190,7 @@ bb0(%0 : $@thin Main.Type):
 
 
 
-sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil [ossa] @main : $@convention(c) () -> Int32 {
   %2 = metatype $@thin Main.Type                  
   
   %3 = function_ref @$s4main4MainV5$mainyyFZ : $@convention(method) (@thin Main.Type) -> () 

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -149,8 +149,7 @@ sil_witness_table <T : P> GenFwdP<T>: P module main {
   method #P.static_member_fn: <Self where Self : P> (Self.Type) -> () -> () : @GenFwdP_static_member_fn
 }
 
-sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
-bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+sil [ossa] @main : $@convention(c) () -> Int32 {
   %0 = integer_literal $Builtin.Word, 0
   %1 = integer_literal $Builtin.Word, 1
   %2 = integer_literal $Builtin.Word, 2


### PR DESCRIPTION
In WebAssembly, `main` function is mangled differently depending on if it takes argc/argv or not. If it doesn't take them, it's mangled to `main` as well as other platforms, so remove unused argc/argv in executable tests to avoid linkage failure.

This is a preparation to enable executable tests against WebAssembly.
Resolves part of rdar://116488131
