### PR TITLE
[Macros] Make sure we actually pass the conformance list to member macros

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1319,7 +1319,7 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
   std::string conformanceList;
   {
     llvm::raw_string_ostream OS(conformanceList);
-    if (role == MacroRole::Extension) {
+    if (role == MacroRole::Extension || role == MacroRole::Member) {
       llvm::interleave(
           conformances,
           [&](const ProtocolDecl *protocol) {

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2041,13 +2041,19 @@ extension RequiredDefaultInitMacro: MemberMacro {
     conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    let decl: DeclSyntax
-    if declaration.is(ClassDeclSyntax.self) && protocols.isEmpty {
-      decl = "required init() { }"
+    let initDecl: DeclSyntax
+    let funcDecl: DeclSyntax
+    if !declaration.is(ClassDeclSyntax.self) {
+      initDecl = "init() { }"
+      funcDecl = "func f() { }"
+    } else if !protocols.isEmpty {
+      initDecl = "required init() { }"
+      funcDecl = "func f() { }"
     } else {
-      decl = "init() { }"
+      initDecl = "required init() { }"
+      funcDecl = "override func f() { }"
     }
-    return [ decl ]
+    return [ initDecl, funcDecl ]
   }
 }
 

--- a/test/Macros/macro_expand_member_with_conformances.swift
+++ b/test/Macros/macro_expand_member_with_conformances.swift
@@ -9,7 +9,7 @@ protocol DefaultInit {
 }
 
 @attached(extension, conformances: DefaultInit)
-@attached(member, conformances: DefaultInit, names: named(init()))
+@attached(member, conformances: DefaultInit, names: named(init()), named(f()))
 macro DefaultInit() = #externalMacro(module: "MacroDefinition", type: "RequiredDefaultInitMacro")
 
 @DefaultInit


### PR DESCRIPTION
A bad test let this trivial bug through. Improve the test, fix the bug. Fixes rdar://117227204.
