### PR TITLE
parse nonisolated(unsafe) as decl contextual keyword in top-level global scope rather than as function invocation

### DIFF
--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -45,6 +45,8 @@ final class TestNonsendable {
   init() {}
 }
 
+nonisolated(unsafe) let immutableNonisolatedUnsafeTopLevelGlobal = TestNonsendable()
+
 @propertyWrapper
 public struct TestWrapper {
   public init() {}


### PR DESCRIPTION
(temporary solution)
