### PR TITLE
Disable SILOptimizer/moveonly_computed_property.swift

### DIFF
--- a/test/SILOptimizer/moveonly_computed_property.swift
+++ b/test/SILOptimizer/moveonly_computed_property.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: asserts
 
+// SIL verification failed: 'MoveOnly' types can only be copied in Raw SIL?!
+// REQUIRES: rdar118135397
+
 // Applying a computed property to a move-only field in a class should occur
 // entirely within a formal access to the class property. rdar://105794506
 


### PR DESCRIPTION
This test is blocking CI and the pass is not actively maintained.

rdar://118135397 (Swift CI: test:
SILOptimizer/moveonly_computed_property.swift (SIL verification failed: 'MoveOnly' types can only be copied in Raw SIL?!))
