### PR TITLE
AST: Trigger IsFinalRequest when retrieving semantic attributes

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1239,20 +1239,6 @@ void PrintAST::printAttributes(const Decl *D) {
 
   attrs.print(Printer, Options, D);
 
-  // Print the implicit 'final' attribute.
-  if (auto VD = dyn_cast<ValueDecl>(D)) {
-    auto VarD = dyn_cast<VarDecl>(D);
-    if (VD->isFinal() &&
-        !attrs.hasAttribute<FinalAttr>() &&
-        // Don't print a redundant 'final' if printing a 'let' or 'static' decl.
-        !(VarD && VarD->isLet()) &&
-        getCorrectStaticSpelling(D) != StaticSpellingKind::KeywordStatic &&
-        VD->getKind() != DeclKind::Accessor) {
-      Printer.printAttrName("final");
-      Printer << " ";
-    }
-  }
-
   Options.ExcludeAttrList.resize(originalExcludeAttrCount);
 }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2075,6 +2075,9 @@ DeclAttributes SemanticDeclAttrsRequest::evaluate(Evaluator &evaluator,
                           {});
 
   // Trigger requests that cause additional semantic attributes to be added.
+  if (auto vd = dyn_cast<ValueDecl>(decl)) {
+    (void)vd->isFinal();
+  }
   if (auto afd = dyn_cast<AbstractFunctionDecl>(decl)) {
     (void)afd->isTransparent();
   } else if (auto asd = dyn_cast<AbstractStorageDecl>(decl)) {

--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -184,6 +184,7 @@ struct InternalStruct: NoTypecheckProto {
 public class PublicClass {
   public var publicProperty: Int
   public var publicPropertyInferredType = ""
+  @PublicWrapper public final var publicFinalWrappedProperty: Bool = false
 
   public init(x: Int) {
     self.publicProperty = x

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -51,6 +51,7 @@ func testPublicClasses() {
   let _: Int = c.publicMethod()
   let _: Int = c.publicProperty
   let _: String = c.publicPropertyInferredType
+  c.publicFinalWrappedProperty = true
   PublicClass.publicClassMethod()
 
   let d = PublicDerivedClass(x: 3)


### PR DESCRIPTION
`ASTPrinter` already had special logic to handle ensuring that `final` is printed when necessary, but we can remove that logic and instead ensure that `IsFinalRequest` runs as part of computing semantic attributes before printing.
