### PR TITLE
[Macros] Support module-qualified attached macro lookup

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -64,6 +64,7 @@ class ModuleDecl;
 class PatternBindingInitializer;
 class TrailingWhereClause;
 class TypeExpr;
+class IdentTypeRepr;
 
 class alignas(1 << AttrAlignInBits) AttributeBase
     : public ASTAllocated<AttributeBase> {
@@ -1768,6 +1769,15 @@ public:
   TypeExpr *getTypeExpr() const { return typeExpr; }
   TypeRepr *getTypeRepr() const;
   Type getType() const;
+
+  /// Destructure an attribute's type repr for a macro reference.
+  ///
+  /// For a 1-level member type repr whose base and member are both identifier
+  /// types, e.g. `Foo.Bar`, return a pair of the base and the member.
+  ///
+  /// For an identifier type repr, return a pair of `nullptr` and the
+  /// identifier.
+  std::pair<IdentTypeRepr *, IdentTypeRepr *> destructureMacroRef();
 
   /// Whether the attribute has any arguments.
   bool hasArgs() const { return argList != nullptr; }

--- a/include/swift/AST/FreestandingMacroExpansion.h
+++ b/include/swift/AST/FreestandingMacroExpansion.h
@@ -34,6 +34,8 @@ class ArgumentList;
 /// declaration/expression nodes.
 struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
   SourceLoc SigilLoc;
+  DeclNameRef ModuleName;
+  DeclNameLoc ModuleNameLoc;
   DeclNameRef MacroName;
   DeclNameLoc MacroNameLoc;
   SourceLoc LeftAngleLoc, RightAngleLoc;
@@ -43,13 +45,16 @@ struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
   /// The referenced macro.
   ConcreteDeclRef macroRef;
 
-  MacroExpansionInfo(SourceLoc sigilLoc, DeclNameRef macroName,
+  MacroExpansionInfo(SourceLoc sigilLoc, DeclNameRef moduleName,
+                     DeclNameLoc moduleNameLoc, DeclNameRef macroName,
                      DeclNameLoc macroNameLoc, SourceLoc leftAngleLoc,
                      SourceLoc rightAngleLoc, ArrayRef<TypeRepr *> genericArgs,
                      ArgumentList *argList)
-      : SigilLoc(sigilLoc), MacroName(macroName), MacroNameLoc(macroNameLoc),
-        LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
-        GenericArgs(genericArgs), ArgList(argList) {}
+      : SigilLoc(sigilLoc), ModuleName(moduleName),
+        ModuleNameLoc(moduleNameLoc), MacroName(macroName),
+        MacroNameLoc(macroNameLoc), LeftAngleLoc(leftAngleLoc),
+        RightAngleLoc(rightAngleLoc), GenericArgs(genericArgs),
+        ArgList(argList) {}
 
   SourceLoc getLoc() const { return SigilLoc; }
   SourceRange getGenericArgsRange() const {
@@ -85,6 +90,10 @@ public:
 
   SourceLoc getPoundLoc() const { return getExpansionInfo()->SigilLoc; }
 
+  DeclNameLoc getModuleNameLoc() const {
+    return getExpansionInfo()->ModuleNameLoc;
+  }
+  DeclNameRef getModuleName() const { return getExpansionInfo()->ModuleName; }
   DeclNameLoc getMacroNameLoc() const {
     return getExpansionInfo()->MacroNameLoc;
   }

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -550,8 +550,10 @@ void filterForDiscriminator(SmallVectorImpl<Result> &results,
 
 /// \returns The set of macro declarations with the given name that
 /// fulfill any of the given macro roles.
-SmallVector<MacroDecl *, 1>
-lookupMacros(DeclContext *dc, DeclNameRef macroName, MacroRoles roles);
+SmallVector<MacroDecl *, 1> lookupMacros(DeclContext *dc,
+                                         DeclNameRef moduleName,
+                                         DeclNameRef macroName,
+                                         MacroRoles roles);
 
 /// \returns Whether the given source location is inside an attached
 /// or freestanding macro argument.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -245,6 +245,8 @@ enum class UnqualifiedLookupFlags {
   ExcludeMacroExpansions = 1 << 6,
   /// This lookup should only return macros.
   MacroLookup            = 1 << 7,
+  /// This lookup should only return modules
+  ModuleLookup           = 1 << 8,
 };
 
 using UnqualifiedLookupOptions = OptionSet<UnqualifiedLookupFlags>;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3436,6 +3436,8 @@ public:
   }
 
   SourceLoc getSigilLoc() const;
+  DeclNameRef getModuleName() const;
+  DeclNameLoc getModuleNameLoc() const;
   DeclNameRef getMacroName() const;
   DeclNameLoc getMacroNameLoc() const;
   SourceRange getGenericArgsRange() const;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2587,6 +2587,21 @@ CustomAttr *CustomAttr::create(ASTContext &ctx, SourceLoc atLoc, TypeExpr *type,
       CustomAttr(atLoc, range, type, initContext, argList, implicit);
 }
 
+std::pair<IdentTypeRepr *, IdentTypeRepr *> CustomAttr::destructureMacroRef() {
+  TypeRepr *typeRepr = getTypeRepr();
+  if (!typeRepr)
+    return {nullptr, nullptr};
+  if (auto *identType = dyn_cast<IdentTypeRepr>(typeRepr))
+    return {nullptr, identType};
+  if (auto *memType = dyn_cast<MemberTypeRepr>(typeRepr))
+    if (auto *base = dyn_cast<IdentTypeRepr>(memType->getBaseComponent()))
+      if (memType->getMemberComponents().size() == 1)
+        if (auto first =
+                dyn_cast<IdentTypeRepr>(memType->getMemberComponents().front()))
+          return {base, first};
+  return {nullptr, nullptr};
+}
+
 TypeRepr *CustomAttr::getTypeRepr() const { return typeExpr->getTypeRepr(); }
 Type CustomAttr::getType() const { return typeExpr->getInstanceType(); }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11479,11 +11479,16 @@ MacroExpansionDecl::create(
     ArgumentList *args
 ) {
   ASTContext &ctx = dc->getASTContext();
-  MacroExpansionInfo *info = new (ctx) MacroExpansionInfo{
-      poundLoc, macro, macroLoc,
-      leftAngleLoc, rightAngleLoc, genericArgs,
-      args ? args : ArgumentList::createImplicit(ctx, {})
-  };
+  MacroExpansionInfo *info = new (ctx)
+      MacroExpansionInfo{poundLoc,
+                         /*moduleName*/ DeclNameRef(),
+                         /*moduleNameLoc*/ DeclNameLoc(),
+                         macro,
+                         macroLoc,
+                         leftAngleLoc,
+                         rightAngleLoc,
+                         genericArgs,
+                         args ? args : ArgumentList::createImplicit(ctx, {})};
   return new (ctx) MacroExpansionDecl(dc, info);
 }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2769,10 +2769,15 @@ MacroExpansionExpr *MacroExpansionExpr::create(
 ) {
   ASTContext &ctx = dc->getASTContext();
   MacroExpansionInfo *info = new (ctx) MacroExpansionInfo{
-      sigilLoc, macroName, macroNameLoc,
-      leftAngleLoc, rightAngleLoc, genericArgs,
-      argList ? argList : ArgumentList::createImplicit(ctx, {})
-  };
+      sigilLoc,
+      /*moduleName*/ DeclNameRef(),
+      /*moduleNameLoc*/ DeclNameLoc(),
+      macroName,
+      macroNameLoc,
+      leftAngleLoc,
+      rightAngleLoc,
+      genericArgs,
+      argList ? argList : ArgumentList::createImplicit(ctx, {})};
   return new (ctx) MacroExpansionExpr(dc, info, roles, isImplicit, ty);
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3580,9 +3580,9 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
   // Look for names at module scope, so we don't trigger name lookup for
   // nested scopes. At this point, we're looking to see whether there are
   // any suitable macros.
-  auto [base, member] = attr->destructureMacroRef();
-  auto moduleName = (base) ? base->getNameRef() : DeclNameRef();
-  auto macroName = (member) ? member->getNameRef() : DeclNameRef();
+  auto [module, macro] = attr->destructureMacroRef();
+  auto moduleName = (module) ? module->getNameRef() : DeclNameRef();
+  auto macroName = (macro) ? macro->getNameRef() : DeclNameRef();
   auto macros = namelookup::lookupMacros(dc, moduleName, macroName,
                                          getAttachedMacroRoles());
   if (!macros.empty())

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1788,14 +1788,35 @@ void swift::simple_display(
 // ResolveMacroRequest computation.
 //----------------------------------------------------------------------------//
 
+/// Destructure a type repr for a macro reference.
+///
+/// For a 1-level member type repr whose base and member are both identifier
+/// types, e.g. `Foo.Bar`, return a pair of the base and the member.
+///
+/// For an identifier type repr, return a pair of `nullptr` and the identifier.
+static std::pair<IdentTypeRepr *, IdentTypeRepr *>
+destructureMacroRefTypeRepr(TypeRepr *typeRepr) {
+  if (!typeRepr)
+    return {nullptr, nullptr};
+  if (auto *identType = dyn_cast<IdentTypeRepr>(typeRepr))
+    return {nullptr, identType};
+  if (auto *memType = dyn_cast<MemberTypeRepr>(typeRepr))
+    if (auto *base = dyn_cast<IdentTypeRepr>(memType->getBaseComponent()))
+      if (memType->getMemberComponents().size() == 1)
+        if (auto first =
+                dyn_cast<IdentTypeRepr>(memType->getMemberComponents().front()))
+          return {base, first};
+  return {nullptr, nullptr};
+}
+
 DeclNameRef UnresolvedMacroReference::getMacroName() const {
   if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
     return expansion->getMacroName();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
-    if (!identTypeRepr)
+    auto [_, member] = destructureMacroRefTypeRepr(attr->getTypeRepr());
+    if (!member)
       return DeclNameRef();
-    return identTypeRepr->getNameRef();
+    return member->getNameRef();
   }
   llvm_unreachable("Unhandled case");
 }
@@ -1808,14 +1829,38 @@ SourceLoc UnresolvedMacroReference::getSigilLoc() const {
   llvm_unreachable("Unhandled case");
 }
 
+DeclNameRef UnresolvedMacroReference::getModuleName() const {
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getModuleName();
+  if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
+    auto [base, _] = destructureMacroRefTypeRepr(attr->getTypeRepr());
+    if (!base)
+      return DeclNameRef();
+    return base->getNameRef();
+  }
+  llvm_unreachable("Unhandled case");
+}
+
+DeclNameLoc UnresolvedMacroReference::getModuleNameLoc() const {
+  if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
+    return expansion->getModuleNameLoc();
+  if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
+    auto [base, _] = destructureMacroRefTypeRepr(attr->getTypeRepr());
+    if (!base)
+      return DeclNameLoc();
+    return base->getNameLoc();
+  }
+  llvm_unreachable("Unhandled case");
+}
+
 DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
   if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
     return expansion->getMacroNameLoc();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
