### PR TITLE
[Diagnostics] Allow multiple non-custom _effects.

### DIFF
--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -110,14 +110,15 @@ void SILFunctionBuilder::addFunctionAttributes(
       auto *effectsAttr = cast<EffectsAttr>(attr);
       if (effectsAttr->getKind() == EffectsKind::Custom) {
         customEffects.push_back(effectsAttr);
+        continue;
+      }
+      if (F->getEffectsKind() != EffectsKind::Unspecified) {
+        // If multiple known effects are specified, the most restrictive one
+        // is used.
+        F->setEffectsKind(
+            std::min(effectsAttr->getKind(), F->getEffectsKind()));
       } else {
-        if (F->getEffectsKind() != EffectsKind::Unspecified &&
-            F->getEffectsKind() != effectsAttr->getKind()) {
-          mod.getASTContext().Diags.diagnose(effectsAttr->getLocation(),
-              diag::warning_in_effects_attribute, "mismatching function effects");
-        } else {
-          F->setEffectsKind(effectsAttr->getKind());
-        }
+        F->setEffectsKind(effectsAttr->getKind());
       }
     }
   }

--- a/test/SIL/diagnose_effects.swift
+++ b/test/SIL/diagnose_effects.swift
@@ -1,0 +1,71 @@
+// RUN: %target-swift-emit-silgen %s -o /dev/null -verify
+class C {}
+struct S {
+
+  var c: C
+
+////////////////////////////////////////////////////////////////////////////////
+// Implicitly consuming argument.                                             //
+////////////////////////////////////////////////////////////////////////////////
+  @_effects(readnone) @_effects(releasenone) // ok
+  init(readnone_releasenone c: C) { self.c = c }
+
+  @_effects(releasenone) @_effects(readnone) // ok
+  init(releasenone_readnone c: C) { self.c = c }
+
+  @_effects(readonly) @_effects(releasenone) // ok
+  init(readonly_releasenone c: C) { self.c = c }
+
+  @_effects(releasenone) @_effects(readonly) // ok
+  init(releasenone_readonly c: C) { self.c = c }
+
+  @_effects(releasenone) // ok
+  init(releasenone c: C) { self.c = c }
+
+////////////////////////////////////////////////////////////////////////////////
+// Explicitly consuming argument.                                             //
+////////////////////////////////////////////////////////////////////////////////
+  @_effects(readnone) @_effects(releasenone) // ok
+  mutating func readnone_releasenoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(releasenone) @_effects(readnone) // ok
+  mutating func releasenone_readnoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(readonly) @_effects(releasenone) // ok
+  mutating func reasonly_releasenoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(releasenone) @_effects(readonly) // ok
+  mutating func releasenone_reasonlyConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+  @_effects(releasenone) // ok
+  mutating func releasenoneConsumeParam(_ c: consuming C) {
+    self.c = c
+  }
+
+////////////////////////////////////////////////////////////////////////////////
+// Explicitly consuming self.                                                 //
+////////////////////////////////////////////////////////////////////////////////
+  @_effects(readnone) @_effects(releasenone) // ok
+  __consuming func readnone_releasenoneConsumeSelf() {}
+
+  @_effects(releasenone) @_effects(readnone) // ok
+  __consuming func readnone_readnoneConsumeSelf() {}
+
+  @_effects(readonly) @_effects(releasenone) // ok
+  __consuming func readonly_releasenoneConsumeSelf() {}
+
+   @_effects(releasenone) @_effects(readonly) // ok
+  __consuming func releasenone_readonlyConsumeSelf() {}
+
+  @_effects(releasenone) // ok
+  __consuming func releasenoneConsumeSelf() {}
+
+}


### PR DESCRIPTION
Adjust `SILFunctionBuilder` to allow distinct non-custom effects and to interpret such "conflicting" guarantees to provide the strongest guarantee. For example, annotating a function both `@_effects(readnone)` and `@_effects(releasenone)` is equivalent to only annotating it `@_effects(readnone)`.

First step to reapplying https://github.com/apple/swift/pull/68285 .

rdar://118216287
