### PR TITLE
[5.10][ClangImporter] Always rebuild any bridging PCH that has errors

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -892,9 +892,6 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   invocation->getHeaderSearchOpts().ModulesValidateSystemHeaders = true;
   invocation->getLangOpts()->NeededByPCHOrCompilationUsesPCH = true;
   invocation->getLangOpts()->CacheGeneratedPCH = true;
-  // If the underlying invocation is allowing PCH errors, then it "can be read",
-  // even if it has its error bit set. Thus, don't override
-  // `AllowPCHWithCompilerErrors`.
 
   // ClangImporter::create adds a remapped MemoryBuffer that we don't need
   // here.  Moreover, it's a raw pointer owned by the preprocessor options; if
@@ -931,6 +928,14 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
     clang::ASTReader::ARR_Missing |
     clang::ASTReader::ARR_OutOfDate |
     clang::ASTReader::ARR_VersionMismatch;
+
+  // If a PCH was output with errors, it may not have serialized all its
+  // inputs. If there was a change to the search path or a headermap now
+  // exists where it didn't previously, it's possible those inputs will now be
+  // found. Ideally we would only rebuild in this particular case rather than
+  // any error in general, but explicit module builds are the real solution
+  // there. For now, just treat PCH with errors as out of date.
+  failureCapabilities |= clang::ASTReader::ARR_TreatModuleWithErrorsAsOutOfDate;
 
   auto result = Reader.ReadAST(PCHFilename, clang::serialization::MK_PCH,
                                clang::SourceLocation(), failureCapabilities);

--- a/test/ClangImporter/AllowErrors/invalid-pch-bridging-header.swift
+++ b/test/ClangImporter/AllowErrors/invalid-pch-bridging-header.swift
@@ -3,27 +3,48 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/pch %t/pch-dir
 // RUN: split-file %s %t
+// RUN: sed -e "s|TEST_DIR|%/t|g" %t/hmap.json > %t/inner.json
 
 // Check that the pch is output even though it has errors
-// RUN: %target-swift-frontend -emit-pch -o %t/pch/bridging-header.pch -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/bridging-header.h
-// RUN: %target-swift-frontend -typecheck -verify -import-objc-header %t/pch/bridging-header.pch -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift
+// RUN: %target-swift-frontend -emit-pch -o %t/pch/bridging-header.pch -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/bridging-header.h -Xcc -I%t/inner.hmap
+// RUN: not %target-swift-frontend -typecheck -import-objc-header %t/pch/bridging-header.pch -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift -Xcc -I%t/inner.hmap 2>&1 | %FileCheck %s -check-prefix MISSING_HMAP
 // RUN: ls %t/pch/*.pch | count 1
 
 // Same but with implicit PCH instead
-// RUN: %target-swift-frontend -typecheck -verify -import-objc-header %t/bridging-header.h -pch-output-dir %t/pch-dir -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift
+// RUN: not %target-swift-frontend -typecheck -import-objc-header %t/bridging-header.h -pch-output-dir %t/pch-dir -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift -Xcc -I%t/inner.hmap 2>&1 | %FileCheck %s -check-prefix MISSING_HMAP
 // RUN: ls %t/pch-dir/*.pch | count 1
 
 // Second implicit run since we may go down a different path if the PCH already
 // exists
-// RUN: %target-swift-frontend -typecheck -verify -import-objc-header %t/bridging-header.h -pch-output-dir %t/pch-dir -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift
+// RUN: not %target-swift-frontend -typecheck -import-objc-header %t/bridging-header.h -pch-output-dir %t/pch-dir -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift -Xcc -I%t/inner.hmap 2>&1 | %FileCheck %s -check-prefix MISSING_HMAP
+// RUN: ls %t/pch-dir/*.pch | count 1
+
+// Create the headermap, should now have no errors
+// RUN: %hmaptool write %t/inner.json %t/inner.hmap
+// RUN: %target-swift-frontend -typecheck -verify -import-objc-header %t/bridging-header.h -pch-output-dir %t/pch-dir -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift -Xcc -I%t/inner.hmap
 // RUN: ls %t/pch-dir/*.pch | count 1
 
 //--- bridging-header.h
-@import DoesNotExist;
+#include "inner.h"
 
 struct SomeTy {
   int a;
 };
 
+//--- inner/inner.h
+struct InnerTy {
+  int b;
+};
+
+//--- hmap.json
+{
+  "mappings": {
+    "inner.h": "TEST_DIR/inner/inner.h"
+  }
+}
+
 //--- use.swift
-func use(s: SomeTy) {}
+func use(s: SomeTy, s2: InnerTy) {}
+// MISSING_HMAP-NOT: cannot find type 'SomeTy' in scope
+// MISSING_HMAP: cannot find type 'InnerTy' in scope
+// MISSING_HMAP-NOT: cannot find type 'SomeTy' in scope


### PR DESCRIPTION
* Explanation: If a PCH was output with errors, it may not have serialized all its inputs. If there was a change to the search path or a headermap now exists where it didn't previously, it's possible those inputs will now be found. This cherry-pick treats any PCH with errors as out of date, which will cause them to be rebuilt to cover this case.
* Scope: Impacts rebuilding PCH with errors, which never happens in the compiler itself (only editor functionality)
* Testing: Extra test case to check we rebuild when there's an error.
* Risk: Low
* Reviewed By: @artemcm
* Main Branch PR: https://github.com/apple/swift/pull/69676
* Resolves: rdar://117037471