### PR TITLE
Revert "Add a mark_dependence while emitting SIL for uninitialized array allocation "

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
@@ -41,6 +41,7 @@ import SIL
 ///
 let objectOutliner = FunctionPass(name: "object-outliner") {
   (function: Function, context: FunctionPassContext) in
+
   for inst in function.instructions {
     if let ari = inst as? AllocRefInstBase {
       if let globalValue = optimizeObjectAllocation(allocRef: ari, context) {
@@ -82,10 +83,6 @@ private func findEndCOWMutation(of object: Value) -> EndCOWMutationInst? {
     switch use.instruction {
     case let uci as UpcastInst:
       if let ecm = findEndCOWMutation(of: uci) {
-        return ecm
-      }
-    case let urci as UncheckedRefCastInst:
-      if let ecm = findEndCOWMutation(of: urci) {
         return ecm
       }
     case let mv as MoveValueInst:
@@ -150,7 +147,7 @@ private func findInitStores(of object: Value,
         return false
       }
     default:
-      if !isValidUseOfObject(use) {
+      if !isValidUseOfObject(use.instruction) {
         return false
       }
     }
@@ -177,18 +174,6 @@ private func findStores(toTailAddress tailAddr: Value, tailElementIndex: Int, st
       if !findStores(inUsesOf: tea, index: tailElementIndex * numTupleElements + tupleIdx, stores: &stores) {
         return false
       }
-    case let atp as AddressToPointerInst:
-      if !findStores(toTailAddress: atp, tailElementIndex: tailElementIndex, stores: &stores) {
-        return false
-      }
-    case let mdi as MarkDependenceInst:
-      if !findStores(toTailAddress: mdi, tailElementIndex: tailElementIndex, stores: &stores) {
-        return false
-      }
-    case let pta as PointerToAddressInst:
-      if !findStores(toTailAddress: pta, tailElementIndex: tailElementIndex, stores: &stores) {
-        return false
-      }
     case let store as StoreInst:
       if store.source.type.isTuple {
         // This kind of SIL is never generated because tuples are stored with separated stores to tuple_element_addr.
@@ -199,7 +184,7 @@ private func findStores(toTailAddress tailAddr: Value, tailElementIndex: Int, st
         return false
       }
     default:
-      if !isValidUseOfObject(use) {
+      if !isValidUseOfObject(use.instruction) {
         return false
       }
     }
@@ -213,7 +198,7 @@ private func findStores(inUsesOf address: Value, index: Int, stores: inout [Stor
       if !handleStore(store, index: index, stores: &stores) {
         return false
       }
-    } else if !isValidUseOfObject(use) {
+    } else if !isValidUseOfObject(use.instruction) {
       return false
     }
   }
@@ -230,8 +215,7 @@ private func handleStore(_ store: StoreInst, index: Int, stores: inout [StoreIns
   return false
 }
 
-private func isValidUseOfObject(_ use: Operand) -> Bool {
-  let inst = use.instruction
+private func isValidUseOfObject(_ inst: Instruction) -> Bool {
   switch inst {
   case is DebugValueInst,
        is LoadInst,
@@ -241,17 +225,6 @@ private func isValidUseOfObject(_ use: Operand) -> Bool {
        is StrongReleaseInst,
        is FixLifetimeInst,
        is EndCOWMutationInst:
-    return true
-
-  case let mdi as MarkDependenceInst:
-    if (use == mdi.baseOperand) {
-      return true;
-    }
-    for mdiUse in mdi.uses {
-      if !isValidUseOfObject(mdiUse) {
-        return false
-      }
-    }
     return true
 
   case is StructElementAddrInst,
@@ -265,12 +238,9 @@ private func isValidUseOfObject(_ use: Operand) -> Bool {
        is UpcastInst,
        is BeginDeallocRefInst,
        is RefTailAddrInst,
-       is RefElementAddrInst,
-       is StructInst,
-       is PointerToAddressInst,
-       is IndexAddrInst:
-    for instUse in (inst as! SingleValueInstruction).uses {
-      if !isValidUseOfObject(instUse) {
+       is RefElementAddrInst:
+    for use in (inst as! SingleValueInstruction).uses {
+      if !isValidUseOfObject(use.instruction) {
         return false
       }
     }
@@ -372,8 +342,6 @@ private func rewriteUses(of startValue: Value, _ context: FunctionPassContext) {
       context.erase(instruction: endMutation)
     case let upCast as UpcastInst:
       worklist.pushIfNotVisited(usersOf: upCast)
-    case let urci as UncheckedRefCastInst:
-      worklist.pushIfNotVisited(usersOf: urci)
     case let moveValue as MoveValueInst:
       worklist.pushIfNotVisited(usersOf: moveValue)
     case is DeallocRefInst, is DeallocStackRefInst:

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6317,10 +6317,7 @@ SILGenFunction::emitUninitializedArrayAllocation(Type ArrayTy,
   SmallVector<ManagedValue, 2> resultElts;
   std::move(result).getAll(resultElts);
 
-  // Add a mark_dependence between the interior pointer and the array value
-  auto dependentValue = B.createMarkDependence(Loc, resultElts[1].getValue(),
-                                               resultElts[0].getValue());
-  return {resultElts[0], dependentValue};
+  return {resultElts[0], resultElts[1].getUnmanagedValue()};
 }
 
 /// Deallocate an uninitialized array.

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -841,8 +841,7 @@ bool swift::ArraySemanticsCall::mapInitializationStores(
     return false;
 
   // Match initialization stores into ElementBuffer. E.g.
-  // %82 = struct_extract %element_buffer : $UnsafeMutablePointer<Int>
-  // %83 = mark_dependence %82 : $Builtin.RawPointer on ArrayVal
+  // %83 = struct_extract %element_buffer : $UnsafeMutablePointer<Int>
   // %84 = pointer_to_address %83 : $Builtin.RawPointer to strict $*Int
   // store %85 to %84 : $*Int
   // %87 = integer_literal $Builtin.Word, 1
@@ -851,27 +850,12 @@ bool swift::ArraySemanticsCall::mapInitializationStores(
 
   // If this an ArrayUninitializedIntrinsic then the ElementBuffer is a
   // builtin.RawPointer. Otherwise, it is an UnsafeMutablePointer, which would
-  // be struct-extracted to obtain a builtin.RawPointer. In this case
-  // mark_dependence can be an operand of the struct_extract or its user.
-
-  SILValue UnsafeMutablePointerExtract;
-  if (getKind() == ArrayCallKind::kArrayUninitializedIntrinsic) {
-    UnsafeMutablePointerExtract = dyn_cast_or_null<MarkDependenceInst>(
-        getSingleNonDebugUser(ElementBuffer));
-  } else {
-    auto user = getSingleNonDebugUser(ElementBuffer);
-    // Match mark_dependence (struct_extract or
-    // struct_extract (mark_dependence
-    if (auto *MDI = dyn_cast_or_null<MarkDependenceInst>(user)) {
-      UnsafeMutablePointerExtract =
-          dyn_cast_or_null<StructExtractInst>(getSingleNonDebugUser(MDI));
-    } else {
-      if (auto *SEI = dyn_cast_or_null<StructExtractInst>(user)) {
-        UnsafeMutablePointerExtract =
-            dyn_cast_or_null<MarkDependenceInst>(getSingleNonDebugUser(SEI));
-      }
-    }
-  }
+  // be struct-extracted to obtain a builtin.RawPointer.
+  SILValue UnsafeMutablePointerExtract =
+      (getKind() == ArrayCallKind::kArrayUninitialized)
+          ? dyn_cast_or_null<StructExtractInst>(
+                getSingleNonDebugUser(ElementBuffer))
+          : ElementBuffer;
   if (!UnsafeMutablePointerExtract)
     return false;
 

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -429,15 +429,12 @@ void DifferentiableActivityInfo::setUsefulThroughArrayInitialization(
       continue;
     // The second tuple field of the return value is the `RawPointer`.
     for (auto use : dti->getResult(1)->getUses()) {
-      // The `RawPointer` passes through a `mark_dependence(pointer_to_address`.
-      // That instruction's first use is a `store` whose source is useful; its
+      // The `RawPointer` passes through a `pointer_to_address`. That
+      // instruction's first use is a `store` whose source is useful; its
       // subsequent uses are `index_addr`s whose only use is a useful `store`.
-      auto *mdi = dyn_cast<MarkDependenceInst>(use->getUser());
-      assert(
-          mdi &&
-          "Expected a mark_dependence user for uninitialized array intrinsic.");
-      auto *ptai = dyn_cast<PointerToAddressInst>(getSingleNonDebugUser(mdi));
-      assert(ptai && "Expected a pointer_to_address.");
+      auto *ptai = dyn_cast<PointerToAddressInst>(use->getUser());
+      assert(ptai && "Expected `pointer_to_address` user for uninitialized "
+                     "array intrinsic");
       setUseful(ptai, dependentVariableIndex);
       // Propagate usefulness through array element addresses:
       // `pointer_to_address` and `index_addr` instructions.

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -1312,8 +1312,7 @@ public:
         if (!origResult->getType().is<TupleType>()) {
           setTangentValue(bb, origResult,
                           makeConcreteTangentValue(differentialResult));
-        } else if (auto *dti =
-                       ai->getSingleUserOfType<DestructureTupleInst>()) {
+        } else if (auto *dti = getSingleDestructureTupleUser(ai)) {
           bool notSetValue = true;
           for (auto result : dti->getResults()) {
             if (activityInfo.isActive(result, getConfig())) {

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -3331,11 +3331,7 @@ void PullbackCloner::Implementation::
   builder.setCurrentDebugScope(remapScope(dti->getDebugScope()));
   builder.setInsertionPoint(arrayAdjoint->getParentBlock());
   for (auto use : dti->getResult(1)->getUses()) {
-    auto *mdi = dyn_cast<MarkDependenceInst>(use->getUser());
-    assert(mdi && "Expected mark_dependence user");
-    auto *ptai =
-        dyn_cast_or_null<PointerToAddressInst>(getSingleNonDebugUser(mdi));
-    assert(ptai && "Expected pointer_to_address user");
+    auto *ptai = dyn_cast<PointerToAddressInst>(use->getUser());
     auto adjBuf = getAdjointBuffer(origBB, ptai);
     auto *eltAdjBuf = getArrayAdjointElementBuffer(arrayAdjoint, 0, loc);
     builder.emitInPlaceAdd(loc, adjBuf, eltAdjBuf);

--- a/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
@@ -302,11 +302,6 @@ void ArrayInfo::classifyUsesOfArray(SILValue arrayValue) {
     // above as the array would be passed indirectly.
     if (isFixLifetimeUseOfArray(user, arrayValue))
       continue;
-    if (auto *MDI = dyn_cast<MarkDependenceInst>(user)) {
-      if (MDI->getBase() == arrayValue) {
-        continue;
-      }
-    }
     // Check if this is a forEach call on the array.
     if (TryApplyInst *forEachCall = isForEachUseOfArray(user, arrayValue)) {
       forEachCalls.insert(forEachCall);

--- a/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
@@ -127,12 +127,6 @@ bool ArrayAllocation::recursivelyCollectUses(ValueBase *Def) {
         isa<DebugValueInst>(User))
       continue;
 
-    if (auto *MDI = dyn_cast<MarkDependenceInst>(User)) {
-      if (Def == MDI->getBase()) {
-        continue;
-      }
-    }
-
     // Array value projection.
     if (auto *SEI = dyn_cast<StructExtractInst>(User)) {
       if (!recursivelyCollectUses(SEI))

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -616,13 +616,6 @@ recursivelyCollectInteriorUses(ValueBase *DefInst,
       AllUsers.insert(User);
       continue;
     }
-    if (auto *MDI = dyn_cast<MarkDependenceInst>(User)) {
-      if (!recursivelyCollectInteriorUses(MDI, AddressNode,
-                                          IsInteriorAddress)) {
-        return false;
-      }
-      continue;
-    }
     if (auto PTAI = dyn_cast<PointerToAddressInst>(User)) {
       // Only one pointer-to-address is allowed for safety.
       if (SeenPtrToAddr)
@@ -1170,15 +1163,9 @@ bool DeadObjectElimination::processAllocApply(ApplyInst *AI,
 
   LLVM_DEBUG(llvm::dbgs() << "    Success! Eliminating apply allocate(...).\n");
 
-  auto *ARI = dyn_cast<AllocRefInst>(AI->getArgument(0));
-
   deleter.forceDeleteWithUsers(AI);
   for (auto *toDelete : instsDeadAfterInitializerRemoved) {
     deleter.trackIfDead(toDelete);
-  }
-
-  if (ARI) {
-    deleter.forceDeleteWithUsers(ARI);
   }
 
   ++DeadAllocApplyEliminated;

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -528,9 +528,6 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
   if (auto *convertEscapeInst = dyn_cast<ConvertEscapeToNoEscapeInst>(value))
     return getConstantValue(convertEscapeInst->getOperand());
 
-  if (auto *mdi = dyn_cast<MarkDependenceInst>(value))
-    return getConstantValue(mdi->getValue());
-
   LLVM_DEBUG(llvm::dbgs() << "ConstExpr Unknown simple: " << *value << "\n");
 
   // Otherwise, we don't know how to handle this.

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -251,12 +251,11 @@ func testArrayUninitializedIntrinsic(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [ACTIVE]   %6 = apply %5<Float>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = mark_dependence %8 : $Builtin.RawPointer on %7 : $Array<Float>
-// CHECK: [ACTIVE]   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [VARIED]   %12 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %13 = index_addr %10 : $*Float, %12 : $Builtin.Word
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %16 = apply %15<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   %15 = apply %14<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 
 @differentiable(reverse where T: Differentiable)
 func testArrayUninitializedIntrinsicGeneric<T>(_ x: T, _ y: T) -> [T] {
@@ -271,12 +270,11 @@ func testArrayUninitializedIntrinsicGeneric<T>(_ x: T, _ y: T) -> [T] {
 // CHECK: [ACTIVE]   %6 = apply %5<T>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
 // CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<T>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = mark_dependence %8 : $Builtin.RawPointer on %7 : $Array<T>
-// CHECK: [ACTIVE]   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*T
-// CHECK: [VARIED]   %12 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %13 = index_addr %10 : $*T, %12 : $Builtin.Word
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*T
+// CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %12 = index_addr %9 : $*T, %11 : $Builtin.Word
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %16 = apply %15<T>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   %15 = apply %14<T>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 
 // TF-952: Test array literal initialized from an address (e.g. `var`).
 @differentiable(reverse)
@@ -299,14 +297,14 @@ func testArrayUninitializedIntrinsicAddress(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [ACTIVE]   %17 = apply %16<Float>(%15) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%18**, %19) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [VARIED] (%18, **%19**) = destructure_tuple %17 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %20 = mark_dependence %19 : $Builtin.RawPointer on %18 : $Array<Float>
-// CHECK: [ACTIVE]   %21 = pointer_to_address %20 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [ACTIVE]   %22 = begin_access [read] [static] %4 : $*Float
-// CHECK: [VARIED]   %25 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %26 = index_addr %21 : $*Float, %25 : $Builtin.Word
-// CHECK: [ACTIVE]   %27 = begin_access [read] [static] %4 : $*Float
+// CHECK: [ACTIVE]   %20 = pointer_to_address %19 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [ACTIVE]   %21 = begin_access [read] [static] %4 : $*Float
+// CHECK: [VARIED]   %24 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %25 = index_addr %20 : $*Float, %24 : $Builtin.Word
+// CHECK: [ACTIVE]   %26 = begin_access [read] [static] %4 : $*Float
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %31 = apply %30<Float>(%18) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   %30 = apply %29<Float>(%18) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+
 // TF-952: Test array literal initialized with `apply` direct results.
 @differentiable(reverse)
 func testArrayUninitializedIntrinsicFunctionResult(_ x: Float, _ y: Float) -> [Float] {
@@ -320,18 +318,16 @@ func testArrayUninitializedIntrinsicFunctionResult(_ x: Float, _ y: Float) -> [F
 // CHECK: [ACTIVE]   %6 = apply %5<Float>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = mark_dependence %8 : $Builtin.RawPointer on %7 : $Array<Float>
-// CHECK: [ACTIVE]   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [USEFUL]   %11 = metatype $@thin Float.Type
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
 // CHECK: [NONE]   // function_ref static Float.* infix(_:_:)
-// CHECK: [ACTIVE]   %13 = apply %12(%0, %1, %11) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
-// CHECK: [VARIED]   %15 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %16 = index_addr %10 : $*Float, %15 : $Builtin.Word
-// CHECK: [USEFUL]   %17 = metatype $@thin Float.Type
+// CHECK: [ACTIVE]   %12 = apply %11(%0, %1, %10) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK: [VARIED]   %14 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %15 = index_addr %9 : $*Float, %14 : $Builtin.Word
+// CHECK: [USEFUL]   %16 = metatype $@thin Float.Type
 // CHECK: [NONE]   // function_ref static Float.* infix(_:_:)
-// CHECK: [ACTIVE]   %19 = apply %18(%0, %1, %17) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK: [ACTIVE]   %18 = apply %17(%0, %1, %16) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %22 = apply %21<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   %21 = apply %20<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 
 // TF-975: Test nested array literals.
 @differentiable(reverse)
@@ -347,37 +343,33 @@ func testArrayUninitializedIntrinsicNested(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [ACTIVE]   %6 = apply %5<Float>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = mark_dependence %8 : $Builtin.RawPointer on %7 : $Array<Float>
-// CHECK: [ACTIVE]   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [VARIED]   %12 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %13 = index_addr %10 : $*Float, %12 : $Builtin.Word
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [VARIED]   %11 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %12 = index_addr %9 : $*Float, %11 : $Builtin.Word
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK:   %15 = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
-// CHECK: [ACTIVE]   %16 = apply %15<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
-// CHECK: [USEFUL]   %18 = integer_literal $Builtin.Word, 2
+// CHECK: [ACTIVE]   [[ARRAY:%.*]] = apply %14<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [USEFUL]   [[INT_LIT:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
-// CHECK:   %19 = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-// CHECK: [ACTIVE]   %20 = apply %19<Float>(%18) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-// CHECK: [ACTIVE] (**%21**, %22) = destructure_tuple %20 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED] (%21, **%22**) = destructure_tuple %20 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [VARIED]   %23 = mark_dependence %22 : $Builtin.RawPointer on %21 : $Array<Float>
-// CHECK: [ACTIVE]   %24 = pointer_to_address %23 : $Builtin.RawPointer to [strict] $*Float
-// CHECK: [USEFUL]   %25 = integer_literal $Builtin.IntLiteral, 0
-// CHECK: [USEFUL]   %26 = metatype $@thin Int.Type
+// CHECK: [ACTIVE]   [[TUP:%.*]] = apply %18<Float>([[INT_LIT]]) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: [ACTIVE] (**[[LHS:%.*]]**, [[RHS:%.*]]) = destructure_tuple [[TUP]] : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [VARIED] ([[LHS]], **[[RHS]]**) = destructure_tuple [[TUP]] : $(Array<Float>, Builtin.RawPointer)
+// CHECK: [ACTIVE]   [[FLOAT_PTR:%.*]] = pointer_to_address [[RHS]] : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [USEFUL]   [[ZERO_LITERAL:%.*]] = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   [[META:%.*]] = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   %28 = apply %27(%25, %26) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [USEFUL]   [[RESULT_2:%.*]] = apply %25([[ZERO_LITERAL]], [[META]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [NONE]   // function_ref Array.subscript.getter
-// CHECK: [NONE]   %30 = apply %29<Float>(%24, %28, %16) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
-// CHECK: [VARIED]   %31 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %32 = index_addr %24 : $*Float, %31 : $Builtin.Word
-// CHECK: [USEFUL]   %33 = integer_literal $Builtin.IntLiteral, 1
-// CHECK: [USEFUL]   %34 = metatype $@thin Int.Type
+// CHECK: [NONE]   %28 = apply %27<Float>([[FLOAT_PTR]], [[RESULT_2]], %15) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
+// CHECK: [VARIED]   [[ONE_LITERAL:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   [[INDEX_ADDR:%.*]] = index_addr [[FLOAT_PTR]] : $*Float, [[ONE_LITERAL]] : $Builtin.Word
+// CHECK: [USEFUL]   [[ONE_LITERAL_AGAIN:%.*]] = integer_literal $Builtin.IntLiteral, 1
+// CHECK: [USEFUL]   [[META_AGAIN:%.*]] = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   %36 = apply %35(%33, %34) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [USEFUL]   %34 = apply %33([[ONE_LITERAL_AGAIN]], [[META_AGAIN]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [NONE]   // function_ref Array.subscript.getter
-// CHECK: [NONE]   %38 = apply %37<Float>(%32, %36, %16) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
+// CHECK: [NONE]   %36 = apply %35<Float>(%30, %34, %15) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %40 = apply %39<Float>(%21) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   %38 = apply %37<Float>(%20) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 
 // TF-978: Test array literal initialized with `apply` indirect results.
 struct Wrapper<T: Differentiable>: Differentiable {
@@ -395,20 +387,19 @@ func testArrayUninitializedIntrinsicApplyIndirectResult<T>(_ x: T, _ y: T) -> [W
 // CHECK: [ACTIVE]   %6 = apply %5<Wrapper<T>>(%4) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**%7**, %8) = destructure_tuple %6 : $(Array<Wrapper<T>>, Builtin.RawPointer)
 // CHECK: [VARIED] (%7, **%8**) = destructure_tuple %6 : $(Array<Wrapper<T>>, Builtin.RawPointer)
-// CHECK: [VARIED]   %9 = mark_dependence %8 : $Builtin.RawPointer on %7 : $Array<Wrapper<T>>
-// CHECK: [ACTIVE]   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*Wrapper<T>
-// CHECK: [USEFUL]   %11 = metatype $@thin Wrapper<T>.Type
-// CHECK: [ACTIVE]   %12 = alloc_stack $T
+// CHECK: [ACTIVE]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Wrapper<T>
+// CHECK: [USEFUL]   %10 = metatype $@thin Wrapper<T>.Type
+// CHECK: [ACTIVE]   %11 = alloc_stack $T
 // CHECK: [NONE]   // function_ref Wrapper.init(value:)
-// CHECK: [NONE]   %15 = apply %14<T>(%10, %12, %11) : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in τ_0_0, @thin Wrapper<τ_0_0>.Type) -> @out Wrapper<τ_0_0>
-// CHECK: [VARIED]   %17 = integer_literal $Builtin.Word, 1
-// CHECK: [ACTIVE]   %18 = index_addr %10 : $*Wrapper<T>, %17 : $Builtin.Word
-// CHECK: [USEFUL]   %19 = metatype $@thin Wrapper<T>.Type
-// CHECK: [ACTIVE]   %20 = alloc_stack $T
+// CHECK: [NONE]   %14 = apply %13<T>(%9, %11, %10) : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in τ_0_0, @thin Wrapper<τ_0_0>.Type) -> @out Wrapper<τ_0_0>
+// CHECK: [VARIED]   %16 = integer_literal $Builtin.Word, 1
+// CHECK: [ACTIVE]   %17 = index_addr %9 : $*Wrapper<T>, %16 : $Builtin.Word
+// CHECK: [USEFUL]   %18 = metatype $@thin Wrapper<T>.Type
+// CHECK: [ACTIVE]   %19 = alloc_stack $T
 // CHECK: [NONE]   // function_ref Wrapper.init(value:)
-// CHECK: [NONE]   %23 = apply %22<T>(%18, %20, %19) : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in τ_0_0, @thin Wrapper<τ_0_0>.Type) -> @out Wrapper<τ_0_0>
+// CHECK: [NONE]   %22 = apply %21<T>(%17, %19, %18) : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in τ_0_0, @thin Wrapper<τ_0_0>.Type) -> @out Wrapper<τ_0_0>
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %26 = apply %25<Wrapper<T>>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   %25 = apply %24<Wrapper<T>>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 
 //===----------------------------------------------------------------------===//
 // `inout` argument differentiation
@@ -667,32 +658,31 @@ func testBeginApplyActiveButInitiallyNonactiveInoutArgument(x: Float) -> Float {
 // CHECK: [USEFUL]   %5 = apply %4<Float>(%3) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [USEFUL] (**%6**, %7) = destructure_tuple %5 : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [NONE] (%6, **%7**) = destructure_tuple %5 : $(Array<Float>, Builtin.RawPointer)
-// CHECK: [NONE]   %8 = mark_dependence %7 : $Builtin.RawPointer on %6 : $Array<Float> // user: %9
-// CHECK: [USEFUL]   %9 = pointer_to_address %8 : $Builtin.RawPointer to [strict] $*Float // user: %14
-// CHECK: [USEFUL]   %10 = integer_literal $Builtin.IntLiteral, 0    // user: %13
-// CHECK: [USEFUL]   %11 = metatype $@thin Float.Type                // user: %13
+// CHECK: [USEFUL]   %8 = pointer_to_address %7 : $Builtin.RawPointer to [strict] $*Float
+// CHECK: [USEFUL]   %9 = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   %10 = metatype $@thin Float.Type
 // CHECK: [NONE]   // function_ref Float.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   %13 = apply %12(%10, %11) : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float // user: %14
+// CHECK: [USEFUL]   %12 = apply %11(%9, %10) : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [USEFUL]   %16 = apply %15<Float>(%6) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0> // user: %17
-// CHECK: [USEFUL]   %18 = integer_literal $Builtin.IntLiteral, 0    // user: %21
-// CHECK: [USEFUL]   %19 = metatype $@thin Int.Type                  // user: %21
+// CHECK: [USEFUL]   %15 = apply %14<Float>(%6) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [USEFUL]   %17 = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   %18 = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   %21 = apply %20(%18, %19) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %24
-// CHECK: [ACTIVE]   %22 = begin_access [modify] [static] %2 : $*Array<Float> // users: %28, %24
+// CHECK: [USEFUL]   %20 = apply %19(%17, %18) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [ACTIVE]   %21 = begin_access [modify] [static] %2 : $*Array<Float>
 // CHECK: [NONE]   // function_ref Array.subscript.modify
-// CHECK: [ACTIVE] (**%24**, %25) = begin_apply %23<Float>(%21, %22) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0 // user: %26
-// CHECK: [VARIED] (%24, **%25**) = begin_apply %23<Float>(%21, %22) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0 // user: %27
-// CHECK: [USEFUL]   %29 = integer_literal $Builtin.IntLiteral, 0    // user: %32
-// CHECK: [USEFUL]   %30 = metatype $@thin Int.Type                  // user: %32
+// CHECK: [ACTIVE] (**%23**, %24) = begin_apply %22<Float>(%20, %21) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+// CHECK: [VARIED] (%23, **%24**) = begin_apply %22<Float>(%20, %21) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+// CHECK: [USEFUL]   %28 = integer_literal $Builtin.IntLiteral, 0
+// CHECK: [USEFUL]   %29 = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   %32 = apply %31(%29, %30) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %37
-// CHECK: [ACTIVE]   %33 = begin_access [read] [static] %2 : $*Array<Float> // users: %40, %34
-// CHECK: [ACTIVE]   %34 = load_borrow %33 : $*Array<Float>          // users: %39, %37
-// CHECK: [ACTIVE]   %35 = alloc_stack $Float                        // users: %41, %38, %37
+// CHECK: [USEFUL]   %31 = apply %30(%28, %29) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [ACTIVE]   %32 = begin_access [read] [static] %2 : $*Array<Float>
+// CHECK: [ACTIVE]   %33 = load_borrow %32 : $*Array<Float>
+// CHECK: [ACTIVE]   %34 = alloc_stack $Float
 // CHECK: [NONE]   // function_ref Array.subscript.getter
-// CHECK: [NONE]   %37 = apply %36<Float>(%35, %32, %34) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
-// CHECK: [ACTIVE]   %38 = load [trivial] %35 : $*Float              // user: %44
+// CHECK: [NONE]   %36 = apply %35<Float>(%34, %31, %33) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
+// CHECK: [ACTIVE]   %37 = load [trivial] %34 : $*Float
 
 //===----------------------------------------------------------------------===//
 // Class differentiation

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -614,8 +614,7 @@ func test_variadic(_ cat: Cat) throws {
 // CHECK:         [[T0:%.*]] = function_ref @$ss27_allocateUninitializedArray{{.*}}F
 // CHECK:         [[T1:%.*]] = apply [[T0]]<Cat>([[N]])
 // CHECK:         ([[ARRAY:%.*]], [[T2:%.*]]) = destructure_tuple [[T1]]
-// CHECK:         [[MDI:%.*]] = mark_dependence [[T2]]  : $Builtin.RawPointer on [[ARRAY]]
-// CHECK:         [[ELT0:%.*]] = pointer_to_address [[MDI]] : $Builtin.RawPointer to [strict] $*Cat
+// CHECK:         [[ELT0:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*Cat
 //   Element 0.
 // CHECK:         [[T0:%.*]] = function_ref @$s6errors10make_a_catAA3CatCyKF : $@convention(thin) () -> (@owned Cat, @error any Error)
 // CHECK:         try_apply [[T0]]() : $@convention(thin) () -> (@owned Cat, @error any Error), normal [[NORM_0:bb[0-9]+]], error [[ERR_0:bb[0-9]+]]

--- a/test/SILGen/literals.swift
+++ b/test/SILGen/literals.swift
@@ -52,8 +52,7 @@ class TakesArrayLiteral<Element> : ExpressibleByArrayLiteral {
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Int>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: store [[TMP:%.*]] to [trivial] [[POINTER]]
 // CHECK: [[IDX1:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK: [[POINTER1:%.*]] = index_addr [[POINTER]] : $*Int, [[IDX1]] : $Builtin.Word
@@ -77,8 +76,7 @@ class Klass {}
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Klass>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: [[KLASS_METATYPE:%.*]] = metatype $@thick Klass.Type
 // CHECK: [[CTOR:%.*]] = function_ref @$s8literals5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
 // CHECK: [[TMP:%.*]] = apply [[CTOR]]([[KLASS_METATYPE]]) : $@convention(method) (@thick Klass.Type) -> @owned Klass
@@ -102,8 +100,7 @@ struct Foo<T> {
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo<T>>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: copy_addr %0 to [init] [[POINTER]] : $*Foo<T>
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
 // CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<Foo<T>>([[ARR]])
@@ -120,8 +117,7 @@ func returnsAddressOnlyElementArray<T>(t: Foo<T>) -> TakesArrayLiteral<Foo<T>> {
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo<T>>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: copy_addr %0 to [init] [[POINTER]] : $*Foo<T>
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
 // CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<Foo<T>>([[ARR]])
@@ -140,8 +136,7 @@ extension Foo {
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo<T>>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] %0 : $*Foo<T>
 // CHECK: copy_addr [[ACCESS]] to [init] [[POINTER]] : $*Foo<T>
 // CHECK: end_access [[ACCESS]] : $*Foo<T>
@@ -166,8 +161,7 @@ struct Foo2 {
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo2>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: [[METATYPE_FOO2:%.*]] = metatype $@thin Foo2.Type
 // CHECK: [[METATYPE_KLASS:%.*]] = metatype $@thick Klass.Type
 // CHECK: [[CTOR:%.*]] = function_ref @$s8literals5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
@@ -191,8 +185,7 @@ func returnsNonTrivialStruct() -> TakesArrayLiteral<Foo2> {
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<NestedLValuePath>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0 : $*NestedLValuePath
 // CHECK: [[OTHER_FN:%.*]] = function_ref @$s8literals16NestedLValuePathV21otherMutatingFunctionACyF : $@convention(method) (@inout NestedLValuePath) -> @owned NestedLValuePath
@@ -230,8 +223,7 @@ protocol WrapsSelfInArray {}
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<any WrapsSelfInArray>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] %0 : $*Self
 // CHECK: [[EXISTENTIAL:%.*]] = init_existential_addr [[POINTER]] : $*any WrapsSelfInArray, $Self
 // CHECK: copy_addr [[ACCESS]] to [init] [[EXISTENTIAL]] : $*Self
@@ -260,8 +252,7 @@ func makeBasic<T : FooProtocol>() -> T { return T() }
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<T>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[POINTER:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: [[FN:%.*]] = function_ref @$s8literals9makeBasicxyAA11FooProtocolRzlF : $@convention(thin)
 // CHECK: [[TMP:%.*]] = apply [[FN]]<T>([[POINTER]])
 // CHECK: [[IDX:%.*]] = integer_literal $Builtin.Word, 1
@@ -294,8 +285,7 @@ class TakesDictionaryLiteral<Key, Value> : ExpressibleByDictionaryLiteral {
 // CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<(Int, Int)>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[ADDRESS]]
-// CHECK: [[TUPLE_ADDR:%.*]] = pointer_to_address [[MDI]] : $Builtin.RawPointer to [strict] $*(Int, Int)
+// CHECK: [[TUPLE_ADDR:%.*]] = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*(Int, Int)
 // CHECK: [[KEY_ADDR:%.*]] = tuple_element_addr [[TUPLE_ADDR]] : $*(Int, Int), 0
 // CHECK: [[VALUE_ADDR:%.*]] = tuple_element_addr [[TUPLE_ADDR]] : $*(Int, Int), 1
 // CHECK: store [[TMP]] to [trivial] [[KEY_ADDR]] : $*Int

--- a/test/SILGen/objc_bridging_array.swift
+++ b/test/SILGen/objc_bridging_array.swift
@@ -22,8 +22,7 @@ func setChildren(p: Parent, c: Child) {
 // CHECK: [[FN:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [[ARRAY_AND_BUFFER:%.*]] = apply [[FN]]<Child>([[LENGTH]]) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: ([[ARRAY:%.*]], [[BUFFER_PTR:%.*]]) = destructure_tuple [[ARRAY_AND_BUFFER]] : $(Array<Child>, Builtin.RawPointer)
-// CHECK: [[MDI:%.*]] = mark_dependence [[BUFFER_PTR]] : $Builtin.RawPointer on [[ARRAY]]
-// CHECK: [[BUFFER:%.*]] = pointer_to_address [[MDI]] : $Builtin.RawPointer to [strict] $*Child
+// CHECK: [[BUFFER:%.*]] = pointer_to_address [[BUFFER_PTR]] : $Builtin.RawPointer to [strict] $*Child
 // CHECK: [[CHILD:%.*]] = copy_value %1 : $Child
 // CHECK: store [[CHILD]] to [init] [[BUFFER]] : $*Child
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -55,8 +55,7 @@ tupleWithDefaults(x: (x,x))
 
 // CHECK: [[ALLOC_ARRAY:%.*]] = apply {{.*}} -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: ([[ARRAY:%.*]], [[MEMORY:%.*]]) = destructure_tuple [[ALLOC_ARRAY]]
-// CHECK: [[MDI:%.*]] = mark_dependence [[MEMORY]]
-// CHECK: [[ADDR:%.*]] = pointer_to_address [[MDI]]
+// CHECK: [[ADDR:%.*]] = pointer_to_address [[MEMORY]]
 // CHECK: [[READ:%.*]] = begin_access [read] [dynamic] [[X_ADDR]] : $*Int
 // CHECK: copy_addr [[READ]] to [init] [[ADDR]]
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF

--- a/test/SILOptimizer/array_count_propagation.sil
+++ b/test/SILOptimizer/array_count_propagation.sil
@@ -49,8 +49,7 @@ bb0:
  %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %6 = apply %5(%2, %3, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %7 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 0
- %8a = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
- %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+ %8 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
  debug_value %7 : $MyArray<MyInt>
  %f = function_ref @finalize : $@convention(thin) (@owned MyArray<MyInt>) -> @owned MyArray<MyInt>
  %a = apply %f(%7) : $@convention(thin) (@owned MyArray<MyInt>) -> @owned MyArray<MyInt>
@@ -77,8 +76,7 @@ bb0:
  %5 = function_ref @allocateUninitialized : $@convention(thin) (MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %6 = apply %5(%3, %4) : $@convention(thin) (MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %7 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 0
- %8a = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
- %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+ %8 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
  debug_value %7 : $MyArray<MyInt>
  %9 = function_ref @getCount : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyInt
  %10 = apply %9(%7) : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyInt
@@ -143,8 +141,7 @@ bb0:
  %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %6 = apply %5(%2, %3, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %7 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 0
- %8a = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
- %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+ %8 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
  store %7 to %15 : $*MyArray<MyInt>
  debug_value %7 : $MyArray<MyInt>
  %9 = function_ref @getCount : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyInt
@@ -174,8 +171,7 @@ bb0:
  %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %6 = apply %5(%2, %3, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %7 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 0
- %8a = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
- %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+ %8 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
  debug_value %7 : $MyArray<MyInt>
  %15 = function_ref @mayWrite : $@convention(thin) (@guaranteed MyArray<MyInt>) -> ()
  %16 = apply %15(%7) : $@convention(thin) (@guaranteed MyArray<MyInt>) -> ()

--- a/test/SILOptimizer/array_count_propagation_ossa.sil
+++ b/test/SILOptimizer/array_count_propagation_ossa.sil
@@ -50,8 +50,7 @@ bb0:
  %4 = metatype $@thin MyArray<MyInt>.Type
  %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %6 = apply %5(%2, %3, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
- (%7, %8a) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
- %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+ (%7, %8) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  debug_value %7 : $MyArray<MyInt>
  %f = function_ref @finalize : $@convention(thin) (@owned MyArray<MyInt>) -> @owned MyArray<MyInt>
  %a = apply %f(%7) : $@convention(thin) (@owned MyArray<MyInt>) -> @owned MyArray<MyInt>
@@ -74,8 +73,7 @@ bb0:
  %4 = metatype $@thin MyArray<MyInt>.Type
  %5 = function_ref @allocateUninitialized : $@convention(thin) (MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %6 = apply %5(%3, %4) : $@convention(thin) (MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
- (%7, %8a) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
- %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+ (%7, %8) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  debug_value %7 : $MyArray<MyInt>
  %9 = function_ref @getCount : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyInt
  %10 = apply %9(%7) : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyInt
@@ -130,8 +128,7 @@ bb0:
  %4 = metatype $@thin MyArray<MyInt>.Type
  %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %6 = apply %5(%2, %3, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
- (%7, %8a) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
- %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+ (%7, %8) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %copy7 = copy_value %7 : $MyArray<MyInt>
  debug_value %7 : $MyArray<MyInt>
  store %7 to [init] %15 : $*MyArray<MyInt>
@@ -158,8 +155,7 @@ bb0:
  %4 = metatype $@thin MyArray<MyInt>.Type
  %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  %6 = apply %5(%2, %3, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
- (%7, %8a) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
- %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+ (%7, %8) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
  debug_value %7 : $MyArray<MyInt>
  %15 = function_ref @mayWrite : $@convention(thin) (@guaranteed MyArray<MyInt>) -> ()
  %16 = apply %15(%7) : $@convention(thin) (@guaranteed MyArray<MyInt>) -> ()

--- a/test/SILOptimizer/array_element_propagation.sil
+++ b/test/SILOptimizer/array_element_propagation.sil
@@ -70,8 +70,7 @@ sil @propagate_with_get_element_returning_direct_result : $@convention(thin) () 
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %7 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 0
-  %8a = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+  %8 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
   debug_value %7 : $MyArray<MyInt>
   debug_value %8 : $UnsafeMutablePointer<MyInt>
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
@@ -145,8 +144,7 @@ sil @repeated_initialization : $@convention(thin) () -> () {
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %7 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 0
-  %8a = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+  %8 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
   %11 = integer_literal $Builtin.Int64, 0
@@ -195,8 +193,7 @@ sil @unknown_use : $@convention(thin) () -> () {
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %7 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 0
-  %8a = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+  %8 = tuple_extract %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>), 1
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
   %11 = integer_literal $Builtin.Int64, 0
@@ -243,8 +240,7 @@ sil @append_contentsOf_int : $@convention(thin) () -> () {
   %5 = function_ref @arrayAdoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
   %7 = tuple_extract %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>), 0
-  %8a = tuple_extract %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>), 1
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $Array<MyInt>
+  %8 = tuple_extract %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>), 1
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
   %11 = integer_literal $Builtin.Int64, 27
@@ -293,8 +289,7 @@ bb0(%0 : $*Array<Hello>, %1 : $Hello):
   %9 = function_ref @adoptStorageHello : $@convention(method) (@owned _ContiguousArrayStorage<Hello>, MyInt, @thin Array<Hello>.Type) -> (@owned Array<Hello>, UnsafeMutablePointer<Hello>)
   %10 = apply %9(%7, %6, %8) : $@convention(method) (@owned _ContiguousArrayStorage<Hello>, MyInt, @thin Array<Hello>.Type) -> (@owned Array<Hello>, UnsafeMutablePointer<Hello>)
   %11 = tuple_extract %10 : $(Array<Hello>, UnsafeMutablePointer<Hello>), 0
-  %12a = tuple_extract %10 : $(Array<Hello>, UnsafeMutablePointer<Hello>), 1
-  %12 = mark_dependence %12a : $UnsafeMutablePointer<Hello> on %7 : $_ContiguousArrayStorage<Hello>
+  %12 = tuple_extract %10 : $(Array<Hello>, UnsafeMutablePointer<Hello>), 1
   %13 = struct_extract %12 : $UnsafeMutablePointer<Hello>, #UnsafeMutablePointer._rawValue
   %22 = pointer_to_address %13 : $Builtin.RawPointer to [strict] $*Hello
   strong_retain %1 : $Hello

--- a/test/SILOptimizer/array_element_propagation_ossa.sil
+++ b/test/SILOptimizer/array_element_propagation_ossa.sil
@@ -68,8 +68,7 @@ sil [ossa] @propagate_with_get_element_returning_direct_result : $@convention(th
   %4 = metatype $@thin MyArray<MyInt>.Type
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-  (%7, %8a) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+  (%7, %8) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   debug_value %7 : $MyArray<MyInt>
   debug_value %8 : $UnsafeMutablePointer<MyInt>
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
@@ -139,8 +138,7 @@ sil [ossa] @repeated_initialization : $@convention(thin) () -> () {
   %4 = metatype $@thin MyArray<MyInt>.Type
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-  (%7, %8a) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+  (%7, %8) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
   %11 = integer_literal $Builtin.Int64, 0
@@ -187,8 +185,7 @@ sil [ossa] @unknown_use : $@convention(thin) () -> () {
   %4 = metatype $@thin MyArray<MyInt>.Type
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-  (%7, %8a) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+  (%7, %8) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
   %11 = integer_literal $Builtin.Int64, 0
@@ -236,8 +233,7 @@ sil [ossa] @append_contentsOf_int : $@convention(thin) () -> () {
   %4 = metatype $@thin Array<MyInt>.Type
   %5 = function_ref @arrayAdoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
-  (%7, %8a) = destructure_tuple %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>)
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $Array<MyInt>
+  (%7, %8) = destructure_tuple %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>)
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
   %11 = integer_literal $Builtin.Int64, 27
@@ -261,7 +257,7 @@ sil [ossa] @append_contentsOf_int : $@convention(thin) () -> () {
 // CHECK-LABEL: sil [ossa] @negative_index
 // CHECK: store %{{[0-9]+}} to [trivial]
 // CHECK: [[GETF:%.*]] = function_ref @getElement : $@convention(method) (MyInt, MyBool, _MyDependenceToken, @guaranteed MyArray<MyInt>) -> MyInt
-// CHECK: apply [[GETF]](%16, %18, %20, %7) : $@convention(method) (MyInt, MyBool, _MyDependenceToken, @guaranteed MyArray<MyInt>) -> MyInt
+// CHECK: apply [[GETF]](%15, %17, %19, %7) : $@convention(method) (MyInt, MyBool, _MyDependenceToken, @guaranteed MyArray<MyInt>) -> MyInt
 // CHECK-LABEL: // end sil function 'negative_index'
 sil [ossa] @negative_index : $@convention(thin) () -> () {
 bb0:
@@ -272,8 +268,7 @@ bb0:
   %4 = metatype $@thin MyArray<MyInt>.Type
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin MyArray<MyInt>.Type) -> @owned (MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-  (%7, %8a) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyInt> on %7 : $MyArray<MyInt>
+  (%7, %8) = destructure_tuple %6 : $(MyArray<MyInt>, UnsafeMutablePointer<MyInt>)
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
   %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
   %11 = integer_literal $Builtin.Int64, 0

--- a/test/SILOptimizer/array_element_propagation_ossa_nontrivial.sil
+++ b/test/SILOptimizer/array_element_propagation_ossa_nontrivial.sil
@@ -68,8 +68,7 @@ bb0(%arg0 : @owned $MyKlass, %arg1 : @owned $MyKlass, %arg2 : @owned $MyKlass):
   %4 = metatype $@thin MyArray<MyKlass>.Type
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned _ContiguousArrayStorage<MyKlass>, MyInt, @thin MyArray<MyKlass>.Type) -> @owned (MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned _ContiguousArrayStorage<MyKlass>, MyInt, @thin MyArray<MyKlass>.Type) -> @owned (MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
-  (%7, %8a) = destructure_tuple %6 : $(MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyKlass> on %7 : $MyArray<MyKlass>
+  (%7, %8) = destructure_tuple %6 : $(MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
   debug_value %7 : $MyArray<MyKlass>
   debug_value %8 : $UnsafeMutablePointer<MyKlass>
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyKlass>, #UnsafeMutablePointer._rawValue
@@ -144,8 +143,7 @@ bb0(%arg0 : @owned $MyKlass, %arg1 : @owned $MyKlass, %arg2 : @owned $MyKlass):
   %4 = metatype $@thin MyArray<MyKlass>.Type
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned _ContiguousArrayStorage<MyKlass>, MyInt, @thin MyArray<MyKlass>.Type) -> @owned (MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned _ContiguousArrayStorage<MyKlass>, MyInt, @thin MyArray<MyKlass>.Type) -> @owned (MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
-  (%7, %8a) = destructure_tuple %6 : $(MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyKlass> on %7 : $MyArray<MyKlass>
+  (%7, %8) = destructure_tuple %6 : $(MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
   debug_value %7 : $MyArray<MyKlass>
   debug_value %8 : $UnsafeMutablePointer<MyKlass>
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyKlass>, #UnsafeMutablePointer._rawValue
@@ -215,8 +213,7 @@ bb0(%arg0 : @owned $MyKlass):
   %4 = metatype $@thin MyArray<MyKlass>.Type
   %5 = function_ref @adoptStorage : $@convention(thin) (@owned _ContiguousArrayStorage<MyKlass>, MyInt, @thin MyArray<MyKlass>.Type) -> @owned (MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
   %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned _ContiguousArrayStorage<MyKlass>, MyInt, @thin MyArray<MyKlass>.Type) -> @owned (MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
-  (%7, %8a) = destructure_tuple %6 : $(MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
-  %8 = mark_dependence %8a : $UnsafeMutablePointer<MyKlass> on %7 : $MyArray<MyKlass>
+  (%7, %8) = destructure_tuple %6 : $(MyArray<MyKlass>, UnsafeMutablePointer<MyKlass>)
   debug_value %7 : $MyArray<MyKlass>
   debug_value %8 : $UnsafeMutablePointer<MyKlass>
   %9 = struct_extract %8 : $UnsafeMutablePointer<MyKlass>, #UnsafeMutablePointer._rawValue
@@ -275,8 +272,7 @@ bb0(%0 : $*Array<MyKlass>, %1 : @owned $MyKlass):
   %8 = metatype $@thin Array<MyKlass>.Type
   %9 = function_ref @adoptStorageMyKlass : $@convention(method) (@owned _ContiguousArrayStorage<MyKlass>, MyInt, @thin Array<MyKlass>.Type) -> (@owned Array<MyKlass>, UnsafeMutablePointer<MyKlass>)
   %10 = apply %9(%7, %6, %8) : $@convention(method) (@owned _ContiguousArrayStorage<MyKlass>, MyInt, @thin Array<MyKlass>.Type) -> (@owned Array<MyKlass>, UnsafeMutablePointer<MyKlass>)
-  (%11, %12a) = destructure_tuple %10 : $(Array<MyKlass>, UnsafeMutablePointer<MyKlass>)
-  %12 = mark_dependence %12a : $UnsafeMutablePointer<MyKlass> on %11 : $Array<MyKlass>
+  (%11, %12) = destructure_tuple %10 : $(Array<MyKlass>, UnsafeMutablePointer<MyKlass>)
   %13 = struct_extract %12 : $UnsafeMutablePointer<MyKlass>, #UnsafeMutablePointer._rawValue
   %22 = pointer_to_address %13 : $Builtin.RawPointer to [strict] $*MyKlass
   %copy1 = copy_value %1 : $MyKlass

--- a/test/SILOptimizer/castoptimizer-wrongscope.swift
+++ b/test/SILOptimizer/castoptimizer-wrongscope.swift
@@ -7,7 +7,7 @@
 
 // CHECK: alloc_stack $any R, loc {{.*}}, scope [[SCOPE:[0-9]+]]
 // CHECK-NEXT: init_existential_addr {{.*}} : $*any R, $Float, loc {{.*}}, scope [[SCOPE]]
-// CHECK-NEXT: copy_addr [take] %9 to [init] {{.*}} : $*Float, loc {{.*}}, scope [[SCOPE]]
+// CHECK-NEXT: copy_addr [take] %8 to [init] {{.*}} : $*Float, loc {{.*}}, scope [[SCOPE]]
 
 protocol R {}
 extension Float: R {}

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -1241,7 +1241,6 @@ bb0:
   %1 = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
   %2 = apply %1<String>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
   (%3, %4) = destructure_tuple %2 : $(Array<String>, Builtin.RawPointer)
-  %5 = mark_dependence %4 : $Builtin.RawPointer on %3 : $Array<String>
   return %3 : $Array<String>
 } // CHECK: Returns Array<String>
   // CHECK: size: 0 contents []

--- a/test/SILOptimizer/dead_array_elim.swift
+++ b/test/SILOptimizer/dead_array_elim.swift
@@ -58,16 +58,14 @@ func testDeadArrayElimWithAddressOnlyValues<T>(x: T, y: T) {
   _ = [x, y]
 }
 
-// Adding mark_dependence to array allocate caused this test to break
-// RLE needs to handle the new init pattern - rdar://117751668
-// TODO-LABEL: sil hidden {{.*}}@$s15dead_array_elim31testDeadArrayAfterOptimizationsySiSSF
-// TODO:      bb0(%0 : $String):
-// TODO-NEXT:   debug_value
-// TODO-NEXT:   integer_literal $Builtin.Int{{[0-9]+}}, 21
-// TODO-NEXT:   debug_value
-// TODO-NEXT:   struct $Int
-// TODO-NEXT:   return
-// TODO:      } // end sil function '$s15dead_array_elim31testDeadArrayAfterOptimizationsySiSSF'
+// CHECK-LABEL: sil hidden {{.*}}@$s15dead_array_elim31testDeadArrayAfterOptimizationsySiSSF
+// CHECK:      bb0(%0 : $String):
+// CHECK-NEXT:   debug_value
+// CHECK-NEXT:   integer_literal $Builtin.Int{{[0-9]+}}, 21
+// CHECK-NEXT:   debug_value
+// CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   return
+// CHECK:      } // end sil function '$s15dead_array_elim31testDeadArrayAfterOptimizationsySiSSF'
 func testDeadArrayAfterOptimizations(_ stringParameter: String) -> Int {
   var sum = 0
   for x in [(1, "hello"),

--- a/test/SILOptimizer/for_each_loop_unroll_test.sil
+++ b/test/SILOptimizer/for_each_loop_unroll_test.sil
@@ -12,6 +12,40 @@ sil [_semantics "sequence.forEach"] @forEach : $@convention(method) <τ_0_0 wher
 
 sil @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error
 
+sil hidden [ossa] @forEachLoopUnrollTest : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Word, 2
+  %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  (%3, %4) = destructure_tuple %2 : $(Array<Builtin.Int64>, Builtin.RawPointer)
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Builtin.Int64
+  %6 = integer_literal $Builtin.Int64, 15
+  store %6 to [trivial] %5 : $*Builtin.Int64
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %5 : $*Builtin.Int64, %12 : $Builtin.Word
+  %14 = integer_literal $Builtin.Int64, 27
+  store %14 to [trivial] %13 : $*Builtin.Int64
+  %21 = begin_borrow %3 : $Array<Builtin.Int64>
+  %22 = alloc_stack $Array<Builtin.Int64>
+  %23 = store_borrow %21 to %22 : $*Array<Builtin.Int64>
+  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error
+  // A stub for Sequence.forEach(_:)
+  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  try_apply %30<[Builtin.Int64]>(%26, %23) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  end_borrow %23 : $*Array<Builtin.Int64>
+  dealloc_stack %22 : $*Array<Builtin.Int64>
+  end_borrow %21 : $Array<Builtin.Int64>
+  destroy_value %3 : $Array<Builtin.Int64>
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $Error):
+  unreachable
+}
 // CHECK-LABEL: forEachLoopUnrollTest
 // CHECK: [[LIT1:%[0-9]+]] = integer_literal $Builtin.Int64, 15
 // CHECK: [[LIT2:%[0-9]+]] = integer_literal $Builtin.Int64, 27
@@ -41,44 +75,40 @@ sil @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error a
 // CHECK: dealloc_stack [[STACK]]
 // CHECK: unreachable
 
-sil hidden [ossa] @forEachLoopUnrollTest : $@convention(thin) () -> () {
-bb0:
-  %0 = integer_literal $Builtin.Word, 2
-  %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-  %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-  (%3, %4a) = destructure_tuple %2 : $(Array<Builtin.Int64>, Builtin.RawPointer)
-  %4 = mark_dependence %4a : $Builtin.RawPointer on %3 : $Array<Builtin.Int64>
-  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Builtin.Int64
-  %6 = integer_literal $Builtin.Int64, 15
-  store %6 to [trivial] %5 : $*Builtin.Int64
+sil @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+
+sil hidden [ossa] @nonTrivialForEachLoopUnrollTest : $@convention(thin) (@owned @callee_guaranteed @substituted <A> () -> @out A for <Int>, @owned @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> () {
+bb0(%0: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>, %1: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>):
+  %2 = integer_literal $Builtin.Word, 2
+  %3 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %4 = apply %3<() -> Int>(%2) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  (%5, %6) = destructure_tuple %4 : $(Array<()->Int>, Builtin.RawPointer)
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
+  store %0 to [init] %7 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
   %12 = integer_literal $Builtin.Word, 1
-  %13 = index_addr %5 : $*Builtin.Int64, %12 : $Builtin.Word
-  %14 = integer_literal $Builtin.Int64, 27
-  store %14 to [trivial] %13 : $*Builtin.Int64
-  %21 = begin_borrow %3 : $Array<Builtin.Int64>
-  %22 = alloc_stack $Array<Builtin.Int64>
-  %23 = store_borrow %21 to %22 : $*Array<Builtin.Int64>
-  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error
-  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error
-  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error
+  %13 = index_addr %7 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>, %12 : $Builtin.Word
+  store %1 to [init] %13 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
+  %21 = begin_borrow %5 : $Array<()->Int>
+  %22 = alloc_stack $Array<()->Int>
+  %23 = store_borrow %21 to %22 : $*Array<()->Int>
+  %24 = function_ref @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
   // A stub for Sequence.forEach(_:)
   %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
-  try_apply %30<[Builtin.Int64]>(%26, %23) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+  try_apply %30<[() -> Int]>(%26, %23) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
 
 bb1(%32 : $()):
-  end_borrow %23 : $*Array<Builtin.Int64>
-  dealloc_stack %22 : $*Array<Builtin.Int64>
-  end_borrow %21 : $Array<Builtin.Int64>
-  destroy_value %3 : $Array<Builtin.Int64>
+  end_borrow %23 : $*Array<() -> Int>
+  dealloc_stack %22 : $*Array<() -> Int>
+  end_borrow %21 : $Array<() -> Int>
+  destroy_value %5 : $Array<() -> Int>
   %37 = tuple ()
   return %37 : $()
 
 bb2(%39 : @owned $Error):
   unreachable
 }
-
-sil @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
-
 // CHECK-LABEL: nonTrivialForEachLoopUnrollTest
 // CHECK: [[ELEM1:%[0-9]+]] = copy_value %0
 // CHECK-NEXT: store %0 to [init] %{{.*}} : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
@@ -113,50 +143,13 @@ sil @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @subst
 // CHECK: [[ERROR3]]([[ERRPARAM3:%[0-9]+]] : @owned $any Error):
 // CHECK: dealloc_stack [[STACK]]
 // CHECK: unreachable
-sil hidden [ossa] @nonTrivialForEachLoopUnrollTest : $@convention(thin) (@owned @callee_guaranteed @substituted <A> () -> @out A for <Int>, @owned @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> () {
-bb0(%0: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>, %1: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>):
-  %2 = integer_literal $Builtin.Word, 2
-  %3 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-  %4 = apply %3<() -> Int>(%2) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-  (%5, %6a) = destructure_tuple %4 : $(Array<()->Int>, Builtin.RawPointer)
-  %6 = mark_dependence %6a : $Builtin.RawPointer on %5 : $Array<() -> Int>
-  %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
-  store %0 to [init] %7 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
-  %12 = integer_literal $Builtin.Word, 1
-  %13 = index_addr %7 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>, %12 : $Builtin.Word
-  store %1 to [init] %13 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
-  %21 = begin_borrow %5 : $Array<()->Int>
-  %22 = alloc_stack $Array<()->Int>
-  %23 = store_borrow %21 to %22 : $*Array<()->Int>
-  %24 = function_ref @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
-  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
-  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
-  // A stub for Sequence.forEach(_:)
-  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
-  try_apply %30<[() -> Int]>(%26, %23) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
 
-bb1(%32 : $()):
-  end_borrow %23 : $*Array<() -> Int>
-  dealloc_stack %22 : $*Array<() -> Int>
-  end_borrow %21 : $Array<() -> Int>
-  destroy_value %5 : $Array<() -> Int>
-  %37 = tuple ()
-  return %37 : $()
-
-bb2(%39 : @owned $Error):
-  unreachable
-}
-
-// CHECK-LABEL: @checkIndirectFixLifetimeUsesAreIgnored
-// CHECK-NOT: function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error any Error, @in_guaranteed τ_0_0) -> @error any Error
-// CHECK: end sil function 'checkIndirectFixLifetimeUsesAreIgnored'
 sil hidden [ossa] @checkIndirectFixLifetimeUsesAreIgnored : $@convention(thin) () -> () {
 bb0:
   %0 = integer_literal $Builtin.Word, 2
   %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
   %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-  (%3, %4a) = destructure_tuple %2 : $(Array<Builtin.Int64>, Builtin.RawPointer)
-  %4 = mark_dependence %4a : $Builtin.RawPointer on %3 : $Array<Builtin.Int64>
+  (%3, %4) = destructure_tuple %2 : $(Array<Builtin.Int64>, Builtin.RawPointer)
   %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Builtin.Int64
   %6 = integer_literal $Builtin.Int64, 15
   store %6 to [trivial] %5 : $*Builtin.Int64
@@ -191,10 +184,10 @@ bb1(%32 : $()):
 bb2(%39 : @owned $Error):
   unreachable
 }
-
-// CHECK-LABEL: @testUnrollOfArrayWithPhiArguments
+// CHECK-LABEL: @checkIndirectFixLifetimeUsesAreIgnored
 // CHECK-NOT: function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error any Error, @in_guaranteed τ_0_0) -> @error any Error
-// CHECK: end sil function 'testUnrollOfArrayWithPhiArguments'
+// CHECK: end sil function 'checkIndirectFixLifetimeUsesAreIgnored'
+
 sil hidden [ossa] @testUnrollOfArrayWithPhiArguments : $@convention(thin) () -> () {
 bb0:
   %0 = integer_literal $Builtin.Int64, 57
@@ -204,8 +197,7 @@ bb1(%arg : $Builtin.Int64):
   %10 = integer_literal $Builtin.Word, 1
   %11 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
   %12 = apply %11<Builtin.Int64>(%10) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
-  (%13, %14a) = destructure_tuple %12 : $(Array<Builtin.Int64>, Builtin.RawPointer)
-  %14 = mark_dependence %14a : $Builtin.RawPointer on %13 : $Array<Builtin.Int64>
+  (%13, %14) = destructure_tuple %12 : $(Array<Builtin.Int64>, Builtin.RawPointer)
   %15 = pointer_to_address %14 : $Builtin.RawPointer to [strict] $*Builtin.Int64
   store %arg to [trivial] %15 : $*Builtin.Int64
   br bb2(%arg : $Builtin.Int64)
@@ -232,4 +224,7 @@ bb3(%32 : $()):
 bb4(%39 : @owned $Error):
   unreachable
 }
+// CHECK-LABEL: @testUnrollOfArrayWithPhiArguments
+// CHECK-NOT: function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error any Error, @in_guaranteed τ_0_0) -> @error any Error
+// CHECK: end sil function 'testUnrollOfArrayWithPhiArguments'
 

--- a/test/SILOptimizer/for_each_loop_unroll_test.swift
+++ b/test/SILOptimizer/for_each_loop_unroll_test.swift
@@ -64,10 +64,8 @@ func unrollLetArrayLiteralWithClosures(i: Int32, j: Int32) {
   a.forEach { print($0()) }
   // CHECK: [[ALLOCATE:%[0-9]+]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
   // CHECK: [[ARRAYTUP:%[0-9]+]] = apply [[ALLOCATE]]<() -> Int32>
-  // CHECK: [[ARRAYVAL:%[0-9]+]] =  tuple_extract [[ARRAYTUP]] : $(Array<() -> Int32>, Builtin.RawPointer), 0
   // CHECK: [[STORAGEPTR:%[0-9]+]] =  tuple_extract [[ARRAYTUP]] : $(Array<() -> Int32>, Builtin.RawPointer), 1
-  // CHECK: [[MDI:%[0-9]+]] = mark_dependence [[STORAGEPTR]] : $Builtin.RawPointer on [[ARRAYVAL]] : $Array<() -> Int32>
-  // CHECK: [[STORAGEADDR:%[0-9]+]] = pointer_to_address [[MDI]]
+  // CHECK: [[STORAGEADDR:%[0-9]+]] = pointer_to_address [[STORAGEPTR]]
   // CHECK: store [[CLOSURE1:%[0-9]+]] to [[STORAGEADDR]]
   // CHECK: [[INDEX1:%[0-9]+]] = index_addr [[STORAGEADDR]]
   // CHECK: store [[CLOSURE2:%[0-9]+]] to [[INDEX1]]


### PR DESCRIPTION
Reverts apple/swift#69450

After bisecting the changes on swift repo, I believe this PR introduced error. 
```
error: 'swift-crypto': close error: Unknown error -1
error: 'swift-format': close error: Unknown error -1
```

Commits tested by building toolchain preset on swift repository:
 ✅ 05271d388d6985038cf181116a890e1e7daa5ed0
 ✅ 4ec627effc03203eee131c04b9c0ddfdfeceb979
 ✅ 2b594b20dbf746c6f6b098d2523b78920a68a43b
 ✅ 8f466f7f8dbf59d964de7a7253bc29f76bfa616e
 ✅ eee45f72329cf25a81701848ca0b75303158f456
 ❌ 192bb2eed222c292f6381daac4baa8cd8e619927


Hopefully, this will unblock https://ci.swift.org/job/oss-swift-package-macos/ bot. 
