### PR TITLE
Update mixin_swiftpm_base to include swift-driver

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1696,6 +1696,7 @@ build-subdir=buildbot_incremental
 libcxx
 llbuild
 swiftpm
+swift-driver
 
 install-llvm
 install-swift
@@ -1703,6 +1704,7 @@ install-llbuild
 install-swiftpm
 install-swiftsyntax
 install-libcxx
+install-swift-driver
 
 skip-test-swift
 


### PR DESCRIPTION
Updates the base spm preset to include building and installing the swift driver. This ensures that ci jobs properly use the new driver instead of the to-be-removed c++ version.

Fixes the issue with the spm LTO test fixture on linux here: https://github.com/apple/swift-package-manager/pull/6891