### PR TITLE
Forbid @objcImpl on root and generic classes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1722,6 +1722,9 @@ ERROR(attr_objc_implementation_must_have_super,none,
       "'@_objcImplementation' cannot be used to implement root %kind0; declare "
       "its superclass in the header",
       (ValueDecl *))
+ERROR(objc_implementation_cannot_have_generics,none,
+      "'@_objcImplementation' cannot be used to implement %kind0",
+      (ValueDecl *))
 ERROR(attr_objc_implementation_category_not_found,none,
       "could not find category %0 on Objective-C class %1; make sure your "
       "umbrella or bridging header imports the header that declares it",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1718,6 +1718,10 @@ ERROR(attr_objc_implementation_must_be_imported,none,
       "defined by a Swift 'class' declaration, not an imported Objective-C "
       "'@interface' declaration",
       (ValueDecl *))
+ERROR(attr_objc_implementation_must_have_super,none,
+      "'@_objcImplementation' cannot be used to implement root %kind0; declare "
+      "its superclass in the header",
+      (ValueDecl *))
 ERROR(attr_objc_implementation_category_not_found,none,
       "could not find category %0 on Objective-C class %1; make sure your "
       "umbrella or bridging header imports the header that declares it",

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1825,7 +1825,8 @@ llvm::Optional<Identifier>
 ExtensionDecl::getCategoryNameForObjCImplementation() const {
   assert(isObjCImplementation());
 
-  auto attr = getAttrs().getAttribute<ObjCImplementationAttr>();
+  auto attr = getAttrs()
+                  .getAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true);
   if (attr->isCategoryNameInvalid())
     return llvm::None;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1510,6 +1510,12 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     return;
   }
 
+  if (CD->isTypeErasedGenericClass()) {
+    diagnoseAndRemoveAttr(attr, diag::objc_implementation_cannot_have_generics,
+                          CD);
+    CD->diagnose(diag::decl_declared_here, CD);
+  }
+
   if (!attr->isCategoryNameInvalid() && !ED->getImplementedObjCDecl()) {
     diagnose(attr->getLocation(),
              diag::attr_objc_implementation_category_not_found,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1503,6 +1503,13 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     return;
   }
 
+  if (!CD->hasSuperclass()) {
+    diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_have_super,
+                          CD);
+    CD->diagnose(diag::decl_declared_here, CD);
+    return;
+  }
+
   if (!attr->isCategoryNameInvalid() && !ED->getImplementedObjCDecl()) {
     diagnose(attr->getLocation(),
              diag::attr_objc_implementation_category_not_found,

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -172,6 +172,10 @@
 
 @end
 
+@interface ObjCImplGenericClass<T> : NSObject
+
+@end
+
 
 
 struct ObjCStruct {

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -168,6 +168,10 @@
 
 @end
 
+@interface ObjCImplRootClass
+
+@end
+
 
 
 struct ObjCStruct {

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -460,6 +460,10 @@ protocol EmptySwiftProto {}
   // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'ObjCImplRootClass'; declare its superclass in the header}}
 }
 
+@_objcImplementation extension ObjCImplGenericClass {
+  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
+}
+
 func usesAreNotAmbiguous(obj: ObjCClass) {
   obj.method(fromHeader1: 1)
   obj.method(fromHeader2: 2)

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -456,6 +456,10 @@ protocol EmptySwiftProto {}
 @_objcImplementation(WTF) extension SwiftClass {} // expected
 // expected-error@-1 {{'@_objcImplementation' cannot be used to extend class 'SwiftClass' because it was defined by a Swift 'class' declaration, not an imported Objective-C '@interface' declaration}} {{1-27=}}
 
+@_objcImplementation extension ObjCImplRootClass {
+  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'ObjCImplRootClass'; declare its superclass in the header}}
+}
+
 func usesAreNotAmbiguous(obj: ObjCClass) {
   obj.method(fromHeader1: 1)
   obj.method(fromHeader2: 2)


### PR DESCRIPTION
`@_objcImplementation` doesn't support two kinds of Objective-C classes:

* **Root classes**: SILGen doesn't know how to generate code for an Objective-C class with no superclass. And even if it could, ClangImporter doesn't import some of the primitive methods, like `-retain` and `-release`, needed to implement a root class.
* **Generic classes**: Lightweight generics import awkwardly enough that it's actually quite difficult to write extension methods on them. We're declaring them out of scope to avoid these complications.

Diagnose attempts to use the attribute on classes of these kinds.

Fixes rdar://109130979&116066409.