### PR TITLE
[region-isolation] Rename pass/feature flag and so some other cleanups.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -219,7 +219,7 @@ EXPERIMENTAL_FEATURE(BuiltinModule, true)
 EXPERIMENTAL_FEATURE(StrictConcurrency, true)
 
 /// Defer Sendable checking to SIL diagnostic phase.
-EXPERIMENTAL_FEATURE(SendNonSendable, false)
+EXPERIMENTAL_FEATURE(TransferNonSendable, false)
 
 /// Within strict concurrency, narrow global variable isolation requirements.
 EXPERIMENTAL_FEATURE(GlobalConcurrency, false)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -218,8 +218,8 @@ EXPERIMENTAL_FEATURE(BuiltinModule, true)
 // Enable strict concurrency.
 EXPERIMENTAL_FEATURE(StrictConcurrency, true)
 
-/// Defer Sendable checking to SIL diagnostic phase.
-EXPERIMENTAL_FEATURE(TransferNonSendable, false)
+/// Region Based Isolation testing using the TransferNonSendable pass
+EXPERIMENTAL_FEATURE(RegionBasedIsolation, false)
 
 /// Within strict concurrency, narrow global variable isolation requirements.
 EXPERIMENTAL_FEATURE(GlobalConcurrency, false)

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -367,7 +367,7 @@ PASS(TempRValueOpt, "temp-rvalue-opt",
      "Remove short-lived immutable temporary copies")
 PASS(IRGenPrepare, "irgen-prepare",
      "Cleanup SIL in preparation for IRGen")
-PASS(SendNonSendable, "send-non-sendable",
+PASS(TransferNonSendable, "transfer-non-sendable",
      "Checks calls that send non-sendable values between isolation domains")
 PASS(SILGenCleanup, "silgen-cleanup",
      "Cleanup SIL in preparation for diagnostics")

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -361,12 +361,12 @@ public:
     if (indices.empty())
       return p;
 
-    Region max_index =
-        Region(*std::max_element(indices.begin(), indices.end()));
-    p.fresh_label = Region(max_index + 1);
+    auto maxIndex = Element(0);
     for (Element index : indices) {
       p.labels.insert_or_assign(index, Region(index));
+      maxIndex = Element(std::max(maxIndex, index));
     }
+    p.fresh_label = Region(maxIndex + 1);
     assert(p.is_canonical_correct());
     return p;
   }

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -634,9 +634,6 @@ public:
     }
     os << "]\n";
   }
-
-  /// Routine used in unittests
-  Region getRegion(Element elt) const { return labels.at(elt); }
 };
 
 } // namespace swift

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/Debug.h"
 #include <algorithm>
 
