### PR TITLE
[region-isolation] When assigning RValues into memory, use tuple_addr_constructor instead of doing it in pieces.

### DIFF
--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -199,7 +199,8 @@ TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) && {
         isa<UncheckedRefCastAddrInst>(user) || isa<KeyPathInst>(user) ||
         isa<RetainValueAddrInst>(user) || isa<ReleaseValueAddrInst>(user) ||
         isa<PackElementSetInst>(user) || isa<PackElementGetInst>(user) ||
-        isa<DeinitExistentialAddrInst>(user) || isa<LoadBorrowInst>(user)) {
+        isa<DeinitExistentialAddrInst>(user) || isa<LoadBorrowInst>(user) ||
+        isa<TupleAddrConstructorInst>(user)) {
       callVisitUse(op);
       continue;
     }

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -205,6 +205,23 @@ private:
 /// polymorphic builtin or does not have any available overload for these types,
 /// return SILValue().
 SILValue getStaticOverloadForSpecializedPolymorphicBuiltin(BuiltinInst *bi);
+
+/// Visit the exploded leaf elements of a tuple type that contains potentially
+/// a tree of tuples.
+///
+/// If visitor returns false, we stop processing early. We return true if we
+/// visited all of the tuple elements without the visitor returing false.
+bool visitExplodedTupleType(SILType type,
+                            llvm::function_ref<bool(SILType)> callback);
+
+/// Visit the exploded leaf elements of a tuple type that contains potentially
+/// a tree of tuples.
+///
+/// If visitor returns false, we stop processing early. We return true if we
+/// visited all of the tuple elements without the visitor returing false.
+bool visitExplodedTupleValue(SILValue value,
+                             llvm::function_ref<SILValue(SILValue, std::optional<unsigned>)> callback);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1644,6 +1644,15 @@ public:
 
   TupleInst *createTuple(SILLocation loc, ArrayRef<SILValue> elts);
 
+  TupleAddrConstructorInst *
+  createTupleAddrConstructor(SILLocation Loc, SILValue DestAddr,
+                             ArrayRef<SILValue> Elements,
+                             IsInitialization_t IsInitOfDest) {
+    return insert(TupleAddrConstructorInst::create(getSILDebugLocation(Loc),
+                                                   DestAddr, Elements,
+                                                   IsInitOfDest, getModule()));
+  }
+
   EnumInst *createEnum(SILLocation Loc, SILValue Operand,
                        EnumElementDecl *Element, SILType Ty) {
     return createEnum(Loc, Operand, Element, Ty,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2181,6 +2181,17 @@ SILCloner<ImplClass>::visitTupleInst(TupleInst *Inst) {
                                    : ValueOwnershipKind(OwnershipKind::None)));
 }
 
+template <typename ImplClass>
+void SILCloner<ImplClass>::visitTupleAddrConstructorInst(
+    TupleAddrConstructorInst *Inst) {
+  auto Elements = getOpValueArray<8>(Inst->getElements());
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  recordClonedInstruction(Inst, getBuilder().createTupleAddrConstructor(
+                                    getOpLocation(Inst->getLoc()),
+                                    getOpValue(Inst->getDestValue()), Elements,
+                                    Inst->isInitializationOfDest()));
+}
+
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitEnumInst(EnumInst *Inst) {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6396,6 +6396,8 @@ public:
     return operand->getOperandNumber() + 1;
   }
 
+  unsigned getNumElements() const { return getTupleType()->getNumElements(); }
+
   TupleType *getTupleType() const {
     return getDest().get()->getType().getRawASTType()->castTo<TupleType>();
   }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6372,10 +6372,10 @@ public:
     Dest = 0,
   };
 
-  Operand &getDest() { return getAllOperands().front(); }
-  const Operand &getDest() const { return getAllOperands().front(); }
+  Operand &getDestOperand() { return getAllOperands().front(); }
+  const Operand &getDestOperand() const { return getAllOperands().front(); }
 
-  SILValue getDestValue() const { return getDest().get(); }
+  SILValue getDest() const { return getDestOperand().get(); }
 
   /// The elements referenced by this TupleInst.
   MutableArrayRef<Operand> getElementOperands() {
@@ -6392,14 +6392,16 @@ public:
 
   unsigned getElementIndex(Operand *operand) {
     assert(operand->getUser() == this);
-    assert(operand != &getDest() && "Cannot pass in the destination");
+    assert(operand != &getDestOperand() && "Cannot pass in the destination");
     return operand->getOperandNumber() + 1;
   }
 
   unsigned getNumElements() const { return getTupleType()->getNumElements(); }
 
   TupleType *getTupleType() const {
-    return getDest().get()->getType().getRawASTType()->castTo<TupleType>();
+    // We use getASTType() since we want to look through a wrapped noncopyable
+    // type to get to the underlying tuple type.
+    return getDest()->getType().getASTType()->castTo<TupleType>();
   }
 
   IsInitialization_t isInitializationOfDest() const {

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -251,6 +251,9 @@ protected:
       isTakeOfSrc : 1,
       isInitializationOfDest : 1);
 
+    SHARED_FIELD(TupleAddrConstructorInst, uint8_t
+      isInitializationOfDest : 1);
+
     SHARED_FIELD(PointerToAddressInst, uint8_t
       isStrict : 1,
       isInvariant : 1);

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -848,6 +848,8 @@ NON_VALUE_INST(CopyAddrInst, copy_addr,
                SILInstruction, MayHaveSideEffects, MayRelease)
 NON_VALUE_INST(ExplicitCopyAddrInst, explicit_copy_addr,
                SILInstruction, MayHaveSideEffects, MayRelease)
+NON_VALUE_INST(TupleAddrConstructorInst, tuple_addr_constructor,
+               SILInstruction, MayHaveSideEffects, MayRelease)
 NON_VALUE_INST(DestroyAddrInst, destroy_addr,
                SILInstruction, MayHaveSideEffects, MayRelease)
 NON_VALUE_INST(EndLifetimeInst, end_lifetime,

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -369,6 +369,8 @@ PASS(IRGenPrepare, "irgen-prepare",
      "Cleanup SIL in preparation for IRGen")
 PASS(TransferNonSendable, "transfer-non-sendable",
      "Checks calls that send non-sendable values between isolation domains")
+PASS(LowerTupleAddrConstructor, "lower-tuple-addr-constructor",
+     "Lower tuple addr constructor to tuple_element_addr+copy_addr")
 PASS(SILGenCleanup, "silgen-cleanup",
      "Cleanup SIL in preparation for diagnostics")
 PASS(SILCombine, "sil-combine",

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1417,6 +1417,9 @@ public:
   void visitMarkUnresolvedMoveAddrInst(MarkUnresolvedMoveAddrInst *mai) {
     llvm_unreachable("Valid only when ownership is enabled");
   }
+  void visitTupleAddrConstructorInst(TupleAddrConstructorInst *i) {
+    llvm_unreachable("Valid only in raw SIL");
+  }
   void visitDestroyAddrInst(DestroyAddrInst *i);
 
   void visitBindMemoryInst(BindMemoryInst *i);

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -676,6 +676,15 @@ OperandOwnership OperandOwnershipClassifier::visitKeyPathInst(KeyPathInst *I) {
   return OperandOwnership::ForwardingConsume;
 }
 
+OperandOwnership OperandOwnershipClassifier::visitTupleAddrConstructorInst(
+    TupleAddrConstructorInst *inst) {
+  // If we have an object, then we have an instantaneous use...
+  if (getValue()->getType().isObject())
+    return OperandOwnership::DestroyingConsume;
+  // Otherwise, we have a trivial use since we have an address.
+  return OperandOwnership::TrivialUse;
+}
+
 //===----------------------------------------------------------------------===//
 //                            Builtin Use Checker
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1460,6 +1460,18 @@ TupleInst *TupleInst::create(SILDebugLocation Loc, SILType Ty,
   return ::new (Buffer) TupleInst(Loc, Ty, Elements, forwardingOwnershipKind);
 }
 
+TupleAddrConstructorInst *TupleAddrConstructorInst::create(
+    SILDebugLocation Loc, SILValue DestAddr, ArrayRef<SILValue> Elements,
+    IsInitialization_t IsInitOfDest, SILModule &M) {
+  assert(DestAddr->getType().isAddress());
+  auto Size = totalSizeToAlloc<swift::Operand>(Elements.size() + 1);
+  auto Buffer = M.allocateInst(Size, alignof(TupleAddrConstructorInst));
+  llvm::SmallVector<SILValue, 16> Data;
+  Data.push_back(DestAddr);
+  copy(Elements, std::back_inserter(Data));
+  return ::new (Buffer) TupleAddrConstructorInst(Loc, Data, IsInitOfDest);
+}
+
 bool TupleExtractInst::isTrivialEltOfOneRCIDTuple() const {
   auto *F = getFunction();
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2215,7 +2215,25 @@ public:
       *this << ')';
     }
   }
-  
+
+  void visitTupleAddrConstructorInst(TupleAddrConstructorInst *TI) {
+    // First print out our dest.
+    if (TI->isInitializationOfDest()) {
+      *this << "[init] ";
+    } else {
+      *this << "[assign] ";
+    }
+    *this << getIDAndType(TI->getDestValue());
+
+    *this << " with (";
+
+    llvm::interleave(
+        TI->getElements(), [&](const SILValue &V) { *this << getIDAndType(V); },
+        [&] { *this << ", "; });
+
+    *this << ')';
+  }
+
   void visitEnumInst(EnumInst *UI) {
     *this << UI->getType() << ", "
           << SILDeclRef(UI->getElement(), SILDeclRef::Kind::EnumElement);

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2223,7 +2223,7 @@ public:
     } else {
       *this << "[assign] ";
     }
-    *this << getIDAndType(TI->getDestValue());
+    *this << getIDAndType(TI->getDest());
 
     *this << " with (";
 

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -750,7 +750,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
   }
   case SILInstructionKind::TupleAddrConstructorInst: {
     auto *ca = cast<TupleAddrConstructorInst>(inst);
-    impactType = ca->getDestValue()->getType();
+    impactType = ca->getDest()->getType();
     if (!ca->isInitializationOfDest())
       return RuntimeEffect::MetaData | RuntimeEffect::Releasing;
     return RuntimeEffect::MetaData;

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -748,6 +748,13 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
       return RuntimeEffect::MetaData | RuntimeEffect::RefCounting;
     return RuntimeEffect::MetaData;
   }
+  case SILInstructionKind::TupleAddrConstructorInst: {
+    auto *ca = cast<TupleAddrConstructorInst>(inst);
+    impactType = ca->getDestValue()->getType();
+    if (!ca->isInitializationOfDest())
+      return RuntimeEffect::MetaData | RuntimeEffect::Releasing;
+    return RuntimeEffect::MetaData;
+  }
   case SILInstructionKind::ExplicitCopyAddrInst: {
     auto *ca = cast<ExplicitCopyAddrInst>(inst);
     impactType = ca->getSrc()->getType();
@@ -1289,4 +1296,43 @@ swift::getStaticOverloadForSpecializedPolymorphicBuiltin(BuiltinInst *bi) {
   }
 
   return newBI;
+}
+
+//===----------------------------------------------------------------------===//
+//                          Exploded Tuple Visitors
+//===----------------------------------------------------------------------===//
+
+bool swift::visitExplodedTupleType(SILType inputType,
+                                   llvm::function_ref<bool(SILType)> callback) {
+  auto tupType = inputType.getAs<TupleType>();
+  if (!tupType || tupType.containsPackExpansionType()) {
+    return callback(inputType);
+  }
+
+  for (auto elt : tupType->getElementTypes()) {
+    auto eltSILTy = SILType::getPrimitiveType(elt->getCanonicalType(),
+                                              inputType.getCategory());
+    if (!visitExplodedTupleType(eltSILTy, callback))
+      return false;
+  }
+
+  return true;
+}
+
+bool swift::visitExplodedTupleValue(
+    SILValue inputValue,
+    llvm::function_ref<SILValue(SILValue, std::optional<unsigned>)> callback) {
+  SILType inputType = inputValue->getType();
+  auto tupType = inputType.getAs<TupleType>();
+  if (!tupType || tupType.containsPackExpansionType()) {
+    return callback(inputValue, {});
+  }
+
+  for (auto eltIndex : range(tupType->getNumElements())) {
+    auto elt = callback(inputValue, eltIndex);
+    if (!visitExplodedTupleValue(elt, callback))
+      return false;
+  }
+
+  return true;
 }

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -411,6 +411,15 @@ void MemoryLifetimeVerifier::initDataflowInBlock(SILBasicBlock *block,
         }
         break;
       }
