### PR TITLE
[Dependency Scanning] Restore propagation of `-Xcc` flags to scanner's Swift Textual interface-reading sub-invocation

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1747,7 +1747,8 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // If the compiler has been asked to be strict with ensuring downstream dependencies
   // get the parent invocation's context, or this is an Explicit build, inherit the
   // extra Clang arguments also.
-  if (LoaderOpts.strictImplicitModuleContext || LoaderOpts.disableImplicitSwiftModule) {
+  if (LoaderOpts.strictImplicitModuleContext || LoaderOpts.disableImplicitSwiftModule ||
+      LoaderOpts.requestedAction == FrontendOptions::ActionType::ScanDependencies) {
     // Inherit any clang-specific state of the compilation (macros, clang flags, etc.)
     subClangImporterOpts.ExtraArgs = clangImporterOpts.ExtraArgs;
     for (auto arg : subClangImporterOpts.ExtraArgs) {

--- a/test/ScanDependencies/ObjCStrict.swift
+++ b/test/ScanDependencies/ObjCStrict.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -Xcc -fobjc-disable-direct-methods-for-testing
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import C
+
+// CHECK: "mainModuleName": "deps"
+/// --------Main module
+// CHECK-LABEL: "modulePath": "deps.swiftmodule",
+// CHECK-NEXT: sourceFiles
+// CHECK-NEXT: ObjCStrict.swift
+// CHECK-NEXT: ],
+// CHECK-NEXT: "directDependencies": [
+// CHECK-DAG:     "clang": "C"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK-DAG:     "swift": "_Concurrency"
+// CHECK: ],
+
+// CHECK:     "swift": "A"
+// CHECK:        "swift": {
+// CHECK-NEXT:          "moduleInterfacePath": "{{.*}}{{/|\\}}Inputs{{/|\\}}Swift{{/|\\}}A.swiftinterface",
+// CHECK:          "commandLine": [
+// CHECK:            "-fobjc-disable-direct-methods-for-testing"
+// CHECK:            "-o",
+// CHECK-NEXT:       "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+
+            
+


### PR DESCRIPTION
This will result in such flags being propagated to interface build command-lines for discovered Swift modules. 

This functionality has been missing since:
https://github.com/apple/swift/pull/68252