### PR TITLE
[5.10][interop] fix consuming-parameter-in-cxx.swift failure

### DIFF
--- a/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
@@ -139,7 +139,7 @@ public struct TheGenericContainerInitNonTriv {
 // CHECK-NEXT: alignas(alignof(LargeStructNonTrivial)) char copyBuffer_consumedParamCopy_2[sizeof(LargeStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_2 = *(new(copyBuffer_consumedParamCopy_2) LargeStructNonTrivial(_2));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<LargeStructNonTrivial> storageGuard_consumedParamCopy_2(consumedParamCopy_2);
-// CHECK-NON_EVO-NEXT: return _impl::$s4Init0A9FromSmallV04takeC5LargeyyAA0C16StructNonTrivialVn_AA0efgH0VntF(_impl::swift_interop_passDirect_Init_void_ptr_0_8_uint32_t_8_12(_impl::_impl_SmallStructNonTrivial::getOpaquePointer(consumedParamCopy_1)), _impl::_impl_LargeStructNonTrivial::getOpaquePointer(consumedParamCopy_2), _impl::swift_interop_passDirect_Init_uint64_t_0_8(_getOpaquePointer()));
+// CHECK-NON_EVO-NEXT: return _impl::$s4Init0A9FromSmallV04takeC5LargeyyAA0C16StructNonTrivialVn_AA0efgH0VntF(_impl::swift_interop_passDirect_Init_{{.*}}(_impl::_impl_SmallStructNonTrivial::getOpaquePointer(consumedParamCopy_1)), _impl::_impl_LargeStructNonTrivial::getOpaquePointer(consumedParamCopy_2), _impl::swift_interop_passDirect_Init_{{.*}}(_getOpaquePointer()));
 
 // CHECK: SWIFT_INLINE_THUNK void LargeStructNonTrivial::takeMe() const {
 // CHECK-NEXT: alignas(alignof(LargeStructNonTrivial)) char copyBuffer_consumedParamCopy_this[sizeof(LargeStructNonTrivial)];


### PR DESCRIPTION
rdar://117805261

- Explanation:
Test is too specific let's make it less so.
- Scope: C++ testing
- Risk: Low, test only
- Testing: This is a test indeed
- Original PR: https://github.com/apple/swift/pull/69702