### PR TITLE
[5.10][Concurrency] Isolated `static let`s are not safe to access across actors.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -512,6 +512,11 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
     if (var->getAttrs().hasAttribute<NonisolatedAttr>())
       return true;
 
+    // Static 'let's are initialized upon first access, so they cannot be
+    // synchronously accessed across actors.
+    if (var->isStatic())
+      return false;
+
     // If it's distributed, generally variable access is not okay...
     if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl()) {
       if (nominalParent->isDistributedActor())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -514,7 +514,7 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
 
     // Static 'let's are initialized upon first access, so they cannot be
     // synchronously accessed across actors.
-    if (var->isStatic())
+    if (var->isGlobalStorage() && var->isLazilyInitializedGlobal())
       return false;
 
     // If it's distributed, generally variable access is not okay...

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -61,6 +61,15 @@ actor Someone {
   }
 }
 
+@MainActor
+struct TestStaticVar {
+  @MainActor static let shared = TestStaticVar()
+
+  init() {
+    checkPreconditionMainActor()
+  }
+}
+
 @main struct Main {
   static func main() async {
     let tests = TestSuite("AssertPreconditionActorExecutor")
@@ -76,6 +85,10 @@ actor Someone {
 
       tests.test("MainActor.preconditionIsolated(): from Main friend") {
         await MainFriend().callCheckMainActor()
+      }
+
+      tests.test("MainActor.assertIsolated() from static let initializer") {
+        _ = await TestStaticVar.shared
       }
 
       #if !os(WASI)

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -61,6 +61,8 @@ actor Someone {
   }
 }
 
+@MainActor let global = TestStaticVar()
+
 @MainActor
 struct TestStaticVar {
   @MainActor static let shared = TestStaticVar()
@@ -89,6 +91,7 @@ struct TestStaticVar {
 
       tests.test("MainActor.assertIsolated() from static let initializer") {
         _ = await TestStaticVar.shared
+        _ = await global
       }
 
       #if !os(WASI)

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -49,7 +49,7 @@ func from_isolated_concrete(_ x: isolated A) async {
 actor Act {
     var i = 0 // expected-note {{mutation of this property is only permitted within the actor}}
 }
-let act = Act()
+nonisolated let act = Act()
 
 func bad() async {
     // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -116,7 +116,9 @@ func globalAsync(_: NotConcurrent?) async {
 }
 
 func globalTest() async {
-  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@+1 {{property access is 'async'}}
+  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
   await globalAsync(a) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
   await globalSync(a)  // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
 }
@@ -137,7 +139,9 @@ class ClassWithGlobalActorInits { // expected-note 2{{class 'ClassWithGlobalActo
 
 @MainActor
 func globalTestMain(nc: NotConcurrent) async {
-  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@+1 {{property access is 'async'}}
+  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
   await globalAsync(a) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
   await globalSync(a)  // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
   _ = await ClassWithGlobalActorInits(nc) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}


### PR DESCRIPTION
* **Explanation**: The rule to allow accessing isolated `let`s synchronously across actors was being applied to `static` variables. However, `static let` variables are initialized upon first access, so synchronously accessing them across actors can lead to data races.
* **Scope**: Only impacts global actor isolated global and static `let` variables that are lazily initialized.
* **Risk**: Low; the code change is trivial and it fixes a source of data races. However, some existing code may now fail to compile with `expression is 'async' but is not marked with 'await'` if it accesses an isolated `static let` from across isolation boundaries without `await`.
* **Testing**: Added a new test case.
* **Issue**: rdar://90436577, https://github.com/apple/swift/issues/58270
* **Reviewer**: @ktoso
* **Main branch PR**: https://github.com/apple/swift/pull/69598, https://github.com/apple/swift/pull/69616