### PR TITLE
Handle `any Error` and `Never` thrown error types during runtime uniquing

### DIFF
--- a/test/IRGen/typed_throws.sil
+++ b/test/IRGen/typed_throws.sil
@@ -406,12 +406,12 @@ entry(%0: $*T):
 // CHECK: define{{.*}} swiftcc void @apply_closure_generic(ptr %0, ptr %1, ptr %T, ptr %V)
 // CHECK:  [[T0:%.*]] = getelementptr inbounds ptr, ptr %T
 // CHECK:  [[T1:%.*]] = load ptr, ptr [[T0]]
-// CHECK:  [[T2:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[T1]]
+// CHECK:  [[T2:%.*]] = getelementptr inbounds %swift.vwtable{{.*}}
 // CHECK:  [[T3:%.*]] = load i64, ptr [[T2]]
 // CHECK:  [[T4:%.*]] = alloca i8, i64 [[T3]]
 // CHECK:  [[V0:%.*]] = getelementptr inbounds ptr, ptr %V
 // CHECK:  [[V1:%.*]] = load ptr, ptr [[V0]]
-// CHECK:  [[V2:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[V1]]
+// CHECK:  [[V2:%.*]] = getelementptr inbounds %swift.vwtable{{.*}}
 // CHECK:  [[V3:%.*]] = load i64, ptr [[V2]]
 // CHECK:  [[V4:%.*]] = alloca i8, i64 [[V3]]
 // CHECK: call swiftcc void %0(ptr noalias sret(%swift.opaque) [[T4]], ptr swiftself %1, ptr noalias nocapture swifterror dereferenceable(8) %swifterror, ptr [[V4]])

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -526,12 +526,26 @@ enum MyBigError: Error {
   case epicFail
 }
 
+@available(SwiftStdlib 5.11, *)
+func getFnTypeWithThrownError<E: Error>(_: E.Type) -> Any.Type {
+  typealias Fn = (Int) throws(E) -> Void
+  return Fn.self
+}
+
 if #available(SwiftStdlib 5.11, *) {
   DemangleToMetadataTests.test("typed throws") {
     typealias Fn = (Int) throws(MyBigError) -> Void
     expectEqual("ySi4main10MyBigErrorOYKc", _mangledTypeName(Fn.self)!)
-    print("Looking up the typed throws... \(_typeByName("ySi4main10MyBigErrorOYKc"))")
     expectEqual(Fn.self, _typeByName("ySi4main10MyBigErrorOYKc")!)
+
+
+    expectEqual(getFnTypeWithThrownError(MyBigError.self), _typeByName("ySi4main10MyBigErrorOYKc")!)
+
+    // throws(any Error) -> throws
+    expectEqual(getFnTypeWithThrownError((any Error).self), _typeByName("ySiKc")!)
+
+    // throws(Never) -> non-throwing
+    expectEqual(getFnTypeWithThrownError(Never.self), _typeByName("ySic")!)
   }
 }
 

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -520,3 +520,11 @@ const long long $ss7KeyPathCMo[1] = {0};
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $ss12__SwiftValueCMn[1] = {0};
+
+// Never and Error
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $ss5NeverOMn[1] = {0};
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $ss5ErrorMp[1] = {0};


### PR DESCRIPTION
When forming runtime metadata for a function type that has either `any Error` or `Never` as the specified thrown error type, drop the thrown error type and normalize down to (untyped) `throws` or non-throwing, as appropriate.
