### PR TITLE
[test][stdlib] Fix calling convention mismatch in test/stdlib/Runtime.swift.gyb

### DIFF
--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 //
 // RUN: %gyb %s -o %t/Runtime.swift
-// RUN: %target-build-swift -parse-stdlib -module-name a %t/Runtime.swift -o %t.out
+// RUN: %target-build-swift -parse-stdlib -module-name a -enable-experimental-feature Extern %t/Runtime.swift -o %t.out
 // RUN: %target-codesign %t.out
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
@@ -24,8 +24,7 @@ import SwiftShims
 #error("Unsupported platform")
 #endif
 
-@_silgen_name("swift_demangle")
-public
+@extern(c, "swift_demangle")
 func _stdlib_demangleImpl(
   mangledName: UnsafePointer<CChar>?,
   mangledNameLength: UInt,


### PR DESCRIPTION
`swift_demangle` is defined with C calling convention, but the test case used SwiftCC.

This is a preparation to enable executable tests against WebAssembly.
Resolves part of rdar://116488131