### PR TITLE
utils: add `--reset-to-remote` to `update-checkout` invocation

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -110,7 +110,7 @@ set "args=%args% --skip-repository swift-integration-tests"
 set "args=%args% --skip-repository swift-stress-tester"
 set "args=%args% --skip-repository swift-xcode-playground-support"
 
-call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --github-comment "%ghprbCommentBody%"
+call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --reset-to-remote --github-comment "%ghprbCommentBody%"
 
 goto :eof
 endlocal


### PR DESCRIPTION
Add `--reset-to-remote` to the `update-checkout` invocation to ensure that the state of the tree is reset.  This should help avoid some of the failures that we occasionally see with the builders being left in a modified state.