### PR TITLE
[swift-inspect]  Add an option to print mangled names while dumping generic metadata.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -3116,7 +3116,8 @@ private:
         break;
         
       case GenericParamKind::TypePack:
-        assert(false && "Packs not supported here yet");
+        // assert(false && "Packs not supported here yet");
+        return {};
 
       default:
         // We don't know about this kind of parameter.

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -853,24 +853,25 @@ public:
 
   /// Returns true if the address is known to the reflection context.
   /// Currently, that means that either the address falls within the text or
-  /// data segments of a registered image, or the address points to a Metadata
-  /// whose type context descriptor is within the text segment of a registered
-  /// image.
-  bool ownsAddress(RemoteAddress Address) {
+  /// data segments of a registered image, or optionally, the address points
+  /// to a Metadata whose type context descriptor is within the text segment
+  /// of a registered image.
+  bool ownsAddress(RemoteAddress Address, bool checkMetadataDescriptor = true) {
     if (ownsAddress(Address, textRanges))
       return true;
     if (ownsAddress(Address, dataRanges))
       return true;
 
-    // This is usually called on a Metadata address which might have been
-    // on the heap. Try reading it and looking up its type context descriptor
-    // instead.
-    if (auto Metadata = readMetadata(Address.getAddressData()))
-      if (auto DescriptorAddress =
-          super::readAddressOfNominalTypeDescriptor(Metadata, true))
-        if (ownsAddress(RemoteAddress(DescriptorAddress), textRanges))
-          return true;
-
+    if (checkMetadataDescriptor) {
+      // This is usually called on a Metadata address which might have been
+      // on the heap. Try reading it and looking up its type context descriptor
+      // instead.
+      if (auto Metadata = readMetadata(Address.getAddressData()))
+        if (auto DescriptorAddress =
+            super::readAddressOfNominalTypeDescriptor(Metadata, true))
+          if (ownsAddress(RemoteAddress(DescriptorAddress), textRanges))
+            return true;
+    }
     return false;
   }
 

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -138,6 +138,15 @@ SWIFT_REMOTE_MIRROR_LINKAGE
 int
 swift_reflection_ownsAddress(SwiftReflectionContextRef ContextRef, uintptr_t Address);
 
+/// Returns whether the given address is strictly in the DATA, AUTH or TEXT
+/// segments of the image added to this library. Images must be added using
+/// swift_reflection_addImage, not swift_reflection_addReflectionInfo, for this
+/// function to work properly. If addReflectionInfo is used, the return value
+/// will always be false.
+SWIFT_REMOTE_MIRROR_LINKAGE
+int
+swift_reflection_ownsAddressStrict(SwiftReflectionContextRef ContextRef, uintptr_t Address);
+
 /// Returns the metadata pointer for a given object.
 SWIFT_REMOTE_MIRROR_LINKAGE
 uintptr_t
@@ -179,6 +188,7 @@ swift_reflection_typeRefForMangledTypeName(SwiftReflectionContextRef ContextRef,
 ///
 /// The returned string is heap allocated and the caller must free() it when
 /// done.
+[[deprecated("Please use swift_reflection_copyNameForTypeRef()")]]
 SWIFT_REMOTE_MIRROR_LINKAGE
 char *
 swift_reflection_copyDemangledNameForTypeRef(
@@ -188,6 +198,18 @@ SWIFT_REMOTE_MIRROR_LINKAGE
 char *
 swift_reflection_copyDemangledNameForProtocolDescriptor(
   SwiftReflectionContextRef ContextRef, swift_reflection_ptr_t Proto);
+
+/// Returns the mangled or demangled name for a typeref, or NULL if the name
+/// couldn't be created.
+///
+/// The returned string is heap allocated and the caller must free() it when
+/// done.
+
+SWIFT_REMOTE_MIRROR_LINKAGE
+char*
+swift_reflection_copyNameForTypeRef(SwiftReflectionContextRef ContextRef,
+                                    swift_typeref_t OpaqueTypeRef,
+                                    bool mangled);
 
 /// Returns a structure describing the layout of a value of a typeref.
 /// For classes, this returns the reference value itself.

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
@@ -64,11 +64,11 @@ extension SwiftReflectionContextRef {
     }
   }
 
-  internal func name(type: swift_reflection_ptr_t) -> String? {
+  internal func name(type: swift_reflection_ptr_t, mangled: Bool = false) -> String? {
     let typeref = swift_reflection_typeRefForMetadata(self, UInt(type))
     if typeref == 0 { return nil }
 
-    guard let name = swift_reflection_copyDemangledNameForTypeRef(self, typeref) else {
+    guard let name = swift_reflection_copyNameForTypeRef(self, typeref, mangled) else {
       return nil
     }
     defer { free(name) }

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -42,6 +42,10 @@ internal struct BacktraceOptions: ParsableArguments {
   }
 }
 
+internal struct GenericMetadataOptions: ParsableArguments {
+  @Flag(help: "Show allocations in mangled form")
+  var mangled: Bool = false
+}
 
 internal func inspect(options: UniversalOptions,
                       _ body: (any RemoteProcess) throws -> Void) throws {


### PR DESCRIPTION
This adds `--mangled` option to print mangled names while dumping generic metadata. We also cross-check to make sure pre-specialized generic metadata strictly exists in the `DATA`, `AUTH`, or `TEXT` segments of the images, and report on errors.