### PR TITLE
[swift-parse-test] Remove unused static function

### DIFF
--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -134,13 +134,6 @@ struct SwiftParserExecutor {
   }
 };
 
-static void appendToVector(void *declPtr, void *vecPtr) {
-  auto vec = static_cast<SmallVectorImpl<ASTNode> *>(vecPtr);
-  auto decl = static_cast<Decl *>(declPtr);
-
-  vec->push_back(decl);
-}
-
 struct ASTGenExecutor {
   constexpr static StringRef name = "ASTGen with SwiftParser";
 


### PR DESCRIPTION
`appendToVector` was a leftover from earlier development, and not used.
