### PR TITLE
Add test with incorrect memberwise inits

### DIFF
--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
@@ -1,5 +1,5 @@
 class Person {
-internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () -> Place = { fatalError() }, secondLocation: (() -> Place)? = nil, wrapped: String = "", didSet: String = "ds") {
+internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () throws -> Place = { fatalError() }, secondLocation: (() -> Place)? = nil, wrapped: String = "", didSet: String = "ds") {
 self.firstName = firstName
 self.lastName = lastName
 self.age = age
@@ -19,7 +19,7 @@ self.didSet = didSet
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
-  var location: () -> Place = { fatalError() }
+  var location: () throws -> Place = { fatalError() }
   var secondLocation: (() -> Place)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
@@ -32,8 +32,9 @@ self.didSet = didSet
   }
 }
 
-struct Place {
+struct Place<T: FixedWidthInteger> {
   typealias Callback = () -> ()
+  let number: T
   let person: Person
   let street: String
   let apartment: Optional<String>

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
@@ -1,5 +1,5 @@
 class Person {
-internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () throws -> Place = { fatalError() }, secondLocation: (() -> Place)? = nil, wrapped: String = "", didSet: String = "ds") {
+internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () throws -> Place<Int> = { fatalError() }, secondLocation: (() -> Place<Int>)? = nil, wrapped: String = "", didSet: String = "ds") {
 self.firstName = firstName
 self.lastName = lastName
 self.age = age
@@ -19,8 +19,8 @@ self.didSet = didSet
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
-  var location: () throws -> Place = { fatalError() }
-  var secondLocation: (() -> Place)!
+  var location: () throws -> Place<Int> = { fatalError() }
+  var secondLocation: (() -> Place<Int>)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
   var getSet: String {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
@@ -6,8 +6,8 @@ class Person {
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
-  var location: () throws -> Place = { fatalError() }
-  var secondLocation: (() -> Place)!
+  var location: () throws -> Place<Int> = { fatalError() }
+  var secondLocation: (() -> Place<Int>)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
   var getSet: String {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
@@ -6,7 +6,7 @@ class Person {
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
-  var location: () -> Place = { fatalError() }
+  var location: () throws -> Place = { fatalError() }
   var secondLocation: (() -> Place)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
@@ -19,8 +19,9 @@ class Person {
   }
 }
 
-struct Place {
+struct Place<T: FixedWidthInteger> {
   typealias Callback = () -> ()
+  let number: T
   let person: Person
   let street: String
   let apartment: Optional<String>

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
@@ -6,8 +6,8 @@ class Person {
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
-  var location: () throws -> Place = { fatalError() }
-  var secondLocation: (() -> Place)!
+  var location: () throws -> Place<Int> = { fatalError() }
+  var secondLocation: (() -> Place<Int>)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
   var getSet: String {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
@@ -6,7 +6,7 @@ class Person {
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
-  var location: () -> Place = { fatalError() }
+  var location: () throws -> Place = { fatalError() }
   var secondLocation: (() -> Place)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
@@ -19,8 +19,9 @@ class Person {
   }
 }
 
-struct Place {
-internal init(person: Person, street: String, apartment: Optional<String> = nil, city: String, state: String, postalCode: Int, plusFour: Int? = nil, callback: @escaping Place.Callback, wrapped: String, `protocol`: String) {
+struct Place<T: FixedWidthInteger> {
+internal init(number: T, person: Person, street: String, apartment: Optional<String> = nil, city: String, state: String, postalCode: Int, plusFour: Int? = nil, callback: @escaping Place.Callback, wrapped: String, `protocol`: String) {
+self.number = number
 self.person = person
 self.street = street
 self.apartment = apartment
@@ -34,6 +35,7 @@ self.`protocol` = `protocol`
 }
 
   typealias Callback = () -> ()
+  let number: T
   let person: Person
   let street: String
   let apartment: Optional<String>

--- a/test/refactoring/MemberwiseInit/generate_memberwise.swift
+++ b/test/refactoring/MemberwiseInit/generate_memberwise.swift
@@ -6,8 +6,8 @@ class Person {
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
-  var location: () throws -> Place = { fatalError() }
-  var secondLocation: (() -> Place)!
+  var location: () throws -> Place<Int> = { fatalError() }
+  var secondLocation: (() -> Place<Int>)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
   var getSet: String {

--- a/test/refactoring/MemberwiseInit/generate_memberwise.swift
+++ b/test/refactoring/MemberwiseInit/generate_memberwise.swift
@@ -6,7 +6,7 @@ class Person {
   var avgHeight = 175
   let line = #line, file = #file, handle = #dsohandle
   lazy var idea: Idea = { fatalError() }()
-  var location: () -> Place = { fatalError() }
+  var location: () throws -> Place = { fatalError() }
   var secondLocation: (() -> Place)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
@@ -19,8 +19,9 @@ class Person {
   }
 }
 
-struct Place {
+struct Place<T: FixedWidthInteger> {
   typealias Callback = () -> ()
+  let number: T
   let person: Person
   let street: String
   let apartment: Optional<String>
@@ -58,9 +59,9 @@ struct MyWrapper {
 // RUN: %refactor -memberwise-init -source-filename %s -pos=22:8 > %t.result/struct_members.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/struct_members.swift.expected %t.result/struct_members.swift
 
-// RUN: %refactor -memberwise-init -source-filename %s -pos=44:8 > %t.result/only_computed_members.swift
+// RUN: %refactor -memberwise-init -source-filename %s -pos=45:8 > %t.result/only_computed_members.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/only_computed_members.swift.expected %t.result/only_computed_members.swift
 
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=36:10 > %t.result/protocol_members.swift
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=40:6 > %t.result/enum_members.swift
+// RUN: not %refactor -memberwise-init -source-filename %s -pos=37:10 > %t.result/protocol_members.swift
+// RUN: not %refactor -memberwise-init -source-filename %s -pos=41:6 > %t.result/enum_members.swift
 


### PR DESCRIPTION
Added generated memberwise initializer tests for generic members and throwing closure members, which don't seem to be handled correctly.