### PR TITLE
A couple of bridging cleanups

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -81,11 +81,12 @@ namespace swift {
 } // end namespace swift
 
 // Define the bridging wrappers for each AST node.
-#define AST_BRIDGING_WRAPPER(Name) BRIDGING_WRAPPER_NONNULL(Name)
+#define AST_BRIDGING_WRAPPER(Name) BRIDGING_WRAPPER_NONNULL(swift::Name, Name)
 #include "swift/AST/ASTBridgingWrappers.def"
 
 // For nullable nodes, also define a nullable variant.
-#define AST_BRIDGING_WRAPPER_NULLABLE(Name) BRIDGING_WRAPPER_NULLABLE(Name)
+#define AST_BRIDGING_WRAPPER_NULLABLE(Name)                                    \
+  BRIDGING_WRAPPER_NULLABLE(swift::Name, Name)
 #define AST_BRIDGING_WRAPPER_NONNULL(Name)
 #include "swift/AST/ASTBridgingWrappers.def"
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -150,7 +150,7 @@ public:
   BridgedDiagnosticArgument(const swift::DiagnosticArgument &arg) {
     *reinterpret_cast<swift::DiagnosticArgument *>(&storage) = arg;
   }
-  const swift::DiagnosticArgument &get() const {
+  const swift::DiagnosticArgument &unbridged() const {
     return *reinterpret_cast<const swift::DiagnosticArgument *>(&storage);
   }
 #endif
@@ -167,7 +167,7 @@ public:
   BridgedDiagnosticFixIt(const swift::DiagnosticInfo::FixIt &fixit){
     *reinterpret_cast<swift::DiagnosticInfo::FixIt *>(&storage) = fixit;
   }
-  const swift::DiagnosticInfo::FixIt &get() const {
+  const swift::DiagnosticInfo::FixIt &unbridged() const {
     return *reinterpret_cast<const swift::DiagnosticInfo::FixIt *>(&storage);
   }
 #endif

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -26,30 +26,72 @@
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 namespace swift {
-  class DiagnosticArgument;
-  class DiagnosticEngine;
+class ASTContext;
+class DiagnosticArgument;
+class DiagnosticEngine;
 }
 
 //===----------------------------------------------------------------------===//
 // MARK: Identifier
 //===----------------------------------------------------------------------===//
 
-struct BridgedIdentifier {
-  const void *_Nullable raw;
+class BridgedIdentifier {
+public:
+  SWIFT_UNAVAILABLE("Use '.raw' instead")
+  const void *_Nullable Raw;
+
+  BridgedIdentifier() : Raw(nullptr) {}
+
+  SWIFT_NAME("init(raw:)")
+  BridgedIdentifier(const void *_Nullable raw) : Raw(raw) {}
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedIdentifier(swift::Identifier ident)
+      : Raw(ident.getAsOpaquePointer()) {}
+
+  swift::Identifier unbridged() const {
+    return swift::Identifier::getFromOpaquePointer(Raw);
+  }
+#endif
 };
 
+SWIFT_NAME("getter:BridgedIdentifier.raw(self:)")
+inline const void *_Nullable BridgedIdentifier_raw(BridgedIdentifier ident) {
+  return ident.Raw;
+}
+
 struct BridgedIdentifierAndSourceLoc {
-  BridgedIdentifier name;
-  BridgedSourceLoc nameLoc;
+  SWIFT_NAME("name")
+  BridgedIdentifier Name;
+
+  SWIFT_NAME("nameLoc")
+  BridgedSourceLoc NameLoc;
 };
 
 //===----------------------------------------------------------------------===//
 // MARK: ASTContext
 //===----------------------------------------------------------------------===//
 
-struct BridgedASTContext {
-  void *_Nonnull raw;
+class BridgedASTContext {
+  swift::ASTContext * _Nonnull Ctx;
+
+public:
+#ifdef USED_IN_CPP_SOURCE
+  SWIFT_UNAVAILABLE("Use init(raw:) instead")
+  BridgedASTContext(swift::ASTContext &ctx) : Ctx(&ctx) {}
+
+  SWIFT_UNAVAILABLE("Use '.raw' instead")
+  swift::ASTContext &unbridged() const { return *Ctx; }
+#endif
 };
+
+SWIFT_NAME("getter:BridgedASTContext.raw(self:)")
+BRIDGED_INLINE
+void * _Nonnull BridgedASTContext_raw(BridgedASTContext bridged);
+
+SWIFT_NAME("BridgedASTContext.init(raw:)")
+BRIDGED_INLINE
+BridgedASTContext BridgedASTContext_fromRaw(void * _Nonnull ptr);
 
 SWIFT_NAME("BridgedASTContext.getIdentifier(self:_:)")
 BridgedIdentifier BridgedASTContext_getIdentifier(BridgedASTContext cContext,
@@ -70,8 +112,11 @@ enum ENUM_EXTENSIBILITY_ATTR(open) ASTNodeKind : size_t {
 };
 
 struct BridgedASTNode {
-  void *_Nonnull ptr;
-  ASTNodeKind kind;
+  SWIFT_NAME("raw")
+  void *_Nonnull Raw;
+
+  SWIFT_NAME("kind")
+  ASTNodeKind Kind;
 };
 
 // Forward declare the underlying AST node type for each wrapper.
@@ -185,8 +230,18 @@ enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticSeverity : size_t {
   BridgedNote,
 };
 
-struct BridgedDiagnostic {
-  void *_Nonnull raw;
+class BridgedDiagnostic {
+public:
+  struct Impl;
+
+  SWIFT_UNAVAILABLE("Unavailable in Swift")
+  Impl *_Nonnull Raw;
+
+  SWIFT_UNAVAILABLE("Unavailable in Swift")
+  BridgedDiagnostic(Impl *_Nonnull raw) : Raw(raw) {}
+
+  SWIFT_UNAVAILABLE("Unavailable in Swift")
+  Impl *_Nonnull unbridged() const { return Raw; }
 };
 
 // FIXME: Can we bridge InFlightDiagnostic?

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -18,6 +18,18 @@
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 //===----------------------------------------------------------------------===//
+// MARK: BridgedASTContext
+//===----------------------------------------------------------------------===//
+
+void * _Nonnull BridgedASTContext_raw(BridgedASTContext bridged) {
+  return &bridged.unbridged();
+}
+
+BridgedASTContext BridgedASTContext_fromRaw(void * _Nonnull ptr) {
+  return *static_cast<swift::ASTContext *>(ptr);
+}
+
+//===----------------------------------------------------------------------===//
 // MARK: BridgedNominalTypeDecl
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -22,11 +22,11 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 //===----------------------------------------------------------------------===//
 
 BridgedStringRef BridgedNominalTypeDecl_getName(BridgedNominalTypeDecl decl) {
-  return decl.get()->getName().str();
+  return decl.unbridged()->getName().str();
 }
 
 bool BridgedNominalTypeDecl_isGlobalActor(BridgedNominalTypeDecl decl) {
-  return decl.get()->isGlobalActor();
+  return decl.unbridged()->isGlobalActor();
 }
 
 //===----------------------------------------------------------------------===//
@@ -34,7 +34,7 @@ bool BridgedNominalTypeDecl_isGlobalActor(BridgedNominalTypeDecl decl) {
 //===----------------------------------------------------------------------===//
 
 BridgedStringRef BridgedVarDecl_getUserFacingName(BridgedVarDecl decl) {
-  return decl.get()->getBaseName().userFacingName();
+  return decl.unbridged()->getBaseName().userFacingName();
 }
 
 SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -93,6 +93,7 @@ public:
   }
   
   bool empty() const { return Pointer == nullptr; }
+  bool nonempty() const { return !empty(); }
 
   LLVM_ATTRIBUTE_USED bool is(StringRef string) const {
     return str().equals(string);
@@ -180,7 +181,7 @@ public:
       return static_cast<const void *>(Pointer);
   }
   
-  static Identifier getFromOpaquePointer(void *P) {
+  static Identifier getFromOpaquePointer(const void *P) {
     return Identifier((const char*)P);
   }
 

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -79,12 +79,12 @@ typedef uintptr_t SwiftUInt;
     Bridged##Name(swift::Node * Nullability ptr) : Ptr(ptr) {}                 \
                                                                                \
     SWIFT_UNAVAILABLE("Use '.raw' instead")                                    \
-    swift::Node * Nullability get() const { return Ptr; }                      \
+    swift::Node * Nullability unbridged() const { return Ptr; }                \
   };                                                                           \
                                                                                \
   SWIFT_NAME("getter:Bridged" #Name ".raw(self:)")                             \
   inline void * Nullability Bridged##Name##_getRaw(Bridged##Name bridged) {    \
-    return bridged.get();                                                      \
+    return bridged.unbridged();                                                \
   }                                                                            \
                                                                                \
   SWIFT_NAME("Bridged" #Name ".init(raw:)")                                    \
@@ -123,7 +123,7 @@ public:
       : Data(arr.data()), Length(arr.size()) {}
 
   template <typename T>
-  llvm::ArrayRef<T> get() const {
+  llvm::ArrayRef<T> unbridged() const {
     return {static_cast<const T *>(Data), Length};
   }
 #endif
@@ -196,7 +196,7 @@ public:
   BridgedStringRef(llvm::StringRef sref)
       : Data(sref.data()), Length(sref.size()) {}
 
-  llvm::StringRef get() const { return llvm::StringRef(Data, Length); }
+  llvm::StringRef unbridged() const { return llvm::StringRef(Data, Length); }
 #endif
 
   BridgedStringRef() : Data(nullptr), Length(0) {}
@@ -226,7 +226,7 @@ public:
 #ifdef USED_IN_CPP_SOURCE
   BridgedOwnedString(const std::string &stringToCopy);
 
-  llvm::StringRef getRef() const { return llvm::StringRef(Data, Length); }
+  llvm::StringRef unbridgedRef() const { return llvm::StringRef(Data, Length); }
 #endif
 
   void destroy() const;
@@ -258,7 +258,7 @@ public:
 #ifdef USED_IN_CPP_SOURCE
   BridgedSourceLoc(swift::SourceLoc loc) : Raw(loc.getOpaquePointerValue()) {}
 
-  swift::SourceLoc get() const {
+  swift::SourceLoc unbridged() const {
     return swift::SourceLoc(
         llvm::SMLoc::getFromPointer(static_cast<const char *>(Raw)));
   }

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -281,15 +281,61 @@ BRIDGED_INLINE bool BridgedSourceLoc_isValid(BridgedSourceLoc loc);
 // MARK: SourceRange
 //===----------------------------------------------------------------------===//
 
-struct BridgedSourceRange {
-  BridgedSourceLoc startLoc;
-  BridgedSourceLoc endLoc;
+class BridgedSourceRange {
+public:
+  SWIFT_NAME("start")
+  BridgedSourceLoc Start;
+
+  SWIFT_NAME("end")
+  BridgedSourceLoc End;
+
+  SWIFT_NAME("init(start:end:)")
+  BridgedSourceRange(BridgedSourceLoc start, BridgedSourceLoc end)
+      : Start(start), End(end) {}
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedSourceRange(swift::SourceRange range)
+      : Start(range.Start), End(range.End) {}
+
+  swift::SourceRange unbridged() const {
+    return swift::SourceRange(Start.unbridged(), End.unbridged());
+  }
+#endif
 };
 
-struct BridgedCharSourceRange {
-  void *_Nonnull start;
-  size_t byteLength;
+class BridgedCharSourceRange {
+public:
+  SWIFT_UNAVAILABLE("Use '.start' instead")
+  BridgedSourceLoc Start;
+
+  SWIFT_UNAVAILABLE("Use '.byteLength' instead")
+  unsigned ByteLength;
+
+  SWIFT_NAME("init(start:byteLength:)")
+  BridgedCharSourceRange(BridgedSourceLoc start, unsigned byteLength)
+      : Start(start), ByteLength(byteLength) {}
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedCharSourceRange(swift::CharSourceRange range)
+      : Start(range.getStart()), ByteLength(range.getByteLength()) {}
+
+  swift::CharSourceRange unbridged() const {
+    return swift::CharSourceRange(Start.unbridged(), ByteLength);
+  }
+#endif
 };
+
+SWIFT_NAME("getter:BridgedCharSourceRange.start(self:)")
+inline BridgedSourceLoc
+BridgedCharSourceRange_start(BridgedCharSourceRange range) {
+  return range.Start;
+}
+
+SWIFT_NAME("getter:BridgedCharSourceRange.byteLength(self:)")
+inline SwiftInt
+BridgedCharSourceRange_byteLength(BridgedCharSourceRange range) {
+  return static_cast<SwiftInt>(range.ByteLength);
+}
 
 //===----------------------------------------------------------------------===//
 // MARK: Plugins

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -57,6 +57,10 @@
 #define BRIDGED_INLINE inline
 #endif
 
+namespace llvm {
+class raw_ostream;
+} // end namespace llvm
+
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 typedef intptr_t SwiftInt;
@@ -72,14 +76,14 @@ typedef uintptr_t SwiftUInt;
 // PURE_BRIDGING_MODE.
 #define BRIDGING_WRAPPER_IMPL(Node, Name, Nullability)                         \
   class Bridged##Name {                                                        \
-    swift::Node * Nullability Ptr;                                             \
+    Node * Nullability Ptr;                                                    \
                                                                                \
   public:                                                                      \
     SWIFT_UNAVAILABLE("Use init(raw:) instead")                                \
-    Bridged##Name(swift::Node * Nullability ptr) : Ptr(ptr) {}                 \
+    Bridged##Name(Node * Nullability ptr) : Ptr(ptr) {}                        \
                                                                                \
     SWIFT_UNAVAILABLE("Use '.raw' instead")                                    \
-    swift::Node * Nullability unbridged() const { return Ptr; }                \
+    Node * Nullability unbridged() const { return Ptr; }                       \
   };                                                                           \
                                                                                \
   SWIFT_NAME("getter:Bridged" #Name ".raw(self:)")                             \
@@ -89,15 +93,15 @@ typedef uintptr_t SwiftUInt;
                                                                                \
   SWIFT_NAME("Bridged" #Name ".init(raw:)")                                    \
   inline Bridged##Name Bridged##Name##_fromRaw(void * Nullability ptr) {       \
-    return static_cast<swift::Node *>(ptr);                                    \
+    return static_cast<Node *>(ptr);                                           \
   }
 
 // Bridging wrapper macros for convenience.
-#define BRIDGING_WRAPPER_NONNULL(Name) \
-  BRIDGING_WRAPPER_IMPL(Name, Name, _Nonnull)
+#define BRIDGING_WRAPPER_NONNULL(Node, Name) \
+  BRIDGING_WRAPPER_IMPL(Node, Name, _Nonnull)
 
-#define BRIDGING_WRAPPER_NULLABLE(Name) \
-  BRIDGING_WRAPPER_IMPL(Name, Nullable##Name, _Nullable)
+#define BRIDGING_WRAPPER_NULLABLE(Node, Name) \
+  BRIDGING_WRAPPER_IMPL(Node, Nullable##Name, _Nullable)
 
 //===----------------------------------------------------------------------===//
 // MARK: ArrayRef
@@ -179,9 +183,7 @@ enum ENUM_EXTENSIBILITY_ATTR(open) BridgedFeature {
 // MARK: OStream
 //===----------------------------------------------------------------------===//
 
-struct BridgedOStream {
-  void * _Nonnull streamAddr;
-};
+BRIDGING_WRAPPER_NONNULL(llvm::raw_ostream, OStream)
 
 //===----------------------------------------------------------------------===//
 // MARK: StringRef

--- a/include/swift/Basic/BasicBridgingImpl.h
+++ b/include/swift/Basic/BasicBridgingImpl.h
@@ -44,30 +44,32 @@ SwiftInt BridgedData_count(BridgedData data) {
 //===----------------------------------------------------------------------===//
 
 const uint8_t *_Nullable BridgedStringRef_data(BridgedStringRef str) {
-  return (const uint8_t *)str.get().data();
+  return (const uint8_t *)str.unbridged().data();
 }
 
 SwiftInt BridgedStringRef_count(BridgedStringRef str) {
-  return (SwiftInt)str.get().size();
+  return (SwiftInt)str.unbridged().size();
 }
 
-bool BridgedStringRef_empty(BridgedStringRef str) { return str.get().empty(); }
+bool BridgedStringRef_empty(BridgedStringRef str) {
+  return str.unbridged().empty();
+}
 
 //===----------------------------------------------------------------------===//
 // MARK: BridgedOwnedString
 //===----------------------------------------------------------------------===//
 
 const uint8_t *_Nullable BridgedOwnedString_data(BridgedOwnedString str) {
-  auto *data = str.getRef().data();
+  auto *data = str.unbridgedRef().data();
   return (const uint8_t *)(data ? data : "");
 }
 
 SwiftInt BridgedOwnedString_count(BridgedOwnedString str) {
-  return (SwiftInt)str.getRef().size();
+  return (SwiftInt)str.unbridgedRef().size();
 }
 
 bool BridgedOwnedString_empty(BridgedOwnedString str) {
-  return str.getRef().empty();
+  return str.unbridgedRef().empty();
 }
 
 //===----------------------------------------------------------------------===//
@@ -79,7 +81,7 @@ bool BridgedSourceLoc_isValid(BridgedSourceLoc loc) {
 }
 
 BridgedSourceLoc BridgedSourceLoc::advancedBy(size_t n) const {
-  return BridgedSourceLoc(get().getAdvancedLoc(n));
+  return BridgedSourceLoc(unbridged().getAdvancedLoc(n));
 }
 
 SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -80,7 +80,7 @@ struct BridgedType {
 #ifdef USED_IN_CPP_SOURCE
   BridgedType(swift::SILType t) : opaqueValue(t.getOpaqueValue()) {}
 
-  swift::SILType get() const {
+  swift::SILType unbridged() const {
     return swift::SILType::getFromOpaqueValue(opaqueValue);
   }
 #endif
@@ -383,7 +383,7 @@ struct BridgedMultiValueResult {
   SwiftObject obj;
 
 #ifdef USED_IN_CPP_SOURCE
-  swift::MultipleValueInstructionResult * _Nonnull get() const {
+  swift::MultipleValueInstructionResult * _Nonnull unbridged() const {
     return static_cast<swift::MultipleValueInstructionResult *>(obj);
   }
 #endif
@@ -399,7 +399,7 @@ struct BridgedSubstitutionMap {
   BridgedSubstitutionMap(swift::SubstitutionMap map) {
     *reinterpret_cast<swift::SubstitutionMap *>(&storage) = map;
   }
-  swift::SubstitutionMap get() const {
+  swift::SubstitutionMap unbridged() const {
     return *reinterpret_cast<const swift::SubstitutionMap *>(&storage);
   }
 #endif
@@ -414,8 +414,8 @@ struct BridgedTypeArray {
 #ifdef USED_IN_CPP_SOURCE
   BridgedTypeArray(llvm::ArrayRef<swift::Type> types) : typeArray(types) {}
 
-  llvm::ArrayRef<swift::Type> get() const {
-    return typeArray.get<swift::Type>();
+  llvm::ArrayRef<swift::Type> unbridged() const {
+    return typeArray.unbridged<swift::Type>();
   }
 #endif
 
@@ -435,8 +435,8 @@ struct BridgedSILTypeArray {
   BridgedSILTypeArray(llvm::ArrayRef<swift::SILType> silTypes)
       : typeArray(silTypes) {}
 
-  llvm::ArrayRef<swift::SILType> get() const {
-    return typeArray.get<swift::SILType>();
+  llvm::ArrayRef<swift::SILType> unbridged() const {
+    return typeArray.unbridged<swift::SILType>();
   }
 #endif
 
@@ -496,7 +496,7 @@ struct BridgedInstruction {
   template <class I> I *_Nonnull getAs() const {
     return llvm::cast<I>(static_cast<swift::SILNode *>(obj)->castToInstruction());
   }
-  swift::SILInstruction * _Nonnull get() const {
+  swift::SILInstruction * _Nonnull unbridged() const {
     return getAs<swift::SILInstruction>();
   }
 #endif
@@ -676,7 +676,7 @@ struct OptionalBridgedInstruction {
   OptionalSwiftObject obj;
 
 #ifdef USED_IN_CPP_SOURCE
-  swift::SILInstruction * _Nullable get() const {
+  swift::SILInstruction * _Nullable unbridged() const {
     if (!obj)
       return nullptr;
     return llvm::cast<swift::SILInstruction>(static_cast<swift::SILNode *>(obj)->castToInstruction());
@@ -704,7 +704,7 @@ struct OptionalBridgedBasicBlock {
   OptionalSwiftObject obj;
 
 #ifdef USED_IN_CPP_SOURCE
-  swift::SILBasicBlock * _Nullable get() const {
+  swift::SILBasicBlock * _Nullable unbridged() const {
     return obj ? static_cast<swift::SILBasicBlock *>(obj) : nullptr;
   }
 #endif
@@ -719,7 +719,7 @@ struct BridgedBasicBlock {
 #ifdef USED_IN_CPP_SOURCE
   BridgedBasicBlock(swift::SILBasicBlock * _Nonnull block) : obj(block) {
   }
-  swift::SILBasicBlock * _Nonnull get() const {
+  swift::SILBasicBlock * _Nonnull unbridged() const {
     return static_cast<swift::SILBasicBlock *>(obj);
   }
 #endif
@@ -840,12 +840,14 @@ struct BridgedBuilder{
   BridgedLocation loc;
 
 #ifdef USED_IN_CPP_SOURCE
-  swift::SILBuilder get() const {
+  swift::SILBuilder unbridged() const {
     switch (insertAt) {
     case BridgedBuilder::InsertAt::beforeInst:
-      return swift::SILBuilder(BridgedInstruction(insertionObj).get(), loc.getLoc().getScope());
+      return swift::SILBuilder(BridgedInstruction(insertionObj).unbridged(),
+                               loc.getLoc().getScope());
     case BridgedBuilder::InsertAt::endOfBlock:
-      return swift::SILBuilder(BridgedBasicBlock(insertionObj).get(), loc.getLoc().getScope());
+      return swift::SILBuilder(BridgedBasicBlock(insertionObj).unbridged(),
+                               loc.getLoc().getScope());
     case BridgedBuilder::InsertAt::intoGlobal:
       return swift::SILBuilder(BridgedGlobalVar(insertionObj).getGlobal());
     }

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -45,180 +45,181 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 //===----------------------------------------------------------------------===//
 
 BridgedOwnedString BridgedType::getDebugDescription() const {
-  return BridgedOwnedString(get().getDebugDescription());
+  return BridgedOwnedString(unbridged().getDebugDescription());
 }
 
 bool BridgedType::isNull() const {
-  return get().isNull();
+  return unbridged().isNull();
 }
 
 bool BridgedType::isAddress() const {
-  return get().isAddress();
+  return unbridged().isAddress();
 }
 
 BridgedType BridgedType::getAddressType() const {
-  return get().getAddressType();
+  return unbridged().getAddressType();
 }
 
 BridgedType BridgedType::getObjectType() const {
-  return get().getObjectType();
+  return unbridged().getObjectType();
 }
 
 bool BridgedType::isTrivial(BridgedFunction f) const {
-  return get().isTrivial(f.getFunction());
+  return unbridged().isTrivial(f.getFunction());
 }
 
 bool BridgedType::isNonTrivialOrContainsRawPointer(BridgedFunction f) const {
-  return get().isNonTrivialOrContainsRawPointer(f.getFunction());
+  return unbridged().isNonTrivialOrContainsRawPointer(f.getFunction());
 }
 
 bool BridgedType::isValueTypeWithDeinit() const {
-  return get().isValueTypeWithDeinit();
+  return unbridged().isValueTypeWithDeinit();
 }
 
 bool BridgedType::isLoadable(BridgedFunction f) const {
-  return get().isLoadable(f.getFunction());
+  return unbridged().isLoadable(f.getFunction());
 }
 
 bool BridgedType::isReferenceCounted(BridgedFunction f) const {
-  return get().isReferenceCounted(f.getFunction());
+  return unbridged().isReferenceCounted(f.getFunction());
 }
 
 bool BridgedType::isUnownedStorageType() const {
-  return get().isUnownedStorageType();
+  return unbridged().isUnownedStorageType();
 }
 
 bool BridgedType::hasArchetype() const {
-  return get().hasArchetype();
+  return unbridged().hasArchetype();
 }
 
 bool BridgedType::isNominalOrBoundGenericNominal() const {
-  return get().getNominalOrBoundGenericNominal() != nullptr;
+  return unbridged().getNominalOrBoundGenericNominal() != nullptr;
 }
 
 BridgedNominalTypeDecl BridgedType::getNominalOrBoundGenericNominal() const {
-  return {get().getNominalOrBoundGenericNominal()};
+  return {unbridged().getNominalOrBoundGenericNominal()};
 }
 
 bool BridgedType::isClassOrBoundGenericClass() const {
-  return get().getClassOrBoundGenericClass() != 0;
+  return unbridged().getClassOrBoundGenericClass() != 0;
 }
 
 bool BridgedType::isStructOrBoundGenericStruct() const {
-  return get().getStructOrBoundGenericStruct() != nullptr;
+  return unbridged().getStructOrBoundGenericStruct() != nullptr;
 }
 
 bool BridgedType::isTuple() const {
-  return get().isTuple();
+  return unbridged().isTuple();
 }
 
 bool BridgedType::isEnumOrBoundGenericEnum() const {
-  return get().getEnumOrBoundGenericEnum() != nullptr;
+  return unbridged().getEnumOrBoundGenericEnum() != nullptr;
 }
 
 bool BridgedType::isFunction() const {
-  return get().isFunction();
+  return unbridged().isFunction();
 }
 
 bool BridgedType::isMetatype() const {
-  return get().isMetatype();
+  return unbridged().isMetatype();
 }
 
 bool BridgedType::isNoEscapeFunction() const {
-  return get().isNoEscapeFunction();
+  return unbridged().isNoEscapeFunction();
 }
 
 bool BridgedType::isAsyncFunction() const {
-  return get().isAsyncFunction();
+  return unbridged().isAsyncFunction();
 }
 
 BridgedType::TraitResult BridgedType::canBeClass() const {
-  return (TraitResult)get().canBeClass();
+  return (TraitResult)unbridged().canBeClass();
 }
 
 bool BridgedType::isMoveOnly() const {
-  return get().isMoveOnly();
+  return unbridged().isMoveOnly();
 }
 
 bool BridgedType::isEscapable() const {
-  return get().isEscapable();
+  return unbridged().isEscapable();
 }
 
 bool BridgedType::isOrContainsObjectiveCClass() const {
-  return get().isOrContainsObjectiveCClass();
+  return unbridged().isOrContainsObjectiveCClass();
 }
 
 bool BridgedType::isBuiltinInteger() const {
-  return get().isBuiltinInteger();
+  return unbridged().isBuiltinInteger();
 }
 
 bool BridgedType::isBuiltinFloat() const {
-  return get().isBuiltinFloat();
+  return unbridged().isBuiltinFloat();
 }
 
 bool BridgedType::isBuiltinVector() const {
-  return get().isBuiltinVector();
+  return unbridged().isBuiltinVector();
 }
 
 BridgedType BridgedType::getBuiltinVectorElementType() const {
-  return get().getBuiltinVectorElementType();
+  return unbridged().getBuiltinVectorElementType();
 }
 
 bool BridgedType::isBuiltinFixedWidthInteger(SwiftInt width) const {
-  return get().isBuiltinFixedWidthInteger((unsigned)width);
+  return unbridged().isBuiltinFixedWidthInteger((unsigned)width);
 }
 
 bool BridgedType::isExactSuperclassOf(BridgedType t) const {
-  return get().isExactSuperclassOf(t.get());
+  return unbridged().isExactSuperclassOf(t.unbridged());
 }
 
 BridgedType BridgedType::getInstanceTypeOfMetatype(BridgedFunction f) const {
-  return get().getInstanceTypeOfMetatype(f.getFunction());
+  return unbridged().getInstanceTypeOfMetatype(f.getFunction());
 }
 
 BridgedType::MetatypeRepresentation BridgedType::getRepresentationOfMetatype(BridgedFunction f) const {
-  return BridgedType::MetatypeRepresentation(get().getRepresentationOfMetatype(f.getFunction()));
+  return BridgedType::MetatypeRepresentation(
+      unbridged().getRepresentationOfMetatype(f.getFunction()));
 }
 
 bool BridgedType::isCalleeConsumedFunction() const {
-  return get().isCalleeConsumedFunction();
+  return unbridged().isCalleeConsumedFunction();
 }
 
 bool BridgedType::isMarkedAsImmortal() const {
-  return get().isMarkedAsImmortal();
+  return unbridged().isMarkedAsImmortal();
 }
 
 SwiftInt BridgedType::getCaseIdxOfEnumType(BridgedStringRef name) const {
-  return get().getCaseIdxOfEnumType(name.get());
+  return unbridged().getCaseIdxOfEnumType(name.unbridged());
 }
 
 SwiftInt BridgedType::getNumNominalFields() const {
-  return get().getNumNominalFields();
+  return unbridged().getNumNominalFields();
 }
 
 
 BridgedType BridgedType::getFieldType(SwiftInt idx, BridgedFunction f) const {
-  return get().getFieldType(idx, f.getFunction());
+  return unbridged().getFieldType(idx, f.getFunction());
 }
 
 SwiftInt BridgedType::getFieldIdxOfNominalType(BridgedStringRef name) const {
-  return get().getFieldIdxOfNominalType(name.get());
+  return unbridged().getFieldIdxOfNominalType(name.unbridged());
 }
 
 BridgedStringRef BridgedType::getFieldName(SwiftInt idx) const {
-  return get().getFieldName(idx);
+  return unbridged().getFieldName(idx);
 }
 
 SwiftInt BridgedType::getNumTupleElements() const {
-  return get().getNumTupleElements();
+  return unbridged().getNumTupleElements();
 }
 
 BridgedType BridgedType::getTupleElementType(SwiftInt idx) const {
-  return get().getTupleElementType(idx);
+  return unbridged().getTupleElementType(idx);
 }
 
 BridgedType BridgedType::getFunctionTypeWithNoEscape(bool withNoEscape) const {
-  auto fnType = get().getAs<swift::SILFunctionType>();
+  auto fnType = unbridged().getAs<swift::SILFunctionType>();
   auto newTy = fnType->getWithExtInfo(fnType->getExtInfo().withNoEscape(true));
   return swift::SILType::getPrimitiveObjectType(newTy);
 }
@@ -350,7 +351,7 @@ BridgedSubstitutionMap::BridgedSubstitutionMap() : BridgedSubstitutionMap(swift:
 }
 
 bool BridgedSubstitutionMap::isEmpty() const {
-  return get().empty();
+  return unbridged().empty();
 }
 
 //===----------------------------------------------------------------------===//
@@ -483,7 +484,7 @@ bool BridgedFunction::isGenericFunction() const {
 }
 
 bool BridgedFunction::hasSemanticsAttr(BridgedStringRef attrName) const {
-  return getFunction()->hasSemanticsAttr(attrName.get());
+  return getFunction()->hasSemanticsAttr(attrName.unbridged());
 }
 
 bool BridgedFunction::hasUnsafeNonEscapableResult() const {
@@ -556,11 +557,11 @@ OptionalBridgedInstruction BridgedGlobalVar::getFirstStaticInitInst() const {
 //===----------------------------------------------------------------------===//
 
 BridgedInstruction BridgedMultiValueResult::getParent() const {
-  return {get()->getParent()};
+  return {unbridged()->getParent()};
 }
 
 SwiftInt BridgedMultiValueResult::getIndex() const {
-  return (SwiftInt)get()->getIndex();
+  return (SwiftInt)unbridged()->getIndex();
 }
 
 //===----------------------------------------------------------------------===//
@@ -569,11 +570,11 @@ SwiftInt BridgedMultiValueResult::getIndex() const {
 
 BridgedTypeArray 
 BridgedTypeArray::fromReplacementTypes(BridgedSubstitutionMap substMap) {
-  return substMap.get().getReplacementTypes();
+  return substMap.unbridged().getReplacementTypes();
 }
 
 BridgedType BridgedTypeArray::getAt(SwiftInt index) const {
-  swift::Type origTy = get()[index];
+  swift::Type origTy = unbridged()[index];
   auto ty = origTy->getCanonicalType();
   if (ty->isLegalSILType())
     return swift::SILType::getPrimitiveObjectType(ty);
@@ -585,7 +586,7 @@ BridgedType BridgedTypeArray::getAt(SwiftInt index) const {
 //===----------------------------------------------------------------------===//
 
 BridgedType BridgedSILTypeArray::getAt(SwiftInt index) const {
-  return get()[index];
+  return unbridged()[index];
 }
 
 //===----------------------------------------------------------------------===//
@@ -593,65 +594,65 @@ BridgedType BridgedSILTypeArray::getAt(SwiftInt index) const {
 //===----------------------------------------------------------------------===//
 
 OptionalBridgedInstruction BridgedInstruction::getNext() const {
-  auto iter = std::next(get()->getIterator());
-  if (iter == get()->getParent()->end())
+  auto iter = std::next(unbridged()->getIterator());
+  if (iter == unbridged()->getParent()->end())
     return {nullptr};
   return {iter->asSILNode()};
 }
 
 OptionalBridgedInstruction BridgedInstruction::getPrevious() const {
-  auto iter = std::next(get()->getReverseIterator());
-  if (iter == get()->getParent()->rend())
+  auto iter = std::next(unbridged()->getReverseIterator());
+  if (iter == unbridged()->getParent()->rend())
     return {nullptr};
   return {iter->asSILNode()};
 }
 
 BridgedBasicBlock BridgedInstruction::getParent() const {
-  assert(!get()->isStaticInitializerInst() &&
+  assert(!unbridged()->isStaticInitializerInst() &&
          "cannot get the parent of a static initializer instruction");
-  return {get()->getParent()};
+  return {unbridged()->getParent()};
 }
 
 BridgedInstruction BridgedInstruction::getLastInstOfParent() const {
-  return {get()->getParent()->back().asSILNode()};
+  return {unbridged()->getParent()->back().asSILNode()};
 }
 
 bool BridgedInstruction::isDeleted() const {
-  return get()->isDeleted();
+  return unbridged()->isDeleted();
 }
 
 BridgedOperandArray BridgedInstruction::getOperands() const {
-  auto operands = get()->getAllOperands();
+  auto operands = unbridged()->getAllOperands();
   return {{operands.data()}, (SwiftInt)operands.size()};
 }
 
 BridgedOperandArray BridgedInstruction::getTypeDependentOperands() const {
-  auto typeOperands = get()->getTypeDependentOperands();
+  auto typeOperands = unbridged()->getTypeDependentOperands();
   return {{typeOperands.data()}, (SwiftInt)typeOperands.size()};
 }
 
 void BridgedInstruction::setOperand(SwiftInt index, BridgedValue value) const {
-  get()->setOperand((unsigned)index, value.getSILValue());
+  unbridged()->setOperand((unsigned)index, value.getSILValue());
 }
 
 BridgedLocation BridgedInstruction::getLocation() const {
-  return get()->getDebugLocation();
+  return unbridged()->getDebugLocation();
 }
 
 BridgedMemoryBehavior BridgedInstruction::getMemBehavior() const {
-  return (BridgedMemoryBehavior)get()->getMemoryBehavior();
+  return (BridgedMemoryBehavior)unbridged()->getMemoryBehavior();
 }
 
 bool BridgedInstruction::mayRelease() const {
-  return get()->mayRelease();
+  return unbridged()->mayRelease();
 }
 
 bool BridgedInstruction::mayHaveSideEffects() const {
-  return get()->mayHaveSideEffects();
+  return unbridged()->mayHaveSideEffects();
 }
 
 bool BridgedInstruction::maySuspend() const {
-  return get()->maySuspend();
+  return unbridged()->maySuspend();
 }
 
 SwiftInt BridgedInstruction::MultipleValueInstruction_getNumResults() const {
@@ -668,22 +669,22 @@ BridgedSuccessorArray BridgedInstruction::TermInst_getSuccessors() const {
 }
 
 OptionalBridgedOperand BridgedInstruction::ForwardingInst_singleForwardedOperand() const {
-  return {swift::ForwardingOperation(get()).getSingleForwardingOperand()};
+  return {swift::ForwardingOperation(unbridged()).getSingleForwardingOperand()};
 }
 
 BridgedOperandArray BridgedInstruction::ForwardingInst_forwardedOperands() const {
   auto operands =
-    swift::ForwardingOperation(get()).getForwardedOperands();
+      swift::ForwardingOperation(unbridged()).getForwardedOperands();
   return {{operands.data()}, (SwiftInt)operands.size()};
 }
 
 BridgedValue::Ownership BridgedInstruction::ForwardingInst_forwardingOwnership() const {
-  auto *forwardingInst = swift::ForwardingInstruction::get(get());
+  auto *forwardingInst = swift::ForwardingInstruction::get(unbridged());
   return castOwnership(forwardingInst->getForwardingOwnershipKind());
 }
 
 bool BridgedInstruction::ForwardingInst_preservesOwnership() const {
-  return swift::ForwardingInstruction::get(get())->preservesOwnership();
+  return swift::ForwardingInstruction::get(unbridged())->preservesOwnership();
 }
 
 BridgedStringRef BridgedInstruction::CondFailInst_getMessage() const {
@@ -839,7 +840,7 @@ SwiftInt BridgedInstruction::ObjectInst_getNumBaseElements() const {
 }
 
 SwiftInt BridgedInstruction::PartialApply_getCalleeArgIndexOfFirstAppliedArg() const {
-  return swift::ApplySite(get()).getCalleeArgIndexOfFirstAppliedArg();
+  return swift::ApplySite(unbridged()).getCalleeArgIndexOfFirstAppliedArg();
 }
 
 bool BridgedInstruction::PartialApplyInst_isOnStack() const {
@@ -946,7 +947,8 @@ void BridgedInstruction::AllocRefInst_setIsBare() const {
 }
 
 void BridgedInstruction::TermInst_replaceBranchTarget(BridgedBasicBlock from, BridgedBasicBlock to) const {
-  getAs<swift::TermInst>()->replaceBranchTarget(from.get(), to.get());
+  getAs<swift::TermInst>()->replaceBranchTarget(from.unbridged(),
+                                                to.unbridged());
 }
 
 SwiftInt BridgedInstruction::KeyPathInst_getNumComponents() const {
@@ -989,22 +991,22 @@ BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getFailureBlock() const 
 }
 
 BridgedSubstitutionMap BridgedInstruction::ApplySite_getSubstitutionMap() const {
-  auto as = swift::ApplySite(get());
+  auto as = swift::ApplySite(unbridged());
   return as.getSubstitutionMap();
 }
 
 BridgedArgumentConvention BridgedInstruction::ApplySite_getArgumentConvention(SwiftInt calleeArgIdx) const {
-  auto as = swift::ApplySite(get());
+  auto as = swift::ApplySite(unbridged());
   auto conv = as.getSubstCalleeConv().getSILArgumentConvention(calleeArgIdx);
   return castToArgumentConvention(conv.Value);
 }
 
 SwiftInt BridgedInstruction::ApplySite_getNumArguments() const {
-  return swift::ApplySite(get()).getNumArguments();
+  return swift::ApplySite(unbridged()).getNumArguments();
 }
 
 SwiftInt BridgedInstruction::FullApplySite_numIndirectResultArguments() const {
-  auto fas = swift::FullApplySite(get());
+  auto fas = swift::FullApplySite(unbridged());
   return fas.getNumIndirectSILResults();
 }
 
@@ -1052,65 +1054,66 @@ BridgedInstruction::AllocBox_getVarInfo() const {
 //===----------------------------------------------------------------------===//
 
 OptionalBridgedBasicBlock BridgedBasicBlock::getNext() const {
-  auto iter = std::next(get()->getIterator());
-  if (iter == get()->getParent()->end())
+  auto iter = std::next(unbridged()->getIterator());
+  if (iter == unbridged()->getParent()->end())
     return {nullptr};
   return {&*iter};
 }
 
 OptionalBridgedBasicBlock BridgedBasicBlock::getPrevious() const {
-  auto iter = std::next(get()->getReverseIterator());
-  if (iter == get()->getParent()->rend())
+  auto iter = std::next(unbridged()->getReverseIterator());
+  if (iter == unbridged()->getParent()->rend())
     return {nullptr};
   return {&*iter};
 }
 
 BridgedFunction BridgedBasicBlock::getFunction() const {
-  return {get()->getParent()};
+  return {unbridged()->getParent()};
 }
 
 OptionalBridgedInstruction BridgedBasicBlock::getFirstInst() const {
-  if (get()->empty())
+  if (unbridged()->empty())
     return {nullptr};
-  return {get()->front().asSILNode()};
+  return {unbridged()->front().asSILNode()};
 }
 
 OptionalBridgedInstruction BridgedBasicBlock::getLastInst() const {
-  if (get()->empty())
+  if (unbridged()->empty())
     return {nullptr};
-  return {get()->back().asSILNode()};
+  return {unbridged()->back().asSILNode()};
 }
 
 SwiftInt BridgedBasicBlock::getNumArguments() const {
-  return get()->getNumArguments();
+  return unbridged()->getNumArguments();
 }
 
 BridgedArgument BridgedBasicBlock::getArgument(SwiftInt index) const {
-  return {get()->getArgument(index)};
+  return {unbridged()->getArgument(index)};
 }
 
 BridgedArgument BridgedBasicBlock::addBlockArgument(BridgedType type, BridgedValue::Ownership ownership) const {
-  return {get()->createPhiArgument(type.get(), BridgedValue::castToOwnership(ownership))};
+  return {unbridged()->createPhiArgument(
+      type.unbridged(), BridgedValue::castToOwnership(ownership))};
 }
 
 void BridgedBasicBlock::eraseArgument(SwiftInt index) const {
-  get()->eraseArgument(index);
+  unbridged()->eraseArgument(index);
 }
 
 void BridgedBasicBlock::moveAllInstructionsToBegin(BridgedBasicBlock dest) const {
-  dest.get()->spliceAtBegin(get());
+  dest.unbridged()->spliceAtBegin(unbridged());
 }
 
 void BridgedBasicBlock::moveAllInstructionsToEnd(BridgedBasicBlock dest) const {
-  dest.get()->spliceAtEnd(get());
+  dest.unbridged()->spliceAtEnd(unbridged());
 }
 
 void BridgedBasicBlock::moveArgumentsTo(BridgedBasicBlock dest) const {
-  dest.get()->moveArgumentList(get());
+  dest.unbridged()->moveArgumentList(unbridged());
 }
 
 OptionalBridgedSuccessor BridgedBasicBlock::getFirstPred() const {
-  return {get()->pred_begin().getSuccessorRef()};
+  return {unbridged()->pred_begin().getSuccessorRef()};
 }
 
 //===----------------------------------------------------------------------===//
@@ -1184,108 +1187,114 @@ BridgedInstruction BridgedBuilder::createBuiltinBinaryFunction(BridgedStringRef 
                                                BridgedType operandType, BridgedType resultType,
                                                BridgedValueArray arguments) const {
   llvm::SmallVector<swift::SILValue, 16> argValues;
-  return {get().createBuiltinBinaryFunction(regularLoc(),
-                                                name.get(),
-                                                operandType.get(), resultType.get(),
-                                                arguments.getValues(argValues))};
+  return {unbridged().createBuiltinBinaryFunction(
+      regularLoc(), name.unbridged(), operandType.unbridged(),
+      resultType.unbridged(), arguments.getValues(argValues))};
 }
 
 BridgedInstruction BridgedBuilder::createCondFail(BridgedValue condition, BridgedStringRef message) const {
-  return {get().createCondFail(regularLoc(), condition.getSILValue(), message.get())};
+  return {unbridged().createCondFail(regularLoc(), condition.getSILValue(),
+                                     message.unbridged())};
 }
 
 BridgedInstruction BridgedBuilder::createIntegerLiteral(BridgedType type, SwiftInt value) const {
-  return {get().createIntegerLiteral(regularLoc(), type.get(), value)};
+  return {
+      unbridged().createIntegerLiteral(regularLoc(), type.unbridged(), value)};
 }
 
 BridgedInstruction BridgedBuilder::createAllocStack(BridgedType type,
                                     bool hasDynamicLifetime, bool isLexical, bool wasMoved) const {
-  return {get().createAllocStack(regularLoc(), type.get(), llvm::None,
-                                         hasDynamicLifetime, isLexical, wasMoved)};
+  return {unbridged().createAllocStack(regularLoc(), type.unbridged(),
+                                       llvm::None, hasDynamicLifetime,
+                                       isLexical, wasMoved)};
 }
 
 BridgedInstruction BridgedBuilder::createDeallocStack(BridgedValue operand) const {
-  return {get().createDeallocStack(regularLoc(), operand.getSILValue())};
+  return {unbridged().createDeallocStack(regularLoc(), operand.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createDeallocStackRef(BridgedValue operand) const {
-  return {get().createDeallocStackRef(regularLoc(), operand.getSILValue())};
+  return {
+      unbridged().createDeallocStackRef(regularLoc(), operand.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createUncheckedRefCast(BridgedValue op, BridgedType type) const {
-  return {get().createUncheckedRefCast(regularLoc(), op.getSILValue(), type.get())};
+  return {unbridged().createUncheckedRefCast(regularLoc(), op.getSILValue(),
+                                             type.unbridged())};
 }
 
 BridgedInstruction BridgedBuilder::createUpcast(BridgedValue op, BridgedType type) const {
-  return {get().createUpcast(regularLoc(), op.getSILValue(), type.get())};
+  return {unbridged().createUpcast(regularLoc(), op.getSILValue(),
+                                   type.unbridged())};
 }
 
 BridgedInstruction BridgedBuilder::createLoad(BridgedValue op, SwiftInt ownership) const {
-  return {get().createLoad(regularLoc(), op.getSILValue(), (swift::LoadOwnershipQualifier)ownership)};
+  return {unbridged().createLoad(regularLoc(), op.getSILValue(),
+                                 (swift::LoadOwnershipQualifier)ownership)};
 }
 
 BridgedInstruction BridgedBuilder::createBeginDeallocRef(BridgedValue reference, BridgedValue allocation) const {
-  return {get().createBeginDeallocRef(regularLoc(), reference.getSILValue(), allocation.getSILValue())};
+  return {unbridged().createBeginDeallocRef(
+      regularLoc(), reference.getSILValue(), allocation.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createEndInitLetRef(BridgedValue op) const {
-  return {get().createEndInitLetRef(regularLoc(), op.getSILValue())};
+  return {unbridged().createEndInitLetRef(regularLoc(), op.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createStrongRetain(BridgedValue op) const {
-  auto b = get();
+  auto b = unbridged();
   return {b.createStrongRetain(regularLoc(), op.getSILValue(), b.getDefaultAtomicity())};
 }
 
 BridgedInstruction BridgedBuilder::createStrongRelease(BridgedValue op) const {
-  auto b = get();
+  auto b = unbridged();
   return {b.createStrongRelease(regularLoc(), op.getSILValue(), b.getDefaultAtomicity())};
 }
 
 BridgedInstruction BridgedBuilder::createUnownedRetain(BridgedValue op) const {
-  auto b = get();
+  auto b = unbridged();
   return {b.createUnownedRetain(regularLoc(), op.getSILValue(), b.getDefaultAtomicity())};
 }
 
 BridgedInstruction BridgedBuilder::createUnownedRelease(BridgedValue op) const {
-  auto b = get();
+  auto b = unbridged();
   return {b.createUnownedRelease(regularLoc(), op.getSILValue(), b.getDefaultAtomicity())};
 }
 
 BridgedInstruction BridgedBuilder::createFunctionRef(BridgedFunction function) const {
-  return {get().createFunctionRef(regularLoc(), function.getFunction())};
+  return {unbridged().createFunctionRef(regularLoc(), function.getFunction())};
 }
 
 BridgedInstruction BridgedBuilder::createCopyValue(BridgedValue op) const {
-  return {get().createCopyValue(regularLoc(), op.getSILValue())};
+  return {unbridged().createCopyValue(regularLoc(), op.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createBeginBorrow(BridgedValue op) const {
-  return {get().createBeginBorrow(regularLoc(), op.getSILValue())};
+  return {unbridged().createBeginBorrow(regularLoc(), op.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createEndBorrow(BridgedValue op) const {
-  return {get().createEndBorrow(regularLoc(), op.getSILValue())};
+  return {unbridged().createEndBorrow(regularLoc(), op.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createCopyAddr(BridgedValue from, BridgedValue to,
                                   bool takeSource, bool initializeDest) const {
-  return {get().createCopyAddr(regularLoc(),
-                                   from.getSILValue(), to.getSILValue(),
-                                   swift::IsTake_t(takeSource),
-                                   swift::IsInitialization_t(initializeDest))};
+  return {unbridged().createCopyAddr(
+      regularLoc(), from.getSILValue(), to.getSILValue(),
+      swift::IsTake_t(takeSource), swift::IsInitialization_t(initializeDest))};
 }
 
 BridgedInstruction BridgedBuilder::createDestroyValue(BridgedValue op) const {
-  return {get().createDestroyValue(regularLoc(), op.getSILValue())};
+  return {unbridged().createDestroyValue(regularLoc(), op.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createDestroyAddr(BridgedValue op) const {
-  return {get().createDestroyAddr(regularLoc(), op.getSILValue())};
+  return {unbridged().createDestroyAddr(regularLoc(), op.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createDebugStep() const {
-  return {get().createDebugStep(regularLoc())};
+  return {unbridged().createDebugStep(regularLoc())};
 }
 
 BridgedInstruction BridgedBuilder::createApply(BridgedValue function, BridgedSubstitutionMap subMap,
@@ -1296,10 +1305,9 @@ BridgedInstruction BridgedBuilder::createApply(BridgedValue function, BridgedSub
   if (isNonThrowing) { applyOpts |= swift::ApplyFlags::DoesNotThrow; }
   if (isNonAsync) { applyOpts |= swift::ApplyFlags::DoesNotAwait; }
 
-  return {get().createApply(regularLoc(),
-                                function.getSILValue(), subMap.get(),
-                                arguments.getValues(argValues),
-                                applyOpts, specInfo.data)};
+  return {unbridged().createApply(
+      regularLoc(), function.getSILValue(), subMap.unbridged(),
+      arguments.getValues(argValues), applyOpts, specInfo.data)};
 }
 
 BridgedInstruction BridgedBuilder::createSwitchEnumInst(BridgedValue enumVal, OptionalBridgedBasicBlock defaultBlock,
@@ -1316,119 +1324,133 @@ BridgedInstruction BridgedBuilder::createSwitchEnumInst(BridgedValue enumVal, Op
   llvm::SmallVector<std::pair<swift::EnumElementDecl *, swift::SILBasicBlock *>, 16> convertedCases;
   for (auto c : cases) {
     assert(mappedElements.count(c.first) && "wrong enum element index");
-    convertedCases.push_back({mappedElements[c.first], c.second.get()});
+    convertedCases.push_back({mappedElements[c.first], c.second.unbridged()});
   }
-  return {get().createSwitchEnum(regularLoc(),
-                                       enumVal.getSILValue(),
-                                       defaultBlock.get(), convertedCases)};
+  return {unbridged().createSwitchEnum(regularLoc(), enumVal.getSILValue(),
+                                       defaultBlock.unbridged(),
+                                       convertedCases)};
 }
 
 BridgedInstruction BridgedBuilder::createUncheckedEnumData(BridgedValue enumVal, SwiftInt caseIdx,
                                            BridgedType resultType) const {
   swift::SILValue en = enumVal.getSILValue();
-  return {get().createUncheckedEnumData(regularLoc(), enumVal.getSILValue(),
-                                            en->getType().getEnumElement(caseIdx), resultType.get())};
+  return {unbridged().createUncheckedEnumData(
+      regularLoc(), enumVal.getSILValue(),
+      en->getType().getEnumElement(caseIdx), resultType.unbridged())};
 }
 
 BridgedInstruction BridgedBuilder::createEnum(SwiftInt caseIdx, OptionalBridgedValue payload,
                               BridgedType resultType) const {
-  swift::EnumElementDecl *caseDecl = resultType.get().getEnumElement(caseIdx);
+  swift::EnumElementDecl *caseDecl =
+      resultType.unbridged().getEnumElement(caseIdx);
   swift::SILValue pl = payload.getSILValue();
-  return {get().createEnum(regularLoc(), pl, caseDecl, resultType.get())};
+  return {unbridged().createEnum(regularLoc(), pl, caseDecl,
+                                 resultType.unbridged())};
 }
 
 BridgedInstruction BridgedBuilder::createThinToThickFunction(BridgedValue fn, BridgedType resultType) const {
-  return {get().createThinToThickFunction(regularLoc(), fn.getSILValue(), resultType.get())};
+  return {unbridged().createThinToThickFunction(regularLoc(), fn.getSILValue(),
+                                                resultType.unbridged())};
 }
 
 BridgedInstruction BridgedBuilder::createBranch(BridgedBasicBlock destBlock, BridgedValueArray arguments) const {
   llvm::SmallVector<swift::SILValue, 16> argValues;
-  return {get().createBranch(regularLoc(), destBlock.get(), arguments.getValues(argValues))};
+  return {unbridged().createBranch(regularLoc(), destBlock.unbridged(),
+                                   arguments.getValues(argValues))};
 }
 
 BridgedInstruction BridgedBuilder::createUnreachable() const {
-  return {get().createUnreachable(regularLoc())};
+  return {unbridged().createUnreachable(regularLoc())};
 }
 
 BridgedInstruction BridgedBuilder::createObject(BridgedType type,
                                                 BridgedValueArray arguments,
                                                 SwiftInt numBaseElements) const {
   llvm::SmallVector<swift::SILValue, 16> argValues;
-  return {get().createObject(swift::ArtificialUnreachableLocation(),
-                                 type.get(), arguments.getValues(argValues), numBaseElements)};
+  return {unbridged().createObject(
+      swift::ArtificialUnreachableLocation(), type.unbridged(),
+      arguments.getValues(argValues), numBaseElements)};
 }
 
 BridgedInstruction BridgedBuilder::createGlobalAddr(BridgedGlobalVar global) const {
-  return {get().createGlobalAddr(regularLoc(), global.getGlobal())};
+  return {unbridged().createGlobalAddr(regularLoc(), global.getGlobal())};
 }
 
 BridgedInstruction BridgedBuilder::createGlobalValue(BridgedGlobalVar global, bool isBare) const {
-  return {get().createGlobalValue(regularLoc(), global.getGlobal(), isBare)};
+  return {
+      unbridged().createGlobalValue(regularLoc(), global.getGlobal(), isBare)};
 }
 
 BridgedInstruction BridgedBuilder::createStruct(BridgedType type, BridgedValueArray elements) const {
   llvm::SmallVector<swift::SILValue, 16> elementValues;
-  return {get().createStruct(regularLoc(), type.get(), elements.getValues(elementValues))};
+  return {unbridged().createStruct(regularLoc(), type.unbridged(),
+                                   elements.getValues(elementValues))};
 }
 
 BridgedInstruction BridgedBuilder::createStructExtract(BridgedValue str, SwiftInt fieldIndex) const {
   swift::SILValue v = str.getSILValue();
-  return {get().createStructExtract(regularLoc(), v, v->getType().getFieldDecl(fieldIndex))};
+  return {unbridged().createStructExtract(
+      regularLoc(), v, v->getType().getFieldDecl(fieldIndex))};
 }
 
 BridgedInstruction BridgedBuilder::createStructElementAddr(BridgedValue addr, SwiftInt fieldIndex) const {
   swift::SILValue v = addr.getSILValue();
-  return {get().createStructElementAddr(regularLoc(), v, v->getType().getFieldDecl(fieldIndex))};
+  return {unbridged().createStructElementAddr(
+      regularLoc(), v, v->getType().getFieldDecl(fieldIndex))};
 }
 
 BridgedInstruction BridgedBuilder::createDestructureStruct(BridgedValue str) const {
-  return {get().createDestructureStruct(regularLoc(), str.getSILValue())};
+  return {unbridged().createDestructureStruct(regularLoc(), str.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createTuple(BridgedType type, BridgedValueArray elements) const {
   llvm::SmallVector<swift::SILValue, 16> elementValues;
-  return {get().createTuple(regularLoc(), type.get(), elements.getValues(elementValues))};
+  return {unbridged().createTuple(regularLoc(), type.unbridged(),
+                                  elements.getValues(elementValues))};
 }
 
 BridgedInstruction BridgedBuilder::createTupleExtract(BridgedValue str, SwiftInt elementIndex) const {
   swift::SILValue v = str.getSILValue();
-  return {get().createTupleExtract(regularLoc(), v, elementIndex)};
+  return {unbridged().createTupleExtract(regularLoc(), v, elementIndex)};
 }
 
 BridgedInstruction BridgedBuilder::createTupleElementAddr(BridgedValue addr, SwiftInt elementIndex) const {
   swift::SILValue v = addr.getSILValue();
-  return {get().createTupleElementAddr(regularLoc(), v, elementIndex)};
+  return {unbridged().createTupleElementAddr(regularLoc(), v, elementIndex)};
 }
 
 BridgedInstruction BridgedBuilder::createDestructureTuple(BridgedValue str) const {
-  return {get().createDestructureTuple(regularLoc(), str.getSILValue())};
+  return {unbridged().createDestructureTuple(regularLoc(), str.getSILValue())};
 }
 
 BridgedInstruction BridgedBuilder::createStore(BridgedValue src, BridgedValue dst,
                                SwiftInt ownership) const {
-  return {get().createStore(regularLoc(), src.getSILValue(), dst.getSILValue(),
-                                (swift::StoreOwnershipQualifier)ownership)};
+  return {unbridged().createStore(regularLoc(), src.getSILValue(),
+                                  dst.getSILValue(),
+                                  (swift::StoreOwnershipQualifier)ownership)};
 }
 
 BridgedInstruction BridgedBuilder::createInitExistentialRef(BridgedValue instance,
                                             BridgedType type,
                                             BridgedInstruction useConformancesOf) const {
   auto *src = useConformancesOf.getAs<swift::InitExistentialRefInst>();
-  return {get().createInitExistentialRef(regularLoc(), type.get(),
-                                             src->getFormalConcreteType(),
-                                             instance.getSILValue(),
-                                             src->getConformances())};
+  return {unbridged().createInitExistentialRef(
+      regularLoc(), type.unbridged(), src->getFormalConcreteType(),
+      instance.getSILValue(), src->getConformances())};
 }
 
 BridgedInstruction BridgedBuilder::createMetatype(BridgedType type,
                                                   BridgedType::MetatypeRepresentation representation) const {
-  auto *mt = swift::MetatypeType::get(type.get().getASTType(), (swift::MetatypeRepresentation)representation);
+  auto *mt =
+      swift::MetatypeType::get(type.unbridged().getASTType(),
+                               (swift::MetatypeRepresentation)representation);
   auto t = swift::SILType::getPrimitiveObjectType(swift::CanType(mt));
-  return {get().createMetatype(regularLoc(), t)};
+  return {unbridged().createMetatype(regularLoc(), t)};
 }
 
 BridgedInstruction BridgedBuilder::createEndCOWMutation(BridgedValue instance, bool keepUnique) const {
-  return {get().createEndCOWMutation(regularLoc(), instance.getSILValue(), keepUnique)};
+  return {unbridged().createEndCOWMutation(regularLoc(), instance.getSILValue(),
+                                           keepUnique)};
 }
 
 SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -84,7 +84,7 @@ struct BridgedCalleeAnalysis {
     CalleeList(swift::CalleeList list) {
       *reinterpret_cast<swift::CalleeList *>(&storage) = list;
     }
-    swift::CalleeList get() const {
+    swift::CalleeList unbridged() const {
       return *reinterpret_cast<const swift::CalleeList *>(&storage);
     }
 #endif

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -36,32 +36,6 @@
 
 using namespace swift;
 
-template <typename T>
-static inline llvm::ArrayRef<T>
-unbridgedArrayRef(const BridgedArrayRef bridged) {
-  return bridged.unbridged<T>();
-}
-
-static inline StringRef unbridged(BridgedStringRef cStr) {
-  return cStr.unbridged();
-}
-
-static inline ASTContext &unbridged(BridgedASTContext cContext) {
-  return cContext.unbridged();
-}
-
-static inline SourceLoc unbridged(BridgedSourceLoc cLoc) {
-  return cLoc.unbridged();
-}
-
-static inline SourceRange unbridged(BridgedSourceRange cRange) {
-  return cRange.unbridged();
-}
-
-static inline Identifier unbridged(BridgedIdentifier cIdentifier) {
-  return cIdentifier.unbridged();
-}
-
 static TypeAttrKind unbridged(BridgedTypeAttrKind kind) {
   switch (kind) {
 #define TYPE_ATTR(X)                                                           \
@@ -79,7 +53,7 @@ static TypeAttrKind unbridged(BridgedTypeAttrKind kind) {
 
 BridgedIdentifier BridgedASTContext_getIdentifier(BridgedASTContext cContext,
                                                   BridgedStringRef cStr) {
-  StringRef str = unbridged(cStr);
+  StringRef str = cStr.unbridged();
   if (str.size() == 1 && str.front() == '_')
     return BridgedIdentifier();
 
@@ -88,47 +62,22 @@ BridgedIdentifier BridgedASTContext_getIdentifier(BridgedASTContext cContext,
     str = str.drop_front().drop_back();
   }
 
-  return unbridged(cContext).getIdentifier(str);
+  return cContext.unbridged().getIdentifier(str);
 }
 
 bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
                                           BridgedFeature feature) {
-  return unbridged(cContext).LangOpts.hasFeature((Feature)feature);
+  return cContext.unbridged().LangOpts.hasFeature((Feature)feature);
 }
 
 //===----------------------------------------------------------------------===//
 // MARK: AST nodes
 //===----------------------------------------------------------------------===//
 
-// Define `bridged` overloads for each AST node.
-#define AST_BRIDGING_WRAPPER(Name)                                             \
-  [[maybe_unused]]                                                             \
-  static Bridged##Name bridged(Name *raw) {                                    \
-    return {raw};                                                              \
-  }                                                                            \
-// Don't define `bridged` overloads for the TypeRepr subclasses, since we always
-// return a BridgedTypeRepr currently, only define `bridged(TypeRepr *)`.
-#define TYPEREPR(Id, Parent)
-#include "swift/AST/ASTBridgingWrappers.def"
-
-// Define `unbridged` overloads for each AST node.
-#define AST_BRIDGING_WRAPPER(Name)                                             \
-  [[maybe_unused]] static Name *unbridged(Bridged##Name bridged) {             \
-    return bridged.unbridged();                                                \
-  }
-#include "swift/AST/ASTBridgingWrappers.def"
-
-#define AST_BRIDGING_WRAPPER_NULLABLE(Name)                                    \
-  [[maybe_unused]] static Name *unbridged(BridgedNullable##Name bridged) {     \
-    return bridged.unbridged();                                                \
-  }
-#define AST_BRIDGING_WRAPPER_NONNULL(Name)
-#include "swift/AST/ASTBridgingWrappers.def"
-
 // Define `.asDecl` on each BridgedXXXDecl type.
 #define DECL(Id, Parent)                                                       \
   BridgedDecl Bridged##Id##Decl_asDecl(Bridged##Id##Decl decl) {               \
-    return bridged(static_cast<Decl *>(unbridged(decl)));                      \
+    return static_cast<Decl *>(decl.unbridged());                              \
   }
 #define ABSTRACT_DECL(Id, Parent) DECL(Id, Parent)
 #include "swift/AST/DeclNodes.def"
@@ -138,7 +87,7 @@ bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
 #define DECL(Id, Parent)
 #define CONTEXT_DECL(Id, Parent)                                               \
   BridgedDeclContext Bridged##Id##Decl_asDeclContext(Bridged##Id##Decl decl) { \
-    return bridged(static_cast<DeclContext *>(unbridged(decl)));               \
+    return static_cast<DeclContext *>(decl.unbridged());                       \
   }
 #define ABSTRACT_CONTEXT_DECL(Id, Parent) CONTEXT_DECL(Id, Parent)
 #include "swift/AST/DeclNodes.def"
@@ -146,7 +95,7 @@ bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
 // Define `.asStmt` on each BridgedXXXStmt type.
 #define STMT(Id, Parent)                                                       \
   BridgedStmt Bridged##Id##Stmt_asStmt(Bridged##Id##Stmt stmt) {               \
-    return bridged(static_cast<Stmt *>(unbridged(stmt)));                      \
+    return static_cast<Stmt *>(stmt.unbridged());                              \
   }
 #define ABSTRACT_STMT(Id, Parent) STMT(Id, Parent)
 #include "swift/AST/StmtNodes.def"
@@ -154,7 +103,7 @@ bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
 // Define `.asExpr` on each BridgedXXXExpr type.
 #define EXPR(Id, Parent)                                                       \
   BridgedExpr Bridged##Id##Expr_asExpr(Bridged##Id##Expr expr) {               \
-    return bridged(static_cast<Expr *>(unbridged(expr)));                      \
+    return static_cast<Expr *>(expr.unbridged());                              \
   }
 #define ABSTRACT_EXPR(Id, Parent) EXPR(Id, Parent)
 #include "swift/AST/ExprNodes.def"
@@ -163,7 +112,7 @@ bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
 #define TYPEREPR(Id, Parent)                                                   \
   BridgedTypeRepr Bridged##Id##TypeRepr_asTypeRepr(                            \
       Bridged##Id##TypeRepr typeRepr) {                                        \
-    return bridged(static_cast<TypeRepr *>(unbridged(typeRepr)));              \
+    return static_cast<TypeRepr *>(typeRepr.unbridged());                      \
   }
 #define ABSTRACT_TYPEREPR(Id, Parent) TYPEREPR(Id, Parent)
 #include "swift/AST/TypeReprNodes.def"
@@ -251,19 +200,15 @@ struct BridgedDiagnostic::Impl {
   }
 };
 
-static inline BridgedDiagnostic::Impl *unbridged(BridgedDiagnostic cDiag) {
-  return cDiag.unbridged();
-}
-
 BridgedDiagnostic BridgedDiagnostic_create(BridgedSourceLoc cLoc,
                                            BridgedStringRef cText,
                                            BridgedDiagnosticSeverity severity,
                                            BridgedDiagnosticEngine cDiags) {
-  StringRef origText = unbridged(cText);
+  StringRef origText = cText.unbridged();
   BridgedDiagnostic::Impl::Allocator alloc;
   StringRef text = origText.copy(alloc);
 
-  SourceLoc loc = unbridged(cLoc);
+  SourceLoc loc = cLoc.unbridged();
 
   Diag<StringRef> diagID;
   switch (severity) {
@@ -284,7 +229,7 @@ BridgedDiagnostic BridgedDiagnostic_create(BridgedSourceLoc cLoc,
     break;
   }
 
-  DiagnosticEngine &diags = *unbridged(cDiags);
+  DiagnosticEngine &diags = *cDiags.unbridged();
   return new BridgedDiagnostic::Impl{diags.diagnose(loc, diagID, text), {text}};
 }
 
@@ -292,10 +237,10 @@ BridgedDiagnostic BridgedDiagnostic_create(BridgedSourceLoc cLoc,
 void BridgedDiagnostic_highlight(BridgedDiagnostic cDiag,
                                  BridgedSourceLoc cStartLoc,
                                  BridgedSourceLoc cEndLoc) {
-  SourceLoc startLoc = unbridged(cStartLoc);
-  SourceLoc endLoc = unbridged(cEndLoc);
+  SourceLoc startLoc = cStartLoc.unbridged();
+  SourceLoc endLoc = cEndLoc.unbridged();
 
-  BridgedDiagnostic::Impl *diag = unbridged(cDiag);
+  BridgedDiagnostic::Impl *diag = cDiag.unbridged();
   diag->inFlight.highlightChars(startLoc, endLoc);
 }
 
@@ -305,21 +250,21 @@ void BridgedDiagnostic_fixItReplace(BridgedDiagnostic cDiag,
                                     BridgedSourceLoc cEndLoc,
                                     BridgedStringRef cReplaceText) {
 
-  SourceLoc startLoc = unbridged(cStartLoc);
-  SourceLoc endLoc = unbridged(cEndLoc);
+  SourceLoc startLoc = cStartLoc.unbridged();
+  SourceLoc endLoc = cEndLoc.unbridged();
 
-  StringRef origReplaceText = unbridged(cReplaceText);
+  StringRef origReplaceText = cReplaceText.unbridged();
   BridgedDiagnostic::Impl::Allocator alloc;
   StringRef replaceText = origReplaceText.copy(alloc);
 
-  BridgedDiagnostic::Impl *diag = unbridged(cDiag);
+  BridgedDiagnostic::Impl *diag = cDiag.unbridged();
   diag->textBlobs.push_back(replaceText);
   diag->inFlight.fixItReplaceChars(startLoc, endLoc, replaceText);
 }
 
 /// Finish the given diagnostic and emit it.
 void BridgedDiagnostic_finish(BridgedDiagnostic cDiag) {
-  BridgedDiagnostic::Impl *diag = unbridged(cDiag);
+  BridgedDiagnostic::Impl *diag = cDiag.unbridged();
   delete diag;
 }
 
@@ -331,22 +276,21 @@ BridgedPatternBindingDecl BridgedPatternBindingDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cBindingKeywordLoc, BridgedExpr nameExpr,
     BridgedExpr initExpr, bool isStatic, bool isLet) {
-  ASTContext &context = unbridged(cContext);
-  DeclContext *declContext = unbridged(cDeclContext);
+  ASTContext &context = cContext.unbridged();
+  DeclContext *declContext = cDeclContext.unbridged();
 
-  auto *name = cast<UnresolvedDeclRefExpr>(unbridged(nameExpr));
+  auto *name = cast<UnresolvedDeclRefExpr>(nameExpr.unbridged());
   auto *varDecl = new (context) VarDecl(
       isStatic, isLet ? VarDecl::Introducer::Let : VarDecl::Introducer::Var,
       name->getLoc(), name->getName().getBaseIdentifier(), declContext);
   auto *pattern = new (context) NamedPattern(varDecl);
-  auto *PBD = PatternBindingDecl::create(
-      context,
-      /*StaticLoc=*/SourceLoc(), // FIXME
-      isStatic ? StaticSpellingKind::KeywordStatic : StaticSpellingKind::None,
-      unbridged(cBindingKeywordLoc), pattern,
-      /*EqualLoc=*/SourceLoc(), // FIXME
-      unbridged(initExpr), declContext);
-  return bridged(PBD);
+  return PatternBindingDecl::create(context,
+                                    /*StaticLoc=*/SourceLoc(), // FIXME
+                                    isStatic ? StaticSpellingKind::KeywordStatic
+                                             : StaticSpellingKind::None,
+                                    cBindingKeywordLoc.unbridged(), pattern,
+                                    /*EqualLoc=*/SourceLoc(), // FIXME
+                                    initExpr.unbridged(), declContext);
 }
 
 BridgedParamDecl BridgedParamDecl_createParsed(
@@ -366,9 +310,9 @@ BridgedParamDecl BridgedParamDecl_createParsed(
     secondNameLoc = firstNameLoc;
   }
 
-  auto *declContext = unbridged(cDeclContext);
+  auto *declContext = cDeclContext.unbridged();
 
-  auto *defaultValue = unbridged(opaqueDefaultValue);
+  auto *defaultValue = opaqueDefaultValue.unbridged();
   DefaultArgumentKind defaultArgumentKind;
 
   if (declContext->getParentSourceFile()->Kind == SourceFileKind::Interface &&
@@ -379,29 +323,29 @@ BridgedParamDecl BridgedParamDecl_createParsed(
     defaultArgumentKind = getDefaultArgKind(defaultValue);
   }
 
-  auto *paramDecl = new (unbridged(cContext)) ParamDecl(
-      unbridged(cSpecifierLoc), firstNameLoc, firstName, secondNameLoc,
-      secondName, declContext);
-  paramDecl->setTypeRepr(unbridged(opaqueType));
+  auto *paramDecl = new (cContext.unbridged())
+      ParamDecl(cSpecifierLoc.unbridged(), firstNameLoc, firstName,
+                secondNameLoc, secondName, declContext);
+  paramDecl->setTypeRepr(opaqueType.unbridged());
   paramDecl->setDefaultExpr(defaultValue, /*isTypeChecked*/ false);
   paramDecl->setDefaultArgumentKind(defaultArgumentKind);
 
-  return bridged(paramDecl);
+  return paramDecl;
 }
 
 void BridgedConstructorDecl_setParsedBody(BridgedConstructorDecl decl,
                                           BridgedBraceStmt body) {
-  unbridged(decl)->setBody(unbridged(body), FuncDecl::BodyKind::Parsed);
+  decl.unbridged()->setBody(body.unbridged(), FuncDecl::BodyKind::Parsed);
 }
 
 void BridgedFuncDecl_setParsedBody(BridgedFuncDecl decl,
                                    BridgedBraceStmt body) {
-  unbridged(decl)->setBody(unbridged(body), FuncDecl::BodyKind::Parsed);
+  decl.unbridged()->setBody(body.unbridged(), FuncDecl::BodyKind::Parsed);
 }
 
 void BridgedDestructorDecl_setParsedBody(BridgedDestructorDecl decl,
                                          BridgedBraceStmt body) {
-  unbridged(decl)->setBody(unbridged(body), FuncDecl::BodyKind::Parsed);
+  decl.unbridged()->setBody(body.unbridged(), FuncDecl::BodyKind::Parsed);
 }
 
 BridgedFuncDecl BridgedFuncDecl_createParsed(
@@ -413,23 +357,23 @@ BridgedFuncDecl BridgedFuncDecl_createParsed(
     BridgedSourceLoc cThrowsLoc, BridgedNullableTypeRepr thrownType,
     BridgedNullableTypeRepr returnType,
     BridgedNullableTrailingWhereClause genericWhereClause) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
-  auto *paramList = unbridged(parameterList);
-  auto declName = DeclName(context, unbridged(cName), paramList);
-  auto asyncLoc = unbridged(cAsyncLoc);
-  auto throwsLoc = unbridged(cThrowsLoc);
+  auto *paramList = parameterList.unbridged();
+  auto declName = DeclName(context, cName.unbridged(), paramList);
+  auto asyncLoc = cAsyncLoc.unbridged();
+  auto throwsLoc = cThrowsLoc.unbridged();
   // FIXME: rethrows
 
   auto *decl = FuncDecl::create(
-      context, unbridged(cStaticLoc), StaticSpellingKind::None,
-      unbridged(cFuncKeywordLoc), declName, unbridged(cNameLoc),
+      context, cStaticLoc.unbridged(), StaticSpellingKind::None,
+      cFuncKeywordLoc.unbridged(), declName, cNameLoc.unbridged(),
       asyncLoc.isValid(), asyncLoc, throwsLoc.isValid(), throwsLoc,
-      unbridged(thrownType), unbridged(genericParamList), paramList,
-      unbridged(returnType), unbridged(cDeclContext));
-  decl->setTrailingWhereClause(unbridged(genericWhereClause));
+      thrownType.unbridged(), genericParamList.unbridged(), paramList,
+      returnType.unbridged(), cDeclContext.unbridged());
+  decl->setTrailingWhereClause(genericWhereClause.unbridged());
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedConstructorDecl BridgedConstructorDecl_createParsed(
@@ -441,36 +385,36 @@ BridgedConstructorDecl BridgedConstructorDecl_createParsed(
     BridgedNullableTrailingWhereClause genericWhereClause) {
   assert(cFailabilityMarkLoc.unbridged().isValid() || !isIUO);
 
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
-  auto *parameterList = unbridged(bridgedParameterList);
+  auto *parameterList = bridgedParameterList.unbridged();
   auto declName =
       DeclName(context, DeclBaseName::createConstructor(), parameterList);
-  auto asyncLoc = unbridged(cAsyncLoc);
-  auto throwsLoc = unbridged(cThrowsLoc);
-  auto failabilityMarkLoc = unbridged(cFailabilityMarkLoc);
+  auto asyncLoc = cAsyncLoc.unbridged();
+  auto throwsLoc = cThrowsLoc.unbridged();
+  auto failabilityMarkLoc = cFailabilityMarkLoc.unbridged();
   // FIXME: rethrows
 
   auto *decl = new (context) ConstructorDecl(
-      declName, unbridged(cInitKeywordLoc), failabilityMarkLoc.isValid(),
+      declName, cInitKeywordLoc.unbridged(), failabilityMarkLoc.isValid(),
       failabilityMarkLoc, asyncLoc.isValid(), asyncLoc, throwsLoc.isValid(),
-      throwsLoc, unbridged(thrownType), parameterList, unbridged(genericParams),
-      unbridged(cDeclContext));
-  decl->setTrailingWhereClause(unbridged(genericWhereClause));
+      throwsLoc, thrownType.unbridged(), parameterList,
+      genericParams.unbridged(), cDeclContext.unbridged());
+  decl->setTrailingWhereClause(genericWhereClause.unbridged());
   decl->setImplicitlyUnwrappedOptional(isIUO);
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedDestructorDecl
 BridgedDestructorDecl_createParsed(BridgedASTContext cContext,
                                    BridgedDeclContext cDeclContext,
                                    BridgedSourceLoc cDeinitKeywordLoc) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
   auto *decl = new (context)
-      DestructorDecl(unbridged(cDeinitKeywordLoc), unbridged(cDeclContext));
+      DestructorDecl(cDeinitKeywordLoc.unbridged(), cDeclContext.unbridged());
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedTypeAliasDecl BridgedTypeAliasDecl_createParsed(
@@ -479,16 +423,16 @@ BridgedTypeAliasDecl BridgedTypeAliasDecl_createParsed(
     BridgedSourceLoc cNameLoc, BridgedNullableGenericParamList genericParamList,
     BridgedSourceLoc cEqualLoc, BridgedTypeRepr opaqueUnderlyingType,
     BridgedNullableTrailingWhereClause genericWhereClause) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
   auto *decl = new (context)
-      TypeAliasDecl(unbridged(cAliasKeywordLoc), unbridged(cEqualLoc),
-                    unbridged(cName), unbridged(cNameLoc),
-                    unbridged(genericParamList), unbridged(cDeclContext));
-  decl->setUnderlyingTypeRepr(unbridged(opaqueUnderlyingType));
-  decl->setTrailingWhereClause(unbridged(genericWhereClause));
+      TypeAliasDecl(cAliasKeywordLoc.unbridged(), cEqualLoc.unbridged(),
+                    cName.unbridged(), cNameLoc.unbridged(),
+                    genericParamList.unbridged(), cDeclContext.unbridged());
+  decl->setUnderlyingTypeRepr(opaqueUnderlyingType.unbridged());
+  decl->setTrailingWhereClause(genericWhereClause.unbridged());
 
-  return bridged(decl);
+  return decl;
 }
 
 static void setParsedMembers(IterableDeclContext *IDC,
@@ -496,7 +440,7 @@ static void setParsedMembers(IterableDeclContext *IDC,
   auto &ctx = IDC->getDecl()->getASTContext();
 
   SmallVector<Decl *> members;
-  for (auto *decl : unbridgedArrayRef<Decl *>(bridgedMembers)) {
+  for (auto *decl : bridgedMembers.unbridged<Decl *>()) {
     members.push_back(decl);
     // Each enum case element is also part of the members list according to the
     // legacy parser.
@@ -514,19 +458,19 @@ static void setParsedMembers(IterableDeclContext *IDC,
 
 void BridgedNominalTypeDecl_setParsedMembers(BridgedNominalTypeDecl bridgedDecl,
                                              BridgedArrayRef bridgedMembers) {
-  setParsedMembers(unbridged(bridgedDecl), bridgedMembers);
+  setParsedMembers(bridgedDecl.unbridged(), bridgedMembers);
 }
 
 void BridgedExtensionDecl_setParsedMembers(BridgedExtensionDecl bridgedDecl,
                                            BridgedArrayRef bridgedMembers) {
-  setParsedMembers(unbridged(bridgedDecl), bridgedMembers);
+  setParsedMembers(bridgedDecl.unbridged(), bridgedMembers);
 }
 
 static SmallVector<InheritedEntry>
 convertToInheritedEntries(BridgedArrayRef cInheritedTypes) {
   SmallVector<InheritedEntry> inheritedEntries;
-  for (auto &repr : unbridgedArrayRef<BridgedTypeRepr>(cInheritedTypes)) {
-    inheritedEntries.emplace_back(unbridged(repr));
+  for (auto &repr : cInheritedTypes.unbridged<BridgedTypeRepr>()) {
+    inheritedEntries.emplace_back(repr.unbridged());
   }
 
   return inheritedEntries;
@@ -539,27 +483,25 @@ BridgedNominalTypeDecl BridgedEnumDecl_createParsed(
     BridgedArrayRef cInheritedTypes,
     BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
   NominalTypeDecl *decl = new (context) EnumDecl(
-      unbridged(cEnumKeywordLoc), unbridged(cName), unbridged(cNameLoc),
+      cEnumKeywordLoc.unbridged(), cName.unbridged(), cNameLoc.unbridged(),
       context.AllocateCopy(convertToInheritedEntries(cInheritedTypes)),
-      unbridged(genericParamList), unbridged(cDeclContext));
-  decl->setTrailingWhereClause(unbridged(genericWhereClause));
-  decl->setBraces(unbridged(cBraceRange));
+      genericParamList.unbridged(), cDeclContext.unbridged());
+  decl->setTrailingWhereClause(genericWhereClause.unbridged());
+  decl->setBraces(cBraceRange.unbridged());
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedEnumCaseDecl
 BridgedEnumCaseDecl_createParsed(BridgedDeclContext cDeclContext,
                                  BridgedSourceLoc cCaseKeywordLoc,
                                  BridgedArrayRef cElements) {
-  auto *decl = EnumCaseDecl::create(
-      unbridged(cCaseKeywordLoc),
-      unbridgedArrayRef<EnumElementDecl *>(cElements), unbridged(cDeclContext));
-
-  return bridged(decl);
+  return EnumCaseDecl::create(cCaseKeywordLoc.unbridged(),
+                              cElements.unbridged<EnumElementDecl *>(),
+                              cDeclContext.unbridged());
 }
 
 BridgedEnumElementDecl BridgedEnumElementDecl_createParsed(
@@ -567,12 +509,12 @@ BridgedEnumElementDecl BridgedEnumElementDecl_createParsed(
     BridgedIdentifier cName, BridgedSourceLoc cNameLoc,
     BridgedNullableParameterList bridgedParameterList,
     BridgedSourceLoc cEqualsLoc, BridgedNullableExpr rawValue) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
-  auto *parameterList = unbridged(bridgedParameterList);
+  auto *parameterList = bridgedParameterList.unbridged();
   DeclName declName;
   {
-    auto identifier = unbridged(cName);
+    auto identifier = cName.unbridged();
     if (parameterList) {
       declName = DeclName(context, identifier, parameterList);
     } else {
@@ -580,10 +522,10 @@ BridgedEnumElementDecl BridgedEnumElementDecl_createParsed(
     }
   }
 
-  auto *EED = new (context) EnumElementDecl(
-      unbridged(cNameLoc), declName, parameterList, unbridged(cEqualsLoc),
-      cast_or_null<LiteralExpr>(unbridged(rawValue)), unbridged(cDeclContext));
-  return bridged(EED);
+  return new (context) EnumElementDecl(
+      cNameLoc.unbridged(), declName, parameterList, cEqualsLoc.unbridged(),
+      cast_or_null<LiteralExpr>(rawValue.unbridged()),
+      cDeclContext.unbridged());
 }
 
 BridgedNominalTypeDecl BridgedStructDecl_createParsed(
@@ -593,16 +535,16 @@ BridgedNominalTypeDecl BridgedStructDecl_createParsed(
     BridgedArrayRef cInheritedTypes,
     BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
   NominalTypeDecl *decl = new (context) StructDecl(
-      unbridged(cStructKeywordLoc), unbridged(cName), unbridged(cNameLoc),
+      cStructKeywordLoc.unbridged(), cName.unbridged(), cNameLoc.unbridged(),
       context.AllocateCopy(convertToInheritedEntries(cInheritedTypes)),
-      unbridged(genericParamList), unbridged(cDeclContext));
-  decl->setTrailingWhereClause(unbridged(genericWhereClause));
-  decl->setBraces(unbridged(cBraceRange));
+      genericParamList.unbridged(), cDeclContext.unbridged());
+  decl->setTrailingWhereClause(genericWhereClause.unbridged());
+  decl->setBraces(cBraceRange.unbridged());
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedNominalTypeDecl BridgedClassDecl_createParsed(
@@ -612,16 +554,16 @@ BridgedNominalTypeDecl BridgedClassDecl_createParsed(
     BridgedArrayRef cInheritedTypes,
     BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange, bool isActor) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
   NominalTypeDecl *decl = new (context) ClassDecl(
-      unbridged(cClassKeywordLoc), unbridged(cName), unbridged(cNameLoc),
+      cClassKeywordLoc.unbridged(), cName.unbridged(), cNameLoc.unbridged(),
       context.AllocateCopy(convertToInheritedEntries(cInheritedTypes)),
-      unbridged(genericParamList), unbridged(cDeclContext), isActor);
-  decl->setTrailingWhereClause(unbridged(genericWhereClause));
-  decl->setBraces(unbridged(cBraceRange));
+      genericParamList.unbridged(), cDeclContext.unbridged(), isActor);
+  decl->setTrailingWhereClause(genericWhereClause.unbridged());
+  decl->setBraces(cBraceRange.unbridged());
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedNominalTypeDecl BridgedProtocolDecl_createParsed(
@@ -632,22 +574,22 @@ BridgedNominalTypeDecl BridgedProtocolDecl_createParsed(
     BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange) {
   SmallVector<PrimaryAssociatedTypeName, 2> primaryAssociatedTypeNames;
-  for (auto &pair : unbridgedArrayRef<BridgedIdentifierAndSourceLoc>(
-           cPrimaryAssociatedTypeNames)) {
-    primaryAssociatedTypeNames.emplace_back(unbridged(pair.Name),
-                                            unbridged(pair.NameLoc));
+  for (auto &pair :
+       cPrimaryAssociatedTypeNames.unbridged<BridgedIdentifierAndSourceLoc>()) {
+    primaryAssociatedTypeNames.emplace_back(pair.Name.unbridged(),
+                                            pair.NameLoc.unbridged());
   }
 
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
   NominalTypeDecl *decl = new (context) ProtocolDecl(
-      unbridged(cDeclContext), unbridged(cProtocolKeywordLoc),
-      unbridged(cNameLoc), unbridged(cName),
+      cDeclContext.unbridged(), cProtocolKeywordLoc.unbridged(),
+      cNameLoc.unbridged(), cName.unbridged(),
       context.AllocateCopy(primaryAssociatedTypeNames),
       context.AllocateCopy(convertToInheritedEntries(cInheritedTypes)),
-      unbridged(genericWhereClause));
-  decl->setBraces(unbridged(cBraceRange));
+      genericWhereClause.unbridged());
+  decl->setBraces(cBraceRange.unbridged());
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedAssociatedTypeDecl BridgedAssociatedTypeDecl_createParsed(
@@ -656,16 +598,16 @@ BridgedAssociatedTypeDecl BridgedAssociatedTypeDecl_createParsed(
     BridgedSourceLoc cNameLoc, BridgedArrayRef cInheritedTypes,
     BridgedNullableTypeRepr defaultType,
     BridgedNullableTrailingWhereClause genericWhereClause) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
   auto *decl = AssociatedTypeDecl::createParsed(
-      context, unbridged(cDeclContext), unbridged(cAssociatedtypeKeywordLoc),
-      unbridged(cName), unbridged(cNameLoc), unbridged(defaultType),
-      unbridged(genericWhereClause));
+      context, cDeclContext.unbridged(), cAssociatedtypeKeywordLoc.unbridged(),
+      cName.unbridged(), cNameLoc.unbridged(), defaultType.unbridged(),
+      genericWhereClause.unbridged());
   decl->setInherited(
       context.AllocateCopy(convertToInheritedEntries(cInheritedTypes)));
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedExtensionDecl BridgedExtensionDecl_createParsed(
@@ -674,14 +616,14 @@ BridgedExtensionDecl BridgedExtensionDecl_createParsed(
     BridgedArrayRef cInheritedTypes,
     BridgedNullableTrailingWhereClause genericWhereClause,
     BridgedSourceRange cBraceRange) {
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
 
   auto *decl = ExtensionDecl::create(
-      context, unbridged(cExtensionKeywordLoc), unbridged(extendedType),
+      context, cExtensionKeywordLoc.unbridged(), extendedType.unbridged(),
       context.AllocateCopy(convertToInheritedEntries(cInheritedTypes)),
-      unbridged(cDeclContext), unbridged(genericWhereClause));
-  decl->setBraces(unbridged(cBraceRange));
-  return bridged(decl);
+      cDeclContext.unbridged(), genericWhereClause.unbridged());
+  decl->setBraces(cBraceRange.unbridged());
+  return decl;
 }
 
 BridgedOperatorDecl BridgedOperatorDecl_createParsed(
@@ -694,18 +636,18 @@ BridgedOperatorDecl BridgedOperatorDecl_createParsed(
   assert(colonLoc.isValid() == cPrecedenceGroupName.unbridged().nonempty());
   assert(colonLoc.isValid() == cPrecedenceGroupLoc.unbridged().isValid());
 
-  ASTContext &context = unbridged(cContext);
-  auto operatorKeywordLoc = unbridged(cOperatorKeywordLoc);
-  auto name = unbridged(cName);
-  auto nameLoc = unbridged(cNameLoc);
-  auto *declContext = unbridged(cDeclContext);
+  ASTContext &context = cContext.unbridged();
+  auto operatorKeywordLoc = cOperatorKeywordLoc.unbridged();
+  auto name = cName.unbridged();
+  auto nameLoc = cNameLoc.unbridged();
+  auto *declContext = cDeclContext.unbridged();
 
   OperatorDecl *decl = nullptr;
   switch (cFixity) {
   case BridgedOperatorFixityInfix:
     decl = new (context) InfixOperatorDecl(
-        declContext, operatorKeywordLoc, name, nameLoc, unbridged(cColonLoc),
-        unbridged(cPrecedenceGroupName), unbridged(cPrecedenceGroupLoc));
+        declContext, operatorKeywordLoc, name, nameLoc, cColonLoc.unbridged(),
+        cPrecedenceGroupName.unbridged(), cPrecedenceGroupLoc.unbridged());
     break;
   case BridgedOperatorFixityPrefix:
     assert(colonLoc.isInvalid());
@@ -719,7 +661,7 @@ BridgedOperatorDecl BridgedOperatorDecl_createParsed(
     break;
   }
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedPrecedenceGroupDecl BridgedPrecedenceGroupDecl_createParsed(
@@ -736,29 +678,27 @@ BridgedPrecedenceGroupDecl BridgedPrecedenceGroupDecl_createParsed(
 
   SmallVector<PrecedenceGroupDecl::Relation, 2> higherThanNames;
   for (auto &pair :
-       unbridgedArrayRef<BridgedIdentifierAndSourceLoc>(cHigherThanNames)) {
+       cHigherThanNames.unbridged<BridgedIdentifierAndSourceLoc>()) {
     higherThanNames.push_back(
-        {unbridged(pair.NameLoc), unbridged(pair.Name), nullptr});
+        {pair.NameLoc.unbridged(), pair.Name.unbridged(), nullptr});
   }
 
   SmallVector<PrecedenceGroupDecl::Relation, 2> lowerThanNames;
   for (auto &pair :
-       unbridgedArrayRef<BridgedIdentifierAndSourceLoc>(cLowerThanNames)) {
+       cLowerThanNames.unbridged<BridgedIdentifierAndSourceLoc>()) {
     lowerThanNames.push_back(
-        {unbridged(pair.NameLoc), unbridged(pair.Name), nullptr});
+        {pair.NameLoc.unbridged(), pair.Name.unbridged(), nullptr});
   }
 
-  auto *decl = PrecedenceGroupDecl::create(
-      unbridged(cDeclContext), unbridged(cPrecedencegroupKeywordLoc),
-      unbridged(cNameLoc), unbridged(cName), unbridged(cLeftBraceLoc),
-      unbridged(cAssociativityKeywordLoc), unbridged(cAssociativityValueLoc),
+  return PrecedenceGroupDecl::create(
+      cDeclContext.unbridged(), cPrecedencegroupKeywordLoc.unbridged(),
+      cNameLoc.unbridged(), cName.unbridged(), cLeftBraceLoc.unbridged(),
+      cAssociativityKeywordLoc.unbridged(), cAssociativityValueLoc.unbridged(),
       static_cast<Associativity>(cAssociativity),
-      unbridged(cAssignmentKeywordLoc), unbridged(cAssignmentValueLoc),
-      isAssignment, unbridged(cHigherThanKeywordLoc), higherThanNames,
-      unbridged(cLowerThanKeywordLoc), lowerThanNames,
-      unbridged(cRightBraceLoc));
-
-  return bridged(decl);
+      cAssignmentKeywordLoc.unbridged(), cAssignmentValueLoc.unbridged(),
+      isAssignment, cHigherThanKeywordLoc.unbridged(), higherThanNames,
+      cLowerThanKeywordLoc.unbridged(), lowerThanNames,
+      cRightBraceLoc.unbridged());
 }
 
 BridgedImportDecl BridgedImportDecl_createParsed(
@@ -767,45 +707,43 @@ BridgedImportDecl BridgedImportDecl_createParsed(
     BridgedSourceLoc cImportKindLoc, BridgedArrayRef cImportPathElements) {
   ImportPath::Builder builder;
   for (auto &element :
-       unbridgedArrayRef<BridgedIdentifierAndSourceLoc>(cImportPathElements)) {
-    builder.push_back(unbridged(element.Name), unbridged(element.NameLoc));
+       cImportPathElements.unbridged<BridgedIdentifierAndSourceLoc>()) {
+    builder.push_back(element.Name.unbridged(), element.NameLoc.unbridged());
   }
 
-  ASTContext &context = unbridged(cContext);
-  auto *decl = ImportDecl::create(
-      context, unbridged(cDeclContext), unbridged(cImportKeywordLoc),
-      static_cast<ImportKind>(cImportKind), unbridged(cImportKindLoc),
+  ASTContext &context = cContext.unbridged();
+  return ImportDecl::create(
+      context, cDeclContext.unbridged(), cImportKeywordLoc.unbridged(),
+      static_cast<ImportKind>(cImportKind), cImportKindLoc.unbridged(),
       std::move(builder).get());
-
-  return bridged(decl);
 }
 
 BridgedTopLevelCodeDecl BridgedTopLevelCodeDecl_createStmt(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cStartLoc, BridgedStmt statement,
     BridgedSourceLoc cEndLoc) {
-  ASTContext &context = unbridged(cContext);
-  DeclContext *declContext = unbridged(cDeclContext);
+  ASTContext &context = cContext.unbridged();
+  DeclContext *declContext = cDeclContext.unbridged();
 
-  auto *S = unbridged(statement);
-  auto Brace =
-      BraceStmt::create(context, unbridged(cStartLoc), {S}, unbridged(cEndLoc),
-                        /*Implicit=*/true);
-  return bridged(new (context) TopLevelCodeDecl(declContext, Brace));
+  auto *S = statement.unbridged();
+  auto Brace = BraceStmt::create(context, cStartLoc.unbridged(), {S},
+                                 cEndLoc.unbridged(),
+                                 /*Implicit=*/true);
+  return new (context) TopLevelCodeDecl(declContext, Brace);
 }
 
 BridgedTopLevelCodeDecl BridgedTopLevelCodeDecl_createExpr(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedSourceLoc cStartLoc, BridgedExpr expression,
     BridgedSourceLoc cEndLoc) {
-  ASTContext &context = unbridged(cContext);
-  DeclContext *declContext = unbridged(cDeclContext);
+  ASTContext &context = cContext.unbridged();
+  DeclContext *declContext = cDeclContext.unbridged();
 
-  auto *E = unbridged(expression);
-  auto Brace =
-      BraceStmt::create(context, unbridged(cStartLoc), {E}, unbridged(cEndLoc),
-                        /*Implicit=*/true);
-  return bridged(new (context) TopLevelCodeDecl(declContext, Brace));
+  auto *E = expression.unbridged();
+  auto Brace = BraceStmt::create(context, cStartLoc.unbridged(), {E},
+                                 cEndLoc.unbridged(),
+                                 /*Implicit=*/true);
+  return new (context) TopLevelCodeDecl(declContext, Brace);
 }
 
 //===----------------------------------------------------------------------===//
@@ -835,24 +773,22 @@ BridgedClosureExpr_createParsed(BridgedASTContext cContext,
   SourceLoc arrowLoc;
   SourceLoc inLoc;
 
-  ASTContext &context = unbridged(cContext);
-  DeclContext *declContext = unbridged(cDeclContext);
+  ASTContext &context = cContext.unbridged();
+  DeclContext *declContext = cDeclContext.unbridged();
 
   auto params = ParameterList::create(context, inLoc, {}, inLoc);
 
   auto *out = new (context) ClosureExpr(
       attributes, bracketRange, nullptr, nullptr, asyncLoc, throwsLoc,
       /*FIXME:thrownType=*/nullptr, arrowLoc, inLoc, nullptr, declContext);
-  out->setBody(unbridged(body), true);
+  out->setBody(body.unbridged(), true);
   out->setParameterList(params);
-  return bridged(out);
+  return out;
 }
 
 BridgedSequenceExpr BridgedSequenceExpr_createParsed(BridgedASTContext cContext,
                                                      BridgedArrayRef exprs) {
-  auto *SE = SequenceExpr::create(unbridged(cContext),
-                                  unbridgedArrayRef<Expr *>(exprs));
-  return bridged(SE);
+  return SequenceExpr::create(cContext.unbridged(), exprs.unbridged<Expr *>());
 }
 
 BridgedTupleExpr BridgedTupleExpr_createParsed(BridgedASTContext cContext,
@@ -861,20 +797,18 @@ BridgedTupleExpr BridgedTupleExpr_createParsed(BridgedASTContext cContext,
                                                BridgedArrayRef names,
                                                BridgedArrayRef cNameLocs,
                                                BridgedSourceLoc cRParen) {
-  ASTContext &context = unbridged(cContext);
-  auto *TE = TupleExpr::create(context, unbridged(cLParen),
-                               unbridgedArrayRef<Expr *>(subs),
-                               unbridgedArrayRef<Identifier>(names),
-                               unbridgedArrayRef<SourceLoc>(cNameLocs),
-                               unbridged(cRParen), /*Implicit*/ false);
-  return bridged(TE);
+  ASTContext &context = cContext.unbridged();
+  return TupleExpr::create(
+      context, cLParen.unbridged(), subs.unbridged<Expr *>(),
+      names.unbridged<Identifier>(), cNameLocs.unbridged<SourceLoc>(),
+      cRParen.unbridged(), /*Implicit*/ false);
 }
 
 BridgedCallExpr BridgedCallExpr_createParsed(BridgedASTContext cContext,
                                              BridgedExpr fn,
                                              BridgedTupleExpr args) {
-  ASTContext &context = unbridged(cContext);
-  TupleExpr *TE = unbridged(args);
+  ASTContext &context = cContext.unbridged();
+  TupleExpr *TE = args.unbridged();
   SmallVector<Argument, 8> arguments;
   for (unsigned i = 0; i < TE->getNumElements(); ++i) {
     arguments.emplace_back(TE->getElementNameLoc(i), TE->getElementName(i),
@@ -883,36 +817,34 @@ BridgedCallExpr BridgedCallExpr_createParsed(BridgedASTContext cContext,
   auto *argList = ArgumentList::create(context, TE->getLParenLoc(), arguments,
                                        TE->getRParenLoc(), llvm::None,
                                        /*isImplicit*/ false);
-  auto *CE = CallExpr::create(context, unbridged(fn), argList,
-                              /*implicit*/ false);
-  return bridged(CE);
+  return CallExpr::create(context, fn.unbridged(), argList,
+                          /*implicit*/ false);
 }
 
 BridgedUnresolvedDeclRefExpr BridgedUnresolvedDeclRefExpr_createParsed(
     BridgedASTContext cContext, BridgedIdentifier base, BridgedSourceLoc cLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto name = DeclNameRef{unbridged(base)};
-  auto *E = new (context) UnresolvedDeclRefExpr(name, DeclRefKind::Ordinary,
-                                                DeclNameLoc{unbridged(cLoc)});
-  return bridged(E);
+  ASTContext &context = cContext.unbridged();
+  auto name = DeclNameRef{base.unbridged()};
+  return new (context) UnresolvedDeclRefExpr(name, DeclRefKind::Ordinary,
+                                             DeclNameLoc{cLoc.unbridged()});
 }
 
 BridgedStringLiteralExpr
 BridgedStringLiteralExpr_createParsed(BridgedASTContext cContext,
                                       BridgedStringRef cStr,
                                       BridgedSourceLoc cTokenLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto str = context.AllocateCopy(unbridged(cStr));
-  return bridged(new (context) StringLiteralExpr(str, unbridged(cTokenLoc)));
+  ASTContext &context = cContext.unbridged();
+  auto str = context.AllocateCopy(cStr.unbridged());
+  return new (context) StringLiteralExpr(str, cTokenLoc.unbridged());
 }
 
 BridgedIntegerLiteralExpr
 BridgedIntegerLiteralExpr_createParsed(BridgedASTContext cContext,
                                        BridgedStringRef cStr,
                                        BridgedSourceLoc cTokenLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto str = context.AllocateCopy(unbridged(cStr));
-  return bridged(new (context) IntegerLiteralExpr(str, unbridged(cTokenLoc)));
+  ASTContext &context = cContext.unbridged();
+  auto str = context.AllocateCopy(cStr.unbridged());
+  return new (context) IntegerLiteralExpr(str, cTokenLoc.unbridged());
 }
 
 BridgedArrayExpr BridgedArrayExpr_createParsed(BridgedASTContext cContext,
@@ -920,45 +852,41 @@ BridgedArrayExpr BridgedArrayExpr_createParsed(BridgedASTContext cContext,
                                                BridgedArrayRef elements,
                                                BridgedArrayRef commas,
                                                BridgedSourceLoc cRLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto *AE = ArrayExpr::create(
-      context, unbridged(cLLoc), unbridgedArrayRef<Expr *>(elements),
-      unbridgedArrayRef<SourceLoc>(commas), unbridged(cRLoc));
-  return bridged(AE);
+  ASTContext &context = cContext.unbridged();
+  return ArrayExpr::create(context, cLLoc.unbridged(),
+                           elements.unbridged<Expr *>(),
+                           commas.unbridged<SourceLoc>(), cRLoc.unbridged());
 }
 
 BridgedBooleanLiteralExpr
 BridgedBooleanLiteralExpr_createParsed(BridgedASTContext cContext, bool value,
                                        BridgedSourceLoc cTokenLoc) {
-  ASTContext &context = unbridged(cContext);
-  return bridged(new (context) BooleanLiteralExpr(value, unbridged(cTokenLoc)));
+  ASTContext &context = cContext.unbridged();
+  return new (context) BooleanLiteralExpr(value, cTokenLoc.unbridged());
 }
 
 BridgedNilLiteralExpr
 BridgedNilLiteralExpr_createParsed(BridgedASTContext cContext,
                                    BridgedSourceLoc cNilKeywordLoc) {
-  auto *e = new (unbridged(cContext)) NilLiteralExpr(unbridged(cNilKeywordLoc));
-  return bridged(e);
+  return new (cContext.unbridged()) NilLiteralExpr(cNilKeywordLoc.unbridged());
 }
 
 BridgedSingleValueStmtExpr BridgedSingleValueStmtExpr_createWithWrappedBranches(
     BridgedASTContext cContext, BridgedStmt S, BridgedDeclContext cDeclContext,
     bool mustBeExpr) {
-  ASTContext &context = unbridged(cContext);
-  DeclContext *declContext = unbridged(cDeclContext);
-  auto *SVE = SingleValueStmtExpr::createWithWrappedBranches(
-      context, unbridged(S), declContext, mustBeExpr);
-  return bridged(SVE);
+  ASTContext &context = cContext.unbridged();
+  DeclContext *declContext = cDeclContext.unbridged();
+  return SingleValueStmtExpr::createWithWrappedBranches(
+      context, S.unbridged(), declContext, mustBeExpr);
 }
 
 BridgedUnresolvedDotExpr BridgedUnresolvedDotExpr_createParsed(
     BridgedASTContext cContext, BridgedExpr base, BridgedSourceLoc cDotLoc,
     BridgedIdentifier name, BridgedSourceLoc cNameLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto *UDE = new (context) UnresolvedDotExpr(
-      unbridged(base), unbridged(cDotLoc), DeclNameRef(unbridged(name)),
-      DeclNameLoc(unbridged(cNameLoc)), false);
-  return bridged(UDE);
+  ASTContext &context = cContext.unbridged();
+  return new (context) UnresolvedDotExpr(
+      base.unbridged(), cDotLoc.unbridged(), DeclNameRef(name.unbridged()),
+      DeclNameLoc(cNameLoc.unbridged()), false);
 }
 
 //===----------------------------------------------------------------------===//
@@ -970,7 +898,7 @@ BridgedBraceStmt BridgedBraceStmt_createParsed(BridgedASTContext cContext,
                                                BridgedArrayRef elements,
                                                BridgedSourceLoc cRBLoc) {
   llvm::SmallVector<ASTNode, 6> nodes;
-  for (auto node : unbridgedArrayRef<BridgedASTNode>(elements)) {
+  for (auto node : elements.unbridged<BridgedASTNode>()) {
     if (node.Kind == ASTNodeKindExpr) {
       auto expr = (Expr *)node.Raw;
       nodes.push_back(expr);
@@ -993,10 +921,9 @@ BridgedBraceStmt BridgedBraceStmt_createParsed(BridgedASTContext cContext,
     }
   }
 
-  ASTContext &context = unbridged(cContext);
-  auto *BS = BraceStmt::create(context, unbridged(cLBLoc),
-                               context.AllocateCopy(nodes), unbridged(cRBLoc));
-  return bridged(BS);
+  ASTContext &context = cContext.unbridged();
+  return BraceStmt::create(context, cLBLoc.unbridged(),
+                           context.AllocateCopy(nodes), cRBLoc.unbridged());
 }
 
 BridgedIfStmt BridgedIfStmt_createParsed(BridgedASTContext cContext,
@@ -1004,18 +931,17 @@ BridgedIfStmt BridgedIfStmt_createParsed(BridgedASTContext cContext,
                                          BridgedExpr cond, BridgedStmt then,
                                          BridgedSourceLoc cElseLoc,
                                          BridgedNullableStmt elseStmt) {
-  ASTContext &context = unbridged(cContext);
-  auto *IS = new (context)
-      IfStmt(unbridged(cIfLoc), unbridged(cond), unbridged(then),
-             unbridged(cElseLoc), unbridged(elseStmt), llvm::None, context);
-  return bridged(IS);
+  ASTContext &context = cContext.unbridged();
+  return new (context)
+      IfStmt(cIfLoc.unbridged(), cond.unbridged(), then.unbridged(),
+             cElseLoc.unbridged(), elseStmt.unbridged(), llvm::None, context);
 }
 
 BridgedReturnStmt BridgedReturnStmt_createParsed(BridgedASTContext cContext,
                                                  BridgedSourceLoc cLoc,
                                                  BridgedNullableExpr expr) {
-  ASTContext &context = unbridged(cContext);
-  return bridged(new (context) ReturnStmt(unbridged(cLoc), unbridged(expr)));
+  ASTContext &context = cContext.unbridged();
+  return new (context) ReturnStmt(cLoc.unbridged(), expr.unbridged());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1023,7 +949,7 @@ BridgedReturnStmt BridgedReturnStmt_createParsed(BridgedASTContext cContext,
 //===----------------------------------------------------------------------===//
 
 BridgedTypeAttrKind BridgedTypeAttrKind_fromString(BridgedStringRef cStr) {
-  TypeAttrKind kind = TypeAttributes::getAttrKindFromString(unbridged(cStr));
+  TypeAttrKind kind = TypeAttributes::getAttrKindFromString(cStr.unbridged());
   switch (kind) {
 #define TYPE_ATTR(X)                                                           \
   case TAK_##X:                                                                \
@@ -1042,10 +968,10 @@ void BridgedTypeAttributes_addSimpleAttr(BridgedTypeAttributes cAttributes,
                                          BridgedTypeAttrKind cKind,
                                          BridgedSourceLoc cAtLoc,
                                          BridgedSourceLoc cAttrLoc) {
-  TypeAttributes *typeAttributes = unbridged(cAttributes);
-  typeAttributes->setAttr(unbridged(cKind), unbridged(cAttrLoc));
+  TypeAttributes *typeAttributes = cAttributes.unbridged();
+  typeAttributes->setAttr(unbridged(cKind), cAttrLoc.unbridged());
   if (typeAttributes->AtLoc.isInvalid())
-    typeAttributes->AtLoc = unbridged(cAtLoc);
+    typeAttributes->AtLoc = cAtLoc.unbridged();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1054,150 +980,139 @@ void BridgedTypeAttributes_addSimpleAttr(BridgedTypeAttributes cAttributes,
 
 BridgedTypeRepr BridgedSimpleIdentTypeRepr_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cLoc, BridgedIdentifier id) {
-  ASTContext &context = unbridged(cContext);
-  auto *SI = new (context) SimpleIdentTypeRepr(DeclNameLoc(unbridged(cLoc)),
-                                               DeclNameRef(unbridged(id)));
-  return bridged(SI);
+  ASTContext &context = cContext.unbridged();
+  return new (context) SimpleIdentTypeRepr(DeclNameLoc(cLoc.unbridged()),
+                                           DeclNameRef(id.unbridged()));
 }
 
 BridgedTypeRepr BridgedGenericIdentTypeRepr_createParsed(
     BridgedASTContext cContext, BridgedIdentifier name,
     BridgedSourceLoc cNameLoc, BridgedArrayRef genericArgs,
     BridgedSourceLoc cLAngleLoc, BridgedSourceLoc cRAngleLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto Loc = DeclNameLoc(unbridged(cNameLoc));
-  auto Name = DeclNameRef(unbridged(name));
-  SourceLoc lAngleLoc = unbridged(cLAngleLoc);
-  SourceLoc rAngleLoc = unbridged(cRAngleLoc);
-  auto *GI = GenericIdentTypeRepr::create(
-      context, Loc, Name, unbridgedArrayRef<TypeRepr *>(genericArgs),
-      SourceRange{lAngleLoc, rAngleLoc});
-  return bridged(GI);
+  ASTContext &context = cContext.unbridged();
+  auto Loc = DeclNameLoc(cNameLoc.unbridged());
+  auto Name = DeclNameRef(name.unbridged());
+  SourceLoc lAngleLoc = cLAngleLoc.unbridged();
+  SourceLoc rAngleLoc = cRAngleLoc.unbridged();
+  return GenericIdentTypeRepr::create(context, Loc, Name,
+                                      genericArgs.unbridged<TypeRepr *>(),
+                                      SourceRange{lAngleLoc, rAngleLoc});
 }
 
 BridgedTypeRepr
 BridgedOptionalTypeRepr_createParsed(BridgedASTContext cContext,
                                      BridgedTypeRepr base,
                                      BridgedSourceLoc cQuestionLoc) {
-  ASTContext &context = unbridged(cContext);
-  return bridged(
-      new (context) OptionalTypeRepr(unbridged(base), unbridged(cQuestionLoc)));
+  ASTContext &context = cContext.unbridged();
+  return new (context)
+      OptionalTypeRepr(base.unbridged(), cQuestionLoc.unbridged());
 }
 
 BridgedTypeRepr BridgedImplicitlyUnwrappedOptionalTypeRepr_createParsed(
     BridgedASTContext cContext, BridgedTypeRepr base,
     BridgedSourceLoc cExclamationLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto *IUO = new (context) ImplicitlyUnwrappedOptionalTypeRepr(
-      unbridged(base), unbridged(cExclamationLoc));
-  return bridged(IUO);
+  ASTContext &context = cContext.unbridged();
+  return new (context) ImplicitlyUnwrappedOptionalTypeRepr(
+      base.unbridged(), cExclamationLoc.unbridged());
 }
 
 BridgedTypeRepr BridgedArrayTypeRepr_createParsed(
     BridgedASTContext cContext, BridgedTypeRepr base,
     BridgedSourceLoc cLSquareLoc, BridgedSourceLoc cRSquareLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc lSquareLoc = unbridged(cLSquareLoc);
-  SourceLoc rSquareLoc = unbridged(cRSquareLoc);
-  auto *ATR = new (context)
-      ArrayTypeRepr(unbridged(base), SourceRange{lSquareLoc, rSquareLoc});
-  return bridged(ATR);
+  ASTContext &context = cContext.unbridged();
+  SourceLoc lSquareLoc = cLSquareLoc.unbridged();
+  SourceLoc rSquareLoc = cRSquareLoc.unbridged();
+  return new (context)
+      ArrayTypeRepr(base.unbridged(), SourceRange{lSquareLoc, rSquareLoc});
 }
 
 BridgedTypeRepr BridgedDictionaryTypeRepr_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cLSquareLoc,
     BridgedTypeRepr keyType, BridgedSourceLoc cColonloc,
     BridgedTypeRepr valueType, BridgedSourceLoc cRSquareLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc lSquareLoc = unbridged(cLSquareLoc);
-  SourceLoc colonLoc = unbridged(cColonloc);
-  SourceLoc rSquareLoc = unbridged(cRSquareLoc);
-  auto *DTR = new (context)
-      DictionaryTypeRepr(unbridged(keyType), unbridged(valueType), colonLoc,
+  ASTContext &context = cContext.unbridged();
+  SourceLoc lSquareLoc = cLSquareLoc.unbridged();
+  SourceLoc colonLoc = cColonloc.unbridged();
+  SourceLoc rSquareLoc = cRSquareLoc.unbridged();
+  return new (context)
+      DictionaryTypeRepr(keyType.unbridged(), valueType.unbridged(), colonLoc,
                          SourceRange{lSquareLoc, rSquareLoc});
-  return bridged(DTR);
 }
 
 BridgedTypeRepr
 BridgedMetatypeTypeRepr_createParsed(BridgedASTContext cContext,
                                      BridgedTypeRepr baseType,
                                      BridgedSourceLoc cTypeLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc tyLoc = unbridged(cTypeLoc);
-  return bridged(new (context) MetatypeTypeRepr(unbridged(baseType), tyLoc));
+  ASTContext &context = cContext.unbridged();
+  SourceLoc tyLoc = cTypeLoc.unbridged();
+  return new (context) MetatypeTypeRepr(baseType.unbridged(), tyLoc);
 }
 
 BridgedTypeRepr
 BridgedProtocolTypeRepr_createParsed(BridgedASTContext cContext,
                                      BridgedTypeRepr baseType,
                                      BridgedSourceLoc cProtoLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc protoLoc = unbridged(cProtoLoc);
-  return bridged(new (context) ProtocolTypeRepr(unbridged(baseType), protoLoc));
+  ASTContext &context = cContext.unbridged();
+  SourceLoc protoLoc = cProtoLoc.unbridged();
+  return new (context) ProtocolTypeRepr(baseType.unbridged(), protoLoc);
 }
 
 BridgedTypeRepr
 BridgedPackExpansionTypeRepr_createParsed(BridgedASTContext cContext,
                                           BridgedTypeRepr base,
                                           BridgedSourceLoc cRepeatLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto *PE = new (context)
-      PackExpansionTypeRepr(unbridged(cRepeatLoc), unbridged(base));
-  return bridged(PE);
+  ASTContext &context = cContext.unbridged();
+  return new (context)
+      PackExpansionTypeRepr(cRepeatLoc.unbridged(), base.unbridged());
 }
 
 BridgedTypeRepr
 BridgedAttributedTypeRepr_createParsed(BridgedASTContext cContext,
                                        BridgedTypeRepr base,
                                        BridgedTypeAttributes cAttributes) {
-  TypeAttributes *typeAttributes = unbridged(cAttributes);
+  TypeAttributes *typeAttributes = cAttributes.unbridged();
   if (typeAttributes->empty())
     return base;
 
-  ASTContext &context = unbridged(cContext);
+  ASTContext &context = cContext.unbridged();
   auto attributedType =
-      new (context) AttributedTypeRepr(*typeAttributes, unbridged(base));
+      new (context) AttributedTypeRepr(*typeAttributes, base.unbridged());
   delete typeAttributes;
-  return bridged(attributedType);
+  return attributedType;
 }
 
 BridgedTypeRepr BridgedSpecifierTypeRepr_createParsed(
     BridgedASTContext cContext, BridgedTypeRepr base,
     BridgedAttributedTypeSpecifier specifier, BridgedSourceLoc cSpecifierLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc loc = unbridged(cSpecifierLoc);
-  TypeRepr *baseType = unbridged(base);
+  ASTContext &context = cContext.unbridged();
+  SourceLoc loc = cSpecifierLoc.unbridged();
+  TypeRepr *baseType = base.unbridged();
   switch (specifier) {
   case BridgedAttributedTypeSpecifierInOut: {
-    auto *OT =
-        new (context) OwnershipTypeRepr(baseType, ParamSpecifier::InOut, loc);
-    return bridged(OT);
+    return new (context)
+        OwnershipTypeRepr(baseType, ParamSpecifier::InOut, loc);
   }
   case BridgedAttributedTypeSpecifierBorrowing: {
-    auto *OT = new (context)
+    return new (context)
         OwnershipTypeRepr(baseType, ParamSpecifier::Borrowing, loc);
-    return bridged(OT);
   }
   case BridgedAttributedTypeSpecifierConsuming: {
-    auto *OT = new (context)
+    return new (context)
         OwnershipTypeRepr(baseType, ParamSpecifier::Consuming, loc);
-    return bridged(OT);
   }
   case BridgedAttributedTypeSpecifierLegacyShared: {
-    auto *OT = new (context)
+    return new (context)
         OwnershipTypeRepr(baseType, ParamSpecifier::LegacyShared, loc);
-    return bridged(OT);
   }
   case BridgedAttributedTypeSpecifierLegacyOwned: {
-    auto *OT = new (context)
+    return new (context)
         OwnershipTypeRepr(baseType, ParamSpecifier::LegacyOwned, loc);
-    return bridged(OT);
   }
   case BridgedAttributedTypeSpecifierConst: {
-    return bridged(new (context) CompileTimeConstTypeRepr(baseType, loc));
+    return new (context) CompileTimeConstTypeRepr(baseType, loc);
   }
   case BridgedAttributedTypeSpecifierIsolated: {
-    return bridged(new (context) IsolatedTypeRepr(baseType, loc));
+    return new (context) IsolatedTypeRepr(baseType, loc);
   }
   }
 }
@@ -1206,71 +1121,67 @@ BridgedTypeRepr
 BridgedVarargTypeRepr_createParsed(BridgedASTContext cContext,
                                    BridgedTypeRepr base,
                                    BridgedSourceLoc cEllipsisLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc ellipsisLoc = unbridged(cEllipsisLoc);
-  TypeRepr *baseType = unbridged(base);
-  return bridged(new (context) VarargTypeRepr(baseType, ellipsisLoc));
+  ASTContext &context = cContext.unbridged();
+  SourceLoc ellipsisLoc = cEllipsisLoc.unbridged();
+  TypeRepr *baseType = base.unbridged();
+  return new (context) VarargTypeRepr(baseType, ellipsisLoc);
 }
 
 BridgedTypeRepr BridgedTupleTypeRepr_createParsed(BridgedASTContext cContext,
                                                   BridgedArrayRef elements,
                                                   BridgedSourceLoc cLParenLoc,
                                                   BridgedSourceLoc cRParenLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc lParen = unbridged(cLParenLoc);
-  SourceLoc rParen = unbridged(cRParenLoc);
+  ASTContext &context = cContext.unbridged();
+  SourceLoc lParen = cLParenLoc.unbridged();
+  SourceLoc rParen = cRParenLoc.unbridged();
 
   SmallVector<TupleTypeReprElement, 8> tupleElements;
-  for (auto element : unbridgedArrayRef<BridgedTupleTypeElement>(elements)) {
+  for (auto element : elements.unbridged<BridgedTupleTypeElement>()) {
     TupleTypeReprElement elementRepr;
-    elementRepr.Name = unbridged(element.Name);
-    elementRepr.NameLoc = unbridged(element.NameLoc);
-    elementRepr.SecondName = unbridged(element.SecondName);
-    elementRepr.SecondNameLoc = unbridged(element.SecondNameLoc);
-    elementRepr.UnderscoreLoc = unbridged(element.UnderscoreLoc);
-    elementRepr.ColonLoc = unbridged(element.ColonLoc);
-    elementRepr.Type = unbridged(element.Type);
-    elementRepr.TrailingCommaLoc = unbridged(element.TrailingCommaLoc);
+    elementRepr.Name = element.Name.unbridged();
+    elementRepr.NameLoc = element.NameLoc.unbridged();
+    elementRepr.SecondName = element.SecondName.unbridged();
+    elementRepr.SecondNameLoc = element.SecondNameLoc.unbridged();
+    elementRepr.UnderscoreLoc = element.UnderscoreLoc.unbridged();
+    elementRepr.ColonLoc = element.ColonLoc.unbridged();
+    elementRepr.Type = element.Type.unbridged();
+    elementRepr.TrailingCommaLoc = element.TrailingCommaLoc.unbridged();
     tupleElements.emplace_back(elementRepr);
   }
 
-  auto *TT = TupleTypeRepr::create(context, tupleElements,
-                                   SourceRange{lParen, rParen});
-  return bridged(TT);
+  return TupleTypeRepr::create(context, tupleElements,
+                               SourceRange{lParen, rParen});
 }
 
 BridgedTypeRepr
 BridgedMemberTypeRepr_createParsed(BridgedASTContext cContext,
                                    BridgedTypeRepr baseComponent,
                                    BridgedArrayRef bridgedMemberComponents) {
-  ASTContext &context = unbridged(cContext);
-  auto memberComponents =
-      unbridgedArrayRef<IdentTypeRepr *>(bridgedMemberComponents);
+  ASTContext &context = cContext.unbridged();
+  auto memberComponents = bridgedMemberComponents.unbridged<IdentTypeRepr *>();
 
-  auto *MT = MemberTypeRepr::create(context, unbridged(baseComponent),
-                                    memberComponents);
-  return bridged(MT);
+  return MemberTypeRepr::create(context, baseComponent.unbridged(),
+                                memberComponents);
 }
 
 BridgedTypeRepr
 BridgedCompositionTypeRepr_createEmpty(BridgedASTContext cContext,
                                        BridgedSourceLoc cAnyLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc anyLoc = unbridged(cAnyLoc);
-  return bridged(CompositionTypeRepr::createEmptyComposition(context, anyLoc));
+  ASTContext &context = cContext.unbridged();
+  SourceLoc anyLoc = cAnyLoc.unbridged();
+  return CompositionTypeRepr::createEmptyComposition(context, anyLoc);
 }
 
 BridgedTypeRepr
 BridgedCompositionTypeRepr_createParsed(BridgedASTContext cContext,
                                         BridgedArrayRef cTypes,
                                         BridgedSourceLoc cFirstAmpLoc) {
-  ASTContext &context = unbridged(cContext);
-  SourceLoc firstAmpLoc = unbridged(cFirstAmpLoc);
-  auto types = unbridgedArrayRef<TypeRepr *>(cTypes);
-  auto *CT = CompositionTypeRepr::create(
+  ASTContext &context = cContext.unbridged();
+  SourceLoc firstAmpLoc = cFirstAmpLoc.unbridged();
+  auto types = cTypes.unbridged<TypeRepr *>();
+  return CompositionTypeRepr::create(
       context, types, types.front()->getStartLoc(),
       SourceRange{firstAmpLoc, types.back()->getEndLoc()});
-  return bridged(CT);
 }
 
 BridgedTypeRepr BridgedFunctionTypeRepr_createParsed(
@@ -1278,40 +1189,35 @@ BridgedTypeRepr BridgedFunctionTypeRepr_createParsed(
     BridgedSourceLoc cAsyncLoc, BridgedSourceLoc cThrowsLoc,
     BridgedNullableTypeRepr thrownType, BridgedSourceLoc cArrowLoc,
     BridgedTypeRepr resultType) {
-  ASTContext &context = unbridged(cContext);
-  auto *FT = new (context) FunctionTypeRepr(
-      nullptr, cast<TupleTypeRepr>(unbridged(argsTy)), unbridged(cAsyncLoc),
-      unbridged(cThrowsLoc), unbridged(thrownType), unbridged(cArrowLoc),
-      unbridged(resultType));
-  return bridged(FT);
+  ASTContext &context = cContext.unbridged();
+  return new (context) FunctionTypeRepr(
+      nullptr, cast<TupleTypeRepr>(argsTy.unbridged()), cAsyncLoc.unbridged(),
+      cThrowsLoc.unbridged(), thrownType.unbridged(), cArrowLoc.unbridged(),
+      resultType.unbridged());
 }
 
 BridgedTypeRepr
 BridgedNamedOpaqueReturnTypeRepr_createParsed(BridgedASTContext cContext,
                                               BridgedTypeRepr baseTy) {
-  ASTContext &context = unbridged(cContext);
-  auto *NR =
-      new (context) NamedOpaqueReturnTypeRepr(unbridged(baseTy), nullptr);
-  return bridged(NR);
+  ASTContext &context = cContext.unbridged();
+  return new (context) NamedOpaqueReturnTypeRepr(baseTy.unbridged(), nullptr);
 }
 
 BridgedTypeRepr
 BridgedOpaqueReturnTypeRepr_createParsed(BridgedASTContext cContext,
                                          BridgedSourceLoc cOpaqueLoc,
                                          BridgedTypeRepr baseTy) {
-  ASTContext &context = unbridged(cContext);
-  auto *OT = new (context)
-      OpaqueReturnTypeRepr(unbridged(cOpaqueLoc), unbridged(baseTy));
-  return bridged(OT);
+  ASTContext &context = cContext.unbridged();
+  return new (context)
+      OpaqueReturnTypeRepr(cOpaqueLoc.unbridged(), baseTy.unbridged());
 }
 BridgedTypeRepr
 BridgedExistentialTypeRepr_createParsed(BridgedASTContext cContext,
                                         BridgedSourceLoc cAnyLoc,
                                         BridgedTypeRepr baseTy) {
-  ASTContext &context = unbridged(cContext);
-  auto *ET =
-      new (context) ExistentialTypeRepr(unbridged(cAnyLoc), unbridged(baseTy));
-  return bridged(ET);
+  ASTContext &context = cContext.unbridged();
+  return new (context)
+      ExistentialTypeRepr(cAnyLoc.unbridged(), baseTy.unbridged());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1325,16 +1231,15 @@ BridgedGenericParamList BridgedGenericParamList_createParsed(
     BridgedSourceLoc cRightAngleLoc) {
   SourceLoc whereLoc;
   ArrayRef<RequirementRepr> requirements;
-  if (auto *genericWhereClause = unbridged(bridgedGenericWhereClause)) {
+  if (auto *genericWhereClause = bridgedGenericWhereClause.unbridged()) {
     whereLoc = genericWhereClause->getWhereLoc();
     requirements = genericWhereClause->getRequirements();
   }
 
-  auto *GP = GenericParamList::create(
-      unbridged(cContext), unbridged(cLeftAngleLoc),
-      unbridgedArrayRef<GenericTypeParamDecl *>(cParameters), whereLoc,
-      requirements, unbridged(cRightAngleLoc));
-  return bridged(GP);
+  return GenericParamList::create(
+      cContext.unbridged(), cLeftAngleLoc.unbridged(),
+      cParameters.unbridged<GenericTypeParamDecl *>(), whereLoc, requirements,
+      cRightAngleLoc.unbridged());
 }
 
 BridgedGenericTypeParamDecl BridgedGenericTypeParamDecl_createParsed(
@@ -1342,19 +1247,19 @@ BridgedGenericTypeParamDecl BridgedGenericTypeParamDecl_createParsed(
     BridgedSourceLoc cEachLoc, BridgedIdentifier cName,
     BridgedSourceLoc cNameLoc, BridgedNullableTypeRepr bridgedInheritedType,
     size_t index) {
-  auto eachLoc = unbridged(cEachLoc);
+  auto eachLoc = cEachLoc.unbridged();
   auto *decl = GenericTypeParamDecl::createParsed(
-      unbridged(cDeclContext), unbridged(cName), unbridged(cNameLoc), eachLoc,
-      index,
+      cDeclContext.unbridged(), cName.unbridged(), cNameLoc.unbridged(),
+      eachLoc, index,
       /*isParameterPack*/ eachLoc.isValid());
 
-  if (auto *inheritedType = unbridged(bridgedInheritedType)) {
+  if (auto *inheritedType = bridgedInheritedType.unbridged()) {
     auto entry = InheritedEntry(inheritedType);
-    ASTContext &context = unbridged(cContext);
+    ASTContext &context = cContext.unbridged();
     decl->setInherited(context.AllocateCopy(llvm::makeArrayRef(entry)));
   }
 
-  return bridged(decl);
+  return decl;
 }
 
 BridgedTrailingWhereClause
@@ -1362,18 +1267,18 @@ BridgedTrailingWhereClause_createParsed(BridgedASTContext cContext,
                                         BridgedSourceLoc cWhereKeywordLoc,
                                         BridgedArrayRef cRequirements) {
   SmallVector<RequirementRepr> requirements;
-  for (auto &cReq : unbridgedArrayRef<BridgedRequirementRepr>(cRequirements)) {
+  for (auto &cReq : cRequirements.unbridged<BridgedRequirementRepr>()) {
     switch (cReq.Kind) {
     case BridgedRequirementReprKindTypeConstraint:
       requirements.push_back(RequirementRepr::getTypeConstraint(
-          unbridged(cReq.FirstType), unbridged(cReq.SeparatorLoc),
-          unbridged(cReq.SecondType),
+          cReq.FirstType.unbridged(), cReq.SeparatorLoc.unbridged(),
+          cReq.SecondType.unbridged(),
           /*isExpansionPattern*/ false));
       break;
     case BridgedRequirementReprKindSameType:
       requirements.push_back(RequirementRepr::getSameType(
-          unbridged(cReq.FirstType), unbridged(cReq.SeparatorLoc),
-          unbridged(cReq.SecondType),
+          cReq.FirstType.unbridged(), cReq.SeparatorLoc.unbridged(),
+          cReq.SecondType.unbridged(),
           /*isExpansionPattern*/ false));
       break;
     case BridgedRequirementReprKindLayoutConstraint:
@@ -1381,7 +1286,7 @@ BridgedTrailingWhereClause_createParsed(BridgedASTContext cContext,
     }
   }
 
-  SourceLoc whereKeywordLoc = unbridged(cWhereKeywordLoc);
+  SourceLoc whereKeywordLoc = cWhereKeywordLoc.unbridged();
   SourceLoc endLoc;
   if (requirements.empty()) {
     endLoc = whereKeywordLoc;
@@ -1389,19 +1294,17 @@ BridgedTrailingWhereClause_createParsed(BridgedASTContext cContext,
     endLoc = requirements.back().getSourceRange().End;
   }
 
-  auto *TW = TrailingWhereClause::create(unbridged(cContext), whereKeywordLoc,
-                                         endLoc, requirements);
-  return bridged(TW);
+  return TrailingWhereClause::create(cContext.unbridged(), whereKeywordLoc,
+                                     endLoc, requirements);
 }
 
 BridgedParameterList BridgedParameterList_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cLeftParenLoc,
     BridgedArrayRef cParameters, BridgedSourceLoc cRightParenLoc) {
-  ASTContext &context = unbridged(cContext);
-  auto *PL = ParameterList::create(context, unbridged(cLeftParenLoc),
-                                   unbridgedArrayRef<ParamDecl *>(cParameters),
-                                   unbridged(cRightParenLoc));
-  return bridged(PL);
+  ASTContext &context = cContext.unbridged();
+  return ParameterList::create(context, cLeftParenLoc.unbridged(),
+                               cParameters.unbridged<ParamDecl *>(),
+                               cRightParenLoc.unbridged());
 }
 
 #pragma clang diagnostic push

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -48,11 +48,11 @@ enum ASTNode {
   var bridged: BridgedASTNode {
     switch self {
     case .expr(let e):
-      return BridgedASTNode(ptr: e.raw, kind: .expr)
+      return BridgedASTNode(raw: e.raw, kind: .expr)
     case .stmt(let s):
-      return BridgedASTNode(ptr: s.raw, kind: .stmt)
+      return BridgedASTNode(raw: s.raw, kind: .stmt)
     case .decl(let d):
-      return BridgedASTNode(ptr: d.raw, kind: .decl)
+      return BridgedASTNode(raw: d.raw, kind: .decl)
     default:
       fatalError("Must be expr, stmt, or decl.")
     }

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -64,7 +64,7 @@ extension BridgedSourceLoc {
 extension BridgedSourceRange {
   @inline(__always)
   init(startToken: TokenSyntax, endToken: TokenSyntax, in astgen: ASTGenVisitor) {
-    self.init(startLoc: startToken.bridgedSourceLoc(in: astgen), endLoc: endToken.bridgedSourceLoc(in: astgen))
+    self.init(start: startToken.bridgedSourceLoc(in: astgen), end: endToken.bridgedSourceLoc(in: astgen))
   }
 }
 

--- a/lib/Basic/BasicBridging.cpp
+++ b/lib/Basic/BasicBridging.cpp
@@ -27,7 +27,7 @@ using namespace swift;
 //===----------------------------------------------------------------------===//
 
 void BridgedStringRef::write(BridgedOStream os) const {
-  static_cast<raw_ostream *>(os.streamAddr)->write(Data, Length);
+  os.unbridged()->write(Data, Length);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -470,7 +470,7 @@ void PrintingDiagnosticConsumer::flush(bool includeTrailingBreak) {
     swift_ASTGen_renderQueuedDiagnostics(queuedDiagnostics, /*contextSize=*/2,
                                          ForceColors ? 1 : 0,
                                          &bridgedRenderedString);
-    auto renderedString = bridgedRenderedString.get();
+    auto renderedString = bridgedRenderedString.unbridged();
     if (renderedString.data()) {
       Stream.write(renderedString.data(), renderedString.size());
       swift_ASTGen_freeBridgedString(renderedString);

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -70,7 +70,7 @@ static void setUnimplementedRange(SwiftMetatype metatype,
 /// Registers the metatype of a swift SIL class.
 /// Called by initializeSwiftModules().
 void registerBridgedClass(BridgedStringRef bridgedClassName, SwiftMetatype metatype) {
-  StringRef className = bridgedClassName.get();
+  StringRef className = bridgedClassName.unbridged();
   nodeMetatypesInitialized = true;
 
   // Handle the important non Node classes.
@@ -141,7 +141,7 @@ void registerBridgedClass(BridgedStringRef bridgedClassName, SwiftMetatype metat
 //===----------------------------------------------------------------------===//
 
 void registerFunctionTest(BridgedStringRef name, void *nativeSwiftInvocation) {
-  new swift::test::FunctionTest(name.get(), nativeSwiftInvocation);
+  new swift::test::FunctionTest(name.unbridged(), nativeSwiftInvocation);
 }
 
 bool BridgedTestArguments::hasUntaken() const {
@@ -227,7 +227,7 @@ BridgedOwnedString BridgedFunction::getDebugDescription() const {
 BridgedOwnedString BridgedBasicBlock::getDebugDescription() const {
   std::string str;
   llvm::raw_string_ostream os(str);
-  get()->print(os);
+  unbridged()->print(os);
   str.pop_back(); // Remove trailing newline.
   return str;
 }
@@ -418,25 +418,25 @@ static_assert((int)BridgedInstruction::AccessKind::Deinit == (int)swift::SILAcce
 BridgedOwnedString BridgedInstruction::getDebugDescription() const {
   std::string str;
   llvm::raw_string_ostream os(str);
-  get()->print(os);
+  unbridged()->print(os);
   str.pop_back(); // Remove trailing newline.
   return str;
 }
 
 bool BridgedInstruction::mayAccessPointer() const {
-  return ::mayAccessPointer(get());
+  return ::mayAccessPointer(unbridged());
 }
 
 bool BridgedInstruction::mayLoadWeakOrUnowned() const {
-  return ::mayLoadWeakOrUnowned(get());
+  return ::mayLoadWeakOrUnowned(unbridged());
 }
 
 bool BridgedInstruction::maySynchronizeNotConsideringSideEffects() const {
-  return ::maySynchronizeNotConsideringSideEffects(get());
+  return ::maySynchronizeNotConsideringSideEffects(unbridged());
 }
 
 bool BridgedInstruction::mayBeDeinitBarrierNotConsideringSideEffects() const {
-  return ::mayBeDeinitBarrierNotConsideringSideEffects(get());
+  return ::mayBeDeinitBarrierNotConsideringSideEffects(unbridged());
 }
 
 void writeCharToStderr(int c) {

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -275,13 +275,13 @@ static void runBridgedFunctionPass(BridgedFunctionPassRunFn &runFunction,
 // Called from initializeSwiftModules().
 void SILPassManager_registerModulePass(BridgedStringRef name,
                                        BridgedModulePassRunFn runFn) {
-  bridgedModulePassRunFunctions[name.get()] = runFn;
+  bridgedModulePassRunFunctions[name.unbridged()] = runFn;
   passesRegistered = true;
 }
 
 void SILPassManager_registerFunctionPass(BridgedStringRef name,
                                          BridgedFunctionPassRunFn runFn) {
-  bridgedFunctionPassRunFunctions[name.get()] = runFn;
+  bridgedFunctionPassRunFunctions[name.unbridged()] = runFn;
   passesRegistered = true;
 }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -541,7 +541,7 @@ static bool passesRegistered = false;
 // Called from initializeSwiftModules().
 void SILCombine_registerInstructionPass(BridgedStringRef instClassName,
                                         BridgedInstructionPassRunFn runFn) {
-  swiftInstPasses[instClassName.get()] = runFn;
+  swiftInstPasses[instClassName.unbridged()] = runFn;
   passesRegistered = true;
 }
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -177,7 +177,7 @@ MacroDefinition MacroDefinitionRequest::evaluate(
   case BridgedExternalMacro: {
     // An external macro described as ModuleName.TypeName. Get both identifiers.
     assert(!replacements && "External macro doesn't have replacements");
-    StringRef externalMacroStr = externalMacroName.get();
+    StringRef externalMacroStr = externalMacroName.unbridged();
     StringRef externalModuleName, externalTypeName;
     std::tie(externalModuleName, externalTypeName) = externalMacroStr.split('.');
 
@@ -219,7 +219,7 @@ MacroDefinition MacroDefinitionRequest::evaluate(
     return handleExternalMacroDefinition(ctx, expansion);
 
   // Expansion string text.
-  StringRef expansionText = externalMacroName.get();
+  StringRef expansionText = externalMacroName.unbridged();
 
   // Copy over the replacements.
   SmallVector<ExpandedMacroReplacement, 2> replacementsVec;
@@ -286,7 +286,7 @@ initializeExecutablePlugin(ASTContext &ctx,
         executablePlugin, resolvedLibraryPathStr.c_str(), moduleNameStr.c_str(),
         &bridgedErrorOut);
 
-    auto errorOut = bridgedErrorOut.get();
+    auto errorOut = bridgedErrorOut.unbridged();
     if (!loaded) {
       SWIFT_DEFER { swift_ASTGen_freeBridgedString(errorOut); };
       return llvm::createStringError(
@@ -1091,10 +1091,10 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
         getRawMacroRole(macroRole), astGenSourceFile,
         expansion->getSourceRange().Start.getOpaquePointerValue(),
         &evaluatedSourceOut);
-    if (!evaluatedSourceOut.get().data())
+    if (!evaluatedSourceOut.unbridged().data())
       return nullptr;
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
-        evaluatedSourceOut.get(),
+        evaluatedSourceOut.unbridged(),
         adjustMacroExpansionBufferName(*discriminator));
     swift_ASTGen_freeBridgedString(evaluatedSourceOut);
     break;
@@ -1371,10 +1371,10 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
         astGenAttrSourceFile, attr->AtLoc.getOpaquePointerValue(),
         astGenDeclSourceFile, searchDecl->getStartLoc().getOpaquePointerValue(),
         astGenParentDeclSourceFile, parentDeclLoc, &evaluatedSourceOut);
-    if (!evaluatedSourceOut.get().data())
+    if (!evaluatedSourceOut.unbridged().data())
       return nullptr;
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
-        evaluatedSourceOut.get(),
+        evaluatedSourceOut.unbridged(),
         adjustMacroExpansionBufferName(*discriminator));
     swift_ASTGen_freeBridgedString(evaluatedSourceOut);
     break;


### PR DESCRIPTION
Follow-up to #69440. Rename `get()` to `unbridged()`, improve some bridging interfaces, and remove `unbridged` + `bridged` free functions.