+      case SILInstructionKind::TupleAddrConstructorInst: {
+        auto *taci = cast<TupleAddrConstructorInst>(&I);
+        for (SILValue elt : taci->getElements()) {
+          if (elt->getType().isAddress())
+            killBits(state, elt);
+        }
+        genBits(state, taci->getDestValue());
+        break;
+      }
       case SILInstructionKind::DestroyAddrInst:
       case SILInstructionKind::DeallocStackInst:
         killBits(state, I.getOperand(0));

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -417,7 +417,7 @@ void MemoryLifetimeVerifier::initDataflowInBlock(SILBasicBlock *block,
           if (elt->getType().isAddress())
             killBits(state, elt);
         }
-        genBits(state, taci->getDestValue());
+        genBits(state, taci->getDest());
         break;
       }
       case SILInstructionKind::DestroyAddrInst:

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3290,6 +3290,22 @@ public:
     }
   }
 
+  void checkTupleAddrConstructorInst(TupleAddrConstructorInst *taci) {
+    require(taci->getNumElements() > 0,
+            "Cannot be applied to tuples that do not contain any real "
+            "elements. E.x.: ((), ())");
+    for (auto elt : taci->getElements()) {
+      // We cannot have any elements that contain only tuple elements. This is
+      // due to our exploded representation. This means when specializing,
+      // cloners must eliminate these parameters.
+      bool hasNonTuple = false;
+      elt->getType().getASTType().visit([&](CanType ty) {
+        hasNonTuple |= !ty->is<TupleType>();
+      });
+      require(hasNonTuple, "Element only consists of tuples");
+    }
+  }
+
   // Is a SIL type a potential lowering of a formal type?
   bool isLoweringOf(SILType loweredType, CanType formalType) {
     return loweredType.isLoweringOf(F.getTypeExpansionContext(), F.getModule(),

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -505,6 +505,19 @@ public:
   void createEndLifetime(SILLocation loc, ManagedValue selfValue) {
     createEndLifetime(loc, selfValue.forward(SGF));
   }
+
+  using SILBuilder::createTupleAddrConstructor;
+
+  void createTupleAddrConstructor(SILLocation loc, SILValue destAddr,
+                                  ArrayRef<ManagedValue> elements,
+                                  IsInitialization_t isInitOfDest) {
+    SmallVector<SILValue, 8> values;
+    for (auto mv : elements) {
+      values.push_back(mv.forward(SGF));
+    }
+
+    createTupleAddrConstructor(loc, destAddr, values, isInitOfDest);
+  }
 };
 
 } // namespace Lowering

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(swiftSILOptimizer PRIVATE
   RawSILInstLowering.cpp
   ReferenceBindingTransform.cpp
   TransferNonSendable.cpp
+  LowerTupleAddrConstructor.cpp
   SILGenCleanup.cpp
   YieldOnceCheck.cpp
   OSLogOptimization.cpp

--- a/lib/SILOptimizer/Mandatory/LowerTupleAddrConstructor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerTupleAddrConstructor.cpp
@@ -1,0 +1,78 @@
+//===--- LowerTupleAddrConstructor.cpp ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                         MARK: Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class LowerTupleAddrConstructorTransform : public SILFunctionTransform {
+  void run() override {
+    SILFunction *function = getFunction();
+
+    // Once we have finished, lower all tuple_addr_constructor that we see.
+    bool deletedInst = false;
+    for (auto &block : *function) {
+      for (auto ii = block.begin(), ie = block.end(); ii != ie;) {
+        auto *inst = dyn_cast<TupleAddrConstructorInst>(&*ii);
+        ++ii;
+
+        if (!inst)
+          continue;
+
+        SILBuilderWithScope builder(inst);
+
+        unsigned count = 0;
+        visitExplodedTupleValue(
+            inst->getDestValue(),
+            [&](SILValue value, std::optional<unsigned> index) -> SILValue {
+              if (!index) {
+                SILValue elt = inst->getElement(count);
+                if (elt->getType().isAddress()) {
+                  builder.createCopyAddr(inst->getLoc(), elt, value, IsTake,
+                                         inst->isInitializationOfDest());
+                } else {
+                  builder.emitStoreValueOperation(
+                      inst->getLoc(), elt, value,
+                      bool(inst->isInitializationOfDest())
+                          ? StoreOwnershipQualifier::Init
+                          : StoreOwnershipQualifier::Assign);
+                }
+                ++count;
+                return value;
+              }
+              auto *teai =
+                  builder.createTupleElementAddr(inst->getLoc(), value, *index);
+              return teai;
+            });
+        inst->eraseFromParent();
+        deletedInst = true;
+      }
+    }
+
+    if (deletedInst)
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createLowerTupleAddrConstructor() {
+  return new LowerTupleAddrConstructorTransform();
+}

--- a/lib/SILOptimizer/Mandatory/LowerTupleAddrConstructor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerTupleAddrConstructor.cpp
@@ -40,7 +40,7 @@ class LowerTupleAddrConstructorTransform : public SILFunctionTransform {
 
         unsigned count = 0;
         visitExplodedTupleValue(
-            inst->getDestValue(),
+            inst->getDest(),
             [&](SILValue value, std::optional<unsigned> index) -> SILValue {
               if (!index) {
                 SILValue elt = inst->getElement(count);

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -21,6 +21,7 @@
 #include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -860,9 +860,14 @@ public:
            "srcID and dstID are different?!");
   }
 
-  void translateSILAssign(SILValue dest, SILValue src) {
-    return translateSILMultiAssign(TinyPtrVector<SILValue>(dest),
-                                   TinyPtrVector<SILValue>(src));
+  template <typename Collection>
+  void translateSILAssign(SILValue dest, Collection collection) {
+    return translateSILMultiAssign(TinyPtrVector<SILValue>(dest), collection);
+  }
+
+  template <>
+  void translateSILAssign<SILValue>(SILValue dest, SILValue src) {
+    return translateSILAssign(dest, TinyPtrVector<SILValue>(src));
   }
 
   void translateSILAssign(SILInstruction *inst) {
@@ -877,13 +882,22 @@ public:
                                    TinyPtrVector<SILValue>());
   }
 
-  void translateSILMerge(SILValue dest, SILValue src) {
+  template <typename Collection>
+  void translateSILMerge(SILValue dest, Collection collection) {
     auto trackableDest = tryToTrackValue(dest);
-    auto trackableSrc = tryToTrackValue(src);
-    if (!trackableDest || !trackableSrc)
+    if (!trackableDest)
       return;
-    builder.addMerge(trackableDest->getRepresentative(),
-                     trackableSrc->getRepresentative());
+    for (SILValue elt : collection) {
+      if (auto trackableSrc = tryToTrackValue(elt)) {
+        builder.addMerge(trackableDest->getRepresentative(),
+                         trackableSrc->getRepresentative());
+      }
+    }
+  }
+
+  template <>
+  void translateSILMerge<SILValue>(SILValue dest, SILValue src) {
+    return translateSILMerge(dest, TinyPtrVector<SILValue>(src));
   }
 
   /// If tgt is known to be unaliased (computed thropugh a combination of
@@ -909,6 +923,30 @@ public:
 
       // Stores to possibly aliased storage must be treated as merges.
       return translateSILMerge(dest, src);
+    }
+
+    // Stores to storage of non-Sendable type can be ignored.
+  }
+
+  void translateSILTupleAddrConstructor(TupleAddrConstructorInst *inst) {
+    SILValue dest = inst->getDest();
+    if (auto nonSendableTgt = tryToTrackValue(dest)) {
+      // In the following situations, we can perform an assign:
+      //
+      // 1. A store to unaliased storage.
+      // 2. A store that is to an entire value.
+      //
+      // DISCUSSION: If we have case 2, we need to merge the regions since we
+      // are not overwriting the entire region of the value. This does mean that
+      // we artificially include the previous region that was stored
+      // specifically in this projection... but that is better than
+      // miscompiling. For memory like this, we probably need to track it on a
+      // per field basis to allow for us to assign.
+      if (nonSendableTgt.value().isNoAlias() && !isProjectedFromAggregate(dest))
+        return translateSILAssign(dest, inst->getElements());
+
+      // Stores to possibly aliased storage must be treated as merges.
+      return translateSILMerge(dest, inst->getElements());
     }
 
     // Stores to storage of non-Sendable type can be ignored.
@@ -1089,6 +1127,10 @@ public:
     case SILInstructionKind::StoreBorrowInst:
     case SILInstructionKind::StoreWeakInst:
       return translateSILStore(inst->getOperand(1), inst->getOperand(0));
+
+    case SILInstructionKind::TupleAddrConstructorInst:
+      return translateSILTupleAddrConstructor(
+          cast<TupleAddrConstructorInst>(inst));
 
     // Applies are handled specially since we need to merge their results.
     case SILInstructionKind::ApplyInst:

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -134,6 +134,10 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
 
   P.addFlowIsolation();
   P.addTransferNonSendable();
+  // Lower tuple addr constructor. Eventually this can be merged into later
+  // passes. This ensures we do not need to update later passes for something
+  // that is only needed by TransferNonSendable().
+  P.addLowerTupleAddrConstructor();
 
   // Automatic differentiation: canonicalize all differentiability witnesses
   // and `differentiable_function` instructions.

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -240,6 +240,7 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::ObjCProtocolInst:
   case SILInstructionKind::ObjectInst:
   case SILInstructionKind::TupleInst:
+  case SILInstructionKind::TupleAddrConstructorInst:
   case SILInstructionKind::TupleExtractInst:
   case SILInstructionKind::TuplePackExtractInst:
   case SILInstructionKind::TupleElementAddrInst:

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -1043,6 +1043,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::CopyBlockWithoutEscapingInst:
   case SILInstructionKind::CopyAddrInst:
   case SILInstructionKind::ExplicitCopyAddrInst:
+  case SILInstructionKind::TupleAddrConstructorInst:
   case SILInstructionKind::MarkUnresolvedMoveAddrInst:
   case SILInstructionKind::RetainValueInst:
   case SILInstructionKind::RetainValueAddrInst:

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 817; // Opaque type export details
+const uint16_t SWIFTMODULE_VERSION_MINOR = 818; // tuple_addr_constructor
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -134,6 +134,7 @@ namespace sil_block {
     SIL_ONE_TYPE_ONE_OPERAND,
     SIL_ONE_TYPE_VALUES,
     SIL_ONE_TYPE_OWNERSHIP_VALUES,
+    SIL_ONE_TYPE_VALUES_CATEGORIES,
     SIL_TWO_OPERANDS,
     SIL_TAIL_ADDR,
     SIL_INST_APPLY,
@@ -382,10 +383,10 @@ namespace sil_block {
   // SIL instructions with one type and a list of values.
   using SILOneTypeValuesLayout = BCRecordLayout<
     SIL_ONE_TYPE_VALUES,
-    SILInstOpCodeField,
-    TypeIDField,
-    SILTypeCategoryField,
-    BCArray<ValueIDField>
+    SILInstOpCodeField,      // opcode
+    TypeIDField,             // destType
+    SILTypeCategoryField,    // destCategory
+    BCArray<ValueIDField>    // operand ids
   >;
 
   // SIL instructions with one type, forwarding ownership, and a list of values.
@@ -397,6 +398,15 @@ namespace sil_block {
     TypeIDField,
     SILTypeCategoryField,
     BCArray<ValueIDField>>;
+
+  using SILOneTypeValuesCategoriesLayout = BCRecordLayout<
+    SIL_ONE_TYPE_VALUES_CATEGORIES,
+    SILInstOpCodeField,           // opcode
+    TypeIDField,                  // destType
+    SILTypeCategoryField,         // destCategory
+    BCFixed<1>,                   // options
+    BCArray<BCFixed<32>>          // operand id and categories.
+  >;
 
   enum ApplyKind : unsigned {
     SIL_APPLY = 0,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2345,7 +2345,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       result |= value->getType().isObject() ? 0 : 0x80000000;
       return result;
     };
-    ListOfValues.push_back(getValue(TI->getDestValue()));
+    ListOfValues.push_back(getValue(TI->getDest()));
     for (auto Elt : TI->getElements()) {
       ListOfValues.push_back(getValue(Elt));
     }
@@ -2354,7 +2354,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     options |= bool(TI->isInitializationOfDest());
     SILOneTypeValuesCategoriesLayout::emitRecord(
         Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(),
-        S.addTypeRef(TI->getDestValue()->getType().getRawASTType()),
+        S.addTypeRef(TI->getDest()->getType().getRawASTType()),
         (unsigned)SILValueCategory::Address, options, ListOfValues);
     break;
   }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -907,12 +907,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       assert(OpType.isObject());
       Args.push_back(S.addTypeRef(OpType.getRawASTType()));
     }
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                       (unsigned)SI.getKind(),
-                                       S.addTypeRef(
-                                         OI->getType().getRawASTType()),
-                                       (unsigned)OI->getType().getCategory(),
-                                       Args);
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(),
+        S.addTypeRef(OI->getType().getRawASTType()),
+        (unsigned)OI->getType().getCategory(), Args);
     break;
   }
 
@@ -1081,12 +1079,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       assert(OpType.isObject());
       Args.push_back(S.addTypeRef(OpType.getRawASTType()));
     }
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                       (unsigned)SI.getKind(),
-                                       S.addTypeRef(
-                                         ARI->getType().getRawASTType()),
-                                       (unsigned)ARI->getType().getCategory(),
-                                       Args);
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(),
+        S.addTypeRef(ARI->getType().getRawASTType()),
+        (unsigned)ARI->getType().getCategory(), Args);
     break;
   }
   case SILInstructionKind::AllocStackInst: {
@@ -1283,10 +1279,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       ListOfValues.push_back(addValueRef(Elt));
     }
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code],
-        (unsigned)SI.getKind(),
-        BasicBlockMap[BrI->getDestBB()], 0, ListOfValues);
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), BasicBlockMap[BrI->getDestBB()], 0,
+        ListOfValues);
     break;
   }
   case SILInstructionKind::CondBranchInst: {
@@ -1312,12 +1308,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       ListOfValues.push_back(addValueRef(Elt));
     }
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code],
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
         S.addTypeRef(CBI->getCondition()->getType().getRawASTType()),
