### PR TITLE
Use Swift Equatable and Hashable conformances from ObjC

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -396,6 +396,11 @@ STANDARD_OBJC_METHOD_IMPLS_FOR_SWIFT_OBJECTS
       swift_conformsToProtocolCommon(
 	selfMetadata, &equatable_support::EquatableProtocolDescriptor));
   if (equatableConformance != nullptr) {
+    const char *clsName = class_getName([self class]);
+    warning(0,
+	    "Obj-C `-hash` invoked on a Swift object of type %s that is not Hashable; "
+	    "this can lead to severe performance problems",
+	    clsName);
     return (NSUInteger)1;
   }
 

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -36,6 +36,7 @@
 #include "swift/Runtime/ObjCBridge.h"
 #include "swift/Runtime/Portability.h"
 #include "swift/Strings.h"
+#include "swift/Threading/Mutex.h"
 #include "swift/shims/RuntimeShims.h"
 #include "swift/shims/AssertionReporting.h"
 #include "../CompatibilityOverride/CompatibilityOverride.h"
@@ -52,6 +53,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unordered_map>
+#include <unordered_set>
 #if SWIFT_OBJC_INTEROP
 # import <CoreFoundation/CFBase.h> // for CFTypeID
 # import <Foundation/Foundation.h>

--- a/test/stdlib/BridgeIdAsAny.swift.gyb
+++ b/test/stdlib/BridgeIdAsAny.swift.gyb
@@ -346,7 +346,7 @@ BridgeAnything.test("SwiftValue(mixed values)/Hashable") {
     }
     return lhs / 2 == rhs / 2
   }
-  checkHashable(boxedXs, equalityOracle: equalityOracle)
+  checkHashable(boxedXs, equalityOracle: equalityOracle, allowIncompleteHashing: true)
 }
 
 runAllTests()

--- a/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
+++ b/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
@@ -116,6 +116,12 @@ void TestSwiftObjectNSObjectHashValue(id e, NSUInteger hashValue)
   expectTrue([e hash] == hashValue);
 }
 
+void TestSwiftObjectNSObjectDefaultHashValue(id e)
+{
+  NSUInteger hashValue = (NSUInteger)e;
+  TestSwiftObjectNSObjectHashValue(e, hashValue);
+}
+
 void TestSwiftObjectNSObject(id c, id d)
 {
   printf("TestSwiftObjectNSObject\n");

--- a/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
+++ b/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
@@ -80,7 +80,10 @@ void HackSwiftObject()
     class_addMethod(cls, @selector(perform2::), (IMP)Perform2, "@@:@@");
 }
 
-void TestSwiftObjectNSObject(id c, id d)
+void TestSwiftObjectNSObject(id c, id d,
+			     id e1a, id e1b, id e2,
+			     id h1a, id h1b, id h2,
+			     NSUInteger hash1, NSUInteger hash2)
 {
   printf("TestSwiftObjectNSObject\n");
 
@@ -159,12 +162,24 @@ void TestSwiftObjectNSObject(id c, id d)
   expectFalse([C_meta isEqual:D_meta]);
   expectFalse([S_meta isEqual:C_meta]);
 
+  // Check that ObjC isEqual delegates to Equatable
+  expectTrue([e1a isEqual: e1b]);
+  expectFalse([e1a isEqual: e2]);
+  expectFalse([e1b isEqual: e2]);
+
+  // Check that ObjC isEqual delegates to Hashable
+  expectTrue([h1a isEqual: h1b]);
+  expectFalse([h1a isEqual: h2]);
+  expectFalse([h1b isEqual: h2]);
 
   printf("NSObjectProtocol.hash\n");
 
   expectTrue ([d hash] + [c hash] + [D hash] + [C hash] + [S hash] +
               [D_meta hash] + [C_meta hash] + [S_meta hash] != 0);
 
+  expectTrue([h1a hash] == hash1);
+  expectTrue([h1b hash] == hash1);
+  expectTrue([h2 hash] == hash2);
 
   printf("NSObjectProtocol.self\n");
 

--- a/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
+++ b/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
@@ -80,10 +80,43 @@ void HackSwiftObject()
     class_addMethod(cls, @selector(perform2::), (IMP)Perform2, "@@:@@");
 }
 
