### PR TITLE
[CSSimplify] Fix handling of holes by OptionalObject constraint

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9184,8 +9184,8 @@ ConstraintSystem::simplifyOptionalObjectConstraint(
   }
 
   if (optTy->isPlaceholder()) {
-    if (auto *typeVar = second->getAs<TypeVariableType>())
-      recordPotentialHole(typeVar);
+    // object type should be simplified because it could be already bound.
+    recordAnyTypeVarAsPotentialHole(simplifyType(second));
     return SolutionKind::Solved;
   }
 

--- a/test/stmt/switch_stmt2.swift
+++ b/test/stmt/switch_stmt2.swift
@@ -150,3 +150,25 @@ func fallthrough_not_last(i: Int) {
     break
   }
 }
+
+// rdar://117871338 - incorrect diagnostic - type of expression is ambiguous when member is missing.
+func test_invalid_optional_chaining() {
+  func test(_: (E) -> Void) {
+  }
+
+  enum E {
+  case a
+  case b
+  }
+
+  struct S {
+    var prop: E
+  }
+
+  test {
+    switch $0.prop? { // expected-error {{value of type 'E' has no member 'prop'}}
+    case .a: break
+    case .b: break
+    }
+  }
+}


### PR DESCRIPTION
When "optional type" is a hole the simplification logic has to simplify "object type"
and mark all of its unresolved components are potential holes, otherwise hole 
propagation won't work since sometimes there is no other contextual information
for such types but "optional type".

Resolves: rdar://117871338

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
