### PR TITLE
[Parse] Remove 'ParseDeclOptions' parameter from 'parseDecl' function 

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -956,10 +956,9 @@ public:
   void consumeDecl(ParserPosition BeginParserPosition, ParseDeclOptions Flags,
                    bool IsTopLevel);
 
-  ParserResult<Decl> parseDecl(ParseDeclOptions Flags,
-                               bool IsAtStartOfLineOrPreviousHadSemi,
+  ParserResult<Decl> parseDecl(bool IsAtStartOfLineOrPreviousHadSemi,
                                bool IfConfigsAreDeclAttrs,
-                               llvm::function_ref<void(Decl*)> Handler);
+                               llvm::function_ref<void(Decl *)> Handler);
 
   std::pair<std::vector<Decl *>, llvm::Optional<Fingerprint>>
   parseDeclListDelayed(IterableDeclContext *IDC);
@@ -1235,11 +1234,9 @@ public:
                                 bool allowAnyObject,
                                 SourceLoc *parseTildeCopyable = nullptr);
   ParserStatus parseDeclItem(bool &PreviousHadSemi,
-                             ParseDeclOptions Options,
-                             llvm::function_ref<void(Decl*)> handler);
+                             llvm::function_ref<void(Decl *)> handler);
   std::pair<std::vector<Decl *>, llvm::Optional<Fingerprint>>
   parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc, Diag<> ErrorDiag,
-                ParseDeclOptions Options, IterableDeclContext *IDC,
                 bool &hadError);
   ParserResult<ExtensionDecl> parseDeclExtension(ParseDeclOptions Flags,
                                                  DeclAttributes &Attributes);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -953,8 +953,7 @@ public:
   /// Options that control the parsing of declarations.
   using ParseDeclOptions = OptionSet<ParseDeclFlags>;
 
-  void consumeDecl(ParserPosition BeginParserPosition, ParseDeclOptions Flags,
-                   bool IsTopLevel);
+  void consumeDecl(ParserPosition BeginParserPosition, bool IsTopLevel);
 
   ParserResult<Decl> parseDecl(bool IsAtStartOfLineOrPreviousHadSemi,
                                bool IfConfigsAreDeclAttrs,

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -34,19 +34,17 @@ enum class IDEInspectionDelayedDeclKind {
 class IDEInspectionDelayedDeclState {
 public:
   IDEInspectionDelayedDeclKind Kind;
-  unsigned Flags;
   DeclContext *ParentContext;
   unsigned StartOffset;
   unsigned EndOffset;
   unsigned PrevOffset;
 
   IDEInspectionDelayedDeclState(IDEInspectionDelayedDeclKind Kind,
-                                unsigned Flags, DeclContext *ParentContext,
+                                DeclContext *ParentContext,
                                 unsigned StartOffset, unsigned EndOffset,
                                 unsigned PrevOffset)
-      : Kind(Kind), Flags(Flags), ParentContext(ParentContext),
-        StartOffset(StartOffset), EndOffset(EndOffset), PrevOffset(PrevOffset) {
-  }
+      : Kind(Kind), ParentContext(ParentContext), StartOffset(StartOffset),
+        EndOffset(EndOffset), PrevOffset(PrevOffset) {}
 };
 
 /// Parser state persistent across multiple parses.
@@ -60,7 +58,6 @@ public:
 
   void setIDEInspectionDelayedDeclState(SourceManager &SM, unsigned BufferID,
                                         IDEInspectionDelayedDeclKind Kind,
-                                        unsigned Flags,
                                         DeclContext *ParentContext,
                                         SourceRange BodyRange,
                                         SourceLoc PreviousLoc);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5695,9 +5695,7 @@ bool Parser::isStartOfFreestandingMacroExpansion() {
   return false;
 }
 
-void Parser::consumeDecl(ParserPosition BeginParserPosition,
-                         ParseDeclOptions Flags,
-                         bool IsTopLevel) {
+void Parser::consumeDecl(ParserPosition BeginParserPosition, bool IsTopLevel) {
   SourceLoc CurrentLoc = Tok.getLoc();
 
   SourceLoc EndLoc = PreviousLoc;
@@ -5706,8 +5704,7 @@ void Parser::consumeDecl(ParserPosition BeginParserPosition,
 
   State->setIDEInspectionDelayedDeclState(
       SourceMgr, L->getBufferID(), IDEInspectionDelayedDeclKind::Decl,
-      Flags.toRaw(), CurDeclContext, {BeginLoc, EndLoc},
-      BeginParserPosition.PreviousLoc);
+      CurDeclContext, {BeginLoc, EndLoc}, BeginParserPosition.PreviousLoc);
 
   while (SourceMgr.isBeforeInBuffer(Tok.getLoc(), CurrentLoc))
     consumeToken();
@@ -5823,8 +5820,7 @@ ParserResult<Decl> Parser::parseDecl(bool IsAtStartOfLineOrPreviousHadSemi,
         }
       });
     if (IfConfigResult.hasCodeCompletion() && isIDEInspectionFirstPass()) {
-      consumeDecl(BeginParserPosition, Flags,
-                  CurDeclContext->isModuleScopeContext());
+      consumeDecl(BeginParserPosition, CurDeclContext->isModuleScopeContext());
       return makeParserError();
     }
 
@@ -6165,7 +6161,7 @@ ParserResult<Decl> Parser::parseDecl(bool IsAtStartOfLineOrPreviousHadSemi,
         !isa<TopLevelCodeDecl>(CurDeclContext) &&
         !isa<AbstractClosureExpr>(CurDeclContext)) {
       // Only consume non-toplevel decls.
-      consumeDecl(BeginParserPosition, Flags, /*IsTopLevel=*/false);
+      consumeDecl(BeginParserPosition, /*IsTopLevel=*/false);
 
       return makeParserError();
     }
@@ -8903,7 +8899,7 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
       State->takeIDEInspectionDelayedDeclState();
     State->setIDEInspectionDelayedDeclState(
         SourceMgr, L->getBufferID(), IDEInspectionDelayedDeclKind::FunctionBody,
-        PD_Default, AFD, BodyRange, BodyPreviousLoc);
+        AFD, BodyRange, BodyPreviousLoc);
   };
 
   bool HasNestedTypeDeclarations;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -407,11 +407,9 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       NeedParseErrorRecovery = Status.isErrorOrHasCompletion();
     } else if (isStartOfSwiftDecl()) {
       SmallVector<Decl*, 8> TmpDecls;
-      ParserResult<Decl> DeclResult = 
-          parseDecl(IsTopLevel ? PD_AllowTopLevel : PD_Default,
-                    IsAtStartOfLineOrPreviousHadSemi,
-                    /*IfConfigsAreDeclAttrs=*/true,
-                    [&](Decl *D) {
+      ParserResult<Decl> DeclResult =
+          parseDecl(IsAtStartOfLineOrPreviousHadSemi,
+                    /*IfConfigsAreDeclAttrs=*/true, [&](Decl *D) {
                       TmpDecls.push_back(D);
 
                       // Any function after a 'guard' statement is marked as

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -275,8 +275,8 @@ void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,
   SourceLoc BeginLoc = Tok.getLoc();
   State->setIDEInspectionDelayedDeclState(
       SourceMgr, L->getBufferID(),
-      IDEInspectionDelayedDeclKind::TopLevelCodeDecl,
-      PD_Default, TLCD, {BeginLoc, EndLoc}, BeginParserPosition.PreviousLoc);
+      IDEInspectionDelayedDeclKind::TopLevelCodeDecl, TLCD, {BeginLoc, EndLoc},
+      BeginParserPosition.PreviousLoc);
 
   // Skip the rest of the file to prevent the parser from constructing the AST
   // for it.  Forward references are not allowed at the top level.
@@ -376,7 +376,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
                           IsFollowingGuard);
         });
       if (IfConfigResult.hasCodeCompletion() && isIDEInspectionFirstPass()) {
-        consumeDecl(BeginParserPosition, llvm::None, IsTopLevel);
+        consumeDecl(BeginParserPosition, IsTopLevel);
         return IfConfigResult;
       }
       BraceItemsStatus |= IfConfigResult;
@@ -426,7 +426,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
         NeedParseErrorRecovery = true;
         if (DeclResult.hasCodeCompletion() && IsTopLevel &&
             isIDEInspectionFirstPass()) {
-          consumeDecl(BeginParserPosition, llvm::None, IsTopLevel);
+          consumeDecl(BeginParserPosition, IsTopLevel);
           return DeclResult;
         }
       }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -179,10 +179,8 @@ void Parser::performIDEInspectionSecondPassImpl(
            "Delayed decl must be a type member or a top-level decl");
     ContextChange CC(*this, DC);
 
