### PR TITLE
[Distributed] Don't crash in thunk generation when missing SR conformance

### DIFF
--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -97,7 +97,7 @@ getDistributedSerializationRequirementProtocols(
 /// If so, we can emit slightly nicer diagnostics.
 bool checkDistributedSerializationRequirementIsExactlyCodable(
     ASTContext &C,
-    const llvm::SmallPtrSetImpl<ProtocolDecl *> &allRequirements);
+    Type type);
 
 /// Get the `SerializationRequirement`, explode it into the specific
 /// protocol requirements and insert them into `requirements`.

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -50,7 +50,8 @@ Type getDistributedActorIDType(NominalTypeDecl *actor);
 /// Similar to `getDistributedSerializationRequirementType`, however, from the
 /// perspective of a concrete function. This way we're able to get the
 /// serialization requirement for specific members, also in protocols.
-Type getConcreteReplacementForMemberSerializationRequirement(ValueDecl *member);
+Type getSerializationRequirementTypesForMember(
+    ValueDecl *member, llvm::SmallPtrSet<ProtocolDecl *, 2> &serializationRequirements);
 
 /// Get specific 'SerializationRequirement' as defined in 'nominal'
 /// type, which must conform to the passed 'protocol' which is expected
@@ -114,17 +115,6 @@ getDistributedSerializationRequirements(
     ProtocolDecl *protocol,
     llvm::SmallPtrSetImpl<ProtocolDecl *> &requirementProtos);
 
-/// Given any set of generic requirements, locate those which are about the
-/// `SerializationRequirement`. Those need to be applied in the parameter and
-/// return type checking of distributed targets.
-void
-extractDistributedSerializationRequirements(
-    ASTContext &C,
-    ArrayRef<Requirement> allRequirements,
-    llvm::SmallPtrSet<ProtocolDecl *, 2> &into);
-
 }
