### PR TITLE
AST: Introduce SemanticDeclAttrsRequest

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -924,7 +924,13 @@ public:
   /// expansions.
   OrigDeclAttributes getOriginalAttrs() const;
 
-  /// Returns the semantic attributes attached to this declaration,
+  /// Returns the semantic CustomAttrs attached to this declaration,
+  /// including attributes that are generated as the result of member
+  /// attribute macro expansion.
+  DeclAttributes::AttributeKindRange<CustomAttr, false>
+  getSemanticCustomAttrs() const;
+
+  /// Returns all semantic attributes attached to this declaration,
   /// including attributes that are generated as the result of member
   /// attribute macro expansion.
   DeclAttributes getSemanticAttrs() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -351,7 +351,7 @@ protected:
   // for the inline bitfields.
   union { uint64_t OpaqueBits;
 
-  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1+1,
     Kind : bitmax(NumDeclKindBits,8),
 
     /// Whether this declaration is invalid.
@@ -374,7 +374,10 @@ protected:
     /// a local context, but should behave like a top-level
     /// declaration for name lookup purposes. This is used by
     /// lldb.
-    Hoisted : 1
+    Hoisted : 1,
+
+    /// Whether the set of semantic attributes has been computed.
+    SemanticAttrsComputed : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(PatternBindingDecl, Decl, 1+1+2+16,
@@ -1088,6 +1091,14 @@ public:
 
   void setEscapedFromIfConfig(bool Escaped) {
     Bits.Decl.EscapedFromIfConfig = Escaped;
+  }
+
+  bool getSemanticAttrsComputed() const {
+    return Bits.Decl.SemanticAttrsComputed;
+  }
+
+  void setSemanticAttrsComputed(bool Computed) {
+    Bits.Decl.SemanticAttrsComputed = Computed;
   }
 
   /// \returns the unparsed comment attached to this declaration.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4600,6 +4600,25 @@ public:
   void cacheResult(bool isSkipped) const;
 };
 
+class SemanticDeclAttrsRequest
+    : public SimpleRequest<SemanticDeclAttrsRequest,
+                           DeclAttributes(const Decl *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  DeclAttributes evaluate(Evaluator &evaluator, const Decl *) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  llvm::Optional<DeclAttributes> getCachedResult() const;
+  void cacheResult(DeclAttributes) const;
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -523,3 +523,6 @@ SWIFT_REQUEST(TypeChecker, IsFunctionBodySkippedRequest,
 SWIFT_REQUEST(TypeChecker, IsCCompatibleFuncDeclRequest,
               bool(const FuncDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SemanticDeclAttrsRequest,
+              DeclAttributes(const Decl *),
+              Cached, NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -375,6 +375,15 @@ OrigDeclAttributes Decl::getOriginalAttrs() const {
   return OrigDeclAttributes(getAttrs(), this);
 }
 
+DeclAttributes::AttributeKindRange<CustomAttr, false>
+Decl::getSemanticCustomAttrs() const {
+  auto mutableThis = const_cast<Decl *>(this);
+  (void)evaluateOrDefault(getASTContext().evaluator,
+                          ExpandMemberAttributeMacros{mutableThis}, {});
+
+  return getAttrs().getAttributes<CustomAttr>();
+}
+
 DeclAttributes Decl::getSemanticAttrs() const {
   (void)evaluateOrDefault(getASTContext().evaluator,
                           SemanticDeclAttrsRequest{this}, {});
@@ -438,7 +447,7 @@ void Decl::visitAuxiliaryDecls(
 
 void Decl::forEachAttachedMacro(MacroRole role,
                                 MacroCallback macroCallback) const {
-  for (auto customAttrConst : getSemanticAttrs().getAttributes<CustomAttr>()) {
+  for (auto customAttrConst : getSemanticCustomAttrs()) {
     auto customAttr = const_cast<CustomAttr *>(customAttrConst);
     auto *macroDecl = getResolvedMacro(customAttr);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -376,11 +376,8 @@ OrigDeclAttributes Decl::getOriginalAttrs() const {
 }
 
 DeclAttributes Decl::getSemanticAttrs() const {
-  auto mutableThis = const_cast<Decl *>(this);
   (void)evaluateOrDefault(getASTContext().evaluator,
-                          ExpandMemberAttributeMacros{mutableThis},
-                          { });
-
+                          SemanticDeclAttrsRequest{this}, {});
   return getAttrs();
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1725,7 +1725,7 @@ void namelookup::forEachPotentialAttachedMacro(
   // We intentionally avoid calling `forEachAttachedMacro` in order to avoid
   // a request cycle.
   auto moduleScopeCtx = decl->getDeclContext()->getModuleScopeContext();
-  for (auto attrConst : decl->getSemanticAttrs().getAttributes<CustomAttr>()) {
+  for (auto attrConst : decl->getSemanticCustomAttrs()) {
     auto *attr = const_cast<CustomAttr *>(attrConst);
     UnresolvedMacroReference macroRef(attr);
     auto macroName = macroRef.getMacroName();

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2062,3 +2062,28 @@ void ExpandPeerMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
                    "peer");
   }
 }
+
+//----------------------------------------------------------------------------//
+// SemanticDeclAttrsRequest computation.
+//----------------------------------------------------------------------------//
+
+DeclAttributes SemanticDeclAttrsRequest::evaluate(Evaluator &evaluator,
+                                                  const Decl *decl) const {
+  auto mutableDecl = const_cast<Decl *>(decl);
+  (void)evaluateOrDefault(evaluator, ExpandMemberAttributeMacros{mutableDecl},
+                          {});
+  return decl->getAttrs();
+}
+
+llvm::Optional<DeclAttributes>
+SemanticDeclAttrsRequest::getCachedResult() const {
+  auto decl = std::get<0>(getStorage());
+  if (decl->getSemanticAttrsComputed())
+    return decl->getAttrs();
+  return llvm::None;
+}
+
+void SemanticDeclAttrsRequest::cacheResult(DeclAttributes attrs) const {
+  auto decl = std::get<0>(getStorage());
+  const_cast<Decl *>(decl)->setSemanticAttrsComputed(true);
+}

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1281,7 +1281,7 @@ public:
   }
 
   void checkAttachedMacrosAccess(const Decl *D) {
-    for (auto customAttrC : D->getSemanticAttrs().getAttributes<CustomAttr>()) {
+    for (auto customAttrC : D->getSemanticCustomAttrs()) {
       auto customAttr = const_cast<CustomAttr *>(customAttrC);
       auto *macroDecl = D->getResolvedMacro(customAttr);
       if (macroDecl) {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1664,7 +1664,7 @@ ArrayRef<unsigned>
 ExpandExtensionMacros::evaluate(Evaluator &evaluator,
                                 NominalTypeDecl *nominal) const {
   SmallVector<unsigned, 2> bufferIDs;
-  for (auto customAttrConst : nominal->getSemanticAttrs().getAttributes<CustomAttr>()) {
+  for (auto customAttrConst : nominal->getSemanticCustomAttrs()) {
     auto customAttr = const_cast<CustomAttr *>(customAttrConst);
     auto *macro = nominal->getResolvedMacro(customAttr);
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -438,8 +438,7 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
   auto dc = var->getDeclContext();
   llvm::TinyPtrVector<CustomAttr *> result;
 
-  auto attachedAttrs = var->getSemanticAttrs();
-  for (auto attr : attachedAttrs.getAttributes<CustomAttr>()) {
+  for (auto attr : var->getSemanticCustomAttrs()) {
     auto mutableAttr = const_cast<CustomAttr *>(attr);
     // Figure out which nominal declaration this custom attribute refers to.
     auto *nominal = evaluateOrDefault(
@@ -480,6 +479,9 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
       ctx.Diags.diagnose(attr->getLocation(), diag::property_wrapper_let);
       continue;
     }
+
+    // Note: Getting the semantic attrs here would trigger a request cycle.
+    auto attachedAttrs = var->getAttrs();
 
     // Check for conflicting attributes.
     if (attachedAttrs.hasAttribute<LazyAttr>() ||


### PR DESCRIPTION
Introduce `SemanticDeclAttrsRequest`, which in the fullness of time should populate every implicit attribute in a declaration's attribute list so that they can be printed and serialized. Future pull requests will add the request triggers to `SemanticDeclAttrsRequest` that accomplish this goal.

Since this new request will be prone to cycles given the number of request dependencies it will have, this pull request also introduces a lighter-weight `getSemanticCustomAttrs()` accessor on `Decl` that can be used as a replacement for `getSemanticAttrs()` where the `CustomAttrs` expanded from attached macros are needed.