-        (unsigned)CBI->getCondition()->getType().getCategory(),
-        ListOfValues);
+        (unsigned)CBI->getCondition()->getType().getCategory(), ListOfValues);
     break;
   }
   case SILInstructionKind::AwaitAsyncContinuationInst: {
@@ -1332,12 +1327,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     if (auto errorBB = AACI->getErrorBB()) {
       ListOfValues.push_back(BasicBlockMap[errorBB]);
     }
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-       SILAbbrCodes[SILOneTypeValuesLayout::Code],
-       (unsigned)SI.getKind(),
-       S.addTypeRef(AACI->getOperand()->getType().getRawASTType()),
-       (unsigned)AACI->getOperand()->getType().getCategory(),
-       ListOfValues);
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(),
+        S.addTypeRef(AACI->getOperand()->getType().getRawASTType()),
+        (unsigned)AACI->getOperand()->getType().getCategory(), ListOfValues);
     break;
   }
   case SILInstructionKind::SwitchEnumInst:
@@ -1435,12 +1429,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       ListOfValues.push_back(addValueRef(value));
       ListOfValues.push_back(BasicBlockMap[dest]);
     }
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code],
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
         S.addTypeRef(SII->getOperand()->getType().getRawASTType()),
-        (unsigned)SII->getOperand()->getType().getCategory(),
-        ListOfValues);
+        (unsigned)SII->getOperand()->getType().getCategory(), ListOfValues);
     break;
   }
   case SILInstructionKind::UnownedCopyValueInst:
