### PR TITLE
[DebugInfo][NFC] Add 64-bit requirement to async tests

### DIFF
--- a/test/DebugInfo/async-let-await.swift
+++ b/test/DebugInfo/async-let-await.swift
@@ -3,6 +3,7 @@
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: concurrency
+// REQUIRES: CPU=x86_64 || CPU=arm64
 
 public func getVegetables() async -> [String] {
   return ["leek", "carrot"]  

--- a/test/DebugInfo/async-local-var.swift
+++ b/test/DebugInfo/async-local-var.swift
@@ -2,6 +2,7 @@
 // RUN:    -module-name a  -disable-availability-checking \
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
+// REQUIRES: CPU=x86_64 || CPU=arm64
 
 func getString() async -> String {
   return ""


### PR DESCRIPTION
Since https://reviews.llvm.org/D158638, entry values are only produced for 64-bit architectures. As such, related tests need to be guarded by the appropriate REQUIRES directive.