### PR TITLE
SimplifyDestructure: support simplifying a destructure_struct with a copy_value in place

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
@@ -84,7 +84,7 @@ private func optimizeOptionalBridging(forArgumentOf block: BasicBlock,
   }
 
   // Check for the first ObjC -> swift bridging operation.
-  let swiftValue = lookThroughOwnershipInsts(swiftValueSwitch.enumOp)
+  let swiftValue = swiftValueSwitch.enumOp.lookThoughOwnershipInstructions
   guard let originalObjCValueSwitch = isOptionalBridging(of: swiftValue, isBridging: isBridgeToSwiftCall) else {
     return true
   }
@@ -126,7 +126,7 @@ private func optimizeNonOptionalBridging(_ apply: ApplyInst,
     return true
   }
 
-  let swiftValue = lookThroughOwnershipInsts(bridgeToObjcCall.arguments[0])
+  let swiftValue = bridgeToObjcCall.arguments[0].lookThoughOwnershipInstructions
 
   // Handle the first case: the ObjC -> swift bridging operation is optional and the swift -> ObjC
   // bridging is within a test for Optional.some, e.g.
@@ -243,18 +243,6 @@ private func removeBridgingCodeInPredecessors(of block: BasicBlock, _ context: F
       context.erase(instruction: bridgingCall as! ApplyInst)
     }
   }
