### PR TITLE
Revert "[cxx-interop] Partially disable a test on Linux"

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -14,11 +14,9 @@ StdOptionalTestSuite.test("pointee") {
   let pointee = nonNilOpt.pointee
   expectEqual(123, pointee)
 
-#if !os(Linux) // crashes on Ubuntu 18.04 (rdar://113414160)
   var modifiedOpt = getNilOptional()
   modifiedOpt.pointee = 777
   expectEqual(777, modifiedOpt.pointee)
-#endif
 }
 
 StdOptionalTestSuite.test("std::optional => Swift.Optional") {


### PR DESCRIPTION
This reverts commit ff5b698602448ccaf02984b28fb9e6a56a0f0b5f.

The crash likely got fixed by https://github.com/apple/swift/pull/68846.