### PR TITLE
SimplifyBeginBorrow: don't remove begin_borrow instructions which have the `[point_escape]` flag set.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginBorrow.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginBorrow.swift
@@ -16,7 +16,9 @@ extension BeginBorrowInst : OnoneSimplifyable {
   func simplify(_ context: SimplifyContext) {
     if borrowedValue.ownership == .owned,
        // We need to keep lexical lifetimes in place.
-       !isLexical
+       !isLexical,
+       // The same for borrow-scopes which encapsulated pointer escapes.
+       !hasPointerEscape
     {
       tryReplaceBorrowWithOwnedOperand(beginBorrow: self, context)
     }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -881,6 +881,7 @@ final public class BeginBorrowInst : SingleValueInstruction, UnaryInstruction {
   }
 
   public var isLexical: Bool { bridged.BeginBorrow_isLexical() }
+  public var hasPointerEscape: Bool { bridged.BeginBorrow_hasPointerEscape() }
 }
 
 final public class ProjectBoxInst : SingleValueInstruction, UnaryInstruction {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -594,6 +594,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE OptionalBridgedValue StructInst_getUniqueNonTrivialFieldValue() const;
   BRIDGED_INLINE SwiftInt StructElementAddrInst_fieldIndex() const;
   BRIDGED_INLINE bool BeginBorrow_isLexical() const;
+  BRIDGED_INLINE bool BeginBorrow_hasPointerEscape() const;
   BRIDGED_INLINE SwiftInt ProjectBoxInst_fieldIndex() const;
   BRIDGED_INLINE bool EndCOWMutationInst_doKeepUnique() const;
   BRIDGED_INLINE SwiftInt EnumInst_caseIndex() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -784,6 +784,10 @@ bool BridgedInstruction::BeginBorrow_isLexical() const {
   return getAs<swift::BeginBorrowInst>()->isLexical();
 }
 
+bool BridgedInstruction::BeginBorrow_hasPointerEscape() const {
+  return getAs<swift::BeginBorrowInst>()->hasPointerEscape();
+}
+
 SwiftInt BridgedInstruction::ProjectBoxInst_fieldIndex() const {
   return getAs<swift::ProjectBoxInst>()->getFieldIndex();
 }

--- a/test/SILOptimizer/simplify_begin_borrow.sil
+++ b/test/SILOptimizer/simplify_begin_borrow.sil
@@ -159,6 +159,20 @@ bb0(%0 : @owned $C):
   return %6 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dont_replace_pointer_escape :
+// CHECK:         begin_borrow
+// CHECK:       } // end sil function 'dont_replace_pointer_escape'
+sil [ossa] @dont_replace_pointer_escape : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  %1 = begin_borrow [pointer_escape] %0 : $C
+  %2 = function_ref @takeC : $@convention(thin) (@guaranteed C) -> ()
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed C) -> ()
+  end_borrow %1 : $C
+  destroy_value %0: $C
+  %6 = tuple ()
+  return %6 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @dont_replace_with_multiple_uses :
 // CHECK:         begin_borrow
 // CHECK:       } // end sil function 'dont_replace_with_multiple_uses'


### PR DESCRIPTION
This is a follow-up on https://github.com/apple/swift/pull/69820