### PR TITLE
[region-isolation] Make sure that we treat Sendable functions as Sendable

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -901,6 +901,12 @@ public:
   /// Determines whether this type is an actor type.
   bool isActorType();
 
+  /// Returns true if this type is a Sendable type.
+  bool isSendableType(DeclContext *declContext);
+
+  /// Returns true if this type is a Sendable type.
+  bool isSendableType(ModuleDecl *parentModule);
+
   /// Determines whether this type conforms or inherits (if it's a protocol
   /// type) from `DistributedActor`.
   bool isDistributedActor();

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -880,6 +880,9 @@ public:
 
   bool isActor() const { return getASTType()->isActorType(); }
 
+  /// Returns true if this function conforms to the Sendable protocol.
+  bool isSendable(SILFunction *fn) const;
+
   ProtocolConformanceRef conformsToProtocol(SILFunction *fn,
                                             ProtocolDecl *protocol) const;
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -506,6 +506,14 @@ bool TypeBase::isActorType() {
   return false;
 }
 
+bool TypeBase::isSendableType(DeclContext *ctx) {
+  return isSendableType(ctx->getParentModule());
+}
+
+bool TypeBase::isSendableType(ModuleDecl *parentModule) {
+  return ::isSendableType(parentModule, Type(this));
+}
+
 bool TypeBase::isDistributedActor() {
   if (auto actor = getAnyActor())
     return actor->isDistributedActor();

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1224,3 +1224,7 @@ ProtocolConformanceRef
 SILType::conformsToProtocol(SILFunction *fn, ProtocolDecl *protocol) const {
   return fn->getParentModule()->conformsToProtocol(getASTType(), protocol);
 }
+
+bool SILType::isSendable(SILFunction *fn) const {
+  return getASTType()->isSendableType(fn->getParentModule());
+}

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -657,6 +657,13 @@ bool swift::isSendableType(ModuleDecl *module, Type type) {
   if (!proto)
     return true;
 
+  // First check if we have a function type. If we do, check if it is
+  // Sendable. We do this since functions cannot conform to protocols.
+  if (auto *fas = type->getCanonicalType()->getAs<SILFunctionType>())
+    return fas->isSendable();
+  if (auto *fas = type->getCanonicalType()->getAs<AnyFunctionType>())
+    return fas->isSendable();
+
   auto conformance = TypeChecker::conformsToProtocol(type, proto, module);
   if (conformance.isInvalid())
     return false;

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -232,10 +232,7 @@ extension MyActor {
 @available(SwiftStdlib 5.1, *)
 func testConversionsAndSendable(a: MyActor, s: any Sendable, f: @Sendable () -> Void) async {
   await a.f(s)
-
-  // FIXME: 'f' is Sendable
   await a.g(f)
-  // expected-tns-warning@-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
 }
 
 @available(SwiftStdlib 5.1, *)


### PR DESCRIPTION
The reason for this issue is that we were originally checking in our NonSendable type oracle just if a type conformed to Sendable. But function types do not conform to protocols, so this would fail for protocols. Instead, we manually check if we have a SIL function type and it is Sendable to answer this query.

There was also a question if we also handled function conversions correctly. I added a test case that shows that we do not error in either of the cases.

rdar://116525224
