### PR TITLE
🍒[5.10][Distributed] Don't crash in thunk generation when missing SR conformance

### DIFF
--- a/include/swift/AST/ASTSynthesis.h
+++ b/include/swift/AST/ASTSynthesis.h
@@ -41,7 +41,7 @@ enum SingletonTypeSynthesizer {
   _any,
   _bridgeObject,
   _error,
-  _executor,
+  _executor, // the 'BuiltinExecutor' type
   _job,
   _nativeObject,
   _never,
@@ -49,7 +49,8 @@ enum SingletonTypeSynthesizer {
   _rawUnsafeContinuation,
   _void,
   _word,
-  _serialExecutor,
+  _executorProtocol, // the '_Concurrency.Executor' protocol
+  _serialExecutor, // the '_Concurrency.SerialExecutor' protocol
 };
 inline Type synthesizeType(SynthesisContext &SC,
                            SingletonTypeSynthesizer kind) {
@@ -66,8 +67,14 @@ inline Type synthesizeType(SynthesisContext &SC,
   case _void: return SC.Context.TheEmptyTupleType;
   case _word: return BuiltinIntegerType::get(BuiltinIntegerWidth::pointer(),
                                              SC.Context);
-  case _serialExecutor:
+  case _executorProtocol:
+    return SC.Context.getProtocol(KnownProtocolKind::Executor)
+      ->getDeclaredInterfaceType();
+    case _serialExecutor:
     return SC.Context.getProtocol(KnownProtocolKind::SerialExecutor)
+      ->getDeclaredInterfaceType();
+  case _taskExecutor:
+    return SC.Context.getProtocol(KnownProtocolKind::TaskExecutor)
       ->getDeclaredInterfaceType();
   }
 }

--- a/include/swift/AST/ASTSynthesis.h
+++ b/include/swift/AST/ASTSynthesis.h
@@ -41,7 +41,7 @@ enum SingletonTypeSynthesizer {
   _any,
   _bridgeObject,
   _error,
-  _executor, // the 'BuiltinExecutor' type
+  _executor,
   _job,
   _nativeObject,
   _never,
@@ -49,8 +49,7 @@ enum SingletonTypeSynthesizer {
   _rawUnsafeContinuation,
   _void,
   _word,
-  _executorProtocol, // the '_Concurrency.Executor' protocol
-  _serialExecutor, // the '_Concurrency.SerialExecutor' protocol
+  _serialExecutor,
 };
 inline Type synthesizeType(SynthesisContext &SC,
                            SingletonTypeSynthesizer kind) {
@@ -67,14 +66,8 @@ inline Type synthesizeType(SynthesisContext &SC,
   case _void: return SC.Context.TheEmptyTupleType;
   case _word: return BuiltinIntegerType::get(BuiltinIntegerWidth::pointer(),
                                              SC.Context);
-  case _executorProtocol:
-    return SC.Context.getProtocol(KnownProtocolKind::Executor)
-      ->getDeclaredInterfaceType();
-    case _serialExecutor:
+  case _serialExecutor:
     return SC.Context.getProtocol(KnownProtocolKind::SerialExecutor)
-      ->getDeclaredInterfaceType();
-  case _taskExecutor:
-    return SC.Context.getProtocol(KnownProtocolKind::TaskExecutor)
       ->getDeclaredInterfaceType();
   }
 }

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -91,12 +91,6 @@ llvm::SmallPtrSet<ProtocolDecl *, 2>
 getDistributedSerializationRequirementProtocols(
     NominalTypeDecl *decl, ProtocolDecl* protocol);
 
-/// Desugar and flatten the `SerializationRequirement` type into a set of
-/// specific protocol declarations.
-llvm::SmallPtrSet<ProtocolDecl *, 2>
-flattenDistributedSerializationTypeToRequiredProtocols(
-    TypeBase *serializationRequirement);
-
 /// Check if the `allRequirements` represent *exactly* the
 /// `Encodable & Decodable` (also known as `Codable`) requirement.
 ///

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -115,6 +115,6 @@ getDistributedSerializationRequirements(
     ProtocolDecl *protocol,
     llvm::SmallPtrSetImpl<ProtocolDecl *> &requirementProtos);
 
-// ==== ------------------------------------------------------------------------
+}
 
 #endif /* SWIFT_DECL_DISTRIBUTEDDECL_H */

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -97,7 +97,7 @@ getDistributedSerializationRequirementProtocols(
 /// If so, we can emit slightly nicer diagnostics.
 bool checkDistributedSerializationRequirementIsExactlyCodable(
     ASTContext &C,
-    const llvm::SmallPtrSetImpl<ProtocolDecl *> &allRequirements);
+    Type type);
 
 /// Get the `SerializationRequirement`, explode it into the specific
 /// protocol requirements and insert them into `requirements`.

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -123,9 +123,11 @@ getDistributedSerializationRequirements(
 /// Given any set of generic requirements, locate those which are about the
 /// `SerializationRequirement`. Those need to be applied in the parameter and
 /// return type checking of distributed targets.
-llvm::SmallPtrSet<ProtocolDecl *, 2>
+void
 extractDistributedSerializationRequirements(
-    ASTContext &C, ArrayRef<Requirement> allRequirements);
+    ASTContext &C,
+    ArrayRef<Requirement> allRequirements,
+    llvm::SmallPtrSet<ProtocolDecl *, 2> &into);
 
 }
 

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -50,7 +50,8 @@ Type getDistributedActorIDType(NominalTypeDecl *actor);
 /// Similar to `getDistributedSerializationRequirementType`, however, from the
 /// perspective of a concrete function. This way we're able to get the
 /// serialization requirement for specific members, also in protocols.
