### PR TITLE
[stdlib] Silence some standard library warnings

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -255,6 +255,20 @@ func checkMacroDefinition(
         case "ExternalMacro":
           return Int(BridgedMacroDefinitionKind.builtinExternalMacro.rawValue)
 
+        // These builtins don't exist, but are put into the standard library at
+        // least for documentation purposes right now. Don't emit a warning for
+        // them, but do fail operation.
+        case "FileIDMacro",
+             "FilePathMacro",
+             "FileMacro",
+             "FunctionMacro",
+             "LineMacro",
+             "ColumnMacro",
+             "DSOHandleMacro",
+             "WarningMacro",
+             "ErrorMacro":
+          return -1
+
         default:
           // Warn about the unknown builtin.
           let srcMgr = SourceManager(cxxDiagnosticEngine: diagEnginePtr)

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2032,6 +2032,17 @@ static void checkProtocolRefinementRequirements(ProtocolDecl *proto) {
       // TODO(kavon): emit tailored error diagnostic to remove the ~Copyable
     }
 
+    // SIMDScalar in the standard library currently emits this warning for:
+    // 'Hashable', 'Encodable', and 'Decodable'. This is unfortunate, but we
+    // cannot fix it as it would alter the ABI of the protocol. Silence these
+    // warnings specifically for those cases.
+    if (proto->isSpecificProtocol(KnownProtocolKind::SIMDScalar) &&
+        (otherProto->isSpecificProtocol(KnownProtocolKind::Hashable) ||
+        otherProto->isSpecificProtocol(KnownProtocolKind::Encodable) ||
+        otherProto->isSpecificProtocol(KnownProtocolKind::Decodable))) {
+      continue;
+    }
+
     // GenericSignature::getRequiredProtocols() canonicalizes the protocol
     // list by dropping protocols that are inherited by other protocols in
     // the list. Any protocols that remain in the list other than 'proto'

--- a/stdlib/public/core/Macros.swift
+++ b/stdlib/public/core/Macros.swift
@@ -25,8 +25,6 @@
 public macro externalMacro<T>(module: String, type: String) -> T =
   Builtin.ExternalMacro
 
-#if false
-
 // File and path-related information
 
 /// Produces a unique identifier for the given source file, comprised of
@@ -72,7 +70,5 @@ public macro warning(_ message: String) = Builtin.WarningMacro
 /// Produce the given error message during compilation.
 @freestanding(declaration)
 public macro error(_ message: String) = Builtin.ErrorMacro
-
-#endif // false
 
 #endif // $Macros && hasAttribute(attached)

--- a/stdlib/public/core/Macros.swift
+++ b/stdlib/public/core/Macros.swift
@@ -25,6 +25,8 @@
 public macro externalMacro<T>(module: String, type: String) -> T =
   Builtin.ExternalMacro
 
+#if false
+
 // File and path-related information
 
 /// Produces a unique identifier for the given source file, comprised of
@@ -71,4 +73,6 @@ public macro warning(_ message: String) = Builtin.WarningMacro
 @freestanding(declaration)
 public macro error(_ message: String) = Builtin.ErrorMacro
 
-#endif
+#endif // false
+
+#endif // $Macros && hasAttribute(attached)


### PR DESCRIPTION
The protocol refinement warning is informational, but for the specific case of `SIMDScalar` implicitly inheriting from `Hashable`, `Encodable`, and `Decodable` we cannot add those to the protocol signature because it would alter its ABI. Skip those cases as we can't fix them in the foreseeable future.

The macro warnings are simply due to the fact that the macro definitions are referencing builtin types that do not exist, so the parser emits a warning and skips that declaration entirely. Just ifdef them out until someone does come around and implement those builtins.