### PR TITLE
[5.10][Macros] Disallow expression macro as default argument

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7349,6 +7349,9 @@ ERROR(extension_macro_invalid_conformance,none,
 ERROR(macro_attached_to_invalid_decl,none,
       "'%0' macro cannot be attached to %1 (%base2)",
       (StringRef, DescriptiveDeclKind, const Decl *))
+ERROR(macro_as_default_argument, none,
+      "non-built-in macro cannot be used as default argument",
+      ())
 ERROR(conformance_macro,none,
       "conformance macros are replaced by extension macros",
       ())

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1134,6 +1134,12 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
   auto *initExpr = param->getStructuralDefaultExpr();
   assert(initExpr);
 
+  // Prohibit default argument that is a non-built-in macro to avoid confusion.
+  if (isa<MacroExpansionExpr>(initExpr)) {
+    ctx.Diags.diagnose(initExpr->getLoc(), diag::macro_as_default_argument);
+    return new (ctx) ErrorExpr(initExpr->getSourceRange(), ErrorType::get(ctx));
+  }
+
   // If the param has an error type, there's no point type checking the default
   // expression, unless we are type checking for code completion, in which case
   // the default expression might contain the code completion token.

--- a/test/Macros/macro_default_argument.swift
+++ b/test/Macros/macro_default_argument.swift
@@ -1,0 +1,32 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s
+
+@freestanding(expression)
+macro MagicLine() -> Int = #externalMacro(module: "MacroDefinition", type: "MagicLineMacro")
+
+struct LineContainer {
+    let line: Int
+}
+
+func partOfDefaultArgumentOkay(container: LineContainer = .init(line: #MagicLine)) {
+    print(container.line)
+}
+
+func parenthesizedExpansionAtDeclOkay(line: Int = (#MagicLine)) {
+    print(line)
+}
+
+func builtInOkay(line: Int = #line) {
+    print(line)
+}
+
+// expected-error@+1{{non-built-in macro cannot be used as default argument}}
+func asDefaultArgument(line: Int = #MagicLine) {
+    print(line)
+}
+
+asDefaultArgument()

--- a/test/ModuleInterface/unbuildable.swift
+++ b/test/ModuleInterface/unbuildable.swift
@@ -22,7 +22,7 @@
 // RUN: not %target-swift-frontend -typecheck-module-from-interface %t/UnbuildableCurrent.swiftinterface 2>&1 | %FileCheck -check-prefixes=ALL,CURRENT-VERIFY %s
 // RUN: not %target-swift-frontend -typecheck-module-from-interface %t/UnbuildableFuture.swiftinterface 2>&1 | %FileCheck -check-prefixes=ALL,FUTURE-VERIFY %s
 
-// ALL: Unbuildable{{[^.]+}}.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: no macro named 'somethingYouveNeverHeardOf'
+// ALL: Unbuildable{{[^.]+}}.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: non-built-in macro cannot be used as default argument
 
 #if CURRENT
 import UnbuildableCurrent


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/68782

---

- Explanation: add error diagnostics to disallow non-built-in expression macros used as default arguments for function declarations. It's important to add this diagnostic early before developers start to rely on the undefined behavior of how macros work in this case
- Scope: function declarations that use non-built-in expression macro as default argument
- Main Branch PR: https://github.com/apple/swift/pull/68782
- Resolves: rdar://115674594
- Risk: Low, as the impacted scope should not be allowed, as specified in SE-0382
- Reviewed By: @DougGregor 
- Testing: added test-cases to the test suite