### PR TITLE
fixed some typos

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -647,7 +647,7 @@ ConstructorDecl *SwiftDeclSynthesizer::createValueConstructor(
   return constructor;
 }
 
-// MARK: Struct RawValue intializers
+// MARK: Struct RawValue initializers
 
 /// Synthesizer callback for a raw value bridging constructor body.
 static std::pair<BraceStmt *, bool>

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
@@ -570,7 +570,7 @@ public:
   /// \c Executing, then \c waitingTask has been added to the
   /// wait queue and will be scheduled when the future completes. Otherwise,
   /// the future has completed and can be queried.
-  /// The waiting task's async context will be intialized with the parameters if
+  /// The waiting task's async context will be initialized with the parameters if
   /// the current's task state is executing.
   __attribute__((visibility("hidden")))
   FutureFragment::Status waitFuture(AsyncTask *waitingTask,

--- a/test/SILGen/delayed_functions.swift
+++ b/test/SILGen/delayed_functions.swift
@@ -10,7 +10,7 @@
 // WHOLEMOD-LABEL: sil hidden [ossa] @$s17delayed_functions3fooSiyF : $@convention(thin) () -> Int
 func foo() -> Int { 5 }
 
-// Cannot delay property intializers that contain user code.
+// Cannot delay property initializers that contain user code.
 struct R {
   // variable initialization expression of R.i
   // SINGLE-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1RV1iSivpfi : $@convention(thin) () -> Int


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes typos in following files.

- in [lib/ClangImporter/SwiftDeclSynthesizer.cpp](https://github.com/apple/swift/blob/main/lib/ClangImporter/SwiftDeclSynthesizer.cpp#L650)  `intializers` -> `initializers`
- in [stdlib/toolchain/Compatibility56/include/Concurrency/Task.h](https://github.com/apple/swift/blob/main/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h#L573) `intialized` -> `initialized`
- in [test/SILGen/delayed_functions.swift](https://github.com/apple/swift/blob/main/test/SILGen/delayed_functions.swift#L13) `intializers` -> `initializers`




