### PR TITLE
[5.10 cherry-pick] Fix infinite lookup importing forward declarations from bridging header

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1422,6 +1422,7 @@ ClangImporter::create(ASTContext &ctx,
     new (ctx) ClangModuleUnit(*importedHeaderModule, importer->Impl, nullptr);
   importedHeaderModule->addFile(*importer->Impl.ImportedHeaderUnit);
   importedHeaderModule->setHasResolvedImports();
+  importedHeaderModule->setIsNonSwiftModule(true);
 
   importer->Impl.IsReadingBridgingPCH = false;
 

--- a/test/ClangImporter/Inputs/incomplete_objc_types_bridging_header.h
+++ b/test/ClangImporter/Inputs/incomplete_objc_types_bridging_header.h
@@ -1,0 +1,4 @@
+@class ForwardDeclaredInterface;
+
+ForwardDeclaredInterface *CFunctionReturningAForwardDeclaredInterface();
+void CFunctionTakingAForwardDeclaredInterface(ForwardDeclaredInterface *param);

--- a/test/ClangImporter/incomplete_objc_types_bridging_header.swift
+++ b/test/ClangImporter/incomplete_objc_types_bridging_header.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/incomplete_objc_types_bridging_header.h -enable-upcoming-feature ImportObjcForwardDeclarations -enable-objc-interop -typecheck %s
+
+// REQUIRES: objc_interop
+
+let foo = CFunctionReturningAForwardDeclaredInterface()
+CFunctionTakingAForwardDeclaredInterface(foo)


### PR DESCRIPTION
**Explanation:**

The upcoming feature `ImportObjcForwardDeclarations` allows forward declared ObjC interfaces and protocols to be represented in Swift. However, a forward declaration `@class Foo` which is defined in Swift is intentionally not imported. To determine if a forward declaration is defined natively in Swift, the ClangImporter must perform a lookup for `Foo` in all imported Swift modules. It uses the `IsNonSwiftModule` bitfield to skip ModuleDecls which contain non-Swift FileUnits.

The __ObjC Swift module is a special module that houses among other things synthesized declarations from the bridging header. It contains a single ClangModuleUnit, but does not point to an underlying Clang module but rather defers to the BridgingHeader lookup table. Prior to this patch, this module was not marked "NonSwift" despite it including exclusively non Swift declarations.

This sent the aforementioned lookup for a native Swift definition Foo into an infinite loop. The loop looks like:

- ClangImporter discovers `@class` Foo
- Looks up Foo in all imported modules including __ObjC
- Lookup is delegated to BridgingHeader table
- Lookup finds the same `@class` Foo declaration
- Repeat

This patch marks the module as NonSwift so it isn't considered in this lookup in the first place.

**Scope:**

Without this change users cannot enable the upcoming feature `ImportObjCForwardDeclarations` while using a bridging header that has forward declared ObjC protocols or interfaces. The stack will overflow if they do. This is a bug fix that should not break any existing behavior. As far as I can tell, users of the `IsNonSwiftModule` already expect the property to be true for overlays, and this module is basically a fancy overlay.

**Risk:**

Some code might be relying on this special module being considered a Swift module, but that would not align with the semantics of the property I've observed. 

**Testing:**

- Swift compatibility test suite
- Swift LIT / unit tests
