### PR TITLE
[region-isolation] Fix actor region propagation and some other smaller issues.

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -171,21 +171,22 @@ public:
   void print(llvm::raw_ostream &os) const {
     switch (OpKind) {
     case PartitionOpKind::Assign:
-      os << "assign %%" << OpArgs[0] << " = %%" << OpArgs[1] << "\n";
+      os << "assign %%" << OpArgs[0] << " = %%" << OpArgs[1];
       break;
     case PartitionOpKind::AssignFresh:
-      os << "assign_fresh %%" << OpArgs[0] << "\n";
+      os << "assign_fresh %%" << OpArgs[0];
       break;
     case PartitionOpKind::Transfer:
-      os << "transfer %%" << OpArgs[0] << "\n";
+      os << "transfer %%" << OpArgs[0];
       break;
     case PartitionOpKind::Merge:
-      os << "merge %%" << OpArgs[0] << " with %%" << OpArgs[1] << "\n";
+      os << "merge %%" << OpArgs[0] << " with %%" << OpArgs[1];
       break;
     case PartitionOpKind::Require:
-      os << "require %%" << OpArgs[0] << "\n";
+      os << "require %%" << OpArgs[0];
       break;
     }
+    os << ": " << *getSourceInst(true);
   }
 };
 

--- a/test/Concurrency/sendnonsendable_basic.swift
+++ b/test/Concurrency/sendnonsendable_basic.swift
@@ -1,5 +1,11 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature SendNonSendable -disable-availability-checking -verify -verify-additional-prefix sns-  %s -o /dev/null
+
+// This run validates that for specific test cases around closures, we properly
+// emit errors in the type checker before we run sns. This ensures that we know that
+// these cases can't happen when SNS is enabled.
+//
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature SendNonSendable -disable-availability-checking -verify -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -10,11 +16,14 @@
 
 /// Classes are always non-sendable, so this is non-sendable
 class NonSendableKlass { // expected-complete-note 9{{}}
+  var field: NonSendableKlass? = nil
+
   func asyncCall() async {}
 }
 
 actor Actor {
   var klass = NonSendableKlass()
+  // expected-typechecker-only-note @-1 7{{property declared here}}
   final var finalKlass = NonSendableKlass()
 
   func useKlass(_ x: NonSendableKlass) {}
@@ -28,6 +37,10 @@ final actor FinalActor {
 func useInOut<T>(_ x: inout T) {}
 func useValue<T>(_ x: T) {}
 
+@MainActor func transferToMain<T>(_ t: T) async {}
+
+var booleanFlag: Bool { false }
+
 ////////////////////////////
 // MARK: Actor Self Tests //
 ////////////////////////////
@@ -40,7 +53,8 @@ extension Actor {
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
-    await self.finalKlass.asyncCall() // expected-warning {{}}
+    await self.finalKlass.asyncCall() // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
   }
 
   // We do not warn on this since we warn in the caller of our getter instead.
@@ -52,7 +66,8 @@ extension Actor {
 extension FinalActor {
   func warningIfCallingAsyncOnFinalField() async {
     // Since our whole class is final, we emit the error directly here.
-    await self.klass.asyncCall() // expected-warning {{}}
+    await self.klass.asyncCall() // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
   }
 }
 
@@ -130,3 +145,317 @@ func closureNonInOut(_ a: Actor) async {
   closure() // expected-sns-note {{access here could race}}
 }
 
+func transferNonIsolatedNonAsyncClosureTwice() async {
+  let a = Actor()
+
+  // This is non-isolated and non-async... we can transfer it safely.
+  var actorCaptureClosure = { print(a) }
+  await transferToMain(actorCaptureClosure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  actorCaptureClosure = { print(a) }
+  await transferToMain(actorCaptureClosure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+extension Actor {
+  // Simple just capture self and access field.
+  func simpleClosureCaptureSelfAndTransfer() async {
+    let closure: () -> () = {
+      print(self.klass)
+    }
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  func simpleClosureCaptureSelfAndTransferThroughTuple() async {
+    let closure: () -> () = {
+      print(self.klass)
+    }
+    let x = (closure, 1)
+    await transferToMain(x) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '(() -> (), Int)' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  func simpleClosureCaptureSelfAndTransferThroughOptional() async {
+    let closure: () -> () = {
+      print(self.klass)
+    }
+    let x: Any? = (1, closure)
+    await transferToMain(x) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
+  }
+
+  func simpleClosureCaptureSelfAndTransferThroughOptionalBackwards() async {
+    let closure: () -> () = {
+      print(self.klass)
+    }
+    // In contrast to the tuple backwards case, we do error here since the value
+    // we are forming is an Any?  so we actually form the tuple as an object and
+    // store it all as once.
+    let x: Any? = (closure, 1)
+    await transferToMain(x) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
+  }
+
+  func simpleClosureCaptureSelfWithReinit() async {
+    var closure: () -> () = {
+      print(self.klass)
+    }
+
+    // Error here.
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+    closure = {}
+
+    // But not here.
+    await transferToMain(closure)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  func simpleClosureCaptureSelfWithReinit2() async {
+    var closure: () -> () = {}
+
+    // No error here.
+    await transferToMain(closure)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+    closure = {
+      print(self.klass)
+    }
+
+    // Error here.
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  func simpleClosureCaptureSelfWithReinit3() async {
+    var closure: () -> () = {}
+
+    // We get a transfer after use error.
+    await transferToMain(closure) // expected-sns-warning {{passing argument of non-sendable type '() -> ()' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+    if await booleanFlag {
+      closure = {
+        print(self.klass)
+      }
+    }
+
+    // We emit the first error that we see. So we do not emit the self error.
+    await transferToMain(closure) // expected-sns-note {{access here could race}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  // In this case, we reinit along both paths, but only one has an actor derived
+  // thing.
+  func simpleClosureCaptureSelfWithReinit4() async {
+    var closure: () -> () = {}
+
+    await transferToMain(closure)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+    if await booleanFlag {
+      closure = {
+        print(self.klass)
+      }
+    } else {
+      closure = {}
+    }
+
+    // TODO: We do not error here yet since we are performing the control flow
+    // union incorrectly.
+    await transferToMain(closure)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  #if TYPECHECKER_ONLY
+
+  func simpleClosureCaptureSelfThroughTupleWithFieldAccess() async {
+    // In this case, we erase that we accessed self so we hit a type checker
+    // error. We could make this a SNS error, but since in the other cases where
+    // we have a non-isolated non-async we are probably going to change it to be
+    // async as well making these errors go away.
+    let x = (self, 1)
+    let closure: () -> () = {
+      print(x.0.klass) // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+    }
+    await transferToMain(closure)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  #endif
+
+  func simpleClosureCaptureSelfThroughTuple() async {
+    let x = (self, self.klass)
+    let closure: () -> () = {
+      print(x.1)
+    }
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  func simpleClosureCaptureSelfThroughTuple2() async {
+    let x = (2, self.klass)
+    let closure: () -> () = {
+      print(x.1)
+    }
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  func simpleClosureCaptureSelfThroughOptional() async {
+    let x: Any? = (2, self.klass)
+    let closure: () -> () = {
+      print(x as Any)
+    }
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+}
+
+func testSimpleLetClosureCaptureActor() async {
+  let a = Actor()
+  let closure = { print(a) }
+  await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+#if TYPECHECKER_ONLY
+
+func testSimpleLetClosureCaptureActorField() async {
+  let a = Actor()
+  let closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleLetClosureCaptureActorFieldThroughTuple() async {
+  let a = (Actor(), 0)
+  let closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleLetClosureCaptureActorFieldThroughOptional() async {
+  let a: Actor? = Actor()
+  let closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+#endif
+
+func testSimpleVarClosureCaptureActor() async {
+  let a = Actor()
+  var closure = {}
+  closure = { print(a) }
+  await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+#if TYPECHECKER_ONLY
+
+func testSimpleVarClosureCaptureActorField() async {
+  let a = Actor()
+  var closure = {}
+  closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleVarClosureCaptureActorFieldThroughTuple() async {
+  let a = (Actor(), 0)
+  var closure = {}
+  closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+func testSimpleVarClosureCaptureActorFieldThroughOptional() async {
+  let a: Actor? = Actor()
+  var closure = {}
+  closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a non-isolated context}}
+  await transferToMain(closure)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+}
+
+#endif
+
+extension Actor {
+  // Make sure that we properly propagate actor derived from klass into field's
+  // value.
+  func simplePropagateNonSendableThroughMultipleProperty() async {
+    let f = self.klass.field!
+    let closure: () -> () = {
+      print(f)
+    }
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+
+  // Make sure that we properly propagate actor derived from klass into field's
+  // value.
+  func simplePropagateNonSendableThroughMultipleProperty2() async {
+    let f = self.klass.field!
+    let closure: () -> () = {
+      print(f.field!)
+    }
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
+}
+
+extension Actor {
+  func testVarReassignStopActorDerived() async {
+    var closure: () -> () = {
+      print(self)
+    }
+
+    // This should error.
+    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+    // This doesnt since we re-assign
+    closure = {}
+    await transferToMain(closure)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+    // This re-assignment shouldn't error.
+    closure = {}
+    await transferToMain(closure)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+    // But this will error since we race.
+    closure()
+  }
+}

--- a/test/Concurrency/sendnonsendable_region_based_sendability.swift
+++ b/test/Concurrency/sendnonsendable_region_based_sendability.swift
@@ -357,8 +357,12 @@ actor A_Sendable {
         // This is not a cross-isolation call, so it should be permitted
         foo_noniso(captures_self)
 
-        // This is a cross-isolation, but self is Sendable, so it should be permitted
-        await a.foo(captures_self)
+        // This is a cross-isolation call passing a call that should be treated
+        // as isolated to self since it captures self which is isolated to our
+        // actor and is non-Sendable. For now, we ban this since we do not
+        // support the ability to dynamically invoke the synchronous closure on
+        // the specific actor.
+        await a.foo(captures_self) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
         // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }


### PR DESCRIPTION
This PR contains a few different changes:

1. It teaches the pass how to handle actor regions. Put simply, we in a flow insensitive way identify if specific values are isolated to an actor and then if a region contains any value with an actor isolated value, then the whole region must be actor isolated. Thus we can take advantage of the region dataflow to make our flow insensitive constraint flow sensitive.
2. A hack was added some time ago that made it so that if an address was passed to any address, then we needed to make it so that assignments were actually merges (meaning that later assignments would not erase the old region a value belonged to). This should only semantically happen with partial_apply. As far as the codegen of the compiler is concerned, I was unable to come up with a case where the unnecessary merges were harmful. I could construct something with SIL but unfortunately we can't write SIL test cases yet with this pass.... = /.
3. I noticed that the whole cache vector of argument IDs for function arguments was only used to construct a Partition for the entry block. Rather than having this extra concept, I changed the function arguments to just initialize directly the partition... eliminating code.
4. I noticed that we were not properly handling begin_access. Specifically, begin_access was being treated as an assignment. That means that if one were to transfer a var and then attempt to reinitialize the var, the begin_access of the reinitialization would be considered a use of the transferred value and we would emit an error... which is incorrect. Instead, we just look through begin_access.
5. The pass as originally written is a pass that does a bunch of work deep in the callstack that doesn't need to be done so deep. By making it so deep, it obscures what the pass is actually trying to do. An example of this is that before this PR, we initialized a block's contained pseudo-IR lazily when we were performing dataflow. This is not necessary and makes it non-obvious where the block's translation is happening. Instead we just perform it for all blocks when we construct their state and before we perform the dataflow. As a bonus, this makes the logging easier to understand since we first translate all blocks to the pseudo-ir and then perform the dataflow instead of interleaving the two.

That being said, I found a few bugs in the process that I filed radars for that I will fix in subsequent PRs. I added tests for all of them into this PR with TODOs.

1. I discovered that in certain cases, I can get SILGen to initialize aggregate values separately in pieces. If a later value is a Sendable type that is fresh, we lose the original region of the value. This can cause us to swallow diagnostics. The solution is to make it so that if we are assigning into only one part of an aggregate, we merge into the region so we don't forget the original region. rdar://117273952
2. I discovered that when one returns a non-Sendable value, if we were going to emit an error on the return (since the return would be a use after a transfer lets say), then we do not have an expression associated with the value so we crash. This is why we really should be using SILLocations instead so we get proper diagnostics. rdar://117438350
3. I discovered that we are not properly performing a union operation when combining regions from different blocks. rdar://117437059.