### PR TITLE
Fix infinite lookup importing forward declarations from bridging header

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1424,6 +1424,7 @@ ClangImporter::create(ASTContext &ctx,
     new (ctx) ClangModuleUnit(*importedHeaderModule, importer->Impl, nullptr);
   importedHeaderModule->addFile(*importer->Impl.ImportedHeaderUnit);
   importedHeaderModule->setHasResolvedImports();
+  importedHeaderModule->setIsNonSwiftModule(true);
 
   importer->Impl.IsReadingBridgingPCH = false;
 

--- a/test/ClangImporter/Inputs/incomplete_objc_types_bridging_header.h
+++ b/test/ClangImporter/Inputs/incomplete_objc_types_bridging_header.h
@@ -1,0 +1,4 @@
+@class ForwardDeclaredInterface;
+
+ForwardDeclaredInterface *CFunctionReturningAForwardDeclaredInterface();
+void CFunctionTakingAForwardDeclaredInterface(ForwardDeclaredInterface *param);

--- a/test/ClangImporter/incomplete_objc_types_bridging_header.swift
+++ b/test/ClangImporter/incomplete_objc_types_bridging_header.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/incomplete_objc_types_bridging_header.h -enable-upcoming-feature ImportObjcForwardDeclarations -enable-objc-interop -typecheck %s
+
+// REQUIRES: objc_interop
+
+let foo = CFunctionReturningAForwardDeclaredInterface()
+CFunctionTakingAForwardDeclaredInterface(foo)


### PR DESCRIPTION
Prior to this patch, if you imported a declaration from a bridging header while passing `-enable-upcoming-feature ImportObjCForwardDeclarations` to the frontend, lookup will loop infinitely.

This is because when importing a forward declared Objective-C type Foo, we first check if it is actually defined natively in  Swift. To do this we look through all imported Swift modules, and perform a lookup. We intentionally skip overlays and Clang modules as we are only interested in finding a native Swift definition.

The Swift overlay for the __ObjC Clang module where synthesized declarations that otherwise have no natural "home", was for some reason not labelled a "NonSwiftModule". This meant it was considered during the aforementioned lookup, leading to lookup in the underlying Clang module and the process repeats. Here is a snippet of the stack trace showing the repetition:

```
    frame #40607: 0x000000010143aaf0 swift-frontend`(anonymous namespace)::SwiftDeclConverter::VisitObjCInterfaceDecl(clang::ObjCInterfaceDecl const*) at ImportDecl.cpp:4794:27 [opt]
    frame #40608: 0x000000010143aa40 swift-frontend`(anonymous namespace)::SwiftDeclConverter::VisitObjCInterfaceDecl(this=0x000000016fdf5a08, decl=0x00000001180c13a0) at ImportDecl.cpp:5022:29 [opt]
    frame #40609: 0x000000010142a2e0 swift-frontend`swift::ClangImporter::Implementation::importDeclImpl(clang::NamedDecl const*, swift::importer::ImportNameVersion, bool&, bool&) [inlined] clang::declvisitor::Base<llvm::make_const_ptr, (anonymous namespace)::SwiftDeclConverter, swift::Decl*>::Visit(this=0x000000016fdf5a08, D=0x00000001180c13a0) at DeclNodes.inc:191:1 [opt]
    frame #40610: 0x000000010142a274 swift-frontend`swift::ClangImporter::Implementation::importDeclImpl(this=0x0000000118012200, ClangDecl=0x00000001180c13a0, version=(rawValue = 4, concurrency = 0), TypedefIsSuperfluous=<unavailable>, HadForwardDeclaration=0x000000016fdf5a76) at ImportDecl.cpp:8275:24 [opt]
    frame #40611: 0x000000010142b0cc swift-frontend`swift::ClangImporter::Implementation::importDeclAndCacheImpl(this=0x0000000118012200, ClangDecl=0x00000001180c13a0, version=(rawValue = 4, concurrency = 0), SuperfluousTypedefsAreTransparent=false, UseCanonicalDecl=<unavailable>) at ImportDecl.cpp:8528:18 [opt]
    frame #40612: 0x00000001013d0af0 swift-frontend`swift::ClangImporter::Implementation::lookupValue(swift::SwiftLookupTable&, swift::DeclName, swift::VisibleDeclConsumer&) [inlined] swift::ClangImporter::Implementation::importDeclReal(this=0x0000000118012200, ClangDecl=<unavailable>, version=<unavailable>, useCanonicalDecl=<unavailable>) at ImporterImpl.h:1082:12 [opt]
    frame #40613: 0x00000001013d0ae4 swift-frontend`swift::ClangImporter::Implementation::lookupValue(this=0x0000000118012200, table=<unavailable>, name=DeclName @ 0x000000016fdf5d00, consumer=0x000000016fdf5d90) at ClangImporter.cpp:4280:11 [opt]
    frame #40614: 0x00000001013d0380 swift-frontend`swift::ClangModuleUnit::lookupValue(this=0x00000001180e0dc0, name=DeclName @ x19, lookupKind=<unavailable>, flags=<unavailable>, results=<unavailable>) const at ClangImporter.cpp:3463:11 [opt]
    frame #40615: 0x00000001017bd6fc swift-frontend`swift::ModuleDecl::lookupValue(this=<unavailable>, Name=DeclName @ x20, LookupKind=QualifiedLookup, Flags=<unavailable>, Result=0x000000016fdf5eb8) const at Module.cpp:1031:3 [opt]
    frame #40616: 0x0000000101443a4c swift-frontend`swift::ClassDecl* (anonymous namespace)::SwiftDeclConverter::resolveSwiftDeclImpl<swift::ClassDecl, clang::ObjCInterfaceDecl>(clang::ObjCInterfaceDecl const*, swift::Identifier, bool, swift::ModuleDecl*, bool, bool) [inlined] swift::ModuleDecl::lookupValue(this=0x00000001180e0800, Name=<unavailable>, LookupKind=QualifiedLookup, Result=0x000000016fdf5eb8) const at Module.h:768:5 [opt]
    frame #40617: 0x0000000101443a34 swift-frontend`swift::ClassDecl* (anonymous namespace)::SwiftDeclConverter::resolveSwiftDeclImpl<swift::ClassDecl, clang::ObjCInterfaceDecl>(this=0x000000016fdf62d8, decl=0x00000001180c13a0, name=(Pointer = "ForwardDeclaredInterface"), hasKnownSwiftName=false, module=<unavailable>, allowObjCMismatchFallback=false, cacheResult=false) at ImportDecl.cpp:4674:15 [opt]
    frame #40618: 0x000000010143aaf0 swift-frontend`(anonymous namespace)::SwiftDeclConverter::VisitObjCInterfaceDecl(clang::ObjCInterfaceDecl const*) at ImportDecl.cpp:4794:27 [opt]
    frame #40619: 0x000000010143aa40 swift-frontend`(anonymous namespace)::SwiftDeclConverter::VisitObjCInterfaceDecl(this=0x000000016fdf62d8, decl=0x00000001180c13a0) at ImportDecl.cpp:5022:29 [opt]
```

We could just as easily exclude the __ObjC module from the search, but it seems more correct to me to mark it as NonSwift.