### PR TITLE
[Linux] Disable fatalError() backtraces when the runtime backtracer is active.

### DIFF
--- a/include/swift/Runtime/Backtrace.h
+++ b/include/swift/Runtime/Backtrace.h
@@ -135,6 +135,10 @@ struct BacktraceSettings {
 
 SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings;
 
+inline bool _swift_backtrace_isEnabled() {
+  return _swift_backtraceSettings.enabled == OnOffTty::On;
+}
+
 SWIFT_RUNTIME_STDLIB_SPI
 bool _swift_backtrace_isThunkFunction(const char *mangledName);
 

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -151,6 +151,7 @@ add_swift_target_library(swiftRuntime OBJECT_LIBRARY
   ${swift_runtime_threading_sources}
   C_COMPILE_FLAGS
     ${swift_runtime_library_compile_flags}
+    ${swift_enable_backtracing}
   LINK_FLAGS ${swift_runtime_linker_flags}
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install)

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -34,6 +34,7 @@
 
 #include "ImageInspection.h"
 #include "swift/Demangling/Demangle.h"
+#include "swift/Runtime/Backtrace.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Portability.h"
 #include "swift/Runtime/Win32.h"
@@ -353,7 +354,13 @@ void swift::swift_reportError(uint32_t flags,
                               const char *message) {
 #if defined(__APPLE__) && NDEBUG
   flags &= ~FatalErrorFlags::ReportBacktrace;
+#else
+  // Disable fatalError backtraces if the backtracer is enabled
+  if (runtime::backtrace::_swift_backtrace_isEnabled()) {
+    flags &= ~FatalErrorFlags::ReportBacktrace;
+  }
 #endif
+
   reportNow(flags, message);
   reportOnCrash(flags, message);
 }
@@ -388,9 +395,9 @@ swift::warningv(uint32_t flags, const char *format, va_list args)
 #pragma GCC diagnostic ignored "-Wuninitialized"
   swift_vasprintf(&log, format, args);
 #pragma GCC diagnostic pop
-  
+
   reportNow(flags, log);
-  
+
   free(log);
 }
 

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -354,7 +354,7 @@ void swift::swift_reportError(uint32_t flags,
                               const char *message) {
 #if defined(__APPLE__) && NDEBUG
   flags &= ~FatalErrorFlags::ReportBacktrace;
-#else
+#elif SWIFT_ENABLE_BACKTRACING
   // Disable fatalError backtraces if the backtracer is enabled
   if (runtime::backtrace::_swift_backtrace_isEnabled()) {
     flags &= ~FatalErrorFlags::ReportBacktrace;

--- a/test/Backtracing/FatalError.swift
+++ b/test/Backtracing/FatalError.swift
@@ -37,6 +37,8 @@ struct FatalError {
   }
 }
 
+// CHECK-NOT: Current stack trace:
+
 // CHECK: *** Program crashed: {{Illegal instruction|System trap}} at 0x{{[0-9a-f]+}} ***
 
 // CHECK: Thread 0 {{(".*" )?}}crashed:

--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | %{python} %utils/backtrace-check
+// RUN: env SWIFT_BACKTRACE=enable=no %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | %{python} %utils/backtrace-check
 
 // NOTE: not.py is used above instead of "not --crash" because %target-run
 // doesn't pass through the crash, and `not` may not be available when running


### PR DESCRIPTION
There's no need for fatalError() to try to generate its own backtraces when the runtime's backtracer is enabled.  Not only is the code it uses more fragile but it also doesn't support async or inline frames and it can't look-up symbols properly either.

rdar://117470489
