### PR TITLE
Replace rethrowing map with generic typed throws

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1214,18 +1214,15 @@ extension Collection {
     return Array(result)
   }
 
-  // ABI-only entrypoint
+  // ABI-only entrypoint for the rethrows version of map, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @usableFromInline
-  @_disfavoredOverload
-  func map<T>(
+  @_silgen_name("$sSlsE3mapySayqd__Gqd__7ElementQzKXEKlF")
+  func __rethrows_map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try map(transform)
   }
 
   /// Returns a subsequence containing all but the given number of initial

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1190,9 +1190,10 @@ extension Collection {
   /// - Returns: An array containing the transformed elements of this
   ///   sequence.
   @inlinable
-  public func map<T>(
-    _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
+  @_alwaysEmitIntoClient
+  public func map<T, E>(
+    _ transform: (Element) throws(E) -> T
+  ) throws(E) -> [T] {
     // TODO: swift-3-indexing-model - review the following
     let n = self.count
     if n == 0 {
@@ -1211,6 +1212,20 @@ extension Collection {
 
     _expectEnd(of: self, is: i)
     return Array(result)
+  }
+
+  // ABI-only entrypoint
+  @usableFromInline
+  @_disfavoredOverload
+  func map<T>(
+    _ transform: (Element) throws -> T
+  ) rethrows -> [T] {
+    do {
+      return try map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
 
   /// Returns a subsequence containing all but the given number of initial

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -526,7 +526,12 @@ internal final class _SequenceBox<S: Sequence>: _AnySequenceBox<S.Element> {
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
-    return try _base.map(transform)
+    do {
+      return try _base.map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
   @inlinable
   internal override func _filter(
@@ -619,7 +624,12 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
-    return try _base.map(transform)
+    do {
+      return try _base.map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
   @inlinable
   internal override func _filter(
@@ -814,7 +824,12 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
-    return try _base.map(transform)
+    do {
+      return try _base.map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
   @inlinable
   internal override func _filter(
@@ -1027,7 +1042,12 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
-    return try _base.map(transform)
+    do {
+      return try _base.map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
   @inlinable
   internal override func _filter(
@@ -1308,10 +1328,29 @@ extension AnySequence {
   }
 
   @inlinable
-  public func map<T>(
+  @_alwaysEmitIntoClient
+  public func map<T, E>(
+    _ transform: (Element) throws(E) -> T
+  ) throws(E) -> [T] {
+    do {
+      return try _box._map(transform)
+    } catch {
+      throw error as! E
+    }
+  }
+
+  // ABI-only entrypoint
+  @usableFromInline
+  @_disfavoredOverload
+  func map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
-    return try _box._map(transform)
+    do {
+      return try map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
 
   @inlinable
@@ -1395,10 +1434,29 @@ extension AnyCollection {
   }
 
   @inlinable
-  public func map<T>(
+  @_alwaysEmitIntoClient
+  public func map<T, E>(
+    _ transform: (Element) throws(E) -> T
+  ) throws(E) -> [T] {
+    do {
+      return try _box._map(transform)
+    } catch {
+      throw error as! E
+    }
+  }
+
+  // ABI-only entrypoint
+  @usableFromInline
+  @_disfavoredOverload
+  func map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
-    return try _box._map(transform)
+    do {
+      return try map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
 
   @inlinable
@@ -1488,10 +1546,29 @@ extension AnyBidirectionalCollection {
   }
 
   @inlinable
-  public func map<T>(
+  @_alwaysEmitIntoClient
+  public func map<T, E>(
+    _ transform: (Element) throws(E) -> T
+  ) throws(E) -> [T] {
+    do {
+      return try _box._map(transform)
+    } catch {
+      throw error as! E
+    }
+  }
+
+  // ABI-only entrypoint
+  @usableFromInline
+  @_disfavoredOverload
+  func map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
-    return try _box._map(transform)
+    do {
+      return try map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
 
   @inlinable
@@ -1583,10 +1660,29 @@ extension AnyRandomAccessCollection {
   }
 
   @inlinable
-  public func map<T>(
+  @_alwaysEmitIntoClient
+  public func map<T, E>(
+    _ transform: (Element) throws(E) -> T
+  ) throws(E) -> [T] {
+    do {
+      return try _box._map(transform)
+    } catch {
+      throw error as! E
+    }
+  }
+
+  // ABI-only entrypoint
+  @usableFromInline
+  @_disfavoredOverload
+  func map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
-    return try _box._map(transform)
+    do {
+      return try map(transform)
+    } catch {
+      try _rethrowsViaClosure { throw error }
+      Builtin.unreachable()
+    }
   }
 
   @inlinable

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -175,7 +175,7 @@ internal class _AnySequenceBox<Element> {
   @inlinable
   internal func _map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
+  ) throws -> [T] {
     _abstract()
   }
 
@@ -525,13 +525,8 @@ internal final class _SequenceBox<S: Sequence>: _AnySequenceBox<S.Element> {
   @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try _base.map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try _base.map(transform)
   }
   @inlinable
   internal override func _filter(
@@ -623,13 +618,8 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
   @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try _base.map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try _base.map(transform)
   }
   @inlinable
   internal override func _filter(
@@ -823,13 +813,8 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
   @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try _base.map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try _base.map(transform)
   }
   @inlinable
   internal override func _filter(
@@ -1041,13 +1026,8 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
   @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try _base.map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try _base.map(transform)
   }
   @inlinable
   internal override func _filter(

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -1339,18 +1339,15 @@ extension AnySequence {
     }
   }
 
-  // ABI-only entrypoint
+  // ABI-only entrypoint for the rethrows version of map, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @usableFromInline
-  @_disfavoredOverload
-  func map<T>(
+  @_silgen_name("$ss11AnySequenceV3mapySayqd__Gqd__xKXEKlF")
+  func __rethrows_map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try map(transform)
   }
 
   @inlinable
@@ -1445,18 +1442,15 @@ extension AnyCollection {
     }
   }
 
-  // ABI-only entrypoint
+  // ABI-only entrypoint for the rethrows version of map, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @usableFromInline
-  @_disfavoredOverload
-  func map<T>(
+  @_silgen_name("$ss13AnyCollectionV3mapySayqd__Gqd__xKXEKlF")
+  func __rethrows_map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try map(transform)
   }
 
   @inlinable
@@ -1557,18 +1551,15 @@ extension AnyBidirectionalCollection {
     }
   }
 
-  // ABI-only entrypoint
+  // ABI-only entrypoint for the rethrows version of map, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @usableFromInline
-  @_disfavoredOverload
-  func map<T>(
+  @_silgen_name("$ss26AnyBidirectionalCollectionV3mapySayqd__Gqd__xKXEKlF")
+  func __rethrows_map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try map(transform)
   }
 
   @inlinable
@@ -1671,18 +1662,15 @@ extension AnyRandomAccessCollection {
     }
   }
 
-  // ABI-only entrypoint
+  // ABI-only entrypoint for the rethrows version of map, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @usableFromInline
-  @_disfavoredOverload
-  func map<T>(
+  @_silgen_name("$ss25AnyRandomAccessCollectionV3mapySayqd__Gqd__xKXEKlF")
+  func __rethrows_map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try map(transform)
   }
 
   @inlinable

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -159,6 +159,16 @@ public func _unsafePerformance<T>(_ c: () -> T) -> T {
   return c()
 }
 
+// Helper function that exploits a bug in rethrows checking to
+// allow us to call rethrows functions from generic typed-throws functions
+// and vice-versa.
+@usableFromInline
+@_alwaysEmitIntoClient
+@inline(__always)
+func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
+  try fn()
+}
+
 #if $NoncopyableGenerics && $NonescapableTypes
 @_marker public protocol Copyable: ~Escapable {}
 @_marker public protocol Escapable: ~Copyable {}

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -691,18 +691,15 @@ extension Sequence {
     return Array(result)
   }
 
-  // ABI-only entrypoint
+  // ABI-only entrypoint for the rethrows version of map, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
   @usableFromInline
-  @_disfavoredOverload
-  func map<T>(
+  @_silgen_name("$sSTsE3mapySayqd__Gqd__7ElementQzKXEKlF")
+  func __rethrows_map<T>(
     _ transform: (Element) throws -> T
-  ) rethrows -> [T] {
-    do {
-      return try map(transform)
-    } catch {
-      try _rethrowsViaClosure { throw error }
-      Builtin.unreachable()
-    }
+  ) throws -> [T] {
+    try map(transform)
   }
 
   /// Returns an array containing, in order, the elements of the sequence

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1143,11 +1143,11 @@ struct R_76250381<Result, Failure: Error> {
 
 // https://github.com/apple/swift/issues/55926
 (0..<10).map { x, y in } 
-// expected-error@-1 {{contextual closure type '(Range<Int>.Element) throws -> ()' (aka '(Int) throws -> ()') expects 1 argument, but 2 were used in closure body}}
+// expected-error@-1 {{contextual closure type '(Range<Int>.Element) -> ()' (aka '(Int) -> ()') expects 1 argument, but 2 were used in closure body}}
 (0..<10).map { x, y, z in } 
-// expected-error@-1 {{contextual closure type '(Range<Int>.Element) throws -> ()' (aka '(Int) throws -> ()') expects 1 argument, but 3 were used in closure body}}
+// expected-error@-1 {{contextual closure type '(Range<Int>.Element) -> ()' (aka '(Int) -> ()') expects 1 argument, but 3 were used in closure body}}
 (0..<10).map { x, y, z, w in } 
-// expected-error@-1 {{contextual closure type '(Range<Int>.Element) throws -> ()' (aka '(Int) throws -> ()') expects 1 argument, but 4 were used in closure body}}
+// expected-error@-1 {{contextual closure type '(Range<Int>.Element) -> ()' (aka '(Int) -> ()') expects 1 argument, but 4 were used in closure body}}
 
 // rdar://77022842 - crash due to a missing argument to a ternary operator
 func rdar77022842(argA: Bool? = nil, argB: Bool? = nil) {
@@ -1171,6 +1171,7 @@ func rdar76058892() {
     test { // expected-error {{contextual closure type '() -> String' expects 0 arguments, but 1 was used in closure body}}
       if let arr = arr {
         arr.map($0.test) // expected-note {{anonymous closure parameter '$0' is used here}} // expected-error {{generic parameter 'T' could not be inferred}}
+        // expected-error@-1 {{generic parameter 'E' could not be inferred}}
       }
     }
   }

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -19,14 +19,14 @@ enum G_E<T> {
 let arr: [String] = []
 let _ = arr.map(E.foo) // Ok
 let _ = arr.map(E.bar) // Ok
-let _ = arr.map(E.two) // expected-error {{cannot convert value of type '(Int, Int) -> E' to expected argument type '(String) throws -> E'}}
+let _ = arr.map(E.two) // expected-error {{cannot convert value of type '(Int, Int) -> E' to expected argument type '(String) -> E'}}
 
-let _ = arr.map(E.tuple) // expected-error {{cannot convert value of type '((x: Int, y: Int)) -> E' to expected argument type '(String) throws -> E'}}
+let _ = arr.map(E.tuple) // expected-error {{cannot convert value of type '((x: Int, y: Int)) -> E' to expected argument type '(String) -> E'}}
 
 let _ = arr.map(G_E<String>.foo) // Ok
 let _ = arr.map(G_E<String>.bar) // Ok
-let _ = arr.map(G_E<String>.two) // expected-error {{cannot convert value of type '(String, String) -> G_E<String>' to expected argument type '(String) throws -> G_E<String>'}}
-let _ = arr.map(G_E<Int>.tuple) // expected-error {{cannot convert value of type '((x: Int, y: Int)) -> G_E<Int>' to expected argument type '(String) throws -> G_E<Int>'}}
+let _ = arr.map(G_E<String>.two) // expected-error {{cannot convert value of type '(String, String) -> G_E<String>' to expected argument type '(String) -> G_E<String>'}}
+let _ = arr.map(G_E<Int>.tuple) // expected-error {{cannot convert value of type '((x: Int, y: Int)) -> G_E<Int>' to expected argument type '(String) -> G_E<Int>'}}
 
 let _ = E.foo("hello") // expected-error {{missing argument label 'bar:' in call}}
 let _ = E.bar("hello") // Ok

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1726,7 +1726,7 @@ do {
 do {
   func f(_: Int...) {}
   let _ = [(1, 2, 3)].map(f) // expected-error {{no exact matches in call to instance method 'map'}}
-  // expected-note@-1 {{found candidate with type '(((Int, Int, Int)) throws -> _) throws -> Array<_>'}}
+  // expected-note@-1 {{found candidate with type '(((Int, Int, Int)) -> _) -> Array<_>'}}
 }
 
 // rdar://problem/48443263 - cannot convert value of type '() -> Void' to expected argument type '(_) -> Void'

--- a/test/DebugInfo/Errors.swift
+++ b/test/DebugInfo/Errors.swift
@@ -26,6 +26,17 @@ public class C {
     }
 }
 
+// Function with typed throws.
+// CHECK: !DISubprogram(name: "genericRethrow", {{.*}}thrownTypes: ![[GENERIC_THROWN:.*]])
+// CHECK: ![[GENERIC_THROWN]] = !{![[GENERIC_THROWN_INNER:.*]]}
+// CHECK: ![[GENERIC_THROWN_INNER]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxD", {{.*}}, elements: ![[GENERIC_THROWN_ELEMENTS:.*]], runtimeLang: DW_LANG_Swift)
+// CHECK: ![[GENERIC_THROWN_ELEMENTS]] = !{![[GENERIC_THROWN_ELEMENTS_INNER:.*]]}
+// CHECK: ![[GENERIC_THROWN_ELEMENTS_INNER]] = !DIDerivedType(tag: DW_TAG_inheritance, {{.*}}baseType: ![[GENERIC_THROWN_BASE:.*]], extraData: {{.*}})
+// CHECK: ![[GENERIC_THROWN_BASE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$ss5Error_pmD", size: {{.*}}, flags: DIFlagArtificial, runtimeLang: DW_LANG_Swift, identifier: "$ss5Error_pmD")
+public func genericRethrow<E: Error>(fn: () throws(E) -> Void) throws(E) {
+  try fn()
+}
+
 // Negative tests.
 // CHECK: !DISubprogram(name: "returnThrowing",
 // CHECK-NOT:           thrownTypes:

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -20,7 +20,7 @@ func protocolExtCollection1a<C : Collection>(_ a: C) {
   a.#^PRIVATE_NOMINAL_MEMBERS_2A?check=PRIVATE_NOMINAL_MEMBERS_2A;check=NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2A;check=NO_STDLIB_PRIVATE^#
 }
 
-// PRIVATE_NOMINAL_MEMBERS_2A-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(transform): (C.Element) throws -> T##(C.Element) throws -> T#})[' rethrows'][#[T]#];
+// PRIVATE_NOMINAL_MEMBERS_2A-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(transform): (C.Element) throws(Error) -> T##(C.Element) throws(Error) -> T#})[' throws'][#[T]#];
 // NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2A-NOT: Decl{{.*}}: index({#before: any Comparable#})
 
 func protocolExtCollection1b(_ a: Collection) {
@@ -28,14 +28,14 @@ func protocolExtCollection1b(_ a: Collection) {
 }
 
 // FIXME(https://github.com/apple/swift/issues/65696): We should not be showing this because (1) it cannot be accessed on the existential (2) we don't have the syntax and features to represent the projected type sig anyway.
-// PRIVATE_NOMINAL_MEMBERS_2B-DAG: map({#(transform): (any Collection.Element) throws -> T##(any Collection.Element) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_2B-DAG: map({#(transform): (any Collection.Element) throws(Error) -> T##(any Collection.Element) throws(Error) -> T#})[' throws'][#[T]#]{{; name=.+}}
 // NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2B-NOT: Decl{{.*}}: index({#before: any Comparable#})
 
 func protocolExtCollection2<C : Collection where C.Index : BidirectionalIndex>(_ a: C) {
   a.#^PRIVATE_NOMINAL_MEMBERS_3?check=PRIVATE_NOMINAL_MEMBERS_3;check=NEGATIVE_PRIVATE_NOMINAL_MEMBERS_3;check=NO_STDLIB_PRIVATE^#
 }
 
-// PRIVATE_NOMINAL_MEMBERS_3-DAG: Decl[InstanceMethod]/Super/IsSystem:         map({#(transform): (C.Element) throws -> T##(C.Element) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_3-DAG: Decl[InstanceMethod]/Super/IsSystem:         map({#(transform): (C.Element) throws(Error) -> T##(C.Element) throws(Error) -> T#})[' throws'][#[T]#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_3-DAG: Decl[InstanceVar]/Super/IsSystem:            lazy[#LazySequence<Collection>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_3-DAG: firstIndex({#where: (C.Element) throws -> Bool##(C.Element) throws -> Bool#})[' rethrows'][#Comparable?#]{{; name=.+}}
 // NEGATIVE_PRIVATE_NOMINAL_MEMBERS_3-NOT: Decl{{.*}}:         firstIndex({#({{.*}}): Self.Iterator.Element
@@ -43,7 +43,7 @@ func protocolExtCollection2<C : Collection where C.Index : BidirectionalIndex>(_
 func protocolExtArray<T : Equatable>(_ a: [T]) {
   a.#^PRIVATE_NOMINAL_MEMBERS_4?check=PRIVATE_NOMINAL_MEMBERS_4;check=NO_STDLIB_PRIVATE^#
 }
-// PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super/IsSystem:         map({#(transform): (Equatable) throws -> T##(Equatable) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super/IsSystem:         map({#(transform): (Equatable) throws(Error) -> T##(Equatable) throws(Error) -> T#})[' throws'][#[T]#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceVar]/Super/IsSystem:            last[#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super/IsSystem:         firstIndex({#of: Equatable#})[#Int?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super/IsSystem:         firstIndex({#where: (Equatable) throws -> Bool##(Equatable) throws -> Bool#})[' rethrows'][#Int?#]{{; name=.+}}
@@ -85,7 +85,7 @@ func testArchetypeReplacement3 (_ a : [Int]) {
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem:   append({#(newElement): Int#})[#Void#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super/IsSystem:         removeLast()[#Int#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceVar]/Super/IsSystem:            first[#Int?#]
-// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super/IsSystem:         map({#(transform): (Int) throws -> T##(Int) throws -> T#})[' rethrows'][#[T]#]
+// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super/IsSystem:         map({#(transform): (Int) throws(Error) -> T##(Int) throws(Error) -> T#})[' throws'][#[T]#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super/IsSystem:         dropLast({#(k): Int#})[#ArraySlice<Int>#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super/IsSystem:         elementsEqual({#(other): Sequence#}, {#by: (Int, Sequence.Element) throws -> Bool##(Int, Sequence.Element) throws -> Bool#})[' rethrows'][#Bool#]; name=elementsEqual(:by:)
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super/IsSystem:         elementsEqual({#(other): Sequence#})[#Bool#]; name=elementsEqual(:)

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -660,14 +660,14 @@ struct FunctionConversionParameterSubstToOrigReabstractionTest {
   }
 }
 
-// CHECK: sil {{.*}} [ossa] @$sS4SIgggoo_S2Ss11AnyHashableVyps5Error_pIegggrrzo_TR
+// CHECK: sil {{.*}} [ossa] @$sS4SIgggoo_S2Ss11AnyHashableVypIegggrr_TR
 // CHECK:  [[TUPLE:%.*]] = apply %4(%2, %3) : $@noescape @callee_guaranteed (@guaranteed String, @guaranteed String) -> (@owned String, @owned String)
 // CHECK:  ([[LHS:%.*]], [[RHS:%.*]]) = destructure_tuple [[TUPLE]]
 // CHECK:  [[ADDR:%.*]] = alloc_stack $String
 // CHECK:  store [[LHS]] to [init] [[ADDR]] : $*String
 // CHECK:  [[CVT:%.*]] = function_ref @$ss21_convertToAnyHashableys0cD0VxSHRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Hashable> (@in_guaranteed τ_0_0) -> @out AnyHashable
 // CHECK:  apply [[CVT]]<String>(%0, [[ADDR]])
-// CHECK: } // end sil function '$sS4SIgggoo_S2Ss11AnyHashableVyps5Error_pIegggrrzo_TR'
+// CHECK: } // end sil function '$sS4SIgggoo_S2Ss11AnyHashableVypIegggrr_TR'
 
 func dontCrash() {
   let userInfo = ["hello": "world"]

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -365,8 +365,16 @@ public struct EnumSeq<Base : Seq> : Seq {
 }
 
 extension Collection {
+  func myMap<T>(_ body: (Element) -> T) -> [T] {
+    var result = [T]()
+    for element in self {
+      result.append(body(element))
+    }
+    return result
+  }
+
   func transformEachElement<U>(_ cl: (Element) -> U) -> [U] {
-    return map(cl)
+    return myMap(cl)
   }
 }
 

--- a/test/SILGen/partial_apply_override.swift
+++ b/test/SILGen/partial_apply_override.swift
@@ -26,11 +26,9 @@ public func convert(strings: [String]) -> [Int] {
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[CURRY_THUNK:%.*]] = function_ref @$s22partial_apply_override7convert7stringsSaySiGSaySSG_tFSiSScAA18StringIntConverterCcfu_ : $@convention(thin) (@guaranteed StringIntConverter) -> @owned @callee_guaranteed (@guaranteed String) -> Int
 // CHECK-NEXT: [[CURRY_RESULT:%.*]] = apply [[CURRY_THUNK]]([[CONVERTER]])
-// CHECK: [[CONVERTED:%.*]] = convert_function [[CURRY_RESULT]]
-// CHECK: [[NOESCAPE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CONVERTED]]
+// CHECK: [[NOESCAPE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CURRY_RESULT]]
 // CHECK: // function_ref
-// CHECK-NEXT: [[THUNK:%.*]] = function_ref @$sSSSis5Error_pIggdzo_SSSisAA_pIegnrzo_TR : $@convention(thin) (@in_guaranteed String, @guaranteed @noescape @callee_guaranteed (@guaranteed String) -> (Int, @error any Error)) -> (@out Int, @error any Error)
-// CHECK-NEXT: [[REABSTRACTED:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[NOESCAPE]])
+// CHECK-NEXT: [[THUNK:%.*]] = function_ref @$sSSSiIggd_SSSis5NeverOIegnrzr_TR : $@convention(thin) (@in_guaranteed String, @guaranteed @noescape @callee_guaranteed (@guaranteed String) -> Int) -> (@out Int, @error_indirect Never)
 
 // CHECK-LABEL: sil private [ossa] @$s22partial_apply_override7convert7stringsSaySiGSaySSG_tFSiSScAA18StringIntConverterCcfu_SiSScfu0_ : $@convention(thin) (@guaranteed String, @guaranteed StringIntConverter) -> Int
 // CHECK:      [[METHOD:%.*]] = class_method %1 : $StringIntConverter, #StringIntConverter.convert : (StringIntConverter) -> (String) -> Int, $@convention(method) (@in_guaranteed String, @guaranteed StringIntConverter) -> @out Int

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -26,5 +26,17 @@ Func Unicode.UTF32.Parser.parseScalar(from:) has generic signature change from <
 Func Unicode.UTF32.decode(_:) has generic signature change from <I where I : Swift.IteratorProtocol, I.Element == Swift.Unicode.UTF32.CodeUnit> to <I where I : Swift.IteratorProtocol, I.Element == Swift.UInt32>
 Func Unicode.UTF8.decode(_:) has generic signature change from <I where I : Swift.IteratorProtocol, I.Element == Swift.Unicode.UTF8.CodeUnit> to <I where I : Swift.IteratorProtocol, I.Element == Swift.UInt8>
 Constructor Mirror.init(_:children:displayStyle:ancestorRepresentation:) has generic signature change from <Subject, C where C : Swift.Collection, C.Element == Swift.Mirror.Child> to <Subject, C where C : Swift.Collection, C.Element == (label: Swift.String?, value: Any)>
+Func AnyBidirectionalCollection.map(_:) has generic signature change from <Element, T> to <Element, T, E where E : Swift.Error>
+Func AnyBidirectionalCollection.map(_:) is now without @rethrows
+Func AnyCollection.map(_:) has generic signature change from <Element, T> to <Element, T, E where E : Swift.Error>
+Func AnyCollection.map(_:) is now without @rethrows
+Func AnyRandomAccessCollection.map(_:) has generic signature change from <Element, T> to <Element, T, E where E : Swift.Error>
+Func AnyRandomAccessCollection.map(_:) is now without @rethrows
+Func AnySequence.map(_:) has generic signature change from <Element, T> to <Element, T, E where E : Swift.Error>
+Func AnySequence.map(_:) is now without @rethrows
+Func Collection.map(_:) has generic signature change from <Self, T where Self : Swift.Collection> to <Self, T, E where Self : Swift.Collection, E : Swift.Error>
+Func Collection.map(_:) is now without @rethrows
+Func Sequence.map(_:) has generic signature change from <Self, T where Self : Swift.Sequence> to <Self, T, E where Self : Swift.Sequence, E : Swift.Error>
+Func Sequence.map(_:) is now without @rethrows
 
 Protocol SIMDScalar has generic signature change from <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar> to <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMDMaskScalar == Self.SIMDMaskScalar.SIMDMaskScalar, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar>

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -88,6 +88,14 @@ Func AnySequence.map(_:) has been renamed to Func __rethrows_map(_:)
 Func AnySequence.map(_:) has mangled name changing from 'Swift.AnySequence.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnySequence.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
 Func AnySequence.map(_:) is now without @rethrows
 
+// These are using
+Func Sequence.map(_:) has been renamed to Func __rethrows_map(_:)
+Func Sequence.map(_:) has mangled name changing from '(extension in Swift):Swift.Sequence.map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1>' to '(extension in Swift):Swift.Sequence.__rethrows_map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1>'
+Func Sequence.map(_:) is now without @rethrows
+Func Collection.map(_:) has been renamed to Func __rethrows_map(_:)
+Func Collection.map(_:) has mangled name changing from '(extension in Swift):Swift.Collection.map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1>' to '(extension in Swift):Swift.Collection.__rethrows_map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1>'
+Func Collection.map(_:) is now without @rethrows
+
 // These haven't actually been removed; they are simply marked unavailable.
 // This seems to be a false positive in the ABI checker. This is not an ABI
 // break because the symbols are still present, and is not a source break

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -75,6 +75,18 @@ Constructor _SmallString.init(taggedCocoa:) has return type change from Swift._S
 Enum Never has added a conformance to an existing protocol Decodable
 Enum Never has added a conformance to an existing protocol Encodable
 Enum Never has added a conformance to an existing protocol Identifiable
+Func AnyBidirectionalCollection.map(_:) has been renamed to Func __rethrows_map(_:)
+Func AnyBidirectionalCollection.map(_:) has mangled name changing from 'Swift.AnyBidirectionalCollection.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnyBidirectionalCollection.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
+Func AnyBidirectionalCollection.map(_:) is now without @rethrows
+Func AnyCollection.map(_:) has been renamed to Func __rethrows_map(_:)
+Func AnyCollection.map(_:) has mangled name changing from 'Swift.AnyCollection.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnyCollection.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
+Func AnyCollection.map(_:) is now without @rethrows
+Func AnyRandomAccessCollection.map(_:) has been renamed to Func __rethrows_map(_:)
+Func AnyRandomAccessCollection.map(_:) has mangled name changing from 'Swift.AnyRandomAccessCollection.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnyRandomAccessCollection.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
+Func AnyRandomAccessCollection.map(_:) is now without @rethrows
+Func AnySequence.map(_:) has been renamed to Func __rethrows_map(_:)
+Func AnySequence.map(_:) has mangled name changing from 'Swift.AnySequence.map<A>((A) throws -> A1) throws -> Swift.Array<A1>' to 'Swift.AnySequence.__rethrows_map<A>((A) throws -> A1) throws -> Swift.Array<A1>'
+Func AnySequence.map(_:) is now without @rethrows
 
 // These haven't actually been removed; they are simply marked unavailable.
 // This seems to be a false positive in the ABI checker. This is not an ABI
@@ -100,6 +112,11 @@ Func UnsafeBufferPointer.withMemoryRebound(to:_:) has been removed
 Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) has been removed
 Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has been removed
 Func UnsafePointer.withMemoryRebound(to:capacity:_:) has been removed
+Func _AnySequenceBox._map(_:) is now without @rethrows
+Func _BidirectionalCollectionBox._map(_:) is now without @rethrows
+Func _CollectionBox._map(_:) is now without @rethrows
+Func _RandomAccessCollectionBox._map(_:) is now without @rethrows
+Func _SequenceBox._map(_:) is now without @rethrows
 Func UnsafeMutableRawBufferPointer.storeBytes(of:toByteOffset:as:) has been removed
 Func UnsafeMutableRawPointer.storeBytes(of:toByteOffset:as:) has been removed
 Func UnsafeMutableBufferPointer.assign(repeating:) has been removed


### PR DESCRIPTION
Adopt typed throws for the `map` operation to propagate thrown error
types through the `map` API. The new `map` has a signature like this:

```swift
  public func map<T, E>(
    _ transform: (Element) throws(E) -> T
  ) throws(E) -> [T]
```

This is done in a manner that is backward compatible for almost all cases:

* The new typed-throws entrypoint is `@_alwaysEmitIntoClient` so it can back-deploy all the way back.
* The old `rethrows` entrypoint is left in place, using `@usableFromInline` with `internal` so it is part of the ABI but not the public interface, `@_silgen_name` so it has the right name in the binary, and a new name `__rethrows_map` so it's otherwise out of the way. The old entrypoint is implemented in terms of the new one.

Note that the implementation details for the existential collection "box" classes rely on method overriding of `_map` operations, and the types are frozen, so  we don't get to change their signatures. However, these are only implementations, not API: the actual API `map` functions can be upgraded to typed throws.

Note that this code makes use of a known hole in `rethrows` checking to allow calling between `rethrows` and typed throws. We'll need to do something about this for source-compatibility reasons, but I'll follow up with that separately.