### PR TITLE
[ConstraintSystem] Initial rework of key path inference

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -678,8 +678,11 @@ ERROR(expr_swift_keypath_not_starting_with_type,none,
 ERROR(expr_swift_keypath_not_starting_with_dot,none,
       "a Swift key path with contextual root must begin with a leading dot",
       ())
-ERROR(expr_smart_keypath_value_covert_to_contextual_type,none,
+ERROR(expr_keypath_value_covert_to_contextual_type,none,
       "key path value type %0 cannot be converted to contextual type %1",
+      (Type, Type))
+ERROR(expr_keypath_type_covert_to_contextual_type,none,
+      "cannot convert key path type %0 to contextual type %1",
       (Type, Type))
 ERROR(expr_swift_keypath_empty, none,
       "key path must have at least one component", ())

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -620,10 +620,7 @@ private:
 
   void addLiteralRequirement(Constraint *literal);
 
-  void addDefault(Constraint *constraint) {
-    auto defaultTy = constraint->getSecondType();
-    Defaults.insert({defaultTy->getCanonicalType(), constraint});
-  }
+  void addDefault(Constraint *constraint);
 
   /// Check whether the given binding set covers any of the
   /// literal protocols associated with this type variable.

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -281,6 +281,9 @@ SIMPLE_LOCATOR_PATH_ELT(ThrownErrorType)
 /// A type coercion operand.
 SIMPLE_LOCATOR_PATH_ELT(CoercionOperand)
 
+/// A fallback type for some AST location (i.e. key path literal).
+SIMPLE_LOCATOR_PATH_ELT(FallbackType)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -339,6 +339,12 @@ enum TypeVariableOptions {
   TVO_PackExpansion = 0x40,
 };
 
+enum class KeyPathCapability : uint8_t {
+  ReadOnly,
+  Writable,
+  ReferenceWritable
+};
+
 /// The implementation object for a type variable used within the
 /// constraint-solving type checker.
 ///
@@ -5512,6 +5518,16 @@ public:
   /// 'Self' or 'Self'-rooted dependent member types in non-covariant position.
   bool isMemberAvailableOnExistential(Type baseTy,
                                       const ValueDecl *member) const;
+
+  /// Attempts to infer a capability of a key path (i.e. whether it
+  /// is read-only, writable, etc.) based on the referenced members.
+  ///
+  /// \param keyPathType The type variable that represents the key path literal.
+  ///
+  /// \returns Capability if key path is sufficiently resolved and None
+  /// otherwise.
+  llvm::Optional<KeyPathCapability>
+  inferKeyPathLiteralCapability(TypeVariableType *keyPathType);
 
   SWIFT_DEBUG_DUMP;
   SWIFT_DEBUG_DUMPER(dump(Expr *));

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5524,9 +5524,9 @@ public:
   ///
   /// \param keyPathType The type variable that represents the key path literal.
   ///
-  /// \returns Capability if key path is sufficiently resolved and None
-  /// otherwise.
-  llvm::Optional<KeyPathCapability>
+  /// \returns `bool` to indicate whether key path is valid or not,
+  /// and capability if it could be determined.
+  std::pair</*isValid=*/bool, llvm::Optional<KeyPathCapability>>
   inferKeyPathLiteralCapability(TypeVariableType *keyPathType);
 
   SWIFT_DEBUG_DUMP;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5522,6 +5522,15 @@ public:
   /// Attempts to infer a capability of a key path (i.e. whether it
   /// is read-only, writable, etc.) based on the referenced members.
   ///
+  /// \param keyPath The key path literal expression.
+  ///
+  /// \returns `bool` to indicate whether key path is valid or not,
+  /// and capability if it could be determined.
+  std::pair</*isValid=*/bool, llvm::Optional<KeyPathCapability>>
+  inferKeyPathLiteralCapability(KeyPathExpr *keyPath);
+
+  /// A convenience overload of \c inferKeyPathLiteralCapability.
+  ///
   /// \param keyPathType The type variable that represents the key path literal.
   ///
   /// \returns `bool` to indicate whether key path is valid or not,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -94,6 +94,11 @@ bool BindingSet::isDelayed() const {
     }
   }
 
