### PR TITLE
[TBDGen] Write tbd-v5 files by default.

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1612,6 +1612,12 @@ public:
   /// entity.
   llvm::Type *getDefaultDeclarationType(IRGenModule &IGM) const;
 
+  /// Determine whether entity that represents a symbol is in TEXT segment.
+  bool isText() const;
+
+  /// Determine whether entity that represents a symbol is in DATA segment.
+  bool isData() const { return !isText(); }
+
   bool isAlwaysSharedLinkage() const;
 #undef LINKENTITY_GET_FIELD
 #undef LINKENTITY_SET_FIELD

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1184,6 +1184,115 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   }
 }
 
+bool LinkEntity::isText() const {
+  switch (getKind()) {
+  // case Kind::DispatchThunkDerivative:
+  // case Kind::DispatchThunkInitializer:
+  case Kind::DispatchThunkAllocator:
+    return true;
+  case Kind::DispatchThunkAsyncFunctionPointer:
+  case Kind::DistributedThunkAsyncFunctionPointer:
+    return false;
+  // case Kind::DispatchThunkInitializerAsyncFunctionPointer:
+  // case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
+  case Kind::MethodDescriptor:
+  case Kind::MethodDescriptorDerivative:
+    return true;
+  // case Kind::MethodDescriptorInitializer:
+  case Kind::MethodDescriptorAllocator:
+  case Kind::MethodLookupFunction:
+  case Kind::EnumCase:
+  case Kind::FieldOffset:
+    return true;
+  // case Kind::ObjCClass:
+  // case Kind::ObjCClassRef:
+  // case Kind::ObjCMetaclass:
+  case Kind::SwiftMetaclassStub:
+  case Kind::ObjCResilientClassStub:
+    return false;
+  // case Kind::ObjCMetadataUpdateFunction:
+  case Kind::ClassMetadataBaseOffset:
+  case Kind::PropertyDescriptor:
+  case Kind::NominalTypeDescriptor:
+  case Kind::OpaqueTypeDescriptor:
+    return true;
+  // case Kind::NominalTypeDescriptorRecord:
+  // case Kind::OpaqueTypeDescriptorRecord:
+  case Kind::OpaqueTypeDescriptorAccessor:
+  case Kind::OpaqueTypeDescriptorAccessorImpl:
+  case Kind::OpaqueTypeDescriptorAccessorKey:
+    return true;
+  case Kind::OpaqueTypeDescriptorAccessorVar:
+    return false;
+  // case Kind::TypeMetadataPattern:
+  // case Kind::TypeMetadataInstantiationCache:
+  // case Kind::TypeMetadataInstantiationFunction:
+  // case Kind::TypeMetadataSingletonInitializationCache:
+  // case Kind::TypeMetadataCompletionFunction:
+  // case Kind::ModuleDescriptor:
+  // case Kind::DefaultAssociatedConformanceAccessor:
+  case Kind::AssociatedConformanceDescriptor:
+  case Kind::AssociatedTypeDescriptor:
+  case Kind::BaseConformanceDescriptor:
+  case Kind::DynamicallyReplaceableFunctionKeyAST:
+  case Kind::DynamicallyReplaceableFunctionImpl:
+    return true;
+  case Kind::DynamicallyReplaceableFunctionVariableAST:
+  // case Kind::CanonicalPrespecializedGenericTypeCachingOnceToken:
+  case Kind::AsyncFunctionPointerAST:
+    return false;
+  // case Kind::DynamicallyReplaceableFunctionKey:
+  // case Kind::SILFunction:
+  // case Kind::ExtensionDescriptor:
+  // case Kind::AnonymousDescriptor:
+  // case Kind::SILGlobalVariable:
+  // case Kind::ReadOnlyGlobalObject:
+  case Kind::ProtocolWitnessTable:
+    return false;
+  // case Kind::ProtocolWitnessTablePattern:
+  // case Kind::GenericProtocolWitnessTableInstantiationFunction:
+  // case Kind::AssociatedTypeWitnessTableAccessFunction:
+  // case Kind::ReflectionAssociatedTypeDescriptor:
+  case Kind::DispatchThunk:
+  case Kind::ProtocolDescriptor:
+  // case Kind::ProtocolDescriptorRecord:
+  case Kind::ProtocolRequirementsBaseDescriptor:
+  case Kind::ProtocolConformanceDescriptor:
+  case Kind::ProtocolConformanceDescriptorRecord:
+    return true;
+  // case Kind::ProtocolWitnessTableLazyAccessFunction:
+  // case Kind::ProtocolWitnessTableLazyCacheVariable:
+  // case Kind::DifferentiabilityWitness:
+  // case Kind::ValueWitness:
+  // case Kind::ValueWitnessTable:
+  case Kind::TypeMetadata:
+    return false;
+  case Kind::TypeMetadataAccessFunction:
+    return true;
+  // case Kind::TypeMetadataLazyCacheVariable:
+  // case Kind::TypeMetadataDemanglingCacheVariable:
+  // case Kind::ReflectionBuiltinDescriptor:
+  // case Kind::ReflectionFieldDescriptor:
+  // case Kind::CoroutineContinuationPrototype:
+  // case Kind::DynamicallyReplaceableFunctionVariable:
+  // case Kind::CanonicalSpecializedGenericSwiftMetaclassStub:
+  // case Kind::CanonicalSpecializedGenericTypeMetadataAccessFunction:
+  // case Kind::NoncanonicalSpecializedGenericTypeMetadata:
+  // case Kind::NoncanonicalSpecializedGenericTypeMetadataCacheVariable:
+  // case Kind::AsyncFunctionPointer:
+  // case Kind::PartialApplyForwarder:
+  // case Kind::PartialApplyForwarderAsyncFunctionPointer:
+  // case Kind::KnownAsyncFunctionPointer:
+  // case Kind::DistributedAccessor:
+  // case Kind::DistributedAccessorAsyncPointer:
+  // case Kind::AccessibleFunctionRecord:
+  // case Kind::ExtendedExistentialTypeShape:
+  //   return false;
+  default:
+    llvm_unreachable("segment kind not specified");
+  }
+}
+
 bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   switch (getKind()) {
   case Kind::SILGlobalVariable:

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -62,6 +62,7 @@ using namespace swift::tbdgen;
 using namespace llvm::yaml;
 using StringSet = llvm::StringSet<>;
 using SymbolKind = llvm::MachO::SymbolKind;
+using SymbolFlags = llvm::MachO::SymbolFlags;
 
 TBDGenVisitor::TBDGenVisitor(const TBDGenDescriptor &desc,
                              APIRecorder &recorder)
@@ -69,7 +70,7 @@ TBDGenVisitor::TBDGenVisitor(const TBDGenDescriptor &desc,
                     desc.getParentModule(), desc.getOptions(), recorder) {}
 
 void TBDGenVisitor::addSymbolInternal(StringRef name, SymbolKind kind,
-                                      SymbolSource source) {
+                                      SymbolSource source, SymbolFlags flags) {
   if (!source.isLinkerDirective() && Opts.LinkerDirectivesOnly)
     return;
 
@@ -82,7 +83,7 @@ void TBDGenVisitor::addSymbolInternal(StringRef name, SymbolKind kind,
   }
 #endif
   recorder.addSymbol(name, kind, source,
-                     DeclStack.empty() ? nullptr : DeclStack.back());
+                     DeclStack.empty() ? nullptr : DeclStack.back(), flags);
 }
 
 static std::vector<OriginallyDefinedInAttr::ActiveVersion>
@@ -341,7 +342,7 @@ void TBDGenVisitor::addLinkerDirectiveSymbolsLdPrevious(StringRef name,
     OS << Ver.Version.getMajor() << "." << getMinor(Ver.Version.getMinor()) << "$";
     OS << name << "$";
     addSymbolInternal(OS.str(), SymbolKind::GlobalSymbol,
-                      SymbolSource::forLinkerDirective());
+                      SymbolSource::forLinkerDirective(), SymbolFlags::Data);
   }
 }
 
