### PR TITLE
[NCGenerics] more work towards getting the stdlib building

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5179,6 +5179,10 @@ public:
   /// semantics but has no corresponding witness table.
   bool isMarkerProtocol() const;
 
+  /// Determine whether this is an invertible protocol,
+  /// i.e., for a protocol P, the inverse constraint ~P exists.
+  bool isInvertibleProtocol() const;
+
 private:
   void computeKnownProtocolKind() const;
 

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -31,9 +31,9 @@ struct ExistentialLayout {
 
   ExistentialLayout() {
     hasExplicitAnyObject = false;
-    hasInverseCopyable = false;
     containsNonObjCProtocol = false;
     containsParameterized = false;
+    representsAnyObject = false;
   }
 
   ExistentialLayout(CanProtocolType type);
@@ -47,14 +47,14 @@ struct ExistentialLayout {
   /// Whether the existential contains an explicit '& AnyObject' constraint.
   bool hasExplicitAnyObject : 1;
 
-  /// Whether the existential contains an explicit '& ~Copyable' constraint.
-  bool hasInverseCopyable : 1;
-
   /// Whether any protocol members are non-@objc.
   bool containsNonObjCProtocol : 1;
 
   /// Whether any protocol members are parameterized.s
   bool containsParameterized : 1;
+
+  /// Whether this layout is the canonical layout for plain-old 'AnyObject'.
+  bool representsAnyObject : 1;
 
   /// Return the kind of this existential (class/error/opaque).
   Kind getKind() {
@@ -69,7 +69,7 @@ struct ExistentialLayout {
     return Kind::Opaque;
   }
 
-  bool isAnyObject() const;
+  bool isAnyObject() const { return representsAnyObject; }
 
   bool isObjC() const {
     // FIXME: Does the superclass have to be @objc?

--- a/include/swift/AST/InverseMarking.h
+++ b/include/swift/AST/InverseMarking.h
@@ -10,14 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_LIB_SEMA_INVERSEMARKING_H
-#define SWIFT_LIB_SEMA_INVERSEMARKING_H
+#ifndef SWIFT_AST_INVERSEMARKING_H
+#define SWIFT_AST_INVERSEMARKING_H
 
 #include "swift/AST/KnownProtocols.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/OptionalEnum.h"
 
 namespace swift {
+
+class NoncopyableAnnotationRequest;
 
 /// Describes the way an inverse and its corresponding positive contraint
 /// appears on a TypeDecl, i.e., the way it was marked.
@@ -26,8 +28,7 @@ struct InverseMarking {
     None,            // No inverse marking is present
     Inferred,        // Inverse is inferred based on generic parameters.
     Explicit,        // Inverse is explicitly present.
-
-    LAST = Explicit
+    LegacyExplicit,   // An equivalent, explicit legacy annotation is present.
   };
 
   // Describes what kind of mark was found, if any.
@@ -43,15 +44,18 @@ struct InverseMarking {
     Mark(Kind k, SourceLoc l = SourceLoc())
       : kind(k), loc(l) {};
 
-    // Is there an inferred or explicit marking?
-    bool isPresent() const {
-      return getKind() != Kind::None;
-    }
-    operator bool() { return isPresent(); }
-
     Kind getKind() const {
       return kind.getValueOr(Kind::None);
     }
+    bool is(Kind k) const {
+      return getKind() == k;
+    }
+
+    // Is there an inferred or explicit marking?
+    bool isPresent() const {
+      return !is(Kind::None);
+    }
+    operator bool() const { return isPresent(); }
 
     SourceLoc getLoc() const { return loc; }
 
@@ -68,34 +72,29 @@ struct InverseMarking {
     }
 
     void setIfUnset(Mark other) {
-      if (kind.hasValue())
+      if (!other.kind.hasValue())
         return;
-      kind = other.kind;
-      loc = other.loc;
+      setIfUnset(other.kind.getValue(), other.loc);
     }
 
-    Mark with(Kind k) {
-      kind = k;
-      return *this;
+    Mark with(Kind k) const {
+      return Mark(k, loc);
     }
   };
 
 private:
   Mark inverse;
   Mark positive;
+
+  // This friend initializes the marks.
+  friend NoncopyableAnnotationRequest;
 public:
 
   // Creates an empty marking.
   InverseMarking() {}
 
-  Mark &getInverse() { return inverse; }
-  Mark &getPositive() { return positive; }
-
-  // Merge the results of another marking into this one.
-  void merge(InverseMarking other) const {
-    other.inverse.setIfUnset(other.inverse);
-    other.positive.setIfUnset(other.positive);
-  }
+  Mark const& getInverse() const { return inverse; }
+  Mark const& getPositive() const { return positive; }
 
   static InverseMarking forInverse(Kind kind, SourceLoc loc = SourceLoc()) {
     InverseMarking marking;
@@ -107,4 +106,4 @@ public:
 
 }
 
-#endif //SWIFT_LIB_SEMA_INVERSEMARKING_H
+#endif //SWIFT_AST_INVERSEMARKING_H

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -541,7 +541,6 @@ public:
   CanType getNominalParent() const; // in Types.h
   NominalTypeDecl *getAnyNominal() const;
   GenericTypeDecl *getAnyGeneric() const;
-  TypeDecl *getAnyTypeDecl() const;
 
   bool isForeignReferenceType(); // in Types.h
 

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -541,6 +541,7 @@ public:
   CanType getNominalParent() const; // in Types.h
   NominalTypeDecl *getAnyNominal() const;
   GenericTypeDecl *getAnyGeneric() const;
+  TypeDecl *getAnyTypeDecl() const;
 
   bool isForeignReferenceType(); // in Types.h
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5790,8 +5790,6 @@ class ProtocolCompositionType final : public TypeBase,
     private llvm::TrailingObjects<ProtocolCompositionType, Type> {
   friend TrailingObjects;
 
-  // TODO(kavon): this could probably be folded into the existing Bits field
-  // or we could just store the InverseType's in the Members array.
   InvertibleProtocolSet Inverses;
   
 public:

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1233,6 +1233,11 @@ public:
   /// declaration.
   GenericTypeDecl *getAnyGeneric();
 
+  // If this a GenericType, ModuleType, or GenericTypeParamType, return the
+  // type declaration.
+  // NOTE: Will not attempt to find an AssociatedTypeDecl.
+  TypeDecl *getAnyTypeDecl();
+
   /// removeArgumentLabels -  Retrieve a version of this type with all
   /// argument labels removed.
   Type removeArgumentLabels(unsigned numArgumentLabels);
@@ -7423,9 +7428,9 @@ inline GenericTypeDecl *TypeBase::getAnyGeneric() {
   return getCanonicalType().getAnyGeneric();
 }
 
-//inline TypeDecl *TypeBase::getAnyTypeDecl() {
-//  return getCanonicalType().getAnyTypeDecl();
-//}
+inline TypeDecl *TypeBase::getAnyTypeDecl() {
+  return getCanonicalType().getAnyTypeDecl();
+}
 
 inline bool TypeBase::isBuiltinIntegerType(unsigned n) {
   if (auto intTy = dyn_cast<BuiltinIntegerType>(getCanonicalType()))

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1233,11 +1233,6 @@ public:
   /// declaration.
   GenericTypeDecl *getAnyGeneric();
 
-  // If this a GenericType, ModuleType, or GenericTypeParamType, return the
-  // type declaration.
-  // NOTE: Will not attempt to find an AssociatedTypeDecl.
-  TypeDecl *getAnyTypeDecl();
-
   /// removeArgumentLabels -  Retrieve a version of this type with all
   /// argument labels removed.
   Type removeArgumentLabels(unsigned numArgumentLabels);
@@ -7424,10 +7419,6 @@ inline Type TypeBase::getNominalParent() {
 
 inline GenericTypeDecl *TypeBase::getAnyGeneric() {
   return getCanonicalType().getAnyGeneric();
-}
-
-inline TypeDecl *TypeBase::getAnyTypeDecl() {
-  return getCanonicalType().getAnyTypeDecl();
 }
 
 inline bool TypeBase::isBuiltinIntegerType(unsigned n) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4340,6 +4340,14 @@ namespace {
 
       printFlag(T->hasExplicitAnyObject(), "any_object");
 
+      for (auto ip : T->getInverses()) {
+        switch (ip) {
+        case InvertibleProtocolKind::Copyable:
+          printFlag("inverse_copyable");
+          break;
+        }
+      }
+
       for (auto proto : T->getMembers()) {
         printRec(proto);
       }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3336,6 +3336,14 @@ static bool hasInverseCopyable(
     Decl *decl,
     std::function<bool(InverseMarking const&)> isRelevantInverse) {
 
+  auto getTypeDecl = [](Type type) -> TypeDecl* {
+    if (auto genericTy = type->getAnyGeneric())
+      return genericTy;
+    if (auto gtpt = dyn_cast<GenericTypeParamType>(type))
+      return gtpt->getDecl();
+    return nullptr;
+  };
+
   if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
     if (auto *nominal = extension->getSelfNominalTypeDecl())
       if (isRelevantInverse(nominal->getNoncopyableMarking()))
@@ -3361,7 +3369,7 @@ static bool hasInverseCopyable(
     // Check for noncopyable types in the types of this declaration.
     if (Type type = value->getInterfaceType()) {
       bool hasNoncopyable = type.findIf([&](Type type) {
-        if (auto typeDecl = type->getAnyTypeDecl())
+        if (auto *typeDecl = getTypeDecl(type))
           if (isRelevantInverse(typeDecl->getNoncopyableMarking()))
             return true;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/InverseMarking.h"
 #include "swift/AST/MacroDefinition.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
@@ -3329,31 +3330,56 @@ static bool usesFeatureFlowSensitiveConcurrencyCaptures(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureMoveOnly(Decl *decl) {
+/// \param isRelevantInverse the function used to inspect a mark corresponding
+/// to an inverse to determine whether it "has" an inverse that we care about.
+static bool hasInverseCopyable(
+    Decl *decl,
+    std::function<bool(InverseMarking const&)> isRelevantInverse) {
+
   if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
     if (auto *nominal = extension->getSelfNominalTypeDecl())
-      if (nominal->canBeNoncopyable())
+      if (isRelevantInverse(nominal->getNoncopyableMarking()))
         return true;
   }
 
   if (auto typeDecl = dyn_cast<TypeDecl>(decl)) {
-    if (typeDecl->canBeNoncopyable())
+    if (isRelevantInverse(typeDecl->getNoncopyableMarking()))
       return true;
+
+    // Check the protocol's associated types too.
+    if (auto proto = dyn_cast<ProtocolDecl>(decl)) {
+      auto hasNoncopyable = llvm::any_of(proto->getAssociatedTypeMembers(),
+                                         [&](AssociatedTypeDecl *assocTyDecl) {
+                                           return isRelevantInverse(assocTyDecl->getNoncopyableMarking());
+                                         });
+      if (hasNoncopyable)
+        return true;
+    }
   }
 
   if (auto value = dyn_cast<ValueDecl>(decl)) {
-    // Check for move-only types in the types of this declaration.
+    // Check for noncopyable types in the types of this declaration.
     if (Type type = value->getInterfaceType()) {
-      bool hasMoveOnly = type.findIf([](Type type) {
-        return type->isNoncopyable();
+      bool hasNoncopyable = type.findIf([&](Type type) {
+        if (auto typeDecl = type->getAnyTypeDecl())
+          if (isRelevantInverse(typeDecl->getNoncopyableMarking()))
+            return true;
+
+        return false;
       });
 
-      if (hasMoveOnly)
+      if (hasNoncopyable)
         return true;
     }
   }
 
   return false;
+}
+
+static bool usesFeatureMoveOnly(Decl *decl) {
+  return hasInverseCopyable(decl, [](auto &marking) -> bool {
+    return marking.getInverse().is(InverseMarking::Kind::LegacyExplicit);
+  });
 }
 
 static bool usesFeatureLazyImmediate(Decl *D) { return false; }
@@ -3393,9 +3419,17 @@ static bool usesFeatureMoveOnlyPartialConsumption(Decl *decl) {
 }
 
 static bool usesFeatureNoncopyableGenerics(Decl *decl) {
-  // FIXME: need to look for suppressed entries on generic parameters or
-  // inheritance clauses!
-  return false;
+  return hasInverseCopyable(decl, [](auto &marking) -> bool {
+    switch (marking.getInverse().getKind()) {
+    case InverseMarking::Kind::None:
+    case InverseMarking::Kind::LegacyExplicit: // covered by MoveOnly
+      return false;
+
+    case InverseMarking::Kind::Explicit:
+    case InverseMarking::Kind::Inferred:
+      return true;
+    }
+  });
 }
 
 static bool usesFeatureOneWayClosureParameters(Decl *decl) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6383,6 +6383,16 @@ bool ProtocolDecl::isMarkerProtocol() const {
   return getAttrs().hasAttribute<MarkerAttr>();
 }
 
+bool ProtocolDecl::isInvertibleProtocol() const {
+  if (auto kp = getKnownProtocolKind()) {
+    if (getInvertibleProtocolKind(*kp)) {
+      assert(isMarkerProtocol());
+      return true;
+    }
+  }
+  return false;
+}
+
 ArrayRef<ProtocolDecl *> ProtocolDecl::getInheritedProtocols() const {
   auto *mutThis = const_cast<ProtocolDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1591,11 +1591,12 @@ ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
   if (!protocol->existentialConformsToSelf())
     return ProtocolConformanceRef::forInvalid();
 
-  // All existentials are Copyable.
-  if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
-    return ProtocolConformanceRef(
-        ctx.getBuiltinConformance(type, protocol,
-                                  BuiltinConformanceKind::Synthesized));
+  if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)
+      && !ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+    // Prior to noncopyable generics, all existentials conform to Copyable.
+        return ProtocolConformanceRef(
+            ctx.getBuiltinConformance(type, protocol,
+                                      BuiltinConformanceKind::Synthesized));
   }
 
   auto layout = type->getExistentialLayout();

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -658,6 +658,13 @@ AbstractGenericSignatureRequest::evaluate(
       requirements.push_back({req, SourceLoc(), /*wasInferred=*/false});
   }
 
+  /// Next, we need to expand default requirements for the added parameters.
+  SmallVector<Type, 2> localGPs;
+  for (auto *gtpt : addedParameters)
+    localGPs.push_back(gtpt);
+
+  expandDefaultRequirements(ctx, localGPs, requirements, errors);
+
   auto &rewriteCtx = ctx.getRewriteContext();
 
   if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -91,6 +91,17 @@ GenericTypeDecl *CanType::getAnyGeneric() const {
   return nullptr;
 }
 
+TypeDecl *CanType::getAnyTypeDecl() const {
+  // NOTE: there is no simple way to determine if it's an AssociatedTypeDecl.
+  if (auto genericTy = getAnyGeneric())
+    return genericTy;
+  if (auto gtpt = dyn_cast<GenericTypeParamType>(*this))
+    return gtpt->getDecl();
+  if (auto module = dyn_cast<ModuleType>(*this))
+    return module->getModule();
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 // Various Type Methods.
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -91,17 +91,6 @@ GenericTypeDecl *CanType::getAnyGeneric() const {
   return nullptr;
 }
 
-TypeDecl *CanType::getAnyTypeDecl() const {
-  // NOTE: there is no simple way to determine if it's an AssociatedTypeDecl.
-  if (auto genericTy = getAnyGeneric())
-    return genericTy;
-  if (auto gtpt = dyn_cast<GenericTypeParamType>(*this))
-    return gtpt->getDecl();
-  if (auto module = dyn_cast<ModuleType>(*this))
-    return module->getModule();
-  return nullptr;
-}
-
 //===----------------------------------------------------------------------===//
 // Various Type Methods.
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -205,7 +205,8 @@ bool TypeBase::isNoncopyable(const DeclContext *dc) {
 
 /// \returns true iff this type lacks conformance to Copyable.
 bool TypeBase::isNoncopyable() {
-  auto canType = getCanonicalType();
+  // Strip @lvalue and canonicalize.
+  auto canType = getRValueType()->getCanonicalType();
   auto &ctx = canType->getASTContext();
 
   // for legacy-mode queries that are not dependent on conformances to Copyable

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -181,20 +181,6 @@ static bool alwaysNoncopyable(Type ty) {
 /// context to substitute unbound types.
 bool TypeBase::isNoncopyable(const DeclContext *dc) {
   assert(dc);
-  auto &ctx = dc->getASTContext();
-
-  // Fast-path for type parameters; ask the generic signature directly.
-  if (isTypeParameter() &&
-      ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
-    auto canType = getCanonicalType();
-
-    auto *copyable = ctx.getProtocol(KnownProtocolKind::Copyable);
-    if (!copyable)
-      llvm_unreachable("missing Copyable protocol!");
-
-    auto sig = dc->getGenericSignatureOfContext();
-    return !sig->requiresProtocol(canType, copyable);
-  }
 
   if (!hasArchetype() || hasOpenedExistential())
     if (auto env = dc->getGenericEnvironmentOfContext())

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -415,7 +415,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       auto layout = castType->getExistentialLayout();
       for (auto proto : layout.getProtocols()) {
-        if (proto->isMarkerProtocol()) {
+        if (proto->isMarkerProtocol() && !proto->isInvertibleProtocol()) {
           // can't conditionally cast to a marker protocol
           Ctx.Diags.diagnose(cast->getLoc(), diag::marker_protocol_cast,
                              proto->getName());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7044,7 +7044,7 @@ void AttributeChecker::visitEagerMoveAttr(EagerMoveAttr *attr) {
   if (visitLifetimeAttr(attr))
     return;
   if (auto *nominal = dyn_cast<NominalTypeDecl>(D)) {
-    if (nominal->getDeclaredInterfaceType()->isNoncopyable()) {
+    if (nominal->getSelfTypeInContext()->isNoncopyable()) {
       diagnoseAndRemoveAttr(attr, diag::eagermove_and_noncopyable_combined);
       return;
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2718,6 +2718,8 @@ public:
   }
 
   void visitSubscriptDecl(SubscriptDecl *SD) {
+    auto *DC = SD->getDeclContext();
+
     // Force requests that can emit diagnostics.
     (void) SD->getInterfaceType();
     (void) SD->getGenericSignature();
@@ -2768,7 +2770,7 @@ public:
     checkDefaultArguments(SD->getIndices());
     checkVariadicParameters(SD->getIndices(), SD);
 
-    if (SD->getDeclContext()->getSelfClassDecl()) {
+    if (DC->getSelfClassDecl()) {
       checkDynamicSelfType(SD, SD->getValueInterfaceType());
 
       if (SD->getValueInterfaceType()->hasDynamicSelfType() &&
@@ -2779,15 +2781,15 @@ public:
 
     // Reject "class" methods on actors.
     if (SD->getStaticSpelling() == StaticSpellingKind::KeywordClass &&
-        SD->getDeclContext()->getSelfClassDecl() &&
-        SD->getDeclContext()->getSelfClassDecl()->isActor()) {
+        DC->getSelfClassDecl() &&
+        DC->getSelfClassDecl()->isActor()) {
       SD->diagnose(diag::class_subscript_not_in_class, false)
           .fixItReplace(SD->getStaticLoc(), "static");
     }
 
     // Reject noncopyable typed subscripts with read/set accessors since we
     // cannot define modify operations upon them without copying the read.
-    if (SD->getElementInterfaceType()->isNoncopyable()) {
+    if (SD->getElementInterfaceType()->isNoncopyable(DC)) {
       if (auto *read = SD->getAccessor(AccessorKind::Read)) {
         if (!read->isImplicit()) {
           if (auto *set = SD->getAccessor(AccessorKind::Set)) {

--- a/lib/Sema/TypeCheckInvertible.cpp
+++ b/lib/Sema/TypeCheckInvertible.cpp
@@ -80,6 +80,7 @@ static void emitAdviceToApplyInverseAfter(InFlightDiagnostic &&diag,
     addConformanceFixIt(nominal, diag, kp, /*inverse=*/true);
   }
     break;
+  case InverseMarking::Kind::LegacyExplicit:
   case InverseMarking::Kind::Explicit:
     // FIXME: we can probably do better here. Look for the extension where the
     // inverse came from.
@@ -141,6 +142,7 @@ static void tryEmitContainmentFixits(InFlightDiagnostic &&diag,
                            diag::note_inverse_preventing_conformance_implicit,
                            nominal, getProtocolName(kp));
         break;
+      case InverseMarking::Kind::LegacyExplicit:
       case InverseMarking::Kind::Explicit:
         assert(loc);
         ctx.Diags.diagnose(loc,
@@ -408,6 +410,7 @@ ProtocolConformance *deriveConformanceForInvertible(Evaluator &evaluator,
     // Check what kind of inverse we have to determine whether to generate a
     // conformance for Copyable.
     switch (marking.getInverse().getKind()) {
+    case InverseMarking::Kind::LegacyExplicit:
     case InverseMarking::Kind::Explicit:
       return nullptr; // No Copyable conformance will be inferred.
 

--- a/test/Generics/inverse_copyable_generics.swift
+++ b/test/Generics/inverse_copyable_generics.swift
@@ -177,3 +177,30 @@ extension EnumExtendo: ~Copyable {} // expected-error {{cannot apply inverse '~C
 
 extension NeedsCopyable where Self: ~Copyable {}
 // expected-error@-1 {{cannot add inverse constraint 'Self: ~Copyable' on generic parameter 'Self' defined in outer scope}}
+
+protocol NoCopyP: ~Copyable {}
+
+func needsCopyable<T>(_ t: T) {} // expected-note 2{{generic parameter 'T' has an implicit Copyable requirement}}
+func noCopyable(_ t: borrowing some ~Copyable) {}
+func noCopyableAndP(_ t: borrowing some NoCopyP & ~Copyable) {}
+
+func openingExistentials(_ a: borrowing any NoCopyP & ~Copyable,
+                         _ b: any NoCopyP,
+                         _ nc: borrowing any ~Copyable) {
+  needsCopyable(a) // expected-error {{noncopyable type 'any NoCopyP & ~Copyable' cannot be substituted for copyable generic parameter 'T' in 'needsCopyable'}}
+  noCopyable(a)
+  noCopyableAndP(a)
+
+  needsCopyable(b)
+  noCopyable(b)
+  noCopyableAndP(b)
+
+  needsCopyable(nc) // expected-error {{noncopyable type 'any ~Copyable' cannot be substituted for copyable generic parameter 'T' in 'needsCopyable'}}
+  noCopyable(nc)
+  noCopyableAndP(nc) // expected-error {{global function 'noCopyableAndP' requires that 'some NoCopyP & ~Copyable' conform to 'NoCopyP'}}
+}
+
+func project<CurValue>(_ base: CurValue) { }
+func testSpecial(_ a: Any) {
+  _openExistential(a, do: project)
+}

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics.swift
@@ -8,3 +8,16 @@ public struct Vector<T: ~Copyable> {
     fatalError("todo")
   }
 }
+
+
+
+
+// These are purely to add test coverage of different constructs
+public struct Toys {
+  static func test_parallelAssignment() {
+    var y: Int
+    var x: Int
+    (x, y) = (10, 11)
+  }
+
+}

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics.swift
@@ -20,4 +20,16 @@ public struct Toys {
     (x, y) = (10, 11)
   }
 
+  public struct rdar118697289_S1<Element> {
+    let element: Element
+    func f() -> Element { element }
+  }
+
+  public struct rdar118697289_S2<Element> {
+      let element: Element
+      subscript(i: Int) -> Element {
+          element
+      }
+  }
+
 }

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics.swift
@@ -1,0 +1,10 @@
+
+
+// A Swift × Haskell stdlib flavour.
+
+public struct Vector<T: ~Copyable> {
+
+  subscript(_ i: UInt) -> T {
+    fatalError("todo")
+  }
+}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -o %t/NoncopyableGenerics.swiftmodule -emit-module-interface-path %t/NoncopyableGenerics.swiftinterface -enable-experimental-feature NoncopyableGenerics %S/Inputs/NoncopyableGenerics.swift
+// RUN: %target-swift-frontend -emit-sil -sil-verify-all -I %t %s > /dev/null
+
+
+import NoncopyableGenerics


### PR DESCRIPTION
The goal of this PR is to shake out issues with just building the existing stdlib with NoncopyableGenerics enabled. This PR does not enable that by-default, so you'll still have to add `swift-stdlib-experimental-noncopyable-generics=1` to your build-script preset.

fixes rdar://118697289