+  // Delay key path literal type binding until there is at least
+  // one contextual binding (or default is promoted into a binding).
+  if (TypeVar->getImpl().isKeyPathType() && Bindings.empty())
+    return true;
+
   if (isHole()) {
     auto *locator = TypeVar->getImpl().getLocator();
     assert(locator && "a hole without locator?");
@@ -168,6 +173,12 @@ bool BindingSet::isPotentiallyIncomplete() const {
   // Generic parameters are always potentially incomplete.
   if (Info.isGenericParameter())
     return true;
+
+  // Key path literal type is incomplete until there is a
+  // contextual type or key path is resolved enough to infer
+  // capability and promote default into a binding.
+  if (TypeVar->getImpl().isKeyPathType())
+    return Bindings.empty();
 
   // If current type variable is associated with a code completion token
   // it's possible that it doesn't have enough contextual information
@@ -871,6 +882,44 @@ findInferableTypeVars(Type type,
 
 void PotentialBindings::addDefault(Constraint *constraint) {
   Defaults.insert(constraint);
+}
+
+void BindingSet::addDefault(Constraint *constraint) {
+  auto defaultTy = constraint->getSecondType();
+
+  if (TypeVar->getImpl().isKeyPathType() && Bindings.empty()) {
+    if (constraint->getKind() == ConstraintKind::FallbackType) {
+      if (auto capability = CS.inferKeyPathLiteralCapability(TypeVar)) {
+        auto *keyPathType = defaultTy->castTo<BoundGenericType>();
+
+        auto root = keyPathType->getGenericArgs()[0];
+        auto value = keyPathType->getGenericArgs()[1];
+
+        auto &ctx = CS.getASTContext();
+
+        switch (*capability) {
+        case KeyPathCapability::ReadOnly:
+          break;
+
+        case KeyPathCapability::Writable:
+          keyPathType = BoundGenericType::get(ctx.getWritableKeyPathDecl(),
+                                              /*parent=*/Type(), {root, value});
+          break;
+
+        case KeyPathCapability::ReferenceWritable:
+          keyPathType =
+              BoundGenericType::get(ctx.getReferenceWritableKeyPathDecl(),
+                                    /*parent=*/Type(), {root, value});
+          break;
+        }
+
+        addBinding({keyPathType, AllowedBindingKind::Exact, constraint});
+        return;
+      }
+    }
+  }
+
+  Defaults.insert({defaultTy->getCanonicalType(), constraint});
 }
 
 bool LiteralRequirement::isCoveredBy(Type type, ConstraintSystem &CS) const {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2097,6 +2097,10 @@ bool TypeVarBindingProducer::computeNext() {
   }
 
   if (newBindings.empty()) {
+    // If key path type had contextual types, let's not attempt fallback.
+    if (TypeVar->getImpl().isKeyPathType() && !ExploredTypes.empty())
+      return false;
+
     // Add defaultable constraints (if any).
     for (auto *constraint : DelayedDefaults) {
       if (constraint->getKind() == ConstraintKind::FallbackType) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2497,7 +2497,7 @@ bool ContextualFailure::diagnoseAsError() {
   if (path.empty()) {
     if (auto *KPE = getAsExpr<KeyPathExpr>(anchor)) {
       emitDiagnosticAt(KPE->getLoc(),
-                       diag::expr_smart_keypath_value_covert_to_contextual_type,
+                       diag::expr_keypath_type_covert_to_contextual_type,
                        getFromType(), getToType());
       return true;
     }
@@ -2741,6 +2741,11 @@ bool ContextualFailure::diagnoseAsError() {
 
   case ConstraintLocator::PatternMatch: {
     diagnostic = diag::cannot_match_value_with_pattern;
+    break;
+  }
+
+  case ConstraintLocator::KeyPathValue: {
+    diagnostic = diag::expr_keypath_value_covert_to_contextual_type;
     break;
   }
 
@@ -7646,7 +7651,7 @@ bool ArgumentMismatchFailure::diagnoseKeyPathAsFunctionResultMismatch() const {
         paramFnType->getParams().front().getPlainType()->isEqual(kpRootType)))
     return false;
 
-  emitDiagnostic(diag::expr_smart_keypath_value_covert_to_contextual_type,
+  emitDiagnostic(diag::expr_keypath_value_covert_to_contextual_type,
                  kpValueType, paramFnType->getResult());
   return true;
 }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3884,6 +3884,13 @@ namespace {
 
       CS.addKeyPathConstraint(kpTy, root, value, componentTypeVars, locator);
 
+      // Add a fallback constraint so we have an anchor to use for
+      // capability inference when there is no context.
+      CS.addUnsolvedConstraint(Constraint::create(
+          CS, ConstraintKind::FallbackType, kpTy,
+          BoundGenericType::get(kpDecl, /*parent=*/Type(), {root, value}),
+          CS.getConstraintLocator(E, ConstraintLocator::FallbackType)));
+
       return kpTy;
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3742,9 +3742,10 @@ namespace {
         // Allow \Derived.property to be inferred as \Base.property to
         // simulate a sort of covariant conversion from
         // KeyPath<Derived, T> to KeyPath<Base, T>.
-        CS.addConstraint(ConstraintKind::Subtype, rootObjectTy, root, locator);
+        CS.addConstraint(ConstraintKind::Subtype, rootObjectTy, root,
+                         rootLocator);
       }
-      
+
       bool didOptionalChain = false;
       // We start optimistically from an lvalue base.
       Type base = LValueType::get(root);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3866,6 +3866,12 @@ namespace {
         base = optTy;
       }
 
+      // If we have a malformed KeyPathExpr e.g. let _: KeyPath<A, C> = \A
+      // let's record a AllowKeyPathMissingComponent fix.
+      if (E->hasSingleInvalidComponent()) {
+        (void)CS.recordFix(AllowKeyPathWithoutComponents::create(CS, locator));
+      }
+
       auto valueLocator =
           CS.getConstraintLocator(E, ConstraintLocator::KeyPathValue);
       auto *value = CS.createTypeVariable(valueLocator, TVO_CanBindToNoEscape |

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11736,13 +11736,6 @@ bool ConstraintSystem::resolveKeyPath(TypeVariableType *typeVar,
         contextualType = BoundGenericType::get(
             keyPathTy->getDecl(), keyPathTy->getParent(), {root, value});
       }
-    } else if (contextualType->isPlaceholder()) {
-      auto root = simplifyType(getKeyPathRootType(keyPath));
-      if (!(root->isTypeVariableOrMember() || root->isPlaceholder())) {
-        auto value = getKeyPathValueType(keyPath);
-        contextualType =
-            BoundGenericType::get(ctx.getKeyPathDecl(), Type(), {root, value});
-      }
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11729,7 +11729,6 @@ bool ConstraintSystem::resolveKeyPath(TypeVariableType *typeVar,
 
       auto root = args.front();
       auto value = getKeyPathValueType(keyPath);
-
       // Make sure that key path always gets a chance to infer its
       // value type from the member chain.
       if (!value->isEqual(args.back())) {
@@ -12212,6 +12211,19 @@ ConstraintSystem::simplifyKeyPathConstraint(
   bool definitelyKeyPathType = false;
   bool resolveAsMultiArgFuncFix = false;
 
+  auto formUnsolved = [&]() -> SolutionKind {
+    if (flags.contains(TMF_GenerateConstraints)) {
+      addUnsolvedConstraint(Constraint::create(
+          *this, ConstraintKind::KeyPath, keyPathTy, rootTy, valueTy,
+          locator.getBaseLocator(), componentTypeVars));
+      return SolutionKind::Solved;
+    }
+    return SolutionKind::Unsolved;
+  };
+
+  if (keyPathTy->isTypeVariableOrMember())
+    return formUnsolved();
+
   auto tryMatchRootAndValueFromType = [&](Type type,
                                           bool allowPartial = true) -> bool {
     Type boundRoot = Type(), boundValue = Type();
@@ -12493,60 +12505,19 @@ ConstraintSystem::simplifyKeyPathConstraint(
       kpDecl = getASTContext().getWritableKeyPathDecl();
   }
 
-  auto formUnsolved = [&]() {
-    addUnsolvedConstraint(Constraint::create(
-        *this, ConstraintKind::KeyPath, keyPathTy, rootTy, valueTy,
-        locator.getBaseLocator(), componentTypeVars));
-  };
-
   auto loc = locator.getBaseLocator();
   if (definitelyFunctionType) {
     increaseScore(SK_FunctionConversion, locator);
     return SolutionKind::Solved;
   } else if (!anyComponentsUnresolved ||
              (definitelyKeyPathType && capability == ReadOnly)) {
-    // If key path is connected to a disjunction (i.e. through coercion
-    // or used as an argument to a function/subscipt call) it cannot be
-    // bound until the choice is selected because it's undetermined
-    // until then whether key path is implicitly converted to a function
-    // type or not.
-    //
-    // \code
-    // struct Data {
-    //   var value: Int = 42
-    // }
-    //
-    // func test<S: Sequence>(_: S, _: (S.Element) -> Int) {}
-    // func test<C: Collection>(_: C, _: (C.Element) -> Int) {}
-    //
-    // func test(arr: [Data]) {
-    //  test(arr, \Data.value)
-    // }
-    // \endcode
-    //
-    // In this example if we did allow to bind the key path before
-    // an overload of `test` is selected, we'd end up with no solutions
-    // because the type of the key path expression is actually: '(Data) -> Int'
-    // and not 'WritableKeyPath<Data, Int>`.
-    auto *typeVar = keyPathTy->getAs<TypeVariableType>();
-    if (typeVar && findConstraintThroughOptionals(
-                       typeVar, OptionalWrappingDirection::Unwrap,
-                       [&](Constraint *match, TypeVariableType *) {
-                         return match->getKind() ==
-                                    ConstraintKind::ApplicableFunction ||
-                                match->getKind() == ConstraintKind::Disjunction;
-                       })) {
-      formUnsolved();
-    } else {
-      auto resolvedKPTy =
-          BoundGenericType::get(kpDecl, nullptr, {rootTy, valueTy});
-      return matchTypes(resolvedKPTy, keyPathTy, ConstraintKind::Bind,
-                        subflags, loc);
-    }
-  } else {
-    formUnsolved();
+    auto resolvedKPTy =
+        BoundGenericType::get(kpDecl, nullptr, {rootTy, valueTy});
+    return matchTypes(resolvedKPTy, keyPathTy, ConstraintKind::Bind, subflags,
+                      loc);
   }
-  return SolutionKind::Solved;
+
+  return formUnsolved();
 }
 
 ConstraintSystem::SolutionKind

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6693,7 +6693,8 @@ bool ConstraintSystem::repairFailures(
     }
 
     conversionsOrFixes.push_back(IgnoreContextualType::create(
-        *this, lhs, rhs, keyPathLoc));
+        *this, lhs, rhs,
+        getConstraintLocator(keyPathLoc, ConstraintLocator::KeyPathValue)));
     break;
   }
   default:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12299,13 +12299,9 @@ ConstraintSystem::simplifyKeyPathConstraint(
     if (keyPathTy->isPlaceholder())
       return SolutionKind::Solved;
 
-    // If we have a malformed KeyPathExpr e.g. let _: KeyPath<A, C> = \A
-    // let's record a AllowKeyPathMissingComponent fix.
-    if (keyPath->hasSingleInvalidComponent()) {
-      auto *fix = AllowKeyPathWithoutComponents::create(
-          *this, getConstraintLocator(locator));
-      return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
-    }
+    if (hasFixFor(getConstraintLocator(keyPath),
+                  FixKind::AllowKeyPathWithoutComponents))
+      return SolutionKind::Solved;
 
     // If the root type has been bound to a hole, we cannot infer it.
     if (getFixedTypeRecursive(rootTy, /*wantRValue*/ true)->isPlaceholder())

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -110,6 +110,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::CoercionOperand:
   case ConstraintLocator::PackExpansionType:
   case ConstraintLocator::ThrownErrorType:
+  case ConstraintLocator::FallbackType:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -522,6 +523,10 @@ void LocatorPathElt::dump(raw_ostream &out) const {
   }
   case ConstraintLocator::ThrownErrorType: {
     out << "thrown error type";
+    break;
+  }
+  case ConstraintLocator::FallbackType: {
+    out << "fallback type";
     break;
   }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6044,6 +6044,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::WrappedValue:
     case ConstraintLocator::OptionalPayload:
     case ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice:
+    case ConstraintLocator::FallbackType:
       break;
     }
 

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -230,11 +230,11 @@ func issue_65965() {
 	
   let refKP: ReferenceWritableKeyPath<S, String>
   refKP = \.s
-  // expected-error@-1 {{key path value type 'WritableKeyPath<S, String>' cannot be converted to contextual type 'ReferenceWritableKeyPath<S, String>'}}
+  // expected-error@-1 {{cannot convert key path type 'WritableKeyPath<S, String>' to contextual type 'ReferenceWritableKeyPath<S, String>'}}
 	
   let writeKP: WritableKeyPath<S, String>
   writeKP = \.v
-  // expected-error@-1 {{key path value type 'KeyPath<S, String>' cannot be converted to contextual type 'WritableKeyPath<S, String>'}}
+  // expected-error@-1 {{cannot convert key path type 'KeyPath<S, String>' to contextual type 'WritableKeyPath<S, String>'}}
 }
 
 func test_any_key_path() {

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -81,8 +81,8 @@ func testVariadicKeypathAsFunc() {
 
   // These are not okay, the KeyPath should have a base that matches the
   // internal parameter type of the function, i.e (S...).
-  let _: (S...) -> Int = \S.i // expected-error {{key path value type 'S' cannot be converted to contextual type 'S...'}}
-  takesVariadicFnWithGenericRet(\S.i) // expected-error {{key path value type 'S' cannot be converted to contextual type 'S...'}}
+  let _: (S...) -> Int = \S.i // expected-error {{key path with root type 'S...' cannot be applied to a base of type 'S'}}
+  takesVariadicFnWithGenericRet(\S.i) // expected-error {{key path with root type 'S...' cannot be applied to a base of type 'S'}}
 }
 
 // rdar://problem/54322807

--- a/test/Constraints/keypath_swift_5.swift
+++ b/test/Constraints/keypath_swift_5.swift
@@ -4,7 +4,7 @@ struct S {
   let i: Int
 
   init() {
-    let _: WritableKeyPath<S, Int> = \.i // expected-error {{cannot convert value of type 'KeyPath<S, Int>' to specified type 'WritableKeyPath<S, Int>'}}
+    let _: WritableKeyPath<S, Int> = \.i // expected-error {{cannot convert key path type 'KeyPath<S, Int>' to contextual type 'WritableKeyPath<S, Int>'}}
 
     S()[keyPath: \.i] = 1
     // expected-error@-1 {{cannot assign through subscript: key path is read-only}}
@@ -12,7 +12,7 @@ struct S {
 }
 
 func test() {
-  let _: WritableKeyPath<C, Int> = \.i // expected-error {{cannot convert value of type 'KeyPath<C, Int>' to specified type 'WritableKeyPath<C, Int>'}}
+  let _: WritableKeyPath<C, Int> = \.i // expected-error {{cannot convert key path type 'KeyPath<C, Int>' to contextual type 'WritableKeyPath<C, Int>'}}
 
   C()[keyPath: \.i] = 1
   // expected-error@-1 {{cannot assign through subscript: key path is read-only}}

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -363,7 +363,7 @@ func testTupleLabelMismatchFuncConversion(fn1: @escaping ((x: Int, y: Int)) -> V
 }
 
 func testTupleLabelMismatchKeyPath() {
-  // Very Cursed.
   let _: KeyPath<(x: Int, y: Int), Int> = \(a: Int, b: Int).x
-  // expected-warning@-1 {{tuple conversion from '(a: Int, b: Int)' to '(x: Int, y: Int)' mismatches labels}}
+// expected-error@-1 {{key path with root type '(x: Int, y: Int)' cannot be applied to a base of type '(a: Int, b: Int)'}}
+// expected-error@-2 {{value of tuple type '(a: Int, b: Int)' has no member 'x'}}
 }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -127,14 +127,14 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: KeyPath<A, Prop> = \.property
   let _: WritableKeyPath<A, Prop> = \.property
   let _: ReferenceWritableKeyPath<A, Prop> = \.property
-  //expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, Prop>' to specified type 'ReferenceWritableKeyPath<A, Prop>'}}
+  //expected-error@-1 {{cannot convert key path type 'WritableKeyPath<A, Prop>' to contextual type 'ReferenceWritableKeyPath<A, Prop>'}}
 
   let _: (A) -> A = \.[sub]
   let _: PartialKeyPath<A> = \.[sub]
   let _: KeyPath<A, A> = \.[sub]
   let _: WritableKeyPath<A, A> = \.[sub]
   let _: ReferenceWritableKeyPath<A, A> = \.[sub]
-  //expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, A>' to specified type 'ReferenceWritableKeyPath<A, A>'}}
+  //expected-error@-1 {{cannot convert key path type 'WritableKeyPath<A, A>' to contextual type 'ReferenceWritableKeyPath<A, A>'}}
 
   let _: (A) -> Prop? = \.optProperty?
   let _: PartialKeyPath<A> = \.optProperty?
@@ -162,7 +162,7 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: KeyPath<C<A>, A> = \.value
   let _: WritableKeyPath<C<A>, A> = \.value
   let _: ReferenceWritableKeyPath<C<A>, A> = \.value
-  // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<C<A>, A>' to specified type 'ReferenceWritableKeyPath<C<A>, A>'}}
+  // expected-error@-1 {{cannot convert key path type 'WritableKeyPath<C<A>, A>' to contextual type 'ReferenceWritableKeyPath<C<A>, A>'}}
 
   let _: (C<A>) -> A = \C.value
   let _: PartialKeyPath<C<A>> = \C.value

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -692,8 +692,7 @@ func testSubtypeKeypathClass(_ keyPath: ReferenceWritableKeyPath<Base, Int>) {
 
 func testSubtypeKeypathProtocol(_ keyPath: ReferenceWritableKeyPath<PP, Int>) {
   testSubtypeKeypathProtocol(\Base.i)
-  // expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Base, Int>' to expected argument type 'ReferenceWritableKeyPath<any PP, Int>'}}
-  // expected-note@-2 {{arguments to generic parameter 'Root' ('Base' and 'any PP') are expected to be equal}}
+  // expected-error@-1 {{key path with root type 'any PP' cannot be applied to a base of type 'Base'}}
 }
 
 // rdar://problem/32057712

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -959,12 +959,18 @@ func testMemberAccessOnOptionalKeyPathComponent() {
   // expected-note@-2 {{chain the optional using '?' to access member 'm' only for non-'nil' base values}} {{17-17=?}}
   // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{17-17=!}}
 
+  // FIXME(diagnostics): Ideally there should be two errors here - one for `b_opt` and one for `c` but since there is
+  // no contextual type it means that both `!` and `?` could work to reference `.d` and that creates ambiguity which
+  // is not possible to diagnose at the moment.
   _ = \S1a.b_opt.c.d
   // expected-error@-1 {{value of optional type 'S1b?' must be unwrapped to refer to member 'c' of wrapped base type 'S1b'}}
   // expected-note@-2 {{chain the optional using '?' to access member 'c' only for non-'nil' base values}} {{17-17=?}}
+  let _: KeyPath<S1a, Int> = \S1a.b_opt.c.d
+  // expected-error@-1 {{value of optional type 'S1b?' must be unwrapped to refer to member 'c' of wrapped base type 'S1b'}}
+  // expected-note@-2 {{chain the optional using '?' to access member 'c' only for non-'nil' base values}} {{40-40=?}}
   // expected-error@-3 {{value of optional type 'S1c?' must be unwrapped to refer to member 'd' of wrapped base type 'S1c'}}
-  // expected-note@-4 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}} {{19-19=?}}
-  // expected-note@-5 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{19-19=!}}
+  // expected-note@-4 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}} {{42-42=?}}
+  // expected-note@-5 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{42-42=!}}
   _ = \S1a.b_opt?.c.d
   // expected-error@-1 {{value of optional type 'S1c?' must be unwrapped to refer to member 'd' of wrapped base type 'S1c'}}
   // expected-note@-2 {{chain the optional using '?' to access member 'd' only for non-'nil' base values}} {{20-20=?}}
@@ -1064,7 +1070,8 @@ func f_56996() {
 func f_55805() {
   let _: KeyPath<String?, Int?> = \.utf8.count
   // expected-error@-1 {{key path root inferred as optional type 'String?' must be unwrapped to refer to member 'utf8' of unwrapped type 'String'}}
-  // expected-error@-2 {{key path value type 'Int' cannot be converted to contextual type 'Int?'}}
+  // expected-error@-2 {{cannot assign value of type 'KeyPath<String?, Int>' to type 'KeyPath<String?, Int?>'}}
+  // expected-note@-3 {{arguments to generic parameter 'Value' ('Int' and 'Int?') are expected to be equal}}
 }
 
 // rdar://74711236 - crash due to incorrect member access in key path


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/69292

- Setup a fallback type for a key path that is going to be used as a base for capability inference.

- If key path has no direct contextual bindings attempt to infer its capabilities and form a binding 
   based on a previously established fallback type (default capability is ReadOnly).

- Delay  `KeyPath` constraint simplification until key path type has been bound.

  This means that the inference now drives key path simplification and problems
  with eager key path binding are resolved (because type variables are already
  delayed if they are connected to an `ApplicableFunction` or `Disjunction` constraint).

Next steps:

- Allow transitive inference of key path root type through key path type bindings
- Delay key path type binding until capability is established (depends on the previous step)
- Unify contextual bindings (if any) with a type inferred based on key path literal
  capabilities. This means that we would no longer need to:
  - Bind a resolved type to a contextual type at the end of simplification.
  - A hack that allows capability downgrades in certain cases 
    (i.e. when contextual type is read-only but key path itself is writable)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
