### PR TITLE
Preliminary SILGen support for address-only typed throws

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1521,6 +1521,22 @@ public:
   /// abstraction pattern for its result type.
   AbstractionPattern getFunctionResultType() const;
 
+  /// Given that the value being abstracted is a function, return the
+  /// abstraction pattern for its thrown error type.
+  llvm::Optional<AbstractionPattern> getFunctionThrownErrorType() const;
+
+  /// Utility method to adjust a thrown error pattern and thrown error type
+  /// to account for some quirks in type lowering.
+  ///
+  /// When lowered with an opaque pattern,
+  ///
+  /// - () -> () becomes () -> (),
+  /// - () throws(any Error) -> () becomes () -> (@error any Error),
+  ///
+  /// *not* () -> (@error_indirect Never) or () -> (@error_indirect any Error).
+  llvm::Optional<std::pair<AbstractionPattern, CanType>>
+  getFunctionThrownErrorType(CanAnyFunctionType substFnInterfaceType) const;
+
   /// Given that the value being abstracted is a function type, return
   /// the abstraction pattern for one of its parameter types.
   AbstractionPattern getFunctionParamType(unsigned index) const;
@@ -1611,15 +1627,19 @@ public:
   /// Given that this is a pack expansion, do the pack elements need to be
   /// passed indirectly?
   bool arePackElementsPassedIndirectly(TypeConverter &TC) const;
-  
+
   /// If this abstraction pattern appears in function return position, how is
   /// the corresponding value returned?
   CallingConventionKind getResultConvention(TypeConverter &TC) const;
-  
+
   /// If this abstraction pattern appears in function parameter position, how
   /// is the corresponding value passed?
   CallingConventionKind getParameterConvention(TypeConverter &TC) const;
-  
+
+  /// If this abstraction pattern appears in function thrown error position, how
+  /// is the corresponding value passed?
+  CallingConventionKind getErrorConvention(TypeConverter &TC) const;
+
   /// Generate the abstraction pattern for lowering the substituted SIL
   /// function type for a function type matching this abstraction pattern.
   ///

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -433,6 +433,8 @@ public:
 
   bool isIndirectResult() const;
 
+  bool isIndirectErrorResult() const;
+
   SILArgumentConvention getArgumentConvention() const;
 
   /// Given that this is an entry block argument, and given that it does

