### PR TITLE
[Typed throws] Implement reabstraction thunks that change the error

### DIFF
--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -216,10 +216,7 @@ public:
     return getSILType(funcTy->getErrorResult(), context);
   }
 
-  bool isTypedError() const {
-    return !funcTy->getErrorResult()
-        .getInterfaceType()->isExistentialWithError();
-  }
+  bool isTypedError() const;
 
   /// Returns an array of result info.
   /// Provides convenient access to the underlying SILFunctionType.

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1279,8 +1279,15 @@ AbstractionPattern::getFunctionThrownErrorType(
                           (*optErrorType)->getCanonicalType());
   }
 
-  if (!optErrorType)
-    optErrorType = ctx.getErrorExistentialType();
+  if (!optErrorType) {
+    Type origErrorSubstType =
+        optOrigErrorType->getType()
+          .subst(optOrigErrorType->getGenericSubstitutions());
+    if (origErrorSubstType->isNever())
+      optErrorType = ctx.getNeverType();
+    else
+      optErrorType = ctx.getErrorExistentialType();
+  }
 
   return std::make_pair(*optOrigErrorType,
                         (*optErrorType)->getCanonicalType());

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4948,5 +4948,5 @@ bool SILFunctionConventions::isTypedError() const {
   return !funcTy->getErrorResult()
         .getInterfaceType()->isEqual(
             funcTy->getASTContext().getErrorExistentialType()) ||
-    getNumIndirectSILResults() > 0;
+    hasIndirectSILErrorResults();
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4946,5 +4946,7 @@ CanSILFunctionType SILFunction::getLoweredFunctionTypeInContext(
 
 bool SILFunctionConventions::isTypedError() const {
   return !funcTy->getErrorResult()
-      .getInterfaceType()->isExistentialWithError();
+        .getInterfaceType()->isEqual(
+            funcTy->getASTContext().getErrorExistentialType()) ||
+    getNumIndirectSILResults() > 0;
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4943,3 +4943,8 @@ CanSILFunctionType SILFunction::getLoweredFunctionTypeInContext(
   auto funTy = M.Types.getLoweredType(origFunTy , context);
   return cast<SILFunctionType>(funTy.getASTType());
 }
+
+bool SILFunctionConventions::isTypedError() const {
+  return !funcTy->getErrorResult()
+      .getInterfaceType()->isExistentialWithError();
+}

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6071,7 +6071,6 @@ public:
     }
 
     if (fnConv.hasIndirectSILErrorResults()) {
-      assert(fnConv.isTypedError());
       auto errorResult = fnConv.getSILErrorType(F.getTypeExpansionContext());
       check("indirect error result", errorResult);
     }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5715,7 +5715,6 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
   CanSILFunctionType silFnType = substFnType.castTo<SILFunctionType>();
   SILFunctionConventions fnConv(silFnType, SGM.M);
   SILType resultType = fnConv.getSILResultType(getTypeExpansionContext());
-
   if (!silFnType->hasErrorResult()) {
     return B.createApply(loc, fn, subs, args);
   }
@@ -5728,19 +5727,64 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
   {
     B.emitBlock(errorBB);
 
-    SILValue error;
-    bool indirectError = fnConv.hasIndirectSILErrorResults();
-
-    if (!indirectError) {
-      error = errorBB->createPhiArgument(
+    // Grab the inner error.
+    SILValue innerError;
+    bool hasInnerIndirectError = fnConv.hasIndirectSILErrorResults();
+    if (!hasInnerIndirectError) {
+      innerError = errorBB->createPhiArgument(
           fnConv.getSILErrorType(getTypeExpansionContext()),
           OwnershipKind::Owned);
+    } else {
+      // FIXME: This probably belongs on SILFunctionConventions.
+      innerError = args[fnConv.getNumIndirectSILResults()];
+    }
+
+    // Convert to the outer error, if we need to.
+    SILValue outerError;
+    SILType innerErrorType = innerError->getType().getObjectType();
+    SILType outerErrorType = F.mapTypeIntoContext(
+        F.getConventions().getSILErrorType(getTypeExpansionContext()));
+    if (IndirectErrorResult && IndirectErrorResult == innerError) {
+      // Fast path: we aliased the indirect error result slot because both are
+      // indirect and the types matched, so we are done.
+    } else if (!IndirectErrorResult && !hasInnerIndirectError &&
+               innerErrorType == outerErrorType) {
+      // Fast path: both have a direct error result and the types line up, so
+      // rethrow the inner error.
+      outerError = innerError;
+    } else {
+      // The error requires some kind of translation.
+
+      // Load the inner error, if it was returned indirectly.
+      if (innerError->getType().isAddress()) {
+        innerError = emitLoad(loc, innerError, getTypeLowering(innerErrorType),
+                              SGFContext(), IsTake).forward(*this);
+      }
+
+      // If we need to convert the error type, do so now.
+      if (innerErrorType != outerErrorType) {
+        auto conversion = Conversion::getOrigToSubst(
+            AbstractionPattern(innerErrorType.getASTType()),
+            outerErrorType.getASTType(),
+            outerErrorType);
+        outerError = emitConvertedRValue(loc, conversion, SGFContext(),
+            [innerError](SILGenFunction &SGF, SILLocation loc, SGFContext C) {
+              return ManagedValue::forForwardedRValue(SGF, innerError);
+            }).forward(*this);
+      }
+
+      // If the outer error is returned indirectly, copy from the converted
+      // inner error to the outer error slot.
+      if (IndirectErrorResult) {
+        emitSemanticStore(loc, outerError, IndirectErrorResult, 
+                          getTypeLowering(outerErrorType), IsInitialization);
+      }
     }
 
     Cleanups.emitCleanupsForReturn(CleanupLocation(loc), IsForUnwind);
 
-    if (!indirectError)
-      B.createThrow(loc, error);
+    if (!IndirectErrorResult)
+      B.createThrow(loc, outerError);
     else
       B.createThrowAddr(loc);
   }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2273,7 +2273,8 @@ public:
   /// Used for emitting SILArguments of bare functions, such as thunks.
   void collectThunkParams(
       SILLocation loc, SmallVectorImpl<ManagedValue> &params,
-      SmallVectorImpl<ManagedValue> *indirectResultParams = nullptr);
+      SmallVectorImpl<ManagedValue> *indirectResultParams = nullptr,
+      SmallVectorImpl<ManagedValue> *indirectErrorParams = nullptr);
 
   /// Build the type of a function transformation thunk.
   CanSILFunctionType buildThunkType(CanSILFunctionType &sourceType,

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1813,17 +1813,21 @@ uint16_t SILGenFunction::emitBasicProlog(
   emitIndirectResultParameters(*this, resultType, origResultType, DC);
 
   llvm::Optional<AbstractionPattern> origErrorType;
-  if (errorType) {
-    if (origClosureType &&
-        !origClosureType->isTypeParameterOrOpaqueArchetype()) {
-      origErrorType =
-          origClosureType->getFunctionThrownErrorType();
-    } else {
-      origErrorType =
-          AbstractionPattern(genericSig.getCanonicalSignature(),
-                             (*errorType)->getCanonicalType());
+  if (origClosureType && !origClosureType->isTypeParameterOrOpaqueArchetype()) {
+    CanType substClosureType = origClosureType->getType()
+        .subst(origClosureType->getGenericSubstitutions())->getCanonicalType();
+    CanAnyFunctionType substClosureFnType =
+        cast<AnyFunctionType>(substClosureType);
+    if (auto optPair = origClosureType->getFunctionThrownErrorType(substClosureFnType)) {
+      origErrorType = optPair->first;
+      errorType = optPair->second;
     }
+  } else if (errorType) {
+    origErrorType = AbstractionPattern(genericSig.getCanonicalSignature(),
+                                       (*errorType)->getCanonicalType());
+  }
 
+  if (origErrorType && errorType) {
     emitIndirectErrorParameter(*this, *errorType, *origErrorType, DC);
   }
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1827,7 +1827,8 @@ uint16_t SILGenFunction::emitBasicProlog(
                                        (*errorType)->getCanonicalType());
   }
 
-  if (origErrorType && errorType) {
+  if (origErrorType && errorType &&
+      F.getConventions().hasIndirectSILErrorResults()) {
     emitIndirectErrorParameter(*this, *errorType, *origErrorType, DC);
   }
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1547,63 +1547,65 @@ void SILGenFunction::emitThrow(SILLocation loc, ManagedValue exnMV,
     }
   }
 
+  bool shouldDiscard = ThrowDest.getThrownError().Discard;
+  SILType exnType = exn->getType().getObjectType();
   SILBasicBlock &throwBB = *ThrowDest.getBlock();
-  if (!throwBB.getArguments().empty()) {
-    assert(exn);
-    assert(!indirectErrorAddr);
+  SILType destErrorType =  indirectErrorAddr
+      ? indirectErrorAddr->getType().getObjectType()
+      : !throwBB.getArguments().empty() 
+        ? throwBB.getArguments()[0]->getType().getObjectType()
+        : exnType;
 
-    auto errorArg = throwBB.getArguments()[0];
+  // If the thrown error type differs from what the throw destination expects,
+  // perform the conversion.
+  // FIXME: Can the AST tell us what to do here?
+  if (exnType != destErrorType && !shouldDiscard) {
+    assert(destErrorType == SILType::getExceptionType(getASTContext()));
 
-    // If we don't have an existential box, create one to jump to the throw
-    // destination.
-    SILType errorArgType = errorArg->getType();
-    if (exn->getType() != errorArgType) {
-      SILType existentialBoxType = SILType::getExceptionType(getASTContext());
-      assert(errorArgType == existentialBoxType);
+    ProtocolConformanceRef conformances[1] = {
+      getModule().getSwiftModule()->conformsToProtocol(
+        exn->getType().getASTType(), getASTContext().getErrorDecl())
+    };
 
-      // FIXME: Callers should provide this conformance from places recorded in
-      // the AST.
-      ProtocolConformanceRef conformances[1] = {
-        getModule().getSwiftModule()->conformsToProtocol(
-          exn->getType().getASTType(), getASTContext().getErrorDecl())
-      };
+    exn = emitExistentialErasure(
+        loc,
+        exnType.getASTType(),
+        getTypeLowering(exnType),
+        getTypeLowering(destErrorType),
+        getASTContext().AllocateCopy(conformances),
+        SGFContext(),
+        [&](SGFContext C) -> ManagedValue {
+          if (exn->getType().isAddress()) {
+            return emitLoad(loc, exn, getTypeLowering(exnType), SGFContext(),
+                            IsTake);
+          }
 
-      exnMV = emitExistentialErasure(
-          loc,
-          exn->getType().getASTType(),
-          getTypeLowering(exn->getType().getObjectType()),
-          getTypeLowering(existentialBoxType),
-          getASTContext().AllocateCopy(conformances),
-          SGFContext(),
-          [&](SGFContext C) -> ManagedValue {
-            if (exn->getType().isAddress()) {
-              return emitLoad(loc, exn, getTypeLowering(exn->getType().getObjectType()), C, IsTake);
-            }
+          return ManagedValue::forForwardedRValue(*this, exn);
+        }).forward(*this);
+  }
+  assert(exn->getType().getObjectType() == destErrorType);
 
-            return ManagedValue::forForwardedRValue(*this, exn);
-          });
-
-      exn = exnMV.forward(*this);
+  if (indirectErrorAddr) {
+    if (exn->getType().isAddress()) {
+      B.createCopyAddr(loc, exn, indirectErrorAddr,
+                       IsTake, IsInitialization);
+    } else {
+      // An indirect error is written into the destination error address.
+      emitSemanticStore(loc, exn, indirectErrorAddr,
+                        getTypeLowering(destErrorType), IsInitialization);
+    }
+  } else if (!throwBB.getArguments().empty()) {
+    // Load if we need to.
+    if (exn->getType().isAddress()) {
+      exn = emitLoad(loc, exn, getTypeLowering(exnType), SGFContext(), IsTake)
+         .forward(*this);
     }
 
     // A direct error value is passed to the epilog block as a BB argument.
     args.push_back(exn);
-  } else if (ThrowDest.getThrownError().Discard) {
-    assert(!indirectErrorAddr);
-    if (exn)
+  } else if (shouldDiscard) {
+    if (exn && exn->getType().isAddress())
       B.createDestroyAddr(loc, exn);
-  } else {
-    assert(indirectErrorAddr);
-
-    // FIXME: opaque values
-
-    // If an error value was provided by the caller, copy it into the
-    // indirect error result. Otherwise we assume the indirect error
-    // result has been initialized.
-    if (exn) {
-      B.createCopyAddr(loc, exn, indirectErrorAddr,
-                       IsTake, IsInitialization);
-    }
   }
 
   // Branch to the cleanup destination.

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1567,14 +1567,19 @@ void SILGenFunction::emitThrow(SILLocation loc, ManagedValue exnMV,
         getModule().getSwiftModule()->conformsToProtocol(
           exn->getType().getASTType(), getASTContext().getErrorDecl())
       };
+
       exnMV = emitExistentialErasure(
           loc,
           exn->getType().getASTType(),
-          getTypeLowering(exn->getType()),
+          getTypeLowering(exn->getType().getObjectType()),
           getTypeLowering(existentialBoxType),
           getASTContext().AllocateCopy(conformances),
           SGFContext(),
           [&](SGFContext C) -> ManagedValue {
+            if (exn->getType().isAddress()) {
+              return emitLoad(loc, exn, getTypeLowering(exn->getType().getObjectType()), C, IsTake);
+            }
+
             return ManagedValue::forForwardedRValue(*this, exn);
           });
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -114,6 +114,10 @@ static bool canSpecializeFunction(SILFunction *F,
   if (F->getConventions().hasIndirectSILResults())
     return false;
 
+  // For now ignore functions with indirect error results.
+  if (F->getConventions().hasIndirectSILErrorResults())
+    return false;
+
   // For now ignore coroutines.
   if (F->getLoweredFunctionType()->isCoroutine())
     return false;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -517,6 +517,10 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
   if (shouldNotSpecialize(Callee, Apply ? Apply.getFunction() : nullptr))
     return false;
 
+  // FIXME: Specialization with typed throws.
+  if (Callee->getConventions().hasIndirectSILErrorResults())
+    return false;
+
   SpecializedGenericEnv = nullptr;
   SpecializedGenericSig = nullptr;
   auto CalleeGenericSig = Callee->getLoweredFunctionType()

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -32,7 +32,7 @@ func buildMetatype() -> Any.Type {
 }
 
 // CHECK-NOMANGLE: define linkonce_odr hidden swiftcc %swift.metadata_response @"$sySi12typed_throws10MyBigErrorOYKcMa"
-// CHECK: call ptr @swift_getExtendedFunctionTypeMetadata({{i32|i64}} 2231369729, {{i32|i64}} 0, ptr [[PARAMS:%.*]], ptr null, ptr getelementptr inbounds (%swift.full_existential_type, ptr @"$sytN", i32 0, i32 1), ptr null, i32 1, ptr getelementptr inbounds (<{ ptr, ptr, i64, ptr }>, ptr {{.*}}@"$s12typed_throws10MyBigErrorOMf"
+// CHECK-NOMANGLE: call ptr @swift_getExtendedFunctionTypeMetadata({{i32|i64}} 2231369729, {{i32|i64}} 0, ptr [[PARAMS:%.*]], ptr null, ptr getelementptr inbounds (%swift.full_existential_type, ptr @"$sytN", i32 0, i32 1), ptr null, i32 1, ptr getelementptr inbounds (<{ ptr, ptr, i64, ptr }>, ptr {{.*}}@"$s12typed_throws10MyBigErrorOMf"
 
 protocol P {
   associatedtype A

--- a/test/Profiler/coverage_closure_returns_never.swift
+++ b/test/Profiler/coverage_closure_returns_never.swift
@@ -6,6 +6,7 @@
 // CHECK-NOT:  increment_profiler_counter
 // CHECK:      [[LOAD:%.*]] = load {{.*}} : $*Never
 // CHECK-NEXT: debug_value [[LOAD]] : $Never
+// CHECK-NEXT: debug_value undef : $any Error, var, name "$error", argno
 // CHECK-NEXT: unreachable
 
 func closure_with_fatal_error(_ arr: [Never]) {

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -237,3 +237,20 @@ func reabstractClosureAsTypedThrowing(b: Bool) throws(MyError) -> Int {
   // CHECK: dealloc_stack [[INT_BOX]] : $*Int
   // CHECK-NEXT: throw [[ERROR]] : $MyError
 }
+
+
+extension Collection {
+  func typedMap<T, E>(body: (Element) throws(E) -> T) throws(E) -> [T] {
+    var result: [T] = []
+    for element in self {
+      result.append(try body(element))
+    }
+    return result
+  }
+}
+
+// CHECK-LABEL: sil private [ossa] @$s20typed_throws_generic9forcedMapySayq_GSayxGr0_lFq_xXEfU_ : $@convention(thin) <T, U> (@in_guaranteed T) -> (@out U, @error Never)
+func forcedMap<T, U>(_ source: [T]) -> [U] {
+  // CHECK: bb0(%0 : $*U, %1 : $*T)
+  return source.typedMap { $0 as! U }
+}


### PR DESCRIPTION
Introduce SILGen support for reabstractions thunks that change the error, between indirect and direct errors as well as conversions amongst error types (e.g., from concrete to `any Error`).
