### PR TITLE
[5.10] Introduce `-application-extension-library` flag

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -219,6 +219,9 @@ namespace swift {
     /// Enable 'availability' restrictions for App Extensions.
     bool EnableAppExtensionRestrictions = false;
 
+    /// Enable 'availability' restrictions for App Extension Libraries.
+    bool EnableAppExtensionLibraryRestrictions = false;
+
     /// Diagnostic level to report when a public declarations doesn't declare
     /// an introduction OS version.
     llvm::Optional<DiagnosticBehavior> RequireExplicitAvailability = llvm::None;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -847,6 +847,10 @@ def enable_app_extension : Flag<["-"], "application-extension">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Restrict code to those available for App Extensions">;
 
+def enable_app_extension_library : Flag<["-"], "application-extension-library">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Restrict code to those available for App Extensions">;
+
 def libc : Separate<["-"], "libc">,
            Flags<[SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
            HelpText<"libc runtime library to use">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -849,7 +849,7 @@ def enable_app_extension : Flag<["-"], "application-extension">,
 
 def enable_app_extension_library : Flag<["-"], "application-extension-library">,
   Flags<[FrontendOption, NoInteractiveOption]>,
-  HelpText<"Restrict code to those available for App Extensions">;
+  HelpText<"Restrict code to those available for App Extension Libraries">;
 
 def libc : Separate<["-"], "libc">,
            Flags<[SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2697,7 +2697,9 @@ bool ModuleDecl::isExternallyConsumed() const {
   // App extensions are special beasts because they build without entrypoints
   // like library targets, but they behave like executable targets because
   // their associated modules are not suitable for distribution.
-  if (getASTContext().LangOpts.EnableAppExtensionRestrictions) {
+  // However, app extension libraries might be consumed externally.
+  if (getASTContext().LangOpts.EnableAppExtensionRestrictions &&
+      !getASTContext().LangOpts.EnableAppExtensionLibraryRestrictions) {
     return false;
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -252,6 +252,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_warn_implicit_overrides);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);
+  inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension_library);
   inputArgs.AddLastArg(arguments, options::OPT_enable_library_evolution);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_target);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -886,7 +886,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.Features.insert(Feature::LayoutPrespecialization);
 
+  Opts.EnableAppExtensionLibraryRestrictions |= Args.hasArg(OPT_enable_app_extension_library);
   Opts.EnableAppExtensionRestrictions |= Args.hasArg(OPT_enable_app_extension);
+  Opts.EnableAppExtensionRestrictions |= Opts.EnableAppExtensionLibraryRestrictions;
 
   Opts.EnableSwift3ObjCInference =
     Args.hasFlag(OPT_enable_swift3_objc_inference,

--- a/test/ClangImporter/availability_app_extension.swift
+++ b/test/ClangImporter/availability_app_extension.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -application-extension %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -application-extension-library %s
 
 // Check the exact error message, which requires a regex match
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -application-extension %s 2>&1 | %FileCheck %s

--- a/test/ClangImporter/availability_ios.swift
+++ b/test/ClangImporter/availability_ios.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension-library %s
 
 // REQUIRES: OS=ios
 

--- a/test/ClangImporter/availability_macosx.swift
+++ b/test/ClangImporter/availability_macosx.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension-library %s
 
 // REQUIRES: OS=macosx
 

--- a/test/PrintAsObjC/accessibility.swift
+++ b/test/PrintAsObjC/accessibility.swift
@@ -19,6 +19,10 @@
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-INTERNAL %s < %t/accessibility-appext.h
 // RUN: %check-in-clang %t/accessibility-appext.h
 
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -typecheck -application-extension-library -emit-objc-header-path %t/accessibility-appextlib.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s < %t/accessibility-appextlib.h
+// RUN: %check-in-clang %t/accessibility-appextlib.h
+
 // REQUIRES: objc_interop
 
 // CHECK: #ifndef ACCESSIBILITY_SWIFT_H

--- a/test/attr/attr_availability_transitive_ios_appext.swift
+++ b/test/attr/attr_availability_transitive_ios_appext.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -application-extension
+// RUN: %target-typecheck-verify-swift -application-extension-library
 // REQUIRES: OS=ios
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.


### PR DESCRIPTION
Explanation: A new flag `-application-extension-library` that helps to deal with overly-exposed internal declarations in generated header.
Scope: Only affects `-application-extension` logic.
Risk: Low; Code change is trivial and the change is purely additive 
Testing: Added a new test case, old tests still pass.
Reviewer: @drodriguez 
Main branch PR: https://github.com/apple/swift/pull/63769