### PR TITLE
[Typed throws] Additional fixes for typed throws

### DIFF
--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -849,8 +849,11 @@ InferredGenericSignatureRequest::evaluate(
   // Finish by adding any remaining requirements. This is used to introduce
   // inferred same-type requirements when building the generic signature of
   // an extension whose extended type is a generic typealias.
+  SmallVector<Requirement, 4> rawAddedRequirements;
   for (const auto &req : addedRequirements)
-    requirements.push_back({req, SourceLoc(), /*wasInferred=*/true});
+    desugarRequirement(req, SourceLoc(), rawAddedRequirements, errors);
+  for (const auto &req : rawAddedRequirements)
+    requirements.push_back({req, SourceLoc(), /*inferred=*/true});
 
   // Re-order requirements so that inferred requirements appear last. This
   // ensures that if an inferred requirement is redundant with some other

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12248,6 +12248,16 @@ ConstraintSystem::simplifyKeyPathConstraint(
       // { root in root[keyPath: kp] }.
       boundRoot = fnTy->getParams()[0].getParameterType();
       boundValue = fnTy->getResult();
+
+      // Key paths never throw, so if the function has a thrown error type
+      // that is a type variable, infer it to be Never.
+      if (auto thrownError = fnTy->getThrownError()) {
+        if (thrownError->isTypeVariableOrMember()) {
+          (void)matchTypes(
+            thrownError, getASTContext().getNeverType(),
+            ConstraintKind::Equal, TMF_GenerateConstraints, locator);
+        }
+      }
     }
 
     if (boundRoot &&

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -768,12 +768,10 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
           inferenceSources.emplace_back(thrownTypeRepr, thrownType);
 
           // Add conformance of this type to the Error protocol.
-          if (thrownType->isTypeParameter()) {
-            if (auto errorProtocol = ctx.getErrorDecl()) {
-              extraReqs.push_back(
-                  Requirement(RequirementKind::Conformance, thrownType,
-                              errorProtocol->getDeclaredInterfaceType()));
-            }
+          if (auto errorProtocol = ctx.getErrorDecl()) {
+            extraReqs.push_back(
+                Requirement(RequirementKind::Conformance, thrownType,
+                            errorProtocol->getDeclaredInterfaceType()));
           }
         }
       }

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -76,10 +76,14 @@ func mapArray<T, U, E: Error>(_ array: [T], body: (T) throws(E) -> U) throws(E) 
   return resultArray
 }
 
+struct Person {
+  var name: String
+}
+
 func addOrThrowUntyped(_ i: Int, _ j: Int) throws -> Int { i + j }
 func addOrThrowMyError(_ i: Int, _ j: Int) throws(MyError) -> Int { i + j }
 
-func testMapArray(numbers: [Int]) {
+func testMapArray(numbers: [Int], friends: [Person]) {
   // Note: try is not required, because this throws Never
   _ = mapArray(numbers) { $0 + 1 }
 
@@ -100,6 +104,11 @@ func testMapArray(numbers: [Int]) {
     _ = try mapArray(numbers) { (x) throws(MyError) in try addOrThrowMyError(x, 1) }
   } catch {
     let _: Int = error // expected-error{{cannot convert value of type 'MyError' to specified type 'Int'}}
+  }
+
+  do {
+    // Keypath-as-function
+    _ = mapArray(friends, body: \Person.name)
   }
 }
 

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -135,3 +135,14 @@ struct HasASubscript {
 
 // expected-error@+1{{thrown type 'any Codable & Error' (aka 'any Decodable & Encodable & Error') does not conform to the 'Error' protocol}}
 func throwCodableErrors() throws(any Codable & Error) { }
+
+enum Either<First, Second> {
+case first(First)
+case second(Second)
+}
+
+extension Either: Error where First: Error, Second: Error { }
+
+func f<E1, E2>(_ error: Either<E1, E2>) throws(Either<E1, E2>) {
+  throw error
+}


### PR DESCRIPTION
Two unrelated fixes for typed throws:
* Make sure that key paths can be passed as an argument where the parameter uses typed throws with the generic result type
* Generalize requirement inference for the thrown error type to handle all types