### PR TITLE
Revert "Thrown types use "convertible to any Error" instead of "conforms to Error`

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2639,11 +2639,11 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
     Type thrownTy = AFD->getThrownInterfaceType();
     if (thrownTy) {
       thrownTy = AFD->getThrownInterfaceType();
-      auto anyErrorType = Context.getErrorExistentialType();
-      if (thrownTy && anyErrorType) {
+      ProtocolDecl *errorProto = Context.getErrorDecl();
+      if (thrownTy && errorProto) {
         Type thrownTyInContext = AFD->mapTypeIntoContext(thrownTy);
-        if (!TypeChecker::isConvertibleTo(
-                thrownTyInContext, anyErrorType, AFD)) {
+        if (!TypeChecker::conformsToProtocol(
+                thrownTyInContext, errorProto, AFD->getParentModule())) {
           SourceLoc loc;
           if (auto thrownTypeRepr = AFD->getThrownTypeRepr())
             loc = thrownTypeRepr->getLoc();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3712,9 +3712,9 @@ NeverNullType TypeResolver::resolveASTFunctionType(
       thrownTy = Type();
     } else if (!options.contains(TypeResolutionFlags::SilenceErrors) &&
                !thrownTy->hasTypeParameter() &&
-               !TypeChecker::isConvertibleTo(
-                   thrownTy, ctx.getErrorExistentialType(),
-                  resolution.getDeclContext())) {
+               !TypeChecker::conformsToProtocol(
+                  thrownTy, ctx.getErrorDecl(),
+                  resolution.getDeclContext()->getParentModule())) {
       diagnoseInvalid(
           thrownTypeRepr, thrownTypeRepr->getLoc(), diag::thrown_type_not_error,
           thrownTy);

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -123,3 +123,6 @@ struct HasASubscript {
     }
   }
 }
+
+// expected-error@+1{{thrown type 'any Codable & Error' (aka 'any Decodable & Encodable & Error') does not conform to the 'Error' protocol}}
+func throwCodableErrors() throws(any Codable & Error) { }

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -123,5 +123,3 @@ struct HasASubscript {
     }
   }
 }
-
-func throwCodableErrors() throws(any Codable & Error) { }


### PR DESCRIPTION
This reverts commit 6e0aeab1490855cdf68697913c245807ffbca9ce. This idea that we can use "convertible to any Error" in lieu of "conforms to Error" doesn't actually work, because it means that you can't use such error types in generic code that has `throws(E)`. Thanks to @slavapestov for realizing how much of a problem this will actually be.
