### PR TITLE
[swift-parse-test] A parser performance check utility

### DIFF
--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -1,0 +1,89 @@
+//===--- ASTGen.h -----------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/CASTBridging.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *_Nonnull swift_ASTGen_createQueuedDiagnostics();
+void swift_ASTGen_destroyQueuedDiagnostics(void *_Nonnull queued);
+void swift_ASTGen_addQueuedSourceFile(
+    void *_Nonnull queuedDiagnostics, ssize_t bufferID,
+    void *_Nonnull sourceFile, const uint8_t *_Nonnull displayNamePtr,
+    intptr_t displayNameLength, ssize_t parentID, ssize_t positionInParent);
+void swift_ASTGen_addQueuedDiagnostic(
+    void *_Nonnull queued, const char *_Nonnull text, ptrdiff_t textLength,
+    BridgedDiagnosticSeverity severity, const void *_Nullable sourceLoc,
+    const void *_Nullable *_Nullable highlightRanges,
+    ptrdiff_t numHighlightRanges);
+void swift_ASTGen_renderQueuedDiagnostics(
+    void *_Nonnull queued, ssize_t contextSize, ssize_t colorize,
+    BridgedString *_Nonnull renderedString);
+
+// FIXME: Hack because we cannot easily get to the already-parsed source
+// file from here. Fix this egregious oversight!
+void *_Nullable swift_ASTGen_parseSourceFile(const char *_Nonnull buffer,
+                                             size_t bufferLength,
+                                             const char *_Nonnull moduleName,
+                                             const char *_Nonnull filename,
+                                             void *_Nullable ctx);
+void swift_ASTGen_destroySourceFile(void *_Nonnull sourceFile);
+
+void *_Nullable swift_ASTGen_resolveMacroType(const void *_Nonnull macroType);
+void swift_ASTGen_destroyMacro(void *_Nonnull macro);
+
+void swift_ASTGen_freeBridgedString(BridgedString);
+
+void *_Nonnull swift_ASTGen_resolveExecutableMacro(
+    const char *_Nonnull moduleName, const char *_Nonnull typeName,
+    void *_Nonnull opaquePluginHandle);
+void swift_ASTGen_destroyExecutableMacro(void *_Nonnull macro);
+
+ptrdiff_t swift_ASTGen_checkMacroDefinition(
+    void *_Nonnull diagEngine, void *_Nonnull sourceFile,
+    const void *_Nonnull macroSourceLocation,
+    BridgedString *_Nonnull expansionSourceOutPtr,
+    ptrdiff_t *_Nullable *_Nonnull replacementsPtr,
+    ptrdiff_t *_Nonnull numReplacements);
+void swift_ASTGen_freeExpansionReplacements(
+    ptrdiff_t *_Nullable replacementsPtr, ptrdiff_t numReplacements);
+
+ptrdiff_t swift_ASTGen_expandFreestandingMacro(
+    void *_Nonnull diagEngine, const void *_Nonnull macro, uint8_t externalKind,
+    const char *_Nonnull discriminator, uint8_t rawMacroRole,
+    void *_Nonnull sourceFile, const void *_Nullable sourceLocation,
+    BridgedString *_Nonnull evaluatedSourceOut);
+
+ptrdiff_t swift_ASTGen_expandAttachedMacro(
+    void *_Nonnull diagEngine, const void *_Nonnull macro, uint8_t externalKind,
+    const char *_Nonnull discriminator, const char *_Nonnull qualifiedType,
+    const char *_Nonnull conformances, uint8_t rawMacroRole,
+    void *_Nonnull customAttrSourceFile,
+    const void *_Nullable customAttrSourceLocation,
+    void *_Nonnull declarationSourceFile,
+    const void *_Nullable declarationSourceLocation,
+    void *_Nullable parentDeclSourceFile,
+    const void *_Nullable parentDeclSourceLocation,
+    BridgedString *_Nonnull evaluatedSourceOut);
+
+bool swift_ASTGen_initializePlugin(void *_Nonnull handle,
+                                   void *_Nullable diagEngine);
+void swift_ASTGen_deinitializePlugin(void *_Nonnull handle);
+bool swift_ASTGen_pluginServerLoadLibraryPlugin(
+    void *_Nonnull handle, const char *_Nonnull libraryPath,
+    const char *_Nonnull moduleName, BridgedString *_Nullable errorOut);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -178,7 +178,8 @@ public:
     SymbolGraph,     // swift-symbolgraph
     APIExtract,      // swift-api-extract
     APIDigester,     // swift-api-digester
