### PR TITLE
build: update build.ps1, use update-checkout for more dependencies

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -70,7 +70,6 @@ if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 set SkipPackagingArg=-SkipPackaging
 if not "%SKIP_PACKAGING%"=="1" set "SkipPackagingArg= "
 
-call :CloneDependencies || (exit /b)
 call :CloneRepositories || (exit /b)
 
 :: We only have write access to BuildRoot, so use that as the image root.
@@ -106,25 +105,11 @@ rem git -C "%SourceRoot%\swift" checkout-index --force --all
 
 set "args=%args% --skip-repository swift"
 set "args=%args% --skip-repository ninja"
-set "args=%args% --skip-repository icu"
 set "args=%args% --skip-repository swift-integration-tests"
 set "args=%args% --skip-repository swift-stress-tester"
 set "args=%args% --skip-repository swift-xcode-playground-support"
 
 call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --github-comment "%ghprbCommentBody%"
-
-goto :eof
-endlocal
-
-:CloneDependencies
-setlocal enableextensions enabledelayedexpansion
-
-:: Always enable symbolic links
-git config --global core.symlink true
-
-:: FIXME(compnerd) avoid the fresh clone
-rd /s /q icu
-git clone --quiet --no-tags --depth 1 --branch maint/maint-69 https://github.com/unicode-org/icu
 
 goto :eof
 endlocal

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -123,13 +123,8 @@ setlocal enableextensions enabledelayedexpansion
 git config --global core.symlink true
 
 :: FIXME(compnerd) avoid the fresh clone
-rd /s /q zlib libxml2 sqlite icu curl
-
-git clone --quiet --no-tags --depth 1 --branch v1.2.11 https://github.com/madler/zlib
-git clone --quiet --no-tags --depth 1 --branch v2.9.12 https://github.com/gnome/libxml2
-git clone --quiet --no-tags --depth 1 --branch version-3.36.0 https://github.com/sqlite/sqlite
+rd /s /q icu
 git clone --quiet --no-tags --depth 1 --branch maint/maint-69 https://github.com/unicode-org/icu
-git clone --quiet --no-tags --depth 1 --branch curl-8_4_0 https://github.com/curl/curl
 
 goto :eof
 endlocal

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -46,10 +46,6 @@
             "remote": { "id": "apple/swift-xcode-playground-support" } },
         "ninja": {
             "remote": { "id": "ninja-build/ninja" } },
-        "icu": {
-            "remote": { "id": "unicode-org/icu" },
-            "platforms": [ "Linux" ]
-        },
         "yams": {
             "remote": { "id": "jpsim/Yams" }
         },
@@ -92,6 +88,9 @@
         "curl": {
           "remote": { "id": "curl/curl" }
         },
+        "icu": {
+          "remote": { "id": "unicode-org/icu" }
+        },
         "libxml2": {
           "remote": { "id": "gnome/libxml2" }
         },
@@ -128,7 +127,6 @@
                 "swift-integration-tests": "main",
                 "swift-xcode-playground-support": "main",
                 "ninja": "release",
-                "icu": "release-65-1",
                 "yams": "5.0.1",
                 "cmake": "v3.24.2",
                 "indexstore-db": "main",
@@ -145,6 +143,7 @@
                 "swift-experimental-string-processing": "swift/main",
                 "wasi-libc": "wasi-sdk-20",
                 "curl": "curl-8_4_0",
+                "icu": "maint/maint-69",
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3"
             }

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -595,7 +595,6 @@
                 "swift-integration-tests": "main",
                 "swift-xcode-playground-support": "main",
                 "ninja": "release",
-                "icu": "release-65-1",
                 "yams": "5.0.1",
                 "cmake": "v3.24.2",
                 "indexstore-db": "main",
@@ -603,7 +602,11 @@
                 "swift-format": "main",
                 "swift-installer-scripts": "main",
                 "swift-experimental-string-processing": "swift/main",
-                "wasi-libc": "wasi-sdk-20"
+                "wasi-libc": "wasi-sdk-20",
+                "curl": "curl-8_4_0",
+                "icu": "maint/maint-69",
+                "libxml2": "v2.11.5",
+                "zlib": "v1.3"
             }
         },
         "release/5.4": {

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -88,7 +88,16 @@
         "llvm-project": {
             "remote": { "id": "apple/llvm-project" } },
         "wasi-libc": {
-            "remote": { "id": "WebAssembly/wasi-libc" } }
+            "remote": { "id": "WebAssembly/wasi-libc" } },
+        "curl": {
+          "remote": { "id": "curl/curl" }
+        },
+        "libxml2": {
+          "remote": { "id": "gnome/libxml2" }
+        },
+        "zlib": {
+          "remote": { "id": "madler/zlib" }
+        }
     },
     "default-branch-scheme": "main",
     "branch-schemes": {
@@ -134,7 +143,10 @@
                 "swift-nio": "2.31.2",
                 "swift-nio-ssl": "2.15.0",
                 "swift-experimental-string-processing": "swift/main",
-                "wasi-libc": "wasi-sdk-20"
+                "wasi-libc": "wasi-sdk-20",
+                "curl": "curl-8_4_0",
+                "libxml2": "v2.11.5",
+                "zlib": "v1.3"
             }
         },
         "release/5.10": {


### PR DESCRIPTION
Update the build.ps1 to match the current state which introduces `-BuildTo` and updates most of the dependencies. Take the opportunity to migrate to update-checkout for the majority of the dependencies. The SQLite amalgamation and installer image are still fetched later, and ICU is still cloned in the CI wrapper.