-    if (!identTypeRepr)
+    auto [_, member] = destructureMacroRefTypeRepr(attr->getTypeRepr());
+    if (!member)
       return DeclNameLoc();
-    return identTypeRepr->getNameLoc();
+    return member->getNameLoc();
   }
   llvm_unreachable("Unhandled case");
 }
@@ -1825,8 +1870,10 @@ SourceRange UnresolvedMacroReference::getGenericArgsRange() const {
     return expansion->getGenericArgsRange();
 
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto *typeRepr = attr->getTypeRepr();
-    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(typeRepr);
+    auto [_, member] = destructureMacroRefTypeRepr(attr->getTypeRepr());
+    if (!member)
+      return SourceRange();
+    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(member);
     if (!genericTypeRepr)
       return SourceRange();
 
@@ -1841,8 +1888,10 @@ ArrayRef<TypeRepr *> UnresolvedMacroReference::getGenericArgs() const {
     return expansion->getGenericArgs();
 
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto *typeRepr = attr->getTypeRepr();
-    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(typeRepr);
+    auto [_, member] = destructureMacroRefTypeRepr(attr->getTypeRepr());
+    if (!member)
+      return {};
+    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(member);
     if (!genericTypeRepr)
       return {};
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1792,10 +1792,10 @@ DeclNameRef UnresolvedMacroReference::getMacroName() const {
   if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
     return expansion->getMacroName();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto [_, member] = attr->destructureMacroRef();
-    if (!member)
+    auto [_, macro] = attr->destructureMacroRef();
+    if (!macro)
       return DeclNameRef();
-    return member->getNameRef();
+    return macro->getNameRef();
   }
   llvm_unreachable("Unhandled case");
 }
@@ -1812,10 +1812,10 @@ DeclNameRef UnresolvedMacroReference::getModuleName() const {
   if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
     return expansion->getModuleName();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto [base, _] = attr->destructureMacroRef();
-    if (!base)
+    auto [module, _] = attr->destructureMacroRef();
+    if (!module)
       return DeclNameRef();
-    return base->getNameRef();
+    return module->getNameRef();
   }
   llvm_unreachable("Unhandled case");
 }
