### PR TITLE
Sema: Expand TypeRefinementContexts lazily for unparsed function bodies

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4541,23 +4541,26 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Expand the children of the type refinement context for the given
-/// declaration.
+/// Expand the children of the given type refinement context.
 class ExpandChildTypeRefinementContextsRequest
     : public SimpleRequest<ExpandChildTypeRefinementContextsRequest,
-                           bool(Decl *, TypeRefinementContext *),
-                           RequestFlags::Cached> {
+                           std::vector<TypeRefinementContext *>(
+                               TypeRefinementContext *),
+                           RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, Decl *decl,
-                TypeRefinementContext *parentTRC) const;
+  std::vector<TypeRefinementContext *>
+  evaluate(Evaluator &evaluator, TypeRefinementContext *parentTRC) const;
 
 public:
+  // Separate caching.
   bool isCached() const { return true; }
+  llvm::Optional<std::vector<TypeRefinementContext *>> getCachedResult() const;
+  void cacheResult(std::vector<TypeRefinementContext *> children) const;
 };
 
 class SerializeAttrGenericSignatureRequest

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -513,8 +513,8 @@ SWIFT_REQUEST(TypeChecker, InitAccessorReferencedVariablesRequest,
                                   ArrayRef<Identifier>),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExpandChildTypeRefinementContextsRequest,
-              bool(Decl *, TypeRefinementContext *),
-              Cached, NoLocationInfo)
+              std::vector<TypeRefinementContext *>(TypeRefinementContext *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SerializeAttrGenericSignatureRequest,
               GenericSignature(Decl *, SpecializeAttr *),
               SeparatelyCached, NoLocationInfo)

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2729,10 +2729,6 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &eval,
   if (tyOpts.DebugTimeFunctionBodies || tyOpts.WarnLongFunctionBodies)
     timer.emplace(AFD);
 
-  auto SF = AFD->getParentSourceFile();
-  if (SF)
-    TypeChecker::buildTypeRefinementContextHierarchyDelayed(*SF, AFD);
-
   BraceStmt *body = AFD->getBody();
   assert(body && "Expected body to type-check");
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1056,10 +1056,6 @@ AvailabilityContext overApproximateAvailabilityAtLocation(
 /// Walk the AST to build the hierarchy of TypeRefinementContexts
 void buildTypeRefinementContextHierarchy(SourceFile &SF);
 
-/// Walk the AST to complete the hierarchy of TypeRefinementContexts for
-/// the delayed function body of \p AFD.
-void buildTypeRefinementContextHierarchyDelayed(SourceFile &SF, AbstractFunctionDecl *AFD);
-
 /// Build the hierarchy of TypeRefinementContexts for the entire
 /// source file, if it has not already been built. Returns the root
 /// TypeRefinementContext for the source file.

--- a/test/Interpreter/lazy/deferred_syntax_errors.swift
+++ b/test/Interpreter/lazy/deferred_syntax_errors.swift
@@ -4,6 +4,7 @@
 
 // -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts
+// REQUIRES: rdar118189728
 
 // Tests that parsing of function bodies is deferred
 // to runtime when the interpreter is invoked using

--- a/test/SILGen/lazy_typecheck_availability.swift
+++ b/test/SILGen/lazy_typecheck_availability.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -module-name Test -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies | %FileCheck %s
+
+// Note: This test has been carefully constructed to create the preconditions of
+// a lazy typechecking bug. First, foo() is parsed and typechecked lazily in
+// order to generate SIL for it. Type checking the body of foo() causes the
+// TypeRefinementContext tree to be built for the file, but bar() has not been
+// parsed yet so it gets skipped during construction of the tree. Therefore
+// when generating the SIL for bar() its TRC must be created on-demand in order
+// to emit the correct SIL for the if #available condition.
+
+// REQUIRES: OS=macosx
+
+// CHECK: sil{{.*}} @$s4Test3fooyS2iF : $@convention(thin) (Int) -> Int {
+// CHECK: } // end sil function '$s4Test3fooyS2iF'
+@inlinable
+public func foo(_ x: Int) -> Int {
+  _ = x
+}
+
+// CHECK: sil{{.*}} @$s4Test3barSiyF : $@convention(thin) () -> Int {
+// CHECK:   {{.*}} = integer_literal $Builtin.Word, 11
+// CHECK:   {{.*}} = integer_literal $Builtin.Word, 0
+// CHECK:   {{.*}} = integer_literal $Builtin.Word, 0
+// CHECK:   {{.*}} = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK: } // end sil function '$s4Test3barSiyF'
+@inlinable
+public func bar() -> Int {
+  if #available(macOS 11.0, *) {
+    return 1
+  } else {
+    return 2
+  }
+}

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -10,7 +10,12 @@
 // CHECK-NEXT: {{^}}      (decl versions=[10.53,+Inf) decl=someInnerFunc()
 // CHECK-NEXT: {{^}}      (decl versions=[10.53,+Inf) decl=InnerClass
 // CHECK-NEXT: {{^}}        (decl versions=[10.54,+Inf) decl=innerClassMethod
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someStaticProperty
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someStaticProperty
+// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticProperty
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyInferredType
+// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticPropertyInferredType
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=multiPatternStaticPropertyA
+// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=multiPatternStaticPropertyA
 // CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someComputedProperty
 // CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someOtherMethod()
 @available(OSX 10.51, *)
