### PR TITLE
[NCGenerics] allow feature-guarded uses of ~Copyable

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -509,6 +509,9 @@ namespace swift {
     void addChildNote(Diagnostic &&D);
     void insertChildNote(unsigned beforeIndex, Diagnostic &&D);
   };
+
+  /// A diagnostic that has no input arguments, so it is trivially-destructable.
+  using ZeroArgDiagnostic = Diag<>;
   
   /// Describes an in-flight diagnostic, which is currently active
   /// within the diagnostic engine and can be augmented within additional

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -961,8 +961,8 @@ ERROR(cannot_suppress_here,none,
 ERROR(only_suppress_copyable,none,
       "can only suppress 'Copyable'", ())
 
-ERROR(already_suppressed,none,
-      "duplicate suppression of %0", (Identifier))
+ERROR(already_suppressed_copyable,none,
+      "duplicate suppression of 'Copyable'", ())
 
 //------------------------------------------------------------------------------
 // MARK: Pattern parsing diagnostics

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -42,6 +42,7 @@ namespace llvm {
 
 namespace swift {
   class IdentTypeRepr;
+  class ErrorTypeRepr;
   class CodeCompletionCallbacks;
   class DoneParsingCallback;
   class IDEInspectionCallbacksFactory;
@@ -2034,11 +2035,6 @@ public:
 
   void performIDEInspectionSecondPassImpl(
       IDEInspectionDelayedDeclState &info);
-
-  /// Returns true if the caller should skip calling `parseType` afterwards.
-  bool parseLegacyTildeCopyable(SourceLoc *parseTildeCopyable,
-                                ParserStatus &Status,
-                                SourceLoc &TildeCopyableLoc);
 
   //===--------------------------------------------------------------------===//
   // ASTGen support.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -42,6 +42,9 @@
 
 using namespace swift;
 
+static_assert(IsTriviallyDestructible<ZeroArgDiagnostic>::value,
+              "ZeroArgDiagnostic is meant to be trivially destructable");
+
 namespace {
 enum class DiagnosticOptions {
   /// No options.

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -653,6 +653,15 @@ void SILBoxTypeRepr::printImpl(ASTPrinter &Printer,
   Printer.printKeyword("sil_box", Opts);
 }
 
+void ErrorTypeRepr::dischargeDiagnostic(swift::ASTContext &Context) {
+  if (!DelayedDiag)
+    return;
+
+  // Consume and emit the diagnostic.
+  Context.Diags.diagnose(Range.Start, *DelayedDiag).highlight(Range);
+  DelayedDiag = llvm::None;
+}
+
 // See swift/Basic/Statistic.h for declaration: this enables tracing
 // TypeReprs, is defined here to avoid too much layering violation / circular
 // linkage dependency.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9665,7 +9665,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
 
     if (ElementTy.isNull()) {
       // Always set an element type.
-      ElementTy = makeParserResult(ElementTy, new (Context) ErrorTypeRepr());
+      ElementTy = makeParserResult(ElementTy, ErrorTypeRepr::create(Context));
     }
   }
 

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -339,7 +339,7 @@ ParserStatus Parser::parseGenericWhereClause(
         ParserResult<TypeRepr> Protocol = parseType();
         Status |= Protocol;
         if (Protocol.isNull())
-          Protocol = makeParserResult(new (Context) ErrorTypeRepr(PreviousLoc));
+          Protocol = makeParserResult(ErrorTypeRepr::create(Context, PreviousLoc));
 
         // Add the requirement.
         Requirements.push_back(RequirementRepr::getTypeConstraint(
@@ -358,7 +358,7 @@ ParserStatus Parser::parseGenericWhereClause(
       ParserResult<TypeRepr> SecondType = parseType();
       Status |= SecondType;
       if (SecondType.isNull())
-        SecondType = makeParserResult(new (Context) ErrorTypeRepr(PreviousLoc));
+        SecondType = makeParserResult(ErrorTypeRepr::create(Context, PreviousLoc));
 
       // Add the requirement
       if (FirstType.hasCodeCompletion()) {
@@ -373,7 +373,7 @@ ParserStatus Parser::parseGenericWhereClause(
         // completion token in the TypeRepr.
         Requirements.push_back(RequirementRepr::getTypeConstraint(
             FirstType.get(), EqualLoc,
-            new (Context) ErrorTypeRepr(SecondType.get()->getLoc()),
+            ErrorTypeRepr::create(Context, SecondType.get()->getLoc()),
             isRequirementExpansion));
       } else {
         Requirements.push_back(RequirementRepr::getSameType(
@@ -383,7 +383,7 @@ ParserStatus Parser::parseGenericWhereClause(
     } else if (FirstType.hasCodeCompletion()) {
       // Recover by adding dummy constraint.
       Requirements.push_back(RequirementRepr::getTypeConstraint(
-          FirstType.get(), PreviousLoc, new (Context) ErrorTypeRepr(PreviousLoc),
+          FirstType.get(), PreviousLoc, ErrorTypeRepr::create(Context, PreviousLoc),
           isRequirementExpansion));
     } else {
       diagnose(Tok, diag::expected_requirement_delim);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1053,7 +1053,7 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
         }
       }
     } else {
-      Ty = makeParserResult(new (Context) ErrorTypeRepr(PreviousLoc));
+      Ty = makeParserResult(ErrorTypeRepr::create(Context, PreviousLoc));
     }
     
     result = makeParserResult(result,
@@ -1278,7 +1278,7 @@ parseOptionalPatternTypeAnnotation(ParserResult<Pattern> result) {
 
   TypeRepr *repr = Ty.getPtrOrNull();
   if (!repr)
-    repr = new (Context) ErrorTypeRepr(PreviousLoc);
+    repr = ErrorTypeRepr::create(Context, PreviousLoc);
 
   return makeParserResult(status, new (Context) TypedPattern(P, repr));
 }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -232,7 +232,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
       CodeCompletionCallbacks->completeTypeSimpleBeginning();
     }
     return makeParserCodeCompletionResult<TypeRepr>(
-        new (Context) ErrorTypeRepr(consumeToken(tok::code_complete)));
+        ErrorTypeRepr::create(Context, consumeToken(tok::code_complete)));
   case tok::l_square: {
     ty = parseTypeCollection();
     break;
@@ -255,7 +255,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
         diag.fixItInsert(getEndOfPreviousLoc(), " <#type#>");
     }
     if (Tok.isKeyword() && !Tok.isAtStartOfLine()) {
-      ty = makeParserErrorResult(new (Context) ErrorTypeRepr(Tok.getLoc()));
+      ty = makeParserErrorResult(ErrorTypeRepr::create(Context, Tok.getLoc()));
       consumeToken();
       return ty;
     }
@@ -685,8 +685,8 @@ ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
       auto diag = diagnose(Tok, diag::extra_rbracket);
       diag.fixItInsert(result.get()->getStartLoc(), getTokenText(tok::l_square));
       consumeToken();
-      return makeParserErrorResult(new (Context)
-                                       ErrorTypeRepr(getTypeErrorLoc()));
+      return makeParserErrorResult(ErrorTypeRepr::create(Context,
+                                                         getTypeErrorLoc()));
     }
 
     if (Tok.is(tok::colon)) {
@@ -702,8 +702,8 @@ ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
           diag.fixItInsertAfter(secondType.get()->getEndLoc(), getTokenText(tok::r_square));
         }
       }
-      return makeParserErrorResult(new (Context)
-                                       ErrorTypeRepr(getTypeErrorLoc()));
+      return makeParserErrorResult(ErrorTypeRepr::create(Context,
+                                                         getTypeErrorLoc()));
     }
   }
   return result;

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2010,7 +2010,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       Ctx.Diags.diagnose(AE->getArgsExpr()->getLoc(),
                          diag::expected_type_before_arrow);
       auto ArgRange = AE->getArgsExpr()->getSourceRange();
-      auto ErrRepr = new (Ctx) ErrorTypeRepr(ArgRange);
+      auto ErrRepr = ErrorTypeRepr::create(Ctx, ArgRange);
       ArgsTypeRepr =
           TupleTypeRepr::create(Ctx, {ErrRepr}, ArgRange);
     }
@@ -2025,8 +2025,8 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     if (!ResultTypeRepr) {
       Ctx.Diags.diagnose(AE->getResultExpr()->getLoc(),
                          diag::expected_type_after_arrow);
-      ResultTypeRepr = new (Ctx)
-          ErrorTypeRepr(AE->getResultExpr()->getSourceRange());
+      ResultTypeRepr =
+          ErrorTypeRepr::create(Ctx, AE->getResultExpr()->getSourceRange());
     }
 
     auto NewTypeRepr = new (Ctx)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2431,6 +2431,7 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
 
   switch (repr->getKind()) {
   case TypeReprKind::Error:
+    cast<ErrorTypeRepr>(repr)->dischargeDiagnostic(getASTContext());
     return ErrorType::get(getASTContext());
 
   case TypeReprKind::Attributed:

--- a/test/Parse/inverses_legacy_ifdef.swift
+++ b/test/Parse/inverses_legacy_ifdef.swift
@@ -1,0 +1,61 @@
+// RUN: %swift-frontend -typecheck %s
+// RUN: %swift-frontend -typecheck %s -DHAVE_NCGENERICS -enable-experimental-feature NoncopyableGenerics
+// RUN: %swift-frontend -typecheck %s -verify -DHAVE_NCGENERICS
+
+// REQUIRES: asserts
+
+/// This test checks that you can write ~Copyable in places that were illegal
+/// in Swift 5.9, as long as those illegal appearances are guarded within
+/// a disabled #if block.
+///
+/// We previously would emit errors during Parse for those illegal appearances,
+/// which would make it impossible to feature-guard new, legal uses of those
+/// annotations. Now we delay those diagnostics until Sema.
+///
+/// So, the first RUN line here checks that there are no error diagnostics emitted
+/// when not providing HAVE_NCGENERICS. Then, we enable that experimental feature to
+/// ensure that what's in the #if has no unexpected errors. Finally, we run without that
+/// feature to ensure we get the expected errors when the #if-block is allowed to be
+/// typechecked.
+
+struct NC: ~Copyable {}
+
+#if HAVE_NCGENERICS
+
+struct Blah: ~Copyable, ~Copyable {}
+// expected-error@-1 {{duplicate suppression of 'Copyable'}}
+
+protocol Compare where Self: ~Copyable { // expected-error {{cannot suppress conformances here}}
+  func lessThan(_ other: borrowing Self) -> Bool
+}
+
+protocol Sortable<Element>: ~Copyable { // expected-error {{cannot suppress conformances here}}
+  associatedtype Element: ~Copyable, Compare // expected-error {{cannot suppress conformances here}} // expected-note {{protocol requires nested type 'Element'; add nested type 'Element' for conformance}}
+
+  mutating func sort()
+}
+
+extension NC: Compare { // expected-error {{noncopyable struct 'NC' cannot conform to 'Compare'}}
+  func lessThan(_ other: borrowing Self) -> Bool { false }
+}
+
+extension NC: Sortable { // expected-error {{noncopyable struct 'NC' cannot conform to 'Sortable'}}
+                         // expected-error@-1 {{type 'NC' does not conform to protocol 'Sortable'}}
+  typealias Element = NC // expected-note {{possibly intended match 'NC.Element' (aka 'NC') does not conform to 'Copyable'}}
+
+  mutating func sort() { }
+}
+
+func f<T>(_ t: inout T) // expected-note {{where 'T.Element' = 'NC.Element'}}
+  where T: ~Copyable,  // expected-error {{cannot suppress conformances here}}
+        T: Sortable,
+        T.Element == NC {
+  t.sort()
+}
+
+do {
+  var x = NC()
+  f(&x) // expected-error {{global function 'f' requires the types 'NC.Element' and 'NC' be equivalent}}
+}
+
+#endif


### PR DESCRIPTION
 We need to delay the pre-NCGenerics errors about illegal uses of ~Copyable from Parse until Sema. Otherwise, such uses can't appear within a false #if-block.