### PR TITLE
[Docs][TaskLocal] Remove comment which is true, but is confusing to end users

### DIFF
--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -90,9 +90,6 @@ import Swift
 ///     func call() {
 ///       print("traceID: \(traceID)") // 1234
 ///     }
-///
-/// This type must be a `class` so it has a stable identity, that is used as key
-/// value for lookups in the task local storage.
 @propertyWrapper
 @available(SwiftStdlib 5.1, *)
 public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible {


### PR DESCRIPTION
because it discusses an implementation detail of the type the comment is on. Instead, when developers read comments they think about what they can store inside a task local -- so the comment about "task local must be a class" led them to believe THEIR types must be classes, while the comment was explaining the implementation detail of `class TaskLocal<T>`.

Resolves rdar://117982608
