### PR TITLE
[swift-vfe] Eliminate unused base method implementations

### DIFF
--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -212,19 +212,25 @@ namespace irgen {
   /// For VFE, returns a type identifier for the given base method on a class.
   llvm::MDString *typeIdForMethod(IRGenModule &IGM, SILDeclRef method);
 
+  /// In some cases, it is statically determinable that we are emitting a vcall
+  /// to a derived method of some kind. Though at runtime there is no
+  /// difference, passing the most derived method known for the
+  /// staticallyKnownDerivedMethod parameter can help virtual function
+  /// elimination be more effective.
+
   /// Given a metadata pointer, emit the callee for the given method.
-  FunctionPointer emitVirtualMethodValue(IRGenFunction &IGF,
-                                         llvm::Value *metadata,
-                                         SILDeclRef method,
-                                         CanSILFunctionType methodType);
+  FunctionPointer emitVirtualMethodValue(
+      IRGenFunction &IGF, llvm::Value *metadata, SILDeclRef method,
+      SILDeclRef staticallyKnownDerivedMethod, CanSILFunctionType methodType);
 
   /// Given an instance pointer (or, for a static method, a class
   /// pointer), emit the callee for the given method.
-  FunctionPointer emitVirtualMethodValue(IRGenFunction &IGF, llvm::Value *base,
-                                         SILType baseType, SILDeclRef method,
-                                         CanSILFunctionType methodType,
-                                         GenericSignature fnSig,
-                                         bool useSuperVTable);
+  FunctionPointer
+  emitVirtualMethodValue(IRGenFunction &IGF, llvm::Value *base,
+                         SILType baseType, SILDeclRef method,
+                         SILDeclRef staticallyKnownDerivedMethod,
+                         CanSILFunctionType methodType, GenericSignature fnSig,
+                         bool useSuperVTable);
 
   /// Is the given class known to have Swift-compatible metadata?
   bool hasKnownSwiftMetadata(IRGenModule &IGM, ClassDecl *theClass);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -374,7 +374,12 @@ void IRGenModule::addVTableTypeMetadata(
   for (auto ventry : vtableEntries) {
     auto method = ventry.second;
     auto offset = ventry.first.getValue();
-    var->addTypeMetadata(offset, typeIdForMethod(*this, method));
+    SILDeclRef nextOverride = method;
+    SILDeclRef currentOverride = method;
+    do {
+      var->addTypeMetadata(offset, typeIdForMethod(*this, nextOverride));
+      currentOverride = nextOverride;
+    } while ((nextOverride = currentOverride.getNextOverriddenVTableEntry()));
     minOffset = std::min(minOffset, offset);
     maxOffset = std::max(maxOffset, offset);
   }
@@ -1958,7 +1963,7 @@ namespace {
             // 2nd field of MethodOverrideDescriptorStructTy
             Size(IGM.DataLayout.getTypeAllocSize(IGM.RelativeAddressTy));
         VTableEntriesForVFE.push_back(
-            std::pair<Size, SILDeclRef>(offset, baseRef));
+            std::pair<Size, SILDeclRef>(offset, declRef));
       }
 
       auto descriptor = B.beginStruct(IGM.MethodOverrideDescriptorStructTy);
@@ -4201,7 +4206,13 @@ namespace {
              && "cannot generate metadata with placeholders in it");
     }
 