@@ -1574,8 +1567,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     }
     args.push_back(BasicBlockMap[YI->getResumeBB()]);
     args.push_back(BasicBlockMap[YI->getUnwindBB()]);
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code],
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)YI->getKind(), 0, 0, args);
     break;
   }
@@ -1823,8 +1816,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       ListOfValues.push_back(addValueRef(Elt));
     }
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code],
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(), 0, 0, ListOfValues);
     break;
   }
@@ -1983,11 +1976,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       S.addTypeRef(CI->getTargetFormalType())
     };
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-             SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
-             (unsigned)CI->getTargetLoweredType().getCategory(),
-             llvm::makeArrayRef(listOfValues));
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(),
+        S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
+        (unsigned)CI->getTargetLoweredType().getCategory(),
+        llvm::makeArrayRef(listOfValues));
     break;
   }
   case SILInstructionKind::UnconditionalCheckedCastAddrInst: {
@@ -2000,11 +1994,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       S.addTypeRef(CI->getTargetFormalType()),
       addValueRef(CI->getDest())
     };
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-             SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
-             (unsigned)CI->getTargetLoweredType().getCategory(),
-             llvm::makeArrayRef(listOfValues));
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(),
+        S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
+        (unsigned)CI->getTargetLoweredType().getCategory(),
+        llvm::makeArrayRef(listOfValues));
     break;
   }
   case SILInstructionKind::UncheckedRefCastAddrInst: {
@@ -2017,11 +2012,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       S.addTypeRef(CI->getTargetFormalType()),
       addValueRef(CI->getDest())
     };
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-             SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
-             (unsigned)CI->getTargetLoweredType().getCategory(),
-             llvm::makeArrayRef(listOfValues));
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(),
+        S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
+        (unsigned)CI->getTargetLoweredType().getCategory(),
+        llvm::makeArrayRef(listOfValues));
     break;
   }
 
@@ -2200,13 +2196,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     ListOfValues.push_back(addValueRef(indexOperand));
 
     SILOneTypeValuesLayout::emitRecord(
-      Out,
-      ScratchRecord,
-      SILAbbrCodes[SILOneTypeValuesLayout::Code],
-      (unsigned)SI.getKind(),
-      S.addTypeRef(boundType.getRawASTType()),
-      (unsigned)boundType.getCategory(),
-      ListOfValues);
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), S.addTypeRef(boundType.getRawASTType()),
+        (unsigned)boundType.getCategory(), ListOfValues);
     break;
   }
   case SILInstructionKind::RebindMemoryInst: {
@@ -2294,10 +2286,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       ListOfValues.push_back(addValueRef(Elt));
     }
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code],
-        (unsigned)SI.getKind(),
-        S.addTypeRef(StrI->getType().getRawASTType()),
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), S.addTypeRef(StrI->getType().getRawASTType()),
         (unsigned)StrI->getType().getCategory(), ListOfValues);
     break;
   }
@@ -2337,11 +2328,34 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     }
 
     unsigned abbrCode = SILAbbrCodes[SILOneTypeValuesLayout::Code];
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord, abbrCode,
-        (unsigned)SI.getKind(),
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(),
         S.addTypeRef(TI->getType().getRawASTType()),
-        (unsigned)TI->getType().getCategory(),
-        ListOfValues);
+        (unsigned)TI->getType().getCategory(), ListOfValues);
+    break;
+  }
+  case SILInstructionKind::TupleAddrConstructorInst: {
+    // Format: a type followed by a list of values. A value is expressed by
+    // 2 IDs: ValueID, ValueResultNumber.
+    const auto *TI = cast<TupleAddrConstructorInst>(&SI);
+    SmallVector<uint64_t, 4> ListOfValues;
+    auto getValue = [&](SILValue value) -> uint64_t {
+      uint32_t result = addValueRef(value);
+      // Set the top bit if we are an address.
+      result |= value->getType().isObject() ? 0 : 0x80000000;
+      return result;
+    };
+    ListOfValues.push_back(getValue(TI->getDestValue()));
+    for (auto Elt : TI->getElements()) {
+      ListOfValues.push_back(getValue(Elt));
+    }
+    unsigned abbrCode = SILAbbrCodes[SILOneTypeValuesCategoriesLayout::Code];
+    unsigned options = 0;
+    options |= bool(TI->isInitializationOfDest());
+    SILOneTypeValuesCategoriesLayout::emitRecord(
+        Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(),
+        S.addTypeRef(TI->getDestValue()->getType().getRawASTType()),
+        (unsigned)SILValueCategory::Address, options, ListOfValues);
     break;
   }
   case SILInstructionKind::EnumInst: {
@@ -2396,9 +2410,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SmallVector<uint64_t, 9> ListOfValues;
     handleMethodInst(CMI, CMI->getOperand(), ListOfValues);
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(Ty.getRawASTType()),
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), S.addTypeRef(Ty.getRawASTType()),
         (unsigned)Ty.getCategory(), ListOfValues);
     break;
   }
@@ -2411,9 +2425,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SmallVector<uint64_t, 9> ListOfValues;
     handleMethodInst(SMI, SMI->getOperand(), ListOfValues);
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(Ty.getRawASTType()),
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), S.addTypeRef(Ty.getRawASTType()),
         (unsigned)Ty.getCategory(), ListOfValues);
     break;
   }
@@ -2426,9 +2440,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SmallVector<uint64_t, 9> ListOfValues;
     handleMethodInst(OMI, OMI->getOperand(), ListOfValues);
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(Ty.getRawASTType()),
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), S.addTypeRef(Ty.getRawASTType()),
         (unsigned)Ty.getCategory(), ListOfValues);
     break;
   }
@@ -2441,9 +2455,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SmallVector<uint64_t, 9> ListOfValues;
     handleMethodInst(SMI, SMI->getOperand(), ListOfValues);
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(Ty.getRawASTType()),
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), S.addTypeRef(Ty.getRawASTType()),
         (unsigned)Ty.getCategory(), ListOfValues);
     break;
   }
@@ -2457,8 +2471,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     ListOfValues.push_back(BasicBlockMap[DMB->getHasMethodBB()]);
     ListOfValues.push_back(BasicBlockMap[DMB->getNoMethodBB()]);
 
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-        SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(),
         S.addTypeRef(DMB->getOperand()->getType().getRawASTType()),
         (unsigned)DMB->getOperand()->getType().getCategory(), ListOfValues);
     break;
@@ -2498,11 +2513,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       BasicBlockMap[CBI->getSuccessBB()],
       BasicBlockMap[CBI->getFailureBB()]
     };
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-             SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(CBI->getTargetLoweredType().getRawASTType()),
-             (unsigned)CBI->getTargetLoweredType().getCategory(),
-             llvm::makeArrayRef(listOfValues));
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(),
+        S.addTypeRef(CBI->getTargetLoweredType().getRawASTType()),
+        (unsigned)CBI->getTargetLoweredType().getCategory(),
+        llvm::makeArrayRef(listOfValues));
     break;
   }
   case SILInstructionKind::InitBlockStorageHeaderInst: {
@@ -2518,12 +2534,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
        S.addTypeRef(IBSHI->getInvokeFunction()->getType().getRawASTType()));
     // Always a value, don't need to save category
     ListOfValues.push_back(S.addSubstitutionMapRef(IBSHI->getSubstitutions()));
-    
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-             SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(IBSHI->getType().getRawASTType()),
-             (unsigned)IBSHI->getType().getCategory(),
-             ListOfValues);
+
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), S.addTypeRef(IBSHI->getType().getRawASTType()),
+        (unsigned)IBSHI->getType().getCategory(), ListOfValues);
 
     break;
   }
