### PR TITLE
[5.10][interop][SwiftToCxx] fix a CHECK line in string-to-nsstring.mm

### DIFF
--- a/test/Interop/SwiftToCxx/stdlib/string/string-to-nsstring.mm
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-to-nsstring.mm
@@ -35,7 +35,7 @@ int main() {
 // CHECKARC: %[[VAL:.*]] = {{(tail )?}}call swiftcc ptr @"$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF"
 // CHECKARC: call ptr @llvm.objc.autorelease(ptr %[[VAL]])
 // CHECKARC: @llvm.objc.
-// CHECKARC-SAME: autorelease(ptr)
+// CHECKARC-SAME: autorelease(ptr
 // CHECKARC-NOT: @llvm.objc.
 
 //--- string-to-nsstring.mm


### PR DESCRIPTION
rdar://118139534

- Explanation:
Failing on CI because of named parameter, so fix the CHECK line.
- Scope: C++ interop testing
- Risk: Low, test only
- Testing: Tested here
- Original PR: https://github.com/apple/swift/pull/69762