### PR TITLE
[IRGen] NFC: Print value witness names in IR.

### DIFF
--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -461,6 +461,7 @@ static FunctionPointer emitLoadOfValueWitnessFunction(IRGenFunction &IGF,
                                     IGF.getOptions().PointerAuth.ValueWitnesses,
                                         slot, index);
 
+  witness->setName(getValueWitnessName(index));
   return FunctionPointer::createSigned(FunctionPointer::Kind::Function, witness,
                                        authInfo, signature);
 }

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -332,7 +332,7 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   // CHECK-NEXT:   br i1 [[COND]], label %[[NOOP:[0-9]+]], label %[[LEFT:[0-9]+]]
   // CHECK:      [[LEFT]]:
   // CHECK:        [[DESTROYADDR:%[0-9]+]] = getelementptr inbounds ptr, ptr %T.valueWitnesses, i32 1
-  // CHECK:        [[DESTROY:%[0-9]+]] = load ptr, ptr [[DESTROYADDR]]
+  // CHECK:        [[DESTROY:%[^,]+]] = load ptr, ptr [[DESTROYADDR]]
   // CHECK:        call void [[DESTROY]](ptr noalias {{%[0-9]+}}, ptr %T)
   // CHECK:        br label %[[NOOP]]
   // CHECK:      [[NOOP]]:
@@ -344,7 +344,7 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   // CHECK-NEXT:   br i1 [[COND]], label %[[TRIVIAL:[0-9]+]], label %[[LEFT:[0-9]+]]
   // CHECK:      [[LEFT]]:
   // CHECK:        [[INITWITHTAKEADDR:%[0-9]+]] = getelementptr inbounds ptr, ptr %T.valueWitnesses, i32 4
-  // CHECK:        [[INITWITHTAKE:%[0-9]+]] = load ptr, ptr [[INITWITHTAKEADDR]]
+  // CHECK:        [[INITWITHTAKE:%[^,]+]] = load ptr, ptr [[INITWITHTAKEADDR]]
   // CHECK:        {{%[0-9]+}} = call ptr [[INITWITHTAKE]](ptr noalias {{%[0-9]+}}, ptr noalias {{%[0-9]+}}, ptr %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
   // CHECK:      [[TRIVIAL]]:
@@ -371,7 +371,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK-NEXT:   ]
   // CHECK:      [[LEFT]]:
   // CHECK:        [[DESTROYADDR:%[0-9]+]] = getelementptr inbounds ptr, ptr %T.valueWitnesses, i32 1
-  // CHECK:        [[DESTROY:%[0-9]+]] = load ptr, ptr [[DESTROYADDR]]
+  // CHECK:        [[DESTROY:%[^,]+]] = load ptr, ptr [[DESTROYADDR]]
   // CHECK:        call void [[DESTROY]](ptr noalias {{%[0-9]+}}, ptr %T)
   // CHECK:        br label %[[NOOP]]
   // CHECK:      [[RIGHT]]:
@@ -385,7 +385,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK-NEXT:   br i1 [[COND]], label %[[TRIVIAL:[0-9]+]], label %[[LEFT:[0-9]+]]
   // CHECK:      [[LEFT]]:
   // CHECK:        [[INITWITHTAKEADDR:%[0-9]+]] = getelementptr inbounds ptr, ptr %T.valueWitnesses, i32 4
-  // CHECK:        [[INITWITHTAKE:%[0-9]+]] = load ptr, ptr [[INITWITHTAKEADDR]]
+  // CHECK:        [[INITWITHTAKE:%[^,]+]] = load ptr, ptr [[INITWITHTAKEADDR]]
   // CHECK:        {{%[0-9]+}} = call ptr [[INITWITHTAKE]](ptr noalias {{%[0-9]+}}, ptr noalias {{%[0-9]+}}, ptr %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
   // CHECK:      [[TRIVIAL]]:
@@ -402,7 +402,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK-NEXT:   ]
   // CHECK:      [[LEFT]]:
   // CHECK:        [[INITWITHCOPYADDR:%[0-9]+]] = getelementptr inbounds ptr, ptr %T.valueWitnesses, i32 2
-  // CHECK:        [[INITWITHCOPY:%[0-9]+]] = load ptr, ptr [[INITWITHCOPYADDR]]
+  // CHECK:        [[INITWITHCOPY:%[^,]+]] = load ptr, ptr [[INITWITHCOPYADDR]]
   // CHECK:        {{%[0-9]+}} = call ptr [[INITWITHCOPY]](ptr noalias {{%[0-9]+}}, ptr noalias {{%[0-9]+}}, ptr %T)
   // CHECK:        br label %[[DONE:[0-9]+]]
   // CHECK:      [[RIGHT]]:

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -310,7 +310,7 @@ extension ResilientMultiPayloadGenericEnum {
 // CHECK-NEXT: [[WITNESSTABLE_ADDR:%[0-9]+]] = getelementptr inbounds ptr, ptr [[METADATA]], {{(i64|i32)}} -1
 // CHECK-NEXT: %.valueWitnesses = load ptr, ptr [[WITNESSTABLE_ADDR]]
 // CHECK-NEXT: [[WITNESS_ADDR:%[0-9]+]] = getelementptr inbounds ptr, ptr %.valueWitnesses, i32 7
-// CHECK-NEXT: [[WITNESS_FN:%[0-9]+]] = load ptr, ptr [[WITNESS_ADDR]]
+// CHECK-NEXT: [[WITNESS_FN:%[^,]+]] = load ptr, ptr [[WITNESS_ADDR]]
 // CHECK-arm64e-NEXT: ptrtoint ptr {{.*}} to i64
 // CHECK-arm64e-NEXT: call i64 @llvm.ptrauth.blend
 // CHECK-NEXT: call void [[WITNESS_FN]](ptr noalias %0, i32 1, i32 1, ptr [[METADATA]])

--- a/test/IRGen/typed_throws.sil
+++ b/test/IRGen/typed_throws.sil
@@ -346,7 +346,7 @@ bb0(%0: $*τ_0_0, %1 : $Builtin.Int64, %2 : $*τ_0_0):
 }
 
 // CHECK: define{{.*}} swifttailcc void @throwErrorAsync(ptr swiftasync %0, i64 %1, ptr noalias %2, ptr %"\CF\84_0_0", ptr %3)
