### PR TITLE
AST: Print semantic attributes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -924,11 +924,10 @@ public:
   /// expansions.
   OrigDeclAttributes getOriginalAttrs() const;
 
-  /// Returns the semantic CustomAttrs attached to this declaration,
+  /// Returns the attributes attached to this declaration,
   /// including attributes that are generated as the result of member
   /// attribute macro expansion.
-  DeclAttributes::AttributeKindRange<CustomAttr, false>
-  getSemanticCustomAttrs() const;
+  DeclAttributes getExpandedAttrs() const;
 
   /// Returns all semantic attributes attached to this declaration,
   /// including attributes that are generated as the result of member

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1150,6 +1150,8 @@ void PrintAST::printAttributes(const Decl *D) {
   if (Options.SkipAttributes)
     return;
 
+  auto attrs = D->getSemanticAttrs();
+
   // Save the current number of exclude attrs to restore once we're done.
   unsigned originalExcludeAttrCount = Options.ExcludeAttrList.size();
 
@@ -1205,7 +1207,7 @@ void PrintAST::printAttributes(const Decl *D) {
     // If the declaration is implicitly @objc, print the attribute now.
     if (auto VD = dyn_cast<ValueDecl>(D)) {
       if (VD->isObjC() && !isa<EnumElementDecl>(VD) &&
-          !VD->getAttrs().hasAttribute<ObjCAttr>()) {
+          !attrs.hasAttribute<ObjCAttr>()) {
         Printer.printAttrName("@objc");
         Printer << " ";
       }
@@ -1235,13 +1237,13 @@ void PrintAST::printAttributes(const Decl *D) {
     Options.ExcludeAttrList.push_back(DAK_Borrowing);
   }
 
-  D->getAttrs().print(Printer, Options, D);
+  attrs.print(Printer, Options, D);
 
   // Print the implicit 'final' attribute.
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     auto VarD = dyn_cast<VarDecl>(D);
     if (VD->isFinal() &&
-        !VD->getAttrs().hasAttribute<FinalAttr>() &&
+        !attrs.hasAttribute<FinalAttr>() &&
         // Don't print a redundant 'final' if printing a 'let' or 'static' decl.
         !(VarD && VarD->isLet()) &&
         getCorrectStaticSpelling(D) != StaticSpellingKind::KeywordStatic &&

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -375,13 +375,12 @@ OrigDeclAttributes Decl::getOriginalAttrs() const {
   return OrigDeclAttributes(getAttrs(), this);
 }
 
-DeclAttributes::AttributeKindRange<CustomAttr, false>
-Decl::getSemanticCustomAttrs() const {
+DeclAttributes Decl::getExpandedAttrs() const {
   auto mutableThis = const_cast<Decl *>(this);
   (void)evaluateOrDefault(getASTContext().evaluator,
                           ExpandMemberAttributeMacros{mutableThis}, {});
 
-  return getAttrs().getAttributes<CustomAttr>();
+  return getAttrs();
 }
 
 DeclAttributes Decl::getSemanticAttrs() const {
@@ -447,7 +446,7 @@ void Decl::visitAuxiliaryDecls(
 
 void Decl::forEachAttachedMacro(MacroRole role,
                                 MacroCallback macroCallback) const {
-  for (auto customAttrConst : getSemanticCustomAttrs()) {
+  for (auto customAttrConst : getExpandedAttrs().getAttributes<CustomAttr>()) {
     auto customAttr = const_cast<CustomAttr *>(customAttrConst);
     auto *macroDecl = getResolvedMacro(customAttr);
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1725,7 +1725,7 @@ void namelookup::forEachPotentialAttachedMacro(
   // We intentionally avoid calling `forEachAttachedMacro` in order to avoid
   // a request cycle.
   auto moduleScopeCtx = decl->getDeclContext()->getModuleScopeContext();
-  for (auto attrConst : decl->getSemanticCustomAttrs()) {
+  for (auto attrConst : decl->getExpandedAttrs().getAttributes<CustomAttr>()) {
     auto *attr = const_cast<CustomAttr *>(attrConst);
     UnresolvedMacroReference macroRef(attr);
     auto macroName = macroRef.getMacroName();

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1281,7 +1281,7 @@ public:
   }
 
   void checkAttachedMacrosAccess(const Decl *D) {
-    for (auto customAttrC : D->getSemanticCustomAttrs()) {
+    for (auto customAttrC : D->getExpandedAttrs().getAttributes<CustomAttr>()) {
       auto customAttr = const_cast<CustomAttr *>(customAttrC);
       auto *macroDecl = D->getResolvedMacro(customAttr);
       if (macroDecl) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1579,7 +1579,7 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
   llvm::SmallVector<AvailableAttr *, 4> availableAttrs;
   llvm::SmallVector<BackDeployedAttr *, 4> backDeployedAttrs;
   llvm::SmallVector<OriginallyDefinedInAttr*, 4> ODIAttrs;
-  for (auto attr : D->getSemanticAttrs()) {
+  for (auto attr : D->getExpandedAttrs()) {
     if (!attr->isValid()) continue;
 
     // If Attr.def says that the attribute cannot appear on this kind of

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1664,7 +1664,8 @@ ArrayRef<unsigned>
 ExpandExtensionMacros::evaluate(Evaluator &evaluator,
                                 NominalTypeDecl *nominal) const {
   SmallVector<unsigned, 2> bufferIDs;
-  for (auto customAttrConst : nominal->getSemanticCustomAttrs()) {
+  for (auto customAttrConst :
+       nominal->getExpandedAttrs().getAttributes<CustomAttr>()) {
     auto customAttr = const_cast<CustomAttr *>(customAttrConst);
     auto *macro = nominal->getResolvedMacro(customAttr);
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -438,7 +438,7 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
   auto dc = var->getDeclContext();
   llvm::TinyPtrVector<CustomAttr *> result;
 
-  for (auto attr : var->getSemanticCustomAttrs()) {
+  for (auto attr : var->getExpandedAttrs().getAttributes<CustomAttr>()) {
     auto mutableAttr = const_cast<CustomAttr *>(attr);
     // Figure out which nominal declaration this custom attribute refers to.
     auto *nominal = evaluateOrDefault(


### PR DESCRIPTION
Follow up to https://github.com/apple/swift/pull/69561.

When enumerating attributes for printing, enumerate the result of `getSemanticAttrs()` to ensure all attributes that might be added to a declaration by semantic attribute requests have been added.

Additionally, only enumerate expanded (not semantic) attributes in `TypeCheckAttr`.  We need to avoid triggering semantic attribute requests in `TypeCheckAttr` because it happens too early in type checking to trigger some semantic attribute requests, and we only want to diagnose attributes that were either written in source or expanded from a macro anyways.