### PR TITLE
Allow normal function results of @yield_once coroutines

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -6067,6 +6067,14 @@ executing the ``begin_apply``) were being "called" by the ``yield``:
   or move the value from that position before ending or aborting the
   coroutine.
 
+A coroutine optionally may produce normal results. These do not have
+``@yields`` annotation in the result type tuple.
+::
+  (%float, %token) = begin_apply %0() : $@yield_once () -> (@yields Float, Int)
+
+Normal results of a coroutine are produced by the corresponding ``end_apply``
+instruction.
+
 A ``begin_apply`` must be uniquely either ended or aborted before
 exiting the function or looping to an earlier portion of the function.
 
@@ -6096,9 +6104,9 @@ end_apply
 `````````
 ::
 
-  sil-instruction ::= 'end_apply' sil-value
+  sil-instruction ::= 'end_apply' sil-value 'as' sil-type
 
-  end_apply %token
+  end_apply %token as $()
 
 Ends the given coroutine activation, which is currently suspended at
 a ``yield`` instruction.  Transfers control to the coroutine and takes
@@ -6108,8 +6116,8 @@ when the coroutine reaches a ``return`` instruction.
 The operand must always be the token result of a ``begin_apply``
 instruction, which is why it need not specify a type.
 
-``end_apply`` currently has no instruction results.  If coroutines were
-allowed to have normal results, they would be producted by ``end_apply``.
+If a coroutine produces normal results on ``resume`` path, they
+will be produced by ``end_apply``.
 
 When throwing coroutines are supported, there will need to be a
 ``try_end_apply`` instruction.

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -6116,8 +6116,8 @@ when the coroutine reaches a ``return`` instruction.
 The operand must always be the token result of a ``begin_apply``
 instruction, which is why it need not specify a type.
 
-If a coroutine produces normal results on ``resume`` path, they
-will be produced by ``end_apply``.
+The result of ``end_apply`` is the normal result of the coroutine function (the
+operand of the ``return`` instruction)."
 
 When throwing coroutines are supported, there will need to be a
 ``try_end_apply`` instruction.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4729,24 +4729,27 @@ public:
   using Representation = SILExtInfoBuilder::Representation;
 
 private:
-  unsigned NumParameters;
+  unsigned NumParameters = 0;
 
-  // These are *normal* results if this is not a coroutine and *yield* results
-  // otherwise.
-  unsigned NumAnyResults;         // Not including the ErrorResult.
-  unsigned NumAnyIndirectFormalResults; // Subset of NumAnyResults.
-  unsigned NumPackResults; // Subset of NumAnyIndirectFormalResults.
+  // These are *normal* results
+  unsigned NumAnyResults = 0;         // Not including the ErrorResult.
+  unsigned NumAnyIndirectFormalResults = 0; // Subset of NumAnyResults.
+  unsigned NumPackResults = 0; // Subset of NumAnyIndirectFormalResults.
+  // These are *yield* results
+  unsigned NumAnyYieldResults = 0;  // Not including the ErrorResult.
+  unsigned NumAnyIndirectFormalYieldResults = 0; // Subset of NumAnyYieldResults.
+  unsigned NumPackYieldResults = 0; // Subset of NumAnyIndirectFormalYieldResults.
 
   // [NOTE: SILFunctionType-layout]
   // The layout of a SILFunctionType in memory is:
   //   SILFunctionType
   //   SILParameterInfo[NumParameters]
-  //   SILResultInfo[isCoroutine() ? 0 : NumAnyResults]
+  //   SILResultInfo[NumAnyResults]
   //   SILResultInfo?    // if hasErrorResult()
-  //   SILYieldInfo[isCoroutine() ? NumAnyResults : 0]
+  //   SILYieldInfo[NumAnyYieldResults]
   //   SubstitutionMap[HasPatternSubs + HasInvocationSubs]
-  //   CanType?          // if !isCoro && NumAnyResults > 1, formal result cache
-  //   CanType?          // if !isCoro && NumAnyResults > 1, all result cache
+  //   CanType?          // if NumAnyResults > 1, formal result cache
+  //   CanType?          // if NumAnyResults > 1, all result cache
 
   CanGenericSignature InvocationGenericSig;
   ProtocolConformanceRef WitnessMethodConformance;
@@ -4785,7 +4788,7 @@ private:
 
   /// Do we have slots for caches of the normal-result tuple type?
   bool hasResultCache() const {
-    return NumAnyResults > 1 && !isCoroutine();
+    return NumAnyResults > 1;
   }
 
   CanType &getMutableFormalResultsCache() const {
@@ -4873,14 +4876,14 @@ public:
   ArrayRef<SILYieldInfo> getYields() const {
     return const_cast<SILFunctionType *>(this)->getMutableYields();
   }
-  unsigned getNumYields() const { return isCoroutine() ? NumAnyResults : 0; }
+  unsigned getNumYields() const { return NumAnyYieldResults; }
 
   /// Return the array of all result information. This may contain inter-mingled
   /// direct and indirect results.
   ArrayRef<SILResultInfo> getResults() const {
     return const_cast<SILFunctionType *>(this)->getMutableResults();
   }
-  unsigned getNumResults() const { return isCoroutine() ? 0 : NumAnyResults; }
+  unsigned getNumResults() const { return NumAnyResults; }
 
   ArrayRef<SILResultInfo> getResultsWithError() const {
     return const_cast<SILFunctionType *>(this)->getMutableResultsWithError();
@@ -4917,17 +4920,17 @@ public:
   // indirect property, not the SIL indirect property, should be consulted to
   // determine whether function reabstraction is necessary.
   unsigned getNumIndirectFormalResults() const {
-    return isCoroutine() ? 0 : NumAnyIndirectFormalResults;
+    return NumAnyIndirectFormalResults;
   }
   /// Does this function have any formally indirect results?
   bool hasIndirectFormalResults() const {
     return getNumIndirectFormalResults() != 0;
   }
   unsigned getNumDirectFormalResults() const {
-    return isCoroutine() ? 0 : NumAnyResults - NumAnyIndirectFormalResults;
+    return NumAnyResults - NumAnyIndirectFormalResults;
   }
   unsigned getNumPackResults() const {
-    return isCoroutine() ? 0 : NumPackResults;
+    return NumPackResults;
   }
   bool hasIndirectErrorResult() const {
     return hasErrorResult() && getErrorResult().isFormalIndirect();
@@ -4985,17 +4988,17 @@ public:
                                      TypeExpansionContext expansion);
 
   unsigned getNumIndirectFormalYields() const {
-    return isCoroutine() ? NumAnyIndirectFormalResults : 0;
+    return NumAnyIndirectFormalYieldResults;
   }
   /// Does this function have any formally indirect yields?
   bool hasIndirectFormalYields() const {
     return getNumIndirectFormalYields() != 0;
   }
   unsigned getNumDirectFormalYields() const {
-    return isCoroutine() ? NumAnyResults - NumAnyIndirectFormalResults : 0;
+    return NumAnyYieldResults - NumAnyIndirectFormalYieldResults;
   }
   unsigned getNumPackYields() const {
-    return isCoroutine() ? NumPackResults : 0;
+    return NumPackYieldResults;
   }
 
   struct IndirectFormalYieldFilter {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -576,11 +576,11 @@ public:
                                                    beginApply));
   }
 
-  EndApplyInst *createEndApply(SILLocation loc, SILValue beginApply) {
+  EndApplyInst *createEndApply(SILLocation loc, SILValue beginApply, SILType ResultType) {
     return insert(new (getModule()) EndApplyInst(getSILDebugLocation(loc),
-                                                 beginApply));
+                                                 beginApply, ResultType));
   }
-
+  
   BuiltinInst *createBuiltin(SILLocation Loc, Identifier Name, SILType ResultTy,
                              SubstitutionMap Subs,
                              ArrayRef<SILValue> Args) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1076,7 +1076,8 @@ SILCloner<ImplClass>::visitEndApplyInst(EndApplyInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createEndApply(getOpLocation(Inst->getLoc()),
-                                        getOpValue(Inst->getOperand())));
+                                        getOpValue(Inst->getOperand()),
+                                        getOpType(Inst->getType())));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3200,11 +3200,12 @@ public:
 /// normally.
 class EndApplyInst
     : public UnaryInstructionBase<SILInstructionKind::EndApplyInst,
-                                  NonValueInstruction> {
+                                  SingleValueInstruction> {
   friend SILBuilder;
 
-  EndApplyInst(SILDebugLocation debugLoc, SILValue beginApplyToken)
-      : UnaryInstructionBase(debugLoc, beginApplyToken) {
+  EndApplyInst(SILDebugLocation debugLoc, SILValue beginApplyToken,
+               SILType Ty)
+    : UnaryInstructionBase(debugLoc, beginApplyToken, Ty) {
     assert(isaResultOf<BeginApplyInst>(beginApplyToken) &&
            isaResultOf<BeginApplyInst>(beginApplyToken)->isBeginApplyToken());
   }

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -568,6 +568,8 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                     SingleValueInstruction, MayHaveSideEffects, MayRelease)
   SINGLE_VALUE_INST(PartialApplyInst, partial_apply,
                     SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
+  SINGLE_VALUE_INST(EndApplyInst, end_apply,
+                    SILInstruction, MayHaveSideEffects, MayRelease)
 
   // Metatypes
   SINGLE_VALUE_INST(MetatypeInst, metatype,
@@ -871,8 +873,6 @@ NON_VALUE_INST(UncheckedRefCastAddrInst, unchecked_ref_cast_addr,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
 NON_VALUE_INST(AllocGlobalInst, alloc_global,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
-NON_VALUE_INST(EndApplyInst, end_apply,
-               SILInstruction, MayHaveSideEffects, MayRelease)
 NON_VALUE_INST(AbortApplyInst, abort_apply,
                SILInstruction, MayHaveSideEffects, MayRelease)
 NON_VALUE_INST(PackElementSetInst, pack_element_set,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4611,29 +4611,29 @@ SILFunctionType::SILFunctionType(
       !ext.getLifetimeDependenceInfo().empty();
   Bits.SILFunctionType.CoroutineKind = unsigned(coroutineKind);
   NumParameters = params.size();
-  if (coroutineKind == SILCoroutineKind::None) {
-    assert(yields.empty());
-    NumAnyResults = normalResults.size();
-    NumAnyIndirectFormalResults = 0;
-    NumPackResults = 0;
-    for (auto &resultInfo : normalResults) {
-      if (resultInfo.isFormalIndirect())
-        NumAnyIndirectFormalResults++;
-      if (resultInfo.isPack())
-        NumPackResults++;
-    }
-    memcpy(getMutableResults().data(), normalResults.data(),
-           normalResults.size() * sizeof(SILResultInfo));
-  } else {
-    assert(normalResults.empty());
-    NumAnyResults = yields.size();
-    NumAnyIndirectFormalResults = 0;
+  assert((coroutineKind == SILCoroutineKind::None && yields.empty()) ||
+         coroutineKind != SILCoroutineKind::None);
+
+  NumAnyResults = normalResults.size();
+  NumAnyIndirectFormalResults = 0;
+  NumPackResults = 0;
+  for (auto &resultInfo : normalResults) {
+    if (resultInfo.isFormalIndirect())
+      NumAnyIndirectFormalResults++;
+    if (resultInfo.isPack())
+      NumPackResults++;
+  }
+  memcpy(getMutableResults().data(), normalResults.data(),
+         normalResults.size() * sizeof(SILResultInfo));
+  if (coroutineKind != SILCoroutineKind::None) {
+    NumAnyYieldResults = yields.size();
+    NumAnyIndirectFormalYieldResults = 0;
     NumPackResults = 0;
     for (auto &yieldInfo : yields) {
       if (yieldInfo.isFormalIndirect())
-        NumAnyIndirectFormalResults++;
+        NumAnyIndirectFormalYieldResults++;
       if (yieldInfo.isPack())
-        NumPackResults++;
+        NumPackYieldResults++;
     }
     memcpy(getMutableYields().data(), yields.data(),
            yields.size() * sizeof(SILYieldInfo));
@@ -4805,7 +4805,6 @@ CanSILFunctionType SILFunctionType::get(
     llvm::Optional<SILResultInfo> errorResult, SubstitutionMap patternSubs,
     SubstitutionMap invocationSubs, const ASTContext &ctx,
     ProtocolConformanceRef witnessMethodConformance) {
-  assert(coroutineKind == SILCoroutineKind::None || normalResults.empty());
   assert(coroutineKind != SILCoroutineKind::None || yields.empty());
   assert(!ext.isPseudogeneric() || genericSig ||
          coroutineKind != SILCoroutineKind::None);

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -266,6 +266,8 @@ namespace irgen {
                        SILType funcResultTypeInContext,
                        CanSILFunctionType fnType, Explosion &result,
                        Explosion &error);
+  void emitYieldOnceCoroutineResult(IRGenFunction &IGF, Explosion &result,
+                                    SILType funcResultType, SILType returnResultType);
 
   Address emitAutoDiffCreateLinearMapContextWithType(
       IRGenFunction &IGF, llvm::Value *topLevelSubcontextMetatype);

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -709,7 +709,7 @@ void IRGenFunction::emitAwaitAsyncContinuation(
       // because the continuation result is not available yet. When the
       // continuation is later resumed, the task will get scheduled
       // starting from the suspension point.
-      emitCoroutineOrAsyncExit();
+      emitCoroutineOrAsyncExit(false);
     }
 
     Builder.emitBlock(contBB);

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -155,6 +155,16 @@ public:
     CoroutineHandle = handle;
   }
 
+  llvm::BasicBlock *getCoroutineExitBlock() const {
+    return CoroutineExitBlock;
+  }
+
+  void setCoroutineExitBlock(llvm::BasicBlock *block) {
+    assert(CoroutineExitBlock == nullptr && "already set exit BB");
+    assert(block != nullptr && "setting a null exit BB");
+    CoroutineExitBlock = block;
+  }
+
   llvm::Value *getAsyncTask();
   llvm::Value *getAsyncContext();
   void storeCurrentAsyncContext(llvm::Value *context);
@@ -236,7 +246,7 @@ private:
   bool callsAnyAlwaysInlineThunksWithForeignExceptionTraps = false;
 
 public:
-  void emitCoroutineOrAsyncExit();
+  void emitCoroutineOrAsyncExit(bool isUnwind);
 
 //--- Helper methods -----------------------------------------------------------
 public:

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1595,7 +1595,7 @@ public:
   }
 
   void visitEndApplyInst(EndApplyInst *AI) {
-    *this << Ctx.getID(AI->getOperand());
+    *this << Ctx.getID(AI->getOperand()) << " as " << AI->getType();
   }
 
   void visitFunctionRefInst(FunctionRefInst *FRI) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2639,8 +2639,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     if (parseCallInstruction(InstLoc, Opcode, B, ResultVal))
       return true;
     break;
-  case SILInstructionKind::AbortApplyInst:
-  case SILInstructionKind::EndApplyInst: {
+  case SILInstructionKind::AbortApplyInst: {
     UnresolvedValueName argName;
     if (parseValueName(argName))
       return true;
@@ -2650,12 +2649,31 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
 
     SILType expectedTy = SILType::getSILTokenType(P.Context);
     SILValue op = getLocalValue(argName, expectedTy, InstLoc, B);
+    ResultVal = B.createAbortApply(InstLoc, op);
+    break;
+  }
+  case SILInstructionKind::EndApplyInst: {
+    UnresolvedValueName argName;
+    if (parseValueName(argName))
+      return true;
 
-    if (Opcode == SILInstructionKind::AbortApplyInst) {
-      ResultVal = B.createAbortApply(InstLoc, op);
-    } else {
-      ResultVal = B.createEndApply(InstLoc, op);
+    if (P.Tok.getKind() != tok::kw_as) {
+      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "as");
+      return true;
     }
+    P.consumeToken(tok::kw_as);
+
+    SILType ResultTy;
+    if (parseSILType(ResultTy))
+      return true;
+
+    if (parseSILDebugLocation(InstLoc, B))
+      return true;
+
+    SILType expectedTy = SILType::getSILTokenType(P.Context);
+    SILValue op = getLocalValue(argName, expectedTy, InstLoc, B);
+
+    ResultVal = B.createEndApply(InstLoc, op, ResultTy);
     break;
   }
   case SILInstructionKind::IntegerLiteralInst: {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2654,20 +2654,10 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   }
   case SILInstructionKind::EndApplyInst: {
     UnresolvedValueName argName;
-    if (parseValueName(argName))
-      return true;
-
-    if (P.Tok.getKind() != tok::kw_as) {
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "as");
-      return true;
-    }
-    P.consumeToken(tok::kw_as);
-
     SILType ResultTy;
-    if (parseSILType(ResultTy))
-      return true;
 
-    if (parseSILDebugLocation(InstLoc, B))
+    if (parseValueName(argName) || parseVerbatim("as") ||
+        parseSILType(ResultTy) || parseSILDebugLocation(InstLoc, B))
       return true;
 
     SILType expectedTy = SILType::getSILTokenType(P.Context);

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1951,34 +1951,11 @@ public:
             "operand of end_apply must be a begin_apply");
 
     BeginApplyInst *bai = AI->getBeginApply();
-    
     SILFunctionConventions calleeConv(bai->getSubstCalleeType(), F.getModule());
-    auto calleeResults = calleeConv.getResults();
-    auto results = AI->getResults();
 
-    require(results.size() == 1,
-            "end_apply must have a single result");
-
-    if (auto tupleTy = results[0]->getType().getAs<TupleType>()) {
-      require(tupleTy.getElementTypes().size() == calleeResults.size(),
-              "length mismatch in callee results vs. end_apply results");
-
-      for (auto typeAndIdx : llvm::enumerate(tupleTy->getElementTypes())) {
-        SILType elTy = SILType::getPrimitiveObjectType(typeAndIdx.value()->getCanonicalType());
-        requireSameType(
-          elTy,
-          calleeConv.getSILType(calleeResults[typeAndIdx.index()], F.getTypeExpansionContext()),
-          "callee result type does not match end_apply result type");
-      }
-    } else {
-      require(calleeResults.size() == 1,
-              "callee must have a single result");
-
-      requireSameType(
-        results[0]->getType(),
-        calleeConv.getSILType(calleeResults[0], F.getTypeExpansionContext()),
-        "callee result type does not match end_apply result type");
-    }
+    requireSameType(
+      AI->getType(), calleeConv.getSILResultType(F.getTypeExpansionContext()),
+      "callee result type does not match end_apply result type");
   }
 
   void verifyLLVMIntrinsic(BuiltinInst *BI, llvm::Intrinsic::ID ID) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1949,6 +1949,36 @@ public:
   void checkEndApplyInst(EndApplyInst *AI) {
     require(getAsResultOf<BeginApplyInst>(AI->getOperand())->isBeginApplyToken(),
             "operand of end_apply must be a begin_apply");
+
+    BeginApplyInst *bai = AI->getBeginApply();
+    
+    SILFunctionConventions calleeConv(bai->getSubstCalleeType(), F.getModule());
+    auto calleeResults = calleeConv.getResults();
+    auto results = AI->getResults();
+
+    require(results.size() == 1,
+            "end_apply must have a single result");
+
+    if (auto tupleTy = results[0]->getType().getAs<TupleType>()) {
+      require(tupleTy.getElementTypes().size() == calleeResults.size(),
+              "length mismatch in callee results vs. end_apply results");
+
+      for (auto typeAndIdx : llvm::enumerate(tupleTy->getElementTypes())) {
+        SILType elTy = SILType::getPrimitiveObjectType(typeAndIdx.value()->getCanonicalType());
+        requireSameType(
+          elTy,
+          calleeConv.getSILType(calleeResults[typeAndIdx.index()], F.getTypeExpansionContext()),
+          "callee result type does not match end_apply result type");
+      }
+    } else {
+      require(calleeResults.size() == 1,
+              "callee must have a single result");
+
+      requireSameType(
+        results[0]->getType(),
+        calleeConv.getSILType(calleeResults[0], F.getTypeExpansionContext()),
+        "callee result type does not match end_apply result type");
+    }
   }
 
   void verifyLLVMIntrinsic(BuiltinInst *BI, llvm::Intrinsic::ID ID) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4906,7 +4906,8 @@ public:
     if (forUnwind) {
       SGF.B.createAbortApply(l, ApplyToken);
     } else {
-      SGF.B.createEndApply(l, ApplyToken);
+      SGF.B.createEndApply(l, ApplyToken,
+                           SILType::getEmptyTupleType(SGF.getASTContext()));
     }
   }
   
@@ -5953,7 +5954,8 @@ void SILGenFunction::emitEndApplyWithRethrow(SILLocation loc,
   // TODO: adjust this to handle results of TryBeginApplyInst.
   assert(token->isBeginApplyToken());
 
-  B.createEndApply(loc, token);
+  B.createEndApply(loc, token,
+                   SILType::getEmptyTupleType(getASTContext()));
 }
 
 void SILGenFunction::emitYield(SILLocation loc,

--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -121,12 +121,14 @@ static void emitBackDeployForwardApplyAndReturnOrThrow(
 
     // Emit resume block.
     SGF.B.emitBlock(resumeBB);
-    SGF.B.createEndApply(loc, token);
+    SGF.B.createEndApply(loc, token,
+                         SILType::getEmptyTupleType(SGF.getASTContext()));
     SGF.B.createBranch(loc, SGF.ReturnDest.getBlock());
 
     // Emit unwind block.
     SGF.B.emitBlock(unwindBB);
-    SGF.B.createEndApply(loc, token);
+    SGF.B.createEndApply(loc, token,
+                         SILType::getEmptyTupleType(SGF.getASTContext()));
     SGF.B.createBranch(loc, SGF.CoroutineUnwindDest.getBlock());
     return;
   }

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -207,13 +207,16 @@ public:
     // instructions in the caller.  That means this entire path is
     // unreachable.
     if (isa<ReturnInst>(terminator) || isa<UnwindInst>(terminator)) {
-      bool isNormal = isa<ReturnInst>(terminator);
-      auto returnBB = isNormal ? EndApplyReturnBB : AbortApplyReturnBB;
+      ReturnInst *retInst = dyn_cast<ReturnInst>(terminator);
+      auto *returnBB = retInst ? EndApplyReturnBB : AbortApplyReturnBB;
+      if (retInst && EndApply)
+        EndApply->replaceAllUsesWith(getMappedValue(retInst->getOperand()));
       if (returnBB) {
         Builder->createBranch(Loc, returnBB);
       } else {
         Builder->createUnreachable(Loc);
       }
+
       return true;
     }
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1574,6 +1574,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   ONEOPERAND_ONETYPE_INST(ObjCMetatypeToObject)
   ONEOPERAND_ONETYPE_INST(ObjCExistentialMetatypeToObject)
   ONEOPERAND_ONETYPE_INST(ProjectBlockStorage)
+  ONEOPERAND_ONETYPE_INST(EndApply)
 #undef ONEOPERAND_ONETYPE_INST
 
   case SILInstructionKind::AddressToPointerInst: {
@@ -2200,7 +2201,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   REFCOUNTING_INSTRUCTION(StrongRelease)
   UNARY_INSTRUCTION(IsUnique)
   UNARY_INSTRUCTION(AbortApply)
-  UNARY_INSTRUCTION(EndApply)
   UNARY_INSTRUCTION(ExtractExecutor)
 #undef UNARY_INSTRUCTION
 #undef REFCOUNTING_INSTRUCTION

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 848; // inroduced a package SIL linkage
+const uint16_t SWIFTMODULE_VERSION_MINOR = 849; // end_apply result
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1548,7 +1548,6 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case SILInstructionKind::HopToExecutorInst:
   case SILInstructionKind::ExtractExecutorInst:
   case SILInstructionKind::AbortApplyInst:
-  case SILInstructionKind::EndApplyInst:
   case SILInstructionKind::ReturnInst:
   case SILInstructionKind::UncheckedOwnershipConversionInst:
   case SILInstructionKind::IsEscapingClosureInst:
@@ -1595,6 +1594,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
                                                                      : false;
     }
     writeOneOperandLayout(SI.getKind(), Attr, SI.getOperand(0));
+    break;
+  }
+  case SILInstructionKind::EndApplyInst: {
+    const auto *eai = cast<EndApplyInst>(&SI);
+    writeOneTypeOneOperandLayout(
+      eai->getKind(), 0, eai->getType(), eai->getOperand());
     break;
   }
   case SILInstructionKind::MarkUnresolvedNonCopyableValueInst: {

--- a/test/IRGen/big_types.sil
+++ b/test/IRGen/big_types.sil
@@ -89,8 +89,7 @@ unwind:
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[USE:%.*]] = function_ref @use_big_struct : $@convention(thin) (@in_guaranteed BigStruct) -> ()
 // CHECK-NEXT:    apply [[USE]]([[TEMP]])
-// CHECK-NEXT:    end_apply [[TOKEN]]
-// CHECK-NEXT:    [[RET:%.*]] = tuple ()
+// CHECK-NEXT:    [[RET:%.*]] = end_apply [[TOKEN]] as $()
 // CHECK-NEXT:    dealloc_stack [[TEMP]] : $*BigStruct
 // CHECK-NEXT:    return [[RET]] : $()
 sil @use_yield_big : $@convention(thin) () -> () {
@@ -99,8 +98,7 @@ entry:
   (%big, %token) = begin_apply %yield_big() : $@convention(thin) @yield_once() -> (@yields BigStruct)
   %use_big = function_ref @use_big_struct : $@convention(thin) (BigStruct) -> ()
   apply %use_big(%big) : $@convention(thin) (BigStruct) -> ()
-  end_apply %token
-  %ret = tuple ()
+  %ret = end_apply %token as $()
   return %ret : $()
 }
 
@@ -116,7 +114,7 @@ bb0:
   yield %3 : $*Optional<@callee_guaranteed (@guaranteed BigStruct) -> ()>, resume bb1, unwind bb2
 
 bb1:
-  end_apply %4
+  end_apply %4 as $()
   %7 = tuple ()
   return %7 : $()
 

--- a/test/IRGen/ptrauth-functions.sil
+++ b/test/IRGen/ptrauth-functions.sil
@@ -77,7 +77,7 @@ sil @test_generic_return : $@convention(thin) <T : F> (@guaranteed T) -> ()  {
 bb0(%0 : $T):
   %1 = function_ref @generic_return : $@convention(thin) @yield_once <T : F> (@guaranteed T) -> (@yields @guaranteed T)
   (%value, %token) = begin_apply %1<T>(%0) : $@convention(thin) @yield_once <T : F> (@guaranteed T) -> (@yields @guaranteed T)
-  end_apply %token
+  end_apply %token as $()
   %ret = tuple ()
   return %ret : $()
 }

--- a/test/IRGen/yield_once.sil
+++ b/test/IRGen/yield_once.sil
@@ -27,19 +27,23 @@ resume:
   // CHECK:         call swiftcc void @marker(i32 2000)
   %2000 = integer_literal $Builtin.Int32, 2000
   apply %marker(%2000) : $@convention(thin) (Builtin.Int32) -> ()
-  // CHECK:         br label %coro.end
+  // CHECK:         br label %coro.end.normal
   %ret = tuple ()
   return %ret : $()
+
+  // CHECK:       coro.end.normal:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false, token none)
+  // CHECK-NEXT:    unreachable
 
 unwind:
   // CHECK:         call swiftcc void @marker(i32 3000)
   %3000 = integer_literal $Builtin.Int32, 3000
   apply %marker(%3000) : $@convention(thin) (Builtin.Int32) -> ()
-  // CHECK:         br label %coro.end
+  // CHECK:         br label %coro.end.unwind
   unwind
 
-  // CHECK:       coro.end:
-  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false)
+  // CHECK:       coro.end.unwind:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 true, token none)
   // CHECK-NEXT:    unreachable
 }
 
@@ -70,7 +74,7 @@ yes:
   // CHECK-64-ptrauth-NEXT: ptrauth.blend
   // CHECK:    call swiftcc void [[CONTINUATION]](ptr noalias dereferenceable([[BUFFER_SIZE]]) [[BUFFER]], i1 false)
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
-  end_apply %token
+  end_apply %token as $()
 
   // CHECK-NEXT:    br label
   br cont
@@ -120,7 +124,7 @@ entry:
   // CHECK-64-ptrauth-NEXT: ptrauth.blend
   // CHECK-NEXT:    call swiftcc void [[CONTINUATION]](ptr noalias dereferenceable([[BUFFER_SIZE]]) [[BUFFER]], i1 false)
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
-  end_apply %token
+  end_apply %token as $()
 
   // CHECK-NEXT:    call swiftcc void @marker(i32 [[SECOND]])
   apply %marker(%second) : $@convention(thin) (Builtin.Int32) -> ()

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -72,20 +72,24 @@ resume:
   %2000 = integer_literal $Builtin.Int32, 2000
   apply %marker(%2000) : $@convention(thin) (Builtin.Int32) -> ()
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[TEMP]])
-  // CHECK-NEXT:    br label %coro.end
+  // CHECK-NEXT:    br label %coro.end.normal
   %ret = tuple ()
   return %ret : $()
+
+  // CHECK:       coro.end.normal:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false, token none)
+  // CHECK-NEXT:    unreachable
 
 unwind:
   // CHECK:         call swiftcc void @marker(i32 3000)
   %3000 = integer_literal $Builtin.Int32, 3000
   apply %marker(%3000) : $@convention(thin) (Builtin.Int32) -> ()
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[TEMP]])
-  // CHECK-NEXT:    br label %coro.end
+  // CHECK-NEXT:    br label %coro.end.unwind
   unwind
 
-  // CHECK:       coro.end:
-  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false)
+  // CHECK:       coro.end.unwind:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 true, token none)
   // CHECK-NEXT:    unreachable
 }
 
@@ -139,7 +143,7 @@ yes:
   // CHECK-64-ptrauth-NEXT: ptrauth.blend
   // CHECK:    call swiftcc void [[CONTINUATION]](ptr noalias dereferenceable([[BUFFER_SIZE]]) [[BUFFER]], i1 false)
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
-  end_apply %token
+  end_apply %token as $()
 
   // CHECK-NEXT:    br label
   br cont
@@ -219,9 +223,13 @@ resume:
   %2000 = integer_literal $Builtin.Int32, 2000
   apply %marker(%2000) : $@convention(thin) (Builtin.Int32) -> ()
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[TEMP]])
-  // CHECK-NEXT:    br label %coro.end
+  // CHECK-NEXT:    br label %coro.end.normal
   %ret = tuple ()
   return %ret : $()
+
+  // CHECK:       coro.end.normal:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false, token none)
+  // CHECK-NEXT:    unreachable
 
 unwind:
   end_borrow %value : $BigWrapper<C>
@@ -229,10 +237,10 @@ unwind:
   %3000 = integer_literal $Builtin.Int32, 3000
   apply %marker(%3000) : $@convention(thin) (Builtin.Int32) -> ()
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[TEMP]])
-  // CHECK-NEXT:    br label %coro.end
+  // CHECK-NEXT:    br label %coro.end.unwind
   unwind
 
-  // CHECK:       coro.end:
-  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false)
+  // CHECK:       coro.end.unwind:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 true, token none)
   // CHECK-NEXT:    unreachable
 }

--- a/test/IRGen/yield_once_biggish.sil
+++ b/test/IRGen/yield_once_biggish.sil
@@ -77,19 +77,23 @@ resume:
   // CHECK:         call swiftcc void @marker(i32 2000)
   %2000 = integer_literal $Builtin.Int32, 2000
   apply %marker(%2000) : $@convention(thin) (Builtin.Int32) -> ()
-  // CHECK:         br label %coro.end
+  // CHECK:         br label %coro.end.normal
   %ret = tuple ()
   return %ret : $()
+
+  // CHECK:       coro.end.normal:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false, token none)
+  // CHECK-NEXT:    unreachable
 
 unwind:
   // CHECK:         call swiftcc void @marker(i32 3000)
   %3000 = integer_literal $Builtin.Int32, 3000
   apply %marker(%3000) : $@convention(thin) (Builtin.Int32) -> ()
-  // CHECK:         br label %coro.end
+  // CHECK:         br label %coro.end.unwind
   unwind
 
-  // CHECK:       coro.end:
-  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false)
+  // CHECK:       coro.end.unwind:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 true, token none)
   // CHECK-NEXT:    unreachable
 }
 
@@ -131,7 +135,7 @@ yes:
   // CHECK-64-ptrauth-NEXT: ptrauth.blend
   // CHECK:    call swiftcc void [[CONTINUATION]](ptr noalias dereferenceable([[BUFFER_SIZE]]) [[BUFFER]], i1 false)
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
-  end_apply %token
+  end_apply %token as $()
 
   // CHECK-NEXT:    br label
   br cont

--- a/test/IRGen/yield_once_indirect.sil
+++ b/test/IRGen/yield_once_indirect.sil
@@ -60,9 +60,13 @@ resume:
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[TEMP]])
   dealloc_stack %temp : $*Indirect<C>
 
-  // CHECK-NEXT:    br label %coro.end
+  // CHECK-NEXT:    br label %coro.end.normal
   %ret = tuple ()
   return %ret : $()
+
+  // CHECK:       coro.end.normal:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false, token none)
+  // CHECK-NEXT:    unreachable
 
 unwind:
   // CHECK:         call swiftcc void @marker(i32 3000)
@@ -72,11 +76,11 @@ unwind:
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 {{.*}}, ptr [[TEMP]])
   dealloc_stack %temp : $*Indirect<C>
 
-  // CHECK-NEXT:    br label %coro.end
+  // CHECK-NEXT:    br label %coro.end.unwind
   unwind
 
-  // CHECK:       coro.end:
-  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false)
+  // CHECK:       coro.end.unwind:
+  // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 true, token none)
   // CHECK-NEXT:    unreachable
 }
 
@@ -116,7 +120,7 @@ yes:
   // CHECK-64-ptrauth-NEXT: ptrauth.blend
   // CHECK:    call swiftcc void [[CONTINUATION]](ptr noalias dereferenceable([[BUFFER_SIZE]]) [[BUFFER]], i1 false)
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
-  end_apply %token
+  end_apply %token as $()
 
   // CHECK-NEXT:    br label
   br cont

--- a/test/IRGen/yield_result.sil
+++ b/test/IRGen/yield_result.sil
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s
+
+import Builtin
+
+sil @marker : $(Builtin.Int64) -> ()
+
+sil @coro_ret : $@yield_once @convention(thin) () -> (@yields Builtin.Int64, Builtin.Int64)
+sil @coro_ret_pair : $@yield_once @convention(thin) () -> (@yields Builtin.Int64, Builtin.Int64, Builtin.Int64)
+
+// CHECK-LABEL: test_coro_ret
+sil @test_coro_ret : $() -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) {
+entry:
+  %marker = function_ref @marker : $@convention(thin) (Builtin.Int64) -> ()
+
+  %coro1 = function_ref @coro_ret : $@yield_once @convention(thin) () -> (@yields Builtin.Int64, Builtin.Int64)
+  (%first, %token1) = begin_apply %coro1() : $@yield_once @convention(thin) () -> (@yields Builtin.Int64, Builtin.Int64)
+
+// CHECK: [[T0:%.*]] = alloca {{\[}}[[BUFFER_SIZE1:.*]] x i8
+// CHECK: [[T1:%.*]] = alloca {{\[}}[[BUFFER_SIZE2:.*]] x i8
+// CHECK: [[BUFFER1:%.*]] = getelementptr inbounds {{\[}}[[BUFFER_SIZE1]] x i8], ptr [[T0]], i32 0, i32 0
+// CHECK: [[CORO1:%.*]] = call ptr @llvm.coro.prepare.retcon(ptr @coro_ret)
+// CHECK: [[FRAME1:%.*]] = call swiftcc { ptr, i64 } [[CORO1]](ptr noalias dereferenceable([[BUFFER_SIZE1]]) [[BUFFER1]]
+// CHECK: [[CONT1:%.*]]  = extractvalue { ptr, i64 } [[FRAME1]], 0
+  
+  apply %marker(%first) : $@convention(thin) (Builtin.Int64) -> ()
+
+  %ret = end_apply %token1 as $Builtin.Int64
+
+// CHECK: call swiftcc i64 [[CONT1]](ptr noalias dereferenceable([[BUFFER_SIZE1]]) [[BUFFER1]], i1 false)
+  
+  apply %marker(%ret) : $@convention(thin) (Builtin.Int64) -> ()
+
+  %coro2 = function_ref @coro_ret_pair : $@yield_once @convention(thin) () -> (@yields Builtin.Int64, Builtin.Int64, Builtin.Int64)
+  (%second, %token2) = begin_apply %coro2() : $@yield_once @convention(thin) () -> (@yields Builtin.Int64, Builtin.Int64, Builtin.Int64)
+
+// CHECK: [[BUFFER2:%.*]] = getelementptr inbounds {{\[}}[[BUFFER_SIZE2]] x i8], ptr [[T1]], i32 0, i32 0
+// CHECK: [[CORO2:%.*]] = call ptr @llvm.coro.prepare.retcon(ptr @coro_ret_pair)
+// CHECK: [[FRAME2:%.*]] = call swiftcc { ptr, i64 } [[CORO2]](ptr noalias dereferenceable([[BUFFER_SIZE2]]) [[BUFFER2]]
+// CHECK: [[CONT2:%.*]]  = extractvalue { ptr, i64 } [[FRAME2]], 0
+
+  %ret2 = end_apply %token2 as $(Builtin.Int64, Builtin.Int64)
+
+// CHECK: call swiftcc { i64, i64 } [[CONT2]](ptr noalias dereferenceable([[BUFFER_SIZE2]]) [[BUFFER2]], i1 false)
+  
+  %ret2_1 = tuple_extract %ret2 : $(Builtin.Int64, Builtin.Int64), 0 
+  %ret2_2 = tuple_extract %ret2 : $(Builtin.Int64, Builtin.Int64), 1
+
+  apply %marker(%second) : $@convention(thin) (Builtin.Int64) -> ()
+
+  %retf = tuple (%ret : $Builtin.Int64, %ret2_1 : $Builtin.Int64, %ret2_2 : $Builtin.Int64)
+  return %retf : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
+}

--- a/test/SIL/OwnershipVerifier/begin_apply_use_after_end_apply.sil
+++ b/test/SIL/OwnershipVerifier/begin_apply_use_after_end_apply.sil
@@ -15,7 +15,7 @@ sil @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'guaranteed_coroutine_caller'
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value: (**%3**, %4) = begin_apply %0() : $@yield_once @convention(thin) () -> @yields @guaranteed Klass // user: %6
-// CHECK: Consuming User:   end_apply %4                                    // id: %5
+// CHECK: Consuming User: %5 = end_apply %4 as $()
 // CHECK: Non Consuming User:   %6 = apply %2(%3) : $@convention(thin) (@guaranteed Klass) -> ()
 // CHECK: Block: bb0
 // CHECK: Error#: 0. End Error in Function: 'guaranteed_coroutine_caller'
@@ -46,21 +46,21 @@ bb0:
   %user_func = function_ref @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 
   (%0a, %0b) = begin_apply %0() : $@yield_once @convention(thin) () -> @yields @guaranteed Klass
-  end_apply %0b
+  end_apply %0b as $()
   apply %user_func(%0a) : $@convention(thin) (@guaranteed Klass) -> ()
 
   (%val1, %tok1) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @owned Klass
-  end_apply %tok1
+  end_apply %tok1 as $()
   apply %user_func(%val1) : $@convention(thin) (@guaranteed Klass) -> ()
 
   (%val2, %tok2) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @owned Klass
   destroy_value %val2 : $Klass
-  end_apply %tok2
+  end_apply %tok2 as $()
   apply %user_func(%val2) : $@convention(thin) (@guaranteed Klass) -> ()
 
   (%val3, %tok3) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @owned Klass
   apply %user_func(%val3) : $@convention(thin) (@guaranteed Klass) -> ()
-  end_apply %tok3
+  end_apply %tok3 as $()
 
   %9999 = tuple()
   return %9999 : $()

--- a/test/SIL/OwnershipVerifier/borrow_scope_introducing_operands.sil
+++ b/test/SIL/OwnershipVerifier/borrow_scope_introducing_operands.sil
@@ -39,7 +39,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value: %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
-// CHECK: Non Consuming User:   end_apply %2
+// CHECK: Non Consuming User: %4 = end_apply %2 as $()
 // CHECK: Block: bb0
 // CHECK: Error#: 0. End Error in Function: 'destroy_value_before_end_borrow_coroutine'
 //
@@ -49,7 +49,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %token = begin_apply %coro(%0) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   destroy_value %0 : $Builtin.NativeObject
-  end_apply %token
+  end_apply %token as $()
   %r = tuple ()
   return %r : $()
 }
@@ -94,7 +94,7 @@ bb1:
   br bb3
 
 bb2:
-  end_apply %token
+  end_apply %token as $()
   destroy_value %0 : $Builtin.NativeObject
   br bb3
 
@@ -107,7 +107,7 @@ bb3:
 // CHECK: Found outside of lifetime use?!
 // CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
 // CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// CHECK: Non Consuming User:   end_apply %3
+// CHECK: Non Consuming User: %5 = end_apply %3 as $()
 // CHECK: Block: bb0
 // CHECK: Error#: 0. End Error in Function: 'parent_borrow_scope_end_before_end_borrow_coroutine'
 //
@@ -118,7 +118,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   end_borrow %1 : $Builtin.NativeObject
-  end_apply %token
+  end_apply %token as $()
   destroy_value %0 : $Builtin.NativeObject
   %r = tuple ()
   return %r : $()
@@ -167,7 +167,7 @@ bb1:
   br bb3
 
 bb2:
-  end_apply %token
+  end_apply %token as $()
   end_borrow %1 : $Builtin.NativeObject
   br bb3
 

--- a/test/SIL/OwnershipVerifier/borrow_scope_introducing_operands_positive.sil
+++ b/test/SIL/OwnershipVerifier/borrow_scope_introducing_operands_positive.sil
@@ -36,7 +36,7 @@ sil [ossa] @destroy_value_before_end_borrow_coroutine : $@convention(thin) (@own
 bb0(%0 : @owned $Builtin.NativeObject):
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %token = begin_apply %coro(%0) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-  end_apply %token
+  end_apply %token as $()
   destroy_value %0 : $Builtin.NativeObject
   %r = tuple ()
   return %r : $()
@@ -46,7 +46,7 @@ sil [ossa] @destroy_value_before_end_borrow_coroutine_1a : $@convention(thin) (@
 bb0(%0 : @owned $Builtin.NativeObject):
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %token = begin_apply %coro(%0) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-  end_apply %token
+  end_apply %token as $()
   br bb1
 
 bb1:
@@ -90,7 +90,7 @@ bb1:
   br bb3
 
 bb2:
-  end_apply %token
+  end_apply %token as $()
   destroy_value %0 : $Builtin.NativeObject
   br bb3
 
@@ -104,7 +104,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-  end_apply %token
+  end_apply %token as $()
   end_borrow %1 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   %r = tuple ()
@@ -116,7 +116,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-  end_apply %token
+  end_apply %token as $()
   br bb1
 
 bb1:
@@ -167,7 +167,7 @@ bb1:
   br bb3
 
 bb2:
-  end_apply %token
+  end_apply %token as $()
   end_borrow %1 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   br bb3

--- a/test/SIL/Parser/coroutines.sil
+++ b/test/SIL/Parser/coroutines.sil
@@ -57,7 +57,7 @@ bb0(%0 : $Int, %1 : $Float):
   %coro = function_ref @yield : $@convention(thin) @yield_once (Int, Float) -> (@yields Int, @yields Float)
   (%int, %float, %token) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once (Int, Float) -> (@yields Int, @yields Float)
 
-  end_apply %token
+  end_apply %token as $()
   %r = tuple ()
   return %r : $()
 }

--- a/test/SIL/Parser/overloaded_member.sil
+++ b/test/SIL/Parser/overloaded_member.sil
@@ -55,7 +55,7 @@ sil [ossa] @test_overloaded_subscript : $@convention(thin) (@guaranteed B, B.Ind
 bb0(%0 : @guaranteed $B, %1 : $B.Index):
   %reader = class_method %0 : $B, #B.subscript!read : (B) -> (B.Index) -> (), $@convention(method) @yield_once (B.Index, @guaranteed B) -> @yields @guaranteed B.Element
   (%element, %token) = begin_apply %reader(%1, %0) : $@convention(method) @yield_once (B.Index, @guaranteed B) -> @yields @guaranteed B.Element
-  end_apply %token
+  end_apply %token as $()
 
   %result = tuple ()
   return %result : $()

--- a/test/SIL/concurrentclosure_capture_verify_canonical_addressonly.sil
+++ b/test/SIL/concurrentclosure_capture_verify_canonical_addressonly.sil
@@ -79,7 +79,7 @@ bb0(%0 : $*T):
   // function_ref inoutUserOptKlass(_:)
   %28 = function_ref @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
   %29 = apply %28(%26) : $@convention(thin) (@inout FakeOptional<Klass>) -> ()
-  end_apply %27                                   // id: %30
+  end_apply %27 as $()                             // id: %30
   end_access %24 : $*T                            // id: %31
   destroy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // id: %32
   destroy_addr %2 : $*F                           // id: %33

--- a/test/SIL/concurrentclosure_capture_verify_raw.sil
+++ b/test/SIL/concurrentclosure_capture_verify_raw.sil
@@ -112,7 +112,7 @@ bb0(%0 : $*T):
   // function_ref inoutUserOptKlass(_:)
   %28 = function_ref @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
   %29 = apply %28(%26) : $@convention(thin) (@inout FakeOptional<Klass>) -> ()
-  end_apply %27                                   // id: %30
+  end_apply %27 as $()                             // id: %30
   end_access %24 : $*T                            // id: %31
   destroy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // id: %32
   destroy_addr %2 : $*F                           // id: %33

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -694,7 +694,7 @@ sil [ossa] @begin_apply_in_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in U
   destroy_addr %instance : $*Inner
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -703,7 +703,7 @@ sil [ossa] @begin_apply_in_constant_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_constant U
   destroy_addr %instance : $*Inner
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -711,7 +711,7 @@ entry:
 sil [ossa] @begin_apply_in_guaranteed_no_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -664,7 +664,7 @@ bb0(%0 : $*Optional<String>):
 sil [ossa] @begin_apply_in_no_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in U
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -673,7 +673,7 @@ entry:
 sil [ossa] @begin_apply_in_use_after_end_apply : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in U
-  end_apply %token
+  end_apply %token as $()
   apply undef<Inner>(%instance) : $@convention(thin) <U> (@in U) -> ()
   %retval = tuple ()
   return %retval : $()
@@ -683,7 +683,7 @@ entry:
 sil [ossa] @begin_apply_in_constant_no_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_constant U
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -692,7 +692,7 @@ entry:
 sil [ossa] @begin_apply_in_constant_use_after_end_apply : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_constant U
-  end_apply %token
+  end_apply %token as $()
   apply undef<Inner>(%instance) : $@convention(thin) <U> (@in_constant U) -> ()
   %retval = tuple ()
   return %retval : $()
@@ -703,7 +703,7 @@ sil [ossa] @begin_apply_in_guaranteed_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
   destroy_addr %instance : $*Inner
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -712,7 +712,7 @@ entry:
 sil [ossa] @begin_apply_in_guaranteed_use_after_end_apply : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
-  end_apply %token
+  end_apply %token as $()
   apply undef<Inner>(%instance) : $@convention(thin) <U> (@in_guaranteed U) -> ()
   %retval = tuple ()
   return %retval : $()
@@ -723,7 +723,7 @@ sil [ossa] @begin_apply_inout_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout U
   destroy_addr %instance : $*Inner
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -732,7 +732,7 @@ entry:
 sil [ossa] @begin_apply_inout_use_after_end_apply : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout U
-  end_apply %token
+  end_apply %token as $()
   apply undef<Inner>(%instance) : $@convention(thin) <U> (@inout U) -> ()
   %retval = tuple ()
   return %retval : $()
@@ -743,7 +743,7 @@ sil [ossa] @begin_apply_inout_aliasable_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout_aliasable U
   destroy_addr %instance : $*Inner
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -752,7 +752,7 @@ entry:
 sil [ossa] @begin_apply_inout_aliasable_use_after_end_apply : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout_aliasable U
-  end_apply %token
+  end_apply %token as $()
   apply undef<Inner>(%instance) : $@convention(thin) <U> (@inout_aliasable U) -> ()
   %retval = tuple ()
   return %retval : $()
@@ -762,7 +762,7 @@ entry:
 sil [ossa] @begin_apply_inout_no_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout U
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -771,7 +771,7 @@ entry:
 sil [ossa] @begin_apply_inout_aliasable_no_destroy : $@convention(thin) () -> () {
 entry:
   (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout_aliasable U
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/access_dom_call.sil
+++ b/test/SILOptimizer/access_dom_call.sil
@@ -138,7 +138,7 @@ bb0(%0 : $C):
   (%3, %4) = begin_apply %m(%0) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Int64
   %a2 = begin_access [read] [dynamic] [no_nested_conflict] %ra : $*Int64
   end_access %a2 : $*Int64
-  end_apply %4
+  end_apply %4 as $()
   %v = tuple ()
   return %v : $()
 }
@@ -155,7 +155,7 @@ bb0(%0 : $C):
   %ra = ref_element_addr %0 : $C, #C.field         // user: %3
   %a1 = begin_access [read] [dynamic] %ra : $*Int64
   end_access %a1 : $*Int64
-  end_apply %4
+  end_apply %4 as $()
   %a2 = begin_access [read] [dynamic] [no_nested_conflict] %ra : $*Int64
   end_access %a2 : $*Int64
   %v = tuple ()
@@ -174,7 +174,7 @@ bb0(%0 : $C):
   %ra = ref_element_addr %0 : $C, #C.field         // user: %3
   %a1 = begin_access [read] [dynamic] %ra : $*Int64
   end_access %a1 : $*Int64
-  end_apply %4
+  end_apply %4 as $()
   %a2 = begin_access [modify] [dynamic] [no_nested_conflict] %ra : $*Int64
   end_access %a2 : $*Int64
   %v = tuple ()
@@ -203,7 +203,7 @@ bb3:
   %ra = ref_element_addr %0 : $C, #C.field         // user: %3
   %a1 = begin_access [modify] [dynamic] [no_nested_conflict] %ra : $*Int64
   end_access %a1 : $*Int64
-  end_apply %4
+  end_apply %4 as $()
   %cond = integer_literal $Builtin.Int1, 1
   cond_br %cond, bb2, bb4
 

--- a/test/SILOptimizer/accessutils.sil
+++ b/test/SILOptimizer/accessutils.sil
@@ -358,7 +358,7 @@ bb0:
   (%1, %2, %3) = begin_apply %0() : $@yield_once @convention(thin) () -> (@yields @in_guaranteed String, @yields @in_guaranteed Int64)
   %4 = load %1 : $*String
   %5 = load %2 : $*Int64
-  end_apply %3
+  end_apply %3 as $()
   %7 = tuple ()
   return %7 : $()
 }
@@ -409,9 +409,9 @@ bb0(%inoutArg : $*Int64, %aliasableArg1 : $*Int64, %aliasableArg2 : $*Int64, %3 
 
   %50 = function_ref @coro : $@yield_once @convention(thin) () -> @yields @inout Int64
   (%yield1, %52) = begin_apply %50() : $@yield_once @convention(thin) () -> @yields @inout Int64
-  end_apply %52
+  end_apply %52 as $()
   (%yield2, %55) = begin_apply %50() : $@yield_once @convention(thin) () -> @yields @inout Int64
-  end_apply %55
+  end_apply %55 as $()
 
   %isDistinct = function_ref @_isDistinct : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
   %isNotDistinct = function_ref @_isNotDistinct : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -289,7 +289,7 @@ bb0(%0 : $X):
   %6 = function_ref @inout_class_argument : $@convention(thin) (@inout X) -> ()
   %7 = apply %6(%4) : $@convention(thin) (@inout X) -> ()
 
-  end_apply %5
+  end_apply %5 as $()
   dealloc_stack %1 : $*X
   %r = tuple ()
   return %r : $()

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1585,7 +1585,7 @@ sil hidden [ossa] @testBeginApply1DeadYield : $@convention(thin) <T> (@guarantee
 bb0(%0 : @guaranteed $TestGeneric<T>):
   %2 = class_method %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
   (%3, %4) = begin_apply %2<T>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
-  end_apply %4
+  end_apply %4 as $()
   %10 = tuple ()
   return %10 : $()
 }
@@ -1596,7 +1596,7 @@ bb0(%0 : @guaranteed $TestGeneric<T>):
 // CHECK:   [[METH:%.*]] = class_method %0 : $TestGeneric<Klass>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
 // CHECK:   ([[Y:%.*]], [[TOK:%.*]]) = begin_apply [[METH]]<Klass>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
 // CHECK:   copy_addr [[Y]] to [init] [[STK]] : $*Klass
-// CHECK:   end_apply [[TOK]]
+// CHECK:   end_apply [[TOK]] as $()
 // CHECK:   destroy_addr [[STK]] : $*Klass
 // CHECK-LABEL: }
 sil hidden [ossa] @testBeginApply2LoadableYieldWithIndirectConv : $@convention(thin) <Klass> (@guaranteed TestGeneric<Klass>) -> () {
@@ -1604,7 +1604,7 @@ bb0(%0 : @guaranteed $TestGeneric<Klass>):
   %2 = class_method %0 : $TestGeneric<Klass>, #TestGeneric.borrowedGeneric!read : <Klass> (TestGeneric<Klass>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
   (%3, %4) = begin_apply %2<Klass>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
   %5 = copy_value %3 : $Klass
-  end_apply %4
+  end_apply %4 as $()
   destroy_value %5 : $Klass
   %10 = tuple ()
   return %10 : $()
@@ -1616,7 +1616,7 @@ bb0(%0 : @guaranteed $TestGeneric<Klass>):
 // CHECK:   [[M:%.*]] = class_method %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
 // CHECK:   ([[Y:%.*]], [[TOK:%.*]]) = begin_apply %2<T>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
 // CHECK:   copy_addr [[Y]] to [init] [[STK]] : $*T
-// CHECK:   end_apply [[TOK]]
+// CHECK:   end_apply [[TOK]] as $()
 // CHECK:   destroy_addr [[STK]] : $*T
 // CHECK-LABEL: } // end sil function 'testBeginApply3OpaqueYield'
 sil hidden [ossa] @testBeginApply3OpaqueYield : $@convention(thin) <T> (@guaranteed TestGeneric<T>) -> () {
@@ -1624,7 +1624,7 @@ bb0(%0 : @guaranteed $TestGeneric<T>):
   %2 = class_method %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
   (%3, %4) = begin_apply %2<T>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
   %5 = copy_value %3 : $T
-  end_apply %4
+  end_apply %4 as $()
   destroy_value %5 : $T
   %10 = tuple ()
   return %10 : $()
@@ -1639,7 +1639,7 @@ sil [ossa] @testBeginApply4YieldLoadableTrivial : $@convention(thin) () -> I {
 entry:
   (%instance, %token) = begin_apply undef<LoadableTrivialExtractable>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
   %extract = struct_extract %instance : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
-  end_apply %token
+  end_apply %token as $()
   return %extract : $I
 }
 
@@ -1655,7 +1655,7 @@ entry:
   (%instance_1, %instance_2, %token) = begin_apply undef<LoadableTrivialExtractable>() : $@yield_once @convention(thin) <U> () -> (@yields @in_guaranteed U, @yields @in_guaranteed U)
   %i_1 = struct_extract %instance_1 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
   %i_2 = struct_extract %instance_2 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
-  end_apply %token
+  end_apply %token as $()
   %tuple = tuple (%i_1 : $I, %i_2 : $I)
   return %tuple : $(I, I)
 }
@@ -1673,7 +1673,7 @@ entry:
   (%instance_1, %instance_2, %token) = begin_apply undef<LoadableTrivialExtractable, T>() : $@yield_once @convention(thin) <U, T> () -> (@yields @in_guaranteed U, @yields @in_guaranteed T)
   %copy = copy_value %instance_2 : $T
   %i = struct_extract %instance_1 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
-  end_apply %token
+  end_apply %token as $()
   %tuple = tuple (%i : $I, %copy : $T)
   return %tuple : $(I, T)
 }
@@ -1688,7 +1688,7 @@ entry:
   (%instance, %token) = begin_apply undef<LoadableNontrivial>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
   %extract = struct_extract %instance : $LoadableNontrivial, #LoadableNontrivial.x
   %retval = copy_value %extract : $Klass
-  end_apply %token
+  end_apply %token as $()
   return %retval : $Klass
 }
 
@@ -1708,7 +1708,7 @@ entry:
   %extract_2 = struct_extract %instance_2 : $LoadableNontrivial, #LoadableNontrivial.x
   %copy_1 = copy_value %extract_1 : $Klass
   %copy_2 = copy_value %extract_2 : $Klass
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple (%copy_1 : $Klass, %copy_2 : $Klass)
   return %retval : $(Klass, Klass)
 }
@@ -1727,7 +1727,7 @@ entry:
   %extract_1 = struct_extract %instance_1 : $LoadableNontrivial, #LoadableNontrivial.x
   %copy_1 = copy_value %extract_1 : $Klass
   %copy_2 = copy_value %instance_2 : $T
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple (%copy_1 : $Klass, %copy_2 : $T)
   return %retval : $(Klass, T)
 }
@@ -1742,7 +1742,7 @@ entry:
 sil [ossa] @testBeginApplyAYieldLoadableNontrivialOwned : $@convention(thin) () -> @owned Klass {
 entry:
   (%instance, %token) = begin_apply undef<LoadableNontrivial>() : $@yield_once @convention(thin) <U> () -> @yields @in U
-  end_apply %token
+  end_apply %token as $()
   %borrow = begin_borrow %instance : $LoadableNontrivial
   %extract = struct_extract %borrow : $LoadableNontrivial, #LoadableNontrivial.x
   %retval = copy_value %extract : $Klass
@@ -1761,7 +1761,7 @@ entry:
 sil [ossa] @testBeginApplyBYield2LoadableNontrivialOwned : $@convention(thin) () -> @owned (Klass, Klass) {
 entry:
   (%instance_1, %instance_2, %token) = begin_apply undef<LoadableNontrivial>() : $@yield_once @convention(thin) <U> () -> (@yields @in U, @yields @in U)
-  end_apply %token
+  end_apply %token as $()
   %borrow_1 = begin_borrow %instance_1 : $LoadableNontrivial
   %extract_1 = struct_extract %borrow_1 : $LoadableNontrivial, #LoadableNontrivial.x
   %copy_1 = copy_value %extract_1 : $Klass
@@ -1791,7 +1791,7 @@ entry:
   %copy_1 = copy_value %extract_1 : $Klass
   end_borrow %borrow_1 : $LoadableNontrivial
   destroy_value %instance_1 : $LoadableNontrivial
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple (%copy_1 : $Klass, %instance_2 : $T)
   return %retval : $(Klass, T)
 }
@@ -1802,7 +1802,7 @@ entry:
 sil [ossa] @testBeginApplyDYieldOpaqueInout : $@yield_once @convention(thin) <T> () -> () {
 entry:
   (%addr, %token) = begin_apply undef<T>() : $@yield_once @convention(method) <U> () -> @yields @inout U
-  end_apply %token
+  end_apply %token as $()
   %8 = tuple ()
   return %8 : $()
 }
@@ -1817,7 +1817,7 @@ entry:
   yield %addr : $*T, resume bb1, unwind bb2
 
 bb1:
-  end_apply %token
+  end_apply %token as $()
   %8 = tuple ()
   return %8 : $()
 
@@ -1831,14 +1831,14 @@ bb2:
 // CHECK:         ([[OWNED_INSTANCE:%[^,]+]], [[ADDR:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
 // CHECK:         destroy_value [[OWNED_INSTANCE]]
 // CHECK:         copy_addr [[ADDR]] to [init] [[OUT_ADDR]]
-// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]] as $()
 // CHECK-LABEL: } // end sil function 'testBeginApplyFYieldDirectOwnedAndAddressOnlyGuaranteed'
 sil [ossa] @testBeginApplyFYieldDirectOwnedAndAddressOnlyGuaranteed : $@convention(thin) <T> () -> @out T {
 entry:
   (%klass, %instance, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <T> () -> (@yields @owned Klass, @yields @in_guaranteed T)
   destroy_value %klass : $Klass
   %retval = copy_value %instance : $T
-  end_apply %token
+  end_apply %token as $()
   return %retval : $T
 }
 
@@ -1848,7 +1848,7 @@ entry:
 // CHECK:         [[COPY_STORAGE:%[^,]+]] = alloc_stack $T                             
 // CHECK:         ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
 // CHECK:         copy_addr [[YIELD_STORAGE]] to [init] [[COPY_STORAGE]]
-// CHECK:         end_apply [[TOKEN]]                                    
+// CHECK:         end_apply [[TOKEN]] as $()
 // CHECK:         apply undef<T>([[COPY_STORAGE]])
 // CHECK:         dealloc_stack [[COPY_STORAGE]]
 // CHECK-LABEL: } // end sil function 'testBeginApplyGCopyConsumeInGuaranteedValue'
@@ -1856,7 +1856,7 @@ sil [ossa] @testBeginApplyGCopyConsumeInGuaranteedValue : $@convention(thin) <T>
 entry:
   (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_guaranteed τ_0_0
   %copy = copy_value %yield : $T
-  end_apply %token
+  end_apply %token as $()
   apply undef<T>(%copy) : $@convention(thin) <T> (@in T) -> ()
   %retval = tuple ()
   return %retval : $()
@@ -1868,7 +1868,7 @@ entry:
 // CHECK:         [[COPY_STORAGE:%[^,]+]] = alloc_stack $T
 // CHECK:         ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
 // CHECK:         copy_addr [[YIELD_STORAGE]] to [init] [[COPY_STORAGE]]
-// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]] as $()
 // CHECK:         [[PTR:%[^,]+]] = apply undef
 // CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[PTR:%[^,]+]]
 // CHECK:         copy_addr [take] [[COPY_STORAGE]] to [[ADDR]]
@@ -1877,7 +1877,7 @@ sil [ossa] @testBeginApplyH1CopyStoreInGuaranteedValue : $@convention(thin) <T> 
 entry:
   (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_guaranteed τ_0_0
   %copy = copy_value %yield : $T
-  end_apply %token
+  end_apply %token as $()
   %ptr = apply undef<T>() : $@convention(method) <τ_0_0> () -> Builtin.RawPointer
   %addr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*T
   store %copy to [assign] %addr : $*T
@@ -1892,7 +1892,7 @@ entry:
 // CHECK:         [[COPY_STORAGE:%[^,]+]] = alloc_stack $T
 // CHECK:         ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply undef
 // CHECK:         copy_addr [[YIELD_STORAGE]] to [init] [[COPY_STORAGE]] : $*T
-// CHECK:         end_apply [[TOKEN]]
+// CHECK:         end_apply [[TOKEN]] as $()
 // CHECK:         [[PTR:%[^,]+]] = apply undef
 // CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[PTR]]
 // CHECK:         copy_addr [take] [[COPY_STORAGE]] to [[ADDR]]
@@ -1904,7 +1904,7 @@ entry:
   apply undef<T>(%borrow) : $@convention(thin) <τ> (@in_guaranteed τ) -> ()
   %copy = copy_value %borrow : $T
   end_borrow %borrow : $T
-  end_apply %token
+  end_apply %token as $()
   %ptr = apply undef<T>() : $@convention(method) <τ_0_0> () -> Builtin.RawPointer
   %addr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*T
   store %copy to [assign] %addr : $*T
@@ -1917,13 +1917,13 @@ entry:
 //   [[IN_STORAGE:%[^,]+]] = alloc_stack $T
 //   ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply undef<T>()
 //   copy_addr [take] [[YIELD_STORAGE]] to [init] [[IN_STORAGE]]
-//   end_apply [[TOKEN]]
+//   end_apply [[TOKEN]] as $()
 //   apply undef<T>([[IN_STORAGE]])
 // } // end sil function 'testBeginApplyIConsumeInValue'
 sil [ossa] @testBeginApplyIConsumeInValue : $@convention(thin) <T> () -> () {
 entry:
   (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in τ_0_0
-  end_apply %token
+  end_apply %token as $()
   apply undef<T>(%yield) : $@convention(thin) <T> (@in T) -> ()
   %retval = tuple ()
   return %retval : $()
@@ -1933,7 +1933,7 @@ entry:
 //   [[IN_STORAGE:%[^,]+]] = alloc_stack $T
 //   ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
 //   copy_addr [take] [[YIELD_STORAGE]] to [init] [[IN_STORAGE]]
-//   end_apply [[TOKEN]]
+//   end_apply [[TOKEN]] as $()
 //   [[PTR:%[^,]+]] = apply
 //   [[ADDR:%[^,]+]] = pointer_to_address [[PTR:%[^,]+]]
 //   copy_addr [take] [[IN_STORAGE]] to [[ADDR]]
@@ -1941,7 +1941,7 @@ entry:
 sil [ossa] @testBeginApplyJStoreInValue : $@convention(thin) <T> () -> () {
 entry:
   (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in τ_0_0
-  end_apply %token
+  end_apply %token as $()
   %ptr = apply undef<T>() : $@convention(method) <τ_0_0> () -> Builtin.RawPointer
   %addr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*T
   store %yield to [assign] %addr : $*T
@@ -1954,13 +1954,13 @@ entry:
 //   [[IN_CONSTANT_STORAGE:%[^,]+]] = alloc_stack $T
 //   ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply undef<T>()
 //   copy_addr [take] [[YIELD_STORAGE]] to [init] [[IN_CONSTANT_STORAGE]]
-//   end_apply [[TOKEN]]
+//   end_apply [[TOKEN]] as $()
 //   apply undef<T>([[IN_CONSTANT_STORAGE]])
 // } // end sil function 'testBeginApplyKConsumeInConstantValue'
 sil [ossa] @testBeginApplyKConsumeInConstantValue : $@convention(thin) <T> () -> () {
 entry:
   (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_constant τ_0_0
-  end_apply %token
+  end_apply %token as $()
   apply undef<T>(%yield) : $@convention(thin) <T> (@in_constant T) -> ()
   %retval = tuple ()
   return %retval : $()
@@ -1970,7 +1970,7 @@ entry:
 //   [[IN_CONSTANT_STORAGE:%[^,]+]] = alloc_stack $T
 //   ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
 //   copy_addr [take] [[YIELD_STORAGE]] to [init] [[IN_CONSTANT_STORAGE]]
-//   end_apply [[TOKEN]]
+//   end_apply [[TOKEN]] as $()
 //   [[PTR:%[^,]+]] = apply
 //   [[ADDR:%[^,]+]] = pointer_to_address [[PTR:%[^,]+]]
 //   copy_addr [take] [[IN_CONSTANT_STORAGE]] to [[ADDR]]
@@ -1978,7 +1978,7 @@ entry:
 sil [ossa] @testBeginApplyLStoreInConstantValue : $@convention(thin) <T> () -> () {
 entry:
   (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_constant τ_0_0
-  end_apply %token
+  end_apply %token as $()
   %ptr = apply undef<T>() : $@convention(method) <τ_0_0> () -> Builtin.RawPointer
   %addr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*T
   store %yield to [assign] %addr : $*T
@@ -3070,7 +3070,7 @@ entry:
   yield %instance : $AnyObject, resume resumebb, unwind unwindbb
 
 resumebb:
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 
@@ -3311,7 +3311,7 @@ entry:
   yield (%instance_1 : $AnyObject, %instance_2 : $T), resume resumebb, unwind unwindbb
 
 resumebb:
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 
@@ -3336,7 +3336,7 @@ bb0:
   yield %3 : $LoadableNontrivialGeneric<T>, resume bb1, unwind bb2
 
 bb1:
-  end_apply %4
+  end_apply %4 as $()
   %7 = tuple ()
   return %7 : $()
 

--- a/test/SILOptimizer/allocboxtostack_localapply.sil
+++ b/test/SILOptimizer/allocboxtostack_localapply.sil
@@ -314,7 +314,7 @@ bb0:
   store %3 to %1 : $*Int64
   %5 = function_ref @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields ()
   (%addr, %token) = begin_apply %5(%0) : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields ()
-  end_apply %token
+  end_apply %token as $()
   strong_release %0 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()

--- a/test/SILOptimizer/allocboxtostack_localapply_ossa.sil
+++ b/test/SILOptimizer/allocboxtostack_localapply_ossa.sil
@@ -314,7 +314,7 @@ bb0:
   store %3 to [trivial] %1 : $*Int64
   %5 = function_ref @$testbeginapplybas : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields ()
   (%addr, %token) = begin_apply %5(%0) : $@yield_once @convention(thin) (@guaranteed { var Int64 }) -> @yields ()
-  end_apply %token
+  end_apply %token as $()
   destroy_value %0 : ${ var Int64 }
   %8 = tuple ()
   return %8 : $()

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -332,7 +332,7 @@ bb0(%0 : $Builtin.Word):
   %bridge = ref_to_bridge_object %c : $C, %0 : $Builtin.Word
   cond_br undef, bb1, bb2
 bb1:
-  end_apply %t
+  end_apply %t as $()
   %r = tuple ()
   return %r : $()
 bb2:

--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -907,7 +907,7 @@ bb0(%0 : $Int):
   cond_br undef, bb1, bb2
 
 bb1:
-  end_apply %token
+  end_apply %token as $()
   br bb3
 
 bb2:

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -275,7 +275,7 @@ bb0(%0 : $*Struct):
   (%6, %7) = begin_apply %5<Struct, Int>(%0, %4) : $@yield_once @convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @guaranteed WritableKeyPath<τ_0_0, τ_0_1>) -> @yields @inout τ_0_1
   %8 = function_ref @modifyInt : $@convention(thin) (@inout Int) -> ()
   %9 = apply %8(%6) : $@convention(thin) (@inout Int) -> ()
-  end_apply %7
+  end_apply %7 as $()
   destroy_value %4 : $WritableKeyPath<Struct, Int>
   destroy_value %2 : $WritableKeyPath<Struct, Int>
   %13 = tuple ()

--- a/test/SILOptimizer/debuginfo_canonicalizer.sil
+++ b/test/SILOptimizer/debuginfo_canonicalizer.sil
@@ -58,7 +58,7 @@ bb0(%0 : $Klass):
   %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
   (%3, %4) = begin_apply %f(%0) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
   %9999 = tuple()
-  end_apply %4
+  end_apply %4 as $()
   return %9999 : $()
 }
 
@@ -86,7 +86,7 @@ bb0(%0 : $Klass):
   cond_br undef, bb1, bb2
 
 bb1:
-  end_apply %token
+  end_apply %token as $()
   br bb3
 
 bb2:
@@ -124,7 +124,7 @@ bb0(%0 : $Klass):
   cond_br undef, bb1, bb2
 
 bb1:
-  end_apply %token
+  end_apply %token as $()
   br bb3
 
 bb2:

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -106,7 +106,7 @@ sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
   (%a, %token) = begin_apply %borrowA() : $@yield_once @convention(thin) () -> @yields @guaranteed A
   specify_test "is-deinit-barrier @instruction"
   hop_to_executor %a : $A
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/destroy_hoisting.sil
+++ b/test/SILOptimizer/destroy_hoisting.sil
@@ -234,7 +234,7 @@ bb0(%0 : $*S, %1 : $Int):
   %f = function_ref @coro : $@yield_once @convention(thin) (@in S) -> @yields @inout Int
   (%i, %t) = begin_apply %f(%0) : $@yield_once @convention(thin) (@in S) -> @yields @inout Int
   store %1 to [trivial] %i : $*Int
-  end_apply %t
+  end_apply %t as $()
   br bb1
 bb1:
   destroy_addr %0 : $*S

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -1526,7 +1526,7 @@ bb0(%0 : $*Int, %1 : $*Dictionary<Int, Int>):
   %mod = function_ref @$sSD_7defaultq_x_q_yXKtciM : $@yield_once @convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in_guaranteed τ_0_0, @noescape @callee_guaranteed () -> @out τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> @yields @inout τ_0_1
   %access = begin_access [modify] [static] %0 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   (%yield, %token) = begin_apply %mod<Int, Int>(%access, %cvt, %1) : $@yield_once @convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in_guaranteed τ_0_0, @noescape @callee_guaranteed () -> @out τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> @yields @inout τ_0_1
-  end_apply %token
+  end_apply %token as $()
   end_access %access : $*Int
   destroy_value %cvt : $@noescape @callee_guaranteed () -> @out Int
   destroy_value %pa : $@callee_guaranteed () -> @out Int
@@ -1579,7 +1579,7 @@ bb0(%0 : $*Dictionary<Int, Int>, %1 : $Int, %2 : $*Int):
   %20 = function_ref @$sSD_7defaultq_x_q_yXKtciM : $@yield_once @convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in_guaranteed τ_0_0, @noescape @callee_guaranteed () -> @out τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> @yields @inout τ_0_1
   (%21, %22) = begin_apply %20<Int, Int>(%14, %18, %13) : $@yield_once @convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in_guaranteed τ_0_0, @noescape @callee_guaranteed () -> @out τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> @yields @inout τ_0_1
   assign %1 to %21 : $*Int
-  end_apply %22
+  end_apply %22 as $()
   destroy_value %18 : $@noescape @callee_guaranteed () -> @out Int
   end_access %13 : $*Dictionary<Int, Int>
   dealloc_stack %14 : $*Int

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -602,7 +602,7 @@ sil [ossa] @nohoist_over_end_apply_use : $@convention(thin) (@inout X, @owned X)
 entry(%addr : $*X, %instance : @owned $X):
   %coro = function_ref @coro : $@yield_once @convention(thin) (@inout X) -> @yields ()
   (%empty, %continuation) = begin_apply %coro(%addr) : $@yield_once @convention(thin) (@inout X) -> @yields ()
-  end_apply %continuation
+  end_apply %continuation as $()
   %retval = tuple ()
   store %instance to [assign] %addr : $*X
   return %retval : $()

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -113,7 +113,7 @@ entry(%flag : $Builtin.Int1):
 yes:
   %10 = integer_literal $Builtin.Int32, 10
   apply %marker(%10) : $@convention(thin) (Builtin.Int32) -> ()
-  end_apply %token
+  end_apply %token as $()
   %20 = integer_literal $Builtin.Int32, 20
   apply %marker(%20) : $@convention(thin) (Builtin.Int32) -> ()
   br cont
@@ -147,7 +147,7 @@ entry(%flag : $Builtin.Int1):
 yes:
   %10 = integer_literal $Builtin.Int32, 10
   apply %marker(%10) : $@convention(thin) (Builtin.Int32) -> ()
-  end_apply %token
+  end_apply %token as $()
   %20 = integer_literal $Builtin.Int32, 20
   apply %marker(%20) : $@convention(thin) (Builtin.Int32) -> ()
   br cont
@@ -223,7 +223,7 @@ entry(%flag : $Builtin.Int1, %flag2 : $Builtin.Int1):
   cond_br %flag2, yes, no
 
 yes:
-  end_apply %token
+  end_apply %token as $()
   br cont
 
 no:
@@ -283,7 +283,7 @@ entry(%flag : $Builtin.Int1, %c: @owned $SomeClass):
   cond_br %flag, yes, no
 
 yes:
-  end_apply %token
+  end_apply %token as $()
   br cont
 
 no:
@@ -359,7 +359,7 @@ entry(%flag : $Builtin.Int1):
 yes:
   %8 = integer_literal $Builtin.Int8, 8
   store %8 to [trivial] %addr : $*Builtin.Int8
-  end_apply %token
+  end_apply %token as $()
   br cont
 
 no:
@@ -370,6 +370,79 @@ cont:
   %ret = tuple ()
   return %ret : $()
 }
+
+sil [transparent] [ossa] [ossa] @yield_inout_result : $@yield_once() -> (@yields @inout Builtin.Int8, Builtin.Int32) {
+entry:
+  %addr = alloc_stack $Builtin.Int8
+  %8 = integer_literal $Builtin.Int8, 8
+  store %8 to [trivial] %addr : $*Builtin.Int8
+  yield %addr : $*Builtin.Int8, resume resume, unwind unwind
+
+resume:
+  %use = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
+  apply %use(%addr) : $@convention(thin) (@in Builtin.Int8) -> ()
+  dealloc_stack %addr: $*Builtin.Int8
+  %42 = integer_literal $Builtin.Int32, 42
+  return %42 : $Builtin.Int32
+
+unwind:
+  %3000 = integer_literal $Builtin.Int32, 3000
+  %marker = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
+  apply %marker(%3000) : $@convention(thin) (Builtin.Int32) -> ()
+  dealloc_stack %addr: $*Builtin.Int8
+  unwind
+}
+
+sil [ossa] @test_simple_call_yield_inout_result : $(Builtin.Int1) -> Builtin.Int32 {
+entry(%flag : $Builtin.Int1):
+  %0 = function_ref @yield_inout_result : $@convention(thin) @yield_once() -> (@yields @inout Builtin.Int8, Builtin.Int32)
+  (%addr, %token) = begin_apply %0() : $@convention(thin) @yield_once() -> (@yields @inout Builtin.Int8, Builtin.Int32)
+  cond_br %flag, yes, no
+
+yes:
+  %8 = integer_literal $Builtin.Int8, 8
+  store %8 to [trivial] %addr : $*Builtin.Int8
+  %42 = end_apply %token as $Builtin.Int32
+  br cont(%42 : $Builtin.Int32)
+
+no:
+  abort_apply %token
+  %0val = integer_literal $Builtin.Int32, 0
+  br cont(%0val : $Builtin.Int32)
+
+cont(%ret : $Builtin.Int32):
+  return %ret : $Builtin.Int32
+}
+
+// CHECK-LABEL: sil [ossa] @test_simple_call_yield_inout_result : $@convention(thin) (Builtin.Int1) -> Builtin.Int32 {
+// CHECK:      bb0(%0 : $Builtin.Int1):
+// CHECK-NEXT:   %1 = alloc_stack $Builtin.Int8
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int8, 8
+// CHECK-NEXT:   store %2 to [trivial] %1 : $*Builtin.Int8
+// CHECK-NEXT:   cond_br %0, bb1, bb2
+
+// CHECK:      bb1:
+// CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int8, 8
+// CHECK-NEXT:   store [[T0]] to [trivial] %1 : $*Builtin.Int8
+// CHECK-NEXT:   // function_ref
+// CHECK-NEXT:   [[USE:%.*]] = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
+// CHECK-NEXT:   apply [[USE]](%1) : $@convention(thin) (@in Builtin.Int8) -> ()
+// CHECK-NEXT:   dealloc_stack %1 : $*Builtin.Int8
+// CHECK-NEXT:   [[NORMAL_RES:%.*]] = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   br bb3([[NORMAL_RES]] : $Builtin.Int32) 
+
+// CHECK:      bb2:
+// CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int32, 3000
+// CHECK-NEXT:   // function_ref
+// CHECK-NEXT:   [[MARKER:%.*]] = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK-NEXT:   apply [[MARKER]]([[T0]]) : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK-NEXT:   dealloc_stack %1 : $*Builtin.Int8
+// CHECK-NEXT:   [[UNWIND_RES:%.*]] = integer_literal $Builtin.Int32, 0
+// CHECK-NEXT:   br bb3([[UNWIND_RES]] : $Builtin.Int32)
+
+// CHECK:      bb3([[RES:%.*]] : $Builtin.Int32):
+// CHECK-NEXT:   return [[RES]] : $Builtin.Int32
+// CHECK:      }
 
 //   We can't inline yet if there are multiple ends.
 // CHECK-LABEL: sil [ossa] @test_multi_end_yield_inout : $@convention(thin) (Builtin.Int1) -> () {
@@ -382,11 +455,11 @@ entry(%flag : $Builtin.Int1):
   cond_br %flag, yes, no
 
 yes:
-  end_apply %token
+  end_apply %token as $()
   br cont
 
 no:
-  end_apply %token
+  end_apply %token as $()
   br cont
 
 cont:
@@ -447,7 +520,7 @@ entry:
   (%addr, %token) = begin_apply %0() : $@convention(thin) @yield_once () -> (@yields @inout Builtin.Int8)
   %use = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
   apply %use(%addr) : $@convention(thin) (@in Builtin.Int8) -> ()
-  end_apply %token
+  end_apply %token as $()
   %ret = tuple ()
   return %ret : $()
 }
@@ -503,7 +576,7 @@ bb0:
   %0 = function_ref @stack_overlap : $@convention(thin) @yield_once () -> (@yields @inout Builtin.Int32)
   (%value, %token) = begin_apply %0() : $@convention(thin) @yield_once () -> (@yields @inout Builtin.Int32)
   dealloc_stack %stack : $*Builtin.Int16
-  end_apply %token
+  end_apply %token as $()
   %ret = tuple ()
   return %ret : $()
 }
@@ -534,7 +607,7 @@ bb0:
   %0 = function_ref @stack_overlap : $@convention(thin) @yield_once () -> (@yields @inout Builtin.Int32)
   (%value, %token) = begin_apply %0() : $@convention(thin) @yield_once () -> (@yields @inout Builtin.Int32)
   %stack = alloc_stack $Builtin.Int16
-  end_apply %token
+  end_apply %token as $()
   dealloc_stack %stack : $*Builtin.Int16
   %ret = tuple ()
   return %ret : $()
@@ -566,7 +639,7 @@ bb1:
   unreachable
 
 bb2:
-  end_apply %token
+  end_apply %token as $()
   dealloc_stack %stack : $*Builtin.Int16
   %ret = tuple ()
   return %ret : $()
@@ -606,7 +679,7 @@ entry:
 bb_resume:
   end_borrow %borrow : $*SomeClass
   dealloc_stack %addr : $*SomeClass
-  end_apply %token
+  end_apply %token as $()
   %retval = tuple ()
   return %retval : $()
 

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -666,7 +666,7 @@ sil [ossa] @caller_owned_callee_coro_owned : $@convention(thin) (@owned C) -> ()
 bb0(%instance : @owned $C):
   %callee_coro_owned = function_ref @callee_coro_owned : $@yield_once @convention(thin) (@owned C) -> @yields @inout C
   (%addr, %continuation) = begin_apply %callee_coro_owned(%instance) : $@yield_once @convention(thin) (@owned C) -> @yields @inout C
-  end_apply %continuation
+  end_apply %continuation as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -693,7 +693,7 @@ sil [ossa] @caller_owned_callee_coro_guaranteed : $@convention(thin) (@owned C) 
 bb0(%instance : @owned $C):
   %callee_coro_guaranteed = function_ref @callee_coro_guaranteed : $@yield_once @convention(thin) (@guaranteed C) -> @yields @inout C
   (%addr, %continuation) = begin_apply %callee_coro_guaranteed(%instance) : $@yield_once @convention(thin) (@guaranteed C) -> @yields @inout C
-  end_apply %continuation
+  end_apply %continuation as $()
   destroy_value %instance : $C
   %retval = tuple ()
   return %retval : $()
@@ -707,7 +707,7 @@ bb0(%instance : @guaranteed $C):
   %copy = copy_value %instance : $C
   %callee_coro_owned = function_ref @callee_coro_owned : $@yield_once @convention(thin) (@owned C) -> @yields @inout C
   (%addr, %continuation) = begin_apply %callee_coro_owned(%copy) : $@yield_once @convention(thin) (@owned C) -> @yields @inout C
-  end_apply %continuation
+  end_apply %continuation as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -733,7 +733,7 @@ sil [ossa] @caller_guaranteed_callee_coro_guaranteed : $@convention(thin) (@guar
 bb0(%instance : @guaranteed $C):
   %callee_coro_guaranteed = function_ref @callee_coro_guaranteed : $@yield_once @convention(thin) (@guaranteed C) -> @yields @inout C
   (%addr, %continuation) = begin_apply %callee_coro_guaranteed(%instance) : $@yield_once @convention(thin) (@guaranteed C) -> @yields @inout C
-  end_apply %continuation
+  end_apply %continuation as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -754,7 +754,7 @@ sil hidden [ossa] @caller_trivial_callee_coro_trivial : $@convention(thin) (S) -
 bb0(%instance : $S):
   %callee_coro_trivial = function_ref @callee_coro_trivial : $@yield_once @convention(thin) (S) -> @yields @inout S
   (%addr, %continuation) = begin_apply %callee_coro_trivial(%instance) : $@yield_once @convention(thin) (S) -> @yields @inout S
-  end_apply %continuation
+  end_apply %continuation as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -771,7 +771,7 @@ sil hidden [ossa] @caller_in_callee_coro_in : $@convention(thin) (@in S) -> () {
 bb0(%instance : $*S):
   %callee_coro_in = function_ref @callee_coro_in : $@yield_once @convention(thin) (@in S) -> @yields @inout S
   (%addr, %continuation) = begin_apply %callee_coro_in(%instance) : $@yield_once @convention(thin) (@in S) -> @yields @inout S
-  end_apply %continuation
+  end_apply %continuation as $()
   %retval = tuple ()
   return %retval : $()
 }
@@ -783,7 +783,7 @@ sil hidden [ossa] @caller_inguaranteed_callee_coro_inguaranteed : $@convention(t
 bb0(%instance : $*T):
   %callee_coro_inguaranteed = function_ref @callee_coro_inguaranteed : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @inout T
   (%addr_out, %continuation) = begin_apply %callee_coro_inguaranteed<T>(%instance) : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @inout T
-  end_apply %continuation
+  end_apply %continuation as $()
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/lexical_destroy_hoisting.sil
+++ b/test/SILOptimizer/lexical_destroy_hoisting.sil
@@ -458,7 +458,7 @@ entry(%instance : @owned $C, %input : $S):
     %modify_s = function_ref @modify_s : $@yield_once @convention(thin) () -> @yields @inout S
     (%addr, %continuation) = begin_apply %modify_s() : $@yield_once @convention(thin) () -> @yields @inout S
     store %input to [trivial] %addr : $*S
-    end_apply %continuation
+    end_apply %continuation as $()
     destroy_value %instance : $C
     %retval = tuple ()
     return %retval : $()

--- a/test/SILOptimizer/liveness_unit.sil
+++ b/test/SILOptimizer/liveness_unit.sil
@@ -136,13 +136,13 @@ bb0(%0 : @owned $D):
 // CHECK-LABEL: testGuaranteedResult: ssa_liveness
 // CHECK: SSA lifetime analysis: %0 = argument of bb0 : $D
 // CHECK: bb0: LiveWithin
-// CHECK: last user:   end_apply
+// CHECK: last user: %{{.*}} = end_apply
 sil [ossa] @testGuaranteedResult : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
   specify_test "ssa_liveness @argument[0]"
   %2 = class_method %0 : $D, #D.borrowed!read : (D) -> () -> (), $@yield_once @convention(method) (@guaranteed D) -> @yields @guaranteed C
   (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed D) -> @yields @guaranteed C
-  end_apply %4
+  end_apply %4 as $()
   %99 = tuple()
   return %99 : $()
 }

--- a/test/SILOptimizer/mandatory_combiner_opt.sil
+++ b/test/SILOptimizer/mandatory_combiner_opt.sil
@@ -129,7 +129,7 @@ bb0(%0 : @owned $C, %1 : $Builtin.Int64):
   %15 = class_method %14 : $C, #C.float!modify : (C) -> () -> (), $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Builtin.Int64
   (%16, %17) = begin_apply %15(%14) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout Builtin.Int64
   store %1 to [trivial] %16 : $*Builtin.Int64
-  end_apply %17
+  end_apply %17 as $()
   end_borrow %14 : $C
   destroy_value %0 : $C
   %23 = tuple ()

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -501,7 +501,7 @@ bb0(%0 : @guaranteed $Klass):
   %6 = copy_value %0 : $Klass
   %12 = function_ref @begin_apply_callee : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Builtin.Int32
   (%13, %14) = begin_apply %12(%6) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Builtin.Int32
-  end_apply %14
+  end_apply %14 as $()
   destroy_value %6 : $Klass
   %19 = tuple ()
   return %19 : $()
@@ -532,7 +532,7 @@ bb0(%0 : @guaranteed $Klass):
   cond_br undef, bb1, bb2
 
 bb1:
-  end_apply %14
+  end_apply %14 as $()
   br bb3
 
 bb2:
@@ -574,7 +574,7 @@ bb0(%0 : @owned $C2):
   br bb1
 
 bb1:
-  end_apply %tok
+  end_apply %tok as $()
   destroy_value %0 : $C2
   %9999 = tuple()
   return %9999 : $()
@@ -606,7 +606,7 @@ bb0(%0 : @owned $C2):
   cond_br undef, bb1, bb2
 
 bb1:
-  end_apply %tok
+  end_apply %tok as $()
   br bb3
 
 bb2:

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -186,7 +186,7 @@ sil [no_locks] @inline_begin_apply : $@convention(thin) () -> Int32 {
 bb0:
   %0 = function_ref @yield_int_value : $@convention(thin) @yield_once () -> (@yields Int32)
   (%1, %2) = begin_apply %0() : $@convention(thin) @yield_once () -> (@yields Int32)
-  end_apply %2
+  end_apply %2 as $()
   return %1 : $Int32
 }
 
@@ -199,10 +199,10 @@ bb0:
   (%1, %2) = begin_apply %0() : $@convention(thin) @yield_once () -> (@yields Int32)
   cond_br undef, bb1, bb2
 bb1:
-  end_apply %2
+  end_apply %2 as $()
   br bb3
 bb2:
-  end_apply %2
+  end_apply %2 as $()
   br bb3
 bb3:
   return %1 : $Int32

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -371,7 +371,7 @@ bb0(%0 : $*Int32):
   (%4, %5) = begin_apply %3(%0) : $@yield_once @convention(thin) (@in Int32) -> @yields Int32
   cond_br undef, bb1, bb2
 bb1:
-  end_apply %5
+  end_apply %5 as $()
   dealloc_stack %1 : $*Int32
   return %4 : $Int32
 bb2:

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -408,7 +408,7 @@ bb0(%0 : @owned $NonTrivialStruct):
   (%9, %10) = begin_apply %8(%6) : $@yield_once @convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @yields ()
   %11 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consumed here}}
   %12 = apply %7(%11) : $@convention(thin) (@owned NonTrivialStruct) -> ()
-  end_apply %10 // expected-note {{used here}}
+  end_apply %10 as $() // expected-note {{used here}}
   destroy_value %6 : $@callee_guaranteed () -> ()
   destroy_addr %2 : $*NonTrivialStruct
   dealloc_stack %1 : $*NonTrivialStruct
@@ -496,7 +496,7 @@ bb1:
 bb2:
   %16 = load [copy] %2 : $*NonTrivialStruct // expected-note {{consumed here}}
   %17 = apply %7(%16) : $@convention(thin) (@owned NonTrivialStruct) -> ()
-  end_apply %10 // expected-note {{used here}}
+  end_apply %10 as $() // expected-note {{used here}}
   br bb3
 
 bb3:

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1291,7 +1291,7 @@ bb0:
   (%1, %2, %3) = begin_apply %0() : $@yield_once @convention(thin) () -> (@yields @in_guaranteed String, @yields @in_guaranteed Int64)
   %4 = load %1 : $*String
   %5 = load %2 : $*Int64
-  end_apply %3
+  end_apply %3 as $()
   %7 = tuple (%4 : $String, %5 : $Int64)
   return %7 : $(String, Int64)
 }

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -923,7 +923,7 @@ entry(%instance : @owned $C, %input : $S):
     %modify_s = function_ref @modify_s : $@yield_once @convention(thin) () -> @yields @inout S
     (%addr, %continuation) = begin_apply %modify_s() : $@yield_once @convention(thin) () -> @yields @inout S
     store %input to [trivial] %addr : $*S
-    end_apply %continuation
+    end_apply %continuation as $()
     end_borrow %lifetime : $C
     destroy_value %instance : $C
     %retval = tuple ()
@@ -952,7 +952,7 @@ entry(%instance : @owned $C, %input : $S):
     try_apply %failable() : $@convention(thin) () -> @error Error, normal success, error failure
 success(%retval : $()):
     store %input to [trivial] %addr : $*S
-    end_apply %continuation
+    end_apply %continuation as $()
     end_borrow %lifetime : $C
     destroy_value %instance : $C
     return %retval : $()

--- a/test/SILOptimizer/simplify_begin_apply.sil
+++ b/test/SILOptimizer/simplify_begin_apply.sil
@@ -22,7 +22,7 @@ bb0:
   %0 = alloc_ref $Bar
   %1 = class_method %0 : $Bar, #Bar.field!read : (Bar) -> () -> (), $@yield_once @convention(method) (@guaranteed Bar) -> @yields Int
   (%2, %3) = begin_apply %1(%0) : $@yield_once @convention(method) (@guaranteed Bar) -> @yields Int
-  end_apply %3
+  end_apply %3 as $()
   return %2 : $Int
 }
 

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -3126,7 +3126,7 @@ bb4:
 bb5:
   br bb6
 bb6:
-  end_apply %token
+  end_apply %token as $()
   %rv = tuple ()
   return %rv : $()
 }

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -1696,7 +1696,7 @@ bb4:
 bb5:
   br bb6
 bb6:
-  end_apply %token
+  end_apply %token as $()
   %rv = tuple ()
   return %rv : $()
 }

--- a/test/SILOptimizer/specialize_opaque_result_types.sil
+++ b/test/SILOptimizer/specialize_opaque_result_types.sil
@@ -62,7 +62,7 @@ bb0(%0 : $*Optional<τ_0_0.Element>, %1 : $*IndexingIterator<τ_0_0>):
 
   %29 = init_enum_data_addr %0 : $*Optional<τ_0_0.Element>, #Optional.some!enumelt
   copy_addr %27 to [init] %29 : $*τ_0_0.Element
-  end_apply %28
+  end_apply %28 as $()
   destroy_addr %22 : $*τ_0_0.Index
   destroy_addr %24 : $*τ_0_0
   dealloc_stack %24 : $*τ_0_0

--- a/test/SILOptimizer/specialize_opaque_result_types_ossa.sil
+++ b/test/SILOptimizer/specialize_opaque_result_types_ossa.sil
@@ -61,7 +61,7 @@ bb0(%0 : $*Optional<τ_0_0.Element>, %1 : $*IndexingIterator<τ_0_0>):
 
   %29 = init_enum_data_addr %0 : $*Optional<τ_0_0.Element>, #Optional.some!enumelt
   copy_addr %27 to [init] %29 : $*τ_0_0.Element
-  end_apply %28
+  end_apply %28 as $()
   destroy_addr %22 : $*τ_0_0.Index
   destroy_addr %24 : $*τ_0_0
   dealloc_stack %24 : $*τ_0_0

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1226,7 +1226,7 @@ bb0(%0 : $Builtin.Int32, %1 : @guaranteed $Builtin.NativeObject):
   %0a = alloc_stack $Builtin.Int32
   store %0 to [trivial] %0a : $*Builtin.Int32
   (%0r, %0token) = begin_apply %f<Builtin.Int32>(%0a) : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @in_guaranteed T
-  end_apply %0token
+  end_apply %0token as $()
   dealloc_stack %0a : $*Builtin.Int32
 
   %1b = alloc_stack $Builtin.NativeObject
@@ -1234,7 +1234,7 @@ bb0(%0 : $Builtin.Int32, %1 : @guaranteed $Builtin.NativeObject):
   store %1c to [init] %1b : $*Builtin.NativeObject
   (%1result, %1token) = begin_apply %f<Builtin.NativeObject>(%1b) : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @in_guaranteed T
 
-  end_apply %1token
+  end_apply %1token as $()
   destroy_addr %1b : $*Builtin.NativeObject
   dealloc_stack %1b : $*Builtin.NativeObject
 
@@ -1253,7 +1253,7 @@ bb0(%0 : $Builtin.Int32, %1 : @guaranteed $Builtin.NativeObject):
   %0a = alloc_stack $Builtin.Int32
   store %0 to [trivial] %0a : $*Builtin.Int32
   (%0r, %0token) = begin_apply %f<Builtin.Int32>(%0a) : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @in T
-  end_apply %0token
+  end_apply %0token as $()
   dealloc_stack %0a : $*Builtin.Int32
 
   %1b = alloc_stack $Builtin.NativeObject
@@ -1262,7 +1262,7 @@ bb0(%0 : $Builtin.Int32, %1 : @guaranteed $Builtin.NativeObject):
   (%1result, %1token) = begin_apply %f<Builtin.NativeObject>(%1b) : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @in T
   destroy_addr %1result : $*Builtin.NativeObject
 
-  end_apply %1token
+  end_apply %1token as $()
   destroy_addr %1b : $*Builtin.NativeObject
   dealloc_stack %1b : $*Builtin.NativeObject
 
@@ -1281,7 +1281,7 @@ bb0(%0 : $Builtin.Int32, %1 : @guaranteed $Builtin.NativeObject):
   %0a = alloc_stack $Builtin.Int32
   store %0 to [trivial] %0a : $*Builtin.Int32
   (%0r, %0token) = begin_apply %f<Builtin.Int32>(%0a) : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @inout T
-  end_apply %0token
+  end_apply %0token as $()
   dealloc_stack %0a : $*Builtin.Int32
 
   %1b = alloc_stack $Builtin.NativeObject
@@ -1289,7 +1289,7 @@ bb0(%0 : $Builtin.Int32, %1 : @guaranteed $Builtin.NativeObject):
   store %1c to [init] %1b : $*Builtin.NativeObject
   (%1result, %1token) = begin_apply %f<Builtin.NativeObject>(%1b) : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @inout T
 
-  end_apply %1token
+  end_apply %1token as $()
   destroy_addr %1b : $*Builtin.NativeObject
   dealloc_stack %1b : $*Builtin.NativeObject
 

--- a/test/SILOptimizer/specialize_reabstraction.sil
+++ b/test/SILOptimizer/specialize_reabstraction.sil
@@ -118,7 +118,7 @@ bb2:
 // CHECK-NEXT:    [[CORO:%.*]] = function_ref @$s9coroutineSb_Tg5 : $@yield_once @convention(thin) (Bool) -> @yields @inout Bool
 // CHECK-NEXT:    [[LOAD:%.*]] = load [[TEMP]] : $*Bool
 // CHECK-NEXT:    ([[ADDR:%.*]], [[TOKEN:%.*]]) = begin_apply [[CORO]]([[LOAD]])
-// CHECK-NEXT:    end_apply [[TOKEN]]
+// CHECK-NEXT:    end_apply [[TOKEN]] as $()
 // CHECK-NEXT:    dealloc_stack [[TEMP]] : $*Bool
 // CHECK-NEXT:    [[RV:%.*]] = tuple ()
 // CHECK-NEXT:    return [[RV]] : $()
@@ -129,7 +129,7 @@ bb0(%0 : $Bool):
   %temp = alloc_stack $Bool
   store %0 to %temp : $*Bool
   (%addr, %token) = begin_apply %coro<Bool>(%temp) : $@yield_once @convention(thin) <T> (@in T) -> @yields @inout T
-  end_apply %token
+  end_apply %token as $()
   dealloc_stack %temp : $*Bool
   %rv = tuple ()
   return %rv : $()

--- a/test/SILOptimizer/specialize_reabstraction_ossa.sil
+++ b/test/SILOptimizer/specialize_reabstraction_ossa.sil
@@ -126,7 +126,7 @@ bb2:
 // CHECK-NEXT:    [[CORO:%.*]] = function_ref @$s9coroutineSb_Tg5 : $@yield_once @convention(thin) (Bool) -> @yields @inout Bool
 // CHECK-NEXT:    [[LOAD:%.*]] = load [trivial] [[TEMP]] : $*Bool
 // CHECK-NEXT:    ([[ADDR:%.*]], [[TOKEN:%.*]]) = begin_apply [[CORO]]([[LOAD]])
-// CHECK-NEXT:    end_apply [[TOKEN]]
+// CHECK-NEXT:    end_apply [[TOKEN]] as $()
 // CHECK-NEXT:    dealloc_stack [[TEMP]] : $*Bool
 // CHECK-NEXT:    [[RV:%.*]] = tuple ()
 // CHECK-NEXT:    return [[RV]] : $()
@@ -137,7 +137,7 @@ bb0(%0 : $Bool):
   %temp = alloc_stack $Bool
   store %0 to [trivial] %temp : $*Bool
   (%addr, %token) = begin_apply %coro<Bool>(%temp) : $@yield_once @convention(thin) <T> (@in T) -> @yields @inout T
-  end_apply %token
+  end_apply %token as $()
   dealloc_stack %temp : $*Bool
   %rv = tuple ()
   return %rv : $()


### PR DESCRIPTION
This adds SIL-level support and LLVM codegen for normal results of a coroutine.

The main user of this will be autodiff as VJP of a coroutine must be a coroutine itself (in order to produce the yielded result) and return a pullback closure as a normal result.

The LLVM IR codegen depends on the following patch from LLVM mainline: https://github.com/apple/llvm-project/commit/51d5d7bbae92493a5bfa7cc6b519de8a5bb32fdb (that is already a part of apple/llvm-project/next)

For now only direct results are supported, but this seems to be enough for autodiff purposes.