### PR TITLE
Serialization: Fix deserializing opaque types details for computed properties and subscripts

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3324,6 +3324,9 @@ public:
     };
   }
 
+  /// Should the underlying type be visible to clients outside of the module?
+  bool exportUnderlyingType() const;
+
   /// The substitutions that map the generic parameters of the opaque type to
   /// the unique underlying types, when that information is known.
   llvm::Optional<SubstitutionMap> getUniqueUnderlyingTypeSubstitutions() const {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 816; // throw_addr
+const uint16_t SWIFTMODULE_VERSION_MINOR = 817; // Opaque type export details
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1641,7 +1641,8 @@ namespace decls_block {
     TypeIDField, // interface type for opaque type
     GenericSignatureIDField, // generic environment
     SubstitutionMapIDField, // optional substitution map for underlying type
-    AccessLevelField // access level
+    AccessLevelField, // access level
+    BCFixed<1> // export underlying type details
     // trailed by generic parameters
     // trailed by conditional substitutions
   >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4490,11 +4490,14 @@ public:
     }
     uint8_t rawAccessLevel =
         getRawStableAccessLevel(opaqueDecl->getFormalAccess());
+    bool exportDetails = opaqueDecl->exportUnderlyingType();
+
     unsigned abbrCode = S.DeclTypeAbbrCodes[OpaqueTypeLayout::Code];
     OpaqueTypeLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                  contextID.getOpaqueValue(), namingDeclID,
                                  interfaceSigID, interfaceTypeID, genericSigID,
-                                 underlyingSubsID, rawAccessLevel);
+                                 underlyingSubsID, rawAccessLevel,
+                                 exportDetails);
     writeGenericParams(opaqueDecl->getGenericParams());
 
     // Serialize all of the conditionally available substitutions expect the

--- a/test/Serialization/ignore-opaque-underlying-type-back-deploy.swift
+++ b/test/Serialization/ignore-opaque-underlying-type-back-deploy.swift
@@ -1,0 +1,70 @@
+/// Variant of ignore-opaque-underlying-type because of the macOS host need.
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: asserts
+// REQUIRES: OS=macosx
+
+/// Resilient scenario, we ignore underlying type of non-inlinable functions.
+/// Build libraries.
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -swift-version 5 -enable-library-evolution \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface -verify
+
+/// Build clients, with and without safety.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -enable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-access-control 2>&1 \
+// RUN:   | %FileCheck %s
+
+/// Build against the swiftinterface.
+// RUN: rm %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck %s
+
+/// Non-resilient scenario, all underlying types are loaded.
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-module-path %t/Lib.swiftmodule -verify
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NON-RESILIENT %s
+// NON-RESILIENT-NOT: Ignoring underlying information
+
+//--- Lib.swift
+public protocol V {}
+
+public struct EV : V {
+    public init () {}
+}
+
+@available(SwiftStdlib 5.1, *)
+public extension V {
+// CHECK: Loading underlying information for opaque type of 'backdeployedOpaqueFunc()'
+  @backDeployed(before: SwiftStdlib 5.1) // expected-warning 4 {{'@backDeployed' is unsupported on a instance method with a 'some' return type}}
+  func backdeployedOpaqueFunc() -> some V { EV() }
+}
+
+//--- Client.swift
+import Lib
+
+if #available(SwiftStdlib 5.1, *) {
+  let v = EV()
+  let _ = v.backdeployedOpaqueFunc()
+}

--- a/test/Serialization/ignore-opaque-underlying-type.swift
+++ b/test/Serialization/ignore-opaque-underlying-type.swift
@@ -1,0 +1,122 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: asserts
+
+/// Resilient scenario, we ignore underlying type of non-inlinable functions.
+/// Build libraries.
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -swift-version 5 -enable-library-evolution \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface -verify
+
+/// Build clients, with and without safety.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -enable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-access-control 2>&1 \
+// RUN:   | %FileCheck %s
+
+/// Build against the swiftinterface.
+// RUN: rm %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck %s
+
+/// Non-resilient scenario, all underlying types are loaded.
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-module-path %t/Lib.swiftmodule -verify
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NON-RESILIENT %s
+// NON-RESILIENT-NOT: Ignoring underlying information
+
+//--- Lib.swift
+public protocol V {}
+
+public struct EV : V {
+    public init () {}
+}
+
+@available(SwiftStdlib 5.1, *)
+public extension V {
+  private func referencedPrivateFunc(v: some V) -> some V { return v }
+
+  /// Hidden underlying types.
+// CHECK: Ignoring underlying information for opaque type of 'opaqueReferencingPrivate()'
+  func opaqueReferencingPrivate() -> some V {
+    referencedPrivateFunc(v: EV())
+  }
+
+// CHECK: Ignoring underlying information for opaque type of 'opaqueReferencingPrivateVar'
+  var opaqueReferencingPrivateVar: some V {
+    referencedPrivateFunc(v: EV())
+  }
+
+// CHECK: Ignoring underlying information for opaque type of 'opaqueReferencingPrivateVarPattern'
+  var opaqueReferencingPrivateVarPattern: some V {
+    get {
+      referencedPrivateFunc(v: EV())
+    }
+  }
+
+// CHECK: Ignoring underlying information for opaque type of 'subscript(_:)'
+  subscript(v: some V) -> some V {
+    referencedPrivateFunc(v: v)
+  }
+
+  /// Visible underlying types.
+// CHECK: Loading underlying information for opaque type of 'inlinableOpaqueFunc()'
+  @inlinable
+  func inlinableOpaqueFunc() -> some V { EV() }
+
+// CHECK: Loading underlying information for opaque type of 'aeicOpaqueFunc()'
+  @_alwaysEmitIntoClient
+  func aeicOpaqueFunc() -> some V { EV() }
+
+// CHECK: Loading underlying information for opaque type of 'transparentOpaqueFunc()'
+  @_transparent
+  func transparentOpaqueFunc() -> some V { EV() }
+
+// CHECK: Loading underlying information for opaque type of 'inlinableOpaqueVar'
+  @inlinable
+  var inlinableOpaqueVar: some V { EV() }
+
+// CHECK: Loading underlying information for opaque type of 'inlinableOpaqueVarPattern'
+  var inlinableOpaqueVarPattern: some V {
+      @inlinable
+      get { EV() }
+  }
+}
+
+//--- Client.swift
+import Lib
+
+if #available(SwiftStdlib 5.1, *) {
+  let v = EV()
+  let _ = v.opaqueReferencingPrivate()
+  let _ = v.opaqueReferencingPrivateVar
+  let _ = v.opaqueReferencingPrivateVarPattern
+  let _ = v[v]
+
+  let _ = v.inlinableOpaqueFunc()
+  let _ = v.aeicOpaqueFunc()
+  let _ = v.transparentOpaqueFunc()
+
+  let _ = v.inlinableOpaqueVar
+  let _ = v.inlinableOpaqueVarPattern
+}


### PR DESCRIPTION
A client shouldn't know about the underlying type of an opaque type unless it can see the body of the naming decl. Attempting to read it can lead to accessing a hidden dependency and a compiler crash.

This was protected by a check specific to function decls but var decls and subscripts were not handled. To support them we have to move this logic to the writer side where we have access to the full AbstractStorageDecl and write in the swifmodule whether the underlying  type should be visible outside of the module.

rdar://117607906