### PR TITLE
[Backtracing][Linux] Handle inaccessible memory properly in Docker.

### DIFF
--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -668,7 +668,7 @@ memserver_read(void *to, const void *from, size_t len) {
       memcpy(to, from, len);
       return len;
     } else {
-      return 1;
+      return -1;
     }
   }
 }


### PR DESCRIPTION
Thanks to a missing `-` sign, we were returning garbage rather than indicating that the memory region in question was inaccessible.  This mainly affects register dumps (since that's the time we expect to have to cope with out-of-bounds reads).

rdar://117900760
