### PR TITLE
Fix the Effective Access Level of package Declarations

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4120,6 +4120,15 @@ AccessLevel ValueDecl::getEffectiveAccess() const {
   case AccessLevel::Open:
     break;
   case AccessLevel::Package:
+    if (getModuleContext()->isTestingEnabled() ||
+        getModuleContext()->arePrivateImportsEnabled()) {
+        effectiveAccess = getMaximallyOpenAccessFor(this);
+    } else {
+        // Package declarations are effectively public within their
+        // package unit.
+        effectiveAccess = AccessLevel::Public;
+    }
+    break;
   case AccessLevel::Public:
   case AccessLevel::Internal:
     if (getModuleContext()->isTestingEnabled() ||

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3740,9 +3740,11 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
                        genericParamType, protocol->getName().str());
         break;
       case UnviableReason::Inaccessible:
-        diags.diagnose(init->getLoc(), diag::type_eraser_init_not_accessible,
-                       init->getEffectiveAccess(), protocolType,
-                       protocol->getEffectiveAccess());
+        diags.diagnose(
+            init->getLoc(), diag::type_eraser_init_not_accessible,
+            init->getFormalAccessScope().requiredAccessForDiagnostics(),
+            protocolType,
+            protocol->getFormalAccessScope().requiredAccessForDiagnostics());
         break;
       case UnviableReason::SPI:
         diags.diagnose(init->getLoc(), diag::type_eraser_init_spi,

--- a/test/IRGen/Inputs/package_types/resilient_class.swift
+++ b/test/IRGen/Inputs/package_types/resilient_class.swift
@@ -1,0 +1,106 @@
+
+import resilient_struct
+
+
+
+// Resilient base class
+
+package class ResilientOutsideParent {
+  package var property: String = "ResilientOutsideParent.property"
+  package final var finalProperty: String = "ResilientOutsideParent.finalProperty"
+
+  package class var classProperty: String {
+    return "ResilientOutsideParent.classProperty"
+  }
+
+  package init() {
+    print("ResilientOutsideParent.init()")
+  }
+
+  package func method() {
+    print("ResilientOutsideParent.method()")
+  }
+
+  package class func classMethod() {
+    print("ResilientOutsideParent.classMethod()")
+  }
+
+  package func getValue() -> Int {
+    return 0
+  }
+}
+
+
+
+// Resilient subclass
+
+package class ResilientOutsideChild : ResilientOutsideParent {
+  package override func method() {
+    print("ResilientOutsideChild.method()")
+    super.method()
+  }
+
+  package override class func classMethod() {
+    print("ResilientOutsideChild.classMethod()")
+    super.classMethod()
+  }
+}
+
+
+// Resilient generic base class
+
+package class ResilientGenericOutsideParent<A> {
+  package var property: A
+  package init(property: A) {
+    self.property = property
+    print("ResilientGenericOutsideParent.init()")
+  }
+
+  package func method() {
+    print("ResilientGenericOutsideParent.method()")
+  }
+
+  package class func classMethod() {
+    print("ResilientGenericOutsideParent.classMethod()")
+  }
+}
+
+
+// Resilient generic subclass
+
+package class ResilientGenericOutsideChild<A> : ResilientGenericOutsideParent<A> {
+  package override init(property: A) {
+    print("ResilientGenericOutsideGenericChild.init(a: A)")
+    super.init(property: property)
+  }
+
+  package override func method() {
+    print("ResilientGenericOutsideChild.method()")
+    super.method()
+  }
+
+  package override class func classMethod() {
+    print("ResilientGenericOutsideChild.classMethod()")
+    super.classMethod()
+  }
+}
+
+
+// Resilient subclass of generic class
+
+package class ResilientConcreteOutsideChild : ResilientGenericOutsideParent<String> {
+  package override init(property: String) {
+    print("ResilientConcreteOutsideChild.init(property: String)")
+    super.init(property: property)
+  }
+
+  package override func method() {
+    print("ResilientConcreteOutsideChild.method()")
+    super.method()
+  }
+
+  package override class func classMethod() {
+    print("ResilientConcreteOutsideChild.classMethod()")
+    super.classMethod()
+  }
+}

--- a/test/IRGen/Inputs/package_types/resilient_enum.swift
+++ b/test/IRGen/Inputs/package_types/resilient_enum.swift
@@ -1,0 +1,217 @@
+import resilient_struct
+
+// Fixed-layout enum with resilient members
+package enum SimpleShape {
+  case KleinBottle
+  case Triangle(Size)
+}
+
+// Fixed-layout enum with resilient members
+package enum Shape {
+  case Point
+  case Rect(Size)
+  case RoundedRect(Size, Size)
+}
+
+// Fixed-layout enum with indirect resilient members
+package enum FunnyShape {
+  indirect case Parallelogram(Size)
+  indirect case Trapezoid(Size)
+}
+
+package enum FullyFixedLayout {
+  case noPayload
+  case hasPayload(Int)
+}
+
+// The enum payload has fixed layout inside this module, but
+// resilient layout outside. Make sure we emit the payload
+// size in the metadata.
+
+package struct Color {
+  package let r: Int, g: Int, b: Int
+
+  package init(r: Int, g: Int, b: Int) {
+    self.r = r
+    self.g = g
+    self.b = b
+  }
+}
+
+package enum CustomColor {
+  case Black
+  case White
+  case Custom(Color)
+  case Bespoke(Color, Color)
+}
+
+// Resilient enum
+package enum Medium {
+  // Indirect case
+  indirect case Pamphlet(Medium)  // -1
+
+  // Case with resilient payload
+  case Postcard(Size)             // -2
+
+  // Empty cases
+  case Paper                      // 0
+  case Canvas                     // 1
+}
+
+// Indirect resilient enum
+package indirect enum IndirectApproach {
+  case Angle(Double)              // -1
+}
+
+// Resilient enum with resilient empty payload case
+package struct EmptyStruct {
+  package init() {}
+}
+
+package enum ResilientEnumWithEmptyCase {
+  case A                          // 0
+  case B                          // 1
+  case Empty(EmptyStruct)         // -1
+}
+
+package func getResilientEnumWithEmptyCase() -> [ResilientEnumWithEmptyCase] {
+  return [.A, .B, .Empty(EmptyStruct())]
+}
+
+// Specific enum implementations for executable tests
+package enum ResilientEmptyEnum {
+  case X
+}
+
+package enum ResilientSingletonEnum {
+  case X(AnyObject)
+}
+
+package enum ResilientSingletonGenericEnum<T> {
+  case X(T)
+}
+
+package enum ResilientNoPayloadEnum {
+  case A
+  case B
+  case C
+}
+
+package enum ResilientSinglePayloadEnum {
+  case X(AnyObject)               // -1
+  case A                          // 0
+  case B                          // 1
+  case C                          // 2
+}
+
+package enum ResilientSinglePayloadGenericEnum<T> {
+  case X(T)                       // -1
+  case A                          // 0
+  case B                          // 1
+  case C                          // 2
+}
+
+package class ArtClass {
+  package init() {}
+}
+
+package enum ResilientMultiPayloadEnum {
+  case A
+  case B
+  case C
+  case X(Int)
+  case Y(Int)
+}
+
+package func makeResilientMultiPayloadEnum(_ n: Int, i: Int)
+    -> ResilientMultiPayloadEnum {
+  switch i {
+  case 0:
+    return .A
+  case 1:
+    return .B
+  case 2:
+    return .C
+  case 3:
+    return .X(n)
+  case 4:
+    return .Y(n)
+  default:
+    while true {}
+  }
+}
+
+package enum ResilientMultiPayloadEnumSpareBits {
+  case A                          // 0
+  case B                          // 1
+  case C                          // 2
+  case X(ArtClass)                // -1
+  case Y(ArtClass)                // -2
+}
+
+package func makeResilientMultiPayloadEnumSpareBits(_ o: ArtClass, i: Int)
+    -> ResilientMultiPayloadEnumSpareBits {
+  switch i {
+  case 0:
+    return .A
+  case 1:
+    return .B
+  case 2:
+    return .C
+  case 3:
+    return .X(o)
+  case 4:
+    return .Y(o)
+  default:
+    while true {}
+  }
+}
+
+package typealias SevenSpareBits = (Bool, Int8, Int8, Int8, Int8, Int8, Int8, Int8)
+
+package enum ResilientMultiPayloadEnumSpareBitsAndExtraBits {
+  // On 64-bit little endian, 7 spare bits at the LSB end
+  case P1(SevenSpareBits)
+  // On 64-bit, 8 spare bits at the MSB end and 3 at the LSB end
+  case P2(ArtClass)
+  case P3(ArtClass)
+  case P4(ArtClass)
+  case P5(ArtClass)
+  case P6(ArtClass)
+  case P7(ArtClass)
+  case P8(ArtClass)
+}
+
+package enum ResilientMultiPayloadGenericEnum<T> {
+  case A                          // 0
+  case B                          // 1
+  case C                          // 2
+  case X(T)                       // -1
+  case Y(T)                       // -2
+}
+
+package enum ResilientMultiPayloadGenericEnumFixedSize<T> {
+  case A                          // 0
+  case B                          // 1
+  case C                          // 2
+  case X(Int)                     // -1
+  case Y(Int)                     // -2
+}
+
+package enum ResilientIndirectEnum {
+  // 0
+  case Base
+
+  // -1
+  indirect case A(ResilientIndirectEnum)
+
+  // -2
+  indirect case B(ResilientIndirectEnum, ResilientIndirectEnum)
+}
+
+package enum ResilientEnumWithUnavailableCase {
+  case available
+
+  @available(*, unavailable)
+  case unavailable
+}

--- a/test/IRGen/Inputs/package_types/resilient_protocol.swift
+++ b/test/IRGen/Inputs/package_types/resilient_protocol.swift
@@ -1,0 +1,46 @@
+
+package protocol OtherResilientProtocol {
+}
+
+var x: Int = 0
+
+extension OtherResilientProtocol {
+  package var propertyInExtension: Int {
+    get { return x }
+    set { x = newValue }
+  }
+
+  package static var staticPropertyInExtension: Int {
+    get { return x }
+    set { x = newValue }
+  }
+}
+
+package protocol ResilientBaseProtocol {
+  func requirement() -> Int
+}
+
+package protocol ResilientDerivedProtocol : ResilientBaseProtocol {}
+
+package protocol ProtocolWithRequirements {
+  associatedtype T
+  func first()
+  func second()
+}
+
+package struct Wrapper<T>: OtherResilientProtocol { }
+
+package struct ConcreteWrapper: OtherResilientProtocol { }
+
+package protocol ProtocolWithAssocTypeDefaults {
+  associatedtype T1 = Self
+  associatedtype T2: OtherResilientProtocol = Wrapper<T1>
+}
+
+package protocol ResilientSelfDefault : ResilientBaseProtocol {
+  associatedtype AssocType: ResilientBaseProtocol = Self
+}
+
+@_fixed_layout package protocol OtherFrozenProtocol {
+  func protocolMethod()
+}

--- a/test/IRGen/Inputs/package_types/resilient_struct.swift
+++ b/test/IRGen/Inputs/package_types/resilient_struct.swift
@@ -1,0 +1,121 @@
+// Fixed-layout struct
+package struct Point {
+  package var x: Int // read-write stored property
+  package let y: Int // read-only stored property
+
+  package init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  package func method() {}
+  package mutating func mutantMethod() {}
+}
+
+// Resilient-layout struct
+package struct Size {
+  package var w: Int // should have getter and setter
+  package let h: Int // getter only
+
+  package init(w: Int, h: Int) {
+    self.w = w
+    self.h = h
+  }
+
+  package func method() {}
+  package mutating func mutantMethod() {}
+}
+
+// Fixed-layout struct with resilient members
+package struct Rectangle {
+  package let p: Point
+  package let s: Size
+  package let color: Int
+
+  package init(p: Point, s: Size, color: Int) {
+    self.p = p
+    self.s = s
+    self.color = color
+  }
+}
+
+// More complicated resilient structs for runtime tests
+package struct ResilientBool {
+  package let b: Bool
+
+  package init(b: Bool) {
+    self.b = b
+  }
+}
+
+package struct ResilientInt {
+  package let i: Int
+
+  package init(i: Int) {
+    self.i = i
+  }
+}
+
+package struct ResilientDouble {
+  package let d: Double
+
+  package init(d: Double) {
+    self.d = d
+  }
+}
+
+package struct ResilientLayoutRuntimeTest {
+  package let b1: ResilientBool
+  package let i: ResilientInt
+  package let b2: ResilientBool
+  package let d: ResilientDouble
+
+  package init(b1: ResilientBool, i: ResilientInt, b2: ResilientBool, d: ResilientDouble) {
+    self.b1 = b1
+    self.i = i
+    self.b2 = b2
+    self.d = d
+  }
+}
+
+package class Referent {
+  package init() {}
+}
+
+package struct ResilientWeakRef {
+  package weak var ref: Referent?
+
+  package init (_ r: Referent) {
+    ref = r
+  }
+}
+
+package struct ResilientRef {
+  package var r: Referent
+
+  package init(r: Referent) { self.r = r }
+}
+
+package struct ResilientWithInternalField {
+  var x: Int
+}
+
+// Tuple parameters with resilient structs
+package class Subject {}
+
+package struct Container {
+  package var s: Subject
+}
+
+package struct PairContainer {
+  package var pair : (Container, Container)
+}
+
+@available(*, unavailable)
+package struct UnavailableResilientInt {
+  package let i: Int
+
+  package init(i: Int) {
+    self.i = i
+  }
+}

--- a/test/IRGen/package_resilience.swift
+++ b/test/IRGen/package_resilience.swift
@@ -1,0 +1,271 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/chex.py < %s > %t/package_resilience.swift
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/Inputs/package_types/resilient_struct.swift
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/Inputs/package_types/resilient_enum.swift
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/Inputs/package_types/resilient_class.swift
+// RUN: %target-swift-frontend -package-name MyPkg -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-%target-import-type-objc-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
+// RUN: %target-swift-frontend -package-name MyPkg -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
+// RUN: %target-swift-frontend -package-name MyPkg -I %t -emit-ir -enable-library-evolution -O %t/package_resilience.swift -package-name MyPkg
+// REQUIRES: objc_codegen
+
+// CHECK: @"$s18package_resilience26ClassWithResilientPropertyC1p16resilient_struct5PointVvpWvd" = constant [[INT]] {{8|16}}, align [[#WORDSIZE]]
+// CHECK: @"$s18package_resilience26ClassWithResilientPropertyC1s16resilient_struct4SizeVvpWvd" = constant [[INT]] {{32|16}}, align [[#WORDSIZE]]
+
+// CHECK: @"$s18package_resilience33ClassWithResilientlySizedPropertyC1r16resilient_struct9RectangleVvpWvd" = constant [[INT]] {{8|16}}, align [[#WORDSIZE]]
+// CHECK: @"$s18package_resilience33ClassWithResilientlySizedPropertyC5colors5Int32VvpWvd" = constant [[INT]] 56, align [[#WORDSIZE]]
+
+// CHECK: @"$s18package_resilience17MyResilientParentCMo" = constant [[BOUNDS:{ (i32|i64), i32, i32 }]]
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32]], i32 3, i32 [[#MDWORDS + 6 + 2]] }, align [[#WORDSIZE]]
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64]], i32 3, i32 [[#MDWORDS + 3 + 2]] }, align [[#WORDSIZE]]
+
+// CHECK: @"$s18package_resilience16MyResilientChildC5fields5Int32VvpWvd" = constant [[INT]] [[#WORDSIZE + WORDSIZE + 4]], align [[#WORDSIZE]]
+
+// CHECK: @"$s18package_resilience16MyResilientChildCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32 + WORDSIZE + WORDSIZE]], i32 3, i32 [[#MDWORDS + 6 + 3]] }
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64 + WORDSIZE + WORDSIZE]], i32 3, i32 [[#MDWORDS + 3 + 3]] }
+
+// CHECK: @"$s18package_resilience24MyResilientGenericParentCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32]], i32 3, i32 [[#MDWORDS + 6 + 3]] }
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64]], i32 3, i32 [[#MDWORDS + 3 + 3]] }
+
+// CHECK: @"$s18package_resilience24MyResilientConcreteChildCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
+// CHECK-32-SAME: { [[INT]] [[#MDSIZE32 + WORDSIZE + WORDSIZE + WORDSIZE]], i32 3, i32 [[#MDWORDS + 6 + 5]] }
+// CHECK-64-SAME: { [[INT]] [[#MDSIZE64 + WORDSIZE + WORDSIZE + WORDSIZE]], i32 3, i32 [[#MDWORDS + 3 + 5]] }
+
+// CHECK: @"$s18package_resilience27ClassWithEmptyThenResilientC5emptyAA0E0VvpWvd" = constant [[INT]] 0,
+// CHECK: @"$s18package_resilience27ClassWithEmptyThenResilientC9resilient0H7_struct0G3IntVvpWvd" = constant [[INT]] [[#WORDSIZE + WORDSIZE]], align [[#WORDSIZE]]
+// CHECK: @"$s18package_resilience27ClassWithResilientThenEmptyC9resilient0H7_struct0E3IntVvpWvd" = constant [[INT]] [[#WORDSIZE + WORDSIZE]], align [[#WORDSIZE]]
+// CHECK: @"$s18package_resilience27ClassWithResilientThenEmptyC5emptyAA0G0VvpWvd" = constant [[INT]] 0,
+
+import resilient_class
+import resilient_struct
+import resilient_enum
+
+// Concrete class with resilient stored property
+
+package class ClassWithResilientProperty {
+  package let p: Point
+  package let s: Size
+  package let color: Int32
+
+  package init(p: Point, s: Size, color: Int32) {
+    self.p = p
+    self.s = s
+    self.color = color
+  }
+}
+
+
+// Concrete class with non-fixed size stored property
+
+package class ClassWithResilientlySizedProperty {
+  package let r: Rectangle
+  package let color: Int32
+
+  package init(r: Rectangle, color: Int32) {
+    self.r = r
+    self.color = color
+  }
+}
+
+
+// Concrete class with resilient stored property that
+// is fixed-layout inside this resilience domain
+
+package struct MyResilientStruct {
+  package let x: Int32
+}
+
+package class ClassWithMyResilientProperty {
+  package let r: MyResilientStruct
+  package let color: Int32
+
+  package init(r: MyResilientStruct, color: Int32) {
+    self.r = r
+    self.color = color
+  }
+}
+
+
+// Enums with indirect payloads are fixed-size
+
+package class ClassWithIndirectResilientEnum {
+  package let s: FunnyShape
+  package let color: Int32
+
+  package init(s: FunnyShape, color: Int32) {
+    self.s = s
+    self.color = color
+  }
+}
+
+// Superclass is resilient and has a resilient value type payload,
+// but everything is in one package
+
+package class MyResilientParent {
+  package let s: MyResilientStruct = MyResilientStruct(x: 0)
+}
+
+package class MyResilientChild : MyResilientParent {
+  package let field: Int32 = 0
+}
+
+package class MyResilientGenericParent<T> {
+  package let t: T
+
+  package init(t: T) {
+    self.t = t
+  }
+}
+
+package class MyResilientConcreteChild : MyResilientGenericParent<Int> {
+  package let x: Int
+
+  package init(x: Int) {
+    self.x = x
+    super.init(t: x)
+  }
+}
+
+extension ResilientGenericOutsideParent {
+  package func genericExtensionMethod() -> A.Type {
+    return A.self
+  }
+}
+
+// rdar://48031465
+// Field offsets for empty fields in resilient classes should be initialized
+// to their best-known value and made non-constant if that value might
+// disagree with the dynamic value.
+
+package struct Empty {}
+
+package class ClassWithEmptyThenResilient {
+  package let empty: Empty
+  package let resilient: ResilientInt
+
+  package init(empty: Empty, resilient: ResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+package class ClassWithResilientThenEmpty {
+  package let resilient: ResilientInt
+  package let empty: Empty
+
+  package init(empty: Empty, resilient: ResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+// ClassWithResilientProperty.color getter
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$s18package_resilience26ClassWithResilientPropertyC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:      [[FIELD_ADDR:%.*]] = getelementptr inbounds %T18package_resilience26ClassWithResilientPropertyC, ptr %0,
+// CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[FIELD_ADDR]], i32 0, i32 0
+// CHECK-NEXT: [[FIELD_VALUE:%.*]] = load i32, ptr [[FIELD_PAYLOAD]]
+// CHECK:      ret i32 [[FIELD_VALUE]]
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$s18package_resilience33ClassWithResilientlySizedPropertyC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:      [[FIELD_ADDR:%.*]] = getelementptr inbounds %T18package_resilience33ClassWithResilientlySizedPropertyC, ptr %0,
+// CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[FIELD_ADDR]], i32 0, i32 0
+// CHECK-NEXT: [[FIELD_VALUE:%.*]] = load i32, ptr [[FIELD_PAYLOAD]]
+// CHECK:      ret i32 [[FIELD_VALUE]]
+
+// ClassWithIndirectResilientEnum.color getter
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$s18package_resilience30ClassWithIndirectResilientEnumC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:      [[FIELD_PTR:%.*]] = getelementptr inbounds %T18package_resilience30ClassWithIndirectResilientEnumC, ptr %0, i32 0, i32 2
+// CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[FIELD_PTR]], i32 0, i32 0
+// CHECK-NEXT: [[FIELD_VALUE:%.*]] = load i32, ptr [[FIELD_PAYLOAD]]
+// CHECK-NEXT: ret i32 [[FIELD_VALUE]]
+
+// Make sure that MemoryLayout always emits constants
+
+
+// MyResilientChild.field getter
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$s18package_resilience16MyResilientChildC5fields5Int32Vvg"(ptr swiftself %0)
+// CHECK:      [[FIELD_ADDR:%.*]] = getelementptr inbounds %T18package_resilience16MyResilientChildC, ptr %0, i32 0, i32 2
+// CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[FIELD_ADDR]], i32 0, i32 0
+// CHECK-NEXT: [[RESULT:%.*]] = load i32, ptr [[PAYLOAD_ADDR]]
+// CHECK:      ret i32 [[RESULT]]
+
+// ResilientGenericOutsideParent.genericExtensionMethod()
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s15resilient_class29ResilientGenericOutsideParentC18package_resilienceE22genericExtensionMethodxmyF"(ptr swiftself %0) {{.*}} {
+// CHECK: [[ISA:%.*]] = load ptr, ptr %0
+// CHECK:      [[BASE:%.*]] = load [[INT]], ptr @"$s15resilient_class29ResilientGenericOutsideParentCMo"
+// CHECK-NEXT: [[GENERIC_PARAM_OFFSET:%.*]] = add [[INT]] [[BASE]], 0
+// CHECK-NEXT: [[GENERIC_PARAM_TMP:%.*]] = getelementptr inbounds i8, ptr [[ISA]], [[INT]] [[GENERIC_PARAM_OFFSET]]
+// CHECK-NEXT: [[GENERIC_PARAM:%.*]] = load ptr, ptr [[GENERIC_PARAM_TMP]]
+// CHECK:       ret ptr [[GENERIC_PARAM]]
+
+// CHECK-LABEL: define{{.*}} swiftcc {{i32|i64}} @"$s18package_resilience38memoryLayoutDotSizeWithResilientStructSiyF"()
+public func memoryLayoutDotSizeWithResilientStruct() -> Int {
+  // CHECK: ret [[INT]] [[#WORDSIZE + WORDSIZE]]
+  return MemoryLayout<Size>.size
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc {{i32|i64}} @"$s18package_resilience40memoryLayoutDotStrideWithResilientStructSiyF"()
+public func memoryLayoutDotStrideWithResilientStruct() -> Int {
+  // CHECK: ret [[INT]] [[#WORDSIZE + WORDSIZE]]
+  return MemoryLayout<Size>.size
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc {{i32|i64}} @"$s18package_resilience43memoryLayoutDotAlignmentWithResilientStructSiyF"()
+public func memoryLayoutDotAlignmentWithResilientStruct() -> Int {
+  // CHECK: ret [[INT]] [[#WORDSIZE]]
+  return MemoryLayout<Size>.alignment
+}
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc [[BOUNDS:{ (i32|i64), (i32|i64), i8 }]] @"$s18package_resilience31constructResilientEnumNoPayload14resilient_enum6MediumOyF"
+package func constructResilientEnumNoPayload() -> Medium {
+  // CHECK: ret [[BOUNDS]] { {{i32|i64}} 0, {{i32|i64}} 0, i8 2 }
+  return Medium.Paper
+}
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc [[BOUNDS:{ (i32|i64), (i32|i64), i8 }]] @"$s18package_resilience39constructExhaustiveWithResilientMembers14resilient_enum11SimpleShapeOyF"() #0 {
+package func constructExhaustiveWithResilientMembers() -> SimpleShape {
+  // CHECK: ret [[BOUNDS]] { {{i32|i64}} 0, {{i32|i64}} 0, i8 1 }
+  return .KleinBottle
+}
+
+// ClassWithResilientProperty metadata accessor
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$s18package_resilience26ClassWithResilientPropertyCMa"(
+// CHECK-objc:      [[METADATA:%.*]] = call ptr {{.*}}@"$s18package_resilience26ClassWithResilientPropertyCMf"{{.*}}
+// CHECK-objc-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, ptr [[METADATA]], 0
+// CHECK-objc-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], i64 0, 1
+// CHECK-objc-NEXT: ret %swift.metadata_response [[T1]]
+
+// CHECK-native: ret %swift.metadata_response
+
+// ClassWithResilientlySizedProperty metadata accessor
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$s18package_resilience33ClassWithResilientlySizedPropertyCMa"(
+// CHECK-objc:      [[METADATA:%.*]] = call ptr {{.*}}@"$s18package_resilience33ClassWithResilientlySizedPropertyCMf"{{.*}}
+// CHECK-objc-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, ptr [[METADATA]], 0
+// CHECK-objc-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], i64 0, 1
+// CHECK-objc-NEXT: ret %swift.metadata_response [[T1]]
+
+// CHECK-native: ret %swift.metadata_response
+
+
+// ClassWithResilientlySizedProperty method lookup function
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s18package_resilience33ClassWithResilientlySizedPropertyCMu"(ptr %0, ptr %1)
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   [[RESULT:%.*]] = call ptr @swift_lookUpClassMethod(ptr %0, ptr %1, ptr @"$s18package_resilience33ClassWithResilientlySizedPropertyCMn{{(\.ptrauth.*)?}}")
+// CHECK-NEXT:   ret ptr [[RESULT]]
+// CHECK-NEXT: }
+
+// ClassWithResilientProperty method lookup function
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s18package_resilience28ClassWithMyResilientPropertyCMu"(ptr %0, ptr %1)
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   [[RESULT:%.*]] = call ptr @swift_lookUpClassMethod(ptr %0, ptr %1, ptr @"$s18package_resilience28ClassWithMyResilientPropertyCMn{{(\.ptrauth.*)?}}")
+// CHECK-NEXT:   ret ptr [[RESULT]]
+// CHECK-NEXT: }

--- a/test/IRGen/package_resilience.swift
+++ b/test/IRGen/package_resilience.swift
@@ -1,3 +1,10 @@
+//
+// Unlike its counterparts in the other *_resilience.swift files, the goal is
+// for the package's component modules to all be considered within the same
+// resilience domain. This file ensures that we use direct access as much as
+// possible.
+//
+
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/package_resilience.swift
 // RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/Inputs/package_types/resilient_struct.swift
@@ -7,6 +14,7 @@
 // RUN: %target-swift-frontend -package-name MyPkg -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
 // RUN: %target-swift-frontend -package-name MyPkg -I %t -emit-ir -enable-library-evolution -O %t/package_resilience.swift -package-name MyPkg
 // REQUIRES: objc_codegen
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
 
 // CHECK: @"$s18package_resilience26ClassWithResilientPropertyC1p16resilient_struct5PointVvpWvd" = constant [[INT]] {{8|16}}, align [[#WORDSIZE]]
 // CHECK: @"$s18package_resilience26ClassWithResilientPropertyC1s16resilient_struct4SizeVvpWvd" = constant [[INT]] {{32|16}}, align [[#WORDSIZE]]

--- a/test/SILGen/accessibility_warnings.swift
+++ b/test/SILGen/accessibility_warnings.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -package-name accessibility_warnings
+// RUN: %target-swift-emit-silgen %s -package-name accessibility_warnings | %FileCheck %s
 
 // This file tests that the AST produced after fixing accessibility warnings
 // is valid according to SILGen and the verifiers.
@@ -138,6 +138,25 @@ internal class InternalClass {
   public var publicVarGetSet: Int { get { return 0 } set {} }
 
   // CHECK-DAG: sil hidden [ossa] @$s22accessibility_warnings13InternalClassCACycfc
+}
+
+package class PackageClass {
+  // CHECK-DAG: sil{{( \[.+\])*}} [ossa] @$s22accessibility_warnings12PackageClassC9publicVarSivg
+  public var publicVar = 0
+
+  // CHECK-DAG: sil{{( \[.+\])*}} [ossa] @$s22accessibility_warnings12PackageClassC19publicVarPrivateSetSivg
+  public private(set) var publicVarPrivateSet = 0
+
+  // expected-warning@+1 {{'public(set)' modifier is redundant for a public property}} {{10-22=}}
+  public public(set) var publicVarPublicSet = 0
+
+  // CHECK-DAG: sil{{( \[.+\])*}} [ossa] @$s22accessibility_warnings12PackageClassC16publicVarGetOnlySivg
+  public var publicVarGetOnly: Int { return 0 }
+
+  // CHECK-DAG: sil{{( \[.+\])*}} [ossa] @$s22accessibility_warnings12PackageClassC15publicVarGetSetSivg
+  public var publicVarGetSet: Int { get { return 0 } set {} }
+
+  // CHECK-DAG: sil hidden{{( \[.+\])*}} [ossa] @$s22accessibility_warnings12PackageClassCACycfc
 }
 
 private class PrivateClass {


### PR DESCRIPTION
swiftc mis-compiles package declarations today because it reports the effective access level of package declarations as less than public. There are a bunch of places in the optimizer that are checking the effective access level against an upper bound of public, so a lot of code winds up internalized or optimized as though it were internal when it definitely is not.

Fixes rdar://118081829