### PR TITLE
[cxx-interop] enable support for move-only types

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5450,8 +5450,10 @@ makeBaseClassMemberAccessors(DeclContext *declContext,
   auto computedType = computedVar->getInterfaceType();
 
   // Use 'address' or 'mutableAddress' accessors for non-copyable
-  // types.
-  bool useAddress = computedType->isNoncopyable(declContext);
+  // types, unless the base accessor returns it by value.
+  bool useAddress = computedType->isNoncopyable(declContext) &&
+                    (baseClassVar->getReadImpl() == ReadImplKind::Stored ||
+                     baseClassVar->getAccessor(AccessorKind::Address));
 
   ParameterList *bodyParams = nullptr;
   if (auto subscript = dyn_cast<SubscriptDecl>(baseClassVar)) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4949,14 +4949,14 @@ const clang::CXXMethodDecl *getCalledBaseCxxMethod(FuncDecl *baseMember) {
   if (!returnStmt)
     return nullptr;
   Expr *returnExpr = returnStmt->getResult();
-  // Look through a potential 'reinterpresetCast' that can be used
+  // Look through a potential 'reinterpretCast' that can be used
   // to cast UnsafeMutablePointer to UnsafePointer in the synthesized
   // Swift body for `.pointee`.
   if (auto *ce = dyn_cast<CallExpr>(returnExpr)) {
     if (auto *v = ce->getCalledValue()) {
       if (v->getModuleContext() ==
               baseMember->getASTContext().TheBuiltinModule &&
-          v->getBaseName().getIdentifier().str() == "reinterpretCast") {
+          v->getBaseIdentifier().is("reinterpretCast")) {
         returnExpr = ce->getArgs()->get(0).getExpr();
       }
     }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2193,6 +2193,10 @@ namespace {
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
       if (recordHasMoveOnlySemantics(decl)) {
+        if (decl->isInStdNamespace() && decl->getName() == "promise") {
+          // Do not import std::promise.
+          return nullptr;
+        }
         result->getAttrs().add(new (Impl.SwiftContext)
                                    MoveOnlyAttr(/*Implicit=*/true));
       }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2183,15 +2183,6 @@ namespace {
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
       if (recordHasMoveOnlySemantics(decl)) {
-        if (!Impl.SwiftContext.LangOpts.hasFeature(Feature::MoveOnly)) {
-          Impl.addImportDiagnostic(
-              decl, Diagnostic(
-                        diag::move_only_requires_move_only,
-                        Impl.SwiftContext.AllocateCopy(decl->getNameAsString())),
-              decl->getLocation());
-          return nullptr;
-        }
-
         result->getAttrs().add(new (Impl.SwiftContext)
                                    MoveOnlyAttr(/*Implicit=*/true));
       }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3922,17 +3922,6 @@ namespace {
       auto loc = Impl.importSourceLoc(decl->getLocation());
       auto dc = Impl.importDeclContextOf(
           decl, importedName.getEffectiveContext());
-
-#ifndef NDEBUG
-      if (dc == nullptr) {
-        llvm::dbgs() << "No decl context!\n";
-        llvm::dbgs() << "Decl: " << importedName.getDeclName().getBaseIdentifier().str() << "\n";
-        llvm::dbgs() << "Decl: "; decl->dump();
-        llvm::dbgs() << "Efective ctx: "; importedName.getEffectiveContext().DC->dumpAsDecl();
-        llvm::dbgs() << "Decl ctx: "; decl->getDeclContext()->dumpAsDecl();
-        llvm_unreachable("");
-      }
-#endif
       
       SmallVector<GenericTypeParamDecl *, 4> genericParams;
       for (auto &param : *decl->getTemplateParameters()) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3923,6 +3923,17 @@ namespace {
       auto dc = Impl.importDeclContextOf(
           decl, importedName.getEffectiveContext());
 
+#ifndef NDEBUG
+      if (dc == nullptr) {
+        llvm::dbgs() << "No decl context!\n";
+        llvm::dbgs() << "Decl: " << importedName.getDeclName().getBaseIdentifier().str() << "\n";
+        llvm::dbgs() << "Decl: "; decl->dump();
+        llvm::dbgs() << "Efective ctx: "; importedName.getEffectiveContext().DC->dumpAsDecl();
+        llvm::dbgs() << "Decl ctx: "; decl->getDeclContext()->dumpAsDecl();
+        llvm_unreachable("");
+      }
+#endif
+      
       SmallVector<GenericTypeParamDecl *, 4> genericParams;
       for (auto &param : *decl->getTemplateParameters()) {
         auto genericParamDecl =

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -60,6 +60,10 @@ public:
                        VarDecl::Introducer introducer, bool isImplicit,
                        AccessLevel access, AccessLevel setterAccess);
 
+  /// Create a reinterpretCast from the `exprType`, to the `givenType`.
+  static Expr *synthesizeReturnReinterpretCast(ASTContext &ctx, Type givenType,
+                                               Type exprType, Expr *baseExpr);
+
   /// Create a new named constant with the given value.
   ///
   /// \param name The name of the constant.

--- a/lib/ClangImporter/bridging
+++ b/lib/ClangImporter/bridging
@@ -153,6 +153,11 @@
 #define SWIFT_UNCHECKED_SENDABLE \
   __attribute__((swift_attr("@Sendable")))
 
+/// Specifies that a specific c++ type such class or struct should be imported
+/// as a non-copyable Swift value type.
+#define SWIFT_NONCOPYABLE \
+  __attribute__((swift_attr("~Copyable")))
+
 #else  // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 
 // Empty defines for compilers that don't support `attribute(swift_attr)`.
@@ -166,6 +171,7 @@
 #define SWIFT_COMPUTED_PROPERTY
 #define SWIFT_MUTATING 
 #define SWIFT_UNCHECKED_SENDABLE
+#define SWIFT_NONCOPYABLE
 
 #endif // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -251,4 +251,15 @@ struct HasMethodThatReturnsIteratorBox {
   IteratorBox getIteratorBox() const;
 };
 
+struct __attribute__((swift_attr("~Copyable"))) StructCopyableMovableAnnotatedNonCopyable {
+  inline StructCopyableMovableAnnotatedNonCopyable() {}
+  StructCopyableMovableAnnotatedNonCopyable(const StructCopyableMovableAnnotatedNonCopyable &) = default;
+  StructCopyableMovableAnnotatedNonCopyable(StructCopyableMovableAnnotatedNonCopyable &&) = default;
+  StructCopyableMovableAnnotatedNonCopyable &
+  operator=(const StructCopyableMovableAnnotatedNonCopyable &) = default;
+    StructCopyableMovableAnnotatedNonCopyable &
+  operator=(StructCopyableMovableAnnotatedNonCopyable &&) = default;
+  ~StructCopyableMovableAnnotatedNonCopyable() = default;
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_TYPE_CLASSIFICATION_H

--- a/test/Interop/Cxx/class/move-only/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/move-only/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module MoveOnlyCxxValueType {
+  header "move-only-cxx-value-type.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
+++ b/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
@@ -1,0 +1,36 @@
+#ifndef TEST_INTEROP_CXX_CLASS_MOVE_ONLY_VT_H
+#define TEST_INTEROP_CXX_CLASS_MOVE_ONLY_VT_H
+
+#include <memory>
+
+struct Copyable {
+    int x;
+};
+
+struct NonCopyable {
+    inline NonCopyable(int x) : x(x) {}
+    inline NonCopyable(const NonCopyable &) = delete;
+    inline NonCopyable(NonCopyable &&other) : x(other.x) { other.x = -123; }
+
+    inline int method(int y) const { return x * y; }
+    inline int mutMethod(int y) {
+      x = y;
+      return y;
+    }
+private:
+    int x;
+};
+
+struct NonCopyableHolder {
+    inline NonCopyableHolder(int x) : x(x) {}
+    inline NonCopyableHolder(const NonCopyableHolder &) = delete;
+    inline NonCopyableHolder(NonCopyableHolder &&other) : x(std::move(other.x)) {}
+
+    inline NonCopyable &returnMutNonCopyableRef() { return x; }
+
+    inline const NonCopyable &returnNonCopyableRef() const { return x; }
+private:
+    NonCopyable x;
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_MOVE_ONLY_VT_H

--- a/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
+++ b/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
@@ -37,7 +37,7 @@ struct NonCopyableHolder {
     inline NonCopyable &returnMutNonCopyableRef() { return x; }
 
     inline const NonCopyable &returnNonCopyableRef() const { return x; }
-private:
+
     NonCopyable x;
 };
 

--- a/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
+++ b/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
@@ -41,4 +41,16 @@ struct NonCopyableHolder {
     NonCopyable x;
 };
 
+struct NonCopyableHolderDerived: NonCopyableHolder {
+    inline NonCopyableHolderDerived(int x) : NonCopyableHolder(x) {}
+};
+
+struct NonCopyableHolderDerivedDerived: NonCopyableHolderDerived {
+    inline NonCopyableHolderDerivedDerived(int x) : NonCopyableHolderDerived(x) {}
+
+    inline int getActualX() const {
+        return x.x;
+    }
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_MOVE_ONLY_VT_H

--- a/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
+++ b/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
@@ -17,8 +17,16 @@ struct NonCopyable {
       x = y;
       return y;
     }
-private:
+
     int x;
+};
+
+struct NonCopyableDerived: public NonCopyable {
+    NonCopyableDerived(int x) : NonCopyable(x) {}
+};
+
+struct NonCopyableDerivedDerived: public NonCopyableDerived {
+    NonCopyableDerivedDerived(int x) : NonCopyableDerived(x) {}
 };
 
 struct NonCopyableHolder {

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs -enable-experimental-cxx-interop %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+
+import MoveOnlyCxxValueType
+
+func testGetX() -> CInt {
+    let derived = NonCopyableHolderDerivedDerived(42)
+    return derived.x.x
+}
+
+let _ = testGetX()
+
+func testSetX(_ x: CInt) {
+    var derived = NonCopyableHolderDerivedDerived(42)
+    derived.x.x = 2
+}
+
+testSetX(2)
+
+// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}__synthesizedBaseCall___synthesizedBaseGetterAccessor{{.*}}
+
+// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}__synthesizedBaseCall___synthesizedBaseSetterAccessor{{.*}}
+
+// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}__synthesizedBaseGetterAccessor{{.*}}
+// CHECK: %[[VPTR:.*]] = getelementptr inbounds %struct.NonCopyableHolder
+// CHECK: ret ptr %[[VPTR]]
+
+// CHECK: define {{.*}}linkonce_odr{{.*}} ptr @{{.*}}__synthesizedBaseSetterAccessor{{.*}}
+// CHECK: %[[VPTRS:.*]] = getelementptr inbounds %struct.NonCopyableHolder
+// CHECK: ret ptr %[[VPTRS]]

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-irgen -I %S/Inputs -enable-experimental-cxx-interop %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
 
 import MoveOnlyCxxValueType
 

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-experimental-cxx-interop %s -validate-tbd-against-ir=none | %FileCheck %s
+
+import MoveOnlyCxxValueType
+
+func testGetX() -> CInt {
+    let derived = NonCopyableHolderDerivedDerived(42)
+    return derived.x.x
+}
+
+let _ = testGetX()
+
+func testSetX(_ x: CInt) {
+    var derived = NonCopyableHolderDerivedDerived(42)
+    derived.x.x = 2
+}
+
+testSetX(2)
+
+// CHECK: sil shared [transparent] @$sSo024NonCopyableHolderDerivedD0V1xSo0aB0Vvlu : $@convention(method) (@in_guaranteed NonCopyableHolderDerivedDerived) -> UnsafePointer<NonCopyable>
+// CHECK: {{.*}}(%[[SELF_VAL:.*]] : $*NonCopyableHolderDerivedDerived):
+// CHECK: function_ref @{{.*}}__synthesizedBaseCall___synthesizedBaseGetterAccessor{{.*}} : $@convention(cxx_method) (@in_guaranteed NonCopyableHolderDerivedDerived) -> UnsafePointer<NonCopyable>
+// CHECK-NEXT: apply %{{.*}}(%[[SELF_VAL]])
+
+// CHECK: sil shared [transparent] @$sSo024NonCopyableHolderDerivedD0V1xSo0aB0Vvau : $@convention(method) (@inout NonCopyableHolderDerivedDerived) -> UnsafeMutablePointer<NonCopyable>
+// CHECK: function_ref @{{.*}}__synthesizedBaseCall___synthesizedBaseSetterAccessor{{.*}} : $@convention(cxx_method) (@inout NonCopyableHolderDerivedDerived) -> UnsafeMutablePointer<NonCopyable>

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -enable-experimental-cxx-interop %s -validate-tbd-against-ir=none | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none | %FileCheck %s
 
 import MoveOnlyCxxValueType
 

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
@@ -1,0 +1,36 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature NoncopyableGenerics)
+//
+// REQUIRES: executable_test
+
+import MoveOnlyCxxValueType
+import StdlibUnittest
+
+var MoveOnlyCxxValueType = TestSuite("Move Only Value Types + Generics")
+
+func borrowNC(_ x: borrowing NonCopyable) -> CInt {
+  return x.method(3)
+}
+
+func inoutNC(_ x: inout NonCopyable, _ y: CInt) -> CInt {
+  return x.mutMethod(y)
+}
+
+func consumingNC(_ x: consuming NonCopyable) {
+  // do nothing.
+}
+
+MoveOnlyCxxValueType.test("Test move only type ref return pointee borrow") {
+  var holder = NonCopyableHolder(11)
+  var k = borrowNC(holder.__returnNonCopyableRefUnsafe().pointee)
+  expectEqual(k, 33)
+  k = inoutNC(&holder.__returnMutNonCopyableRefUnsafe().pointee, 2)
+  expectEqual(k, 2)
+  k = borrowNC(holder.__returnMutNonCopyableRefUnsafe().pointee)
+  expectEqual(k, 6)
+  consumingNC(holder.__returnMutNonCopyableRefUnsafe().pointee)
+  k = borrowNC(holder.__returnNonCopyableRefUnsafe().pointee)
+  expectEqual(k, -123 * 3)
+}
+
+runAllTests()
+

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature NoncopyableGenerics)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature NoncopyableGenerics -O)
 //
 // REQUIRES: executable_test
 
@@ -27,9 +28,11 @@ MoveOnlyCxxValueType.test("Test move only type ref return pointee borrow") {
   expectEqual(k, 2)
   k = borrowNC(holder.__returnMutNonCopyableRefUnsafe().pointee)
   expectEqual(k, 6)
+#if ALLOW_CONSUME
   consumingNC(holder.__returnMutNonCopyableRefUnsafe().pointee)
   k = borrowNC(holder.__returnNonCopyableRefUnsafe().pointee)
   expectEqual(k, -123 * 3)
+#endif
 }
 
 runAllTests()

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
@@ -1,7 +1,8 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature NoncopyableGenerics)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature NoncopyableGenerics -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-none)
 //
 // REQUIRES: executable_test
+// REQUIRES: GH_ISSUE_70246
 
 import MoveOnlyCxxValueType
 import StdlibUnittest

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature NoncopyableGenerics)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-none)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature NoncopyableGenerics -O -Xfrontend -sil-verify-none)
 //
 // REQUIRES: executable_test
 // REQUIRES: GH_ISSUE_70246

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import MoveOnlyCxxValueType
+import StdlibUnittest
+
+var MoveOnlyCxxValueType = TestSuite("Move Only Value Types")
+
+MoveOnlyCxxValueType.test("Test move only type member access") {
+  var c = NonCopyable(2)
+  let k = c.method(-2)
+  expectEqual(k, -4)
+  expectEqual(c.method(1), 2)
+}
+
+runAllTests()
+

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -33,4 +33,21 @@ MoveOnlyCxxValueType.test("Test derived move only type member access") {
   expectEqual(k, -13)
 }
 
+func borrowNC(_ x: borrowing NonCopyable) -> CInt {
+  return x.method(3)
+}
+
+func inoutNC(_ x: inout NonCopyable, _ y: CInt) -> CInt {
+  return x.mutMethod(y)
+}
+
+MoveOnlyCxxValueType.test("Test move only field access in holder") {
+  var c = NonCopyableHolder(11)
+  var k = borrowNC(c.x)
+  expectEqual(k, 33)
+  k = inoutNC(&c.x, 7)
+  expectEqual(k, 7)
+  expectEqual(c.x.x, 7)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -48,6 +48,24 @@ MoveOnlyCxxValueType.test("Test move only field access in holder") {
   k = inoutNC(&c.x, 7)
   expectEqual(k, 7)
   expectEqual(c.x.x, 7)
+  c.x.x = 78
+  expectEqual(c.x.x, 78)
+  c.x.mutMethod(5)
+  expectEqual(c.x.x, 5)
+}
+
+MoveOnlyCxxValueType.test("Test move only field access in derived holder") {
+  var c = NonCopyableHolderDerivedDerived(-11)
+  var k = borrowNC(c.x)
+  expectEqual(k, -33)
+  expectEqual(c.getActualX(), -11)
+  k = inoutNC(&c.x, 7)
+  expectEqual(k, 7)
+  expectEqual(c.x.x, 7)
+  c.x.x = 78
+  expectEqual(c.x.x, 78)
+  c.x.mutMethod(5)
+  expectEqual(c.x.x, 5)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -9,10 +9,28 @@ var MoveOnlyCxxValueType = TestSuite("Move Only Value Types")
 
 MoveOnlyCxxValueType.test("Test move only type member access") {
   var c = NonCopyable(2)
-  let k = c.method(-2)
+  var k = c.method(-2)
   expectEqual(k, -4)
   expectEqual(c.method(1), 2)
+  k = c.x
+  expectEqual(k, 2)
+  c.x = -3
+  expectEqual(c.x, -3)
+  k = c.mutMethod(72)
+  expectEqual(k, 72)
+}
+
+MoveOnlyCxxValueType.test("Test derived move only type member access") {
+  var c = NonCopyableDerivedDerived(2)
+  var k = c.method(-3)
+  expectEqual(k, -6)
+  expectEqual(c.method(1), 2)
+  k = c.x
+  expectEqual(k, 2)
+  c.x = 11
+  expectEqual(c.x, 11)
+  k = c.mutMethod(-13)
+  expectEqual(k, -13)
 }
 
 runAllTests()
-

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -O)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -5,13 +5,7 @@
 // CHECK-NOT: StructWithPrivateDefaultedCopyConstructor
 // CHECK-NOT: StructWithInheritedPrivateDefaultedCopyConstructor
 // CHECK-NOT: StructWithSubobjectPrivateDefaultedCopyConstructor
-// CHECK-NOT: StructNonCopyableTriviallyMovable
-// CHECK-NOT: StructWithPointerNonCopyableTriviallyMovable
-// CHECK-NOT: StructWithPointerNonCopyableTriviallyMovableField
 // CHECK-NOT: StructNonCopyableNonMovable
-// CHECK-NOT: StructWithMoveConstructor
-// CHECK-NOT: StructWithInheritedMoveConstructor
-// CHECK-NOT: StructWithSubobjectMoveConstructor
 // CHECK-NOT: StructWithMoveAssignment
 // CHECK-NOT: StructWithInheritedMoveAssignment
 // CHECK-NOT: StructWithSubobjectMoveAssignment
@@ -23,6 +17,14 @@
 // CHECK-NOT: StructWithDeletedDestructor
 // CHECK-NOT: StructWithInheritedDeletedDestructor
 // CHECK-NOT: StructWithSubobjectDeletedDestructor
+
+// CHECK: struct StructWithMoveConstructor
+
+// CHECK: struct StructWithInheritedMoveConstructor
+
+// CHECK: struct StructWithSubobjectMoveConstructor
+
+// CHECK: struct StructNonCopyableTriviallyMovable
 
 // CHECK: struct Iterator {
 // CHECK: }

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -26,6 +26,9 @@
 
 // CHECK: struct StructNonCopyableTriviallyMovable
 
+// CHECK: struct StructWithPointerNonCopyableTriviallyMovable
+// CHECK: struct StructWithPointerNonCopyableTriviallyMovableField
+
 // CHECK: struct Iterator {
 // CHECK: }
 

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -skip-unsafe-cxx-methods -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s -check-prefix=CHECK-SKIP-UNSAFE
+// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -skip-unsafe-cxx-methods -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s -check-prefix=CHECK-SKIP-UNSAFE
 
 // Make sure we don't import objects that we can't copy or destroy.
 // CHECK-NOT: StructWithPrivateDefaultedCopyConstructor

--- a/test/Interop/Cxx/class/type-classification-typechecker.swift
+++ b/test/Interop/Cxx/class/type-classification-typechecker.swift
@@ -1,6 +1,6 @@
 // Test various aspects of the C++ `nodiscard` keyword.
 
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
 
 import TypeClassification
 

--- a/test/Interop/Cxx/class/type-classification-typechecker.swift
+++ b/test/Interop/Cxx/class/type-classification-typechecker.swift
@@ -1,0 +1,13 @@
+// Test various aspects of the C++ `nodiscard` keyword.
+
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+
+import TypeClassification
+
+func test() {
+  let x = StructCopyableMovableAnnotatedNonCopyable()
+  let v = copy x // expected-error {{'copy' cannot be applied to noncopyable types}}
+  _ = v
+}
+
+test()

--- a/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
+++ b/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
@@ -84,6 +84,15 @@ class SWIFT_UNCHECKED_SENDABLE UnsafeSendable {
 public:
 };
 
+class SWIFT_NONCOPYABLE NonCopyableCopyable {
+public:
+    NonCopyableCopyable(const NonCopyableCopyable &other) = default;
+    NonCopyableCopyable(NonCopyableCopyable &&other);
+    ~NonCopyableCopyable();
+private:
+    int x;
+};
+
 
 // CHECK: struct SelfContained {
 
@@ -106,3 +115,5 @@ public:
 // CHECK: struct ConformsTo : Proto {
 
 // CHECK: struct UnsafeSendable : @unchecked Sendable {
+
+// CHECK: struct NonCopyableCopyable

--- a/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
+++ b/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
@@ -8,6 +8,8 @@
 
 // RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=CxxModule -I %t -I %t/Inputs -I %swift_src_root/lib/ClangImporter -source-filename=x -enable-experimental-cxx-interop -Xcc -DINCMOD | %FileCheck %s
 
+// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=CxxModule -I %t -I %t/Inputs -I %swift_src_root/lib/ClangImporter -source-filename=x -cxx-interoperability-mode=upcoming-swift -Xcc -DINCMOD | %FileCheck --check-prefixes=CHECK,CHECKLATEST %s
+
 // Test through the use of the bridging header
 // RUN: %target-swift-frontend -emit-ir -I %t -import-objc-header %t/Inputs/header.h -I %swift_src_root/lib/ClangImporter -enable-experimental-cxx-interop -DBRIDGING_HEADER_TEST -disable-availability-checking %t/SwiftMod.swift
 
@@ -116,4 +118,4 @@ private:
 
 // CHECK: struct UnsafeSendable : @unchecked Sendable {
 
-// CHECK: struct NonCopyableCopyable
+// CHECKLATEST: struct NonCopyableCopyable

--- a/test/Interop/Cxx/operators/move-only/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/move-only/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module MoveOnlyCxxOperators {
+  header "move-only-cxx-value-operators.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
+++ b/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
@@ -74,4 +74,6 @@ using NonCopyableHolderMutDerefDerivedDerived = OneDerived<OneDerived<NonCopyabl
 
 using NonCopyableHolderValueConstDerefDerivedDerived = OneDerived<OneDerived<NonCopyableHolderValueConstDeref>>;
 
+using NonCopyableHolderValueMutDerefDerivedDerived = OneDerived<OneDerived<NonCopyableHolderValueMutDeref>>;
+
 #endif // TEST_INTEROP_CXX_OPERATORS_MOVE_ONLY_OPS_H

--- a/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
+++ b/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
@@ -35,4 +35,17 @@ class NonCopyableHolderConstDeref {
     inline const NonCopyable & operator *() const { return x; }
 };
 
+class NonCopyableHolderPairedDeref {
+    NONCOPYABLE_HOLDER_WRAPPER(NonCopyableHolderPairedDeref)
+
+    inline const NonCopyable & operator *() const { return x; }
+    inline NonCopyable & operator *() { return x; }
+};
+
+class NonCopyableHolderMutDeref {
+    NONCOPYABLE_HOLDER_WRAPPER(NonCopyableHolderMutDeref)
+
+    inline NonCopyable & operator *() { return x; }
+};
+
 #endif // TEST_INTEROP_CXX_OPERATORS_MOVE_ONLY_OPS_H

--- a/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
+++ b/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
@@ -1,0 +1,38 @@
+#ifndef TEST_INTEROP_CXX_OPERATORS_MOVE_ONLY_OPS_H
+#define TEST_INTEROP_CXX_OPERATORS_MOVE_ONLY_OPS_H
+
+#include <memory>
+
+struct Copyable {
+    int x;
+};
+
+struct NonCopyable {
+    inline NonCopyable(int x) : x(x) {}
+    inline NonCopyable(const NonCopyable &) = delete;
+    inline NonCopyable(NonCopyable &&other) : x(other.x) { other.x = 0; }
+
+    inline int method(int y) const { return x * y; }
+    inline int mutMethod(int y) {
+      x = y;
+      return y;
+    }
+
+    int x;
+};
+
+#define NONCOPYABLE_HOLDER_WRAPPER(Name) \
+private: \
+NonCopyable x; \
+public: \
+inline Name(int x) : x(x) {} \
+inline Name(const Name &) = delete; \
+inline Name(Name &&other) : x(std::move(other.x)) {}
+
+class NonCopyableHolderConstDeref {
+    NONCOPYABLE_HOLDER_WRAPPER(NonCopyableHolderConstDeref)
+
+    inline const NonCopyable & operator *() const { return x; }
+};
+
+#endif // TEST_INTEROP_CXX_OPERATORS_MOVE_ONLY_OPS_H

--- a/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
+++ b/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
@@ -48,4 +48,16 @@ class NonCopyableHolderMutDeref {
     inline NonCopyable & operator *() { return x; }
 };
 
+class NonCopyableHolderValueConstDeref {
+    NONCOPYABLE_HOLDER_WRAPPER(NonCopyableHolderValueConstDeref)
+
+    inline NonCopyable operator *() const { return NonCopyable(x.x); }
+};
+
+class NonCopyableHolderValueMutDeref {
+    NONCOPYABLE_HOLDER_WRAPPER(NonCopyableHolderValueMutDeref)
+
+    inline NonCopyable operator *() { return NonCopyable(x.x); }
+};
+
 #endif // TEST_INTEROP_CXX_OPERATORS_MOVE_ONLY_OPS_H

--- a/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
+++ b/test/Interop/Cxx/operators/move-only/Inputs/move-only-cxx-value-operators.h
@@ -60,4 +60,18 @@ class NonCopyableHolderValueMutDeref {
     inline NonCopyable operator *() { return NonCopyable(x.x); }
 };
 
+template<class T>
+class OneDerived: public T {
+public:
+    OneDerived(int x) : T(x) {}
+};
+
+using NonCopyableHolderConstDerefDerivedDerived = OneDerived<OneDerived<NonCopyableHolderConstDeref>>;
+
+using NonCopyableHolderPairedDerefDerivedDerived = OneDerived<OneDerived<NonCopyableHolderPairedDeref>>;
+
+using NonCopyableHolderMutDerefDerivedDerived = OneDerived<OneDerived<NonCopyableHolderMutDeref>>;
+
+using NonCopyableHolderValueConstDerefDerivedDerived = OneDerived<OneDerived<NonCopyableHolderValueConstDeref>>;
+
 #endif // TEST_INTEROP_CXX_OPERATORS_MOVE_ONLY_OPS_H

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import MoveOnlyCxxOperators
+import StdlibUnittest
+
+var MoveOnlyCxxOperators = TestSuite("Move Only Operators")
+
+func borrowNC(_ x: borrowing NonCopyable) -> CInt {
+  return x.method(3)
+}
+
+func inoutNC(_ x: inout NonCopyable, _ y: CInt) -> CInt {
+  return x.mutMethod(y)
+}
+
+func consumingNC(_ x: consuming NonCopyable) {
+  // do nothing.
+}
+
+MoveOnlyCxxOperators.test("NonCopyableHolderConstDeref pointee borrow") {
+  let holder = NonCopyableHolderConstDeref(11)
+  var k = borrowNC(holder.pointee)
+  expectEqual(k, 33)
+  k = holder.pointee.method(2)
+  expectEqual(k, 22)
+  k = holder.pointee.x
+  expectEqual(k, 11)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -O)
 //
 // REQUIRES: executable_test
 
@@ -44,8 +45,10 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderPairedDeref pointee borrow") {
   expectEqual(holder.pointee.x, 3)
   holder.pointee.x = 34
   expectEqual(holder.pointee.x, 34)
+#if SUPPORT_CONSUME
   consumingNC(holder.pointee)
   expectEqual(holder.pointee.x, 0)
+#endif
 }
 
 MoveOnlyCxxOperators.test("testNonCopyableHolderMutDeref pointee borrow") {
@@ -63,8 +66,10 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderMutDeref pointee borrow") {
   expectEqual(holder.pointee.x, 3)
   holder.pointee.x = 34
   expectEqual(holder.pointee.x, 34)
+#if SUPPORT_CONSUME
   consumingNC(holder.pointee)
   expectEqual(holder.pointee.x, 0)
+#endif
 }
 
 MoveOnlyCxxOperators.test("testNonCopyableHolderValueConstDeref pointee value") {
@@ -106,8 +111,10 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderPairedDerefDerivedDerived pointe
   expectEqual(holder.pointee.x, 3)
   holder.pointee.x = 34
   expectEqual(holder.pointee.x, 34)
+#if SUPPORT_CONSUME
   consumingNC(holder.pointee)
   expectEqual(holder.pointee.x, 0)
+#endif
 }
 
 MoveOnlyCxxOperators.test("testNonCopyableHolderMutDerefDerivedDerived pointee borrow") {
@@ -125,8 +132,10 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderMutDerefDerivedDerived pointee b
   expectEqual(holder.pointee.x, 3)
   holder.pointee.x = 34
   expectEqual(holder.pointee.x, 34)
+#if SUPPORT_CONSUME
   consumingNC(holder.pointee)
   expectEqual(holder.pointee.x, 0)
+#endif
 }
 
 MoveOnlyCxxOperators.test("testNonCopyableHolderValueConstDerefDerivedDerived pointee value") {

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -67,5 +67,18 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderMutDeref pointee borrow") {
   expectEqual(holder.pointee.x, 0)
 }
 
+MoveOnlyCxxOperators.test("testNonCopyableHolderValueConstDeref pointee value") {
+  let holder = NonCopyableHolderValueConstDeref(11)
+  var k = holder.pointee
+  var k2 = holder.pointee
+  expectEqual(k.x, k2.x)
+}
+
+MoveOnlyCxxOperators.test("testNonCopyableHolderValueMutDeref pointee value") {
+  var holder = NonCopyableHolderValueMutDeref(11)
+  var k = holder.pointee
+  var k2 = holder.pointee
+  expectEqual(k.x, k2.x)
+}
 
 runAllTests()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -81,4 +81,52 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderValueMutDeref pointee value") {
   expectEqual(k.x, k2.x)
 }
 
+MoveOnlyCxxOperators.test("NonCopyableHolderConstDerefDerivedDerived pointee borrow") {
+  let holder = NonCopyableHolderConstDerefDerivedDerived(11)
+  var k = borrowNC(holder.pointee)
+  expectEqual(k, 33)
+  k = holder.pointee.method(2)
+  expectEqual(k, 22)
+  k = holder.pointee.x
+  expectEqual(k, 11)
+}
+
+MoveOnlyCxxOperators.test("testNonCopyableHolderPairedDerefDerivedDerived pointee borrow") {
+  var holder = NonCopyableHolderPairedDerefDerivedDerived(11)
+  var k = borrowNC(holder.pointee)
+  expectEqual(k, 33)
+  k = holder.pointee.method(2)
+  expectEqual(k, 22)
+  k = holder.pointee.x
+  expectEqual(k, 11)
+  k = inoutNC(&holder.pointee, -1)
+  expectEqual(k, -1)
+  expectEqual(holder.pointee.x, -1)
+  holder.pointee.mutMethod(3)
+  expectEqual(holder.pointee.x, 3)
+  holder.pointee.x = 34
+  expectEqual(holder.pointee.x, 34)
+  consumingNC(holder.pointee)
+  expectEqual(holder.pointee.x, 0)
+}
+
+MoveOnlyCxxOperators.test("testNonCopyableHolderMutDerefDerivedDerived pointee borrow") {
+  var holder = NonCopyableHolderMutDerefDerivedDerived(11)
+  var k = borrowNC(holder.pointee)
+  expectEqual(k, 33)
+  k = holder.pointee.method(2)
+  expectEqual(k, 22)
+  k = holder.pointee.x
+  expectEqual(k, 11)
+  k = inoutNC(&holder.pointee, -1)
+  expectEqual(k, -1)
+  expectEqual(holder.pointee.x, -1)
+  holder.pointee.mutMethod(3)
+  expectEqual(holder.pointee.x, 3)
+  holder.pointee.x = 34
+  expectEqual(holder.pointee.x, 34)
+  consumingNC(holder.pointee)
+  expectEqual(holder.pointee.x, 0)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -129,4 +129,20 @@ MoveOnlyCxxOperators.test("testNonCopyableHolderMutDerefDerivedDerived pointee b
   expectEqual(holder.pointee.x, 0)
 }
 
+MoveOnlyCxxOperators.test("testNonCopyableHolderValueConstDerefDerivedDerived pointee value") {
+  let holder = NonCopyableHolderValueConstDerefDerivedDerived(11)
+  var k = holder.pointee
+  expectEqual(k.x, 11)
+  var k2 = holder.pointee
+  expectEqual(k.x, k2.x)
+}
+
+MoveOnlyCxxOperators.test("testNonCopyableHolderValueMutDerefDerivedDerived pointee value") {
+  let holder = NonCopyableHolderValueMutDerefDerivedDerived(23)
+  var k = holder.pointee
+  expectEqual(k.x, 23)
+  var k2 = holder.pointee
+  expectEqual(k.x, k2.x)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -29,4 +29,43 @@ MoveOnlyCxxOperators.test("NonCopyableHolderConstDeref pointee borrow") {
   expectEqual(k, 11)
 }
 
+MoveOnlyCxxOperators.test("testNonCopyableHolderPairedDeref pointee borrow") {
+  var holder = NonCopyableHolderPairedDeref(11)
+  var k = borrowNC(holder.pointee)
+  expectEqual(k, 33)
+  k = holder.pointee.method(2)
+  expectEqual(k, 22)
+  k = holder.pointee.x
+  expectEqual(k, 11)
+  k = inoutNC(&holder.pointee, -1)
+  expectEqual(k, -1)
+  expectEqual(holder.pointee.x, -1)
+  holder.pointee.mutMethod(3)
+  expectEqual(holder.pointee.x, 3)
+  holder.pointee.x = 34
+  expectEqual(holder.pointee.x, 34)
+  consumingNC(holder.pointee)
+  expectEqual(holder.pointee.x, 0)
+}
+
+MoveOnlyCxxOperators.test("testNonCopyableHolderMutDeref pointee borrow") {
+  var holder = NonCopyableHolderMutDeref(11)
+  var k = borrowNC(holder.pointee)
+  expectEqual(k, 33)
+  k = holder.pointee.method(2)
+  expectEqual(k, 22)
+  k = holder.pointee.x
+  expectEqual(k, 11)
+  k = inoutNC(&holder.pointee, -1)
+  expectEqual(k, -1)
+  expectEqual(holder.pointee.x, -1)
+  holder.pointee.mutMethod(3)
+  expectEqual(holder.pointee.x, 3)
+  holder.pointee.x = 34
+  expectEqual(holder.pointee.x, 34)
+  consumingNC(holder.pointee)
+  expectEqual(holder.pointee.x, 0)
+}
+
+
 runAllTests()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
@@ -33,4 +33,40 @@ func testNonCopyableHolderConstDerefPointee() {
 #endif
 }
 
+func testNonCopyableHolderPairedDerefPointee() {
+    var holder = NonCopyableHolderPairedDeref(11)
+    _ = borrowNC(holder.pointee) // ok
+    _ = holder.pointee.method(2)
+    _ = holder.pointee.x
+    _ = inoutNC(&holder.pointee)
+    _ = holder.pointee.mutMethod(1)
+    holder.pointee.x = 2
+    consumingNC(holder.pointee)
+    let consumeVal = holder.pointee
+    _ = borrowNC(consumeVal)
+}
+
+func testNonCopyableHolderMutDerefPointee() {
+    var holder = NonCopyableHolderMutDeref(11)
+    _ = borrowNC(holder.pointee) // ok
+    _ = holder.pointee.method(2)
+    _ = holder.pointee.x
+    _ = inoutNC(&holder.pointee)
+    _ = holder.pointee.mutMethod(1)
+    holder.pointee.x = 2
+    consumingNC(holder.pointee)
+    let consumeVal = holder.pointee
+    _ = borrowNC(consumeVal)
+}
+
+func testNonCopyableHolderMutDerefPointeeLet() {
+#if NO_CONSUME
+    let holder = NonCopyableHolderMutDeref(11) // expected-note {{}}
+    _ = borrowNC(holder.pointee) // expected-error {{cannot use mutating getter on immutable value: 'holder' is a 'let' constant}}
+#endif
+}
+
 testNonCopyableHolderConstDerefPointee()
+testNonCopyableHolderPairedDerefPointee()
+testNonCopyableHolderMutDerefPointee()
+testNonCopyableHolderMutDerefPointeeLet()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -DNO_CONSUME
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -DNO_CONSUME
 
 // Note: some errors need full SIL emission right now.
 // FIXME: they should be type checker errors.
-// RUN: not %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-emit-sil %s -I %S/Inputs -cxx-interoperability-mode=upcoming-swift 2>&1 | %FileCheck %s
 
 import MoveOnlyCxxOperators
 

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -DNO_CONSUME
+
+// Note: some errors need full SIL emission right now.
+// FIXME: they should be type checker errors.
+// RUN: not %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+
+import MoveOnlyCxxOperators
+
+func borrowNC(_ x: borrowing NonCopyable) -> CInt {
+  return x.method(3)
+}
+
+func inoutNC(_ x: inout NonCopyable) -> CInt {
+  return x.mutMethod(5)
+}
+
+func consumingNC(_ x: consuming NonCopyable) {
+  // do nothing.
+}
+
+func testNonCopyableHolderConstDerefPointee() {
+    var holder = NonCopyableHolderConstDeref(11)
+    _ = borrowNC(holder.pointee) // ok
+    _ = holder.pointee.method(2)
+    _ = holder.pointee.x
+#if NO_CONSUME
+    _ = inoutNC(holder.pointee)  // expected-error {{cannot pass immutable value as inout argument: 'pointee' is a get-only property}}
+    holder.pointee.mutMethod(1) // expected-error {{cannot use mutating member on immutable value: 'pointee' is a get-only property}}
+    holder.pointee.x = 2 // expected-error {{cannot assign to property: 'pointee' is a get-only property}}
+#else
+    consumingNC(holder.pointee) // CHECK: [[@LINE]]:{{.*}}: error:
+    let consumeVal = holder.pointee // CHECK: [[@LINE]]:{{.*}}: error:
+#endif
+}
+
+testNonCopyableHolderConstDerefPointee()

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
@@ -66,7 +66,27 @@ func testNonCopyableHolderMutDerefPointeeLet() {
 #endif
 }
 
+func testNonCopyableHolderValueConstDerefPointeeLet() {
+    let holder = NonCopyableHolderValueConstDeref(11)
+    let val = holder.pointee // expected-note {{}}
+    _ = borrowNC(val) // ok
+#if NO_CONSUME
+    val.mutMethod(3) // expected-error {{cannot use mutating member on immutable value: 'val' is a 'let' constant}}
+#endif
+}
+
+func testNonCopyableHolderValueMutDerefPointeeLet() {
+    var holder = NonCopyableHolderValueMutDeref(11)
+    let val = holder.pointee // expected-note {{}}
+    _ = borrowNC(val) // ok
+#if NO_CONSUME
+    val.mutMethod(3) // expected-error {{cannot use mutating member on immutable value: 'val' is a 'let' constant}}
+#endif
+}
+
 testNonCopyableHolderConstDerefPointee()
 testNonCopyableHolderPairedDerefPointee()
 testNonCopyableHolderMutDerefPointee()
 testNonCopyableHolderMutDerefPointeeLet()
+testNonCopyableHolderValueConstDerefPointeeLet()
+testNonCopyableHolderValueMutDerefPointeeLet()

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -28,3 +28,8 @@ module MsvcUseVecIt {
   requires cplusplus
   export *
 }
+
+module StdUniquePtr {
+  header "std-unique-ptr.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
@@ -1,0 +1,29 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H
+
+#include <memory>
+
+std::unique_ptr<int> makeInt() {
+  return std::make_unique<int>(42);
+}
+
+std::unique_ptr<int[]> makeArray() {
+  int *array = new int[3];
+  array[0] = 1;
+  array[1] = 2;
+  array[2] = 3;
+  return std::unique_ptr<int[]>(array);
+}
+
+static bool dtorCalled = false;
+struct HasDtor {
+  ~HasDtor() {
+    dtorCalled = true;
+  }
+};
+
+std::unique_ptr<HasDtor> makeDtor() {
+  return std::make_unique<HasDtor>();
+}
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_UNIQUE_PTR_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
@@ -20,7 +20,7 @@ struct HasDtor {
   HasDtor() = default;
 #if __is_target_os(windows)
   // On windows, force this type to be address-only.
-  HasDtor(const StructWithDestructor &other);
+  HasDtor(const HasDtor &other);
 #endif
   ~HasDtor() {
     dtorCalled = true;

--- a/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-unique-ptr.h
@@ -17,9 +17,16 @@ std::unique_ptr<int[]> makeArray() {
 
 static bool dtorCalled = false;
 struct HasDtor {
+  HasDtor() = default;
+#if __is_target_os(windows)
+  // On windows, force this type to be address-only.
+  HasDtor(const StructWithDestructor &other);
+#endif
   ~HasDtor() {
     dtorCalled = true;
   }
+private:
+  int x;
 };
 
 std::unique_ptr<HasDtor> makeDtor() {

--- a/test/Interop/Cxx/stdlib/std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/std-unique-ptr.swift
@@ -1,0 +1,42 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdUniquePtr
+#if os(Linux)
+import CxxStdlib
+// FIXME: import CxxStdlib.string once libstdc++ is split into submodules.
+#else
+import CxxStdlib.memory
+#endif
+
+var StdUniquePtrTestSuite = TestSuite("StdUniquePtr")
+
+StdUniquePtrTestSuite.test("int") {
+  let u = makeInt()
+  expectEqual(u.pointee, 42)
+}
+
+StdUniquePtrTestSuite.test("array") {
+  var u = makeArray()
+  expectEqual(u[0], 1)
+// Over consume:
+//  expectEqual(u[1], 2)
+//  expectEqual(u[2], 3)
+// Crash:
+//  u[0] = 10
+//  expectEqual(u[0], 10)
+}
+
+StdUniquePtrTestSuite.test("custom dtor") {
+  expectEqual(dtorCalled, false)
+  let c = {
+    _ = makeDtor()
+  }
+  c()
+  expectEqual(dtorCalled, true)
+}
+
+runAllTests()
+

--- a/test/Interop/Cxx/stdlib/std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/std-unique-ptr.swift
@@ -21,12 +21,10 @@ StdUniquePtrTestSuite.test("int") {
 StdUniquePtrTestSuite.test("array") {
   var u = makeArray()
   expectEqual(u[0], 1)
-// Over consume:
-//  expectEqual(u[1], 2)
-//  expectEqual(u[2], 3)
-// Crash:
-//  u[0] = 10
-//  expectEqual(u[0], 10)
+  expectEqual(u[1], 2)
+  expectEqual(u[2], 3)
+  u[0] = 10
+  expectEqual(u[0], 10)
 }
 
 StdUniquePtrTestSuite.test("custom dtor") {

--- a/test/Interop/Cxx/stdlib/std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/std-unique-ptr.swift
@@ -4,12 +4,7 @@
 
 import StdlibUnittest
 import StdUniquePtr
-#if os(Linux)
 import CxxStdlib
-// FIXME: import CxxStdlib.string once libstdc++ is split into submodules.
-#else
-import CxxStdlib.memory
-#endif
 
 var StdUniquePtrTestSuite = TestSuite("StdUniquePtr")
 

--- a/test/Interop/Cxx/stdlib/std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/std-unique-ptr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/std-unique-ptr.swift
@@ -2,6 +2,9 @@
 //
 // REQUIRES: executable_test
 
+// https://github.com/apple/swift/issues/70226
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import StdUniquePtr
 import CxxStdlib

--- a/test/Interop/Cxx/stdlib/std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/std-unique-ptr.swift
@@ -16,6 +16,8 @@ var StdUniquePtrTestSuite = TestSuite("StdUniquePtr")
 StdUniquePtrTestSuite.test("int") {
   let u = makeInt()
   expectEqual(u.pointee, 42)
+  u.pointee = -11
+  expectEqual(u.pointee, -11)
 }
 
 StdUniquePtrTestSuite.test("array") {


### PR DESCRIPTION
Still working on more testing and bug fixing. Some features require `-enable-experimental-feature NoncopyableGenerics`.