### PR TITLE
Obj-C class metatypes should never satisfy Obj-C existentials

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1272,6 +1272,15 @@ id swift_dynamicCastObjCProtocolUnconditional(id object,
                                               Protocol * const *protocols,
                                               const char *filename,
                                               unsigned line, unsigned column) {
+  if (numProtocols == 0) {
+    return object;
+  }
+  if (object_isClass(object)) {
+    // ObjC classes never conform to protocols
+    Class sourceType = object_getClass(object);
+    swift_dynamicCastFailure(sourceType, class_getName(sourceType),
+	                     protocols[0], protocol_getName(protocols[0]));
+  }
   for (size_t i = 0; i < numProtocols; ++i) {
     if (![object conformsToProtocol:protocols[i]]) {
       Class sourceType = object_getClass(object);
@@ -1292,6 +1301,10 @@ id swift_dynamicCastObjCProtocolConditional(id object,
       // SwiftValue wrapper never holds a class object
       return nil;
     }
+  }
+  if (object_isClass(object)) {
+    // ObjC classes never conform to protocols
+    return nil;
   }
   for (size_t i = 0; i < numProtocols; ++i) {
     if (![object conformsToProtocol:protocols[i]]) {

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1081,4 +1081,23 @@ CastsTests.test("type(of:) should look through __SwiftValue")
   expectEqual(t, "S")  // Fails: currently says `__SwiftValue`
 }
 
+#if _runtime(_ObjC)
+@objc protocol P106973771 {
+  func sayHello()
+}
+CastsTests.test("Class metatype values should not cast to Obj-C existentials") {
+  class C106973771: NSObject, P106973771 {
+    func sayHello() { print("Hello") }
+  }
+  // A class instance clearly conforms to the protocol
+  expectTrue(C106973771() is any P106973771)
+  // But the metatype definitely does not
+  expectFalse(C106973771.self is any P106973771)
+  // The cast should not succeed
+  expectNil(C106973771.self as? any P106973771)
+  // The following will crash if the cast succeeds
+  (C106973771.self as? any P106973771)?.sayHello()
+}
+#endif
+
 runAllTests()


### PR DESCRIPTION
Given this
```
@objc protocol P { func f() }
class C: P { func f() {} }
```
the casts `C.self is any P` and `C.self as? any P` should always fail, because the metatype of `C.self` does not have an `f()` implementation.

These casts previously succeeded because the runtime implementation deferred to Obj-C's `[o conformsToProtocol:p]`, and that behaves differently depending on whether `o` is a class instance or a Class itself.

Since these casts should never succeed, I've just modified the Swift runtime logic to fail whenever the source of the cast is an Obj-C Class and the target is a protocol existential.

Resolves: rdar://106973771