### PR TITLE
[NoncopyableGenerics] provide stdlib build option

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -168,6 +168,10 @@ option(SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK
        "Should stdlib be built with -experimental-hermetic-seal-at-link"
        FALSE)
 
+option(SWIFT_STDLIB_EXPERIMENTAL_NONCOPYABLE_GENERICS
+      "Should stdlib be built with -experimental-feature NoncopyableGenerics"
+      FALSE)
+
 option(SWIFT_STDLIB_PASSTHROUGH_METADATA_ALLOCATOR
        "Build stdlib without a custom implementation of MetadataAllocator, relying on malloc+free instead."
        FALSE)

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -578,6 +578,10 @@ function(_compile_swift_files
     list(APPEND swift_flags "-experimental-hermetic-seal-at-link")
   endif()
 
+  if(SWIFT_STDLIB_EXPERIMENTAL_NONCOPYABLE_GENERICS)
+    list(APPEND swift_flags "-enable-experimental-feature" "NoncopyableGenerics")
+  endif()
+
   if (SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES)
     list(APPEND swift_flags "-Xfrontend" "-enable-relative-protocol-witness-tables")
     list(APPEND swift_flags "-Xfrontend" "-swift-async-frame-pointer=never")
@@ -1181,4 +1185,3 @@ function(_compile_swift_files
       LANGUAGE C
       OBJECT_DEPENDS "${source_files}")
 endfunction()
-

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -236,6 +236,7 @@ KNOWN_SETTINGS=(
     swift-stdlib-short-mangling-lookups           "1"               "whether to build stdlib with fast-path context descriptor lookups based on well-known short manglings"
     swift-stdlib-enable-vector-types              "1"               "whether to build stdlib with support for SIMD and vector types"
     swift-stdlib-experimental-hermetic-seal-at-link     "0"         "whether stdlib should be built with -experimental-hermetic-seal-at-link"
+    swift-stdlib-experimental-noncopyable-generics      "0"         "whether stdlib should be built with -enable-experimental-feature NoncopyableGenerics"
     swift-stdlib-disable-instantiation-caches     "0"               "whether to build stdlib with -disable-preallocated-instantiation-caches"
     swift-stdlib-has-type-printing                "1"               "whether stdlib should support printing user-friendly type name as strings at runtime"
     swift-stdlib-trap-function                    ""                "Name of function to call instead of emitting a trap instruction"
@@ -1851,6 +1852,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_STDLIB_HAS_TYPE_PRINTING:BOOL=$(true_false "${SWIFT_STDLIB_HAS_TYPE_PRINTING}")
                     -DSWIFT_STDLIB_TRAP_FUNCTION:STRING="${SWIFT_STDLIB_TRAP_FUNCTION}"
                     -DSWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK:BOOL=$(true_false "${SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK}")
+                    -DSWIFT_STDLIB_EXPERIMENTAL_NONCOPYABLE_GENERICS:BOOL=$(true_false "${SWIFT_STDLIB_EXPERIMENTAL_NONCOPYABLE_GENERICS}")
                     -DSWIFT_STDLIB_DISABLE_INSTANTIATION_CACHES:BOOL=$(true_false "${SWIFT_STDLIB_DISABLE_INSTANTIATION_CACHES}")
                     -DSWIFT_STDLIB_REFLECTION_METADATA:STRING="${SWIFT_STDLIB_REFLECTION_METADATA}"
                     -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING="${native_llvm_tools_path}"


### PR DESCRIPTION
This helps set the stage for getting the stdlib building correctly with `NoncopyableGenerics` enabled. Disabled by default for now so this is an NFC.

The new build-script flag is `--swift-stdlib-experimental-noncopyable-generics=1`