### PR TITLE
FIx: typo in NameLookup.cpp

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3297,7 +3297,7 @@ createExtensionGenericParams(ASTContext &ctx,
 }
 
 /// If the extended type is a generic typealias whose underlying type is
-/// a tuple, the extension inherits the generic paramter list from the
+/// a tuple, the extension inherits the generic parameter list from the
 /// typealias.
 static GenericParamList *
 createTupleExtensionGenericParams(ASTContext &ctx,


### PR DESCRIPTION
Typo in NameLookup.cpp file:

paramter -> parameter