-
-// ==== ------------------------------------------------------------------------
 
 #endif /* SWIFT_DECL_DISTRIBUTEDDECL_H */

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -117,9 +117,11 @@ getDistributedSerializationRequirements(
 /// Given any set of generic requirements, locate those which are about the
 /// `SerializationRequirement`. Those need to be applied in the parameter and
 /// return type checking of distributed targets.
-llvm::SmallPtrSet<ProtocolDecl *, 2>
+void
 extractDistributedSerializationRequirements(
-    ASTContext &C, ArrayRef<Requirement> allRequirements);
+    ASTContext &C,
+    ArrayRef<Requirement> allRequirements,
+    llvm::SmallPtrSet<ProtocolDecl *, 2> &into);
 
 }
 

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1224,14 +1224,13 @@ swift::extractDistributedSerializationRequirements(
       DA->getAssociatedType(C.Id_SerializationRequirement);
 
   for (auto req : allRequirements) {
-    if (req.getSecondType()->isAny()) {
-      continue;
-    }
-    if (!req.getFirstType()->hasDependentMember())
+    // FIXME: Seems unprincipled
+    if (req.getKind() != RequirementKind::SameType &&
+        req.getKind() != RequirementKind::Conformance)
       continue;
 
     if (auto dependentMemberType =
-            req.getFirstType()->castTo<DependentMemberType>()) {
+            req.getFirstType()->getAs<DependentMemberType>()) {
       if (dependentMemberType->getAssocType() == daSerializationReqAssocType) {
         // auto requirementProto = req.getSecondType();
         // if (auto proto = dyn_cast_or_null<ProtocolDecl>(
@@ -1248,7 +1247,7 @@ swift::extractDistributedSerializationRequirements(
         //   }
         auto layout = req.getSecondType()->getExistentialLayout();
         for (auto p : layout.getProtocols()) {
-          serializationReqs.insert(p);
+          into.insert(p);
         }
       }
     }

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -341,12 +341,11 @@ swift::getDistributedSerializationRequirements(
     return true; // we're done here, any means there are no requirements
 
   auto *serialReqType = existentialRequirementTy->getAs<ExistentialType>();
-                                       ->getAs<ExistentialType>();
   if (!serialReqType || serialReqType->hasError()) {
     return false;
   }
 
-  auto desugaredTy = serialReqType->getConstraintType();
+  auto layout = serialReqType->getExistentialLayout();
   for (auto p : layout.getProtocols()) {
     requirementProtos.insert(p);
   }
@@ -1234,16 +1233,20 @@ swift::extractDistributedSerializationRequirements(
     if (auto dependentMemberType =
             req.getFirstType()->castTo<DependentMemberType>()) {
       if (dependentMemberType->getAssocType() == daSerializationReqAssocType) {
-        auto requirementProto = req.getSecondType();
-        if (auto proto = dyn_cast_or_null<ProtocolDecl>(
-                requirementProto->getAnyNominal())) {
-          into.insert(proto);
-        } else {
-          auto serialReqType = requirementProto->castTo<ExistentialType>()
-                                   ->getConstraintType();
-          auto flattenedRequirements =
-              flattenDistributedSerializationTypeToRequiredProtocols(
-                  serialReqType.getPointer());
+        // auto requirementProto = req.getSecondType();
+        // if (auto proto = dyn_cast_or_null<ProtocolDecl>(
+        //         requirementProto->getAnyNominal())) {
+        //   into.insert(proto);
+        // } else {
+        //   auto serialReqType = requirementProto->castTo<ExistentialType>()
+        //                            ->getConstraintType();
+        //   auto flattenedRequirements =
+        //       flattenDistributedSerializationTypeToRequiredProtocols(
+        //           serialReqType.getPointer());
+        //   for (auto p : flattenedRequirements) {
+        //     into.insert(p);
+        //   }
+        auto layout = req.getSecondType()->getExistentialLayout();
         for (auto p : layout.getProtocols()) {
           serializationReqs.insert(p);
         }

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1214,10 +1214,11 @@ AbstractFunctionDecl::isDistributedTargetInvocationResultHandlerOnReturn() const
     return true;
 }
 
-llvm::SmallPtrSet<ProtocolDecl *, 2>
+void
 swift::extractDistributedSerializationRequirements(
-    ASTContext &C, ArrayRef<Requirement> allRequirements) {
-  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs;
+    ASTContext &C,
+    ArrayRef<Requirement> allRequirements,
+    llvm::SmallPtrSet<ProtocolDecl *, 2> &into) {
   auto DA = C.getDistributedActorDecl();
   auto daSerializationReqAssocType =
       DA->getAssociatedType(C.Id_SerializationRequirement);
@@ -1238,8 +1239,6 @@ swift::extractDistributedSerializationRequirements(
       }
     }
   }
-
-  return serializationReqs;
 }
 
 /******************************************************************************/

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -842,8 +842,14 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
     if (!distributedTarget->isDistributed())
       return nullptr;
   }
-
   assert(distributedTarget);
+
+  // This evaluation type-check by now was already computed and cached;
+  // We need to check in order to avoid emitting a THUNK for a distributed func
+  // which had errors; as the thunk then may also cause un-addressable issues and confusion.
+  if (swift::checkDistributedFunction(distributedTarget)) {
+    return nullptr;
+  }
 
   auto &C = distributedTarget->getASTContext();
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2071,7 +2071,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
       return (prop &&
               prop->isFinal() &&
               isa<ClassDecl>(prop->getDeclContext()) &&
-              cast<ClassDecl>(prop->getDeclContext())->isActor() &&
+              cast<ClassDecl>(prop->getDeclContext())->isAnyActor() &&
               !prop->isStatic() &&
               prop->getName() == ctx.Id_unownedExecutor &&
               prop->getInterfaceType()->getAnyNominal() == ctx.getUnownedSerialExecutorDecl());

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -376,9 +376,12 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
 
 static bool checkDistributedTargetResultType(
     ModuleDecl *module, ValueDecl *valueDecl,
-    const llvm::SmallPtrSetImpl<ProtocolDecl *> &serializationRequirements,
+    Type serializationRequirement,
     bool diagnose) {
   auto &C = valueDecl->getASTContext();
+
+  if (!serializationRequirement || serializationRequirement->hasError())
+    return false; // error of the type would be diagnosed elsewhere
 
   Type resultType;
   if (auto func = dyn_cast<FuncDecl>(valueDecl)) {
@@ -394,36 +397,39 @@ static bool checkDistributedTargetResultType(
 
   auto isCodableRequirement =
       checkDistributedSerializationRequirementIsExactlyCodable(
-          C, serializationRequirements);
+          C, serializationRequirement);
 
-  for(auto serializationReq : serializationRequirements) {
-    auto conformance =
-        TypeChecker::conformsToProtocol(resultType, serializationReq, module);
-    if (conformance.isInvalid()) {
-      if (diagnose) {
-        llvm::StringRef conformanceToSuggest = isCodableRequirement ?
-            "Codable" : // Codable is a typealias, easier to diagnose like that
-            serializationReq->getNameStr();
+  if (serializationRequirement && !serializationRequirement->hasError()) {
+    auto srl = serializationRequirement->getExistentialLayout();
+    for (auto serializationReq: srl.getProtocols()) {
+      auto conformance =
+          TypeChecker::conformsToProtocol(resultType, serializationReq, module);
+      if (conformance.isInvalid()) {
+        if (diagnose) {
+          llvm::StringRef conformanceToSuggest = isCodableRequirement ?
+                                                 "Codable" : // Codable is a typealias, easier to diagnose like that
+                                                 serializationReq->getNameStr();
 
-        auto diag = valueDecl->diagnose(
-            diag::distributed_actor_target_result_not_codable,
-            resultType,
-            valueDecl,
-            conformanceToSuggest
-        );
+          auto diag = valueDecl->diagnose(
+              diag::distributed_actor_target_result_not_codable,
+              resultType,
+              valueDecl,
+              conformanceToSuggest
+          );
 
-        if (isCodableRequirement) {
-          if (auto resultNominalType = resultType->getAnyNominal()) {
-            addCodableFixIt(resultNominalType, diag);
+          if (isCodableRequirement) {
+            if (auto resultNominalType = resultType->getAnyNominal()) {
+              addCodableFixIt(resultNominalType, diag);
+            }
           }
-        }
-      } // end if: diagnose
-      
-      return true;
+        } // end if: diagnose
+
+        return true;
+      }
     }
   }
 
-  return false;
+    return false;
 }
 
 bool swift::checkDistributedActorSystem(const NominalTypeDecl *system) {
@@ -494,74 +500,35 @@ bool CheckDistributedFunctionRequest::evaluate(
   if (!C.getLoadedModule(C.Id_Distributed))
     return true;
 
-  // === All parameters and the result type must conform
-  // SerializationRequirement
-  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationRequirements;
-  if (auto extension = dyn_cast<ExtensionDecl>(DC)) {
-    auto actorOrProtocol = extension->getExtendedNominal();
-    if (auto actor = dyn_cast<ClassDecl>(actorOrProtocol)) {
-      assert(actor->isAnyActor());
-      serializationRequirements = getDistributedSerializationRequirementProtocols(
-          getDistributedActorSystemType(actor)->getAnyNominal(),
-          C.getProtocol(KnownProtocolKind::DistributedActorSystem));
-    } else if (auto protocol = dyn_cast<ProtocolDecl>(actorOrProtocol)) {
-      extractDistributedSerializationRequirements(
-          C, protocol->getGenericRequirements(),
-          /*into=*/serializationRequirements);
-      extractDistributedSerializationRequirements(
-          C, extension->getGenericRequirements(),
-          /*into=*/serializationRequirements);
-    } else {
-      // ignore
-    }
-  } else if (auto actor = dyn_cast<ClassDecl>(DC)) {
-    serializationRequirements = getDistributedSerializationRequirementProtocols(
-        getDistributedActorSystemType(actor)->getAnyNominal(),
-        C.getProtocol(KnownProtocolKind::DistributedActorSystem));
-  } else if (isa<ProtocolDecl>(DC)) {
-    if (auto seqReqTy =
-        getConcreteReplacementForMemberSerializationRequirement(func)) {
-      auto layout = seqReqTy->getExistentialLayout();
-      for (auto req : layout.getProtocols()) {
-        serializationRequirements.insert(req);
-      }
-    }
+  Type serializationReqType = getConcreteReplacementForMemberSerializationRequirement(func);
+  for (auto param: *func->getParameters()) {
 
-    // The distributed actor constrained protocol has no serialization requirements
-    // or actor system defined, so these will only be enforced, by implementations
-    // of DAs conforming to it, skip checks here.
-    if (serializationRequirements.empty()) {
-      return false;
-    }
-  } else {
-    llvm_unreachable("Distributed function detected in type other than extension, "
-                     "distributed actor, or protocol! This should not be possible "
-                     ", please file a bug.");
-  }
+    // --- Check the parameter conforming to serialization requirements
+    if (serializationReqType && !serializationReqType->hasError()) {
+      // If the requirement is exactly `Codable` we diagnose it ia bit nicer.
+      auto serializationRequirementIsCodable =
+          checkDistributedSerializationRequirementIsExactlyCodable(
+              C, serializationReqType);
 
-  // If the requirement is exactly `Codable` we diagnose it ia bit nicer.
-  auto serializationRequirementIsCodable =
-      checkDistributedSerializationRequirementIsExactlyCodable(
-          C, serializationRequirements);
+      // --- Check parameters for 'SerializationRequirement' conformance
+      auto paramTy = func->mapTypeIntoContext(param->getInterfaceType());
 
-  for (auto param : *func->getParameters()) {
-    // --- Check parameters for 'Codable' conformance
-    auto paramTy = func->mapTypeIntoContext(param->getInterfaceType());
+      auto srl = serializationReqType->getExistentialLayout();
+      for (auto req: srl.getProtocols()) {
+        if (TypeChecker::conformsToProtocol(paramTy, req, module).isInvalid()) {
+          auto diag = func->diagnose(
+              diag::distributed_actor_func_param_not_codable,
+              param->getArgumentName().str(), param->getInterfaceType(),
+              func->getDescriptiveKind(),
+              serializationRequirementIsCodable ? "Codable"
+                                                : req->getNameStr());
 
-    for (auto req : serializationRequirements) {
-      if (TypeChecker::conformsToProtocol(paramTy, req, module).isInvalid()) {
-        auto diag = func->diagnose(
-            diag::distributed_actor_func_param_not_codable,
-            param->getArgumentName().str(), param->getInterfaceType(),
-            func->getDescriptiveKind(),
-            serializationRequirementIsCodable ? "Codable"
-                                              : req->getNameStr());
+          if (auto paramNominalTy = paramTy->getAnyNominal()) {
+            addCodableFixIt(paramNominalTy, diag);
+          } // else, no nominal type to suggest the fixit for, e.g. a closure
 
-        if (auto paramNominalTy = paramTy->getAnyNominal()) {
-          addCodableFixIt(paramNominalTy, diag);
-        } // else, no nominal type to suggest the fixit for, e.g. a closure
-
-        return true;
+          return true;
+        }
       }
     }
 
@@ -598,10 +565,12 @@ bool CheckDistributedFunctionRequest::evaluate(
     }
   }
 
-  // --- Result type must be either void or a codable type
-  if (checkDistributedTargetResultType(module, func, serializationRequirements,
-                                       /*diagnose=*/true)) {
-    return true;
+  if (serializationReqType && !serializationReqType->hasError()) {
+    // --- Result type must be either void or a codable type
+    if (checkDistributedTargetResultType(module, func, serializationReqType,
+        /*diagnose=*/true)) {
+      return true;
+    }
   }
 
   return false;
@@ -649,13 +618,15 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
       DC->getSelfNominalTypeDecl()->getDistributedActorSystemProperty();
   auto systemDecl = systemVar->getInterfaceType()->getAnyNominal();
 
-  auto serializationRequirements =
-      getDistributedSerializationRequirementProtocols(
-          systemDecl,
-          C.getProtocol(KnownProtocolKind::DistributedActorSystem));
+//  auto serializationRequirements =
+//      getDistributedSerializationRequirementProtocols(
+//          systemDecl,
+//          C.getProtocol(KnownProtocolKind::DistributedActorSystem));
+  auto serializationRequirement =
+      getConcreteReplacementForMemberSerializationRequirement(systemVar);
 
   auto module = var->getModuleContext();
-  if (checkDistributedTargetResultType(module, var, serializationRequirements, diagnose)) {
+  if (checkDistributedTargetResultType(module, var, serializationRequirement, diagnose)) {
     return true;
   }
 
@@ -762,6 +733,7 @@ bool TypeChecker::checkDistributedFunc(FuncDecl *func) {
   return swift::checkDistributedFunction(func);
 }
 
+// TODO(distributed): Remove this entirely and rely on generic signature and getConcrete to implement checks
 llvm::SmallPtrSet<ProtocolDecl *, 2>
 swift::getDistributedSerializationRequirementProtocols(
     NominalTypeDecl *nominal, ProtocolDecl *protocol) {

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -498,8 +498,22 @@ bool CheckDistributedFunctionRequest::evaluate(
   // SerializationRequirement
   llvm::SmallPtrSet<ProtocolDecl *, 2> serializationRequirements;
   if (auto extension = dyn_cast<ExtensionDecl>(DC)) {
-    serializationRequirements = extractDistributedSerializationRequirements(
-        C, extension->getGenericRequirements());
+    auto actorOrProtocol = extension->getExtendedNominal();
+    if (auto actor = dyn_cast<ClassDecl>(actorOrProtocol)) {
+      assert(actor->isAnyActor());
+      serializationRequirements = getDistributedSerializationRequirementProtocols(
+          getDistributedActorSystemType(actor)->getAnyNominal(),
+          C.getProtocol(KnownProtocolKind::DistributedActorSystem));
+    } else if (auto protocol = dyn_cast<ProtocolDecl>(actorOrProtocol)) {
+      extractDistributedSerializationRequirements(
+          C, protocol->getGenericRequirements(),
+          /*into=*/serializationRequirements);
+      extractDistributedSerializationRequirements(
+          C, extension->getGenericRequirements(),
+          /*into=*/serializationRequirements);
+    } else {
+      // ignore
+    }
   } else if (auto actor = dyn_cast<ClassDecl>(DC)) {
     serializationRequirements = getDistributedSerializationRequirementProtocols(
         getDistributedActorSystemType(actor)->getAnyNominal(),
@@ -546,6 +560,7 @@ bool CheckDistributedFunctionRequest::evaluate(
         if (auto paramNominalTy = paramTy->getAnyNominal()) {
           addCodableFixIt(paramNominalTy, diag);
         } // else, no nominal type to suggest the fixit for, e.g. a closure
+
         return true;
       }
     }
@@ -740,11 +755,11 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
   (void)nominal->getDistributedActorIDProperty();
 }
 
-void TypeChecker::checkDistributedFunc(FuncDecl *func) {
+bool TypeChecker::checkDistributedFunc(FuncDecl *func) {
   if (!func->isDistributed())
-    return;
+    return false;
 
-  swift::checkDistributedFunction(func);
+  return swift::checkDistributedFunction(func);
 }
 
 llvm::SmallPtrSet<ProtocolDecl *, 2>

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -377,11 +377,16 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
 static bool checkDistributedTargetResultType(
     ModuleDecl *module, ValueDecl *valueDecl,
     Type serializationRequirement,
+    llvm::SmallPtrSet<ProtocolDecl *, 2> serializationRequirements,
     bool diagnose) {
   auto &C = valueDecl->getASTContext();
 
-  if (!serializationRequirement || serializationRequirement->hasError())
+  if (serializationRequirement && serializationRequirement->hasError()) {
+    return false;
+  }
+  if ((!serializationRequirement || serializationRequirement->hasError()) && serializationRequirements.empty()) {
     return false; // error of the type would be diagnosed elsewhere
+  }
 
   Type resultType;
   if (auto func = dyn_cast<FuncDecl>(valueDecl)) {
@@ -395,37 +400,43 @@ static bool checkDistributedTargetResultType(
   if (resultType->isVoid())
     return false;
 
+
+  // Collect extra "SerializationRequirement: SomeProtocol" requirements
+  if (serializationRequirement && !serializationRequirement->hasError()) {
+    auto srl = serializationRequirement->getExistentialLayout();
+    for (auto s: srl.getProtocols()) {
+      serializationRequirements.insert(s);
+    }
+  }
+
   auto isCodableRequirement =
       checkDistributedSerializationRequirementIsExactlyCodable(
           C, serializationRequirement);
 
-  if (serializationRequirement && !serializationRequirement->hasError()) {
-    auto srl = serializationRequirement->getExistentialLayout();
-    for (auto serializationReq: srl.getProtocols()) {
-      auto conformance =
-          TypeChecker::conformsToProtocol(resultType, serializationReq, module);
-      if (conformance.isInvalid()) {
-        if (diagnose) {
-          llvm::StringRef conformanceToSuggest = isCodableRequirement ?
-                                                 "Codable" : // Codable is a typealias, easier to diagnose like that
-                                                 serializationReq->getNameStr();
+  for (auto serializationReq: serializationRequirements) {
+    auto conformance =
+        TypeChecker::conformsToProtocol(resultType, serializationReq, module);
+    if (conformance.isInvalid()) {
+      if (diagnose) {
+        llvm::StringRef conformanceToSuggest = isCodableRequirement ?
+                                               "Codable" : // Codable is a typealias, easier to diagnose like that
+                                               serializationReq->getNameStr();
 
-          auto diag = valueDecl->diagnose(
-              diag::distributed_actor_target_result_not_codable,
-              resultType,
-              valueDecl,
-              conformanceToSuggest
-          );
+        auto diag = valueDecl->diagnose(
+            diag::distributed_actor_target_result_not_codable,
+            resultType,
+            valueDecl,
+            conformanceToSuggest
+        );
 
-          if (isCodableRequirement) {
-            if (auto resultNominalType = resultType->getAnyNominal()) {
-              addCodableFixIt(resultNominalType, diag);
-            }
+        if (isCodableRequirement) {
+          if (auto resultNominalType = resultType->getAnyNominal()) {
+            addCodableFixIt(resultNominalType, diag);
           }
-        } // end if: diagnose
+        }
+      } // end if: diagnose
 
-        return true;
-      }
+      return true;
     }
   }
 
@@ -493,16 +504,16 @@ bool CheckDistributedFunctionRequest::evaluate(
   }
 
   auto &C = func->getASTContext();
-  auto DC = func->getDeclContext();
   auto module = func->getParentModule();
 
   /// If no distributed module is available, then no reason to even try checks.
   if (!C.getLoadedModule(C.Id_Distributed))
     return true;
 
-  Type serializationReqType = getConcreteReplacementForMemberSerializationRequirement(func);
-  for (auto param: *func->getParameters()) {
+  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationRequirements;
+  Type serializationReqType = getSerializationRequirementTypesForMember(func, serializationRequirements);
 
+  for (auto param: *func->getParameters()) {
     // --- Check the parameter conforming to serialization requirements
     if (serializationReqType && !serializationReqType->hasError()) {
       // If the requirement is exactly `Codable` we diagnose it ia bit nicer.
@@ -565,12 +576,11 @@ bool CheckDistributedFunctionRequest::evaluate(
     }
   }
 
-  if (serializationReqType && !serializationReqType->hasError()) {
-    // --- Result type must be either void or a codable type
-    if (checkDistributedTargetResultType(module, func, serializationReqType,
-        /*diagnose=*/true)) {
-      return true;
-    }
+  // --- Result type must be either void or a serialization requirement conforming type
+  if (checkDistributedTargetResultType(
+      module, func, serializationReqType, serializationRequirements,
+      /*diagnose=*/true)) {
+    return true;
   }
 
   return false;
@@ -618,15 +628,16 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
       DC->getSelfNominalTypeDecl()->getDistributedActorSystemProperty();
   auto systemDecl = systemVar->getInterfaceType()->getAnyNominal();
 
-//  auto serializationRequirements =
-//      getDistributedSerializationRequirementProtocols(
-//          systemDecl,
-//          C.getProtocol(KnownProtocolKind::DistributedActorSystem));
+  auto serializationRequirements =
+      getDistributedSerializationRequirementProtocols(
+          systemDecl,
+          C.getProtocol(KnownProtocolKind::DistributedActorSystem));
+
   auto serializationRequirement =
-      getConcreteReplacementForMemberSerializationRequirement(systemVar);
+      getSerializationRequirementTypesForMember(systemVar, serializationRequirements);
 
   auto module = var->getModuleContext();
-  if (checkDistributedTargetResultType(module, var, serializationRequirement, diagnose)) {
+  if (checkDistributedTargetResultType(module, var, serializationRequirement, serializationRequirements, diagnose)) {
     return true;
   }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2775,6 +2775,14 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &eval,
   // So, build out the body now.
   ASTScope::expandFunctionBody(AFD);
 
+  if (AFD->isDistributedThunk()) {
+    if (auto func = dyn_cast<FuncDecl>(AFD)) {
+      if (TypeChecker::checkDistributedFunc(func)) {
+        return errorBody();
+      }
+    }
+  }
+
   // Type check the function body if needed.
   bool hadError = false;
   if (!alreadyTypeChecked) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1127,7 +1127,9 @@ diagnosePotentialUnavailability(SourceRange ReferenceRange,
 void checkDistributedActor(SourceFile *SF, NominalTypeDecl *decl);
 
 /// Type check a single 'distributed func' declaration.
-void checkDistributedFunc(FuncDecl *func);
+///
+/// Returns `true` if there was an error.
+bool checkDistributedFunc(FuncDecl *func);
 
 bool checkAvailability(SourceRange ReferenceRange,
                        AvailabilityContext Availability,

--- a/test/Distributed/distributed_actor_func_param_not_conforming_req_full.swift
+++ b/test/Distributed/distributed_actor_func_param_not_conforming_req_full.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2> %t/output.txt || echo 'failed expectedly'
+// RUN: %FileCheck %s < %t/output.txt
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Distributed
+
+// Notes:
+// This test specifically is not just a -typecheck -verify test but attempts to generate the whole module.
+// This is because we may be emitting errors but otherwise still attempt to emit a thunk for an "error-ed"
+// distributed function, which would then crash in later phases of compilation when we try to get types
+// of the `func` the THUNK is based on.
+
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+distributed actor Service {
+}
+
+extension Service {
+  distributed func boombox(_ id: Box) async throws {}
+  // CHECK: parameter '' of type 'Box' in distributed instance method does not conform to serialization requirement 'Codable'
+
+  distributed func boxIt() async throws -> Box { fatalError() }
+  // CHECK: result type 'Box' of distributed instance method 'boxIt' does not conform to serialization requirement 'Codable'
+}
+
+public enum Box: Hashable { case boom }
+
+@main struct Main {
+  static func main() async {
+    try? await Service(actorSystem: .init()).boombox(Box.boom)
+  }
+}
+

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -82,7 +82,7 @@ extension NoSerializationRequirementYet
 
 extension NoSerializationRequirementYet
   where SerializationRequirement: Codable {
-  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test4' does not conform to serialization requirement 'Codable'}}
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test4' does not conform to serialization requirement 'Decodable'}}
   distributed func test4() -> NotCodable {
     .init()
   }


### PR DESCRIPTION
**Problem:** We would properly diagnose the missing conformance; but the compiler would still try to emit a thunk for the errored `func`. Tests which only `-typecheck -verify` would not catch this issue because it is _after_ type checking.

**The fix:** This prevents distributed thunks from being generated when the func they are based on already has errors -- otherwise we can run into missing types and null pointers as we try to generate the thunk.
a
**Radar:** rdar://116261701

And found a follow up we should do: rdar://117677422