### PR TITLE
Don't keep generic versions of PtrAuth functions alive

### DIFF
--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -881,6 +881,9 @@ bool SILFunction::shouldBePreservedForDebugger() const {
   if (getEffectiveOptimizationMode() != OptimizationMode::NoOptimization)
     return false;
 
+  if (hasSemanticsAttr("no.preserve.debugger"))
+    return false;
+
   // Only keep functions defined in this module.
   if (!isDefinition())
     return false;

--- a/stdlib/public/core/PtrAuth.swift
+++ b/stdlib/public/core/PtrAuth.swift
@@ -95,6 +95,7 @@ internal enum _PtrAuth {
   }
 
   /// Sign an unauthenticated pointer.
+  @_semantics("no.preserve.debugger") // Relies on inlining this function.
   @_transparent
   static func sign(pointer: UnsafeRawPointer,
                    key: Key,
@@ -110,6 +111,7 @@ internal enum _PtrAuth {
 
   /// Authenticate a pointer using one scheme and resign it using another.
   @_transparent
+  @_semantics("no.preserve.debugger") // Relies on inlining this function.
   static func authenticateAndResign(pointer: UnsafeRawPointer,
                                 oldKey: Key,
                                 oldDiscriminator: UInt64,
@@ -127,6 +129,7 @@ internal enum _PtrAuth {
   }
 
   /// Get the type-specific discriminator for a function type.
+  @_semantics("no.preserve.debugger") // Don't keep the generic version alive
   @_transparent
   static func discriminator<T>(for type: T.Type) -> UInt64 {
     return UInt64(Builtin.typePtrAuthDiscriminator(type))
@@ -175,6 +178,7 @@ internal enum _PtrAuth {
 extension UnsafeRawPointer {
   /// Load a function pointer from memory that has been authenticated
   /// specifically for its given address.
+  @_semantics("no.preserve.debugger") // Don't keep the generic version alive
   @_transparent
   internal func _loadAddressDiscriminatedFunctionPointer<T>(
     fromByteOffset offset: Int = 0,
@@ -196,6 +200,7 @@ extension UnsafeRawPointer {
     return unsafeBitCast(resigned, to: type)
   }
 
+  @_semantics("no.preserve.debugger") // Don't keep the generic version alive
   @_transparent
   internal func _loadAddressDiscriminatedFunctionPointer<T>(
     fromByteOffset offset: Int = 0,


### PR DESCRIPTION
We don't support generating code for ptrauth builtins with generic inputs (or non-constant inputs). We rely on specialization/inlining for such code to work.

After a recent commit (#68843 ) code in IRGen keeps internal unreferenced functions alive for debugging purposes.

This is a problem for the generic functions in PtrAuth.swift using ptrauth builtins.

Opt out of this new behavior by sprinkling some pixie dust.

Fixes debug swift standard library builds targeting arm64e.

rdar://117411740
