### PR TITLE
Fix a round trip debug type failure with typealias

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -98,10 +98,11 @@ public:
 };
 
 static bool equalWithoutExistentialTypes(Type t1, Type t2) {
-  auto withoutExistentialTypes = [](Type type) -> Type {
+  static Type (*withoutExistentialTypes)(Type) = [](Type type) -> Type {
     return type.transform([](Type type) -> Type {
-      if (auto existential = type->getAs<ExistentialType>())
-        return existential->getConstraintType();
+      if (auto existential = type->getAs<ExistentialType>()) {
+        return withoutExistentialTypes(existential->getConstraintType());
+      }
       return type;
     });
   };

--- a/test/IRGen/round-trip-debug-types-typealias.swift
+++ b/test/IRGen/round-trip-debug-types-typealias.swift
@@ -1,0 +1,10 @@
+// RUN: %target-build-swift -g %s
+
+// https://github.com/apple/swift/issues/66554
+// IRGenDebugInfo type reconstruction crash because existential types
+// inside typealias are not taken into account when comparing type
+// equality
+
+protocol Protocol<T> { associatedtype T }
+typealias AnyProtocol<T> = any Protocol<T>
+let crash: AnyProtocol<Any?>


### PR DESCRIPTION
When checking equality of types with existential types removed, recursively remove existential types inside an existential type.

Fixes: #66554

Cherrypick https://github.com/apple/swift/commit/fda6f9b62febaba0620469a901de4168df47e27e
