### PR TITLE
[cxx-interop] Import using decls that expose methods from private base classes

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7074,6 +7074,11 @@ static bool isSufficientlyTrivial(const clang::CXXRecordDecl *decl) {
 /// Checks if a record provides the required value type lifetime operations
 /// (copy and destroy).
 static bool hasCopyTypeOperations(const clang::CXXRecordDecl *decl) {
+  // Hack for a base type of std::optional from the Microsoft standard library.
+  if (decl->isInStdNamespace() && decl->getIdentifier() &&
+      decl->getName() == "_Optional_construct_base")
+    return true;
+
   // If we have no way of copying the type we can't import the class
   // at all because we cannot express the correct semantics as a swift
   // struct.

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1522,6 +1522,17 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     return ImportedName();
   result.effectiveContext = effectiveCtx;
 
+  // If this is a using declaration, import the name of the shadowed decl and
+  // adjust the context.
+  if (auto usingShadowDecl = dyn_cast<clang::UsingShadowDecl>(D)) {
+    auto targetDecl = usingShadowDecl->getTargetDecl();
+    if (isa<clang::CXXMethodDecl>(targetDecl)) {
+      ImportedName baseName = importName(targetDecl, version, givenName);
+      baseName.effectiveContext = effectiveCtx;
+      return baseName;
+    }
+  }
+
   // Gather information from the swift_async attribute, if there is one.
   llvm::Optional<unsigned> completionHandlerParamIndex;
   bool completionHandlerFlagIsZeroOnError = false;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -663,9 +663,9 @@ private:
   llvm::DenseMap<std::pair<ValueDecl *, DeclContext *>, ValueDecl *>
       clonedBaseMembers;
 
+public:
   ValueDecl *importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext);
 
-public:
   static size_t getImportedBaseMemberDeclArity(const ValueDecl *valueDecl);
 
   // Cache for already-specialized function templates and any thunks they may

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1991,6 +1991,12 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
       }
     }
   }
+  if (auto usingDecl = dyn_cast<clang::UsingDecl>(named)) {
+    for (auto usingShadowDecl : usingDecl->shadows()) {
+      if (isa<clang::CXXMethodDecl>(usingShadowDecl->getTargetDecl()))
+        addEntryToLookupTable(table, usingShadowDecl, nameImporter);
+    }
+  }
 }
 
 /// Returns the nearest parent of \p module that is marked \c explicit in its

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -80,10 +80,4 @@ struct DeletedCopyConstructor {
   DeletedCopyConstructor(const DeletedCopyConstructor &) = delete;
 };
 
-// TODO: we should be able to import this constructor correctly. Until we can,
-// make sure not to crash.
-struct UsingBaseConstructor : ConstructorWithParam {
-  using ConstructorWithParam::ConstructorWithParam;
-};
-
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_CONSTRUCTORS_H

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -28,6 +28,11 @@ module TypeAliases {
   header "type-aliases.h"
 }
 
