### PR TITLE
[follow-up][Distributed]Adjust overload detection for distributed funcs

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3226,14 +3226,12 @@ bool swift::conflicting(const OverloadSignature& sig1,
   // versions, as that is what the async overloading aimed to address.
   //
   // Note also, that overloading on throws is already illegal anyway.
-  if (sig1.IsDistributed || sig2.IsDistributed) {
-    if (sig1.IsAsyncFunction != sig2.IsAsyncFunction)
-      return true;
-  } else {
-    // Otherwise one is an async function and the other is not, they don't conflict.
+  if (!sig1.IsDistributed && !sig2.IsDistributed) {
+    // For non-distributed functions,
+    // if one is an async function and the other is not, they don't conflict.
     if (sig1.IsAsyncFunction != sig2.IsAsyncFunction)
       return false;
-  }
+  } // else, if any of the methods was distributed, continue checking
 
   // If one is a macro and the other is not, they can't conflict.
   if (sig1.IsMacro != sig2.IsMacro)


### PR DESCRIPTION
Follow up after review in https://github.com/apple/swift/pull/69596/files#r1383692925

I wasn't really able to find and make a test case for which case this is fixing though...?

> I do not believe this is correct; if one of them is distributed, and mismatch on async, we should fall through to check the names below, not determine that they are always conflicting. They might have different argument names entirely.

Seems to imply different argument labels; but when that is the case we don't end up checking in this method anyway it seems 🤔 

rdar://117818281