### PR TITLE
fix: typo in SILDeclRef.cpp from intializers to initializers

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -476,7 +476,7 @@ static LinkageLimit getLinkageLimit(SILDeclRef constant) {
                                      : Limit::None;
     }
     // Otherwise, regular property wrapper backing initializers (for properties)
-    // are treated just like stored property intializers.
+    // are treated just like stored property initializers.
     LLVM_FALLTHROUGH;
   }
   case Kind::StoredPropertyInitializer: {


### PR DESCRIPTION
This PR fixes typos in l**ib/SIL/IR/SILDeclRef.cpp** file.

Following typos have been fixed:

`intializers` -> `initializers`


No other changes.