### PR TITLE
[android][test] Disable a C++ Interop test that doesn't work with clang 14 from LTS NDK 25

### DIFF
--- a/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
@@ -7,6 +7,8 @@
 
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fsyntax-only -c %t/test-stdlib.cpp -I %t -Wall -Werror -Werror=ignored-attributes -Wno-error=unused-command-line-argument
 
+// XFAIL: OS=linux-android, OS=linux-androideabi
+
 //--- print-string.swift
 
 public func printString(_ s: String) {


### PR DESCRIPTION
This is [the last failing test on the community Android CI](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/5647/consoleText):
```
In file included from /home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android-arm64/buildbot_linux/swift-linux-x86_64/test-android-aarch64/Interop/SwiftToCxx/stdlib/Output/stdlib-in-cxx-no-diagnostics-generated-header.cpp.tmp/test-stdlib.cpp:2:
/home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android-arm64/buildbot_linux/swift-linux-x86_64/test-android-aarch64/Interop/SwiftToCxx/stdlib/Output/stdlib-in-cxx-no-diagnostics-generated-header.cpp.tmp/Stringer.h:286:34: error: unknown warning group '-Wunsafe-buffer-usage', ignored [-Werror,-Wunknown-warning-option]
#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
                                 ^
1 error generated.
```
I will re-enable it when we switch the CI to the latest NDK 26, which has a new clang.

@drodriguez, please review.