### PR TITLE
Update CODEOWNERS for the runtime and Threading directories.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -148,8 +148,10 @@
 /stdlib/public/Cxx/                       @zoecarver @hyp @egorzhdan
 /stdlib/public/Distributed/               @ktoso
 /stdlib/public/Observation/               @phausler
+/stdlib/public/Threading/                 @al45tair
 /stdlib/public/Windows/                   @compnerd
 /stdlib/public/libexec/swift-backtrace/   @al45tair
+/stdlib/public/runtime/                   @mikeash @al45tair
 
 # test
 /test/ASTGen/                                       @zoecarver @CodaFi


### PR DESCRIPTION
The top-level stdlib directory has been claimed by the stdlib team, so we should probably grab public/runtime and public/Threading to make sure that we get pinged about changes to those.
