### PR TITLE
[embedded] Fix class_method devirtualizer to consider specialized VTables

### DIFF
--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -73,10 +73,11 @@ tryDevirtualizeApply(ApplySite AI, ClassHierarchyAnalysis *CHA,
                      bool isMandatory = false);
 bool canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA);
 bool canDevirtualizeClassMethod(FullApplySite AI, ClassDecl *CD,
+                                CanType ClassType,
                                 OptRemark::Emitter *ORE = nullptr,
                                 bool isEffectivelyFinalMethod = false);
 SILFunction *getTargetClassMethod(SILModule &M, ClassDecl *CD,
-                                  MethodInst *MI);
+                                  CanType ClassType, MethodInst *MI);
 CanType getSelfInstanceType(CanType ClassOrMetatypeType);
 
 /// Devirtualize the given apply site, which is known to be devirtualizable.
@@ -84,10 +85,9 @@ CanType getSelfInstanceType(CanType ClassOrMetatypeType);
 /// The caller must call deleteDevirtualizedApply on the original apply site.
 ///
 /// Return the new apply and true if the CFG was also modified.
-std::pair<FullApplySite, bool> devirtualizeClassMethod(FullApplySite AI,
-                                                       SILValue ClassInstance,
-                                                       ClassDecl *CD,
-                                                       OptRemark::Emitter *ORE);
+std::pair<FullApplySite, bool>
+devirtualizeClassMethod(FullApplySite AI, SILValue ClassInstance, ClassDecl *CD,
+                        CanType classType, OptRemark::Emitter *ORE);
 
 /// Attempt to devirtualize the given apply site, which is known to be
 /// of a class method.  If this fails, the returned FullApplySite will be null.
