### PR TITLE
[AST/TypeChecker] Allow existential values of Sendable be used from Objective-C

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6047,8 +6047,9 @@ ERROR(invalid_objc_decl_context,none,
       "@objc can only be used with members of classes, @objc protocols, and "
       "concrete extensions of classes", ())
 ERROR(invalid_objc_decl,none,
-      "only classes (and their extensions), protocols, methods, initializers, "
-      "properties, and subscript declarations can be declared @objc", ())
+      "only classes (and their extensions), non-marker protocols, methods, "
+      "initializers, properties, and subscript declarations can be declared"
+      " @objc", ())
 ERROR(invalid_objc_swift_rooted_class,none,
       "only classes that inherit from NSObject can be declared @objc", ())
 NOTE(invalid_objc_swift_root_class_insert_nsobject,none,

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -110,6 +110,10 @@ private:
   /// Zero or more primary associated type requirements from a
   /// ParameterizedProtocolType
   ArrayRef<Type> sameTypeRequirements;
+
+  /// Existentials allow a relaxed notion of \c ValueDecl::isObjC
+  /// that includes `Sendable` protocol.
+  static bool isObjCProtocol(ProtocolDecl *P);
 };
 
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -342,7 +342,7 @@ ExistentialLayout::ExistentialLayout(CanProtocolType type) {
 
   hasExplicitAnyObject = false;
   hasInverseCopyable = false;
-  containsNonObjCProtocol = !protoDecl->isObjC();
+  containsNonObjCProtocol = !isObjCProtocol(protoDecl);
   containsParameterized = false;
 
   protocols.push_back(protoDecl);
@@ -392,9 +392,7 @@ ExistentialLayout::ExistentialLayout(CanProtocolCompositionType type) {
       protoDecl = parameterized->getProtocol();
       containsParameterized = true;
     }
-    containsNonObjCProtocol |=
-        !protoDecl->isObjC() &&
-        !protoDecl->isSpecificProtocol(KnownProtocolKind::Sendable);
+    containsNonObjCProtocol |= !isObjCProtocol(protoDecl);
     protocols.push_back(protoDecl);
   }
 }
@@ -403,6 +401,10 @@ ExistentialLayout::ExistentialLayout(CanParameterizedProtocolType type)
     : ExistentialLayout(type.getBaseType()) {
   sameTypeRequirements = type->getArgs();
   containsParameterized = true;
+}
+
+bool ExistentialLayout::isObjCProtocol(ProtocolDecl *P) {
+  return P->isObjC() || P->isSpecificProtocol(KnownProtocolKind::Sendable);
 }
 
 ExistentialLayout TypeBase::getExistentialLayout() {

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -326,7 +326,8 @@ public:
         (void)addImport(CD);
       }
     } else if (auto PD = dyn_cast<ProtocolDecl>(TD)) {
-      forwardDeclare(PD);
+      if (!PD->isMarkerProtocol())
+        forwardDeclare(PD);
     } else if (auto TAD = dyn_cast<TypeAliasDecl>(TD)) {
       bool imported = false;
       if (TAD->hasClangNode())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1310,9 +1310,12 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
 
   // Only certain decls can be ObjC.
   llvm::Optional<Diag<>> error;
-  if (isa<ClassDecl>(D) ||
-      isa<ProtocolDecl>(D)) {
+  if (isa<ClassDecl>(D)) {
     /* ok */
+  } else if (auto *P = dyn_cast<ProtocolDecl>(D)) {
+    if (P->isMarkerProtocol())
+      error = diag::invalid_objc_decl;
+    /* ok on non-marker protocols */
   } else if (auto Ext = dyn_cast<ExtensionDecl>(D)) {
     if (!Ext->getSelfClassDecl())
       error = diag::objc_extension_not_class;

--- a/test/Concurrency/emit_objc_header_with_Sendable.swift
+++ b/test/Concurrency/emit_objc_header_with_Sendable.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
+// RUN: %FileCheck %s < %t/swift.h
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc public protocol P {}
+
+@objc public class Klass : NSObject {
+  // CHECK: - (void)test1:(NSDictionary<NSString *, id> * _Nonnull)_;
+  @objc public func test1(_: [String: any Sendable]) {}
+  // CHECK: - (void)test2:(NSDictionary<NSString *, id <P>> * _Nonnull)_;
+  @objc public func test2(_: [String: any P & Sendable]) {}
+}
+
+@objc public protocol Q {
+  // CHECK: - (NSArray<NSDictionary<NSString *, id> *> * _Nonnull)data1 SWIFT_WARN_UNUSED_RESULT;
+  func data1() -> [[String: any Sendable]]
+  // CHECK: - (NSArray<id> * _Nullable)data2 SWIFT_WARN_UNUSED_RESULT;
+  func data2() -> [any Sendable]?
+  // CHECK: - (void)data3:(id _Nonnull)_;
+  func data3(_: any Sendable)
+  // CHECK: - (void)data4:(id _Nullable)_;
+  func data4(_: (any Sendable)?)
+}

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -67,3 +67,6 @@ protocol P10 { }
 
 extension Array: P10 where Element: P10, Element: P8 { }
 // expected-error@-1{{conditional conformance to non-marker protocol 'P10' cannot depend on conformance of 'Element' to marker protocol 'P8'}}
+
+@objc @_marker protocol P11 {}
+// expected-error@-1 {{only classes (and their extensions), non-marker protocols, methods, initializers, properties, and subscript declarations can be declared @objc}}


### PR DESCRIPTION
- Make sure that marker protocols are not allowed to declare @objc and are not printed in the compatibility header.

- Add a missing check for Sendable in single protocol existential case
  `any Sendable` should be considered Objective-C capable just like
   it's protocol composition with other Objective-C capable types.

 Resolves: rdar://102728938
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
