### PR TITLE
Make @objcImpl work with @_cdecl

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -246,7 +246,7 @@ DECL_ATTR(_restatedObjCConformance, RestatedObjCConformance,
   OnProtocol | UserInaccessible | LongAttribute | RejectByParser | NotSerialized | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   70)
 DECL_ATTR(_objcImplementation, ObjCImplementation,
-  OnExtension | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
+  OnExtension | OnAbstractFunction | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   72)
 DECL_ATTR(_optimize, Optimize,
   OnAbstractFunction | OnSubscript | OnVar | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2778,6 +2778,10 @@ public:
     return DeclNameRef(Name);
   }
 
+  /// Retrieve the C declaration name that names this function, or empty
+  /// string if it has none.
+  StringRef getCDeclName() const;
+
   /// Retrieve the name to use for this declaration when interoperating
   /// with the Objective-C runtime.
   ///

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -941,6 +941,11 @@ public:
   /// attribute macro expansion.
   DeclAttributes getSemanticAttrs() const;
 
+  /// True if this declaration provides an implementation for an imported
+  /// Objective-C declaration. This implies various restrictions and special
+  /// behaviors for it and, if it's an extension, its members.
+  bool isObjCImplementation() const;
+
   using AuxiliaryDeclCallback = llvm::function_ref<void(Decl *)>;
 
   /// Iterate over the auxiliary declarations for this declaration,
@@ -1835,11 +1840,6 @@ public:
   /// extension mangling, because an extension method implementation could be
   /// resiliently moved into the original protocol itself.
   bool isEquivalentToExtendedContext() const;
