### PR TITLE
[5.10][CMake] Install '.private.swiftinterface' of swift-syntax libraries

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -59,8 +59,8 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
   # Install Swift module interface files.
   foreach(module ${SWIFT_SYNTAX_MODULES})
     set(module_dir "${module}.swiftmodule")
-    set(module_file "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${module_dir}/${SWIFT_HOST_MODULE_TRIPLE}.swiftinterface")
-    swift_install_in_component(FILES "${module_file}"
+    set(module_file "${SWIFT_HOST_LIBRARIES_DEST_DIR}/${module_dir}/${SWIFT_HOST_MODULE_TRIPLE}")
+    swift_install_in_component(FILES "${module_file}.swiftinterface" "${module_file}.private.swiftinterface"
                                DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/${module_dir}"
                                COMPONENT swift-syntax-lib)
   endforeach()


### PR DESCRIPTION
Cherry-pick #69557 into release/5.10

* **Explanation**: Since #68882  `.private.swiftinterface` of swift-syntax libraries were not installed. This change restores  `.private.swiftinterface` in the install directory
* **Scope**: Installation
* **Risk**: Low, having `.private.swiftinterface` in the toolchain doesn't change the compiler behavior
* **Testing**: Passes the current test suite
* **Issues**: rdar://117698556
* **Reviewer**: TBA