### PR TITLE
[Concurrency] Downgrade the error for accessing isolated static `let`s across actors.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -496,7 +496,8 @@ Type swift::getExplicitGlobalActor(ClosureExpr *closure) {
 /// nonisolated or it is accessed from within the same module.
 static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
                                   VarDecl *var,
-                                  const ActorIsolation &varIsolation) {
+                                  const ActorIsolation &varIsolation,
+                                  ActorReferenceResult::Options &options) {
   // must be immutable
   if (!var->isLet())
     return false;
@@ -517,8 +518,12 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
 
     // Static 'let's are initialized upon first access, so they cannot be
     // synchronously accessed across actors.
-    if (var->isGlobalStorage() && var->isLazilyInitializedGlobal())
+    if (var->isGlobalStorage() && var->isLazilyInitializedGlobal()) {
+      // Compiler versions <= 5.9 accepted this code, so downgrade to a
+      // warning prior to Swift 6.
+      options = ActorReferenceResult::Flags::Preconcurrency;
       return false;
+    }
 
     // If it's distributed, generally variable access is not okay...
     if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl()) {
@@ -534,7 +539,8 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
 bool swift::isLetAccessibleAnywhere(const ModuleDecl *fromModule,
                                     VarDecl *let) {
   auto isolation = getActorIsolation(let);
-  return varIsSafeAcrossActors(fromModule, let, isolation);
+  ActorReferenceResult::Options options = llvm::None;
+  return varIsSafeAcrossActors(fromModule, let, isolation, options);
 }
 
 namespace {
@@ -5814,7 +5820,8 @@ static bool isNonValueReference(const ValueDecl *value) {
 
 bool swift::isAccessibleAcrossActors(
     ValueDecl *value, const ActorIsolation &isolation,
-    const DeclContext *fromDC, llvm::Optional<ReferencedActor> actorInstance) {
+    const DeclContext *fromDC, ActorReferenceResult::Options &options,
+    llvm::Optional<ReferencedActor> actorInstance) {
   // Initializers and enum elements are accessible across actors unless they
   // are global-actor qualified.
   if (isa<ConstructorDecl>(value) || isa<EnumElementDecl>(value)) {
@@ -5834,10 +5841,20 @@ bool swift::isAccessibleAcrossActors(
   // 'let' declarations are immutable, so some of them can be accessed across
   // actors.
   if (auto var = dyn_cast<VarDecl>(value)) {
-    return varIsSafeAcrossActors(fromDC->getParentModule(), var, isolation);
+    return varIsSafeAcrossActors(
+        fromDC->getParentModule(), var, isolation, options);
   }
 
   return false;
+}
+
+bool swift::isAccessibleAcrossActors(
+    ValueDecl *value, const ActorIsolation &isolation,
+    const DeclContext *fromDC,
+    llvm::Optional<ReferencedActor> actorInstance) {
+  ActorReferenceResult::Options options = llvm::None;
+  return isAccessibleAcrossActors(
+      value, isolation, fromDC, options, actorInstance);
 }
 
 ActorReferenceResult ActorReferenceResult::forSameConcurrencyDomain(
@@ -5978,16 +5995,18 @@ ActorReferenceResult ActorReferenceResult::forReference(
       (isa<ConstructorDecl>(fromDC) || isa<DestructorDecl>(fromDC)))
     return forSameConcurrencyDomain(declIsolation);
 
+  // Determine what adjustments we need to perform for cross-actor
+  // references.
+  Options options = llvm::None;
+
   // At this point, we are accessing the target from outside the actor.
   // First, check whether it is something that can be accessed directly,
   // without any kind of promotion.
   if (isAccessibleAcrossActors(
-          declRef.getDecl(), declIsolation, fromDC, actorInstance))
+          declRef.getDecl(), declIsolation, fromDC, options, actorInstance))
     return forEntersActor(declIsolation, llvm::None);
 
-  // This is a cross-actor reference, so determine what adjustments we need
-  // to perform.
-  Options options = llvm::None;
+  // This is a cross-actor reference.
 
   // Note if the reference originates from a @preconcurrency-isolated context.
   if (contextIsolation.preconcurrency() || declIsolation.preconcurrency())

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -537,6 +537,20 @@ VarDecl *getReferencedParamOrCapture(
 /// \param value The value we are checking.
 /// \param isolation The actor isolation of the value.
 /// \param fromDC The context where we are performing the access.
+/// \param options The reference options, such as whether reference
+/// violations should be downgraded to warnings prior to Swift 6.
+bool isAccessibleAcrossActors(
+    ValueDecl *value, const ActorIsolation &isolation,
+    const DeclContext *fromDC,
+    ActorReferenceResult::Options &options,
+    llvm::Optional<ReferencedActor> actorInstance = llvm::None);
+
+/// Determine whether the given value can be accessed across actors
+/// without from normal synchronous code.
+///
+/// \param value The value we are checking.
+/// \param isolation The actor isolation of the value.
+/// \param fromDC The context where we are performing the access.
 bool isAccessibleAcrossActors(
     ValueDecl *value, const ActorIsolation &isolation,
     const DeclContext *fromDC,

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1569,3 +1569,16 @@ actor AnotherActor {
     _ = a.ns
   }
 }
+
+@MainActor
+class MainActorIsolated {
+  init() {}
+
+  // expected-note@+1 {{static property declared here}}
+  static let shared = MainActorIsolated()
+}
+
+nonisolated func accessAcrossActors() {
+  // expected-warning@+1 {{main actor-isolated static property 'shared' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+  let _ = MainActorIsolated.shared
+}

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -80,3 +80,16 @@ struct NoGlobalActorValueType {
 }
 
 /// -----------------------------------------------------------------
+
+@MainActor
+class MainActorIsolated {
+  init() {}
+
+  // expected-note@+1 {{static property declared here}}
+  static let shared = MainActorIsolated()
+}
+
+nonisolated func accessAcrossActors() {
+  // expected-error@+1 {{main actor-isolated static property 'shared' can not be referenced from a non-isolated context}}
+  let _ = MainActorIsolated.shared
+}


### PR DESCRIPTION
https://github.com/apple/swift/pull/69598 and https://github.com/apple/swift/pull/69616 closed a data-race safety hold around lazily initialized global constants that are isolated to an actor. Because compiler versions <= 5.9 accepted this code, this change downgrades the error to a warning prior to Swift 6.