### PR TITLE
[Typed throws] Add compatibility carve-out within rethrows functions

### DIFF
--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -138,3 +138,11 @@ func testTryIncompatibleTyped(cond: Bool) throws(HomeworkError) {
     throw .forgot
   }
 }
+
+// "Rethrow-like" functions are only allowed to be called from rethrows
+// functions as a compatibility hack, which is removed under FullTypedThrows.
+func rethrowsLike<E>(_ body: () throws(E) -> Void) throws(E) { }
+
+func fromRethrows(body: () throws -> Void) rethrows {
+  try rethrowsLike(body) // expected-error{{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
+}


### PR DESCRIPTION
Allow a rethrows function to call a typed-throws function that has a specific form that looks like it only rethrows, i.e., it is generic over its thrown error type and carries the thrown error type from its closure parameters to itself. This is a compatibility carve-out to allow existing rethrows functions to move to typed throws without breaking their clients.

Note that it is possible to write a sneaky function that passes this check but throws when it shouldn't, so this compatibility carve-out is phased out with the upcoming feature FullTypedThrows.
