### PR TITLE
[interop] include the headers for the underlying clang module in the …

### DIFF
--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -17,10 +17,12 @@
 #include "SwiftToClangInteropContext.h"
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/FileUnit.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/Basic/Version.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/Frontend/FrontendOptions.h"
 
 #include "clang/Basic/FileManager.h"
@@ -450,6 +452,7 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
   // Track printed names to handle overlay modules.
   llvm::SmallPtrSet<Identifier, 8> seenImports;
   bool includeUnderlying = false;
+  ModuleDecl *underlyingMD = nullptr;
   StringRef importDirective =
       useCxxImport ? "#pragma clang module import" : "@import";
   StringRef importDirectiveLineEnd = useCxxImport ? "\n" : ";\n";
@@ -461,11 +464,20 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
         auto it = exposedModuleHeaderNames.find(swiftModule->getName().str());
         if (it != exposedModuleHeaderNames.end())
           textualIncludes.push_back(it->getValue());
+
+        // Import the underlying clang module in the C++ section if necessary.
+        if (isUnderlyingModule(swiftModule)) {
+          includeUnderlying = true;
+          underlyingMD = swiftModule;
+          continue;
+        }
         continue;
       }
       auto Name = swiftModule->getName();
+      swiftModule->dump();
       if (isUnderlyingModule(swiftModule)) {
         includeUnderlying = true;
+        underlyingMD = swiftModule;
         continue;
       }
       if (seenImports.insert(Name).second) {
@@ -513,10 +525,26 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
   }
 
   if (includeUnderlying) {
-    if (bridgingHeader.empty())
+    if (bridgingHeader.empty()) {
+      if (auto *underlyingClangMod =
+              underlyingMD->findUnderlyingClangModule()) {
+        if (!underlyingClangMod->getTopLevelModule()->IsFramework) {
+          // When including an underlying non-framework module,
+          // import its headers directly in the generated header.
+          requiredTextualIncludes.clear();
+          visitedModules.clear();
+          collectClangModuleHeaderIncludes(
+              underlyingClangMod, fileManager, requiredTextualIncludes,
+              visitedModules, includeDirs, cwd.get());
+          for (auto header : requiredTextualIncludes) {
+            out << "#import <" << header << ">\n";
+          }
+          return;
+        }
+      }
       out << "#import <" << M.getName().str() << '/' << M.getName().str()
           << ".h>\n\n";
-    else
+    } else
       out << "#import \"" << bridgingHeader << "\"\n\n";
   }
 }

--- a/test/PrintAsCxx/lit.local.cfg
+++ b/test/PrintAsCxx/lit.local.cfg
@@ -1,0 +1,9 @@
+# Make a local copy of the substitutions.
+config.substitutions = list(config.substitutions)
+
+clang_compile_opt = '-I' + config.swiftlib_dir + ' '
+
+config.substitutions.insert(0, ('%check-interop-cxx-file-in-clang\(([^)]+)\)',
+                             SubstituteCaptures(r'%check-cxx-header-in-clang -x c++ -std=c++14 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB ' + clang_compile_opt + r'\1 && '
+                                                r'%check-cxx-header-in-clang -x c++ -std=c++17 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB ' + clang_compile_opt + r'\1 && '
+                                                r'%check-cxx-header-in-clang -x c++ -std=c++20 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB ' + clang_compile_opt + r'\1')))

--- a/test/PrintAsCxx/mixed-target-underlying-umbrella-cxx.swift
+++ b/test/PrintAsCxx/mixed-target-underlying-umbrella-cxx.swift
@@ -1,0 +1,84 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: sed -e "s@DIR@%{/t:regex_replacement}@g" %t/MixedTarget/Sources/needsfixing-module.modulemap > %t/MixedTarget/Sources/module.modulemap
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t/MixedTarget/Sources/ -module-name Mixed -import-underlying-module -parse-as-library %t/MixedTarget/Sources/test.swift -typecheck -emit-clang-header-path %t/mixed.h -cxx-interoperability-mode=default
+
+// RUN: %FileCheck -check-prefixes=CHECK,CHECK-HDR %s <  %t/mixed.h
+
+// RUN: %check-interop-cxx-file-in-clang(-I %t %t/test.cpp -Wno-import-preprocessor-directive-pedantic)
+
+// RUN: sed -e "s@DIR@%{/t:regex_replacement}@g" %t/MixedTarget/Sources/needsfixing-umbrella-module.modulemap > %t/MixedTarget/Sources/module.modulemap
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t/MixedTarget/Sources/ -module-name Mixed -import-underlying-module -parse-as-library %t/MixedTarget/Sources/test.swift -typecheck -emit-clang-header-path %t/mixed-umbrella.h -cxx-interoperability-mode=default
+
+// RUN: %FileCheck -check-prefixes=CHECK,CHECK-UMB %s <  %t/mixed-umbrella.h
+
+//--- MixedTarget/Sources/needsfixing-module.modulemap
+
+module Mixed {
+  umbrella "DIR/MixedTarget/Sources"
+  export *
+}
+
+//--- MixedTarget/Sources/needsfixing-umbrella-module.modulemap
+
+module Mixed {
+  umbrella header "DIR/MixedTarget/Sources/include/MixedTarget.h"
+  export *
+}
+
+//--- MixedTarget/Sources/include/MixedTarget.h
+#pragma once
+
+#import "test.h"
+
+typedef int MyType;
+
+//--- MixedTarget/Sources/include/test.h
+#pragma once
+
+class CxxClass {
+public:
+    void test() const;
+
+    int x;
+};
+
+//--- MixedTarget/Sources/empty.h
+#pragma once
+
+// empty header
+
+//--- MixedTarget/Sources/test.swift
+
+public func makeCxxClass() -> CxxClass {
+  let c = CxxClass(x: 2)
+  c.test()
+  return c
+}
+
+//--- test.cpp
+
+#include "mixed.h"
+
+void testFunc();
+void testFunc() {
+  CxxClass v = Mixed::makeCxxClass();
+  (void)v;
+}
+
+// CHECK: #if __has_feature(objc_modules)
+// CHECK-NEXT: #if __has_warning("-Watimport-in-framework-header")
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
+// CHECK-NEXT: #endif
+// CHECK-NEXT: #endif
+// CHECK-EMPTY:
+// CHECK-NEXT: #endif
+
+// CHECK-HDR: #import <{{.*}}MixedTarget{{[/\\]}}Sources{{[/\\]}}include{{[/\\]}}test.h>
+// CHECK-HDR: #import <{{.*}}MixedTarget{{[/\\]}}Sources{{[/\\]}}include{{[/\\]}}MixedTarget.h>
+// CHECK-HDR: #import <{{.*}}MixedTarget{{[/\\]}}Sources{{[/\\]}}empty.h>
+
+// CHECK-UMB: #import <{{.*}}MixedTarget{{[/\\]}}Sources{{[/\\]}}include{{[/\\]}}MixedTarget.h>