-#define DEBUG_TYPE "send-non-sendable"
+#define DEBUG_TYPE "transfer-non-sendable"
 
 namespace swift {
 
@@ -91,7 +91,7 @@ enum class PartitionOpKind : uint8_t {
 };
 
 // PartitionOp represents a primitive operation that can be performed on
-// Partitions. This is part of the SendNonSendable SIL pass workflow:
+// Partitions. This is part of the TransferNonSendable SIL pass workflow:
 // first SILBasicBlocks are compiled to vectors of PartitionOps, then a fixed
 // point partition is found over the CFG.
 class PartitionOp {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3569,9 +3569,7 @@ static bool usesFeatureParameterPacks(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureSendNonSendable(Decl *decl) {
-  return false;
-}
+static bool usesFeatureTransferNonSendable(Decl *decl) { return false; }
 
 static bool usesFeatureGlobalConcurrency(Decl *decl) { return false; }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3569,7 +3569,7 @@ static bool usesFeatureParameterPacks(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureTransferNonSendable(Decl *decl) { return false; }
+static bool usesFeatureRegionBasedIsolation(Decl *decl) { return false; }
 
 static bool usesFeatureGlobalConcurrency(Decl *decl) { return false; }
 

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -42,7 +42,7 @@ target_sources(swiftSILOptimizer PRIVATE
   PMOMemoryUseCollector.cpp
   RawSILInstLowering.cpp
   ReferenceBindingTransform.cpp
-  SendNonSendable.cpp
+  TransferNonSendable.cpp
   SILGenCleanup.cpp
   YieldOnceCheck.cpp
   OSLogOptimization.cpp

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -232,7 +232,7 @@ class PartitionOpTranslator;
 
 struct PartitionOpBuilder {
   /// Parent translator that contains state.
-  PartitionOpTranslator *translater;
+  PartitionOpTranslator *translator;
 
   /// Used to statefully track the instruction currently being translated, for
   /// insertion into generated PartitionOps.
@@ -470,7 +470,7 @@ public:
     assert(sendableProtocol && "PartitionOpTranslators should only be created "
                                "in contexts in which the availability of the "
                                "Sendable protocol has already been checked.");
-    builder.translater = this;
+    builder.translator = this;
     initCapturedUniquelyIdentifiedValues();
 
     LLVM_DEBUG(llvm::dbgs() << "Initializing Function Args:\n");
@@ -1134,11 +1134,11 @@ public:
 };
 
 TrackableValueID PartitionOpBuilder::lookupValueID(SILValue value) {
-  return translater->lookupValueID(value);
+  return translator->lookupValueID(value);
 }
 
 bool PartitionOpBuilder::valueHasID(SILValue value, bool dumpIfHasNoID) {
-  return translater->valueHasID(value, dumpIfHasNoID);
+  return translator->valueHasID(value, dumpIfHasNoID);
 }
 
 void PartitionOpBuilder::print(llvm::raw_ostream &os) const {
@@ -1182,9 +1182,9 @@ void PartitionOpBuilder::print(llvm::raw_ostream &os) const {
   sortUnique(opsToPrint);
   for (unsigned opArg : opsToPrint) {
     llvm::dbgs() << "          └╼ ";
-    SILValue value = translater->stateIndexToEquivalenceClass[opArg];
-    auto iter = translater->equivalenceClassValuesToState.find(value);
-    assert(iter != translater->equivalenceClassValuesToState.end());
+    SILValue value = translator->stateIndexToEquivalenceClass[opArg];
+    auto iter = translator->equivalenceClassValuesToState.find(value);
+    assert(iter != translator->equivalenceClassValuesToState.end());
     llvm::dbgs() << "State: %%" << opArg << ". ";
     iter->getSecond().print(llvm::dbgs());
     llvm::dbgs() << "\n             Value: " << value;

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -2013,7 +2013,7 @@ class TransferNonSendable : public SILFunctionTransform {
     SILFunction *function = getFunction();
 
     if (!function->getASTContext().LangOpts.hasFeature(
-            Feature::TransferNonSendable))
+            Feature::RegionBasedIsolation))
       return;
 
     LLVM_DEBUG(llvm::dbgs()

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -133,7 +133,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addAddressLowering();
 
   P.addFlowIsolation();
-  P.addSendNonSendable();
+  P.addTransferNonSendable();
 
   // Automatic differentiation: canonicalize all differentiability witnesses
   // and `differentiable_function` instructions.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3182,7 +3182,7 @@ namespace {
 
       // check if language features ask us to defer sendable diagnostics
       // if so, don't check for sendability of arguments here
-      if (!ctx.LangOpts.hasFeature(Feature::TransferNonSendable)) {
+      if (!ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation)) {
         diagnoseApplyArgSendability(apply, getDeclContext());
       }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3182,7 +3182,7 @@ namespace {
 
       // check if language features ask us to defer sendable diagnostics
       // if so, don't check for sendability of arguments here
-      if (!ctx.LangOpts.hasFeature(Feature::SendNonSendable)) {
+      if (!ctx.LangOpts.hasFeature(Feature::TransferNonSendable)) {
         diagnoseApplyArgSendability(apply, getDeclContext());
       }
 

--- a/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
+++ b/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
+++ b/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -enable-actor-data-race-checks -o - %s | %FileCheck %s
 

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -enable-actor-data-race-checks -o - %s | %FileCheck %s
 

--- a/test/Concurrency/actor_derived_conformances.swift
+++ b/test/Concurrency/actor_derived_conformances.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_derived_conformances.swift
+++ b/test/Concurrency/actor_derived_conformances.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix targeted-complete- -verify-additional-prefix minimal-targeted- -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix targeted-complete- -verify-additional-prefix complete-tns- -verify-additional-prefix complete- -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-sns- -verify-additional-prefix targeted-complete- -verify-additional-prefix minimal-targeted- -strict-concurrency=targeted
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-sns- -verify-additional-prefix targeted-complete- -verify-additional-prefix complete-sns- -verify-additional-prefix complete- -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-sns- -verify-additional-prefix complete-sns- -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix targeted-complete- -verify-additional-prefix minimal-targeted- -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix targeted-complete- -verify-additional-prefix complete-tns- -verify-additional-prefix complete- -strict-concurrency=complete
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -102,8 +102,8 @@ extension TestActor {
 // external class method call
 @available(SwiftStdlib 5.1, *)
 class NonAsyncClass { // expected-targeted-complete-note {{class 'NonAsyncClass' does not conform to the 'Sendable' protocol}}
-  // expected-targeted-complete-sns-note @-1 {{class 'NonAsyncClass' does not conform to the 'Sendable' protocol}}
-  // expected-sns-note @-2 {{class 'NonAsyncClass' does not conform to the 'Sendable' protocol}}
+  // expected-targeted-complete-tns-note @-1 {{class 'NonAsyncClass' does not conform to the 'Sendable' protocol}}
+  // expected-tns-note @-2 {{class 'NonAsyncClass' does not conform to the 'Sendable' protocol}}
   func modifyOtherAsync(_ other : inout Int) async {
     // ...
   }
@@ -121,7 +121,7 @@ extension TestActor {
   func passStateIntoDifferentClassMethod() async {
     let other = NonAsyncClass()
     let otherCurry = other.modifyOtherAsync
-    // expected-targeted-complete-sns-warning @-1 {{non-sendable type 'NonAsyncClass' exiting actor-isolated context in call to non-isolated instance method 'modifyOtherAsync' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning @-1 {{non-sendable type 'NonAsyncClass' exiting actor-isolated context in call to non-isolated instance method 'modifyOtherAsync' cannot cross actor boundary}}
     await other.modifyOtherAsync(&value2)
     // expected-error @-1 {{actor-isolated property 'value2' cannot be passed 'inout' to 'async' function call}}
     // expected-targeted-complete-warning @-2 {{passing argument of non-sendable type 'NonAsyncClass' outside of actor-isolated context may introduce data races}}
@@ -217,22 +217,22 @@ struct MyGlobalActor {
 // expected-note @-1 {{var declared here}}
 // expected-note @-2 {{var declared here}}
 // expected-note @-3 {{mutation of this var is only permitted within the actor}}
-// expected-complete-sns-error @-4 {{top-level code variables cannot have a global actor}}
-// expected-complete-sns-note @-5 4{{mutation of this var is only permitted within the actor}}
+// expected-complete-tns-error @-4 {{top-level code variables cannot have a global actor}}
+// expected-complete-tns-note @-5 4{{mutation of this var is only permitted within the actor}}
 
 
 if #available(SwiftStdlib 5.1, *) {
   let _ = Task.detached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
   // expected-error @-1 {{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
   // expected-minimal-targeted-error @-2 {{global actor 'MyGlobalActor'-isolated var 'number' can not be used 'inout' from a non-isolated context}}
-  // expected-complete-sns-error @-3 {{main actor-isolated var 'number' can not be used 'inout' from a non-isolated context}}
+  // expected-complete-tns-error @-3 {{main actor-isolated var 'number' can not be used 'inout' from a non-isolated context}}
 }
 
 // attempt to pass global state owned by the global actor to another async function
 @available(SwiftStdlib 5.1, *)
 @MyGlobalActor func sneaky() async { await modifyAsynchronously(&number) }
 // expected-error @-1 {{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-// expected-complete-sns-error @-2 {{main actor-isolated var 'number' can not be used 'inout' from global actor 'MyGlobalActor'}}
+// expected-complete-tns-error @-2 {{main actor-isolated var 'number' can not be used 'inout' from global actor 'MyGlobalActor'}}
 
 
 // It's okay to pass actor state inout to synchronous functions!
@@ -242,13 +242,13 @@ func globalSyncFunction(_ foo: inout Int) { }
 @MyGlobalActor func globalActorSyncFunction(_ foo: inout Int) { }
 @available(SwiftStdlib 5.1, *)
 @MyGlobalActor func globalActorAsyncOkay() async { globalActorSyncFunction(&number) }
-// expected-complete-sns-error @-1 {{main actor-isolated var 'number' can not be used 'inout' from global actor 'MyGlobalActor'}}
+// expected-complete-tns-error @-1 {{main actor-isolated var 'number' can not be used 'inout' from global actor 'MyGlobalActor'}}
 @available(SwiftStdlib 5.1, *)
 @MyGlobalActor func globalActorAsyncOkay2() async { globalSyncFunction(&number) }
-// expected-complete-sns-error @-1 {{main actor-isolated var 'number' can not be used 'inout' from global actor 'MyGlobalActor'}}
+// expected-complete-tns-error @-1 {{main actor-isolated var 'number' can not be used 'inout' from global actor 'MyGlobalActor'}}
 @available(SwiftStdlib 5.1, *)
 @MyGlobalActor func globalActorSyncOkay() { globalSyncFunction(&number) }
-// expected-complete-sns-error @-1 {{main actor-isolated var 'number' can not be used 'inout' from global actor 'MyGlobalActor'}}
+// expected-complete-tns-error @-1 {{main actor-isolated var 'number' can not be used 'inout' from global actor 'MyGlobalActor'}}
 
 // Gently unwrap things that are fine
 @available(SwiftStdlib 5.1, *)
@@ -293,11 +293,11 @@ actor ProtectArray {
   func test() async {
     // FIXME: this is invalid too!
     _ = await array.mutateAsynchronously
-    // expected-targeted-complete-sns-warning@-1 {{non-sendable type '@lvalue [Int]' exiting actor-isolated context in call to non-isolated property 'mutateAsynchronously' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning@-1 {{non-sendable type '@lvalue [Int]' exiting actor-isolated context in call to non-isolated property 'mutateAsynchronously' cannot cross actor boundary}}
 
     _ = await array[mutateAsynchronously: 0]
     // expected-error@-1 {{actor-isolated property 'array' cannot be passed 'inout' to 'async' function call}}
-    // expected-targeted-complete-sns-warning@-2 {{non-sendable type 'inout Array<Int>' exiting actor-isolated context in call to non-isolated subscript 'subscript(mutateAsynchronously:)' cannot cross actor boundary}}
+    // expected-targeted-complete-tns-warning@-2 {{non-sendable type 'inout Array<Int>' exiting actor-isolated context in call to non-isolated subscript 'subscript(mutateAsynchronously:)' cannot cross actor boundary}}
 
     await passToAsync(array[0])
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_isolation_cycle.swift
+++ b/test/Concurrency/actor_isolation_cycle.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_isolation_cycle.swift
+++ b/test/Concurrency/actor_isolation_cycle.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -disable-availability-checking -warn-concurrency -swift-version 6 -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -warn-concurrency -swift-version 6 -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -warn-concurrency -swift-version 6 -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -disable-availability-checking -warn-concurrency -swift-version 6 -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -warn-concurrency -swift-version 6 -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -warn-concurrency -swift-version 6 -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-sns- -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-sns- -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-tns- -strict-concurrency=complete
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -14,14 +14,14 @@ actor SomeGlobalActor {
 @MainActor(unsafe) func globalMain() { } // expected-note {{calls to global function 'globalMain()' from outside of its actor context are implicitly asynchronous}}
 
 @SomeGlobalActor(unsafe) func globalSome() { } // expected-note 2{{calls to global function 'globalSome()' from outside of its actor context are implicitly asynchronous}}
-// expected-complete-sns-note @-1 {{calls to global function 'globalSome()' from outside of its actor context are implicitly asynchronous}}
+// expected-complete-tns-note @-1 {{calls to global function 'globalSome()' from outside of its actor context are implicitly asynchronous}}
 
 // ----------------------------------------------------------------------
 // Witnessing and unsafe global actor
 // ----------------------------------------------------------------------
 protocol P1 {
   @MainActor(unsafe) func onMainActor() // expected-note{{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
-  // expected-complete-sns-note @-1 {{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
+  // expected-complete-tns-note @-1 {{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
 }
 
 struct S1_P1: P1 {
@@ -38,7 +38,7 @@ struct S3_P1: P1 {
 
 struct S4_P1_quietly: P1 {
   @SomeGlobalActor func onMainActor() { }
-  // expected-complete-sns-warning @-1 {{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated protocol requirement}}
+  // expected-complete-tns-warning @-1 {{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated protocol requirement}}
 }
 
 @SomeGlobalActor
@@ -50,13 +50,13 @@ struct S4_P1: P1 {
 @MainActor(unsafe)
 protocol P2 {
   func f() // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-sns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-tns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
   nonisolated func g()
 }
 
 struct S5_P2: P2 {
   func f() { } // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-sns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-tns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
   func g() { }
 }
 
@@ -68,12 +68,12 @@ nonisolated func testP2(x: S5_P2, p2: P2) {
 }
 
 func testP2_noconcurrency(x: S5_P2, p2: P2) {
-  // expected-complete-sns-note @-1 2{{add '@MainActor' to make global function 'testP2_noconcurrency(x:p2:)' part of global actor 'MainActor'}}
+  // expected-complete-tns-note @-1 2{{add '@MainActor' to make global function 'testP2_noconcurrency(x:p2:)' part of global actor 'MainActor'}}
   p2.f() // okay without complete. with targeted/minimal not concurrency-related code.
-  // expected-complete-sns-error @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  // expected-complete-tns-error @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p2.g() // okay
   x.f() // okay without complete. with targeted/minimal not concurrency-related code
-  // expected-complete-sns-error @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  // expected-complete-tns-error @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   x.g() // OKAY
 }
 
@@ -87,7 +87,7 @@ class C1 {
 class C2: C1 {
   override func method() { // expected-note 2{{overridden declaration is here}}
     globalSome() // okay when not in complete
-    // expected-complete-sns-error @-1 {{call to global actor 'SomeGlobalActor'-isolated global function 'globalSome()' in a synchronous main actor-isolated context}}
+    // expected-complete-tns-error @-1 {{call to global actor 'SomeGlobalActor'-isolated global function 'globalSome()' in a synchronous main actor-isolated context}}
   }
 }
 

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-tns- -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_keypath_isolation_swift6.swift
+++ b/test/Concurrency/actor_keypath_isolation_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -swift-version 6 %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency && asserts
 

--- a/test/Concurrency/actor_keypath_isolation_swift6.swift
+++ b/test/Concurrency/actor_keypath_isolation_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -swift-version 6 %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency && asserts
 

--- a/test/Concurrency/actor_withCancellationHandler.swift
+++ b/test/Concurrency/actor_withCancellationHandler.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_withCancellationHandler.swift
+++ b/test/Concurrency/actor_withCancellationHandler.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_computed_property.swift
+++ b/test/Concurrency/async_computed_property.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_computed_property.swift
+++ b/test/Concurrency/async_computed_property.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_conformance.swift
+++ b/test/Concurrency/async_conformance.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s
-// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/async_conformance.swift
+++ b/test/Concurrency/async_conformance.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s
-// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s -verify-additional-prefix complete-and-tns-
-// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s -verify-additional-prefix complete-and-tns-
+// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation %s -verify-additional-prefix complete-and-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
-// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s -verify-additional-prefix complete-and-sns-
-// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable %s -verify-additional-prefix complete-and-sns-
+// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s -verify-additional-prefix complete-and-tns-
+// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s -verify-additional-prefix complete-and-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -113,10 +113,10 @@ struct SomeStruct {
   @MainActor init(asyncMainActor: Int) async {}
   @MainActor init(mainActor: Int) {} // expected-note {{calls to initializer 'init(mainActor:)' from outside of its actor context are implicitly asynchronous}}
   @MainActor(unsafe) init(asyncMainActorUnsafe: Int) async {}
-  @MainActor(unsafe) init(mainActorUnsafe: Int) {} // expected-complete-and-sns-note {{calls to initializer 'init(mainActorUnsafe:)' from outside of its actor context are implicitly asynchronous}}
+  @MainActor(unsafe) init(mainActorUnsafe: Int) {} // expected-complete-and-tns-note {{calls to initializer 'init(mainActorUnsafe:)' from outside of its actor context are implicitly asynchronous}}
 }
 
-// expected-complete-and-sns-note @+3 {{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}
+// expected-complete-and-tns-note @+3 {{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}
 // expected-note @+2 {{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}
 // expected-note @+1 2 {{add 'async' to function 'globActorTest1()' to make it asynchronous}}
 func globActorTest1() {
@@ -126,7 +126,7 @@ func globActorTest1() {
 
   _ = SomeStruct(asyncMainActorUnsafe: 0) // expected-error {{'async' call in a function that does not support concurrency}}
 
-  _ = SomeStruct(mainActorUnsafe: 0) // expected-complete-and-sns-error {{call to main actor-isolated initializer 'init(mainActorUnsafe:)' in a synchronous nonisolated context}}
+  _ = SomeStruct(mainActorUnsafe: 0) // expected-complete-and-tns-error {{call to main actor-isolated initializer 'init(mainActorUnsafe:)' in a synchronous nonisolated context}}
 }
 
 func globActorTestAsyncEdition() async {

--- a/test/Concurrency/async_initializer_objc.swift
+++ b/test/Concurrency/async_initializer_objc.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/async_initializer_objc.swift
+++ b/test/Concurrency/async_initializer_objc.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/async_let_capture.swift
+++ b/test/Concurrency/async_let_capture.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_let_capture.swift
+++ b/test/Concurrency/async_let_capture.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking  %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_main_invalid_global_actor.swift
+++ b/test/Concurrency/async_main_invalid_global_actor.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_main_invalid_global_actor.swift
+++ b/test/Concurrency/async_main_invalid_global_actor.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_main_mainactor_isolation.swift
+++ b/test/Concurrency/async_main_mainactor_isolation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_main_mainactor_isolation.swift
+++ b/test/Concurrency/async_main_mainactor_isolation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_task_locals_basic_warnings.swift
+++ b/test/Concurrency/async_task_locals_basic_warnings.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_task_locals_basic_warnings.swift
+++ b/test/Concurrency/async_task_locals_basic_warnings.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking %s -o /dev/null -verify -emit-sil
 // RUN: %target-swift-frontend -strict-concurrency=strict -disable-availability-checking %s -o /dev/null -verify -emit-sil
-// RUN: %target-swift-frontend -strict-concurrency=strict -disable-availability-checking %s -o /dev/null -verify -emit-sil -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=strict -disable-availability-checking %s -o /dev/null -verify -emit-sil -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking %s -o /dev/null -verify -emit-sil
 // RUN: %target-swift-frontend -strict-concurrency=strict -disable-availability-checking %s -o /dev/null -verify -emit-sil
-// RUN: %target-swift-frontend -strict-concurrency=strict -disable-availability-checking %s -o /dev/null -verify -emit-sil -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=strict -disable-availability-checking %s -o /dev/null -verify -emit-sil -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_throwing.swift
+++ b/test/Concurrency/async_throwing.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_throwing.swift
+++ b/test/Concurrency/async_throwing.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/attr_discardableResult_async_await.swift
+++ b/test/Concurrency/attr_discardableResult_async_await.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/attr_discardableResult_async_await.swift
+++ b/test/Concurrency/attr_discardableResult_async_await.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrency_module_shadowing.swift
+++ b/test/Concurrency/concurrency_module_shadowing.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrency_module_shadowing.swift
+++ b/test/Concurrency/concurrency_module_shadowing.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -enable-library-evolution -warn-concurrency %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -enable-library-evolution -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -enable-library-evolution -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -enable-library-evolution -warn-concurrency %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -enable-library-evolution -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -enable-library-evolution -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrent_value_inference_public.swift
+++ b/test/Concurrency/concurrent_value_inference_public.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/concurrent_value_inference_public.swift
+++ b/test/Concurrency/concurrent_value_inference_public.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -enable-infer-public-sendable %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/concurrentfunction_capturediagnostics.swift
+++ b/test/Concurrency/concurrentfunction_capturediagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null
 // RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrentfunction_capturediagnostics.swift
+++ b/test/Concurrency/concurrentfunction_capturediagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null
 // RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -enable-experimental-flow-sensitive-concurrent-captures -verify -emit-sil %s -o - >/dev/null -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/custom_executor_enqueue_availability.swift
+++ b/test/Concurrency/custom_executor_enqueue_availability.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx

--- a/test/Concurrency/custom_executor_enqueue_availability.swift
+++ b/test/Concurrency/custom_executor_enqueue_availability.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx

--- a/test/Concurrency/custom_executor_enqueue_deprecation_on_executor_extension.swift
+++ b/test/Concurrency/custom_executor_enqueue_deprecation_on_executor_extension.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s
-// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/custom_executor_enqueue_deprecation_on_executor_extension.swift
+++ b/test/Concurrency/custom_executor_enqueue_deprecation_on_executor_extension.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s
-// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s
-// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete %s
-// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/default_actor_definit.swift
+++ b/test/Concurrency/default_actor_definit.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking -strict-concurrency=targeted | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking -strict-concurrency=complete | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature TransferNonSendable | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/default_actor_definit.swift
+++ b/test/Concurrency/default_actor_definit.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking -strict-concurrency=targeted | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking -strict-concurrency=complete | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature SendNonSendable | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature TransferNonSendable | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/derived_conformances_nonisolated.swift
+++ b/test/Concurrency/derived_conformances_nonisolated.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/derived_conformances_nonisolated.swift
+++ b/test/Concurrency/derived_conformances_nonisolated.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: libdispatch

--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %import-libdispatch -warn-concurrency %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: libdispatch

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -enable-experimental-feature StrictConcurrency=targeted %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency_targeted.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -enable-experimental-feature StrictConcurrency=targeted %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
-// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s
-// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-sns- -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-sns- -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -133,7 +133,7 @@ func fromAsync() async {
 }
 
 // expected-minimal-and-targeted-note @+2 {{mutation of this var is only permitted within the actor}}
-// expected-complete-and-sns-error @+1 {{top-level code variables cannot have a global actor}}
+// expected-complete-and-tns-error @+1 {{top-level code variables cannot have a global actor}}
 @SomeGlobalActor var value: Int = 42
 
 func topLevelSyncFunction(_ number: inout Int) { }

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -1,8 +1,8 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-sns-
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable  -verify-additional-prefix complete-sns-
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable  -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -32,7 +32,7 @@ func testConversions(f: @escaping @SomeGlobalActor (Int) -> Void, g: @escaping (
 
 @OtherGlobalActor func onOtherGlobalActor() -> Int { 5 } // expected-note{{calls to global function 'onOtherGlobalActor()' from outside of its actor context are implicitly asynchronous}}
 @OtherGlobalActor(unsafe) func onOtherGlobalActorUnsafe() -> Int { 5 }  // expected-note 2{{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
-// expected-complete-sns-note @-1 {{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
+// expected-complete-tns-note @-1 {{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
 
 func someSlowOperation() async -> Int { 5 }
 
@@ -93,7 +93,7 @@ func testClosuresOld() {
   }
 
   acceptOnSomeGlobalActor { () -> Int in
-    let i = onOtherGlobalActorUnsafe() // expected-complete-sns-error {{call to global actor 'OtherGlobalActor'-isolated global function 'onOtherGlobalActorUnsafe()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
+    let i = onOtherGlobalActorUnsafe() // expected-complete-tns-error {{call to global actor 'OtherGlobalActor'-isolated global function 'onOtherGlobalActorUnsafe()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
     return i
   }
 
@@ -123,16 +123,16 @@ func g2(_ x: X<() -> Void>) {
 
 
 func testTypesNonConcurrencyContext() { // expected-note{{add '@SomeGlobalActor' to make global function 'testTypesNonConcurrencyContext()' part of global actor 'SomeGlobalActor'}}
-  // expected-complete-sns-note @-1 {{add '@SomeGlobalActor' to make global function 'testTypesNonConcurrencyContext()' part of global actor 'SomeGlobalActor'}}
+  // expected-complete-tns-note @-1 {{add '@SomeGlobalActor' to make global function 'testTypesNonConcurrencyContext()' part of global actor 'SomeGlobalActor'}}
   let f1 = onSomeGlobalActor // expected-note{{calls to let 'f1' from outside of its actor context are implicitly asynchronous}}
-  let f2 = onSomeGlobalActorUnsafe // expected-complete-sns-note {{calls to let 'f2' from outside of its actor context are implicitly asynchronous}}
+  let f2 = onSomeGlobalActorUnsafe // expected-complete-tns-note {{calls to let 'f2' from outside of its actor context are implicitly asynchronous}}
 
   let _: () -> Int = f1 // expected-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
-  let _: () -> Int = f2 // expected-complete-sns-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  let _: () -> Int = f2 // expected-complete-tns-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
 
   _ = {
     let _: () -> Int = f1 // expected-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
-    let _: () -> Int = f2 // expected-complete-sns-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+    let _: () -> Int = f2 // expected-complete-tns-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
   }
 
   @SomeGlobalActor func isolated() {
@@ -141,7 +141,7 @@ func testTypesNonConcurrencyContext() { // expected-note{{add '@SomeGlobalActor'
   }
 
   _ = f1() // expected-error{{call to global actor 'SomeGlobalActor'-isolated let 'f1' in a synchronous nonisolated context}}
-  _ = f2() // expected-complete-sns-error {{call to global actor 'SomeGlobalActor'-isolated let 'f2' in a synchronous nonisolated context}}
+  _ = f2() // expected-complete-tns-error {{call to global actor 'SomeGlobalActor'-isolated let 'f2' in a synchronous nonisolated context}}
 }
 
 func testTypesConcurrencyContext() async {

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable  -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation  -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -3,8 +3,8 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -warn-concurrency %S/Inputs/other_global_actor_inference.swift
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-sns-
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable -verify-additional-prefix complete-sns-
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -560,15 +560,15 @@ struct WrapperOnUnsafeActor<Wrapped> {
 struct HasWrapperOnUnsafeActor {
   @WrapperOnUnsafeActor var synced: Int = 0
   // expected-note @-1 3{{property declared here}}
-  // expected-complete-sns-note @-2 3{{property declared here}}
+  // expected-complete-tns-note @-2 3{{property declared here}}
 
   func testUnsafeOkay() {
-    // expected-complete-sns-note @-1 {{add '@OtherGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'OtherGlobalActor'}}
-    // expected-complete-sns-note @-2 {{add '@SomeGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'SomeGlobalActor'}}
-    // expected-complete-sns-note @-3 {{add '@MainActor' to make instance method 'testUnsafeOkay()' part of global actor 'MainActor'}}
-    _ = synced // expected-complete-sns-error {{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
-    _ = $synced // expected-complete-sns-error {{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
-    _ = _synced // expected-complete-sns-error {{global actor 'OtherGlobalActor'-isolated property '_synced' can not be referenced from a non-isolated context}}
+    // expected-complete-tns-note @-1 {{add '@OtherGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'OtherGlobalActor'}}
+    // expected-complete-tns-note @-2 {{add '@SomeGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'SomeGlobalActor'}}
+    // expected-complete-tns-note @-3 {{add '@MainActor' to make instance method 'testUnsafeOkay()' part of global actor 'MainActor'}}
+    _ = synced // expected-complete-tns-error {{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
+    _ = $synced // expected-complete-tns-error {{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
+    _ = _synced // expected-complete-tns-error {{global actor 'OtherGlobalActor'-isolated property '_synced' can not be referenced from a non-isolated context}}
   }
 
   nonisolated func testErrors() {
@@ -644,7 +644,7 @@ func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable 
 // defer bodies inherit global actor-ness
 @MainActor
 var statefulThingy: Bool = false // expected-note {{var declared here}}
-// expected-complete-sns-error @-1 {{top-level code variables cannot have a global actor}}
+// expected-complete-tns-error @-1 {{top-level code variables cannot have a global actor}}
 
 @MainActor
 func useFooInADefer() -> String { // expected-note {{calls to global function 'useFooInADefer()' from outside of its actor context are implicitly asynchronous}}

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -swift-version 6 -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -warn-concurrency %S/Inputs/other_global_actor_inference.swift
 
 // RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -swift-version 6 -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -warn-concurrency %S/Inputs/other_global_actor_inference.swift
 
 // RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_serialized.swift
+++ b/test/Concurrency/global_actor_serialized.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedStruct.swiftmodule -module-name SerializedStruct %S/Inputs/SerializedStruct.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_serialized.swift
+++ b/test/Concurrency/global_actor_serialized.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedStruct.swiftmodule -module-name SerializedStruct %S/Inputs/SerializedStruct.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/hop_to_executor_unreachable_code.swift
+++ b/test/Concurrency/hop_to_executor_unreachable_code.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/hop_to_executor_unreachable_code.swift
+++ b/test/Concurrency/hop_to_executor_unreachable_code.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify -o /dev/null %s -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultValues %S/Inputs/serialized_default_arguments.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature TransferNonSendable -enable-experimental-feature IsolatedDefaultValues
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature RegionBasedIsolation -enable-experimental-feature IsolatedDefaultValues
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultValues %S/Inputs/serialized_default_arguments.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-experimental-feature IsolatedDefaultValues
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature TransferNonSendable -enable-experimental-feature IsolatedDefaultValues
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -disable-availability-checking -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/issue-57376.swift
+++ b/test/Concurrency/issue-57376.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -disable-availability-checking -strict-concurrency=targeted %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/issue-57376.swift
+++ b/test/Concurrency/issue-57376.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -disable-availability-checking -strict-concurrency=targeted %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s -strict-concurrency=complete
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s -strict-concurrency=complete
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -emit-sil -o /dev/null -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/objc_require_explicit_sendable.swift
+++ b/test/Concurrency/objc_require_explicit_sendable.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=targeted
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=complete
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/objc_require_explicit_sendable.swift
+++ b/test/Concurrency/objc_require_explicit_sendable.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=targeted
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=complete
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/preconcurrency_implementationonly_override.swift
+++ b/test/Concurrency/preconcurrency_implementationonly_override.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify -strict-concurrency=complete %s
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/preconcurrency_implementationonly_override.swift
+++ b/test/Concurrency/preconcurrency_implementationonly_override.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify -strict-concurrency=targeted %s
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify -strict-concurrency=complete %s
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -enable-library-evolution -swift-version 5 -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/preconcurrency_overload.swift
+++ b/test/Concurrency/preconcurrency_overload.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-and-tns- -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-and-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-and-tns- -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/preconcurrency_overload.swift
+++ b/test/Concurrency/preconcurrency_overload.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-and-sns- -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-and-sns- -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-and-tns- -strict-concurrency=complete
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-and-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -24,15 +24,15 @@ extension Future {
 extension Future {
   @available(*, deprecated, message: "")
   func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (T) -> Future<NewValue>) -> Future<NewValue> { // #2
-    // expected-complete-and-sns-note @-1 {{parameter 'callback' is implicitly non-sendable}}
+    // expected-complete-and-tns-note @-1 {{parameter 'callback' is implicitly non-sendable}}
     return self.flatMap(callback)
-    // expected-complete-and-sns-warning @-1 {{passing non-sendable parameter 'callback' to function expecting a @Sendable closure}}
+    // expected-complete-and-tns-warning @-1 {{passing non-sendable parameter 'callback' to function expecting a @Sendable closure}}
   }
 
   @inlinable
   @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
   public func flatMapErrorThrowing(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) throws -> T) -> Future<T> {
     return self.flatMapErrorThrowing(callback)
-    // expected-complete-and-sns-warning @-1 {{function call causes an infinite recursion}}
+    // expected-complete-and-tns-warning @-1 {{function call causes an infinite recursion}}
   }
 }

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-tns- -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-sns- -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-sns- -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-tns- -strict-concurrency=complete
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
 @preconcurrency @MainActor func f() { }
 // expected-note @-1 2{{calls to global function 'f()' from outside of its actor context are implicitly asynchronous}}
-// expected-complete-sns-note @-2 2{{calls to global function 'f()' from outside of its actor context are implicitly asynchronous}}
+// expected-complete-tns-note @-2 2{{calls to global function 'f()' from outside of its actor context are implicitly asynchronous}}
 
 @preconcurrency typealias FN = @Sendable () -> Void
 
@@ -20,18 +20,18 @@ struct Outer {
 
 func test() {
   var _: Outer.FN = {
-    f() // expected-complete-sns-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    f() // expected-complete-tns-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
   }
 
   var _: FN = {
-    f() // expected-complete-sns-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    f() // expected-complete-tns-warning {{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
     print("Hello")
   }
 
   var mutableVariable = 0
   preconcurrencyFunc {
     mutableVariable += 1 // no sendable warning unless we have complete
-    // expected-complete-sns-warning @-1 {{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in Swift 6}}
+    // expected-complete-tns-warning @-1 {{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in Swift 6}}
   }
   mutableVariable += 1
 }
@@ -59,10 +59,10 @@ func testAsync() async {
 @preconcurrency typealias Handler = (@Sendable () -> OtherHandler?)?
 @preconcurrency func f(arg: Int, withFn: Handler?) {}
 
-class C { // expected-complete-sns-note {{class 'C' does not conform to the 'Sendable' protocol}}
+class C { // expected-complete-tns-note {{class 'C' does not conform to the 'Sendable' protocol}}
   func test() {
     f(arg: 5, withFn: { [weak self] () -> OtherHandler? in
-        _ = self // expected-complete-sns-warning {{capture of 'self' with non-sendable type 'C?' in a `@Sendable` closure}}
+        _ = self // expected-complete-tns-warning {{capture of 'self' with non-sendable type 'C?' in a `@Sendable` closure}}
         return nil
       })
   }

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted-
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted-
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-sns-
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable -verify-additional-prefix complete-sns-
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -48,38 +48,38 @@ func testInAsync(x: X, plainClosure: () -> Void) async { // expected-note 2{{par
 
 func testElsewhere(x: X) {
   let _: Int = unsafelySendableClosure // expected-minimal-targeted-error {{type '(() -> Void) -> ()'}}
-  // expected-complete-sns-error @-1 {{type '(@Sendable () -> Void) -> ()'}}
+  // expected-complete-tns-error @-1 {{type '(@Sendable () -> Void) -> ()'}}
   let _: Int = unsafelyMainActorClosure // expected-minimal-targeted-error {{type '(() -> Void) -> ()'}}
-  // expected-complete-sns-error @-1 {{type '(@MainActor () -> Void) -> ()'}}
+  // expected-complete-tns-error @-1 {{type '(@MainActor () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-minimal-targeted-error {{type '(() -> Void) -> ()'}}
-  // expected-complete-sns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  // expected-complete-tns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = x.unsafelyDoEverythingClosure // expected-minimal-targeted-error{{type '(() -> Void) -> ()'}}
-  // expected-complete-sns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  // expected-complete-tns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = X.unsafelyDoEverythingClosure // expected-minimal-targeted-error{{type '(X) -> (() -> Void) -> ()'}}
-  // expected-complete-sns-error @-1 {{type '(X) -> (@MainActor @Sendable () -> Void) -> ()'}}
+  // expected-complete-tns-error @-1 {{type '(X) -> (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-minimal-targeted-error{{type '(() -> Void) -> ()'}}
-  // expected-complete-sns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  // expected-complete-tns-error @-1 {{type '(@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = x.sendableVar // expected-minimal-targeted-error {{type '() -> Void'}}
-  // expected-complete-sns-error @-1 {{type '@Sendable () -> Void'}}
+  // expected-complete-tns-error @-1 {{type '@Sendable () -> Void'}}
   let _: Int = x.mainActorVar // expected-minimal-targeted-error {{type '() -> Void'}}
-  // expected-complete-sns-error @-1 {{type '@MainActor () -> Void'}}
+  // expected-complete-tns-error @-1 {{type '@MainActor () -> Void'}}
   let _: Int = x[{ onMainActor() }] // expected-minimal-targeted-error {{type '() -> Void'}}
-  // expected-complete-sns-error @-1 {{type '@Sendable () -> Void'}}
+  // expected-complete-tns-error @-1 {{type '@Sendable () -> Void'}}
   let _: Int = X[statically: { onMainActor() }] // expected-minimal-targeted-error {{type '() -> Void'}}
-  // expected-complete-sns-error @-1 {{type '@Sendable () -> Void'}}
+  // expected-complete-tns-error @-1 {{type '@Sendable () -> Void'}}
 }
 
 @MainActor @preconcurrency func onMainActorAlways() { }
-// expected-complete-sns-note @-1 {{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
+// expected-complete-tns-note @-1 {{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
 
 @preconcurrency @MainActor class MyModelClass {
-  // expected-complete-sns-note @-1 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-tns-note @-1 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
   func f() { }
-  // expected-complete-sns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-tns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 }
 
 func testCalls(x: X) {
-  // expected-complete-sns-note @-1 3{{add '@MainActor' to make global function 'testCalls(x:)' part of global actor 'MainActor'}}
+  // expected-complete-tns-note @-1 3{{add '@MainActor' to make global function 'testCalls(x:)' part of global actor 'MainActor'}}
   unsafelyMainActorClosure {
     onMainActor()
   }
@@ -97,14 +97,14 @@ func testCalls(x: X) {
     })
 
   onMainActorAlways() // okay with minimal/targeted concurrency. Not ok with complete.
-  // expected-complete-sns-warning @-1 {{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
+  // expected-complete-tns-warning @-1 {{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
 
   // Ok with minimal/targeted concurrency, Not ok with complete.
-  let _: () -> Void = onMainActorAlways // expected-complete-sns-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
+  let _: () -> Void = onMainActorAlways // expected-complete-tns-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
   // both okay with minimal/targeted... an error with complete.
-  let c = MyModelClass() // expected-complete-sns-error {{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
-  c.f() // expected-complete-sns-error {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  let c = MyModelClass() // expected-complete-tns-error {{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
+  c.f() // expected-complete-tns-error {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
 }
 
 func testCallsWithAsync() async {
@@ -126,14 +126,14 @@ func testCallsWithAsync() async {
 protocol Q: P { }
 
 class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' protocol}}
-// expected-complete-sns-note @-1 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+// expected-complete-tns-note @-1 2{{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct S1: P {
-  var ns: NS // expected-complete-sns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S1' has non-sendable type 'NS'}}
+  var ns: NS // expected-complete-tns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S1' has non-sendable type 'NS'}}
 }
 
 struct S2: Q {
-  var ns: NS // expected-complete-sns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S2' has non-sendable type 'NS'}}
+  var ns: NS // expected-complete-tns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S2' has non-sendable type 'NS'}}
 }
 
 struct S3: Q, Sendable {
@@ -170,11 +170,11 @@ public enum StringPlacement : Sendable {
 func testStringPlacement() {
   let fn1 = StringPlacement.position(before: "Test")
   let _: Int = fn1   // expected-minimal-targeted-error{{cannot convert value of type '([String]) -> Int' to specified type 'Int'}}
-  // expected-complete-sns-error @-1 {{type 'StringPlacement.StringPosition' (aka '@Sendable (Array<String>) -> Int')}}
+  // expected-complete-tns-error @-1 {{type 'StringPlacement.StringPosition' (aka '@Sendable (Array<String>) -> Int')}}
 
   let fn2 = StringPlacement.position(before:)
   let _: Int = fn2 // expected-minimal-targeted-error{{cannot convert value of type '(String) -> ([String]) -> Int' to specified type 'Int'}}
-  // expected-complete-sns-error @-1 {{type '(String) -> StringPlacement.StringPosition' (aka '(String) -> @Sendable (Array<String>) -> Int')}}
+  // expected-complete-tns-error @-1 {{type '(String) -> StringPlacement.StringPosition' (aka '(String) -> @Sendable (Array<String>) -> Int')}}
 }
 
 // @preconcurrency in an outer closure
@@ -190,17 +190,17 @@ class EventLoop {
   func scheduleTask<T>(deadline: Int, _ task: @escaping @Sendable () throws -> T) -> Scheduled<T> { fatalError("") }
 }
 
-class C { // expected-complete-sns-note {{'C' does not conform to the 'Sendable' protocol}}
+class C { // expected-complete-tns-note {{'C' does not conform to the 'Sendable' protocol}}
   var ev: EventLoop? = nil
 
   func test(i: Int) {
-    func doNext() { // expected-complete-sns-warning {{concurrently-executed local function 'doNext()' must be marked as '@Sendable'}}
+    func doNext() { // expected-complete-tns-warning {{concurrently-executed local function 'doNext()' must be marked as '@Sendable'}}
       doPreconcurrency {
         self.ev?.scheduleTask(deadline: i, doNext)
-        // expected-complete-sns-warning @-1 {{capture of 'self' with non-sendable type 'C' in a `@Sendable` closure}}
-        // expected-complete-sns-warning @-2 {{converting non-sendable function value to '@Sendable () throws -> ()' may introduce data races}}
-        // expected-complete-sns-warning @-3 {{capture of 'doNext()' with non-sendable type '() -> ()' in a `@Sendable` closure}}
-        // expected-complete-sns-note @-4 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+        // expected-complete-tns-warning @-1 {{capture of 'self' with non-sendable type 'C' in a `@Sendable` closure}}
+        // expected-complete-tns-warning @-2 {{converting non-sendable function value to '@Sendable () throws -> ()' may introduce data races}}
+        // expected-complete-tns-warning @-3 {{capture of 'doNext()' with non-sendable type '() -> ()' in a `@Sendable` closure}}
+        // expected-complete-tns-note @-4 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
         return
       }
     }

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/predates_concurrency_import_emitmodule.swift
+++ b/test/Concurrency/predates_concurrency_import_emitmodule.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies
 // RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/predates_concurrency_import_emitmodule.swift
+++ b/test/Concurrency/predates_concurrency_import_emitmodule.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies
 // RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 
 // RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 
 // RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/property_initializers_swift6.swift
+++ b/test/Concurrency/property_initializers_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -warn-concurrency -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -warn-concurrency -emit-sil -o /dev/null -verify %s -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -warn-concurrency -emit-sil -o /dev/null -verify %s -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/property_initializers_swift6.swift
+++ b/test/Concurrency/property_initializers_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -warn-concurrency -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -warn-concurrency -emit-sil -o /dev/null -verify %s -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -swift-version 6 -disable-availability-checking -warn-concurrency -emit-sil -o /dev/null -verify %s -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/radar_concurrency_nio.swift
+++ b/test/Concurrency/radar_concurrency_nio.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/radar_concurrency_nio.swift
+++ b/test/Concurrency/radar_concurrency_nio.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -enable-experimental-move-only %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/reasync.swift
+++ b/test/Concurrency/reasync.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/reasync.swift
+++ b/test/Concurrency/reasync.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -enable-experimental-concurrency -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -require-explicit-sendable -warn-concurrency %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -require-explicit-sendable -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -require-explicit-sendable -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -require-explicit-sendable -warn-concurrency %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -require-explicit-sendable -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -require-explicit-sendable -warn-concurrency %s -emit-sil -o /dev/null -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/sendable_associated_type.swift
+++ b/test/Concurrency/sendable_associated_type.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -strict-concurrency=complete -emit-sil -o /dev/null %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -emit-sil -o /dev/null %s -verify
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -emit-sil -o /dev/null %s -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_associated_type.swift
+++ b/test/Concurrency/sendable_associated_type.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -strict-concurrency=complete -emit-sil -o /dev/null %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature SendNonSendable -emit-sil -o /dev/null %s -verify
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -emit-sil -o /dev/null %s -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -verify -strict-concurrency=targeted -verify-additional-prefix targeted-and-complete- -emit-sil -o /dev/null %s
-// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix targeted-and-complete- -verify-additional-prefix complete-and-sns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s
-// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix sns- -verify-additional-prefix complete-and-sns- -emit-sil -o /dev/null %s -enable-experimental-feature SendNonSendable 
+// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix targeted-and-complete- -verify-additional-prefix complete-and-tns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s
+// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix tns- -verify-additional-prefix complete-and-tns- -emit-sil -o /dev/null %s -enable-experimental-feature TransferNonSendable 
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -18,7 +18,7 @@ extension NS1: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 struct NS2 { // expected-note {{consider making struct 'NS2' conform to the 'Sendable' protocol}}
-  // expected-complete-and-sns-note @-1 {{consider making struct 'NS2' conform to the 'Sendable' protocol}}
+  // expected-complete-and-tns-note @-1 {{consider making struct 'NS2' conform to the 'Sendable' protocol}}
   var ns1: NS1
 }
 
@@ -30,7 +30,7 @@ extension NS3: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 class NS4 { } // expected-note {{class 'NS4' does not conform to the 'Sendable' protocol}}
-// expected-complete-and-sns-note @-1 {{class 'NS4' does not conform to the 'Sendable' protocol}}
+// expected-complete-and-tns-note @-1 {{class 'NS4' does not conform to the 'Sendable' protocol}}
 
 @available(SwiftStdlib 5.1, *)
 func acceptCV<T: Sendable>(_: T) { }
@@ -47,15 +47,15 @@ func testCV(
 
   acceptCV(ns1array) // expected-warning {{conformance of 'NS1' to 'Sendable' is unavailable}}
 
-  acceptCV(ns2) // expected-complete-and-sns-warning {{type 'NS2' does not conform to the 'Sendable' protocol}}
+  acceptCV(ns2) // expected-complete-and-tns-warning {{type 'NS2' does not conform to the 'Sendable' protocol}}
 
   acceptCV(ns3) // expected-warning {{conformance of 'NS3' to 'Sendable' is only available in macOS 11.0 or newer}}
   // expected-note @-1 {{add 'if #available' version check}}
 
-  acceptCV(ns4) // expected-complete-and-sns-warning {{type 'NS4' does not conform to the 'Sendable' protocol}}
+  acceptCV(ns4) // expected-complete-and-tns-warning {{type 'NS4' does not conform to the 'Sendable' protocol}}
 
-  acceptCV(fn) // expected-complete-and-sns-warning {{type '() -> Void' does not conform to the 'Sendable' protocol}}
-  // expected-complete-and-sns-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptCV(fn) // expected-complete-and-tns-warning {{type '() -> Void' does not conform to the 'Sendable' protocol}}
+  // expected-complete-and-tns-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   acceptSendableFn(fn) // expected-warning{{passing non-sendable parameter 'fn' to function expecting a @Sendable closure}}
 }
@@ -235,15 +235,15 @@ func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> 
 
   // FIXME: 'f' is Sendable
   await a.g(f)
-  // expected-sns-warning@-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-tns-warning@-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
 }
 
 @available(SwiftStdlib 5.1, *)
 final class NonSendable {
   // expected-note @-1 3 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
-  // SendNonSendable emits 3 fewer errors here.
+  // TransferNonSendable emits 3 fewer errors here.
   // expected-targeted-and-complete-note @-3 5 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
-  // expected-complete-and-sns-note @-4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+  // expected-complete-and-tns-note @-4 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
   var value = ""
 
   @MainActor
@@ -254,21 +254,21 @@ final class NonSendable {
   func call() async {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-sns-warning@-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-    // expected-sns-warning@-3 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function (3 access sites displayed)}}
+    // expected-tns-warning@-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-tns-warning@-3 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function (3 access sites displayed)}}
 
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-sns-note@-2 {{access here could race}}
+    // expected-tns-note@-2 {{access here could race}}
 
     _ = await x
     // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
-    // expected-sns-note@-2 {{access here could race}}
+    // expected-tns-note@-2 {{access here could race}}
 
     _ = await self.x
     // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
-    // expected-sns-note@-2 {{access here could race}}
+    // expected-tns-note@-2 {{access here could race}}
   }
 
   @MainActor
@@ -280,11 +280,11 @@ func testNonSendableBaseArg() async {
   let t = NonSendable()
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-sns-warning@-2 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+  // expected-tns-warning@-2 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
-  // expected-sns-note@-2 {{access here could race}}
+  // expected-tns-note@-2 {{access here could race}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -299,13 +299,13 @@ func callNonisolatedAsyncClosure(
 ) async {
   await g(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-sns-warning@-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-  // expected-sns-warning@-3 {{passing argument of non-sendable type 'NonSendable' from main actor-isolated context to nonisolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+  // expected-tns-warning@-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-tns-warning@-3 {{passing argument of non-sendable type 'NonSendable' from main actor-isolated context to nonisolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-sns-note@-2 {{access here could race}}
+  // expected-tns-note@-2 {{access here could race}}
 
 }
 
@@ -315,7 +315,7 @@ func testLocalCaptures() {
 
   @Sendable func a2() -> NonSendable {
     return ns
-    // expected-complete-and-sns-warning@-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
+    // expected-complete-and-tns-warning@-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a `@Sendable` local function}}
   }
 }
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -verify -strict-concurrency=targeted -verify-additional-prefix targeted-and-complete- -emit-sil -o /dev/null %s
 // RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix targeted-and-complete- -verify-additional-prefix complete-and-tns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s
-// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix tns- -verify-additional-prefix complete-and-tns- -emit-sil -o /dev/null %s -enable-experimental-feature TransferNonSendable 
+// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix tns- -verify-additional-prefix complete-and-tns- -emit-sil -o /dev/null %s -enable-experimental-feature RegionBasedIsolation 
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_checking_errors.swift
+++ b/test/Concurrency/sendable_checking_errors.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -verify -strict-concurrency=complete %s
 
-// Don't test SendNonSendable because this test will not make
+// Don't test TransferNonSendable because this test will not make
 // it past Sema to the SIL pass.
 
 // REQUIRES: concurrency

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete-and-sns- -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete-and-sns- -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete-and-tns- -strict-concurrency=complete
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete-and-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -160,9 +160,9 @@ actor A10: AsyncThrowingProtocolWithNotSendable {
 // rdar://86653457 - Crash due to missing Sendable conformances.
 // expected-warning @+1 {{non-final class 'Klass' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
 class Klass<Output: Sendable>: Sendable {}
-// expected-complete-and-sns-warning @+1 {{type 'S' does not conform to the 'Sendable' protocol}}
+// expected-complete-and-tns-warning @+1 {{type 'S' does not conform to the 'Sendable' protocol}}
 final class SubKlass: Klass<[S]> {}
-// expected-complete-and-sns-note @+1 {{consider making struct 'S' conform to the 'Sendable' protocol}}
+// expected-complete-and-tns-note @+1 {{consider making struct 'S' conform to the 'Sendable' protocol}}
 public struct S {}
 
 // rdar://88700507 - redundant conformance of @MainActor-isolated subclass to 'Sendable'

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete-and-tns- -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete-and-tns- -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify -verify-additional-prefix complete-and-tns- -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_cycle.swift
+++ b/test/Concurrency/sendable_cycle.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null
 // RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_cycle.swift
+++ b/test/Concurrency/sendable_cycle.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null
 // RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_existentials.swift
+++ b/test/Concurrency/sendable_existentials.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -emit-sil -o /dev/null %s -verify
 // RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete-and-tns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete-and-tns- -emit-sil -o /dev/null %s -verify -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete-and-tns- -emit-sil -o /dev/null %s -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx

--- a/test/Concurrency/sendable_existentials.swift
+++ b/test/Concurrency/sendable_existentials.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -emit-sil -o /dev/null %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete-and-sns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete-and-sns- -emit-sil -o /dev/null %s -verify -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete-and-tns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s -verify
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete-and-tns- -emit-sil -o /dev/null %s -verify -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
@@ -37,22 +37,22 @@ func testE(a: Any, aOpt: Any?) async {
 }
 
 func testESilently(a: Any, aOpt: Any?) {
-  send(a) // expected-complete-and-sns-warning {{'Any' does not conform to the 'Sendable' protocol}}
-  sendOpt(a) // expected-complete-and-sns-warning {{'Any' does not conform to the 'Sendable' protocol}}
-  sendOpt(aOpt) // expected-complete-and-sns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  send(a) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  sendOpt(a) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  sendOpt(aOpt) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
 
-  let _: E = .something(a) // expected-complete-and-sns-warning {{'Any' does not conform to the 'Sendable' protocol}}
-  _ = E.something(a) // expected-complete-and-sns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  let _: E = .something(a) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  _ = E.something(a) // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
 
   var sendable: Sendable
-  sendable = a // expected-complete-and-sns-warning {{'Any' does not conform to the 'Sendable' protocol}}
+  sendable = a // expected-complete-and-tns-warning {{'Any' does not conform to the 'Sendable' protocol}}
 
   var arrayOfSendable: [Sendable]
-  arrayOfSendable = [a, a] // expected-complete-and-sns-warning 2{{'Any' does not conform to the 'Sendable' protocol}}
+  arrayOfSendable = [a, a] // expected-complete-and-tns-warning 2{{'Any' does not conform to the 'Sendable' protocol}}
 
   func localFunc() { }
-  sendable = localFunc // expected-complete-and-sns-warning {{'() -> ()' does not conform to the 'Sendable' protocol}}
-  // expected-complete-and-sns-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  sendable = localFunc // expected-complete-and-tns-warning {{'() -> ()' does not conform to the 'Sendable' protocol}}
+  // expected-complete-and-tns-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   _ = sendable
   _ = arrayOfSendable
 }

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_obc_protocol.swift
+++ b/test/Concurrency/sendable_obc_protocol.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/sendable_obc_protocol.swift
+++ b/test/Concurrency/sendable_obc_protocol.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s -verify -parse-as-library -o /dev/null -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/sendable_override_checking.swift
+++ b/test/Concurrency/sendable_override_checking.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s
 // RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_override_checking.swift
+++ b/test/Concurrency/sendable_override_checking.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s
 // RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -verify -emit-sil -o /dev/null %s -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t %s -o /dev/null -verify -emit-sil
 // RUN: %target-swift-frontend -disable-availability-checking -I %t %s -o /dev/null -verify -emit-sil -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -I %t %s -o /dev/null -verify -emit-sil -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -I %t %s -o /dev/null -verify -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t %s -o /dev/null -verify -emit-sil
 // RUN: %target-swift-frontend -disable-availability-checking -I %t %s -o /dev/null -verify -emit-sil -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -I %t %s -o /dev/null -verify -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -I %t %s -o /dev/null -verify -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_preconcurrency_unused.swift
+++ b/test/Concurrency/sendable_preconcurrency_unused.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_preconcurrency_unused.swift
+++ b/test/Concurrency/sendable_preconcurrency_unused.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -verify -emit-sil %s -o /dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil
 // RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete-
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil
 // RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete-
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
 // RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
 // RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_witness_check_delayed.swift
+++ b/test/Concurrency/sendable_witness_check_delayed.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify
 // RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/sendable_witness_check_delayed.swift
+++ b/test/Concurrency/sendable_witness_check_delayed.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify
 // RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -o /dev/null -emit-sil %s -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/sendnonsendable_basic.swift
+++ b/test/Concurrency/sendnonsendable_basic.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature SendNonSendable -disable-availability-checking -verify -verify-additional-prefix sns-  %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
 
 // This run validates that for specific test cases around closures, we properly
 // emit errors in the type checker before we run sns. This ensures that we know that
 // these cases can't happen when SNS is enabled.
 //
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature SendNonSendable -disable-availability-checking -verify -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -disable-availability-checking -verify -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -47,13 +47,13 @@ var booleanFlag: Bool { false }
 
 extension Actor {
   func warningIfCallingGetter() async {
-    await self.klass.asyncCall() // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await self.klass.asyncCall() // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
   }
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
-    await self.finalKlass.asyncCall() // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await self.finalKlass.asyncCall() // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
   }
 
@@ -66,7 +66,7 @@ extension Actor {
 extension FinalActor {
   func warningIfCallingAsyncOnFinalField() async {
     // Since our whole class is final, we emit the error directly here.
-    await self.klass.asyncCall() // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await self.klass.asyncCall() // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
   }
 }
@@ -96,11 +96,11 @@ func closureInOut(_ a: Actor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-sns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
-  await a.useKlass(ns1) // expected-sns-note {{access here could race}}
+  // expected-tns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await a.useKlass(ns1) // expected-tns-note {{access here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
-  closure() // expected-sns-note {{access here could race}}
+  closure() // expected-tns-note {{access here could race}}
 }
 
 func closureInOut2(_ a: Actor) async {
@@ -113,12 +113,12 @@ func closureInOut2(_ a: Actor) async {
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await a.useKlass(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
-  closure = { useInOut(&contents) } // expected-sns-note {{access here could race}}
+  closure = { useInOut(&contents) } // expected-tns-note {{access here could race}}
 
-  await a.useKlass(ns1) // expected-sns-note {{access here could race}}
+  await a.useKlass(ns1) // expected-tns-note {{access here could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure()
@@ -139,10 +139,10 @@ func closureNonInOut(_ a: Actor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await a.useKlass(ns1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
-  closure() // expected-sns-note {{access here could race}}
+  closure() // expected-tns-note {{access here could race}}
 }
 
 func transferNonIsolatedNonAsyncClosureTwice() async {
@@ -150,11 +150,11 @@ func transferNonIsolatedNonAsyncClosureTwice() async {
 
   // This is non-isolated and non-async... we can transfer it safely.
   var actorCaptureClosure = { print(a) }
-  await transferToMain(actorCaptureClosure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToMain(actorCaptureClosure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   actorCaptureClosure = { print(a) }
-  await transferToMain(actorCaptureClosure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToMain(actorCaptureClosure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -165,7 +165,7 @@ extension Actor {
     let closure: () -> () = {
       print(self.klass)
     }
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -175,7 +175,7 @@ extension Actor {
       print(self.klass)
     }
     let x = (1, closure)
-    await transferToMain(x) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, () -> ())' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -197,7 +197,7 @@ extension Actor {
       print(self.klass)
     }
     let x: Any? = (1, closure)
-    await transferToMain(x) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
   }
 
@@ -209,7 +209,7 @@ extension Actor {
     // we are forming is an Any?  so we actually form the tuple as an object and
     // store it all as once.
     let x: Any? = (closure, 1)
-    await transferToMain(x) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
   }
 
@@ -219,7 +219,7 @@ extension Actor {
     }
 
     // Error here.
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -244,7 +244,7 @@ extension Actor {
     }
 
     // Error here.
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -253,7 +253,7 @@ extension Actor {
     var closure: () -> () = {}
 
     // We get a transfer after use error.
-    await transferToMain(closure) // expected-sns-warning {{passing argument of non-sendable type '() -> ()' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(closure) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -263,8 +263,8 @@ extension Actor {
       }
     }
 
-    await transferToMain(closure) // expected-sns-note {{access here could race}}
-    // expected-sns-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-note {{access here could race}}
+    // expected-tns-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -286,7 +286,7 @@ extension Actor {
       closure = {}
     }
 
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -314,7 +314,7 @@ extension Actor {
     let closure: () -> () = {
       print(x.1)
     }
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -324,7 +324,7 @@ extension Actor {
     let closure: () -> () = {
       print(x.1)
     }
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -334,7 +334,7 @@ extension Actor {
     let closure: () -> () = {
       print(x as Any)
     }
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -343,7 +343,7 @@ extension Actor {
 func testSimpleLetClosureCaptureActor() async {
   let a = Actor()
   let closure = { print(a) }
-  await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -380,7 +380,7 @@ func testSimpleVarClosureCaptureActor() async {
   let a = Actor()
   var closure = {}
   closure = { print(a) }
-  await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
@@ -424,7 +424,7 @@ extension Actor {
     let closure: () -> () = {
       print(f)
     }
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -436,7 +436,7 @@ extension Actor {
     let closure: () -> () = {
       print(f.field!)
     }
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -449,7 +449,7 @@ extension Actor {
     }
 
     // This should error.
-    await transferToMain(closure) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(closure) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -461,11 +461,11 @@ extension Actor {
 
     // This re-assignment shouldn't error.
     closure = {}
-    await transferToMain(closure) // expected-sns-warning {{passing argument of non-sendable type '() -> ()' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(closure) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
     // But this will error since we race.
-    closure() // expected-sns-note {{access here could race}}
+    closure() // expected-tns-note {{access here could race}}
   }
 }

--- a/test/Concurrency/sendnonsendable_basic.swift
+++ b/test/Concurrency/sendnonsendable_basic.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
 
 // This run validates that for specific test cases around closures, we properly
 // emit errors in the type checker before we run sns. This ensures that we know that
 // these cases can't happen when SNS is enabled.
 //
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferNonSendable -disable-availability-checking -verify -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendnonsendable_defer_and_typecheck_only.swift
+++ b/test/Concurrency/sendnonsendable_defer_and_typecheck_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendnonsendable_defer_and_typecheck_only.swift
+++ b/test/Concurrency/sendnonsendable_defer_and_typecheck_only.swift
@@ -1,10 +1,10 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
 /*
- This file tests the experimental SendNonSendable feature. This feature causes the passing
+ This file tests the experimental TransferNonSendable feature. This feature causes the passing
  of non-sendable values to isolation-crossing calls to not yield diagnostics during AST passes,
  but to instead emit them later during a mandatory SIL pass. This file in particular checks that
  isolation crossing via argument passing is deferred, but that isolation crossing via returned

--- a/test/Concurrency/sendnonsendable_region_based_sendability.swift
+++ b/test/Concurrency/sendnonsendable_region_based_sendability.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix complete- %s
-// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix sns- -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- -enable-experimental-feature TransferNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
 /*
- This file tests the early features of the flow-sensitive Sendable checking implemented by the SendNonSendable SIL pass.
+ This file tests the early features of the flow-sensitive Sendable checking implemented by the TransferNonSendable SIL pass.
  In particular, it tests the behavior of applications that cross isolation domains:
  - non-Sendable values are statically grouped into "regions" of values that may alias or point to each other
  - passing a non-Sendable value to an isolation-crossing call "consumed" the region of that value
@@ -56,11 +56,11 @@ func test_isolation_crossing_sensitivity(a : A) async {
     foo_noniso(ns0);
 
     //this call consumes ns1
-    await a.foo(ns1); // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    await a.foo(ns1); // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     print(ns0);
-    print(ns1); // expected-sns-note {{access here could race}}
+    print(ns1); // expected-tns-note {{access here could race}}
 }
 
 func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
@@ -73,7 +73,7 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
     await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     // Not safe to consume an arg.
-    await a.foo(ns_arg); // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await a.foo(ns_arg); // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     // Check for no duplicate warnings once self is "consumed"
@@ -99,34 +99,34 @@ func test_closure_capture(a : A) async {
     print(ns3)
 
     // this should consume ns0
-    await a.run_closure(captures0) // expected-sns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (3 access sites displayed)}}
+    await a.run_closure(captures0) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (3 access sites displayed)}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-    print(ns0) // expected-sns-note {{access here could race}}
+    print(ns0) // expected-tns-note {{access here could race}}
     print(ns1)
     print(ns2)
     print(ns3)
 
     // this should consume ns1 and ns2
-    await a.run_closure(captures12) // expected-sns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (4 access sites displayed)}}
+    await a.run_closure(captures12) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (4 access sites displayed)}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-    print(ns0) // expected-sns-note {{access here could race}}
-    print(ns1) // expected-sns-note {{access here could race}}
-    print(ns2) // expected-sns-note {{access here could race}}
+    print(ns0) // expected-tns-note {{access here could race}}
+    print(ns1) // expected-tns-note {{access here could race}}
+    print(ns2) // expected-tns-note {{access here could race}}
     print(ns3)
 
     // this should consume ns3
-    await a.run_closure(captures3indirect) // expected-sns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    await a.run_closure(captures3indirect) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-    print(ns0) // expected-sns-note {{access here could race}}
-    print(ns1) // expected-sns-note {{access here could race}}
-    print(ns2) // expected-sns-note {{access here could race}}
-    print(ns3) // expected-sns-note {{access here could race}}
+    print(ns0) // expected-tns-note {{access here could race}}
+    print(ns1) // expected-tns-note {{access here could race}}
+    print(ns2) // expected-tns-note {{access here could race}}
+    print(ns3) // expected-tns-note {{access here could race}}
 }
 
 func test_regions(a : A, b : Bool) async {
@@ -149,45 +149,45 @@ func test_regions(a : A, b : Bool) async {
     // check for each of the above pairs that consuming half of it consumes the other half
 
     if (b) {
-        await a.foo(ns0_0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns0_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns0_0) // expected-sns-note {{access here could race}}
-        print(ns0_1) // expected-sns-note {{access here could race}}
+        print(ns0_0) // expected-tns-note {{access here could race}}
+        print(ns0_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns0_1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns0_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns0_0) // expected-sns-note {{access here could race}}
-        print(ns0_1) // expected-sns-note {{access here could race}}
+        print(ns0_0) // expected-tns-note {{access here could race}}
+        print(ns0_1) // expected-tns-note {{access here could race}}
     }
 
     if (b) {
-        await a.foo(ns1_0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns1_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns1_0) // expected-sns-note {{access here could race}}
-        print(ns1_1) // expected-sns-note {{access here could race}}
+        print(ns1_0) // expected-tns-note {{access here could race}}
+        print(ns1_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns1_1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns1_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
       // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns1_0) // expected-sns-note {{access here could race}}
-        print(ns1_1) // expected-sns-note {{access here could race}}
+        print(ns1_0) // expected-tns-note {{access here could race}}
+        print(ns1_1) // expected-tns-note {{access here could race}}
     }
 
     if (b) {
-        await a.foo(ns2_0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns2_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns2_0) // expected-sns-note {{access here could race}}
-        print(ns2_1) // expected-sns-note {{access here could race}}
+        print(ns2_0) // expected-tns-note {{access here could race}}
+        print(ns2_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns2_1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns2_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns2_0) // expected-sns-note {{access here could race}}
-        print(ns2_1) // expected-sns-note {{access here could race}}
+        print(ns2_0) // expected-tns-note {{access here could race}}
+        print(ns2_1) // expected-tns-note {{access here could race}}
     }
 }
 
@@ -230,87 +230,87 @@ func test_indirect_regions(a : A, b : Bool) async {
     // now check for each pair that consuming half of it consumed the other half
 
     if (b) {
-        await a.foo(ns0_0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns0_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns0_0) // expected-sns-note {{access here could race}}
-        print(ns0_1) // expected-sns-note {{access here could race}}
+        print(ns0_0) // expected-tns-note {{access here could race}}
+        print(ns0_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns0_1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns0_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns0_0) // expected-sns-note {{access here could race}}
-        print(ns0_1) // expected-sns-note {{access here could race}}
+        print(ns0_0) // expected-tns-note {{access here could race}}
+        print(ns0_1) // expected-tns-note {{access here could race}}
     }
 
     if (b) {
-        await a.foo(ns1_0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns1_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns1_0) // expected-sns-note {{access here could race}}
-        print(ns1_1) // expected-sns-note {{access here could race}}
+        print(ns1_0) // expected-tns-note {{access here could race}}
+        print(ns1_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns1_1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns1_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns1_0) // expected-sns-note {{access here could race}}
-        print(ns1_1) // expected-sns-note {{access here could race}}
+        print(ns1_0) // expected-tns-note {{access here could race}}
+        print(ns1_1) // expected-tns-note {{access here could race}}
     }
 
     if (b) {
-        await a.foo(ns2_0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns2_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns2_0) // expected-sns-note {{access here could race}}
-        print(ns2_1) // expected-sns-note {{access here could race}}
+        print(ns2_0) // expected-tns-note {{access here could race}}
+        print(ns2_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns2_1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns2_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns2_0) // expected-sns-note {{access here could race}}
-        print(ns2_1) // expected-sns-note {{access here could race}}
+        print(ns2_0) // expected-tns-note {{access here could race}}
+        print(ns2_1) // expected-tns-note {{access here could race}}
     }
 
     if (b) {
-        await a.foo(ns3_0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns3_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns3_0) // expected-sns-note {{access here could race}}
-        print(ns3_1) // expected-sns-note {{access here could race}}
+        print(ns3_0) // expected-tns-note {{access here could race}}
+        print(ns3_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns3_1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns3_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns3_0) // expected-sns-note {{access here could race}}
-        print(ns3_1) // expected-sns-note {{access here could race}}
+        print(ns3_0) // expected-tns-note {{access here could race}}
+        print(ns3_1) // expected-tns-note {{access here could race}}
     }
 
     if (b) {
-        await a.foo(ns4_0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns4_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns4_0) // expected-sns-note {{access here could race}}
-        print(ns4_1) // expected-sns-note {{access here could race}}
+        print(ns4_0) // expected-tns-note {{access here could race}}
+        print(ns4_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns4_1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns4_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        print(ns4_0) // expected-sns-note {{access here could race}}
-        print(ns4_1) // expected-sns-note {{access here could race}}
+        print(ns4_0) // expected-tns-note {{access here could race}}
+        print(ns4_1) // expected-tns-note {{access here could race}}
     }
 
     if (b) {
-        await a.foo(ns5_0) // expected-sns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns5_0) // expected-tns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
-        print(ns5_0) // expected-sns-note {{access here could race}}
-        print(ns5_1) // expected-sns-note {{access here could race}}
+        print(ns5_0) // expected-tns-note {{access here could race}}
+        print(ns5_1) // expected-tns-note {{access here could race}}
     } else {
-        await a.foo(ns5_1) // expected-sns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
+        await a.foo(ns5_1) // expected-tns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (2 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
-        print(ns5_0) // expected-sns-note {{access here could race}}
-        print(ns5_1) // expected-sns-note {{access here could race}}
+        print(ns5_0) // expected-tns-note {{access here could race}}
+        print(ns5_1) // expected-tns-note {{access here could race}}
     }
 }
 
@@ -326,7 +326,7 @@ class C_NonSendable {
         foo_noniso(captures_self)
 
         // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
-        await a.foo(captures_self) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+        await a.foo(captures_self) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
         // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }
@@ -362,7 +362,7 @@ actor A_Sendable {
         // actor and is non-Sendable. For now, we ban this since we do not
         // support the ability to dynamically invoke the synchronous closure on
         // the specific actor.
-        await a.foo(captures_self) // expected-sns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+        await a.foo(captures_self) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
         // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }
@@ -373,8 +373,8 @@ func basic_loopiness(a : A, b : Bool) async {
 
     while (b) {
         await a.foo(ns)
-        // expected-sns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
-        // expected-sns-note @-2 {{access here could race}}
+        // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+        // expected-tns-note @-2 {{access here could race}}
         // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     }
 }
@@ -390,9 +390,9 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
         (ns0, ns1, ns2, ns3) = (ns1, ns2, ns3, ns0)
     }
 
-    await a.foo(ns0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    await a.foo(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns3) // expected-sns-note {{access here could race}}
+    await a.foo(ns3) // expected-tns-note {{access here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -454,9 +454,9 @@ func test_class_assign_merges(a : A, b : Bool) async {
     box.contents = ns0
     box.contents = ns1
 
-    await a.foo(ns0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    await a.foo(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns1) // expected-sns-note {{access here could race}}
+    await a.foo(ns1) // expected-tns-note {{access here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -490,9 +490,9 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
     contents = ns0
     contents = ns1
 
-    await a.foo(ns0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    await a.foo(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns1) // expected-sns-note {{access here could race}}
+    await a.foo(ns1) // expected-tns-note {{access here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -507,71 +507,71 @@ func test_tuple_formation(a : A, i : Int) async {
 
     switch (i) {
     case 0:
-        await a.foo(ns0) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
+        await a.foo(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        foo_noniso(ns0); // expected-sns-note {{access here could race}}
-        foo_noniso(ns1); // expected-sns-note {{access here could race}}
-        foo_noniso(ns2); // expected-sns-note {{access here could race}}
-        foo_noniso(ns3); // expected-sns-note {{access here could race}}
+        foo_noniso(ns0); // expected-tns-note {{access here could race}}
+        foo_noniso(ns1); // expected-tns-note {{access here could race}}
+        foo_noniso(ns2); // expected-tns-note {{access here could race}}
+        foo_noniso(ns3); // expected-tns-note {{access here could race}}
         foo_noniso(ns4);
-        foo_noniso(ns012); // expected-sns-note {{access here could race}}
-        foo_noniso(ns13); // expected-sns-note {{access here could race}}
+        foo_noniso(ns012); // expected-tns-note {{access here could race}}
+        foo_noniso(ns13); // expected-tns-note {{access here could race}}
     case 1:
-        await a.foo(ns1) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
+        await a.foo(ns1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        foo_noniso(ns0); // expected-sns-note {{access here could race}}
-        foo_noniso(ns1); // expected-sns-note {{access here could race}}
-        foo_noniso(ns2); // expected-sns-note {{access here could race}}
-        foo_noniso(ns3); // expected-sns-note {{access here could race}}
+        foo_noniso(ns0); // expected-tns-note {{access here could race}}
+        foo_noniso(ns1); // expected-tns-note {{access here could race}}
+        foo_noniso(ns2); // expected-tns-note {{access here could race}}
+        foo_noniso(ns3); // expected-tns-note {{access here could race}}
         foo_noniso(ns4);
-        foo_noniso(ns012); // expected-sns-note {{access here could race}}
-        foo_noniso(ns13); // expected-sns-note {{access here could race}}
+        foo_noniso(ns012); // expected-tns-note {{access here could race}}
+        foo_noniso(ns13); // expected-tns-note {{access here could race}}
     case 2:
-        await a.foo(ns2) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
+        await a.foo(ns2) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        foo_noniso(ns0); // expected-sns-note {{access here could race}}
-        foo_noniso(ns1); // expected-sns-note {{access here could race}}
-        foo_noniso(ns2); // expected-sns-note {{access here could race}}
-        foo_noniso(ns3); // expected-sns-note {{access here could race}}
+        foo_noniso(ns0); // expected-tns-note {{access here could race}}
+        foo_noniso(ns1); // expected-tns-note {{access here could race}}
+        foo_noniso(ns2); // expected-tns-note {{access here could race}}
+        foo_noniso(ns3); // expected-tns-note {{access here could race}}
         foo_noniso(ns4);
-        foo_noniso(ns012); // expected-sns-note {{access here could race}}
-        foo_noniso(ns13); // expected-sns-note {{access here could race}}
+        foo_noniso(ns012); // expected-tns-note {{access here could race}}
+        foo_noniso(ns13); // expected-tns-note {{access here could race}}
     case 3:
-        await a.foo(ns4) // expected-sns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+        await a.foo(ns4) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         foo_noniso(ns0);
         foo_noniso(ns1);
         foo_noniso(ns2);
-        foo_noniso(ns4); // expected-sns-note {{access here could race}}
+        foo_noniso(ns4); // expected-tns-note {{access here could race}}
         foo_noniso(ns012);
         foo_noniso(ns13);
     case 4:
-        await a.foo(ns012) // expected-sns-warning {{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
+        await a.foo(ns012) // expected-tns-warning {{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
         // TODO: Interestingly with complete, we emit this error 3 times?!
         // expected-complete-warning @-2 3{{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
-        foo_noniso(ns0); // expected-sns-note {{access here could race}}
-        foo_noniso(ns1); // expected-sns-note {{access here could race}}
-        foo_noniso(ns2); // expected-sns-note {{access here could race}}
-        foo_noniso(ns3); // expected-sns-note {{access here could race}}
+        foo_noniso(ns0); // expected-tns-note {{access here could race}}
+        foo_noniso(ns1); // expected-tns-note {{access here could race}}
+        foo_noniso(ns2); // expected-tns-note {{access here could race}}
+        foo_noniso(ns3); // expected-tns-note {{access here could race}}
         foo_noniso(ns4);
-        foo_noniso(ns012); // expected-sns-note {{access here could race}}
-        foo_noniso(ns13); // expected-sns-note {{access here could race}}
+        foo_noniso(ns012); // expected-tns-note {{access here could race}}
+        foo_noniso(ns13); // expected-tns-note {{access here could race}}
     default:
-        await a.foo(ns13) // expected-sns-warning {{passing argument of non-sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
+        await a.foo(ns13) // expected-tns-warning {{passing argument of non-sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (6 access sites displayed)}}
         // expected-complete-warning @-1 2{{passing argument of non-sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
-        foo_noniso(ns0); // expected-sns-note {{access here could race}}
-        foo_noniso(ns1); // expected-sns-note {{access here could race}}
-        foo_noniso(ns2); // expected-sns-note {{access here could race}}
-        foo_noniso(ns3); // expected-sns-note {{access here could race}}
+        foo_noniso(ns0); // expected-tns-note {{access here could race}}
+        foo_noniso(ns1); // expected-tns-note {{access here could race}}
+        foo_noniso(ns2); // expected-tns-note {{access here could race}}
+        foo_noniso(ns3); // expected-tns-note {{access here could race}}
         foo_noniso(ns4);
-        foo_noniso(ns012); // expected-sns-note {{access here could race}}
-        foo_noniso(ns13); // expected-sns-note {{access here could race}}
+        foo_noniso(ns012); // expected-tns-note {{access here could race}}
+        foo_noniso(ns13); // expected-tns-note {{access here could race}}
     }
 }
 
@@ -595,12 +595,12 @@ func one_consume_many_require(a : A) async {
     let ns4 = NonSendable();
 
     await a.foo_multi(ns0, ns1, ns2);
-    // expected-sns-warning @-1 3{{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 3{{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    foo_noniso_multi(ns0, ns3, ns4); // expected-sns-note {{access here could race}}
-    foo_noniso_multi(ns3, ns1, ns4); // expected-sns-note {{access here could race}}
-    foo_noniso_multi(ns4, ns3, ns2); // expected-sns-note {{access here could race}}
+    foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{access here could race}}
+    foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{access here could race}}
+    foo_noniso_multi(ns4, ns3, ns2); // expected-tns-note {{access here could race}}
 }
 
 func one_consume_one_require(a : A) async {
@@ -609,10 +609,10 @@ func one_consume_one_require(a : A) async {
     let ns2 = NonSendable();
 
     await a.foo_multi(ns0, ns1, ns2);
-    // expected-sns-warning @-1 3{{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 3{{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    foo_noniso_multi(ns0, ns1, ns2); // expected-sns-note 3{{access here could race}}
+    foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{access here could race}}
 }
 
 func many_consume_one_require(a : A) async {
@@ -624,15 +624,15 @@ func many_consume_one_require(a : A) async {
     let ns5 = NonSendable();
 
     await a.foo_multi(ns0, ns3, ns3)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo_multi(ns4, ns1, ns4)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo_multi(ns5, ns5, ns2)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    foo_noniso_multi(ns0, ns1, ns2); //expected-sns-note 3{{access here could race}}
+    foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{access here could race}}
 }
 
 func many_consume_many_require(a : A) async {
@@ -646,18 +646,18 @@ func many_consume_many_require(a : A) async {
     let ns7 = NonSendable();
 
     await a.foo_multi(ns0, ns3, ns3)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo_multi(ns4, ns1, ns4)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo_multi(ns5, ns5, ns2)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    foo_noniso_multi(ns0, ns6, ns7); // expected-sns-note {{access here could race}}
-    foo_noniso_multi(ns6, ns1, ns7); // expected-sns-note {{access here could race}}
-    foo_noniso_multi(ns7, ns6, ns2); // expected-sns-note {{access here could race}}
+    foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{access here could race}}
+    foo_noniso_multi(ns6, ns1, ns7); // expected-tns-note {{access here could race}}
+    foo_noniso_multi(ns7, ns6, ns2); // expected-tns-note {{access here could race}}
 }
 
 
@@ -682,12 +682,12 @@ func one_consume_many_require_varag(a : A) async {
 
     //TODO: find a way to make the type used in the diagnostic more specific than the signature type
     await a.foo_vararg(ns0, ns1, ns2);
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (3 access sites displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (3 access sites displayed)}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    foo_noniso_vararg(ns0, ns3, ns4); // expected-sns-note {{access here could race}}
-    foo_noniso_vararg(ns3, ns1, ns4); // expected-sns-note {{access here could race}}
-    foo_noniso_vararg(ns4, ns3, ns2); // expected-sns-note {{access here could race}}
+    foo_noniso_vararg(ns0, ns3, ns4); // expected-tns-note {{access here could race}}
+    foo_noniso_vararg(ns3, ns1, ns4); // expected-tns-note {{access here could race}}
+    foo_noniso_vararg(ns4, ns3, ns2); // expected-tns-note {{access here could race}}
 }
 
 func one_consume_one_require_vararg(a : A) async {
@@ -696,10 +696,10 @@ func one_consume_one_require_vararg(a : A) async {
     let ns2 = NonSendable();
 
     await a.foo_vararg(ns0, ns1, ns2);
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (3 access sites displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (3 access sites displayed)}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    foo_noniso_vararg(ns0, ns1, ns2); // expected-sns-note 3{{access here could race}}
+    foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{access here could race}}
 }
 
 func many_consume_one_require_vararg(a : A) async {
@@ -711,16 +711,16 @@ func many_consume_one_require_vararg(a : A) async {
     let ns5 = NonSendable();
 
     await a.foo_vararg(ns0, ns3, ns3)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
     await a.foo_vararg(ns4, ns1, ns4)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
     await a.foo_vararg(ns5, ns5, ns2)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    foo_noniso_vararg(ns0, ns1, ns2); //expected-sns-note 3{{access here could race}}
+    foo_noniso_vararg(ns0, ns1, ns2); //expected-tns-note 3{{access here could race}}
 }
 
 func many_consume_many_require_vararg(a : A) async {
@@ -734,18 +734,18 @@ func many_consume_many_require_vararg(a : A) async {
     let ns7 = NonSendable();
 
     await a.foo_vararg(ns0, ns3, ns3)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
     await a.foo_vararg(ns4, ns1, ns4)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
     await a.foo_vararg(ns5, ns5, ns2)
-    // expected-sns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    foo_noniso_vararg(ns0, ns6, ns7); // expected-sns-note {{access here could race}}
-    foo_noniso_vararg(ns6, ns1, ns7); // expected-sns-note {{access here could race}}
-    foo_noniso_vararg(ns7, ns6, ns2); // expected-sns-note {{access here could race}}
+    foo_noniso_vararg(ns0, ns6, ns7); // expected-tns-note {{access here could race}}
+    foo_noniso_vararg(ns6, ns1, ns7); // expected-tns-note {{access here could race}}
+    foo_noniso_vararg(ns7, ns6, ns2); // expected-tns-note {{access here could race}}
 }
 
 enum E { // expected-complete-note {{consider making enum 'E' conform to the 'Sendable' protocol}}
@@ -774,7 +774,7 @@ func enum_test(a : A) async {
     case .E2:
         switch (e3) {
         case let .E3(ns3):
-            await a.foo(ns3.x); // expected-sns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+            await a.foo(ns3.x); // expected-tns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
             // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
         default: ()
         }
@@ -784,9 +784,9 @@ func enum_test(a : A) async {
         foo_noniso(e4);
     }
 
-    await a.foo(e1); // expected-sns-warning {{passing argument of non-sendable type 'E' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
+    await a.foo(e1); // expected-tns-warning {{passing argument of non-sendable type 'E' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function (1 access site displayed)}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
-    foo_noniso(e2); // expected-sns-note {{access here could race}}
-    foo_noniso(e3); // expected-sns-note {{access here could race}}
+    foo_noniso(e2); // expected-tns-note {{access here could race}}
+    foo_noniso(e3); // expected-tns-note {{access here could race}}
     foo_noniso(e4);
 }

--- a/test/Concurrency/sendnonsendable_region_based_sendability.swift
+++ b/test/Concurrency/sendnonsendable_region_based_sendability.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix complete- %s
-// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- -enable-experimental-feature TransferNonSendable %s
+// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -strict-concurrency=minimal -o /dev/null -emit-sil %s -verify
 // RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted- -o /dev/null -emit-sil %s -verify
 // RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -o /dev/null -emit-sil %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -enable-experimental-feature SendNonSendable -o /dev/null -emit-sil %s -verify
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -enable-experimental-feature TransferNonSendable -o /dev/null -emit-sil %s -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -strict-concurrency=minimal -o /dev/null -emit-sil %s -verify
 // RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted- -o /dev/null -emit-sil %s -verify
 // RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -o /dev/null -emit-sil %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -enable-experimental-feature TransferNonSendable -o /dev/null -emit-sil %s -verify
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -enable-experimental-feature RegionBasedIsolation -o /dev/null -emit-sil %s -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -emit-sil -verify -o /dev/null %s
 // RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -emit-sil -verify -o /dev/null %s
 // RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/taskgroup_cancelAll_from_child.swift
+++ b/test/Concurrency/taskgroup_cancelAll_from_child.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/taskgroup_cancelAll_from_child.swift
+++ b/test/Concurrency/taskgroup_cancelAll_from_child.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/unavailable_from_async.swift
+++ b/test/Concurrency/unavailable_from_async.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/unavailable_from_async.swift
+++ b/test/Concurrency/unavailable_from_async.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=targeted
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=targeted
 // RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -verify -disable-availability-checking %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/unsafe_inherit_executor_lib.swift
+++ b/test/Concurrency/unsafe_inherit_executor_lib.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
+// RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/unsafe_inherit_executor_lib.swift
+++ b/test/Concurrency/unsafe_inherit_executor_lib.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete -enable-experimental-feature TransferNonSendable
 
 // REQUIRES: asserts
 

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -159,7 +159,7 @@ func withVouchers(call: @Sendable @escaping (voucher_t?, voucher_t?, voucher_t?)
 
       // Clear any voucher that the call adopted.
       adopt(voucher: nil)
-      group.leave() // expected-complete-sns-warning {{capture of 'group' with non-sendable type 'DispatchGroup' in a `@Sendable` closure}}
+      group.leave() // expected-complete-tns-warning {{capture of 'group' with non-sendable type 'DispatchGroup' in a `@Sendable` closure}}
     }
     group.wait()
 

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -41,9 +41,9 @@ using PartitionTester = Partition::PartitionTester;
 //                                   Tests
 //===----------------------------------------------------------------------===//
 
-// this test tests that if a series of merges is split between two partitions
+// This test tests that if a series of merges is split between two partitions
 // p1 and p2, but also applied in its entirety to p3, then joining p1 and p2
-// yields p3
+// yields p3.
 TEST(PartitionUtilsTest, TestMergeAndJoin) {
   Partition p1;
   Partition p2;
@@ -354,7 +354,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
   ASSERT_EQ(tester.getRegion(44), 3);
 }
 
-// This test tests the semantics of assignment
+// This test tests the semantics of assignment.
 TEST(PartitionUtilsTest, TestAssign) {
   Partition p1;
   Partition p2;


### PR DESCRIPTION
Before we get too late in the development cycle, I am doing some renames/cleanups in this PR. This includes:

1. Renaming SendNonSendable.cpp -> TransferNonSendable.cpp.
2. Renamed the experimental flag from SendNonSendable -> RegionBasedIsolation.
3. Went through and standardized all of the comments. This means using 3 slashes for declarations, 2 slashes inside functions and using complete sentences.
4. In a previous PR I by mistake added Partition::getRegion() when I didn't need it... I removed it.
5. In a previous PR, I was asked to simplify how we computed the max to remove an unnecessary loop. Took care of that in this PR.
6. There was a typo where I wrote translater instead of translator. Fixed here.
7. Did another pass over changing consume and friends -> transfer and friends. I hope it is the last time I have to go over this.