### PR TITLE
[Concurrency] Isolated global `let`s are not safe to access across actors.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -517,7 +517,7 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
 
     // Static 'let's are initialized upon first access, so they cannot be
     // synchronously accessed across actors.
-    if (var->isStatic())
+    if (var->isGlobalStorage() && var->isLazilyInitializedGlobal())
       return false;
 
     // If it's distributed, generally variable access is not okay...

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -61,6 +61,8 @@ actor Someone {
   }
 }
 
+@MainActor let global = TestStaticVar()
+
 @MainActor
 struct TestStaticVar {
   @MainActor static let shared = TestStaticVar()
@@ -89,6 +91,7 @@ struct TestStaticVar {
 
       tests.test("MainActor.assertIsolated() from static let initializer") {
         _ = await TestStaticVar.shared
+        _ = await global
       }
 
       #if !os(WASI)

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -49,7 +49,7 @@ func from_isolated_concrete(_ x: isolated A) async {
 actor Act {
     var i = 0 // expected-note {{mutation of this property is only permitted within the actor}}
 }
-let act = Act()
+nonisolated let act = Act()
 
 func bad() async {
     // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -116,7 +116,9 @@ func globalAsync(_: NotConcurrent?) async {
 }
 
 func globalTest() async {
-  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@+1 {{property access is 'async'}}
+  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
   await globalAsync(a) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
   await globalSync(a)  // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
 }
@@ -137,7 +139,9 @@ class ClassWithGlobalActorInits { // expected-note 2{{class 'ClassWithGlobalActo
 
 @MainActor
 func globalTestMain(nc: NotConcurrent) async {
-  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@+1 {{property access is 'async'}}
+  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
   await globalAsync(a) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
   await globalSync(a)  // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent?' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}
   _ = await ClassWithGlobalActorInits(nc) // expected-complete-warning{{passing argument of non-sendable type 'NotConcurrent' into global actor 'SomeGlobalActor'-isolated context may introduce data races}}


### PR DESCRIPTION
Same as https://github.com/apple/swift/pull/69598 but I forgot global variables!

Global `let` variables are initialized upon first access, so they cannot be synchronously accessed across actors.