### PR TITLE
[5.10] Fix precondition in UMRBP.initialize(as:fromContentsOf:)

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -845,7 +845,7 @@ extension Unsafe${Mutable}RawBufferPointer {
         "buffer base address must be properly aligned to access C.Element"
       )
       _precondition(
-        $0.count * MemoryLayout<C.Element>.stride < self.count,
+        $0.count * MemoryLayout<C.Element>.stride <= self.count,
         "buffer cannot contain every element from source collection."
       )
       let start = baseAddress?.initializeMemory(

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -1264,6 +1264,9 @@ UnsafeMutableRawBufferPointerTestSuite.test("UMRBP.initializeMemory.collection.o
     alignment: MemoryLayout<Int>.alignment
   )
   defer { b.deallocate() }
+  let i = b.initializeMemory(as: Int.self, fromContentsOf: s.dropLast())
+  i.deinitialize()
+
   expectCrash {
     let i = b.initializeMemory(as: Int.self, fromContentsOf: s)
     i.deinitialize()


### PR DESCRIPTION
This precondition checks to make sure that the content-providing collection isn't larger than the allocated buffer, but was preventing using a buffer that is the exact same size as the collection.

Cherry-pick of: https://github.com/apple/swift/pull/69420

Addresses rdar://117516235