### PR TITLE
[wasm][test] Skip some executable IRGen tests

### DIFF
--- a/test/IRGen/async/run-call-dynamic-void_to_void.swift
+++ b/test/IRGen/async/run-call-dynamic-void_to_void.swift
@@ -9,6 +9,9 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// LLVM does not support swifttailcc for WebAssembly target for now
+// See https://github.com/apple/swift/issues/69333
+// UNSUPPORTED: CPU=wasm32
 
 import _Concurrency
 

--- a/test/IRGen/report_dead_method_call.swift
+++ b/test/IRGen/report_dead_method_call.swift
@@ -15,6 +15,8 @@
 // UNSUPPORTED: freestanding
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// WebAssembly support only in-process testing for now.
+// UNSUPPORTED: CPU=wasm32
 
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 // UNSUPPORTED: swift_test_mode_optimize_with_implicit_dynamic

--- a/test/IRGen/testing-enabled-resilient-super-class-external-module.swift
+++ b/test/IRGen/testing-enabled-resilient-super-class-external-module.swift
@@ -9,6 +9,8 @@
 // RUN: %target-run %t/main %t/%target-library-name(FrameworkA) %t/%target-library-name(FrameworkB) | %FileCheck --check-prefix=EXEC-CHECK %s
 
 // REQUIRES: executable_test
+// WebAssembly does not have stable dynamic linking ABI yet
+// UNSUPPORTED: CPU=wasm32
 
 @testable import FrameworkB
 


### PR DESCRIPTION
Disable those tests until we get dynamic linking/swifttailcc/crash testing support