### PR TITLE
[NoncopyableGenerics] Synthesize conditional conformances

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -94,6 +94,7 @@ namespace swift {
   class NamedPattern;
   class EnumCaseDecl;
   class EnumElementDecl;
+  struct InverseMarking;
   class ParameterList;
   class ParameterTypeFlags;
   class Pattern;
@@ -3117,16 +3118,6 @@ class TypeDecl : public ValueDecl {
 private:
   ArrayRef<InheritedEntry> Inherited;
 
-  struct {
-    /// Whether the "noncopyableAnnotationKind" field has been computed yet.
-    unsigned isNoncopyableAnnotationComputed : 1;
-
-    unsigned noncopyableAnnotationKind : 2;
-    static_assert((unsigned)InverseMarkingKind::LAST < 4);
-
-  } LazySemanticInfo = { };
-  friend class NoncopyableAnnotationRequest;
-
 protected:
   TypeDecl(DeclKind K, llvm::PointerUnion<DeclContext *, ASTContext *> context,
            Identifier name, SourceLoc NameLoc,
@@ -3157,12 +3148,10 @@ public:
   /// Is it possible for this type to lack a Copyable constraint?
   /// If you need a more precise answer, ask this Decl's corresponding
   /// Type if it `isNoncopyable` instead of using this.
-  bool canBeNoncopyable() const {
-    return getNoncopyableMarking() != InverseMarkingKind::None;
-  }
+  bool canBeNoncopyable() const;
 
   /// Determine how the ~Copyable was applied to this TypeDecl, if at all.
-  InverseMarkingKind getNoncopyableMarking() const;
+  InverseMarking getNoncopyableMarking() const;
 
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_TypeDecl &&

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -429,8 +429,6 @@ ERROR(destructor_decl_outside_class_or_noncopyable,none,
       "deinitializers may only be declared within a class, actor, or noncopyable type", ())
 ERROR(destructor_decl_on_noncopyable_enum,none,
       "deinitializers are not yet supported on noncopyable enums", ())
-ERROR(destructor_decl_on_objc_enum,none,
-      "deinitializers cannot be declared on an @objc enum type", ())
 ERROR(expected_lbrace_destructor,PointsToFirstBadToken,
       "expected '{' for deinitializer", ())
 ERROR(destructor_has_name,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3170,7 +3170,7 @@ ERROR(recursive_superclass_constraint,none,
 ERROR(requires_same_concrete_type,none,
       "generic signature requires types %0 and %1 to be the same", (Type, Type))
 WARNING(redundant_conformance_constraint,none,
-        "redundant conformance constraint %0 : %1", (Type, ProtocolDecl *))
+        "redundant conformance constraint %0 : %1", (Type, Type))
 
 WARNING(missing_protocol_refinement, none,
         "protocol %0 should be declared to refine %1 due to a same-type constraint on 'Self'",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7539,6 +7539,9 @@ ERROR(noncopyable_but_copyable, none,
 ERROR(noncopyable_class, none,
       "classes cannot be noncopyable",
       ())
+ERROR(inverse_extension, none,
+      "cannot apply inverse %0 to extension",
+      (Type))
 ERROR(copyable_illegal_deinit, none,
       "deinitializer cannot be declared in %kind0 that conforms to 'Copyable'",
       (const ValueDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7533,7 +7533,9 @@ ERROR(accessor_macro_not_single_var, none,
 //------------------------------------------------------------------------------
 // MARK: Noncopyable Types Diagnostics
 //------------------------------------------------------------------------------
-
+ERROR(noncopyable_but_copyable, none,
+      "%kind0 required to be 'Copyable' but is marked with '~Copyable'",
+      (const ValueDecl *))
 ERROR(noncopyable_class, none,
       "classes cannot be noncopyable",
       ())
@@ -7541,14 +7543,18 @@ ERROR(noncopyable_type_member_in_copyable,none,
       "%select{stored property %2|associated value %2}1 of "
       "'Copyable'-conforming %kind3 has noncopyable type %0",
       (Type, bool, DeclName, const ValueDecl *))
-NOTE(add_inverse_for_containment,none,
-     "consider removing implicit '%1' conformance from %kind0",
+NOTE(add_inverse,none,
+     "consider adding '~%1' to %kind0",
      (const ValueDecl *, StringRef))
-NOTE(remove_inverse_on_generic_parameter_for_conformance,none,
-     "consider removing '~%1' from generic parameter %0 so it conforms to the '%1' protocol",
+NOTE(note_inverse_preventing_conformance,none,
+     "%0 has '~%1' constraint preventing implicit '%1' conformance",
      (Type, StringRef))
-NOTE(remove_inverse_on_nominal_for_conformance,none,
-     "consider removing '~%1' from %kind0 so it conforms to the '%1' protocol",
+NOTE(note_inverse_preventing_conformance_implicit,none,
+     "%kind0 has '~%1' constraint on a generic parameter, "
+     "making its '%1' conformance conditional",
+     (const ValueDecl *, StringRef))
+NOTE(note_inverse_preventing_conformance_explicit,none,
+     "%kind0 has '~%1' constraint preventing '%1' conformance",
      (const ValueDecl *, StringRef))
 NOTE(add_explicit_protocol_for_conformance,none,
      "consider making %kind0 explicitly conform to the '%1' protocol",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7539,6 +7539,9 @@ ERROR(noncopyable_but_copyable, none,
 ERROR(noncopyable_class, none,
       "classes cannot be noncopyable",
       ())
+ERROR(copyable_illegal_deinit, none,
+      "deinitializer cannot be declared in %kind0 that conforms to 'Copyable'",
+      (const ValueDecl *))
 ERROR(noncopyable_type_member_in_copyable,none,
       "%select{stored property %2|associated value %2}1 of "
       "'Copyable'-conforming %kind3 has noncopyable type %0",

--- a/include/swift/AST/InverseMarking.h
+++ b/include/swift/AST/InverseMarking.h
@@ -1,0 +1,110 @@
+//===- InverseMarking.h - Utilities for tracking inverse types -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_LIB_SEMA_INVERSEMARKING_H
+#define SWIFT_LIB_SEMA_INVERSEMARKING_H
+
+#include "swift/AST/KnownProtocols.h"
+#include "swift/Basic/SourceLoc.h"
+#include "swift/Basic/OptionalEnum.h"
+
+namespace swift {
+
+/// Describes the way an inverse and its corresponding positive contraint
+/// appears on a TypeDecl, i.e., the way it was marked.
+struct InverseMarking {
+  enum class Kind : uint8_t {
+    None,            // No inverse marking is present
+    Inferred,        // Inverse is inferred based on generic parameters.
+    Explicit,        // Inverse is explicitly present.
+
+    LAST = Explicit
+  };
+
+  // Describes what kind of mark was found, if any.
+  struct Mark {
+  private:
+    OptionalEnum<Kind> kind;
+    SourceLoc loc;
+  public:
+    // Creates an empty mark.
+    Mark() {};
+
+    // Creates a mark.
+    Mark(Kind k, SourceLoc l = SourceLoc())
+      : kind(k), loc(l) {};
+
+    // Is there an inferred or explicit marking?
+    bool isPresent() const {
+      return getKind() != Kind::None;
+    }
+    operator bool() { return isPresent(); }
+
+    Kind getKind() const {
+      return kind.getValueOr(Kind::None);
+    }
+
+    SourceLoc getLoc() const { return loc; }
+
+    void set(Kind k, SourceLoc l = SourceLoc()) {
+      assert(!kind.hasValue());
+      kind = k;
+      loc = l;
+    }
+
+    void setIfUnset(Kind k, SourceLoc l = SourceLoc()) {
+      if (kind.hasValue())
+        return;
+      set(k, l);
+    }
+
+    void setIfUnset(Mark other) {
+      if (kind.hasValue())
+        return;
+      kind = other.kind;
+      loc = other.loc;
+    }
+
+    Mark with(Kind k) {
+      kind = k;
+      return *this;
+    }
+  };
+
+private:
+  Mark inverse;
+  Mark positive;
+public:
+
+  // Creates an empty marking.
+  InverseMarking() {}
+
+  Mark &getInverse() { return inverse; }
+  Mark &getPositive() { return positive; }
+
+  // Merge the results of another marking into this one.
+  void merge(InverseMarking other) const {
+    other.inverse.setIfUnset(other.inverse);
+    other.positive.setIfUnset(other.positive);
+  }
+
+  static InverseMarking forInverse(Kind kind, SourceLoc loc = SourceLoc()) {
+    InverseMarking marking;
+    marking.inverse.set(kind, loc);
+    marking.positive.set(Kind::None);
+    return marking;
+  }
+};
+
+}
+
+#endif //SWIFT_LIB_SEMA_INVERSEMARKING_H

--- a/include/swift/AST/KnownProtocols.h
+++ b/include/swift/AST/KnownProtocols.h
@@ -73,15 +73,6 @@ llvm::Optional<InvertibleProtocolKind>
 /// Returns the KnownProtocolKind corresponding to an InvertibleProtocolKind.
 KnownProtocolKind getKnownProtocolKind(InvertibleProtocolKind ip);
 
-/// Describes the way an inverse was applied to a TypeDecl.
-enum class InverseMarkingKind: uint8_t {
-  None,            // No inverse marking is present
-  Inferred,        // Inverse is inferred based on generic parameters.
-  Explicit,        // Inverse is explicitly present.
-
-  LAST = Explicit
-};
-
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/KnownProtocols.h
+++ b/include/swift/AST/KnownProtocols.h
@@ -73,6 +73,15 @@ llvm::Optional<InvertibleProtocolKind>
 /// Returns the KnownProtocolKind corresponding to an InvertibleProtocolKind.
 KnownProtocolKind getKnownProtocolKind(InvertibleProtocolKind ip);
 
+/// Describes the way an inverse was applied to a TypeDecl.
+enum class InverseMarkingKind: uint8_t {
+  None,            // No inverse marking is present
+  Inferred,        // Inverse is inferred based on generic parameters.
+  Explicit,        // Inverse is explicitly present.
+
+  LAST = Explicit
+};
+
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -427,10 +427,10 @@ public:
   void cacheResult(bool value) const;
 };
 
-/// Determine whether the given declaration has any markings that would cause it
-/// to not have an implicit, unconditional conformance to Copyable.
-class HasNoncopyableAnnotationRequest
-    : public SimpleRequest<HasNoncopyableAnnotationRequest, bool(TypeDecl *),
+/// Determine the kind of noncopyable marking present for this declaration.
+class NoncopyableAnnotationRequest
+    : public SimpleRequest<NoncopyableAnnotationRequest,
+                           InverseMarkingKind(TypeDecl *),
                            RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -439,13 +439,13 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  bool evaluate(Evaluator &evaluator, TypeDecl *decl) const;
+  InverseMarkingKind evaluate(Evaluator &evaluator, TypeDecl *decl) const;
 
 public:
   // Separate caching.
   bool isCached() const { return true; }
-  llvm::Optional<bool> getCachedResult() const;
-  void cacheResult(bool value) const;
+  llvm::Optional<InverseMarkingKind> getCachedResult() const;
+  void cacheResult(InverseMarkingKind value) const;
 };
 
 /// Determine whether the given declaration is escapable.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -430,8 +430,8 @@ public:
 /// Determine the kind of noncopyable marking present for this declaration.
 class NoncopyableAnnotationRequest
     : public SimpleRequest<NoncopyableAnnotationRequest,
-                           InverseMarkingKind(TypeDecl *),
-                           RequestFlags::SeparatelyCached> {
+                           InverseMarking(TypeDecl *),
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -439,13 +439,11 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  InverseMarkingKind evaluate(Evaluator &evaluator, TypeDecl *decl) const;
+  InverseMarking evaluate(Evaluator &evaluator, TypeDecl *decl) const;
 
 public:
-  // Separate caching.
+  // Caching.
   bool isCached() const { return true; }
-  llvm::Optional<InverseMarkingKind> getCachedResult() const;
-  void cacheResult(InverseMarkingKind value) const;
 };
 
 /// Determine whether the given declaration is escapable.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -211,8 +211,8 @@ SWIFT_REQUEST(TypeChecker, IsDynamicRequest, bool(ValueDecl *),
 SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, NoncopyableAnnotationRequest,
-              InverseMarkingKind(TypeDecl *),
-              SeparatelyCached, NoLocationInfo)
+              InverseMarking(TypeDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsNoncopyableRequest,
               bool (CanType),
               Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -210,8 +210,9 @@ SWIFT_REQUEST(TypeChecker, IsDynamicRequest, bool(ValueDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached,
               NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, HasNoncopyableAnnotationRequest, bool(TypeDecl *), SeparatelyCached,
-              NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, NoncopyableAnnotationRequest,
+              InverseMarkingKind(TypeDecl *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsNoncopyableRequest,
               bool (CanType),
               Cached, NoLocationInfo)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3324,12 +3324,12 @@ static bool usesFeatureFlowSensitiveConcurrencyCaptures(Decl *decl) {
 static bool usesFeatureMoveOnly(Decl *decl) {
   if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
     if (auto *nominal = extension->getSelfNominalTypeDecl())
-      if (nominal->isNoncopyable())
+      if (nominal->canBeNoncopyable())
         return true;
   }
 
   if (auto typeDecl = dyn_cast<TypeDecl>(decl)) {
-    if (typeDecl->isNoncopyable())
+    if (typeDecl->canBeNoncopyable())
       return true;
   }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3238,7 +3238,7 @@ public:
       PrettyStackTraceDecl debugStack("verifying DestructorDecl", DD);
 
       auto *ND = DD->getDeclContext()->getSelfNominalTypeDecl();
-      if (!isa<ClassDecl>(ND) && !ND->isNoncopyable() && !DD->isInvalid()) {
+      if (!isa<ClassDecl>(ND) && !ND->canBeNoncopyable() && !DD->isInvalid()) {
         Out << "DestructorDecls outside classes/move only types should be "
                "marked invalid\n";
         abort();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -31,6 +31,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/InverseMarking.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/MacroDefinition.h"
 #include "swift/AST/MacroDiscriminatorContext.h"
@@ -4876,11 +4877,16 @@ GenericParameterReferenceInfo ValueDecl::findExistentialSelfReferences(
                                         llvm::None);
 }
 
-InverseMarkingKind TypeDecl::getNoncopyableMarking() const {
-  return evaluateOrDefault(getASTContext().evaluator,
-                           NoncopyableAnnotationRequest{
-                               const_cast<TypeDecl *>(this)},
-                           InverseMarkingKind::Explicit);
+InverseMarking TypeDecl::getNoncopyableMarking() const {
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      NoncopyableAnnotationRequest{const_cast<TypeDecl *>(this)},
+      InverseMarking::forInverse(InverseMarking::Kind::None)
+  );
+}
+
+bool TypeDecl::canBeNoncopyable() const {
+  return getNoncopyableMarking().getInverse().isPresent();
 }
 
 Type TypeDecl::getDeclaredInterfaceType() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4876,12 +4876,11 @@ GenericParameterReferenceInfo ValueDecl::findExistentialSelfReferences(
                                         llvm::None);
 }
 
-bool TypeDecl::isNoncopyable() const {
-  // NOTE: must answer true iff it is unconditionally noncopyable.
+InverseMarkingKind TypeDecl::getNoncopyableMarking() const {
   return evaluateOrDefault(getASTContext().evaluator,
-                           HasNoncopyableAnnotationRequest{
+                           NoncopyableAnnotationRequest{
                                const_cast<TypeDecl *>(this)},
-                           true); // default to true for safety
+                           InverseMarkingKind::Explicit);
 }
 
 Type TypeDecl::getDeclaredInterfaceType() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2019,7 +2019,7 @@ LookupConformanceInModuleRequest::evaluate(
         // We only need to do this until we are properly dealing with or
         // omitting Copyable conformances in modules/interfaces.
 
-        if (nominal->isNoncopyable())
+        if (nominal->canBeNoncopyable())
           return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
         else
           return ProtocolConformanceRef(protocol);

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1047,7 +1047,7 @@ void NominalTypeDecl::prepareConformanceTable() const {
       return;
 
     // No synthesized conformances for move-only nominals.
-    if (isNoncopyable()) {
+    if (canBeNoncopyable()) {
       // assumption is Sendable gets synthesized elsewhere.
       assert(!proto->isSpecificProtocol(KnownProtocolKind::Sendable));
       return;

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -227,7 +227,7 @@ bool swift::rewriting::diagnoseRequirementErrors(
       case RequirementKind::Conformance:
         ctx.Diags.diagnose(loc, diag::redundant_conformance_constraint,
                            requirement.getFirstType(),
-                           requirement.getProtocolDecl());
+                           requirement.getSecondType());
         break;
       case RequirementKind::Superclass:
         ctx.Diags.diagnose(loc, diag::redundant_superclass_constraint,

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -823,8 +823,19 @@ void swift::rewriting::expandDefaultRequirements(ASTContext &ctx,
       return true;
     }
 
+    auto currentDefaults = defaults[subject];
+    auto inverseKind = inverse->getInverseKind();
+
+    // Check if this inverse is redundant.
+    if (!currentDefaults.contains(inverseKind)) {
+      errors.push_back(
+          RequirementError::forRedundantRequirement(req, structReq.loc));
+      return true;
+    }
+
     // Apply the inverse to the subject's defaults.
-    defaults[subject].remove(inverse->getInverseKind());
+    currentDefaults.remove(inverseKind);
+    defaults[subject] = currentDefaults;
 
     // Remove this inverse conformance requirement.
     return true;

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -234,7 +234,7 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
     if (isa<ProtocolDecl>(typeDecl))
       return {Unsupported, UnrepresentableProtocol};
     // Swift's consume semantics are not yet supported in C++.
-    if (typeDecl->isNoncopyable())
+    if (typeDecl->canBeNoncopyable())
       return {Unsupported, UnrepresentableMoveOnly};
     if (typeDecl->isGeneric()) {
       if (isa<ClassDecl>(VD))

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -161,7 +161,7 @@ bool TypeBase::isMarkerExistential() {
 /// that does not rely on conformances.
 static bool alwaysNoncopyable(Type ty) {
   if (auto *nominal = ty->getNominalOrBoundGenericNominal())
-    return nominal->isNoncopyable();
+    return nominal->canBeNoncopyable();
 
   if (auto *expansion = ty->getAs<PackExpansionType>()) {
     return alwaysNoncopyable(expansion->getPatternType());

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -314,35 +314,6 @@ void IsFinalRequest::cacheResult(bool value) const {
 }
 
 //----------------------------------------------------------------------------//
-// NoncopyableAnnotationRequest computation.
-//----------------------------------------------------------------------------//
-
-llvm::Optional<InverseMarkingKind>
-NoncopyableAnnotationRequest::getCachedResult() const {
-  auto decl = std::get<0>(getStorage());
-  if (decl->LazySemanticInfo.isNoncopyableAnnotationComputed)
-    return static_cast<InverseMarkingKind>(
-              decl->LazySemanticInfo.noncopyableAnnotationKind);
-
-  return llvm::None;
-}
-
-void NoncopyableAnnotationRequest::cacheResult(InverseMarkingKind value) const {
-  auto decl = std::get<0>(getStorage());
-  decl->LazySemanticInfo.isNoncopyableAnnotationComputed = true;
-  decl->LazySemanticInfo.noncopyableAnnotationKind =
-      static_cast<unsigned>(value);
-
-  if (!decl->getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
-    // Add an attribute for printing
-    if (value == InverseMarkingKind::Explicit
-        && !decl->getAttrs().hasAttribute<MoveOnlyAttr>())
-      decl->getAttrs().add(new(decl->getASTContext())
-                               MoveOnlyAttr(/*Implicit=*/true));
-  }
-}
-
-//----------------------------------------------------------------------------//
 // isEscapable computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1066,7 +1066,7 @@ void IRGenModule::addObjCClassStub(llvm::Constant *classPtr) {
 
 void IRGenModule::addRuntimeResolvableType(GenericTypeDecl *type) {
   // Collect the nominal type records we emit into a special section.
-  if (type->isNoncopyable()) {
+  if (type->canBeNoncopyable()) {
     // Older runtimes should not be allowed to discover noncopyable types, since
     // they will try to expose them dynamically as copyable types. Record
     // noncopyable type descriptors in a separate vector so that future

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6597,7 +6597,7 @@ SingletonEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
                                                   llvm::StructType *enumTy) {
   auto deinit = theEnum->getValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
-  auto copyable = theEnum->isNoncopyable()
+  auto copyable = theEnum->canBeNoncopyable()
     ? IsNotCopyable : IsCopyable;
   if (ElementsWithPayload.empty()) {
     enumTy->setBody(ArrayRef<llvm::Type*>{}, /*isPacked*/ true);
@@ -6673,7 +6673,7 @@ NoPayloadEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
 
   auto deinit = theEnum->getValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
-  auto copyable = theEnum->isNoncopyable()
+  auto copyable = theEnum->canBeNoncopyable()
     ? IsNotCopyable : IsCopyable;
   return registerEnumTypeInfo(new LoadableEnumTypeInfo(*this,
                               enumTy, tagSize, std::move(spareBits),
@@ -6793,7 +6793,7 @@ TypeInfo *SinglePayloadEnumImplStrategy::completeFixedLayout(
 
   auto deinit = theEnum->getValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
-  auto copyable = theEnum->isNoncopyable()
+  auto copyable = theEnum->canBeNoncopyable()
     ? IsNotCopyable : IsCopyable;
   getFixedEnumTypeInfo(
       enumTy, Size(sizeWithTag), spareBits.build(), alignment,
@@ -6828,7 +6828,7 @@ TypeInfo *SinglePayloadEnumImplStrategy::completeDynamicLayout(
 
   auto deinit = theEnum->getValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
-  auto copyable = theEnum->isNoncopyable()
+  auto copyable = theEnum->canBeNoncopyable()
     ? IsNotCopyable : IsCopyable;
   return registerEnumTypeInfo(new NonFixedEnumTypeInfo(*this, enumTy,
          alignment,
@@ -6864,7 +6864,7 @@ MultiPayloadEnumImplStrategy::completeFixedLayout(TypeConverter &TC,
   // of the largest payload.
   CommonSpareBits = {};
   Alignment worstAlignment(1);
-  auto isCopyable = theEnum->isNoncopyable()
+  auto isCopyable = theEnum->canBeNoncopyable()
     ? IsNotCopyable : IsCopyable;
   auto isTriviallyDestroyable = theEnum->getValueTypeDestructor()
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
@@ -7046,7 +7046,7 @@ TypeInfo *MultiPayloadEnumImplStrategy::completeDynamicLayout(
 
   auto enumAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
   
-  auto cp = theEnum->isNoncopyable()
+  auto cp = theEnum->canBeNoncopyable()
     ? IsNotCopyable : IsCopyable;
   return registerEnumTypeInfo(new NonFixedEnumTypeInfo(*this, enumTy,
                                                        alignment, td, bt, cp,
@@ -7070,7 +7070,7 @@ ResilientEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
                                                   EnumDecl *theEnum,
                                                   llvm::StructType *enumTy) {
   auto abiAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
-  auto copyable = theEnum->isNoncopyable()
+  auto copyable = theEnum->canBeNoncopyable()
     ? IsNotCopyable : IsCopyable;
   return registerEnumTypeInfo(
                        new ResilientEnumTypeInfo(*this, enumTy, copyable,

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1699,7 +1699,7 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
       || IGM.getSILTypes().getTypeLowering(SILType::getPrimitiveAddressType(type),
                                             TypeExpansionContext::minimal())
             .getRecursiveProperties().isInfinite()) {
-    auto copyable = D->isNoncopyable()
+    auto copyable = D->canBeNoncopyable()
       ? IsNotCopyable : IsCopyable;
     auto structAccessible =
       IsABIAccessible_t(IGM.getSILModule().isTypeMetadataAccessible(type));

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -71,7 +71,7 @@ StructLayout::StructLayout(IRGenModule &IGM,
 
   auto deinit = (decl && decl->getValueTypeDestructor())
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
-  auto copyable = (decl && decl->isNoncopyable())
+  auto copyable = (decl && decl->canBeNoncopyable())
     ? IsNotCopyable : IsCopyable;
 
   // Handle a raw layout specification on a struct.

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -680,7 +680,7 @@ lookUpFunctionInVTable(ClassDecl *Class, SILDeclRef Member) {
 
 SILFunction *
 SILModule::lookUpMoveOnlyDeinitFunction(const NominalTypeDecl *nomDecl) {
-  assert(nomDecl->isNoncopyable());
+  assert(nomDecl->canBeNoncopyable());
 
   auto *tbl = lookUpMoveOnlyDeinit(nomDecl);
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2403,7 +2403,7 @@ namespace {
       properties =
           applyLifetimeAnnotation(D->getLifetimeAnnotation(), properties);
 
-      if (D->isNoncopyable()) {
+      if (D->canBeNoncopyable()) {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
         if (properties.isAddressOnly())
@@ -2487,7 +2487,7 @@ namespace {
       properties =
           applyLifetimeAnnotation(D->getLifetimeAnnotation(), properties);
 
-      if (D->isNoncopyable()) {
+      if (D->canBeNoncopyable()) {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
         if (properties.isAddressOnly())

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1612,7 +1612,7 @@ void SILGenModule::emitDestructor(ClassDecl *cd, DestructorDecl *dd) {
 
 void SILGenModule::emitMoveOnlyDestructor(NominalTypeDecl *cd,
                                           DestructorDecl *dd) {
-  assert(cd->isNoncopyable());
+  assert(cd->canBeNoncopyable());
 
   emitAbstractFuncDecl(dd);
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -753,7 +753,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
                                            {selfDecl->getTypeInContext()},
                                            {}),
                       selfLV.getLValueAddress());
-    } else if (isa<StructDecl>(nominal) && nominal->isNoncopyable()
+    } else if (isa<StructDecl>(nominal) && nominal->canBeNoncopyable()
                && nominal->getStoredProperties().empty()) {
       auto *si = B.createStruct(ctor, lowering.getLoweredType(), {});
       B.emitStoreValueOperation(ctor, si, selfLV.getLValueAddress(),

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -170,7 +170,7 @@ void SILGenFunction::emitDeallocatingDestructor(DestructorDecl *dd) {
   auto *nom = dd->getDeclContext()->getSelfNominalTypeDecl();
   if (isa<ClassDecl>(nom))
     return emitDeallocatingClassDestructor(dd);
-  assert(nom->isNoncopyable());
+  assert(nom->canBeNoncopyable());
   return emitDeallocatingMoveOnlyDestructor(dd);
 }
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1113,7 +1113,7 @@ public:
 
     // If this is a nominal type that is move only, emit a deinit table for it.
     if (auto *nom = dyn_cast<NominalTypeDecl>(theType)) {
-      if (nom->isNoncopyable()) {
+      if (nom->canBeNoncopyable()) {
         SGM.emitNonCopyableTypeDeinitTable(nom);
       }
     }
@@ -1178,7 +1178,7 @@ public:
     if (auto *cd = dyn_cast<ClassDecl>(theType))
       return SGM.emitDestructor(cast<ClassDecl>(theType), dd);
     if (auto *nom = dyn_cast<NominalTypeDecl>(theType)) {
-      if (nom->isNoncopyable()) {
+      if (nom->canBeNoncopyable()) {
         return SGM.emitMoveOnlyDestructor(nom, dd);
       }
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -6255,7 +6255,7 @@ void swift::diagnoseCopyableTypeContainingMoveOnlyType(
 
   // If we already have a move only type, just bail, we have no further work to
   // do.
-  if (copyableNominalType->isNoncopyable())
+  if (copyableNominalType->canBeNoncopyable())
     return;
 
   LLVM_DEBUG(llvm::dbgs() << "DiagnoseCopyableType for: "

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7169,7 +7169,7 @@ void AttributeChecker::visitRawLayoutAttr(RawLayoutAttr *attr) {
     return;
   }
   
-  if (!sd->isNoncopyable()) {
+  if (!sd->canBeNoncopyable()) {
     diagnoseAndRemoveAttr(attr, diag::attr_rawlayout_cannot_be_copyable);
   }
   

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -963,7 +963,7 @@ NoncopyableAnnotationRequest::evaluate(Evaluator &evaluator,
     return false;
   };
 
-  auto isInverseTarget = [](Type t) -> bool {
+  auto isInverseTarget = [&](Type t) -> bool {
     if (auto inverse = t->getAs<InverseType>())
       return inverse->getInverseKind() == TARGET;
     else if (auto pct = t->getAs<ProtocolCompositionType>())
@@ -1038,7 +1038,7 @@ NoncopyableAnnotationRequest::evaluate(Evaluator &evaluator,
         // Try to find a good location.
         SourceLoc loc;
         if (repr && !repr->isInvalid())
-          if (auto *constraintRepr = repr->getSecondTypeRepr())
+          if (auto *constraintRepr = repr->getConstraintRepr())
             if (!repr->isInvalid())
               loc = constraintRepr->getLoc();
 
@@ -1056,10 +1056,6 @@ NoncopyableAnnotationRequest::evaluate(Evaluator &evaluator,
 
   auto nominal = cast<NominalTypeDecl>(decl);
   assert(!isa<BuiltinTupleDecl>(nominal));
-
-  // Classes can't be noncopyable; it's diagnosed elsewhere.
-  if (isa<ClassDecl>(nominal))
-    return InverseMarking::forInverse(Kind::None);
 
   /// Protocols are handled specially since they do not infer an inverse based
   /// on their associated types.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -25,6 +25,7 @@
 #include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
+#include "swift/AST/InverseMarking.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
@@ -914,23 +915,26 @@ IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   return explicitFinalAttr;
 }
 
-InverseMarkingKind
+InverseMarking
 NoncopyableAnnotationRequest::evaluate(Evaluator &evaluator,
                                        TypeDecl *decl) const {
   auto &ctx = decl->getASTContext();
+  const auto TARGET = InvertibleProtocolKind::Copyable;
+  using Kind = InverseMarking::Kind;
+  using Mark = InverseMarking::Mark;
 
   // ----------------
   // The legacy check
   if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
     if (isa<ClassDecl>(decl) || isa<StructDecl>(decl) || isa<EnumDecl>(decl)) {
-      if (decl->getAttrs().hasAttribute<MoveOnlyAttr>()) {
+      if (auto attr = decl->getAttrs().getAttribute<MoveOnlyAttr>()) {
         if (!decl->getASTContext().supportsMoveOnlyTypes())
           decl->diagnose(diag::moveOnly_requires_lexical_lifetimes);
 
-        return InverseMarkingKind::Explicit;
+        return InverseMarking::forInverse(Kind::Explicit, attr->getLocation());
       }
     }
-    return InverseMarkingKind::None;
+    return InverseMarking::forInverse(Kind::None);
   }
   // ----------------
 
@@ -938,82 +942,161 @@ NoncopyableAnnotationRequest::evaluate(Evaluator &evaluator,
   if (!ctx.supportsMoveOnlyTypes())
     decl->diagnose(diag::moveOnly_requires_lexical_lifetimes);
 
-  if (isa<TypeAliasDecl>(decl)) {
-    llvm_unreachable("todo: handle type aliases");
-  }
-
-  assert(isa<NominalTypeDecl>(decl) && "todo: handle non-nominals");
-
   // Handle the legacy '@_moveOnly' attribute
-  if (decl->getAttrs().hasAttribute<MoveOnlyAttr>()) {
+  if (auto attr = decl->getAttrs().getAttribute<MoveOnlyAttr>()) {
     assert(isa<StructDecl>(decl) || isa<EnumDecl>(decl)
                || (ctx.LangOpts.hasFeature(Feature::MoveOnlyClasses)
                    && isa<ClassDecl>(decl)));
-    return InverseMarkingKind::Explicit;
+    return InverseMarking::forInverse(Kind::Explicit, attr->getLocation());
   }
 
-  // For all other nominals, we can simply check the inheritance clause.
+  /// The invertible protocol being targeted by this annotation request.
 
-  // The set of defaults all types start with.
-  auto defaults = InvertibleProtocolSet::full();
-
-  auto foundInverse = [&](SourceLoc loc, InvertibleProtocolKind kind) {
-    defaults.remove(kind);
-  };
-
-  // Check the inheritance clause for inverses.
-  auto inherited = decl->getInherited();
-  for (size_t i = 0; i < inherited.size(); i++) {
-    auto *repr = inherited.getTypeRepr(i);
-
-    if (auto type = inherited.getResolvedType(i,
-                                              TypeResolutionStage::Structural))
-      if (auto inverse = type->getAs<InverseType>())
-        foundInverse(repr->getLoc(), inverse->getInverseKind());
-  }
-
-  // Check the where-clause for a constraint Subject: ~Copyable where Subject
-  // refers to the where-clause owner.
-
-  Type owner;
-  if (auto *proto = dyn_cast<ProtocolDecl>(decl)) {
-    owner = proto->getSelfInterfaceType();
-  } else if (auto *nom = dyn_cast<NominalTypeDecl>(decl)) {
-    owner = nom->getDeclaredInterfaceType();
-  }
-  // TODO(kavon): handle other TypeDecls
-
-
-  // Checks a requirement in a where-clause
-  auto checkRequirement = [&](const Requirement &req,
-                              RequirementRepr *repr) -> bool {
-    if (req.getKind() != RequirementKind::Conformance)
-      return false;
-
-    auto subject = req.getFirstType();
-    auto constraint = req.getSecondType();
-    auto constraintLoc = repr->getConstraintRepr()->getLoc();
-
-    if (auto inverse = constraint->getAs<InverseType>())
-      if (subject->getCanonicalType() == owner->getCanonicalType())
-        foundInverse(constraintLoc, inverse->getInverseKind());
+  std::function<bool(Type)> isTarget = [&](Type t) -> bool {
+    if (auto kp = t->getKnownProtocol()) {
+      if (auto ip = getInvertibleProtocolKind(*kp))
+        return *ip == TARGET;
+    } else if (auto pct = t->getAs<ProtocolCompositionType>()) {
+      return llvm::any_of(pct->getMembers(), isTarget);
+    }
 
     return false;
   };
 
-  if (owner) {
-    if (auto *nominal = dyn_cast<NominalTypeDecl>(decl)) {
-      WhereClauseOwner(nominal).visitRequirements(TypeResolutionStage::Structural,
-                                                  checkRequirement);
-    } else if (auto *assocTy = dyn_cast<AssociatedTypeDecl>(decl)) {
-      WhereClauseOwner(assocTy).visitRequirements(TypeResolutionStage::Structural,
-                                                  checkRequirement);
+  auto isInverseTarget = [](Type t) -> bool {
+    if (auto inverse = t->getAs<InverseType>())
+      return inverse->getInverseKind() == TARGET;
+    else if (auto pct = t->getAs<ProtocolCompositionType>())
+      return pct->getInverses().contains(TARGET);
+
+    return false;
+  };
+
+  // Function to check an inheritance clause for the noncopyable marking.
+  auto searchInheritanceClause =
+      [&](InheritedTypes inherited) -> InverseMarking {
+    InverseMarking result;
+
+    for (size_t i = 0; i < inherited.size(); i++) {
+      auto type = inherited.getResolvedType(i, TypeResolutionStage::Structural);
+      if (!type)
+        continue;
+
+      SourceLoc loc;
+      if (auto *repr = inherited.getTypeRepr(i))
+        loc = repr->getLoc();
+
+      if (isTarget(type))
+        result.getPositive().setIfUnset(Kind::Explicit, loc);
+
+      if (isInverseTarget(type))
+          result.getInverse().setIfUnset(Kind::Explicit, loc);
     }
+
+    return result;
+  };
+
+  // Function to check the generic parameters for an explicit ~TARGET marking
+  // which would result in an Inferred ~TARGET marking for this context.
+  auto hasInverseTarget = [&](GenericContext *genCtx) -> Mark {
+    if (!genCtx->isGeneric())
+      return InverseMarking::Mark();
+
+    auto *gpList = genCtx->getParsedGenericParams();
+    llvm::SmallSet<GenericTypeParamDecl*, 4> params;
+
+    // Scan the inheritance clauses of generic parameters only for an inverse.
+    for (GenericTypeParamDecl *param : gpList->getParams()) {
+      auto clause = searchInheritanceClause(param->getInherited());
+      if (auto inverse = clause.getInverse())
+        return inverse.with(Kind::Inferred);
+
+      params.insert(param);
+    }
+
+    Mark result;
+    // Next, scan the where clause and return the result.
+    WhereClauseOwner(genCtx).visitRequirements(TypeResolutionStage::Structural,
+      [&](Requirement req, RequirementRepr *repr) -> bool /* = stop search */ {
+      if (req.getKind() != RequirementKind::Conformance)
+        return false;
+
+      auto subject = req.getFirstType();
+      if (!subject->isTypeParameter())
+        return false;
+
+      // Skip outer params and implicit ones.
+      auto *param = subject->getRootGenericParam()->getDecl();
+      if (!param || !params.contains(param))
+        return false;
+
+      // Check constraint type
+      auto constraint = req.getSecondType();
+
+      // Found it?
+      if (isInverseTarget(constraint)) {
+        // Try to find a good location.
+        SourceLoc loc;
+        if (repr && !repr->isInvalid())
+          if (auto *constraintRepr = repr->getSecondTypeRepr())
+            if (!repr->isInvalid())
+              loc = constraintRepr->getLoc();
+
+        result.set(Kind::Inferred, loc);
+        return true;
+      }
+
+      return false;
+    });
+    return result;
+  };
+
+
+  /// MARK: procedure for determining if a nominal is marked with ~TARGET.
+
+  auto nominal = cast<NominalTypeDecl>(decl);
+  assert(!isa<BuiltinTupleDecl>(nominal));
+
+  // Classes can't be noncopyable; it's diagnosed elsewhere.
+  if (isa<ClassDecl>(nominal))
+    return InverseMarking::forInverse(Kind::None);
+
+  /// Protocols are handled specially since they do not infer an inverse based
+  /// on their associated types.
+  if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
+    // Check inheritance clause.
+    auto result = searchInheritanceClause(proto);
+
+    // Next, check the where clause for Self: TARGET or Self: ~TARGET
+    auto selfTy = proto->getSelfInterfaceType()->getCanonicalType();
+    WhereClauseOwner(proto).visitRequirements(TypeResolutionStage::Structural,
+      [&](Requirement req, RequirementRepr *repr) -> bool /* = stop search */ {
+        if (req.getKind() != RequirementKind::Conformance)
+          return false;
+
+        if (req.getFirstType()->getCanonicalType() != selfTy)
+          return false;
+
+        // Check constraint type
+        auto loc = repr->getSecondTypeRepr()->getLoc();
+        auto constraint = req.getSecondType();
+
+        if (isTarget(constraint))
+          result.getPositive().setIfUnset(Kind::Explicit, loc);
+
+        if (isInverseTarget(constraint))
+          result.getInverse().setIfUnset(Kind::Explicit, loc);
+
+        return false;
+      });
+
+    return result;
   }
 
-  return !defaults.contains(InvertibleProtocolKind::Copyable)
-         ? InverseMarkingKind::Explicit
-         : InverseMarkingKind::None;
+  // Handle non-protocol nominals.
+  auto result = searchInheritanceClause(nominal->getInherited());
+  result.getInverse().setIfUnset(hasInverseTarget(nominal));
+  return result;
 }
 
 bool IsEscapableRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -263,7 +263,7 @@ static void checkInheritanceClause(
       // Noncopyable types cannot have a raw type until there is support for
       // generics, since the raw type here is only useful if we'll generate
       // a conformance to RawRepresentable, which is currently disabled.
-      if (enumDecl->isNoncopyable()) {
+      if (enumDecl->canBeNoncopyable()) {
         // TODO: getRemovalRange is not yet aware of ~Copyable entries so it
         // will accidentally delete commas or colons that are needed.
         diags.diagnose(inherited.getSourceRange().Start,
@@ -2026,7 +2026,7 @@ static void checkProtocolRefinementRequirements(ProtocolDecl *proto) {
       // unless it was suppressed via `Self: ~Copyable`. So if this suppression
       // annotation exists yet Copyable was implied anyway, emit a diagnostic.
       if (otherProto->isSpecificProtocol(KnownProtocolKind::Copyable))
-        if (!proto->isNoncopyable())
+        if (!proto->canBeNoncopyable())
           continue; // no ~Copyable annotation
 
       // TODO(kavon): emit tailored error diagnostic to remove the ~Copyable
@@ -2465,7 +2465,7 @@ public:
     // completely type checked at that point.
     if (auto attr = VD->getAttrs().getAttribute<NoImplicitCopyAttr>()) {
       if (auto *nom = VD->getInterfaceType()->getNominalOrBoundGenericNominal()) {
-        if (nom->isNoncopyable()) {
+        if (nom->canBeNoncopyable()) {
           DE.diagnose(attr->getLocation(),
                       diag::noimplicitcopy_attr_not_allowed_on_moveonlytype)
             .fixItRemove(attr->getRange());
@@ -2968,7 +2968,7 @@ public:
     // NonCopyableChecks
     //
 
-    if (ED->isObjC() && ED->isNoncopyable()) {
+    if (ED->isObjC() && ED->canBeNoncopyable()) {
       ED->diagnose(diag::noncopyable_objc_enum);
     }
     // FIXME(kavon): see if these can be integrated into other parts of Sema
@@ -2983,7 +2983,7 @@ public:
 
     // If our enum is marked as move only, it cannot be indirect or have any
     // indirect cases.
-    if (ED->isNoncopyable()) {
+    if (ED->canBeNoncopyable()) {
       if (ED->isIndirect())
         ED->diagnose(diag::noncopyable_enums_do_not_support_indirect,
                      ED->getBaseIdentifier());
@@ -3140,7 +3140,7 @@ public:
                                                    NominalTypeDecl *moveonlyType,
                                                    Type type) {
     assert(type && "got an empty type?");
-    assert(moveonlyType->isNoncopyable());
+    assert(moveonlyType->canBeNoncopyable());
 
     // no need to emit a diagnostic if the type itself is already problematic.
     if (type->hasError())
@@ -3166,7 +3166,7 @@ public:
       return; // taken care of elsewhere.
 
     if (auto *nomDecl = dyn_cast<NominalTypeDecl>(decl)) {
-      if (!nomDecl->isNoncopyable())
+      if (!nomDecl->canBeNoncopyable())
         return;
 
       // go over the all protocols directly conformed-to by this nominal
@@ -3176,7 +3176,7 @@ public:
 
     } else if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
       if (auto *nomDecl = extension->getExtendedNominal()) {
-        if (!nomDecl->isNoncopyable())
+        if (!nomDecl->canBeNoncopyable())
           return;
 
         // go over the all types directly conformed-to by the extension
@@ -4060,7 +4060,7 @@ public:
     // that would require the ability to wrap one inside an optional
     if (CD->isFailable()) {
       if (auto *nom = CD->getDeclContext()->getSelfNominalTypeDecl()) {
-        if (nom->isNoncopyable()) {
+        if (nom->canBeNoncopyable()) {
           CD->diagnose(diag::noncopyable_failable_init);
         }
       }
@@ -4076,7 +4076,7 @@ public:
     if (!DD->isInvalid()) {
       auto *nom = dyn_cast<NominalTypeDecl>(
                              DD->getDeclContext()->getImplementedObjCContext());
-      if (!nom || (!isa<ClassDecl>(nom) && !nom->isNoncopyable())) {
+      if (!nom || (!isa<ClassDecl>(nom) && !nom->canBeNoncopyable())) {
         DD->diagnose(diag::destructor_decl_outside_class_or_noncopyable);
       }
 
@@ -4084,7 +4084,7 @@ public:
       // feature flag is set.
       if (!DD->getASTContext().LangOpts.hasFeature(
               Feature::MoveOnlyEnumDeinits) &&
-          nom->isNoncopyable() && isa<EnumDecl>(nom)) {
+          nom->canBeNoncopyable() && isa<EnumDecl>(nom)) {
         DD->diagnose(diag::destructor_decl_on_noncopyable_enum);
       }
 
@@ -4220,7 +4220,7 @@ void TypeChecker::checkParameterList(ParameterList *params,
     // is not move only. It is redundant.
     if (auto attr = param->getAttrs().getAttribute<NoImplicitCopyAttr>()) {
       if (auto *nom = param->getInterfaceType()->getNominalOrBoundGenericNominal()) {
-        if (nom->isNoncopyable()) {
+        if (nom->canBeNoncopyable()) {
           param->diagnose(diag::noimplicitcopy_attr_not_allowed_on_moveonlytype)
             .fixItRemove(attr->getRange());
         }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1640,7 +1640,7 @@ static void diagnoseRetroactiveConformances(
   // We better only be conforming it to protocols declared within this module.
   llvm::SmallSetVector<ProtocolDecl *, 8> externalProtocols;
   for (const InheritedEntry &entry : ext->getInherited().getEntries()) {
-    if (entry.getType().isNull()) {
+    if (entry.getType().isNull() || !entry.getTypeRepr()) {
       continue;
     }
 
@@ -3821,7 +3821,7 @@ public:
       auto *extTypeNominal = extType->getAnyNominal();
       bool firstNominalIsNotMostSpecific =
         extTypeNominal && extTypeNominal != nominal;
-      if (isa<CompositionTypeRepr>(extTypeRepr)
+      if ((extTypeRepr && isa<CompositionTypeRepr>(extTypeRepr))
           || firstNominalIsNotMostSpecific) {
         auto diag = ED->diagnose(diag::composition_in_extended_type,
                                  nominal->getDeclaredType());

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -205,6 +205,10 @@ static void checkInheritanceClause(
     if (inheritedTy->isConstraintType()) {
       auto layout = inheritedTy->getExistentialLayout();
 
+      // An inverse on an extension is an error.
+      if (isa<ExtensionDecl>(decl) && inheritedTy->is<InverseType>())
+        decl->diagnose(diag::inverse_extension, inheritedTy);
+
       // Subclass existentials are not allowed except on classes and
       // non-@objc protocols.
       if (layout.explicitSuperclass &&
@@ -224,12 +228,6 @@ static void checkInheritanceClause(
       // AnyObject is not allowed except on protocols.
       if (layout.hasExplicitAnyObject) {
         decl->diagnose(diag::inheritance_from_anyobject);
-        continue;
-      }
-
-      // Classes are always copyable.
-      if (layout.hasInverseCopyable && isa<ClassDecl>(decl)) {
-        decl->diagnose(diag::noncopyable_class);
         continue;
       }
 

--- a/lib/Sema/TypeCheckInvertible.cpp
+++ b/lib/Sema/TypeCheckInvertible.cpp
@@ -78,7 +78,6 @@ static void tryEmitContainmentFixits(NominalTypeDecl *enclosingNom,
   }
     break;
   case InverseMarking::Kind::Explicit:
-    assert(false && "how did it become Copyable?");
     break;
   };
 
@@ -326,11 +325,11 @@ ProtocolConformance *deriveConformanceForInvertible(Evaluator &evaluator,
     ext->setExtendedNominal(nominal);
     nominal->addExtension(ext);
 
-    // Make it accessible to getTopLevelDecls()
-    if (auto file = dyn_cast<FileUnit>(nominal->getModuleScopeContext()))
-      file->getOrCreateSynthesizedFile().addTopLevelDecl(ext);
+    // Make it accessible to getTopLevelDecls() so it gets type-checked.
+    auto file = cast<FileUnit>(nominal->getModuleScopeContext());
+    file->getOrCreateSynthesizedFile().addTopLevelDecl(ext);
 
-    // Then reate the conformance using the extension as the conformance's
+    // Then create the conformance using the extension as the conformance's
     // DeclContext, which is how we register these conditional requirements
     // with the conformance.
     return generateConformance(ext);

--- a/lib/Sema/TypeCheckInvertible.cpp
+++ b/lib/Sema/TypeCheckInvertible.cpp
@@ -42,7 +42,7 @@ SourceRange findInverseRemovalRange(const TypeDecl *typeDecl,
           return inheritedTypes.getRemovalRange(i);
   }
 
-  // TODO: just ask HasNoncopyableAnnotationRequest for the annotation?
+  // TODO: just ask NoncopyableAnnotationRequest for the annotation?
   // so we can handle where clauses.
 
   return SourceRange();
@@ -274,7 +274,7 @@ ProtocolConformance *deriveConformanceForInvertible(Evaluator &evaluator,
 
   switch (kp) {
   case KnownProtocolKind::Copyable: {
-    if (evaluateOrDefault(evaluator, HasNoncopyableAnnotationRequest{nominal}, false))
+    if (nominal->canBeNoncopyable())
       return nullptr; // it's not Copyable.
 
     // TODO: generate conditional conformances implied by ~Copyable on generic params.

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/Types.h"
+#include "swift/AST/InverseMarking.h"
 #include "swift/Subsystems.h"
 
 using namespace swift;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -293,8 +293,18 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     // Type-check macro-generated or implicitly-synthesized extensions.
     if (auto *synthesizedSF = SF->getSynthesizedFile()) {
       for (auto *decl : synthesizedSF->getTopLevelDecls()) {
-        assert(isa<ExtensionDecl>(decl));
-        TypeChecker::typeCheckDecl(decl);
+        auto extension = cast<ExtensionDecl>(decl);
+
+        // Limit typechecking of synthesized _impicit_ extensions to conformance
+        // checking. This is done because a conditional conformance to Copyable
+        // is synthesized as an extension, based on the markings of `~Copyable`
+        // in a value type. This call to `checkConformancesInContext` will
+        // the actual check to verify that the conditional extension is correct,
+        // as it may be an invalid conformance.
+        if (extension->isImplicit())
+          TypeChecker::checkConformancesInContext(extension);
+        else
+          TypeChecker::typeCheckDecl(extension);
       }
     }
     SF->typeCheckDelayedFunctions();

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -290,13 +290,11 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
       }
     }
 
-    // Type-check macro-generated extensions.
+    // Type-check macro-generated or implicitly-synthesized extensions.
     if (auto *synthesizedSF = SF->getSynthesizedFile()) {
       for (auto *decl : synthesizedSF->getTopLevelDecls()) {
-        if (!decl->isImplicit()) {
-          assert(isa<ExtensionDecl>(decl));
-          TypeChecker::typeCheckDecl(decl);
-        }
+        assert(isa<ExtensionDecl>(decl));
+        TypeChecker::typeCheckDecl(decl);
       }
     }
     SF->typeCheckDelayedFunctions();

--- a/test/Generics/inverse_copyable_generics.swift
+++ b/test/Generics/inverse_copyable_generics.swift
@@ -47,6 +47,7 @@ protocol RemovedAgain where Self: ~Copyable {
 
 struct StructContainment<T: ~Copyable> : Copyable {
     // expected-note@-1 {{consider adding '~Copyable' to generic struct 'StructContainment'}}{{50-50=, ~Copyable}}
+    // expected-note@-2 {{generic struct 'StructContainment' has '~Copyable' constraint on a generic parameter, making its 'Copyable' conformance conditional}}
 
     var storage: Maybe<T>
     // expected-error@-1 {{stored property 'storage' of 'Copyable'-conforming generic struct 'StructContainment' has noncopyable type 'Maybe<T>'}}
@@ -55,6 +56,7 @@ struct StructContainment<T: ~Copyable> : Copyable {
 enum EnumContainment<T: ~Copyable> : Copyable {
     // expected-note@-1 {{'T' has '~Copyable' constraint preventing implicit 'Copyable' conformance}}
     // expected-note@-2{{consider adding '~Copyable' to generic enum 'EnumContainment'}}{{46-46=, ~Copyable}}
+    // expected-note@-3{{generic enum 'EnumContainment' has '~Copyable' constraint on a generic parameter, making its 'Copyable' conformance conditional}}
 
     case some(T) // expected-error {{associated value 'some' of 'Copyable'-conforming generic enum 'EnumContainment' has noncopyable type 'T'}}
     case other(Int)
@@ -69,6 +71,7 @@ class ClassContainment<T: ~Copyable> {
     }
 }
 
+// expected-note@+2 {{generic struct 'ConditionalContainment' has '~Copyable' constraint on a generic parameter, making its 'Copyable' conformance conditional}}
 // expected-note@+1 {{consider adding '~Copyable' to generic struct 'ConditionalContainment'}}{{45-45=: ~Copyable}}
 struct ConditionalContainment<T: ~Copyable> {
   var x: T
@@ -116,6 +119,7 @@ extension Maybe where Self: Copyable {
   func check2(_ t: RequireCopyable<Self>) {}
 }
 
+// expected-note@+2 {{generic struct 'CornerCase' has '~Copyable' constraint on a generic parameter, making its 'Copyable' conformance conditional}}
 // expected-note@+1 {{consider adding '~Copyable' to generic struct 'CornerCase'}}{{33-33=: ~Copyable}}
 struct CornerCase<T: ~Copyable> {
   let t: T

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -warn-redundant-requirements
 
 // REQUIRES: asserts
 
@@ -25,16 +25,21 @@ func blah<T>(_ t: borrowing T) where T: ~Copyable,
 func foo<T: ~Copyable>(x: borrowing T) {}
 
 struct Buurap<T: ~Copyable> where T: ~Copyable {}
+// expected-warning@-1 {{redundant conformance constraint 'T' : '~Copyable'}}
 
 struct ExtraNoncopyStruct: ~Copyable, ~Copyable {}
 struct ExtraNoncopyEnum: ~Copyable, ~Copyable {}
+
 protocol ExtraNoncopyProto: ~Copyable, ~Copyable {}
+// expected-warning@-1 {{redundant conformance constraint 'Self' : '~Copyable'}}
 
 protocol Foo: ~Copyable
          where Self: ~Copyable {
+         // expected-warning@-1 {{redundant conformance constraint 'Self' : '~Copyable'}}
 
     associatedtype Touch : ~Copyable,
                            ~Copyable
+    // expected-warning@-1 {{redundant conformance constraint 'Self.Touch' : '~Copyable'}}
 
     func test<T>(_ t: T) where T: ~Self  // expected-error {{type 'Self' is not invertible}}
 }

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -59,7 +59,7 @@ protocol Rope<Element>: Hashable, ~ Copyable {
   associatedtype Element: ~Copyable
 }
 
-extension S: ~Copyable {}
+extension S: ~Copyable {} // expected-error {{cannot apply inverse '~Copyable' to extension}}
 
 struct S: ~U, // expected-error {{type 'U' is not invertible}}
           ~Copyable {}

--- a/test/Sema/moveonly_objc_enum.swift
+++ b/test/Sema/moveonly_objc_enum.swift
@@ -8,7 +8,7 @@
 @objc enum Foo : Int { // expected-error {{noncopyable enums cannot be marked '@objc'}}
                        // expected-error@-1 {{'Foo' declares raw type 'Int', but cannot yet conform to RawRepresentable because it is noncopyable}}
   case X, Y, Z
-  deinit {} // expected-error {{deinitializers cannot be declared on an @objc enum type}}
+  deinit {}
 }
 
 @_moveOnly


### PR DESCRIPTION
This PR takes care of a few pieces for NoncopyableGenerics:

1. When `~Copyable` is written on the generic parameter of a struct or enum, then synthesize a conditional conformance to ~Copyable. This helps people skip a step in making some piece of generic stored data support noncopyable data.
2. Ensure that deinits do not appear in conditionally-copyable types.
3. Provide good fix-its for containment issues.