### PR TITLE
CMake: allow to only build Core and Onone when building the stdlib

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -99,6 +99,13 @@ option(SWIFT_STDLIB_EMIT_API_DESCRIPTORS
         "Emit api descriptors for the standard library"
         FALSE)
 
+option(SWIFT_STDLIB_BUILD_ONLY_CORE_MODULES
+       "Build only the core subset of the standard library,
+       ignoring additional libraries such as Concurrency, Distributed and StringProcessing.
+       This is an option meant for internal configurations inside Apple
+       that need to build the standard libraries in chunks when constructing an SDK"
+       FALSE)
+
 if("${SWIFT_HOST_VARIANT_SDK}" IN_LIST SWIFT_DARWIN_PLATFORMS)
   set(SWIFT_STDLIB_ENABLE_PRESPECIALIZATION_default TRUE)
 elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -166,7 +166,12 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(stubs)
   add_subdirectory(core)
   add_subdirectory(SwiftOnoneSupport)
+endif()
 
+if(SWIFT_BUILD_STDLIB AND NOT SWIFT_STDLIB_BUILD_ONLY_CORE_MODULES)
+  # In some internal Apple configurations we have the need
+  # to build Core and Onone separately from the rest
+  # of the stdlib
   if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
     add_subdirectory(Differentiation)
   endif()


### PR DESCRIPTION
This is needed for some internal Apple configurations that needs to build the standard library in pieces to construct an SDK.
Given the limited audience, only introduce this flag in CMake.

Addresses rdar://118178539