### PR TITLE
[Macros] Adjust insertion position of peer macros for var decls

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -926,8 +926,12 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
     return CharSourceRange(rightBraceLoc, 0);
   }
   case MacroRole::Peer: {
-    SourceLoc afterDeclLoc =
-        Lexer::getLocForEndOfToken(sourceMgr, target.getEndLoc());
+    SourceLoc endLoc = target.getEndLoc();
+    if (auto var = dyn_cast<VarDecl>(target.get<Decl *>())) {
+      if (auto binding = var->getParentPatternBinding())
+        endLoc = binding->getEndLoc();
+    }
+    SourceLoc afterDeclLoc = Lexer::getLocForEndOfToken(sourceMgr, endLoc);
     return CharSourceRange(afterDeclLoc, 0);
     break;
   }

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -293,3 +293,7 @@ struct S5 {
 // RUN: %sourcekitd-test -req=cursor -pos=67:7 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=CURSOR_ON_DECL_WITH_PEER %s
 // CURSOR_ON_DECL_WITH_PEER: <decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>test</decl.name>: <decl.var.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.type></decl.var.instance>
 // CURSOR_ON_DECL_WITH_PEER-NOT: _foo
+
+//##-- Expansion on the peer macro attached to pattern binding decl
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=66:4 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=EXPAND_PEER_ON_VAR %s
+// EXPAND_PEER_ON_VAR: 67:21-67:21 (@__swiftmacro_9MacroUser2S5V4test21AddPeerStoredPropertyfMp_.swift) "public var _foo: Int = 100"

--- a/test/SourceKit/Macros/syntactic_expansion.swift.expected
+++ b/test/SourceKit/Macros/syntactic_expansion.swift.expected
@@ -20,7 +20,7 @@ source.edit.kind.active:
       }
 }"
 source.edit.kind.active:
-  7:12-7:12 "var _value: MyWrapperThingy<Int>"
+  7:17-7:17 "var _value: MyWrapperThingy<Int>"
 source.edit.kind.active:
   2:1-2:19 ""
 source.edit.kind.active:
@@ -96,7 +96,7 @@ source.edit.kind.active:
       }
 }"
 source.edit.kind.active:
-  7:12-7:12 "var _value: MyWrapperThingy<Int>"
+  7:17-7:17 "var _value: MyWrapperThingy<Int>"
 source.edit.kind.active:
   1:1-1:22 ""
 source.edit.kind.active:


### PR DESCRIPTION
When the target decl is a VarDecl, peer macro should expand at the end of the pattern binding decl, instead of the end of the VarDecl which only covers the name.

rdar://117098598
