### PR TITLE
corrected implementation of parsing nonisolated(unsafe) as decl contextual keyword in top-level global scope

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -43,6 +43,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include <algorithm>
+#include <initializer_list>
 
 using namespace swift;
 
@@ -5400,18 +5401,34 @@ bool swift::isKeywordPossibleDeclStart(const LangOptions &options,
   }
 }
 
-/// Given a current token of 'unowned', check to see if it is followed by a
-/// "(safe)" or "(unsafe)" specifier.
-static bool isParenthesizedUnowned(Parser &P) {
-  assert(P.Tok.getText() == "unowned" && P.peekToken().is(tok::l_paren) &&
+static bool
+isParenthesizedModifier(Parser &P, StringRef name,
+                        std::initializer_list<StringRef> allowedArguments) {
+  assert((P.Tok.getText() == name) && P.peekToken().is(tok::l_paren) &&
          "Invariant violated");
-  
+
   // Look ahead to parse the parenthesized expression.
   Parser::BacktrackingScope Backtrack(P);
   P.consumeToken(tok::identifier);
   P.consumeToken(tok::l_paren);
-  return P.Tok.is(tok::identifier) && P.peekToken().is(tok::r_paren) &&
-          (P.Tok.getText() == "safe" || P.Tok.getText() == "unsafe");
+
+  const bool argumentIsAllowed =
+      std::find(allowedArguments.begin(), allowedArguments.end(),
+                P.Tok.getText()) != allowedArguments.end();
+  return argumentIsAllowed && P.Tok.is(tok::identifier) &&
+         P.peekToken().is(tok::r_paren);
+}
+
+/// Given a current token of 'unowned', check to see if it is followed by a
+/// "(safe)" or "(unsafe)" specifier.
+static bool isParenthesizedUnowned(Parser &P) {
+  return isParenthesizedModifier(P, "unowned", {"safe", "unsafe"});
+}
+
+/// Given a current token of 'nonisolated', check to see if it is followed by an
+/// "(unsafe)" specifier.
+static bool isParenthesizedNonisolated(Parser &P) {
+  return isParenthesizedModifier(P, "nonisolated", {"unsafe"});
 }
 
 static void skipAttribute(Parser &P) {
@@ -5441,30 +5458,10 @@ static void skipAttribute(Parser &P) {
 
 bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes,
                                 bool hadAttrsOrModifiers) {
-  const bool isTopLevelLibrary = (SF.Kind == SourceFileKind::Library) ||
-                                 (SF.Kind == SourceFileKind::Interface) ||
-                                 (SF.Kind == SourceFileKind::SIL);
   if (Tok.is(tok::at_sign) && peekToken().is(tok::kw_rethrows)) {
     // @rethrows does not follow the general rule of @<identifier> so
     // it is needed to short circuit this else there will be an infinite
     // loop on invalid attributes of just rethrows
-  } else if (Context.LangOpts.hasFeature(Feature::GlobalConcurrency) &&
-             (Tok.getKind() == tok::identifier) &&
-             Tok.getText().equals("nonisolated") && isTopLevelLibrary &&
-             !CurDeclContext->isLocalContext()) {
-    // TODO: hack to unblock proposal review by treating top-level nonisolated
-    // contextual keyword like an attribute; more robust implementation pending
-    BacktrackingScope backtrack(*this);
-    skipAttribute(*this);
-
-    // If this attribute is the last element in the block,
-    // consider it is a start of incomplete decl.
-    if (Tok.isAny(tok::r_brace, tok::eof) ||
-        (Tok.is(tok::pound_endif) && !allowPoundIfAttributes))
-      return true;
-
-    return isStartOfSwiftDecl(allowPoundIfAttributes,
-                              /*hadAttrsOrModifiers=*/true);
   } else if (!isKeywordPossibleDeclStart(Context.LangOpts, Tok)) {
     // If this is obviously not the start of a decl, then we're done.
     return false;
@@ -5595,6 +5592,19 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes,
   if (Tok.getText() == "unowned" && Tok2.is(tok::l_paren) &&
       isParenthesizedUnowned(*this)) {
     Parser::BacktrackingScope Backtrack(*this);
+    consumeToken(tok::identifier);
+    consumeToken(tok::l_paren);
+    consumeToken(tok::identifier);
+    consumeToken(tok::r_paren);
+    return isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false,
+                              /*hadAttrsOrModifiers=*/true);
+  }
+
+  // If this is 'nonisolated', check to see if it is valid.
+  if (Context.LangOpts.hasFeature(Feature::GlobalConcurrency) &&
+      Tok.isContextualKeyword("nonisolated") && Tok2.is(tok::l_paren) &&
+      isParenthesizedNonisolated(*this)) {
+    BacktrackingScope backtrack(*this);
     consumeToken(tok::identifier);
     consumeToken(tok::l_paren);
     consumeToken(tok::identifier);


### PR DESCRIPTION
follow up to https://github.com/apple/swift/pull/69624