### PR TITLE
PerformanceInliner: favor inlining of co-routines

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -120,6 +120,9 @@ class SILPerformanceInliner {
     /// call overhead itself.
     RemovedCallBenefit = 20,
 
+    /// The benefit of inlining a `begin_apply`.
+    RemovedCoroutineCallBenefit = 300,
+
     /// The benefit if the operand of an apply gets constant, e.g. if a closure
     /// is passed to an apply instruction in the callee.
     RemovedClosureBenefit = RemovedCallBenefit + 50,
@@ -373,7 +376,8 @@ bool SILPerformanceInliner::isProfitableToInline(
   bool IsGeneric = AI.hasSubstitutions();
 
   // Start with a base benefit.
-  int BaseBenefit = RemovedCallBenefit;
+  int BaseBenefit = isa<BeginApplyInst>(AI) ? RemovedCoroutineCallBenefit
+                                            : RemovedCallBenefit;
 
   // Osize heuristic.
   //

--- a/test/SILOptimizer/inline_coroutine.swift
+++ b/test/SILOptimizer/inline_coroutine.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -primary-file %s -parse-as-library -module-name=test -emit-sil -O | %FileCheck %s
+
+// Check that co-routines are inlined, even if the yielded value is something non-trivial.
+
+struct S {
+  var i: Int64
+  var s: String
+}
+
+public struct Foo {
+  final class Box {
+    var value = S(i: 0, s: "")
+  }
+
+  var storage: Box = .init()
+
+  var value: S {
+    get {
+      storage.value
+    }
+    _modify {
+      var value = storage.value
+      defer { storage.value = value }
+      yield &value
+    }
+  }
+}
+
+// CHECK-LABEL: sil hidden @$s4test6testit1x3boxys5Int64V_AA3FooVztF :
+// CHECK-NOT:     begin_apply
+// CHECK:       } // end sil function '$s4test6testit1x3boxys5Int64V_AA3FooVztF'
+func testit(x: Int64, box: inout Foo) {
+  box.value.i ^= x
+}
+


### PR DESCRIPTION
Not inlined co-routines are so expensive that they should be inlined, unless they are really large. So far co-routines didn't get any special treatment in the inliner, except generic co-routines. With this change, even non-generic co-routines are treated as high-priority to inline.

rdar://117201823
