### PR TITLE
[test/Prototypes] Fix DoubleWidth think-o that trips an assert

### DIFF
--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -702,8 +702,9 @@ extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {
     let rhs = rhs &<< shift
     let high = (lhs &>> (Magnitude.bitWidth &- shift)).low
     let lhs = lhs &<< shift
-    let (quotient, remainder) =
-      Magnitude._divide((high, lhs.high, lhs.low), by: rhs)
+    let (quotient, remainder) = high == (0 as Low)
+      ? (1, lhs &- rhs)
+      : Magnitude._divide((high, lhs.high, lhs.low), by: rhs)
     return (Magnitude(0, quotient), remainder &>> shift)
   }
 }
@@ -805,6 +806,12 @@ dwTests.test("Arithmetic/unsigned") {
 
   expectEqual(x % 3, 1)
   expectEqual(x % y, x)
+
+  do {
+    let lhs = DoubleWidth<UInt8>((high: 0b0011_0000, low: 0))
+    let rhs = DoubleWidth<UInt8>((high: 0b0010_0000, low: 0))
+    expectEqual(lhs % rhs, 4096)
+  }
 }
 
 dwTests.test("Arithmetic/signed") {

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -699,8 +699,8 @@ extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {
 
     // Left shift both rhs and lhs, then divide and right shift the remainder.
     let shift = rhs.leadingZeroBitCount
+    let high = (lhs >> (Magnitude.bitWidth &- shift)).low
     let rhs = rhs &<< shift
-    let high = (lhs &>> (Magnitude.bitWidth &- shift)).low
     let lhs = lhs &<< shift
     let (quotient, remainder) = high == (0 as Low)
       ? (1, lhs &- rhs)
@@ -811,6 +811,16 @@ dwTests.test("Arithmetic/unsigned") {
     let lhs = DoubleWidth<UInt8>((high: 0b0011_0000, low: 0))
     let rhs = DoubleWidth<UInt8>((high: 0b0010_0000, low: 0))
     expectEqual(lhs % rhs, 4096)
+  }
+  do {
+    let lhs = DoubleWidth<UInt64>((high: 0xa0c7d7165cf01386, low: 0xbf3f66a93056143f))
+    let rhs = DoubleWidth<UInt64>((high: 0x9ac3a19b1e7d6b83, low: 0x513929792d588736))
+    expectEqual(String(lhs % rhs), "7997221894243298914179865336050715913")
+  }
+  do {
+    let lhs = DoubleWidth<UInt64>((high: 0xea8a9116b7af33b7, low: 0x3d9d6779ddd22ca3))
+    let rhs = DoubleWidth<UInt64>((high: 0xc3673efc7f1f37cc, low: 0x312f661057d0ba94))
+    expectEqual(String(lhs % rhs), "52023287460685389410162512181093036559")
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
If `lhs` and `rhs` have the same number of leading zero bits (and we know `rhs < lhs`), then we can't call `_divide` to divide a triple-width magnitude by a double-width magnitude (this trips the assert on line 598), but rather we know that the quotient is one. Additionally, we must use `>>` instead of `&>>` when computing the high word because in this scenario the leading zero bits may be zero.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift-numerics/issues/272

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
