### PR TITLE
Avoid memory mapping source files opened by SourceKit

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -938,11 +938,13 @@ CompilerInstance::getInputBuffersIfPresent(const InputFile &input) {
   // FIXME: Working with filenames is fragile, maybe use the real path
   // or have some kind of FileManager.
   using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
+  // Avoid memory-mapping when the compiler is run for IDE inspection,
+  // since that would prevent the user from saving the file.
   FileOrError inputFileOrErr =
     swift::vfs::getFileOrSTDIN(getFileSystem(), input.getFileName(),
                               /*FileSize*/-1,
                               /*RequiresNullTerminator*/true,
-                              /*IsVolatile*/false,
+                              /*IsVolatile*/getInvocation().isIDEInspection(),
       /*Bad File Descriptor Retry*/getInvocation().getFrontendOptions()
                                .BadFileDescriptorRetryCount);
   if (!inputFileOrErr) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -884,8 +884,11 @@ SwiftASTManager::Implementation::getMemoryBuffer(
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) const {
   assert(FileSystem);
+  // Avoid memory-mapping as it could prevent the user from
+  // saving the file in the editor.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-      FileSystem->getBufferForFile(Filename);
+      FileSystem->getBufferForFile(Filename, /*FileSize*/-1,
+          /*RequiresNullTerminator*/true, /*IsVolatile*/true);
   if (FileBufOrErr)
     return std::move(FileBufOrErr.get());
 


### PR DESCRIPTION
Memory mapping holds a read-only lock by nature, so we often got into cases where VS Code couldn't save files in which SourceKit-LSP was active. This may also be related to build issues observed where SPM fails to open files, which tend to be correlated with SourceKit-LSP running.

The fix is to only open files with `IsVolatile: true` in SourceKit/IDE-supporting code paths. I was unable to repro a file mapping and the locking issue after this change (monitoring events using Process Monitor).