-    void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {}
+    void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {
+      for (auto &entry : VTableEntriesForVFE) {
+        if (entry.second == baseRef) {
+          entry.second = declRef;
+        }
+      }
+    }
 
     void createMetadataAccessFunction() {
       assert(!Target->isGenericContext());

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -246,7 +246,7 @@ Callee IRGenThunk::lookupMethod() {
   }
 
   // Find the method we're interested in.
-  auto method = emitVirtualMethodValue(IGF, metadata, declRef, origTy);
+  auto method = emitVirtualMethodValue(IGF, metadata, declRef, declRef, origTy);
 
   return Callee(std::move(info), method, selfValue);
 }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7804,8 +7804,8 @@ void IRGenSILFunction::visitSuperMethodInst(swift::SuperMethodInst *i) {
   // Non-resilient case.
 
   auto fn =
-      emitVirtualMethodValue(*this, baseValue, baseType, method, methodType,
-                             CurSILFn->getGenericSignature(),
+      emitVirtualMethodValue(*this, baseValue, baseType, method, i->getMember(),
+                             methodType, CurSILFn->getGenericSignature(),
                              /*useSuperVTable*/ true);
 
   setLoweredFunctionPointer(i, fn);
@@ -7869,8 +7869,8 @@ void IRGenSILFunction::visitClassMethodInst(swift::ClassMethodInst *i) {
   // For Swift classes, get the method implementation from the vtable.
   // FIXME: better explosion kind, map as static.
   FunctionPointer fn = emitVirtualMethodValue(
-      *this, baseValue, i->getOperand()->getType(), method, methodType,
-      CurSILFn->getGenericSignature(),
+      *this, baseValue, i->getOperand()->getType(), method, i->getMember(),
+      methodType, CurSILFn->getGenericSignature(),
       /*useSuperVTable*/ false);
 
   setLoweredFunctionPointer(i, fn);

--- a/test/IRGen/virtual-function-elimination-eliminate-unused-base-implementation.swift
+++ b/test/IRGen/virtual-function-elimination-eliminate-unused-base-implementation.swift
@@ -1,0 +1,45 @@
+// Tests that under -enable-llvm-vfe, a base method implementation that is provably
+// never called is safely removed
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+// REQUIRES: no_asan
+// UNSUPPORTED: remote_run
+
+// RUN: %empty-directory(%t)
+
+// (1) Build the program
+// RUN: %target-build-swift -Xfrontend -enable-llvm-vfe -lto=llvm-full %lto_flags -o %t/main %s
+
+// (2) Check that Base.foo, Derived.foo, and Derived.bar are preserved but Base.bar is not
+// RUN: %llvm-nm --defined-only %t/main | %FileCheck %s --check-prefix=NM
+
+// (3) Run the program
+// RUN: %target-run %t/main | %FileCheck %s
+
+class Base {
+    func foo() { print("Base.foo") }
+    func bar() { print("Base.bar") }
+}
+
+class Derived : Base {
+    override func foo() { print("Derived.foo") }
+    override func bar() { print("Derived.bar") }
+}
+
+let base = Base()
+let typeErasedDerived: Base = Derived()
+let derived = Derived()
+
+// NM-NOT: $s4main4BaseC3baryyF 
+// NM:     $s4main4BaseC3fooyyF
+// NM:     $s4main7DerivedC3baryyF
+// NM:     $s4main7DerivedC3fooyyF
+
+base.foo()
+// CHECK: Base.foo
+typeErasedDerived.foo()
+// CHECK: Derived.foo
+derived.bar()
+// CHECK: Derived.bar
+

--- a/test/IRGen/virtual-function-elimination-ir-thunks.swift
+++ b/test/IRGen/virtual-function-elimination-ir-thunks.swift
@@ -3,7 +3,8 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -disable-objc-interop -Xfrontend -enable-llvm-vfe -parse-as-library %s -DLIBRARY -module-name Library -emit-module -o %t/Library.swiftmodule
-// RUN: %target-build-swift -Xfrontend -disable-objc-interop -Xfrontend -enable-llvm-vfe -parse-as-library %s -DCLIENT -module-name Main -I%t -emit-ir -o - | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -disable-objc-interop -Xfrontend -enable-llvm-vfe -parse-as-library %s -DLIBRARY -module-name Library -emit-ir -o - | %FileCheck %s --check-prefix=LIBRARY
+// RUN: %target-build-swift -Xfrontend -disable-objc-interop -Xfrontend -enable-llvm-vfe -parse-as-library %s -DCLIENT -module-name Main -I%t -emit-ir -o - | %FileCheck %s --check-prefix=CLIENT
 
 // UNSUPPORTED: OS=windows-msvc
 
@@ -12,6 +13,20 @@
 public class MyLibraryClass {
   public func foo() { }
 }
+
+public class MyLibraryDerivedClass : MyLibraryClass {
+  override public func foo() { }
+}
+
+// For now at least, dispatch thunks should pass metadata pointing to the base implementation of methods
+
+// LIBRARY: define {{(protected )?}}swiftcc void @"$s7Library02MyA5ClassC3fooyyFTj"(ptr swiftself %0)
+// LIBRARY: @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"$s7Library02MyA5ClassC3fooyyFTq")
+// LIBRARY: ret void
+
+// LIBRARY: define hidden swiftcc ptr @"$s7Library02MyA5ClassCACycfCTj"(ptr swiftself %0)
+// LIBRARY: @llvm.type.checked.load(ptr %{{[0-9]+}}, i32 0, metadata !"$s7Library02MyA5ClassCACycfCTq")
+// LIBRARY: ret
 
 #endif
 
@@ -23,22 +38,53 @@ public class MyLocalClass {
   public func bar() { }
 }
 
+public class MyLocalDerivedClass : MyLocalClass {
+  override public func bar() {  }
+}
+
+// Virtual calls made within the same module should load from the vtable directly
+
 func func1(o: MyLocalClass) {
   // CHECK: define hidden swiftcc void @"$s4Main5func11oyAA12MyLocalClassC_tF"(ptr %0)
   o.bar()
   // CHECK:  [[SLOT:%.*]] = getelementptr inbounds ptr, ptr {{.*}}, {{i64|i32}} {{.*}}
   // CHECK:  call { ptr, i1 } @llvm.type.checked.load(ptr [[SLOT]], i32 0, metadata !"$s4Main12MyLocalClassC3baryyFTq")
 
-  // CHECK: ret void
+  // CLIENT: ret void
 }
 
-func func2(o: MyLibraryClass) {
-  // CHECK: define hidden swiftcc void @"$s4Main5func21oy7Library02MyC5ClassC_tF"(ptr %0)
-  o.foo()
-  // CHECK: call swiftcc void @"$s7Library02MyA5ClassC3fooyyFTj"
+// Direct loads should be made using metadata pointing to the most derived method known to be called
 
-  // CHECK-NOT: @llvm.type.checked.load
-  // CHECK: ret void
+func func2(o: MyLocalDerivedClass) {
+  // CLIENT: define hidden swiftcc void @"$s4Main5func21oyAA19MyLocalDerivedClassC_tF"(ptr %0)
+  o.bar()
+  // CLIENT:  [[SLOT:%.*]] = getelementptr inbounds ptr, ptr
+  // CLIENT:  call { ptr, i1 } @llvm.type.checked.load(ptr [[SLOT]], i32 0, metadata !"$s4Main19MyLocalDerivedClassC3baryyFTq")
+
+  // CLIENT: ret void
+}
+
+// Virtual calls accross module boundaries should always use the dispatch thunk
+
+func func3(o: MyLibraryClass) {
+  // CLIENT: define hidden swiftcc void @"$s4Main5func31oy7Library02MyC5ClassC_tF"(ptr %0)
+  o.foo()
+  // CLIENT: call swiftcc void @"$s7Library02MyA5ClassC3fooyyFTj"
+
+  // CLIENT-NOT: @llvm.type.checked.load
+  // CLIENT: ret void
+}
+
+// For now at least, the virtual calls should use the same dispatch thunk regardless of which class
+// in the hierarchy they make the call through
+
+func func4(o: MyLibraryDerivedClass) {
+  // CLIENT; define hidden swiftcc void @"$s4Main5func41oy7Library02MyC12DerivedClassC_tF"(ptr %0)
+  o.foo()
+  // CLIENT: call swiftcc void @"$s7Library02MyA5ClassC3fooyyFTj"
+
+  // CLIENT-NOT @llvm.type.checked.load
+  // CLIENT: ret void
 }
 
 #endif

--- a/test/IRGen/virtual-function-elimination-ir.swift
+++ b/test/IRGen/virtual-function-elimination-ir.swift
@@ -20,19 +20,19 @@ class MyDerivedClass: MyClass {
 // CHECK:      @"$s4main7MyClassCMn" =
 // CHECK-SAME:     align 4, !type !0, !type !1, !type !2, !vcall_visibility !3, !typed_global_not_for_cfi !4
 
-// Has vfunc slots at offsets 72, 80, 88 (on 64-bit) / 48, 52, 56 (on 32-bit).
+// Has vfunc slots at offsets 80, 88, 96 (on 64-bit) / 52, 56, 60 (on 32-bit).
 // CHECK:         @"$s4main7MyClassCMf" =
 // CHECK-64-SAME:     align 8, !type !5, !type !6, !type !7, !vcall_visibility !8, !typed_global_not_for_cfi !4
 // CHECK-32-SAME:     align 4, !type !5, !type !6, !type !7, !vcall_visibility !8, !typed_global_not_for_cfi !4
 
 // Has vfunc slots at offsets 56, 68, 80 (in swift.method_override_descriptor structs).
 // CHECK:      @"$s4main14MyDerivedClassCMn" =
-// CHECK-SAME:     align 4, !type !0, !type !9, !type !10, !vcall_visibility !11, !typed_global_not_for_cfi !4
+// CHECK-SAME:     align 4, !type !9, !type !0, !type !10, !type !11, !type !12, !type !13, !vcall_visibility !14, !typed_global_not_for_cfi !4
 
-// Has vfunc slots at offsets 72, 80, 88 (on 64-bit) / 48, 52, 56 (on 32-bit)
+// Has vfunc slots at offsets 80, 88, 96 (on 64-bit) / 52, 56, 60 (on 32-bit)
 // CHECK:         @"$s4main14MyDerivedClassCMf" =
-// CHECK-64-SAME:     align 8, !type !5, !type !6, !type !7, !vcall_visibility !8, !typed_global_not_for_cfi !4
-// CHECK-32-SAME:     align 4, !type !5, !type !6, !type !7, !vcall_visibility !8, !typed_global_not_for_cfi !4
+// CHECK-64-SAME:     align 8, !type !15, !type !5, !type !16, !type !6, !type !17, !type !7, !vcall_visibility !8, !typed_global_not_for_cfi !4
+// CHECK-32-SAME:     align 4, !type !15, !type !5, !type !16, !type !6, !type !17, !type !7, !vcall_visibility !8, !typed_global_not_for_cfi !4
 
 
 func func1() {
@@ -48,31 +48,43 @@ func func2() {
   let o: MyDerivedClass = MyDerivedClass()
   o.foo()
   // CHECK:  [[SLOT:%.*]] = getelementptr inbounds ptr, ptr {{.*}}, {{i64|i32}} {{.*}}
-  // CHECK:  call { ptr, i1 } @llvm.type.checked.load(ptr [[SLOT]], i32 0, metadata !"$s4main7MyClassC3fooyyFTq")
+  // CHECK:  call { ptr, i1 } @llvm.type.checked.load(ptr [[SLOT]], i32 0, metadata !"$s4main14MyDerivedClassC3fooyyFTq")
 }
 
-// CHECK-64: !0 = !{i64 56, !"$s4main7MyClassC3fooyyFTq"}
-// CHECK-64: !1 = !{i64 64, !"$s4main7MyClassC3baryyFTq"}
-// CHECK-64: !2 = !{i64 72, !"$s4main7MyClassCACycfCTq"}
-// CHECK-64: !3 = !{i64 1, i64 56, i64 76}
-// CHECK-64: !4 = !{}
-// CHECK-64: !5 = !{i64 80, !"$s4main7MyClassC3fooyyFTq"}
-// CHECK-64: !6 = !{i64 88, !"$s4main7MyClassC3baryyFTq"}
-// CHECK-64: !7 = !{i64 96, !"$s4main7MyClassCACycfCTq"}
-// CHECK-64: !8 = !{i64 1, i64 80, i64 100}
-// CHECK-64: !9 = !{i64 68, !"$s4main7MyClassC3baryyFTq"}
-// CHECK-64: !10 = !{i64 80, !"$s4main7MyClassCACycfCTq"}
-// CHECK-64: !11 = !{i64 1, i64 56, i64 84}
+// CHECK-64: !0 =  !{i64 [[MyDerivedClassCMnFooOffset:56]], !"$s4main7MyClassC3fooyyFTq"}
+// CHECK-64: !1 =  !{i64 64, !"$s4main7MyClassC3baryyFTq"}
+// CHECK-64: !2 =  !{i64 72, !"$s4main7MyClassCACycfCTq"}
+// CHECK-64: !3 =  !{i64 1, i64 56, i64 76}
+// CHECK-64: !4 =  !{}
+// CHECK-64: !5 =  !{i64 [[MyDerivedClassCMfFooOffset:80]], !"$s4main7MyClassC3fooyyFTq"}
+// CHECK-64: !6 =  !{i64 [[MyDerivedClassCMfBarOffset:88]], !"$s4main7MyClassC3baryyFTq"}
+// CHECK-64: !7 =  !{i64 [[MyDerivedClassCMfInitOffset:96]], !"$s4main7MyClassCACycfCTq"}
+// CHECK-64: !8 =  !{i64 1, i64 80, i64 100}
+// CHECK-64: !9 =  !{i64 [[MyDerivedClassCMnFooOffset]], !"$s4main14MyDerivedClassC3fooyyFTq"}
+// CHECK-64: !10 = !{i64 [[MyDerivedClassCMnBarOffset:68]], !"$s4main14MyDerivedClassC3baryyFTq"}
+// CHECK-64: !11 = !{i64 [[MyDerivedClassCMnBarOffset]], !"$s4main7MyClassC3baryyFTq"}
+// CHECK-64: !12 = !{i64 [[MyDerivedClassCMnInitOffset:80]], !"$s4main14MyDerivedClassCACycfCTq"}
+// CHECK-64: !13 = !{i64 [[MyDerivedClassCMnInitOffset]], !"$s4main7MyClassCACycfCTq"}
+// CHECK-64: !14 = !{i64 1, i64 56, i64 84}
+// CHECK-64: !15 = !{i64 [[MyDerivedClassCMfFooOffset]], !"$s4main14MyDerivedClassC3fooyyFTq"}
+// CHECK-64: !16 = !{i64 [[MyDerivedClassCMfBarOffset]], !"$s4main14MyDerivedClassC3baryyFTq"}
+// CHECK-64: !17 = !{i64 [[MyDerivedClassCMfInitOffset]], !"$s4main14MyDerivedClassCACycfCTq"}
 
-// CHECK-32: !0 = !{i64 56, !"$s4main7MyClassC3fooyyFTq"}
-// CHECK-32: !1 = !{i64 64, !"$s4main7MyClassC3baryyFTq"}
-// CHECK-32: !2 = !{i64 72, !"$s4main7MyClassCACycfCTq"}
-// CHECK-32: !3 = !{i64 1, i64 56, i64 76}
-// CHECK-32: !4 = !{}
-// CHECK-32: !5 = !{i64 52, !"$s4main7MyClassC3fooyyFTq"}
-// CHECK-32: !6 = !{i64 56, !"$s4main7MyClassC3baryyFTq"}
-// CHECK-32: !7 = !{i64 60, !"$s4main7MyClassCACycfCTq"}
-// CHECK-32: !8 = !{i64 1, i64 52, i64 64}
-// CHECK-32: !9 = !{i64 68, !"$s4main7MyClassC3baryyFTq"}
-// CHECK-32: !10 = !{i64 80, !"$s4main7MyClassCACycfCTq"}
-// CHECK-32: !11 = !{i64 1, i64 56, i64 84}
+// CHECK-32: !0 =  !{i64 [[MyDerivedClassCMnFooOffset:56]], !"$s4main7MyClassC3fooyyFTq"}
+// CHECK-32: !1 =  !{i64 64, !"$s4main7MyClassC3baryyFTq"}
+// CHECK-32: !2 =  !{i64 72, !"$s4main7MyClassCACycfCTq"}
+// CHECK-32: !3 =  !{i64 1, i64 56, i64 76}
+// CHECK-32: !4 =  !{}
+// CHECK-32: !5 =  !{i64 [[MyDerivedClassCMfFooOffset:52]], !"$s4main7MyClassC3fooyyFTq"}
+// CHECK-32: !6 =  !{i64 [[MyDerivedClassCMfBarOffset:56]], !"$s4main7MyClassC3baryyFTq"}
+// CHECK-32: !7 =  !{i64 [[MyDerivedClassCMfInitOffset:60]], !"$s4main7MyClassCACycfCTq"}
+// CHECK-32: !8 =  !{i64 1, i64 52, i64 64}
+// CHECK-32: !9 =  !{i64 [[MyDerivedClassCMnFooOffset]], !"$s4main14MyDerivedClassC3fooyyFTq"}
+// CHECK-32: !10 = !{i64 [[MyDerivedClassCMnBarOffset:68]], !"$s4main14MyDerivedClassC3baryyFTq"}
+// CHECK-32: !11 = !{i64 [[MyDerivedClassCMnBarOffset]], !"$s4main7MyClassC3baryyFTq"}
+// CHECK-32: !12 = !{i64 [[MyDerivedClassCMnInitOffset:80]], !"$s4main14MyDerivedClassCACycfCTq"}
+// CHECK-32: !13 = !{i64 [[MyDerivedClassCMnInitOffset]], !"$s4main7MyClassCACycfCTq"}
+// CHECK-32: !14 = !{i64 1, i64 56, i64 84}
+// CHECK-32: !15 = !{i64 [[MyDerivedClassCMfFooOffset]], !"$s4main14MyDerivedClassC3fooyyFTq"}
+// CHECK-32: !16 = !{i64 [[MyDerivedClassCMfBarOffset]], !"$s4main14MyDerivedClassC3baryyFTq"}
+// CHECK-32: !17 = !{i64 [[MyDerivedClassCMfInitOffset]], !"$s4main14MyDerivedClassCACycfCTq"}


### PR DESCRIPTION
The LLVM VFE infrastructure was built to enable eliminating virtual functions that cannot possibly be called. Previously, given methods Base.foo and Derived.foo, we were only able to eliminate if neither Base.foo nor Derived.foo are called.

This patch improves this in that if all calls to foo are made through Derived, we can eliminate Base.foo. It only does this if all calls to foo are made within the defining module for now.

It is possible to expand this to inter-module vcalls, but more complicated. (We need our own thunks instead of re-using the resilient dispatch thunks)

This brings us closer to the C++ implementation of VFE. A high-level description of the implementation:

- Rather than attaching !type metadata to a vtable corresponding to the base version of each method as we do now, we attach !type metadata for each methods, at each level of derivation. For example, we have classes Base and Derived, and Derived override Base.foo, then the vtable for Derived will have !type metadata for Derived.foo, and Base.foo, but the metadata for Base will only be for Base.foo. This is because you can call Derived.foo, through Base.foo.
- Then when we emit a `llvm.type.checked.load` we must use the most derived type id we can determine statically. This let's GlobalDCE see there are never any calls to `Base.foo`, only `Derived.foo`. At the same time, a call to `Base.foo` still keeps `Derived.foo` alive. 