### PR TITLE
SILGen: Skip emitting distributed thunks for skipped accessors

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1416,13 +1416,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
       emitNativeToForeignThunk(thunk);
   }
 
-  if (auto thunkDecl = AFD->getDistributedThunk()) {
-    if (!thunkDecl->isBodySkipped()) {
-      auto thunk = SILDeclRef(thunkDecl).asDistributed();
-      emitFunctionDefinition(SILDeclRef(thunkDecl).asDistributed(),
-                             getFunction(thunk, ForDefinition));
-    }
-  }
+  emitDistributedThunkForDecl(AFD);
 
   if (AFD->isBackDeployed(M.getASTContext())) {
     // Emit the fallback function that will be used when the original function

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -360,6 +360,11 @@ public:
   /// Emits a thunk from an actor function to a potentially distributed call.
   void emitDistributedThunk(SILDeclRef thunk);
 
+  /// Emits the distributed actor thunk for the decl if there is one associated
+  /// with it.
+  void emitDistributedThunkForDecl(
+      llvm::PointerUnion<AbstractFunctionDecl *, VarDecl *> varOrAFD);
+
   /// Returns true if the given declaration must be referenced through a
   /// back deployment thunk in a context with the given resilience expansion.
   bool requiresBackDeploymentThunk(ValueDecl *decl,

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -110,6 +110,23 @@ void SILGenModule::emitNativeToForeignThunk(SILDeclRef thunk) {
   emitFunctionDefinition(thunk, getFunction(thunk, ForDefinition));
 }
 
+void SILGenModule::emitDistributedThunkForDecl(
+    llvm::PointerUnion<AbstractFunctionDecl *, VarDecl *> varOrAFD) {
+  FuncDecl *thunkDecl =
+      varOrAFD.is<AbstractFunctionDecl *>()
+          ? varOrAFD.get<AbstractFunctionDecl *>()->getDistributedThunk()
+          : varOrAFD.get<VarDecl *>()->getDistributedThunk();
+  if (!thunkDecl)
+    return;
+
+  if (thunkDecl->isBodySkipped())
+    return;
+
+  auto thunk = SILDeclRef(thunkDecl).asDistributed();
+  emitFunctionDefinition(SILDeclRef(thunkDecl).asDistributed(),
+                         getFunction(thunk, ForDefinition));
+}
+
 void SILGenModule::emitDistributedThunk(SILDeclRef thunk) {
   // Thunks are always emitted by need, so don't need delayed emission.
   assert(thunk.isDistributedThunk() && "distributed thunks only");

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1223,12 +1223,7 @@ public:
       SGM.emitPropertyWrapperBackingInitializer(vd);
     }
 
-    if (auto *thunk = vd->getDistributedThunk()) {
-      auto thunkRef = SILDeclRef(thunk).asDistributed();
-      SGM.emitFunctionDefinition(thunkRef,
-                                 SGM.getFunction(thunkRef, ForDefinition));
-    }
-
+    SGM.emitDistributedThunkForDecl(vd);
     visitAbstractStorageDecl(vd);
   }
 
@@ -1404,12 +1399,7 @@ public:
       }
     }
 
-    if (auto *thunk = vd->getDistributedThunk()) {
-      auto thunkRef = SILDeclRef(thunk).asDistributed();
-      SGM.emitFunctionDefinition(thunkRef,
-                                 SGM.getFunction(thunkRef, ForDefinition));
-    }
-
+    SGM.emitDistributedThunkForDecl(vd);
     visitAbstractStorageDecl(vd);
   }
 

--- a/test/Distributed/SIL/distributed_thunk_skip_function_bodies.swift
+++ b/test/Distributed/SIL/distributed_thunk_skip_function_bodies.swift
@@ -8,12 +8,25 @@ import Distributed
 
 public distributed actor DA {
   public typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  // CHECK-NOT: s38distributed_thunk_skip_function_bodies2DAC9publicVarSiyYaKFTE
+  distributed var publicVar: Int {
+    let NEVER_TYPECHECK = 1
+    blackHole(NEVER_TYPECHECK)
+    return 1
+  }
 }
 
 @inline(never)
 public func blackHole<T>(_ t: T) { }
 
 extension DA {
+  // CHECK-NOT: s38distributed_thunk_skip_function_bodies2DAC20publicVarInExtensionSiyYaKFTE
+  distributed var publicVarInExtension: Int {
+    let NEVER_TYPECHECK = 1
+    blackHole(NEVER_TYPECHECK)
+    return 1
+  }
 
   // CHECK-NOT: s38distributed_thunk_skip_function_bodies2DAC10publicFuncyyYaKFTE
   public distributed func publicFunc() {


### PR DESCRIPTION
Generalizes https://github.com/apple/swift/pull/68917 to cover accessors in addition to methods.

Resolves rdar://117226130
