### PR TITLE
[Profiler] Emit skipped regions for inactive `#if` branches

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -48,6 +48,39 @@ enum class RestrictedImportKind {
 /// Import that limits the access level of imported entities.
 using ImportAccessLevel = llvm::Optional<AttributedImport<ImportedModule>>;
 
+/// Stores range information for a \c #if block in a SourceFile.
+class IfConfigRangeInfo final {
+  /// The range of the entire \c #if block, including \c #else and \c #endif.
+  CharSourceRange WholeRange;
+
+  /// The range of the active selected body, if there is one. This does not
+  /// include the outer syntax of the \c #if. This may be invalid, which
+  /// indicates there is no active body.
+  CharSourceRange ActiveBodyRange;
+
+public:
+  IfConfigRangeInfo(CharSourceRange wholeRange, CharSourceRange activeBodyRange)
+      : WholeRange(wholeRange), ActiveBodyRange(activeBodyRange) {
+    assert(wholeRange.getByteLength() > 0 && "Range must be non-empty");
+    assert(activeBodyRange.isInvalid() || wholeRange.contains(activeBodyRange));
+  }
+
+  CharSourceRange getWholeRange() const { return WholeRange; }
+  SourceLoc getStartLoc() const { return WholeRange.getStart(); }
+
+  friend bool operator==(const IfConfigRangeInfo &lhs,
+                         const IfConfigRangeInfo &rhs) {
+    return lhs.WholeRange == rhs.WholeRange &&
+           lhs.ActiveBodyRange == rhs.ActiveBodyRange;
+  }
+
+  /// Retrieve the ranges produced by subtracting the active body range from
+  /// the whole range. This includes both inactive branches as well as the
+  /// other syntax of the \c #if.
+  SmallVector<CharSourceRange, 2>
+  getRangesWithoutActiveBody(const SourceManager &SM) const;
+};
+
 /// A file containing Swift source code.
 ///
 /// This is a .swift or .sil file (or a virtual file, such as the contents of
@@ -208,6 +241,19 @@ private:
   /// resume parsing at the code completion token in the file.
   ParserStatePtr DelayedParserState =
       ParserStatePtr(/*ptr*/ nullptr, /*deleter*/ nullptr);
+
+  struct IfConfigRangesData {
+    /// All the \c #if source ranges in this file.
+    std::vector<IfConfigRangeInfo> Ranges;
+
+    /// Whether the elemnts in \c Ranges are sorted in source order within
+    /// this file. We flip this to \c false any time a new range gets recorded,
+    /// and lazily do the sorting when doing a query.
+    bool IsSorted = false;
+  };
+
+  /// Stores all the \c #if source range info in this file.
+  mutable IfConfigRangesData IfConfigRanges;
 
   friend class HasImportsMatchingFlagRequest;
 
@@ -447,6 +493,13 @@ public:
   void addMissingImportedModule(ImportedModule module) const {
      const_cast<SourceFile *>(this)->MissingImportedModules.insert(module);
   }
+
+  /// Record the source range info for a parsed \c #if block.
+  void recordIfConfigRangeInfo(IfConfigRangeInfo ranges);
+
+  /// Retrieve the source range infos for any \c #if blocks contained within a
+  /// given source range of this file.
+  ArrayRef<IfConfigRangeInfo> getIfConfigsWithin(SourceRange outer) const;
 
   void getMissingImportedModules(
          SmallVectorImpl<ImportedModule> &imports) const override;

--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -41,17 +41,52 @@ namespace swift {
 class SILCoverageMap : public llvm::ilist_node<SILCoverageMap>,
                        public SILAllocated<SILCoverageMap> {
 public:
-  struct MappedRegion {
+  class MappedRegion {
+  public:
+    enum class Kind {
+      /// A code region, which represents a regular region of source code.
+      Code,
+
+      /// A skipped region, which represents a region that cannot have any
+      /// coverage associated with it. This is used for e.g the inactive body of
+      /// a \c #if.
+      Skipped
+    };
+
+    Kind RegionKind;
     unsigned StartLine;
     unsigned StartCol;
     unsigned EndLine;
     unsigned EndCol;
     llvm::coverage::Counter Counter;
 
-    MappedRegion(unsigned StartLine, unsigned StartCol, unsigned EndLine,
-                 unsigned EndCol, llvm::coverage::Counter Counter)
-        : StartLine(StartLine), StartCol(StartCol), EndLine(EndLine),
-          EndCol(EndCol), Counter(Counter) {}
+  private:
+    MappedRegion(Kind RegionKind, unsigned StartLine, unsigned StartCol,
+                 unsigned EndLine, unsigned EndCol,
+                 llvm::coverage::Counter Counter)
+        : RegionKind(RegionKind), StartLine(StartLine), StartCol(StartCol),
+          EndLine(EndLine), EndCol(EndCol), Counter(Counter) {}
+
+  public:
+    /// A code region, which represents a regular region of source code.
+    static MappedRegion code(unsigned StartLine, unsigned StartCol,
+                             unsigned EndLine, unsigned EndCol,
+                             llvm::coverage::Counter Counter) {
+      return MappedRegion(Kind::Code, StartLine, StartCol, EndLine, EndCol,
+                          Counter);
+    }
+
+    /// A skipped region, which represents a region that cannot have any
+    /// coverage associated with it. This is used for e.g the inactive body of
+    /// a \c #if.
+    static MappedRegion skipped(unsigned StartLine, unsigned StartCol,
+                                unsigned EndLine, unsigned EndCol) {
+      return MappedRegion(Kind::Skipped, StartLine, StartCol, EndLine, EndCol,
+                          llvm::coverage::Counter());
+    }
+
+    /// Retrieve the equivalent LLVM mapped region.
+    llvm::coverage::CounterMappingRegion getLLVMRegion(unsigned FileID) const;
   };
 
 private:

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3326,6 +3326,70 @@ SourceFile::getImportAccessLevel(const ModuleDecl *targetModule) const {
   return restrictiveImport;
 }
 
+SmallVector<CharSourceRange, 2>
+IfConfigRangeInfo::getRangesWithoutActiveBody(const SourceManager &SM) const {
+  SmallVector<CharSourceRange, 2> result;
+  if (ActiveBodyRange.isValid()) {
+    // Split the whole range by the active range.
+    result.emplace_back(SM, WholeRange.getStart(), ActiveBodyRange.getStart());
+    result.emplace_back(SM, ActiveBodyRange.getEnd(), WholeRange.getEnd());
+  } else {
+    // No active body, we just return the whole range.
+    result.push_back(WholeRange);
+  }
+  return result;
+}
+
+void SourceFile::recordIfConfigRangeInfo(IfConfigRangeInfo ranges) {
+  IfConfigRanges.Ranges.push_back(ranges);
+  IfConfigRanges.IsSorted = false;
+}
+
+ArrayRef<IfConfigRangeInfo>
+SourceFile::getIfConfigsWithin(SourceRange outer) const {
+  auto &SM = getASTContext().SourceMgr;
+  assert(SM.getRangeForBuffer(BufferID).contains(outer.Start) &&
+         "Range not within this file?");
+
+  if (!IfConfigRanges.IsSorted) {
+    // Sort the ranges if we need to.
+    llvm::sort(IfConfigRanges.Ranges, [&](IfConfigRangeInfo lhs,
+                                          IfConfigRangeInfo rhs) {
+      return SM.isBeforeInBuffer(lhs.getStartLoc(), rhs.getStartLoc());
+    });
+
+    // Be defensive and eliminate duplicates in case we've parsed twice.
+    auto newEnd = std::unique(
+        IfConfigRanges.Ranges.begin(), IfConfigRanges.Ranges.end(),
+        [&](const IfConfigRangeInfo &lhs, const IfConfigRangeInfo &rhs) {
+          if (lhs.getWholeRange() != rhs.getWholeRange())
+            return false;
+
+          assert(lhs == rhs && "Active ranges changed on a re-parse?");
+          return true;
+        });
+    IfConfigRanges.Ranges.erase(newEnd, IfConfigRanges.Ranges.end());
+    IfConfigRanges.IsSorted = true;
+  }
+
+  // First let's find the first #if that is after the outer start loc.
+  auto ranges = llvm::makeArrayRef(IfConfigRanges.Ranges);
+  auto lower = llvm::lower_bound(
+      ranges, outer.Start, [&](IfConfigRangeInfo range, SourceLoc loc) {
+        return SM.isBeforeInBuffer(range.getStartLoc(), loc);
+      });
+  if (lower == ranges.end() ||
+      SM.isBeforeInBuffer(outer.End, lower->getStartLoc())) {
+    return {};
+  }
+  // Next let's find the first #if that's after the outer end loc.
+  auto upper = llvm::upper_bound(
+      ranges, outer.End, [&](SourceLoc loc, IfConfigRangeInfo range) {
+        return SM.isBeforeInBuffer(loc, range.getStartLoc());
+      });
+  return llvm::makeArrayRef(lower, upper - lower);
+}
+
 void ModuleDecl::setPackageName(Identifier name) {
   Package = PackageUnit::create(name, *this, getASTContext());
 }

--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -143,11 +143,9 @@ void IRGenModule::emitCoverageMaps(ArrayRef<const SILCoverageMap *> Mappings) {
 
     std::vector<CounterMappingRegion> Regions;
     for (const auto &MR : M->getMappedRegions()) {
-      // The SubFileID here is 0, because it's an index into VirtualFileMapping,
+      // The FileID here is 0, because it's an index into VirtualFileMapping,
       // and we only ever have a single file associated for a function.
-      Regions.emplace_back(CounterMappingRegion::makeRegion(
-          MR.Counter, /*SubFileID*/ 0, MR.StartLine, MR.StartCol, MR.EndLine,
-          MR.EndCol));
+      Regions.push_back(MR.getLLVMRegion(/*FileID*/ 0));
     }
     // Append each function's regions into the encoded buffer.
     ArrayRef<unsigned> VirtualFileMapping(FileID);

--- a/lib/SIL/IR/SILCoverageMap.cpp
+++ b/lib/SIL/IR/SILCoverageMap.cpp
@@ -22,6 +22,7 @@
 using namespace swift;
 
 using llvm::coverage::CounterExpression;
+using llvm::coverage::CounterMappingRegion;
 
 SILCoverageMap *
 SILCoverageMap::create(SILModule &M, SourceFile *ParentSourceFile,
@@ -55,6 +56,19 @@ SILCoverageMap::SILCoverageMap(SourceFile *ParentSourceFile, uint64_t Hash)
   : ParentSourceFile(ParentSourceFile), Hash(Hash) {}
 
 SILCoverageMap::~SILCoverageMap() {}
+
+CounterMappingRegion
+SILCoverageMap::MappedRegion::getLLVMRegion(unsigned int FileID) const {
+  switch (RegionKind) {
+  case MappedRegion::Kind::Code:
+    return CounterMappingRegion::makeRegion(Counter, FileID, StartLine,
+                                            StartCol, EndLine, EndCol);
+  case MappedRegion::Kind::Skipped:
+    return CounterMappingRegion::makeSkipped(FileID, StartLine, StartCol,
+                                             EndLine, EndCol);
+  }
+  llvm_unreachable("Unhandled case in switch!");
+}
 
 namespace {
 struct Printer {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -4168,7 +4168,14 @@ void SILCoverageMap::print(SILPrintContext &PrintCtx) const {
   for (auto &MR : getMappedRegions()) {
     OS << "  " << MR.StartLine << ":" << MR.StartCol << " -> " << MR.EndLine
        << ":" << MR.EndCol << " : ";
-    printCounter(OS, MR.Counter);
+    switch (MR.RegionKind) {
+    case MappedRegion::Kind::Code:
+      printCounter(OS, MR.Counter);
+      break;
+    case MappedRegion::Kind::Skipped:
+      OS << "skipped";
+      break;
+    }
     OS << "\n";
   }
   OS << "}\n\n";

--- a/test/Profiler/coverage_pound_if.swift
+++ b/test/Profiler/coverage_pound_if.swift
@@ -1,0 +1,154 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_pound_if %s | %FileCheck %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
+
+func poundIf1() -> Int {
+  #if true
+    #if true
+    return 1
+    #else
+    return 2
+    #endif
+  #else
+    #if true
+    return 3
+    #else
+    return 4
+    #endif
+  #endif
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If1SiyF"
+// CHECK-NEXT:    [[@LINE-16]]:24 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-16]]:3 -> [[@LINE-16]]:11 : skipped
+// CHECK-NEXT:    [[@LINE-16]]:5 -> [[@LINE-16]]:13 : skipped
+// CHECK-NEXT:    [[@LINE-15]]:5 -> [[@LINE-13]]:11 : skipped
+// CHECK-NEXT:    [[@LINE-13]]:3 -> [[@LINE-7]]:9 : skipped
+// CHECK-NEXT:  }
+
+func poundIf2(_ x: [Int]) -> [Int] {
+  return x
+  #if false
+    .map { $0 + 1 }
+  #endif
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If2ySaySiGACF"
+// CHECK-NEXT:    [[@LINE-7]]:36 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-6]]:3 -> [[@LINE-4]]:9 : skipped
+// CHECK-NEXT:  }
+
+
+func poundIf3() -> Any {
+#if false
+  @objc
+#endif
+  class C {}
+  return C()
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If3ypyF"
+// CHECK-NEXT:    [[@LINE-8]]:24 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-8]]:1 -> [[@LINE-6]]:7 : skipped
+// CHECK-NEXT:  }
+
+func poundIf4(_ x: Bool) -> Int {
+  switch x {
+  #if true
+  case true:
+    return 0
+  #else
+  case false:
+    return 0
+  #endif
+  #if false
+  case false:
+    return 1
+  #endif
+  case false:
+    return 0
+  }
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If4ySiSbF"
+// CHECK-NEXT:    [[@LINE-18]]:33 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-18]]:10 -> [[@LINE-18]]:11 : 0
+// CHECK-NEXT:    [[@LINE-18]]:3 -> [[@LINE-18]]:11 : skipped
+// CHECK-NEXT:    [[@LINE-18]]:3 -> [[@LINE-17]]:13 : 1
+// CHECK-NEXT:    [[@LINE-17]]:3 -> [[@LINE-14]]:9 : skipped
+// CHECK-NEXT:    [[@LINE-14]]:3 -> [[@LINE-11]]:9 : skipped
+// CHECK-NEXT:    [[@LINE-11]]:3 -> [[@LINE-10]]:13 : 2
+// CHECK-NEXT:  }
+
+func poundIf5() {
+  struct S {
+#if false
+    var foo: Int
+#else
+    var foo: Int
+#endif
+  }
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If5yyF"
+// CHECK-NEXT:    [[@LINE-10]]:17 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-9]]:1 -> [[@LINE-7]]:6 : skipped
+// CHECK-NEXT:    [[@LINE-6]]:1 -> [[@LINE-6]]:7 : skipped
+// CHECK-NEXT:  }
+
+func poundIf6() -> Int {
+  #if true
+  struct S {
+    var foo: Int
+  }
+  #else
+  struct S {
+    var foo: Int
+  }
+  #endif
+  return S(foo: 0).foo
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If6SiyF"
+// CHECK-NEXT:    [[@LINE-13]]:24 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-13]]:3 -> [[@LINE-13]]:11 : skipped
+// CHECK-NEXT:    [[@LINE-10]]:3 -> [[@LINE-6]]:9 : skipped
+// CHECK-NEXT:  }
+
+func poundIf7() -> Int {
+  #if false
+  #endif
+  return 0
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If7SiyF"
+// CHECK-NEXT:    [[@LINE-6]]:24 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-6]]:3 -> [[@LINE-5]]:9 : skipped
+// CHECK-NEXT:  }
+
+func poundIf8() -> Int {
+  #if true
+  #endif
+  return 0
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If8SiyF"
+// CHECK-NEXT:    [[@LINE-6]]:24 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-6]]:3 -> [[@LINE-6]]:11 : skipped
+// CHECK-NEXT:    [[@LINE-6]]:3 -> [[@LINE-6]]:9 : skipped
+// CHECK-NEXT:  }
+
+func poundIf9() -> Int {
+  #if true
+  #else
+  #endif
+  return 0
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B3If9SiyF"
+// CHECK-NEXT:    [[@LINE-7]]:24 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-7]]:3 -> [[@LINE-7]]:11 : skipped
+// CHECK-NEXT:    [[@LINE-7]]:3 -> [[@LINE-6]]:9 : skipped
+// CHECK-NEXT:  }
+
+func poundIf10() -> Int {
+  #if true
+  return 0
+  #else
+  return 1#endif
+}
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_pound_if0B4If10SiyF"
+// CHECK-NEXT:    [[@LINE-7]]:25 -> [[@LINE-2]]:2 : 0
+// CHECK-NEXT:    [[@LINE-7]]:3 -> [[@LINE-7]]:11 : skipped
+// CHECK-NEXT:    [[@LINE-6]]:3 -> [[@LINE-5]]:17 : skipped
+// CHECK-NEXT:  }

--- a/test/Profiler/coverage_pound_if_exec.swift
+++ b/test/Profiler/coverage_pound_if_exec.swift
@@ -1,0 +1,129 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift %s -profile-generate -profile-coverage-mapping -o %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-codesign %t/main
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
+// RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
+// RUN: %llvm-cov export -summary-only %t/main -instr-profile=%t/default.profdata | %FileCheck --check-prefix SUMMARY %s
+// RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck --implicit-check-not "{{[ ]*\|[ ]*[0-9]+}}" %s
+
+// REQUIRES: profile_runtime
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+// The line count here excludes the inactive regions.
+// SUMMARY: "lines":{"count":41,"covered":0
+
+// This test works by marking active lines with the pattern. The implicit
+// CHECK-NOT in the FileCheck invocation ensures everything else is a skipped
+// region (or doesn't have any coverage mapping such as these comments).
+
+func poundIfDecl() -> Int {  // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #if true
+    #if true
+    return 1                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+    #else
+    return 2
+    #endif
+  #else
+    #if true
+    return 3
+    #else
+    return 4
+    #endif
+  #endif
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func poundIfMember(
+  _ x: [Int]
+) -> [Int] {                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  return x                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #if false
+    .map { $0 + 1 }
+  #endif
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func poundIfAttr() -> Any {  // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+#if false
+  @objc
+#endif
+  class C {}                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  return C()                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func poundIfSwitch(
+  _ x: Bool
+) -> Int {                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  switch x {                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #if true
+  case true:                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+    return 0                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #else
+  case false:
+    return 0
+  #endif
+  #if false
+  case false:
+    return 1
+  #endif
+  case false:                // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+    return 0                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  }                          // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func poundIfMember() {       // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  struct S {                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+#if false
+    var foo: Int
+#else
+    var foo: Int             // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+#endif
+  }                          // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func poundIfDecl2() -> Int { // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #if true
+  struct S {                 // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+    var foo: Int             // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  }                          // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #else
+  struct S {
+    var foo: Int
+  }
+  #endif
+  return S(foo: 0).foo       // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func emptyPoundIf1(
+) -> Int {                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #if false
+  #endif
+  return 0                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func emptyPoundIf2(
+) -> Int {                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #if true
+  #endif
+  return 0                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func emptyPoundIf3(
+) -> Int {                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #if true
+  #else
+  #endif
+  return 0                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+
+func poundEndIfSameLine(
+) -> Int {                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #if true
+  return 0                   // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}
+  #else
+  return 1#endif
+}                            // CHECK: [[@LINE]]{{[ ]*\|[ ]*[0-9]+}}

--- a/test/SIL/Parser/coverage_maps.sil
+++ b/test/SIL/Parser/coverage_maps.sil
@@ -18,6 +18,7 @@ sil_coverage_map "coverage_maps.sil" "someFunction" "coverage_maps.sil:someFunct
 // CHECK: 17:9 -> 17:17 : ((0 + 2) - 3)
 // CHECK: 17:9 -> 17:17 : ((0 + 2) - 3)
 // CHECK: 22:11 -> 139:2 : 1
+// CHECK: 54:1 -> 55:1 : skipped
 // CHECK: }
 sil_coverage_map "/some/other/file.sil" "someFunction" "/some/other/file.sil:someFunction" 0 {
   4:19 -> 31:1 : 0
@@ -26,4 +27,5 @@ sil_coverage_map "/some/other/file.sil" "someFunction" "/some/other/file.sil:som
   17:9 -> 17:17: ((0 + 2) - 3)
   17:9 -> 17:17: (0 + (2 - 3))
   22:11->139:2 : (zero + 1)
+  54:1 -> 55:1 : skipped
 }


### PR DESCRIPTION
For any `#if` blocks in the function we're emitting, emit skipped ranges for the inactive clauses, including the syntax for the `#if` itself, since that should not be considered executable code.

rdar://116860865