### PR TITLE
[5.10] Add `ld-path-driver-option` to `features.json`

### DIFF
--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -35,6 +35,9 @@
     },
     {
       "name": "const-extract-complete-metadata"
+    },
+    {
+      "name": "ld-path-driver-option"
     }
   ]
 }


### PR DESCRIPTION
Dependency of https://github.com/apple/swift-package-manager/pull/7021.

Cherry-pick of https://github.com/apple/swift/pull/69586.

The `-ld-path` option was introduced on `main` in https://github.com/apple/swift-driver/pull/1442 and 5.10 in https://github.com/apple/swift-driver/pull/1442. SwiftPM needs to detect this flag to pass options to the driver correctly, and it's suitable to do this via `feature.json` instead of checking for the compiler version via other means.

Partially resolves rdar://117049947.