-void TestSwiftObjectNSObject(id c, id d,
-			     id e1a, id e1b, id e2,
-			     id h1a, id h1b, id h2,
-			     NSUInteger hash1, NSUInteger hash2)
+void TestSwiftObjectNSObjectAssertNoErrors(void)
+{
+  printf("\nTotal: %d error%s\n",
+         Errors, Errors == 1 ? "" : "s");
+  if (Errors > 0) {
+    exit(1);
+  }
+}
+
+
+void TestSwiftObjectNSObjectEquals(id e1, id e2)
+{
+  printf("NSObjectProtocol.isEqual: Expect %s == %s\n",
+	 [[e1 description] UTF8String],
+	 [[e2 description] UTF8String]);
+  expectTrue([e1 isEqual:e2]);
+  expectTrue([e2 isEqual:e1]);
+}
+
+void TestSwiftObjectNSObjectNotEquals(id e1, id e2)
+{
+  printf("NSObjectProtocol.isEqual: Expect %s != %s\n",
+	 [[e1 description] UTF8String],
+	 [[e2 description] UTF8String]);
+  expectFalse([e1 isEqual:e2]);
+  expectFalse([e2 isEqual:e1]);
+}
+
+void TestSwiftObjectNSObjectHashValue(id e, NSUInteger hashValue)
+{
+  printf("NSObjectProtocol.hash: Expect [%s hashValue] == %lu\n",
+	 [[e description] UTF8String],
+	 (unsigned long)hashValue);
+  expectTrue([e hash] == hashValue);
+}
+
+void TestSwiftObjectNSObject(id c, id d)
 {
   printf("TestSwiftObjectNSObject\n");
 
@@ -162,24 +195,10 @@ void TestSwiftObjectNSObject(id c, id d,
   expectFalse([C_meta isEqual:D_meta]);
   expectFalse([S_meta isEqual:C_meta]);
 
-  // Check that ObjC isEqual delegates to Equatable
-  expectTrue([e1a isEqual: e1b]);
-  expectFalse([e1a isEqual: e2]);
-  expectFalse([e1b isEqual: e2]);
-
-  // Check that ObjC isEqual delegates to Hashable
-  expectTrue([h1a isEqual: h1b]);
-  expectFalse([h1a isEqual: h2]);
-  expectFalse([h1b isEqual: h2]);
-
   printf("NSObjectProtocol.hash\n");
 
   expectTrue ([d hash] + [c hash] + [D hash] + [C hash] + [S hash] +
               [D_meta hash] + [C_meta hash] + [S_meta hash] != 0);
-
-  expectTrue([h1a hash] == hash1);
-  expectTrue([h1b hash] == hash1);
-  expectTrue([h2 hash] == hash2);
 
   printf("NSObjectProtocol.self\n");
 
@@ -813,9 +832,4 @@ void TestSwiftObjectNSObject(id c, id d,
   expectTrue ([S_meta instanceMethodForSelector:@selector(DESSLOK)] == fwd);
   expectTrue ([C_meta instanceMethodForSelector:@selector(DESSLOK)] == fwd);
   expectTrue ([D_meta instanceMethodForSelector:@selector(DESSLOK)] == fwd);
-
-
-  printf("TestSwiftObjectNSObject: %d error%s\n",
-         Errors, Errors == 1 ? "" : "s");
-  exit(Errors ? 1 : 0);
 }

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -79,6 +79,8 @@ func TestSwiftObjectNSObjectEquals(_: AnyObject, _: AnyObject)
 func TestSwiftObjectNSObjectNotEquals(_: AnyObject, _: AnyObject)
 @_silgen_name("TestSwiftObjectNSObjectHashValue")
 func TestSwiftObjectNSObjectHashValue(_: AnyObject, _: Int)
+@_silgen_name("TestSwiftObjectNSObjectDefaultHashValue")
+func TestSwiftObjectNSObjectDefaultHashValue(_: AnyObject)
 @_silgen_name("TestSwiftObjectNSObjectAssertNoErrors")
 func TestSwiftObjectNSObjectAssertNoErrors()
 
@@ -101,12 +103,16 @@ func TestHashable(_ h: H)
   TestSwiftObjectNSObjectHashValue(h, h.hashValue)
 }
 
-// Test Obj-C hashValue for Swift types that are not Hashable
-func TestNonHashableHash(_ e: AnyObject)
+// Test Obj-C hashValue for Swift types that are Equatable but not Hashable
+func TestEquatableHash(_ e: AnyObject)
 {
-  // Non-Hashable type should always have the
-  // same hash value in Obj-C
+  // These should have a constant hash value
   TestSwiftObjectNSObjectHashValue(e, 1)
+}
+
+func TestNonEquatableHash(_ e: AnyObject)
+{
+  TestSwiftObjectNSObjectDefaultHashValue(e)
 }
 
 // This check is for NSLog() output from TestSwiftObjectNSObject().
@@ -154,12 +160,14 @@ if #available(OSX 10.12, iOS 10.0, *) {
   TestNonEquatableEquals(F1(i: 1), E(i: 1))
   TestEquatableEquals(H(i:1), E(i:1))
 
-  // Non-Hashable: alway have the same Obj-C hashValue
-  TestNonHashableHash(E(i: 1))
-  TestNonHashableHash(E1(i: 3))
-  TestNonHashableHash(E2(i: 8))
-  TestNonHashableHash(C())
-  TestNonHashableHash(D())
+  // Equatable but not Hashable: alway have the same Obj-C hashValue
+  TestEquatableHash(E(i: 1))
+  TestEquatableHash(E1(i: 3))
+  TestEquatableHash(E2(i: 8))
+
+  // Neither Equatable nor Hashable
+  TestNonEquatableHash(C())
+  TestNonEquatableHash(D())
 
   // Hashable types are also Equatable
   TestEquatableEquals(H(i:1), H(i:1))

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -13,7 +13,7 @@
 // RUN: %empty-directory(%t)
 // 
 // RUN: %target-clang %S/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m -c -o %t/SwiftObjectNSObject.o -g
-// RUN: %target-build-swift %s -I %S/Inputs/SwiftObjectNSObject/ -Xlinker %t/SwiftObjectNSObject.o -o %t/SwiftObjectNSObject
+// RUN: %target-build-swift %s -g -I %S/Inputs/SwiftObjectNSObject/ -Xlinker %t/SwiftObjectNSObject.o -o %t/SwiftObjectNSObject
 // RUN: %target-codesign %t/SwiftObjectNSObject
 // RUN: %target-run %t/SwiftObjectNSObject 2> %t/log.txt
 // RUN: %FileCheck %s < %t/log.txt
@@ -39,24 +39,75 @@ class D : C {
   @objc override class func cClassOverride() -> Int { return 8 }
 }
 
-class E : Equatable {
+class E : Equatable, CustomStringConvertible {
   var i : Int
   static func ==(lhs: E, rhs: E) -> Bool { lhs.i == rhs.i }
   init(i: Int) { self.i = i }
+  var description: String { "\(type(of:self))(i:\(self.i))" }
 }
 
-class H : Hashable {
+class E1: E {
+}
+
+class E2: E {
+}
+
+class F : CustomStringConvertible {
   var i : Int
+  init(i: Int) { self.i = i }
+  var description: String { "\(type(of:self))(i:\(self.i))" }
+}
+
+class F1: F, Equatable {
+  static func ==(lhs: F1, rhs: F1) -> Bool { lhs.i == rhs.i }
+}
+
+class F2: F, Equatable {
+  static func ==(lhs: F2, rhs: F2) -> Bool { lhs.i == rhs.i }
+}
+
+class H : E, Hashable {
   static func ==(lhs: H, rhs: H) -> Bool { lhs.i == rhs.i }
   func hash(into hasher: inout Hasher) { hasher.combine(i + 17) }
-  init(i: Int) { self.i = i }
 }
 
-@_silgen_name("TestSwiftObjectNSObject") 
-func TestSwiftObjectNSObject(
-  _ c: C, _ d: D,
-  _ e1a: E, _ e1b: E, _ e2: E,
-  _ h1a: H, _ h1b: H, _ h2: H, _ hash1: UInt, _ hash2: UInt)
+@_silgen_name("TestSwiftObjectNSObject")
+func TestSwiftObjectNSObject(_ c: C, _ d: D)
+@_silgen_name("TestSwiftObjectNSObjectEquals")
+func TestSwiftObjectNSObjectEquals(_: AnyObject, _: AnyObject)
+@_silgen_name("TestSwiftObjectNSObjectNotEquals")
+func TestSwiftObjectNSObjectNotEquals(_: AnyObject, _: AnyObject)
+@_silgen_name("TestSwiftObjectNSObjectHashValue")
+func TestSwiftObjectNSObjectHashValue(_: AnyObject, _: Int)
+@_silgen_name("TestSwiftObjectNSObjectAssertNoErrors")
+func TestSwiftObjectNSObjectAssertNoErrors()
+
+// Verify that Obj-C isEqual: provides same answer as Swift ==
+func TestEquatableEquals<T: Equatable & AnyObject>(_ e1: T, _ e2: T) {
+  if e1 == e2 {
+    TestSwiftObjectNSObjectEquals(e1, e2)
+  } else {
+    TestSwiftObjectNSObjectNotEquals(e1, e2)
+  }
+}
+
+func TestNonEquatableEquals(_ e1: AnyObject, _ e2: AnyObject) {
+  TestSwiftObjectNSObjectNotEquals(e1, e2)
+}
+
+// Verify that Obj-C hashValue matches Swift hashValue for Hashable types
+func TestHashable(_ h: H)
+{
+  TestSwiftObjectNSObjectHashValue(h, h.hashValue)
+}
+
+// Test Obj-C hashValue for Swift types that are not Hashable
+func TestNonHashableHash(_ e: AnyObject)
+{
+  // Non-Hashable type should always have the
+  // same hash value in Obj-C
+  TestSwiftObjectNSObjectHashValue(e, 1)
+}
 
 // This check is for NSLog() output from TestSwiftObjectNSObject().
 // CHECK: c ##SwiftObjectNSObject.C##
@@ -66,10 +117,61 @@ func TestSwiftObjectNSObject(
 // Temporarily disable this test on older OSes until we have time to
 // look into why it's failing there. rdar://problem/47870743
 if #available(OSX 10.12, iOS 10.0, *) {
-  TestSwiftObjectNSObject(C(), D(),
-    E(i:1), E(i:1), E(i:2),
-    H(i:1), H(i:1), H(i:2), UInt(H(i:1).hashValue), UInt(H(i:2).hashValue))
-  // does not return
+  // Test a large number of Obj-C APIs
+  TestSwiftObjectNSObject(C(), D())
+
+  // ** Equatable types with an Equatable parent class
+  // Same type and class
+  TestEquatableEquals(E(i: 1), E(i: 1))
+  TestEquatableEquals(E(i: 790), E(i: 790))
+  TestEquatableEquals(E1(i: 1), E1(i: 1))
+  TestEquatableEquals(E1(i: 18), E1(i: 18))
+  TestEquatableEquals(E2(i: 1), E2(i: 1))
+  TestEquatableEquals(E2(i: 2), E2(i: 2))
+  // Different class
+  TestEquatableEquals(E1(i: 1), E2(i: 1))
+  TestEquatableEquals(E1(i: 1), E(i: 1))
+  TestEquatableEquals(E2(i: 1), E(i: 1))
+  // Different value
+  TestEquatableEquals(E(i: 1), E(i: 2))
+  TestEquatableEquals(E1(i: 1), E1(i: 2))
+  TestEquatableEquals(E2(i: 1), E2(i: 2))
+
+  // ** Non-Equatable parent class
+  // Same class and value
+  TestEquatableEquals(F1(i: 1), F1(i: 1))
+  TestEquatableEquals(F1(i: 1), F1(i: 2))
+  TestEquatableEquals(F2(i: 1), F2(i: 1))
+  TestEquatableEquals(F2(i: 1), F2(i: 2))
+
+  // Different class and/or value
+  TestNonEquatableEquals(F(i: 1), F(i: 2))
+  TestNonEquatableEquals(F(i: 1), F(i: 1))
+  TestNonEquatableEquals(F1(i: 1), F2(i: 1))
+  TestNonEquatableEquals(F1(i: 1), F(i: 1))
+
+  // Two equatable types with no common parent class
+  TestNonEquatableEquals(F1(i: 1), E(i: 1))
+  TestEquatableEquals(H(i:1), E(i:1))
+
+  // Non-Hashable: alway have the same Obj-C hashValue
+  TestNonHashableHash(E(i: 1))
+  TestNonHashableHash(E1(i: 3))
+  TestNonHashableHash(E2(i: 8))
+  TestNonHashableHash(C())
+  TestNonHashableHash(D())
+
+  // Hashable types are also Equatable
+  TestEquatableEquals(H(i:1), H(i:1))
+  TestEquatableEquals(H(i:1), H(i:2))
+  TestEquatableEquals(H(i:2), H(i:1))
+
+  // Verify Obj-C hash value agrees with Swift
+  TestHashable(H(i:1))
+  TestHashable(H(i:2))
+  TestHashable(H(i:18))
+
+  TestSwiftObjectNSObjectAssertNoErrors()
 } else {
   // Horrible hack to satisfy FileCheck
   fputs("c ##SwiftObjectNSObject.C##\n", stderr)

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -16,6 +16,7 @@
 // RUN: %target-build-swift %s -g -I %S/Inputs/SwiftObjectNSObject/ -Xlinker %t/SwiftObjectNSObject.o -o %t/SwiftObjectNSObject
 // RUN: %target-codesign %t/SwiftObjectNSObject
 // RUN: %target-run %t/SwiftObjectNSObject 2> %t/log.txt
+// RUN: cat %t/log.txt 1>&2
 // RUN: %FileCheck %s < %t/log.txt
 // REQUIRES: executable_test
 
@@ -115,10 +116,16 @@ func TestNonEquatableHash(_ e: AnyObject)
   TestSwiftObjectNSObjectDefaultHashValue(e)
 }
 
-// This check is for NSLog() output from TestSwiftObjectNSObject().
+// Check NSLog() output from TestSwiftObjectNSObject().
+
 // CHECK: c ##SwiftObjectNSObject.C##
 // CHECK-NEXT: d ##SwiftObjectNSObject.D##
 // CHECK-NEXT: S ##{{.*}}SwiftObject##
+
+// Full message is longer, but this is the essential part...
+// CHECK-NEXT: Obj-C `-hash` {{.*}} type `SwiftObjectNSObject.E` {{.*}} Equatable but not Hashable
+// CHECK-NEXT: Obj-C `-hash` {{.*}} type `SwiftObjectNSObject.E1` {{.*}} Equatable but not Hashable
+// CHECK-NEXT: Obj-C `-hash` {{.*}} type `SwiftObjectNSObject.E2` {{.*}} Equatable but not Hashable
 
 // Temporarily disable this test on older OSes until we have time to
 // look into why it's failing there. rdar://problem/47870743
@@ -185,4 +192,7 @@ if #available(OSX 10.12, iOS 10.0, *) {
   fputs("c ##SwiftObjectNSObject.C##\n", stderr)
   fputs("d ##SwiftObjectNSObject.D##\n", stderr)
   fputs("S ##Swift._SwiftObject##\n", stderr)
+  fputs("Obj-C `-hash` ... type `SwiftObjectNSObject.E` ... Equatable but not Hashable", stderr)
+  fputs("Obj-C `-hash` ... type `SwiftObjectNSObject.E1` ... Equatable but not Hashable", stderr)
+  fputs("Obj-C `-hash` ... type `SwiftObjectNSObject.E2` ... Equatable but not Hashable", stderr)
 }

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -39,8 +39,24 @@ class D : C {
   @objc override class func cClassOverride() -> Int { return 8 }
 }
 
+class E : Equatable {
+  var i : Int
+  static func ==(lhs: E, rhs: E) -> Bool { lhs.i == rhs.i }
+  init(i: Int) { self.i = i }
+}
+
+class H : Hashable {
+  var i : Int
+  static func ==(lhs: H, rhs: H) -> Bool { lhs.i == rhs.i }
+  func hash(into hasher: inout Hasher) { hasher.combine(i + 17) }
+  init(i: Int) { self.i = i }
+}
+
 @_silgen_name("TestSwiftObjectNSObject") 
-func TestSwiftObjectNSObject(_ c: C, _ d: D)
+func TestSwiftObjectNSObject(
+  _ c: C, _ d: D,
+  _ e1a: E, _ e1b: E, _ e2: E,
+  _ h1a: H, _ h1b: H, _ h2: H, _ hash1: UInt, _ hash2: UInt)
 
 // This check is for NSLog() output from TestSwiftObjectNSObject().
 // CHECK: c ##SwiftObjectNSObject.C##
@@ -50,7 +66,9 @@ func TestSwiftObjectNSObject(_ c: C, _ d: D)
 // Temporarily disable this test on older OSes until we have time to
 // look into why it's failing there. rdar://problem/47870743
 if #available(OSX 10.12, iOS 10.0, *) {
-  TestSwiftObjectNSObject(C(), D())
+  TestSwiftObjectNSObject(C(), D(),
+    E(i:1), E(i:1), E(i:2),
+    H(i:1), H(i:1), H(i:2), UInt(H(i:1).hashValue), UInt(H(i:2).hashValue))
   // does not return
 } else {
   // Horrible hack to satisfy FileCheck


### PR DESCRIPTION
If a Swift type implements Equatable and/or Hashable and we then pass that object into ObjC, we want ObjC
`isEqual:` and `hashValue` to use that.  This allows ObjC code to put Swift objects into ObjC collections, including NSSet and NSDictionary.

* Support for Hashable struct/enum types was implemented in #4124
* Support for Equatable struct/enum types was implemented in #68720
* This PR implements support for Hashable and Equatable _class_ types

Caveats:
1. This does a lot of dynamic lookup work for each operation, so is inherently rather slow.  (Update:  Mike Ash suggested some changes that rely on heavily-cached results, so it's not as bad as I feared.)
2. This is a behavioral change to low-level support code.  There is a risk of breaking code that may be relying on the old behavior.
3. For a Swift type that is Equatable but not Hashable, the only sound way to forward `isEqual:` is to use a constant value for the hash.  This can cause major performance problems -- I've included a log message that warns whenever someone tries to hash such an object.

Resolves rdar://67093675