### PR TITLE
Two small fixes for the embedded stdlib

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -414,6 +414,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS
         ${swift_stdlib_compile_flags} -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
+        -Xfrontend -enable-ossa-modules
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -270,3 +270,8 @@ public func swift_once(predicate: UnsafeMutablePointer<Int>, fn: (@convention(c)
 public func swift_deletedMethodError() -> Never {
   Builtin.int_trap()
 }
+
+@_silgen_name("swift_willThrow")
+public func swift_willThrow() throws {
+}
+

--- a/test/embedded/throw-trap-stdlib.swift
+++ b/test/embedded/throw-trap-stdlib.swift
@@ -10,4 +10,4 @@ public func test() {
   }
 }
 
-// CHECK-NOT: swift_willThrow
+// CHECK: swift_willThrow


### PR DESCRIPTION
In preparation for the FixedArray work:

* build the embedded stdlib core with -enable-ossa-modules (as it's done for the regular stdlib core)
* add the swift_willThrow runtime function. This will be required for typed throws. But even now a call to swift_willThrow can be generated in embedded swift.