### PR TITLE
build: tweak the Windows build to build against the internal swift-syntax

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1467,30 +1467,17 @@ function Build-IndexStoreDB($Arch) {
     }
 }
 
-function Build-Syntax($Arch) {
-  Build-CMakeProject `
-    -Src $SourceCache\swift-syntax `
-    -Bin $BinaryCache\14 `
-    -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
-    -Arch $Arch `
-    -UseBuiltCompilers Swift `
-    -SwiftSDK $SDKInstallRoot `
-    -BuildTargets default `
-    -Defines @{
-      BUILD_SHARED_LIBS = "NO";
-    }
-}
-
 function Build-SourceKitLSP($Arch) {
   Build-CMakeProject `
     -Src $SourceCache\sourcekit-lsp `
-    -Bin $BinaryCache\15 `
+    -Bin $BinaryCache\14 `
     -InstallTo "$($Arch.ToolchainInstallRoot)\usr" `
     -Arch $Arch `
     -UseBuiltCompilers C,Swift `
     -SwiftSDK $SDKInstallRoot `
     -BuildTargets default `
     -Defines @{
+      SwiftSyntax_DIR = "$BinaryCache\1\cmake\modules";
       SwiftSystem_DIR = "$BinaryCache\2\cmake\modules";
       TSC_DIR = "$BinaryCache\3\cmake\modules";
       LLBuild_DIR = "$BinaryCache\4\cmake\modules";
@@ -1499,7 +1486,6 @@ function Build-SourceKitLSP($Arch) {
       SwiftCollections_DIR = "$BinaryCache\9\cmake\modules";
       SwiftPM_DIR = "$BinaryCache\12\cmake\modules";
       IndexStoreDB_DIR = "$BinaryCache\13\cmake\modules";
-      SwiftSyntax_DIR = "$BinaryCache\14\cmake\modules";
     }
 }
 
@@ -1654,7 +1640,6 @@ if (-not $SkipBuild) {
   Invoke-BuildStep Build-Certificates $HostArch
   Invoke-BuildStep Build-PackageManager $HostArch
   Invoke-BuildStep Build-IndexStoreDB $HostArch
-  Invoke-BuildStep Build-Syntax $HostArch
   Invoke-BuildStep Build-SourceKitLSP $HostArch
 }
 


### PR DESCRIPTION
Use the internal copy of swift-syntax that the compiler uses for macros to build the LSP. By sharing the swift-syntax build, we shave ~6MiB off the LSP binary. Additionally, we avoid building swift-syntax twice as a single copy is now used.