### PR TITLE
Move workaround for `swifterror` miscompile earlier

### DIFF
--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -83,6 +83,7 @@ entry(%0 : $AnyObject):
   // CHECK-native-NEXT: [[RESULT:%.*]] = call swiftcc ptr @try_apply_helper(ptr %0, ptr swiftself undef, ptr noalias nocapture [[SWIFTERROR]]{{( )?}}dereferenceable({{.}}) [[ERRORSLOT]])
   // CHECK-NEXT: [[ERR:%.*]] = load ptr, ptr [[ERRORSLOT]], align
   // CHECK-NEXT: [[T0:%.*]] = icmp ne ptr [[ERR]], null
+  // CHECK-NEXT: ptrtoint ptr [[ERR]] to i
   // CHECK-NEXT: br i1 [[T0]],
   %1 = function_ref @try_apply_helper : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error Error)
   try_apply %1(%0) : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error Error),

--- a/test/IRGen/unmanaged_objc_throw_func.swift
+++ b/test/IRGen/unmanaged_objc_throw_func.swift
@@ -24,13 +24,14 @@ import Foundation
     // CHECK-NEXT: call void @llvm.objc.release(ptr %[[T4]])
     // CHECK-NEXT: ret ptr %[[T4]]
     let arr = [1] as CFArray
-    return Unmanaged.passUnretained(arr) 
-  } 
+    return Unmanaged.passUnretained(arr)
+  }
 }
 
 // CHECK: %[[T0:.+]] = call swiftcc ptr @"$s25unmanaged_objc_throw_func1CC22returnUnmanagedCFArrays0F0VySo0G3RefaGyKF"
 // CHECK-NEXT: %[[T2:.+]] = load ptr, ptr %swifterror, align {{[0-9]+}}
 // CHECK-NEXT: %[[T3:.+]] = icmp ne ptr %[[T2]], null
+// CHECK-NEXT: ptrtoint ptr %[[T2]] to i
 // CHECK-NEXT: br i1 %[[T3]], label %[[L1:.+]], label %[[L2:.+]]
 
 // CHECK: [[L2]]:                                     ; preds = %entry


### PR DESCRIPTION
Thank you, Arnold for figuring out this miscompile on x86 and providing the fix.
