### PR TITLE
[DebugInfo][NFC] Update tests to account for C11 compile units

### DIFF
--- a/test/DebugInfo/BridgingHeaderPCH.swift
+++ b/test/DebugInfo/BridgingHeaderPCH.swift
@@ -1,13 +1,11 @@
-// REQUIRES: rdar114728459
-
 // RUN: %target-swift-frontend \
 // RUN:   -emit-pch %S/Inputs/InlineBridgingHeader.h -o %t.pch 
 // RUN: %target-swift-frontend \
 // RUN:   -import-objc-header %t.pch -emit-ir -g %s -o - | %FileCheck %s
 
 // CHECK: !DICompileUnit(language: DW_LANG_Swift
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},
 // CHECK-SAME:           splitDebugFilename: "{{.*}}.pch"
 // CHECK-SAME:           dwoId:
 

--- a/test/DebugInfo/ClangModuleBreadcrumbs.swift
+++ b/test/DebugInfo/ClangModuleBreadcrumbs.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar114728459
-
 // RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs \
 // RUN:   -Xcc -DFOO="foo" -Xcc -UBAR -o - | %FileCheck %s
 //
@@ -18,29 +16,29 @@ import OtherClangModule.SubModule
 let _ = someFunc(0)
 
 // Check for Clang module breadcrumbs.
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}Swift
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift
 // CHECK-SAME:           ClangModule
 // CHECK-SAME:           dwoId:
 
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}}, {{.*}} producer: "{{.*}}Swift
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}}, {{.*}} producer: "{{.*}}Swift
 // CHECK-SAME:           OtherClangModule
 // CHECK-SAME:           dwoId:
 
-// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}clang
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}clang
 // CHECK-SAME:           ClangModule
 // CHECK-SAME:           dwoId:
 
 // NONE: DICompileUnit({{.*}}
 // NONE-NOT: DICompileUnit({{.*}}ClangModule
 
-// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}Swift
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift
 // REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule
 // REMAP-SAME:           dwoId:
 
-// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}Swift
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}Swift
 // REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}OtherClangModule
 // REMAP-SAME:           dwoId:
 
-// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}clang
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99|C11}},{{.*}} producer: "{{.*}}clang
 // REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule
 // REMAP-SAME:           dwoId:


### PR DESCRIPTION
These tests were specifically checking for C99 compile units, causing them to fail on the Ubuntu bots.
