### PR TITLE
Weak-Link the Immediate Re-Exports of a Weak-Linked Module

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3441,6 +3441,17 @@ bool SourceFile::importsModuleAsWeakLinked(const ModuleDecl *module) const {
         importedModule->getUnderlyingModuleIfOverlay();
     if (module == clangModule)
       return true;
+
+    // Traverse the exported modules of this weakly-linked module to ensure
+    // that we weak-link declarations from its exported peers.
+    SmallVector<ImportedModule, 8> reexportedModules;
+    importedModule->getImportedModules(reexportedModules,
+                                       ModuleDecl::ImportFilterKind::Exported);
+    for (const ImportedModule &reexportedModule : reexportedModules) {
+      if (!module->isNonSwiftModule() &&
+          module == reexportedModule.importedModule)
+        return true;
+    }
   }
   return false;
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3448,8 +3448,7 @@ bool SourceFile::importsModuleAsWeakLinked(const ModuleDecl *module) const {
     importedModule->getImportedModules(reexportedModules,
                                        ModuleDecl::ImportFilterKind::Exported);
     for (const ImportedModule &reexportedModule : reexportedModules) {
-      if (!module->isNonSwiftModule() &&
-          module == reexportedModule.importedModule)
+      if (module == reexportedModule.importedModule)
         return true;
     }
   }

--- a/test/IRGen/Inputs/weaklinked_import_helper_clang.h
+++ b/test/IRGen/Inputs/weaklinked_import_helper_clang.h
@@ -1,0 +1,1 @@
+extern void clang_fn(void);

--- a/test/IRGen/Inputs/weaklinked_import_helper_clang.modulemap
+++ b/test/IRGen/Inputs/weaklinked_import_helper_clang.modulemap
@@ -1,0 +1,4 @@
+module weaklinked_import_helper_clang {
+  header "weaklinked_import_helper_clang.h"
+  export *
+}

--- a/test/IRGen/weaklinked_import_peer_transitive.swift
+++ b/test/IRGen/weaklinked_import_peer_transitive.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weaklinked_import_helper.swiftmodule -parse-as-library %S/Inputs/weaklinked_import_helper.swift -enable-library-evolution
+//
+// RUN: echo '@_exported import weaklinked_import_helper' > %t/intermediate.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/intermediate.swiftmodule -parse-as-library %t/intermediate.swift -I %t -enable-library-evolution
+//
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s
+
+// UNSUPPORTED: OS=windows-msvc
+
+@_weakLinked import intermediate
+
+// CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper2fnyyF"()
+fn()

--- a/test/IRGen/weaklinked_import_peer_transitive.swift
+++ b/test/IRGen/weaklinked_import_peer_transitive.swift
@@ -5,11 +5,17 @@
 // RUN: echo '@_exported import weaklinked_import_helper' > %t/intermediate.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/intermediate.swiftmodule -parse-as-library %t/intermediate.swift -I %t -enable-library-evolution
 //
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s
+// RUN: echo '@_exported import weaklinked_import_helper_clang' > %t/intermediate_clang.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/intermediate_clang.swiftmodule -parse-as-library %t/intermediate_clang.swift -I %t -enable-library-evolution -Xcc -fmodule-map-file=%S/Inputs/weaklinked_import_helper_clang.modulemap
+//
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -Xcc -fmodule-map-file=%S/Inputs/weaklinked_import_helper_clang.modulemap | %FileCheck %s
 
 // UNSUPPORTED: OS=windows-msvc
 
 @_weakLinked import intermediate
+@_weakLinked import intermediate_clang
 
 // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper2fnyyF"()
 fn()
+// CHECK-DAG: declare extern_weak void @clang_fn()
+clang_fn()


### PR DESCRIPTION
When a module is imported @_weakLinked, its re-exported peer modules have their definitions imported with strong linkage which can often defeat the point of weak linking the parent in the first place. Allow the weak-linkage to float to the immediate re-exports of the @_weakLinked module.

Resolves rdar://117166194