### PR TITLE
Fix typo in NameLookup.cpp from paramter to parameter

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3297,7 +3297,7 @@ createExtensionGenericParams(ASTContext &ctx,
 }
 
 /// If the extended type is a generic typealias whose underlying type is
-/// a tuple, the extension inherits the generic paramter list from the
+/// a tuple, the extension inherits the generic parameter list from the
 /// typealias.
 static GenericParamList *
 createTupleExtensionGenericParams(ASTContext &ctx,


### PR DESCRIPTION
<!-- What's in this pull request? -->
Typo in NameLookup.cpp file:

_paramter -> parameter_

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #69394

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