-}
-
-private func lookThroughOwnershipInsts(_ value: Value) -> Value {
-  // Looks like it's sufficient to support begin_borrow and copy_value for now.
-  // TODO: add move_value if needed.
-  if let bbi = value as? BeginBorrowInst {
-    return bbi.borrowedValue
-  }
-  if let cvi = value as? CopyValueInst {
-    return cvi.fromValue
-  }
-  return value
 }
 
 /// Checks for an optional bridging `switch_enum` diamond.

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestructure.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestructure.swift
@@ -31,15 +31,55 @@ extension DestructureTupleInst : OnoneSimplifyable {
 extension DestructureStructInst : OnoneSimplifyable {
   func simplify(_ context: SimplifyContext) {
 
-    // Eliminate the redundant instruction pair
-    // ```
-    //   %s = struct (%0, %1, %2)
-    //   (%3, %4, %5) = destructure_struct %s
-    // ```
-    // and replace the results %3, %4, %5 with %0, %1, %2, respectively
-    //
-    if let str = self.struct as? StructInst {
+    switch self.struct {
+    case let str as StructInst:
+      // Eliminate the redundant instruction pair
+      // ```
+      //   %s = struct (%0, %1, %2)
+      //   (%3, %4, %5) = destructure_struct %s
+      // ```
+      // and replace the results %3, %4, %5 with %0, %1, %2, respectively
+      //
       tryReplaceConstructDestructPair(construct: str, destruct: self, context)
+
+    case let copy as CopyValueInst:
+      // Similar to the pattern above, but with a copy_value:
+      // Replace
+      // ```
+      //   %s = struct (%0, %1, %2)
+      //   %c = copy_value %s           // can also be a chain of multiple copies
+      //   (%3, %4, %5) = destructure_struct %c
+      // ```
+      // with
+      // ```
+      //   %c0 = copy_value %0
+      //   %c1 = copy_value %1
+      //   %c2 = copy_value %2
+      //   %s = struct (%0, %1, %2)    // keep the original struct
+      // ```
+      // and replace the results %3, %4, %5 with %c0, %c1, %c2, respectively.
+      //
+      // This transformation has the advantage that we can do it even if the `struct` instruction
+      // has other uses than the `copy_value`.
+      //
+      if copy.uses.singleUse?.instruction == self,
+         let structInst = copy.fromValue.lookThroughCopy as? StructInst,
+         structInst.parentBlock == self.parentBlock
+      {
+        for (result, operand) in zip(self.results, structInst.operands) {
+          if operand.value.type.isTrivial(in: parentFunction) {
+            result.uses.replaceAll(with: operand.value, context)
+          } else {
+            let builder = Builder(before: structInst, context)
+            let copiedOperand = builder.createCopyValue(operand: operand.value)
+            result.uses.replaceAll(with: copiedOperand, context)
+          }
+        }
+        context.erase(instruction: self)
+        context.erase(instruction: copy)
+      }
+    default:
+      break
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -18,6 +18,33 @@ extension Value {
     uses.lazy.filter { !($0.instruction is DebugValueInst) }
   }
 
+  var lookThroughBorrow: Value {
+    if let beginBorrow = self as? BeginBorrowInst {
+      return beginBorrow.borrowedValue.lookThroughBorrow
+    }
+    return self
+  }
+
+  var lookThroughCopy: Value {
+    if let copy = self as? CopyValueInst {
+      return copy.fromValue.lookThroughCopy
+    }
+    return self
+  }
+
+  var lookThoughOwnershipInstructions: Value {
+    switch self {
+    case let beginBorrow as BeginBorrowInst:
+      return beginBorrow.borrowedValue.lookThoughOwnershipInstructions
+    case let copy as CopyValueInst:
+      return copy.fromValue.lookThoughOwnershipInstructions
+    case let move as MoveValueInst:
+      return move.fromValue.lookThoughOwnershipInstructions
+    default:
+      return self
+    }
+  }
+
   /// Walks over all fields of an aggregate and checks if a reference count
   /// operation for this value is required. This differs from a simple `Type.isTrivial`
   /// check, because it treats a value_to_bridge_object instruction as "trivial".

--- a/test/SILOptimizer/simplify_destructure_struct.sil
+++ b/test/SILOptimizer/simplify_destructure_struct.sil
@@ -70,4 +70,74 @@ bb0(%0 : @owned $String, %1 : $Int):
   return %4 : $String
 }
 
+// CHECK-LABEL: sil [ossa] @forward_with_copy :
+// CHECK:         %2 = copy_value %0
+// CHECK:         %3 = struct $S (%0 : $String, %1 : $Int)
+// CHECK:         fix_lifetime %1
+// CHECK:         destroy_value %3
+// CHECK:         return %2
+// CHECK:       } // end sil function 'forward_with_copy'
+sil [ossa] @forward_with_copy : $@convention(thin) (@owned String, Int) -> @owned String {
+bb0(%0 : @owned $String, %1 : $Int):
+  %2 = struct $S (%0 : $String, %1 : $Int)
+  %3 = copy_value %2 : $S
+  (%4, %5) = destructure_struct %3 : $S
+  fix_lifetime %5 : $Int
+  destroy_value %2 : $S
+  return %4 : $String
+}
+
+// CHECK-LABEL: sil [ossa] @forward_with_two_copies :
+// CHECK:         %2 = copy_value %0
+// CHECK:         %3 = struct $S (%0 : $String, %1 : $Int)
+// CHECK:         %4 = copy_value %3
+// CHECK:         fix_lifetime %1
+// CHECK:         destroy_value %3
+// CHECK:         destroy_value %4
+// CHECK:         return %2
+// CHECK:       } // end sil function 'forward_with_two_copies'
+sil [ossa] @forward_with_two_copies : $@convention(thin) (@owned String, Int) -> @owned String {
+bb0(%0 : @owned $String, %1 : $Int):
+  %2 = struct $S (%0 : $String, %1 : $Int)
+  %3 = copy_value %2 : $S
+  %4 = copy_value %3 : $S
+  (%5, %6) = destructure_struct %4 : $S
+  fix_lifetime %6 : $Int
+  destroy_value %2 : $S
+  destroy_value %3 : $S
+  return %5 : $String
+}
+
+// CHECK-LABEL: sil [ossa] @copy_has_other_uses :
+// CHECK:         destructure_struct
+// CHECK:       } // end sil function 'copy_has_other_uses'
+sil [ossa] @copy_has_other_uses : $@convention(thin) (@owned String, Int) -> @owned String {
+bb0(%0 : @owned $String, %1 : $Int):
+  %2 = struct $S (%0 : $String, %1 : $Int)
+  %3 = copy_value %2 : $S
+  fix_lifetime %3 : $S
+  (%5, %6) = destructure_struct %3 : $S
+  fix_lifetime %6 : $Int
+  destroy_value %2 : $S
+  return %5 : $String
+}
+
+// CHECK-LABEL: sil [ossa] @different_basic_block :
+// CHECK:       bb2:
+// CHECK:         destructure_struct
+// CHECK:       } // end sil function 'different_basic_block'
+sil [ossa] @different_basic_block : $@convention(thin) (@owned String, Int) -> @owned String {
+bb0(%0 : @owned $String, %1 : $Int):
+  %2 = struct $S (%0 : $String, %1 : $Int)
+  %3 = copy_value %2 : $S
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_value %3 : $S
+  unreachable
+bb2:
+  (%4, %5) = destructure_struct %3 : $S
+  fix_lifetime %5 : $Int
+  destroy_value %2 : $S
+  return %4 : $String
+}
 


### PR DESCRIPTION
Replace
```
  %s = struct (%0, %1, %2)
  %c = copy_value %s           // can also be a chain of multiple copies
  (%3, %4, %5) = destructure_struct %c
```
with
```
  %c0 = copy_value %0
  %c1 = copy_value %1
  %c2 = copy_value %2
  %s = struct (%0, %1, %2)    // keep the original struct
```
and replace the results %3, %4, %5 with %c0, %c1, %c2, respectively.