### PR TITLE
Thrown types use "convertible to any Error" instead of "conforms to Error"

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2639,11 +2639,11 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
     Type thrownTy = AFD->getThrownInterfaceType();
     if (thrownTy) {
       thrownTy = AFD->getThrownInterfaceType();
-      ProtocolDecl *errorProto = Context.getErrorDecl();
-      if (thrownTy && errorProto) {
+      auto anyErrorType = Context.getErrorExistentialType();
+      if (thrownTy && anyErrorType) {
         Type thrownTyInContext = AFD->mapTypeIntoContext(thrownTy);
-        if (!TypeChecker::conformsToProtocol(
-                thrownTyInContext, errorProto, AFD->getParentModule())) {
+        if (!TypeChecker::isConvertibleTo(
+                thrownTyInContext, anyErrorType, AFD)) {
           SourceLoc loc;
           if (auto thrownTypeRepr = AFD->getThrownTypeRepr())
             loc = thrownTypeRepr->getLoc();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3712,9 +3712,9 @@ NeverNullType TypeResolver::resolveASTFunctionType(
       thrownTy = Type();
     } else if (!options.contains(TypeResolutionFlags::SilenceErrors) &&
                !thrownTy->hasTypeParameter() &&
-               !TypeChecker::conformsToProtocol(
-                  thrownTy, ctx.getErrorDecl(),
-                  resolution.getDeclContext()->getParentModule())) {
+               !TypeChecker::isConvertibleTo(
+                   thrownTy, ctx.getErrorExistentialType(),
+                  resolution.getDeclContext())) {
       diagnoseInvalid(
           thrownTypeRepr, thrownTypeRepr->getLoc(), diag::thrown_type_not_error,
           thrownTy);

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -123,3 +123,5 @@ struct HasASubscript {
     }
   }
 }
+
+func throwCodableErrors() throws(any Codable & Error) { }


### PR DESCRIPTION
Allow one to throw a type that is convertible to `any Error` even if it doesn't conform to the `Error` protocol, e.g., an existential type like `any Codable & Error`.
