### PR TITLE
Strip comments from inlinable text when printing in `swiftinterface` files

### DIFF
--- a/lib/AST/InlinableText.cpp
+++ b/lib/AST/InlinableText.cpp
@@ -218,10 +218,15 @@ static void appendRange(
 
     // Skip over #sourceLocation's in the file.
     if (token.is(tok::pound_sourceLocation)) {
-      lexer.lex(token);
 
-      // Skip from the left paren to the right paren.
-      assert(token.is(tok::l_paren));
+      // Append the text leading up to the #sourceLocation
+      auto charRange = CharSourceRange(
+        sourceMgr, nonCommentStart, token.getLoc());
+      StringRef text = sourceMgr.extractText(charRange);
+      scratch.append(text.begin(), text.end());
+
+      // Skip to the right paren. We know the AST is already valid, so there's
+      // definitely a right paren.
       while (!token.is(tok::r_paren)) {
         lexer.lex(token);
       }

--- a/lib/AST/InlinableText.cpp
+++ b/lib/AST/InlinableText.cpp
@@ -210,10 +210,9 @@ static void appendRange(
     lexer.lex(token);
 
     if (token.is(tok::comment)) {
-      // Grab the range from the last non-comment token to the beginning of this comment
+      // Append the range from the last non-comment token to the beginning of this comment
       // token.
       SourceLoc commentLoc = token.getLoc();
-
       auto charRange = CharSourceRange(sourceMgr, nonCommentStart, commentLoc);
       StringRef text = sourceMgr.extractText(charRange);
       scratch.append(text.begin(), text.end());

--- a/test/ModuleInterface/if-configs.swift
+++ b/test/ModuleInterface/if-configs.swift
@@ -141,6 +141,7 @@ public func hasIfCompilerCheck(_ x: () -> Bool = {
 // CHECK-NEXT: let y = 2
 // CHECK: let a = 3
 // CHECK: let b = 2
+// CHECK-NOT: #sourceLocation
 // CHECK-NOT: #if
 // CHECK-NOT: comment!
 // CHECK: return true
@@ -170,6 +171,8 @@ public func hasComments() -> Bool {
 
   let a = 3
   /* test */let b = 2
+
+  #sourceLocation(file: "if-configs.swift", line: 200)
 
   #if !NOT_PROVIDED
     // comment!

--- a/test/ModuleInterface/if-configs.swift
+++ b/test/ModuleInterface/if-configs.swift
@@ -128,8 +128,14 @@ public func hasIfCompilerCheck(_ x: () -> Bool = {
 }
 
 // CHECK: func hasComments
+// CHECK: print(
+// CHECK-NOT: comment! don't mess up indentation!
+// CHECK: {{^}}    """
+// CHECK: {{^}}    """
+// CHECK-NOT: #if
 // CHECK-NOT: comment!
-public func hasComments(_ x: () -> Bool = {
+// CHECK: return true
+public func hasComments() -> Bool {
   /* comment! */ // comment!
   #if NOT_PROVIDED
     // comment!
@@ -147,7 +153,6 @@ public func hasComments(_ x: () -> Bool = {
 
   #if !NOT_PROVIDED
     // comment!
-    return /* comment! */ true /* comment! */
+    return/* comment! */true/* comment! */
   #endif
-}) {
 }

--- a/test/ModuleInterface/if-configs.swift
+++ b/test/ModuleInterface/if-configs.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Swift.Void = {
+// CHECK-LABEL: func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Swift.Void = {
 // CHECK-NOT: #if NOT_PROVIDED
 // CHECK-NOT: print("should not exist")
 // CHECK-NOT: #elseif !NOT_PROVIDED
@@ -35,7 +35,7 @@ public func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Void = {
 }) {
 }
 
-// CHECK: func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Swift.Void = {
+// CHECK-LABEL: func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Swift.Void = {
 // CHECK-NOT: #if NOT_PROVIDED
 // CHECK-NOT: print("should not exist")
 // CHECK-NOT: #else
@@ -64,7 +64,7 @@ public func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Void = {
 }) {
 }
 
-// CHECK: func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Swift.Void = {
+// CHECK-LABEL: func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Swift.Void = {
 // CHECK-NOT: #if (
 // CHECK-NOT:   !false && true
 // CHECK-NOT: )
@@ -95,7 +95,7 @@ public func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Void = 
 }) {
 }
 
-// CHECK: func hasClosureDefaultArgWithSinglePoundIf(_ x: () -> Swift.Void = {
+// CHECK-LABEL: func hasClosureDefaultArgWithSinglePoundIf(_ x: () -> Swift.Void = {
 // CHECK-NOT: #if true
 // CHECK: print("true")
 // CHECK-NOT: #else
@@ -111,24 +111,7 @@ public func hasClosureDefaultArgWithSinglePoundIf(_ x: () -> Void = {
 }) {
 }
 
-// CHECK: func hasIfCompilerCheck
-// CHECK:      #if compiler(>=5.3)
-// CHECK-NEXT:   return true
-// CHECK-NEXT: #else
-// CHECK-NEXT:   return false
-// CHECK-NEXT: #endif
-@_alwaysEmitIntoClient
-public func hasIfCompilerCheck(_ x: () -> Bool = {
-#if compiler(>=5.3)
-  return true
-#else
-  return false
-#endif
-  }) {
-}
-
-// CHECK: func hasComments
-// CHECK-NOT: #if NOT_PROVIDED
+// CHECK-LABEL: func hasComments
 // CHECK: print(
 // CHECK: "this should show up"
 // CHECK-NOT: comment! don't mess up indentation!
@@ -146,7 +129,7 @@ public func hasIfCompilerCheck(_ x: () -> Bool = {
 // CHECK-NOT: comment!
 // CHECK: return true
 @inlinable
-public func hasComments() -> Bool {
+public func hasComments(_ x: () -> Bool = {
   /* comment! */ // comment!
   #if NOT_PROVIDED
     // comment!
@@ -178,4 +161,21 @@ public func hasComments() -> Bool {
     // comment!
     return/* comment! */true/* comment! */
   #endif
+}) {
+}
+
+// CHECK-LABEL: func hasIfCompilerCheck
+// CHECK:      #if compiler(>=5.3)
+// CHECK-NEXT:   return true
+// CHECK-NEXT: #else
+// CHECK-NEXT:   return false
+// CHECK-NEXT: #endif
+@_alwaysEmitIntoClient
+public func hasIfCompilerCheck(_ x: () -> Bool = {
+#if compiler(>=5.3)
+  return true
+#else
+  return false
+#endif
+  }) {
 }

--- a/test/ModuleInterface/if-configs.swift
+++ b/test/ModuleInterface/if-configs.swift
@@ -126,3 +126,28 @@ public func hasIfCompilerCheck(_ x: () -> Bool = {
 #endif
   }) {
 }
+
+// CHECK: func hasComments
+// CHECK-NOT: comment!
+public func hasComments(_ x: () -> Bool = {
+  /* comment! */ // comment!
+  #if NOT_PROVIDED
+    // comment!
+    return true
+  #endif
+
+  print(/* 
+    comment! 
+  */"this should show up")
+
+  print(
+    // comment! don't mess up indentation!
+    """
+    """)
+
+  #if !NOT_PROVIDED
+    // comment!
+    return /* comment! */ true /* comment! */
+  #endif
+}) {
+}

--- a/test/ModuleInterface/if-configs.swift
+++ b/test/ModuleInterface/if-configs.swift
@@ -128,13 +128,23 @@ public func hasIfCompilerCheck(_ x: () -> Bool = {
 }
 
 // CHECK: func hasComments
+// CHECK-NOT: #if NOT_PROVIDED
 // CHECK: print(
+// CHECK: "this should show up"
 // CHECK-NOT: comment! don't mess up indentation!
 // CHECK: {{^}}    """
 // CHECK: {{^}}    """
+// CHECK: #if compiler(>=5.3) {{$}}
+// CHECK: print( "")
+// CHECK: #endif
+// CHECK: let x = 1
+// CHECK-NEXT: let y = 2
+// CHECK: let a = 3
+// CHECK: let b = 2
 // CHECK-NOT: #if
 // CHECK-NOT: comment!
 // CHECK: return true
+@inlinable
 public func hasComments() -> Bool {
   /* comment! */ // comment!
   #if NOT_PROVIDED
@@ -150,6 +160,16 @@ public func hasComments() -> Bool {
     // comment! don't mess up indentation!
     """
     """)
+
+  #if compiler(>=5.3) // comment!
+  print(/*comment!*/"")
+  #endif
+
+  let x = 1/*
+  */let y = 2
+
+  let a = 3
+  /* test */let b = 2
 
   #if !NOT_PROVIDED
     // comment!


### PR DESCRIPTION
This adds support in `InlinableText.cpp` for ignoring the ranges of comment tokens and stripping comments from swiftinterface files. Ideally we'd be able to use SwiftSyntax to read in these source ranges and just reprint them while skipping comment trivia, but that infrastructure isn't quite there yet.

Resolves rdar://44318472