@@ -98,7 +98,8 @@ std::pair<FullApplySite, bool> devirtualizeClassMethod(FullApplySite AI,
 /// Return the new apply and true if the CFG was also modified.
 std::pair<FullApplySite, bool>
 tryDevirtualizeClassMethod(FullApplySite AI, SILValue ClassInstance,
-                           ClassDecl *CD, OptRemark::Emitter *ORE,
+                           ClassDecl *CD, CanType ClassType,
+                           OptRemark::Emitter *ORE,
                            bool isEffectivelyFinalMethod = false);
 
 /// Attempt to devirtualize the given apply site, which is known to be

--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -90,7 +90,7 @@ static bool isRecursiveCall(FullApplySite applySite) {
     if (classDecl && classDecl->getModuleContext() != module.getSwiftModule())
       return false;
 
-    SILFunction *method = getTargetClassMethod(module, classDecl, CMI);
+    SILFunction *method = getTargetClassMethod(module, classDecl, classType, CMI);
     if (method != parentFunc)
       return false;
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -646,11 +646,17 @@ void swift::deleteDevirtualizedApply(ApplySite old) {
 }
 
 SILFunction *swift::getTargetClassMethod(SILModule &module, ClassDecl *cd,
-                                         MethodInst *mi) {
-  assert((isa<ClassMethodInst>(mi) || isa<SuperMethodInst>(mi))
-         && "Only class_method and super_method instructions are supported");
+                                         CanType classType, MethodInst *mi) {
+  assert((isa<ClassMethodInst>(mi) || isa<SuperMethodInst>(mi)) &&
+         "Only class_method and super_method instructions are supported");
 
   SILDeclRef member = mi->getMember();
+
+  SILType silType = SILType::getPrimitiveObjectType(classType);
+  if (auto *vtable = module.lookUpSpecializedVTable(silType)) {
+    return vtable->getEntry(module, member)->getImplementation();
+  }
+
   return module.lookUpFunctionInVTable(cd, member);
 }
 
@@ -672,6 +678,7 @@ CanType swift::getSelfInstanceType(CanType classOrMetatypeType) {
 /// \p cd is the class declaration we are devirtualizing for.
 /// return true if it is possible to devirtualize, false - otherwise.
 bool swift::canDevirtualizeClassMethod(FullApplySite applySite, ClassDecl *cd,
+                                       CanType classType,
                                        OptRemark::Emitter *ore,
                                        bool isEffectivelyFinalMethod) {
 
@@ -683,7 +690,7 @@ bool swift::canDevirtualizeClassMethod(FullApplySite applySite, ClassDecl *cd,
   auto *mi = cast<MethodInst>(applySite.getCallee());
 
   // Find the implementation of the member which should be invoked.
-  auto *f = getTargetClassMethod(module, cd, mi);
+  auto *f = getTargetClassMethod(module, cd, classType, mi);
 
   // If we do not find any such function, we have no function to devirtualize
   // to... so bail.
@@ -742,7 +749,7 @@ bool swift::canDevirtualizeClassMethod(FullApplySite applySite, ClassDecl *cd,
 std::pair<FullApplySite, bool /* changedCFG */>
 swift::devirtualizeClassMethod(FullApplySite applySite,
                                SILValue classOrMetatype, ClassDecl *cd,
-                               OptRemark::Emitter *ore) {
+                               CanType classType, OptRemark::Emitter *ore) {
   bool changedCFG = false;
   LLVM_DEBUG(llvm::dbgs() << "    Trying to devirtualize : "
                           << *applySite.getInstruction());
@@ -750,7 +757,7 @@ swift::devirtualizeClassMethod(FullApplySite applySite,
   SILModule &module = applySite.getModule();
   auto *mi = cast<MethodInst>(applySite.getCallee());
 
-  auto *f = getTargetClassMethod(module, cd, mi);
+  auto *f = getTargetClassMethod(module, cd, classType, mi);
 
   CanSILFunctionType genCalleeType = f->getLoweredFunctionTypeInContext(
       TypeExpansionContext(*applySite.getFunction()));
@@ -835,10 +842,11 @@ swift::devirtualizeClassMethod(FullApplySite applySite,
 
 std::pair<FullApplySite, bool> swift::tryDevirtualizeClassMethod(
     FullApplySite applySite, SILValue classInstance, ClassDecl *cd,
-    OptRemark::Emitter *ore, bool isEffectivelyFinalMethod) {
-  if (!canDevirtualizeClassMethod(applySite, cd, ore, isEffectivelyFinalMethod))
+    CanType classType, OptRemark::Emitter *ore, bool isEffectivelyFinalMethod) {
+  if (!canDevirtualizeClassMethod(applySite, cd, classType, ore,
+                                  isEffectivelyFinalMethod))
     return {FullApplySite(), false};
-  return devirtualizeClassMethod(applySite, classInstance, cd, ore);
+  return devirtualizeClassMethod(applySite, classInstance, cd, classType, ore);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1322,7 +1330,7 @@ swift::tryDevirtualizeApply(ApplySite applySite, ClassHierarchyAnalysis *cha,
     auto *cd = classType.getClassOrBoundGenericClass();
 
     if (isEffectivelyFinalMethod(fas, classType, cd, cha))
-      return tryDevirtualizeClassMethod(fas, instance, cd, ore,
+      return tryDevirtualizeClassMethod(fas, instance, cd, classType, ore,
                                         true /*isEffectivelyFinalMethod*/);
 
     // Try to check if the exact dynamic type of the instance is statically
@@ -1333,13 +1341,14 @@ swift::tryDevirtualizeApply(ApplySite applySite, ClassHierarchyAnalysis *cha,
       CanType classType = getSelfInstanceType(instance->getType().getASTType());
       // This should never be null - make the check just to be on the safe side.
       if (ClassDecl *cd = classType.getClassOrBoundGenericClass())
-        return tryDevirtualizeClassMethod(fas, instance, cd, ore);
+        return tryDevirtualizeClassMethod(fas, instance, cd, classType, ore);
       return {ApplySite(), false};
     }
 
     if (auto exactTy = getExactDynamicType(cmi->getOperand(), cha)) {
       if (exactTy == cmi->getOperand()->getType())
-        return tryDevirtualizeClassMethod(fas, cmi->getOperand(), cd, ore);
+        return tryDevirtualizeClassMethod(fas, cmi->getOperand(), cd, classType,
+                                          ore);
     }
   }
 
@@ -1348,7 +1357,7 @@ swift::tryDevirtualizeApply(ApplySite applySite, ClassHierarchyAnalysis *cha,
     auto classType = getSelfInstanceType(instance->getType().getASTType());
     auto *cd = classType.getClassOrBoundGenericClass();
 
-    return tryDevirtualizeClassMethod(fas, instance, cd, ore);
+    return tryDevirtualizeClassMethod(fas, instance, cd, classType, ore);
   }
 
   return {ApplySite(), false};
@@ -1389,7 +1398,8 @@ bool swift::canDevirtualizeApply(FullApplySite applySite,
     auto *cd = classType.getClassOrBoundGenericClass();
 
     if (isEffectivelyFinalMethod(applySite, classType, cd, cha))
-      return canDevirtualizeClassMethod(applySite, cd, nullptr /*ore*/,
+      return canDevirtualizeClassMethod(applySite, cd, classType,
+                                        nullptr /*ore*/,
                                         true /*isEffectivelyFinalMethod*/);
 
     // Try to check if the exact dynamic type of the instance is statically
@@ -1397,12 +1407,12 @@ bool swift::canDevirtualizeApply(FullApplySite applySite,
     if (auto instance = getInstanceWithExactDynamicType(cmi->getOperand(), cha)) {
       CanType classType = getSelfInstanceType(instance->getType().getASTType());
       ClassDecl *cd = classType.getClassOrBoundGenericClass();
-      return cd && canDevirtualizeClassMethod(applySite, cd);
+      return cd && canDevirtualizeClassMethod(applySite, cd, classType);
     }
 
     if (auto exactTy = getExactDynamicType(cmi->getOperand(), cha)) {
       if (exactTy == cmi->getOperand()->getType())
-        return canDevirtualizeClassMethod(applySite, cd);
+        return canDevirtualizeClassMethod(applySite, cd, classType);
     }
   }
 
@@ -1411,7 +1421,7 @@ bool swift::canDevirtualizeApply(FullApplySite applySite,
     auto classType = getSelfInstanceType(instance->getType().getASTType());
     auto *cd = classType.getClassOrBoundGenericClass();
 
-    return canDevirtualizeClassMethod(applySite, cd);
+    return canDevirtualizeClassMethod(applySite, cd, classType);
   }
 
   return false;

--- a/test/embedded/generic-classes.swift
+++ b/test/embedded/generic-classes.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Osize %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib


### PR DESCRIPTION
The performance devirtualizer can introduce / re-introduce generic functions in embedded Swift mode, *after* MandatoryPerformanceOptimizations has made sure everything is specialized. See the attached test case (actually it's just an existing test but built with -Osize), which currently triggers an IRGen crash due to a generic function being referenced:

```
Assertion failed: (!f->isGeneric()), function addLazyFunction, file GenDecl.cpp, line 1567.
...
 #8 0x000000010079ace4 swift::irgen::IRGenerator::addLazyFunction(swift::SILFunction*)
 #9 0x000000010079d118 swift::irgen::IRGenModule::getAddrOfSILFunction(swift::SILFunction*, swift::ForDefinition_t, bool, bool)
#10 0x00000001008ffaac (anonymous namespace)::IRGenSILFunction::visitFunctionRefBaseInst(swift::FunctionRefBaseInst*)
#11 0x00000001008e98c0 (anonymous namespace)::IRGenSILFunction::visitSILBasicBlock(swift::SILBasicBlock*)
#12 0x00000001008e1fa8 (anonymous namespace)::IRGenSILFunction::emitSILFunction()
#13 0x00000001008df6b0 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*)
#14 0x0000000100798ba0 swift::irgen::IRGenerator::emitGlobalTopLevel(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)
```

Turns out that the Devirtualizer pass turns this

```
  %2 = alloc_ref $GenericFooableClass<Int>
  %4 = end_init_let_ref %2 : $GenericFooableClass<Int>
  %7 = class_method %4 : $GenericFooableClass<Int>, #GenericFooableClass.foo : <T> (GenericFooableClass<T>) -> () -> (), $@convention(method) (@guaranteed GenericFooableClass<Int>) -> ()
  %8 = apply %7(%4) : $@convention(method) (@guaranteed GenericFooableClass<Int>) -> ()
```

into:

```
  %2 = alloc_ref $GenericFooableClass<Int>
  %4 = end_init_let_ref %2 : $GenericFooableClass<Int>
  // function_ref GenericFooableClass.foo()
  %7 = function_ref @$s4main19GenericFooableClassC3fooyyF : $@convention(method) <τ_0_0> (@guaranteed GenericFooableClass<τ_0_0>) -> ()
  %8 = apply %7<Int>(%4) : $@convention(method) <τ_0_0> (@guaranteed GenericFooableClass<τ_0_0>) -> ()
```

But it should instead call the specialization (from the specialized VTable), not the generic function (from the regular VTable).