### PR TITLE
[5.10][ConstraintSystem] Rework overload ranking based on Sendable conformances

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2575,7 +2575,8 @@ public:
 
 class CompareDeclSpecializationRequest
     : public SimpleRequest<CompareDeclSpecializationRequest,
-                           bool(DeclContext *, ValueDecl *, ValueDecl *, bool),
+                           bool(DeclContext *, ValueDecl *, ValueDecl *, bool,
+                                bool),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2584,9 +2585,9 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  bool evaluate(Evaluator &evaluator, DeclContext *DC,
-                ValueDecl *VD1, ValueDecl *VD2,
-                bool dynamic) const;
+  bool evaluate(Evaluator &evaluator, DeclContext *DC, ValueDecl *VD1,
+                ValueDecl *VD2, bool dynamic,
+                bool allowMissingConformances) const;
 
 public:
   // Caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -47,8 +47,8 @@ SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest,
 SWIFT_REQUEST(TypeChecker, IDEInspectionFileRequest,
               SourceFile *(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CompareDeclSpecializationRequest,
-              bool (DeclContext *, ValueDecl *, ValueDecl *, bool), Cached,
-              NoLocationInfo)
+              bool (DeclContext *, ValueDecl *, ValueDecl *, bool, bool),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ConditionalRequirementsRequest,
               ArrayRef<Requirement> (NormalProtocolConformance *),
               Cached, NoLocationInfo)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -979,6 +979,10 @@ enum ScoreKind: unsigned int {
   SK_ValueToPointerConversion,
   /// A closure/function conversion to an autoclosure parameter.
   SK_FunctionToAutoClosureConversion,
+  /// A type with a missing conformance(s) that has be synthesized
+  /// or diagnosed later, such types are allowed to appear in
+  /// a valid solution.
+  SK_MissingSynthesizableConformance,
   /// An unapplied reference to a function. The purpose of this
   /// score bit is to prune overload choices that are functions
   /// when a solution has already been found using property.
@@ -989,12 +993,8 @@ enum ScoreKind: unsigned int {
   /// ambiguity tie-breakers should go after this; anything else
   /// should be added above.
   SK_UnappliedFunction,
-  /// A type with a missing conformance(s) that has be synthesized
-  /// or diagnosed later, such types are allowed to appear in
-  /// a valid solution.
-  SK_MissingSynthesizableConformance,
 
-  SK_LastScoreKind = SK_MissingSynthesizableConformance,
+  SK_LastScoreKind = SK_UnappliedFunction,
 };
 
 /// The number of score kinds.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -989,8 +989,12 @@ enum ScoreKind: unsigned int {
   /// ambiguity tie-breakers should go after this; anything else
   /// should be added above.
   SK_UnappliedFunction,
+  /// A type with a missing conformance(s) that has be synthesized
+  /// or diagnosed later, such types are allowed to appear in
+  /// a valid solution.
+  SK_MissingSynthesizableConformance,
 
-  SK_LastScoreKind = SK_UnappliedFunction,
+  SK_LastScoreKind = SK_MissingSynthesizableConformance,
 };
 
 /// The number of score kinds.
