### PR TITLE
ModuleInterface: Resolve types of CustomAttrs when printing

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -970,9 +970,9 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
   case DAK_Custom: {
-
     auto attr = cast<CustomAttr>(this);
-    if (auto type = attr->getType()) {
+    if (auto type =
+            D->getResolvedCustomAttrType(const_cast<CustomAttr *>(attr))) {
       // Print custom attributes only if the attribute decl is accessible.
       // FIXME: rdar://85477478 They should be rejected.
       if (auto attrDecl = type->getNominalOrBoundGenericNominal()) {

--- a/test/ModuleInterface/lazy-typecheck.swift
+++ b/test/ModuleInterface/lazy-typecheck.swift
@@ -15,20 +15,16 @@
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/lazy/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck
 // RUN: rm -rf %t/lazy/*.swiftmodule
 // RUN: %target-swift-frontend -package-name ClientPackage -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -I %t/lazy
-// FIXME: The emitted interfaces should be identical
-// diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy/lazy_typecheck.swiftinterface
+// RUN: diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy/lazy_typecheck.swiftinterface
 
 // (3) Same as (2), but with -experimental-skip-all-function-bodies added.
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/lazy-skip-all/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-exportable-decls -experimental-skip-all-function-bodies
 // RUN: rm -rf %t/lazy-skip-all/*.swiftmodule
 // RUN: %target-swift-frontend -package-name ClientPackage -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -I %t/lazy-skip-all
-// FIXME: The emitted interfaces should be identical
-// diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy-skip-all/lazy_typecheck.swiftinterface
+// RUN: diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy-skip-all/lazy_typecheck.swiftinterface
 
 // (4) Same as (2), but with -experimental-skip-non-inlinable-function-bodies added.
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -typecheck -emit-module-interface-path %t/lazy-skip-non-inlinable/lazy_typecheck.swiftinterface -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies
 // RUN: rm -rf %t/lazy-skip-non-inlinable/*.swiftmodule
 // RUN: %target-swift-frontend -package-name ClientPackage -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -I %t/lazy-skip-non-inlinable
-// FIXME: The emitted interfaces should be identical
-// diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy-skip-non-inlinable/lazy_typecheck.swiftinterface
-
+// RUN: diff -u %t/baseline/lazy_typecheck.swiftinterface %t/lazy-skip-non-inlinable/lazy_typecheck.swiftinterface


### PR DESCRIPTION
When printing the CustomAttrs attached to a decl, those attrs may not have been type checked yet if lazy typechecking is enabled. We need to make sure that printing invokes a request that will resolve the type.

Resolves rdar://117443319
