### PR TITLE
Add support for `SWIFTCI_USE_LOCAL_DEPS` in `swift-inspect`

### DIFF
--- a/tools/swift-inspect/Package.swift
+++ b/tools/swift-inspect/Package.swift
@@ -2,14 +2,12 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import class Foundation.ProcessInfo
 
 let package = Package(
     name: "swift-inspect",
     products: [
         .library(name: "SwiftInspectClient", type: .dynamic, targets: ["SwiftInspectClient"]),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -36,3 +34,11 @@ let package = Package(
             name: "SymbolicationShims")
     ]
 )
+
+if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+    package.dependencies += [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
+    ]
+} else {
+    package.dependencies += [.package(path: "../../../swift-argument-parser")]
+}

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1530,12 +1530,14 @@ function Install-HostToolchain() {
 function Build-Inspect() {
   $OutDir = Join-Path -Path $HostArch.BinaryCache -ChildPath swift-inspect
 
-  Build-SPMProject `
-    -Src $SourceCache\swift\tools\swift-inspect `
-    -Bin $OutDir `
-    -Arch $HostArch `
-    -Xcc "-I$SDKInstallRoot\usr\include\swift\SwiftRemoteMirror" -Xlinker "$SDKInstallRoot\usr\lib\swift\windows\$($HostArch.LLVMName)\swiftRemoteMirror.lib" `
-    -Xcc -Xclang -Xcc -fno-split-cold-code # Workaround https://github.com/llvm/llvm-project/issues/40056
+  Isolate-EnvVars {
+    $env:SWIFTCI_USE_LOCAL_DEPS=1
+    Build-SPMProject `
+      -Src $SourceCache\swift\tools\swift-inspect `
+      -Bin $OutDir `
+      -Arch $HostArch `
+      -Xcc "-I$SDKInstallRoot\usr\include\swift\SwiftRemoteMirror" -Xlinker "$SDKInstallRoot\usr\lib\swift\windows\$($HostArch.LLVMName)\swiftRemoteMirror.lib"
+  }
 }
 
 function Build-Format() {


### PR DESCRIPTION
If the `SWIFTCI_USE_LOCAL_DEPS` environment variable is set, we're building in the Swift.org CI system alongside other projects in the Swift toolchain and we can depend on local versions of our dependencies instead of fetching them remotely.

Also removes manual CXX flags set by `build.ps1` invocation since they're already in `Package.swift`.