### PR TITLE
5.10: [AccessBase] Find visitor visits nested accesses.

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -193,11 +193,19 @@ public:
 
   // Override AccessUseDefChainVisitor to ignore access markers and find the
   // outer access base.
-  SILValue visitNestedAccess(BeginAccessInst *access) {
+  SILValue visitNestedAccessImpl(BeginAccessInst *access) {
     if (nestedAccessTy == NestedAccessType::IgnoreAccessBegin)
       return access->getSource();
 
     return SuperTy::visitNestedAccess(access);
+  }
+
+  SILValue visitNestedAccess(BeginAccessInst *access) {
+    auto value = visitNestedAccessImpl(access);
+    if (value) {
+      reenterUseDef(value);
+    }
+    return SILValue();
   }
 
   SILValue visitPhi(SILPhiArgument *phiArg) {
@@ -362,6 +370,18 @@ SILValue swift::getTypedAccessAddress(SILValue address) {
   return accessAddress;
 }
 
+namespace swift::test {
+static FunctionTest
+    GetTypedAccessAddress("get_typed_access_address",
+                          [](auto &function, auto &arguments, auto &test) {
+                            auto address = arguments.takeValue();
+                            function.dump();
+                            llvm::dbgs() << "Address: " << address;
+                            auto access = getTypedAccessAddress(address);
+                            llvm::dbgs() << "Access: " << access;
+                          });
+} // end namespace swift::test
+
 // TODO: When the optimizer stops stripping begin_access markers and SILGen
 // protects all memory operations with at least an "unsafe" access scope, then
 // we should be able to assert that this returns a BeginAccessInst.
@@ -378,6 +398,18 @@ SILValue swift::getAccessBase(SILValue address) {
                                IgnoreStorageCast)
       .findPossibleBaseAddress(address);
 }
+
+namespace swift::test {
+static FunctionTest GetAccessBaseTest("get_access_base",
+                                      [](auto &function, auto &arguments,
+                                         auto &test) {
+                                        auto address = arguments.takeValue();
+                                        function.dump();
+                                        llvm::dbgs() << "Address: " << address;
+                                        auto base = getAccessBase(address);
+                                        llvm::dbgs() << "Base: " << base;
+                                      });
+} // end namespace swift::test
 
 static bool isLetForBase(SILValue base) {
   // Is this an address of a "let" class member?
@@ -1155,6 +1187,18 @@ AccessStorageWithBase::computeInScope(SILValue sourceAddress) {
 AccessStorage AccessStorage::compute(SILValue sourceAddress) {
   return AccessStorageWithBase::compute(sourceAddress).storage;
 }
+
+namespace swift::test {
+static FunctionTest ComputeAccessStorage("compute_access_storage",
+                                      [](auto &function, auto &arguments,
+                                         auto &test) {
+                                        auto address = arguments.takeValue();
+                                        function.dump();
+                                        llvm::dbgs() << "Address: " << address;
+                                        auto accessStorage = AccessStorage::compute(address);
+                                        accessStorage.dump();
+                                      });
+} // end namespace swift::test
 
 AccessStorage AccessStorage::computeInScope(SILValue sourceAddress) {
   return AccessStorageWithBase::computeInScope(sourceAddress).storage;

--- a/test/SILOptimizer/accessbase_unit.sil
+++ b/test/SILOptimizer/accessbase_unit.sil
@@ -1,0 +1,67 @@
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+import Builtin
+
+class Box<T> {
+  var value: T
+}
+
+class C {}
+
+
+// CHECK-LABEL: begin running test {{.*}} on test_phi_nested_access: get_access_base with
+// CHECK:       sil @test_phi_nested_access : {{.*}} {
+// CHECK:       bb0([[BOX:%[^,]+]] :
+// CHECK:         [[VALUE_ADDR:%[^,]+]] = ref_element_addr [[BOX]]
+// CHECK:         [[VALUE_ACCESS:%[^,]+]] = begin_access [read] [unsafe] [[VALUE_ADDR]]
+// CHECK:         [[VALUE_PTR:%[^,]+]] = address_to_pointer [stack_protection] [[VALUE_ACCESS]]
+// CHECK:         end_access [[VALUE_ACCESS]]
+// CHECK:         br bb1([[VALUE_PTR]]
+// CHECK:       bb1([[VALUE_PHI:%[^,]+]] :
+// CHECK:       } // end sil function 'test_phi_nested_access'
+// CHECK:       Address: [[VALUE_PHI]] = argument of bb1
+// CHECK:       Base:   [[VALUE_ADDR]] = ref_element_addr
+// CHECK-LABEL: end running test {{.*}} on test_phi_nested_access: get_access_base with
+// CHECK-LABEL: begin running test {{.*}} on test_phi_nested_access: compute_access_storage with
+// CHECK:       Address: [[VALUE_PHI]] = argument of bb1
+// CHECK:       Class [[BOX]] = argument of bb0
+// CHECK:         Field: var value: T Index: 0
+// CHECK-LABEL: end running test {{.*}} on test_phi_nested_access: compute_access_storage with
+// CHECK-LABEL: begin running test 3 of 3 on test_phi_nested_access: accesspath-base
+// CHECK:       Access path base: %6 = argument of bb1
+// CHECK:       Exact Use:   end_access %2
+// CHECK-LABEL: end running test 3 of 3 on test_phi_nested_access: accesspath-base
+sil @test_phi_nested_access : $@convention(method) (@guaranteed Box<C>) -> () {
+bb1(%box : $Box<C>):         
+  %value_addr = ref_element_addr %box : $Box<C>, #Box.value 
+  %value_access = begin_access [read] [unsafe] %value_addr : $*C 
+  %value_ptr = address_to_pointer [stack_protection] %value_access : $*C to $Builtin.RawPointer 
+  end_access %value_access : $*C          
+  br exit(%value_ptr : $Builtin.RawPointer)               
+
+exit(%phi : $Builtin.RawPointer):                   
+  test_specification "get_access_base @argument"
+  test_specification "compute_access_storage @argument"
+  test_specification "accesspath-base @argument"
+  %retval = tuple ()
+  return %retval : $()
+} 
+
+sil_global @global_c : $C
+
+// CHECK-LABEL: begin running test {{.*}} on test_access_global
+// CHECK:       sil @test_access_global : {{.*}} {
+// CHECK:         [[GLOBAL:%[^,]+]] = global_addr @global_c
+// CHECK:         [[ACCESS:%[^,]+]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK:       } // end sil function 'test_access_global'
+// CHECK:       Address:   [[ACCESS]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK:       Access:   [[ACCESS]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK-LABEL: end running test {{.*}} on test_access_global
+sil @test_access_global : $@convention(thin) () -> () {
+  %15 = global_addr @global_c : $*C
+  test_specification "get_typed_access_address @instruction"
+  %16 = begin_access [read] [dynamic] %15 : $*C
+  end_access %16 : $*C
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
**Description**: Fix compiler crash during RedundantLoadElimination.

The pass relies on the AccessBase utility via the `isLetAddress` function to determine whether a load is redundant.  The utility would stop its walk prematurely in the face of certain SIL (e.g., a begin_access after following a phi).  The fix is to teach the utility to walk through such nested accesses.

**Risk**: Low.  Removes an early bailout from a utility.  The fix has been in builds for over two months; this commit _just_ missed the 5.10 branch; it's the first commit after the branch.

**Scope**: Affects memory access analysis.

**Original PR**: https://github.com/apple/swift/pull/68389

**Reviewed By**: Andrew Trick ( @atrick )

**Testing**: Added several tests.

**Resolves**: rdar://115033825