@@ -32,6 +37,13 @@ class SomeClass {
 
   @available(OSX 10.52, *)
   static var someStaticProperty: Int = 7
+
+  @available(OSX 10.52, *)
+  static var someStaticPropertyInferredType = 7
+
+  @available(OSX 10.52, *)
+  static var multiPatternStaticPropertyA = 7,
+             multiPatternStaticPropertyB = 8
 
   @available(OSX 10.52, *)
   var someComputedProperty: Int {
@@ -191,4 +203,67 @@ func functionWithWhile() {
     @available(OSX 10.54, *)
     func funcInWhileBody() { }
   }
+}
+
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}        (condition_following_availability versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}        (if_then versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}        (condition_following_availability versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}        (if_then versions=[10.54,+Inf)
+@available(OSX 10.51, *)
+extension SomeClass {
+  @available(OSX 10.52, *)
+  static var someStaticPropertyWithClosureInit: Int = {
+    if #available(OSX 10.54, *) {
+      return 54
+    }
+    return 53
+  }()
+
+  @available(OSX 10.52, *)
+  static var someStaticPropertyWithClosureInitInferred = {
+    if #available(OSX 10.54, *) {
+      return 54
+    }
+    return 53
+  }()
+}
+
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+}
+
+// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeStruct
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someLazyVar
+// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.52,+Inf)
+// CHECK-NEXT: {{^}}      (guard_fallthrough versions=[10.52,+Inf)
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someWrappedVar
+// CHECK-NEXT: {{^}}      (condition_following_availability versions=[10.52,+Inf)
+// CHECK-NEXT: {{^}}      (guard_fallthrough versions=[10.52,+Inf)
+// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someMethodAvailable52()
+@available(OSX 10.51, *)
+struct SomeStruct {
+  lazy var someLazyVar = {
+    guard #available(OSX 10.52, *) else {
+      return someMethod()
+    }
+    return someMethodAvailable52()
+  }()
+
+  @Wrapper var someWrappedVar = {
+    guard #available(OSX 10.52, *) else {
+      return 51
+    }
+    return 52
+  }()
+
+  func someMethod() -> Int { return 51 }
+
+  @available(OSX 10.52, *)
+  func someMethodAvailable52() -> Int { return 52 }
 }

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -42,36 +42,43 @@
 /// inlining target.
 public struct NoAvailable {
   @usableFromInline internal init() {}
+  init<T>(_ t: T) {}
 }
 
 @available(macOS 10.9, *)
 public struct BeforeInliningTarget {
   @usableFromInline internal init() {}
+  init<T>(_ t: T) {}
 }
 
 @available(macOS 10.10, *)
 public struct AtInliningTarget {
   @usableFromInline internal init() {}
+  init<T>(_ t: T) {}
 }
 
 @available(macOS 10.14.5, *)
 public struct BetweenTargets { // expected-note {{enclosing scope requires availability of macOS 10.14.5 or newer}}
   @usableFromInline internal init() {}
+  init<T>(_ t: T) {}
 }
 
 @available(macOS 10.15, *)
 public struct AtDeploymentTarget {
   @usableFromInline internal init() {}
+  init<T>(_ t: T) {}
 }
 
 @available(macOS 11, *)
 public struct AfterDeploymentTarget {
   @usableFromInline internal init() {}
+  init<T>(_ t: T) {}
 }
 
 @available(macOS, unavailable)
 public struct Unavailable {
   @usableFromInline internal init() {}
+  init<T>(_ t: T) {}
 }
 
 // MARK: - Protocol definitions
