### PR TITLE
EscapeUtils: handle `load_borrow`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -104,6 +104,7 @@ extension ProjectedValue {
                                          _ context: some Context) -> V.Result? {
     var walker = EscapeWalker(visitor: visitor, complexityBudget: complexityBudget, context)
     if walker.walkUp(addressOrValue: value, path: path.escapePath) == .abortWalk {
+      walker.visitor.cleanupOnAbort()
       return nil
     }
     return walker.visitor.result
@@ -119,6 +120,7 @@ extension ProjectedValue {
                                                       _ context: some Context) -> V.Result? {
     var walker = EscapeWalker(visitor: visitor, context)
     if walker.walkDown(addressOrValue: value, path: path.escapePath) == .abortWalk {
+      walker.visitor.cleanupOnAbort()
       return nil
     }
     return walker.visitor.result
@@ -182,6 +184,12 @@ extension EscapeVisitor {
 protocol EscapeVisitorWithResult : EscapeVisitor {
   associatedtype Result
   var result: Result { get }
+
+  mutating func cleanupOnAbort()
+}
+
+extension EscapeVisitorWithResult {
+  mutating func cleanupOnAbort() {}
 }
 
 // FIXME: This ought to be marked private, but that triggers a compiler bug

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -490,7 +490,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       // 1. the closure (with the captured values) itself can escape
       // 2. something can escape in a destructor when the context is destroyed
       return walkDownUses(ofValue: pai, path: path.with(knownType: nil))
-    case is LoadInst, is LoadWeakInst, is LoadUnownedInst:
+    case is LoadInst, is LoadWeakInst, is LoadUnownedInst, is LoadBorrowInst:
       if !followLoads(at: path.projectionPath) {
         return .continueWalk
       }
@@ -701,7 +701,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       }
     case let ap as ApplyInst:
       return walkUpApplyResult(apply: ap, path: path.with(knownType: nil))
-    case is LoadInst, is LoadWeakInst, is LoadUnownedInst:
+    case is LoadInst, is LoadWeakInst, is LoadUnownedInst, is LoadBorrowInst:
       if !followLoads(at: path.projectionPath) {
         // When walking up we shouldn't end up at a load where followLoads is false,
         // because going from a (non-followLoads) address to a load always involves a class indirection.

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -77,6 +77,8 @@ enum E {
   case B(Z)
 }
 
+sil @escaping_argument : $@convention(thin) (@guaranteed Y) -> ()
+
 sil @not_escaping_argument : $@convention(thin) (@guaranteed Z) -> () {
 [%0: noescape **]
 }
@@ -799,6 +801,32 @@ bb0:
   destroy_value %8 : $E
   %9 = tuple ()
   return %9 : $()
+}
+
+// CHECK-LABEL: Escape information for test_load_borrow:
+// CHECK: global: %0 = alloc_ref $Y
+// CHECK:  -    : %1 = alloc_ref $Y
+// CHECK: End function test_load_borrow
+sil [ossa] @test_load_borrow : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $Y
+  %1 = alloc_ref $Y
+  %2 = alloc_stack $Y
+  %3 = alloc_stack $Y
+  store %0 to [init] %2 : $*Y
+  store %1 to [init] %3 : $*Y
+  %6 = load_borrow %2 : $*Y
+  %7 = load_borrow %3 : $*Y
+  %8 = function_ref @escaping_argument : $@convention(thin) (@guaranteed Y) -> ()
+  %9 = apply %8(%6) : $@convention(thin) (@guaranteed Y) -> ()
+  end_borrow %7 : $Y
+  end_borrow %6 : $Y
+  destroy_addr %3 : $*Y
+  destroy_addr %2 : $*Y
+  dealloc_stack %3 : $*Y
+  dealloc_stack %2 : $*Y
+  %r = tuple ()
+  return %r : $()
 }
 
 // CHECK-LABEL: Escape information for call_unknown:


### PR DESCRIPTION
Also add `EscapeVisitorWithResult.cleanupOnAbort()` which is useful to destroy the result if it's not returned