### PR TITLE
[5.10][interop][SwiftToCxx] dispatch 'class' methods directly to avoid brok…

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1131,7 +1131,8 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   }
   llvm::Optional<StringRef> indirectFunctionVar;
   using DispatchKindTy = IRABIDetailsProvider::MethodDispatchInfo::Kind;
-  if (dispatchInfo) {
+  if (dispatchInfo && !isStaticMethod) {
+    // Always dispatch class methods directly to the concrete class instance.
     switch (dispatchInfo->getKind()) {
     case DispatchKindTy::Direct:
       break;

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx-execution.cpp
@@ -72,5 +72,13 @@ int main() {
     largeStruct.dump();
 // CHECK-NEXT: 1, -1, -9075, -2, 9075, -456 
   }
+
+  {
+    auto x = ClassWithNonFinalMethods::classClassMethod(3);
+    assert(x == 5);
+    ClassWithNonFinalMethods::staticClassMethod();
+  }
+// CHECK-NEXT: ClassWithNonFinalMethods.classClassMethod;
+// CHECK-NEXT: ClassWithNonFinalMethods.staticClassMethod;
   return 0;
 }

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -61,6 +61,16 @@ public final class ClassWithMethods {
     }
 }
 
+public class ClassWithNonFinalMethods {
+    class public func classClassMethod(x: Int) -> Int {
+        print("ClassWithNonFinalMethods.classClassMethod;")
+        return x + 2
+    }
+    static public func staticClassMethod() {
+        print("ClassWithNonFinalMethods.staticClassMethod;")
+    }
+}
+
 public final class PassStructInClassMethod {
     var largeStruct: LargeStruct
     init() { largeStruct = LargeStruct(x1: 1, x2: 2, x3: 3, x4: 4, x5: 5, x6: 6) }
@@ -162,6 +172,12 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 // CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods09ClassWithA0C011staticFinalB6Method1xAA11LargeStructVSi_tFZ(result, x, swift::TypeMetadataTrait<ClassWithMethods>::getTypeMetadata());
 // CHECK-NEXT: });
+// CHECK-NEXT: }
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int ClassWithNonFinalMethods::classClassMethod(swift::Int x) {
+// CHECK-NEXT: return _impl::$s7Methods017ClassWithNonFinalA0C05classB6Method1xS2i_tFZ(x, swift::TypeMetadataTrait<ClassWithNonFinalMethods>::getTypeMetadata());
+// CHECK-NEXT: }
+// CHECK-NEXT: SWIFT_INLINE_THUNK void ClassWithNonFinalMethods::staticClassMethod() {
+// CHECK-NEXT: return _impl::$s7Methods017ClassWithNonFinalA0C06staticB6MethodyyFZ(swift::TypeMetadataTrait<ClassWithNonFinalMethods>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK LargeStruct LargeStruct::doubled() const {


### PR DESCRIPTION
…en header generation

rdar://117814849

- Explanation:
Swift `class` methods are being exposed to C++ as static C++ member functions, that call directly to the underlying class method. Unfortunately since they can be dispatched virtually, the header generation tried to generate a virtual table lookup using `this`, which is not possible in a `static` C++ member function. This change avoids that and just calls the Swift method directly.
- Scope: C++ interop, generated header generation
- Risk: Low, affects dispatch of `class` methods only 
- Testing: Unit tests
- Original PR: https://github.com/apple/swift/pull/69708