--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -78,6 +78,8 @@ class SILModuleConventions {
 public:
   static bool isPassedIndirectlyInSIL(SILType type, SILModule &M);
 
+  static bool isThrownIndirectlyInSIL(SILType type, SILModule &M);
+
   static bool isReturnedIndirectlyInSIL(SILType type, SILModule &M);
 
   static SILModuleConventions getLoweredAddressConventions(SILModule &M) {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -340,6 +340,13 @@ public:
     return isAddressOnly(type, tc, sig, TypeExpansionContext::minimal());
   }
 
+  /// Return true if this type must be thrown indirectly.
+  static bool isFormallyThrownIndirectly(CanType type,
+                                         Lowering::TypeConverter &tc,
+                                         CanGenericSignature sig) {
+    return isAddressOnly(type, tc, sig, TypeExpansionContext::minimal());
+  }
+
   /// True if the type, or the referenced type of an address type, is loadable.
   /// This is the opposite of isAddressOnly.
   bool isLoadable(const SILFunction &F) const {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4224,9 +4224,6 @@ namespace {
         printFlag(T->isAsync(), "async");
         printFlag(T->isThrowing(), "throws");
       }
-      if (Type thrownError = T->getThrownError()) {
-        printFieldQuoted(thrownError.getString(), "thrown_error");
-      }
       if (Type globalActor = T->getGlobalActor()) {
         printFieldQuoted(globalActor.getString(), "global_actor");
       }
@@ -4234,6 +4231,9 @@ namespace {
       printClangTypeRec(T->getClangTypeInfo(), T->getASTContext());
       printAnyFunctionParamsRec(T->getParams(), "input");
       printRec(T->getResult(), "output");
+      if (Type thrownError = T->getThrownError()) {
+        printRec(thrownError, "thrown_error");
+      }
     }
 
     void visitFunctionType(FunctionType *T, StringRef label) {

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1214,6 +1214,78 @@ AbstractionPattern AbstractionPattern::getFunctionResultType() const {
   llvm_unreachable("bad kind");
 }
 
+llvm::Optional<AbstractionPattern>
+AbstractionPattern::getFunctionThrownErrorType() const {
+  switch (getKind()) {
+  case Kind::Invalid:
+    llvm_unreachable("querying invalid abstraction pattern!");
+  case Kind::ObjCCompletionHandlerArgumentsType:
+  case Kind::Tuple:
+    llvm_unreachable("abstraction pattern for tuple cannot be function");
+  case Kind::Opaque:
+    return *this;
+  case Kind::Type: {
+    if (isTypeParameterOrOpaqueArchetype())
+      return getOpaque();
+
+    if (auto errorType = cast<AnyFunctionType>(getType())->getEffectiveThrownErrorType()) {
+      return AbstractionPattern(getGenericSubstitutions(),
+                                getGenericSignatureForFunctionComponent(),
+                                (*errorType)->getCanonicalType());
+    }
+
+    return llvm::None;
+  }
+  case Kind::Discard:
+    llvm_unreachable("don't need to discard function abstractions yet");
+  case Kind::ClangType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::PartialCurriedCFunctionAsMethodType:
+  case Kind::CXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
+  case Kind::CurriedObjCMethodType:
+  case Kind::CurriedCFunctionAsMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedObjCMethodType:
+  case Kind::ObjCMethodType:
+    llvm_unreachable("implement me");
+  case Kind::OpaqueFunction:
+  case Kind::OpaqueDerivativeFunction:
+    return llvm::None;
+  }
+  llvm_unreachable("bad kind");
+}
+
+llvm::Optional<std::pair<AbstractionPattern, CanType>>
+AbstractionPattern::getFunctionThrownErrorType(
+    CanAnyFunctionType substFnInterfaceType) const {
+  auto optOrigErrorType = getFunctionThrownErrorType();
+  if (!optOrigErrorType)
+    return llvm::None;
+
+  auto &ctx = substFnInterfaceType->getASTContext();
+  auto optErrorType = substFnInterfaceType->getEffectiveThrownErrorType();
+
+  if (isTypeParameterOrOpaqueArchetype()) {
+    if (!optErrorType)
+      return llvm::None;
+
+    if (!(*optErrorType)->isEqual(ctx.getErrorExistentialType())) {
+      llvm::errs() << "unsupported reabstraction\n";
+      abort();
+    }
+
+    return std::make_pair(AbstractionPattern(*optErrorType),
+                          (*optErrorType)->getCanonicalType());
+  }
+
+  if (!optErrorType)
+    optErrorType = ctx.getErrorExistentialType();
+
+  return std::make_pair(*optOrigErrorType,
+                        (*optErrorType)->getCanonicalType());
+}
+
 AbstractionPattern
 AbstractionPattern::getObjCMethodAsyncCompletionHandlerType(
                                      CanType swiftCompletionHandlerType) const {
@@ -1939,7 +2011,7 @@ AbstractionPattern::getParameterConvention(TypeConverter &TC) const {
   case Kind::Opaque:
     // Maximally abstracted values are always passed indirectly.
     return Indirect;
-  
+
   case Kind::OpaqueFunction:
   case Kind::OpaqueDerivativeFunction:
   case Kind::PartialCurriedObjCMethodType:
@@ -1953,16 +2025,57 @@ AbstractionPattern::getParameterConvention(TypeConverter &TC) const {
   case Kind::PartialCurriedCXXMethodType:
     // Function types are always passed directly
     return Direct;
-      
+
   case Kind::ClangType:
   case Kind::Type:
   case Kind::Discard:
     // Pass according to the formal type.
     return SILType::isFormallyPassedIndirectly(getType(),
-                                                 TC,
-                                                 getGenericSignatureOrNull())
+                                               TC,
+                                               getGenericSignatureOrNull())
       ? Indirect : Direct;
-  
+
+  case Kind::Invalid:
+  case Kind::Tuple:
+  case Kind::ObjCCompletionHandlerArgumentsType:
+    llvm_unreachable("should not get here");
+  }
+}
+
+AbstractionPattern::CallingConventionKind
+AbstractionPattern::getErrorConvention(TypeConverter &TC) const {
+  // Tuples should be destructured.
+  if (isTuple()) {
+    return Destructured;
+  }
+  switch (getKind()) {
+  case Kind::Opaque:
+    // Maximally abstracted values are always thrown indirectly.
+    return Indirect;
+
+  case Kind::OpaqueFunction:
+  case Kind::OpaqueDerivativeFunction:
+  case Kind::PartialCurriedObjCMethodType:
+  case Kind::CurriedObjCMethodType:
+  case Kind::PartialCurriedCFunctionAsMethodType:
+  case Kind::CurriedCFunctionAsMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::ObjCMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
+    // Function types are always thrown directly
+    return Direct;
+
+  case Kind::ClangType:
+  case Kind::Type:
+  case Kind::Discard:
+    // Pass according to the formal type.
+    return SILType::isFormallyThrownIndirectly(getType(),
+                                               TC,
+                                               getGenericSignatureOrNull())
+      ? Indirect : Direct;
+
   case Kind::Invalid:
   case Kind::Tuple:
   case Kind::ObjCCompletionHandlerArgumentsType:
@@ -2562,7 +2675,7 @@ const {
   auto substTy = visitor.handleUnabstractedFunctionType(substType, *this,
                                                         substYieldType,
                                                         origYieldType);
-  
+
   auto substSig = buildGenericSignature(TC.Context, GenericSignature(),
                                         std::move(visitor.substGenericParams),
                                         std::move(visitor.substRequirements))

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -64,6 +64,15 @@ bool SILFunctionArgument::isIndirectResult() const {
   return getIndex() < numIndirectResults;
 }
 
+bool SILFunctionArgument::isIndirectErrorResult() const {
+  auto numIndirectResults =
+      getFunction()->getConventions().getNumIndirectSILResults();
+  auto numIndirectErrorResults =
+      getFunction()->getConventions().getNumIndirectSILErrorResults();
+  return ((getIndex() >= numIndirectResults) &&
+          (getIndex() < numIndirectResults + numIndirectErrorResults));
+}
+
 SILArgumentConvention SILFunctionArgument::getArgumentConvention() const {
   return getFunction()->getConventions().getSILArgumentConvention(getIndex());
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2190,32 +2190,6 @@ static CanSILFunctionType getSILFunctionType(
     isAsync = true;
   }
 
-  // Map 'throws' to the appropriate error convention.
-  // Give the type an error argument whether the substituted type semantically
-  // `throws` or if the abstraction pattern specifies a Swift function type
-  // that also throws. This prevents the need for a second possibly-thunking
-  // conversion when using a non-throwing function in more abstract throwing
-  // context.
-  bool isThrowing = substFnInterfaceType->getExtInfo().isThrowing();
-  if (auto origFnType = origType.getAs<AnyFunctionType>()) {
-    isThrowing |= origFnType->getExtInfo().isThrowing();
-  }
-  if (isThrowing && !foreignInfo.error &&
-      !foreignInfo.async) {
-    assert(!origType.isForeign()
-           && "using native Swift error convention for foreign type!");
-    SILType exnType;
-    if (CanType thrownError = substFnInterfaceType.getThrownError()) {
-      exnType = TC.getLoweredType(thrownError, expansionContext);
-    } else {
-      // Untyped error throws the exception type.
-      exnType = SILType::getExceptionType(TC.Context);
-    }
-    assert(exnType.isObject());
-    errorResult = SILResultInfo(exnType.getASTType(),
-                                ResultConvention::Owned);
-  }
-  
   // Get the yield type for an accessor coroutine.
   SILCoroutineKind coroutineKind = SILCoroutineKind::None;
   AbstractionPattern coroutineOrigYieldType = AbstractionPattern::getInvalid();
@@ -2306,6 +2280,36 @@ static CanSILFunctionType getSILFunctionType(
       coroutineOrigYieldType = substYieldType;
       coroutineSubstYieldType = substYieldType.getType();
     }
+  }
+
+  // Map 'throws' to the appropriate error convention.
+  // Give the type an error argument whether the substituted type semantically
+  // `throws` or if the abstraction pattern specifies a Swift function type
+  // that also throws. This prevents the need for a second possibly-thunking
+  // conversion when using a non-throwing function in more abstract throwing
+  // context.
+  bool isThrowing = substFnInterfaceType->getExtInfo().isThrowing();
+  if (auto origFnType = origType.getAs<AnyFunctionType>()) {
+    isThrowing |= origFnType->getExtInfo().isThrowing();
+  }
+
+  if (isThrowing && !foreignInfo.error &&
+      !foreignInfo.async) {
+    assert(!origType.isForeign()
+           && "using native Swift error convention for foreign type!");
+    auto optPair = origType.getFunctionThrownErrorType(substFnInterfaceType);
+    assert(optPair &&
+           "Lowering a throwing function type against non-throwing pattern");
+
+    auto origErrorType = optPair->first;
+    auto errorType = optPair->second;
+    auto &errorTLConv = TC.getTypeLowering(origErrorType, errorType,
+                                           TypeExpansionContext::minimal());
+
+    errorResult = SILResultInfo(errorTLConv.getLoweredType().getASTType(),
+                                errorTLConv.isAddressOnly()
+                                ? ResultConvention::Indirect
+                                : ResultConvention::Owned);
   }
 
   // Lower the result type.

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -713,6 +713,15 @@ bool SILModuleConventions::isPassedIndirectlyInSIL(SILType type, SILModule &M) {
   return false;
 }
 
+bool SILModuleConventions::isThrownIndirectlyInSIL(SILType type, SILModule &M) {
+  if (SILModuleConventions(M).loweredAddresses) {
+    return M.Types.getTypeLowering(type, TypeExpansionContext::minimal())
+        .isAddressOnly();
+  }
+
+  return false;
+}
+
 bool SILFunctionType::isNoReturnFunction(SILModule &M,
                                          TypeExpansionContext context) const {
   for (unsigned i = 0, e = getNumResults(); i < e; ++i) {

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -563,7 +563,12 @@ void MemoryLifetimeVerifier::checkFunction(BitDataflow &dataFlow) {
       locations.setBits(expectedThrowBits, funcArg);
       break;
     case SILArgumentConvention::Indirect_Out:
-      locations.setBits(expectedReturnBits, funcArg);
+      if (funcArg->isIndirectErrorResult()) {
+        locations.setBits(expectedThrowBits, funcArg);
+      } else {
+        assert(funcArg->isIndirectResult());
+        locations.setBits(expectedReturnBits, funcArg);
+      }
       break;
     default:
       break;

--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -237,7 +237,8 @@ void SILGenFunction::emitBackDeploymentThunk(SILDeclRef thunk) {
     paramsForForwarding.emplace_back(param.forward(*this));
   }
 
-  prepareEpilog(getResultInterfaceType(AFD),
+  prepareEpilog(AFD,
+                getResultInterfaceType(AFD),
                 AFD->getEffectiveThrownErrorType(),
                 CleanupLocation(AFD));
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -2134,7 +2134,10 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   // Set up the throw destination if necessary.
   CleanupLocation cleanupLoc(fd);
   if (thrownErrorType) {
-    prepareRethrowEpilog(*thrownErrorType, cleanupLoc);
+    prepareRethrowEpilog(fd,
+                         AbstractionPattern(*thrownErrorType),
+                         *thrownErrorType,
+                         cleanupLoc);
   }
 
   SILValue result;

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -658,10 +658,11 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   assert(selfLV);
 
   // Emit the prolog.
-  emitBasicProlog(ctor->getParameters(),
+  emitBasicProlog(ctor,
+                  ctor->getParameters(),
                   /*selfParam=*/nullptr,
-                  ctor->getResultInterfaceType(), ctor,
-                  ctor->hasThrows(),
+                  ctor->getResultInterfaceType(),
+                  ctor->getEffectiveThrownErrorType(),
                   ctor->getThrowsLoc(),
                   /*ignored parameters*/ 1);
   emitConstructorMetatypeArg(*this, ctor);
@@ -680,7 +681,9 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   // Create a basic block to jump to for the implicit 'self' return.
   // We won't emit this until after we've emitted the body.
   // The epilog takes a void return because the return of 'self' is implicit.
-  prepareEpilog(llvm::None, ctor->getEffectiveThrownErrorType(),
+  prepareEpilog(ctor,
+                llvm::None,
+                ctor->getEffectiveThrownErrorType(),
                 CleanupLocation(ctor));
 
   // If the constructor can fail, set up an alternative epilog for constructor
@@ -1105,9 +1108,11 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
 
   // Emit the prolog for the non-self arguments.
   // FIXME: Handle self along with the other body patterns.
-  uint16_t ArgNo = emitBasicProlog(ctor->getParameters(), /*selfParam=*/nullptr,
-                                   TupleType::getEmpty(F.getASTContext()), ctor,
-                                   ctor->hasThrows(), ctor->getThrowsLoc(),
+  uint16_t ArgNo = emitBasicProlog(ctor,
+                                   ctor->getParameters(), /*selfParam=*/nullptr,
+                                   TupleType::getEmpty(F.getASTContext()),
+                                   ctor->getEffectiveThrownErrorType(),
+                                   ctor->getThrowsLoc(),
                                    /*ignored parameters*/ 1);
 
   SILType selfTy = getLoweredLoadableType(selfDecl->getTypeInContext());
@@ -1185,7 +1190,9 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
 
   // Create a basic block to jump to for the implicit 'self' return.
   // We won't emit the block until after we've emitted the body.
-  prepareEpilog(llvm::None, ctor->getEffectiveThrownErrorType(),
+  prepareEpilog(ctor,
+                llvm::None,
+                ctor->getEffectiveThrownErrorType(),
                 CleanupLocation(endOfInitLoc));
 
   auto resultType = ctor->mapTypeIntoContext(ctor->getResultInterfaceType());
@@ -1680,7 +1687,7 @@ void SILGenFunction::emitIVarInitializer(SILDeclRef ivarInitializer) {
   VarLocs[selfDecl] = VarLoc::get(selfArg);
 
   auto cleanupLoc = CleanupLocation(loc);
-  prepareEpilog(llvm::None, llvm::None, cleanupLoc);
+  prepareEpilog(cd, llvm::None, llvm::None, cleanupLoc);
 
   // Emit the initializers.
   emitMemberInitializers(cd, selfDecl, cd);
@@ -1732,9 +1739,11 @@ void SILGenFunction::emitInitAccessor(AccessorDecl *accessor) {
   auto accessedProperties = accessor->getAccessedProperties();
 
   // Emit `newValue` argument.
-  emitBasicProlog(accessor->getParameters(), /*selfParam=*/nullptr,
-                  TupleType::getEmpty(F.getASTContext()), accessor,
-                  /*throws=*/false, /*throwsLoc=*/SourceLoc(),
+  emitBasicProlog(accessor,
+                  accessor->getParameters(), /*selfParam=*/nullptr,
+                  TupleType::getEmpty(F.getASTContext()),
+                  /*errorType=*/llvm::None,
+                  /*throwsLoc=*/SourceLoc(),
                   /*ignored parameters*/
                   accessedProperties.size());
 
@@ -1750,7 +1759,8 @@ void SILGenFunction::emitInitAccessor(AccessorDecl *accessor) {
     }
   }
 
-  prepareEpilog(accessor->getResultInterfaceType(),
+  prepareEpilog(accessor,
+                accessor->getResultInterfaceType(),
                 accessor->getEffectiveThrownErrorType(),
                 CleanupLocation(accessor));
 

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -45,7 +45,7 @@ void SILGenFunction::emitDestroyingDestructor(DestructorDecl *dd) {
   // Create a basic block to jump to for the implicit destruction behavior
   // of releasing the elements and calling the superclass destructor.
   // We won't actually emit the block until we finish with the destructor body.
-  prepareEpilog(llvm::None, llvm::None, CleanupLocation(Loc));
+  prepareEpilog(dd, llvm::None, llvm::None, CleanupLocation(Loc));
 
   auto cleanupLoc = CleanupLocation(Loc);
 
@@ -248,7 +248,7 @@ void SILGenFunction::emitDeallocatingMoveOnlyDestructor(DestructorDecl *dd) {
   // Create a basic block to jump to for the implicit destruction behavior
   // of releasing the elements and calling the superclass destructor.
   // We won't actually emit the block until we finish with the destructor body.
-  prepareEpilog(llvm::None, llvm::None, CleanupLocation(loc));
+  prepareEpilog(dd, llvm::None, llvm::None, CleanupLocation(loc));
 
   auto cleanupLoc = CleanupLocation(loc);
 
@@ -286,7 +286,7 @@ void SILGenFunction::emitIVarDestroyer(SILDeclRef ivarDestroyer) {
   assert(selfValue);
 
   auto cleanupLoc = CleanupLocation(loc);
-  prepareEpilog(llvm::None, llvm::None, cleanupLoc);
+  prepareEpilog(cd, llvm::None, llvm::None, cleanupLoc);
   {
     Scope S(*this, cleanupLoc);
     // Self is effectively guaranteed for the duration of any destructor.  For
@@ -577,7 +577,7 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
   // Create a basic block to jump to for the implicit destruction behavior
   // of releasing the elements and calling the superclass destructor.
   // We won't actually emit the block until we finish with the destructor body.
-  prepareEpilog(llvm::None, llvm::None, CleanupLocation(loc));
+  prepareEpilog(dd, llvm::None, llvm::None, CleanupLocation(loc));
 
   emitProfilerIncrement(dd->getTypecheckedBody());
   // Emit the destructor body.

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1210,16 +1210,17 @@ static void emitCaptureArguments(SILGenFunction &SGF,
 }
 
 void SILGenFunction::emitProlog(
-    CaptureInfo captureInfo, ParameterList *paramList, ParamDecl *selfParam,
-    DeclContext *DC, Type resultType, bool throws, SourceLoc throwsLoc,
+    DeclContext *DC, CaptureInfo captureInfo,
+    ParameterList *paramList, ParamDecl *selfParam, Type resultType,
+    llvm::Optional<Type> errorType, SourceLoc throwsLoc,
     llvm::Optional<AbstractionPattern> origClosureType) {
   // Emit the capture argument variables. These are placed last because they
   // become the first curry level of the SIL function.
   assert(captureInfo.hasBeenComputed() &&
          "can't emit prolog of function with uncomputed captures");
 
-  uint16_t ArgNo = emitBasicProlog(paramList, selfParam, resultType,
-                                   DC, throws, throwsLoc,
+  uint16_t ArgNo = emitBasicProlog(DC, paramList, selfParam, resultType,
+                                   errorType, throwsLoc,
                                    /*ignored parameters*/
                                      captureInfo.getCaptures().size(),
                                    origClosureType);
@@ -1722,18 +1723,10 @@ static void emitIndirectResultParameters(SILGenFunction &SGF,
   assert(!resultType->is<PackExpansionType>());
 
   // If the return type is address-only, emit the indirect return argument.
-  auto &resultTI =
-    SGF.SGM.Types.getTypeLowering(origResultType, resultTypeInContext,
-                                  SGF.getTypeExpansionContext());
-  
+
   // The calling convention always uses minimal resilience expansion.
-  auto &resultTIConv = SGF.SGM.Types.getTypeLowering(
+  auto resultConvType = SGF.SGM.Types.getLoweredType(
       resultTypeInContext, TypeExpansionContext::minimal());
-  auto resultConvType = resultTIConv.getLoweredType();
-
-  auto &ctx = SGF.getASTContext();
-
-  SILType resultSILType = resultTI.getLoweredType().getAddressType();
 
   // And the abstraction pattern may force an indirect return even if the
   // concrete type wouldn't normally be returned indirectly.
@@ -1743,19 +1736,63 @@ static void emitIndirectResultParameters(SILGenFunction &SGF,
         || origResultType.getResultConvention(SGF.SGM.Types) != AbstractionPattern::Indirect)
       return;
   }
+
+  auto &ctx = SGF.getASTContext();
   auto var = new (ctx) ParamDecl(SourceLoc(), SourceLoc(),
                                  ctx.getIdentifier("$return_value"), SourceLoc(),
                                  ctx.getIdentifier("$return_value"),
                                  DC);
   var->setSpecifier(ParamSpecifier::InOut);
   var->setInterfaceType(resultType);
+  auto &resultTI =
+    SGF.SGM.Types.getTypeLowering(origResultType, resultTypeInContext,
+                                  SGF.getTypeExpansionContext());
+  SILType resultSILType = resultTI.getLoweredType().getAddressType();
   auto *arg = SGF.F.begin()->createFunctionArgument(resultSILType, var);
   (void)arg;
 }
 
+static void emitIndirectErrorParameter(SILGenFunction &SGF,
+                                       Type errorType,
+                                       AbstractionPattern origErrorType,
+                                       DeclContext *DC) {
+  CanType errorTypeInContext =
+    DC->mapTypeIntoContext(errorType)->getCanonicalType();
+
+  // If the error type is address-only, emit the indirect error argument.
+
+  // The calling convention always uses minimal resilience expansion.
+  auto errorConvType = SGF.SGM.Types.getLoweredType(
+      errorTypeInContext, TypeExpansionContext::minimal());
+
+  // And the abstraction pattern may force an indirect return even if the
+  // concrete type wouldn't normally be returned indirectly.
+  if (!SILModuleConventions::isThrownIndirectlyInSIL(errorConvType,
+                                                     SGF.SGM.M)) {
+    if (!SILModuleConventions(SGF.SGM.M).useLoweredAddresses()
+        || origErrorType.getErrorConvention(SGF.SGM.Types) != AbstractionPattern::Indirect)
+      return;
+  }
+
+  auto &ctx = SGF.getASTContext();
+  auto var = new (ctx) ParamDecl(SourceLoc(), SourceLoc(),
+                                 ctx.getIdentifier("$error"), SourceLoc(),
+                                 ctx.getIdentifier("$error"),
+                                 DC);
+  var->setSpecifier(ParamSpecifier::InOut);
+  var->setInterfaceType(errorType);
+
+  auto &errorTI =
+    SGF.SGM.Types.getTypeLowering(origErrorType, errorTypeInContext,
+                                  SGF.getTypeExpansionContext());
+  SILType errorSILType = errorTI.getLoweredType().getAddressType();
+  assert(SGF.IndirectErrorResult == nullptr);
+  SGF.IndirectErrorResult = SGF.F.begin()->createFunctionArgument(errorSILType, var);
+}
+
 uint16_t SILGenFunction::emitBasicProlog(
-    ParameterList *paramList, ParamDecl *selfParam, Type resultType,
-    DeclContext *DC, bool throws, SourceLoc throwsLoc,
+    DeclContext *DC, ParameterList *paramList, ParamDecl *selfParam,
+    Type resultType, llvm::Optional<Type> errorType, SourceLoc throwsLoc,
     unsigned numIgnoredTrailingParameters,
     llvm::Optional<AbstractionPattern> origClosureType) {
   // Create the indirect result parameters.
@@ -1769,20 +1806,31 @@ uint16_t SILGenFunction::emitBasicProlog(
   
   emitIndirectResultParameters(*this, resultType, origResultType, DC);
 
+  llvm::Optional<AbstractionPattern> origErrorType;
+  if (errorType) {
+    origErrorType = origClosureType
+      ? origClosureType->getFunctionThrownErrorType()
+      : AbstractionPattern(genericSig.getCanonicalSignature(),
+                           (*errorType)->getCanonicalType());
+    emitIndirectErrorParameter(*this, *errorType, *origErrorType, DC);
+  }
+
   // Emit the argument variables in calling convention order.
   unsigned ArgNo =
     ArgumentInitHelper(*this, numIgnoredTrailingParameters)
       .emitParams(origClosureType, paramList, selfParam);
 
   // Record the ArgNo of the artificial $error inout argument. 
-  if (throws) {
-     auto NativeErrorTy = SILType::getExceptionType(getASTContext());
-    ManagedValue Undef = emitUndef(NativeErrorTy);
-    SILDebugVariable DbgVar("$error", /*Constant*/ false, ++ArgNo);
+  if (errorType && IndirectErrorResult == nullptr) {
+    CanType errorTypeInContext =
+      DC->mapTypeIntoContext(*errorType)->getCanonicalType();
+    auto loweredErrorTy = getLoweredType(*origErrorType, errorTypeInContext);
+    ManagedValue undef = emitUndef(loweredErrorTy);
+    SILDebugVariable dbgVar("$error", /*Constant*/ false, ++ArgNo);
     RegularLocation loc = RegularLocation::getAutoGeneratedLocation();
     if (throwsLoc.isValid())
       loc = throwsLoc;
-    B.createDebugValue(loc, Undef.getValue(), DbgVar);
+    B.createDebugValue(loc, undef.getValue(), dbgVar);
   }
 
   return ArgNo;

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1765,7 +1765,7 @@ uint16_t SILGenFunction::emitBasicProlog(
   AbstractionPattern origResultType = origClosureType
     ? origClosureType->getFunctionResultType()
     : AbstractionPattern(genericSig.getCanonicalSignature(),
-                         CanType(resultType));
+                         resultType->getCanonicalType());
   
   emitIndirectResultParameters(*this, resultType, origResultType, DC);
 

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -42,7 +42,8 @@ void SILGenModule::emitEntryPoint(SourceFile *SF, SILFunction *TopLevel) {
   auto moduleCleanupLoc = CleanupLocation::getModuleCleanupLocation();
 
   TopLevelSGF.prepareEpilog(
-      llvm::None, getASTContext().getErrorExistentialType(), moduleCleanupLoc);
+      SF, llvm::None, getASTContext().getErrorExistentialType(),
+      moduleCleanupLoc);
 
   auto prologueLoc = RegularLocation::getModuleLocation();
   prologueLoc.markAsPrologue();

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature TypedThrows | %FileCheck %s
+
+public func genericThrows<E>(_: () throws(E) -> ()) throws(E) -> () {}
+
+// CHECK-LABEL: sil [ossa] @$s20typed_throws_generic0C6ThrowsyyyyKXEKs5ErrorRzlF : $@convention(thin) <E where E : Error> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> () -> @error_indirect τ_0_0 for <E>) -> @error_indirect E {
+// CHECK: bb0(%0 : $*E, %1 : @guaranteed $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @error_indirect τ_0_0 for <E>):


### PR DESCRIPTION
If the thrown error type is address-only, our function type has an indirect error result. Handle this in type lowering and SILGen prolog/epilog emission.

Next steps are introducing a zero-operand `throw_addr` instruction to exit out of a block after initializing the thrown error result, and setting up a stack-allocated box to receive the indirect error result from a try_apply, all the conversions and re-abstraction support, etc.