### PR TITLE
[Embedded] enable random APIs if a RandomNumberGenerator is provided

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -111,7 +111,6 @@ public struct Bool: Sendable {
   /// - Returns: Either `true` or `false`, randomly chosen with equal
   ///   probability.
   @inlinable
-  @_unavailableInEmbedded
   public static func random<T: RandomNumberGenerator>(
     using generator: inout T
   ) -> Bool {

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -221,7 +221,7 @@ split_embedded_sources(
     NORMAL Diffing.swift
   EMBEDDED Duration.swift
   EMBEDDED DurationProtocol.swift
-    NORMAL FloatingPointRandom.swift
+  EMBEDDED FloatingPointRandom.swift
   EMBEDDED Instant.swift
     NORMAL Mirror.swift
     NORMAL PlaygroundDisplay.swift

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -923,7 +923,6 @@ extension Collection {
   ///   sequence may change when your program is compiled using a different
   ///   version of Swift.
   @inlinable
-  @_unavailableInEmbedded
   public func randomElement<T: RandomNumberGenerator>(
     using generator: inout T
   ) -> Element? {

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -455,7 +455,6 @@ extension Collection {
 // shuffled()/shuffle()
 //===----------------------------------------------------------------------===//
 
-@_unavailableInEmbedded
 extension Sequence {
   /// Returns the elements of the sequence, shuffled using the given generator
   /// as a source for randomness.
@@ -504,13 +503,13 @@ extension Sequence {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
+  @_unavailableInEmbedded
   public func shuffled() -> [Element] {
     var g = SystemRandomNumberGenerator()
     return shuffled(using: &g)
   }
 }
 
-@_unavailableInEmbedded
 extension MutableCollection where Self: RandomAccessCollection {
   /// Shuffles the collection in place, using the given generator as a source
   /// for randomness.
@@ -563,6 +562,7 @@ extension MutableCollection where Self: RandomAccessCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
+  @_unavailableInEmbedded
   public mutating func shuffle() {
     var g = SystemRandomNumberGenerator()
     shuffle(using: &g)

--- a/stdlib/public/core/FloatingPointRandom.swift
+++ b/stdlib/public/core/FloatingPointRandom.swift
@@ -108,6 +108,7 @@ extension BinaryFloatingPoint where Self.RawSignificand: FixedWidthInteger {
   ///   `range` must be finite and non-empty.
   /// - Returns: A random value within the bounds of `range`.
   @inlinable
+  @_unavailableInEmbedded
   public static func random(in range: Range<Self>) -> Self {
     var g = SystemRandomNumberGenerator()
     return Self.random(in: range, using: &g)
@@ -208,6 +209,7 @@ extension BinaryFloatingPoint where Self.RawSignificand: FixedWidthInteger {
   /// - Parameter range: The range in which to create a random value. Must be finite.
   /// - Returns: A random value within the bounds of `range`.
   @inlinable
+  @_unavailableInEmbedded
   public static func random(in range: ClosedRange<Self>) -> Self {
     var g = SystemRandomNumberGenerator()
     return Self.random(in: range, using: &g)

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -2622,7 +2622,6 @@ extension FixedWidthInteger {
   }
 }
 
-@_unavailableInEmbedded
 extension FixedWidthInteger {
   /// Returns a random value within the specified range, using the given
   /// generator as a source for randomness.
@@ -2695,6 +2694,7 @@ extension FixedWidthInteger {
   ///   `range` must not be empty.
   /// - Returns: A random value within the bounds of `range`.
   @inlinable
+  @_unavailableInEmbedded
   public static func random(in range: Range<Self>) -> Self {
     var g = SystemRandomNumberGenerator()
     return Self.random(in: range, using: &g)
@@ -2767,6 +2767,7 @@ extension FixedWidthInteger {
   /// - Parameter range: The range in which to create a random value.
   /// - Returns: A random value within the bounds of `range`.
   @inlinable
+  @_unavailableInEmbedded
   public static func random(in range: ClosedRange<Self>) -> Self {
     var g = SystemRandomNumberGenerator()
     return Self.random(in: range, using: &g)
@@ -3357,7 +3358,6 @@ extension FixedWidthInteger {
   }
 }
 
-@_unavailableInEmbedded
 extension FixedWidthInteger {
   @inlinable
   public static func _random<R: RandomNumberGenerator>(

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -51,7 +51,6 @@ import SwiftShims
 ///
 /// Types that conform to `RandomNumberGenerator` should specifically document
 /// the thread safety and quality of the generator.
-@_unavailableInEmbedded
 public protocol RandomNumberGenerator {
   /// Returns a value from a uniform, independent distribution of binary data.
   ///
@@ -64,7 +63,6 @@ public protocol RandomNumberGenerator {
   mutating func next() -> UInt64
 }
 
-@_unavailableInEmbedded
 extension RandomNumberGenerator {
   
   // An unavailable default implementation of next() prevents types that do


### PR DESCRIPTION
but leave system random number generators unavailable.

Some embedded systems can potentially provide a cryptographically secure pseudo random number generator. So in those cases we can leave the APIs that take a RandomNumberGenerator available and just require either folks to pass one in, or add extensions for using their own "system default random number generator".