### PR TITLE
5.10: [InstructionDeleter] Delete dead load [take]s.

### DIFF
--- a/test/SILOptimizer/instruction_deleter.sil
+++ b/test/SILOptimizer/instruction_deleter.sil
@@ -5,6 +5,10 @@ struct MOS : ~Copyable {}
 sil @getMOS : $() -> (@owned MOS)
 sil @barrier : $() -> ()
 
+class C {}
+
+sil @get : $<T> () -> (@out T)
+
 // CHECK-LABEL: begin running test {{.*}} on dontDeleteDeadMoveOnlyValue
 // CHECK:       Deleting-if-dead {{.*}} move_value
 // CHECK:       deleteIfDead returned 0
@@ -25,6 +29,29 @@ sil [ossa] @dontDeleteDeadMoveOnlyValue : $() -> () {
   %mov = move_value %mos : $MOS
   apply %barrier() : $@convention(thin) () -> ()
   destroy_value %mov : $MOS
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} on doDeleteLoadTake
+// CHECK:       Deleting-if-dead   {{%[^,]+}} = load [take]
+// CHECK:       deleteIfDead returned 1
+// CHECK-LABEL: sil [ossa] @doDeleteLoadTake : {{.*}} {
+// CHECK:         [[STACK:%[^,]+]] = alloc_stack $C
+// CHECK:         [[GET:%[^,]+]] = function_ref @get
+// CHECK:         apply [[GET]]<C>([[STACK]])
+// CHECK:         destroy_addr [[STACK]]
+// CHECK:         dealloc_stack [[STACK]]
+// CHECK-LABEL: } // end sil function 'doDeleteLoadTake'
+// CHECK-LABEL: end running test {{.*}} on doDeleteLoadTake
+sil [ossa] @doDeleteLoadTake : $() -> () {
+  %stack = alloc_stack $C
+  %get = function_ref @get : $@convention(thin) <T> () -> (@out T)
+  apply %get<C>(%stack) : $@convention(thin) <T> () -> (@out T)
+  test_specification "deleter-delete-if-dead @instruction"
+  %c = load [take] %stack : $*C
+  destroy_value %c : $C
+  dealloc_stack %stack : $*C
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
+++ b/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
@@ -156,8 +156,7 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : $*Builtin.NativeObject):
 // CHECK: bb0([[ARG0:%.*]] : @owned $Builtin.NativeObject, [[ARG1:%.*]] : $*Builtin.NativeObject):
 // CHECK-NOT: alloc_stack
 // CHECK:  destroy_value [[ARG0]]
-// CHECK:  [[ARG1_LOADED:%.*]] = load [take] [[ARG1]]
-// CHECK:  destroy_value [[ARG1_LOADED]]
+// CHECK:  destroy_addr [[ARG1]]
 // CHECK: } // end sil function 'simple_init_take'
 sil [ossa] @simple_init_take : $@convention(thin) (@owned Builtin.NativeObject, @in Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject, %1 : $*Builtin.NativeObject):

--- a/validation-test/SILOptimizer/rdar117011668.swift
+++ b/validation-test/SILOptimizer/rdar117011668.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -verify %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+import os.log
+
+struct Log {
+  static let attachmentLedgerTopic = Logger(
+    subsystem: "com.xxx.yyy.zzz",
+    category: "ccc")
+}
+
+// CHECK-LABEL: sil @logWriter : {{.*}} {
+// CHECK-NOT: $s2os18OSLogInterpolationV13appendLiteralyySSF
+// CHECK-LABEL: } // end sil function 'logWriter'
+@_silgen_name("logWriter")
+public func logWriter(_ attachmentID: UUID) {
+  Log.attachmentLedgerTopic.info("aaa: \(attachmentID)")
+}


### PR DESCRIPTION
**Description**: Fix code-size regression of constant evaluable OSLog code.

The InstructionDeleter utility is the primary tool for deleting dead code in volume.  It was added in order to support OSLogOptimization, which deletes large quantities of code.  To that end, it fixes up OSSA lifetimes, inserting destroys for values which were previously consumed by an instruction that's being deleted as dead.  

The utility knows how to delete-as-dead a `load [copy]` instruction with only scope-ending (e.g. `destroy_value`) and debug users: by deleting those scope-ending and debug users as well as the `load [copy]`.

Previously, however, it did _not_ know how to delete-as-dead a `load [take]` with only such users.  This patch teaches the utility how, addressing a TODO in the utility's source.  All that's necessary is--in addition to deleting the same instructions as before (i.e. the users and the `load [take]` itself)--to insert a `destroy_addr` of the taken-from address.

Failing to delete a `load [take]` could result in the failure to delete weighty graphs of dead instructions: the `load [take]` remaining prevented the allocation that's the source of the load from being deleted as dead.  In the context of code with routine uses of OSLog, the effect was to fail to delete a significant amount of dead code.

These new `load [take]`s were introduced by folding `load [copy]`s with `destroy_addr`s, an operation which _decreases_ code size.  That folding is done by DestroyAddrHoisting.  Becuase of the incomplete downstream utility, however, the result was to significantly increase code size because of a missed pattern match.

Risk: Low.  The patch allows dead code to be deleted.  Replacing the `load [take]` with a `destroy_addr` has the same effect on the storage.  The lifetime shortening is equivalent to that performed by standard OSSA optimizations.

**Scope**: Affects dead code deletion.

**Original PR**: https://github.com/apple/swift/pull/69588

**Reviewed By**: Andrew Trick ( @atrick )

**Testing**: Added several tests.

**Resolves**: rdar://117011668
