### PR TITLE
[sil-optimizer] Add FP comparison support in constant folder

### DIFF
--- a/include/swift/SILOptimizer/Utils/ConstantFolding.h
+++ b/include/swift/SILOptimizer/Utils/ConstantFolding.h
@@ -31,10 +31,16 @@ class SILOptFunctionBuilder;
 /// The \p ID must be the ID of a binary bit-operation builtin.
 APInt constantFoldBitOperation(APInt lhs, APInt rhs, BuiltinValueKind ID);
 
+/// Evaluates the constant result of a floating point comparison.
+///
+/// The \p ID must be the ID of a floating point builtin operation.
+APInt constantFoldComparisonFloat(APFloat lhs, APFloat rhs,
+                                  BuiltinValueKind ID);
+
 /// Evaluates the constant result of an integer comparison.
 ///
 /// The \p ID must be the ID of an integer builtin operation.
-APInt constantFoldComparison(APInt lhs, APInt rhs, BuiltinValueKind ID);
+APInt constantFoldComparisonInt(APInt lhs, APInt rhs, BuiltinValueKind ID);
 
 /// Evaluates the constant result of a binary operation with overflow.
 ///

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -50,7 +50,37 @@ APInt swift::constantFoldBitOperation(APInt lhs, APInt rhs, BuiltinValueKind ID)
   }
 }
 
