### PR TITLE
Add underscore prefix to extern attribute

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -437,19 +437,19 @@ the export name.
 
 It's the equivalent of clang's `__attribute__((export_name))`.
 
-## `@extern(<language>)`
+## `@_extern(<language>)`
 
 Indicates that a particular declaration should be imported
 from the external environment.
 
-### `@extern(wasm, module: <"moduleName">, name: <"fieldName">)`
+### `@_extern(wasm, module: <"moduleName">, name: <"fieldName">)`
 
 Indicates that a particular declaration should be imported
 through WebAssembly's import interface.
 
 It's the equivalent of clang's `__attribute__((import_module("module"), import_name("field")))`.
 
-### `@extern(c, [, <"cName">])`
+### `@_extern(c, [, <"cName">])`
 
 Indicates that a particular declaration should refer to a
 C declaration with the given name. If the optional "cName"
@@ -462,7 +462,7 @@ C declarations from Swift, while `@_cdecl` is used to define
 Swift functions that can be referenced from C.
 
 Also similar to `@_silgen_name`, but a function declared with
-`@extern(c)` is assumed to use the C ABI, while `@_silgen_name`
+`@_extern(c)` is assumed to use the C ABI, while `@_silgen_name`
 assumes the Swift ABI.
 
 ## `@_fixed_layout`

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -421,7 +421,7 @@ DECL_ATTR(_section, Section,
 DECL_ATTR(_rawLayout, RawLayout,
   OnStruct | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   146)
-DECL_ATTR(extern, Extern,
+DECL_ATTR(_extern, Extern,
   OnFunc | AllowMultipleAttributes | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   147)
 SIMPLE_DECL_ATTR(_nonEscapable, NonEscapable,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2343,7 +2343,7 @@ public:
   }
 };
 
-/// Define the `@extern` attribute, used to import external declarations in
+/// Define the `@_extern` attribute, used to import external declarations in
 /// the specified way to interoperate with Swift.
 class ExternAttr : public DeclAttribute {
   SourceLoc LParenLoc, RParenLoc;
@@ -2368,7 +2368,7 @@ public:
   const llvm::Optional<StringRef> ModuleName;
 
   /// The declaration name to import
-  /// std::nullopt if the declaration name is not specified with @extern(c)
+  /// std::nullopt if the declaration name is not specified with @_extern(c)
   const llvm::Optional<StringRef> Name;
 
   SourceLoc getLParenLoc() const { return LParenLoc; }

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -112,7 +112,7 @@ enum class ExposureKind: uint8_t {
 enum : unsigned { NumExposureKindBits =
   countBitsUsed(static_cast<unsigned>(ExposureKind::Last_ExposureKind)) };
   
-/// This enum represents the possible values of the @extern attribute.
+/// This enum represents the possible values of the @_extern attribute.
 enum class ExternKind: uint8_t {
   /// Reference an externally defined C function.
   /// The imported function has C function pointer representation,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1869,7 +1869,7 @@ ERROR(attr_rawlayout_expected_params,none,
       "expected %1 argument after %0 argument in @_rawLayout attribute", (StringRef, StringRef))
 
 ERROR(attr_extern_expected_label,none,
-      "expected %0 argument to @extern attribute", (StringRef))
+      "expected %0 argument to @_extern attribute", (StringRef))
 //------------------------------------------------------------------------------
 // MARK: Generics parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1900,17 +1900,17 @@ ERROR(section_not_at_top_level,none,
 ERROR(section_empty_name,none,
       "@_section section name cannot be empty", ())
 
-// @extern
+// @_extern
 ERROR(attr_extern_experimental,none,
-      "@extern requires '-enable-experimental-feature Extern'", ())
+      "@_extern requires '-enable-experimental-feature Extern'", ())
 ERROR(extern_not_at_top_level_func,none,
-      "@extern attribute can only be applied to global functions", ())
+      "@_extern attribute can only be applied to global functions", ())
 ERROR(extern_empty_c_name,none,
-      "expected non-empty C name in @extern attribute", ())
+      "expected non-empty C name in @_extern attribute", ())
 ERROR(extern_only_non_other_attr,none,
-      "@extern attribute cannot be applied to an '@%0' declaration", (StringRef))
+      "@_extern attribute cannot be applied to an '@%0' declaration", (StringRef))
 WARNING(extern_c_maybe_invalid_name, none,
-        "C name '%0' may be invalid; explicitly specify the name in @extern(c) to suppress this warning",
+        "C name '%0' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning",
         (StringRef))
 
 ERROR(c_func_variadic, none,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -257,7 +257,7 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 /// lifetime-dependent results.
 EXPERIMENTAL_FEATURE(NonEscapableTypes, false)
 
-/// Enable the `@extern` attribute.
+/// Enable the `@_extern` attribute.
 EXPERIMENTAL_FEATURE(Extern, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1095,7 +1095,7 @@ public:
   ParserResult<DifferentiableAttr> parseDifferentiableAttribute(SourceLoc AtLoc,
                                                                 SourceLoc Loc);
 
-  /// Parse the @extern attribute.
+  /// Parse the @_extern attribute.
   bool parseExternAttribute(DeclAttributes &Attributes, bool &DiscardAttribute,
                             StringRef AttrName, SourceLoc AtLoc, SourceLoc Loc);
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -303,7 +303,7 @@ private:
   /// empty.
   StringRef WasmExportName;
 
-  /// Name of a Wasm import module and field if @extern(wasm) attribute
+  /// Name of a Wasm import module and field if @_extern(wasm) attribute
   llvm::Optional<std::pair<StringRef, StringRef>> WasmImportModuleAndField;
 
   /// Has value if there's a profile for this function
@@ -1288,14 +1288,14 @@ public:
   StringRef wasmExportName() const { return WasmExportName; }
   void setWasmExportName(StringRef value) { WasmExportName = value; }
 
-  /// Return Wasm import module name if @extern(wasm) was used otherwise empty
+  /// Return Wasm import module name if @_extern(wasm) was used otherwise empty
   StringRef wasmImportModuleName() const {
     if (WasmImportModuleAndField)
       return WasmImportModuleAndField->first;
     return StringRef();
   }
 
-  /// Return Wasm import field name if @extern(wasm) was used otherwise empty
+  /// Return Wasm import field name if @_extern(wasm) was used otherwise empty
   StringRef wasmImportFieldName() const {
     if (WasmImportModuleAndField)
       return WasmImportModuleAndField->second;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1144,7 +1144,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DAK_Extern: {
     auto *Attr = cast<ExternAttr>(this);
-    Printer.printAttrName("@extern");
+    Printer.printAttrName("@_extern");
     Printer << "(";
     switch (Attr->getExternKind()) {
     case ExternKind::C:
@@ -1155,7 +1155,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
       break;
     case ExternKind::Wasm:
       Printer << "wasm";
-      // @extern(wasm) always has names.
+      // @_extern(wasm) always has names.
       Printer << ", module: \"" << *Attr->ModuleName << "\"";
       Printer << ", name: \"" << *Attr->Name << "\"";
       break;
@@ -1749,7 +1749,7 @@ StringRef DeclAttribute::getAttrName() const {
   case DAK_RawLayout:
     return "_rawLayout";
   case DAK_Extern:
-    return "extern";
+    return "_extern";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1436,7 +1436,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
                                   SourceLoc AtLoc, SourceLoc Loc) {
   SourceLoc lParenLoc = Tok.getLoc(), rParenLoc;
 
-  // Parse @extern(<language>, ...)
+  // Parse @_extern(<language>, ...)
   if (!consumeIf(tok::l_paren)) {
     diagnose(Loc, diag::attr_expected_lparen, AttrName,
              DeclAttribute::isDeclModifier(DAK_Extern));
@@ -1488,7 +1488,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
   auto kindTok = Tok;
   consumeToken(tok::identifier);
 
-  // Parse @extern(wasm, module: "x", name: "y") or @extern(c[, "x"])
+  // Parse @_extern(wasm, module: "x", name: "y") or @_extern(c[, "x"])
   ExternKind kind;
   llvm::Optional<StringRef> importModuleName, importName;
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1149,7 +1149,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
       }
 
     if (auto *ExternA = ExternAttr::find(getDecl()->getAttrs(), ExternKind::C)) {
-      assert(isa<FuncDecl>(getDecl()) && "non-FuncDecl with @extern should be rejected by typechecker");
+      assert(isa<FuncDecl>(getDecl()) && "non-FuncDecl with @_extern should be rejected by typechecker");
       return ExternA->getCName(cast<FuncDecl>(getDecl())).str();
     }
 

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -181,7 +181,7 @@ void SILFunctionBuilder::addFunctionAttributes(
   }
 
   if (auto *EA = ExternAttr::find(Attrs, ExternKind::Wasm)) {
-    // @extern(wasm) always has explicit names
+    // @_extern(wasm) always has explicit names
     F->setWasmImportModuleAndField(*EA->ModuleName, *EA->Name);
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2173,7 +2173,7 @@ void AttributeChecker::visitExternAttr(ExternAttr *attr) {
   }
 
   for (auto *otherAttr : D->getAttrs()) {
-    // @_cdecl cannot be mixed with @extern since @_cdecl is for definitions
+    // @_cdecl cannot be mixed with @_extern since @_cdecl is for definitions
     // @_silgen_name cannot be mixed to avoid SIL-level name ambiguity
     if (isa<CDeclAttr>(otherAttr) || isa<SILGenNameAttr>(otherAttr)) {
       diagnose(attr->getLocation(), diag::extern_only_non_other_attr,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3440,7 +3440,7 @@ public:
   /// Determine whether the given declaration should not have a definition.
   static bool requiresNoDefinition(Decl *decl) {
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      // Function with @extern should not have a body.
+      // Function with @_extern should not have a body.
       return func->getAttrs().hasAttribute<ExternAttr>();
     }
     // Everything else can have a definition.

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -109,7 +109,6 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD2-NEXT:             Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // KEYWORD2-NEXT:             Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // KEYWORD2-NEXT:             Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
-// KEYWORD2-NEXT:             Keyword/None:                       extern[#Func Attribute#]; name=extern
 // KEYWORD2-NOT:              Keyword
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -249,7 +248,6 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
 // ON_METHOD-DAG: Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // ON_METHOD-DAG: Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
-// ON_METHOD-DAG: Keyword/None:                       extern[#Func Attribute#]; name=extern
 // ON_METHOD-NOT: Keyword
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper

--- a/test/IRGen/extern_c.swift
+++ b/test/IRGen/extern_c.swift
@@ -15,10 +15,10 @@ func test() {
 test()
 
 // CHECK: declare void @explicit_extern_c()
-@extern(c, "explicit_extern_c") func explicit_extern_c()
+@_extern(c, "explicit_extern_c") func explicit_extern_c()
 
 // CHECK: declare void @implicit_extern_c()
-@extern(c) func implicit_extern_c()
+@_extern(c) func implicit_extern_c()
 
 // CHECK: declare void @default_arg_value(i32)
-@extern(c) func default_arg_value(_: Int32 = 42)
+@_extern(c) func default_arg_value(_: Int32 = 42)

--- a/test/IRGen/extern_c_abitypes.swift
+++ b/test/IRGen/extern_c_abitypes.swift
@@ -34,25 +34,25 @@ module c_abi_types {
 
 import c_abi_types
 
-@extern(c, "swift_roundtrip_void")
+@_extern(c, "swift_roundtrip_void")
 func swift_roundtrip_void()
-@extern(c, "swift_roundtrip_bool")
+@_extern(c, "swift_roundtrip_bool")
 func swift_roundtrip_bool(_: Bool) -> Bool
-@extern(c, "swift_roundtrip_char")
+@_extern(c, "swift_roundtrip_char")
 func swift_roundtrip_char(_: CChar) -> CChar
-@extern(c, "swift_roundtrip_int")
+@_extern(c, "swift_roundtrip_int")
 func swift_roundtrip_int(_: CInt) -> CInt
-@extern(c, "swift_roundtrip_float")
+@_extern(c, "swift_roundtrip_float")
 func swift_roundtrip_float(_: CFloat) -> CFloat
-@extern(c, "swift_roundtrip_double")
+@_extern(c, "swift_roundtrip_double")
 func swift_roundtrip_double(_: CDouble) -> CDouble
-@extern(c, "swift_roundtrip_opaque_ptr")
+@_extern(c, "swift_roundtrip_opaque_ptr")
 func swift_roundtrip_opaque_ptr(_: OpaquePointer!) -> OpaquePointer!
-@extern(c, "swift_roundtrip_void_star")
+@_extern(c, "swift_roundtrip_void_star")
 func swift_roundtrip_void_star(_: UnsafeMutableRawPointer!) -> UnsafeMutableRawPointer!
-@extern(c, "swift_roundtrip_c_struct")
+@_extern(c, "swift_roundtrip_c_struct")
 func swift_roundtrip_c_struct(_: c_struct) -> c_struct
-@extern(c, "swift_roundtrip_c_struct_ptr")
+@_extern(c, "swift_roundtrip_c_struct_ptr")
 func swift_roundtrip_c_struct_ptr(_: UnsafeMutablePointer<c_struct>!) -> UnsafeMutablePointer<c_struct>!
 
 func test() {

--- a/test/Interop/WebAssembly/extern-wasm-cdecls.swift
+++ b/test/Interop/WebAssembly/extern-wasm-cdecls.swift
@@ -2,23 +2,23 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-experimental-feature Extern -module-name Extern | %FileCheck %s
 
 // CHECK: declare void @import1() [[EA1:#[0-9]+]]
-@extern(c)
-@extern(wasm, module: "m0", name: "import1")
+@_extern(c)
+@_extern(wasm, module: "m0", name: "import1")
 func import1()
 
 // CHECK: declare i32 @import2WithReturnInt() [[EA2:#[0-9]+]]
-@extern(c)
-@extern(wasm, module: "m0", name: "import2")
+@_extern(c)
+@_extern(wasm, module: "m0", name: "import2")
 func import2WithReturnInt() -> Int32
 
 // CHECK: declare void @import3TakingInt(i32) [[EA3:#[0-9]+]]
-@extern(c)
-@extern(wasm, module: "m0", name: "import3")
+@_extern(c)
+@_extern(wasm, module: "m0", name: "import3")
 func import3TakingInt(_: Int32)
 
 // CHECK: declare void @c_import4() [[EA4:#[0-9]+]]
-@extern(c, "c_import4")
-@extern(wasm, module: "m0", name: "import4")
+@_extern(c, "c_import4")
+@_extern(wasm, module: "m0", name: "import4")
 func import4()
 
 func test() {

--- a/test/Interop/WebAssembly/extern-wasm-decls-to-swift.swift
+++ b/test/Interop/WebAssembly/extern-wasm-decls-to-swift.swift
@@ -2,15 +2,15 @@
 // RUN: %target-swift-frontend %s -enable-experimental-feature Extern -emit-ir -module-name Extern | %FileCheck %s
 
 // CHECK: declare {{.*}} void @"$s6Extern7import1yyF"() [[EA1:#[0-9]+]]
-@extern(wasm, module: "m0", name: "import1")
+@_extern(wasm, module: "m0", name: "import1")
 func import1()
 
 // CHECK: declare {{.*}} i32 @"$s6Extern20import2WithReturnInts5Int32VyF"() [[EA2:#[0-9]+]]
-@extern(wasm, module: "m0", name: "import2")
+@_extern(wasm, module: "m0", name: "import2")
 func import2WithReturnInt() -> Int32
 
 // CHECK: declare {{.*}} void @"$s6Extern16import3TakingIntyys5Int32VF"(i32) [[EA3:#[0-9]+]]
-@extern(wasm, module: "m0", name: "import3")
+@_extern(wasm, module: "m0", name: "import3")
 func import3TakingInt(_: Int32)
 
 func test() {

--- a/test/ModuleInterface/extern_attr.swift
+++ b/test/ModuleInterface/extern_attr.swift
@@ -5,16 +5,16 @@
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
 // CHECK:      #if compiler(>=5.3) && $Extern
-// CHECK-NEXT:   @extern(c) public func externalCFunc()
+// CHECK-NEXT:   @_extern(c) public func externalCFunc()
 // CHECK-NEXT: #endif
-@extern(c) public func externalCFunc()
+@_extern(c) public func externalCFunc()
 
 // CHECK:      #if compiler(>=5.3) && $Extern
-// CHECK-NEXT:   @extern(c, "renamedCFunc") public func externalRenamedCFunc()
+// CHECK-NEXT:   @_extern(c, "renamedCFunc") public func externalRenamedCFunc()
 // CHECK-NEXT: #endif
-@extern(c, "renamedCFunc") public func externalRenamedCFunc()
+@_extern(c, "renamedCFunc") public func externalRenamedCFunc()
 
 // CHECK:      #if compiler(>=5.3) && $Extern
-// CHECK-NEXT:   @extern(wasm, module: "m", name: "f") public func wasmImportedFunc()
+// CHECK-NEXT:   @_extern(wasm, module: "m", name: "f") public func wasmImportedFunc()
 // CHECK-NEXT: #endif
-@extern(wasm, module: "m", name: "f") public func wasmImportedFunc()
+@_extern(wasm, module: "m", name: "f") public func wasmImportedFunc()

--- a/test/SILGen/extern_c.swift
+++ b/test/SILGen/extern_c.swift
@@ -1,28 +1,28 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature Extern %s | %FileCheck %s
 
 // CHECK-DAG: sil hidden_external @my_c_name : $@convention(c) (Int) -> Int
-@extern(c, "my_c_name")
+@_extern(c, "my_c_name")
 func withCName(_ x: Int) -> Int
 
 // CHECK-DAG: sil hidden_external @take_c_func_ptr : $@convention(c) (@convention(c) (Int) -> Int) -> ()
-@extern(c, "take_c_func_ptr")
+@_extern(c, "take_c_func_ptr")
 func takeCFuncPtr(_ f: @convention(c) (Int) -> Int)
 
 // CHECK-DAG: sil @public_visible : $@convention(c) (Int) -> Int
-@extern(c, "public_visible")
+@_extern(c, "public_visible")
 public func publicVisibility(_ x: Int) -> Int
 
 // CHECK-DAG: sil @private_visible : $@convention(c) (Int) -> Int
-@extern(c, "private_visible")
+@_extern(c, "private_visible")
 private func privateVisiblity(_ x: Int) -> Int
 
 // CHECK-DAG: sil hidden_external @withoutCName : $@convention(c) () -> Int
-@extern(c)
+@_extern(c)
 func withoutCName() -> Int
 
 // CHECK-DAG: sil hidden [ossa] @$s8extern_c10defaultArgyySiFfA_ : $@convention(thin) () -> Int {
 // CHECK-DAG: sil hidden_external @default_arg : $@convention(c) (Int) -> ()
-@extern(c, "default_arg")
+@_extern(c, "default_arg")
 func defaultArg(_ x: Int = 42)
 
 func main() {

--- a/test/Serialization/attr-extern.swift
+++ b/test/Serialization/attr-extern.swift
@@ -5,6 +5,6 @@
 
 // BC-CHECK: <Extern_DECL_ATTR
 
-// MODULE-CHECK: @extern(wasm, module: "m0", name: "import1") func import1()
-@extern(wasm, module: "m0", name: "import1")
+// MODULE-CHECK: @_extern(wasm, module: "m0", name: "import1") func import1()
+@_extern(wasm, module: "m0", name: "import1")
 func import1()

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -1,152 +1,152 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -disable-availability-checking
 
-@extern(wasm, module: "m1", name: "f1")
+@_extern(wasm, module: "m1", name: "f1")
 func f1(x: Int) -> Int
 
-@extern(wasm, module: "m2", name: ) // expected-error  {{expected string literal in 'extern' attribute}}
+@_extern(wasm, module: "m2", name: ) // expected-error  {{expected string literal in '_extern' attribute}}
 func f2ErrorOnMissingNameLiteral(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@extern(wasm, module: "m3", name) // expected-error  {{expected ':' after label 'name'}}
+@_extern(wasm, module: "m3", name) // expected-error  {{expected ':' after label 'name'}}
 func f3ErrorOnMissingNameColon(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@extern(wasm, module: "m4",) // expected-error  {{expected name argument to @extern attribute}}
+@_extern(wasm, module: "m4",) // expected-error  {{expected name argument to @_extern attribute}}
 func f4ErrorOnMissingNameLabel(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@extern(wasm, module: "m5") // expected-error {{expected ',' in 'extern' attribute}}
+@_extern(wasm, module: "m5") // expected-error {{expected ',' in '_extern' attribute}}
 func f5ErrorOnMissingName(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@extern(wasm, module: ) // expected-error {{expected string literal in 'extern' attribute}} expected-error {{expected ',' in 'extern' attribute}}
+@_extern(wasm, module: ) // expected-error {{expected string literal in '_extern' attribute}} expected-error {{expected ',' in '_extern' attribute}}
 func f6ErrorOnMissingModuleLiteral(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@extern(wasm, module) // expected-error {{expected ':' after label 'module'}} expected-error {{expected ',' in 'extern' attribute}}
+@_extern(wasm, module) // expected-error {{expected ':' after label 'module'}} expected-error {{expected ',' in '_extern' attribute}}
 func f7ErrorOnMissingModuleColon(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@extern(wasm,) // expected-error {{expected module argument to @extern attribute}} expected-error {{expected ',' in 'extern' attribute}}
+@_extern(wasm,) // expected-error {{expected module argument to @_extern attribute}} expected-error {{expected ',' in '_extern' attribute}}
 func f8ErrorOnMissingModuleLabel(x: Int) -> Int // expected-error{{expected '{' in body of function declaration}}
 
-@extern(wasm, module: "m9", name: "f9")
+@_extern(wasm, module: "m9", name: "f9")
 func f9WithBody() {} // expected-error {{unexpected body of function declaration}}
 
 struct S {
-    @extern(wasm, module: "m10", name: "f10") // expected-error {{@extern attribute can only be applied to global functions}}
+    @_extern(wasm, module: "m10", name: "f10") // expected-error {{@_extern attribute can only be applied to global functions}}
     func f10Member()
 }
 
 func f11Scope() {
-    @extern(wasm, module: "m11", name: "f11")
+    @_extern(wasm, module: "m11", name: "f11")
     func f11Inner()
 }
 
-@extern(invalid, module: "m12", name: "f12") // expected-error {{expected 'extern' option such as 'c'}}
+@_extern(invalid, module: "m12", name: "f12") // expected-error {{expected '_extern' option such as 'c'}}
 func f12InvalidLang() // expected-error {{expected '{' in body of function declaration}}
 
-@extern(c, "valid")
+@_extern(c, "valid")
 func externCValid()
 
-@extern(c, "_start_with_underscore")
+@_extern(c, "_start_with_underscore")
 func underscoredValid()
 
-@extern(c, "") // expected-error {{expected non-empty C name in @extern attribute}}
+@_extern(c, "") // expected-error {{expected non-empty C name in @_extern attribute}}
 func emptyCName()
 
 // Allow specifying any identifier explicitly
-@extern(c, "0start_with_digit")
+@_extern(c, "0start_with_digit")
 func explicitDigitPrefixed()
 
-@extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @extern(c) to suppress this warning}}
+@_extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
 func +(a: Int, b: Bool) -> Bool
 
-@extern(c) // expected-warning {{C name '🥸_implicitInvalid' may be invalid; explicitly specify the name in @extern(c) to suppress this warning}}
+@_extern(c) // expected-warning {{C name '🥸_implicitInvalid' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
 func 🥸_implicitInvalid()
 
-@extern(c)
+@_extern(c)
 func omitCName()
 
-@extern(c, ) // expected-error {{expected string literal in 'extern' attribute}}
+@_extern(c, ) // expected-error {{expected string literal in '_extern' attribute}}
 func editingCName() // expected-error {{expected '{' in body of function declaration}}
 
 struct StructScopeC {
-    @extern(c, "member_decl") // expected-error {{@extern attribute can only be applied to global functions}}
+    @_extern(c, "member_decl") // expected-error {{@_extern attribute can only be applied to global functions}}
     func memberDecl()
 
-    @extern(c, "static_member_decl")
+    @_extern(c, "static_member_decl")
     static func staticMemberDecl()
 }
 
 func funcScopeC() {
-    @extern(c, "func_scope_inner")
+    @_extern(c, "func_scope_inner")
     func inner()
 }
 
-@extern(c, "c_value") // expected-error {{@extern may only be used on 'func' declarations}}
+@_extern(c, "c_value") // expected-error {{@_extern may only be used on 'func' declarations}}
 var nonFunc: Int = 0
 
-@extern(c, "with_body")
+@_extern(c, "with_body")
 func withInvalidBody() {} // expected-error {{unexpected body of function declaration}}
 
-@extern(c, "duplicate_attr_c_1")
-@extern(c, "duplicate_attr_c_2") // expected-error {{duplicate attribute}}
+@_extern(c, "duplicate_attr_c_1")
+@_extern(c, "duplicate_attr_c_2") // expected-error {{duplicate attribute}}
 func duplicateAttrsC()
 
-@extern(wasm, module: "dup", name: "duplicate_attr_wasm_1")
-@extern(wasm, module: "dup", name: "duplicate_attr_wasm_2") // expected-error {{duplicate attribute}}
+@_extern(wasm, module: "dup", name: "duplicate_attr_wasm_1")
+@_extern(wasm, module: "dup", name: "duplicate_attr_wasm_2") // expected-error {{duplicate attribute}}
 func duplicateAttrsWasm()
 
-@extern(c, "mixed_attr_c")
-@extern(wasm, module: "mixed", name: "mixed_attr_wasm")
+@_extern(c, "mixed_attr_c")
+@_extern(wasm, module: "mixed", name: "mixed_attr_wasm")
 func mixedAttrs_C_Wasm()
 
 class NonC {}
-@extern(c)
+@_extern(c)
 func nonCReturnTypes() -> NonC // expected-error {{'NonC' cannot be represented in C}}
-// @extern(wasm) have no interface limitation
-@extern(wasm, module: "non-c", name: "return_wasm")
+// @_extern(wasm) have no interface limitation
+@_extern(wasm, module: "non-c", name: "return_wasm")
 func nonCReturnTypesWasm() -> NonC
-@extern(c)
-@extern(wasm, module: "non-c", name: "return_mixed")
+@_extern(c)
+@_extern(wasm, module: "non-c", name: "return_mixed")
 func nonCReturnTypesMixed() -> NonC // expected-error {{'NonC' cannot be represented in C}}
 
-@extern(c)
+@_extern(c)
 func nonCParamTypes(_: Int, _: NonC) // expected-error {{'NonC' cannot be represented in C}}
-@extern(wasm, module: "non-c", name: "param_wasm")
+@_extern(wasm, module: "non-c", name: "param_wasm")
 func nonCParamTypesWasm(_: Int, _: NonC)
 
-@extern(c)
-@extern(wasm, module: "non-c", name: "param_mixed")
+@_extern(c)
+@_extern(wasm, module: "non-c", name: "param_mixed")
 func nonCParamTypesMixed(_: Int, _: NonC) // expected-error {{'NonC' cannot be represented in C}}
 
-@extern(c)
+@_extern(c)
 func defaultArgValue_C(_: Int = 42)
 
-@extern(wasm, module: "", name: "")
+@_extern(wasm, module: "", name: "")
 func defaultArgValue_Wasm(_: Int = 24)
 
-@extern(c)
+@_extern(c)
 func asyncFuncC() async // expected-error {{async functions cannot be represented in C}}
 
-@extern(c)
+@_extern(c)
 func throwsFuncC() throws // expected-error {{raising errors from C functions is not supported}}
 
-@extern(c)
+@_extern(c)
 func genericFuncC<T>(_: T) // expected-error {{'T' cannot be represented in C}}
 
-@extern(c) // expected-error {{@extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_C()
 
-@extern(wasm, module: "", name: "") // expected-error {{@extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_Wasm()
 
-@extern(c) // expected-error {{@extern attribute cannot be applied to an '@_silgen_name' declaration}}
+@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}}
 @_silgen_name("another_sil_name")
 func withAtSILGenName_C()
 
-@extern(wasm, module: "", name: "") // expected-error {{@extern attribute cannot be applied to an '@_silgen_name' declaration}}
+@_extern(wasm, module: "", name: "") // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}}
 @_silgen_name("another_sil_name")
 func withAtSILGenName_Wasm()
 
-@extern(c) // expected-error {{@extern attribute cannot be applied to an '@_silgen_name' declaration}} expected-error {{@extern attribute cannot be applied to an '@_cdecl' declaration}}
+@_extern(c) // expected-error {{@_extern attribute cannot be applied to an '@_silgen_name' declaration}} expected-error {{@_extern attribute cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 @_silgen_name("another_sil_name")
 func withAtSILGenName_CDecl_C()

--- a/test/attr/attr_extern_fixit.swift
+++ b/test/attr/attr_extern_fixit.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
 // RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
-@extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @extern(c) to suppress this warning}}
+@_extern(c) // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
 func +(a: Int, b: Bool) -> Bool

--- a/test/attr/attr_extern_fixit.swift.result
+++ b/test/attr/attr_extern_fixit.swift.result
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -emit-fixits-path %t.remap -fixit-all -diagnostics-editor-mode
 // RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
-@extern(c, "+") // expected-warning {{C name '+' may be invalid; explicitly specify the name in @extern(c) to suppress this warning}}
+@_extern(c, "+") // expected-warning {{C name '+' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning}}
 func +(a: Int, b: Bool) -> Bool

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -24,7 +24,7 @@ import SwiftShims
 #error("Unsupported platform")
 #endif
 
-@extern(c, "swift_demangle")
+@_extern(c, "swift_demangle")
 func _stdlib_demangleImpl(
   mangledName: UnsafePointer<CChar>?,
   mangledNameLength: UInt,


### PR DESCRIPTION
It's already guarded by a feature flag, but it would be nice to signal users that it's not stable yet by adding an underscore prefix.

This change is suggested by @lorentey 