### PR TITLE
[Sema] Don't propagate `allowsMissing` to existential superclass check

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5777,12 +5777,16 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
 
     // First, if we have a superclass constraint, the class may conform
     // concretely.
+    //
+    // Note that `allowMissing` is not propagated here because it
+    // would result in a missing conformance if type is `& Sendable`
+    // protocol composition. It's handled for type as a whole below.
     if (auto superclass = layout.getSuperclass()) {
       auto result =
           (skipConditionalRequirements
-           ? M->lookupConformance(superclass, Proto, allowMissing)
-           : TypeChecker::conformsToProtocol(
-               superclass, Proto, M, allowMissing));
+               ? M->lookupConformance(superclass, Proto, /*allowMissing=*/false)
+               : TypeChecker::conformsToProtocol(superclass, Proto, M,
+                                                 /*allowMissing=*/false));
       if (result) {
         return result;
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5804,15 +5804,8 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
         return ProtocolConformanceRef(Proto);
     }
 
-    // FIXME: Unify with shouldCreateMissingConformances
-    if (allowMissing &&
-        Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
-      return ProtocolConformanceRef(
-          M->getASTContext().getBuiltinConformance(
-            T, Proto, BuiltinConformanceKind::Missing));
-    }
-
-    return ProtocolConformanceRef::forInvalid();
+    return allowMissing ? ProtocolConformanceRef::forMissingOrInvalid(T, Proto)
+                        : ProtocolConformanceRef::forInvalid();
   }
 
   // For non-existential types, this is equivalent to checking conformance.

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -369,9 +369,7 @@ func testSender(
   sender.sendAnyArray([nonSendableObject])
   // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable; this is an error in Swift 6}}
 
-  sender.sendGeneric(sendableGeneric)
-  // expected-warning@-1{{type 'GenericObject<SendableClass>' does not conform to the 'Sendable' protocol}}
-  // FIXME: Shouldn't warn
+  sender.sendGeneric(sendableGeneric) // no warning
 
   sender.sendGeneric(nonSendableGeneric)
   // expected-warning@-1 {{type 'GenericObject<SendableClass>' does not conform to the 'Sendable' protocol}}

--- a/test/Concurrency/sendable_existentials.swift
+++ b/test/Concurrency/sendable_existentials.swift
@@ -56,3 +56,14 @@ func testESilently(a: Any, aOpt: Any?) {
   _ = sendable
   _ = arrayOfSendable
 }
+
+func testErasure() {
+  class A {}
+  class B : A {}
+
+  func produce() -> any B & Sendable {
+    fatalError()
+  }
+
+  let _: any A & Sendable = produce() // no warning
+}


### PR DESCRIPTION
`TypeChecker::containsProtocol` shouldn't propagate user-provided
`allowMissing` to existential superclass check because the type
could be `& Sendable` and `allowMissing` propagation would result
in invalid builtin conformance returned for a non-conforming
superclass.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
