### PR TITLE
Remove two pImpl abstraction layers in rename

### DIFF
--- a/include/swift/Refactoring/Refactoring.h
+++ b/include/swift/Refactoring/Refactoring.h
@@ -100,13 +100,11 @@ public:
 };
 
 class FindRenameRangesAnnotatingConsumer : public FindRenameRangesConsumer {
-  struct Implementation;
-  Implementation &Impl;
+  std::unique_ptr<SourceEditConsumer> pRewriter;
 
 public:
   FindRenameRangesAnnotatingConsumer(SourceManager &SM, unsigned BufferId,
                                      llvm::raw_ostream &OS);
-  ~FindRenameRangesAnnotatingConsumer();
   void accept(SourceManager &SM, RegionType RegionType,
               ArrayRef<RenameRangeDetail> Ranges) override;
 };

--- a/lib/Refactoring/FindRenameRangesAnnotatingConsumer.cpp
+++ b/lib/Refactoring/FindRenameRangesAnnotatingConsumer.cpp
@@ -14,55 +14,34 @@
 
 using namespace swift::refactoring;
 
-struct swift::ide::FindRenameRangesAnnotatingConsumer::Implementation {
-  std::unique_ptr<SourceEditConsumer> pRewriter;
-  Implementation(SourceManager &SM, unsigned BufferId, raw_ostream &OS)
-      : pRewriter(new SourceEditOutputConsumer(SM, BufferId, OS)) {}
-  static StringRef tag(RefactoringRangeKind Kind) {
-    switch (Kind) {
-    case RefactoringRangeKind::BaseName:
-      return "base";
-    case RefactoringRangeKind::KeywordBaseName:
-      return "keywordBase";
-    case RefactoringRangeKind::ParameterName:
-      return "param";
-    case RefactoringRangeKind::NoncollapsibleParameterName:
-      return "noncollapsibleparam";
-    case RefactoringRangeKind::DeclArgumentLabel:
-      return "arglabel";
-    case RefactoringRangeKind::CallArgumentLabel:
-      return "callarg";
-    case RefactoringRangeKind::CallArgumentColon:
-      return "callcolon";
-    case RefactoringRangeKind::CallArgumentCombined:
-      return "callcombo";
-    case RefactoringRangeKind::SelectorArgumentLabel:
-      return "sel";
-    }
-    llvm_unreachable("unhandled kind");
+static StringRef tag(RefactoringRangeKind Kind) {
+  switch (Kind) {
+  case RefactoringRangeKind::BaseName:
+    return "base";
+  case RefactoringRangeKind::KeywordBaseName:
+    return "keywordBase";
+  case RefactoringRangeKind::ParameterName:
+    return "param";
+  case RefactoringRangeKind::NoncollapsibleParameterName:
+    return "noncollapsibleparam";
+  case RefactoringRangeKind::DeclArgumentLabel:
+    return "arglabel";
+  case RefactoringRangeKind::CallArgumentLabel:
+    return "callarg";
+  case RefactoringRangeKind::CallArgumentColon:
+    return "callcolon";
+  case RefactoringRangeKind::CallArgumentCombined:
+    return "callcombo";
+  case RefactoringRangeKind::SelectorArgumentLabel:
+    return "sel";
   }
-  void accept(SourceManager &SM, const RenameRangeDetail &Range) {
-    std::string NewText;
-    llvm::raw_string_ostream OS(NewText);
-    StringRef Tag = tag(Range.RangeKind);
-    OS << "<" << Tag;
-    if (Range.Index.has_value())
-      OS << " index=" << *Range.Index;
-    OS << ">" << Range.Range.str() << "</" << Tag << ">";
-    pRewriter->accept(SM, {/*Path=*/{}, Range.Range, /*BufferName=*/{},
-                           OS.str(), /*RegionsWorthNote=*/{}});
-  }
-};
+  llvm_unreachable("unhandled kind");
+}
 
 swift::ide::FindRenameRangesAnnotatingConsumer::
     FindRenameRangesAnnotatingConsumer(SourceManager &SM, unsigned BufferId,
                                        raw_ostream &OS)
-    : Impl(*new Implementation(SM, BufferId, OS)) {}
-
-swift::ide::FindRenameRangesAnnotatingConsumer::
-    ~FindRenameRangesAnnotatingConsumer() {
-  delete &Impl;
-}
+    : pRewriter(new SourceEditOutputConsumer(SM, BufferId, OS)) {}
 
 void swift::ide::FindRenameRangesAnnotatingConsumer::accept(
     SourceManager &SM, RegionType RegionType,
@@ -70,6 +49,15 @@ void swift::ide::FindRenameRangesAnnotatingConsumer::accept(
   if (RegionType == RegionType::Mismatch || RegionType == RegionType::Unmatched)
     return;
   for (const auto &Range : Ranges) {
-    Impl.accept(SM, Range);
+    std::string NewText;
+    llvm::raw_string_ostream OS(NewText);
+    StringRef Tag = tag(Range.RangeKind);
+    OS << "<" << Tag;
+    if (Range.Index.has_value())
+      OS << " index=" << *Range.Index;
+    OS << ">" << Range.Range.str() << "</" << Tag << ">";
+    Replacement Repl{/*Path=*/{}, Range.Range, /*BufferName=*/{}, OS.str(),
+                     /*RegionsWorthNote=*/{}};
+    pRewriter->accept(SM, Repl);
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -24,12 +24,13 @@
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/PluginRegistry.h"
 #include "swift/Basic/ThreadSafeRefCounted.h"
+#include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/CancellableResult.h"
 #include "swift/IDE/Indenting.h"
-#include "swift/Refactoring/Refactoring.h"
 #include "swift/IDETool/CompileInstance.h"
 #include "swift/IDETool/IDEInspectionInstance.h"
 #include "swift/Index/IndexSymbol.h"
+#include "swift/Refactoring/Refactoring.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Mutex.h"
@@ -276,8 +277,12 @@ public:
 
 class RequestRenameRangeConsumer : public swift::ide::FindRenameRangesConsumer,
                                    public swift::DiagnosticConsumer {
-  class Implementation;
-  Implementation &Impl;
+  CategorizedRenameRangesReceiver Receiver;
+  std::string ErrBuffer;
+  llvm::raw_string_ostream OS;
+  std::vector<CategorizedRenameRanges> CategorizedRanges;
+
+  swift::PrintingDiagnosticConsumer DiagConsumer;
 
 public:
   RequestRenameRangeConsumer(CategorizedRenameRangesReceiver Receiver);


### PR DESCRIPTION
IMO the code is a lot easier to read if we don’t hide the implementation in an `Implementation` class. AFAICT the abstraction layer wasn’t giving us anything.