@@ -2561,12 +2576,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       ListOfValues.push_back(S.addTypeRef(value->getType().getRawASTType()));
       ListOfValues.push_back((unsigned)value->getType().getCategory());
     }
-    
-    SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
-         SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-         S.addTypeRef(KPI->getType().getRawASTType()),
-         (unsigned)KPI->getType().getCategory(),
-         ListOfValues);
+
+    SILOneTypeValuesLayout::emitRecord(
+        Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
+        (unsigned)SI.getKind(), S.addTypeRef(KPI->getType().getRawASTType()),
+        (unsigned)KPI->getType().getCategory(), ListOfValues);
 
     break;
   }
@@ -3100,6 +3114,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   registerSILAbbr<SILInitExistentialLayout>();
   registerSILAbbr<SILOneTypeValuesLayout>();
   registerSILAbbr<SILOneTypeOwnershipValuesLayout>();
+  registerSILAbbr<SILOneTypeValuesCategoriesLayout>();
   registerSILAbbr<SILTwoOperandsLayout>();
   registerSILAbbr<SILTwoOperandsExtraAttributeLayout>();
   registerSILAbbr<SILTailAddrLayout>();

--- a/test/Concurrency/sendnonsendable_basic.swift
+++ b/test/Concurrency/sendnonsendable_basic.swift
@@ -596,24 +596,24 @@ func multipleFieldTupleMergeTest2() async {
   var box = (NonSendableKlass(), NonSendableKlass())
 
   // This transfers the entire region.
-  await transferToMain(box.0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(box.0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let box2 = (NonSendableKlass(), NonSendableKlass())
   // But if we assign over box completely, we can use it again.
-  box = box2 // expected-tns-note {{access here could race}}
+  box = box2
 
-  useValue(box.0) // expected-tns-note {{access here could race}}
-  useValue(box.1) // expected-tns-note {{access here could race}}
-  useValue(box) // expected-tns-note {{access here could race}}
+  useValue(box.0)
+  useValue(box.1)
+  useValue(box)
 
-  await transferToMain(box.1) // expected-tns-note {{access here could race}}
+  await transferToMain(box.1)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // But if we assign over box completely, we can use it again.
-  box = (NonSendableKlass(), NonSendableKlass()) // expected-tns-note {{access here could race}}
+  box = (NonSendableKlass(), NonSendableKlass())
 
-  useValue(box.0) // expected-tns-note {{access here could race}}
-  useValue(box.1) // expected-tns-note {{access here could race}}
-  useValue(box) // expected-tns-note {{access here could race}}
+  useValue(box.0)
+  useValue(box.1)
+  useValue(box)
 }

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -219,3 +219,69 @@ bb0:
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject)) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject,
+// CHECK: [[RHS:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: tuple_addr_constructor [assign] [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject) with ([[LHS]] : $*Builtin.NativeObject, [[RHS]] : $*Builtin.NativeObject)
+// CHECK: } // end sil function 'tuple_addr_constructor_assign'
+sil [ossa] @tuple_addr_constructor_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject)) -> () {
+bb0(%0 : $*Builtin.NativeObject, %0a : $*(Builtin.NativeObject, Builtin.NativeObject)):
+  %1 = alloc_stack $Builtin.NativeObject
+  copy_addr %0 to [init] %1 : $*Builtin.NativeObject
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  copy_addr [take] %0a to [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [assign] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_init : $@convention(thin) (@in Builtin.NativeObject) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*
+// CHECK: [[RHS:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: tuple_addr_constructor [init] [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject) with ([[LHS]] : $*Builtin.NativeObject, [[RHS]] : $*Builtin.NativeObject)
+// CHECK: } // end sil function 'tuple_addr_constructor_init'
+sil [ossa] @tuple_addr_constructor_init : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %1 = alloc_stack $Builtin.NativeObject
+  copy_addr %0 to [init] %1 : $*Builtin.NativeObject
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_differing_category : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject, [[RHS:%.*]] : @owned $Builtin.NativeObject)
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: tuple_addr_constructor [init] [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject) with ([[LHS]] : $*Builtin.NativeObject, [[RHS]] : $Builtin.NativeObject)
+// CHECK: } // end sil function 'tuple_addr_constructor_differing_category'
+sil [ossa] @tuple_addr_constructor_differing_category : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_unfriendly_tuple : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: tuple_addr_constructor [init] {{%.*}} : $*((), (Builtin.NativeObject, Builtin.NativeObject)) with
+sil [ossa] @tuple_addr_constructor_unfriendly_tuple : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = alloc_stack $((), (Builtin.NativeObject, Builtin.NativeObject))
+  tuple_addr_constructor [init] %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject)) with (%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject)
+  destroy_addr %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject))
+  dealloc_stack %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject))
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/SIL/Serialization/basic2.sil
+++ b/test/SIL/Serialization/basic2.sil
@@ -116,3 +116,72 @@ bb0:
   %9999 = tuple ()
   return %9999 : $()
 }
+
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject)) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject,
+// CHECK: [[RHS:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: tuple_addr_constructor [assign] [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject) with ([[LHS]] : $*Builtin.NativeObject, [[RHS]] : $*Builtin.NativeObject)
+// CHECK: } // end sil function 'tuple_addr_constructor_assign'
+sil [ossa] @tuple_addr_constructor_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject)) -> () {
+bb0(%0 : $*Builtin.NativeObject, %0a : $*(Builtin.NativeObject, Builtin.NativeObject)):
+  %1 = alloc_stack $Builtin.NativeObject
+  copy_addr %0 to [init] %1 : $*Builtin.NativeObject
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  copy_addr [take] %0a to [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [assign] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  destroy_addr %1 : $*Builtin.NativeObject
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_differing_category : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject, [[RHS:%.*]] : @owned $Builtin.NativeObject)
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: tuple_addr_constructor [init] [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject) with ([[LHS]] : $*Builtin.NativeObject, [[RHS]] : $Builtin.NativeObject)
+// CHECK: } // end sil function 'tuple_addr_constructor_differing_category'
+sil [ossa] @tuple_addr_constructor_differing_category : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_init : $@convention(thin) (@in Builtin.NativeObject) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*
+// CHECK: [[RHS:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: tuple_addr_constructor [init] [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject) with ([[LHS]] : $*Builtin.NativeObject, [[RHS]] : $*Builtin.NativeObject)
+// CHECK: } // end sil function 'tuple_addr_constructor_init'
+sil [ossa] @tuple_addr_constructor_init : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %1 = alloc_stack $Builtin.NativeObject
+  copy_addr %0 to [init] %1 : $*Builtin.NativeObject
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_unfriendly_tuple : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: tuple_addr_constructor [init] {{%.*}} : $*((), (Builtin.NativeObject, Builtin.NativeObject)) with
+sil [ossa] @tuple_addr_constructor_unfriendly_tuple : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = alloc_stack $((), (Builtin.NativeObject, Builtin.NativeObject))
+  tuple_addr_constructor [init] %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject)) with (%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject)
+  destroy_addr %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject))
+  dealloc_stack %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject))
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -154,10 +154,7 @@ func assign_tuple(_ x: (Builtin.Int64, Builtin.NativeObject),
   var x = x
   var y = y
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*(Builtin.Int64, Builtin.NativeObject)
-  // CHECK: [[T0:%.*]] = tuple_element_addr [[ADDR]]
-  // CHECK: assign {{%.*}} to [[T0]]
-  // CHECK: [[T0:%.*]] = tuple_element_addr [[ADDR]]
-  // CHECK: assign {{%.*}} to [[T0]]
+  // CHECK: tuple_addr_constructor [assign] [[ADDR]] : $*(Builtin.Int64, Builtin.NativeObject) with
   // CHECK: destroy_value
   Builtin.assign(x, y)
 }

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -57,10 +57,7 @@ func testShuffleOpaque() {
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples7make_xySi1x_AA1P_p1ytyF
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[TMP]])
   // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBPAIR]] : $*(y: any P, x: Int)
-  // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[WRITE]] : $*(y: any P, x: Int), 0
-  // CHECK-NEXT: copy_addr [take] [[TMP]] to [[PAIR_0]]
-  // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[WRITE]] : $*(y: any P, x: Int), 1
-  // CHECK-NEXT: assign [[T1]] to [[PAIR_1]]
+  // CHECK-NEXT: tuple_addr_constructor [assign] [[WRITE]] : $*(y: any P, x: Int) with ([[TMP]] : $*any P, [[T1]] : $Int)
   // CHECK-NEXT: end_access [[WRITE]] : $*(y: any P, x: Int)
   // CHECK-NEXT: dealloc_stack [[TMP]]
   pair = make_xy()