@@ -1824,10 +1824,10 @@ DeclNameLoc UnresolvedMacroReference::getModuleNameLoc() const {
   if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
     return expansion->getModuleNameLoc();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto [base, _] = attr->destructureMacroRef();
-    if (!base)
+    auto [module, _] = attr->destructureMacroRef();
+    if (!module)
       return DeclNameLoc();
-    return base->getNameLoc();
+    return module->getNameLoc();
   }
   llvm_unreachable("Unhandled case");
 }
@@ -1836,10 +1836,10 @@ DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
   if (auto *expansion = pointer.dyn_cast<FreestandingMacroExpansion *>())
     return expansion->getMacroNameLoc();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto [_, member] = attr->destructureMacroRef();
-    if (!member)
+    auto [_, macro] = attr->destructureMacroRef();
+    if (!macro)
       return DeclNameLoc();
-    return member->getNameLoc();
+    return macro->getNameLoc();
   }
   llvm_unreachable("Unhandled case");
 }
@@ -1849,10 +1849,10 @@ SourceRange UnresolvedMacroReference::getGenericArgsRange() const {
     return expansion->getGenericArgsRange();
 
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto [_, member] = attr->destructureMacroRef();
-    if (!member)
+    auto [_, macro] = attr->destructureMacroRef();
+    if (!macro)
       return SourceRange();
-    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(member);
+    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(macro);
     if (!genericTypeRepr)
       return SourceRange();
 
@@ -1867,10 +1867,10 @@ ArrayRef<TypeRepr *> UnresolvedMacroReference::getGenericArgs() const {
     return expansion->getGenericArgs();
 
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
-    auto [_, member] = attr->destructureMacroRef();
-    if (!member)
+    auto [_, macro] = attr->destructureMacroRef();
+    if (!macro)
       return {};
-    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(member);
+    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(macro);
     if (!genericTypeRepr)
       return {};
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -281,6 +281,12 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
                                   "performUnqualifiedLookup",
                                   DC->getParentSourceFile());
 
+  if (options.contains(UnqualifiedLookupFlags::ModuleLookup)) {
+    lookForAModuleWithTheGivenName(DC->getModuleScopeContext());
+    recordCompletionOfAScope();
+    return;
+  }
+
   if (Loc.isValid() && DC->getParentSourceFile()) {
     // Operator lookup is always global, for the time being.
     if (!Name.isOperator())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1367,9 +1367,9 @@ namespace {
           return Type();
 
         auto macroIdent = ctx.getIdentifier(kind);
-        auto macros = lookupMacros(
-            macroIdent, FunctionRefKind::Unapplied,
-            MacroRole::Expression);
+        auto macros =
+            lookupMacros(Identifier(), macroIdent, FunctionRefKind::Unapplied,
+                         MacroRole::Expression);
         if (!macros.empty()) {
           // Introduce an overload set for the macro reference.
           auto locator = CS.getConstraintLocator(expr);
@@ -4002,13 +4002,13 @@ namespace {
     }
 
     /// Lookup all macros with the given macro name.
-    SmallVector<OverloadChoice, 1>
-    lookupMacros(Identifier macroName,
-                 FunctionRefKind functionRefKind,
-                 MacroRoles roles) {
+    SmallVector<OverloadChoice, 1> lookupMacros(Identifier moduleName,
+                                                Identifier macroName,
+                                                FunctionRefKind functionRefKind,
+                                                MacroRoles roles) {
       SmallVector<OverloadChoice, 1> choices;
-      auto results = namelookup::lookupMacros(
-          CurDC, DeclNameRef(macroName), roles);
+      auto results = namelookup::lookupMacros(CurDC, DeclNameRef(moduleName),
+                                              DeclNameRef(macroName), roles);
       for (const auto &result : results) {
         OverloadChoice choice = OverloadChoice(Type(), result, functionRefKind);
         choices.push_back(choice);
@@ -4030,10 +4030,11 @@ namespace {
       CS.associateArgumentList(locator, expr->getArgs());
 
       // Look up the macros with this name.
+      auto moduleIdent = expr->getModuleName().getBaseIdentifier();
       auto macroIdent = expr->getMacroName().getBaseIdentifier();
       FunctionRefKind functionRefKind = FunctionRefKind::SingleApply;
-      auto macros = lookupMacros(
-          macroIdent, functionRefKind, expr->getMacroRoles());
+      auto macros = lookupMacros(moduleIdent, macroIdent, functionRefKind,
+                                 expr->getMacroRoles());
       if (macros.empty()) {
         ctx.Diags.diagnose(expr->getMacroNameLoc(), diag::macro_undefined,
                            macroIdent)

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1885,8 +1885,8 @@ ConcreteDeclRef ResolveMacroRequest::evaluate(Evaluator &evaluator,
   // When a macro is not found for a custom attribute, it may be a non-macro.
   // So bail out to prevent diagnostics from the contraint system.
   if (macroRef.getAttr()) {
-    auto foundMacros = namelookup::lookupMacros(
-        dc, macroRef.getMacroName(), roles);
+    auto foundMacros = namelookup::lookupMacros(dc, macroRef.getModuleName(),
+                                                macroRef.getMacroName(), roles);
     if (foundMacros.empty())
       return ConcreteDeclRef();
   }

--- a/test/Macros/Inputs/macro_library.swift
+++ b/test/Macros/Inputs/macro_library.swift
@@ -42,3 +42,14 @@ public macro AddClassReferencingSelf() = #externalMacro(module: "MacroDefinition
 
 @attached(peer, names: named(value))
 public macro declareVarValuePeer() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")
+
+@propertyWrapper
+public struct declareVarValuePeerShadowed {
+  public var wrappedValue: Int
+  public init(wrappedValue: Int) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+@attached(peer, names: named(value))
+public macro declareVarValuePeerShadowed() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -917,14 +917,23 @@ public struct AddCompletionHandler: PeerMacro {
 
     // Drop the @addCompletionHandler attribute from the new declaration.
     let newAttributeList = funcDecl.attributes.filter {
-      guard case let .attribute(attribute) = $0,
-            let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
-            let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
-      else {
+      guard case let .attribute(attribute) = $0  else {
         return true
       }
 
-      return attributeType.name.text != nodeType.name.text
+      if let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+         let nodeType = node.attributeName.as(IdentifierTypeSyntax.self) {
+        return attributeType.name.text != nodeType.name.text
+      }
+      if let attributeMemberType = attribute.attributeName.as(MemberTypeIdentifierSyntax.self),
+         let attributeModuleName = attributeMemberType.baseType.as(SimpleTypeIdentifierSyntax.self),
+         let nodeMemberType = node.attributeName.as(MemberTypeIdentifierSyntax.self),
+         let moduleName = nodeMemberType.baseType.as(SimpleTypeIdentifierSyntax.self) {
+        return attributeModuleName.name.text != moduleName.name.text ||
+               nodeMemberType.name.text != attributeMemberType.name.text
+      }
+
+      return true
     }
 
     var newFunc = funcDecl

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -925,10 +925,10 @@ public struct AddCompletionHandler: PeerMacro {
          let nodeType = node.attributeName.as(IdentifierTypeSyntax.self) {
         return attributeType.name.text != nodeType.name.text
       }
-      if let attributeMemberType = attribute.attributeName.as(MemberTypeIdentifierSyntax.self),
-         let attributeModuleName = attributeMemberType.baseType.as(SimpleTypeIdentifierSyntax.self),
-         let nodeMemberType = node.attributeName.as(MemberTypeIdentifierSyntax.self),
-         let moduleName = nodeMemberType.baseType.as(SimpleTypeIdentifierSyntax.self) {
+      if let attributeMemberType = attribute.attributeName.as(MemberTypeSyntax.self),
+         let attributeModuleName = attributeMemberType.baseType.as(IdentifierTypeSyntax.self),
+         let nodeMemberType = node.attributeName.as(MemberTypeSyntax.self),
+         let moduleName = nodeMemberType.baseType.as(IdentifierTypeSyntax.self) {
         return attributeModuleName.name.text != moduleName.name.text ||
                nodeMemberType.name.text != attributeMemberType.name.text
       }

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -39,10 +39,17 @@ macro declareVarValuePeer() = #externalMacro(module: "MacroDefinition", type: "V
 macro addCompletionHandlerArbitrarily(_: Int) = #externalMacro(module: "MacroDefinition", type: "AddCompletionHandler")
 
 struct S {
+#if IMPORT_MACRO_LIBRARY
+  @macro_library.addCompletionHandler // test module qualified macro lookup
+  func f(a: Int, for b: String, _ value: Double) async -> String {
+    return b
+  }
+#else
   @addCompletionHandler
   func f(a: Int, for b: String, _ value: Double) async -> String {
     return b
   }
+#endif
 
   // CHECK-DUMP: @__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_.swift
   // CHECK-DUMP: func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {

--- a/test/Macros/macro_shadowing.swift
+++ b/test/Macros/macro_shadowing.swift
@@ -7,14 +7,29 @@
 
 // Build library that declares macros
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/freestanding_macro_library.swiftmodule %S/Inputs/freestanding_macro_library.swift -module-name freestanding_macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
-
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-experimental-feature ExtensionMacros 
 // 
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -I %t
 
 import freestanding_macro_library
+import macro_library
 
 struct stringify<T> { }
 
 func testStringify(a: Int, b: Int) {
   _ = #stringify(a + b)
 }
+
+enum macro_library {
+  @propertyWrapper
+  struct declareVarValuePeerShadowed {
+    var wrappedValue: Int
+  }
+}
+
+struct TestShadowedQualified {
+  @macro_library.declareVarValuePeerShadowed
+  var shouldFindMacro: Int = 3
+}
+
+_ = TestShadowedQualified().value

--- a/test/Macros/macro_shadowing.swift
+++ b/test/Macros/macro_shadowing.swift
@@ -20,6 +20,18 @@ func testStringify(a: Int, b: Int) {
   _ = #stringify(a + b)
 }
 
+@propertyWrapper
+struct declareVarValuePeer {
+  var wrappedValue: Int
+}
+
+struct TestShadowUnqualified {
+  @declareVarValuePeer
+  var shouldFindMacro: Int = 2
+}
+
+_ = TestShadowUnqualified().value
+
 enum macro_library {
   @propertyWrapper
   struct declareVarValuePeerShadowed {


### PR DESCRIPTION
Allow attached macro expansion syntax to have a module qualifier, `@Foo.Bar`.

Resolves #65485 / rdar://108621205