### PR TITLE
[Concurrency] Isolated `static let`s are not safe to access across actors.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -513,6 +513,11 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
     if (var->getAttrs().hasAttribute<NonisolatedAttr>())
       return true;
 
+    // Static 'let's are initialized upon first access, so they cannot be
+    // synchronously accessed across actors.
+    if (var->isStatic())
+      return false;
+
     // If it's distributed, generally variable access is not okay...
     if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl()) {
       if (nominalParent->isDistributedActor())

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -61,6 +61,15 @@ actor Someone {
   }
 }
 
+@MainActor
+struct TestStaticVar {
+  @MainActor static let shared = TestStaticVar()
+
+  init() {
+    checkPreconditionMainActor()
+  }
+}
+
 @main struct Main {
   static func main() async {
     let tests = TestSuite("AssertPreconditionActorExecutor")
@@ -76,6 +85,10 @@ actor Someone {
 
       tests.test("MainActor.preconditionIsolated(): from Main friend") {
         await MainFriend().callCheckMainActor()
+      }
+
+      tests.test("MainActor.assertIsolated() from static let initializer") {
+        _ = await TestStaticVar.shared
       }
 
       #if !os(WASI)


### PR DESCRIPTION
`static let` variables are initialized upon first access, so they cannot be synchronously accessed across actors.

Resolves: rdar://90436577, https://github.com/apple/swift/issues/58270