### PR TITLE
🍒[cxx-interop] Avoid circular reference errors when importing C++ structs

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2197,6 +2197,13 @@ namespace {
       // FIXME: Figure out what to do with superclasses in C++. One possible
       // solution would be to turn them into members and add conversion
       // functions.
+      if (auto cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(decl)) {
+        for (auto base : cxxRecordDecl->bases()) {
+          if (auto *baseRecordDecl = base.getType()->getAsCXXRecordDecl()) {
+            Impl.importDecl(baseRecordDecl, getVersion());
+          }
+        }
+      }
 
       // Import each of the members.
       SmallVector<VarDecl *, 4> members;

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -11,6 +11,11 @@ module Polymorphism {
   requires cplusplus
 }
 
+module ReferenceToDerived {
+  header "reference-to-derived.h"
+  requires cplusplus
+}
+
 module SubTypes {
   header "sub-types.h"
 }

--- a/test/Interop/Cxx/class/inheritance/Inputs/reference-to-derived.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/reference-to-derived.h
@@ -1,0 +1,13 @@
+class E;
+
+class C {
+public:
+  E *getE() const;
+};
+
+class D : public C {};
+
+class E : public D {
+public:
+  D *getD() const;
+};

--- a/test/Interop/Cxx/class/inheritance/reference-to-derived-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/reference-to-derived-irgen.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -validate-tbd-against-ir=none
+// We should not fail with a circular reference error here.
+
+import ReferenceToDerived
+
+func foo(_ x: D) {}


### PR DESCRIPTION
**Explanation**:
When importing a C++ struct, if its owning module `requires cplusplus`, Swift tried to auto-conform it to certain protocols from the Cxx module. This triggers name lookup in the clang struct, specifically for `__beginUnsafe()` and `__endUnsafe()` methods, which imports all of the base structs including their methods.
This moves the import of base structs out of the name lookup request, preventing cycles.
**Scope**: All of the code changes are on a C++ interop only code path.
**Risk**: Low, only takes effect when C++ interop is enabled.
**Testing**: Covered by LIT tests.
**Original PR**: https://github.com/apple/swift/pull/69327

rdar://116426238
(cherry picked from commit 4632d894e67ba5a8f75bbce9197dc2ee7957ad6e)
