### PR TITLE
[ASTGen] Utilize base specific SyntaxEnum and start Pattern generation

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -177,6 +177,13 @@ namespace swift {
 #define ABSTRACT_TYPEREPR(Id, Parent) TYPEREPR(Id, Parent)
 #include "swift/AST/TypeReprNodes.def"
 
+// Declare `.asPattern` on each BridgedXXXPattern type, which upcasts a wrapper
+// for a Pattern subclass to a BridgedPattern.
+#define PATTERN(Id, Parent)                                                    \
+  SWIFT_NAME("getter:Bridged" #Id "Pattern.asPattern(self:)")                  \
+  BridgedPattern Bridged##Id##Pattern_asPattern(Bridged##Id##Pattern pattern);
+#include "swift/AST/PatternNodes.def"
+
 //===----------------------------------------------------------------------===//
 // MARK: Diagnostic Engine
 //===----------------------------------------------------------------------===//
@@ -289,10 +296,10 @@ void BridgedDiagnostic_finish(BridgedDiagnostic cDiag);
 
 SWIFT_NAME(
     "BridgedPatternBindingDecl.createParsed(_:declContext:bindingKeywordLoc:"
-    "nameExpr:initializer:isStatic:isLet:)")
+    "pattern:initializer:isStatic:isLet:)")
 BridgedPatternBindingDecl BridgedPatternBindingDecl_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
-    BridgedSourceLoc cBindingKeywordLoc, BridgedExpr opaqueNameExpr,
+    BridgedSourceLoc cBindingKeywordLoc, BridgedPattern pattern,
     BridgedExpr opaqueInitExpr, bool isStatic, bool isLet);
 
 SWIFT_NAME("BridgedParamDecl.createParsed(_:declContext:specifierLoc:firstName:"
@@ -859,6 +866,16 @@ BridgedVarargTypeRepr_createParsed(BridgedASTContext cContext,
 
 SWIFT_NAME("BridgedTypeRepr.dump(self:)")
 void BridgedTypeRepr_dump(BridgedTypeRepr type);
+
+//===----------------------------------------------------------------------===//
+// MARK: Patterns
+//===----------------------------------------------------------------------===//
+
+SWIFT_NAME("BridgedNamedPattern.createParsed(_:declContext:name:loc:)")
+BridgedNamedPattern
+BridgedNamedPattern_createParsed(BridgedASTContext astContext,
+                                 BridgedDeclContext declContext,
+                                 BridgedIdentifier name, BridgedSourceLoc cLoc);
 
 //===----------------------------------------------------------------------===//
 // MARK: Misc

--- a/include/swift/AST/ASTBridgingWrappers.def
+++ b/include/swift/AST/ASTBridgingWrappers.def
@@ -55,6 +55,11 @@
 #define ABSTRACT_TYPEREPR(Id, Parent) TYPEREPR(Id, Parent)
 #include "swift/AST/TypeReprNodes.def"
 
+#ifndef PATTERN
+#define PATTERN(Id, Parent) AST_BRIDGING_WRAPPER_NONNULL(Id##Pattern)
+#endif
+#include "swift/AST/PatternNodes.def"
+
 // Some of the base classes need to be nullable to allow them to be used as
 // optional parameters.
 AST_BRIDGING_WRAPPER_NONNULL(Decl)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5838,13 +5838,6 @@ protected:
           SourceLoc nameLoc, Identifier name, DeclContext *dc,
           StorageIsMutable_t supportsMutation);
 
-protected:
-  // Only \c ParamDecl::setSpecifier is allowed to flip this - and it's also
-  // on the way out of that business.
-  void setIntroducer(Introducer value) {
-    Bits.VarDecl.Introducer = uint8_t(value);
-  }
-
 public:
   VarDecl(bool isStatic, Introducer introducer,
           SourceLoc nameLoc, Identifier name, DeclContext *dc)
@@ -6063,6 +6056,12 @@ public:
   /// Is this a stored property that will _not_ trigger any user-defined code
   /// upon any kind of access?
   bool isOrdinaryStoredProperty() const;
+
+  /// Set the introducer kind.
+  /// Note: do not call this after type checking begun.
+  void setIntroducer(Introducer value) {
+    Bits.VarDecl.Introducer = uint8_t(value);
+  }
 
   Introducer getIntroducer() const {
     return Introducer(Bits.VarDecl.Introducer);

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -17,6 +17,7 @@ add_pure_swift_host_library(swiftASTGen STATIC
   Sources/ASTGen/Literals.swift
   Sources/ASTGen/Macros.swift
   Sources/ASTGen/ParameterClause.swift
+  Sources/ASTGen/Patterns.swift
   Sources/ASTGen/PluginHost.swift
   Sources/ASTGen/SourceFile.swift
   Sources/ASTGen/SourceManager.swift

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -14,7 +14,7 @@ import ASTBridging
 import BasicBridging
 import ParseBridging
 // Needed to use BumpPtrAllocator
-@_spi(BumpPtrAllocator) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+@_spi(BumpPtrAllocator) import SwiftSyntax
 
 import struct SwiftDiagnostics.Diagnostic
 

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -14,7 +14,7 @@ import ASTBridging
 import BasicBridging
 import ParseBridging
 // Needed to use BumpPtrAllocator
-@_spi(BumpPtrAllocator) import SwiftSyntax
+@_spi(BumpPtrAllocator) @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 import struct SwiftDiagnostics.Diagnostic
 
@@ -132,7 +132,7 @@ struct ASTGenVisitor {
 
     for element in node.statements {
       let loc = element.bridgedSourceLoc(in: self)
-      let swiftASTNodes = generate(element)
+      let swiftASTNodes = generate(codeBlockItem: element)
       switch swiftASTNodes {
       case .decl(let d):
         out.append(d.raw)
@@ -188,179 +188,67 @@ extension ASTGenVisitor {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: DeclSyntax) -> BridgedDecl {
-    return generate(Syntax(node)).castToDecl
-  }
-
-  func generate(_ node: ExprSyntax) -> BridgedExpr {
-    if !isExprMigrated(node) {
-      return generateWithLegacy(node)
-    }
-    return generate(Syntax(node)).castToExpr
-  }
-
-  func generate(_ node: PatternSyntax) -> ASTNode {
-    return generate(Syntax(node))
-  }
-
-  func generate(_ node: StmtSyntax) -> BridgedStmt {
-    return generate(Syntax(node)).castToStmt
-  }
-
-  func generate(_ node: TypeSyntax) -> BridgedTypeRepr {
-    if !isTypeMigrated(node) {
-      return generateWithLegacy(node)
-    }
-    return generate(Syntax(node)).castToType
-  }
-
-  func generate(_ node: some SyntaxChildChoices) -> ASTNode {
-    return self.generate(Syntax(node))
-  }
-
+  /// Generate AST from a Syntax node. The node must be a decl, stmt, expr, or
+  /// type.
   func generate(_ node: Syntax) -> ASTNode {
-    switch node.as(SyntaxEnum.self) {
-    case .actorDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .arrayElement(let node):
-      return .expr(generate(node))
-    case .arrayExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .arrayType(let node):
-      return .type(generate(node))
-    case .associatedTypeDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .attributedType(let node):
-      return .type(generate(node))
-    case .booleanLiteralExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .classDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .closureExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .codeBlock(let node):
-      return .stmt(generate(node).asStmt)
-    case .codeBlockItem(let node):
-      return generate(node)
-    case .compositionType(let node):
-      return .type(generate(node))
-    case .conditionElement(let node):
-      return generate(node)
-    case .declReferenceExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .deinitializerDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .dictionaryType(let node):
-      return .type(generate(node))
-    case .enumCaseDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .enumDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .expressionStmt(let node):
-      return .stmt(generate(node))
-    case .extensionDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .functionCallExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .functionDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .functionType(let node):
-      return .type(generate(node))
-    case .identifierPattern(let node):
-      return .expr(generate(node).asExpr)
-    case .identifierType(let node):
-      return .type(generate(node))
-    case .ifExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .implicitlyUnwrappedOptionalType(let node):
-      return .type(generate(node))
-    case .importDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .initializerClause(let node):
-      return .expr(generate(node))
-    case .initializerDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .integerLiteralExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .memberAccessExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .memberBlockItem(let node):
-      return .decl(generate(node))
-    case .memberType(let node):
-      return .type(generate(node))
-    case .metatypeType(let node):
-      return .type(generate(node))
-    case .namedOpaqueReturnType(let node):
-      return .type(generate(node))
-    case .nilLiteralExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .operatorDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .optionalType(let node):
-      return .type(generate(node))
-    case .packExpansionType(let node):
-      return .type(generate(node))
-    case .precedenceGroupDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .protocolDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .returnStmt(let node):
-      return .stmt(generate(node).asStmt)
-    case .someOrAnyType(let node):
-      return .type(generate(node))
-    case .stringLiteralExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .structDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .tupleExpr(let node):
-      return .expr(generate(node).asExpr)
-    case .tupleType(let node):
-      return .type(generate(node))
-    case .typeAliasDecl(let node):
-      return .decl(generate(node).asDecl)
-    case .variableDecl(let node):
-      return .decl(generate(node).asDecl)
-
-    // Un-migrated nodes.
-    case _ where node.is(ExprSyntax.self):
-      return .expr(self.generateWithLegacy(node.cast(ExprSyntax.self)))
-    case _ where node.is(StmtSyntax.self):
-      return .stmt(self.generateWithLegacy(node.cast(StmtSyntax.self)))
-    case _ where node.is(DeclSyntax.self):
-      return .decl(self.generateWithLegacy(node.cast(DeclSyntax.self)))
-
-    default:
-      fatalError("case does not correspond to an ASTNode")
+    if let decl = node.as(DeclSyntax.self) {
+      return .decl(self.generate(decl: decl))
     }
+    if let stmt = node.as(StmtSyntax.self) {
+      return .stmt(self.generate(stmt: stmt))
+    }
+    if let expr = node.as(ExprSyntax.self) {
+      return .expr(self.generate(expr: expr))
+    }
+    if let type = node.as(TypeSyntax.self) {
+      return .type(self.generate(type: type))
+    }
+
+    // --- Special cases where `node` doesn't belong to one of the base kinds.
+
+    // CodeBlockSyntax -> BraceStmt.
+    if let node = node.as(CodeBlockSyntax.self) {
+      return .stmt(self.generate(codeBlock: node).asStmt)
+    }
+    // CodeBlockItemSyntax -> ASTNode.
+    if let node = node.as(CodeBlockItemSyntax.self) {
+      return self.generate(codeBlockItem: node)
+    }
+
+    fatalError("node does not correspond to an ASTNode \(node.kind)")
   }
 }
 
 // Misc visits.
 // TODO: Some of these are called within a single file/method; we may want to move them to the respective files.
 extension ASTGenVisitor {
+  func generate(_ node: some SyntaxChildChoices) -> ASTNode {
+    return self.generate(Syntax(node))
+  }
+
   public func generate(_ node: MemberBlockItemSyntax) -> BridgedDecl {
-    generate(node.decl)
+    generate(decl: node.decl)
   }
 
   public func generate(_ node: InitializerClauseSyntax) -> BridgedExpr {
-    generate(node.value)
+    generate(expr: node.value)
   }
 
   public func generate(_ node: ConditionElementSyntax) -> ASTNode {
     generate(node.condition)
   }
 
-  public func generate(_ node: CodeBlockItemSyntax) -> ASTNode {
+  public func generate(codeBlockItem node: CodeBlockItemSyntax) -> ASTNode {
     generate(node.item)
   }
 
   public func generate(_ node: ArrayElementSyntax) -> BridgedExpr {
-    generate(node.expression)
+    generate(expr: node.expression)
   }
 
   @inline(__always)
   func generate(_ node: CodeBlockItemListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.generate($0).bridged }.bridgedArray(in: self)
+    node.lazy.map { self.generate(codeBlockItem: $0).bridged }.bridgedArray(in: self)
   }
 }
 
@@ -373,7 +261,7 @@ extension ASTGenVisitor {
       return nil
     }
 
-    return self.generate(node)
+    return self.generate(type: node)
   }
 
   @inline(__always)
@@ -382,7 +270,7 @@ extension ASTGenVisitor {
       return nil
     }
 
-    return self.generate(node)
+    return self.generate(expr: node)
   }
 
   @inline(__always)

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -18,6 +18,60 @@ import SwiftDiagnostics
 // MARK: - TypeDecl
 
 extension ASTGenVisitor {
+  func generate(decl node: DeclSyntax) -> BridgedDecl {
+    switch node.as(DeclSyntaxEnum.self) {
+    case .accessorDecl:
+      break
+    case .actorDecl(let node):
+      return self.generate(node).asDecl
+    case .associatedTypeDecl(let node):
+      return self.generate(node).asDecl
+    case .classDecl(let node):
+      return self.generate(node).asDecl
+    case .deinitializerDecl(let node):
+      return self.generate(node).asDecl
+    case .editorPlaceholderDecl:
+      break
+    case .enumCaseDecl(let node):
+      return self.generate(node).asDecl
+    case .enumDecl(let node):
+      return self.generate(node).asDecl
+    case .extensionDecl(let node):
+      return self.generate(node).asDecl
+    case .functionDecl(let node):
+      return self.generate(node).asDecl
+    case .ifConfigDecl:
+      break
+    case .importDecl(let node):
+      return self.generate(node).asDecl
+    case .initializerDecl(let node):
+      return self.generate(node).asDecl
+    case .macroDecl:
+      break
+    case .macroExpansionDecl:
+      break
+    case .missingDecl:
+      break
+    case .operatorDecl(let node):
+      return self.generate(node).asDecl
+    case .poundSourceLocation:
+      break
+    case .precedenceGroupDecl(let node):
+      return self.generate(node).asDecl
+    case .protocolDecl(let node):
+      return self.generate(node).asDecl
+    case .structDecl(let node):
+      return self.generate(node).asDecl
+    case .subscriptDecl:
+      break
+    case .typeAliasDecl(let node):
+      return self.generate(node).asDecl
+    case .variableDecl(let node):
+      return self.generate(node).asDecl
+    }
+    return self.generateWithLegacy(node)
+  }
+
   public func generate(_ node: TypeAliasDeclSyntax) -> BridgedTypeAliasDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
@@ -29,7 +83,7 @@ extension ASTGenVisitor {
       nameLoc: nameLoc,
       genericParamList: self.generate(node.genericParameterClause).asNullable,
       equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
-      underlyingType: self.generate(node.initializer.value),
+      underlyingType: self.generate(type: node.initializer.value),
       genericWhereClause: self.generate(node.genericWhereClause).asNullable
     )
   }
@@ -193,7 +247,7 @@ extension ASTGenVisitor {
       self.ctx,
       declContext: self.declContext,
       extensionKeywordLoc: node.extensionKeyword.bridgedSourceLoc(in: self),
-      extendedType: self.generate(node.extendedType),
+      extendedType: self.generate(type: node.extendedType),
       inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
@@ -241,7 +295,7 @@ extension ASTGenVisitor {
 
 extension ASTGenVisitor {
   public func generate(_ node: VariableDeclSyntax) -> BridgedPatternBindingDecl {
-    let pattern = generate(node.bindings.first!.pattern)
+    let pattern = generate(pattern: node.bindings.first!.pattern)
     let initializer = generate(node.bindings.first!.initializer!)
 
     let isStatic = false  // TODO: compute this
@@ -286,7 +340,7 @@ extension ASTGenVisitor {
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        decl.setParsedBody(self.generate(body))
+        decl.setParsedBody(self.generate(codeBlock: body))
       }
     }
 
@@ -310,7 +364,7 @@ extension ASTGenVisitor {
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        decl.setParsedBody(self.generate(body))
+        decl.setParsedBody(self.generate(codeBlock: body))
       }
     }
 
@@ -326,7 +380,7 @@ extension ASTGenVisitor {
 
     if let body = node.body {
       self.withDeclContext(decl.asDeclContext) {
-        decl.setParsedBody(self.generate(body))
+        decl.setParsedBody(self.generate(codeBlock: body))
       }
     }
 
@@ -539,7 +593,7 @@ extension ASTGenVisitor {
 
   @inline(__always)
   func generate(_ node: InheritedTypeListSyntax) -> BridgedArrayRef {
-    node.lazy.map { self.generate($0.type) }.bridgedArray(in: self)
+    node.lazy.map { self.generate(type: $0.type) }.bridgedArray(in: self)
   }
 
   @inline(__always)

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -305,7 +305,7 @@ extension ASTGenVisitor {
       self.ctx,
       declContext: self.declContext,
       bindingKeywordLoc: node.bindingSpecifier.bridgedSourceLoc(in: self),
-      nameExpr: pattern.castToExpr,
+      pattern: pattern,
       initializer: initializer,
       isStatic: isStatic,
       isLet: isLet

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -255,12 +255,6 @@ extension ASTGenVisitor {
     return .createParsed(self.ctx, base: name, loc: nameLoc)
   }
 
-  public func generate(_ node: IdentifierPatternSyntax) -> BridgedUnresolvedDeclRefExpr {
-    let (name, nameLoc) = node.identifier.bridgedIdentifierAndSourceLoc(in: self)
-
-    return .createParsed(self.ctx, base: name, loc: nameLoc)
-  }
-
   public func generate(_ node: MemberAccessExprSyntax) -> BridgedUnresolvedDotExpr {
     let loc = node.bridgedSourceLoc(in: self)
     let base = generate(expr: node.base!)

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -83,6 +83,121 @@ func isExprMigrated(_ node: ExprSyntax) -> Bool {
 }
 
 extension ASTGenVisitor {
+  func generate(expr node: ExprSyntax) -> BridgedExpr {
+    guard isExprMigrated(node) else {
+      return generateWithLegacy(node)
+    }
+    switch node.as(ExprSyntaxEnum.self) {
+    case .arrayExpr(let node):
+      return self.generate(node).asExpr
+    case .arrowExpr:
+      break
+    case .asExpr:
+      break
+    case .assignmentExpr:
+      break
+    case .awaitExpr:
+      break
+    case .binaryOperatorExpr:
+      break
+    case .booleanLiteralExpr(let node):
+      return self.generate(node).asExpr
+    case .borrowExpr:
+      break
+    case .canImportExpr:
+      break
+    case .canImportVersionInfo:
+      break
+    case .closureExpr(let node):
+      return self.generate(node).asExpr
+    case .consumeExpr:
+      break
+    case .copyExpr:
+      break
+    case .declReferenceExpr(let node):
+      return self.generate(node).asExpr
+    case .dictionaryExpr:
+      break
+    case .discardAssignmentExpr:
+      break
+    case .doExpr:
+      break
+    case .editorPlaceholderExpr:
+      break
+    case .floatLiteralExpr:
+      break
+    case .forceUnwrapExpr:
+      break
+    case .functionCallExpr(let node):
+      return self.generate(node).asExpr
+    case .genericSpecializationExpr:
+      break
+    case .ifExpr(let node):
+      return self.generate(node).asExpr
+    case .inOutExpr:
+      break
+    case .infixOperatorExpr:
+      break
+    case .integerLiteralExpr(let node):
+      return self.generate(node).asExpr
+    case .isExpr:
+      break
+    case .keyPathExpr:
+      break
+    case .macroExpansionExpr:
+      break
+    case .memberAccessExpr(let node):
+      return self.generate(node).asExpr
+    case .missingExpr:
+      break
+    case .nilLiteralExpr(let node):
+      return self.generate(node).asExpr
+    case .optionalChainingExpr:
+      break
+    case .packElementExpr:
+      break
+    case .packExpansionExpr:
+      break
+    case .patternExpr:
+      break
+    case .postfixIfConfigExpr:
+      break
+    case .postfixOperatorExpr:
+      break
+    case .prefixOperatorExpr:
+      break
+    case .regexLiteralExpr:
+      break
+    case .sequenceExpr:
+      break
+    case .simpleStringLiteralExpr:
+      break
+    case .stringLiteralExpr(let node):
+      return self.generate(node).asExpr
+    case .subscriptCallExpr:
+      break
+    case .superExpr:
+      break
+    case .switchExpr:
+      break
+    case .ternaryExpr:
+      break
+    case .tryExpr:
+      break
+    case .tupleExpr(let node):
+      return self.generate(node).asExpr
+    case .typeExpr:
+      break
+    case .unresolvedAsExpr:
+      break
+    case .unresolvedIsExpr:
+      break
+    case .unresolvedTernaryExpr:
+      break
+    }
+    preconditionFailure("isExprMigrated() mismatch")
+  }
+
   public func generate(_ node: ClosureExprSyntax) -> BridgedClosureExpr {
     let body = BridgedBraceStmt.createParsed(
       self.ctx,
@@ -129,7 +244,7 @@ extension ASTGenVisitor {
       leftParen: node.leftParen,
       rightParen: node.rightParen
     )
-    let callee = generate(node.calledExpression)
+    let callee = generate(expr: node.calledExpression)
 
     return .createParsed(self.ctx, fn: callee, args: argumentTuple)
   }
@@ -148,7 +263,7 @@ extension ASTGenVisitor {
 
   public func generate(_ node: MemberAccessExprSyntax) -> BridgedUnresolvedDotExpr {
     let loc = node.bridgedSourceLoc(in: self)
-    let base = generate(node.base!)
+    let base = generate(expr: node.base!)
     let name = node.declName.baseName.bridgedIdentifier(in: self)
 
     return .createParsed(ctx, base: base, dotLoc: loc, name: name, nameLoc: loc)
@@ -177,7 +292,7 @@ extension ASTGenVisitor {
   /// Generate a tuple expression from a ``LabeledExprListSyntax`` and parentheses.
   func generate(_ node: LabeledExprListSyntax, leftParen: TokenSyntax?, rightParen: TokenSyntax?) -> BridgedTupleExpr {
     let expressions = node.lazy.map {
-      self.generate($0.expression)
+      self.generate(expr: $0.expression)
     }
     let labels = node.lazy.map {
       $0.label.bridgedIdentifier(in: self)

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -56,15 +56,15 @@ extension ASTGenVisitor {
         return BridgedRequirementRepr(
           SeparatorLoc: conformance.colon.bridgedSourceLoc(in: self),
           Kind: .typeConstraint,
-          FirstType: self.generate(conformance.leftType),
-          SecondType: self.generate(conformance.rightType)
+          FirstType: self.generate(type: conformance.leftType),
+          SecondType: self.generate(type: conformance.rightType)
         )
       case .sameTypeRequirement(let sameType):
         return BridgedRequirementRepr(
           SeparatorLoc: sameType.equal.bridgedSourceLoc(in: self),
           Kind: .sameType,
-          FirstType: self.generate(sameType.leftType),
-          SecondType: self.generate(sameType.rightType)
+          FirstType: self.generate(type: sameType.leftType),
+          SecondType: self.generate(type: sameType.rightType)
         )
       case .layoutRequirement(_):
         // FIXME: Implement layout requirement translation.

--- a/lib/ASTGen/Sources/ASTGen/Patterns.swift
+++ b/lib/ASTGen/Sources/ASTGen/Patterns.swift
@@ -1,3 +1,14 @@
+//===--- Patterns.swift ---------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 
 import ASTBridging
 import BasicBridging
@@ -5,25 +16,34 @@ import SwiftDiagnostics
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 extension ASTGenVisitor {
-  func generate(pattern node: PatternSyntax) -> ASTNode {
+  func generate(pattern node: PatternSyntax) -> BridgedPattern {
     switch node.as(PatternSyntaxEnum.self) {
-    case .expressionPattern(_):
+    case .expressionPattern:
       break
     case .identifierPattern(let node):
-      // FIXME: Generate proper pattern instead of temporary Expr.
-      return .expr(self.generate(node).asExpr)
-    case .isTypePattern(_):
+      return self.generate(identifierPattern: node).asPattern
+    case .isTypePattern:
       break
-    case .missingPattern(_):
+    case .missingPattern:
       break
-    case .tuplePattern(_):
+    case .tuplePattern:
       break
-    case .valueBindingPattern(_):
+    case .valueBindingPattern:
       break
-    case .wildcardPattern(_):
+    case .wildcardPattern:
       break
     }
-    fatalError("unimplmented")
+
+    preconditionFailure("unimplemented")
+  }
+
+  func generate(identifierPattern node: IdentifierPatternSyntax) -> BridgedNamedPattern {
+    let (name, nameLoc) = node.identifier.bridgedIdentifierAndSourceLoc(in: self)
+    return .createParsed(
+      ctx, declContext: declContext,
+      name: name,
+      loc: nameLoc
+    )
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Patterns.swift
+++ b/lib/ASTGen/Sources/ASTGen/Patterns.swift
@@ -1,0 +1,30 @@
+
+import ASTBridging
+import BasicBridging
+import SwiftDiagnostics
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+
+extension ASTGenVisitor {
+  func generate(pattern node: PatternSyntax) -> ASTNode {
+    switch node.as(PatternSyntaxEnum.self) {
+    case .expressionPattern(_):
+      break
+    case .identifierPattern(let node):
+      // FIXME: Generate proper pattern instead of temporary Expr.
+      return .expr(self.generate(node).asExpr)
+    case .isTypePattern(_):
+      break
+    case .missingPattern(_):
+      break
+    case .tuplePattern(_):
+      break
+    case .valueBindingPattern(_):
+      break
+    case .wildcardPattern(_):
+      break
+    }
+    fatalError("unimplmented")
+  }
+}
+
+

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -11,10 +11,50 @@
 //===----------------------------------------------------------------------===//
 
 import ASTBridging
-import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func generate(_ node: CodeBlockSyntax) -> BridgedBraceStmt {
+  func generate(stmt node: StmtSyntax) -> BridgedStmt {
+    switch node.as(StmtSyntaxEnum.self) {
+    case .breakStmt:
+      break
+    case .continueStmt:
+      break
+    case .deferStmt:
+      break
+    case .discardStmt:
+      break
+    case .doStmt:
+      break
+    case .expressionStmt(let node):
+      return self.generate(node)
+    case .fallThroughStmt:
+      break
+    case .forStmt:
+      break
+    case .guardStmt:
+      break
+    case .labeledStmt:
+      break
+    case .missingStmt:
+      break
+    case .repeatStmt:
+      break
+    case .returnStmt(let node):
+      return self.generate(node).asStmt
+    case .thenStmt:
+      break
+    case .throwStmt:
+      break
+    case .whileStmt:
+      break
+    case .yieldStmt:
+      break
+    }
+    return self.generateWithLegacy(node)
+  }
+
+  public func generate(codeBlock node: CodeBlockSyntax) -> BridgedBraceStmt {
     BridgedBraceStmt.createParsed(
       self.ctx,
       lBraceLoc: node.leftBrace.bridgedSourceLoc(in: self),
@@ -31,7 +71,7 @@ extension ASTGenVisitor {
       self.ctx,
       ifKeywordLoc: node.ifKeyword.bridgedSourceLoc(in: self),
       condition: conditions.first!.castToExpr,
-      thenStmt: self.generate(node.body).asStmt,
+      thenStmt: self.generate(codeBlock: node.body).asStmt,
       elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
       elseStmt: (self.generate(node.elseBody)?.castToStmt).asNullable
     )

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -2,7 +2,8 @@
 
 // -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts
-// REQUIRES: rdar116686158
+// rdar://116686158
+// UNSUPPORTED: asan
 
 protocol P { }
 protocol Q { }

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -10,7 +10,8 @@
 
 // -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts
-// REQUIRES: rdar116686158
+// rdar://116686158
+// UNSUPPORTED: asan
 
 // NB: Ridiculous formatting to test that we do not include leading trivia in locations.
 


### PR DESCRIPTION
* Utilize `{Decl|Stmt|Expr|Type|Pattern}SyntaxEnum` introduced in https://github.com/apple/swift-syntax/pull/2351
* Separate `generate(_: Syntax)` into `generate(decl: DeclSyntax)`, `generate(expr: ExprSyntax)` etc.
* Start `Patterns.swift` to generate Patterns as the same scheme as other kinds. (C++ parser ping-pong is not implmented)
* Enable ASTGen tests in non-ASAN