### PR TITLE
[cxx-interop] Allow removing elements from `std::vector`

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1003,18 +1003,28 @@ void swift::conformToCxxVectorIfNeeded(ClangImporter::Implementation &impl,
       decl, ctx.getIdentifier("value_type"));
   auto iterType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
       decl, ctx.getIdentifier("const_iterator"));
-  if (!valueType || !iterType)
+  auto mutableIterType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+      decl, ctx.getIdentifier("iterator"));
+  if (!valueType || !iterType || !mutableIterType)
     return;
 
   ProtocolDecl *cxxRandomAccessIteratorProto =
       ctx.getProtocol(KnownProtocolKind::UnsafeCxxRandomAccessIterator);
-  if (!cxxRandomAccessIteratorProto)
+  ProtocolDecl *cxxMutableRandomAccessIteratorProto =
+      ctx.getProtocol(KnownProtocolKind::UnsafeCxxMutableRandomAccessIterator);
+  if (!cxxRandomAccessIteratorProto || !cxxMutableRandomAccessIteratorProto)
     return;
 
   auto rawIteratorTy = iterType->getUnderlyingType();
+  auto rawMutableIteratorTy = mutableIterType->getUnderlyingType();
 
   // Check if RawIterator conforms to UnsafeCxxRandomAccessIterator.
   if (!checkConformance(rawIteratorTy, cxxRandomAccessIteratorProto))
+    return;
+
+  // Check if RawMutableIterator conforms to UnsafeCxxMutableInputIterator.
+  if (!checkConformance(rawMutableIteratorTy,
+                        cxxMutableRandomAccessIteratorProto))
     return;
 
   impl.addSynthesizedTypealias(decl, ctx.Id_Element,
@@ -1023,6 +1033,8 @@ void swift::conformToCxxVectorIfNeeded(ClangImporter::Implementation &impl,
                                valueType->getUnderlyingType());
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawIterator"),
                                rawIteratorTy);
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawMutableIterator"),
+                               rawMutableIteratorTy);
   impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxVector});
 }
 

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -85,6 +85,48 @@ func fill(vector v: inout Vector) {
     v.push_back(CInt(3))
 }
 
+StdVectorTestSuite.test("VectorOfInt.remove(at:)") {
+    var v = Vector()
+    fill(vector: &v)
+
+    let rm1 = v.remove(at: 1)
+    expectEqual(rm1, 2)
+    expectEqual(v.size(), 2)
+    expectEqual(v[0], 1)
+    expectEqual(v[1], 3)
+
+    let rm2 = v.remove(at: 0)
+    expectEqual(rm2, 1)
+    expectEqual(v.size(), 1)
+    expectEqual(v[0], 3)
+}
+
+StdVectorTestSuite.test("VectorOfString.remove(at:)") {
+    var v = VectorOfString()
+    v.push_back(std.string())
+    v.push_back(std.string("123"))
+    v.push_back(std.string("abc"))
+    v.push_back(std.string("qwe"))
+
+    let rm1 = v.remove(at: 3)
+    expectEqual(rm1, std.string("qwe"))
+    expectEqual(v.size(), 3)
+    expectEqual(v[0], std.string())
+    expectEqual(v[1], std.string("123"))
+    expectEqual(v[2], std.string("abc"))
+
+    let rm2 = v.remove(at: 1)
+    expectEqual(rm2, std.string("123"))
+    expectEqual(v.size(), 2)
+
+    v.remove(at: 0)
+    expectEqual(v.size(), 1)
+
+    v.remove(at: 0)
+    expectEqual(v.size(), 0)
+    expectTrue(v.empty())
+}
+
 StdVectorTestSuite.test("VectorOfInt for loop") {
     var v = Vector()
     fill(vector: &v)


### PR DESCRIPTION
This adds `func remove(at index: Int)` to all instantiations of `std::vector` via an extension for `protocol CxxVector`.

The original C++ method `std::vector::erase` is not visible in Swift because all of its overloads return unsafe iterators.

rdar://113704853