### PR TITLE
[test] Adjust extern_c_abitypes.swift to accept armv7k struct layout

### DIFF
--- a/test/IRGen/extern_c_abitypes.swift
+++ b/test/IRGen/extern_c_abitypes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -emit-ir -enable-experimental-feature Extern %t/extern_c.swift -I%t | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-experimental-feature Extern %t/extern_c.swift -I%t | %FileCheck %s --check-prefixes CHECK,CHECK-%target-cpu
 
 //--- c_abi_types.h
 #include <stdbool.h>
@@ -99,8 +99,14 @@ func test() {
 
   // assume %struct.c_struct and %TSo8c_structV have compatible layout
   //
-  // CHECK: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
-  // CHECK: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
+  // CHECK-x86_64: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-x86_64: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
+  // CHECK-arm64:  call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-arm64:  call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
+  // CHECK-wasm32: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-wasm32: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
+  // CHECK-armv7k: call [3 x i32]     @c_roundtrip_c_struct([3 x i32] {{.*}})
+  // CHECK-armv7k: call [3 x i32] @swift_roundtrip_c_struct([3 x i32] {{.*}})
   var c_struct_val = c_struct(foo: 496, bar: 28, baz: 8)
   _ = c_roundtrip_c_struct(c_struct_val)
   _ = swift_roundtrip_c_struct(c_struct_val)


### PR DESCRIPTION
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/4712/

Resolve rdar://117418785

```
/Users/ec2-user/jenkins/workspace/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/swift/test/IRGen/extern_c_abitypes.swift:102:12: error: CHECK: expected string not found in input
 // CHECK: call void @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
           ^
<stdin>:112:52: note: scanning from here
 %26 = call ptr @swift_roundtrip_void_star(ptr %25)
```

Actual IR was 
```llvm
  store i8 %30, ptr %coerced-arg.coerced.baz._value, align 4
  %31 = load [3 x i32], ptr %coerced-arg.coerced, align 4
  call void @llvm.lifetime.end.p0(i64 96, ptr %coerced-arg.coerced)
  %32 = call [3 x i32] @c_roundtrip_c_struct([3 x i32] %31)
```