### PR TITLE
SILGen fixes for -experimental-skip-non-exportable-decls

### DIFF
--- a/include/swift/AST/DeclExportabilityVisitor.h
+++ b/include/swift/AST/DeclExportabilityVisitor.h
@@ -127,7 +127,7 @@ public:
 #define DEFAULT_TO_ACCESS_LEVEL(KIND)                                          \
   bool visit##KIND##Decl(const KIND##Decl *D) {                                \
     static_assert(std::is_convertible<KIND##Decl *, ValueDecl *>::value,       \
-                  "##KIND##Decl must be a ValueDecl");                         \
+                  #KIND "Decl must be a ValueDecl");                           \
     return false;                                                              \
   }
   DEFAULT_TO_ACCESS_LEVEL(NominalType);
@@ -145,12 +145,11 @@ public:
   // exportability queries.
 #define UNREACHABLE(KIND)                                                      \
   bool visit##KIND##Decl(const KIND##Decl *D) {                                \
-    llvm_unreachable("unexpected decl kind");                                  \
+    llvm_unreachable("unexpected " #KIND "Decl");                              \
     return true;                                                               \
   }
   UNREACHABLE(Module);
   UNREACHABLE(TopLevelCode);
-  UNREACHABLE(Import);
   UNREACHABLE(PoundDiagnostic);
   UNREACHABLE(Missing);
   UNREACHABLE(MissingMember);
@@ -169,6 +168,7 @@ public:
 #define UNINTERESTING(KIND)                                                    \
   bool visit##KIND##Decl(const KIND##Decl *D) { return true; }
   UNINTERESTING(IfConfig);
+  UNINTERESTING(Import);
   UNINTERESTING(PrecedenceGroup);
   UNINTERESTING(EnumCase);
   UNINTERESTING(Operator);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -322,8 +322,6 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.SkipNonExportableDecls |=
       Args.hasArg(OPT_experimental_skip_non_exportable_decls);
-  // FIXME: Remove this with rdar://117020997
-  Opts.SkipNonExportableDecls |= Args.hasArg(OPT_experimental_lazy_typecheck);
   Opts.DebugPrefixSerializedDebuggingOptions |=
       Args.hasArg(OPT_prefix_serialized_debugging_options);
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -801,11 +801,28 @@ bool SILGenModule::shouldSkipDecl(Decl *D) {
   if (!D->isAvailableDuringLowering())
     return true;
 
-  if (getASTContext().SILOpts.SkipNonExportableDecls &&
-      !D->isExposedToClients())
-    return true;
+  if (!getASTContext().SILOpts.SkipNonExportableDecls)
+    return false;
 
-  return false;
+  if (auto *afd = dyn_cast<AbstractFunctionDecl>(D)) {
+    do {
+      if (afd->isExposedToClients())
+        return false;
+
+      // If this function is nested within another function that is exposed to
+      // clients then it should be emitted.
+      auto dc = afd->getDeclContext()->getAsDecl();
+      afd = dc ? dyn_cast<AbstractFunctionDecl>(dc) : nullptr;
+    } while (afd);
+
+    // We didn't find a parent function that is exposed.
+    return true;
+  }
+
+  if (D->isExposedToClients())
+    return false;
+
+  return true;
 }
 
 void SILGenModule::visit(Decl *D) {

--- a/test/SILGen/skip-non-exportable-decls.swift
+++ b/test/SILGen/skip-non-exportable-decls.swift
@@ -2,6 +2,8 @@
 // RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -module-name Test | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-SKIP
 // RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -module-name Test -experimental-skip-non-exportable-decls | %FileCheck %s --check-prefixes=CHECK,CHECK-SKIP
 
+import Swift
+
 // CHECK-NO-SKIP: sil private{{.*}} @$s4Test11privateFunc33_E3F0E1C7B46D05C8067CB98677DE566CLLyyF : $@convention(thin) () -> () {
 // CHECK-SKIP-NOT: s4Test11privateFunc33_E3F0E1C7B46D05C8067CB98677DE566CLLyyF
 private func privateFunc() {}

--- a/test/SILGen/skip-non-exportable-decls.swift
+++ b/test/SILGen/skip-non-exportable-decls.swift
@@ -12,8 +12,38 @@ private func privateFunc() {}
 // CHECK-SKIP-NOT: s4Test12internalFuncyyF
 internal func internalFunc() {}
 
+// CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test022internalFuncWithNestedC0yyF : $@convention(thin) () -> () {
+// CHECK-SKIP-NOT: s4Test022internalFuncWithNestedC0yyF
+internal func internalFuncWithNestedFunc() {
+  func nested() {}
+  nested()
+}
+// CHECK-NO-SKIP: sil private{{.*}} @$s4Test022internalFuncWithNestedC0yyF6nestedL_yyF : $@convention(thin) () -> () {
+// CHECK-SKIP-NOT: s4Test022internalFuncWithNestedC0yyF6nestedL_yyF
+
 // CHECK: sil{{.*}} @$s4Test10publicFuncyyF : $@convention(thin) () -> () {
 public func publicFunc() {}
+
+// CHECK: sil{{.*}} @$s4Test25publicFuncWithNestedFuncsyyF : $@convention(thin) () -> () {
+public func publicFuncWithNestedFuncs() {
+  defer { publicFunc() }
+  func nested() {}
+  nested()
+}
+// CHECK: sil private{{.*}} @$s4Test25publicFuncWithNestedFuncsyyF6$deferL_yyF : $@convention(thin) () -> () {
+// CHECK: sil private{{.*}} @$s4Test25publicFuncWithNestedFuncsyyF6nestedL_yyF : $@convention(thin) () -> () {
+
+// CHECK: sil [serialized]{{.*}} @$s4Test13inlinableFuncyyF : $@convention(thin) () -> () {
+@inlinable internal func inlinableFunc() {}
+
+// CHECK: sil [serialized]{{.*}} @$s4Test023inlinableFuncWithNestedC0yyF : $@convention(thin) () -> () {
+@inlinable internal func inlinableFuncWithNestedFunc() {
+  defer { publicFunc() }
+  func nested() {}
+  nested()
+}
+// CHECK: sil shared [serialized]{{.*}} @$s4Test023inlinableFuncWithNestedC0yyF6$deferL_yyF : $@convention(thin) () -> () {
+// CHECK: sil shared [serialized]{{.*}} @$s4Test023inlinableFuncWithNestedC0yyF6nestedL_yyF : $@convention(thin) () -> () {
 
 private class PrivateClass {
   // CHECK-NO-SKIP: sil private{{.*}} @$s4Test12PrivateClass33_E3F0E1C7B46D05C8067CB98677DE566CLLCfd : $@convention(method) (@guaranteed PrivateClass) -> @owned Builtin.NativeObject {

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -2,10 +2,6 @@
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -enable-library-evolution -parse-as-library -package-name Package -DFLAG -typecheck -verify
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path %t/lazy_typecheck.swiftmodule -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
 
-// Verify the module also builds without -experimental-skip-non-exportable-decls
-// FIXME: Remove with rdar://117020997
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies
-
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t
 
 // FIXME: Re-run the test with -experimental-skip-non-inlinable-function-bodies


### PR DESCRIPTION
Various fixes for SILGen behavior when -experimental-skip-non-exportable-decls is specified. See commits for details.

Resolves rdar://117020997&117438934&117440503