### PR TITLE
build: extract the WiX engine during the CI job

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -1012,6 +1012,10 @@ move %PackageRoot%\online\Release\amd64\*.msi %BuildRoot%\artifacts\online\ || (
 :: Workaround for lack of control over Jenkins ...
 copy %BuildRoot%\artifacts\offline\installer.exe %BuildRoot%\artifacts\
 
+:: Detach the engine for CodeSigning simplicity
+md %BuildRoot%\artifacts\offline\extracted\
+"WiX-4.0.1\tools\net6.0\any\wix.exe" burn detach %BuildRoot%\artifacts\offline\installer.exe -engine %BuildRoot%\artifacts\installer-engine.exe -intermediateFolder %BuildRoot%\artifacts\offline\extracted\
+
 goto :eof
 endlocal
 


### PR DESCRIPTION
Extract the installer engine for simplifying the code signing process. We need to currently shuffle files around more than necessary to just extract the installer engine, this will allow us to skip that step.