### PR TITLE
[ASTContext] Add setter for PreModuleImportCallback

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -294,7 +294,8 @@ public:
   /// OutputBackend for writing outputs.
   llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend;
 
-  void SetPreModuleImportCallback(std::function<bool(llvm::StringRef ModuleName, bool IsOverlay)> callback);
+  /// Set the callback function that is invoked before Swift module importing is performed
+  void SetPreModuleImportCallback(std::function<void(llvm::StringRef ModuleName, bool IsOverlay)> callback);
 
   /// If the shared pointer is not a \c nullptr and the pointee is \c true,
   /// all operations working on this ASTContext should be aborted at the next
@@ -406,7 +407,7 @@ private:
   getAllocator(AllocationArena arena = AllocationArena::Permanent) const;
 
   /// An optional generic callback function invoked prior to importing a module.
-  mutable std::function<bool(llvm::StringRef ModuleName, bool IsOverlay)>
+  mutable std::function<void(llvm::StringRef ModuleName, bool IsOverlay)>
       PreModuleImportCallback;
 
 public:

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -294,8 +294,10 @@ public:
   /// OutputBackend for writing outputs.
   llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend;
 
-  /// Set the callback function that is invoked before Swift module importing is performed
-  void SetPreModuleImportCallback(std::function<void(llvm::StringRef ModuleName, bool IsOverlay)> callback);
+  /// Set the callback function that is invoked before Swift module importing is
+  /// performed
+  void SetPreModuleImportCallback(
+      std::function<void(llvm::StringRef ModuleName, bool IsOverlay)> callback);
 
   /// If the shared pointer is not a \c nullptr and the pointee is \c true,
   /// all operations working on this ASTContext should be aborted at the next

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -239,8 +239,8 @@ class ASTContext final {
       ClangImporterOptions &ClangImporterOpts,
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
-      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr,
-      std::function<bool(llvm::StringRef, bool)> PreModuleImportCallback = {});
+      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr
+      );
 
 public:
   // Members that should only be used by ASTContext.cpp.
@@ -257,8 +257,8 @@ public:
       ClangImporterOptions &ClangImporterOpts,
       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
-      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr,
-      std::function<bool(llvm::StringRef, bool)> PreModuleImportCallback = {});
+      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr
+      );
   ~ASTContext();
 
   /// Optional table of counters to report, nullptr when not collecting.
@@ -293,6 +293,8 @@ public:
 
   /// OutputBackend for writing outputs.
   llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend;
+
+  void SetPreModuleImportCallback(std::function<bool(llvm::StringRef ModuleName, bool IsOverlay)> callback);
 
   /// If the shared pointer is not a \c nullptr and the pointee is \c true,
   /// all operations working on this ASTContext should be aborted at the next

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -714,8 +714,8 @@ ASTContext::~ASTContext() {
   getImpl().~Implementation();
 }
 
-void ASTContext::SetPreModuleImportCallback(std::function<bool(llvm::StringRef ModuleName, bool IsOverlay)> callback) {
-  ASTContext::PreModuleImportCallback = callback;
+void ASTContext::SetPreModuleImportCallback(std::function<void(llvm::StringRef ModuleName, bool IsOverlay)> callback) {
+  PreModuleImportCallback = callback;
 }
 
 llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -629,8 +629,7 @@ ASTContext *ASTContext::get(
     ClangImporterOptions &ClangImporterOpts,
     symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend
-    ) {
+    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend) {
   // If more than two data structures are concatentated, then the aggregate
   // size math needs to become more complicated due to per-struct alignment
   // constraints.
@@ -714,7 +713,8 @@ ASTContext::~ASTContext() {
   getImpl().~Implementation();
 }
 
-void ASTContext::SetPreModuleImportCallback(std::function<void(llvm::StringRef ModuleName, bool IsOverlay)> callback) {
+void ASTContext::SetPreModuleImportCallback(
+    std::function<void(llvm::StringRef ModuleName, bool IsOverlay)> callback) {
   PreModuleImportCallback = callback;
 }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -629,8 +629,8 @@ ASTContext *ASTContext::get(
     ClangImporterOptions &ClangImporterOpts,
     symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend,
-    std::function<bool(llvm::StringRef, bool)> PreModuleImportCallback) {
+    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend
+    ) {
   // If more than two data structures are concatentated, then the aggregate
   // size math needs to become more complicated due to per-struct alignment
   // constraints.
@@ -644,7 +644,7 @@ ASTContext *ASTContext::get(
   return new (mem)
       ASTContext(langOpts, typecheckOpts, silOpts, SearchPathOpts,
                  ClangImporterOpts, SymbolGraphOpts, SourceMgr, Diags,
-                 std::move(OutputBackend), PreModuleImportCallback);
+                 std::move(OutputBackend));
 }
 
 ASTContext::ASTContext(
@@ -653,8 +653,8 @@ ASTContext::ASTContext(
     ClangImporterOptions &ClangImporterOpts,
     symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend,
-    std::function<bool(llvm::StringRef, bool)> PreModuleImportCallback)
+    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend
+    )
     : LangOpts(langOpts), TypeCheckerOpts(typecheckOpts), SILOpts(silOpts),
       SearchPathOpts(SearchPathOpts), ClangImporterOpts(ClangImporterOpts),
       SymbolGraphOpts(SymbolGraphOpts), SourceMgr(SourceMgr), Diags(Diags),
@@ -662,7 +662,6 @@ ASTContext::ASTContext(
       TheBuiltinModule(createBuiltinModule(*this)),
       StdlibModuleName(getIdentifier(STDLIB_NAME)),
       SwiftShimsModuleName(getIdentifier(SWIFT_SHIMS_NAME)),
-      PreModuleImportCallback(PreModuleImportCallback),
       TheErrorType(new (*this, AllocationArena::Permanent) ErrorType(
           *this, Type(), RecursiveTypeProperties::HasError)),
       TheUnresolvedType(new(*this, AllocationArena::Permanent)
@@ -713,6 +712,10 @@ ASTContext::ASTContext(
 
 ASTContext::~ASTContext() {
   getImpl().~Implementation();
+}
+
+void ASTContext::SetPreModuleImportCallback(std::function<bool(llvm::StringRef ModuleName, bool IsOverlay)> callback) {
+  ASTContext::PreModuleImportCallback = callback;
 }
 
 llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {


### PR DESCRIPTION
`PreModuleImportCallback` is a variable for a callback function called before module importing in the Swift compiler. It is currently being used by LLDB to report progress updates on importing Swift modules in LLDB. This commit adds a setter for `PreModuleImportCallback` for greater flexibility in LLDB and removes the reference to this variable in the constructor.

Related to https://github.com/apple/llvm-project/pull/7769

rdar://105286354