-    CacheTool        // swift-cache-tool
+    CacheTool,       // swift-cache-tool
+    ParseTest,       // swift-parse-test
   };
 
   class InputInfoMap;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -112,6 +112,7 @@ void Driver::parseDriverKind(ArrayRef<const char *> Args) {
           .Case("swift-api-extract", DriverKind::APIExtract)
           .Case("swift-api-digester", DriverKind::APIDigester)
           .Case("swift-cache-tool", DriverKind::CacheTool)
+          .Case("swift-parse-test", DriverKind::ParseTest)
           .Default(llvm::None);
 
   if (Kind.has_value())
@@ -3577,6 +3578,7 @@ void Driver::printHelp(bool ShowHidden) const {
   case DriverKind::APIExtract:
   case DriverKind::APIDigester:
   case DriverKind::CacheTool:
+  case DriverKind::ParseTest:
     ExcludedFlagsBitmask |= options::NoBatchOption;
     break;
   }

--- a/lib/DriverTool/CMakeLists.txt
+++ b/lib/DriverTool/CMakeLists.txt
@@ -13,7 +13,8 @@ set(driver_sources_and_options
                 swift_cache_tool_main.cpp
                 swift_indent_main.cpp
                 swift_symbolgraph_extract_main.cpp
-                swift_api_extract_main.cpp)
+                swift_api_extract_main.cpp
+                swift_parse_test_main.cpp)
 
 set(driver_common_libs
                 swiftAPIDigester

--- a/lib/DriverTool/CMakeLists.txt
+++ b/lib/DriverTool/CMakeLists.txt
@@ -35,6 +35,13 @@ if(NOT SWIFT_BUILT_STANDALONE)
   add_dependencies(swiftDriverTool clang-resource-headers)
 endif()
 
+if (SWIFT_BUILD_SWIFT_SYNTAX)
+  target_compile_definitions(swiftDriverTool
+    PRIVATE
+    SWIFT_BUILD_SWIFT_SYNTAX
+  )
+endif()
+
 set_swift_llvm_is_available(swiftDriverTool)
 
 set(LLVM_TARGET_DEFINITIONS SwiftCacheToolOptions.td)

--- a/lib/DriverTool/driver.cpp
+++ b/lib/DriverTool/driver.cpp
@@ -111,6 +111,10 @@ extern int swift_api_extract_main(ArrayRef<const char *> Args,
 extern int swift_cache_tool_main(ArrayRef<const char *> Args, const char *Argv0,
                                  void *MainAddr);
 
+/// Run 'swift-parse-test'
+extern int swift_parse_test_main(ArrayRef<const char *> Args, const char *Argv0,
+                                 void *MainAddr);
+
 /// Determine if the given invocation should run as a "subcommand".
 ///
 /// Examples of "subcommands" are 'swift build' or 'swift test', which are
@@ -379,6 +383,9 @@ static int run_driver(StringRef ExecName,
     return swift_cache_tool_main(
         TheDriver.getArgsWithoutProgramNameAndDriverMode(argv), argv[0],
         (void *)(intptr_t)getExecutablePath);
+  case Driver::DriverKind::ParseTest:
+    return swift_parse_test_main(argv, argv[0],
+                                 (void *)(intptr_t)getExecutablePath);
   default:
     break;
   }

--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -1,0 +1,209 @@
+//===--- swift_parse_test_main.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A utility tool to measure the parser performance.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTContext.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/LangOptions.h"
+#include "swift/Bridging/ASTGen.h"
+#include "swift/Parse/Parser.h"
+#include "llvm/Support/CommandLine.h"
+
+#include <chrono>
+#include <ctime>
+#include <numeric>
+
+using namespace swift;
+
+namespace {
+
+struct SwiftParseTestOptions {
+  llvm::cl::opt<bool> SwiftParser =
+      llvm::cl::opt<bool>("swift-parser", llvm::cl::desc("Use SwiftParser"));
+
+  llvm::cl::opt<bool> LibParse =
+      llvm::cl::opt<bool>("lib-parse", llvm::cl::desc("Use libParse"));
+
+  llvm::cl::opt<unsigned int> Iteration = llvm::cl::opt<unsigned int>(
+      "n", llvm::cl::desc("iteration"), llvm::cl::init(1));
+
+  llvm::cl::list<std::string> InputPaths = llvm::cl::list<std::string>(
+      llvm::cl::Positional, llvm::cl::desc("input paths"));
+};
+
+enum class ParseMode {
+  SwiftParser,
+  LibParse,
+};
+
+struct LibParseExecutor {
+  constexpr static StringRef name = "libParse";
+
+  static void performParse(llvm::MemoryBufferRef buffer) {
+    SourceManager SM;
+    unsigned bufferID =
+        SM.addNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(buffer));
+    DiagnosticEngine diagEngine(SM);
+    LangOptions langOpts;
+    TypeCheckerOptions typeckOpts;
+    SILOptions silOpts;
+    SearchPathOptions searchPathOpts;
+    ClangImporterOptions clangOpts;
+    symbolgraphgen::SymbolGraphOptions symbolOpts;
+    std::unique_ptr<ASTContext> ctx(
+        ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
+                        clangOpts, symbolOpts, SM, diagEngine));
+
+    SourceFile::ParsingOptions parseOpts;
+    // Always disable body skipping because SwiftParser currently don't have it.
+    // When SwiftParser implements delayed parsing, this should be a command
+    // line option.
+    parseOpts |= SourceFile::ParsingFlags::DisableDelayedBodies;
+    parseOpts |= SourceFile::ParsingFlags::DisablePoundIfEvaluation;
+
+    ModuleDecl *M = ModuleDecl::create(Identifier(), *ctx);
+    SourceFile *SF =
+        new (*ctx) SourceFile(*M, SourceFileKind::Library, bufferID, parseOpts);
+
+    Parser parser(bufferID, *SF, /*SILParserState=*/nullptr);
+    SmallVector<ASTNode> items;
+    parser.parseTopLevelItems(items);
+  }
+};
+
+struct SwiftParserExecutor {
+  constexpr static StringRef name = "SwiftParser";
+
+  static void performParse(llvm::MemoryBufferRef buffer) {
+    auto sourceFile = swift_ASTGen_parseSourceFile(
+        buffer.getBufferStart(), buffer.getBufferSize(), "",
+        buffer.getBufferIdentifier().data(), nullptr);
+    swift_ASTGen_destroySourceFile(sourceFile);
+  }
+};
+
+static void _loadSwiftFilesRecursively(
+    StringRef path,
+    SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>> &buffers) {
+  if (llvm::sys::fs::is_directory(path)) {
+    std::error_code err;
+    for (auto I = llvm::sys::fs::directory_iterator(path, err),
+              E = llvm::sys::fs::directory_iterator();
+         I != E; I.increment(err)) {
+      _loadSwiftFilesRecursively(I->path(), buffers);
+    }
+  } else if (path.endswith(".swift")) {
+    if (auto buffer = llvm::MemoryBuffer::getFile(path)) {
+      buffers.push_back(std::move(*buffer));
+    }
+  }
+}
+
+/// Load all '.swift' files in the specified \p filePaths into \p buffers.
+/// If the path is a directory, this recursively collects the files in it.
+static void
+loadSources(ArrayRef<std::string> filePaths,
+            SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>> &buffers) {
+  for (auto path : filePaths) {
+    _loadSwiftFilesRecursively(path, buffers);
+  }
+}
+
+/// Measure the duration of \p body execution.
+template <typename Duration>
+static std::pair<Duration, Duration> measure(llvm::function_ref<void()> body) {
+  auto cStart = std::clock();
+  auto tStart = std::chrono::steady_clock::now();
+  body();
+  auto cEnd = std::clock();
+  auto tEnd = std::chrono::steady_clock::now();
+
+  auto clockMultiply =
+      Duration::period::den / CLOCKS_PER_SEC / Duration::period::num;
+
+  Duration cDuration((cEnd - cStart) * clockMultiply);
+  return {std::chrono::duration_cast<Duration>(tEnd - tStart),
+          std::chrono::duration_cast<Duration>(cDuration)};
+}
+
+/// Perform the performance measurement using \c Executor .
+/// Parse all \p buffers using \c Executor , \p iteration times, and print out
+/// the measurement to the \c stdout.
+template <typename Executor>
+static void
+perform(const SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>> &buffers,
+        unsigned iteration, uintmax_t totalBytes, uintmax_t totalLines) {
+
+  llvm::outs() << "----\n";
+  llvm::outs() << "parser: " << Executor::name << "\n";
+
+  using duration_t = std::chrono::nanoseconds;
+  auto tDuration = duration_t::zero();
+  auto cDuration = duration_t::zero();
+
+  for (unsigned i = 0; i < iteration; i++) {
+    for (auto &buffer : buffers) {
+      std::pair<duration_t, duration_t> elapsed = measure<duration_t>(
+          [&] { Executor::performParse(buffer->getMemBufferRef()); });
+      tDuration += elapsed.first;
+      cDuration += elapsed.second;
+    }
+  }
+
+  auto tDisplay =
+      std::chrono::duration_cast<std::chrono::milliseconds>(tDuration).count();
+  auto cDisplay =
+      std::chrono::duration_cast<std::chrono::milliseconds>(cDuration).count();
+
+  auto byteTPS = totalBytes * duration_t::period::den / cDuration.count();
+  auto lineTPS = totalLines * duration_t::period::den / cDuration.count();
+
+  llvm::outs() << llvm::format("wall clock time (ms): %8d\n", tDisplay)
+               << llvm::format("cpu time (ms):        %8d\n", cDisplay)
+               << llvm::format("throughput (byte/s):  %8d\n", byteTPS)
+               << llvm::format("throughput (line/s):  %8d\n", lineTPS);
+}
+
+} // namespace
+
+int swift_parse_test_main(ArrayRef<const char *> args, const char *argv0,
+                          void *mainAddr) {
+  SwiftParseTestOptions options;
+  llvm::cl::ParseCommandLineOptions(args.size(), args.data(),
+                                    "Swift parse test\n");
+
+  unsigned iteration = options.Iteration;
+
+  SmallVector<std::unique_ptr<llvm::MemoryBuffer>> buffers;
+  loadSources(options.InputPaths, buffers);
+  unsigned int byteCount = 0;
+  unsigned int lineCount = 0;
+  for (auto &buffer : buffers) {
+    byteCount += buffer->getBufferSize();
+    lineCount += buffer->getBuffer().count('\n');
+  }
+
+  llvm::outs() << llvm::format("file count:  %8d\n", buffers.size())
+               << llvm::format("total bytes: %8d\n", byteCount)
+               << llvm::format("total lines: %8d\n", lineCount)
+               << llvm::format("iterations:  %8d\n", iteration);
+
+  if (options.SwiftParser)
+    perform<SwiftParserExecutor>(buffers, iteration, byteCount, lineCount);
+  if (options.LibParse)
+    perform<LibParseExecutor>(buffers, iteration, byteCount, lineCount);
+
+  return 0;
+}

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/DiagnosticsCommon.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/Bridging/ASTGen.h"
 #include "swift/Markup/Markup.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
