### PR TITLE
[Runtime] Fix missing memcpy in handleSingleRefCountInitWithCopy

### DIFF
--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -543,6 +543,12 @@ public enum PrespecializedMultiPayloadEnum<T> {
     case nonEmpty1(T, Int)
 }
 
+public enum SinglePayloadEnumExistential {
+    case a(SomeProtocol, AnyObject)
+    case b
+    case c
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}
@@ -573,6 +579,10 @@ public func testAssign<T>(_ ptr: UnsafeMutablePointer<T>, from x: T) {
 @inline(never)
 public func testAssign<T>(_ ptr: UnsafeMutablePointer<T>, from x: UnsafeMutablePointer<T>) {
     ptr.assign(from: x, count: 1)
+}
+
+public func testAssignCopy<T>(_ ptr: UnsafeMutablePointer<T>, from x: inout T) {
+    ptr.update(from: &x, count: 1)
 }
 
 @inline(never)


### PR DESCRIPTION
rdar://117755666

Missing memcpy in handleSingleRefCountInitWithCopy caused wrong enum cases, crashes etc.