### PR TITLE
[swift-vfe][swift-wme] Stop disabling function mergers for Swift VFE / WME

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -202,14 +202,6 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
 
   PipelineTuningOptions PTO;
 
-  bool RunSwiftMergeFunctions = true;
-  // LLVM MergeFunctions and SwiftMergeFunctions don't understand that the
-  // string in the metadata on calls in @llvm.type.checked.load intrinsics is
-  // semantically meaningful, and mis-compile (mis-merge) unrelated functions.
-  if (Opts.VirtualFunctionElimination || Opts.WitnessMethodElimination) {
-    RunSwiftMergeFunctions = false;
-  }
-
   bool RunSwiftSpecificLLVMOptzns =
       !Opts.DisableSwiftSpecificLLVMOptzns && !Opts.DisableLLVMOptzns;
 
@@ -222,7 +214,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
     PTO.LoopInterleaving = true;
     PTO.LoopVectorization = true;
     PTO.SLPVectorization = true;
-    PTO.MergeFunctions = RunSwiftMergeFunctions;
+    PTO.MergeFunctions = true;
     level = llvm::OptimizationLevel::Os;
   } else {
     level = llvm::OptimizationLevel::O0;
@@ -310,7 +302,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
                                         allowlistFiles, ignorelistFiles));
     });
   }
-  if (RunSwiftSpecificLLVMOptzns && RunSwiftMergeFunctions) {
+  if (RunSwiftSpecificLLVMOptzns) {
     PB.registerOptimizerLastEPCallback(
         [&](ModulePassManager &MPM, OptimizationLevel Level) {
           if (Level != OptimizationLevel::O0) {

--- a/test/LLVMPasses/merge_func_preserves_vfe.ll
+++ b/test/LLVMPasses/merge_func_preserves_vfe.ll
@@ -1,0 +1,43 @@
+; RUN: %swift-llvm-opt -passes='swift-merge-functions' -swiftmergefunc-threshold=2 %s | %FileCheck %s
+
+@g1 = external global i1
+@g2 = external global i1
+@g3 = external global i1
+
+declare { ptr, i1 } @llvm.type.checked.load(ptr, i32, metadata)
+
+define i1 @merge_candidate_a(ptr %ptr, i32 %offset) {
+    %1 = call { ptr, i1 } @llvm.type.checked.load(ptr %ptr, i32 %offset, metadata !"common_metadata")
+    %2 = extractvalue { ptr, i1 } %1, 1
+    %3 = load i1, i1* @g1
+    %4 = and i1 %2, %3
+    ret i1 %4
+}
+
+; The function using common metadata should call into the merged function
+
+define i1 @merge_candidate_b(ptr %ptr, i32 %offset) {
+    %1 = call { ptr, i1 } @llvm.type.checked.load(ptr %ptr, i32 %offset, metadata !"common_metadata")
+    %2 = extractvalue { ptr, i1 } %1, 1
+    %3 = load i1, i1* @g2
+    %4 = and i1 %2, %3
+    ret i1 %4
+}
+; CHECK-LABEL: @merge_candidate_b
+; CHECK:       call i1 @merge_candidate_aTm
+; CHECK:       ret
+
+; The function using different metadata should not
+
+define i1 @merge_candidate_c(ptr %ptr, i32 %offset) {
+    %1 = call { ptr, i1 } @llvm.type.checked.load(ptr %ptr, i32 %offset, metadata !"different_metadata")
+    %2 = extractvalue { ptr, i1 } %1, 1
+    %3 = load i1, i1* @g3
+    %4 = and i1 %2, %3
+    ret i1 %4
+}
+; CHECK-LABEL: @merge_candidate_c
+; CHECK-NOT:   call i1 @merge_candidate_aTm
+; CHECK:       @llvm.type.checked.load(ptr %ptr, i32 %offset, metadata !"different_metadata")
+; CHECK-NOT:   call i1 @merge_candidate_aTm
+; CHECK:       ret


### PR DESCRIPTION
The Swift and LLVM function mergers were disabled when Swift VFE or WME are enabled because the function merger did not respect metadata on calls to `llvm.type.checked.load`. This is no longer the case, so we can turn these passes back on.