### PR TITLE
[stdlib] Mark Unicode.Scalar.Properties as `@frozen`

### DIFF
--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -19,10 +19,12 @@ extension Unicode.Scalar {
 
   /// A value that provides access to properties of a Unicode scalar that are
   /// defined by the Unicode standard.
+  @frozen
   public struct Properties: Sendable {
     @usableFromInline
     internal var _scalar: Unicode.Scalar
 
+    @inlinable
     internal init(_ scalar: Unicode.Scalar) {
       self._scalar = scalar
     }
@@ -39,6 +41,7 @@ extension Unicode.Scalar {
   ///         $0.properties.isMath
   ///     })
   ///     // hasMathSymbols == true
+  @inlinable
   public var properties: Properties {
     return Properties(self)
   }


### PR DESCRIPTION
The `Unicode.Scalar.Properties` type is a namespacing wrapper struct. It should be frozen, and its initialiser should be `@inlinable` so that calling `.properties` on a scalar value becomes free.

Currently, the following code:

```swift
func test(_ x: Unicode.Scalar) -> Bool {
    x.properties.isAlphabetic
}
```

Compiles down to this (`-O`). Note that there are 2 runtime calls which are only needed for creating the wrapper struct.

```assembly
output.test(Swift.Unicode.Scalar) -> Swift.Bool:
        push    rbp
        mov     rbp, rsp
        push    r15
        push    r14
        push    r13
        push    rbx
        mov     ebx, edi
        xor     edi, edi
        call    ($ss7UnicodeO6ScalarV10PropertiesVMa)@PLT  ; type metadata accessor for Swift.Unicode.Scalar.Properties
        mov     r14, rax
        mov     r15, qword ptr [rax - 8]
        mov     rax, qword ptr [r15 + 64]
        mov     r13, rsp
        add     rax, 15
        and     rax, -16
        sub     r13, rax
        mov     rsp, r13
        mov     rax, r13
        mov     edi, ebx
        call    ($ss7UnicodeO6ScalarV10propertiesAD10PropertiesVvg)@PLT    ; Swift.Unicode.Scalar.properties.getter : Swift.Unicode.Scalar.Properties
        call    ($ss7UnicodeO6ScalarV10PropertiesV12isAlphabeticSbvg)@PLT  ; Swift.Unicode.Scalar.Properties.isAlphabetic.getter : Swift.Bool
        mov     ebx, eax
        mov     rdi, r13
        mov     rsi, r14
        call    qword ptr [r15 + 8]
        mov     eax, ebx
        lea     rsp, [rbp - 32]
        pop     rbx
        pop     r13
        pop     r14
        pop     r15
        pop     rbp
        ret
```