### PR TITLE
[VIM] Fix syntax highlighting of nested comments

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -180,9 +180,9 @@ syn region swiftString contains=swiftInterpolationRegion
       \ start=/"/ skip=/\\\\\|\\"/ end=/"/
 syn region swiftInterpolationRegion contained contains=TOP
       \ matchgroup=swiftInterpolation start=/\\(/ end=/)/
-syn region swiftComment contains=swiftComment,swiftLineComment,swiftTodo
+syn region swiftComment contains=swiftComment,swiftTodo
       \ start="/\*" end="\*/"
-syn region swiftLineComment contains=swiftComment,swiftTodo
+syn region swiftLineComment contains=swiftTodo
       \ start="//" end="$"
 
 syn match swiftDecimal


### PR DESCRIPTION
This fixes incorrect vim syntax highlighting of some comments. The following examples incorrectly highlight `foo` as a comment.

```
/* // */ foo
```

```
// /*
foo
*/ foo
```

This was previously fixed in https://github.com/apple/swift/commit/fea0f4d45000e982e76eebe2f31a11deeb392e51 but was a regression introduced in https://github.com/apple/swift/commit/633986e4db2a6f1f58675dc717b35275aa1ecac0.

The simplest test is to place the two syntax files of `swift.vim`, before and after this change, into `~/.vim/syntax` with unique names, open the above comments in vim and then toggle between them with eg `:set syntax=swiftfix.vim`.