### PR TITLE
Docs: Document library evolution restrictions for @inlinable functions

### DIFF
--- a/docs/LibraryEvolution.rst
+++ b/docs/LibraryEvolution.rst
@@ -262,6 +262,10 @@ compiler):
 - They must not reference any ``internal`` entities except for those that have
   been declared ``@usableFromInline`` or ``@inlinable``.
 
+Inlinable functions that return opaque types also have additional restrictions.
+The underlying concrete type cannot be changed for such a function without
+breaking backward compatibility, because the identity of the concrete type has
+been exposed by inlining the body of the function into client modules.
 
 Always Emit Into Client
 -----------------------


### PR DESCRIPTION
As documented in the [SE-244 proposal](https://github.com/apple/swift-evolution/blob/main/proposals/0244-opaque-result-types.md#effect-on-api-resilience), it is illegal to change the concrete return type of an `@inlinable` function with an opaque return type. This ought to be documented since it is an extremely subtle rule that authors of ABI stable libraries should be aware of.
