### PR TITLE
[Typed throws] Record thrown error types and conversions in the AST

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -28,6 +28,7 @@
 #include "swift/AST/FreestandingMacroExpansion.h"
 #include "swift/AST/FunctionRefKind.h"
 #include "swift/AST/ProtocolConformanceRef.h"
+#include "swift/AST/ThrownErrorDestination.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/InlineBitfield.h"
@@ -324,9 +325,8 @@ protected:
     NumCaptures : 32
   );
 
-  SWIFT_INLINE_BITFIELD(ApplyExpr, Expr, 1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ApplyExpr, Expr, 1+1+1+1+1,
     ThrowsIsSet : 1,
-    Throws : 1,
     ImplicitlyAsync : 1,
     ImplicitlyThrows : 1,
     NoAsync : 1,
@@ -1180,6 +1180,11 @@ class DeclRefExpr : public Expr {
   DeclNameLoc Loc;
   ActorIsolation implicitActorHopTarget;
 
+  /// Destination information for a thrown error, which includes any
+  /// necessary conversions from the actual type thrown to the type that
+  /// is expected by the enclosing context.
+  ThrownErrorDestination ThrowDest;
+
 public:
   DeclRefExpr(ConcreteDeclRef D, DeclNameLoc Loc, bool Implicit,
               AccessSemantics semantics = AccessSemantics::Ordinary,
@@ -1228,6 +1233,14 @@ public:
   /// implementation itself..
   bool isImplicitlyThrows() const {
     return Bits.DeclRefExpr.IsImplicitlyThrows;
+  }
+
+  /// The error thrown from this access.
+  ThrownErrorDestination throws() const { return ThrowDest; }
+
+  void setThrows(ThrownErrorDestination throws) {
+    assert(!ThrowDest);
+    ThrowDest = throws;
   }
 
   /// Set whether this reference must account for a `throw` occurring for reasons
@@ -1562,6 +1575,11 @@ protected:
     assert(Base);
   }
 
+  /// Destination information for a thrown error, which includes any
+  /// necessary conversions from the actual type thrown to the type that
+  /// is expected by the enclosing context.
+  ThrownErrorDestination ThrowDest;
+
 public:
   /// Retrieve the base of the expression.
   Expr *getBase() const { return Base; }
@@ -1601,6 +1619,14 @@ public:
   void setImplicitlyAsync(ActorIsolation target) {
     Bits.LookupExpr.IsImplicitlyAsync = true;
     implicitActorHopTarget = target;
+  }
+
+  /// The error thrown from this access.
+  ThrownErrorDestination throws() const { return ThrowDest; }
+
+  void setThrows(ThrownErrorDestination throws) {
+    assert(!ThrowDest);
+    ThrowDest = throws;
   }
 
   /// Determine whether this reference needs may implicitly throw.
@@ -4627,6 +4653,11 @@ class ApplyExpr : public Expr {
   // isolations in this struct.
   llvm::Optional<ApplyIsolationCrossing> IsolationCrossing;
 
+  /// Destination information for a thrown error, which includes any
+  /// necessary conversions from the actual type thrown to the type that
+  /// is expected by the enclosing context.
+  ThrownErrorDestination ThrowDest;
+
 protected:
   ApplyExpr(ExprKind kind, Expr *fn, ArgumentList *argList, bool implicit,
             Type ty = Type())
@@ -4656,16 +4687,18 @@ public:
   /// Does this application throw?  This is only meaningful after
   /// complete type-checking.
   ///
-  /// If true, the function expression must have a throwing function
-  /// type.  The converse is not true because of 'rethrows' functions.
-  bool throws() const {
+  /// Returns the thrown error destination, which includes both the type
+  /// thrown from this application as well as the the context's error type,
+  /// which may be different.
+  ThrownErrorDestination throws() const {
     assert(Bits.ApplyExpr.ThrowsIsSet);
-    return Bits.ApplyExpr.Throws;
+    return ThrowDest;
   }
-  void setThrows(bool throws) {
+
+  void setThrows(ThrownErrorDestination throws) {
     assert(!Bits.ApplyExpr.ThrowsIsSet);
     Bits.ApplyExpr.ThrowsIsSet = true;
-    Bits.ApplyExpr.Throws = throws;
+    ThrowDest = throws;
   }
 
   /// Is this a 'rethrows' function that is known not to throw?

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -24,6 +24,7 @@
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/TypeAlignments.h"
+#include "swift/AST/ThrownErrorDestination.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/NullablePtr.h"
 #include "llvm/ADT/None.h"
@@ -1383,6 +1384,7 @@ class DoCatchStmt final
 
   SourceLoc DoLoc;
   Stmt *Body;
+  ThrownErrorDestination RethrowDest;
 
   DoCatchStmt(LabeledStmtInfo labelInfo, SourceLoc doLoc, Stmt *body,
               ArrayRef<CaseStmt *> catches, llvm::Optional<bool> implicit)
@@ -1432,6 +1434,15 @@ public:
   // aren't exhausive, this is also the type of the error that is implicitly
   // rethrown.
   Type getCaughtErrorType() const;
+
+  /// Retrieves the rethrown error and its conversion to the error type
+  /// expected by the enclosing context.
+  ThrownErrorDestination rethrows() const { return RethrowDest; }
+
+  void setRethrows(ThrownErrorDestination rethrows) {
+    assert(!RethrowDest);
+    RethrowDest = rethrows;
+  }
 
   static bool classof(const Stmt *S) {
     return S->getKind() == StmtKind::DoCatch;

--- a/include/swift/AST/ThrownErrorDestination.h
+++ b/include/swift/AST/ThrownErrorDestination.h
@@ -1,0 +1,87 @@
+//===--- ThrownErrorDestination.h - Thrown error dest -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ThrownErrorDestination class.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_THROWNERRORDESTINATION
+#define SWIFT_AST_THROWNERRORDESTINATION
+
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/PointerUnion.h"
+#include "swift/AST/Type.h"
+#include "swift/AST/TypeAlignments.h"
+
+namespace swift {
+class Expr;
+class OpaqueValueExpr;
+
+/// Describes an error thrown from a particular operation and its conversion
+/// to the error type expected by its context.
+class ThrownErrorDestination {
+  struct Conversion {
+    /// The opaque value, which is of the thrown error type.
+    OpaqueValueExpr *thrownError;
+
+    /// The conversion from the opaque value type to the type needed by the
+    /// context.
+    Expr *conversion;
+  };
+
+  llvm::PointerUnion<TypeBase *, Conversion *> storage;
+
+  ThrownErrorDestination(Type type) : storage(type.getPointer()) { }
+  ThrownErrorDestination(Conversion *conversion) : storage(conversion) { }
+
+public:
+  /// Construct a non-throwing destination.
+  ThrownErrorDestination() : storage(nullptr) { }
+
+  /// Construct a non-throwing destination.
+  ThrownErrorDestination(std::nullptr_t) : storage(nullptr) { }
+
+  /// Whether there is a thrown error destination at all.
+  explicit operator bool() const { return !storage.isNull(); }
+
+  /// A thrown error destination where the thrown type corresponds to the
+  /// type caught (or rethrows) by the enclosing context.
+  static ThrownErrorDestination forMatchingContextType(Type thrownError) {
+    return ThrownErrorDestination(thrownError);
+  }
+
+  /// A thrown error destination where the thrown error requires a conversion
+  /// to the error type expected by its context.
+  static ThrownErrorDestination forConversion(OpaqueValueExpr *thrownError,
+                                              Expr *conversion);
+
+  /// Retrieve the type of error thrown from this function call.
+  Type getThrownErrorType() const;
+
+  /// Retrieve the type of the error expected in this context.
+  Type getContextErrorType() const;
+
+  /// Retrieve the conversion as a pair of (opaque thrown error value,
+  /// conversion expression), when a conversion from the thrown error type
+  /// to the context error type is required.
+  llvm::Optional<std::pair<OpaqueValueExpr *, Expr *>> getConversion() const {
+    if (auto conversion = storage.dyn_cast<Conversion *>()) {
+      return std::make_pair(conversion->thrownError, conversion->conversion);
+    }
+
+    return llvm::None;
+  }
+};
+
+} // end namespace swift
+
+#endif // SWIFT_AST_THROWNERRORDESTINATION

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2860,3 +2860,36 @@ Type Expr::findOriginalType() const {
 
   return expr->getType()->getRValueType();
 }
+
+ThrownErrorDestination
+ThrownErrorDestination::forConversion(OpaqueValueExpr *thrownError,
+                                      Expr *conversion) {
+  ASTContext &ctx = thrownError->getType()->getASTContext();
+  auto conversionStorage = ctx.Allocate<Conversion>();
+  conversionStorage->thrownError = thrownError;
+  conversionStorage->conversion = conversion;
+
+  return ThrownErrorDestination(conversionStorage);
+}
+
+Type ThrownErrorDestination::getThrownErrorType() const {
+  if (!*this)
+    return Type();
+
+  if (auto type = storage.dyn_cast<TypeBase *>())
+    return Type(type);
+
+  auto conversion = storage.get<Conversion *>();
+  return conversion->thrownError->getType();
+}
+
+Type ThrownErrorDestination::getContextErrorType() const {
+  if (!*this)
+    return Type();
+
+  if (auto type = storage.dyn_cast<TypeBase *>())
+    return Type(type);
+
+  auto conversion = storage.get<Conversion *>();
+  return conversion->conversion->getType();
+}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4720,7 +4720,7 @@ MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
     builtinFnRefExpr->setType(fnType);
     auto *argList = ArgumentList::createImplicit(ctx, {arg});
     auto callExpr = CallExpr::create(ctx, builtinFnRefExpr, argList, /*implicit*/ true);
-    callExpr->setThrows(false);
+    callExpr->setThrows(nullptr);
     return callExpr;
   };
 
@@ -4748,7 +4748,7 @@ MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
   // This will be "Optional<UnsafeMutablePointer<Base>>"
   casted->setType(cast<FunctionType>(staticCastRefExpr->getType().getPointer())
                       ->getResult());
-  casted->setThrows(false);
+  casted->setThrows(nullptr);
 
   SubstitutionMap pointeeSubst = SubstitutionMap::get(
       ctx.getUnsafeMutablePointerDecl()->getGenericSignature(),
@@ -5033,13 +5033,13 @@ synthesizeBaseClassMethodBody(AbstractFunctionDecl *afd, void *context) {
   auto baseMemberDotCallExpr =
       DotSyntaxCallExpr::create(ctx, baseMemberExpr, SourceLoc(), selfArg);
   baseMemberDotCallExpr->setType(baseMember->getMethodInterfaceType());
-  baseMemberDotCallExpr->setThrows(false);
+  baseMemberDotCallExpr->setThrows(nullptr);
 
   auto *argList = ArgumentList::forImplicitUnlabeled(ctx, forwardingParams);
   auto *baseMemberCallExpr = CallExpr::createImplicit(
       ctx, baseMemberDotCallExpr, argList);
   baseMemberCallExpr->setType(baseMember->getResultInterfaceType());
-  baseMemberCallExpr->setThrows(false);
+  baseMemberCallExpr->setThrows(nullptr);
 
   auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), baseMemberCallExpr,
                                          /*implicit=*/true);
@@ -5264,7 +5264,7 @@ synthesizeBaseClassFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
   auto baseMemberDotCallExpr =
       DotSyntaxCallExpr::create(ctx, baseMemberExpr, SourceLoc(), selfArg);
   baseMemberDotCallExpr->setType(baseGetterMethod->getMethodInterfaceType());
-  baseMemberDotCallExpr->setThrows(false);
+  baseMemberDotCallExpr->setThrows(nullptr);
 
   ArgumentList *argumentList;
   if (auto subscript = dyn_cast<SubscriptDecl>(baseClassVar)) {
@@ -5280,7 +5280,7 @@ synthesizeBaseClassFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
   auto *baseMemberCallExpr =
       CallExpr::createImplicit(ctx, baseMemberDotCallExpr, argumentList);
   baseMemberCallExpr->setType(baseGetterMethod->getResultInterfaceType());
-  baseMemberCallExpr->setThrows(false);
+  baseMemberCallExpr->setThrows(nullptr);
 
   auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), baseMemberCallExpr,
                                          /*implicit=*/true);
@@ -6444,7 +6444,7 @@ synthesizeDependentTypeThunkParamForwarding(AbstractFunctionDecl *afd, void *con
     auto selfArg = createSelfArg(thunkDecl);
     auto *memberCall = DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef,
                                                  SourceLoc(), selfArg);
-    memberCall->setThrows(false);
+    memberCall->setThrows(nullptr);
     auto resultType = specializedFuncDecl->getInterfaceType()->getAs<FunctionType>()->getResult();
     specializedFuncDeclRef = memberCall;
     specializedFuncDeclRef->setType(resultType);
@@ -6455,7 +6455,7 @@ synthesizeDependentTypeThunkParamForwarding(AbstractFunctionDecl *afd, void *con
     auto *memberCall =
         DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef, SourceLoc(),
                                   Argument::unlabeled(selfTypeExpr));
-    memberCall->setThrows(false);
+    memberCall->setThrows(nullptr);
     specializedFuncDeclRef = memberCall;
     specializedFuncDeclRef->setType(resultType);
   }
@@ -6463,7 +6463,7 @@ synthesizeDependentTypeThunkParamForwarding(AbstractFunctionDecl *afd, void *con
   auto argList = ArgumentList::createImplicit(ctx, forwardingParams);
   auto *specializedFuncCallExpr = CallExpr::createImplicit(ctx, specializedFuncDeclRef, argList);
   specializedFuncCallExpr->setType(specializedFuncDecl->getResultInterfaceType());
-  specializedFuncCallExpr->setThrows(false);
+  specializedFuncCallExpr->setThrows(nullptr);
 
   Expr *resultExpr = nullptr;
   if (specializedFuncCallExpr->getType()->isEqual(
@@ -6576,7 +6576,7 @@ synthesizeForwardingThunkBody(AbstractFunctionDecl *afd, void *context) {
     auto selfArg = createSelfArg(thunkDecl);
     auto *memberCall = DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef,
                                                  SourceLoc(), selfArg);
-    memberCall->setThrows(false);
+    memberCall->setThrows(nullptr);
     auto resultType = specializedFuncDecl->getInterfaceType()->getAs<FunctionType>()->getResult();
     specializedFuncDeclRef = memberCall;
     specializedFuncDeclRef->setType(resultType);
@@ -6587,7 +6587,7 @@ synthesizeForwardingThunkBody(AbstractFunctionDecl *afd, void *context) {
     auto *memberCall =
         DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef, SourceLoc(),
                                   Argument::unlabeled(selfTypeExpr));
-    memberCall->setThrows(false);
+    memberCall->setThrows(nullptr);
     specializedFuncDeclRef = memberCall;
     specializedFuncDeclRef->setType(resultType);
   }
@@ -6595,7 +6595,7 @@ synthesizeForwardingThunkBody(AbstractFunctionDecl *afd, void *context) {
   auto argList = ArgumentList::createImplicit(ctx, forwardingParams);
   auto *specializedFuncCallExpr = CallExpr::createImplicit(ctx, specializedFuncDeclRef, argList);
   specializedFuncCallExpr->setType(thunkDecl->getResultInterfaceType());
-  specializedFuncCallExpr->setThrows(false);
+  specializedFuncCallExpr->setThrows(nullptr);
 
   auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), specializedFuncCallExpr,
                                          /*implicit=*/true);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5948,7 +5948,7 @@ Decl *SwiftDeclConverter::importEnumCaseAlias(
         DotSyntaxCallExpr::create(Impl.SwiftContext, constantRef, SourceLoc(),
                                   Argument::unlabeled(typeRef));
     instantiate->setType(importedEnumTy);
-    instantiate->setThrows(false);
+    instantiate->setThrows(nullptr);
 
     result = instantiate;
   } else {

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -50,7 +50,7 @@ static CallExpr *createAccessorImplCallExpr(FuncDecl *accessorImpl,
   auto accessorImplDotCallExpr =
       DotSyntaxCallExpr::create(ctx, accessorImplExpr, SourceLoc(), selfArg);
   accessorImplDotCallExpr->setType(accessorImpl->getMethodInterfaceType());
-  accessorImplDotCallExpr->setThrows(false);
+  accessorImplDotCallExpr->setThrows(nullptr);
 
   ArgumentList *argList;
   if (keyRefExpr) {
@@ -61,7 +61,7 @@ static CallExpr *createAccessorImplCallExpr(FuncDecl *accessorImpl,
   auto *accessorImplCallExpr =
       CallExpr::createImplicit(ctx, accessorImplDotCallExpr, argList);
   accessorImplCallExpr->setType(accessorImpl->getResultInterfaceType());
-  accessorImplCallExpr->setThrows(false);
+  accessorImplCallExpr->setThrows(nullptr);
   return accessorImplCallExpr;
 }
 
@@ -348,7 +348,7 @@ synthesizeConstantGetterBody(AbstractFunctionDecl *afd, void *voidContext) {
     initTy = initTy->castTo<FunctionType>()->getResult();
     auto initRef = DotSyntaxCallExpr::create(
         ctx, declRef, SourceLoc(), Argument::unlabeled(typeRef), initTy);
-    initRef->setThrows(false);
+    initRef->setThrows(nullptr);
 
     // (rawValue: T) -> ...
     initTy = initTy->castTo<FunctionType>()->getResult();
@@ -356,7 +356,7 @@ synthesizeConstantGetterBody(AbstractFunctionDecl *afd, void *voidContext) {
     auto *argList = ArgumentList::forImplicitSingle(ctx, ctx.Id_rawValue, expr);
     auto initCall = CallExpr::createImplicit(ctx, initRef, argList);
     initCall->setType(initTy);
-    initCall->setThrows(false);
+    initCall->setThrows(nullptr);
 
     expr = initCall;
 
@@ -467,7 +467,7 @@ synthesizeStructDefaultConstructorBody(AbstractFunctionDecl *afd,
 
   auto call = CallExpr::createImplicitEmpty(ctx, zeroInitializerRef);
   call->setType(selfType);
-  call->setThrows(false);
+  call->setThrows(nullptr);
 
   auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), call, /*implicit*/ true);
   assign->setType(emptyTuple);
@@ -852,7 +852,7 @@ synthesizeUnionFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
   auto reinterpreted =
       CallExpr::createImplicit(ctx, reinterpretCastRefExpr, argList);
   reinterpreted->setType(importedFieldDecl->getInterfaceType());
-  reinterpreted->setThrows(false);
+  reinterpreted->setThrows(nullptr);
   auto ret = new (ctx) ReturnStmt(SourceLoc(), reinterpreted);
   auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
                                 /*implicit*/ true);
@@ -897,7 +897,7 @@ synthesizeUnionFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
   auto selfPointer =
       CallExpr::createImplicit(ctx, addressofFnRefExpr, selfPtrArgs);
   selfPointer->setType(ctx.TheRawPointerType);
-  selfPointer->setThrows(false);
+  selfPointer->setThrows(nullptr);
 
   auto initializeFn =
       cast<FuncDecl>(getBuiltinValueDecl(ctx, ctx.getIdentifier("initialize")));
@@ -919,7 +919,7 @@ synthesizeUnionFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
   auto initialize =
       CallExpr::createImplicit(ctx, initializeFnRefExpr, initArgs);
   initialize->setType(TupleType::getEmpty(ctx));
-  initialize->setThrows(false);
+  initialize->setThrows(nullptr);
 
   auto body = BraceStmt::create(ctx, SourceLoc(), {initialize}, SourceLoc(),
                                 /*implicit*/ true);
@@ -1237,7 +1237,7 @@ synthesizeEnumRawValueConstructorBody(AbstractFunctionDecl *afd,
   auto reinterpreted =
       CallExpr::createImplicit(ctx, reinterpretCastRef, argList);
   reinterpreted->setType(enumTy);
-  reinterpreted->setThrows(false);
+  reinterpreted->setThrows(nullptr);
 
   auto assign = new (ctx) AssignExpr(selfRef, SourceLoc(), reinterpreted,
                                      /*implicit*/ true);
@@ -1309,7 +1309,7 @@ synthesizeEnumRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
   auto reinterpreted =
       CallExpr::createImplicit(ctx, reinterpretCastRef, argList);
   reinterpreted->setType(rawTy);
-  reinterpreted->setThrows(false);
+  reinterpreted->setThrows(nullptr);
 
   auto ret = new (ctx) ReturnStmt(SourceLoc(), reinterpreted);
   auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
@@ -1892,12 +1892,12 @@ synthesizeOperatorMethodBody(AbstractFunctionDecl *afd, void *context) {
   auto dotCallExpr =
       DotSyntaxCallExpr::create(ctx, methodExpr, SourceLoc(), baseArg);
   dotCallExpr->setType(methodDecl->getMethodInterfaceType());
-  dotCallExpr->setThrows(false);
+  dotCallExpr->setThrows(nullptr);
 
   auto *argList = ArgumentList::createImplicit(ctx, forwardingArgs);
   auto callExpr = CallExpr::createImplicit(ctx, dotCallExpr, argList);
   callExpr->setType(funcDecl->getResultInterfaceType());
-  callExpr->setThrows(false);
+  callExpr->setThrows(nullptr);
 
   auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), callExpr,
                                          /*implicit*/ true);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8911,7 +8911,14 @@ static Expr *wrapAsyncLetInitializer(
   // actual calls and translate them into a different mechanism.
   auto autoclosureCall = CallExpr::createImplicitEmpty(ctx, autoclosureExpr);
   autoclosureCall->setType(initializerType);
-  autoclosureCall->setThrows(throws);
+  // FIXME: Use thrown type from above.
+  if (throws) {
+    autoclosureCall->setThrows(
+        ThrownErrorDestination::forMatchingContextType(
+          ctx.getErrorExistentialType()));
+  } else {
+    autoclosureCall->setThrows(nullptr);
+  }
 
   // For a throwing expression, wrap the call in a 'try'.
   Expr *resultInit = autoclosureCall;

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -333,7 +333,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
     auto *makeInvocationArgs = ArgumentList::createImplicit(C, {});
     auto makeInvocationCallExpr =
         CallExpr::createImplicit(C, makeInvocationExpr, makeInvocationArgs);
-    makeInvocationCallExpr->setThrows(false);
+    makeInvocationCallExpr->setThrows(nullptr);
 
     auto invocationEncoderPB = PatternBindingDecl::createImplicit(
         C, StaticSpellingKind::None, invocationPattern, makeInvocationCallExpr,

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -253,7 +253,7 @@ private:
 
     auto *POArgList = ArgumentList::forImplicitUnlabeled(Ctx, {DstRef});
     auto *POCall = CallExpr::createImplicit(Ctx, PODeclRef, POArgList);
-    POCall->setThrows(false);
+    POCall->setThrows(nullptr);
 
     // Create the call to checkExpect.
     UnresolvedDeclRefExpr *CheckExpectDRE = new (Ctx)
@@ -263,7 +263,7 @@ private:
         ArgumentList::forImplicitUnlabeled(Ctx, {Varname, POCall});
     auto *CheckExpectExpr =
         CallExpr::createImplicit(Ctx, CheckExpectDRE, CheckArgList);
-    CheckExpectExpr->setThrows(false);
+    CheckExpectExpr->setThrows(nullptr);
 
     // Create the closure.
     auto *Params = ParameterList::createEmpty(Ctx);
@@ -283,7 +283,7 @@ private:
 
     // Call the closure.
     auto *ClosureCall = CallExpr::createImplicitEmpty(Ctx, Closure);
-    ClosureCall->setThrows(false);
+    ClosureCall->setThrows(nullptr);
 
     // TODO: typeCheckExpression() seems to assign types to everything here,
     // but may not be sufficient in some cases.

--- a/lib/Sema/DerivedConformanceActor.cpp
+++ b/lib/Sema/DerivedConformanceActor.cpp
@@ -73,14 +73,14 @@ static Expr *constructUnownedSerialExecutor(ASTContext &ctx,
     auto selfApply = ConstructorRefCallExpr::create(ctx, initRef, metatypeRef,
                                                     ctorAppliedType);
     selfApply->setImplicit(true);
-    selfApply->setThrows(false);
+    selfApply->setThrows(nullptr);
 
     // Call the constructor, building an expression of type
     // UnownedSerialExecutor.
     auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {arg});
     auto call = CallExpr::createImplicit(ctx, selfApply, argList);
     call->setType(executorType);
-    call->setThrows(false);
+    call->setThrows(nullptr);
     return call;
   }
 

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -619,14 +619,14 @@ static Expr *constructDistributedUnownedSerialExecutor(ASTContext &ctx,
     auto selfApply = ConstructorRefCallExpr::create(ctx, initRef, metatypeRef,
                                                     ctorAppliedType);
     selfApply->setImplicit(true);
-    selfApply->setThrows(false);
+    selfApply->setThrows(nullptr);
 
     // Call the constructor, building an expression of type
     // UnownedSerialExecutor.
     auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {arg});
     auto call = CallExpr::createImplicit(ctx, selfApply, argList);
     call->setType(executorType);
-    call->setThrows(false);
+    call->setThrows(nullptr);
     return call;
   }
 
@@ -685,7 +685,7 @@ deriveBodyDistributedActor_unownedExecutor(AbstractFunctionDecl *getter, void *)
                                       ErasureExpr::create(ctx, selfForIsLocalArg, ctx.getAnyObjectType(), {}, {}));
   CallExpr *isLocalActorCall = CallExpr::createImplicit(ctx, isLocalActorExpr, argListForIsLocal);
   isLocalActorCall->setType(ctx.getBoolType());
-  isLocalActorCall->setThrows(false);
+  isLocalActorCall->setThrows(nullptr);
 
   GuardStmt* guardElseRemoteReturnExec;
   {
@@ -724,7 +724,7 @@ deriveBodyDistributedActor_unownedExecutor(AbstractFunctionDecl *getter, void *)
     CallExpr *buildRemoteExecutorCall = CallExpr::createImplicit(ctx, buildRemoteExecutorExpr,
                                                                  argListForBuildRemoteExecutor);
     buildRemoteExecutorCall->setType(ctx.getUnownedSerialExecutorType());
-    buildRemoteExecutorCall->setThrows(false);
+    buildRemoteExecutorCall->setThrows(nullptr);
 
     SmallVector<ASTNode, 1> statements = {
         new(ctx) ReturnStmt(SourceLoc(), buildRemoteExecutorCall)

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -132,7 +132,7 @@ deriveBodyEquatable_enum_noAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
     auto *callExpr = DotSyntaxCallExpr::create(
         C, ref, SourceLoc(), Argument::unlabeled(base), fnType);
     callExpr->setImplicit();
-    callExpr->setThrows(false);
+    callExpr->setThrows(nullptr);
     cmpFuncExpr = callExpr;
   } else {
     cmpFuncExpr = new (C) DeclRefExpr(cmpFunc, DeclNameLoc(),
@@ -144,7 +144,7 @@ deriveBodyEquatable_enum_noAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
   auto *cmpExpr =
       BinaryExpr::create(C, aIndex, cmpFuncExpr, bIndex, /*implicit*/ true,
                          fnType->castTo<FunctionType>()->getResult());
-  cmpExpr->setThrows(false);
+  cmpExpr->setThrows(nullptr);
   statements.push_back(new (C) ReturnStmt(SourceLoc(), cmpExpr));
 
   BraceStmt *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());
@@ -859,7 +859,7 @@ deriveBodyHashable_hashValue(AbstractFunctionDecl *hashValueDecl, void *) {
   auto *argList = ArgumentList::forImplicitSingle(C, C.Id_for, selfRef);
   auto *callExpr = CallExpr::createImplicit(C, hashExpr, argList);
   callExpr->setType(hashFuncResultType);
-  callExpr->setThrows(false);
+  callExpr->setThrows(nullptr);
 
   auto returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr);
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -488,7 +488,7 @@ DerivedConformance::createBuiltinCall(ASTContext &ctx,
   auto *argList = ArgumentList::forImplicitUnlabeled(ctx, args);
   auto *call = CallExpr::createImplicit(ctx, ref, argList);
   call->setType(resultType);
-  call->setThrows(false);
+  call->setThrows(nullptr);
 
   return call;
 }
@@ -502,7 +502,7 @@ CallExpr *DerivedConformance::createDiagnoseUnavailableCodeReachedCallExpr(
   auto argList = ArgumentList::createImplicit(ctx, {});
   auto callExpr = CallExpr::createImplicit(ctx, diagnoseDeclRefExpr, argList);
   callExpr->setType(ctx.getNeverType());
-  callExpr->setThrows(false);
+  callExpr->setThrows(nullptr);
   return callExpr;
 }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1354,7 +1354,7 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
                                         Argument::unlabeled(Val));
   DSCE->setImplicit();
   DSCE->setType(copyMethodType);
-  DSCE->setThrows(false);
+  DSCE->setThrows(nullptr);
 
   Expr *Nil = new (Ctx) NilLiteralExpr(SourceLoc(), /*implicit*/true);
   Nil->setType(copyMethodType->getParams()[0].getParameterType());
@@ -1363,7 +1363,7 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
       ArgumentList::forImplicitCallTo(copyMethod->getParameters(), {Nil}, Ctx);
   auto *Call = CallExpr::createImplicit(Ctx, DSCE, argList);
   Call->setType(copyMethodType->getResult());
-  Call->setThrows(false);
+  Call->setThrows(nullptr);
 
   // If we're working with non-optional types, we're forcing the cast.
   if (!isOptional) {
@@ -1849,7 +1849,7 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
       if (auto funcType = type->getAs<FunctionType>())
         type = funcType->getResult();
       DSCE->setType(type);
-      DSCE->setThrows(false);
+      DSCE->setThrows(nullptr);
       Callee = DSCE;
     }
 
@@ -1864,7 +1864,7 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
     if (auto funcType = type->getAs<FunctionType>())
       type = funcType->getResult();
     Call->setType(type);
-    Call->setThrows(false);
+    Call->setThrows(nullptr);
 
     SetterBody.push_back(Call);
   };
@@ -2032,7 +2032,7 @@ synthesizeModifyCoroutineBodyWithSimpleDidSet(AccessorDecl *accessor,
       if (auto funcType = type->getAs<FunctionType>())
         type = funcType->getResult();
       DSCE->setType(type);
-      DSCE->setThrows(false);
+      DSCE->setThrows(nullptr);
       Callee = DSCE;
     }
 
@@ -2040,7 +2040,7 @@ synthesizeModifyCoroutineBodyWithSimpleDidSet(AccessorDecl *accessor,
     if (auto funcType = type->getAs<FunctionType>())
       type = funcType->getResult();
     Call->setType(type);
-    Call->setThrows(false);
+    Call->setThrows(nullptr);
 
     body.push_back(Call);
   };

--- a/test/stmt/typed_throws_ast.swift
+++ b/test/stmt/typed_throws_ast.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -enable-experimental-feature TypedThrows %s -dump-ast | %FileCheck %s
+
+enum MyError: Error {
+case failed
+case epicFailed
+}
+
+enum HomeworkError: Error {
+case dogAteIt
+case forgot
+}
+
+var homework: String {
+  get throws(HomeworkError) {
+    throw .dogAteIt
+  }
+}
+
+func printOrFail(_ message: String) throws(MyError) {
+}
+
+// CHECK-LABEL: func_decl{{.*}}"throwsAnything()"
+func throwsAnything() throws {
+  // CHECK: do_catch_stmt{{.*}}throws
+  do {
+    // CHECK: declref_expr{{.*}}throws(HomeworkError to any Error)
+    let hw = try homework
+    // CHECK: call_expr{{.*}}throws(MyError to any Error)
+    try printOrFail(hw)
+  } catch let e as HomeworkError {
+    // swallow this error
+    _ = e
+  } // implicit rethrow
+}


### PR DESCRIPTION
For any operation that can throw an error, such as calls, property accesses, and non-exhaustive do..catch statements, record the thrown error type along with the conversion from that thrown error to the error type expected in context, as appropriate. This will prevent later stages from having to re-compute the conversion sequences.
