### PR TITLE
[CSFix] Allow `invalid property wrapper type` to be diagnosed in ambi…

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1368,6 +1368,10 @@ public:
     return "allow invalid property wrapper type";
   }
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static bool classof(const ConstraintFix *fix) {

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -279,3 +279,15 @@ func testInvalidWrapperInference() {
   // expected-error@+1 {{contextual closure type '() -> Void' expects 0 arguments, but 1 was used in closure body}}
   testExtraParameter { $value in }
 }
+
+// rdar://116522161 - failed to produce a diagnostic on invalid projection use
+func testInvalidProjectionInAmbiguousContext() {
+  func test<T>(_: [T], _: (T) -> Void) {}
+
+  func ambiguous() -> Int { 42 }
+  func ambiguous() -> String { "" }
+
+  test([42]) { $v in // expected-error {{inferred projection type 'Int' is not a property wrapper}}
+    ambiguous()
+  }
+}


### PR DESCRIPTION
…guous context

Adds `diagnoseForAmbiguity` to `AllowInvalidPropertyWrapperType` fix
because it could be attached to a closure parameter that has ambiguity in
the body so it has to be diagnosable in ambiguous contexts.

Resolves: rdar://116522161

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