-    parseDecl(ParseDeclOptions(info.Flags),
-              /*IsAtStartOfLineOrPreviousHadSemi=*/true,
-              /*IfConfigsAreDeclAttrs=*/false,
-              [&](Decl *D) {
+    parseDecl(/*IsAtStartOfLineOrPreviousHadSemi=*/true,
+              /*IfConfigsAreDeclAttrs=*/false, [&](Decl *D) {
                 if (auto *NTD = dyn_cast<NominalTypeDecl>(DC)) {
                   NTD->addMemberPreservingSourceOrder(D);
                 } else if (auto *ED = dyn_cast<ExtensionDecl>(DC)) {

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -28,8 +28,7 @@ PersistentParserState::~PersistentParserState() { }
 
 void PersistentParserState::setIDEInspectionDelayedDeclState(
     SourceManager &SM, unsigned BufferID, IDEInspectionDelayedDeclKind Kind,
-    unsigned Flags, DeclContext *ParentContext, SourceRange BodyRange,
-    SourceLoc PreviousLoc) {
+    DeclContext *ParentContext, SourceRange BodyRange, SourceLoc PreviousLoc) {
   assert(!IDEInspectionDelayedDeclStat.get() &&
          "only one decl can be delayed for code completion");
   unsigned startOffset = SM.getLocOffsetInBuffer(BodyRange.Start, BufferID);
@@ -39,12 +38,12 @@ void PersistentParserState::setIDEInspectionDelayedDeclState(
     prevOffset = SM.getLocOffsetInBuffer(PreviousLoc, BufferID);
 
   IDEInspectionDelayedDeclStat.reset(new IDEInspectionDelayedDeclState(
-      Kind, Flags, ParentContext, startOffset, endOffset, prevOffset));
+      Kind, ParentContext, startOffset, endOffset, prevOffset));
 }
 
 void PersistentParserState::restoreIDEInspectionDelayedDeclState(
     const IDEInspectionDelayedDeclState &other) {
   IDEInspectionDelayedDeclStat.reset(new IDEInspectionDelayedDeclState(
-      other.Kind, other.Flags, other.ParentContext,
-      other.StartOffset, other.EndOffset, other.PrevOffset));
+      other.Kind, other.ParentContext, other.StartOffset, other.EndOffset,
+      other.PrevOffset));
 }


### PR DESCRIPTION
`ParseDeclOptions` can be trivially calculated from the current decl context. To reduce the number of the contextual parameters, calculate it inside the function.