-Type getConcreteReplacementForMemberSerializationRequirement(ValueDecl *member);
+Type getSerializationRequirementTypesForMember(
+    ValueDecl *member, llvm::SmallPtrSet<ProtocolDecl *, 2> &serializationRequirements);
 
 /// Get specific 'SerializationRequirement' as defined in 'nominal'
 /// type, which must conform to the passed 'protocol' which is expected
@@ -113,17 +114,6 @@ getDistributedSerializationRequirements(
     NominalTypeDecl *decl,
     ProtocolDecl *protocol,
     llvm::SmallPtrSetImpl<ProtocolDecl *> &requirementProtos);
-
-/// Given any set of generic requirements, locate those which are about the
-/// `SerializationRequirement`. Those need to be applied in the parameter and
-/// return type checking of distributed targets.
-void
-extractDistributedSerializationRequirements(
-    ASTContext &C,
-    ArrayRef<Requirement> allRequirements,
-    llvm::SmallPtrSet<ProtocolDecl *, 2> &into);
-
-}
 
 // ==== ------------------------------------------------------------------------
 

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -178,13 +178,7 @@ Type swift::getDistributedActorSystemResultHandlerType(
   auto module = system->getParentModule();
   Type selfType = system->getSelfInterfaceType();
   auto conformance = module->lookupConformance(selfType, DAS);
-  auto witness =
-      conformance.getTypeWitnessByName(selfType, ctx.Id_ResultHandler);
-  if (auto alias = dyn_cast<TypeAliasType>(witness.getPointer())) {
-    return alias->getDecl()->getUnderlyingType();
-  } else {
-    return witness;
-  }
+  return conformance.getTypeWitnessByName(selfType, ctx.Id_ResultHandler);
 }
 
 Type swift::getDistributedActorSystemInvocationEncoderType(NominalTypeDecl *system) {

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -110,7 +110,7 @@ Type swift::getSerializationRequirementTypesForMember(
   auto SerReqAssocType = DA->getAssociatedType(C.Id_SerializationRequirement)
       ->getDeclaredInterfaceType();
 
-  if (DC->getSelfProtocolDecl() || isa<ExtensionDecl>(DC)) {
+  if (DC->getSelfProtocolDecl()) {
     GenericSignature signature;
     if (auto *genericContext = member->getAsGenericContext()) {
       signature = genericContext->getGenericSignature();

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -119,15 +119,8 @@ Type swift::getSerializationRequirementTypesForMember(
     }
 
     // Also store all `SerializationRequirement : SomeProtocol` requirements
-    for (auto requirement: signature.getRequirements()) {
-      if (requirement.getFirstType()->isEqual(SerReqAssocType) &&
-          requirement.getKind() == RequirementKind::Conformance) {
-        if (auto nominal = requirement.getSecondType()->getAnyNominal()) {
-          if (auto protocol = dyn_cast<ProtocolDecl>(nominal)) {
-            serializationRequirements.insert(protocol);
-          }
-        }
-      }
+    for (auto proto: signature->getRequiredProtocols(SerReqAssocType)) {
+      serializationRequirements.insert(proto);
     }
 
     // Note that this may be null, e.g. if we're a distributed func inside

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1224,14 +1224,13 @@ swift::extractDistributedSerializationRequirements(
       DA->getAssociatedType(C.Id_SerializationRequirement);
 
   for (auto req : allRequirements) {
-    if (req.getSecondType()->isAny()) {
-      continue;
-    }
-    if (!req.getFirstType()->hasDependentMember())
+    // FIXME: Seems unprincipled
+    if (req.getKind() != RequirementKind::SameType &&
+        req.getKind() != RequirementKind::Conformance)
       continue;
 
     if (auto dependentMemberType =
-            req.getFirstType()->castTo<DependentMemberType>()) {
+            req.getFirstType()->getAs<DependentMemberType>()) {
       if (dependentMemberType->getAssocType() == daSerializationReqAssocType) {
         auto layout = req.getSecondType()->getExistentialLayout();
         for (auto p : layout.getProtocols()) {

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -95,8 +95,9 @@ Type swift::getConcreteReplacementForProtocolActorSystemType(ValueDecl *member) 
   llvm_unreachable("Unable to fetch ActorSystem type!");
 }
 
-Type swift::getConcreteReplacementForMemberSerializationRequirement(
-    ValueDecl *member) {
+Type swift::getSerializationRequirementTypesForMember(
+    ValueDecl *member,
+    llvm::SmallPtrSet<ProtocolDecl *, 2> &serializationRequirements) {
   auto &C = member->getASTContext();
   auto *DC = member->getDeclContext();
   auto DA = C.getDistributedActorDecl();
@@ -115,6 +116,18 @@ Type swift::getConcreteReplacementForMemberSerializationRequirement(
       signature = genericContext->getGenericSignature();
     } else {
       signature = DC->getGenericSignatureOfContext();
+    }
+
+    // Also store all `SerializationRequirement : SomeProtocol` requirements
+    for (auto requirement: signature.getRequirements()) {
+      if (requirement.getFirstType()->isEqual(SerReqAssocType) &&
+          requirement.getKind() == RequirementKind::Conformance) {
+        if (auto nominal = requirement.getSecondType()->getAnyNominal()) {
+          if (auto protocol = dyn_cast<ProtocolDecl>(nominal)) {
+            serializationRequirements.insert(protocol);
+          }
+        }
+      }
     }
 
     // Note that this may be null, e.g. if we're a distributed func inside
@@ -1220,33 +1233,6 @@ AbstractFunctionDecl::isDistributedTargetInvocationResultHandlerOnReturn() const
     }
 
     return true;
-}
-
-void
-swift::extractDistributedSerializationRequirements(
-    ASTContext &C,
-    ArrayRef<Requirement> allRequirements,
-    llvm::SmallPtrSet<ProtocolDecl *, 2> &into) {
-  auto DA = C.getDistributedActorDecl();
-  auto daSerializationReqAssocType =
-      DA->getAssociatedType(C.Id_SerializationRequirement);
-
-  for (auto req : allRequirements) {
-    // FIXME: Seems unprincipled
-    if (req.getKind() != RequirementKind::SameType &&
-        req.getKind() != RequirementKind::Conformance)
-      continue;
-
-    if (auto dependentMemberType =
-            req.getFirstType()->getAs<DependentMemberType>()) {
-      if (dependentMemberType->getAssocType() == daSerializationReqAssocType) {
-        auto layout = req.getSecondType()->getExistentialLayout();
-        for (auto p : layout.getProtocols()) {
-          serializationReqs.insert(p);
-        }
-      }
-    }
-  }
 }
 
 /******************************************************************************/

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -340,21 +340,16 @@ swift::getDistributedSerializationRequirements(
   if (existentialRequirementTy->isAny())
     return true; // we're done here, any means there are no requirements
 
-  if (!existentialRequirementTy->isExistentialType()) {
-    // SerializationRequirement must be an existential type
-    return false;
-  }
-
   ExistentialType *serialReqType = existentialRequirementTy
-                                       ->castTo<ExistentialType>();
+                                       ->getAs<ExistentialType>();
   if (!serialReqType || serialReqType->hasError()) {
     return false;
   }
 
-  auto desugaredTy = serialReqType->getConstraintType()->getDesugaredType();
+  auto desugaredTy = serialReqType->getConstraintType();
   auto flattenedRequirements =
       flattenDistributedSerializationTypeToRequiredProtocols(
-          desugaredTy);
+          desugaredTy.getPointer());
   for (auto p : flattenedRequirements) {
     requirementProtos.insert(p);
   }
@@ -565,25 +560,19 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
 
   // --- Check requirement: conforms_to: Act DistributedActor
   auto actorReq = requirements[0];
-  auto distActorTy = C.getProtocol(KnownProtocolKind::DistributedActor)
-                       ->getInterfaceType()
-                       ->getMetatypeInstanceType();
   if (actorReq.getKind() != RequirementKind::Conformance) {
     return false;
   }
-  if (!actorReq.getSecondType()->isEqual(distActorTy)) {
+  if (!actorReq.getProtocolDecl()->isSpecificProtocol(KnownProtocolKind::DistributedActor)) {
     return false;
   }
 
   // --- Check requirement: conforms_to: Err Error
   auto errorReq = requirements[1];
-  auto errorTy = C.getProtocol(KnownProtocolKind::Error)
-                     ->getInterfaceType()
-                     ->getMetatypeInstanceType();
   if (errorReq.getKind() != RequirementKind::Conformance) {
     return false;
   }
-  if (!errorReq.getSecondType()->isEqual(errorTy)) {
+  if (!errorReq.getProtocolDecl()->isSpecificProtocol(KnownProtocolKind::Error)) {
     return false;
   }
 
@@ -598,10 +587,9 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
     assert(ResParam && "Non void function, yet no Res generic parameter found");
     if (auto func = dyn_cast<FuncDecl>(this)) {
       auto resultType = func->mapTypeIntoContext(func->getResultInterfaceType())
-                            ->getMetatypeInstanceType()
-                            ->getDesugaredType();
+                            ->getMetatypeInstanceType();
       auto resultParamType = func->mapTypeIntoContext(
-          ResParam->getInterfaceType()->getMetatypeInstanceType());
+          ResParam->getDeclaredInterfaceType());
       // The result of the function must be the `Res` generic argument.
       if (!resultType->isEqual(resultParamType)) {
         return false;
@@ -797,12 +785,10 @@ AbstractFunctionDecl::isDistributedTargetInvocationEncoderRecordArgument() const
 
       // the <Value> of the RemoteCallArgument<Value>
       auto remoteCallArgValueGenericTy =
-          mapTypeIntoContext(argGenericParams[0]->getInterfaceType())
-              ->getDesugaredType()
-              ->getMetatypeInstanceType();
+          mapTypeIntoContext(argGenericParams[0]->getDeclaredInterfaceType());
       // expected (the <Value> from the recordArgument<Value>)
       auto expectedGenericParamTy = mapTypeIntoContext(
-          ArgumentParam->getInterfaceType()->getMetatypeInstanceType());
+          ArgumentParam->getDeclaredInterfaceType());
 
       if (!remoteCallArgValueGenericTy->isEqual(expectedGenericParamTy)) {
             return false;
@@ -932,11 +918,10 @@ AbstractFunctionDecl::isDistributedTargetInvocationEncoderRecordReturnType() con
   // ...
 
   auto resultType = func->mapTypeIntoContext(argumentParam->getInterfaceType())
-                        ->getMetatypeInstanceType()
-                        ->getDesugaredType();
+                        ->getMetatypeInstanceType();
 
   auto resultParamType = func->mapTypeIntoContext(
-      ArgumentParam->getInterfaceType()->getMetatypeInstanceType());
+      ArgumentParam->getDeclaredInterfaceType());
 
   // The result of the function must be the `Res` generic argument.
   if (!resultType->isEqual(resultParamType)) {
@@ -1046,13 +1031,10 @@ AbstractFunctionDecl::isDistributedTargetInvocationEncoderRecordErrorType() cons
 
     // --- Check requirement: conforms_to: Err Error
     auto errorReq = requirements[0];
-    auto errorTy = C.getProtocol(KnownProtocolKind::Error)
-                       ->getInterfaceType()
-                       ->getMetatypeInstanceType();
     if (errorReq.getKind() != RequirementKind::Conformance) {
       return false;
     }
-    if (!errorReq.getSecondType()->isEqual(errorTy)) {
+    if (!errorReq.getProtocolDecl()->isSpecificProtocol(KnownProtocolKind::Error)) {
       return false;
     }
 
@@ -1139,10 +1121,9 @@ AbstractFunctionDecl::isDistributedTargetInvocationDecoderDecodeNextArgument() c
     // --- Check: Argument: SerializationRequirement
     GenericTypeParamDecl *ArgumentParam = genericParams->getParams()[0];
     auto resultType = func->mapTypeIntoContext(func->getResultInterfaceType())
-                          ->getMetatypeInstanceType()
-                          ->getDesugaredType();
+                          ->getMetatypeInstanceType();
     auto resultParamType = func->mapTypeIntoContext(
-        ArgumentParam->getInterfaceType()->getMetatypeInstanceType());
+        ArgumentParam->getDeclaredInterfaceType());
     // The result of the function must be the `Res` generic argument.
     if (!resultType->isEqual(resultParamType)) {
       return false;
@@ -1237,11 +1218,10 @@ AbstractFunctionDecl::isDistributedTargetInvocationResultHandlerOnReturn() const
     // === Check generic parameters in detail
     // --- Check: Argument: SerializationRequirement
     GenericTypeParamDecl *ArgumentParam = genericParams->getParams()[0];
-    auto argumentType = func->mapTypeIntoContext(valueParam->getInterfaceType())
-                            ->getMetatypeInstanceType()
-                            ->getDesugaredType();
+    auto argumentType = func->mapTypeIntoContext(
+        valueParam->getInterfaceType()->getMetatypeInstanceType());
     auto resultParamType = func->mapTypeIntoContext(
-        ArgumentParam->getInterfaceType()->getMetatypeInstanceType());
+        ArgumentParam->getDeclaredInterfaceType());
     // The result of the function must be the `Res` generic argument.
     if (!argumentType->isEqual(resultParamType)) {
       return false;
@@ -1270,7 +1250,6 @@ swift::extractDistributedSerializationRequirements(
   auto DA = C.getDistributedActorDecl();
   auto daSerializationReqAssocType =
       DA->getAssociatedType(C.Id_SerializationRequirement);
-  auto daSystemSerializationReqTy = daSerializationReqAssocType->getInterfaceType();
 
   for (auto req : allRequirements) {
     if (req.getSecondType()->isAny()) {
@@ -1281,21 +1260,17 @@ swift::extractDistributedSerializationRequirements(
 
     if (auto dependentMemberType =
             req.getFirstType()->castTo<DependentMemberType>()) {
-      auto dependentTy =
-          dependentMemberType->getAssocType()->getInterfaceType();
-
-      if (dependentTy->isEqual(daSystemSerializationReqTy)) {
+      if (dependentMemberType->getAssocType() == daSerializationReqAssocType) {
         auto requirementProto = req.getSecondType();
         if (auto proto = dyn_cast_or_null<ProtocolDecl>(
                 requirementProto->getAnyNominal())) {
           serializationReqs.insert(proto);
         } else {
           auto serialReqType = requirementProto->castTo<ExistentialType>()
-                                   ->getConstraintType()
-                                   ->getDesugaredType();
+                                   ->getConstraintType();
           auto flattenedRequirements =
               flattenDistributedSerializationTypeToRequiredProtocols(
-                  serialReqType);
+                  serialReqType.getPointer());
           for (auto p : flattenedRequirements) {
             serializationReqs.insert(p);
           }

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1268,10 +1268,11 @@ AbstractFunctionDecl::isDistributedTargetInvocationResultHandlerOnReturn() const
     return true;
 }
 
-llvm::SmallPtrSet<ProtocolDecl *, 2>
+void
 swift::extractDistributedSerializationRequirements(
-    ASTContext &C, ArrayRef<Requirement> allRequirements) {
-  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs;
+    ASTContext &C,
+    ArrayRef<Requirement> allRequirements,
+    llvm::SmallPtrSet<ProtocolDecl *, 2> &into) {
   auto DA = C.getDistributedActorDecl();
   auto daSerializationReqAssocType =
       DA->getAssociatedType(C.Id_SerializationRequirement);
@@ -1308,8 +1309,6 @@ swift::extractDistributedSerializationRequirements(
       }
     }
   }
-
-  return serializationReqs;
 }
 
 /******************************************************************************/

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -842,8 +842,14 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
     if (!distributedTarget->isDistributed())
       return nullptr;
   }
-
   assert(distributedTarget);
+
+  // This evaluation type-check by now was already computed and cached;
+  // We need to check in order to avoid emitting a THUNK for a distributed func
+  // which had errors; as the thunk then may also cause un-addressable issues and confusion.
+  if (swift::checkDistributedFunction(distributedTarget)) {
+    return nullptr;
+  }
 
   auto &C = distributedTarget->getASTContext();
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2067,7 +2067,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
       return (prop &&
               prop->isFinal() &&
               isa<ClassDecl>(prop->getDeclContext()) &&
-              cast<ClassDecl>(prop->getDeclContext())->isActor() &&
+              cast<ClassDecl>(prop->getDeclContext())->isAnyActor() &&
               !prop->isStatic() &&
               prop->getName() == ctx.Id_unownedExecutor &&
               prop->getInterfaceType()->getAnyNominal() == ctx.getUnownedSerialExecutorDecl());

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -911,8 +911,7 @@ GetDistributedActorArgumentDecodingMethodRequest::evaluate(Evaluator &evaluator,
       continue;
 
     auto paramTy = genericParamList->getParams()[0]
-                       ->getInterfaceType()
-                       ->getMetatypeInstanceType();
+                       ->getDeclaredInterfaceType();
 
     // `decodeNextArgument` should return its generic parameter value
     if (!FD->getResultInterfaceType()->isEqual(paramTy))

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2778,6 +2778,14 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &eval,
   // So, build out the body now.
   ASTScope::expandFunctionBody(AFD);
 
+  if (AFD->isDistributedThunk()) {
+    if (auto func = dyn_cast<FuncDecl>(AFD)) {
+      if (TypeChecker::checkDistributedFunc(func)) {
+        return errorBody();
+      }
+    }
+  }
+
   // Type check the function body if needed.
   bool hadError = false;
   if (!alreadyTypeChecked) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1132,7 +1132,9 @@ diagnosePotentialUnavailability(SourceRange ReferenceRange,
 void checkDistributedActor(SourceFile *SF, NominalTypeDecl *decl);
 
 /// Type check a single 'distributed func' declaration.
-void checkDistributedFunc(FuncDecl *func);
+///
+/// Returns `true` if there was an error.
+bool checkDistributedFunc(FuncDecl *func);
 
 bool checkAvailability(SourceRange ReferenceRange,
                        AvailabilityContext Availability,

--- a/test/Distributed/distributed_actor_func_param_not_conforming_req_full.swift
+++ b/test/Distributed/distributed_actor_func_param_not_conforming_req_full.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2> %t/output.txt || echo 'failed expectedly'
+// RUN: %FileCheck %s < %t/output.txt
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Distributed
+
+// Notes:
+// This test specifically is not just a -typecheck -verify test but attempts to generate the whole module.
+// This is because we may be emitting errors but otherwise still attempt to emit a thunk for an "error-ed"
+// distributed function, which would then crash in later phases of compilation when we try to get types
+// of the `func` the THUNK is based on.
+
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+distributed actor Service {
+}
+
+extension Service {
+  distributed func boombox(_ id: Box) async throws {}
+  // CHECK: parameter '' of type 'Box' in distributed instance method does not conform to serialization requirement 'Codable'
+
+  distributed func boxIt() async throws -> Box { fatalError() }
+  // CHECK: result type 'Box' of distributed instance method 'boxIt' does not conform to serialization requirement 'Codable'
+}
+
+public enum Box: Hashable { case boom }
+
+@main struct Main {
+  static func main() async {
+    try? await Service(actorSystem: .init()).boombox(Box.boom)
+  }
+}
+

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -82,7 +82,7 @@ extension NoSerializationRequirementYet
 
 extension NoSerializationRequirementYet
   where SerializationRequirement: Codable {
-  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test4' does not conform to serialization requirement 'Codable'}}
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test4' does not conform to serialization requirement 'Decodable'}}
   distributed func test4() -> NotCodable {
     .init()
   }

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -88,6 +88,13 @@ extension NoSerializationRequirementYet
   }
 }
 
+extension ProtocolWithChecksSeqReqDA {
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test4' does not conform to serialization requirement 'Codable'}}
+  distributed func test4() -> NotCodable {
+    .init()
+  }
+}
+
 // FIXME(distributed): remove the -verify-ignore-unknown
 // <unknown>:0: error: unexpected error produced: instance method 'recordReturnType' requires that 'NotCodable' conform to 'Decodable'
 // <unknown>:0: error: unexpected error produced: instance method 'recordReturnType' requires that 'NotCodable' conform to 'Encodable'


### PR DESCRIPTION
**Problem:** We would properly diagnose the missing conformance; but the compiler would still try to emit a thunk for the errored func. Tests which only -typecheck -verify would not catch this issue because it is after type checking.
**Solution:** This prevents distributed thunks from being generated when the func they are based on already has errors -- otherwise we can run into missing types and null pointers as we try to generate the thunk.
**Risk:** Low, affects only this specific situation and just avoids emitting thunks when they cannot be correct to begin with -- when the funk is broken.
**Impact:** Only distributed functions; This provides a better failure path - rather than a crash, just the expected error reporting.

**Review by:** @xedin @slavapestov 
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift/pull/69501
**Radar:** rdar://116261701

Related radar: rdar://117677422