### PR TITLE
AST: Spot fix for latent issue with thrown error in transformWithPosition()

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5045,8 +5045,7 @@ case TypeKind::Id:
     // Transform the thrown error.
     Type thrownError;
     if (Type origThrownError = function->getThrownError()) {
-      thrownError = origThrownError.transformWithPosition(
-          TypePosition::Invariant, fn);
+      thrownError = origThrownError.transformWithPosition(pos, fn);
       if (!thrownError)
         return Type();
 


### PR DESCRIPTION
We probably don't have a way to exercise this, but the thrown error type appears in the same position as the function, instead of being invariant. That is, we wish to allow converting `() throws(E) -> ()` into `() throws(F) -> ()` when E converts to F.