+module UsingBaseMembers {
+  header "using-base-members.h"
+  requires cplusplus
+}
+
 module VirtualMethods {
   header "virtual-methods.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/inheritance/Inputs/using-base-members.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/using-base-members.h
@@ -1,0 +1,47 @@
+struct PublicBase {
+private:
+  int value = 123;
+
+public:
+  int publicGetter() const { return value; }
+  void publicSetter(int v) { value = v; }
+  void notExposed() const {}
+};
+
+struct PublicBasePrivateInheritance : private PublicBase {
+  using PublicBase::publicGetter;
+  using PublicBase::publicSetter;
+};
+
+struct PublicBaseProtectedInheritance : protected PublicBase {
+  using PublicBase::publicGetter;
+  using PublicBase::publicSetter;
+};
+
+struct IntBox {
+  int value;
+  IntBox(int value) : value(value) {}
+  IntBox(unsigned value) : value(value) {}
+};
+
+struct UsingBaseConstructorWithParam : IntBox {
+  using IntBox::IntBox;
+};
+
+struct Empty {};
+
+struct UsingBaseConstructorEmpty : private Empty {
+  using Empty::Empty;
+
+  int value = 456;
+};
+
+// TODO: make this work for protected base methods as well
+//struct ProtectedBase {
+//protected:
+//  int protectedGetter() const { return 456; }
+//};
+//
+//struct ProtectedMemberPrivateInheritance : private ProtectedBase {
+//  using ProtectedBase::protectedGetter;
+//};

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=UsingBaseMembers -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: struct PublicBase {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func publicGetter() -> Int32
+// CHECK-NEXT:   mutating func publicSetter(_ v: Int32)
+// CHECK-NEXT:   func notExposed()
+// CHECK-NEXT:   }
+
+// CHECK: struct PublicBasePrivateInheritance {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func publicGetter() -> Int32
+// CHECK-NEXT:   mutating func publicSetter(_ v: Int32)
+// CHECK-NEXT: }
+
+// CHECK: struct PublicBaseProtectedInheritance {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func publicGetter() -> Int32
+// CHECK-NEXT:   mutating func publicSetter(_ v: Int32)
+// CHECK-NEXT: }
+
+// CHECK: struct UsingBaseConstructorWithParam {
+// CHECK-NEXT:   init(_: IntBox)
+// CHECK-NEXT:   init(_: UInt32)
+// CHECK-NEXT:   init(_: Int32)
+// CHECK-NEXT:   var value: Int32
+// CHECK-NEXT: }
+
+// CHECK: struct UsingBaseConstructorEmpty {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(_: Empty)
+// CHECK-NEXT:   var value: Int32
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-typechecker.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+
+import UsingBaseMembers
+
+let a = PublicBasePrivateInheritance()
+let _ = a.publicGetter()
+a.notExposed() // expected-error {{value of type 'PublicBasePrivateInheritance' has no member 'notExposed'}}
+
+let b = PublicBaseProtectedInheritance()
+let _ = b.publicGetter()
+b.notExposed() // expected-error {{value of type 'PublicBaseProtectedInheritance' has no member 'notExposed'}}
+
+let _ = UsingBaseConstructorWithParam(566 as Int32)
+let _ = UsingBaseConstructorWithParam(566 as UInt32)
+
+let _ = UsingBaseConstructorEmpty()

--- a/test/Interop/Cxx/class/inheritance/using-base-members.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members.swift
@@ -1,0 +1,36 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=upcoming-swift)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import UsingBaseMembers
+
+var UsingBaseTestSuite = TestSuite("Using Base Members")
+
+UsingBaseTestSuite.test("PublicBasePrivateInheritance") {
+  var p = PublicBasePrivateInheritance()
+  expectEqual(123, p.publicGetter())
+  p.publicSetter(456)
+  expectEqual(456, p.publicGetter())
+}
+
+UsingBaseTestSuite.test("PublicBaseProtectedInheritance") {
+  var p = PublicBaseProtectedInheritance()
+  expectEqual(123, p.publicGetter())
+  p.publicSetter(987)
+  expectEqual(987, p.publicGetter())
+}
+
+UsingBaseTestSuite.test("UsingBaseConstructorWithParam") {
+  let p1 = UsingBaseConstructorWithParam(566 as Int32)
+  expectEqual(566, p1.value)
+  let p2 = UsingBaseConstructorWithParam(987 as UInt32)
+  expectEqual(987, p2.value)
+}
+
+UsingBaseTestSuite.test("UsingBaseConstructorEmpty") {
+  let p = UsingBaseConstructorEmpty()
+  expectEqual(456, p.value)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -431,4 +431,13 @@ private:
   T *p;
 };
 
+struct DerivedFromConstIteratorPrivatelyWithUsingDecl : private ConstIterator {
+  using ConstIterator::operator*;
+};
+
+struct DerivedFromAmbiguousOperatorStarPrivatelyWithUsingDecl
+    : private AmbiguousOperatorStar {
+  using AmbiguousOperatorStar::operator*;
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MemberInline -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MemberInline -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
 
 // CHECK: struct LoadableIntWrapper {
 // CHECK:   func successor() -> LoadableIntWrapper
@@ -239,6 +239,29 @@
 // CHECK-NEXT:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
 // CHECK-NEXT:   func __operatorStar() -> UnsafePointer<Int32>
+// CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
+// CHECK-NEXT:   func __operatorStar() -> UnsafePointer<Int32>
+// CHECK-NEXT: }
+
+// CHECK: struct DerivedFromConstIterator {
+// CHECK-NEXT:   init()
+// TODO:   @available(*, unavailable, message: "use .pointee property")
+// CHECK-NEXT:   func __operatorStar() -> UnsafePointer<Int32>
+// TODO: `var pointee` should be printed here
+// CHECK-NEXT: }
+
+// CHECK: struct DerivedFromConstIteratorPrivatelyWithUsingDecl {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var pointee: Int32 { get }
+// CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
+// CHECK-NEXT:   func __operatorStar() -> UnsafePointer<Int32>
+// CHECK-NEXT: }
+
+// CHECK: struct DerivedFromAmbiguousOperatorStarPrivatelyWithUsingDecl {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var pointee: Int32
+// CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
+// CHECK-NEXT:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
 // CHECK-NEXT:   func __operatorStar() -> UnsafePointer<Int32>
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
 
 import MemberInline
 
@@ -70,3 +70,6 @@ let immortalIncrement = myCounter.successor() // expected-error {{value of type 
 
 let derivedConstIter = DerivedFromConstIteratorPrivately()
 derivedConstIter.pointee // expected-error {{value of type 'DerivedFromConstIteratorPrivately' has no member 'pointee'}}
+
+let derivedConstIterWithUD = DerivedFromConstIteratorPrivatelyWithUsingDecl()
+let _ = derivedConstIterWithUD.pointee

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift)
 //
 // REQUIRES: executable_test
 
@@ -381,6 +381,18 @@ OperatorsTestSuite.test("DerivedFromConstIterator.pointee") {
 OperatorsTestSuite.test("SubscriptSetterConst") {
   var setterConst = SubscriptSetterConst()
   setterConst[0] = 10
+}
+
+OperatorsTestSuite.test("DerivedFromConstIteratorPrivatelyWithUsingDecl.pointee") {
+  let stars = DerivedFromConstIteratorPrivatelyWithUsingDecl()
+  let res = stars.pointee
+  expectEqual(234, res)
+}
+
+OperatorsTestSuite.test("DerivedFromAmbiguousOperatorStarPrivatelyWithUsingDecl.pointee") {
+  let stars = DerivedFromAmbiguousOperatorStarPrivatelyWithUsingDecl()
+  let res = stars.pointee
+  expectEqual(567, res)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -1,7 +1,6 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
 //
 // REQUIRES: executable_test
-// REQUIRES: SR68068
 
 import StdlibUnittest
 import StdOptional

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -796,6 +796,11 @@ static llvm::cl::opt<bool>
                      llvm::cl::desc("Enable C++ interop."),
                      llvm::cl::cat(Category), llvm::cl::init(false));
 
+static llvm::cl::opt<std::string>
+    CxxInteropVersion("cxx-interoperability-mode",
+                      llvm::cl::desc("C++ interop mode."),
+                      llvm::cl::cat(Category));
+
 static llvm::cl::opt<bool>
     CxxInteropGettersSettersAsProperties("cxx-interop-getters-setters-as-properties",
         llvm::cl::desc("Imports getters and setters as computed properties."),
@@ -4382,6 +4387,14 @@ int main(int argc, char *argv[]) {
   }
   if (options::EnableCxxInterop) {
     InitInvok.getLangOptions().EnableCXXInterop = true;
+  }
+  if (!options::CxxInteropVersion.empty()) {
+    InitInvok.getLangOptions().EnableCXXInterop = true;
+    if (options::CxxInteropVersion == "upcoming-swift")
+      InitInvok.getLangOptions().cxxInteropCompatVersion =
+          version::Version({version::getUpcomingCxxInteropCompatVersion()});
+    else
+      llvm::errs() << "invalid CxxInteropVersion\n";
   }
   if (options::CxxInteropGettersSettersAsProperties) {
     InitInvok.getLangOptions().CxxInteropGettersSettersAsProperties = true;


### PR DESCRIPTION
If a C++ type `Derived` inherits from `Base` privately, the public methods from `Base` should not be callable on an instance of `Derived`. However, C++ supports exposing such methods via a using declaration: `using MyPrivateBase::myPublicMethod;`.

MSVC started using this feature for `std::optional` which means Swift doesn't correctly import `var pointee: Pointee` for instantiations of `std::optional` on Windows. This prevents the automatic conformance to `CxxOptional` from being synthesized.

 rdar://114282353 / resolves https://github.com/apple/swift/issues/68068