### PR TITLE
[Concurrency] Un-deprecate enqueue(UnownedJob) for easier adoption

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6935,10 +6935,6 @@ WARNING(hashvalue_implementation,Deprecation,
         "conform type %0 to 'Hashable' by implementing 'hash(into:)' instead",
         (Type))
 
-WARNING(executor_enqueue_deprecated_unowned_implementation,Deprecation,
-        "'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; "
-        "conform type %0 to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead",
-        (Type))
 WARNING(executor_enqueue_deprecated_owned_job_implementation,Deprecation,
         "'Executor.enqueue(Job)' is deprecated as a protocol requirement; "
         "conform type %0 to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead",

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1459,14 +1459,10 @@ void swift::tryDiagnoseExecutorConformance(ASTContext &C,
     }
   }
 
-  // Old UnownedJob based impl is present, warn about it suggesting the new protocol requirement.
-  if (canRemoveOldDecls && unownedEnqueueWitnessDecl) {
-    if (!isStdlibDefaultImplDecl(unownedEnqueueWitnessDecl)) {
-      diags.diagnose(unownedEnqueueWitnessDecl->getLoc(),
-                     diag::executor_enqueue_deprecated_unowned_implementation,
-                     nominalTy);
-    }
-  }
+  // We specifically do allow the old UnownedJob implementation to be present.
+  // In order to ease migration and compatibility for libraries which remain compatible with old Swift versions,
+  // and would be getting this warning in situations they cannot address it.
+
   // Old Job based impl is present, warn about it suggesting the new protocol requirement.
   if (legacyMoveOnlyEnqueueWitnessDecl) {
     if (!isStdlibDefaultImplDecl(legacyMoveOnlyEnqueueWitnessDecl)) {

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -20,7 +20,6 @@ public protocol Executor: AnyObject, Sendable {
   // Do not deprecate the UnownedJob enqueue in that configuration just yet - as we cannot introduce the replacements.
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(SwiftStdlib 5.1, *)
-  @available(*, deprecated, message: "Implement 'enqueue(_: __owned ExecutorJob)' instead")
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   func enqueue(_ job: UnownedJob)
 

--- a/test/Concurrency/custom_executor_enqueue_availability.swift
+++ b/test/Concurrency/custom_executor_enqueue_availability.swift
@@ -40,7 +40,7 @@ final class BothExecutorOldStdlib: SerialExecutor {
 /// that it can be dropped.
 @available(SwiftStdlib 5.9, *)
 final class BothExecutorNewStdlib: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'BothExecutorNewStdlib' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+  func enqueue(_ job: UnownedJob) {} // no warning, we're not deprecating the UnownedJob enqueue method yet
 
   func enqueue(_ job: __owned ExecutorJob) {}
 
@@ -51,7 +51,7 @@ final class BothExecutorNewStdlib: SerialExecutor {
 
 @available(SwiftStdlib 5.9, *)
 final class TripleExecutor: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'TripleExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+  func enqueue(_ job: UnownedJob) {} // no warning, we're not deprecating the UnownedJob enqueue method yet
 
   // expected-warning@+2{{'Job' is deprecated: renamed to 'ExecutorJob'}}
   // expected-note@+1{{use 'ExecutorJob' instead}}

--- a/test/Concurrency/custom_executor_enqueue_deprecation_on_executor_extension.swift
+++ b/test/Concurrency/custom_executor_enqueue_deprecation_on_executor_extension.swift
@@ -11,7 +11,7 @@
 
 
 extension Executor {
-  func enqueue(_ job: UnownedJob) { // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'NoneExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+  func enqueue(_ job: UnownedJob) { // no warning, we don't deprecate this just yet. It was deprecated in 5.9.0 but we undid this.
     fatalError()
   }
 }

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -14,7 +14,7 @@
 //
 // We keep support for them, but also log a deprecation warning that they should move to the new signature.
 final class OldExecutor: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'OldExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+  func enqueue(_ job: UnownedJob) {} // no warning, we're not deprecating the UnownedJob enqueue method yet
 
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     UnownedSerialExecutor(ordinary: self)
@@ -26,7 +26,7 @@ final class OldExecutor: SerialExecutor {
 ///
 /// That's why we do log the deprecation warning, people should use the move-only version.
 final class BothExecutor: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'BothExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+  func enqueue(_ job: UnownedJob) {} // no warning, we're not deprecating the UnownedJob enqueue method yet
 
   func enqueue(_ job: __owned ExecutorJob) {}
 
@@ -37,7 +37,7 @@ final class BothExecutor: SerialExecutor {
 
 /// For now we must keep all 3 implementation kinds and warn about deprecated ones
 final class TripleExecutor: SerialExecutor {
-  func enqueue(_ job: UnownedJob) {} // expected-warning{{'Executor.enqueue(UnownedJob)' is deprecated as a protocol requirement; conform type 'TripleExecutor' to 'Executor' by implementing 'func enqueue(ExecutorJob)' instead}}
+  func enqueue(_ job: UnownedJob) {} // no warning, we're not deprecating the UnownedJob enqueue method yet
 
   // expected-warning@+2{{'Job' is deprecated: renamed to 'ExecutorJob'}}
   // expected-note@+1{{use 'ExecutorJob' instead}}


### PR DESCRIPTION
**Description:** We were emitting a custom deprecation about the `enqueue(UnownedJob)` in order to nudge people to use the move-only ExecutorJob. With this deprecation emitted by the compiler some codebases that support many old Swift versions have been forced into warnings they cannot avoid due to the compatibility promises they made.

The `UnownedJob` never was deprecated, so no change to it.

**Risk:** Low, only a deprecation removal.
**Impact:** This removes the warning but changes no functionality. Helps projects adopting custom executors but having to support old Swift versions avoid compile warnings.

**Review by:** @FranzBusch 

**Radar:** rdar://117123460