### PR TITLE
Symlink `swift` and `swiftc` to `swift-driver`, when available

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -99,6 +99,8 @@ void Driver::parseDriverKind(ArrayRef<const char *> Args) {
       llvm::StringSwitch<llvm::Optional<DriverKind>>(DriverName)
           .Case("swift", DriverKind::Interactive)
           .Case("swiftc", DriverKind::Batch)
+          .Case("swift-legacy-driver", DriverKind::Interactive)
+          .Case("swiftc-legacy-driver", DriverKind::Batch)
           .Case("sil-opt", DriverKind::SILOpt)
           .Case("sil-func-extractor", DriverKind::SILFuncExtractor)
           .Case("sil-nm", DriverKind::SILNM)

--- a/test/Driver/LegacyDriver/legacy-driver-propagates-response-file-to-new-driver.swift
+++ b/test/Driver/LegacyDriver/legacy-driver-propagates-response-file-to-new-driver.swift
@@ -6,7 +6,7 @@
 // REQUIRES: shell
 // RUN: %{python} -c 'for i in range(500001): print("-DTEST5_" + str(i))' > %t.resp
 // RUN: cp %S/Inputs/print-args.sh %swift-bin-dir/legacy-driver-propagates-response-file.sh
-// RUN: env SWIFT_USE_NEW_DRIVER=legacy-driver-propagates-response-file.sh %swiftc_driver_plain %s @%t.resp | %FileCheck %s
+// RUN: env SWIFT_OVERLOAD_DRIVER=legacy-driver-propagates-response-file.sh %swiftc_driver_plain -disallow-use-new-driver %s @%t.resp | %FileCheck %s
 // RUN: rm %swift-bin-dir/legacy-driver-propagates-response-file.sh
 
 // CHECK:      -Xfrontend

--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -6,7 +6,7 @@
 
 // RUN: %empty-directory(%t/usr/bin/)
 // RUN: %empty-directory(%t/usr/lib/)
-// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/usr/bin/swift)
+// RUN: %hardlink-or-copy(from: %swift_driver_plain-legacy-driver, to: %t/usr/bin/swift)
 
 // RUN: %host-library-env %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=INTEGRATED %s
 // RUN: %host-library-env %t/usr/bin/swift -### | %FileCheck -check-prefix=INTEGRATED %s

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -34,5 +34,5 @@
 // RUN: echo "#!/bin/sh" > %t.dir/swift-foo
 // RUN: echo "echo \"exec: \$0\"" >> %t.dir/swift-foo
 // RUN: chmod +x %t.dir/swift-foo
-// RUN: env PATH=%t.dir %swift_driver_plain foo | %FileCheck -check-prefix=CHECK-SWIFT-SUBCOMMAND %s
+// RUN: env PATH=%t.dir SWIFT_USE_OLD_DRIVER=1 %swift_driver_plain foo | %FileCheck -check-prefix=CHECK-SWIFT-SUBCOMMAND %s
 // CHECK-SWIFT-SUBCOMMAND: exec: {{.*}}/swift-foo

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -79,7 +79,7 @@ swift_create_early_driver_copies(swift-frontend)
 
 # If a `swift-driver` executable adjacent to the `swift-frontend` executable exists
 # then the `swift` and `swiftc` symlinks should point to it by-default
-if(EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-driver" AND EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-help")
+if(EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-driver${CMAKE_EXECUTABLE_SUFFIX}" AND EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-help${CMAKE_EXECUTABLE_SUFFIX}")
   message(STATUS "Pointing 'swift' and 'swiftc' symlinks at 'swift-driver'.")
   swift_create_post_build_symlink(swift-frontend
     SOURCE "swift-driver${CMAKE_EXECUTABLE_SUFFIX}"
@@ -200,4 +200,11 @@ add_dependencies(editor-integration swift-frontend)
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-indent${CMAKE_EXECUTABLE_SUFFIX}"
                            DESTINATION "bin"
                            COMPONENT editor-integration)
-
+if(EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-driver${CMAKE_EXECUTABLE_SUFFIX}" AND EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-help${CMAKE_EXECUTABLE_SUFFIX}")
+  swift_install_in_component(PROGRAMS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-driver${CMAKE_EXECUTABLE_SUFFIX}"
+                             DESTINATION "bin"
+                             COMPONENT compiler)
+  swift_install_in_component(PROGRAMS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-help${CMAKE_EXECUTABLE_SUFFIX}"
+                             DESTINATION "bin"
+                             COMPONENT compiler)
+endif()

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -77,15 +77,31 @@ add_swift_parser_link_libraries(swift-frontend)
 # to ensure that `swiftc` forwards to the standalone driver when invoked.
 swift_create_early_driver_copies(swift-frontend)
 
-swift_create_post_build_symlink(swift-frontend
-  SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
-  DESTINATION "swift${CMAKE_EXECUTABLE_SUFFIX}"
-  WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+# If a `swift-driver` executable adjacent to the `swift-frontend` executable exists
+# then the `swift` and `swiftc` symlinks should point to it by-default
+if(EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-driver" AND EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-help")
+  message(STATUS "Pointing 'swift' and 'swiftc' symlinks at 'swift-driver'.")
+  swift_create_post_build_symlink(swift-frontend
+    SOURCE "swift-driver${CMAKE_EXECUTABLE_SUFFIX}"
+    DESTINATION "swift${CMAKE_EXECUTABLE_SUFFIX}"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
-swift_create_post_build_symlink(swift-frontend
-  SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
-  DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
-  WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+  swift_create_post_build_symlink(swift-frontend
+    SOURCE "swift-driver${CMAKE_EXECUTABLE_SUFFIX}"
+    DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+else()
+  message(STATUS "Pointing 'swift' and 'swiftc' symlinks at 'swift-frontend' - no early SwiftDriver build found.")
+  swift_create_post_build_symlink(swift-frontend
+    SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+    DESTINATION "swift${CMAKE_EXECUTABLE_SUFFIX}"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+
+  swift_create_post_build_symlink(swift-frontend
+    SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+    DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+endif()
 
 swift_create_post_build_symlink(swift-frontend
   SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -85,10 +85,19 @@ if(EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-driver${CMAKE_EXECUTABLE_SUFFIX}
     SOURCE "swift-driver${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "swift${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
-
   swift_create_post_build_symlink(swift-frontend
     SOURCE "swift-driver${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+
+  message(STATUS "Pointing 'swift-legacy-driver' and 'swiftc-legacy-driver' symlinks at 'swift-frontend'.")
+  swift_create_post_build_symlink(swift-frontend
+    SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+    DESTINATION "swift-legacy-driver${CMAKE_EXECUTABLE_SUFFIX}"
+    WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+  swift_create_post_build_symlink(swift-frontend
+    SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+    DESTINATION "swiftc-legacy-driver${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 else()
   message(STATUS "Pointing 'swift' and 'swiftc' symlinks at 'swift-frontend' - no early SwiftDriver build found.")
@@ -205,6 +214,12 @@ if(EXISTS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-driver${CMAKE_EXECUTABLE_SUFFIX}
                              DESTINATION "bin"
                              COMPONENT compiler)
   swift_install_in_component(PROGRAMS "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-help${CMAKE_EXECUTABLE_SUFFIX}"
+                             DESTINATION "bin"
+                             COMPONENT compiler)
+  swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc-legacy-driver${CMAKE_EXECUTABLE_SUFFIX}"
+                             DESTINATION "bin"
+                             COMPONENT compiler)
+  swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-legacy-driver${CMAKE_EXECUTABLE_SUFFIX}"
                              DESTINATION "bin"
                              COMPONENT compiler)
 endif()

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -157,15 +157,6 @@ swift_create_post_build_symlink(swift-frontend
   DESTINATION "swift-parse-test${CMAKE_EXECUTABLE_SUFFIX}"
   WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
-add_swift_tool_symlink(swift swift-frontend compiler)
-add_swift_tool_symlink(swiftc swift-frontend compiler)
-add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler)
-add_swift_tool_symlink(swift-api-extract swift-frontend compiler)
-add_swift_tool_symlink(swift-autolink-extract swift-frontend autolink-driver)
-add_swift_tool_symlink(swift-indent swift-frontend editor-integration)
-add_swift_tool_symlink(swift-api-digester swift-frontend compiler)
-add_swift_tool_symlink(swift-cache-tool swift-frontend compiler)
-
 add_dependencies(compiler swift-frontend)
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift${CMAKE_EXECUTABLE_SUFFIX}"
                            DESTINATION "bin"


### PR DESCRIPTION
- Remove redundant calls to `add_swift_tool_symlink` on `/bin` executables of the driver CMake target
- Symlink `swift` and `swiftc` to `swift-driver`, when available (when `earlyswiftdriver` was built with the host toolchain (default))
- Install host-built `swift-driver` and `swift-help` when installing the 'compiler' component
- Add symlinks for the legacy driver invocation (for emergency fallback invoked from `swift-driver`)
    - Corresponding `swift-driver` change: https://github.com/apple/swift-driver/pull/1485