### PR TITLE
build: guard against builds where SwiftSyntax may not be enabled

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -71,6 +71,8 @@ set(compile_options
   "SHELL:-Xcc -UIBOutlet -Xcc -UIBAction -Xcc -UIBInspectable"
 )
 
-foreach(target swiftASTGen swiftLLVMJSON)
-  target_compile_options(${target} PRIVATE ${compile_options})
-endforeach()
+if(SWIFT_BUILD_SWIFT_SYNTAX)
+  foreach(target swiftASTGen swiftLLVMJSON)
+    target_compile_options(${target} PRIVATE ${compile_options})
+  endforeach()
+endif()


### PR DESCRIPTION
Fix the build after #69440