### PR TITLE
[5.10][Runtime] Fix missing memcpy in handleSingleRefCountInitWithCopy

### DIFF
--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -296,7 +296,7 @@ static void singlePayloadEnumGenericBranchless(const Metadata *metadata,
     if (SWIFT_LIKELY(xiType)) {
       auto tag = xiType->vw_getEnumTagSinglePayload(
           (const OpaqueValue *)(addr + addrOffset + xiTagBytesOffset),
-          numEmptyCases);
+          xiType->vw_getNumExtraInhabitants());
       if (SWIFT_LIKELY(tag == 0)) {
         return;
       }
@@ -523,7 +523,7 @@ static void singlePayloadEnumGenericBranchless(const Metadata *metadata,
     if (SWIFT_LIKELY(xiType)) {
       auto tag = xiType->vw_getEnumTagSinglePayload(
           (const OpaqueValue *)(src + addrOffset + xiTagBytesOffset),
-          numEmptyCases);
+          xiType->vw_getNumExtraInhabitants());
       if (SWIFT_LIKELY(tag == 0)) {
         return;
       }
@@ -1378,7 +1378,12 @@ static void handleSingleRefCountInitWithCopy(const Metadata *metadata,
                                         uint8_t *dest,
                                         uint8_t *src) {
   auto tag = reader.readBytes<uint64_t>();
-  addrOffset += (tag & ~(0xFFULL << 56));
+  auto _addrOffset = addrOffset;
+  auto offset = (tag & ~(0xFFULL << 56));
+  if (SWIFT_UNLIKELY(offset)) {
+    memcpy(dest + _addrOffset, src + _addrOffset, offset);
+  }
+  addrOffset = _addrOffset + offset;
   tag >>= 56;
   if (SWIFT_UNLIKELY(tag == 0)) {
     return;
@@ -1551,13 +1556,13 @@ static void singlePayloadEnumGenericAssignWithCopy(const Metadata *metadata,
       if (!srcTag) {
         srcTag = xiType->vw_getEnumTagSinglePayload(
             (const OpaqueValue *)(src + addrOffset + xiTagBytesOffset),
-            numEmptyCases);
+            xiType->vw_getNumExtraInhabitants());
       }
 
       if (!destTag) {
         destTag = xiType->vw_getEnumTagSinglePayload(
             (const OpaqueValue *)(dest + addrOffset + xiTagBytesOffset),
-            numEmptyCases);
+            xiType->vw_getNumExtraInhabitants());
       }
     }
 
@@ -2107,7 +2112,8 @@ swift_singlePayloadEnumGeneric_getEnumTag(swift::OpaqueValue *address,
                           uint8_t numExtraTagBytes) -> unsigned {
     if (xiType) {
       return xiType->vw_getEnumTagSinglePayload(
-          (const OpaqueValue *)(addr + xiTagBytesOffset), numEmptyCases);
+          (const OpaqueValue *)(addr + xiTagBytesOffset),
+          xiType->vw_getNumExtraInhabitants());
     }
 
     return 0;

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -534,6 +534,12 @@ public enum PrespecializedMultiPayloadEnum<T> {
     case nonEmpty1(T, Int)
 }
 
+public enum SinglePayloadEnumExistential {
+    case a(SomeProtocol, AnyObject)
+    case b
+    case c
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}
@@ -564,6 +570,10 @@ public func testAssign<T>(_ ptr: UnsafeMutablePointer<T>, from x: T) {
 @inline(never)
 public func testAssign<T>(_ ptr: UnsafeMutablePointer<T>, from x: UnsafeMutablePointer<T>) {
     ptr.assign(from: x, count: 1)
+}
+
+public func testAssignCopy<T>(_ ptr: UnsafeMutablePointer<T>, from x: inout T) {
+    ptr.update(from: &x, count: 1)
 }
 
 @inline(never)


### PR DESCRIPTION
Explanation: Missing memcpy in handleSingleRefCountInitWithCopy caused wrong enum cases, crashes etc.
Scope: Only impact compact value witnesses
Risk: Low; Code change is trivial and the feature is still experimental
Testing: Added a new test case, old tests still pass.
Issue: rdar://117755666
Reviewer: @aschwaighofer
Main branch PR: https://github.com/apple/swift/pull/69632