### PR TITLE
[cxx-interop] Do not import inherited methods with rvalue this

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5481,6 +5481,13 @@ cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
         (fn->getClangDecl() &&
          isa<clang::FunctionTemplateDecl>(fn->getClangDecl())))
       return nullptr;
+    if (auto cxxMethod =
+            dyn_cast_or_null<clang::CXXMethodDecl>(fn->getClangDecl())) {
+      // FIXME: if this function has rvalue this, we won't be able to synthesize
+      // the accessor correctly (https://github.com/apple/swift/issues/69745).
+      if (cxxMethod->getRefQualifier() == clang::RefQualifierKind::RQ_RValue)
+        return nullptr;
+    }
 
     ASTContext &context = decl->getASTContext();
     auto out = FuncDecl::createImplicit(

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -22,6 +22,10 @@ struct Base {
       __attribute__((swift_attr("import_unsafe"))) {
     return "Base::constInBase";
   }
+  inline const char *rvalueThisInBase() const&&
+      __attribute__((swift_attr("import_unsafe"))) {
+    return "Base::rvalueThisInBase";
+  }
   // TODO: if these are unnamed we hit an (unrelated) SILGen bug. Same for
   // subscripts.
   inline const char *takesArgsInBase(int a, int b, int c) const

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -15,6 +15,8 @@
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   func rvalueThisInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>!

--- a/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
@@ -17,3 +17,6 @@ Derived().sameMethodNameSameSignature()
 Derived().sameMethodDifferentSignature(1)
 // ok, this is the base class method.
 Derived().sameMethodDifferentSignature()
+
+// FIXME: we should import this (https://github.com/apple/swift/issues/69745):
+Derived().rvalueThisInBase() // expected-error {{value of type 'Derived' has no member 'rvalueThisInBase'}}


### PR DESCRIPTION
We do not synthesize the inheritance thunks correctly for such methods. Do not try to synthesize them, as that causes issues when there are two overloads of the same method, one with rvalue this and one without.

```
<unknown>:0: error: 'this' argument to member function 'rvalueThisInBase' is an lvalue, but function has rvalue ref-qualifier
functions.h:25:22: note: 'rvalueThisInBase' declared here
  inline const char *rvalueThisInBase() const&&
                     ^
<unknown>:0: error: failed to synthesize call to the base method 'rvalueThisInBase()' of type 'rvalueThisInBase()'
<unknown>:0: error: missing return in instance method expected to return 'UnsafePointer<CChar>?' (aka 'Optional<UnsafePointer<Int8>>')
```

The proper solution is tracked as https://github.com/apple/swift/issues/69745

Unblocks rdar://114282353 / https://github.com/apple/swift/pull/69623