-
-  /// True if this extension provides an implementation for an imported
-  /// Objective-C \c \@interface. This implies various restrictions and special
-  /// behaviors for its members.
-  bool isObjCImplementation() const;
 
   /// Returns the name of the category specified by the \c \@_objcImplementation
   /// attribute, or \c None if the name is invalid. Do not call unless

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -134,8 +134,9 @@ WARNING(api_pattern_attr_ignored, none,
 
 ERROR(objc_implementation_two_impls, none,
       "duplicate implementation of Objective-C %select{|category %0 on }0"
-      "class %1",
-      (Identifier, ValueDecl *))
+      "%kind1",
+      (Identifier, Decl *))
+
 NOTE(previous_objc_implementation, none,
      "previously implemented by extension here", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1743,6 +1743,10 @@ ERROR(attr_objc_implementation_category_not_found,none,
 NOTE(attr_objc_implementation_fixit_remove_category_name,none,
      "remove arguments to implement the main '@interface' for this class",
      ())
+ERROR(attr_objc_implementation_no_category_for_func,none,
+      "%kind0 does not belong to an Objective-C category; remove the category "
+      "name from this attribute",
+      (ValueDecl*))
 ERROR(attr_objc_implementation_no_conformance,none,
       "'@_objcImplementation' extension cannot add conformance to %0; "
       "add this conformance %select{with an ordinary extension|"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1740,6 +1740,10 @@ ERROR(attr_objc_implementation_category_not_found,none,
       "could not find category %0 on Objective-C class %1; make sure your "
       "umbrella or bridging header imports the header that declares it",
       (Identifier, ValueDecl*))
+ERROR(attr_objc_implementation_func_not_found,none,
+      "could not find imported function '%0' matching %kind1; make sure your "
+      "umbrella or bridging header imports the header that declares it",
+      (StringRef, ValueDecl*))
 NOTE(attr_objc_implementation_fixit_remove_category_name,none,
      "remove arguments to implement the main '@interface' for this class",
      ())

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -41,7 +41,8 @@ enum NLOptions : unsigned {
 
   /// Don't check access when doing lookup into a type.
   ///
-  /// This option is not valid when performing lookup into a module.
+  /// When performing lookup into a module, this option only applies to
+  /// declarations in the same module the lookup is coming from.
   NL_IgnoreAccessControl = 1 << 3,
 
   /// This lookup should only return type declarations.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4544,7 +4544,7 @@ public:
 /// This is done on all of a class's implementations at once to improve diagnostics.
 class TypeCheckObjCImplementationRequest
     : public SimpleRequest<TypeCheckObjCImplementationRequest,
-                           evaluator::SideEffect(ExtensionDecl *),
+                           evaluator::SideEffect(Decl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -4554,7 +4554,7 @@ private:
 
   // Evaluation.
   evaluator::SideEffect
-  evaluate(Evaluator &evaluator, ExtensionDecl *ED) const;
+  evaluate(Evaluator &evaluator, Decl *D) const;
 
 public:
   // Separate caching.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3878,8 +3878,9 @@ StringRef ValueDecl::getCDeclName() const {
   }
 
   // Handle explicit cdecl attributes.
-  if (auto *cdecl = getAttrs().getAttribute<CDeclAttr>())
-    return cdecl->Name;
+  if (auto cdeclAttr = getAttrs().getAttribute<CDeclAttr>()) {
+    return cdeclAttr->Name;
+  }
 
   return "";
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3869,6 +3869,21 @@ void ValueDecl::setInterfaceType(Type type) {
                                         std::move(type));
 }
 
+StringRef ValueDecl::getCDeclName() const {
+  // Treat imported C functions as implicitly @_cdecl.
+  if (auto clangDecl = dyn_cast_or_null<clang::FunctionDecl>(getClangDecl())) {
+    if (clangDecl->getLanguageLinkage() == clang::CLanguageLinkage
+          && clangDecl->getIdentifier())
+      return clangDecl->getName();
+  }
+
+  // Handle explicit cdecl attributes.
+  if (auto *cdecl = getAttrs().getAttribute<CDeclAttr>())
+    return cdecl->Name;
+
+  return "";
+}
+
 llvm::Optional<ObjCSelector>
 ValueDecl::getObjCRuntimeName(bool skipIsObjCResolution) const {
   if (auto func = dyn_cast<AbstractFunctionDecl>(this))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1847,7 +1847,7 @@ Type ExtensionDecl::getExtendedType() const {
   return ErrorType::get(ctx);
 }
 
-bool ExtensionDecl::isObjCImplementation() const {
+bool Decl::isObjCImplementation() const {
   return getAttrs().hasAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true);
 }
 
@@ -4404,7 +4404,8 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
   // a context where we would access its storage directly, forbid access. Name
   // lookups will instead find and use the matching interface decl.
   // FIXME: Passing `true` for `isAccessOnSelf` may cause false positives.
-  if (isObjCMemberImplementation(VD, getAccessLevel) &&
+  if ((VD->isObjCImplementation() ||
+         isObjCMemberImplementation(VD, getAccessLevel)) &&
       VD->getAccessSemanticsFromContext(useDC, /*isAccessOnSelf=*/true)
           != AccessSemantics::DirectToStorage)
     return false;

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -165,6 +165,11 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
         if (resolutionKind == ResolutionKind::MacrosOnly && !isa<MacroDecl>(VD))
           return true;
         if (respectAccessControl &&
+            // NL_IgnoreAccessControl applies only to the current module.
+            !((options & NL_IgnoreAccessControl) &&
+                moduleScopeContext &&
+                moduleScopeContext->getParentModule() ==
+                    VD->getDeclContext()->getParentModule()) &&
             !VD->isAccessibleFrom(moduleScopeContext, false,
                                   includeUsableFromInline))
           return true;

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -139,7 +139,7 @@ getObjCNameForSwiftDecl(const ValueDecl *VD, DeclName PreferredName){
 bool swift::objc_translation::
 isVisibleToObjC(const ValueDecl *VD, AccessLevel minRequiredAccess,
                 bool checkParent) {
-  if (!(VD->isObjC() || VD->getAttrs().hasAttribute<CDeclAttr>()))
+  if (!(VD->isObjC() || !VD->getCDeclName().empty()))
     return false;
   if (VD->getFormalAccess() >= minRequiredAccess) {
     return true;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3544,7 +3544,10 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
       if (hasOrderNumber) {
         auto &fnList = Module.getFunctionList();
         fnList.remove(fn);
-        fnList.insert(llvm::Module::iterator(insertBefore), fn);
+        if (insertBefore)
+          fnList.insert(llvm::Module::iterator(insertBefore), fn);
+        else
+          fnList.push_back(fn);
 
         EmittedFunctionsByOrder.insert(orderNumber, fn);
       }

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1414,8 +1414,7 @@ private:
 
     assert(FD->getAttrs().hasAttribute<CDeclAttr>() && "not a cdecl function");
     os << "SWIFT_EXTERN ";
-    printFunctionDeclAsCFunctionDecl(
-        FD, FD->getAttrs().getAttribute<CDeclAttr>()->Name, resultTy);
+    printFunctionDeclAsCFunctionDecl(FD, FD->getCDeclName(), resultTy);
     printFunctionClangAttributes(FD, funcTy);
     printAvailability(FD);
     os << ";\n";
@@ -1425,12 +1424,12 @@ private:
     FunctionSwiftABIInformation(AbstractFunctionDecl *FD,
                                 LoweredFunctionSignature signature)
         : signature(signature) {
-      isCDecl = FD->getAttrs().hasAttribute<CDeclAttr>();
+      isCDecl = !FD->getCDeclName().empty();
       if (!isCDecl) {
         auto mangledName = SILDeclRef(FD).mangle();
         symbolName = FD->getASTContext().AllocateCopy(mangledName);
       } else {
-        symbolName = FD->getAttrs().getAttribute<CDeclAttr>()->Name;
+        symbolName = FD->getCDeclName();
       }
     }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2858,12 +2858,16 @@ static bool hasExposeAttr(const ValueDecl *VD, bool isExtension = false) {
   return false;
 }
 
-/// Skip \c \@objcImplementation \c extension member implementations and
-/// overrides. They are already declared in handwritten headers, and they may
-/// have attributes that aren't allowed in a category.
+/// Skip \c \@objcImplementation functions, \c extension member
+/// implementations, and overrides. They are already declared in handwritten
+/// headers, and they may have attributes that aren't allowed in a category.
 ///
 /// \return true if \p VD should \em not be included in the header.
 static bool excludeForObjCImplementation(const ValueDecl *VD) {
+  // If it's an ObjC implementation (and not an extension, which might have
+  // members that need printing), skip it; it's declared elsewhere.
+  if (VD->isObjCImplementation() && ! isa<ExtensionDecl>(VD))
+    return true;
   // Exclude member implementations; they are declared elsewhere.
   if (VD->isObjCMemberImplementation())
     return true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1590,6 +1590,14 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
 
       attr->setCategoryNameInvalid();
     }
+
+    // FIXME: if (AFD->getCDeclName().empty())
+
+    if (!AFD->getImplementedObjCDecl()) {
+      diagnose(attr->getLocation(),
+               diag::attr_objc_implementation_func_not_found,
+               AFD->getCDeclName(), AFD);
+    }
   }
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2118,7 +2118,7 @@ void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {
   case ExposureKind::Cxx: {
     auto *VD = cast<ValueDecl>(D);
     // Expose cannot be mixed with '@_cdecl' declarations.
-    if (VD->getAttrs().hasAttribute<CDeclAttr>())
+    if (!VD->getCDeclName().empty())
       diagnose(attr->getLocation(), diag::expose_only_non_other_attr, "@_cdecl");
 
     // Nested exposed declarations are expected to be inside

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1517,60 +1517,79 @@ void AttributeChecker::visitNonObjCAttr(NonObjCAttr *attr) {
 
 void AttributeChecker::
 visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
-  auto ED = cast<ExtensionDecl>(D);
-  if (ED->isConstrainedExtension())
-    diagnoseAndRemoveAttr(attr,
-                          diag::attr_objc_implementation_must_be_unconditional);
+  if (auto ED = dyn_cast<ExtensionDecl>(D)) {
+    if (ED->isConstrainedExtension())
+      diagnoseAndRemoveAttr(attr,
+                            diag::attr_objc_implementation_must_be_unconditional);
 
-  auto CD = dyn_cast<ClassDecl>(ED->getExtendedNominal());
-  if (!CD) {
-    diagnoseAndRemoveAttr(attr,
-                          diag::attr_objc_implementation_must_extend_class,
-                          ED->getExtendedNominal());
-    ED->getExtendedNominal()->diagnose(diag::decl_declared_here,
-                                       ED->getExtendedNominal());
-    return;
-  }
-
-  if (!CD->hasClangNode()) {
-    diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_be_imported,
-                          CD);
-    CD->diagnose(diag::decl_declared_here, CD);
-    return;
-  }
-
-  if (!CD->hasSuperclass()) {
-    diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_have_super,
-                          CD);
-    CD->diagnose(diag::decl_declared_here, CD);
-    return;
-  }
-
-  if (CD->isTypeErasedGenericClass()) {
-    diagnoseAndRemoveAttr(attr, diag::objc_implementation_cannot_have_generics,
-                          CD);
-    CD->diagnose(diag::decl_declared_here, CD);
-  }
-
-  if (!attr->isCategoryNameInvalid() && !ED->getImplementedObjCDecl()) {
-    diagnose(attr->getLocation(),
-             diag::attr_objc_implementation_category_not_found,
-             attr->CategoryName, CD);
-
-    // attr->getRange() covers the attr name and argument list; adjust it to
-    // exclude the first token.
-    auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
-                                               attr->getRange().Start);
-    if (attr->getRange().contains(newStart)) {
-      auto argListRange = SourceRange(newStart, attr->getRange().End);
-      diagnose(attr->getLocation(),
-               diag::attr_objc_implementation_fixit_remove_category_name)
-        .fixItRemove(argListRange);
+    auto CD = dyn_cast<ClassDecl>(ED->getExtendedNominal());
+    if (!CD) {
+      diagnoseAndRemoveAttr(attr,
+                            diag::attr_objc_implementation_must_extend_class,
+                            ED->getExtendedNominal());
+      ED->getExtendedNominal()->diagnose(diag::decl_declared_here,
+                                         ED->getExtendedNominal());
+      return;
     }
 
-    attr->setCategoryNameInvalid();
+    if (!CD->hasClangNode()) {
+      diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_be_imported,
+                            CD);
+      CD->diagnose(diag::decl_declared_here, CD);
+      return;
+    }
 
-    return;
+    if (!CD->hasSuperclass()) {
+      diagnoseAndRemoveAttr(attr, diag::attr_objc_implementation_must_have_super,
+                            CD);
+      CD->diagnose(diag::decl_declared_here, CD);
+      return;
+    }
+
+    if (CD->isTypeErasedGenericClass()) {
+      diagnoseAndRemoveAttr(attr, diag::objc_implementation_cannot_have_generics,
+                            CD);
+      CD->diagnose(diag::decl_declared_here, CD);
+    }
+
+    if (!attr->isCategoryNameInvalid() && !ED->getImplementedObjCDecl()) {
+      diagnose(attr->getLocation(),
+               diag::attr_objc_implementation_category_not_found,
+               attr->CategoryName, CD);
+
+      // attr->getRange() covers the attr name and argument list; adjust it to
+      // exclude the first token.
+      auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
+                                                 attr->getRange().Start);
+      if (attr->getRange().contains(newStart)) {
+        auto argListRange = SourceRange(newStart, attr->getRange().End);
+        diagnose(attr->getLocation(),
+                 diag::attr_objc_implementation_fixit_remove_category_name)
+            .fixItRemove(argListRange);
+      }
+
+      attr->setCategoryNameInvalid();
+
+      return;
+    }
+  }
+  else if (auto AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+    if (!attr->CategoryName.empty()) {
+      auto diagnostic =
+          diagnose(attr->getLocation(),
+                   diag::attr_objc_implementation_no_category_for_func, AFD);
+
+      // attr->getRange() covers the attr name and argument list; adjust it to
+      // exclude the first token.
+      auto newStart = Lexer::getLocForEndOfToken(Ctx.SourceMgr,
+                                                 attr->getRange().Start);
+      if (attr->getRange().contains(newStart)) {
+        auto argListRange = SourceRange(newStart, attr->getRange().End);
+        diagnostic.fixItRemove(argListRange);
+      }
+
+      attr->setCategoryNameInvalid();
+    }
   }
 }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3389,9 +3389,10 @@ private:
   }
 
   static Type getMemberType(ValueDecl *decl) {
-    if (isa<AbstractFunctionDecl>(decl))
-      // Strip off the uncurried `self` parameter.
-      return decl->getInterfaceType()->getAs<AnyFunctionType>()->getResult();
+    if (auto fn = dyn_cast<AbstractFunctionDecl>(decl))
+      if (fn->hasImplicitSelfDecl())
+        // Strip off the uncurried `self` parameter.
+        return fn->getMethodInterfaceType();
     return decl->getInterfaceType();
   }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3567,6 +3567,8 @@ public:
         reason.setAttrInvalid();
       }
     }
+
+    TypeChecker::checkObjCImplementation(FD);
   }
 
   void visitModuleDecl(ModuleDecl *) { }
@@ -4006,6 +4008,8 @@ public:
 
     checkDefaultArguments(CD->getParameters());
     checkVariadicParameters(CD->getParameters(), CD);
+
+    TypeChecker::checkObjCImplementation(CD);
   }
 
   void visitDestructorDecl(DestructorDecl *DD) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -652,8 +652,8 @@ void checkDeclCircularity(NominalTypeDecl *decl);
 /// Type check whether an extension matches its Objective-C interface, if it
 /// has one.
 ///
-/// \param ED The extension to check.
-void checkObjCImplementation(ExtensionDecl *ED);
+/// \param D The declaration to check.
+void checkObjCImplementation(Decl *D);
 
 /// Type check whether the given switch statement exhaustively covers
 /// its domain.

--- a/test/IRGen/Inputs/objc_implementation.h
+++ b/test/IRGen/Inputs/objc_implementation.h
@@ -24,6 +24,8 @@
 
 @end
 
+extern void implFunc(int param);
+
 
 @interface NoImplClass
 

--- a/test/IRGen/objc_implementation.swift
+++ b/test/IRGen/objc_implementation.swift
@@ -139,9 +139,13 @@ open class SwiftSubclass: ImplClass {
 // Functions
 //
 
+@_objcImplementation @_cdecl("implFunc")
+public func implFunc(_ param: Int32) {}
+
 public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
   impl.mainMethod(0)
   swiftSub.mainMethod(1)
+  implFunc(2)
 }
 
 // Swift calling convention -[ImplClass init]
@@ -239,12 +243,18 @@ public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
 // Swift calling convention SwiftSubclass.deinit (deallocating)
 // CHECK-LABEL: define swiftcc void @"$s19objc_implementation13SwiftSubclassCfD"
 
+// inplFunc(_:)
+// CHECK-LABEL: define void @implFunc
+// FIXME: We'd like this to be internal or hidden, not public.
+// CHECK: define swiftcc void @"$s19objc_implementation8implFuncyys5Int32VF"
+
 // fn(impl:swiftSub:)
 // CHECK-LABEL: define swiftcc void @"$s19objc_implementation2fn4impl8swiftSubySo9ImplClassC_AA13SwiftSubclassCtF"
 // CHECK:   [[SEL_1:%[^ ]+]] = load ptr, ptr @"\01L_selector(mainMethod:)", align 8
 // CHECK:   call void @objc_msgSend(ptr {{.*}}, ptr [[SEL_1]], i32 0)
 // CHECK:   [[SEL_2:%[^ ]+]] = load ptr, ptr @"\01L_selector(mainMethod:)", align 8
 // CHECK:   call void @objc_msgSend(ptr {{.*}}, ptr [[SEL_2]], i32 1)
+// CHECK:   call void @implFunc
 // CHECK:   ret void
 // CHECK: }
 

--- a/test/Interpreter/Inputs/objc_implementation.h
+++ b/test/Interpreter/Inputs/objc_implementation.h
@@ -14,4 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+extern void implFunc(int param);
+
 NS_ASSUME_NONNULL_END

--- a/test/Interpreter/objc_implementation.swift
+++ b/test/Interpreter/objc_implementation.swift
@@ -54,6 +54,8 @@ class LastWords {
       print("otherProperty =", swiftSub.otherProperty)
       print("implProperty =", swiftSub.implProperty)
     }
+
+    implFunc(2023 - 34)
   }
 
   @objc func someMethod() -> String { "ImplClass.someMethod()" }
