### PR TITLE
[sil] Fix the no-assert build by not calling an ifndef NDEBUG method (part 2)

### DIFF
--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1393,10 +1393,15 @@ public:
     os << SEP_STR << "BlockPartitionState[reached=" << reached
        << ", needsUpdate=" << needsUpdate << "]\nid: ";
 #ifndef NDEBUG
-    basicBlock->printID(os);
+    auto printID = [&](SILBasicBlock *block) {
+      block->printID(os);
+    };
 #else
-    os << "NOASSERTS. ";
+    auto printID = [&](SILBasicBlock *) {
+      os << "NOASSERTS. ";
+    };
 #endif
+    printID(basicBlock);
     os << "entry partition: ";
     entryPartition.print(os);
     os << "exit partition: ";
@@ -1409,12 +1414,12 @@ public:
     os << "└──────────╼\nSuccs:\n";
     for (auto succ : basicBlock->getSuccessorBlocks()) {
       os << "→";
-      succ->printID(os);
+      printID(succ);
     }
     os << "Preds:\n";
     for (auto pred : basicBlock->getPredecessorBlocks()) {
       os << "←";
-      pred->printID(os);
+      printID(pred);
     }
     os << SEP_STR;
   }


### PR DESCRIPTION
PR #69652 protected one call of `printID` but left another two in the file. Create two small lambdas to print the ID with `printID` or just print `NOASSERTS` depending on `NDEBUG` being defined. Change all the callsites of `printID` to use that lambda.
