### PR TITLE
Fix failing 32bit tests: IRGen/typed_throws.swift

### DIFF
--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -5,6 +5,7 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-experimental-feature TypedThrows  | %FileCheck %s --check-prefix=CHECK
 
 // XFAIL: CPU=arm64e
+// REQUIRES: PTRSIZE=64
 
 enum MyBigError: Error {
   case epicFail


### PR DESCRIPTION
rdar://118336279
