### PR TITLE
Remove allocations due to copying target Triple to local variable.

### DIFF
--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -143,14 +143,13 @@ static bool isPlatformActiveForTarget(PlatformKind Platform,
 
 bool swift::isPlatformActive(PlatformKind Platform, const LangOptions &LangOpts,
                              bool ForTargetVariant) {
-  llvm::Triple TT = LangOpts.Target;
-
   if (ForTargetVariant) {
     assert(LangOpts.TargetVariant && "Must have target variant triple");
-    TT = *LangOpts.TargetVariant;
+    return isPlatformActiveForTarget(Platform, *LangOpts.TargetVariant,
+                                     LangOpts.EnableAppExtensionRestrictions);
   }
 
-  return isPlatformActiveForTarget(Platform, TT,
+  return isPlatformActiveForTarget(Platform, LangOpts.Target,
                                    LangOpts.EnableAppExtensionRestrictions);
 }
 


### PR DESCRIPTION
The isPlatformActive() function wants to choose between Target and TargetVariant. It currently copies in to a local to do this, but Triple contains strings which result in allocations for the copy.

This uses a pointer instead, to avoid the allocations entirely, reducing total allocations in the compiler by 5%.

rdar://117879768