@@ -1154,6 +1158,9 @@ struct Score {
 
     case SK_UnappliedFunction:
       return "use of overloaded unapplied function";
+
+    case SK_MissingSynthesizableConformance:
+      return "type with missing synthesizable conformance";
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8310,6 +8310,16 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     if (isConformanceUnavailable(conformance, loc))
       increaseScore(SK_Unavailable, locator);
 
+    unsigned numMissing = 0;
+    conformance.forEachMissingConformance(DC->getParentModule(),
+                                          [&numMissing](auto *missing) {
+                                            ++numMissing;
+                                            return false;
+                                          });
+
+    if (numMissing > 0)
+      increaseScore(SK_MissingSynthesizableConformance, locator, numMissing);
+
     // This conformance may be conditional, in which case we need to consider
     // those requirements as constraints too.
     if (conformance.isConcrete()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8650,7 +8650,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
 
   // First, let's check whether the type itself conforms,
   // if it does - we are done.
-  if (M->lookupConformance(resolvedTy, protocol))
+  if (M->lookupConformance(resolvedTy, protocol, /*allowMissing=*/true))
     return SolutionKind::Solved;
 
   // If the type doesn't conform, let's check whether

--- a/test/Concurrency/sendable_disambiguation.swift
+++ b/test/Concurrency/sendable_disambiguation.swift
@@ -25,3 +25,24 @@ do {
     _ = SendableOnly(value: v) // Ok
   }
 }
+
+do {
+  class K {
+    func value() {}
+  }
+
+  struct X {
+    var fn: (Int) -> K
+    func fn(_: Int) -> Int { 42 }
+  }
+
+  func sendable<T>(_ fn: (Int) -> T) -> T { fn(42) }
+  func sendable<T: Sendable>(_ fn: (Int) -> T) -> T { fn(0) }
+
+  func test(x: X) {
+    let res = sendable(x.fn) // Ok (non-ambiguous and non-Sendable overload)
+    res.value() // To make sure that previous expression picks a property
+    let _: K = sendable(x.fn) // Ok (picks `sendable<T>` with a property)
+    let _: Int = sendable(x.fn) // Ok (picks `sendable<T: Sendable>` with a method)
+  }
+}

--- a/test/Concurrency/sendable_disambiguation.swift
+++ b/test/Concurrency/sendable_disambiguation.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: OS=macosx
+
+do {
+  struct Test {
+    init<T: Sendable>(value: T) {}
+    // expected-note@-1 {{found this candidate}}
+    init<T>(value: T) {}
+    // expected-note@-1 {{found this candidate}}
+  }
+
+  struct SendableOnly {
+    init<T: Sendable>(value: T) {}
+  }
+
+  func testNonSendable<T>(v: T) { // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
+    _ = Test(value: v) // Ok (non-Sendable overload)
+    _ = SendableOnly(value: v)
+    // expected-warning@-1 {{type 'T' does not conform to the 'Sendable' protocol}}
+  }
+
+  func testSendable<T: Sendable>(v: T) {
+    _ = Test(value: v)
+    // expected-error@-1 {{ambiguous use of 'init(value:)'}}
+    _ = SendableOnly(value: v) // Ok
+  }
+}

--- a/test/Concurrency/sendable_disambiguation.swift
+++ b/test/Concurrency/sendable_disambiguation.swift
@@ -7,9 +7,7 @@
 do {
   struct Test {
     init<T: Sendable>(value: T) {}
-    // expected-note@-1 {{found this candidate}}
     init<T>(value: T) {}
-    // expected-note@-1 {{found this candidate}}
   }
 
   struct SendableOnly {
@@ -23,8 +21,7 @@ do {
   }
 
   func testSendable<T: Sendable>(v: T) {
-    _ = Test(value: v)
-    // expected-error@-1 {{ambiguous use of 'init(value:)'}}
+    _ = Test(value: v) // Ok
     _ = SendableOnly(value: v) // Ok
   }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/69549

---

- Explanation:

  Fixes overload ranking when one of the differences is Sendable conformance requirements.

  - Increase score if conformance constraint finds missing conformances
  
    Add a new score kind to denote presence of missing conformances -
    `SK_MissingSynthesizableConformance`.

    The types with missing conformances are allowed to appear in a
    valid solution but such solutions should be ranked lower comparing
    to solutions fewer or without them.

  - Specify whether specialization check allows missing conformances or not

    We have two places where `CompareDeclSpecializationRequest` is used:

    - A performance optimization that compares two generic overloads;
    - Solution ranking that checks all of the selected overloads against
       another solution.

    The former can allow missing conformances and shouldn't prevent
    the solver from checking overloads that differ on `Sendable`
    (because there is no information about what is passed as arguments)
    but the latter, since it has a solution, should prefer Sendable
    overloads over non-Sendable ones if possible
    (i.e. `init<T: Sendable>(_: T)` is a subtype of `init<T>(_: T)`).

- Scope: Expressions that reference overloaded entities that differ on Sendable conformance requirements.

- Main Branch PR: https://github.com/apple/swift/pull/69549

- Resolves: rdar://117227549, rdar://106159581

- Risk: Low

- Reviewed By: @hborla  

- Testing: added test-cases to the test suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