@@ -33,39 +34,6 @@
 
 using namespace swift;
 using namespace swift::markup;
-
-extern "C" void *swift_ASTGen_createQueuedDiagnostics();
-extern "C" void swift_ASTGen_destroyQueuedDiagnostics(void *queued);
-extern "C" void swift_ASTGen_addQueuedSourceFile(
-      void *queuedDiagnostics,
-      ssize_t bufferID,
-      void *sourceFile,
-      const uint8_t *displayNamePtr,
-      intptr_t displayNameLength,
-      ssize_t parentID,
-      ssize_t positionInParent);
-extern "C" void swift_ASTGen_addQueuedDiagnostic(
-    void *queued,
-    const char* text, ptrdiff_t textLength,
-    BridgedDiagnosticSeverity severity,
-    const void *sourceLoc,
-    const void **highlightRanges,
-    ptrdiff_t numHighlightRanges
-);
-extern "C" void
-swift_ASTGen_renderQueuedDiagnostics(void *queued, ssize_t contextSize,
-                                     ssize_t colorize,
-                                     BridgedString *renderedString);
-extern "C" void swift_ASTGen_freeBridgedString(BridgedString);
-
-// FIXME: Hack because we cannot easily get to the already-parsed source
-// file from here. Fix this egregious oversight!
-extern "C" void *swift_ASTGen_parseSourceFile(const char *buffer,
-                                              size_t bufferLength,
-                                              const char *moduleName,
-                                              const char *filename,
-                                              void *_Nullable ctx);
-extern "C" void swift_ASTGen_destroySourceFile(void *sourceFile);
 
 namespace {
   class ColoredStream : public raw_ostream {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -16,8 +16,8 @@
 
 #include "TypeCheckMacros.h"
 #include "../AST/InlinableText.h"
-#include "TypeChecker.h"
 #include "TypeCheckType.h"
+#include "TypeChecker.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
@@ -37,6 +37,7 @@
 #include "swift/Basic/Lazy.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
+#include "swift/Bridging/ASTGen.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Parse/Lexer.h"
@@ -45,43 +46,6 @@
 #include "llvm/Config/config.h"
 
 using namespace swift;
-
-extern "C" void *swift_ASTGen_resolveMacroType(const void *macroType);
-extern "C" void swift_ASTGen_destroyMacro(void *macro);
-
-extern "C" void swift_ASTGen_freeBridgedString(BridgedString);
-
-extern "C" void *swift_ASTGen_resolveExecutableMacro(const char *moduleName,
-                                                     const char *typeName,
-                                                     void *opaquePluginHandle);
-extern "C" void swift_ASTGen_destroyExecutableMacro(void *macro);
-
-extern "C" ptrdiff_t swift_ASTGen_checkMacroDefinition(
-    void *diagEngine, void *sourceFile, const void *macroSourceLocation,
-    BridgedString *expansionSourceOutPtr, ptrdiff_t **replacementsPtr,
-    ptrdiff_t *numReplacements);
-extern "C" void swift_ASTGen_freeExpansionReplacements(
-    ptrdiff_t *replacementsPtr,
-    ptrdiff_t numReplacements);
-
-extern "C" ptrdiff_t swift_ASTGen_expandFreestandingMacro(
-    void *diagEngine, const void *macro, uint8_t externalKind,
-    const char *discriminator, uint8_t rawMacroRole, void *sourceFile,
-    const void *sourceLocation, BridgedString *evaluatedSourceOut);
-
-extern "C" ptrdiff_t swift_ASTGen_expandAttachedMacro(
-    void *diagEngine, const void *macro, uint8_t externalKind,
-    const char *discriminator, const char *qualifiedType,
-    const char *conformances, uint8_t rawMacroRole, void *customAttrSourceFile,
-    const void *customAttrSourceLocation, void *declarationSourceFile,
-    const void *declarationSourceLocation, void *parentDeclSourceFile,
-    const void *parentDeclSourceLocation, BridgedString *evaluatedSourceOut);
-
-extern "C" bool swift_ASTGen_initializePlugin(void *handle, void *diagEngine);
-extern "C" void swift_ASTGen_deinitializePlugin(void *handle);
-extern "C" bool swift_ASTGen_pluginServerLoadLibraryPlugin(
-    void *handle, const char *libraryPath, const char *moduleName,
-    BridgedString *errorOut);
 
 static inline StringRef toStringRef(BridgedString bridged) {
   return {reinterpret_cast<const char *>(bridged.data), size_t(bridged.length)};

--- a/test/Misc/parse_test.swift
+++ b/test/Misc/parse_test.swift
@@ -1,0 +1,8 @@
+// REQUIRES: swift_swift_parser
+// RUN: %swift-parse-test -swift-parser -lib-parse -skip-bodies -n 2 %s
+
+struct S {
+  func foo() {
+    print(1)
+  }
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -345,6 +345,7 @@ config.benchmark_o = inferSwiftBinary('Benchmark_O')
 config.benchmark_driver = inferSwiftBinary('Benchmark_Driver')
 config.wasm_ld = inferSwiftBinary('wasm-ld')
 config.swift_plugin_server = inferSwiftBinary('swift-plugin-server')
+config.swift_parse_test = inferSwiftBinary('swift-parse-test')
 
 config.swift_utils = make_path(config.swift_src_root, 'utils')
 config.line_directive = make_path(config.swift_utils, 'line-directive')
@@ -636,6 +637,7 @@ config.substitutions.append( ('%llvm-strings', config.llvm_strings) )
 config.substitutions.append( ('%target-ptrauth', run_ptrauth ) )
 config.substitutions.append( ('%swift-path', config.swift) )
 config.substitutions.append( ('%swift-plugin-server', config.swift_plugin_server) )
+config.substitutions.append( ('%swift-parse-test', config.swift_parse_test) )
 config.substitutions.append( ('%validate-json', f"{config.python} -m json.tool") )
 
 # This must come after all substitutions containing "%swift".

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -152,6 +152,11 @@ swift_create_post_build_symlink(swift-frontend
   DESTINATION "swift-cache-tool${CMAKE_EXECUTABLE_SUFFIX}"
   WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
+swift_create_post_build_symlink(swift-frontend
+  SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+  DESTINATION "swift-parse-test${CMAKE_EXECUTABLE_SUFFIX}"
+  WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+
 add_swift_tool_symlink(swift swift-frontend compiler)
 add_swift_tool_symlink(swiftc swift-frontend compiler)
 add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler)


### PR DESCRIPTION

As a ground work, move `ASTGen` exported C function declaration to `include/swift/Bridiging`.

Usage:
```
% swift-parse-test -swift-parser -lib-parse -n 20 ../swift-syntax/Sources
files count: 228
total bytes: 5662399
total lines: 158428
iteration: 20
----
parser: SwiftParser
wall clock time (ms): 3848
cpu time (ms): 3843
throughput (byte/sec): 355824
throughput (line/sec): 41225
----
parser: libParse
wall clock time (ms): 296
cpu time (ms): 290
throughput (byte/sec): 4715281
throughput (line/sec): 546303
```
