### PR TITLE
Introduce @_staticExclusiveOnly

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -530,6 +530,9 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(actor, Actor,
 CONTEXTUAL_SIMPLE_DECL_ATTR(_resultDependsOnSelf, ResultDependsOnSelf,
   OnFunc | DeclModifier | UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   150)
+SIMPLE_DECL_ATTR(_staticExclusiveOnly, StaticExclusiveOnly,
+  OnStruct | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  151)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -531,7 +531,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(_resultDependsOnSelf, ResultDependsOnSelf,
   OnFunc | DeclModifier | UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   150)
 SIMPLE_DECL_ATTR(_staticExclusiveOnly, StaticExclusiveOnly,
-  OnStruct | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  OnStruct | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   151)
 
 #undef TYPE_ATTR

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1929,7 +1929,7 @@ NOTE(attr_static_exclusive_only_type_nonmutating,none,
 ERROR(attr_static_exclusive_only_let_only_param,none,
       "parameter of type %0 must be declared as either 'borrowing' or 'consuming'", (Type))
 ERROR(attr_static_exclusive_only_mutating,none,
-      "@_staticExclusiveOnly type %0 cannot have mutating function %1", (Type, ValueDecl *))
+      "type %0 cannot have mutating function %1", (Type, ValueDecl *))
 
 ERROR(c_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1924,6 +1924,8 @@ ERROR(attr_static_exclusive_only_noncopyable,none,
       "@_staticExclusiveOnly can only be applied to noncopyable types", ())
 ERROR(attr_static_exclusive_only_let_only,none,
       "variable of type %0 must be declared with a 'let'", (Type))
+NOTE(attr_static_exclusive_only_type_nonmutating,none,
+     "%0 is a non-mutable type", (Type))
 ERROR(attr_static_exclusive_only_let_only_param,none,
       "parameter of type %0 must be declared as either 'borrowing' or 'consuming'", (Type))
 ERROR(attr_static_exclusive_only_mutating,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1917,6 +1917,18 @@ WARNING(extern_c_maybe_invalid_name, none,
         "C name '%0' may be invalid; explicitly specify the name in @_extern(c) to suppress this warning",
         (StringRef))
 
+// @_staticExclusiveOnly
+ERROR(attr_static_exclusive_only_disabled,none,
+      "attribute requires '-enable-experimental feature StaticExclusiveOnly'", ())
+ERROR(attr_static_exclusive_only_noncopyable,none,
+      "@_staticExclusiveOnly can only be applied to noncopyable types", ())
+ERROR(attr_static_exclusive_only_let_only,none,
+      "variable of type %0 must be declared with a 'let'", (Type))
+ERROR(attr_static_exclusive_only_let_only_param,none,
+      "parameter of type %0 must be declared as either 'borrowing' or 'consuming'", (Type))
+ERROR(attr_static_exclusive_only_mutating,none,
+      "@_staticExclusiveOnly type %0 cannot have mutating function %1", (Type, ValueDecl *))
+
 ERROR(c_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -259,6 +259,9 @@ EXPERIMENTAL_FEATURE(Extern, true)
 // global functions and key paths.
 EXPERIMENTAL_FEATURE(InferSendableFromCaptures, false)
 
+/// Enable the `@_staticExclusiveOnly` attribute.
+EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3640,6 +3640,10 @@ static bool usesFeatureExtern(Decl *decl) {
   return decl->getAttrs().hasAttribute<ExternAttr>();
 }
 
+static bool usesFeatureStaticExclusiveOnly(Decl *decl) {
+  return decl->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>();
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -353,6 +353,8 @@ public:
 
   void visitNonEscapableAttr(NonEscapableAttr *attr);
   void visitUnsafeNonEscapableResultAttr(UnsafeNonEscapableResultAttr *attr);
+
+  void visitStaticExclusiveOnlyAttr(StaticExclusiveOnlyAttr *attr);
 };
 
 } // end anonymous namespace
@@ -499,6 +501,15 @@ void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
                               attrModifier, FD->getDescriptiveKind(),
                               DC->getSelfProtocolDecl() != nullptr);
         break;
+      }
+    }
+
+    // Types who are marked @_staticExclusiveOnly cannot have mutating functions.
+    if (auto SD = contextTy->getStructOrBoundGenericStruct()) {
+      if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
+          attrModifier == SelfAccessKind::Mutating) {
+        diagnoseAndRemoveAttr(attr, diag::attr_static_exclusive_only_mutating,
+                              contextTy, FD);
       }
     }
   } else {
@@ -7241,6 +7252,20 @@ void AttributeChecker::visitUnsafeNonEscapableResultAttr(
   UnsafeNonEscapableResultAttr *attr) {
   if (!Ctx.LangOpts.hasFeature(Feature::NonEscapableTypes)) {
     diagnoseAndRemoveAttr(attr, diag::nonescapable_types_attr_disabled);
+  }
+}
+
+void AttributeChecker::visitStaticExclusiveOnlyAttr(
+    StaticExclusiveOnlyAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::StaticExclusiveOnly)) {
+    diagnoseAndRemoveAttr(attr, diag::attr_static_exclusive_only_disabled);
+  }
+
+  // Can only be applied to structs.
+  auto structDecl = cast<StructDecl>(D);
+
+  if (!structDecl->isNoncopyable()) {
+    diagnoseAndRemoveAttr(attr, diag::attr_static_exclusive_only_noncopyable);
   }
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7259,12 +7259,14 @@ void AttributeChecker::visitStaticExclusiveOnlyAttr(
     StaticExclusiveOnlyAttr *attr) {
   if (!Ctx.LangOpts.hasFeature(Feature::StaticExclusiveOnly)) {
     diagnoseAndRemoveAttr(attr, diag::attr_static_exclusive_only_disabled);
+    return;
   }
 
   // Can only be applied to structs.
   auto structDecl = cast<StructDecl>(D);
 
-  if (!structDecl->isNoncopyable()) {
+  if (!structDecl->getDeclaredInterfaceType()
+                 ->isNoncopyable(D->getDeclContext())) {
     diagnoseAndRemoveAttr(attr, diag::attr_static_exclusive_only_noncopyable);
   }
 }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1630,6 +1630,7 @@ namespace  {
     UNINTERESTING_ATTR(LexicalLifetimes)
     UNINTERESTING_ATTR(NonEscapable)
     UNINTERESTING_ATTR(UnsafeNonEscapableResult)
+    UNINTERESTING_ATTR(StaticExclusiveOnly)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2484,10 +2484,16 @@ public:
 
     // @_staticExclusiveOnly types cannot be put into 'var's, only 'let'.
     if (auto SD = VD->getInterfaceType()->getStructOrBoundGenericStruct()) {
-      if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
+      if (getASTContext().LangOpts.hasFeature(Feature::StaticExclusiveOnly) &&
+          SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
           !VD->isLet()) {
-        VD->diagnose(diag::attr_static_exclusive_only_let_only,
-                     VD->getInterfaceType());
+        SD->getASTContext().Diags.diagnoseWithNotes(
+          VD->diagnose(diag::attr_static_exclusive_only_let_only,
+                       VD->getInterfaceType()),
+          [&]() {
+            SD->diagnose(diag::attr_static_exclusive_only_type_nonmutating,
+                       SD->getDeclaredInterfaceType());
+          });
       }
     }
   }
@@ -4236,10 +4242,16 @@ void TypeChecker::checkParameterList(ParameterList *params,
     // @_staticExclusiveOnly types cannot be passed as 'inout', only as either
     // a borrow or as consuming.
     if (auto SD = param->getInterfaceType()->getStructOrBoundGenericStruct()) {
-      if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
+      if (SD->getASTContext().LangOpts.hasFeature(Feature::StaticExclusiveOnly) &&
+          SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
           param->isInOut()) {
-        param->diagnose(diag::attr_static_exclusive_only_let_only_param,
-                        param->getInterfaceType());
+        SD->getASTContext().Diags.diagnoseWithNotes(
+          param->diagnose(diag::attr_static_exclusive_only_let_only_param,
+                          param->getInterfaceType()),
+          [&]() {
+            SD->diagnose(diag::attr_static_exclusive_only_type_nonmutating,
+                       SD->getDeclaredInterfaceType());
+          });
       }
     }
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3556,9 +3556,21 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
     }
 
     // Validate the presence of ownership for a noncopyable parameter.
-    if (inStage(TypeResolutionStage::Interface))
+    if (inStage(TypeResolutionStage::Interface)) {
       diagnoseMissingOwnership(getASTContext(), dc, ownership,
                                eltTypeRepr, ty, options);
+
+      // @_staticExclusiveOnly types cannot be passed as 'inout' in function
+      // types.
+      if (auto SD = ty->getStructOrBoundGenericStruct()) {
+        if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
+            ownership == ParamSpecifier::InOut) {
+          diagnose(eltTypeRepr->getLoc(),
+                   diag::attr_static_exclusive_only_let_only_param,
+                   ty);
+        }
+      }
+    }
 
     Identifier argumentLabel;
     Identifier parameterName;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3563,7 +3563,8 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
       // @_staticExclusiveOnly types cannot be passed as 'inout' in function
       // types.
       if (auto SD = ty->getStructOrBoundGenericStruct()) {
-        if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
+        if (getASTContext().LangOpts.hasFeature(Feature::StaticExclusiveOnly) &&
+            SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
             ownership == ParamSpecifier::InOut) {
           diagnose(eltTypeRepr->getLoc(),
                    diag::attr_static_exclusive_only_let_only_param,

--- a/test/attr/attr_static_exclusive_only.swift
+++ b/test/attr/attr_static_exclusive_only.swift
@@ -1,10 +1,14 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature StaticExclusiveOnly
 
-@_staticExclusiveOnly // expected-error{{@_staticExclusiveOnly can only be applied to noncopyable types}}
+@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly can only be applied to noncopyable types}}
 struct A {}
 
 @_staticExclusiveOnly // OK
-struct B: ~Copyable {
+struct B: ~Copyable { // expected-note {{'B' is a non-mutable type}}
+                      // expected-note@-1 {{'B' is a non-mutable type}}
+                      // expected-note@-2 {{'B' is a non-mutable type}}
+                      // expected-note@-3 {{'B' is a non-mutable type}}
+                      // expected-note@-4 {{'B' is a non-mutable type}}
   mutating func change() { // expected-error {{@_staticExclusiveOnly type 'B' cannot have mutating function 'change()'}}
     print("123")
   }
@@ -40,3 +44,27 @@ func i() {
     return $0 + $1
   }
 }
+
+@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+enum J {}
+
+@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+class K {}
+
+@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+func l() {}
+
+@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+let m = 123
+
+@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+protocol N {}
+
+func o(_: consuming B) {} // OK
+
+func p(_: (consuming B) -> ()) {} // OK
+
+@_staticExclusiveOnly
+struct Q<T>: ~Copyable {} // expected-note {{'Q<T>' is a non-mutable type}}
+
+var r0 = Q<Int>() // expected-error {{variable of type 'Q<Int>' must be declared with a 'let'}}

--- a/test/attr/attr_static_exclusive_only.swift
+++ b/test/attr/attr_static_exclusive_only.swift
@@ -9,7 +9,7 @@ struct B: ~Copyable { // expected-note {{'B' is a non-mutable type}}
                       // expected-note@-2 {{'B' is a non-mutable type}}
                       // expected-note@-3 {{'B' is a non-mutable type}}
                       // expected-note@-4 {{'B' is a non-mutable type}}
-  mutating func change() { // expected-error {{@_staticExclusiveOnly type 'B' cannot have mutating function 'change()'}}
+  mutating func change() { // expected-error {{type 'B' cannot have mutating function 'change()'}}
     print("123")
   }
 }

--- a/test/attr/attr_static_exclusive_only.swift
+++ b/test/attr/attr_static_exclusive_only.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature StaticExclusiveOnly
+
+@_staticExclusiveOnly // expected-error{{@_staticExclusiveOnly can only be applied to noncopyable types}}
+struct A {}
+
+@_staticExclusiveOnly // OK
+struct B: ~Copyable {
+  mutating func change() { // expected-error {{@_staticExclusiveOnly type 'B' cannot have mutating function 'change()'}}
+    print("123")
+  }
+}
+
+let b0 = B() // OK
+
+var b1 = B() // expected-error {{variable of type 'B' must be declared with a 'let'}}
+
+class C {
+  var b2 = B() // expected-error {{variable of type 'B' must be declared with a 'let'}}
+  let b3 = B() // OK
+}
+
+struct D: ~Copyable {
+  var b4 = B() // expected-error {{variable of type 'B' must be declared with a 'let'}}
+  let b5 = B() // OK
+}
+
+func e(_: borrowing B) {} // OK
+
+func f(_: inout B) {} // expected-error {{parameter of type 'B' must be declared as either 'borrowing' or 'consuming'}}
+
+func g(_: (inout B) -> ()) {} // expected-error {{parameter of type 'B' must be declared as either 'borrowing' or 'consuming'}}
+
+func h(_: (borrowing B) -> ()) {} // OK
+
+func i() {
+  let _: (Int, Int) -> Int = {
+    var b6 = B() // expected-error {{variable of type 'B' must be declared with a 'let'}}
+                 // expected-warning@-1 {{initialization of variable 'b6' was never used; consider replacing with assignment to '_' or removing it}}
+
+    return $0 + $1
+  }
+}


### PR DESCRIPTION
This introduces a new attribute who provides diagnostics about being used as a `var`, passed as `inout`, and whether the type declares `mutating` functions methods.