### PR TITLE
IRGen,Serialization: account for transitive dynamic linkage

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -424,9 +424,6 @@ private:
   /// The function's effects attribute.
   unsigned EffectsKindAttr : NumEffectsKindBits;
 
-  /// The function is in a statically linked module.
-  unsigned IsStaticallyLinked : 1;
-
   /// If true, the function has lexical lifetimes even if the module does not.
   unsigned ForceEnableLexicalLifetimes : 1;
 
@@ -696,12 +693,6 @@ public:
 
   void setWasDeserializedCanonical(bool val = true) {
     WasDeserializedCanonical = val;
-  }
-
-  bool isStaticallyLinked() const { return IsStaticallyLinked; }
-
-  void setIsStaticallyLinked(bool value) {
-    IsStaticallyLinked = value;
   }
 
   ForceEnableLexicalLifetimes_t forceEnableLexicalLifetimes() const {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2404,7 +2404,8 @@ LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
     // an associated DeclContext and are serialized into the current module.  As
     // a result, we explicitly handle SIL Functions here. We do not expect other
     // types to be referenced directly.
-    isKnownLocal = entity.getSILFunction()->isStaticallyLinked();
+    if (const auto *MD = entity.getSILFunction()->getParentModule())
+      isKnownLocal = MD == swiftModule || MD->isStaticLibrary();
   }
 
   bool weakImported = entity.isWeakImported(swiftModule);

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -214,7 +214,6 @@ void SILFunction::init(
   this->Zombie = false;
   this->HasOwnership = true,
   this->WasDeserializedCanonical = false;
-  this->IsStaticallyLinked = false;
   this->IsWithoutActuallyEscapingThunk = false;
   this->OptMode = unsigned(OptimizationMode::NotSet);
   this->perfConstraints = PerformanceConstraints::None;
@@ -290,7 +289,6 @@ void SILFunction::createSnapshot(int id) {
   newSnapshot->HasOwnership = HasOwnership;
   newSnapshot->IsWithoutActuallyEscapingThunk = IsWithoutActuallyEscapingThunk;
   newSnapshot->OptMode = OptMode;
-  newSnapshot->IsStaticallyLinked = IsStaticallyLinked;
   newSnapshot->copyEffects(this);
 
   SILFunctionCloner cloner(newSnapshot);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -639,10 +639,6 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     if (getFile()->getParentModule() == SILMod.getSwiftModule())
       fn->setLinkage(linkage);
 
-    if (getFile()->getParentModule()->isStaticLibrary() ||
-        getFile()->getParentModule() == SILMod.getSwiftModule())
-      fn->setIsStaticallyLinked(true);
-
     // Don't override the transparency or linkage of a function with
     // an existing declaration, except if we deserialized a
     // PublicNonABI function, which has HiddenExternal when
@@ -678,7 +674,6 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setIsAlwaysWeakImported(isWeakImported);
     fn->setClassSubclassScope(SubclassScope(subclassScope));
     fn->setHasCReferences(bool(hasCReferences));
-    fn->setIsStaticallyLinked(MF->getAssociatedModule()->isStaticLibrary());
 
     llvm::VersionTuple available;
     DECODE_VER_TUPLE(available);

--- a/test/IRGen/windows-transitive-static-linking.swift
+++ b/test/IRGen/windows-transitive-static-linking.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// REQUIRES: OS=windows-msvc
+
+// RUN: %target-swiftc_driver -emit-module -emit-module-path %t/swift/dynamic.swiftmodule -I %t/swift %t/dynamic.swift
+// RUN: %target-swiftc_driver -static -emit-module -emit-module-path %t/swift/static.swiftmodule -I %t/swift %t/static.swift
+// RUN: %target-swiftc_driver -O -emit-ir -I %t/swift %t/library.swift | %FileCheck %s
+
+// CHECK: declare dllimport swiftcc i{{[0-9]+}} @"$s7dynamic1fSiyF"()
+
+//--- dynamic.swift
+public func f() -> Int { 32 }
+
+//--- static.swift
+import dynamic
+
+@inlinable
+public func g() -> Int { f() + 1 }
+
+//--- library.swift
+import `static`
+public func h() -> Int { g() + 1 }


### PR DESCRIPTION
When building complex projects, there may cases of static libraries which expose `@inlinable` functions which reference functions from dynamically linked dependencies. In such a case, we need to consider the provenance of the `function_ref` when determining the DLL storage for linkage. We would previously use the deserialised metadata on the `SILFunction` as there are entities where the `DeclContext` may not be deserialised. However, this leaves us in a state where we are unable to determine the actual provenance correctly in some cases. By simply accessing the parent module directly from the `SILFunction` we ensure that we properly identify the origin of the function allowing us to query the DLL storage property. This further allows us to remove the extra storage required for whether the `SILFunction` is statically linked.