@@ -110,10 +107,7 @@ func testShuffleTuple() {
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples6make_pAA1P_pyF 
   // CHECK-NEXT: apply [[T0]]([[TEMP]])
   // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBPAIR]] : $*(y: any P, x: Int)
-  // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[WRITE]] : $*(y: any P, x: Int), 0
-  // CHECK-NEXT: copy_addr [take] [[TEMP]] to [[PAIR_0]]
-  // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[WRITE]] : $*(y: any P, x: Int), 1
-  // CHECK-NEXT: assign [[INT]] to [[PAIR_1]]
+  // CHECK-NEXT: tuple_addr_constructor [assign] [[WRITE]] : $*(y: any P, x: Int) with ([[TEMP]] : $*any P, [[INT]] : $Int)
   // CHECK-NEXT: end_access [[WRITE]] : $*(y: any P, x: Int)
   // CHECK-NEXT: dealloc_stack [[TEMP]]
   pair = (x: make_int(), y: make_p())

--- a/test/SILOptimizer/definite_init_tuple.sil
+++ b/test/SILOptimizer/definite_init_tuple.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify
 
 import Builtin
 import Swift
@@ -24,4 +24,68 @@ bb0(%0 : $*S<T>, %1 : $@thin S<T>.Type):
   destroy_value %3 : $<τ_0_0> { var S<τ_0_0> } <T>
   %12 = tuple ()
   return %12 : $()
+}
+
+struct MyText<V> {
+  let label: String
+  // expected-note @-1 {{'self.label' not initialized}}
+  let value: V
+  // expected-note @-1 {{'self.value.0' not initialized}}
+  // expected-note @-2 {{'self.value.1' not initialized}} 
+}
+
+sil [ossa] @tuple_addr_constructor_1 : $@convention(method) (@owned String, Int, @thin MyText<(Int, Int)>.Type) -> @owned MyText<(Int, Int)> {
+bb0(%0 : @owned $String, %1 : $Int, %2 : $@thin MyText<(Int, Int)>.Type):
+  %3 = alloc_stack $MyText<(Int, Int)>, var, name "self", implicit
+  %4 = mark_uninitialized [rootself] %3 : $*MyText<(Int, Int)>
+  %7 = copy_value %0 : $String
+  %8 = begin_access [modify] [static] %4 : $*MyText<(Int, Int)>
+  %9 = struct_element_addr %8 : $*MyText<(Int, Int)>, #MyText.label
+  assign %7 to %9 : $*String
+  end_access %8 : $*MyText<(Int, Int)>
+  %12 = begin_access [modify] [static] %4 : $*MyText<(Int, Int)>
+  %13 = struct_element_addr %12 : $*MyText<(Int, Int)>, #MyText.value
+  tuple_addr_constructor [assign] %13 : $*(Int, Int) with (%1 : $Int, %1 : $Int)
+  end_access %12 : $*MyText<(Int, Int)>
+  %16 = load [copy] %4 : $*MyText<(Int, Int)>
+  destroy_value %0 : $String
+  destroy_addr %4 : $*MyText<(Int, Int)>
+  dealloc_stack %3 : $*MyText<(Int, Int)>
+  return %16 : $MyText<(Int, Int)>
+}
+
+sil [ossa] @tuple_addr_constructor_2 : $@convention(method) (@owned String, Int, @thin MyText<(Int, Int)>.Type) -> @owned MyText<(Int, Int)> {
+bb0(%0 : @owned $String, %1 : $Int, %2 : $@thin MyText<(Int, Int)>.Type):
+  %3 = alloc_stack $MyText<(Int, Int)>, var, name "self", implicit
+  %4 = mark_uninitialized [rootself] %3 : $*MyText<(Int, Int)>
+  %7 = copy_value %0 : $String
+  %8 = begin_access [modify] [static] %4 : $*MyText<(Int, Int)>
+  %9 = struct_element_addr %8 : $*MyText<(Int, Int)>, #MyText.label
+  destroy_value %7 : $String
+  end_access %8 : $*MyText<(Int, Int)>
+  %12 = begin_access [modify] [static] %4 : $*MyText<(Int, Int)>
+  %13 = struct_element_addr %12 : $*MyText<(Int, Int)>, #MyText.value
+  tuple_addr_constructor [assign] %13 : $*(Int, Int) with (%1 : $Int, %1 : $Int)
+  end_access %12 : $*MyText<(Int, Int)>
+  %16 = load [copy] %4 : $*MyText<(Int, Int)> // expected-error {{return from initializer without initializing all stored properties}}
+  destroy_value %0 : $String
+  destroy_addr %4 : $*MyText<(Int, Int)>
+  dealloc_stack %3 : $*MyText<(Int, Int)>
+  return %16 : $MyText<(Int, Int)>
+}
+
+sil [ossa] @tuple_addr_constructor_3 : $@convention(method) (@owned String, Int, @thin MyText<(Int, Int)>.Type) -> @owned MyText<(Int, Int)> {
+bb0(%0 : @owned $String, %1 : $Int, %2 : $@thin MyText<(Int, Int)>.Type):
+  %3 = alloc_stack $MyText<(Int, Int)>, var, name "self", implicit
+  %4 = mark_uninitialized [rootself] %3 : $*MyText<(Int, Int)>
+  %7 = copy_value %0 : $String
+  %8 = begin_access [modify] [static] %4 : $*MyText<(Int, Int)>
+  %9 = struct_element_addr %8 : $*MyText<(Int, Int)>, #MyText.label
+  assign %7 to %9 : $*String
+  end_access %8 : $*MyText<(Int, Int)>
+  %16 = load [copy] %4 : $*MyText<(Int, Int)> // expected-error {{return from initializer without initializing all stored properties}}
+  destroy_value %0 : $String
+  destroy_addr %4 : $*MyText<(Int, Int)>
+  dealloc_stack %3 : $*MyText<(Int, Int)>
+  return %16 : $MyText<(Int, Int)>
 }

