### PR TITLE
LoopRotate: ignore single-block loops where the "backedge" block only contains trivial instructions

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -288,7 +288,11 @@ static bool isSingleBlockLoop(SILLoop *L) {
          && "Loop not well formed");
 
   // Check whether the back-edge block is just a split-edge.
-  return ++BackEdge->begin() == BackEdge->end();
+  for (SILInstruction &inst : make_range(BackEdge->begin(), --BackEdge->end())) {
+    if (instructionInlineCost(inst) != InlineCost::Free)
+      return false;
+  }
+  return true;
 }
 
 /// We rotated a loop if it has the following properties.

--- a/test/SILOptimizer/looprotate_ossa.sil
+++ b/test/SILOptimizer/looprotate_ossa.sil
@@ -465,6 +465,7 @@ bb1:
   cond_br %0, bb1a, bb2
 
 bb1a:
+  %t = tuple(%0 : $Builtin.Int1, %0 : $Builtin.Int1)
   br bb1
 
 bb2:


### PR DESCRIPTION
This avoids that LoopRotate increases code size without any benefit.

rdar://117362048
