### PR TITLE
[CMake] Install '.private.swiftinterface' of swift-syntax libraries

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -59,8 +59,8 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
   # Install Swift module interface files.
   foreach(module ${SWIFT_SYNTAX_MODULES})
     set(module_dir "${module}.swiftmodule")
-    set(module_file "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${module_dir}/${SWIFT_HOST_MODULE_TRIPLE}.swiftinterface")
-    swift_install_in_component(FILES "${module_file}"
+    set(module_file "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${module_dir}/${SWIFT_HOST_MODULE_TRIPLE}")
+    swift_install_in_component(FILES "${module_file}.swiftinterface" "${module_file}.private.swiftinterface"
                                DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/${module_dir}"
                                COMPONENT swift-syntax-lib)
   endforeach()


### PR DESCRIPTION
Restore `.private.swiftinterface` after #68408 
rdar://117698556