--- a/test/SILOptimizer/lower_tuple_addr_constructor.sil
+++ b/test/SILOptimizer/lower_tuple_addr_constructor.sil
@@ -1,0 +1,158 @@
+// RUN: %target-sil-opt -lower-tuple-addr-constructor %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_init : $@convention(thin) (@in Builtin.NativeObject) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*
+// CHECK: [[RHS:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: [[LHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+// CHECK: copy_addr [take] [[LHS]] to [init] [[LHS_ADDR]]
+// CHECK: [[RHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: copy_addr [take] [[RHS]] to [init] [[RHS_ADDR]]
+// CHECK: } // end sil function 'tuple_addr_constructor_init'
+sil [ossa] @tuple_addr_constructor_init : $@convention(thin) (@in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %1 = alloc_stack $Builtin.NativeObject
+  copy_addr %0 to [init] %1 : $*Builtin.NativeObject
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject)) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject,
+// CHECK: [[RHS:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: [[LHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+// CHECK: copy_addr [take] [[LHS]] to [[LHS_ADDR]]
+// CHECK: [[RHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: copy_addr [take] [[RHS]] to [[RHS_ADDR]]
+// CHECK: } // end sil function 'tuple_addr_constructor_assign'
+sil [ossa] @tuple_addr_constructor_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject)) -> () {
+bb0(%0 : $*Builtin.NativeObject, %0a : $*(Builtin.NativeObject, Builtin.NativeObject)):
+  %1 = alloc_stack $Builtin.NativeObject
+  copy_addr %0 to [init] %1 : $*Builtin.NativeObject
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  copy_addr [take] %0a to [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [assign] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_mixed_init : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject, [[RHS:%.*]] : @owned $Builtin.NativeObject):
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: [[LHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+// CHECK: copy_addr [take] [[LHS]] to [init] [[LHS_ADDR]]
+// CHECK: [[RHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: store [[RHS]] to [init] [[RHS_ADDR]]
+// CHECK: } // end sil function 'tuple_addr_constructor_mixed_init'
+sil [ossa] @tuple_addr_constructor_mixed_init : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_mixed_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject), @owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject, {{%.*}} : $*(Builtin.NativeObject, Builtin.NativeObject), [[RHS:%.*]] : @owned
+// CHECK: [[DEST:%.*]] = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+// CHECK: [[LHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+// CHECK: copy_addr [take] [[LHS]] to [[LHS_ADDR]]
+// CHECK: [[RHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: store [[RHS]] to [assign] [[RHS_ADDR]]
+// CHECK: } // end sil function 'tuple_addr_constructor_mixed_assign'
+sil [ossa] @tuple_addr_constructor_mixed_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject), @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %0a : $*(Builtin.NativeObject, Builtin.NativeObject), %0b : @owned $Builtin.NativeObject):
+  %2 = alloc_stack $(Builtin.NativeObject, Builtin.NativeObject)
+  copy_addr [take] %0a to [init] %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  tuple_addr_constructor [assign] %2 : $*(Builtin.NativeObject, Builtin.NativeObject) with (%0 : $*Builtin.NativeObject, %0b : $Builtin.NativeObject)
+  destroy_addr %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  dealloc_stack %2 : $*(Builtin.NativeObject, Builtin.NativeObject)
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_unfriendly : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject, [[RHS:%.*]] : @owned
+// CHECK: [[DEST:%.*]] = alloc_stack $((), (Builtin.NativeObject, Builtin.NativeObject))
+// CHECK: [[LHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*((), (Builtin.NativeObject, Builtin.NativeObject)), 0
+// CHECK: [[RHS_ADDR:%.*]] = tuple_element_addr [[DEST]] : $*((), (Builtin.NativeObject, Builtin.NativeObject)), 1
+// CHECK: [[RHS_ADDR_1:%.*]] = tuple_element_addr [[RHS_ADDR]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+// CHECK: copy_addr [take] [[LHS]] to [init] [[RHS_ADDR_1]]
+// CHECK: [[RHS_ADDR_2:%.*]] = tuple_element_addr [[RHS_ADDR]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: store [[RHS]] to [init] [[RHS_ADDR_2]]
+// CHECK: } // end sil function 'tuple_addr_constructor_unfriendly'
+sil [ossa] @tuple_addr_constructor_unfriendly : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %0a : @owned $Builtin.NativeObject):
+  %2 = alloc_stack $((), (Builtin.NativeObject, Builtin.NativeObject))
+  tuple_addr_constructor [init] %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject)) with (%0 : $*Builtin.NativeObject, %0a : $Builtin.NativeObject)
+  destroy_addr %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject))
+  dealloc_stack %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject))
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_unfriendly_2 : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%.*]] : $*Builtin.NativeObject, [[ARG2:%.*]] : @owned $Builtin.NativeObject, [[ARG3:%.*]] : $*Builtin.NativeObject
+// CHECK: [[DEST:%.*]] = alloc_stack $((), (Builtin.NativeObject, Builtin.NativeObject), ((), (), Builtin.NativeObject))
+// CHECK: [[ADDR_1:%.*]] = tuple_element_addr [[DEST]] : $*((), (Builtin.NativeObject, Builtin.NativeObject), ((), (), Builtin.NativeObject))
+// CHECK: [[ADDR_2:%.*]] = tuple_element_addr [[DEST]] : $*((), (Builtin.NativeObject, Builtin.NativeObject), ((), (), Builtin.NativeObject))
+// CHECK: [[ADDR_2_1:%.*]] = tuple_element_addr [[ADDR_2]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+// CHECK: copy_addr [take] [[ARG1]] to [init] [[ADDR_2_1]]
+// CHECK: [[ADDR_2_2:%.*]] = tuple_element_addr [[ADDR_2]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: store [[ARG2]] to [init] [[ADDR_2_2]]
+// CHECK: [[ADDR_3:%.*]] = tuple_element_addr [[DEST]] : $*((), (Builtin.NativeObject, Builtin.NativeObject), ((), (), Builtin.NativeObject))
+// CHECK: [[ADDR_3_1:%.*]] = tuple_element_addr [[ADDR_3]] : $*((), (), Builtin.NativeObject), 0
+// CHECK: [[ADDR_3_2:%.*]] = tuple_element_addr [[ADDR_3]] : $*((), (), Builtin.NativeObject), 1
+// CHECK: [[ADDR_3_3:%.*]] = tuple_element_addr [[ADDR_3]] : $*((), (), Builtin.NativeObject), 2
+// CHECK: copy_addr [take] [[ARG3]] to [init] [[ADDR_3_3]]
+// CHECK: } // end sil function 'tuple_addr_constructor_unfriendly_2'
+sil [ossa] @tuple_addr_constructor_unfriendly_2 : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %0a : @owned $Builtin.NativeObject, %0b : $*Builtin.NativeObject):
+  %2 = alloc_stack $((), (Builtin.NativeObject, Builtin.NativeObject), ((), (), (Builtin.NativeObject)))
+  tuple_addr_constructor [init] %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject), ((), (), (Builtin.NativeObject))) with (%0 : $*Builtin.NativeObject, %0a : $Builtin.NativeObject, %0b : $*Builtin.NativeObject)
+  destroy_addr %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject), ((), (), (Builtin.NativeObject)))
+  dealloc_stack %2 : $*((), (Builtin.NativeObject, Builtin.NativeObject), ((), (), (Builtin.NativeObject)))
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tuple_addr_constructor_unfriendly_3 : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG1:%.*]] : $*Builtin.NativeObject, [[ARG2:%.*]] : @owned $Builtin.NativeObject, [[ARG3:%.*]] : $*Builtin.NativeObject
+// CHECK: [[DEST:%.*]] = alloc_stack $((a: ()), (Builtin.NativeObject, Builtin.NativeObject), ((), (), b: Builtin.NativeObject))
+// CHECK: [[ADDR_1:%.*]] = tuple_element_addr [[DEST]] : $*((a: ()), (Builtin.NativeObject, Builtin.NativeObject), ((), (), b: Builtin.NativeObject))
+// CHECK: [[ADDR_2:%.*]] = tuple_element_addr [[DEST]] : $*((a: ()), (Builtin.NativeObject, Builtin.NativeObject), ((), (), b: Builtin.NativeObject))
+// CHECK: [[ADDR_2_1:%.*]] = tuple_element_addr [[ADDR_2]] : $*(Builtin.NativeObject, Builtin.NativeObject), 0
+// CHECK: copy_addr [take] [[ARG1]] to [init] [[ADDR_2_1]]
+// CHECK: [[ADDR_2_2:%.*]] = tuple_element_addr [[ADDR_2]] : $*(Builtin.NativeObject, Builtin.NativeObject), 1
+// CHECK: store [[ARG2]] to [init] [[ADDR_2_2]]
+// CHECK: [[ADDR_3:%.*]] = tuple_element_addr [[DEST]] : $*((a: ()), (Builtin.NativeObject, Builtin.NativeObject), ((), (), b: Builtin.NativeObject))
+// CHECK: [[ADDR_3_1:%.*]] = tuple_element_addr [[ADDR_3]] : $*((), (), b: Builtin.NativeObject), 0
+// CHECK: [[ADDR_3_2:%.*]] = tuple_element_addr [[ADDR_3]] : $*((), (), b: Builtin.NativeObject), 1
+// CHECK: [[ADDR_3_3:%.*]] = tuple_element_addr [[ADDR_3]] : $*((), (), b: Builtin.NativeObject), 2
+// CHECK: copy_addr [take] [[ARG3]] to [init] [[ADDR_3_3]]
+// CHECK: } // end sil function 'tuple_addr_constructor_unfriendly_3'
+sil [ossa] @tuple_addr_constructor_unfriendly_3 : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %0a : @owned $Builtin.NativeObject, %0b : $*Builtin.NativeObject):
+  %2 = alloc_stack $*((a: ()), (Builtin.NativeObject, Builtin.NativeObject), ((), (), b: (Builtin.NativeObject)))
+  tuple_addr_constructor [init] %2 : $*((a: ()), (Builtin.NativeObject, Builtin.NativeObject), ((), (), b: (Builtin.NativeObject))) with (%0 : $*Builtin.NativeObject, %0a : $Builtin.NativeObject, %0b : $*Builtin.NativeObject)
+  destroy_addr %2 : $*((a: ()), (Builtin.NativeObject, Builtin.NativeObject), ((), (), b: (Builtin.NativeObject)))
+  dealloc_stack %2 : $*((a: ()), (Builtin.NativeObject, Builtin.NativeObject), ((), (), b: (Builtin.NativeObject)))
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1483,3 +1483,131 @@ bb0(%0 : @guaranteed $GenericKlass<Int>):
   return %3 : $()
 }
 
