### PR TITLE
Distributed: Enabled availability checking in Distributed test

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN:  %target-run %t/a.out
 
@@ -76,6 +76,7 @@ distributed actor FiveSevenActor_FiveNineExecutor {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 @main struct Main {
   static func main() async {
     if #available(SwiftStdlib 5.9, *) {

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
@@ -19,6 +19,7 @@
 import Distributed
 import FakeDistributedActorSystems
 
+@available(SwiftStdlib 5.7, *)
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 @available(SwiftStdlib 5.9, *) // because conforming to the protocol... that has this field in 5.9?
@@ -38,6 +39,7 @@ distributed actor Worker {
 
 }
 
+@available(SwiftStdlib 5.9, *)
 @main struct Main {
   static func main() async {
     let worker = Worker(actorSystem: DefaultDistributedActorSystem())

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
@@ -21,6 +21,7 @@
 import Distributed
 import FakeDistributedActorSystems
 
+@available(SwiftStdlib 5.7, *)
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 @available(SwiftStdlib 5.9, *)
@@ -43,12 +44,14 @@ distributed actor Worker {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension DefaultDistributedActorSystem.ActorID {
   var executorPreference: UnownedSerialExecutor? {
     MainActor.sharedUnownedExecutor
   }
 }
 
+@available(SwiftStdlib 5.9, *)
 @main struct Main {
   static func main() async {
     let worker = Worker(actorSystem: DefaultDistributedActorSystem())

--- a/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
+++ b/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -module-name default_deinit -primary-file %s -emit-sil -verify -disable-availability-checking -I %t | %FileCheck %s --enable-var-scope
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -module-name default_deinit -primary-file %s -emit-sil -verify -I %t | %FileCheck %s --enable-var-scope
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
@@ -9,6 +9,7 @@
 import Distributed
 import FakeDistributedActorSystems
 
+@available(SwiftStdlib 5.7, *)
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 // ==== ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Various distributed actors test cases were testing behavior that ultimately depends on availability checking but then disabled availability checking on the command line when building. This will break with future planned changes to availability checking infrastructure.