### PR TITLE
Clarify the error we emit when we see an unexpected null pointer

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -126,9 +126,9 @@ static HeapObject * getNonNullSrcObject(OpaqueValue *srcValue,
 
   std::string srcTypeName = nameForMetadata(srcType);
   std::string destTypeName = nameForMetadata(destType);
-  const char * const msg = "Found unexpected null pointer value"
-                    " while trying to cast value of type '%s' (%p)"
-                    " to '%s' (%p)%s\n";
+  const char * const msg = "Non-Optional value of type '%s' (%p)"
+                    " holds a null pointer?!"
+                    " (Detected while casting to '%s' (%p))%s\n";
   if (runtime::bincompat::useLegacyPermissiveObjCNullSemanticsInCasting()) {
     // In backwards compatibility mode, this code will warn and return the null
     // reference anyway: If you examine the calls to the function, you'll see

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -126,8 +126,8 @@ static HeapObject * getNonNullSrcObject(OpaqueValue *srcValue,
 
   std::string srcTypeName = nameForMetadata(srcType);
   std::string destTypeName = nameForMetadata(destType);
-  const char * const msg = "Non-Optional value of type '%s' (%p)"
-                    " holds a null pointer?!"
+  const char * const msg = "Found a null pointer in a value of type '%s' (%p)."
+                    " Non-Optional values are not allowed to hold null pointers."
                     " (Detected while casting to '%s' (%p))%s\n";
   if (runtime::bincompat::useLegacyPermissiveObjCNullSemanticsInCasting()) {
     // In backwards compatibility mode, this code will warn and return the null

--- a/test/Casting/CastTraps.swift.gyb
+++ b/test/Casting/CastTraps.swift.gyb
@@ -107,9 +107,10 @@ CastTrapsTestSuite.test("${t1}__${t2}")
 protocol P2 {}
 if #available(SwiftStdlib 5.5, *) {
 CastTrapsTestSuite.test("Unexpected null")
-  .crashOutputMatches("Found unexpected null pointer value while trying to cast value of type '")
+  .crashOutputMatches("Non-Optional value of type '")
   .crashOutputMatches("Foo'")
-  .crashOutputMatches(" to '")
+  .crashOutputMatches("holds a null pointer")
+  .crashOutputMatches("(Detected while casting to '")
   .crashOutputMatches("P2'")
   .code
 {
@@ -127,9 +128,9 @@ CastTrapsTestSuite.test("Unexpected null")
 #if _runtime(_ObjC)
 if #available(SwiftStdlib 5.5, *) {
 CastTrapsTestSuite.test("Unexpected Obj-C null")
-  .crashOutputMatches("Found unexpected null pointer value while trying to cast value of type '")
-  .crashOutputMatches("NSObject'")
-  .crashOutputMatches(" to '")
+  .crashOutputMatches("Non-Optional value of type 'NSObject'")
+  .crashOutputMatches("holds a null pointer")
+  .crashOutputMatches("(Detected while casting to '")
   .crashOutputMatches("P2'")
   .code
 {

--- a/test/Casting/CastTraps.swift.gyb
+++ b/test/Casting/CastTraps.swift.gyb
@@ -107,9 +107,8 @@ CastTrapsTestSuite.test("${t1}__${t2}")
 protocol P2 {}
 if #available(SwiftStdlib 5.5, *) {
 CastTrapsTestSuite.test("Unexpected null")
-  .crashOutputMatches("Non-Optional value of type '")
+  .crashOutputMatches("Found a null pointer in a value of type '")
   .crashOutputMatches("Foo'")
-  .crashOutputMatches("holds a null pointer")
   .crashOutputMatches("(Detected while casting to '")
   .crashOutputMatches("P2'")
   .code
@@ -128,8 +127,7 @@ CastTrapsTestSuite.test("Unexpected null")
 #if _runtime(_ObjC)
 if #available(SwiftStdlib 5.5, *) {
 CastTrapsTestSuite.test("Unexpected Obj-C null")
-  .crashOutputMatches("Non-Optional value of type 'NSObject'")
-  .crashOutputMatches("holds a null pointer")
+  .crashOutputMatches("Found a null pointer in a value of type 'NSObject'")
   .crashOutputMatches("(Detected while casting to '")
   .crashOutputMatches("P2'")
   .code


### PR DESCRIPTION
Informal discussion suggests that the original wording wasn't obvious to everyone.  Hopefully, this is clearer.

**Old message**: "Found unexpected null pointer value while trying to cast value of type '%s' to '%s'"

It seems folks didn't connect "null pointer" to "non-Optional value that came from Obj-C" and tended to focus on the destination type.

**New message**: "Non-Optional value of type '%s' holds a null pointer?!  (Detected while casting to '%s')"

This de-emphasizes the target type of the cast and more clearly explains the actual problem.