### PR TITLE
[Linux] Improve backtracer ELF/DWARF parsing performance.

### DIFF
--- a/stdlib/public/Backtracing/FileImageSource.swift
+++ b/stdlib/public/Backtracing/FileImageSource.swift
@@ -60,12 +60,15 @@ class FileImageSource: ImageSource {
 
   public func fetch<T>(from addr: Address,
                        into buffer: UnsafeMutableBufferPointer<T>) throws {
-    let size = buffer.count * MemoryLayout<T>.stride
-    guard Int(addr) < _mapping.count && _mapping.count - Int(addr) >= size else {
-      throw FileImageSourceError.outOfRangeRead
-    }
-    let slice = _mapping[Int(addr)...]
-    _ = buffer.withMemoryRebound(to: UInt8.self) { byteBuf in
+    let start = Int(addr)
+    _ = try buffer.withMemoryRebound(to: UInt8.self) { byteBuf in
+      guard _mapping.indices.contains(start) else {
+        throw FileImageSourceError.outOfRangeRead
+      }
+      let slice = _mapping[start...]
+      guard slice.count >= byteBuf.count else {
+        throw FileImageSourceError.outOfRangeRead
+      }
       byteBuf.update(from: slice)
     }
   }

--- a/stdlib/public/Backtracing/FileImageSource.swift
+++ b/stdlib/public/Backtracing/FileImageSource.swift
@@ -20,51 +20,54 @@ import Swift
 
 enum FileImageSourceError: Error {
   case posixError(Int32)
-  case truncatedRead
+  case outOfRangeRead
 }
 
 class FileImageSource: ImageSource {
-  private var fd: Int32
+  private var _fd: Int32
+  private var _mapping: UnsafeRawBufferPointer
 
   public var isMappedImage: Bool { return false }
 
   private var _path: String
   public var path: String? { return _path }
 
-  public lazy var bounds: Bounds? = {
-    let size = lseek(fd, 0, SEEK_END)
-    if size < 0 {
-      return nil
-    }
-    return Bounds(base: 0, size: Size(size))
-  }()
+  public var bounds: Bounds? {
+    return Bounds(base: 0, size: Size(_mapping.count))
+  }
 
   public init(path: String) throws {
     _path = path
-    fd = _swift_open(path, O_RDONLY, 0)
-    if fd < 0 {
+    _fd = _swift_open(path, O_RDONLY, 0)
+    if _fd < 0 {
       throw FileImageSourceError.posixError(_swift_get_errno())
     }
+    let size = lseek(_fd, 0, SEEK_END)
+    if size < 0 {
+      throw FileImageSourceError.posixError(_swift_get_errno())
+    }
+    let base = mmap(nil, Int(size), PROT_READ, MAP_FILE|MAP_PRIVATE, _fd, 0)
+    if base == nil || base! == UnsafeRawPointer(bitPattern: -1)! {
+      throw FileImageSourceError.posixError(_swift_get_errno())
+    }
+    _mapping = UnsafeRawBufferPointer(start: base, count: Int(size))
   }
 
   deinit {
-    close(fd)
+    munmap(UnsafeMutableRawPointer(mutating: _mapping.baseAddress),
+           _mapping.count)
+    close(_fd)
   }
 
   public func fetch<T>(from addr: Address,
                        into buffer: UnsafeMutableBufferPointer<T>) throws {
-    while true {
-      let size = MemoryLayout<T>.stride * buffer.count
-      let result = pread(fd, buffer.baseAddress, size, off_t(addr))
-
-      if result < 0 {
-        throw FileImageSourceError.posixError(_swift_get_errno())
-      }
-
-      if result != size {
-        throw FileImageSourceError.truncatedRead
-      }
-      break
+    let size = buffer.count * MemoryLayout<T>.stride
+    guard Int(addr) < _mapping.count && _mapping.count - Int(addr) >= size else {
+      throw FileImageSourceError.outOfRangeRead
+    }
+    let slice = _mapping[Int(addr)...]
+    _ = buffer.withMemoryRebound(to: UInt8.self) { byteBuf in
+      byteBuf.update(from: slice)
     }
   }
 }

--- a/stdlib/public/Backtracing/modules/OS/Libc.h
+++ b/stdlib/public/Backtracing/modules/OS/Libc.h
@@ -21,6 +21,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#if __has_include(<sys/mman.h>)
+#include <sys/mman.h>
+#endif
+
 #if __has_include(<dlfcn.h>)
 #include <dlfcn.h>
 #endif


### PR DESCRIPTION
On Linux we use FileImageSource to read data from ELF images.  We were doing this in a fairly naive manner, which turns out to be a performance issue with larger statically linked binaries on Linux.

Change FileImageSource to use mmap() instead.

rdar://117590155