@@ -73,6 +75,10 @@ class SwiftSubclass: ImplClass {
   override func someMethod() -> String { "SwiftSubclass.someMethod()" }
 }
 
+@_objcImplementation @_cdecl("implFunc") public func implFunc(_ param: Int32) {
+  print("implFunc(\(param))")
+}
+
 // `#if swift` to ignore the inactive branch's contents
 #if swift(>=5.0) && TOP_LEVEL_CODE
 ImplClass.runTests()
@@ -90,4 +96,5 @@ ImplClass.runTests()
 // CHECK: otherProperty = 13
 // CHECK: implProperty = 42
 // CHECK: SwiftSubclass It's better to burn out than to fade away.
+// CHECK: implFunc(1989)
 #endif

--- a/test/NameLookup/Inputs/accessibility_other.swift
+++ b/test/NameLookup/Inputs/accessibility_other.swift
@@ -2,7 +2,7 @@ import has_accessibility
 
 public let a = 0 // expected-note * {{did you mean 'a'?}}
 internal let b = 0 // expected-note * {{did you mean 'b'?}}
-private let c = 0
+private let c = 0 // expected-note {{'c' declared here}}
 
 extension Foo {
   public static func a() {}

--- a/test/NameLookup/accessibility.swift
+++ b/test/NameLookup/accessibility.swift
@@ -26,7 +26,7 @@ markUsed(has_accessibility.z) // expected-error {{module 'has_accessibility' has
 
 markUsed(accessibility.a)
 markUsed(accessibility.b)
-markUsed(accessibility.c) // expected-error {{module 'accessibility' has no member named 'c'}}
+markUsed(accessibility.c) // expected-error {{'c' is inaccessible due to 'private' protection level}}
 
 markUsed(x)
 markUsed(y) // expected-error {{cannot find 'y' in scope}}

--- a/test/PrintAsObjC/Inputs/custom-modules/objc_implementation/objc_implementation.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/objc_implementation/objc_implementation.h
@@ -6,3 +6,4 @@
 
 @end
 
+void CImplFunc(void);

--- a/test/PrintAsObjC/objc_implementation.swift
+++ b/test/PrintAsObjC/objc_implementation.swift
@@ -35,3 +35,6 @@ extension ObjCClass {
   // NEGATIVE-NOT: )privateMethod{{ }}
   @objc private func privateMethod() -> Any? { nil }
 }
+
+@_cdecl("CImplFunc") @_objcImplementation func CImplFunc() {}
+// NEGATIVE-NOT: CImplFunc(

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -179,6 +179,19 @@
 void CImplFunc1(int param);
 void CImplFunc2(int param);
 
+void CImplFuncMismatch1(int param);
+void CImplFuncMismatch2(int param);
+void CImplFuncMismatch3(_Nullable id param);
+void CImplFuncMismatch4(_Nullable id param);
+void CImplFuncMismatch5(_Nonnull id param);
+void CImplFuncMismatch6(_Nonnull id param);
+_Nullable id CImplFuncMismatch3a(int param);
+_Nullable id CImplFuncMismatch4a(int param);
+_Nonnull id CImplFuncMismatch5a(int param);
+_Nonnull id CImplFuncMismatch6a(int param);
+void CImplFuncNameMismatch1(int param);
+void CImplFuncNameMismatch2(int param);
+
 struct ObjCStruct {
   int foo;
 };

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -176,7 +176,8 @@
 
 @end
 
-
+void CImplFunc1(int param);
+void CImplFunc2(int param);
 
 struct ObjCStruct {
   int foo;

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -192,6 +192,13 @@ _Nonnull id CImplFuncMismatch6a(int param);
 void CImplFuncNameMismatch1(int param);
 void CImplFuncNameMismatch2(int param);
 
+int CImplGetComputedGlobal1(void) __attribute__((swift_name("getter:cImplComputedGlobal1()")));
+void CImplSetComputedGlobal1(int param) __attribute__((swift_name("setter:cImplComputedGlobal1(newValue:)")));
+
+typedef struct CImplStruct {} CImplStruct;
+
+void CImplStructStaticFunc1(int param) __attribute__((swift_name("CImplStruct.staticFunc1(_:)")));
+
 struct ObjCStruct {
   int foo;
 };

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -464,6 +464,10 @@ protocol EmptySwiftProto {}
   // expected-error@-1 {{'@_objcImplementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
 }
 
+//
+// @_cdecl for global functions
+//
+
 @_objcImplementation @_cdecl("CImplFunc1")
 func CImplFunc1(_: Int32) {
   // OK
@@ -540,6 +544,38 @@ func mismatchedName1(_: Int32) {
 func CImplFuncNameMismatch2(_: Int32) {
   // expected-error@-2 {{could not find imported function 'mismatchedName2' matching global function 'CImplFuncNameMismatch2'; make sure your umbrella or bridging header imports the header that declares it}}
   // FIXME: Improve diagnostic for a partial match.
+}
+
+//
+// TODO: @_cdecl for global functions imported as computed vars
+//
+var cImplComputedGlobal1: Int32 {
+  @_objcImplementation @_cdecl("CImplGetComputedGlobal1")
+  get {
+    // FIXME: Lookup for vars isn't working yet
+    // expected-error@-3 {{could not find imported function 'CImplGetComputedGlobal1' matching getter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
+    return 0
+  }
+
+  @_objcImplementation @_cdecl("CImplSetComputedGlobal1")
+  set {
+    // FIXME: Lookup for vars isn't working yet
+    // expected-error@-3 {{could not find imported function 'CImplSetComputedGlobal1' matching setter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
+    print(newValue)
+  }
+}
+
+//
+// TODO: @_cdecl for import-as-member functions
+//
+extension CImplStruct {
+  @_objcImplementation @_cdecl("CImplStructStaticFunc1")
+  static func staticFunc1(_: Int32) {
+    // FIXME: Add underlying support for this
+    // expected-error@-3 {{@_cdecl can only be applied to global functions}}
+    // FIXME: Lookup in an enclosing type is not working yet
+    // expected-error@-5 {{could not find imported function 'CImplStructStaticFunc1' matching static method 'staticFunc1'; make sure your umbrella or bridging header imports the header that declares it}}
+  }
 }
 
 func usesAreNotAmbiguous(obj: ObjCClass) {

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -479,6 +479,69 @@ func CImplFuncMissing(_: Int32) {
   // expected-error@-2 {{could not find imported function 'CImplFuncMissing' matching global function 'CImplFuncMissing'; make sure your umbrella or bridging header imports the header that declares it}}
 }
 
+@_objcImplementation @_cdecl("CImplFuncMismatch1")
+func CImplFuncMismatch1(_: Float) {
+  // expected-warning@-1 {{global function 'CImplFuncMismatch1' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+}
+
+@_objcImplementation @_cdecl("CImplFuncMismatch2")
+func CImplFuncMismatch2(_: Int32) -> Float {
+  // expected-warning@-1 {{global function 'CImplFuncMismatch2' of type '(Int32) -> Float' does not match type '(Int32) -> Void' declared by the header}}
+}
+
+@_objcImplementation @_cdecl("CImplFuncMismatch3")
+func CImplFuncMismatch3(_: Any?) {
+  // OK
+}
+
+@_objcImplementation @_cdecl("CImplFuncMismatch4")
+func CImplFuncMismatch4(_: Any) {
+  // expected-warning@-1 {{global function 'CImplFuncMismatch4' of type '(Any) -> ()' does not match type '(Any?) -> Void' declared by the header}}
+}
+
+@_objcImplementation @_cdecl("CImplFuncMismatch5")
+func CImplFuncMismatch5(_: Any) {
+  // OK
+}
+
+@_objcImplementation @_cdecl("CImplFuncMismatch6")
+func CImplFuncMismatch6(_: Any!) {
+  // OK, mismatch allowed
+}
+
+
+@_objcImplementation @_cdecl("CImplFuncMismatch3a")
+func CImplFuncMismatch3a(_: Int32) -> Any? {
+  // OK
+}
+
+@_objcImplementation @_cdecl("CImplFuncMismatch4a")
+func CImplFuncMismatch4a(_: Int32) -> Any {
+  // expected-warning@-1 {{global function 'CImplFuncMismatch4a' of type '(Int32) -> Any' does not match type '(Int32) -> Any?' declared by the header}}
+}
+
+@_objcImplementation @_cdecl("CImplFuncMismatch5a")
+func CImplFuncMismatch5a(_: Int32) -> Any {
+  // OK
+}
+
+@_objcImplementation @_cdecl("CImplFuncMismatch6a")
+func CImplFuncMismatch6a(_: Int32) -> Any! {
+  // OK, mismatch allowed
+}
+
+@_objcImplementation @_cdecl("CImplFuncNameMismatch1")
+func mismatchedName1(_: Int32) {
+  // expected-error@-2 {{could not find imported function 'CImplFuncNameMismatch1' matching global function 'mismatchedName1'; make sure your umbrella or bridging header imports the header that declares it}}
+  // FIXME: Improve diagnostic for a partial match.
+}
+
+@_objcImplementation @_cdecl("mismatchedName2")
+func CImplFuncNameMismatch2(_: Int32) {
+  // expected-error@-2 {{could not find imported function 'mismatchedName2' matching global function 'CImplFuncNameMismatch2'; make sure your umbrella or bridging header imports the header that declares it}}
+  // FIXME: Improve diagnostic for a partial match.
+}
+
 func usesAreNotAmbiguous(obj: ObjCClass) {
   obj.method(fromHeader1: 1)
   obj.method(fromHeader2: 2)

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -476,7 +476,7 @@ func CImplFunc2(_: Int32) {
 
 @_objcImplementation @_cdecl("CImplFuncMissing")
 func CImplFuncMissing(_: Int32) {
-  // FIXME: expected-DISABLED-error@-1 {{fnord}}
+  // expected-error@-2 {{could not find imported function 'CImplFuncMissing' matching global function 'CImplFuncMissing'; make sure your umbrella or bridging header imports the header that declares it}}
 }
 
 func usesAreNotAmbiguous(obj: ObjCClass) {

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -464,6 +464,21 @@ protocol EmptySwiftProto {}
   // expected-error@-1 {{'@_objcImplementation' cannot be used to implement generic class 'ObjCImplGenericClass'}}
 }
 
+@_objcImplementation @_cdecl("CImplFunc1")
+func CImplFunc1(_: Int32) {
+  // OK
+}
+
+@_objcImplementation(BadCategory) @_cdecl("CImplFunc2")
+func CImplFunc2(_: Int32) {
+  // expected-error@-2 {{global function 'CImplFunc2' does not belong to an Objective-C category; remove the category name from this attribute}} {{21-34=}}
+}
+
+@_objcImplementation @_cdecl("CImplFuncMissing")
+func CImplFuncMissing(_: Int32) {
+  // FIXME: expected-DISABLED-error@-1 {{fnord}}
+}
+
 func usesAreNotAmbiguous(obj: ObjCClass) {
   obj.method(fromHeader1: 1)
   obj.method(fromHeader2: 2)


### PR DESCRIPTION
Swift can now emit C functions which match a global function declaration in a C header. That is, you can apply  `@_objcImplementation` to a `@_cdecl` function and it will match it to a global C function in a header.

This doesn't yet have all the functionality I'd like—I'm hoping to cover computed properties and at least some import-as-member functions too. But it already has enough functionality to be useful.

Fixes rdar://103845088.