### PR TITLE
[5.10][Concurrency] Downgrade the error for accessing isolated static `let`s across actors.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -531,6 +531,20 @@ VarDecl *getReferencedParamOrCapture(
 /// \param value The value we are checking.
 /// \param isolation The actor isolation of the value.
 /// \param fromDC The context where we are performing the access.
+/// \param options The reference options, such as whether reference
+/// violations should be downgraded to warnings prior to Swift 6.
+bool isAccessibleAcrossActors(
+    ValueDecl *value, const ActorIsolation &isolation,
+    const DeclContext *fromDC,
+    ActorReferenceResult::Options &options,
+    llvm::Optional<ReferencedActor> actorInstance = llvm::None);
+
+/// Determine whether the given value can be accessed across actors
+/// without from normal synchronous code.
+///
+/// \param value The value we are checking.
+/// \param isolation The actor isolation of the value.
+/// \param fromDC The context where we are performing the access.
 bool isAccessibleAcrossActors(
     ValueDecl *value, const ActorIsolation &isolation,
     const DeclContext *fromDC,

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1569,3 +1569,16 @@ actor AnotherActor {
     _ = a.ns
   }
 }
+
+@MainActor
+class MainActorIsolated {
+  init() {}
+
+  // expected-note@+1 {{static property declared here}}
+  static let shared = MainActorIsolated()
+}
+
+nonisolated func accessAcrossActors() {
+  // expected-warning@+1 {{main actor-isolated static property 'shared' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+  let _ = MainActorIsolated.shared
+}

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -80,3 +80,16 @@ struct NoGlobalActorValueType {
 }
 
 /// -----------------------------------------------------------------
+
+@MainActor
+class MainActorIsolated {
+  init() {}
+
+  // expected-note@+1 {{static property declared here}}
+  static let shared = MainActorIsolated()
+}
+
+nonisolated func accessAcrossActors() {
+  // expected-error@+1 {{main actor-isolated static property 'shared' can not be referenced from a non-isolated context}}
+  let _ = MainActorIsolated.shared
+}


### PR DESCRIPTION
* **Explanation**: https://github.com/apple/swift/pull/69607 closed a data-race safety hold around lazily initialized global constants that are isolated to an actor. Because compiler versions <= 5.9 accepted this code, this change downgrades the error to a warning prior to Swift 6.
* **Scope**: Only impacts global actor isolated global and static `let` variables that are lazily initialized.
* **Risk**: Low; downgrades a newly-diagnosed error to a warning until Swift 6.
* **Testing**: Added new test cases for Swift 5 and Swift 6 mode.
* **Issue**: rdar://118332974
* **Reviewer**: @ktoso
* **Main branch PR**: https://github.com/apple/swift/pull/69830