### PR TITLE
[Typed throws] Handle error conversions in other SILGen thunks

### DIFF
--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -221,13 +221,17 @@ void SILGenFunction::emitBackDeploymentThunk(SILDeclRef thunk) {
   // Generate the thunk prolog by collecting parameters.
   SmallVector<ManagedValue, 4> params;
   SmallVector<ManagedValue, 4> indirectParams;
-  collectThunkParams(loc, params, &indirectParams);
+  SmallVector<ManagedValue, 4> indirectErrorResults;
+  collectThunkParams(loc, params, &indirectParams, &indirectErrorResults);
 
   // Build up the list of arguments that we're going to invoke the the real
   // function with.
   SmallVector<SILValue, 8> paramsForForwarding;
   for (auto indirectParam : indirectParams) {
     paramsForForwarding.emplace_back(indirectParam.getLValueAddress());
+  }
+  for (auto indirectErrorResult : indirectErrorResults) {
+    paramsForForwarding.emplace_back(indirectErrorResult.getLValueAddress());
   }
 
   for (auto param : params) {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -758,7 +758,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
     CanAnyFunctionType::get(genericSig,
                             reqtSubstTy->getParams(),
                             reqtSubstTy.getResult(),
-                            reqtOrigTy->getExtInfo());
+                            reqtSubstTy->getExtInfo());
 
   // Coroutine lowering requires us to provide these substitutions
   // in order to recreate the appropriate yield types for the accessor


### PR DESCRIPTION
Ensure that we handle error conversions for the various forms of SILGen thunks, such as protocol witness thunks and vtable thunks.