### PR TITLE
[5.10] [Macros] Make sure we actually pass the conformance list to member macros

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1270,7 +1270,7 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
   std::string conformanceList;
   {
     llvm::raw_string_ostream OS(conformanceList);
-    if (role == MacroRole::Extension) {
+    if (role == MacroRole::Extension || role == MacroRole::Member) {
       llvm::interleave(
           conformances,
           [&](const ProtocolDecl *protocol) {

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2045,13 +2045,19 @@ extension RequiredDefaultInitMacro: MemberMacro {
     conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    let decl: DeclSyntax
-    if declaration.is(ClassDeclSyntax.self) && protocols.isEmpty {
-      decl = "required init() { }"
+    let initDecl: DeclSyntax
+    let funcDecl: DeclSyntax
+    if !declaration.is(ClassDeclSyntax.self) {
+      initDecl = "init() { }"
+      funcDecl = "func f() { }"
+    } else if !protocols.isEmpty {
+      initDecl = "required init() { }"
+      funcDecl = "func f() { }"
     } else {
-      decl = "init() { }"
+      initDecl = "required init() { }"
+      funcDecl = "override func f() { }"
     }
-    return [ decl ]
+    return [ initDecl, funcDecl ]
   }
 }
 

--- a/test/Macros/macro_expand_member_with_conformances.swift
+++ b/test/Macros/macro_expand_member_with_conformances.swift
@@ -9,7 +9,7 @@ protocol DefaultInit {
 }
 
 @attached(extension, conformances: DefaultInit)
-@attached(member, conformances: DefaultInit, names: named(init()))
+@attached(member, conformances: DefaultInit, names: named(init()), named(f()))
 macro DefaultInit() = #externalMacro(module: "MacroDefinition", type: "RequiredDefaultInitMacro")
 
 @DefaultInit


### PR DESCRIPTION
* **Explanation**: Ensure that we pass protocol conformance information that we compute in the compiler along to the macro implementation.
* **Scope**: Narrow. Only affects member macros using the new "conformances" extension from [SE-0407](https://github.com/apple/swift-evolution/blob/main/proposals/0407-member-macro-conformances.md).
* **Risk**: Very low: passes a string along to macros that have opted into it.
* **Original pull request**: https://github.com/apple/swift/pull/69446
* **Issue**: rdar://117227204
