### PR TITLE
Tests package types for non-resiliency

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4779,7 +4779,7 @@ int TypeDecl::compare(const TypeDecl *type1, const TypeDecl *type2) {
 }
 
 bool NominalTypeDecl::isFormallyResilient() const {
-  // Private and (unversioned) internal types always have a
+  // Private, (unversioned) internal, and package types always have a
   // fixed layout.
   if (!getFormalAccessScope(/*useDC=*/nullptr,
                             /*treatUsableFromInlineAsPublic=*/true).isPublic())

--- a/test/Sema/package_resilience_access.swift
+++ b/test/Sema/package_resilience_access.swift
@@ -1,0 +1,203 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Utils.swift \
+// RUN:   -module-name Utils -swift-version 5 -I %t \
+// RUN:   -package-name mypkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t -swift-version 5 -package-name mypkg -verify
+
+// RUN: %target-swift-frontend -emit-sil %t/Client.swift -package-name mypkg -I %t > %t/Client.sil
+// RUN: %FileCheck %s < %t/Client.sil
+
+
+//--- Utils.swift
+
+// Resilient; public. Acessed indirectly.
+public struct PublicStruct {
+  public var data: Int
+}
+
+// Non-resilient; non-public. Accessed directly.
+package struct PkgStruct {
+  package var data: Int
+}
+
+// Non-resilient but accessed indirectly since generic.
+package struct PkgStructGeneric<T> {
+  package var data: T
+}
+
+// Non-resilient but accessed indirectly; member is of a resilient type.
+package struct PkgStructWithPublicMember {
+  package var member: PublicStruct
+}
+
+// Non-resilient but accessed indirectly; contains existential.
+package struct PkgStructWithPublicExistential {
+  package var member: any PublicProto
+}
+
+// Non-resilient but accessed indirectly; contains existential.
+package struct PkgStructWithPkgExistential {
+  package var member: any PkgProto
+}
+
+// Resilient; public. Acessed indirectly.
+public protocol PublicProto {
+  var data: Int { get set }
+}
+
+// Non-resilient but acessed indirectly; existential.
+package protocol PkgProto {
+  var data: Int { get set }
+}
+
+
+//--- Client.swift
+import Utils
+
+package func f(_ arg: PublicStruct) -> Int {
+  return arg.data
+}
+
+// CHECK: // f(_:)
+// CHECK-NEXT: sil @$s6Client1fySi5Utils12PublicStructVF : $@convention(thin) (@in_guaranteed PublicStruct) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %3, %1
+// CHECK-NEXT: bb0(%0 : $*PublicStruct):
+// CHECK-NEXT:   debug_value %0 : $*PublicStruct, let, name "arg", argno 1, expr op_deref // id: %1
+// CHECK-NEXT:   %2 = alloc_stack $PublicStruct                  // users: %7, %6, %5, %3
+// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PublicStruct      // id: %3
+// CHECK-NEXT:   // function_ref PublicStruct.data.getter
+// CHECK-NEXT:   %4 = function_ref @$s5Utils12PublicStructV4dataSivg : $@convention(method) (@in_guaranteed PublicStruct) -> Int // user: %5
+// CHECK-NEXT:   %5 = apply %4(%2) : $@convention(method) (@in_guaranteed PublicStruct) -> Int // user: %8
+// CHECK-NEXT:   destroy_addr %2 : $*PublicStruct                // id: %6
+// CHECK-NEXT:   dealloc_stack %2 : $*PublicStruct               // id: %7
+// CHECK-NEXT:   return %5 : $Int                                // id: %8
+// CHECK-NEXT: } // end sil function '$s6Client1fySi5Utils12PublicStructVF'
+
+
+package func g(_ arg: PkgStruct) -> Int {
+  return arg.data
+}
+
+// CHECK: // g(_:)
+// CHECK-NEXT: sil @$s6Client1gySi5Utils9PkgStructVF : $@convention(thin) (PkgStruct) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
+// CHECK-NEXT: bb0(%0 : $PkgStruct):
+// CHECK-NEXT:   debug_value %0 : $PkgStruct, let, name "arg", argno 1 // id: %1
+// CHECK-NEXT:   %2 = struct_extract %0 : $PkgStruct, #PkgStruct.data // user: %3
+// CHECK-NEXT:   return %2 : $Int                                // id: %3
+// CHECK-NEXT: } // end sil function '$s6Client1gySi5Utils9PkgStructVF'
+
+package func m<T>(_ arg: PkgStructGeneric<T>) -> T {
+  return arg.data
+}
+
+// CHECK: // m<A>(_:)
+// CHECK-NEXT: sil @$s6Client1myx5Utils16PkgStructGenericVyxGlF : $@convention(thin) <T> (@in_guaranteed PkgStructGeneric<T>) -> @out T {
+// CHECK-NEXT: // %0 "$return_value"                             // user: %4
+// CHECK-NEXT: // %1 "arg"                                       // users: %3, %2
+// CHECK-NEXT: bb0(%0 : $*T, %1 : $*PkgStructGeneric<T>):
+// CHECK-NEXT:   debug_value %1 : $*PkgStructGeneric<T>, let, name "arg", argno 1, expr op_deref // id: %2
+// CHECK-NEXT:   %3 = struct_element_addr %1 : $*PkgStructGeneric<T>, #PkgStructGeneric.data // user: %4
+// CHECK-NEXT:   copy_addr %3 to [init] %0 : $*T                 // id: %4
+// CHECK-NEXT:   %5 = tuple ()                                   // user: %6
+// CHECK-NEXT:   return %5 : $()                                 // id: %6
+// CHECK-NEXT: } // end sil function '$s6Client1myx5Utils16PkgStructGenericVyxGlF'
+
+package func n(_ arg: PkgStructWithPublicMember) -> Int {
+  return arg.member.data
+}
+
+// CHECK: // n(_:)
+// CHECK-NEXT: sil @$s6Client1nySi5Utils25PkgStructWithPublicMemberVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicMember) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
+// CHECK-NEXT: bb0(%0 : $*PkgStructWithPublicMember):
+// CHECK-NEXT:   debug_value %0 : $*PkgStructWithPublicMember, let, name "arg", argno 1, expr op_deref // id: %1
+// CHECK-NEXT:   %2 = struct_element_addr %0 : $*PkgStructWithPublicMember, #PkgStructWithPublicMember.member // user: %4
+// CHECK-NEXT:   %3 = alloc_stack $PublicStruct                  // users: %12, %10, %6, %4
+// CHECK-NEXT:   copy_addr %2 to [init] %3 : $*PublicStruct      // id: %4
+// CHECK-NEXT:   %5 = alloc_stack $PublicStruct                  // users: %11, %9, %8, %6
+// CHECK-NEXT:   copy_addr %3 to [init] %5 : $*PublicStruct      // id: %6
+// CHECK-NEXT:   // function_ref PublicStruct.data.getter
+// CHECK-NEXT:   %7 = function_ref @$s5Utils12PublicStructV4dataSivg : $@convention(method) (@in_guaranteed PublicStruct) -> Int // user: %8
+// CHECK-NEXT:   %8 = apply %7(%5) : $@convention(method) (@in_guaranteed PublicStruct) -> Int // user: %13
+// CHECK-NEXT:   destroy_addr %5 : $*PublicStruct                // id: %9
+// CHECK-NEXT:   destroy_addr %3 : $*PublicStruct                // id: %10
+// CHECK-NEXT:   dealloc_stack %5 : $*PublicStruct               // id: %11
+// CHECK-NEXT:   dealloc_stack %3 : $*PublicStruct               // id: %12
+// CHECK-NEXT:   return %8 : $Int                                // id: %13
+// CHECK-NEXT: } // end sil function '$s6Client1nySi5Utils25PkgStructWithPublicMemberVF'
+
+package func p(_ arg: PkgStructWithPublicExistential) -> any PublicProto {
+  return arg.member
+}
+
+// CHECK: // p(_:)
+// CHECK-NEXT: sil @$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto {
+// CHECK-NEXT: // %0 "$return_value"                             // user: %4
+// CHECK-NEXT: // %1 "arg"                                       // users: %3, %2
+// CHECK-NEXT: bb0(%0 : $*any PublicProto, %1 : $*PkgStructWithPublicExistential):
+// CHECK-NEXT:   debug_value %1 : $*PkgStructWithPublicExistential, let, name "arg", argno 1, expr op_deref // id: %2
+// CHECK-NEXT:   %3 = struct_element_addr %1 : $*PkgStructWithPublicExistential, #PkgStructWithPublicExistential.member // user: %4
+// CHECK-NEXT:   copy_addr %3 to [init] %0 : $*any PublicProto   // id: %4
+// CHECK-NEXT:   %5 = tuple ()                                   // user: %6
+// CHECK-NEXT:   return %5 : $()                                 // id: %6
+// CHECK-NEXT: } // end sil function '$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF'
+
+package func q(_ arg: PkgStructWithPkgExistential) -> any PkgProto {
+  return arg.member
+}
+
+// CHECK: // q(_:)
+// CHECK-NEXT: sil @$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto {
+// CHECK-NEXT: // %0 "$return_value"                             // user: %4
+// CHECK-NEXT: // %1 "arg"                                       // users: %3, %2
+// CHECK-NEXT: bb0(%0 : $*any PkgProto, %1 : $*PkgStructWithPkgExistential):
+// CHECK-NEXT:   debug_value %1 : $*PkgStructWithPkgExistential, let, name "arg", argno 1, expr op_deref // id: %2
+// CHECK-NEXT:   %3 = struct_element_addr %1 : $*PkgStructWithPkgExistential, #PkgStructWithPkgExistential.member // user: %4
+// CHECK-NEXT:   copy_addr %3 to [init] %0 : $*any PkgProto      // id: %4
+// CHECK-NEXT:   %5 = tuple ()                                   // user: %6
+// CHECK-NEXT:   return %5 : $()                                 // id: %6
+// CHECK-NEXT: } // end sil function '$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF'
+
+package func r(_ arg: PublicProto) -> Int {
+  return arg.data
+}
+
+// CHECK: // r(_:)
+// CHECK-NEXT: sil @$s6Client1rySi5Utils11PublicProto_pF : $@convention(thin) (@in_guaranteed any PublicProto) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
+// CHECK-NEXT: bb0(%0 : $*any PublicProto):
+// CHECK-NEXT:   debug_value %0 : $*any PublicProto, let, name "arg", argno 1, expr op_deref // id: %1
+// CHECK-NEXT:   %2 = open_existential_addr immutable_access %0 : $*any PublicProto
+// CHECK-NEXT:   %3 = alloc_stack $@opened
+// CHECK-NEXT:   copy_addr %2 to [init] %3 : $*@opened
+// CHECK-NEXT:   %5 = witness_method $@opened
+// CHECK-NEXT:   %6 = apply %5<@opened
+// CHECK-NEXT:   destroy_addr %3 : $*@opened
+// CHECK-NEXT:   dealloc_stack %3 : $*@opened
+// CHECK-NEXT:   return %6 : $Int
+// CHECK-NEXT: } // end sil function '$s6Client1rySi5Utils11PublicProto_pF'
+
+package func s(_ arg: PkgProto) -> Int {
+  return arg.data
+}
+// CHECK: // s(_:)
+// CHECK-NEXT: sil @$s6Client1sySi5Utils8PkgProto_pF : $@convention(thin) (@in_guaranteed any PkgProto) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
+// CHECK-NEXT: bb0(%0 : $*any PkgProto):
+// CHECK-NEXT:   debug_value %0 : $*any PkgProto, let, name "arg", argno 1, expr op_deref // id: %1
+// CHECK-NEXT:   %2 = open_existential_addr immutable_access %0 : $*any PkgProto to $*@opened
+// CHECK-NEXT:   %3 = alloc_stack $@opened
+// CHECK-NEXT:   copy_addr %2 to [init] %3 : $*@opened
+// CHECK-NEXT:   %5 = witness_method $@opened
+// CHECK-NEXT:   %6 = apply %5<@opened
+// CHECK-NEXT:   destroy_addr %3 : $*@opened
+// CHECK-NEXT:   dealloc_stack %3 : $*@opened
+// CHECK-NEXT:   return %6 : $Int
+// CHECK-NEXT: } // end sil function '$s6Client1sySi5Utils8PkgProto_pF'
+

--- a/test/Sema/package_resilience_bypass_exhaustive_switch.swift
+++ b/test/Sema/package_resilience_bypass_exhaustive_switch.swift
@@ -1,0 +1,179 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Utils.swift \
+// RUN:   -module-name Utils -swift-version 5 -I %t \
+// RUN:   -package-name mypkg \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule
+
+// RUN: %target-swift-frontend -emit-sil %t/Client.swift -package-name mypkg -I %t > %t/Client.sil
+// RUN: %FileCheck %s < %t/Client.sil
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t -swift-version 5 -package-name mypkg -verify
+
+//--- Utils.swift
+
+// Resilient; public.
+// Switch stmt requires @unknown default.
+public enum PublicEnum {
+  case one
+  case two(Int)
+}
+
+// Resilient; public.
+public struct PublicStruct {
+  public var publicVar: Int
+}
+
+// Non-resilient; frozen. Accessed directly.
+// Switch stmt does not require @unknown default.
+@frozen
+public enum FrozenPublicEnum {
+  case one
+  case two(Int)
+}
+
+// Non-resilient; non-public / associated value is also non-resilient (Int is @frozen public).
+// Accessed directly.
+// Switch stmt does not require @unknown default.
+package enum PkgEnum {
+  case one
+  case two(Int)
+}
+
+// Non-resilient but accessed indirectly since associated value is resilient.
+// Passed by address to func as @in_guaranteed in Silgen.
+// Switch stmt does not require @unknown default.
+package enum PkgEnumWithPublicCase {
+  case one
+  case two(PublicStruct)
+}
+
+// Non-resilient but accessed indirectly since associated value is resilient (existential).
+// Passed by address to func as @in_guaranteed in Silgen.
+// Switch stmt does not require @unknown default.
+package enum PkgEnumWithExistentialCase {
+  case one
+  case two(any StringProtocol)
+}
+
+// Resilient since inlinable.
+@usableFromInline
+package enum UfiPkgEnum {
+  case one
+  case two(Int)
+}
+
+
+//--- Client.swift
+import Utils
+
+package func f(_ arg: PkgEnum) -> Int {
+  switch arg { // no-warning
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}
+
+// CHECK: // f(_:)
+// CHECK-NEXT: sil @$s6Client1fySi5Utils7PkgEnumOF : $@convention(thin) (PkgEnum) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
+// CHECK-NEXT: bb0(%0 : $PkgEnum):
+// CHECK-NEXT:   debug_value %0 : $PkgEnum, let, name "arg", argno 1 // id: %1
+// CHECK-NEXT:   switch_enum %0 : $PkgEnum, case #PkgEnum.one!enumelt: bb1, case #PkgEnum.two!enumelt: bb2 // id: %2
+
+package func g1(_ arg: PkgEnumWithPublicCase) -> Int {
+  switch arg { // no-warning
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val.publicVar
+  }
+}
+
+// CHECK: // g1(_:)
+// CHECK-NEXT: sil @$s6Client2g1ySi5Utils21PkgEnumWithPublicCaseOF : $@convention(thin) (@in_guaranteed PkgEnumWithPublicCase) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %3, %1
+// CHECK-NEXT: bb0(%0 : $*PkgEnumWithPublicCase):
+// CHECK-NEXT:   debug_value %0 : $*PkgEnumWithPublicCase, let, name "arg", argno 1, expr op_deref // id: %1
+// CHECK-NEXT:   %2 = alloc_stack $PkgEnumWithPublicCase         // users: %29, %9, %7, %4, %3
+// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PkgEnumWithPublicCase // id: %3
+// CHECK-NEXT:   switch_enum_addr %2 : $*PkgEnumWithPublicCase, case #PkgEnumWithPublicCase.one!enumelt: bb1, case #PkgEnumWithPublicCase.two!enumelt: bb2 // id: %4
+
+package func g2(_ arg: PkgEnumWithExistentialCase) -> any StringProtocol {
+  switch arg { // no-warning
+  case .one:
+    return "1"
+  case .two(let val):
+    return val
+  }
+}
+
+// CHECK: // g2(_:)
+// CHECK-NEXT: sil @$s6Client2g2ySy_p5Utils26PkgEnumWithExistentialCaseOF : $@convention(thin) (@in_guaranteed PkgEnumWithExistentialCase) -> @out any StringProtocol {
+// CHECK-NEXT: // %0 "$return_value"                             // users: %20, %12
+// CHECK-NEXT: // %1 "arg"                                       // users: %4, %2
+// CHECK-NEXT: bb0(%0 : $*any StringProtocol, %1 : $*PkgEnumWithExistentialCase):
+// CHECK-NEXT:   debug_value %1 : $*PkgEnumWithExistentialCase, let, name "arg", argno 1, expr op_deref // id: %2
+// CHECK-NEXT:   %3 = alloc_stack $PkgEnumWithExistentialCase    // users: %23, %16, %14, %5, %4
+// CHECK-NEXT:   copy_addr %1 to [init] %3 : $*PkgEnumWithExistentialCase // id: %4
+// CHECK-NEXT:   switch_enum_addr %3 : $*PkgEnumWithExistentialCase, case #PkgEnumWithExistentialCase.one!enumelt: bb1, case #PkgEnumWithExistentialCase.two!enumelt: bb2 // id: %5
+
+
+@inlinable
+package func h(_ arg: UfiPkgEnum) -> Int {
+  switch arg { // expected-warning {{switch covers known cases, but 'UfiPkgEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}
+
+// CHECK: // h(_:)
+// CHECK-NEXT: sil @$s6Client1hySi5Utils10UfiPkgEnumOF : $@convention(thin) (@in_guaranteed UfiPkgEnum) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %3, %1
+// CHECK-NEXT: bb0(%0 : $*UfiPkgEnum):
+// CHECK-NEXT:   debug_value %0 : $*UfiPkgEnum, let, name "arg", argno 1, expr op_deref // id: %1
+// CHECK-NEXT:   %2 = alloc_stack $UfiPkgEnum                    // users: %21, %10, %8, %5, %4, %3
+// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*UfiPkgEnum        // id: %3
+// CHECK-NEXT:   %4 = value_metatype $@thick UfiPkgEnum.Type, %2 : $*UfiPkgEnum // user: %24
+// CHECK-NEXT:   switch_enum_addr %2 : $*UfiPkgEnum, case #UfiPkgEnum.one!enumelt: bb1, case #UfiPkgEnum.two!enumelt: bb2, default bb3 // id: %5
+
+public func k(_ arg: PublicEnum) -> Int {
+  switch arg { // expected-warning {{switch covers known cases, but 'PublicEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}
+// CHECK: // k(_:)
+// CHECK-NEXT: sil @$s6Client1kySi5Utils10PublicEnumOF : $@convention(thin) (@in_guaranteed PublicEnum) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %3, %1
+// CHECK-NEXT: bb0(%0 : $*PublicEnum):
+// CHECK-NEXT:   debug_value %0 : $*PublicEnum, let, name "arg", argno 1, expr op_deref // id: %1
+// CHECK-NEXT:   %2 = alloc_stack $PublicEnum                    // users: %21, %10, %8, %5, %4, %3
+// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PublicEnum        // id: %3
+// CHECK-NEXT:   %4 = value_metatype $@thick PublicEnum.Type, %2 : $*PublicEnum // user: %24
+// CHECK-NEXT:   switch_enum_addr %2 : $*PublicEnum, case #PublicEnum.one!enumelt: bb1, case #PublicEnum.two!enumelt: bb2, default bb3 // id: %5
+
+public func m(_ arg: FrozenPublicEnum) -> Int {
+  switch arg { // no-warning
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}
+
+// CHECK: // m(_:)
+// CHECK-NEXT: sil @$s6Client1mySi5Utils16FrozenPublicEnumOF : $@convention(thin) (FrozenPublicEnum) -> Int {
+// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
+// CHECK-NEXT: bb0(%0 : $FrozenPublicEnum):
+// CHECK-NEXT:   debug_value %0 : $FrozenPublicEnum, let, name "arg", argno 1 // id: %1
+// CHECK-NEXT:   switch_enum %0 : $FrozenPublicEnum, case #FrozenPublicEnum.one!enumelt: bb1, case #FrozenPublicEnum.two!enumelt: bb2 // id: %2
+
+

--- a/test/Sema/package_resilience_super_class.swift
+++ b/test/Sema/package_resilience_super_class.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Access a package class (non-resilient type) subclassing a resilient class from a resilient module.
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Utils)) %t/Utils.swift -module-name Utils -package-name mypkg -emit-module -emit-module-path %t/Utils.swiftmodule -enable-library-evolution
+// RUN: %target-build-swift -I %t -L %t -lUtils %s -o %t/main %target-rpath(%t) -package-name mypkg
+// RUN: %target-run %t/main %t/%target-library-name(Utils) | %FileCheck %s
+
+// RUN: rm -rf %t/%target-library-name(Utils)
+
+/// Access a package class (non-resilient type) subclassing a resilient class from a non-resilient module.
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Utils)) %t/Utils.swift -module-name Utils -package-name mypkg -emit-module -emit-module-path %t/Utils.swiftmodule
+// RUN: %target-build-swift -I %t -L %t -lUtils %s -o %t/main %target-rpath(%t) -package-name mypkg
+// RUN: %target-run %t/main %t/%target-library-name(Utils) | %FileCheck %s
+
+// RUN: rm -rf %t/%target-library-name(Utils)
+
+/// Super class of the package class becomes non-resilient due to -enable-testing.
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Utils)) %t/Utils.swift -module-name Utils -package-name mypkg -emit-module -emit-module-path %t/Utils.swiftmodule -enable-library-evolution -enable-testing
+// RUN: %target-build-swift -I %t -L %t -lUtils %s -o %t/main %target-rpath(%t) -package-name mypkg -DTESTABLE
+// RUN: %target-run %t/main %t/%target-library-name(Utils) | %FileCheck %s
+
+//--- Utils.swift
+
+open class OpenKlass {
+  public init() {}
+  open var openVar = "open var"
+}
+
+package struct PkgStructWithEnum {
+  package enum PkgEnum: String {
+    case first = "First"
+    case second = "Second"
+  }
+}
+
+package class PkgKlass: OpenKlass {
+  package var klassVar: PkgStructWithEnum.PkgEnum
+  package override init() {
+    klassVar = .second
+  }
+}
+
+
+//--- main.swift
+
+#if TESTABLE
+@testable import Utils
+#else
+import Utils
+#endif
+
+public func f() {
+  let k = PkgKlass()
+  print(k.klassVar) // CHECK: second
+  print("Value is", isEqual(k.klassVar, .second)) // CHECK: Value is true
+}
+
+public func isEqual<T:Equatable>(_ l: T, _ r: T) -> Bool {
+  return l == r
+}
+
+f()


### PR DESCRIPTION
Package types are non-public and should already be treated as non-resilient
although they can be accessed indirectly. Added tests to cover various use cases
incl. enum switch exhaustive stmts and addition of resilient members resulting in
indirect access in silgen.

Resolves rdar://104617177