### PR TITLE
Fix a bunch of reflection tests to be correct for Ubuntu

### DIFF
--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic3.swift
@@ -9,12 +9,6 @@
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest
-import Darwin
-
-private func debugLog(_ message: @autoclosure () -> String) {
-  fputs("Child: \(message())\n", stderr)
-  fflush(stderr)
-}
 
 struct StructWithEnumDepth0<T> {
   enum E {

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic4.swift
@@ -9,12 +9,6 @@
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest
-import Darwin
-
-private func debugLog(_ message: @autoclosure () -> String) {
-  fputs("Child: \(message())\n", stderr)
-  fflush(stderr)
-}
 
 struct StructWithEnumDepth0<T> {
   enum E {

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic5.swift
@@ -9,7 +9,6 @@
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest
-import Darwin
 
 struct StructWithEnumDepth0<T> {
   enum E {

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic6.swift
@@ -9,7 +9,6 @@
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest
-import Darwin
 
 struct StructWithEnumDepth0<T> {
   enum E {

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_generic7.swift
@@ -9,7 +9,6 @@
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest
-import Darwin
 
 // This will always get treated as a single-payload enum
 enum A<T> {

--- a/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
+// REQUIRES: objc_interop
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest

--- a/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
+++ b/validation-test/Reflection/reflect_Enum_SinglePayload_generic1.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_SinglePayload_generic1
 // RUN: %target-codesign %t/reflect_Enum_SinglePayload_generic1
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SinglePayload_generic1 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SinglePayload_generic1 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize %add_num_extra_inhabitants --dump-input=fail
 
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
@@ -31,7 +31,7 @@ reflect(enum: SimplePayload1<ClassTypeA>.b(ClassTypeA()))
 // (Unlike MPEs, SPEs do not automatically use a tag just because they're generic)
 
 // CHECK: Type info:
-// X64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=2147483645 bitwise_takable=1
+// X64-NEXT: (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // X32-NEXT: (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants={{[0-9]+}} bitwise_takable=1
 // CHECK-NEXT:   (case name=b index=0 offset=0
 // CHECK-NEXT:     (reference kind=strong refcounting=native))


### PR DESCRIPTION
These tests had Darwin-specific code in them, mostly unnecessary, that caused them to break on non-Darwin platforms.  In particular, they break on Ubuntu 22.10 aarch64.

Only one (reflect_Enum_SingleCaseCFPayload.swift) was actually specific to Darwin.  That one has been disabled on non-Darwin.  For the rest, just delete the unnecessary `import Darwin` and similar.