-APInt swift::constantFoldComparison(APInt lhs, APInt rhs, BuiltinValueKind ID) {
+APInt swift::constantFoldComparisonFloat(APFloat lhs, APFloat rhs,
+                                         BuiltinValueKind ID) {
+  bool result;
+  bool isOrdered = !lhs.isNaN() && !rhs.isNaN();
+
+  switch (ID) {
+  default: llvm_unreachable("Invalid float compare kind");
+  // Ordered comparisons
+  case BuiltinValueKind::FCMP_OEQ: result = isOrdered && lhs == rhs; break;
+  case BuiltinValueKind::FCMP_OGT: result = isOrdered && lhs > rhs; break;
+  case BuiltinValueKind::FCMP_OGE: result = isOrdered && lhs >= rhs; break;
+  case BuiltinValueKind::FCMP_OLT: result = isOrdered && lhs < rhs; break;
+  case BuiltinValueKind::FCMP_OLE: result = isOrdered && lhs <= rhs; break;
+  case BuiltinValueKind::FCMP_ONE: result = isOrdered && lhs != rhs; break;
+  case BuiltinValueKind::FCMP_ORD: result = isOrdered; break;
+
+  // Unordered comparisons
+  case BuiltinValueKind::FCMP_UEQ: result = !isOrdered || lhs == rhs; break;
+  case BuiltinValueKind::FCMP_UGT: result = !isOrdered || lhs > rhs; break;
+  case BuiltinValueKind::FCMP_UGE: result = !isOrdered || lhs >= rhs; break;
+  case BuiltinValueKind::FCMP_ULT: result = !isOrdered || lhs < rhs; break;
+  case BuiltinValueKind::FCMP_ULE: result = !isOrdered || lhs <= rhs; break;
+  case BuiltinValueKind::FCMP_UNE: result = !isOrdered || lhs != rhs; break;
+  case BuiltinValueKind::FCMP_UNO: result = !isOrdered; break;
+  }
+
+  return APInt(1, result);
+}
+
+APInt swift::constantFoldComparisonInt(APInt lhs, APInt rhs,
+                                       BuiltinValueKind ID) {
   bool result;
   switch (ID) {
     default: llvm_unreachable("Invalid integer compare kind");
@@ -351,14 +381,356 @@ static SILValue constantFoldIntrinsic(BuiltinInst *BI, llvm::Intrinsic::ID ID,
   return nullptr;
 }
 
-static SILValue constantFoldCompare(BuiltinInst *BI, BuiltinValueKind ID) {
+static SILValue constantFoldCompareFloat(BuiltinInst *BI, BuiltinValueKind ID) {
+  static auto hasIEEEFloatNanBitRepr = [](const APInt val) -> bool {
+    auto bitWidth = val.getBitWidth();
+    if (bitWidth == 32) {
+      APInt nanBitRepr =
+          APFloat::getNaN(llvm::APFloatBase::IEEEsingle()).bitcastToAPInt();
+      return bitWidth == nanBitRepr.getBitWidth() && val == nanBitRepr;
+    } else {
+      APInt nanBitRepr =
+          APFloat::getNaN(llvm::APFloatBase::IEEEdouble()).bitcastToAPInt();
+      return bitWidth == nanBitRepr.getBitWidth() && val == nanBitRepr;
+    }
+  };
+
+  static auto hasIEEEFloatPosInfBitRepr = [](const APInt val) -> bool {
+    auto bitWidth = val.getBitWidth();
+    if (bitWidth == 32) {
+      APInt infBitRepr =
+          APFloat::getInf(llvm::APFloatBase::IEEEsingle()).bitcastToAPInt();
+      return bitWidth == infBitRepr.getBitWidth() && val == infBitRepr;
+    } else {
+      APInt infBitRepr =
+          APFloat::getInf(llvm::APFloatBase::IEEEdouble()).bitcastToAPInt();
+      return bitWidth == infBitRepr.getBitWidth() && val == infBitRepr;
+    }
+  };
+
+  OperandValueArrayRef Args = BI->getArguments();
+
+  // Fold for floating point constant arguments.
+  auto *LHS = dyn_cast<FloatLiteralInst>(Args[0]);
+  auto *RHS = dyn_cast<FloatLiteralInst>(Args[1]);
+  if (LHS && RHS) {
+    APInt Res =
+        constantFoldComparisonFloat(LHS->getValue(), RHS->getValue(), ID);
+    SILBuilderWithScope B(BI);
+    return B.createIntegerLiteral(BI->getLoc(), BI->getType(), Res);
+  }
+
+  using namespace swift::PatternMatch;
+
+  // Ordered comparisons with NaN always return false
+  SILValue Other;
+  IntegerLiteralInst *builtinArg;
+  if (match(BI, m_CombineOr(
+                    // x == NaN
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OEQ, 
+                                  m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                    // x == NaN
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OGT, 
+                                  m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                    // x >= NaN
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OGE, 
+                                  m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                    // x < NaN
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OLT, 
+                                  m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                    // x <= NaN
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OLE, 
+                                  m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                    // x != NaN
+                    m_BuiltinInst(BuiltinValueKind::FCMP_ONE, 
+                                  m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                    // NaN == x
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OEQ, 
+                                  m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                    // NaN > x
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OGT, 
+                                  m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                    // NaN >= x
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OGE, 
+                                  m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                    // NaN < x
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OLT, 
+                                  m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                    // NaN <= x
+                    m_BuiltinInst(BuiltinValueKind::FCMP_OLE, 
+                                  m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                    // NaN != x
+                    m_BuiltinInst(BuiltinValueKind::FCMP_ONE, 
+                                  m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other))))) {
+    APInt val = builtinArg->getValue();
+    if (hasIEEEFloatNanBitRepr(val)) {
+      SILBuilderWithScope B(BI);
+      return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 0));
+    } else {
+      // An edge case where we're comparing NaN with another value
+      // defined using the BitCast builtin instruction.
+      //
+      // In this case, the `builtinArg` capture does not actually represent the NaN
+      // argument that we want. Therefore we need to pattern-match
+      // the definition of the SILValue `Other`, to see if it represents a NaN.
+      if (auto *bci = dyn_cast<BuiltinInst>(Other)) {
+        if (bci->getBuiltinInfo().ID == BuiltinValueKind::BitCast) {
+          if (auto *arg = dyn_cast<IntegerLiteralInst>(bci->getArguments()[0])) {
+            if (hasIEEEFloatNanBitRepr(arg->getValue())) {
+              SILBuilderWithScope B(BI);
+              return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 0));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Unordered comparisons with NaN always return true
+  if (match(BI, 
+            m_CombineOr(
+                // x == NaN
+                m_BuiltinInst(BuiltinValueKind::FCMP_UEQ, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x == NaN
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGT, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x >= NaN
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x < NaN
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULT, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x <= NaN
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x != NaN
+                m_BuiltinInst(BuiltinValueKind::FCMP_UNE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // NaN == x
+                m_BuiltinInst(BuiltinValueKind::FCMP_UEQ, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // NaN > x
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGT, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // NaN >= x
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // NaN < x
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULT, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // NaN <= x
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // NaN != x
+                m_BuiltinInst(BuiltinValueKind::FCMP_UNE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other))))) {
+    APInt val = builtinArg->getValue();
+    if (hasIEEEFloatNanBitRepr(val)) {
+      SILBuilderWithScope B(BI);
+      return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
+    } else {
+      // An edge case where we're comparing NaN with another value
+      // defined using the BitCast builtin instruction.
+      //
+      // In this case, the `builtinArg` capture does not actually represent the NaN
+      // argument that we want. Therefore we need to pattern-match
+      // the definition of the SILValue `Other`, to see if it represents a NaN.
+      if (auto *bci = dyn_cast<BuiltinInst>(Other)) {
+        if (bci->getBuiltinInfo().ID == BuiltinValueKind::BitCast) {
+          if (auto *arg = dyn_cast<IntegerLiteralInst>(bci->getArguments()[0])) {
+            if (hasIEEEFloatNanBitRepr(arg->getValue())) {
+              SILBuilderWithScope B(BI);
+              return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Infinity is equal to, greater than equal to and less than equal to itself
+  IntegerLiteralInst *inf1;
+  IntegerLiteralInst *inf2;
+
+  if (match(BI, 
+            m_CombineOr(
+                // Inf == Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OEQ, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf >= Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OGE, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf <= Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OLE, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),                                                            
+                // Inf == Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_UEQ, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf >= Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGE, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf <= Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULE, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2)))))) {
+    APInt val1 = inf1->getValue();
+    APInt val2 = inf2->getValue();
+
+    if (hasIEEEFloatPosInfBitRepr(val1) && hasIEEEFloatPosInfBitRepr(val2)) {
+      SILBuilderWithScope B(BI);
+      return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
+    }
+  }
+
+  // Infinity cannot be unequal to, greater than or less than itself
+  if (match(BI, 
+            m_CombineOr(
+                // Inf != Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_ONE, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf > Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OGT, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf < Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OLT, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf != Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_UNE, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf > Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGT, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2))),
+                // Inf < Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULT, 
+                              m_BitCast(m_IntegerLiteralInst(inf1)), m_BitCast(m_IntegerLiteralInst(inf2)))))) {
+    APInt val1 = inf1->getValue();
+    APInt val2 = inf2->getValue();
+
+    if (hasIEEEFloatPosInfBitRepr(val1) && hasIEEEFloatPosInfBitRepr(val2)) {
+      SILBuilderWithScope B(BI);
+      return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 0));
+    }
+  }
+
+  // Everything is less than, less than equal to or unequal to positive infinity
+  if (match(BI,
+            m_CombineOr(
+                // Inf > x
+                m_BuiltinInst(BuiltinValueKind::FCMP_OGT, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // Inf >= x
+                m_BuiltinInst(BuiltinValueKind::FCMP_OGE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // x < Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OLT, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x <= Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OLE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x != Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_ONE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // Inf != x
+                m_BuiltinInst(BuiltinValueKind::FCMP_ONE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // Inf > x
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGT, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // Inf >= x
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // x < Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULT, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x <= Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x != Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_UNE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // Inf != x
+                m_BuiltinInst(BuiltinValueKind::FCMP_UNE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other))))) {
+    APInt val = builtinArg->getValue();
+    if (hasIEEEFloatPosInfBitRepr(val)) {
+      // One of the operands is infinity, but unless the other operand is not
+      // fully visible we cannot definitively say what it is. It can be anything, 
+      // including NaN and infinity itself. Therefore, we cannot fold the comparison
+      // just yet.
+      if (isa<StructExtractInst>(Other) || isa<TupleExtractInst>(Other)) {
+        return nullptr;
+      } else {  
+        SILBuilderWithScope B(BI);
+        return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
+      }
+    }
+  }
+
+  // Positive infinity is not less than, less than equal to or equal to anything
+  if (match(BI, 
+            m_CombineOr(
+                // x > Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OGT, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x >= Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OGE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // Inf < x
+                m_BuiltinInst(BuiltinValueKind::FCMP_OLT, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // Inf <= x
+                m_BuiltinInst(BuiltinValueKind::FCMP_OLE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // x == Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_OEQ, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // Inf == x
+                m_BuiltinInst(BuiltinValueKind::FCMP_OEQ, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // x > Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGT, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // x >= Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_UGE, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // Inf < x
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULT, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // Inf <= x
+                m_BuiltinInst(BuiltinValueKind::FCMP_ULE, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
+                // x == Inf
+                m_BuiltinInst(BuiltinValueKind::FCMP_UEQ, 
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
+                // Inf == x
+                m_BuiltinInst(BuiltinValueKind::FCMP_UEQ, 
+                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other))))) {
+    APInt val = builtinArg->getValue();
+    if (hasIEEEFloatPosInfBitRepr(val)) {
+      // One of the operands is infinity, but unless the other operand is not
+      // fully visible we cannot definitively say what it is. It can be anything, 
+      // including NaN and infinity itself. Therefore, we cannot fold the comparison
+      // just yet.
+      if (isa<StructExtractInst>(Other) || isa<TupleExtractInst>(Other)) {
+        return nullptr;
+      } else {  
+        SILBuilderWithScope B(BI);
+        return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 0));
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+static SILValue constantFoldCompareInt(BuiltinInst *BI, BuiltinValueKind ID) {
   OperandValueArrayRef Args = BI->getArguments();
 
   // Fold for integer constant arguments.
   auto *LHS = dyn_cast<IntegerLiteralInst>(Args[0]);
   auto *RHS = dyn_cast<IntegerLiteralInst>(Args[1]);
   if (LHS && RHS) {
-    APInt Res = constantFoldComparison(LHS->getValue(), RHS->getValue(), ID);
+    APInt Res = constantFoldComparisonInt(LHS->getValue(), RHS->getValue(), ID);
     SILBuilderWithScope B(BI);
     return B.createIntegerLiteral(BI->getLoc(), BI->getType(), Res);
   }
@@ -477,6 +849,17 @@ static SILValue constantFoldCompare(BuiltinInst *BI, BuiltinValueKind ID) {
       return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt());
     }
   }
+  return nullptr;
+}
+
+static SILValue constantFoldCompare(BuiltinInst *BI, BuiltinValueKind ID) {
+  // Try folding integer comparison
+  if (auto result = constantFoldCompareInt(BI, ID))
+    return result;
+  // Try folding floating point comparison
+  if (auto result = constantFoldCompareFloat(BI, ID))
+    return result;
+  // Else, return nullptr
   return nullptr;
 }
 
@@ -1891,6 +2274,12 @@ ConstantFolder::processWorkList() {
               WorkList.insert(User);
             }
           }
+        }
+
+        // If the user is a bitcast, we may be able to constant
+        // fold its users.
+        if (isApplyOfBuiltin(*User, BuiltinValueKind::BitCast)) {
+          WorkList.insert(User);
         }
 
         // Initialize ResultsInError as a None optional.

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -612,7 +612,7 @@ static SILValue constantFoldCompareFloat(BuiltinInst *BI, BuiltinValueKind ID) {
     }
   }
 
-  // Everything is less than, less than equal to or unequal to positive infinity
+  // Everything is less than or less than equal to positive infinity
   if (match(BI,
             m_CombineOr(
                 // Inf > x
@@ -627,12 +627,6 @@ static SILValue constantFoldCompareFloat(BuiltinInst *BI, BuiltinValueKind ID) {
                 // x <= Inf
                 m_BuiltinInst(BuiltinValueKind::FCMP_OLE, 
                               m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
-                // x != Inf
-                m_BuiltinInst(BuiltinValueKind::FCMP_ONE, 
-                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
-                // Inf != x
-                m_BuiltinInst(BuiltinValueKind::FCMP_ONE, 
-                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
                 // Inf > x
                 m_BuiltinInst(BuiltinValueKind::FCMP_UGT, 
                               m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
@@ -644,13 +638,7 @@ static SILValue constantFoldCompareFloat(BuiltinInst *BI, BuiltinValueKind ID) {
                               m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
                 // x <= Inf
                 m_BuiltinInst(BuiltinValueKind::FCMP_ULE, 
-                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
-                // x != Inf
-                m_BuiltinInst(BuiltinValueKind::FCMP_UNE, 
-                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
-                // Inf != x
-                m_BuiltinInst(BuiltinValueKind::FCMP_UNE, 
-                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other))))) {
+                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg)))))) {
     APInt val = builtinArg->getValue();
     if (hasIEEEFloatPosInfBitRepr(val)) {
       // One of the operands is infinity, but unless the other operand is not
@@ -666,7 +654,7 @@ static SILValue constantFoldCompareFloat(BuiltinInst *BI, BuiltinValueKind ID) {
     }
   }
 
-  // Positive infinity is not less than, less than equal to or equal to anything
+  // Positive infinity is not less than or less than equal to anything
   if (match(BI, 
             m_CombineOr(
                 // x > Inf
@@ -681,12 +669,6 @@ static SILValue constantFoldCompareFloat(BuiltinInst *BI, BuiltinValueKind ID) {
                 // Inf <= x
                 m_BuiltinInst(BuiltinValueKind::FCMP_OLE, 
                               m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
-                // x == Inf
-                m_BuiltinInst(BuiltinValueKind::FCMP_OEQ, 
-                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
-                // Inf == x
-                m_BuiltinInst(BuiltinValueKind::FCMP_OEQ, 
-                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
                 // x > Inf
                 m_BuiltinInst(BuiltinValueKind::FCMP_UGT, 
                               m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
@@ -698,12 +680,6 @@ static SILValue constantFoldCompareFloat(BuiltinInst *BI, BuiltinValueKind ID) {
                               m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
                 // Inf <= x
                 m_BuiltinInst(BuiltinValueKind::FCMP_ULE, 
-                              m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other)),
-                // x == Inf
-                m_BuiltinInst(BuiltinValueKind::FCMP_UEQ, 
-                              m_SILValue(Other), m_BitCast(m_IntegerLiteralInst(builtinArg))),
-                // Inf == x
-                m_BuiltinInst(BuiltinValueKind::FCMP_UEQ, 
                               m_BitCast(m_IntegerLiteralInst(builtinArg)), m_SILValue(Other))))) {
     APInt val = builtinArg->getValue();
     if (hasIEEEFloatPosInfBitRepr(val)) {

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -190,9 +190,9 @@ case BuiltinValueKind::id:
       IntConst lhs = getIntConst(Args[0], depth);
       IntConst rhs = getIntConst(Args[1], depth);
       if (lhs.isValid && rhs.isValid) {
-        return IntConst(constantFoldComparison(lhs.value, rhs.value,
-                                               Builtin.ID),
-                        lhs.isFromCaller || rhs.isFromCaller);
+        return IntConst(
+            constantFoldComparisonInt(lhs.value, rhs.value, Builtin.ID),
+            lhs.isFromCaller || rhs.isFromCaller);
       }
       break;
     }

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -525,9 +525,468 @@ bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
 // CHECK: } // end sil function 'dont_fold_unsigned_op_with_overflow_lt_zero'
 }
 
+// fold float comparison operations involving literals only
+sil @fold_literal_float_comparison : $@convention(thin) () -> () {
+  %0 = float_literal $Builtin.FPIEEE32, 0x3F800000 // 1
+  %1 = float_literal $Builtin.FPIEEE32, 0x40000000 // 2
+  
+  // Ordered
+  %3 = builtin "fcmp_oeq_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %4 = builtin "fcmp_ogt_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %5 = builtin "fcmp_oge_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %6 = builtin "fcmp_olt_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %7 = builtin "fcmp_ole_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %8 = builtin "fcmp_one_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %9 = builtin "fcmp_ord_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  
+  // Unordered
+  %11 = builtin "fcmp_ueq_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %12 = builtin "fcmp_ugt_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %13 = builtin "fcmp_uge_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %14 = builtin "fcmp_ult_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %15 = builtin "fcmp_ule_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %16 = builtin "fcmp_une_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %17 = builtin "fcmp_uno_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
 
-// fold_float_operations
-sil @fold_float_operations : $@convention(thin) () -> Builtin.FPIEEE64 {
+  %404 = tuple ()     
+  return %404 : $()  
+
+// CHECK-LABEL:sil @fold_literal_float_comparison
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %3 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %4 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %5 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %6 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %7 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %8 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %9 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %10 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %11 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %12 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %13 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %14 = tuple ()                                  
+// CHECK-NEXT:   return %14 : $()                                
+// CHECK-NEXT: } // end sil function 'fold_literal_float_comparison'
+}
+
+// fold float comparison operations with NaN
+sil @fold_float_comparison_with_nan : $@convention(thin) () -> () {
+    %1 = float_literal $Builtin.FPIEEE32, 0x3F800000 // 1
+  %900 = integer_literal $Builtin.Int32, 2143289344 // user: %3
+  %909 = builtin "bitcast_Int32_FPIEEE32"(%900 : $Builtin.Int32) : $Builtin.FPIEEE32 
+
+  // Ordered
+  %3 = builtin "fcmp_oeq_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %4 = builtin "fcmp_ogt_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %5 = builtin "fcmp_oge_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %6 = builtin "fcmp_olt_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %7 = builtin "fcmp_ole_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %8 = builtin "fcmp_one_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+  %31 = builtin "fcmp_oeq_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %41 = builtin "fcmp_ogt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %51 = builtin "fcmp_oge_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %61 = builtin "fcmp_olt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %71 = builtin "fcmp_ole_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %81 = builtin "fcmp_one_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  
+  // Unordered
+  %11 = builtin "fcmp_ueq_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %12 = builtin "fcmp_ugt_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %13 = builtin "fcmp_uge_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %14 = builtin "fcmp_ult_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %15 = builtin "fcmp_ule_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %16 = builtin "fcmp_une_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+  %111 = builtin "fcmp_ueq_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %121 = builtin "fcmp_ugt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %131 = builtin "fcmp_uge_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %141 = builtin "fcmp_ult_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %151 = builtin "fcmp_ule_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %161 = builtin "fcmp_une_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+  %404 = tuple ()     
+  return %404 : $() 
+
+// CHECK-LABEL:sil @fold_float_comparison_with_nan
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %3 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %4 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %5 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %6 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %7 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %8 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %9 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %10 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %11 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %12 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %13 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %14 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %15 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %16 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %17 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %18 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %19 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %20 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %21 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %22 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %23 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %24 = tuple ()                                  
+// CHECK-NEXT:   return %24 : $()                                
+// CHECK-NEXT: } // end sil function 'fold_float_comparison_with_nan'
+}
+
+// fold float comparison operations with Infinity
+sil @fold_float_comparison_with_inf : $@convention(thin) () -> () {
+  %1 = float_literal $Builtin.FPIEEE32, 0x3F800000 // 1
+
+  %900 = integer_literal $Builtin.Int32, 2139095040 // user: %4
+  %909 = builtin "bitcast_Int32_FPIEEE32"(%900 : $Builtin.Int32) : $Builtin.FPIEEE32 
+
+  // Ordered
+  %4 = builtin "fcmp_ogt_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %5 = builtin "fcmp_oge_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %6 = builtin "fcmp_olt_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %7 = builtin "fcmp_ole_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+  %41 = builtin "fcmp_ogt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %51 = builtin "fcmp_oge_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %61 = builtin "fcmp_olt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %71 = builtin "fcmp_ole_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  
+  // Unordered
+  %12 = builtin "fcmp_ugt_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %13 = builtin "fcmp_uge_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %14 = builtin "fcmp_ult_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %15 = builtin "fcmp_ule_FPIEEE32"(%909 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+  %121 = builtin "fcmp_ugt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %131 = builtin "fcmp_uge_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %141 = builtin "fcmp_ult_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %151 = builtin "fcmp_ule_FPIEEE32"(%1 : $Builtin.FPIEEE32, %909 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+  %404 = tuple ()     
+  return %404 : $()  
+
+// CHECK-LABEL: sil @fold_float_comparison_with_inf
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %3 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %4 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %5 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %6 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %7 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %8 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %9 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %10 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %11 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %12 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %13 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %14 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %15 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %16 = tuple ()
+// CHECK-NEXT:   return %16 : $()
+// CHECK-NEXT: } // end sil function 'fold_float_comparison_with_inf'
+}
+
+// fold double comparison operations involving literals only
+sil @fold_literal_double_comparison : $@convention(thin) () -> () {
+  %0 = float_literal $Builtin.FPIEEE64, 0x3FF0000000000000 // 1
+  %1 = float_literal $Builtin.FPIEEE64, 0x4000000000000000 // 2
+  
+  // Ordered
+  %3 = builtin "fcmp_oeq_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %4 = builtin "fcmp_ogt_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %5 = builtin "fcmp_oge_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %6 = builtin "fcmp_olt_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %7 = builtin "fcmp_ole_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %8 = builtin "fcmp_one_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %9 = builtin "fcmp_ord_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  
+  // Unordered
+  %11 = builtin "fcmp_ueq_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %12 = builtin "fcmp_ugt_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %13 = builtin "fcmp_uge_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %14 = builtin "fcmp_ult_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %15 = builtin "fcmp_ule_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %16 = builtin "fcmp_une_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %17 = builtin "fcmp_uno_FPIEEE64"(%0 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+
+  %404 = tuple ()     
+  return %404 : $()  
+
+// CHECK-LABEL:sil @fold_literal_double_comparison
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %3 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %4 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %5 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %6 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %7 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %8 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %9 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %10 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %11 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %12 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %13 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %14 = tuple ()                                  
+// CHECK-NEXT:   return %14 : $()                                
+// CHECK-NEXT: } // end sil function 'fold_literal_double_comparison'
+}
+
+// fold double comparison operations with NaN
+sil @fold_double_comparison_with_nan : $@convention(thin) () -> () {
+bb0:
+  %1 = float_literal $Builtin.FPIEEE64, 0x3FF0000000000000 // 1
+  %900 = integer_literal $Builtin.Int64, 9221120237041090560 
+  %909 = builtin "bitcast_Int64_FPIEEE64"(%900 : $Builtin.Int64) : $Builtin.FPIEEE64 
+
+  // Ordered
+  %3 = builtin "fcmp_oeq_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %4 = builtin "fcmp_ogt_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %5 = builtin "fcmp_oge_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %6 = builtin "fcmp_olt_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %7 = builtin "fcmp_ole_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %8 = builtin "fcmp_one_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+
+  %31 = builtin "fcmp_oeq_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %41 = builtin "fcmp_ogt_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %51 = builtin "fcmp_oge_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %61 = builtin "fcmp_olt_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %71 = builtin "fcmp_ole_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %81 = builtin "fcmp_one_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  
+  // Unordered
+  %11 = builtin "fcmp_ueq_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %12 = builtin "fcmp_ugt_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %13 = builtin "fcmp_uge_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %14 = builtin "fcmp_ult_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %15 = builtin "fcmp_ule_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %16 = builtin "fcmp_une_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+
+  %111 = builtin "fcmp_ueq_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %121 = builtin "fcmp_ugt_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %131 = builtin "fcmp_uge_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %141 = builtin "fcmp_ult_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %151 = builtin "fcmp_ule_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %161 = builtin "fcmp_une_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+
+  %404 = tuple ()     
+  return %404 : $() 
+
+// CHECK-LABEL:sil @fold_double_comparison_with_nan
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %3 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %4 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %5 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %6 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %7 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %8 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %9 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %10 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %11 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %12 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %13 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %14 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %15 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %16 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %17 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %18 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %19 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %20 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %21 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %22 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %23 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %24 = tuple ()                                  
+// CHECK-NEXT:   return %24 : $()                                
+// CHECK-NEXT: } // end sil function 'fold_double_comparison_with_nan'
+}
+
+// fold double comparison operations with Infinity
+sil @fold_double_comparison_with_inf : $@convention(thin) () -> () {
+bb0:
+  %1 = float_literal $Builtin.FPIEEE64, 0x3FF0000000000000 // 1
+  %900 = integer_literal $Builtin.Int64, 9218868437227405312 
+  %909 = builtin "bitcast_Int64_FPIEEE64"(%900 : $Builtin.Int64) : $Builtin.FPIEEE64 
+
+  // Ordered
+  %4 = builtin "fcmp_ogt_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %5 = builtin "fcmp_oge_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %6 = builtin "fcmp_olt_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %7 = builtin "fcmp_ole_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+
+  %41 = builtin "fcmp_ogt_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %51 = builtin "fcmp_oge_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %61 = builtin "fcmp_olt_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %71 = builtin "fcmp_ole_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  
+  // Unordered
+  %12 = builtin "fcmp_ugt_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %13 = builtin "fcmp_uge_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %14 = builtin "fcmp_ult_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %15 = builtin "fcmp_ule_FPIEEE64"(%909 : $Builtin.FPIEEE64, %1 : $Builtin.FPIEEE64) : $Builtin.Int1
+
+  %121 = builtin "fcmp_ugt_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %131 = builtin "fcmp_uge_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %141 = builtin "fcmp_ult_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+  %151 = builtin "fcmp_ule_FPIEEE64"(%1 : $Builtin.FPIEEE64, %909 : $Builtin.FPIEEE64) : $Builtin.Int1
+
+  %404 = tuple ()     
+  return %404 : $()  
+
+// CHECK-LABEL: sil @fold_double_comparison_with_inf
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %1 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %3 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %4 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %5 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %6 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %7 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %8 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %9 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %10 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %11 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %12 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %13 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   %14 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %15 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %16 = tuple ()
+// CHECK-NEXT:   return %16 : $()
+// CHECK-NEXT: } // end sil function 'fold_double_comparison_with_inf'
+}
+
+// fold float comparison operations with Infinity/NaN when the other argument is not constant
+sil @fold_float_comparison_with_non_constant_arg : $@convention(thin) (Float) -> () {
+bb0(%0: $Float):
+  %1 = struct_extract %0 : $Float, #Float._value
+  
+  %2 = integer_literal $Builtin.Int32, 2143289344 // user: %3   
+  %3 = builtin "bitcast_Int32_FPIEEE32"(%2 : $Builtin.Int32) : $Builtin.FPIEEE32 // NaN
+  
+  %4 = integer_literal $Builtin.Int32, 2139095040 // user: %4
+  %5 = builtin "bitcast_Int32_FPIEEE32"(%4 : $Builtin.Int32) : $Builtin.FPIEEE32 // Inf
+
+  %6 = builtin "fcmp_oge_FPIEEE32"(%3 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %7 = builtin "fcmp_oge_FPIEEE32"(%5 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  
+  %8 = tuple ()     
+  return %8 : $()  
+
+// CHECK-LABEL: sil @fold_float_comparison_with_non_constant_arg
+// CHECK: bb0(%0 : $Float):
+// CHECK-NEXT: %1 = struct_extract %0 : $Float, #Float._value  // user: %5
+// CHECK-NEXT: %2 = integer_literal $Builtin.Int32, 2139095040 // user: %3
+// CHECK-NEXT: %3 = builtin "bitcast_Int32_FPIEEE32"(%2 : $Builtin.Int32) : $Builtin.FPIEEE32 // user: %5
+
+// Comparison with NaN is always folded
+// CHECK-NEXT: %4 = integer_literal $Builtin.Int1, 0 
+
+// Comparison with Inf is not folded unless the other argument can be proven to be constant
+// CHECK-NEXT: %5 = builtin "fcmp_oge_FPIEEE32"(%3 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+// CHECK-NEXT: %6 = tuple ()                                   // user: %7
+// CHECK-NEXT: return %6 : $()                                 // id: %7
+// CHECK-NEXT: } // end sil function 'fold_float_comparison_with_non_constant_arg'
+}
+
+sil @fold_inf_comparisons_with_itself : $@convention(thin) () -> () {
+  %0 = integer_literal $Builtin.Int32, 2139095040 // user: %4
+  %1 = builtin "bitcast_Int32_FPIEEE32"(%0 : $Builtin.Int32) : $Builtin.FPIEEE32 
+
+  // Infinity is equal to, greater than equal to and less than equal to itself
+  %3 = builtin "fcmp_oeq_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %4 = builtin "fcmp_oge_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %5 = builtin "fcmp_ole_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %6 = builtin "fcmp_ueq_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %7 = builtin "fcmp_uge_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %8 = builtin "fcmp_ule_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+  // Infinity cannot be unequal to, greater than or less than itself
+  %9 = builtin "fcmp_one_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %10 = builtin "fcmp_ogt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %11 = builtin "fcmp_olt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %12 = builtin "fcmp_une_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %13 = builtin "fcmp_ugt_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+  %14 = builtin "fcmp_ult_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.Int1
+
+  %15 = tuple ()     
+  return %15 : $()  
+
+// CHECK-LABEL: sil @fold_inf_comparisons_with_itself
+// CHECK: bb0:
+// CHECK:   %0 = integer_literal $Builtin.Int1, -1
+// CHECK:   %1 = integer_literal $Builtin.Int1, -1
+// CHECK:   %2 = integer_literal $Builtin.Int1, -1
+// CHECK:   %3 = integer_literal $Builtin.Int1, -1
+// CHECK:   %4 = integer_literal $Builtin.Int1, -1
+// CHECK:   %5 = integer_literal $Builtin.Int1, -1
+// CHECK:   %6 = integer_literal $Builtin.Int1, -1
+// CHECK:   %7 = integer_literal $Builtin.Int1, -1
+// CHECK:   %8 = integer_literal $Builtin.Int1, -1
+// CHECK:   %9 = integer_literal $Builtin.Int1, -1
+// CHECK:   %10 = integer_literal $Builtin.Int1, -1
+// CHECK:   %11 = integer_literal $Builtin.Int1, -1
+// CHECK:   %12 = integer_literal $Builtin.Int1, 0
+// CHECK:   %13 = integer_literal $Builtin.Int1, 0
+// CHECK:   %14 = integer_literal $Builtin.Int1, 0
+// CHECK:   %15 = integer_literal $Builtin.Int1, 0
+// CHECK:   %16 = integer_literal $Builtin.Int1, 0
+// CHECK:   %17 = integer_literal $Builtin.Int1, 0
+// CHECK:   %18 = integer_literal $Builtin.Int1, 0
+// CHECK:   %19 = integer_literal $Builtin.Int1, 0
+// CHECK:   %20 = integer_literal $Builtin.Int1, 0
+// CHECK:   %21 = integer_literal $Builtin.Int1, 0
+// CHECK:   %22 = integer_literal $Builtin.Int1, 0
+// CHECK:   %23 = integer_literal $Builtin.Int1, 0
+// CHECK:   %24 = tuple ()                                  
+// CHECK:   return %24 : $()                                
+// CHECK: } // end sil function 'fold_inf_comparisons_with_itself'
+}
+
+// fold float comparison operations with opaque values, that may be constant
+// but are hidden behind a struct or a tuple.
+sil @fold_float_comparison_between_opaque_val : $@convention(thin) () -> () {
+  %0 = integer_literal $Builtin.Int32, 2143289344 
+  
+  %1 = builtin "bitcast_Int32_FPIEEE32"(%0 : $Builtin.Int32) : $Builtin.FPIEEE32 
+  %2 = struct $Float (%1 : $Builtin.FPIEEE32)     
+  %3 = struct_extract %2 : $Float, #Float._value  
+  %4 = integer_literal $Builtin.Int32, 2139095040 
+  
+  %5 = builtin "bitcast_Int32_FPIEEE32"(%4 : $Builtin.Int32) : $Builtin.FPIEEE32 
+  %6 = struct $Float (%5 : $Builtin.FPIEEE32)     
+  %7 = struct_extract %6 : $Float, #Float._value  
+  
+  %8 = builtin "fcmp_olt_FPIEEE32"(%3 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.Int1 
+    
+  %9 = tuple ()     
+  return %9 : $()  
+
+// CHECK-LABEL: sil @fold_float_comparison_between_opaque_val
+// CHECK: bb0:
+// CHECK:   %0 = integer_literal $Builtin.Int1, 0           
+// CHECK:   %1 = tuple ()                                  
+// CHECK:   return %1 : $()           
+// CHECK: } // end sil function 'fold_float_comparison_between_opaque_val'
+}
+
+// fold_float_arith_operations
+sil @fold_float_arith_operations : $@convention(thin) () -> Builtin.FPIEEE64 {
 bb0:
   %4 = float_literal $Builtin.FPIEEE64, 0x402E4CCCCCCCCCCD // 15.15
   %11 = float_literal $Builtin.FPIEEE64, 0x400A666666666666 // 3.2999999999999998 // user: %12
@@ -537,7 +996,7 @@ bb0:
   %13 = builtin "fmul_FPIEEE64"(%4 : $Builtin.FPIEEE64, %11 : $Builtin.FPIEEE64) : $Builtin.FPIEEE64
   return %13 : $Builtin.FPIEEE64
 
-// CHECK-LABEL: sil @fold_float_operations
+// CHECK-LABEL: sil @fold_float_arith_operations
 // CHECK: bb0:
 // CHECK-NEXT: %0 = float_literal $Builtin.FPIEEE64, 0x4032733333333333
 // CHECK-NEXT: %1 = float_literal $Builtin.FPIEEE64, 0x40125D1745D1745D

--- a/validation-test/SILOptimizer/constant_folded_fp_operations.swift
+++ b/validation-test/SILOptimizer/constant_folded_fp_operations.swift
@@ -270,6 +270,9 @@ struct FPConstantFoldedComparisonOpsValidator: FPOptimizedOpsValidator {
             for op in FPOperation.allCases {
                 for op1 in FPOperand.allCases {
                     for op2 in FPOperand.allCases {
+                        if checkIfEqCmpBetweenInfAndNonInf(op: op, op1: op1, op2: op2) {
+                            continue
+                        }
                         generateFuncDeclWithCheckDirectives(fpType: fpType, op: op, op1: op1, op2: op2, isopt: true)
                     }
                 }
@@ -282,6 +285,9 @@ struct FPConstantFoldedComparisonOpsValidator: FPOptimizedOpsValidator {
             for op in FPOperation.allCases {
                 for op1 in FPOperand.allCases {
                     for op2 in FPOperand.allCases {
+                        if checkIfEqCmpBetweenInfAndNonInf(op: op, op1: op1, op2: op2) {
+                            continue
+                        }
                         generateFuncDeclWithCheckDirectives(fpType: fpType, op: op, op1: op1, op2: op2, isopt: false)
                     }
                 }
@@ -294,6 +300,9 @@ struct FPConstantFoldedComparisonOpsValidator: FPOptimizedOpsValidator {
             for op in FPOperation.allCases {
                 for op1 in FPOperand.allCases {
                     for op2 in FPOperand.allCases {
+                        if checkIfEqCmpBetweenInfAndNonInf(op: op, op1: op1, op2: op2) {
+                            continue
+                        }
                         let comparisonFuncName = ["comparison", fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
                         let optFuncName = [optPrefix, fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
                         let unoptFuncName = [unoptPrefix, fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
@@ -316,6 +325,9 @@ struct FPConstantFoldedComparisonOpsValidator: FPOptimizedOpsValidator {
             for op in FPOperation.allCases {
                 for op1 in FPOperand.allCases {
                     for op2 in FPOperand.allCases {
+                        if checkIfEqCmpBetweenInfAndNonInf(op: op, op1: op1, op2: op2) {
+                            continue
+                        }
                         let comparison = resultComparisonCheck(fpType: fpType, op: op, op1: op1, op2: op2)
 
                         print("""
@@ -371,6 +383,20 @@ struct FPConstantFoldedComparisonOpsValidator: FPOptimizedOpsValidator {
         \(checkDirectives)
                 
         """)
+    }
+
+    // Equality comparisons b/w infinity and non-infinity are not constant folded.
+    // In such comparisons, special floating point types - Float80 and Float16, may 
+    // come into play and pattern matching againt them complicates the constant folding
+    // logic more than we'd like.
+    private func checkIfEqCmpBetweenInfAndNonInf(op: FPOperation, op1: FPOperand, op2: FPOperand) -> Bool {
+        if op == .Equal || op == .NotEqual {
+            // If only one of the operands is infinity
+            if (op1 == .Infinity || op2 == .Infinity) && !(op1 == .Infinity && op2 == .Infinity) {
+                return true
+            }
+        }
+        return false
     }
 }
 

--- a/validation-test/SILOptimizer/constant_folded_fp_operations.swift
+++ b/validation-test/SILOptimizer/constant_folded_fp_operations.swift
@@ -1,0 +1,372 @@
+// RUN: %empty-directory(%t) 
+// RUN: %swift_driver %s >%t/constant_folded_fp_operation_validation.swift
+
+// RUN: %target-swift-frontend -emit-sil -O -suppress-warnings -verify %t/constant_folded_fp_operation_validation.swift 2>&1 | %FileCheck --check-prefix=CHECK-SIL %t/constant_folded_fp_operation_validation.swift
+// RUN: %target-build-swift -O -suppress-warnings %t/constant_folded_fp_operation_validation.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefix=COMPARE-RESULT %t/constant_folded_fp_operation_validation.swift
+
+// REQUIRES: executable_test,optimized_stdlib
+// REQUIRES: swift_in_compiler
+
+// Note: This code is not the testfile itself but generates the testfile in the %t directory.
+
+createTestFile()
+
+func createTestFile() {
+    let validator = FPConstantFoldedComparisonOpsValidator()
+    validator.generateOptimizedFuncDecls()
+    validator.generateUnoptimizedFuncDecls()
+    validator.generateComparisonFuncDecls()
+    validator.generateComparisonFuncCalls()
+}
+
+/////////////////// Protocols ///////////////////
+
+/// Implemented by types that have distinct ways of 
+/// being represented in an expression context vs all
+/// other contexts. 
+protocol Representable {
+    func math_name() -> String
+    func printable_name() -> String
+}
+
+/// An rough estimation of a type that needs to validate
+/// optimized floating point operations in Swift.
+/// 
+/// Any new validator should conform to this protocol
+/// and then call the generate* functions to generate
+/// corresponding test file code.
+protocol FPOptimizedOpsValidator {
+    associatedtype FPType: Representable
+    associatedtype FPOperation: Representable
+    associatedtype FPOperand: Representable
+
+    func generateOptimizedFuncDecls()
+    func generateUnoptimizedFuncDecls()
+    func generateComparisonFuncDecls()
+    func generateComparisonFuncCalls()
+
+    func optimizedFunDeclCheck(fpType: FPType, op: FPOperation, op1: FPOperand, op2: FPOperand) -> String
+    func unoptimizedFunDeclCheck(fpType: FPType, op: FPOperation, op1: FPOperand, op2: FPOperand) -> String
+    func resultComaparisonCheck(fpType: FPType, op: FPOperation, op1: FPOperand, op2: FPOperand) -> String
+}
+
+////////////////// Common ///////////////////
+
+// Generates accessors for floating point operands
+// commonly used in the tests.
+//
+// These accessors prevent the unoptimized function versions
+// from getting optimized by the mandatory optimization passes
+// and returning a constant value.
+func generateOperandAccessors() {
+    print("""
+    @inline(never) @_silgen_name("zero_float") @_optimize(none)
+    func zero_float() -> Float {
+        return 0.0
+    }
+
+    @inline(never) @_silgen_name("one_float") @_optimize(none)
+    func one_float() -> Float {
+        return 1.0
+    }
+
+    @inline(never) @_silgen_name("zero_double") @_optimize(none)
+    func zero_double() -> Double {
+        return 0.0
+    }
+
+    @inline(never) @_silgen_name("one_double") @_optimize(none)
+    func one_double() -> Double {
+        return 1.0
+    }
+    """)
+}
+
+////////////////// Comparison Operations Validator ///////////////////
+
+struct FPConstantFoldedComparisonOpsValidator: FPOptimizedOpsValidator {
+    /////////////////////// TYPES ///////////////////////
+    
+    /// Type of floating points this validator deals with.
+    enum _FpType : CaseIterable, Representable, Equatable {
+        case Float
+        case Double
+
+        func math_name() -> String {
+            switch self {
+            case .Float:
+                return "Float"
+            case .Double:
+                return "Double"
+            }
+        }
+
+        func printable_name() -> String {
+            switch self {
+            case .Float:
+                return "float"
+            case .Double:
+                return "double"
+            }
+        }
+    }
+
+    /// Type of floating point operations this validator deals with.
+    enum _FPOperation : CaseIterable, Representable, Equatable {
+        case LessThan
+        case GreaterThan
+        case LessThanOrEqual
+        case GreaterThanOrEqual
+        case Equal
+        case NotEqual
+
+        func math_name() -> String {
+            switch self {
+                case .LessThan:
+                    return "<"
+                case .GreaterThan:
+                    return ">"
+                case .LessThanOrEqual:
+                    return "<="
+                case .GreaterThanOrEqual:
+                    return ">="
+                case .Equal:
+                    return "=="
+                case .NotEqual:
+                    return "!="
+            }
+        }
+
+        func printable_name() -> String {
+            switch self {
+                case .LessThan:
+                    return "lessThan"
+                case .GreaterThan:
+                    return "greaterThan"
+                case .LessThanOrEqual:
+                    return "lessThanOrEqual"
+                case .GreaterThanOrEqual:
+                    return "greaterThanOrEqual"
+                case .Equal:
+                    return "equal"
+                case .NotEqual:
+                    return "notEqual"
+            }
+        }
+    }
+
+    /// Type of floating point operands this validator deals with.
+    enum _FPOperand : CaseIterable, Representable, Equatable {
+        case Zero
+        case One
+        case Infinity
+        case Nan
+
+        func isSpecial() -> Bool {
+            switch self {
+                case .Zero:
+                    return false
+                case .One:
+                    return false
+                case .Infinity:
+                    return true
+                case .Nan:
+                    return true
+            }
+        }
+
+        func math_name() -> String {
+            switch self {
+                case .Zero:
+                    return "0.0"
+                case .One:
+                    return "1.0"
+                case .Infinity:
+                    return "infinity"
+                case .Nan:
+                    return "nan"
+            }
+        }
+
+        func printable_name() -> String {
+            switch self {
+                case .Zero:
+                    return "zero"
+                case .One:
+                    return "one"
+                case .Infinity:
+                    return "infinity"
+                case .Nan:
+                    return "nan"
+            }
+        }
+    }
+
+    private let optPrefix = "opt"
+    private let unoptPrefix = "unopt"
+
+    /////////////////////// FPOptimizedOpsValidator Conformances ///////////////////////
+    typealias FPType = _FpType
+    typealias FPOperation = _FPOperation
+    typealias FPOperand = _FPOperand
+
+    func optimizedFunDeclCheck(
+        fpType: FPType, 
+        op: FPOperation, 
+        op1: FPOperand, 
+        op2: FPOperand
+    ) -> String {
+        let funcName = [optPrefix, fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+
+        return """
+        // CHECK-SIL-LABEL: sil hidden [noinline] @\(funcName)
+        // CHECK-SIL-NEXT: [global: ]
+        // CHECK-SIL-NEXT: bb0:
+        // CHECK-SIL-NOT: {{.*}}fcmp{{.*}}
+        // CHECK-SIL: } // end sil function '\(funcName)' 
+        """
+    }
+
+    func unoptimizedFunDeclCheck(
+        fpType: FPType, 
+        op: FPOperation, 
+        op1: FPOperand, 
+        op2: FPOperand
+    ) -> String {
+        let funcName = [unoptPrefix, fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+
+        return """
+        // CHECK-SIL-LABEL: sil hidden [noinline] [Onone] @\(funcName)
+        // CHECK-SIL-NEXT: bb0:
+        // CHECK-SIL: {{.*}}fcmp{{.*}}
+        // CHECK-SIL: } // end sil function '\(funcName)' 
+        """
+    }
+
+    func resultComaparisonCheck(
+        fpType: FPType, 
+        op: FPOperation, 
+        op1: FPOperand, 
+        op2: FPOperand
+    ) -> String {
+        let resultVarName = ["var", fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+
+        return """
+        // COMPARE-RESULT: [\(resultVarName)] result equal? true
+        """
+    }
+
+    func generateOptimizedFuncDecls() {
+        for fpType in FPType.allCases {
+            for op in FPOperation.allCases {
+                for op1 in FPOperand.allCases {
+                    for op2 in FPOperand.allCases {
+                        generateFuncDeclWithCheckDirectives(fpType: fpType, op: op, op1: op1, op2: op2, isopt: true)
+                    }
+                }
+            }
+        }
+    }
+
+    func generateUnoptimizedFuncDecls() {
+        for fpType in FPType.allCases {
+            for op in FPOperation.allCases {
+                for op1 in FPOperand.allCases {
+                    for op2 in FPOperand.allCases {
+                        generateFuncDeclWithCheckDirectives(fpType: fpType, op: op, op1: op1, op2: op2, isopt: false)
+                    }
+                }
+            }
+        }
+    }
+
+    func generateComparisonFuncDecls() {
+        for fpType in FPType.allCases {
+            for op in FPOperation.allCases {
+                for op1 in FPOperand.allCases {
+                    for op2 in FPOperand.allCases {
+                        let comparisonFuncName = ["comparison", fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+                        let resultVarName = ["var", fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+                        let optFuncName = [optPrefix, fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+                        let unoptFuncName = [unoptPrefix, fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+                        
+                        print("""
+                        @inline(never) @_silgen_name("\(comparisonFuncName)") @_optimize(none)
+                        func \(comparisonFuncName)() {
+                            let \(resultVarName) = \(optFuncName)() == \(unoptFuncName)()
+                            print("[\(resultVarName)] result equal? \\(\(resultVarName))")
+                        }
+                                
+                        """)
+                    }
+                }
+            }
+        }
+    }
+
+    func generateComparisonFuncCalls() {
+        for fpType in FPType.allCases {
+            for op in FPOperation.allCases {
+                for op1 in FPOperand.allCases {
+                    for op2 in FPOperand.allCases {
+                        let comparisonFuncName = ["comparison", fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+                        let checkDirective = resultComaparisonCheck(fpType: fpType, op: op, op1: op1, op2: op2)
+
+                        print("""
+                        \(checkDirective)
+                        \(comparisonFuncName)()
+
+                        """)
+                        
+                    }
+                }
+            }
+        }
+    }
+
+    /////////////////////// Utilities ///////////////////////
+    private func generateFuncDeclWithCheckDirectives(
+        fpType: FPType, 
+        op: FPOperation, 
+        op1: FPOperand, 
+        op2: FPOperand, 
+        isopt: Bool = false
+    ) {
+        var operand1 = op1.isSpecial() ? fpType.math_name() + "." + op1.math_name() : op1.math_name()
+        var operand2 = op2.isSpecial() ? fpType.math_name() + "." + op2.math_name() : op2.math_name()
+
+        if !isopt {
+            if !op1.isSpecial() {
+                if fpType == .Double {
+                    operand1 = op1 == .Zero ? "zero_double()": "one_double()"
+                } else {
+                    operand1 = op1 == .Zero ? "zero_float()": "one_float()"
+                }
+            }
+            if !op2.isSpecial() {
+                if fpType == .Double {
+                    operand2 = op2 == .Zero ? "zero_double()": "one_double()"
+                } else {
+                    operand2 = op2 == .Zero ? "zero_float()": "one_float()"
+                }
+            }
+        }
+
+        let optPrefix = isopt ? optPrefix : unoptPrefix
+        let optAttr = isopt ? "" : "@_optimize(none)"
+        let funcName = [optPrefix, fpType.printable_name(), op.printable_name(), op1.printable_name(), op2.printable_name()].joined(separator: "_")
+        let checkDirectives = isopt ? 
+        optimizedFunDeclCheck(fpType: fpType, op: op, op1: op1, op2: op2) : 
+        unoptimizedFunDeclCheck(fpType: fpType, op: op, op1: op1, op2: op2)
+
+        print("""
+        @inline(never) @_silgen_name("\(funcName)") \(optAttr)
+        func \(funcName)() -> Bool {
+            return \(operand1) \(op.math_name()) \(operand2)
+        }
+        \(checkDirectives)
+                
+        """)
+    }
+}


### PR DESCRIPTION
This pull request adds support for handling floating point comparisons to the constant folder. 

Partially fixes #68901
