### PR TITLE
SILGen: Skip emitting non-exportable initializer expressions

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1648,6 +1648,14 @@ void SILGenModule::emitDefaultArgGenerator(SILDeclRef constant,
 
 void SILGenModule::
 emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
+  // The SIL emitted for property init expressions is only needed by clients of
+  // resilient modules if the property belongs to a frozen type. When
+  // -experimental-skip-non-exportable-decls is specified, skip emitting
+  // property inits if possible.
+  if (M.getOptions().SkipNonExportableDecls &&
+      !pbd->getAnchoringVarDecl(i)->isInitExposedToClients())
+    return;
+
   auto *var = pbd->getAnchoringVarDecl(i);
   SILDeclRef constant(var, SILDeclRef::Kind::StoredPropertyInitializer);
   emitOrDelayFunction(constant);

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -205,6 +205,12 @@ struct GenGlobalAccessors : public PatternVisitor<GenGlobalAccessors>
 /// Emit a global initialization.
 void SILGenModule::emitGlobalInitialization(PatternBindingDecl *pd,
                                             unsigned pbdEntry) {
+  // The SIL emitted for global initialization is never needed clients of
+  // resilient modules, so skip it if -experimental-skip-non-exportable-decls
+  // is specified.
+  if (M.getOptions().SkipNonExportableDecls)
+    return;
+
   // Generic and dynamic static properties require lazy initialization, which
   // isn't implemented yet.
   if (pd->isStatic()) {

--- a/test/SILGen/skip-non-exportable-decls.swift
+++ b/test/SILGen/skip-non-exportable-decls.swift
@@ -85,6 +85,23 @@ private class PrivateClass {
 }
 
 public class PublicClass {
+  // CHECK-NO-SKIP: sil [transparent]{{.*}} @$s4Test11PublicClassC11internalVarSivpfi : $@convention(thin) () -> Int {
+  // CHECK-SKIP-NOT: s4Test11PublicClassC11internalVarSivpfi
+  // CHECK-NO-SKIP: sil hidden [transparent]{{.*}} @$s4Test11PublicClassC11internalVarSivg : $@convention(method) (@guaranteed PublicClass) -> Int {
+  // CHECK-SKIP-NOT: s4Test11PublicClassC11internalVarSivg
+  // CHECK-NO-SKIP: sil hidden [transparent]{{.*}} @$s4Test11PublicClassC11internalVarSivs : $@convention(method) (Int, @guaranteed PublicClass) -> () {
+  // CHECK-SKIP-NOT: s4Test11PublicClassC11internalVarSivs
+  // CHECK-NO-SKIP: sil hidden [transparent]{{.*}} @$s4Test11PublicClassC11internalVarSivM : $@yield_once @convention(method) (@guaranteed PublicClass) -> @yields @inout Int {
+  // CHECK-SKIP-NOT: s4Test11PublicClassC11internalVarSivM
+  var internalVar = 1
+
+  // CHECK-NO-SKIP: sil [transparent]{{.*}} @$s4Test11PublicClassC9publicVarSivpfi : $@convention(thin) () -> Int {
+  // CHECK-SKIP-NOT: s4Test11PublicClassC9publicVarSivpfi
+  // CHECK: sil [transparent] [serialized]{{.*}} @$s4Test11PublicClassC9publicVarSivg : $@convention(method) (@guaranteed PublicClass) -> Int {
+  // CHECK: sil [transparent] [serialized]{{.*}} @$s4Test11PublicClassC9publicVarSivs : $@convention(method) (Int, @guaranteed PublicClass) -> () {
+  // CHECK: sil [transparent] [serialized]{{.*}} @$s4Test11PublicClassC9publicVarSivM : $@yield_once @convention(method) (@guaranteed PublicClass) -> @yields @inout Int {
+  public var publicVar = 1
+
   // CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test11PublicClassC14internalMethodyyF : $@convention(method) (@guaranteed PublicClass) -> () {
   // CHECK-SKIP-NOT: s4Test11PublicClassC14internalMethodyyF
   internal func internalMethod() {}
@@ -106,6 +123,11 @@ extension PublicClass {
   internal func internalMethodInExtension() {}
 }
 
+@frozen public struct FrozenPublicStruct {
+  // CHECK: sil non_abi [transparent] [serialized]{{.*}} @$s4Test18FrozenPublicStructV11internalVarSivpfi : $@convention(thin) () -> Int {
+  var internalVar = 1
+}
+
 // CHECK-NO-SKIP-LABEL: sil_vtable PrivateClass {
 // CHECK-NO-SKIP-NEXT:    #PrivateClass.init!allocator
 // CHECK-NO-SKIP-NEXT:    #PrivateClass.deinit!deallocator
@@ -113,9 +135,20 @@ extension PublicClass {
 // CHECK-SKIP-NOT:      sil_vtable PrivateClass
 
 // CHECK-LABEL:         sil_vtable [serialized] PublicClass {
+// CHECK-NO-SKIP-NEXT:    #PublicClass.internalVar!getter
+// CHECK-SKIP-NOT:        #PublicClass.internalVar!getter
+// CHECK-NO-SKIP-NEXT:    #PublicClass.internalVar!setter
+// CHECK-SKIP-NOT:        #PublicClass.internalVar!setter
+// CHECK-NO-SKIP-NEXT:    #PublicClass.internalVar!modify
+// CHECK-SKIP-NOT:        #PublicClass.internalVar!modify
+// CHECK-NEXT:            #PublicClass.publicVar!getter
+// CHECK-NEXT:            #PublicClass.publicVar!setter
+// CHECK-NEXT:            #PublicClass.publicVar!modify
 // CHECK-NO-SKIP-NEXT:    #PublicClass.internalMethod
 // CHECK-SKIP-NOT:        #PublicClass.internalMethod
 // CHECK-NO-SKIP-NEXT:    #PublicClass.init!allocator
 // CHECK-SKIP-NOT:        #PublicClass.init!allocator
 // CHECK-NEXT:            #PublicClass.deinit!deallocator
 // CHECK-NEXT:          }
+
+// CHECK:               sil_property #PublicClass.publicVar ()

--- a/test/SILGen/skip-non-exportable-decls.swift
+++ b/test/SILGen/skip-non-exportable-decls.swift
@@ -4,6 +4,17 @@
 
 import Swift
 
+// CHECK-NO-SKIP: sil_global private @$s4Test17internalGlobalVar_Wz : $Builtin.Word
+// CHECK-SKIP-NOT: s4Test17internalGlobalVar_Wz
+
+// CHECK-NO-SKIP: sil_global hidden @$s4Test17internalGlobalVarSivp : $Int
+// CHECK-SKIP-NOT: s4Test17internalGlobalVarSivp
+
+// CHECK-NO-SKIP: sil_global private @$s4Test15publicGlobalVar_Wz : $Builtin.Word
+// CHECK-SKIP-NOT: s4Test15publicGlobalVar_Wz
+
+// CHECK: sil_global @$s4Test15publicGlobalVarSivp : $Int
+
 // CHECK-NO-SKIP: sil private{{.*}} @$s4Test11privateFunc33_E3F0E1C7B46D05C8067CB98677DE566CLLyyF : $@convention(thin) () -> () {
 // CHECK-SKIP-NOT: s4Test11privateFunc33_E3F0E1C7B46D05C8067CB98677DE566CLLyyF
 private func privateFunc() {}
@@ -35,6 +46,20 @@ public func publicFuncWithNestedFuncs() {
 
 // CHECK: sil [serialized]{{.*}} @$s4Test13inlinableFuncyyF : $@convention(thin) () -> () {
 @inlinable internal func inlinableFunc() {}
+
+// CHECK-NO-SKIP: sil private [global_init_once_fn]{{.*}} @$s4Test17internalGlobalVar_WZ : $@convention(c) (Builtin.RawPointer) -> () {
+// CHECK-SKIP-NOT: s4Test17internalGlobalVar_WZ
+
+// CHECK-NO-SKIP: sil hidden [global_init]{{.*}} @$s4Test17internalGlobalVarSivau : $@convention(thin) () -> Builtin.RawPointer {
+// CHECK-SKIP-NOT: s4Test17internalGlobalVarSivau
+internal var internalGlobalVar = 1
+
+// CHECK-NO-SKIP: sil private [global_init_once_fn]{{.*}} @$s4Test15publicGlobalVar_WZ : $@convention(c) (Builtin.RawPointer) -> () {
+// CHECK-SKIP-NOT: s4Test15publicGlobalVar_WZ
+
+// CHECK-NO-SKIP: sil [global_init]{{.*}} @$s4Test15publicGlobalVarSivau : $@convention(thin) () -> Builtin.RawPointer {
+// CHECK-SKIP-NOT: s4Test15publicGlobalVarSivau
+public var publicGlobalVar = 1
 
 // CHECK: sil [serialized]{{.*}} @$s4Test023inlinableFuncWithNestedC0yyF : $@convention(thin) () -> () {
 @inlinable internal func inlinableFuncWithNestedFunc() {


### PR DESCRIPTION
When `-experimental-skip-non-exportable-decls` is specified, the SIL for the initializers of global variables and stored properties may be skipped so long as the init is not exposed to clients (e.g. for a property in a `@frozen` type).