### PR TITLE
[ASTGen] Protect parseASTFromSyntaxTree for SWIFT_BUILD_SWIFT_SYNTAX

### DIFF
--- a/lib/Parse/ParseBridging.cpp
+++ b/lib/Parse/ParseBridging.cpp
@@ -96,6 +96,7 @@ using ASTFromSyntaxTreeCallback = T *(void *sourceFile,
                                       BridgedSourceLoc sourceLoc,
                                       BridgedSourceLoc &endLoc);
 
+#if SWIFT_BUILD_SWIFT_SYNTAX
 /// Parse by constructing a C++ AST node from the Swift syntax tree via ASTGen.
 template <typename T>
 static ParserResult<T>
@@ -123,6 +124,7 @@ parseASTFromSyntaxTree(swift::Parser &P,
 
   return makeParserResult(astNode);
 }
+#endif
 
 ParserResult<TypeRepr> Parser::parseTypeReprFromSyntaxTree() {
 #if SWIFT_BUILD_SWIFT_SYNTAX
@@ -133,7 +135,7 @@ ParserResult<TypeRepr> Parser::parseTypeReprFromSyntaxTree() {
                                       CurDeclContext, Context, *this, &endLoc);
   });
 #else
-  llvm_unreachable("ASTGen is not supported")
+  llvm_unreachable("ASTGen is not supported");
 #endif
 }
 


### PR DESCRIPTION
The field `IsForASTGen` only exists when `SWIFT_BUILD_SWIFT_SYNTAX` is defined, but the usage was unprotected. The whole function can be inside the protected block because it only seems to be invoked from inside blocks already protected by `SWIFT_BUILD_SWIFT_SYNTAX`.

Fix for #69761