@@ -387,13 +388,13 @@ void TBDGenVisitor::addLinkerDirectiveSymbolsLdHide(StringRef name,
       llvm::raw_svector_ostream OS(Buffer);
       OS << "$ld$hide$os" << CurMaj << "." << CurMin << "$" << name;
       addSymbolInternal(OS.str(), SymbolKind::GlobalSymbol,
-                        SymbolSource::forLinkerDirective());
+                        SymbolSource::forLinkerDirective(), SymbolFlags::Data);
     }
   }
 }
 
 void TBDGenVisitor::addSymbol(StringRef name, SymbolSource source,
-                              SymbolKind kind) {
+                              SymbolFlags flags, SymbolKind kind) {
   // The linker expects to see mangled symbol names in TBD files,
   // except when being passed objective c classes,
   // so make sure to mangle before inserting the symbol.
@@ -406,7 +407,7 @@ void TBDGenVisitor::addSymbol(StringRef name, SymbolSource source,
     llvm::Mangler::getNameWithPrefix(mangled, name, *DataLayout);
   }
 
-  addSymbolInternal(mangled, kind, source);
+  addSymbolInternal(mangled, kind, source, flags);
   if (previousInstallNameMap) {
     addLinkerDirectiveSymbolsLdPrevious(mangled, kind);
   } else {
@@ -434,30 +435,33 @@ void TBDGenVisitor::didVisitDecl(Decl *D) {
 }
 
 void TBDGenVisitor::addFunction(SILDeclRef declRef) {
-  addSymbol(declRef.mangle(), SymbolSource::forSILDeclRef(declRef));
+  addSymbol(declRef.mangle(), SymbolSource::forSILDeclRef(declRef),
+            SymbolFlags::Text);
 }
 
 void TBDGenVisitor::addFunction(StringRef name, SILDeclRef declRef) {
-  addSymbol(name, SymbolSource::forSILDeclRef(declRef));
+  addSymbol(name, SymbolSource::forSILDeclRef(declRef), SymbolFlags::Text);
 }
 
 void TBDGenVisitor::addGlobalVar(VarDecl *VD) {
   Mangle::ASTMangler mangler;
-  addSymbol(mangler.mangleEntity(VD), SymbolSource::forGlobal(VD));
+  addSymbol(mangler.mangleEntity(VD), SymbolSource::forGlobal(VD),
+            SymbolFlags::Data);
 }
 
 void TBDGenVisitor::addLinkEntity(LinkEntity entity) {
   auto linkage =
       LinkInfo::get(UniversalLinkInfo, SwiftModule, entity, ForDefinition);
 
-  addSymbol(linkage.getName(), SymbolSource::forIRLinkEntity(entity));
+  SymbolFlags flags = entity.isData() ? SymbolFlags::Data : SymbolFlags::Text;
+  addSymbol(linkage.getName(), SymbolSource::forIRLinkEntity(entity), flags);
 }
 
 void TBDGenVisitor::addObjCInterface(ClassDecl *CD) {
   // FIXME: We ought to have a symbol source for this.
   SmallString<128> buffer;
   addSymbol(CD->getObjCRuntimeName(buffer), SymbolSource::forUnknown(),
-            SymbolKind::ObjectiveCClass);
+            SymbolFlags::Data, SymbolKind::ObjectiveCClass);
   recorder.addObjCInterface(CD);
 }
 
@@ -474,13 +478,14 @@ void TBDGenVisitor::addProtocolWitnessThunk(RootProtocolConformance *C,
 
   std::string decorated = Mangler.mangleWitnessThunk(C, requirementDecl);
   // FIXME: We should have a SILDeclRef SymbolSource for this.
-  addSymbol(decorated, SymbolSource::forUnknown());
+  addSymbol(decorated, SymbolSource::forUnknown(), SymbolFlags::Text);
 
   if (requirementDecl->isProtocolRequirement()) {
     ValueDecl *PWT = C->getWitness(requirementDecl).getDecl();
     if (const auto *AFD = dyn_cast<AbstractFunctionDecl>(PWT))
       if (AFD->hasAsync())
-        addSymbol(decorated + "Tu", SymbolSource::forUnknown());
+        addSymbol(decorated + "Tu", SymbolSource::forUnknown(),
+                  SymbolFlags::Text);
   }
 }
 
@@ -488,8 +493,10 @@ void TBDGenVisitor::addFirstFileSymbols() {
   if (!Opts.ModuleLinkName.empty()) {
     // FIXME: We ought to have a symbol source for this.
     SmallString<32> buf;
+    // TODO (Cyndy): Add weak defined.
+    SymbolFlags flags = SymbolFlags::Data;
     addSymbol(irgen::encodeForceLoadSymbolName(buf, Opts.ModuleLinkName),
-              SymbolSource::forUnknown());
+              SymbolSource::forUnknown(), flags);
   }
 }
 
@@ -615,7 +622,9 @@ TBDFile GenerateTBDRequest::evaluate(Evaluator &evaluator,
   }
 
   auto addSymbol = [&](StringRef symbol, SymbolKind kind, SymbolSource source,
-                       Decl *decl) { file.addSymbol(kind, symbol, targets); };
+                       Decl *decl, SymbolFlags flags) {
+    file.addSymbol(kind, symbol, targets, flags);
+  };
   SimpleAPIRecorder recorder(addSymbol);
   TBDGenVisitor visitor(desc, recorder);
   visitor.visit(desc);