--- a/test/PrintAsObjC/mixed-target-underlying-umbrella.swift
+++ b/test/PrintAsObjC/mixed-target-underlying-umbrella.swift
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: sed -e "s@DIR@%{/t:regex_replacement}@g" %t/MixedTarget/Sources/needsfixing-module.modulemap > %t/MixedTarget/Sources/module.modulemap
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t/MixedTarget/Sources/ -module-name Mixed -import-underlying-module -parse-as-library %t/MixedTarget/Sources/test.swift -typecheck -emit-clang-header-path %t/mixed.h
+
+// RUN: %FileCheck -check-prefix=CHECK-HDR %s <  %t/mixed.h
+
+// RUN: sed -e "s@DIR@%{/t:regex_replacement}@g" %t/MixedTarget/Sources/needsfixing-umbrella-module.modulemap > %t/MixedTarget/Sources/module.modulemap
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t/MixedTarget/Sources/ -module-name Mixed -import-underlying-module -parse-as-library %t/MixedTarget/Sources/test.swift -typecheck -emit-clang-header-path %t/mixed-umbrella.h
+
+// RUN: %FileCheck -check-prefix=CHECK-UMB %s <  %t/mixed-umbrella.h
+
+// REQUIRES: objc_interop
+
+//--- MixedTarget/Sources/needsfixing-module.modulemap
+
+module Mixed {
+  umbrella "DIR/MixedTarget/Sources"
+  export *
+}
+
+//--- MixedTarget/Sources/needsfixing-umbrella-module.modulemap
+
+module Mixed {
+  umbrella header "DIR/MixedTarget/Sources/include/MixedTarget.h"
+  export *
+}
+
+//--- MixedTarget/Sources/include/MixedTarget.h
+#pragma once
+
+#import "test.h"
+
+//--- MixedTarget/Sources/include/test.h
+#pragma once
+
+void cFunc();
+
+typedef int MyType;
+
+//--- MixedTarget/Sources/empty.h
+#pragma once
+
+// empty header
+
+//--- MixedTarget/Sources/test.swift
+
+@_cdecl("test")
+public func test() -> MyType {
+  cFunc()
+  return 0
+}
+
+// CHECK-HDR: #if __has_feature(objc_modules)
+// CHECK-HDR-NEXT: #if __has_warning("-Watimport-in-framework-header")
+// CHECK-HDR-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
+// CHECK-HDR-NEXT: #endif
+// CHECK-HDR-NEXT: #endif
+// CHECK-HDR-EMPTY:
+// CHECK-HDR-NEXT: #import <{{.*}}MixedTarget{{[/\\]}}Sources{{[/\\]}}include{{[/\\]}}test.h>
+// CHECK-HDR-NEXT: #import <{{.*}}MixedTarget{{[/\\]}}Sources{{[/\\]}}include{{[/\\]}}MixedTarget.h>
+// CHECK-HDR-NEXT: #import <{{.*}}MixedTarget{{[/\\]}}Sources{{[/\\]}}empty.h>
+// CHECK-HDR-NEXT: #endif
+
+// CHECK-UMB: #if __has_feature(objc_modules)
+// CHECK-UMB-NEXT: #if __has_warning("-Watimport-in-framework-header")
+// CHECK-UMB-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
+// CHECK-UMB-NEXT: #endif
+// CHECK-UMB-NEXT: #endif
+// CHECK-UMB-EMPTY:
+// CHECK-UMB-NEXT: #import <{{.*}}MixedTarget{{[/\\]}}Sources{{[/\\]}}include{{[/\\]}}MixedTarget.h>
+// CHECK-UMB-NEXT: #endif


### PR DESCRIPTION
…generated header, when the underlying module is not a framework

this is needed for the mixed language SwiftPM target support
