### PR TITLE
[Dependency Scanning] Special-case imports of the 'Builtin' module not referencing an "actual" module

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -136,6 +136,15 @@ void ModuleDependencyInfo::addModuleImport(
 
     ImportPath::Builder scratch;
     auto realPath = importDecl->getRealModulePath(scratch);
+
+    // Explicit 'Builtin' import is not a part of the module's
+    // dependency set, does not exist on the filesystem,
+    // and is resolved within the compiler during compilation.
+    SmallString<64> importedModuleName;
+    realPath.getString(importedModuleName);
+    if (importedModuleName == BUILTIN_NAME)
+      continue;
+
     addModuleImport(realPath, &alreadyAddedModules);
 
     // Additionally, keep track of which dependencies of a Source

--- a/test/ScanDependencies/Inputs/Swift/HasBuiltinImport.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/HasBuiltinImport.swiftinterface
@@ -1,0 +1,3 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name HasBuiltinImport -enable-builtin-module
+import Builtin

--- a/test/ScanDependencies/module_builtin.swift
+++ b/test/ScanDependencies/module_builtin.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -verify
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+import HasBuiltinImport
+
+// CHECK: "mainModuleName": "deps"
+


### PR DESCRIPTION
Otherwise the scanner will attempt to locate such a module on the filesystem and fail, because it does not exist.

Import resolution has special handling for such module, resolving it to an in-memory entity within the compiler:
https://github.com/apple/swift/blob/4a2eefe2fad3bc0c77245d19da1a3591ba6d1180/lib/Sema/ImportResolution.cpp#L386