### PR TITLE
[DebugInfo][NFC] Re-enable async-direct-arg.swift test

### DIFF
--- a/test/DebugInfo/async-direct-arg.swift
+++ b/test/DebugInfo/async-direct-arg.swift
@@ -2,21 +2,26 @@
 // RUN:    -module-name a  -disable-availability-checking \
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
+// REQUIRES: CPU=x86_64 || CPU=arm64
 
-// REQUIRES: rdar74588568
 
 // Test that x is described as a direct dbg.declare of the incoming function
 // argument.
 
-// CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYF.resume.0"
-// CHECK: call void @llvm.dbg.declare
-// CHECK: call void @llvm.dbg.declare
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[X0:[0-9]+]], {{.*}}!DIExpression(DW_OP
-// CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYF.resume.1"
-// FIXME: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[X1:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYaFTY0_"
+// CHECK-SAME:    (ptr swiftasync %[[ARG:.*]])
+// CHECK: call void @llvm.dbg.declare(metadata ptr %[[ARG]], metadata {{.*}}, metadata !DIExpression(DW_OP_LLVM_entry_value
+// CHECK: call void @llvm.dbg.declare(metadata ptr %[[ARG]], metadata {{.*}}, metadata !DIExpression(DW_OP_LLVM_entry_value
+// CHECK: call void @llvm.dbg.declare(metadata ptr %[[ARG]], metadata ![[X0:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_entry_value
+
+// CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYaFTY2_"
+// CHECK-SAME:    (ptr swiftasync %[[ARG:.*]])
+// CHECK: call void @llvm.dbg.declare(metadata ptr %[[ARG]], metadata {{.*}}, metadata !DIExpression(DW_OP_LLVM_entry_value
+// CHECK: call void @llvm.dbg.declare(metadata ptr %[[ARG]], metadata {{.*}}, metadata !DIExpression(DW_OP_LLVM_entry_value
+// CHECK: call void @llvm.dbg.declare(metadata ptr %[[ARG]], metadata ![[X1:[0-9]+]], metadata !DIExpression(DW_OP_LLVM_entry_value
 
 // CHECK: ![[X0]] = !DILocalVariable(name: "x"
-// FIXME: ![[X1]] = !DILocalVariable(name: "x"
+// CHECK: ![[X1]] = !DILocalVariable(name: "x"
 func fib(_ x: Int) async -> Int {
   if x <= 1 { return 1 }
   let a = await fib(x - 1)


### PR DESCRIPTION
This test had been disabled back in 2021:
https://github.com/apple/swift/pull/36479

With this commit, it should now pass.

We also add a 64-bit target requirement, since this test relies on entry_values being produced.