### PR TITLE
AST: Make HasMissingDesignatedInitializersRequest more consistent

### DIFF
--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -206,6 +206,8 @@ public class PublicClass {
 
 public class PublicDerivedClass: PublicClass {}
 
+open class PublicClassSynthesizedDesignatedInit {}
+
 class InternalClass: NoTypecheckProto {
   init(x: NoTypecheck) {}
 }

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -43,7 +43,7 @@ func testPublicStruct() {
   PublicStruct.activeMethod()
 }
 
-func testPublicClass() {
+func testPublicClasses() {
   let c = PublicClass(x: 2)
   let _: Int = c.publicMethod()
   let _: Int = c.publicProperty
@@ -55,6 +55,11 @@ func testPublicClass() {
   let _: Int = d.publicProperty
   let _: String = d.publicPropertyInferredType
   PublicDerivedClass.publicClassMethod()
+
+  class DerivedFromPublicClassSynthesizedDesignatedInit: PublicClassSynthesizedDesignatedInit {
+    init() {}
+  }
+  let _ = DerivedFromPublicClassSynthesizedDesignatedInit()
 }
 
 func testPublicEnum(_ e: PublicEnum) {


### PR DESCRIPTION
The `@_hasMissingDesignatedInitializers` attribute was not emitted in swiftinterfaces on empty public classes because the request implementation did not ensure synthesized inits were requested prior to looking up constructors.

Resolves rdar://117769017
