### PR TITLE
[stdlib] 3rd attempt to fix calling convention mismatch for debugger utility functions

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -300,6 +300,7 @@ list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-experimental-concis
 
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Macros")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "FreestandingMacros")
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Extern")
 
 set(swift_core_incorporate_object_libraries)
 list(APPEND swift_core_incorporate_object_libraries swiftRuntime)

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -51,6 +51,15 @@ Func _prespecialize() is a new API without @available attribute
 Func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(_:_:_:_:_:_:) is a new API without @available attribute
 Func _diagnoseUnavailableCodeReached() is a new API without @available attribute
 
+// These functions are not actually added to the ABI, but they had been a part of
+// the ABI exposed by the runtime library, so this is not breakage.
+// They are now referenced by @_extern(c) declarations in the standard library, but
+// api-digester cannot match them with the baseline symbols in the baseline runtime
+// library, which were not exposed by the baseline stdlib module.
+Func _swift_retainCount(_:) is a new API without @available attribute
+Func _swift_unownedRetainCount(_:) is a new API without @available attribute
+Func _swift_weakRetainCount(_:) is a new API without @available attribute
+
 Func Collection.removingSubranges(_:) has been removed
 Func Collection.subranges(of:) has been removed
 Func Collection.subranges(where:) has been removed


### PR DESCRIPTION
This is the 3rd attempt to fix the mismatch, where the actual definition (e.g. `swift_retainCount`) are defined with C calling-convention and the callers wrongly expect Swift calling-convention.

The [1st](https://github.com/apple/swift/pull/66531) fix broke ABI compatibility by introducing new symbol references from app-side without any availability checks.
The [2nd](https://github.com/apple/swift/pull/67853) fix broke lldb's retain counting feature due to new x-ref to Clang module in serialized function body by `@_alwaysEmitIntoClient`.

This attemps to avoid introducing serialized x-ref to Clang module by using new `@extern(c)` attribute.

Resolves rdar://113910821