### PR TITLE
[ASTGen] Build with `-disable-target-os-checking`

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -67,6 +67,9 @@ set(compile_options
   "SHELL: ${cxx_interop_flag}"
   "SHELL: -Xcc -std=c++17 -Xcc -DCOMPILED_WITH_SWIFT"
 
+  # FIXME: Needed to work around an availability issue with CxxStdlib
+  "SHELL: -Xfrontend -disable-target-os-checking"
+
   # Necessary to avoid treating IBOutlet and IBAction as keywords
   "SHELL:-Xcc -UIBOutlet -Xcc -UIBAction -Xcc -UIBInspectable"
 )

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -31,16 +31,16 @@ let swiftSetttings: [SwiftSetting] = [
     "-Xcc", "-I../../../build/Default/swift/include",
     "-Xcc", "-I../../../build/Default/llvm/include",
     "-Xcc", "-I../../../build/Default/llvm/tools/clang/include",
+
+    // FIXME: Needed to work around an availability issue with CxxStdlib
+    "-Xfrontend", "-disable-target-os-checking",
   ]),
 ]
 
 let package = Package(
   name: "swiftSwiftCompiler",
   platforms: [
-    // We need at least macOS 13 here to avoid hitting an availability error
-    // for CxxStdlib. It's only needed for the package though, the CMake build
-    // works fine with a lower deployment target.
-    .macOS(.v13)
+    .macOS(.v10_15)
   ],
   products: [
     .library(name: "swiftASTGen", targets: ["swiftASTGen"]),


### PR DESCRIPTION
Temporarily workaround an availability issue with CxxStdlib.
