### PR TITLE
5.10: [interop][SwiftToCxx] Use 'SWIFT_INLINE_PRIVATE_HELPER' for getTypeMetadata helper to avoid emitting a reference to it when 'DEBUG' macro is set

### DIFF
--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -638,7 +638,7 @@ void ClangValueTypePrinter::printTypeGenericTraits(
   }
   os << "> {\n";
   os << "  static ";
-  ClangSyntaxPrinter(os).printInlineForThunk();
+  ClangSyntaxPrinter(os).printInlineForHelperFunction();
   os << "void * _Nonnull getTypeMetadata() {\n";
   os << "    return ";
   if (!typeDecl->hasClangNode()) {

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -202,7 +202,7 @@ public struct Strct {
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<ns::NonTrivialTemplateInt> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateInt> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return _impl::$sSo2nsO0030NonTrivialTemplateCInt_hHAFhrbVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -241,7 +241,7 @@ public struct Strct {
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<ns::NonTrivialTemplateTrivial> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateTrivial> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return _impl::$sSo2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };

--- a/test/Interop/CxxToSwiftToCxx/link-cxx-type-metadata-accessor.swift
+++ b/test/Interop/CxxToSwiftToCxx/link-cxx-type-metadata-accessor.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
+
+// Use the 'DEBUG' flug to force llvm used
+// RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -DDEBUG
+// RUN: %target-interop-build-swift %t/use-cxx-types.swift -o %t/swift-cxx-execution -Xlinker %t/swift-cxx-execution.o -module-name UseCxx -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t
+
+//--- header.h
+
+struct CxxStruct {
+    inline CxxStruct(int x) : x(x) {}
+    inline CxxStruct(const CxxStruct &other) : x(other.x) {}
+    inline ~CxxStruct() {}
+
+    int x;
+};
+
+//--- module.modulemap
+module CxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- use-cxx-types.swift
+import CxxTest
+
+public func retCxxStruct() -> CxxStruct {
+    return CxxStruct(2)
+}
+
+//--- use-swift-cxx-types.cpp
+
+#include "header.h"
+#include "UseCxx.h"
+#include <assert.h>
+
+int main() {
+  auto x = UseCxx::retCxxStruct();
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
@@ -89,7 +89,7 @@ public final class ClassWithIntField {
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<Class::ClassWithIntField> {
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return Class::_impl::$s5Class0A12WithIntFieldCMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -269,7 +269,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
 // CHECK-NEXT: struct TypeMetadataTrait<Generics::GenericPair<T_0_0, T_0_1>> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return Generics::_impl::$s8Generics11GenericPairVMa(0, swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata())._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -85,7 +85,7 @@ public struct FirstSmallStruct {
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<Structs::FirstSmallStruct> {
-// CHECK-NEXT: SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT: SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:   return Structs::_impl::$s7Structs16FirstSmallStructVMa(0)._0;
 // CHECK-NEXT: }
 // CHECK-NEXT: };

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -106,7 +106,7 @@
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<Structs::StructWithIntField>
-// CHECK-NEXT: SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT: SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:   return Structs::_impl::$s7Structs18StructWithIntFieldVMa(0)._0;
 // CHECK-NEXT: }
 // CHECK-NEXT: };


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/69234

Based on https://github.com/apple/swift/pull/69522, see last commit only for the diff - https://github.com/apple/swift/pull/69524/commits/5f4e33d64592e7f023d4e50c1c8a312f5187ccd7
rdar://117089662

- Explanation:
`SWIFT_INLINE_THUNK` macro used for `getTypeMetadata` helper in the generated header adds LLVM `used` attribute to the inline functions when `DEBUG` is set, to have functions be callable from LLDB's expression evaluation. `getTypeMetadata` is also emitted for C++ types that are exposed back from Swift to C++, to allow them to be used in Swift generics. However, this can sometimes lead to a linking error  because of the `used` attribute when Swift doesn't actually emit the C++ type metadata, e.g. when such C++ type is not used in a Swift generic type, but is used directly in an exposed Swift API. This change uses `SWIFT_INLINE_PRIVATE_HELPER` instead for the `getTypeMetadata` helpers to avoid force linking with the not existing metadata for a C++ type.
- Scope: C++ interop, generated header generator
- Risk: Low, this doesn't change underlying behavior, just removes the `used` LLVM attribute.
- Testing: Unit tests
- Original PR: https://github.com/apple/swift/pull/69519