### PR TITLE
[Build] Enable building the early Swift Driver on linux with the prebuilt host toolchain

### DIFF
--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,4 +1,4 @@
-// XFAIL: OS=linux-gnu, OS=openbsd, OS=windows-msvc, OS=linux-android, OS=linux-androideabi
+// XFAIL: OS=openbsd, OS=windows-msvc
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/only-skip-once/* %t
@@ -9,7 +9,7 @@
 // CHECK-INITIAL: {{(Job finished: {compile: main.o <= main.swift}|Finished Compiling main.swift)}}
 // CHECK-INITIAL: {{(Job finished: {compile: file1.o <= file1.swift}|Finished Compiling file1.swift)}}
 // CHECK-INITIAL: {{(Job finished: {compile: file2.o <= file2.swift}|Finished Compiling file2.swift)}}
-// CHECK-INITIAL: {{(Job finished: {link: main <= main.o file1.o file2.o}|Finished Linking main)}}
+// CHECK-INITIAL: {{(Job finished: {link: main <= main.o file1.o file2.o|Finished Linking main)}}
 
 // RUN: touch -t 201401240006 %t/file2.swift
 // RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 |  %FileCheck -check-prefix=CHECK-REBUILD %s
@@ -18,5 +18,5 @@
 // CHECK-REBUILD-DAG: {{(Job finished: {compile: file2.o <= file2.swift}|Finished Compiling file2.swift)}}
 // CHECK-REBUILD-DAG: {{(Job skipped: {compile: main.o <= main.swift}|Skipped Compiling main.swift)}}
 // CHECK-REBUILD-DAG: {{(Job skipped: {compile: file1.o <= file1.swift}|Skipped Compiling file1.swift)}}
-// CHECK-REBUILD-DAG: {{(Job finished: {link: main <= main.o file1.o file2.o}|Finished Linking main)}}
+// CHECK-REBUILD-DAG: {{(Job finished: {link: main <= main.o file1.o file2.o|Finished Linking main)}}
 // CHECK-REBUILD-NOT: {{(Job skipped:|Skipped)}}

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
@@ -11,7 +11,6 @@
 # ----------------------------------------------------------------------------
 
 import os
-import sys
 
 from . import product
 from .. import shell
@@ -42,11 +41,6 @@ class EarlySwiftDriver(product.Product):
         return True
 
     def should_build(self, host_target):
-        # Temporarily disable for non-darwin since this build never works
-        # outside of that case currently.
-        if sys.platform != 'darwin':
-            return False
-
         if self.is_cross_compile_target(host_target):
             return False
 

--- a/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
+++ b/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
@@ -2,7 +2,7 @@
 # RUN: mkdir -p %t
 # RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --infer --swiftpm --cmake %cmake 2>&1 | %FileCheck %s
 
-# REQUIRES: standalone_build, OS=macosx
+# REQUIRES: standalone_build
 
 # Just make sure we compute the build graph/emit output.
 #

--- a/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
@@ -1,4 +1,4 @@
-# REQUIRES: standalone_build, OS=macosx
+# REQUIRES: standalone_build
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t

--- a/validation-test/BuildSystem/test_early_swift_driver_and_test.test
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_test.test
@@ -1,4 +1,4 @@
-# REQUIRES: standalone_build, OS=macosx
+# REQUIRES: standalone_build
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t


### PR DESCRIPTION
@bnbarham, let's see if this works on the linux CI now. This simply reverts most of your #68091, with the prebuilt Swift toolchain now installed on the linux CI.