### PR TITLE
[5.11][stdlib] Bump runtime version indicator to 5.11

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -101,9 +101,11 @@ extension _SwiftStdlibVersion {
   public static var v5_9_0: Self { Self(_value: 0x050900) }
   @_alwaysEmitIntoClient
   public static var v5_10_0: Self { Self(_value: 0x050A00) }
+  @_alwaysEmitIntoClient
+  public static var v5_11_0: Self { Self(_value: 0x050B00) }
 
   @available(SwiftStdlib 5.7, *)
-  public static var current: Self { .v5_10_0 }
+  public static var current: Self { .v5_11_0 }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -99,9 +99,11 @@ extension _SwiftStdlibVersion {
   public static var v5_8_0: Self { Self(_value: 0x050800) }
   @_alwaysEmitIntoClient
   public static var v5_9_0: Self { Self(_value: 0x050900) }
+  @_alwaysEmitIntoClient
+  public static var v5_10_0: Self { Self(_value: 0x050A00) }
 
   @available(SwiftStdlib 5.7, *)
-  public static var current: Self { .v5_9_0 }
+  public static var current: Self { .v5_10_0 }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -35,7 +35,9 @@ SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
 SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
 SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
 SwiftStdlib 5.10:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+SwiftStdlib 5.11:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
 # TODO: Also update ASTContext::getSwift510Availability when needed
+# TODO: Also update ASTContext::getSwift511Availability when needed
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
The stdlib built from main needs to report itself as version 5.11.

This also includes the definition of v5.10 from #69444.

rdar://117549628