### PR TITLE
[SE-0393] Enable value pack expansion in array literal

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5824,8 +5824,8 @@ ERROR(expansion_not_allowed,none,
       "pack expansion %0 can only appear in a function parameter list, "
       "tuple element, or generic argument of a variadic type", (Type))
 ERROR(expansion_expr_not_allowed,none,
-      "value pack expansion can only appear inside a function argument list "
-      "or tuple element", ())
+      "value pack expansion can only appear inside a function argument list, "
+      "tuple element, or an array literal", ())
 ERROR(invalid_expansion_argument,none,
       "cannot pass value pack expansion to non-pack parameter of type %0",
       (Type))

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2334,15 +2334,11 @@ RValue RValueEmitter::visitUnderlyingToOpaqueExpr(UnderlyingToOpaqueExpr *E,
 
 VarargsInfo Lowering::emitBeginVarargs(SILGenFunction &SGF, SILLocation loc,
                                        CanType baseTy, CanType arrayTy,
-                                       unsigned numElements) {
+                                       SILValue numEltsVal) {
   // Reabstract the base type against the array element type.
   auto baseAbstraction = AbstractionPattern::getOpaque();
   auto &baseTL = SGF.getTypeLowering(baseAbstraction, baseTy);
 
-  // Allocate the array.
-  SILValue numEltsVal = SGF.B.createIntegerLiteral(loc,
-                             SILType::getBuiltinWordType(SGF.getASTContext()),
-                             numElements);
   // The first result is the array value.
   ManagedValue array;
   // The second result is a RawPointer to the base address of the array.
@@ -4321,37 +4317,119 @@ RValue RValueEmitter::visitCollectionExpr(CollectionExpr *E, SGFContext C) {
     elementType = genericType.getGenericArgs()[0];
   }
 
+  // First, check if there are any value parameter packs in the array.
+  bool arrayHasParameterPacks = false;
+  for (unsigned index : range(E->getNumElements())) {
+    auto element = E->getElements()[index];
+    if (dyn_cast<PackExpansionExpr>(element)) {
+      arrayHasParameterPacks = true;
+      break;
+    }
+  }
+
+  SILValue numElements = SGF.B.createIntegerLiteral(
+      loc, SILType::getBuiltinWordType(SGF.getASTContext()),
+      E->getNumElements());
+
+  auto wordTy = SILType::getBuiltinWordType(SGF.getASTContext());
+
+  // If there are value parameter packs, iterate over the array again and add up
+  // lenghts of all packs encountered to get the total length of the array.
+  if (arrayHasParameterPacks) {
+    numElements = SGF.B.createIntegerLiteral(loc, wordTy, 0);
+    SILValue one = SGF.B.createIntegerLiteral(loc, wordTy, 1);
+
+    // Get number of elements in all packs in the array
+    for (unsigned index : range(E->getNumElements())) {
+      auto element = E->getElements()[index];
+      if (auto packExpansionExpr = dyn_cast<PackExpansionExpr>(element)) {
+        auto type = packExpansionExpr->getType()->getCanonicalType();
+        assert(isa<PackExpansionType>(type));
+        auto formalPackType = CanPackType::get(SGF.getASTContext(), {type});
+        SILValue packLength = SGF.B.createPackLength(loc, formalPackType);
+        SGF.B.createBuiltinBinaryFunction(loc, "add", wordTy, wordTy,
+                                          {numElements, packLength});
+      } else {
+        SGF.B.createBuiltinBinaryFunction(loc, "add", wordTy, wordTy,
+                                          {numElements, one});
+      }
+    }
+  }
+
   VarargsInfo varargsInfo =
-      emitBeginVarargs(SGF, loc, elementType, arrayType,
-                       E->getNumElements());
+      emitBeginVarargs(SGF, loc, elementType, arrayType, numElements);
 
   // Cleanups for any elements that have been initialized so far.
   SmallVector<CleanupHandle, 8> cleanups;
 
   for (unsigned index : range(E->getNumElements())) {
-    auto destAddr = varargsInfo.getBaseAddress();
-    if (index != 0) {
-      SILValue indexValue = SGF.B.createIntegerLiteral(
-          loc, SILType::getBuiltinWordType(SGF.getASTContext()), index);
-      destAddr = SGF.B.createIndexAddr(loc, destAddr, indexValue,
-              /*needsStackProtection=*/ false);
+    auto element = E->getElements()[index];
+    if (auto packExpansionExpr = dyn_cast<PackExpansionExpr>(element)) {
+      auto type = packExpansionExpr->getType()->getCanonicalType();
+      assert(isa<PackExpansionType>(type));
+      auto formalPackType = CanPackType::get(SGF.getASTContext(), {type});
+
+      // Emit the dynamic pack loop to populate the array with the elements of
+      // the parameter pack.
+      SGF.emitDynamicPackLoop(
+          packExpansionExpr, formalPackType, 0,
+          packExpansionExpr->getGenericEnvironment(),
+          [&](SILValue indexWithinComponent, SILValue packExpansionIndex,
+              SILValue packIndex) {
+            // TODO: Code duplication here and in the `else` branch, and the
+            // `dynamicIndexValue` should not be created outside of this lambda.
+            auto destAddr = varargsInfo.getBaseAddress();
+            SILValue indexValue = SGF.B.createIntegerLiteral(
+                loc, SILType::getBuiltinWordType(SGF.getASTContext()), index);
+            auto dynamicIndexValue = SGF.B.createBuiltinBinaryFunction(
+                loc, "add", wordTy, wordTy, {indexValue, packIndex});
+
+            destAddr = SGF.B.createIndexAddr(loc, destAddr, dynamicIndexValue,
+                                             /*needsStackProtection=*/false);
+
+            auto &destTL = varargsInfo.getBaseTypeLowering();
+            // Create a dormant cleanup for the value in case we exit before the
+            // full array has been constructed.
+
+            CleanupHandle destCleanup = CleanupHandle::invalid();
+            if (!destTL.isTrivial()) {
+              destCleanup = SGF.enterDestroyCleanup(destAddr);
+              SGF.Cleanups.setCleanupState(destCleanup, CleanupState::Dormant);
+              cleanups.push_back(destCleanup);
+            }
+
+            TemporaryInitialization init(destAddr, destCleanup);
+
+            init.performPackExpansionInitialization(
+                SGF, E, indexWithinComponent, [&](Initialization *eltInit) {
+                  SGF.emitExprInto(packExpansionExpr->getPatternExpr(),
+                                   eltInit);
+                });
+          });
+    } else {
+      auto destAddr = varargsInfo.getBaseAddress();
+      if (index != 0) {
+        SILValue indexValue = SGF.B.createIntegerLiteral(
+            loc, SILType::getBuiltinWordType(SGF.getASTContext()), index);
+        destAddr = SGF.B.createIndexAddr(loc, destAddr, indexValue,
+                                         /*needsStackProtection=*/false);
+      }
+      auto &destTL = varargsInfo.getBaseTypeLowering();
+      // Create a dormant cleanup for the value in case we exit before the
+      // full array has been constructed.
+
+      CleanupHandle destCleanup = CleanupHandle::invalid();
+      if (!destTL.isTrivial()) {
+        destCleanup = SGF.enterDestroyCleanup(destAddr);
+        SGF.Cleanups.setCleanupState(destCleanup, CleanupState::Dormant);
+        cleanups.push_back(destCleanup);
+      }
+
+      TemporaryInitialization init(destAddr, destCleanup);
+
+      ArgumentSource(element).forwardInto(
+          SGF, varargsInfo.getBaseAbstractionPattern(), &init, destTL);
     }
-    auto &destTL = varargsInfo.getBaseTypeLowering();
-    // Create a dormant cleanup for the value in case we exit before the
-    // full array has been constructed.
-
-    CleanupHandle destCleanup = CleanupHandle::invalid();
-    if (!destTL.isTrivial()) {
-      destCleanup = SGF.enterDestroyCleanup(destAddr);
-      SGF.Cleanups.setCleanupState(destCleanup, CleanupState::Dormant);
-      cleanups.push_back(destCleanup);
-    }
-
-    TemporaryInitialization init(destAddr, destCleanup);
-
-    ArgumentSource(E->getElements()[index])
-        .forwardInto(SGF, varargsInfo.getBaseAbstractionPattern(), &init,
-                     destTL);
   }
 
   // Kill the per-element cleanups. The array will take ownership of them.

--- a/lib/SILGen/Varargs.h
+++ b/lib/SILGen/Varargs.h
@@ -64,7 +64,7 @@ public:
 /// Begin a varargs emission sequence.
 VarargsInfo emitBeginVarargs(SILGenFunction &SGF, SILLocation loc,
                              CanType baseTy, CanType arrayTy,
-                             unsigned numElements);
+                             SILValue numEltsVal);
 
 /// Successfully end a varargs emission sequence.
 ManagedValue emitEndVarargs(SILGenFunction &SGF, SILLocation loc,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3718,6 +3718,11 @@ namespace {
       auto elementType = expr->getElementType();
 
       for (unsigned i = 0, n = expr->getNumElements(); i != n; ++i) {
+        if (auto packExpr = dyn_cast<PackExpansionExpr>(expr->getElement(i))) {
+          auto countType =
+              cs.getType(packExpr)->castTo<PackExpansionType>()->getCountType();
+          elementType = PackExpansionType::get(elementType, countType);
+        }
         expr->setElement(
             i, coerceToType(expr->getElement(i), elementType,
                             cs.getConstraintLocator(
@@ -7234,7 +7239,12 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     auto *pattern = coerceToType(expansion->getPatternExpr(),
                                  toElementType, locator);
     auto *packEnv = cs.DC->getGenericEnvironmentOfContext();
-    auto patternType = packEnv->mapElementTypeIntoPackContext(toElementType);
+    Type patternType = toElementType;
+    // Only map the element type into pack context if the pattern type has an
+    // element archetype.
+    if (toElementType->hasElementArchetype()) {
+      patternType = packEnv->mapElementTypeIntoPackContext(toElementType);
+    }
     auto shapeType = toExpansionType->getCountType();
     auto expansionTy = PackExpansionType::get(patternType, shapeType);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2118,9 +2118,17 @@ namespace {
         CS.addJoinConstraint<Iterator>(
             locator, elements.begin(), elements.end(), elementType,
             [&](const auto it) {
-              auto *locator = CS.getConstraintLocator(
-                  expr, LocatorPathElt::TupleElement(index++));
-              return std::make_pair(CS.getType(*it), locator);
+              if (auto packExpr = dyn_cast<PackExpansionExpr>(*it)) {
+                auto *locator = CS.getConstraintLocator(
+                    packExpr, LocatorPathElt::TupleElement(index++));
+                auto *eltLocator = CS.getConstraintLocator(packExpr);
+                Type elementType = CS.getType(packExpr->getPatternExpr());
+                return std::make_pair(elementType, locator);
+              } else {
+                auto *locator = CS.getConstraintLocator(
+                    expr, LocatorPathElt::TupleElement(index++));
+                return std::make_pair(CS.getType(*it), locator);
+              }
             });
       };
 


### PR DESCRIPTION
# What's here
This is a draft PR that resolves #67192. 

Currently, there are two major issues:

- [ ] The `TemporaryInitialization` init type does not support pack expansion initialization, causing a crash. It seems natural in this case to use this type of initializer, so we need to implement such a capability for this initializer. 
- [ ] Change the logic for `dynamicPackIndex` to account for when there are multiple packs in the array literal.
