### PR TITLE
[c-interop] Fix @extern attribute printing for module interface

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1154,9 +1154,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
       Printer << "wasm";
       // @extern(wasm) always has names.
       Printer << ", module: \"" << *Attr->ModuleName << "\"";
-      Printer << ", name: \"" << *Attr->Name << "\")";
+      Printer << ", name: \"" << *Attr->Name << "\"";
       break;
     }
+    Printer << ")";
     break;
   }
 

--- a/test/ModuleInterface/extern_attr.swift
+++ b/test/ModuleInterface/extern_attr.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -enable-experimental-feature Extern -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -enable-experimental-feature Extern -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// CHECK:      #if compiler(>=5.3) && $Extern
+// CHECK-NEXT:   @extern(c) public func externalCFunc()
+// CHECK-NEXT: #endif
+@extern(c) public func externalCFunc()
+
+// CHECK:      #if compiler(>=5.3) && $Extern
+// CHECK-NEXT:   @extern(c, "renamedCFunc") public func externalRenamedCFunc()
+// CHECK-NEXT: #endif
+@extern(c, "renamedCFunc") public func externalRenamedCFunc()
+
+// CHECK:      #if compiler(>=5.3) && $Extern
+// CHECK-NEXT:   @extern(wasm, module: "m", name: "f") public func wasmImportedFunc()
+// CHECK-NEXT: #endif
+@extern(wasm, module: "m", name: "f") public func wasmImportedFunc()


### PR DESCRIPTION
The new `@extern(c)` was printed without r-paren in swiftinterface.

This is a preparation to enable executable tests against WebAssembly
Resolves part of rdar://116488131