@@ -880,7 +887,7 @@ public struct PropertyWrapper<T> {
   public init(_ value: T) { self.wrappedValue = value }
 }
 
-public struct PublicStruct { // expected-note 15 {{add @available attribute}}
+public struct PublicStruct { // expected-note 21 {{add @available attribute}}
   // Public property declarations are exposed.
   public var aPublic: NoAvailable,
              bPublic: BeforeInliningTarget,
@@ -958,7 +965,51 @@ public struct PublicStruct { // expected-note 15 {{add @available attribute}}
              dPublicInit: Any = BetweenTargets(),
              ePublicInit: Any = AtDeploymentTarget(),
              fPublicInit: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
-  
+
+  @available(macOS 10.14.5, *)
+  public var  aPublicInitAvailBetween: Any = {
+                if #available(macOS 11, *) {
+                  return NoAvailable(AfterDeploymentTarget())
+                } else {
+                  return NoAvailable(AfterDeploymentTarget()) // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
+                }
+              }(),
+              bPublicInitAvailBetween: Any = {
+                if #available(macOS 11, *) {
+                  return BeforeInliningTarget(AfterDeploymentTarget())
+                } else {
+                  return BeforeInliningTarget(AfterDeploymentTarget()) // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
+                }
+              }(),
+              cPublicInitAvailBetween: Any = {
+                if #available(macOS 11, *) {
+                  return AtInliningTarget(AfterDeploymentTarget())
+                } else {
+                  return AtInliningTarget(AfterDeploymentTarget()) // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
+                }
+              }(),
+              dPublicInitAvailBetween: Any = {
+                if #available(macOS 11, *) {
+                  return BetweenTargets(AfterDeploymentTarget())
+                } else {
+                  return BetweenTargets(AfterDeploymentTarget()) // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
+                }
+              }(),
+              ePublicInitAvailBetween: Any = {
+                if #available(macOS 11, *) {
+                  return AtDeploymentTarget(AfterDeploymentTarget())
+                } else {
+                  return AtDeploymentTarget(AfterDeploymentTarget()) // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
+                }
+              }(),
+              fPublicInitAvailBetween: Any = {
+                if #available(macOS 11, *) {
+                  return AfterDeploymentTarget()
+                } else {
+                  return AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
+                }
+              }()
+
   // Internal declarations are not exposed.
   var aInternal: NoAvailable = .init(),
       bInternal: BeforeInliningTarget = .init(),


### PR DESCRIPTION
When building the TypeRefinementContext subtree for a function declaration, postpone creation of the subtree if the function body is unparsed. This allows the compiler to completely avoid parsing function bodies that have been skipped    (e.g. with -experimental-skip-non-inlinable-function-bodies) while still ensuring that the TRCs for functions are built lazily later if needed. When lazily generating SIL for a function with -experimental-lazy-typecheck, the TRCs must be built out while typechecking the function in order to emit correct diagnostics and SIL for `if #available` queries.

Resolves rdar://117448323