-// CHECK:   call ptr {{%[0-9]+}}(ptr noalias %3, ptr noalias %2, ptr %"\CF\84_0_0")
+// CHECK:   call ptr {{%[^,]+}}(ptr noalias %3, ptr noalias %2, ptr %"\CF\84_0_0")
 // CHECK:   call i1 (ptr, i1, ...) @llvm.coro.end.async(ptr {{%[0-9]+}}, i1 false, ptr @throwErrorAsync.0, ptr {{%[0-9]+}}, ptr {{%[0-9]+}}, ptr inttoptr (i64 1 to ptr))
 
 sil @throwErrorAsync : $@convention(thin) @async <τ_0_0> (Builtin.Int64, @in τ_0_0) -> @error_indirect τ_0_0 {

--- a/test/IRGen/weak_import_native_hoist.swift
+++ b/test/IRGen/weak_import_native_hoist.swift
@@ -63,7 +63,7 @@ public func test_not_hoist_weakly_linked4() {
 }
 
 // CHECK-LABEL: define {{.*}} @"$s24weak_import_native_hoist29test_weakly_linked_enum_cases1eSi0a1_b1_c1_D7_helper1EO_tF
-// CHECK:  [[TAG:%.*]] = call i32 %{{[0-9]+}}(
+// CHECK:  [[TAG:%.*]] = call i32 %{{[^,]+}}(
 // CHECK:  [[STRONG_CASE:%.*]] = load i32, ptr @"$s31weak_import_native_hoist_helper1EO6strongyA2CmFWC"
 // CHECK:  [[IS_STRONG:%.*]] = icmp eq i32 [[TAG]], [[STRONG_CASE]]
 // CHECK:  br i1 [[IS_STRONG]], label %[[BB0:[0-9]+]], label %[[BB1:[0-9]+]]

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -721,10 +721,10 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 // CHECK-IRGEN:   %3 = getelementptr inbounds ptr, ptr %S, i{{.*}} -1
 // CHECK-IRGEN-NEXT:   %S.valueWitnesses = load ptr, ptr %3
 // CHECK-IRGEN-NEXT:   %4 = getelementptr inbounds ptr, ptr %S.valueWitnesses
-// CHECK-IRGEN-NEXT:   %5 = load ptr, ptr %4
+// CHECK-IRGEN-NEXT:   %InitializeWithCopy = load ptr, ptr %4
 // CHECK-IRGEN-arm64e-NEXT:   ptrtoint ptr %4 to i64
 // CHECK-IRGEN-arm64e-NEXT:   call i64 @llvm.ptrauth.blend.i64
-// CHECK-IRGEN-NEXT:   call {{.*}} %5
+// CHECK-IRGEN-NEXT:   call {{.*}} %InitializeWithCopy
 // CHECK-IRGEN-NEXT:   ret void
 // CHECK-IRGEN-NEXT: }
 

--- a/test/SILOptimizer/eager_specialize_ossa.sil
+++ b/test/SILOptimizer/eager_specialize_ossa.sil
@@ -909,10 +909,10 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 // CHECK-IRGEN:   %3 = getelementptr inbounds ptr, ptr %S, i{{.*}} -1
 // CHECK-IRGEN-NEXT:   %S.valueWitnesses = load ptr, ptr %3
 // CHECK-IRGEN-NEXT:   %4 = getelementptr inbounds ptr, ptr %S.valueWitnesses
-// CHECK-IRGEN-NEXT:   %5 = load ptr, ptr %4
+// CHECK-IRGEN-NEXT:   %InitializeWithCopy = load ptr, ptr %4
 // CHECK-IRGEN-arm64e-NEXT:   ptrtoint ptr %4 to i64
 // CHECK-IRGEN-arm64e-NEXT:   call i64 @llvm.ptrauth.blend.i64
-// CHECK-IRGEN-NEXT:   call {{.*}} %5
+// CHECK-IRGEN-NEXT:   call {{.*}} %InitializeWithCopy
 // CHECK-IRGEN-NEXT:   ret void
 // CHECK-IRGEN-NEXT: }
 


### PR DESCRIPTION
It eases reading the code.

Updated a few tests that were overly strict (requiring registers to be named with only numbers) to accept more register names.
