### PR TITLE
AST: Requestify unique underlying type substitutions

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3214,6 +3214,7 @@ class OpaqueTypeDecl final :
     public GenericTypeDecl,
     private llvm::TrailingObjects<OpaqueTypeDecl, TypeRepr *> {
   friend TrailingObjects;
+  friend class UniqueUnderlyingTypeSubstitutionsRequest;
 
 public:
   /// A set of substitutions that represents a possible underlying type iff
@@ -3252,6 +3253,10 @@ private:
       ConditionallyAvailableTypes = llvm::None;
 
   mutable Identifier OpaqueReturnTypeIdentifier;
+
+  struct {
+    unsigned UniqueUnderlyingTypeComputed : 1;
+  } LazySemanticInfo = { };
 
   OpaqueTypeDecl(ValueDecl *NamingDecl, GenericParamList *GenericParams,
                  DeclContext *DC,
@@ -3329,9 +3334,7 @@ public:
 
   /// The substitutions that map the generic parameters of the opaque type to
   /// the unique underlying types, when that information is known.
-  llvm::Optional<SubstitutionMap> getUniqueUnderlyingTypeSubstitutions() const {
-    return UniqueUnderlyingType;
-  }
+  llvm::Optional<SubstitutionMap> getUniqueUnderlyingTypeSubstitutions() const;
 
   void setUniqueUnderlyingTypeSubstitutions(SubstitutionMap subs) {
     assert(!UniqueUnderlyingType.has_value() && "resetting underlying type?!");

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4623,6 +4623,27 @@ public:
   void cacheResult(DeclAttributes) const;
 };
 
+class UniqueUnderlyingTypeSubstitutionsRequest
+    : public SimpleRequest<UniqueUnderlyingTypeSubstitutionsRequest,
+                           llvm::Optional<SubstitutionMap>(
+                               const OpaqueTypeDecl *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  llvm::Optional<SubstitutionMap> evaluate(Evaluator &evaluator,
+                                           const OpaqueTypeDecl *) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  llvm::Optional<llvm::Optional<SubstitutionMap>> getCachedResult() const;
+  void cacheResult(llvm::Optional<SubstitutionMap>) const;
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -527,3 +527,6 @@ SWIFT_REQUEST(TypeChecker, IsCCompatibleFuncDeclRequest,
 SWIFT_REQUEST(TypeChecker, SemanticDeclAttrsRequest,
               DeclAttributes(const Decl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, UniqueUnderlyingTypeSubstitutionsRequest,
+              llvm::Optional<SubstitutionMap>(const Decl *),
+              SeparatelyCached, NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9608,6 +9608,12 @@ bool OpaqueTypeDecl::exportUnderlyingType() const {
   llvm_unreachable("The naming decl is expected to be either an AFD or ASD");
 }
 
+llvm::Optional<SubstitutionMap>
+OpaqueTypeDecl::getUniqueUnderlyingTypeSubstitutions() const {
+  return evaluateOrDefault(getASTContext().evaluator,
+                           UniqueUnderlyingTypeSubstitutionsRequest{this}, {});
+}
+
 llvm::Optional<unsigned>
 OpaqueTypeDecl::getAnonymousOpaqueParamOrdinal(TypeRepr *repr) const {
   assert(NamingDeclAndHasOpaqueReturnTypeRepr.getInt() &&

--- a/test/SILGen/lazy_typecheck_opaque_result_type.swift
+++ b/test/SILGen/lazy_typecheck_opaque_result_type.swift
@@ -1,0 +1,139 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module %t/Library.swift -parse-as-library -module-name Library -enable-library-evolution -emit-module-path %t/Library.swiftmodule
+// RUN: %target-swift-frontend -emit-silgen -primary-file %t/Primary.swift %t/Other.swift -parse-as-library -module-name Test -I %t | %FileCheck %s --check-prefixes CHECK,CHECK-PRIMARY,CHECK-COMMON
+// RUN: %target-swift-frontend -emit-silgen %t/Primary.swift %t/Other.swift -parse-as-library -module-name Test -I %t | %FileCheck %s --check-prefixes CHECK,CHECK-WHOLE-MODULE,CHECK-COMMON
+// RUN: %target-swift-frontend -emit-silgen -primary-file %t/Primary.swift %t/Other.swift -parse-as-library -module-name Test -I %t -experimental-lazy-typecheck | %FileCheck %s --check-prefixes CHECK,CHECK-PRIMARY,CHECK-COMMON
+// RUN: %target-swift-frontend -emit-silgen -primary-file %t/Primary.swift %t/Other.swift -parse-as-library -module-name Test -I %t -experimental-skip-non-inlinable-function-bodies | %FileCheck %s --check-prefixes CHECK-SKIP,CHECK-COMMON
+
+//--- Library.swift
+
+public protocol P {}
+
+@usableFromInline struct LibraryStruct: P {
+  @usableFromInline init() {}
+}
+
+@available(SwiftStdlib 5.5, *)
+public func returnsLibraryStruct() -> some P {
+  return LibraryStruct()
+}
+
+@available(SwiftStdlib 5.5, *)
+@inlinable public func inlinableReturnsLibraryStruct() -> some P {
+  return LibraryStruct()
+}
+
+//--- Other.swift
+
+import Library
+
+struct OtherStruct: P {}
+
+@available(SwiftStdlib 5.5, *)
+public func returnsOtherStruct() -> some P {
+  return OtherStruct()
+}
+
+//--- Primary.swift
+
+import Library
+
+public struct PrimaryStruct: P {
+  public init() {}
+}
+
+// CHECK-LABEL: sil{{.*}} @$s4Test20returnsPrimaryStructQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s4Test20returnsPrimaryStructQryF", 0) __> {
+// CHECK:       bb0(%0 : $*PrimaryStruct):
+// CHECK:       } // end sil function '$s4Test20returnsPrimaryStructQryF'
+@available(SwiftStdlib 5.5, *)
+public func returnsPrimaryStruct() -> some P {
+  return PrimaryStruct()
+}
+
+// CHECK-LABEL: sil{{.*}} @$s4Test39globalComputedVarReturningPrimaryStructQrvg : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s4Test39globalComputedVarReturningPrimaryStructQrvp", 0) __> {
+// CHECK:        bb0(%0 : $*PrimaryStruct):
+// CHECK:        } // end sil function '$s4Test39globalComputedVarReturningPrimaryStructQrvg'
+@available(SwiftStdlib 5.5, *)
+public var globalComputedVarReturningPrimaryStruct: some P {
+  return PrimaryStruct()
+}
+
+@available(SwiftStdlib 5.5, *)
+public struct S {
+  private var privatePrimaryStruct: PrimaryStruct
+
+  public var computedVarReturningPrimaryStruct: some P {
+    // CHECK-LABEL: sil{{.*}} @$s4Test1SV33computedVarReturningPrimaryStructQrvg : $@convention(method) (S) -> @out @_opaqueReturnTypeOf("$s4Test1SV33computedVarReturningPrimaryStructQrvp", 0) __ {
+    // CHECK:       bb0(%0 : $*PrimaryStruct, %1 : $S):
+    // CHECK:       } // end sil function '$s4Test1SV33computedVarReturningPrimaryStructQrvg'
+    get { privatePrimaryStruct }
+
+    // CHECK-LABEL: sil{{.*}} @$s4Test1SV33computedVarReturningPrimaryStructQrvs : $@convention(method) (@in @_opaqueReturnTypeOf("$s4Test1SV33computedVarReturningPrimaryStructQrvp", 0) __, @inout S) -> () {
+    // CHECK:       bb0(%0 : $*PrimaryStruct, %1 : $*S):
+    // CHECK:       } // end sil function '$s4Test1SV33computedVarReturningPrimaryStructQrvs'
+    set {}
+  }
+
+  public subscript(subscriptReturningPrimaryStruct: Void) -> some P {
+    // CHECK-LABEL: sil{{.*}} @$s4Test1SVyQryt_tcig : $@convention(method) (S) -> @out @_opaqueReturnTypeOf("$s4Test1SVyQryt_tcip", 0) __ {
+    // CHECK:       bb0(%0 : $*PrimaryStruct, %1 : $S):
+    // CHECK:       } // end sil function '$s4Test1SVyQryt_tcig'
+    get { privatePrimaryStruct }
+    // CHECK-LABEL: sil{{.*}} @$s4Test1SVyQryt_tcis : $@convention(method) (@in @_opaqueReturnTypeOf("$s4Test1SVyQryt_tcip", 0) __, @inout S) -> () {
+    // CHECK:       bb0(%0 : $*PrimaryStruct, %1 : $*S):
+    // CHECK:       } // end sil function '$s4Test1SVyQryt_tcis'
+    set {}
+  }
+}
+
+// CHECK-COMMON-LABEL:  sil{{.*}} @$s4Test024inlinableReturnsResultOfC13PrimaryStructQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s4Test024inlinableReturnsResultOfC13PrimaryStructQryF", 0) __> {
+// CHECK:               bb0(%0 : $*PrimaryStruct):
+// CHECK-SKIP:          bb0(%0 : $*@_opaqueReturnTypeOf("$s4Test20returnsPrimaryStructQryF", 0) __):
+// CHECK-COMMON:        } // end sil function '$s4Test024inlinableReturnsResultOfC13PrimaryStructQryF'
+@available(SwiftStdlib 5.5, *)
+@inlinable public func inlinableReturnsResultOfReturnsPrimaryStruct() -> some P {
+  return returnsPrimaryStruct()
+}
+
+// CHECK-LABEL: sil{{.*}} @$s4Test19returnsNestedStructQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s4Test19returnsNestedStructQryF", 0) __> {
+// CHECK:       bb0(%0 : $*NestedStruct):
+// CHECK:       } // end sil function '$s4Test19returnsNestedStructQryF'
+@available(SwiftStdlib 5.5, *)
+public func returnsNestedStruct() -> some P {
+  struct NestedStruct: P {}
+  return NestedStruct()
+}
+
+// CHECK-LABEL: sil{{.*}} @$s4Test34returnsResultOfReturnsNestedStructQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s4Test34returnsResultOfReturnsNestedStructQryF", 0) __> {
+// CHECK:       bb0(%0 : $*NestedStruct):
+// CHECK:       } // end sil function '$s4Test34returnsResultOfReturnsNestedStructQryF'
+@available(SwiftStdlib 5.5, *)
+public func returnsResultOfReturnsNestedStruct() -> some P {
+  return returnsNestedStruct()
+}
+
+// CHECK-LABEL:         sil{{.*}} @$s4Test33returnsResultOfReturnsOtherStructQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s4Test33returnsResultOfReturnsOtherStructQryF", 0) __> {
+// CHECK-PRIMARY:       bb0(%0 : $*@_opaqueReturnTypeOf("$s4Test18returnsOtherStructQryF", 0) __):
+// CHECK-WHOLE-MODULE:  bb0(%0 : $*OtherStruct):
+// CHECK:               } // end sil function '$s4Test33returnsResultOfReturnsOtherStructQryF'
+@available(SwiftStdlib 5.5, *)
+public func returnsResultOfReturnsOtherStruct() -> some P {
+  return returnsOtherStruct()
+}
+
+// CHECK-LABEL: sil{{.*}} @$s4Test35returnsResultOfReturnsLibraryStructQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s4Test35returnsResultOfReturnsLibraryStructQryF", 0) __> {
+// CHECK:       bb0(%0 : $*@_opaqueReturnTypeOf("$s7Library07returnsA6StructQryF", 0) __):
+// CHECK:       } // end sil function '$s4Test35returnsResultOfReturnsLibraryStructQryF'
+@available(SwiftStdlib 5.5, *)
+public func returnsResultOfReturnsLibraryStruct() -> some P {
+  return returnsLibraryStruct()
+}
+
+// CHECK-LABEL: sil{{.*}}  @$s4Test44returnsResulfOfInlinableReturnsLibraryStructQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s4Test44returnsResulfOfInlinableReturnsLibraryStructQryF", 0) __> {
+// CHECK:       bb0(%0 : $*LibraryStruct):
+// CHECK:       } // end sil function '$s4Test44returnsResulfOfInlinableReturnsLibraryStructQryF'
+@available(SwiftStdlib 5.5, *)
+public func returnsResulfOfInlinableReturnsLibraryStruct() -> some P {
+  return inlinableReturnsLibraryStruct()
+}

--- a/test/SILOptimizer/specialize_opaque_result_types2.sil
+++ b/test/SILOptimizer/specialize_opaque_result_types2.sil
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -primary-file %S/Inputs/specialize_opaque_result_types.swift -enable-library-evolution -module-name A -emit-sib -o %t/A.sib
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -enable-library-evolution -O -module-name A %t/A.sib -o - | %FileCheck %s
 
-// REQUIRES: CPU=x86_64
+// REQUIRES: CPU=x86_64 || CPU=arm64
 
 sil_stage canonical
 


### PR DESCRIPTION
Introduce a request that computes the unique underlying type substitution of an opaque type declaration. This ensures that the type substitution is available on-demand when generating SIL in lazy typechecking mode.

Resolves rdar://117439760