@@ -627,7 +636,7 @@ PublicSymbolsRequest::evaluate(Evaluator &evaluator,
                                TBDGenDescriptor desc) const {
   std::vector<std::string> symbols;
   auto addSymbol = [&](StringRef symbol, SymbolKind kind, SymbolSource source,
-                       Decl *decl) {
+                       Decl *decl, SymbolFlags flags) {
     if (kind == SymbolKind::GlobalSymbol)
       symbols.push_back(symbol.str());
     // TextAPI ObjC Class Kinds represents two symbols.
@@ -675,7 +684,7 @@ public:
   ~APIGenRecorder() {}
 
   void addSymbol(StringRef symbol, SymbolKind kind, SymbolSource source,
-                 Decl *decl) override {
+                 Decl *decl, SymbolFlags flags) override {
     if (kind != SymbolKind::GlobalSymbol)
       return;
 
@@ -879,7 +888,7 @@ SymbolSourceMapRequest::evaluate(Evaluator &evaluator,
   auto *SymbolSources = Ctx.Allocate<SymbolSourceMap>();
 
   auto addSymbol = [=](StringRef symbol, SymbolKind kind, SymbolSource source,
-                       Decl *decl) {
+                       Decl *decl, SymbolFlags flags) {
     SymbolSources->insert({symbol, source});
   };
 

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -595,7 +595,7 @@ TBDFile GenerateTBDRequest::evaluate(Evaluator &evaluator,
   auto &ctx = M->getASTContext();
 
   llvm::MachO::InterfaceFile file;
-  file.setFileType(llvm::MachO::FileType::TBD_V4);
+  file.setFileType(llvm::MachO::FileType::TBD_V5);
   file.setApplicationExtensionSafe(isApplicationExtensionSafe(ctx.LangOpts));
   file.setInstallName(opts.InstallName);
   file.setTwoLevelNamespace();
@@ -661,7 +661,7 @@ void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
   auto desc = TBDGenDescriptor::forModule(M, opts);
   auto file = llvm::cantFail(evaluator(GenerateTBDRequest{desc}));
   llvm::cantFail(llvm::MachO::TextAPIWriter::writeToStream(os, file),
-                 "YAML writing should be error-free");
+                 "TBD writing should be error-free");
 }
 
 class APIGenRecorder final : public APIRecorder {

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule %S/Inputs/cross-module/default-submodule.swift -c -o %t/submodule.o
 // RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/module.o
-// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o -Xfrontend -tbd-install_name -Xfrontend module
 
 // RUN: %target-build-swift -O -wmo -module-name=Main -I%t -I%S/Inputs/cross-module %s -emit-sil | %FileCheck %s
 

--- a/test/SPI/spi_symbols.swift
+++ b/test/SPI/spi_symbols.swift
@@ -1,10 +1,10 @@
 // REQUIRES: VENDOR=apple
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/Inputs/spi_helper.swift -emit-ir -o %t/spi_helper.ll -emit-tbd-path %t/spi_helper.tbd -module-name spi_helper
+// RUN: %target-swift-frontend %S/Inputs/spi_helper.swift -emit-ir -o %t/spi_helper.ll -emit-tbd-path %t/spi_helper.tbd -module-name spi_helper -tbd-install_name spi_helper
 
 // RUN: cat %t/spi_helper.ll | %FileCheck -check-prefix=CHECK-IR %s
-// RUN: cat %t/spi_helper.tbd | %FileCheck -check-prefix=CHECK-TBD %s
+// RUN: %llvm-nm %t/spi_helper.tbd | %FileCheck -check-prefix=CHECK-TBD %s
 
 // Look for the SPI symbols in the IR
 // CHECK-IR: define swiftcc void @"$s10spi_helper0A4FuncyyF"

--- a/test/TBD/abi-version.swift
+++ b/test/TBD/abi-version.swift
@@ -6,7 +6,7 @@
 
 // 1. Emit IR and a TBD for this file
 
-// RUN: %target-swift-frontend -emit-ir -o %t/test.ll %s -emit-tbd-path %t/test.tbd
+// RUN: %target-swift-frontend -emit-ir -o %t/test.ll %s -emit-tbd-path %t/test.tbd -tbd-install_name test
 
 // 2. Concatenate them and FileCheck them both in the same file, so we can capture
 //    the ABI version in a variable.
@@ -19,4 +19,4 @@
 
 // 4. Look in the TBD for the same version listed
 
-// CHECK: swift-abi-version: [[VERSION]]
+// CHECK: "abi": [[VERSION]]

--- a/test/TBD/all-in-one.swift
+++ b/test/TBD/all-in-one.swift
@@ -8,14 +8,14 @@
 // RUN: %target-build-swift %S/Inputs/extension_types.swift -module-name ExtensionTypes -emit-module -emit-module-path %t/ExtensionTypes.swiftmodule
 // RUN: %target-build-swift %S/Inputs/subclass_super.swift -emit-library -emit-module -o %t/subclass_super%{target-shared-library-suffix} -enable-library-evolution
 
-// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/incremental_Onone.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h  -Xfrontend -disable-objc-attr-requires-foundation-module
-// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/wmo_Onone.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -wmo
+// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/incremental_Onone.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h  -Xfrontend -disable-objc-attr-requires-foundation-module -Xfrontend -tbd-install_name -Xfrontend all_in_one
+// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/wmo_Onone.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -wmo -Xfrontend -tbd-install_name -Xfrontend all_in_one
 
-// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/incremental_O.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -O
-// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/wmo_O.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -wmo -O -Xllvm -sil-disable-pass=cmo
+// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/incremental_O.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -Xfrontend -tbd-install_name -Xfrontend all_in_one -O
+// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/wmo_O.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -wmo -O -Xllvm -sil-disable-pass=cmo -Xfrontend -tbd-install_name -Xfrontend all_in_one
 
-// RUN: diff %t/incremental_Onone.tbd %t/wmo_Onone.tbd
-// RUN: diff %t/incremental_O.tbd %t/wmo_O.tbd
-// RUN: diff %t/incremental_Onone.tbd %t/incremental_O.tbd
+// RUN: %llvm-readtapi --compare %t/incremental_Onone.tbd %t/wmo_Onone.tbd
+// RUN: %llvm-readtapi --compare %t/incremental_O.tbd %t/wmo_O.tbd
+// RUN: %llvm-readtapi --compare %t/incremental_Onone.tbd %t/incremental_O.tbd
 
 // REQUIRES: objc_interop

--- a/test/TBD/app-extension.swift
+++ b/test/TBD/app-extension.swift
@@ -1,16 +1,16 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/safe.tbd
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/not-safe.tbd
+// RUN: %target-swift-frontend -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/safe.tbd -tbd-install_name app_safe
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/not-safe.tbd -tbd-install_name no_app_safe
 
-// RUN: %FileCheck %s --check-prefix EXTENSIONSAFE < %t/safe.tbd
-// RUN: %FileCheck %s --check-prefix NOTEXTENSIONSAFE < %t/not-safe.tbd
+// RUN: %validate-json %t/safe.tbd | %FileCheck %s --check-prefix EXTENSIONSAFE
+// RUN: %validate-json %t/not-safe.tbd | %FileCheck %s --check-prefix NOTEXTENSIONSAFE
 
 // EXTENSIONSAFE-NOT: not_app_extension_safe
 // NOTEXTENSIONSAFE: not_app_extension_safe
 
-// RUN: %target-swift-frontend -target-variant %target-cpu-apple-ios13.1-macabi -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/target-variant.tbd
-// RUN: %FileCheck %s --check-prefix MACABI < %t/target-variant.tbd
+// RUN: %target-swift-frontend -target-variant %target-cpu-apple-ios13.1-macabi -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/target-variant.tbd -tbd-install_name target-variant
+// RUN: %validate-json %t/target-variant.tbd | %FileCheck %s --check-prefix MACABI
 
-// MACABI: targets: [ {{.*}}macos{{.*}}maccatalyst{{.*}} ]
-
+// MACABI: "target": "{{.*}}-macos"
+// MACABI: "target": "{{.*}}-maccatalyst"

--- a/test/TBD/arm64e-arch.swift
+++ b/test/TBD/arm64e-arch.swift
@@ -1,7 +1,7 @@
-// RUN: %swift -typecheck -target arm64e-apple-ios12.0 -parse-stdlib -parse-as-library %s -module-name TBDTester -emit-tbd -emit-tbd-path - | %FileCheck %s
+// RUN: %swift -typecheck -target arm64e-apple-ios12.0 -parse-stdlib -parse-as-library %s -module-name TBDTester -emit-tbd -emit-tbd-path %t/arm64e.tbd  -tbd-install_name arm64e 
+// RUN: %llvm-nm -arch arm64e %t/arm64e.tbd | %FileCheck %s
 
 public func testSwiftFunc() {}
 
-// CHECK: --- !tapi-tbd
-// CHECK: arm64e
-// CHECK: symbols: [ '_$s{{.*}}testSwiftFunc{{.*}}' ]
+
+// CHECK: _$s{{.*}}testSwiftFunc{{.*}}

--- a/test/TBD/class.swift
+++ b/test/TBD/class.swift
@@ -10,9 +10,9 @@
 // RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd -tbd-install_name class
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd -tbd-install_name class
+// RUN: %llvm-readtapi --compare %t/typecheck.tbd %t/emit-ir.tbd
 
 open class OpenNothing {}
 

--- a/test/TBD/custom_objc_error.swift
+++ b/test/TBD/custom_objc_error.swift
@@ -1,7 +1,7 @@
 // REQUIRES: VENDOR=apple
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -I %S/Inputs/ -disable-objc-attr-requires-foundation-module -emit-tbd -emit-tbd-path %t/test.tbd
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -I %S/Inputs/ -disable-objc-attr-requires-foundation-module -emit-tbd -emit-tbd-path %t/test.tbd -tbd-install_name objc_err
 
 import Foundation
 @_exported import CustomError

--- a/test/TBD/distributed.swift
+++ b/test/TBD/distributed.swift
@@ -3,8 +3,8 @@
 // REQUIRES: distributed
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -enable-testing -disable-availability-checking -emit-ir -o %t/test.ll -emit-tbd -emit-tbd-path %t/test.tbd -I %t
-// RUN cat %t/test.tbd | %FileCheck %s --dump-input=always
+// RUN: %target-swift-frontend %s -enable-testing -disable-availability-checking -emit-ir -o %t/test.ll -emit-tbd -emit-tbd-path %t/test.tbd -I %t -tbd-install_name distributed
+// RUN %llvm-nm -g %t/test.tbd | %FileCheck %s --dump-input=always
 
 import Distributed
 

--- a/test/TBD/dylib-version-truncation.swift
+++ b/test/TBD/dylib-version-truncation.swift
@@ -1,27 +1,35 @@
 // REQUIRES: VENDOR=apple
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd-path - -tbd-current-version 2.0 | %FileCheck %s --check-prefix TWOPOINTZERO
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd-path - -tbd-current-version 2 | %FileCheck %s --check-prefix TWOPOINTZERO
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd-path - -tbd-current-version 20.10 | %FileCheck %s --check-prefix TWENTYPOINTTEN
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name some_dylib -emit-tbd-path - -tbd-current-version 2.0 | %FileCheck %s --check-prefix TWOPOINTZERO
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name some_dylib -emit-tbd-path - -tbd-current-version 2 | %FileCheck %s --check-prefix TWOPOINTZERO
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name some_dylib -emit-tbd-path - -tbd-current-version 20.10 | %FileCheck %s --check-prefix TWENTYPOINTTEN
 
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd-path - -tbd-compatibility-version 2.0 | %FileCheck %s --check-prefix TWOPOINTZEROCOMPAT
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd-path - -tbd-compatibility-version 2 | %FileCheck %s --check-prefix TWOPOINTZEROCOMPAT
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd-path - -tbd-compatibility-version 20.10 | %FileCheck %s --check-prefix TWENTYPOINTTENCOMPAT
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name some_dylib -emit-tbd-path - -tbd-compatibility-version 2.0 | %FileCheck %s --check-prefix TWOPOINTZEROCOMPAT
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name some_dylib -emit-tbd-path - -tbd-compatibility-version 2 | %FileCheck %s --check-prefix TWOPOINTZEROCOMPAT
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name some_dylib -emit-tbd-path - -tbd-compatibility-version 20.10 | %FileCheck %s --check-prefix TWENTYPOINTTENCOMPAT
 
 // Make sure we correctly truncate a value over 255
 
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd-path - -tbd-current-version 20.300 2>&1 | %FileCheck %s --check-prefix TWENTYPOINTTHREEHUNDRED
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd-path - -tbd-compatibility-version 20.300 2>&1 | %FileCheck %s --check-prefix TWENTYPOINTTHREEHUNDREDCOMPAT
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name some_dylib -emit-tbd-path - -tbd-current-version 20.300 2>&1 | %FileCheck %s --check-prefix TWENTYPOINTTHREEHUNDRED
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name some_dylib -emit-tbd-path - -tbd-compatibility-version 20.300 2>&1 | %FileCheck %s --check-prefix TWENTYPOINTTHREEHUNDREDCOMPAT
 
-// TWOPOINTZERO: current-version: 2
-// TWENTYPOINTTEN: current-version: 20.10
+// TWOPOINTZERO: current_versions
+// TWOPOINTZERO: "version": "2"
 
-// TWOPOINTZEROCOMPAT: compatibility-version: 2
-// TWENTYPOINTTENCOMPAT: compatibility-version: 20.10
+// TWENTYPOINTTEN: current_versions 
+// TWENTYPOINTTEN: "version": "20.10"
+
+// TWOPOINTZEROCOMPAT: compatibility_versions
+// TWOPOINTZEROCOMPAT: "version": "2"
+
+// TWENTYPOINTTENCOMPAT: compatibility_versions
+// TWENTYPOINTTENCOMPAT: "version": "20.10"
 
 // TWENTYPOINTTHREEHUNDRED: warning: truncating current version '20.300' in TBD file to fit in 32-bit space used by old mach-o format
-// TWENTYPOINTTHREEHUNDRED: current-version: 20.255
+// TWENTYPOINTTHREEHUNDRED: current_versions
+// TWENTYPOINTTHREEHUNDRED: "version": "20.255"
 
 // TWENTYPOINTTHREEHUNDREDCOMPAT: warning: truncating compatibility version '20.300' in TBD file to fit in 32-bit space used by old mach-o format
-// TWENTYPOINTTHREEHUNDREDCOMPAT: compatibility-version: 20.255
+// TWENTYPOINTTHREEHUNDREDCOMPAT: compatibility_versions
+// TWENTYPOINTTHREEHUNDREDCOMPAT: "version": "20.255"

--- a/test/TBD/dylib-version.swift
+++ b/test/TBD/dylib-version.swift
@@ -1,17 +1,23 @@
 // REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-current-version 2.0.3 -tbd-compatibility-version 1.7 -emit-tbd -emit-tbd-path %t/both_provided.tbd
-// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-current-version 2.0 -emit-tbd -emit-tbd-path %t/only_current_provided.tbd
-// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-compatibility-version 2 -emit-tbd -emit-tbd-path %t/only_compat_provided.tbd
-// RUN: not %target-swift-frontend -emit-ir -o /dev/null %s -tbd-compatibility-version not_a_version_string -emit-tbd -emit-tbd-path /dev/null 2>&1 | %FileCheck %s --check-prefix BOGUS
+// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-install_name some_dylib -tbd-current-version 2.0.3 -tbd-compatibility-version 1.7 -emit-tbd -emit-tbd-path %t/both_provided.tbd
+// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-install_name some_dylib -tbd-current-version 2.0 -emit-tbd -emit-tbd-path %t/only_current_provided.tbd
+// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-install_name some_dylib -tbd-compatibility-version 2 -emit-tbd -emit-tbd-path %t/only_compat_provided.tbd
+// RUN: not %target-swift-frontend -emit-ir -o /dev/null %s -tbd-install_name some_dylib -tbd-compatibility-version not_a_version_string -emit-tbd -emit-tbd-path /dev/null 2>&1 | %FileCheck %s --check-prefix BOGUS
 
-// RUN: %FileCheck %s --check-prefix BOTH < %t/both_provided.tbd
-// RUN: %FileCheck %s --check-prefix CURRENT < %t/only_current_provided.tbd
-// RUN: %FileCheck %s --check-prefix COMPAT < %t/only_compat_provided.tbd
+// RUN: %validate-json %t/both_provided.tbd | %FileCheck %s --check-prefix BOTH
+// RUN: %validate-json %t/only_current_provided.tbd | %FileCheck %s --check-prefix CURRENT
+// RUN: %validate-json %t/only_compat_provided.tbd | %FileCheck %s --check-prefix COMPAT
 
-// BOTH: current-version: 2.0.3
-// BOTH: compatibility-version: 1.7
-// CURRENT: current-version: 2
-// COMPAT: compatibility-version: 2
+// BOTH: compatibility_versions
+// BOTH: "version": "1.7"
+// BOTH: current_versions
+// BOTH: "version": "2.0.3"
+
+// CURRENT: current_versions
+// CURRENT: "version": "2"
+
+// COMPAT: compatibility_versions
+// COMPAT: "version": "2"
 
 // BOGUS: invalid dynamic library compatibility version 'not_a_version_string'

--- a/test/TBD/embed-symbol.swift
+++ b/test/TBD/embed-symbol.swift
@@ -5,11 +5,11 @@
 // RUN: echo 'public class Bar {}' > %t/bar.swift
 // RUN: %target-swift-frontend -emit-module %t/foo.swift -emit-module-path %t/foo.swiftmodule
 // RUN: %target-swift-frontend -emit-module %t/bar.swift -emit-module-path %t/bar.swiftmodule
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/flag-not-provided.tbd -I %t -module-name main
-// RUN: %FileCheck %s --check-prefix FLAG-NOT-PROVIDED < %t/flag-not-provided.tbd
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/flag-not-provided.tbd -I %t -module-name main -tbd-install_name main
+// RUN: %llvm-nm %t/flag-not-provided.tbd | %FileCheck %s --check-prefix FLAG-NOT-PROVIDED 
 
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/flag-provided.tbd -I %t -embed-tbd-for-module foo -embed-tbd-for-module bar -module-name main
-// RUN: %FileCheck %s --check-prefix FLAG-PROVIDED < %t/flag-provided.tbd
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/flag-provided.tbd -I %t -embed-tbd-for-module foo -embed-tbd-for-module bar -module-name main -tbd-install_name main 
+// RUN: %llvm-nm %t/flag-provided.tbd | %FileCheck %s --check-prefix FLAG-PROVIDED
 
 import foo
 import bar

--- a/test/TBD/emit-tbd-from-driver.swift
+++ b/test/TBD/emit-tbd-from-driver.swift
@@ -7,8 +7,8 @@
 // RUN: echo "public func foo() -> some CustomStringConvertible { 32 }" > %t/source1.swift
 // RUN: echo "" > %t/source2.swift
 
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -module-name multifile %t/source1.swift  %t/source2.swift -Xfrontend -validate-tbd-against-ir=all -emit-tbd -emit-tbd-path %t/multifile.tbd -enable-library-evolution -emit-module
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -module-name multifile %t/source1.swift  %t/source2.swift -Xfrontend -validate-tbd-against-ir=all -emit-tbd -emit-tbd-path %t/multifile.tbd -Xfrontend -tbd-install_name -Xfrontend multifile -enable-library-evolution -emit-module
 
-// RUN: %FileCheck %s < %t/multifile.tbd
+// RUN: %validate-json %t/multifile.tbd | %FileCheck %s 
 
 // CHECK: s9multifile3fooQryFQOMQ

--- a/test/TBD/enum.swift
+++ b/test/TBD/enum.swift
@@ -11,9 +11,9 @@
 // RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd -tbd-install_name test
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd -tbd-install_name test
+// RUN: %llvm-readtapi --compare %t/typecheck.tbd %t/emit-ir.tbd
 
 
 public protocol P {}

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -5,9 +5,9 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing -O
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd -tbd-install_name test 
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd -tbd-install_name test
+// RUN: %llvm-readtapi --compare %t/typecheck.tbd %t/emit-ir.tbd
 
 public func publicNoArgs() {}
 public func publicSomeArgs(_: Int, x: Int) {}

--- a/test/TBD/global.swift
+++ b/test/TBD/global.swift
@@ -9,9 +9,9 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -enable-library-evolution -enable-testing %s -O
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd -tbd-install_name global
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd -tbd-install_name global
+// RUN: %llvm-readtapi --compare %t/typecheck.tbd %t/emit-ir.tbd
 
 public let publicLet: Int = 0
 internal let internalLet: Int = 0

--- a/test/TBD/implied_objc_symbols.swift
+++ b/test/TBD/implied_objc_symbols.swift
@@ -3,11 +3,14 @@
 
 // RUN: echo "import Foundation" > %t/main.swift
 // RUN: echo "@objc(CApi) public class Api {}" >> %t/main.swift
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module -emit-tbd -emit-tbd-path %t/main.tbd
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module -emit-tbd -emit-tbd-path %t/main.tbd -tbd-install_name objc_classes
 
-// RUN: %FileCheck %s < %t/main.tbd
+// RUN: %validate-json %t/main.tbd |  %FileCheck %s
 
 // CHECK-NOT: '_OBJC_CLASS_$_CApi'
 // CHECK-NOT: '_OBJC_METACLASS_$_CApi' 
 
-// CHECK: objc-classes: [ CApi ]
+// CHECK: "objc_class": [
+// CHECK-NEXT:   "CApi"
+// CHECK-NEXT: ]
+

--- a/test/TBD/lazy-typecheck-bad-conformance.swift
+++ b/test/TBD/lazy-typecheck-bad-conformance.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -experimental-lazy-typecheck -emit-tbd -emit-tbd-path %t/lazy.tbd %s -enable-library-evolution -parse-as-library
+// RUN: %target-swift-frontend -typecheck -experimental-lazy-typecheck -emit-tbd -emit-tbd-path %t/lazy.tbd %s -enable-library-evolution -parse-as-library -tbd-install_name lazy
 
 public protocol P {
   func req()

--- a/test/TBD/lazy-typecheck.swift
+++ b/test/TBD/lazy-typecheck.swift
@@ -3,13 +3,13 @@
 // RUN: %empty-directory(%t/lazy-skip-all)
 
 // (1) Generate a baseline .tbd file.
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/baseline/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/baseline/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG -tbd-install_name @rpath/Package
 
 // (2) Generate a .tbd file passing -experimental-lazy-typecheck, -experimental-skip-all-function-bodies,
 //     and -experimental-skip-non-exportable-decls. It should be identical to the baseline and avoid
 //     triggering typechecking for any "NoTypecheck" decls.
-// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/lazy-skip-all/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck  -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
-// RUN: diff -u %t/baseline/lazy_typecheck.tbd %t/lazy-skip-all/lazy_typecheck.tbd
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -emit-module -emit-module-path /dev/null -emit-tbd-path %t/lazy-skip-all/lazy_typecheck.tbd -enable-library-evolution -parse-as-library -package-name Package -DFLAG -debug-forbid-typecheck-prefix NoTypecheck  -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -tbd-install_name @rpath/Package
+// RUN: %llvm-readtapi --compare %t/baseline/lazy_typecheck.tbd %t/lazy-skip-all/lazy_typecheck.tbd
 
 // FIXME: Re-run the test with -experimental-skip-non-inlinable-function-bodies
 

--- a/test/TBD/linker-directives-ld-previous-macos.swift
+++ b/test/TBD/linker-directives-ld-previous-macos.swift
@@ -2,22 +2,22 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
-// RUN: %FileCheck %s < %t/linker_directives.tbd
-// RUN: %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s < %t/linker_directives.tbd
-// RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
-// RUN: %FileCheck %s < %t/linker_directives.tbd
-// RUN: %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s < %t/linker_directives.tbd
+// RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json -tbd-install_name toasterkit
+// RUN: %validate-json %t/linker_directives.tbd | %FileCheck %s
+// RUN: %validate-json %t/linker_directives.tbd | %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s 
+// RUN: %target-swift-frontend -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json -tbd-install_name toasterkit
+// RUN: %validate-json %t/linker_directives.tbd | %FileCheck %s 
+// RUN: %validate-json %t/linker_directives.tbd | %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s 
 
-// RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.1-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
-// RUN: %FileCheck -check-prefix=CHECK-ZIPPERED %s < %t/linker_directives.tbd
-// RUN: %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s < %t/linker_directives.tbd
+// RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.1-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json -tbd-install_name toasterkit
+// RUN: %validate-json %t/linker_directives.tbd | %FileCheck -check-prefix=CHECK-ZIPPERED %s
+// RUN: %validate-json %t/linker_directives.tbd | %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s 
 
-// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$
-// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleV4moveyyF$
-// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMa$
-// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMn$
 // CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVN$
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMa$
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleV4moveyyF$
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$
+// CHECK: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit7VehicleVMn$
 
 // CHECK-ZIPPERED: $ld$previous$/System/Previous/iOS/ToasterKit.dylib$$2$10.2$13.0$_$s10ToasterKit5toastyyF$
 // CHECK-ZIPPERED: $ld$previous$/System/Previous/macOS/ToasterKit.dylib$$1$10.8$10.15$_$s10ToasterKit5toastyyF$

--- a/test/TBD/linker-directives.swift
+++ b/test/TBD/linker-directives.swift
@@ -3,10 +3,11 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd
-// RUN: %FileCheck %s --check-prefix CHECK-HAS --check-prefix CHECK-HAS-NOT < %t/linker_directives.tbd
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/linker_directives.tbd
-// RUN: %FileCheck %s --check-prefix CHECK-HAS --check-prefix CHECK-HAS-NOT < %t/linker_directives.tbd
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name directive_use -tbd-is-installapi -emit-tbd -emit-tbd-path %t/linker_directives.tbd
+
+// RUN: %llvm-nm %t/linker_directives.tbd | %FileCheck %s --check-prefix CHECK-HAS --check-prefix CHECK-HAS-NOT 
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name directive_use -emit-tbd -emit-tbd-path %t/linker_directives.tbd
+// RUN: %llvm-nm %t/linker_directives.tbd | %FileCheck %s --check-prefix CHECK-HAS --check-prefix CHECK-HAS-NOT 
 
 @available(OSX 10.8, *)
 @_originallyDefinedIn(module: "ToasterKit", macOS 10.15)

--- a/test/TBD/main.swift
+++ b/test/TBD/main.swift
@@ -3,8 +3,8 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -module-name test -validate-tbd-against-ir=all %s -O
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -tbd-install_name test -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -tbd-install_name test -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: %llvm-readtapi --compare %t/typecheck.tbd %t/emit-ir.tbd
 
 // Top-level code (i.e. implicit `main`) should be handled

--- a/test/TBD/move_to_extension.swift
+++ b/test/TBD/move_to_extension.swift
@@ -1,18 +1,18 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/before_move.tbd -D BEFORE_MOVE -module-name Foo -enable-library-evolution -emit-sil -o %t/before_move.sil
-// RUN: %FileCheck %s < %t/before_move.tbd
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -tbd-install_name Foo -emit-tbd-path %t/before_move.tbd -D BEFORE_MOVE -module-name Foo -enable-library-evolution -emit-sil -o %t/before_move.sil
+// RUN: %llvm-nm %t/before_move.tbd | %FileCheck %s 
 // RUN: %FileCheck %s --check-prefix=CHECK-SIL < %t/before_move.sil
 
 // RUN: %target-swift-frontend %s -emit-module -emit-module-path %t/FooCore.swiftmodule -D AFTER_MOVE_FOO_CORE -module-name FooCore -enable-library-evolution
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/after_move.tbd -D AFTER_MOVE_FOO -module-name Foo -I %t -enable-library-evolution -emit-sil -o %t/after_move.sil
-// RUN: %FileCheck %s < %t/after_move.tbd
+// RUN: %target-swift-frontend -typecheck %s -tbd-install_name Foo -emit-tbd -emit-tbd-path %t/after_move.tbd -D AFTER_MOVE_FOO -module-name Foo -I %t -enable-library-evolution -emit-sil -o %t/after_move.sil
+// RUN: %llvm-nm %t/after_move.tbd | %FileCheck %s 
 // RUN: %FileCheck %s --check-prefix=CHECK-SIL < %t/after_move.sil
 
-// CHECK: '_$s3Foo4DateC14getCurrentYearSiyFZ'
-// CHECK: '_$s3Foo9DateValueV4yearACSi_tcfC'
-// CHECK: '_$s3Foo9DateValueV4yearSivg'
+// CHECK: _$s3Foo4DateC14getCurrentYearSiyFZ
+// CHECK: _$s3Foo9DateValueV4yearACSi_tcfC
+// CHECK: _$s3Foo9DateValueV4yearSivg
 
 // CHECK-SIL: sil [available 10.7] @$s3Foo4DateC14getCurrentYearSiyFZ : $@convention(method) (@thick Date.Type) -> Int
 // CHECK-SIL: sil [available 10.7] @$s3Foo9DateValueV4yearACSi_tcfC : $@convention(method) (Int, @thin DateValue.Type) -> @out DateValue

--- a/test/TBD/move_to_extension_comove.swift
+++ b/test/TBD/move_to_extension_comove.swift
@@ -1,17 +1,18 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/before_move.tbd -D BEFORE_MOVE -module-name Foo -enable-library-evolution -emit-sil -o %t/before_move.sil
-// RUN: %FileCheck %s --check-prefix=CHECK-TBD < %t/before_move.tbd
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/before_move.tbd -D BEFORE_MOVE -tbd-install_name FooCore -module-name Foo -enable-library-evolution -emit-sil -o %t/before_move.sil
+
+// RUN: %llvm-nm %t/before_move.tbd | %FileCheck %s --check-prefix=CHECK-TBD 
 // RUN: %FileCheck %s --check-prefix=CHECK-SIL < %t/before_move.sil
 
-// RUN: %target-swift-frontend %s -emit-module -emit-module-path %t/FooCore.swiftmodule -D AFTER_MOVE_FOO_CORE -module-name FooCore -enable-library-evolution -emit-tbd -emit-tbd-path %t/after_move.tbd -emit-sil -o %t/after_move.sil
+// RUN: %target-swift-frontend %s -emit-module -emit-module-path %t/FooCore.swiftmodule -D AFTER_MOVE_FOO_CORE -module-name FooCore -enable-library-evolution -tbd-install_name FooCore -emit-tbd -emit-tbd-path %t/after_move.tbd -emit-sil -o %t/after_move.sil
 
-// RUN: %FileCheck %s --check-prefix=CHECK-TBD < %t/after_move.tbd
+// RUN: %llvm-nm %t/after_move.tbd | %FileCheck %s --check-prefix=CHECK-TBD 
 // RUN: %FileCheck %s --check-prefix=CHECK-SIL < %t/after_move.sil
 
-// CHECK-TBD: '_$s3Foo4DateC03SubB0V4yearAESi_tcfC'
-// CHECK-TBD: '_$s3Foo4DateC03SubB0VMn'
+// CHECK-TBD: _$s3Foo4DateC03SubB0V4yearAESi_tcfC
+// CHECK-TBD: _$s3Foo4DateC03SubB0VMn
 
 // CHECK-SIL: sil [available 10.7] @$s3Foo4DateC03SubB0V4yearAESi_tcfC : $@convention(method) (Int, @thin Date.SubDate.Type) -> @out Date.SubDate
 

--- a/test/TBD/multi-file.swift
+++ b/test/TBD/multi-file.swift
@@ -5,8 +5,8 @@
 // RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-library -o %t/JustForTBDValidation %s %S/Inputs/multi-file2.swift -wmo -Xfrontend -validate-tbd-against-ir=all
 // RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-library -o %t/JustForTBDValidation %s %S/Inputs/multi-file2.swift -Xfrontend -validate-tbd-against-ir=all
 
-// RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-tbd-path %t/TBD-wmo.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -wmo
-// RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-tbd-path %t/TBD-incremental.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift
+// RUN: %target-build-swift -swift-version 4 -module-name multifile -Xfrontend -tbd-install_name -Xfrontend multifile -emit-tbd-path %t/TBD-wmo.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -wmo
+// RUN: %target-build-swift -swift-version 4 -module-name multifile -Xfrontend -tbd-install_name -Xfrontend multifile -emit-tbd-path %t/TBD-incremental.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift
 // RUN: diff %t/TBD-wmo.tbd %t/TBD-incremental.tbd
 
 // -O, non-resilient
@@ -14,8 +14,8 @@
 // RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-library -o %t/JustForTBDValidation %s %S/Inputs/multi-file2.swift -wmo -O -Xfrontend -validate-tbd-against-ir=all
 // RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-library -o %t/JustForTBDValidation %s %S/Inputs/multi-file2.swift -O -Xfrontend -validate-tbd-against-ir=all
 
-// RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-tbd-path %t/TBD-wmo.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -wmo -O
-// RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-tbd-path %t/TBD-incremental.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -O
+// RUN: %target-build-swift -swift-version 4 -module-name multifile -Xfrontend -tbd-install_name -Xfrontend multifile -emit-tbd-path %t/TBD-wmo.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -wmo -O
+// RUN: %target-build-swift -swift-version 4 -module-name multifile -Xfrontend -tbd-install_name -Xfrontend multifile -emit-tbd-path %t/TBD-incremental.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -O
 // RUN: diff %t/TBD-wmo.tbd %t/TBD-incremental.tbd
 
 // -Onone, resilient
@@ -23,8 +23,8 @@
 // RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-library -o %t/JustForTBDValidation %s %S/Inputs/multi-file2.swift -wmo -enable-library-evolution -Xfrontend -validate-tbd-against-ir=all
 // RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-library -o %t/JustForTBDValidation %s %S/Inputs/multi-file2.swift -enable-library-evolution -Xfrontend -validate-tbd-against-ir=all
 
-// RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-tbd-path %t/TBD-wmo.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -wmo -enable-library-evolution
-// RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-tbd-path %t/TBD-incremental.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -enable-library-evolution
+// RUN: %target-build-swift -swift-version 4 -module-name multifile -Xfrontend -tbd-install_name -Xfrontend multifile -emit-tbd-path %t/TBD-wmo.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -wmo -enable-library-evolution
+// RUN: %target-build-swift -swift-version 4 -module-name multifile -Xfrontend -tbd-install_name -Xfrontend multifile -emit-tbd-path %t/TBD-incremental.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -enable-library-evolution
 // RUN: diff %t/TBD-wmo.tbd %t/TBD-incremental.tbd
 
 // -O, resilient
@@ -32,8 +32,8 @@
 // RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-library -o %t/JustForTBDValidation %s %S/Inputs/multi-file2.swift -wmo -O -enable-library-evolution -Xfrontend -validate-tbd-against-ir=all
 // RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-library -o %t/JustForTBDValidation %s %S/Inputs/multi-file2.swift -O -enable-library-evolution -Xfrontend -validate-tbd-against-ir=all
 
-// RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-tbd-path %t/TBD-wmo.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -wmo -O -enable-library-evolution
-// RUN: %target-build-swift -swift-version 4 -module-name multifile -emit-tbd-path %t/TBD-incremental.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -O -enable-library-evolution
+// RUN: %target-build-swift -swift-version 4 -module-name multifile -Xfrontend -tbd-install_name -Xfrontend multifile -emit-tbd-path %t/TBD-wmo.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -wmo -O -enable-library-evolution
+// RUN: %target-build-swift -swift-version 4 -module-name multifile -Xfrontend -tbd-install_name -Xfrontend multifile -emit-tbd-path %t/TBD-incremental.tbd -emit-module-path %t/multifile.swiftmodule %s %S/Inputs/multi-file2.swift -O -enable-library-evolution
 // RUN: diff %t/TBD-wmo.tbd %t/TBD-incremental.tbd
 
 // REQUIRES: objc_interop

--- a/test/TBD/multimodule-implied-objc.swift
+++ b/test/TBD/multimodule-implied-objc.swift
@@ -19,10 +19,12 @@
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/cache \
 // RUN:   %t/Client.swift -emit-ir -o/dev/null -parse-as-library \
 // RUN:   -module-name client -validate-tbd-against-ir=missing \
-// RUN:   -emit-tbd -emit-tbd-path %t/client.tbd 
+// RUN:   -tbd-install_name client -emit-tbd -emit-tbd-path %t/client.tbd 
 
-// RUN: %FileCheck %s < %t/client.tbd
-// CHECK: objc-classes: [ _TtCO6client11extendedAPI6Square ]
+// RUN: %validate-json %t/client.tbd | %FileCheck %s
+
+// CHECK: "objc_class": 
+// CHECK: "_TtCO6client11extendedAPI6Square"
 // CHECK-NOT: _OBJC_CLASS_$
 // CHECK-NOT: _OBJC_METACLASS_$
 

--- a/test/TBD/omit-witness-table.swift
+++ b/test/TBD/omit-witness-table.swift
@@ -1,7 +1,14 @@
 // REQUIRES: VENDOR=apple
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-library-evolution -emit-tbd -emit-tbd-path %t.result.tbd -tbd-is-installapi -parse-as-library -emit-ir -o/dev/null
+// RUN: %target-swift-frontend -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-library-evolution -emit-tbd -emit-tbd-path %t.result.tbd -tbd-is-installapi -parse-as-library -emit-ir -o/dev/null -tbd-install_name test
+// RUN: %llvm-nm -g %t.result.tbd | %FileCheck %s 
 
 public enum TestError : Error {
   case unsupportedVersion(Int)
 }
+
+// CHECK:      T _$s4test9TestErrorO18unsupportedVersionyACSicACmFWC
+// CHECK-NEXT: T _$s4test9TestErrorOMa
+// CHECK-NEXT: T _$s4test9TestErrorOMn
+// CHECK-NEXT: D _$s4test9TestErrorON
+// CHECK-NEXT: T _$s4test9TestErrorOs0C0AAMc

--- a/test/TBD/opaque_result_type.swift
+++ b/test/TBD/opaque_result_type.swift
@@ -1,6 +1,6 @@
 // REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null -module-name opaque_result_type -emit-tbd -emit-tbd-path %t/opaque_result_type.tbd %s -validate-tbd-against-ir=missing
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null -module-name opaque_result_type -emit-tbd -emit-tbd-path %t/opaque_result_type.tbd %s -validate-tbd-against-ir=missing -tbd-install_name opaque_result_type
 
 public protocol O {
   func bar()

--- a/test/TBD/output-path-deduction.swift
+++ b/test/TBD/output-path-deduction.swift
@@ -1,13 +1,13 @@
 // REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 
-// RUN: cd %t; %target-build-swift -emit-module -emit-tbd %s
+// RUN: cd %t; %target-build-swift -emit-module -emit-tbd %s -Xfrontend -tbd-install_name -Xfrontend test
 // RUN: test -e %t/main.tbd
-// RUN: %target-build-swift -emit-module -emit-tbd %s -o %t/default
+// RUN: %target-build-swift -emit-module -emit-tbd %s -o %t/default -Xfrontend -tbd-install_name -Xfrontend test
 // RUN: test -e %t/default.tbd
-// RUN: %target-build-swift -emit-module -emit-tbd %s -o %t/module_name -module-name module_name_different
+// RUN: %target-build-swift -emit-module -emit-tbd %s -o %t/module_name -module-name module_name_different -Xfrontend -tbd-install_name -Xfrontend test
 // RUN: test -e %t/module_name.tbd
-// RUN: %target-build-swift -emit-module -emit-tbd-path %t/hard_to_guess_explicit_path.tbd %s -o %t/explicit_path
+// RUN: %target-build-swift -emit-module -emit-tbd-path %t/hard_to_guess_explicit_path.tbd %s -o %t/explicit_path -Xfrontend -tbd-install_name -Xfrontend test
 // RUN: test -e %t/hard_to_guess_explicit_path.tbd
-// RUN: %target-build-swift -emit-module -emit-tbd %s -emit-module-path %t/emit_module_path.swiftmodule -module-name emit_module_path_different
+// RUN: %target-build-swift -emit-module -emit-tbd %s -emit-module-path %t/emit_module_path.swiftmodule -module-name emit_module_path_different -Xfrontend -tbd-install_name -Xfrontend test
 // RUN: test -e %t/emit_module_path.tbd

--- a/test/TBD/package_symbol_with_default_arg.swift
+++ b/test/TBD/package_symbol_with_default_arg.swift
@@ -6,7 +6,7 @@
 // RUN:  -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN:  -emit-tbd -emit-tbd-path %t/libUtils.tbd -Xfrontend -tbd-install_name=%t/libUtils.dylib -Xfrontend -validate-tbd-against-ir=all
 
-// RUN: %FileCheck %s --check-prefix CHECK-TBD < %t/libUtils.tbd
+// RUN: %llvm-nm %t/libUtils.tbd | %FileCheck %s --check-prefix CHECK-TBD 
 // CHECK-TBD-NOT: $s5Utils6pubBar3argS2i_tFfA_
 // CHECK-TBD-NOT: $s5Utils11internalBar3argS2i_tF
 // CHECK-TBD-NOT: $s5Utils11internalBar3argS2i_tFfA_
@@ -24,7 +24,7 @@
 // RUN:  -enable-testing -Xfrontend -validate-tbd-against-ir=all
 
 
-// RUN: %FileCheck %s --check-prefix CHECK-TEST < %t/libUtilsForTesting.tbd
+// RUN: %llvm-nm %t/libUtilsForTesting.tbd | %FileCheck %s --check-prefix CHECK-TEST 
 // CHECK-TEST-NOT: $s15UtilsForTesting6pubBar3argS2i_tFfA_
 // CHECK-TEST: $s15UtilsForTesting11internalBar3argS2i_tF
 // CHECK-TEST: $s15UtilsForTesting11internalBar3argS2i_tFfA_

--- a/test/TBD/protocol.swift
+++ b/test/TBD/protocol.swift
@@ -10,9 +10,9 @@
 // RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -disable-objc-attr-requires-foundation-module -validate-tbd-against-ir=missing %s -enable-testing -O
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test -disable-objc-attr-requires-foundation-module %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test -disable-objc-attr-requires-foundation-module %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test -disable-objc-attr-requires-foundation-module %s -emit-tbd -emit-tbd-path %t/typecheck.tbd -tbd-install_name test
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test -disable-objc-attr-requires-foundation-module %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd -tbd-install_name test
+// RUN: %llvm-readtapi --compare  %t/typecheck.tbd %t/emit-ir.tbd
 
 public protocol Public {
     func publicMethod()

--- a/test/TBD/rdar80485869.swift
+++ b/test/TBD/rdar80485869.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -emit-module-path %t/module -emit-tbd -enable-testing -disable-availability-checking
+// RUN: %target-swift-frontend %s -emit-module-path %t/module -emit-tbd -enable-testing -disable-availability-checking -tbd-install_name test 
 
 public actor Tom {
     init() async {

--- a/test/TBD/rdar82045176.swift
+++ b/test/TBD/rdar82045176.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(first)) %s -emit-module -module-name thing -emit-tbd -enable-testing -Xfrontend -disable-availability-checking -Xfrontend -validate-tbd-against-ir=all
+// RUN: %target-build-swift-dylib(%t/%target-library-name(first)) %s -emit-module -module-name thing -emit-tbd -enable-testing -Xfrontend -disable-availability-checking -Xfrontend -validate-tbd-against-ir=all -Xfrontend -tbd-install_name -Xfrontend thing
 
 class Test {
   init() async { }

--- a/test/TBD/resolve_imports.swift
+++ b/test/TBD/resolve_imports.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -resolve-imports -emit-tbd -emit-tbd-path %t/resolve_imports.tbd %s -disable-availability-checking
-// RUN: %FileCheck %s < %t/resolve_imports.tbd
+// RUN: %target-swift-frontend -resolve-imports -emit-tbd -emit-tbd-path %t/resolve_imports.tbd %s -disable-availability-checking -tbd-install_name resolve_imports
+// RUN: %llvm-nm %t/resolve_imports.tbd |  %FileCheck %s 
 
 // REQUIRES: OS=macosx 
 
@@ -27,17 +27,15 @@ extension PrivateProto {
 
 public struct S: PrivateProto {}
 
-// CHECK: symbols: [
-// CHECK: '_$s15resolve_imports1CCMa',
-// CHECK: '_$s15resolve_imports1CCMm',
-// CHECK: '_$s15resolve_imports1CCMn',
-// CHECK: '_$s15resolve_imports1CCN',
-// CHECK: '_$s15resolve_imports1CCfD',
-// CHECK: '_$s15resolve_imports1CCfd',
-// CHECK: '_$s15resolve_imports1SVMa',
-// CHECK: '_$s15resolve_imports1SVMn',
-// CHECK: '_$s15resolve_imports1SVN',
-// CHECK: '_$s15resolve_imports1SVSQAAMc',
-// CHECK: '_$s15resolve_imports1SVSQAASQ2eeoiySbx_xtFZTW',
-// CHECK: _main
-// CHECK: ]
+// CHECK: T _$s15resolve_imports1CCMa
+// CHECK-NEXT: D _$s15resolve_imports1CCMm
+// CHECK-NEXT: T _$s15resolve_imports1CCMn
+// CHECK-NEXT: D _$s15resolve_imports1CCN
+// CHECK-NEXT: T _$s15resolve_imports1CCfD
+// CHECK-NEXT: T _$s15resolve_imports1CCfd
+// CHECK-NEXT: T _$s15resolve_imports1SVMa
+// CHECK-NEXT: T _$s15resolve_imports1SVMn
+// CHECK-NEXT: D _$s15resolve_imports1SVN
+// CHECK-NEXT: T _$s15resolve_imports1SVSQAAMc
+// CHECK-NEXT: T _$s15resolve_imports1SVSQAASQ2eeoiySbx_xtFZTW
+// CHECK-NEXT: T _main

--- a/test/TBD/specialization.swift
+++ b/test/TBD/specialization.swift
@@ -11,9 +11,9 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -O -validate-tbd-against-ir=all -enable-library-evolution -enable-testing %s
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd -tbd-install_name specialization
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd -tbd-install_name specialization
+// RUN: %llvm-readtapi --compare %t/typecheck.tbd %t/emit-ir.tbd
 
 // rdar://problem/40738913
 

--- a/test/TBD/struct.swift
+++ b/test/TBD/struct.swift
@@ -9,9 +9,9 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-library-evolution -enable-testing -O
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd -tbd-install_name test
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd -tbd-install_name test
+// RUN: %llvm-readtapi --compare %t/typecheck.tbd %t/emit-ir.tbd
 
 public struct StructPublicNothing {}
 

--- a/test/TBD/subscript.swift
+++ b/test/TBD/subscript.swift
@@ -5,9 +5,9 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing -O
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
-// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd -tbd-install_name test
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd -tbd-install_name  test
+// RUN: %llvm-readtapi --compare  %t/typecheck.tbd %t/emit-ir.tbd
 
 public protocol DefaultInit {
   init()

--- a/test/TBD/zippered.swift
+++ b/test/TBD/zippered.swift
@@ -2,8 +2,8 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %swift -target arm64-apple-macos13.0 -target-variant arm64-apple-ios16.0-macabi -typecheck -parse-as-library %t/test.swift -emit-tbd -emit-tbd-path %t/zippered.tbd
-// RUN: %llvm-readtapi %t/zippered.tbd %t/expected.tbd
+// RUN: %swift -target arm64-apple-macos13.0 -target-variant arm64-apple-ios16.0-macabi -typecheck -parse-as-library %t/test.swift -emit-tbd -emit-tbd-path %t/zippered.tbd -tbd-install_name Zippered 
+// RUN: %llvm-readtapi --compare %t/zippered.tbd %t/expected.tbd
 
 //--- test.swift
 public func foo() -> Bool {
@@ -11,15 +11,54 @@ public func foo() -> Bool {
 }
 
 //--- expected.tbd
---- !tapi-tbd
-tbd-version:     4
-targets:         [ arm64-macos, arm64-maccatalyst ]
-flags:           [ not_app_extension_safe ]
-install-name:    ''
-current-version: 0
-compatibility-version: 0
-swift-abi-version: 7
-exports:
-  - targets:         [ arm64-macos, arm64-maccatalyst ]
-    symbols:         [ '_$s4test3fooSbyF' ]
-...
+{
+  "main_library": {
+    "compatibility_versions": [
+      {
+        "version": "0"
+      }
+    ],
+    "current_versions": [
+      {
+        "version": "0"
+      }
+    ],
+    "exported_symbols": [
+      {
+        "text": {
+          "global": [
+            "_$s4test3fooSbyF"
+          ]
+        }
+      }
+    ],
+    "flags": [
+      {
+        "attributes": [
+          "not_app_extension_safe"
+        ]
+      }
+    ],
+    "install_names": [
+      {
+        "name": "Zippered"
+      }
+    ],
+    "swift_abi": [
+      {
+        "abi": 7
+      }
+    ],
+    "target_info": [
+      {
+        "min_deployment": "13.0",
+        "target": "arm64-macos"
+      },
+      {
+        "min_deployment": "16.0",
+        "target": "arm64-maccatalyst"
+      }
+    ]
+  },
+  "tapi_tbd_version": 5
+}

--- a/test/api-digester/ignore-spi-by-given-group-name.swift
+++ b/test/api-digester/ignore-spi-by-given-group-name.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-before.json %s -enable-library-evolution -DBASELINE -emit-tbd-path %t/abi-before.tbd
-// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-after.json %s -enable-library-evolution -emit-tbd-path %t/abi-after.tbd
+// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-before.json %s -enable-library-evolution -DBASELINE -emit-tbd-path %t/abi-before.tbd -tbd-install_name Foo
+// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-after.json %s -enable-library-evolution -emit-tbd-path %t/abi-after.tbd -tbd-install_name Foo
 // RUN: %api-digester -diagnose-sdk --input-paths %t/abi-before.json -input-paths %t/abi-after.json -abi -o %t/include-result.txt
 // RUN: %FileCheck %s -check-prefix CHECK_INCLUDE_SPI < %t/include-result.txt
 

--- a/test/api-digester/move-to-extension.swift
+++ b/test/api-digester/move-to-extension.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-before.json %s -enable-library-evolution -DBASELINE -emit-tbd-path %t/abi-before.tbd
-// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-after.json %s -enable-library-evolution -emit-tbd-path %t/abi-after.tbd
+// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-before.json %s -enable-library-evolution -DBASELINE -emit-tbd-path %t/abi-before.tbd -tbd-install_name Foo
+// RUN: %target-swift-frontend -emit-module -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi-after.json %s -enable-library-evolution -emit-tbd-path %t/abi-after.tbd -tbd-install_name Foo
 // RUN: %api-digester -diagnose-sdk --input-paths %t/abi-before.json -input-paths %t/abi-after.json -abi -o %t/result.txt
 // RUN: %FileCheck %s < %t/result.txt
 

--- a/test/reproducible-builds/swiftc-emit-tbd.swift
+++ b/test/reproducible-builds/swiftc-emit-tbd.swift
@@ -1,6 +1,6 @@
 // REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-1.tbd -whole-module-optimization
-// RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-2.tbd -whole-module-optimization
-// RUN: diff -u %t/run-1.tbd %t/run-2.tbd
+// RUN: %target-build-swift -O -g -module-name foo %s -tbd-install_name run -emit-tbd-path %t/run-1.tbd -whole-module-optimization
+// RUN: %target-build-swift -O -g -module-name foo %s -tbd-install_name run -emit-tbd-path %t/run-2.tbd -whole-module-optimization
+// RUN: %llvm-readtapi --compare %t/run-1.tbd %t/run-2.tbd
 print("foo")


### PR DESCRIPTION
TBD-v5 was introduced last year to encode more relevant information in TBD files and to transition to the JSON format.
This patch updates the compiler to start emitting tbd-v5 files. TBD files now include _best effort_ information about the segment the symbol is defined in. This restores back information that gets lost when compared to binary dylibs. 

 resolves: rdar://117604275