### PR TITLE
build: Enable building on non UTF-8 hosts

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -528,7 +528,7 @@ function Build-CMakeProject {
 
     $GenerateDebugInfo = $Defines["CMAKE_BUILD_TYPE"] -ne "Release"
 
-    $CFlags = @("/GS-", "/Gw", "/Gy", "/Oi", "/Oy", "/Zc:inline")
+    $CFlags = @("/GS-", "/Gw", "/Gy", "/Oi", "/Oy", "/utf-8", "/Zc:inline")
     if ($GenerateDebugInfo) { $CFlags += "/Zi" }
     $CXXFlags = $CFlags.Clone() + "/Zc:__cplusplus"
 


### PR DESCRIPTION
`/utf-8` flag forces `cl` to read source file as UTF-8 and assume build target to be native UTF-8. This is no-op for UTF-8 hosts (65001) or `clang-cl` (which only supports UTF-8), but is important for building (and developing) Swift on non UTF-8 hosts.