### PR TITLE
5.10: [cxx-interop] use raw pointer metadata for dynamic FRT field metadata

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3708,8 +3708,7 @@ namespace {
         llvm_unreachable("classes shouldn't have this kind of refcounting");
       case ReferenceCounting::None:
       case ReferenceCounting::Custom:
-        llvm_unreachable(
-            "Foreign reference types don't conform to 'AnyClass'.");
+        return emitFromValueWitnessTable(IGF.IGM.Context.TheRawPointerType);
       }
 
       llvm_unreachable("Not a valid ReferenceCounting.");

--- a/test/Interop/Cxx/foreign-reference/layout-in-opaque-layout-struct.swift
+++ b/test/Interop/Cxx/foreign-reference/layout-in-opaque-layout-struct.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+
+// RUN: %target-build-swift %t/struct.swift -emit-module -emit-library -static -module-name OpaqueStruct -emit-module-path %t/Inputs/OpaqueStruct.swiftmodule -enable-library-evolution
+
+// RUN: %target-swift-emit-irgen %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
+ 
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- Inputs/header.h
+
+class
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")))
+SingletonReference {
+public:
+    SingletonReference(const SingletonReference &) = delete;
+
+    void method();
+};
+
+class
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retainS")))
+__attribute__((swift_attr("release:releaseS")))
+SingletonReferenceRef {
+public:
+    SingletonReferenceRef(const SingletonReferenceRef &) = delete;
+
+    void method();
+};
+
+void retainS(SingletonReferenceRef *);
+void releaseS(SingletonReferenceRef *);
+
+//--- struct.swift
+
+public struct ResilientStruct {
+    let x: Int
+}
+
+//--- test.swift
+
+import OpaqueStruct
+import CxxModule
+
+public struct ImmortalFRT_OpaqueLayout {
+    public let y: SingletonReference
+    public let x: ResilientStruct
+}
+
+public struct SharedFRT_OpaqueLayout {
+    public let x: ResilientStruct
+    public let y: SingletonReferenceRef
+}
+
+// CHECK: define{{.*}} @"$s4test24ImmortalFRT_OpaqueLayoutVMr"
+// CHECK: store ptr getelementptr inbounds (ptr, ptr @"$sBpWV", i32
+
+// CHECK: define{{.*}} @"$s4test22SharedFRT_OpaqueLayoutVMr"
+// CHECK: store ptr getelementptr inbounds (ptr, ptr @"$sBpWV", i32

--- a/test/Interop/Cxx/foreign-reference/pod.swift
+++ b/test/Interop/Cxx/foreign-reference/pod.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
-// XFAIL: OS=windows-msvc
 
 import StdlibUnittest
 import POD


### PR DESCRIPTION
rdar://117494091


- Explanation: The 5.10 toolchain fails to emit dynamic type metadata creation function (e.g. for resilient type) when one of the fields is an FRT. This change fixes that by using the raw pointer metadata for such field, as that's what's also being used for statically emitted type metadata for non-resilient types.
- Scope: C++ interop, IRGen
- Risk: Low, this originally worked in 5.9 but regressed somewhere along the way.
- Testing: Unit tests
- Original PR: https://github.com/apple/swift/pull/69424