### PR TITLE
utils: adjust build.ps1 help invocation in helper launcher

### DIFF
--- a/utils/build.cmd
+++ b/utils/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 if "%1"=="/?" (
-    powershell.exe -Command "& Get-Help -Detailed .\build.ps1"
+    powershell.exe -Command "& Get-Help -Detailed ""%~dp0\build.ps1"""
     exit /b
 )
 


### PR DESCRIPTION
As the helper script could (and probably always would) be launched from a directory outside of the source tree, it is convenient to use an absolute path in `Get-Help` invocation, just like we do in the `build.ps1` invocation below. Also, quoting might be necessary for paths with spaces.
