### PR TITLE
[5.10][Concurrency] Only apply Sendable initialization rules to actor isolated storage of `self`.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5920,7 +5920,8 @@ ActorReferenceResult ActorReferenceResult::forReference(
       declIsolation.isGlobalActor()) {
     auto *init = dyn_cast<ConstructorDecl>(fromDC);
     auto *decl = declRef.getDecl();
-    if (init && init->isDesignatedInit() && isStoredProperty(decl)) {
+    if (init && init->isDesignatedInit() && isStoredProperty(decl) &&
+        (!actorInstance || actorInstance->isSelf())) {
       auto type =
           fromDC->mapTypeIntoContext(declRef.getDecl()->getInterfaceType());
       if (!isSendableType(fromDC->getParentModule(), type)) {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1531,3 +1531,41 @@ class OverridesNonsiolatedInit: SuperWithNonisolatedInit {
     super.x = 10
   }
 }
+
+// expected-note@+1 2 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
+class NonSendable {}
+
+actor ProtectNonSendable {
+  // expected-note@+1 {{property declared here}}
+  let ns = NonSendable()
+
+  init() {}
+
+  @MainActor init(fromMain: Void) {
+    // expected-warning@+1 {{actor-isolated property 'ns' can not be referenced from the main actor; this is an error in Swift 6}}
+    _ = self.ns
+  }
+}
+
+@MainActor
+class ReferenceActor {
+  let a: ProtectNonSendable
+
+  init() async {
+    self.a = ProtectNonSendable()
+
+    // expected-warning@+1 {{non-sendable type 'NonSendable' in asynchronous access to actor-isolated property 'ns' cannot cross actor boundary}}
+    _ = a.ns
+  }
+}
+
+actor AnotherActor {
+  let a: ProtectNonSendable
+
+  init() {
+    self.a = ProtectNonSendable()
+
+    // expected-warning@+1 {{non-sendable type 'NonSendable' in asynchronous access to actor-isolated property 'ns' cannot cross actor boundary}}
+    _ = a.ns
+  }
+}


### PR DESCRIPTION
* **Explanation**: The actor isolation checker only allows initializing stored properties across isolation boundaries if the property has `Sendable` type. For `nonisolated` actor initializers, the `Sendable` check applies to arguments at the call-site. For global actor isolated initializers, the check applies at the point of property access in the initializer. This is done by marking the property reference as entering an actor. However, this was accidentally applied to `nonisolated` reference on arbitrary actor instances inside `init`s that are not isolated to the actor, which caused unexpected `expression is 'async' but is not marked with 'await'` error messages.
* **Scope**: Only impacts actor-isolated stored property references inside global actor isolated designated initializers.
* **Risk**: Low, only narrows the check to early-exit from `ActorReferenceResult::forReference` with a result value of `ActorReferenceResult::EntersActor`.
* **Testing**: Added a new test case.
* **Issue**: rdar://117703032
* **Reviewer**: @xedin 
* **Main branch PR**: https://github.com/apple/swift/pull/69562