### PR TITLE
PerformanceDiagnostics: correctly handle functions with multiple throws

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -170,6 +170,12 @@ bool PerformanceDiagnostics::visitFunction(SILFunction *function,
     if (isa<ThrowInst>(block.getTerminator()))
       continue;
 
+    // If a function has multiple throws, all throw-path branch to the single throw-block.
+    if (SILBasicBlock *succ = block.getSingleSuccessorBlock()) {
+      if (isa<ThrowInst>(succ->getTerminator()))
+        continue;
+    }
+
     if (!neBlocks.isNonErrorHandling(&block))
       continue;
 

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -92,6 +92,7 @@ func testMemoryLayout() -> Int {
 }
 
 class MyError : Error {}
+class MyError2 : Error {}
 
 @_noLocks
 func errorExistential(_ b: Bool) throws -> Int {
@@ -99,6 +100,17 @@ func errorExistential(_ b: Bool) throws -> Int {
     return 28
   }
   throw MyError()
+}
+
+@_noLocks
+func multipleThrows(_ b1: Bool, _ b2: Bool) throws -> Int {
+  if b1 {
+    throw MyError()
+  }
+  if b2 {
+    throw MyError2()
+  }
+  return 28
 }
 
 @_noLocks


### PR DESCRIPTION
This is a follow-up of https://github.com/apple/swift/pull/69300, which didn't handle function with multiple throws correctly.

rdar://117857767
