### PR TITLE
AST: Compute actor isolation when expanding semantic attributes

### DIFF
--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2050,7 +2050,8 @@ DeclAttributes SemanticDeclAttrsRequest::evaluate(Evaluator &evaluator,
                           {});
 
   // Trigger requests that cause additional semantic attributes to be added.
-  if (auto vd = dyn_cast<ValueDecl>(decl)) {
+  if (auto vd = dyn_cast<ValueDecl>(mutableDecl)) {
+    (void)getActorIsolation(vd);
     (void)vd->isDynamic();
     (void)vd->isFinal();
   }

--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -115,6 +115,12 @@ public protocol PublicProtoWithAssociatedType {
   func req() throws -> Int
 }
 
+extension MainActorProtocol {
+  public func req() throws -> Int {
+    return 1
+  }
+}
+
 protocol InternalProtoWithAssociatedType {
   associatedtype A
   func internalReq() -> A


### PR DESCRIPTION
Declarations may have semantic actor isolation requirements that were not written in source. For example, the default implementation of a protocol requirement must be `@MainActor` isolated if the protocol declaration itself is `@MainActor` isolated. When computing the semantic attributes of a declaration lazily, we must compute the actor isolation of the declaration to ensure that any global actor constraint attributes are added.

Also, avoid request cycles and recursive diagnostic emission by only triggering the computation of semantic attributes when printing for swiftinterfaces.

Resolves rdar://118277555
