### PR TITLE
utils: add a helper to launch build.ps1

### DIFF
--- a/utils/build.cmd
+++ b/utils/build.cmd
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+if "%1"=="/?" (
+    powershell.exe -Command "& Get-Help -Detailed .\build.ps1"
+    exit /b
+)
+
+powershell.exe -ExecutionPolicy RemoteSigned -File "%~dp0\build.ps1" %*
+endlocal


### PR DESCRIPTION
When using build.ps1 as a developer, we may be working in a shell that does not have the ability to run the PowerShell script due to signing. Add a little helper that launches the script properly to not require the user to disable code signature on scripts.