### PR TITLE
[swift-wme] Prevent WME on cross module conformances

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2369,6 +2369,25 @@ static void addWTableTypeMetadata(IRGenModule &IGM,
   if (minOffset == UINT64_MAX)
     return;
 
+  // Under -enable-llvm-wme cross module calls to witness methods are made via
+  // dispatch thunk in order to co-locate witness table loads with the witness
+  // table they load from in the same LTO unit. However, these dispatch thunks
+  // are emitted in the module defining the protocol, not the module defining
+  // the witness table. If the conforming type and any protocol it conforms to
+  // are in different modules, a dispatch thunk may be emitted into a different
+  // module than the witness table. This defeats the purpose of the thunk at
+  // least partially. Unless the protocol and conforming type are in the same
+  // LTO unit, it is unsafe to perform WME and we should bail.
+  if (conf->getProtocol()->getModuleContext() != IGM.getSwiftModule())
+    return;
+
+  ArrayRef<ProtocolDecl *> transitiveConformances =
+      conf->getProtocol()->getInheritedProtocols();
+  for (const ProtocolDecl *protocol : transitiveConformances) {
+    if (protocol->getModuleContext() != IGM.getSwiftModule())
+      return;
+  }
+
   using VCallVisibility = llvm::GlobalObject::VCallVisibility;
   VCallVisibility vis = VCallVisibility::VCallVisibilityPublic;
   auto linkage = stripExternalFromLinkage(wt->getLinkage());

--- a/test/IRGen/witness-method-elimination-across-modules.swift
+++ b/test/IRGen/witness-method-elimination-across-modules.swift
@@ -1,0 +1,82 @@
+// Tests that under -enable-llvm-vfe + -internalize-at-link,
+// calls to a witness method that satisfies a protcol requirement
+// defined in another module are safe.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// (1) Build the ProtocolModule swift module
+// RUN: %target-build-swift -Xfrontend -enable-llvm-wme -parse-as-library -emit-module %t/ProtocolModule.swift -module-name ProtocolModule -emit-module \
+// RUN:     -o %t/ProtocolModule.swiftmodule -emit-tbd -emit-tbd-path %t/libProtocol.tbd -Xfrontend -tbd-install_name=%t/libProtocol.dylib
+
+// (2) Build the ConformingClassModule swift module
+// RUN: %target-build-swift -Xfrontend -enable-llvm-wme -parse-as-library -I %t -emit-module %t/ConformingClassModule.swift -module-name ConformingClassModule -emit-module \
+// RUN:     -o %t/ConformingClassModule.swiftmodule -emit-tbd -emit-tbd-path %t/libConformingClass.tbd -Xfrontend -tbd-install_name=%t/libConformingClass.dylib
+
+// (3) Build the client
+// RUN: %target-build-swift -parse-as-library -Xfrontend -enable-llvm-wme -I%t %t/Client.swift -L%t -lProtocol -lConformingClass -o %t/main
+
+// (4) Extract a list of used symbols by client from protocol
+// RUN: %llvm-nm --undefined-only -m %t/main | grep 'libProtocol' | awk '{print $3}' > %t/protocol-used-symbols
+
+// (5) Extract a list of used symbols by client from derived
+// RUN: %llvm-nm --undefined-only -m %t/main | grep 'libConformingClass' | awk '{print $3}' > %t/conforming-used-symbols
+
+// (6) Build libConformingClass.dylib with only the requested symbols
+// RUN: %target-build-swift -I%t -parse-as-library -Xfrontend -enable-llvm-wme -Xfrontend -internalize-at-link \
+// RUN:    %t/ConformingClassModule.swift -lto=llvm-full %lto_flags -module-name ConformingClassModule -emit-library -o %t/libConformingClass.dylib \
+// RUN:    -runtime-compatibility-version none -Xlinker -exported_symbols_list -Xlinker %t/conforming-used-symbols -Xlinker -dead_strip -L%t -lProtocol
+
+// (7) Extract a list of used symbols by conforming class from protocol, appending to the same list as earlier
+// RUN: %llvm-nm --undefined-only -m %t/libConformingClass.dylib | grep 'libProtocol' | awk '{print $3}' >> %t/protocol-used-symbols
+
+// (8) Build libProtocol.dylib with only the symbols requested by either the client or conforming
+// RUN: %target-build-swift -parse-as-library -Xfrontend -enable-llvm-wme -Xfrontend -internalize-at-link \
+// RUN:    %t/ProtocolModule.swift -lto=llvm-full %lto_flags -module-name ProtocolModule -emit-library -o %t/libProtocol.dylib \
+// RUN:    -runtime-compatibility-version none -Xlinker -exported_symbols_list -Xlinker %t/protocol-used-symbols -Xlinker -dead_strip
+
+// (9) Check list of symbols in libConformingClass.dylib
+// RUN: %llvm-nm --defined-only %t/libConformingClass.dylib | %FileCheck %s --check-prefix CONFORMING-SYMBOLS
+
+// (10) Run the client
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+// REQUIRES: no_asan
+// UNSUPPORTED: remote_run
+
+//--- ProtocolModule.swift
+
+public protocol Protocol {
+    func foo()
+}
+
+//--- ConformingClassModule.swift
+
+import ProtocolModule
+
+public class Class : Protocol {
+    public func foo() {
+        print("Class.foo")
+    }
+}
+
+// CONFORMING-SYMBOLS: s21ConformingClassModule0B0C08ProtocolC00D0AadEP3fooyyFTW
+
+public func getProtocolConformer() -> Protocol {
+    return Class()
+}
+
+//--- Client.swift
+
+import ProtocolModule
+import ConformingClassModule
+
+@_cdecl("main")
+func main() -> Int32 {
+    let p = getProtocolConformer()
+    p.foo()
+    // CHECK: Class.foo
+    return 0
+}


### PR DESCRIPTION
If a type conforms to a protocol defined in a different module (and therefore potentially a different LTO unit), the protocol dispatch thunk and protocol witness table can end up in different LTO units, making WME unsafe.

Avoid this by only applying vcall visibility to the witness table if all protocols conformed to are in the same module as the conforming type.