### PR TITLE
[embedded] Avoid materializing generic functions for debuginfo purposes in embedded Swift

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2328,7 +2328,11 @@ llvm::DIScope *IRGenDebugInfoImpl::getOrCreateScope(const SILDebugScope *DS) {
     // Force the debug info for the function to be emitted, even if it
     // is external or has been inlined.
     llvm::Function *Fn = nullptr;
-    if (!SILFn->getName().empty() && !SILFn->isZombie())
+    // Avoid materializing generic functions in embedded Swift mode.
+    bool genericInEmbedded =
+        IGM.Context.LangOpts.hasFeature(Feature::Embedded) &&
+        SILFn->isGeneric();
+    if (!SILFn->getName().empty() && !SILFn->isZombie() && !genericInEmbedded)
       Fn = IGM.getAddrOfSILFunction(SILFn, NotForDefinition);
     auto *SP = emitFunction(*SILFn, Fn);
 

--- a/test/embedded/generic-classes-debuginfo.swift
+++ b/test/embedded/generic-classes-debuginfo.swift
@@ -1,0 +1,49 @@
+// RUN: %target-run-simple-swift(-g %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-g -Osize %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+struct User {
+  let o: BaseClass
+}
+
+class BaseClass {
+  func foo() {}
+}
+
+protocol Protocol {
+  func protofoo()
+}
+
+class Implementor: Protocol {
+  func protofoo() { print("Implementor.protofoo") }
+}
+
+class GenericSubClass<P: Protocol>: BaseClass {
+  let p: P
+
+  init(p: P) {
+    self.p = p
+  }
+
+  override func foo() {
+    let x = { self.p.protofoo() }
+    x()
+  }
+}
+
+@main
+struct Main {
+  static func main() {
+    let p = Implementor()
+    let o = GenericSubClass(p: p)
+    let user = User(o: o)
+    user.o.foo()
+  }
+}
+
+// CHECK: Implementor.protofoo
+


### PR DESCRIPTION
The attached testcase triggers a crash in embedded Swift mode because debuginfo ends up referencing a generic function (in the "inlined from" debuginfo data). This generic function is otherwise unused (and harmless in embedded Swift mode), but debuginfo generation will actually try to materialize it. Let's avoid that in embedded Swift.

```
Assertion failed: (!f->isGeneric()), function addLazyFunction, file GenDecl.cpp, line 1567.
...
3.	While evaluating request IRGenRequest(IR Generation for module main)
4.	While emitting IR SIL function "@$s4main15GenericSubClassC3fooyyFyycfU_AA11ImplementorC_Tg5".
 for expression at [/Users/kuba/swift-github-main/swift/test/embedded/generic-classes-debuginfo.swift:33:13 - line:33:33] RangeText="{ self.p.protofoo() "
...
 #8 0x00000001011c3090 swift::irgen::IRGenerator::addLazyFunction(swift::SILFunction*)
 #9 0x00000001011c54c4 swift::irgen::IRGenModule::getAddrOfSILFunction(swift::SILFunction*, swift::ForDefinition_t, bool, bool)
#10 0x00000001012cd910 (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateScope(swift::SILDebugScope const*)
#11 0x00000001012d3cd0 (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateContext(swift::DeclContext*)
#12 0x00000001012cdfa0 (anonymous namespace)::IRGenDebugInfoImpl::emitFunction(swift::SILDebugScope const*, llvm::Function*, swift::SILFunctionTypeRepresentation, swift::SILType, swift::DeclContext*, llvm::StringRef)
#13 0x00000001012cebc0 (anonymous namespace)::IRGenDebugInfoImpl::emitFunction(swift::SILFunction&, llvm::Function*)
#14 0x000000010130829c (anonymous namespace)::IRGenSILFunction::emitSILFunction()
#15 0x0000000101307a0c swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*)
#16 0x00000001011c0f4c swift::irgen::IRGenerator::emitGlobalTopLevel(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&)
#17 0x00000001012c0d68 swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const
```
