### PR TITLE
[5.10][cxx-interop] code-complete namespace members

### DIFF
--- a/test/Interop/Cxx/namespace/Inputs/enums.h
+++ b/test/Interop/Cxx/namespace/Inputs/enums.h
@@ -1,0 +1,14 @@
+#ifndef TEST_INTEROP_CXX_NAMESPACE_INPUTS_ENUMS_H
+#define TEST_INTEROP_CXX_NAMESPACE_INPUTS_ENUMS_H
+
+namespace EnumNS1 {
+
+enum AnEnum {
+    one,
+    two,
+    three
+};
+
+} // namespace EnumNS1
+
+#endif // TEST_INTEROP_CXX_NAMESPACE_INPUTS_ENUMS_H

--- a/test/Interop/Cxx/namespace/Inputs/module.modulemap
+++ b/test/Interop/Cxx/namespace/Inputs/module.modulemap
@@ -54,3 +54,8 @@ module Extensions {
   header "extensions.h"
   requires cplusplus
 }
+
+module Enums {
+  header "enums.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/namespace/namespace-completion.swift
+++ b/test/Interop/Cxx/namespace/namespace-completion.swift
@@ -1,0 +1,59 @@
+// RUN: %target-swift-ide-test -code-completion -enable-experimental-cxx-interop -source-filename %s -code-completion-token=NS1 -I %S/Inputs | %FileCheck %s -check-prefix=CHECK-NS1
+// RUN: %target-swift-ide-test -code-completion -enable-experimental-cxx-interop -source-filename %s -code-completion-token=NS2 -I %S/Inputs | %FileCheck %s -check-prefix=CHECK-NS2
+// RUN: %target-swift-ide-test -code-completion -enable-experimental-cxx-interop -source-filename %s -code-completion-token=TemplatesNS1 -I %S/Inputs | %FileCheck %s -check-prefix=CHECK-TNS1
+// RUN: %target-swift-ide-test -code-completion -enable-experimental-cxx-interop -source-filename %s -code-completion-token=EnumsNS1 -I %S/Inputs | %FileCheck %s -check-prefix=CHECK-ENS1
+
+import Submodules
+import Templates
+import Enums
+
+func ns1() {
+  NS1.#^NS1^#
+}
+// CHECK-NS1: Begin completions, 5 items
+// CHECK-NS1-NEXT: Keyword[self]/CurrNominal:          self[#NS1.Type#]; name=self
+// CHECK-NS1-NEXT: Keyword/CurrNominal:                Type[#NS1.Type#]; name=Type
+// CHECK-NS1-NEXT: Decl[Enum]/CurrNominal:             NS2[#NS1.NS2#]; name=NS2
+// CHECK-NS1-NEXT: Decl[Struct]/CurrNominal:           BasicB[#NS1.BasicB#]; name=BasicB
+// CHECK-NS1-NEXT: Decl[Struct]/CurrNominal:           BasicA[#NS1.BasicA#]; name=BasicA
+// CHECK-NS1-NEXT: End completions
+
+func ns2() {
+  NS1.NS2.#^NS2^#
+}
+
+// CHECK-NS2: Begin completions, 4 items
+// CHECK-NS2-NEXT: Keyword[self]/CurrNominal:          self[#NS1.NS2.Type#]; name=self
+// CHECK-NS2-NEXT: Keyword/CurrNominal:                Type[#NS1.NS2.Type#]; name=Type
+// CHECK-NS2-NEXT: Decl[Struct]/CurrNominal:           BasicDeepB[#NS1.NS2.BasicDeepB#]; name=BasicDeepB
+// CHECK-NS2-NEXT: Decl[Struct]/CurrNominal:           BasicDeepA[#NS1.NS2.BasicDeepA#]; name=BasicDeepA
+// CHECK-NS2-NEXT: End completions
+
+func nsTemplates() {
+  TemplatesNS1.#^TemplatesNS1^#
+}
+
+// CHECK-TNS1: Begin completions, 10 items
+// CHECK-TNS1-NEXT: Keyword[self]/CurrNominal:          self[#TemplatesNS1.Type#]; name=self
+// CHECK-TNS1-NEXT: Keyword/CurrNominal:                Type[#TemplatesNS1.Type#]; name=Type
+// CHECK-TNS1-NEXT: Decl[StaticMethod]/CurrNominal:     basicFunctionTemplateDefinedInDefs({#T#})[#UnsafePointer<CChar>!#]; name=basicFunctionTemplateDefinedInDefs()
+// CHECK-TNS1-NEXT: Decl[TypeAlias]/CurrNominal:        UseTemplate[#TemplatesNS4.HasSpecialization<CChar>#]; name=UseTemplate
+// CHECK-TNS1-NEXT: Decl[TypeAlias]/CurrNominal:        UseSpecialized[#TemplatesNS4.HasSpecialization<CInt>#]; name=UseSpecialized
+// CHECK-TNS1-NEXT: Decl[Enum]/CurrNominal:             TemplatesNS2[#TemplatesNS1.TemplatesNS2#]; name=TemplatesNS2
+// CHECK-TNS1-NEXT: Decl[Enum]/CurrNominal:             TemplatesNS3[#TemplatesNS1.TemplatesNS3#]; name=TemplatesNS3
+// CHECK-TNS1-NEXT: Decl[TypeAlias]/CurrNominal:        ForwardDeclaredClassTemplateChar[#TemplatesNS1.TemplatesNS2.ForwardDeclaredClassTemplate<CChar>#]; name=ForwardDeclaredClassTemplateChar
+// CHECK-TNS1-NEXT: Decl[StaticMethod]/CurrNominal:     basicFunctionTemplate({#T#})[#UnsafePointer<CChar>!#]; name=basicFunctionTemplate()
+// CHECK-TNS1-NEXT: Decl[TypeAlias]/CurrNominal:        BasicClassTemplateChar[#TemplatesNS1.BasicClassTemplate<CChar>#]; name=BasicClassTemplateChar
+// CHECK-TNS1-NEXT: End completions
+
+func nsEnums() {
+  EnumNS1.#^EnumsNS1^#
+}
+
+// CHECK-ENS1: Keyword[self]/CurrNominal:          self[#EnumNS1.Type#]; name=self
+// CHECK-ENS1-NEXT: Keyword/CurrNominal:                Type[#EnumNS1.Type#]; name=Type
+// CHECK-ENS1-NEXT: Decl[Struct]/CurrNominal:           AnEnum[#EnumNS1.AnEnum#]; name=AnEnum
+// CHECK-ENS1-NEXT: Decl[StaticVar]/CurrNominal:        one[#EnumNS1.AnEnum#]; name=one
+// CHECK-ENS1-NEXT: Decl[StaticVar]/CurrNominal:        two[#EnumNS1.AnEnum#]; name=two
+// CHECK-ENS1-NEXT: Decl[StaticVar]/CurrNominal:        three[#EnumNS1.AnEnum#]; name=three
+// CHECK-ENS1-NEXT: End completions


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/65736

rdar://109714059

- Explanation:
Swift's SourceKit didn't code complete C++ namespace members. This changes fixes that by adding a special case that checks if an enum that's being completed is a namespace and in that case it code completes its members by looking them up using Clang APIs.
- Scope: C++ interop, member lookup of namespace members
- Risk: Low, affects code completion lookups for C++ interop
- Testing: Unit tests, manual testing
- Original PR: https://github.com/apple/swift/pull/69648