+// Specialize tuple_addr_constructor
+
+// In this case we specialized using all non-tuple types
+// CHECK-LABEL: sil shared [ossa] @$s29tuple_addr_constructor_calleeBo_4main4BaseCBoADTg5 : $@convention(thin) (@owned Builtin.NativeObject, @owned Base, @owned Builtin.NativeObject, @owned Base) -> () {
+// CHECK: tuple_addr_constructor [init] {{%.*}} : $*(Builtin.NativeObject, Base, Builtin.NativeObject, Base) with ({{%.*}} : $*Builtin.NativeObject, {{%.*}} : $*Base, {{%.*}} : $Builtin.NativeObject, {{%.*}} : $Base)
+// CHECK: } // end sil function '$s29tuple_addr_constructor_calleeBo_4main4BaseCBoADTg5'
+
+// In this case, we specialized where a single parameter was an empty
+// tuple... make sure that we eliminated it as a parameter to tuple_addr_constructor
+// CHECK-LABEL: sil shared [ossa] @$s29tuple_addr_constructor_calleeBo_4main4BaseCytADTg5 : $@convention(thin) (@owned Builtin.NativeObject, @owned Base, @owned (), @owned Base) -> () {
+// CHECK: tuple_addr_constructor [init] {{%.*}} : $*(Builtin.NativeObject, Base, (), Base) with ({{%.*}} : $*Builtin.NativeObject, {{%.*}} : $*Base, {{%.*}} : $Base)
+// CHECK: } // end sil function '$s29tuple_addr_constructor_calleeBo_4main4BaseCytADTg5'
+
+// Make sure we handle this with multiple level tuples
+// CHECK-LABEL: sil shared [ossa] @$s29tuple_addr_constructor_calleeBo_4main4BaseCyt_yt_ytttADTg5 : $@convention(thin) (@owned Builtin.NativeObject, @owned Base, @owned ((), ((), ())), @owned Base) -> () {
+// CHECK: tuple_addr_constructor [init] {{%.*}} : $*(Builtin.NativeObject, Base, ((), ((), ())), Base) with ({{%.*}} : $*Builtin.NativeObject, {{%.*}} : $*Base, {{%.*}} : $Base)
+// CHECK: } // end sil function '$s29tuple_addr_constructor_calleeBo_4main4BaseCyt_yt_ytttADTg5'
+
+// Make sure we keep in the parameter if we have one leaf node.
+// CHECK-LABEL: sil shared [ossa] @$s29tuple_addr_constructor_calleeBo_4main4BaseCyt_Bo_ytttADTg5 : $@convention(thin) (@owned Builtin.NativeObject, @owned Base, @owned ((), (Builtin.NativeObject, ())), @owned Base) -> () {
+// CHECK: tuple_addr_constructor [init] {{%.*}} : $*(Builtin.NativeObject, Base, ((), (Builtin.NativeObject, ())), Base) with ({{%.*}} : $*Builtin.NativeObject, {{%.*}} : $*Base, {{%.*}} : $((), (Builtin.NativeObject, ())), {{%.*}} : $Base)
+// CHECK: } // end sil function '$s29tuple_addr_constructor_calleeBo_4main4BaseCyt_Bo_ytttADTg5'
+
+// CHECK-LABEL: sil shared [ossa] @$s29tuple_addr_constructor_calleeyt_ytyt_yt_ytttytTg5 : $@convention(thin) ((), (), @owned ((), ((), ())), @owned ()) -> () {
+// CHECK-NOT: tuple_addr_constructor
+// CHECK: } // end sil function '$s29tuple_addr_constructor_calleeyt_ytyt_yt_ytttytTg5'
+
+sil [ossa] @tuple_addr_constructor_callee : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> () {
+bb0(%arg0 : $*T1, %arg1 : $*T2, %arg2 : @owned $T3, %arg3 : @owned $T4):
+  %tup = alloc_stack $(T1, T2, T3, T4)
+  tuple_addr_constructor [init] %tup : $*(T1, T2, T3, T4) with (%arg0 : $*T1, %arg1 : $*T2, %arg2 : $T3, %arg3 : $T4)
+  destroy_addr %tup : $*(T1, T2, T3, T4)
+  dealloc_stack %tup : $*(T1, T2, T3, T4)
+  %2 = tuple ()
+  return %2 : $()
+}
+
+sil [ossa] @specializeTupleAddrConstructorSimple : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Base):
+  %2 = function_ref @tuple_addr_constructor_callee : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  %3 = alloc_stack $*Builtin.NativeObject
+  %4 = alloc_stack $*Base
+  %0a = copy_value %0 : $Builtin.NativeObject
+  %0b = copy_value %0 : $Builtin.NativeObject
+  store %0b to [init] %3 : $*Builtin.NativeObject
+  %1a = copy_value %1 : $Base
+  %1b = copy_value %1 : $Base
+  store %1b to [init] %4 : $*Base
+  apply %2<Builtin.NativeObject, Base, Builtin.NativeObject, Base>(%3, %4, %0a, %1a) : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  dealloc_stack %4 : $*Base
+  dealloc_stack %3 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @specializeTupleAddrConstructorEliminateTuple : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Base):
+  %2 = function_ref @tuple_addr_constructor_callee : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  %3 = alloc_stack $*Builtin.NativeObject
+  %4 = alloc_stack $*Base
+  %0a = tuple ()
+  %0b = copy_value %0 : $Builtin.NativeObject
+  store %0b to [init] %3 : $*Builtin.NativeObject
+  %1a = copy_value %1 : $Base
+  %1b = copy_value %1 : $Base
+  store %1b to [init] %4 : $*Base
+  apply %2<Builtin.NativeObject, Base, (), Base>(%3, %4, %0a, %1a) : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  dealloc_stack %4 : $*Base
+  dealloc_stack %3 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @specializeTupleAddrConstructorEliminateMultiLevelTuple : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Base):
+  %2 = function_ref @tuple_addr_constructor_callee : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  %3 = alloc_stack $*Builtin.NativeObject
+  %4 = alloc_stack $*Base
+  %0b = copy_value %0 : $Builtin.NativeObject
+  store %0b to [init] %3 : $*Builtin.NativeObject
+  %1a = copy_value %1 : $Base
+  %1b = copy_value %1 : $Base
+  store %1b to [init] %4 : $*Base
+  %tup = tuple ()
+  %tup2 = tuple (%tup : $(), %tup : $())
+  %tup3 = tuple (%tup : $(), %tup2 : $((), ()))
+  apply %2<Builtin.NativeObject, Base, ((), ((), ())), Base>(%3, %4, %tup3, %1a) : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  dealloc_stack %4 : $*Base
+  dealloc_stack %3 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @specializeTupleAddrConstructorEliminateNoEliminateIfOneElt : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @guaranteed $Base):
+  %2 = function_ref @tuple_addr_constructor_callee : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  %3 = alloc_stack $*Builtin.NativeObject
+  %4 = alloc_stack $*Base
+  %0a = copy_value %0 : $Builtin.NativeObject
+  %0b = copy_value %0 : $Builtin.NativeObject
+  store %0b to [init] %3 : $*Builtin.NativeObject
+  %1a = copy_value %1 : $Base
+  %1b = copy_value %1 : $Base
+  store %1b to [init] %4 : $*Base
+  %tup = tuple ()
+  %tup2 = tuple (%0a : $Builtin.NativeObject, %tup : $())
+  %tup3 = tuple (%tup : $(), %tup2 : $(Builtin.NativeObject, ()))
+  apply %2<Builtin.NativeObject, Base, ((), (Builtin.NativeObject, ())), Base>(%3, %4, %tup3, %1a) : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  dealloc_stack %4 : $*Base
+  dealloc_stack %3 : $*Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @specializeTupleAddrConstructorNoEmitIfAllTuple : $@convention(thin) () -> () {
+bb0:
+  %2 = function_ref @tuple_addr_constructor_callee : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  %3 = alloc_stack $*()
+  %4 = alloc_stack $*()
+  %tup = tuple ()
+  %tup2 = tuple (%tup : $(), %tup : $())
+  %tup3 = tuple (%tup : $(), %tup2 : $((), ()))
+  apply %2<(), (), ((), ((), ())), ()>(%3, %4, %tup3, %tup) : $@convention(thin) <T1, T2, T3, T4> (@in T1, @in T2, @owned T3, @owned T4) -> ()
+  dealloc_stack %4 : $*()
+  dealloc_stack %3 : $*()
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
This PR contains 2 commits that create infrastructure and a final infrastructure that actually implements the subject of this radar. I did this to ease reviewing.

The purpose of this PR is that it ensures that diagnostic passes like TransferNonSendable can discern in between full assignments to tuples vs assignments to projects of the tuple. Before, SILGen would perform tuple assignment by performing it in pieces. This PR introduces a new instruction called tuple_addr_constructor that is equivalent to those in pieces assignments and provides the one memory writing instruction that such diagnostic passes can understand are an assignment over the entire tuple.

I included the full message for the main patch (#3) at the bottom of the PR. Below I included short high level abstracts of the patches:

1. I added support for the tuple_addr_constructor instruction. This instruction takes in a tuple address (that may have multiple tuple levels) and initializes its tuple leaf elements with the arguments of the instruction. The arguments may be objects or addresses. This mimics how RValue initializes output and was done this way to ensure that we can easily handle complex tuples with arguments and empty tuple members. Semantically it acts like a specialized copy_addr [take]/store. Thus from a memory effect perspective it has side-effects and the behavior of copy_addr/store.
2. I added a small pass that runs after TransferNonSendable that lowers tuple_addr_constructor. It does this by emitting the relevant tuple_element_addr + copy_addr/store as appropriate. This ensures that I did not need to update huge amounts of the pass pipeline in order to fix this issue.
3. In this patch I changed RValue::assignInto to use the new instruction and updated DI/TransferNonSendable/other parts of the optimizer to handle this instruction. As part of this, I updated the relevant diagnostic test in TransferNonSendable that show we properly identify tuple assignments vs assignments to their projections.

----

[region-isolation] When assigning RValues into memory, use tuple_addr_constructor instead of doing it in pieces.

I also included changes to the rest of the SIL optimizer pipeline to ensure that
the part of the optimizer pipeline before we lower tuple_addr_constructor (which
is right after we run TransferNonSendable) work as before.

The reason why I am doing this is that this ensures that diagnostic passes can
tell the difference in between:

```
x = (a, b, c)
```

and

```
x.0 = a
x.1 = b
x.2 = c
```

This is important for things like TransferNonSendable where assigning over the
entire tuple element is treated differently from if one were to initialize it in
pieces using projections.

rdar://117880194