### PR TITLE
Yet more typed throws fixes

### DIFF
--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -647,7 +647,8 @@ public:
 
     if (auto tryApplyInst = dyn_cast<TryApplyInst>(inst)) {
       foundResults.emplace_back(tryApplyInst->getNormalBB()->getArgument(0));
-      foundResults.emplace_back(tryApplyInst->getErrorBB()->getArgument(0));
+      if (tryApplyInst->getErrorBB()->getNumArguments() > 0)
+        foundResults.emplace_back(tryApplyInst->getErrorBB()->getArgument(0));
       return;
     }
 

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -179,3 +179,14 @@ func fromRethrows(body: () throws -> Void) rethrows {
   try notRethrowsLike2(body) // expected-error{{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
   try notRethrowsLike3(body) // expected-error{{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
 }
+
+// Substitution involving 'any Error' or 'Never' thrown error types should
+// use untyped throws or be non-throwing.
+enum G_E<T> {
+  case tuple((x: T, y: T))
+}
+
+func testArrMap(arr: [String]) {
+  _ = mapArray(arr, body: G_E<Int>.tuple)
+  // expected-error@-1{{cannot convert value of type '((x: Int, y: Int)) -> G_E<Int>' to expected argument type '(String) -> G_E<Int>'}}
+}


### PR DESCRIPTION
Minor fixes for typed throws that were uncovered while testing the typed throws `map` implementation in the standard library:
* When substituting into a generic `throws(E)`, and `E` is either `any Error` or `Never`, simplify to `throws` or non-throwing
* Teach TransferNonSendable, forEach unrolling, and speculative devirtualization  that not all Error BB's have arguments