### PR TITLE
NFC: Use forbidden typechecking prefix in lazy typechecking tests

### DIFF
--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -1,46 +1,54 @@
-// This source file contains intentional type checking errors that should be
-// avoided when compiling with -experimental-lazy-typecheck and emitting module
-// outputs since all the errors occur in regions of the AST that do not
-// need to be type checked in order to emit a module or module interface.
+
+struct NoTypecheck {
+  static let int: Int = 0
+  static func fatalError() -> Never { Swift.fatalError() }
+}
+
+protocol NoTypecheckProto {}
+
+extension NoTypecheck: PublicProto {
+  func req() -> Int { return 0 }
+}
 
 // MARK: - Global functions
 
 public func publicFunc() -> Int {
-  return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+  return NoTypecheck.int
 }
 
 public func publicFuncWithDefaultArg(_ x: Int = 1) -> Int {
-  return doesNotExist() // expected-error {{cannot find 'doesNotExist' in scope}}
+  return NoTypecheck.int
 }
 
 package func packageFunc() -> Int {
-  return false // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+  return NoTypecheck.int
 }
 
-func internalFunc() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
-  return 1
+func internalFunc() -> NoTypecheck {
+  return NoTypecheck()
 }
 
 @inlinable func inlinableFunc() -> Int {
   return 1
 }
 
-private func privateFunc() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
-  return 1
+private func privateFunc() -> NoTypecheck {
+  return NoTypecheck()
 }
 
 public func constrainedGenericPublicFunction<T>(_ t: T) where T: PublicProto {
-  doesNotExist() // expected-error {{cannot find 'doesNotExist' in scope}}
+  _ = NoTypecheck()
 }
 
 @_specialize(exported: true, where T == PublicProto)
 public func publicSpecializedFunc<T>(_ t: T) -> T {
-  return doesNotExist() // expected-error {{cannot find 'doesNotExist' in scope}}
+  _ = NoTypecheck()
+  return t
 }
 
 @available(SwiftStdlib 5.1, *)
