### PR TITLE
[utils] Enable lldb in Linux smoke testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -306,7 +306,7 @@ lldb-assertions
 # Build libcxx for tests
 libcxx
 lldb
-lit-args=-v 
+lit-args=-v
 
 lldb-use-system-debugserver
 release-debuginfo
@@ -1023,6 +1023,7 @@ mixin-preset=
 mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts
     mixin_linux_installation
+    lldb-smoketest,tools=RA
 build-subdir=buildbot_linux
 lldb
 release
@@ -1037,7 +1038,6 @@ lit-args=-v
 install-foundation
 install-libdispatch
 reconfigure
-skip-test-lldb
 test-optimized
 
 


### PR DESCRIPTION
Enable lldb in Linux smoke testing.