-public func publicFuncWithOpaqueReturnType() -> some PublicProto { // expected-note {{opaque return type declared here}}
-  return 1 // expected-error {{return type of global function 'publicFuncWithOpaqueReturnType()' requires that 'Int' conform to 'PublicProto'}}
+public func publicFuncWithOpaqueReturnType() -> some PublicProto {
+  return NoTypecheck()
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -58,22 +66,24 @@ public func publicFuncWithOpaqueReturnType() -> some PublicProto { // expected-n
 public struct PublicWrapper<T> {
   public var wrappedValue: T {
     get {
-      _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+      NoTypecheck.fatalError()
     }
     set {
-      _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+      NoTypecheck.fatalError()
     }
   }
 
   public var projectedValue: PublicWrapper { self }
 
   public init(wrappedValue value: T) {
-    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+    NoTypecheck.fatalError()
   }
 }
 
 @propertyWrapper
-struct InternalWrapper<T> {} // expected-error {{property wrapper type 'InternalWrapper' does not contain a non-static property named 'wrappedValue'}}
+struct InternalWrapper {
+  var wrappedValue: NoTypecheck
+}
 
 // MARK: - Global vars
 
@@ -81,15 +91,20 @@ public var publicGlobalVar: Int = 0
 public var publicGlobalVarInferredType = ""
 public var (publicGlobalVarInferredTuplePatX, publicGlobalVarInferredTuplePatY) = (0, 1)
 
-var internalGlobalVar: DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
-var internalGlobalVarInferredType = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+var internalGlobalVar: NoTypecheck = NoTypecheck()
+var internalGlobalVarInferredType = NoTypecheck()
 
 // MARK: - Nominal types
 
 public protocol EmptyPublicProto {}
 
 public protocol PublicProto {
-  func req() -> Int // expected-note 2 {{protocol requires function 'req()' with type '() -> Int'; add a stub for conformance}}
+  func req() -> Int
+}
+
+public protocol PublicProtoWithAssociatedType {
+  associatedtype A
+  func req() -> A
 }
 
 @rethrows public protocol PublicRethrowsProto {
@@ -100,13 +115,13 @@ public protocol PublicProto {
   func req() throws -> Int
 }
 
-protocol InternalProto {
-  func goodReq() -> Int // expected-note 2 {{protocol requires function 'goodReq()' with type '() -> Int'; add a stub for conformance}}
-  func badReq() -> DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
+protocol InternalProtoWithAssociatedType {
+  associatedtype A
+  func internalReq() -> A
 }
 
 protocol InternalProtoConformingToPublicProto: PublicProto {
-  func internalReq() -> DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  func internalReq() -> NoTypecheck
 }
 
 public struct PublicStruct {
@@ -115,40 +130,44 @@ public struct PublicStruct {
   @PublicWrapper public var publicWrappedProperty = 3.14
 
   public init(x: Int) {
-    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+    self.publicProperty = 1
+    _ = NoTypecheck()
   }
 
   public func publicMethod() -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 
   @MainActor public func publicMainActorMethod() -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 
   public static func publicStaticMethod() {
-    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+    _ = NoTypecheck()
   }
 
-  func internalMethod() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
-    return 1
+  func internalMethod() -> NoTypecheck {
+    return NoTypecheck()
   }
 
-  static func internalStaticMethod() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
-    return 1
+  static func internalStaticMethod() -> NoTypecheck {
+    return NoTypecheck()
   }
 }
 
 public struct PublicGenericStruct<T> {
+  var t: T
+
   public func publicMethod() -> T {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'T'}}
+    _ = NoTypecheck()
+    return t
   }
 }
 
-struct InternalStruct: DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
-  var x: DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
+struct InternalStruct: NoTypecheckProto {
+  var x: NoTypecheck
 
-  func f(_ x: DoesNotExist) {} // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  func f(_ x: NoTypecheck) {}
 }
 
 public class PublicClass {
@@ -156,29 +175,39 @@ public class PublicClass {
   public var publicPropertyInferredType = ""
 
   public init(x: Int) {
-    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+    self.publicProperty = x
+    _ = NoTypecheck()
   }
 
-  // FIXME: TBDGen causes this constructor to be type checked
-//  init(_ x: DoesNotExist) {}
+  convenience init(_ x: NoTypecheck) {
+    NoTypecheck.fatalError()
+  }
 
   public func publicMethod() -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 
   public class func publicClassMethod() {
-    _ = DoesNotExist() // expected-error {{cannot find 'DoesNotExist' in scope}}
+    _ = NoTypecheck()
   }
 
-  // FIXME: TBDGen causes these methods to be type checked
-//  func internalMethod() -> DoesNotExist {}
-//  class func internalClassMethod() -> DoesNotExist {}
+  public static func publicStaticMethod() {
+    _ = NoTypecheck()
+  }
+
+  func internalMethod() -> NoTypecheck {
+    return NoTypecheck()
+  }
+
+  class func internalClassMethod() -> NoTypecheck {
+    return NoTypecheck()
+  }
 }
 
 public class PublicDerivedClass: PublicClass {}
 
-class InternalClass: DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
-  init(x: DoesNotExist) {} // expected-error {{cannot find type 'DoesNotExist' in scope}}
+class InternalClass: NoTypecheckProto {
+  init(x: NoTypecheck) {}
 }
 
 public enum PublicEnum {
@@ -186,18 +215,19 @@ public enum PublicEnum {
   case b(x: Int)
 
   public func publicMethod() -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 
   public var publicComputedVar: Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 }
 
 enum InternalEnum {
-  case bad(DoesNotExist) // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  case bad(NoTypecheck)
 
-  func method() -> DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  func method() -> NoTypecheck {
+    return NoTypecheck()
   }
 }
 
@@ -206,21 +236,25 @@ enum InternalEnum {
 public struct PublicStructConformingToPublicProto: PublicProto {
   public init() {}
   public func req() -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 }
 
 public struct PublicStructIndirectlyConformingToPublicProto: InternalProtoConformingToPublicProto {
   public init() {}
   public func req() -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
+  }
+
+  func internalReq() -> NoTypecheck {
+    return NoTypecheck()
   }
 }
 
 public class PublicClassConformingToPublicProto: PublicProto {
   public init() {}
   public func req() -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 }
 
@@ -228,25 +262,40 @@ public class PublicClassInheritingConformanceToPublicProto: PublicClassConformin
 
 extension String: PublicProto {
   public func req() -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 }
 
-extension String: InternalProto {} // expected-error {{type 'String' does not conform to protocol 'InternalProto'}}
+extension String: InternalProtoWithAssociatedType {
+  func internalReq() -> NoTypecheck {
+    return NoTypecheck()
+  }
+}
 
 extension Int: PublicRethrowsProto {
   public func req() throws -> Int {
-    return true // expected-error {{cannot convert return expression of type 'Bool' to return type 'Int'}}
+    return NoTypecheck.int
   }
 }
 
-struct InternalStructConformingToPublicProto: PublicProto { // expected-error {{type 'InternalStructConformingToPublicProto' does not conform to protocol 'PublicProto'}}
+struct InternalStructConformingToPublicProto: PublicProtoWithAssociatedType {
+  typealias A = NoTypecheck
+  func req() -> A {
+    return NoTypecheck()
+  }
 }
 
-extension InternalStruct: PublicProto { // expected-error {{type 'InternalStruct' does not conform to protocol 'PublicProto'}}
+extension InternalStruct: PublicProtoWithAssociatedType {
+  typealias A = NoTypecheck
+  func req() -> A {
+    return NoTypecheck()
+  }
 }
 
-struct InternalStructConformingToInternalProto: InternalProto { // expected-error {{type 'InternalStructConformingToInternalProto' does not conform to protocol 'InternalProto'}}
+struct InternalStructConformingToInternalProto: InternalProtoWithAssociatedType {
+  func internalReq() -> NoTypecheck {
+    return NoTypecheck()
+  }
 }
 
 struct InternalStructForConstraint {}
@@ -258,7 +307,7 @@ extension PublicGenericStruct: EmptyPublicProto where T == InternalStructForCons
 // MARK: - Type aliases
 
 public typealias PublicStructAlias = PublicStruct
-typealias InternalTypeAlias = DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}}
+typealias InternalTypeAlias = NoTypecheck
 
 // MARK: - Compiler directives
 
@@ -266,7 +315,7 @@ extension PublicStruct {
 #if FLAG
   public static func activeMethod() {}
 #else
-  public static func inactiveMethod() -> DoesNotExist {}
+  public static func inactiveMethod() -> NoTypecheck {}
 #endif
 }
 

--- a/test/ModuleInterface/lazy-typecheck.swift
+++ b/test/ModuleInterface/lazy-typecheck.swift
@@ -1,128 +1,34 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/baseline)
+// RUN: %empty-directory(%t/lazy)
+// RUN: %empty-directory(%t/lazy-skip-all)
+// RUN: %empty-directory(%t/lazy-skip-non-inlinable)
 
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck
-// RUN: %FileCheck %s < %t/lazy_typecheck.swiftinterface
+// (1) Generate a baseline .swiftinterface and build a client against it.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/baseline/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -DFLAG
+// RUN: rm -rf %t/baseline/*.swiftmodule
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -I %t/baseline/
 
-// RUN: rm -rf %t/*.swiftmodule
-// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -I %t
+// (2) Generate a .swiftinterface with -experimental-lazy-typecheck and build the client against it.
+//     The .swiftinterface should be identical to the baseline and avoid triggering typechecking
+//     for any "NoTypecheck" decls.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/lazy/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck
+// RUN: rm -rf %t/lazy/*.swiftmodule
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -I %t/lazy
+// FIXME: The emitted interfaces should be identical
+// diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy/lazy_typecheck.swiftinterface
 
-// CHECK: import Swift
+// (3) Same as (2), but with -experimental-skip-all-function-bodies added.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/lazy-skip-all/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-exportable-decls -experimental-skip-all-function-bodies
+// RUN: rm -rf %t/lazy-skip-all/*.swiftmodule
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -I %t/lazy-skip-all
+// FIXME: The emitted interfaces should be identical
+// diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy-skip-all/lazy_typecheck.swiftinterface
 
-// CHECK:       public func publicFunc() -> Swift.Int
-// CHECK:       publicFuncWithDefaultArg(_ x: Swift.Int = 1) -> Swift.Int
-// CHECK:       @inlinable internal func inlinableFunc() -> Swift.Int {
-// CHECK-NEXT:    return 1
-// CHECK-NEXT:  }
-// CHECK:       public func constrainedGenericPublicFunction<T>(_ t: T) where T : lazy_typecheck.PublicProto
-// CHECK:       @_specialize(exported: true, kind: full, where T == any lazy_typecheck.PublicProto)
-// CHECK-NEXT:  public func publicSpecializedFunc<T>(_ t: T) -> T
-// CHECK:       @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-// CHECK-NEXT:  public func publicFuncWithOpaqueReturnType() -> some lazy_typecheck.PublicProto
+// (4) Same as (2), but with -experimental-skip-non-inlinable-function-bodies added.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/lazy-skip-non-inlinable/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies
+// RUN: rm -rf %t/lazy-skip-non-inlinable/*.swiftmodule
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -I %t/lazy-skip-non-inlinable
+// FIXME: The emitted interfaces should be identical
+// diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy-skip-non-inlinable/lazy_typecheck.swiftinterface
 
-// CHECK:       @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-// CHECK-NEXT:  @_alwaysEmitIntoClient public func publicAEICFuncWithOpaqueReturnType() -> some Any {
-// CHECK-NEXT:    if #available(macOS 20, *) {
-// CHECK-NEXT:      return 3
-// CHECK-NEXT:    } else {
-// CHECK-NEXT:      return "hi"
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-
-// CHECK:       public var publicGlobalVar: Swift.Int
-// CHECK:       public var publicGlobalVarInferredType: Swift.String
-// CHECK:       public var (publicGlobalVarInferredTuplePatX, publicGlobalVarInferredTuplePatY): (Swift.Int, Swift.Int)
-// CHECK:       public protocol EmptyPublicProto {
-// CHECK:       }
-// CHECK:       public protocol PublicProto {
-// CHECK:         func req() -> Swift.Int
-// CHECK:       }
-// CHECK:       #if compiler(>=5.3) && $RethrowsProtocol
-// CHECK:       @rethrows public protocol PublicRethrowsProto {
-// CHECK:         func req() throws -> Swift.Int
-// CHECK:       }
-// CHECK:       #endif
-// CHECK:       @MainActor public protocol MainActorProtocol {
-// CHECK:         func req() throws -> Swift.Int
-// CHECK:       }
-// CHECK:       public struct PublicStruct {
-// CHECK:         public var publicProperty: Swift.Int
-// CHECK:         public var publicPropertyInferredType: Swift.String
-// CHECK:         @lazy_typecheck.PublicWrapper @_projectedValueProperty($publicWrappedProperty) public var publicWrappedProperty: Swift.Double {
-// CHECK-NEXT:      get
-// CHECK-NEXT:      set
-// CHECK-NEXT:      _modify
-// CHECK-NEXT:    }
-// CHECK:         public var $publicWrappedProperty: lazy_typecheck.PublicWrapper<Swift.Double> {
-// CHECK-NEXT:      get
-// CHECK-NEXT:    }
-// CHECK:         public init(x: Swift.Int)
-// CHECK:         public func publicMethod() -> Swift.Int
-// CHECK:         @MainActor public func publicMainActorMethod() -> Swift.Int
-// CHECK:         public static func publicStaticMethod()
-// CHECK:       }
-// CHECK:       public struct PublicGenericStruct<T> {
-// CHECK:         public func publicMethod() -> T
-// CHECK:       }
-// CHECK:       public class PublicClass {
-// CHECK:         public var publicProperty: Swift.Int
-// CHECK:         public var publicPropertyInferredType: Swift.String
-// CHECK:         public init(x: Swift.Int)
-// CHECK:         public func publicMethod() -> Swift.Int
-// CHECK:         public class func publicClassMethod()
-// CHECK:         deinit
-// CHECK:       }
-// CHECK:       @_inheritsConvenienceInitializers public class PublicDerivedClass : lazy_typecheck.PublicClass {
-// CHECK:         override public init(x: Swift.Int)
-// CHECK:         deinit
-// CHECK:       }
-// CHECK:       public enum PublicEnum {
-// CHECK:         case a
-// CHECK:         case b(x: Swift.Int)
-// CHECK:         public func publicMethod() -> Swift.Int
-// CHECK:         public var publicComputedVar: Swift.Int {
-// CHECK-NEXT:      get
-// CHECK-NEXT:    }
-// CHECK:       }
-// CHECK:       public struct PublicStructConformingToPublicProto : lazy_typecheck.PublicProto {
-// CHECK:         public init()
-// CHECK:         public func req() -> Swift.Int
-// CHECK:       }
-// CHECK:       public struct PublicStructIndirectlyConformingToPublicProto {
-// CHECK:         public init()
-// CHECK:         public func req() -> Swift.Int
-// CHECK:       }
-// CHECK:       public class PublicClassConformingToPublicProto : lazy_typecheck.PublicProto {
-// CHECK:         public init()
-// CHECK:         public func req() -> Swift.Int
-// CHECK:         deinit
-// CHECK:       }
-// CHECK:       @_inheritsConvenienceInitializers public class PublicClassInheritingConformanceToPublicProto : lazy_typecheck.PublicClassConformingToPublicProto {
-// CHECK:         override public init()
-// CHECK:         deinit
-// CHECK:       }
-// CHECK:       extension Swift.String : lazy_typecheck.PublicProto {
-// CHECK:         public func req() -> Swift.Int
-// CHECK:       }
-// CHECK:       #if compiler(>=5.3) && $RethrowsProtocol
-// CHECK:       extension Swift.Int : lazy_typecheck.PublicRethrowsProto {
-// CHECK:         public func req() throws -> Swift.Int
-// CHECK:       }
-// CHECK:       #endif
-// CHECK:       public typealias PublicStructAlias = lazy_typecheck.PublicStruct
-// CHECK:       extension lazy_typecheck.PublicStruct {
-// CHECK:         public static func activeMethod()
-// CHECK:       }
-// CHECK:       precedencegroup FooPrecedence {
-// CHECK:         associativity: right
-// CHECK:         assignment: true
-// CHECK:       }
-// CHECK:       infix operator <<< : FooPrecedence
-// CHECK:       extension lazy_typecheck.PublicStruct {
-// CHECK:         public static func <<< (lhs: inout lazy_typecheck.PublicStruct, rhs: lazy_typecheck.PublicStruct)
-// CHECK:       }
-// CHECK:       @available(*, unavailable)
-// CHECK-NEXT:  extension lazy_typecheck.PublicGenericStruct : lazy_typecheck.EmptyPublicProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
-// CHECK:       extension lazy_typecheck.PublicStructIndirectlyConformingToPublicProto : lazy_typecheck.PublicProto {}
-
-// CHECK:       @usableFromInline
-// CHECK:       internal protocol _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -1,8 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -enable-library-evolution -parse-as-library -package-name Package -DFLAG -typecheck -verify
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path %t/lazy_typecheck.swiftmodule -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
+// RUN: %empty-directory(%t/baseline)
+// RUN: %empty-directory(%t/lazy-skip-all)
 
-// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t
+// (1) Build the module normally and verify that a client can deserialize it and use its public declarations.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/baseline/lazy_typecheck.swiftmodule
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/baseline
+
+// (2) Verify that a module built with -experimental-lazy-typecheck, -experimental-skip-all-function-bodies,
+//     and -experimental-skip-non-exportable-decls can be used by the same client as in (1).
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-all/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-all
 
 // FIXME: Re-run the test with -experimental-skip-non-inlinable-function-bodies
-

--- a/test/TBD/lazy-typecheck.swift
+++ b/test/TBD/lazy-typecheck.swift
@@ -1,144 +1,16 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %s %t
+// RUN: %empty-directory(%t/baseline)
+// RUN: %empty-directory(%t/lazy-skip-all)
 
-// RUN: %target-swift-frontend -target arm64-apple-macosx10.13 -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
-// RUN: %llvm-readtapi %t/lazy_typecheck.tbd %t/expected.tbd
+// (1) Generate a baseline .tbd file.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/baseline/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG
 
-// REQUIRES: OS=macosx
+// (2) Generate a .tbd file passing -experimental-lazy-typecheck, -experimental-skip-all-function-bodies,
+//     and -experimental-skip-non-exportable-decls. It should be identical to the baseline and avoid
+//     triggering typechecking for any "NoTypecheck" decls.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/lazy-skip-all/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck  -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
+// RUN: diff -u %t/baseline/lazy_typecheck.tbd %t/lazy-skip-all/lazy_typecheck.tbd
 
-//--- expected.tbd
---- !tapi-tbd
-tbd-version:     4
-targets:         [ arm64-macos ]
-flags:           [ not_app_extension_safe ]
-install-name:    ''
-current-version: 0
-compatibility-version: 0
-swift-abi-version: 7
-exports:
-  - targets:         [ arm64-macos ]
-    symbols:         [ '_$s14lazy_typecheck023PublicClassConformingToC5ProtoC3reqSiyFTj',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoC3reqSiyFTq',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCAA0cG0AAMc',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCAA0cG0AAWP',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCACycfC',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCACycfCTj',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCACycfCTq',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCACycfc',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCMa',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCMm',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCMn',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCMo',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCMu',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCN',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCfD',
-                       '_$s14lazy_typecheck023PublicClassConformingToC5ProtoCfd',
-                       '_$s14lazy_typecheck024PublicStructConformingToC5ProtoV3reqSiyF',
-                       '_$s14lazy_typecheck024PublicStructConformingToC5ProtoVAA0cG0AAMc',
-                       '_$s14lazy_typecheck024PublicStructConformingToC5ProtoVAA0cG0AAWP',
-                       '_$s14lazy_typecheck024PublicStructConformingToC5ProtoVACycfC',
-                       '_$s14lazy_typecheck024PublicStructConformingToC5ProtoVMa',
-                       '_$s14lazy_typecheck024PublicStructConformingToC5ProtoVMn',
-                       '_$s14lazy_typecheck024PublicStructConformingToC5ProtoVN',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCACycfC',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCACycfc',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCMa',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCMm',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCMn',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCMo',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCN',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCfD',
-                       '_$s14lazy_typecheck034PublicClassInheritingConformanceToC5ProtoCfd',
-                       '_$s14lazy_typecheck034PublicStructIndirectlyConformingToC5ProtoV3reqSiyF',
-                       '_$s14lazy_typecheck034PublicStructIndirectlyConformingToC5ProtoVAA0cH0AAMc',
-                       '_$s14lazy_typecheck034PublicStructIndirectlyConformingToC5ProtoVAA0cH0AAWP',
-                       '_$s14lazy_typecheck034PublicStructIndirectlyConformingToC5ProtoVACycfC',
-                       '_$s14lazy_typecheck034PublicStructIndirectlyConformingToC5ProtoVMa',
-                       '_$s14lazy_typecheck034PublicStructIndirectlyConformingToC5ProtoVMn',
-                       '_$s14lazy_typecheck034PublicStructIndirectlyConformingToC5ProtoVN',
-                       '_$s14lazy_typecheck10PublicEnumO12publicMethodSiyF', '_$s14lazy_typecheck10PublicEnumO17publicComputedVarSivg',
-                       '_$s14lazy_typecheck10PublicEnumO17publicComputedVarSivpMV',
-                       '_$s14lazy_typecheck10PublicEnumO1ayA2CmFWC', '_$s14lazy_typecheck10PublicEnumO1byACSi_tcACmFWC',
-                       '_$s14lazy_typecheck10PublicEnumOMa', '_$s14lazy_typecheck10PublicEnumOMn',
-                       '_$s14lazy_typecheck10PublicEnumON', '_$s14lazy_typecheck10publicFuncSiyF',
-                       '_$s14lazy_typecheck11PublicClassC06publicD6MethodyyFZTj',
-                       '_$s14lazy_typecheck11PublicClassC06publicD6MethodyyFZTq',
-                       '_$s14lazy_typecheck11PublicClassC12publicMethodSiyFTj', '_$s14lazy_typecheck11PublicClassC12publicMethodSiyFTq',
-                       '_$s14lazy_typecheck11PublicClassC14publicPropertySivMTj',
-                       '_$s14lazy_typecheck11PublicClassC14publicPropertySivMTq',
-                       '_$s14lazy_typecheck11PublicClassC14publicPropertySivgTj',
-                       '_$s14lazy_typecheck11PublicClassC14publicPropertySivgTq',
-                       '_$s14lazy_typecheck11PublicClassC14publicPropertySivpMV',
-                       '_$s14lazy_typecheck11PublicClassC14publicPropertySivsTj',
-                       '_$s14lazy_typecheck11PublicClassC14publicPropertySivsTq',
-                       '_$s14lazy_typecheck11PublicClassC1xACSi_tcfC', '_$s14lazy_typecheck11PublicClassC1xACSi_tcfCTj',
-                       '_$s14lazy_typecheck11PublicClassC1xACSi_tcfCTq', '_$s14lazy_typecheck11PublicClassC1xACSi_tcfc',
-                       '_$s14lazy_typecheck11PublicClassC26publicPropertyInferredTypeSSvMTj',
-                       '_$s14lazy_typecheck11PublicClassC26publicPropertyInferredTypeSSvMTq',
-                       '_$s14lazy_typecheck11PublicClassC26publicPropertyInferredTypeSSvgTj',
-                       '_$s14lazy_typecheck11PublicClassC26publicPropertyInferredTypeSSvgTq',
-                       '_$s14lazy_typecheck11PublicClassC26publicPropertyInferredTypeSSvpMV',
-                       '_$s14lazy_typecheck11PublicClassC26publicPropertyInferredTypeSSvsTj',
-                       '_$s14lazy_typecheck11PublicClassC26publicPropertyInferredTypeSSvsTq',
-                       '_$s14lazy_typecheck11PublicClassCMa', '_$s14lazy_typecheck11PublicClassCMm',
-                       '_$s14lazy_typecheck11PublicClassCMn', '_$s14lazy_typecheck11PublicClassCMo',
-                       '_$s14lazy_typecheck11PublicClassCMu', '_$s14lazy_typecheck11PublicClassCN',
-                       '_$s14lazy_typecheck11PublicClassCfD', '_$s14lazy_typecheck11PublicClassCfd',
-                       '_$s14lazy_typecheck11PublicProtoMp', '_$s14lazy_typecheck11PublicProtoP3reqSiyFTj',
-                       '_$s14lazy_typecheck11PublicProtoP3reqSiyFTq', '_$s14lazy_typecheck11PublicProtoTL',
-                       '_$s14lazy_typecheck11packageFuncSiyF', '_$s14lazy_typecheck12PublicStructV12activeMethodyyFZ',
-                       '_$s14lazy_typecheck12PublicStructV12publicMethodSiyF', '_$s14lazy_typecheck12PublicStructV14publicPropertySivM',
-                       '_$s14lazy_typecheck12PublicStructV14publicPropertySivg',
-                       '_$s14lazy_typecheck12PublicStructV14publicPropertySivpMV',
-                       '_$s14lazy_typecheck12PublicStructV14publicPropertySivs',
-                       '_$s14lazy_typecheck12PublicStructV18publicStaticMethodyyFZ',
-                       '_$s14lazy_typecheck12PublicStructV1xACSi_tcfC', '_$s14lazy_typecheck12PublicStructV21publicMainActorMethodSiyF',
-                       '_$s14lazy_typecheck12PublicStructV21publicWrappedPropertySdvM',
-                       '_$s14lazy_typecheck12PublicStructV21publicWrappedPropertySdvg',
-                       '_$s14lazy_typecheck12PublicStructV21publicWrappedPropertySdvpMV',
-                       '_$s14lazy_typecheck12PublicStructV21publicWrappedPropertySdvs',
-                       '_$s14lazy_typecheck12PublicStructV22$publicWrappedPropertyAA0C7WrapperVySdGvg',
-                       '_$s14lazy_typecheck12PublicStructV22$publicWrappedPropertyAA0C7WrapperVySdGvpMV',
-                       '_$s14lazy_typecheck12PublicStructV26publicPropertyInferredTypeSSvM',
-                       '_$s14lazy_typecheck12PublicStructV26publicPropertyInferredTypeSSvg',
-                       '_$s14lazy_typecheck12PublicStructV26publicPropertyInferredTypeSSvpMV',
-                       '_$s14lazy_typecheck12PublicStructV26publicPropertyInferredTypeSSvs',
-                       '_$s14lazy_typecheck12PublicStructV3llloiyyACz_ACtFZ', '_$s14lazy_typecheck12PublicStructVMa',
-                       '_$s14lazy_typecheck12PublicStructVMn', '_$s14lazy_typecheck12PublicStructVN',
-                       '_$s14lazy_typecheck13PublicWrapperV12wrappedValueACyxGx_tcfC',
-                       '_$s14lazy_typecheck13PublicWrapperV12wrappedValuexvM', '_$s14lazy_typecheck13PublicWrapperV12wrappedValuexvg',
-                       '_$s14lazy_typecheck13PublicWrapperV12wrappedValuexvpMV',
-                       '_$s14lazy_typecheck13PublicWrapperV12wrappedValuexvs', '_$s14lazy_typecheck13PublicWrapperV14projectedValueACyxGvg',
-                       '_$s14lazy_typecheck13PublicWrapperV14projectedValueACyxGvpMV',
-                       '_$s14lazy_typecheck13PublicWrapperVMa', '_$s14lazy_typecheck13PublicWrapperVMn',
-                       '_$s14lazy_typecheck13inlinableFuncSiyF', '_$s14lazy_typecheck15publicGlobalVarSivM',
-                       '_$s14lazy_typecheck15publicGlobalVarSivg', '_$s14lazy_typecheck15publicGlobalVarSivs',
-                       '_$s14lazy_typecheck16EmptyPublicProtoMp', '_$s14lazy_typecheck16EmptyPublicProtoTL',
-                       '_$s14lazy_typecheck17MainActorProtocolMp', '_$s14lazy_typecheck17MainActorProtocolP3reqSiyKFTj',
-                       '_$s14lazy_typecheck17MainActorProtocolP3reqSiyKFTq', '_$s14lazy_typecheck17MainActorProtocolTL',
-                       '_$s14lazy_typecheck18PublicDerivedClassC1xACSi_tcfC', '_$s14lazy_typecheck18PublicDerivedClassC1xACSi_tcfc',
-                       '_$s14lazy_typecheck18PublicDerivedClassCMa', '_$s14lazy_typecheck18PublicDerivedClassCMm',
-                       '_$s14lazy_typecheck18PublicDerivedClassCMn', '_$s14lazy_typecheck18PublicDerivedClassCMo',
-                       '_$s14lazy_typecheck18PublicDerivedClassCN', '_$s14lazy_typecheck18PublicDerivedClassCfD',
-                       '_$s14lazy_typecheck18PublicDerivedClassCfd', '_$s14lazy_typecheck19PublicGenericStructV12publicMethodxyF',
-                       '_$s14lazy_typecheck19PublicGenericStructVMa', '_$s14lazy_typecheck19PublicGenericStructVMn',
-                       '_$s14lazy_typecheck19PublicGenericStructVyxGAA05EmptyC5ProtoA2A08InternalE13ForConstraintVRszlMc',
-                       '_$s14lazy_typecheck19PublicGenericStructVyxGAA05EmptyC5ProtoA2A08InternalE13ForConstraintVRszlWP',
-                       '_$s14lazy_typecheck19PublicRethrowsProtoMp', '_$s14lazy_typecheck19PublicRethrowsProtoP3reqSiyKFTj',
-                       '_$s14lazy_typecheck19PublicRethrowsProtoP3reqSiyKFTq', '_$s14lazy_typecheck19PublicRethrowsProtoTL',
-                       '_$s14lazy_typecheck21publicSpecializedFuncyxxlF', '_$s14lazy_typecheck21publicSpecializedFuncyxxlFAA11PublicProto_p_Ts5',
-                       '_$s14lazy_typecheck24publicFuncWithDefaultArgyS2iF', '_$s14lazy_typecheck27publicGlobalVarInferredTypeSSvM',
-                       '_$s14lazy_typecheck27publicGlobalVarInferredTypeSSvg', '_$s14lazy_typecheck27publicGlobalVarInferredTypeSSvs',
-                       '_$s14lazy_typecheck30publicFuncWithOpaqueReturnTypeQryF',
-                       '_$s14lazy_typecheck30publicFuncWithOpaqueReturnTypeQryFQOMQ',
-                       '_$s14lazy_typecheck32constrainedGenericPublicFunctionyyxAA0E5ProtoRzlF',
-                       '_$s14lazy_typecheck32publicGlobalVarInferredTuplePatXSivM',
-                       '_$s14lazy_typecheck32publicGlobalVarInferredTuplePatXSivg',
-                       '_$s14lazy_typecheck32publicGlobalVarInferredTuplePatXSivs',
-                       '_$s14lazy_typecheck32publicGlobalVarInferredTuplePatYSivM',
-                       '_$s14lazy_typecheck32publicGlobalVarInferredTuplePatYSivg',
-                       '_$s14lazy_typecheck32publicGlobalVarInferredTuplePatYSivs',
-                       '_$sSS14lazy_typecheck11PublicProtoAAMc', '_$sSS14lazy_typecheck11PublicProtoAAWP',
-                       '_$sSS14lazy_typecheckE3reqSiyF', '_$sSi14lazy_typecheck19PublicRethrowsProtoAAMc',
-                       '_$sSi14lazy_typecheck19PublicRethrowsProtoAAWP', '_$sSi14lazy_typecheckE3reqSiyKF' ]
-...
+// FIXME: Re-run the test with -experimental-skip-non-inlinable-function-bodies
+
+// REQUIRES: VENDOR=apple


### PR DESCRIPTION
Enhance the -experimental-lazy-typecheck suite of tests by adopting -debug-forbid-typecheck-prefix instead of including broken code in the source file that would cause diagnostics to be emitted if the compiler typechecks too much during lazy typechecking. The content of .tbds and .swiftinterfaces emitted with and without lazy typechecking enabled can now be compared since the source compiles regardless of mode. This new test regime is less tedious to maintain and should catch regressions more reliably since it doesn't require new CHECK lines to be added to several tests every time a new test case is added in the shared input file.
