### PR TITLE
Requirement lowering cleanup and accept-invalid fix for @objc protocols

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3718,35 +3718,31 @@ public:
       return;
     }
 
-    printFieldQuotedRaw([&](raw_ostream &out) { genericSig->print(out); },
-                        "generic_signature");
-
-    auto printSubstitution = [&](GenericTypeParamType * genericParam,
-                                 Type replacementType) {
-      printFieldQuotedRaw([&](raw_ostream &out) {
-        genericParam->print(out);
-        out << " -> ";
-        if (replacementType) {
-          PrintOptions opts;
-          opts.PrintForSIL = true;
-          opts.PrintTypesForDebugging = true;
-          replacementType->print(out, opts);
-        }
-        else
-          out << "<unresolved concrete type>";
-      }, "");
-    };
+    printFieldRaw([&](raw_ostream &out) { genericSig->print(out); },
+                  "generic_signature");
 
     auto genericParams = genericSig.getGenericParams();
     auto replacementTypes =
     static_cast<const SubstitutionMap &>(map).getReplacementTypesBuffer();
     for (unsigned i : indices(genericParams)) {
       if (style == SubstitutionMap::DumpStyle::Minimal) {
-        printSubstitution(genericParams[i], replacementTypes[i]);
+        printFieldRaw([&](raw_ostream &out) {
+          genericParams[i]->print(out);
+          out << " -> ";
+          if (replacementTypes[i])
+            out << replacementTypes[i];
+          else
+            out << "<unresolved concrete type>";
+        }, "");
       } else {
         printRecArbitrary([&](StringRef label) {
           printHead("substitution", ASTNodeColor, label);
-          printSubstitution(genericParams[i], replacementTypes[i]);
+          printFieldRaw([&](raw_ostream &out) {
+            genericParams[i]->print(out);
+            out << " -> ";
+          }, "");
+          if (replacementTypes[i])
+            printRec(replacementTypes[i]);
           printFoot();
         });
       }

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -952,6 +952,10 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
 
     desugarRequirements(result, errors);
     expandDefaultRequirements(ctx, needsDefaultRequirements, result, errors);
+
+    diagnoseRequirementErrors(ctx, errors,
+                              AllowConcreteTypePolicy::NestedAssocTypes);
+
     return ctx.AllocateCopy(result);
   }
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -458,6 +458,25 @@ swift::rewriting::desugarRequirement(Requirement req, SourceLoc loc,
   }
 }
 
+void swift::rewriting::desugarRequirements(SmallVector<StructuralRequirement, 2> &reqs,
+                                           SmallVectorImpl<RequirementError> &errors) {
+  SmallVector<StructuralRequirement, 2> result;
+  for (auto req : reqs) {
+    SmallVector<Requirement, 2> desugaredReqs;
+    SmallVector<RequirementError, 2> ignoredErrors;
+
+    if (req.inferred)
+      desugarRequirement(req.req, SourceLoc(), desugaredReqs, ignoredErrors);
+    else
+      desugarRequirement(req.req, req.loc, desugaredReqs, errors);
+
+    for (auto desugaredReq : desugaredReqs)
+      result.push_back({desugaredReq, req.loc, req.inferred});
+  }
+
+  std::swap(reqs, result);
+}
+
 //
 // Requirement realization and inference.
 //
@@ -467,8 +486,6 @@ static void realizeTypeRequirement(DeclContext *dc,
                                    SourceLoc loc,
                                    SmallVectorImpl<StructuralRequirement> &result,
                                    SmallVectorImpl<RequirementError> &errors) {
-  SmallVector<Requirement, 2> reqs;
-
   // The GenericSignatureBuilder allowed the right hand side of a
   // conformance or superclass requirement to reference a protocol
   // typealias whose underlying type was a protocol or class.
@@ -497,22 +514,19 @@ static void realizeTypeRequirement(DeclContext *dc,
   }
 
   if (constraintType->isConstraintType()) {
-    Requirement req(RequirementKind::Conformance, subjectType, constraintType);
-    desugarRequirement(req, loc, reqs, errors);
+    result.push_back({Requirement(RequirementKind::Conformance,
+                                  subjectType, constraintType),
+                      loc, /*wasInferred=*/false});
   } else if (constraintType->getClassOrBoundGenericClass()) {
-    Requirement req(RequirementKind::Superclass, subjectType, constraintType);
-    desugarRequirement(req, loc, reqs, errors);
+    result.push_back({Requirement(RequirementKind::Superclass,
+                                  subjectType, constraintType),
+                      loc, /*wasInferred=*/false});
   } else {
     errors.push_back(
         RequirementError::forInvalidTypeRequirement(subjectType,
                                                     constraintType,
                                                     loc));
-    return;
   }
-
-  // Add source location information.
-  for (auto req : reqs)
-    result.push_back({req, loc, /*wasInferred=*/false});
 }
 
 namespace {
@@ -521,11 +535,11 @@ namespace {
 struct InferRequirementsWalker : public TypeWalker {
   ModuleDecl *module;
   DeclContext *dc;
-  SmallVector<Requirement, 2> reqs;
-  SmallVector<RequirementError, 2> errors;
+  SmallVectorImpl<StructuralRequirement> &reqs;
 
-  explicit InferRequirementsWalker(ModuleDecl *module, DeclContext *dc)
-      : module(module), dc(dc) {}
+  explicit InferRequirementsWalker(ModuleDecl *module, DeclContext *dc,
+                                   SmallVectorImpl<StructuralRequirement> &reqs)
+      : module(module), dc(dc), reqs(reqs) {}
 
   Action walkToTypePre(Type ty) override {
     // Unbound generic types are the result of recovered-but-invalid code, and
@@ -555,8 +569,7 @@ struct InferRequirementsWalker : public TypeWalker {
         return false;
 
       return (req.getKind() == RequirementKind::Conformance &&
-          req.getSecondType()->castTo<ProtocolType>()->getDecl()
-            ->isSpecificProtocol(KnownProtocolKind::Sendable));
+          req.getProtocolDecl()->isSpecificProtocol(KnownProtocolKind::Sendable));
     };
 
     // Infer from generic typealiases.
@@ -567,7 +580,7 @@ struct InferRequirementsWalker : public TypeWalker {
         if (skipRequirement(rawReq, decl))
           continue;
 
-        desugarRequirement(rawReq.subst(subMap), SourceLoc(), reqs, errors);
+        reqs.push_back({rawReq.subst(subMap), SourceLoc(), /*inferred=*/true});
       }
 
       return Action::Continue;
@@ -581,10 +594,9 @@ struct InferRequirementsWalker : public TypeWalker {
       packExpansion->getPatternType()->getTypeParameterPacks(packReferences);
 
       auto countType = packExpansion->getCountType();
-      for (auto pack : packReferences) {
-        Requirement req(RequirementKind::SameShape, countType, pack);
-        desugarRequirement(req, SourceLoc(), reqs, errors);
-      }
+      for (auto pack : packReferences)
+        reqs.push_back({Requirement(RequirementKind::SameShape, countType, pack),
+                        SourceLoc(), /*inferred=*/true});
     }
 
     // Infer requirements from `@differentiable` function types.
@@ -596,9 +608,9 @@ struct InferRequirementsWalker : public TypeWalker {
     if (auto *fnTy = ty->getAs<AnyFunctionType>()) {
       // Add a new conformance constraint for a fixed protocol.
       auto addConformanceConstraint = [&](Type type, ProtocolDecl *protocol) {
-        Requirement req(RequirementKind::Conformance, type,
-                        protocol->getDeclaredInterfaceType());
-        desugarRequirement(req, SourceLoc(), reqs, errors);
+        reqs.push_back({Requirement(RequirementKind::Conformance, type,
+                                    protocol->getDeclaredInterfaceType()),
+                        SourceLoc(), /*inferred=*/true});
       };
 
       auto &ctx = module->getASTContext();
@@ -610,8 +622,9 @@ struct InferRequirementsWalker : public TypeWalker {
           auto secondType = assocType->getDeclaredInterfaceType()
               ->castTo<DependentMemberType>()
               ->substBaseType(module, firstType);
-          Requirement req(RequirementKind::SameType, firstType, secondType);
-          desugarRequirement(req, SourceLoc(), reqs, errors);
+          reqs.push_back({Requirement(RequirementKind::SameType,
+                                      firstType, secondType),
+                          SourceLoc(), /*inferred=*/true});
         };
         auto *tangentVectorAssocType =
             differentiableProtocol->getAssociatedType(ctx.Id_TangentVector);
@@ -659,8 +672,7 @@ struct InferRequirementsWalker : public TypeWalker {
       if (skipRequirement(rawReq, decl))
         continue;
 
-      auto req = rawReq.subst(subMap);
-      desugarRequirement(req, SourceLoc(), reqs, errors);
+      reqs.push_back({rawReq.subst(subMap), SourceLoc(), /*inferred=*/true});
     }
 
     return Action::Continue;
@@ -683,15 +695,12 @@ void swift::rewriting::inferRequirements(
   if (!type)
     return;
 
-  InferRequirementsWalker walker(module, dc);
+  InferRequirementsWalker walker(module, dc, result);
   type.walk(walker);
-
-  for (const auto &req : walker.reqs)
-    result.push_back({req, loc, /*wasInferred=*/true});
 }
 
-/// Desugar a requirement and perform requirement inference if requested
-/// to obtain zero or more structural requirements.
+/// Perform requirement inference from the type representations in the
+/// requirement itself (eg, `T == Set<U>` infers `U: Hashable`).
 void swift::rewriting::realizeRequirement(
     DeclContext *dc,
     Requirement req, RequirementRepr *reqRepr,
@@ -732,12 +741,7 @@ void swift::rewriting::realizeRequirement(
       inferRequirements(firstType, firstLoc, moduleForInference, dc, result);
     }
 
-    SmallVector<Requirement, 2> reqs;
-    desugarRequirement(req, loc, reqs, errors);
-
-    for (auto req : reqs)
-      result.push_back({req, loc, /*wasInferred=*/false});
-
+    result.push_back({req, loc, /*wasInferred=*/false});
     break;
   }
 
@@ -754,11 +758,7 @@ void swift::rewriting::realizeRequirement(
       inferRequirements(secondType, secondLoc, moduleForInference, dc, result);
     }
 
-    SmallVector<Requirement, 2> reqs;
-    desugarRequirement(req, loc, reqs, errors);
-
-    for (auto req : reqs)
-      result.push_back({req, loc, /*wasInferred=*/false});
+    result.push_back({req, loc, /*wasInferred=*/false});
     break;
   }
   }
@@ -903,13 +903,13 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
                                         ProtocolDecl *proto) const {
   assert(!proto->hasLazyRequirementSignature());
 
-  SmallVector<StructuralRequirement, 4> result;
-  SmallVector<RequirementError, 4> errors;
+  SmallVector<StructuralRequirement, 2> result;
+  SmallVector<RequirementError, 2> errors;
 
   auto &ctx = proto->getASTContext();
   auto selfTy = proto->getSelfInterfaceType();
 
-  SmallVector<Type, 4> needsDefaultReqirements({selfTy});
+  SmallVector<Type, 4> needsDefaultRequirements({selfTy});
 
   unsigned errorCount = errors.size();
   realizeInheritedRequirements(proto, selfTy,
@@ -950,7 +950,8 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
     result.push_back({Requirement(RequirementKind::Layout, selfTy, layout),
                       proto->getLoc(), /*inferred=*/true});
 
-    expandDefaultRequirements(ctx, needsDefaultReqirements, result, errors);
+    desugarRequirements(result, errors);
+    expandDefaultRequirements(ctx, needsDefaultRequirements, result, errors);
     return ctx.AllocateCopy(result);
   }
 
@@ -976,7 +977,7 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
           return false;
         });
 
-    needsDefaultReqirements.push_back(assocType);
+    needsDefaultRequirements.push_back(assocType);
   }
 
   // Add requirements for each typealias.
@@ -1014,7 +1015,8 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  expandDefaultRequirements(ctx, needsDefaultReqirements, result, errors);
+  desugarRequirements(result, errors);
+  expandDefaultRequirements(ctx, needsDefaultRequirements, result, errors);
 
   diagnoseRequirementErrors(ctx, errors,
                             AllowConcreteTypePolicy::NestedAssocTypes);

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -38,6 +38,9 @@ namespace rewriting {
 // documentation
 // comments.
 
+void desugarRequirements(SmallVector<StructuralRequirement, 2> &result,
+                         SmallVectorImpl<RequirementError> &errors);
+
 void desugarRequirement(Requirement req, SourceLoc loc,
                         SmallVectorImpl<Requirement> &result,
                         SmallVectorImpl<RequirementError> &errors);

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -716,7 +716,6 @@ void RewriteSystem::dump(llvm::raw_ostream &out) const {
   }
   if (!WrittenRequirements.empty()) {
     out << "Written requirements: {\n";
-
     for (unsigned reqID : indices(WrittenRequirements)) {
       out << " - ID: " << reqID << " - ";
       const auto &requirement = WrittenRequirements[reqID];
@@ -725,6 +724,6 @@ void RewriteSystem::dump(llvm::raw_ostream &out) const {
       requirement.loc.print(out, Context.getASTContext().SourceMgr);
       out << "\n";
     }
+    out << "}\n";
   }
-  out << "}\n";
 }

--- a/test/Constraints/result_builder_generic_infer.swift
+++ b/test/Constraints/result_builder_generic_infer.swift
@@ -22,34 +22,34 @@ struct ProtocolSubstitution: P {
   typealias A = Int
 
   // CHECK: var_decl{{.*}}x1
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> Int')
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> T -> ProtocolSubstitution.A)
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> ProtocolSubstitution')
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> T -> ProtocolSubstitution)
   var x2: [S] { S() }
 }
 
 // CHECK: struct_decl{{.*}}ArchetypeSubstitution
 struct ArchetypeSubstitution<A>: P {
   // CHECK: var_decl{{.*}}x1
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> A')
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> T -> A)
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> ArchetypeSubstitution<A>')
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> T -> ArchetypeSubstitution<A>)
   var x2: [S] { S() }
 }
 
 // CHECK-LABEL: struct_decl{{.*}}ExplicitGenericAttribute
 struct ExplicitGenericAttribute<T: P> {
   // CHECK: var_decl{{.*}}x1
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> T')
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> T -> T)
   @Builder<T>
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> T.A')
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> T -> T.A)
   @Builder<T.A>
   var x2: [S] { S() }
 }
@@ -61,10 +61,10 @@ extension ConcreteTypeSubstitution: P where Value == Int {
   typealias A = Value
 
   // CHECK: var_decl{{.*}}x1
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> Int')
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> T -> ConcreteTypeSubstitution<Int>.A)
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature='<T>' 'T -> ConcreteTypeSubstitution<Int>')
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> T -> ConcreteTypeSubstitution<Int>)
   var x2: [S] { S() }
 }

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -118,9 +118,11 @@ extension Super: P2 where T: P2, U: P2 {
 // CHECK-LABEL: ClassDecl name=Sub
 // CHECK-NEXT: (inherited_conformance type="Sub" protocol="P2"
 // CHECK-NEXT:   (specialized_conformance type="Super<NonRecur, Recur>" protocol="P2"
-// CHECK-NEXT:      (substitution_map generic_signature="<T, U where T : P2, U : P2>"
-// CHECK-NEXT:         (substitution "T -> NonRecur")
-// CHECK-NEXT:         (substitution "U -> Recur")
+// CHECK-NEXT:      (substitution_map generic_signature=<T, U where T : P2, U : P2>
+// CHECK-NEXT:        (substitution T -> 
+// CHECK-NEXT:          (struct_type decl="{{.*}}"))
+// CHECK-NEXT:        (substitution U -> 
+// CHECK-NEXT:          (struct_type decl="{{.*}}"))
 // CHECK-NEXT:         (conformance type="T"
 // CHECK-NEXT:            (normal_conformance type="NonRecur" protocol="P2"
 // CHECK-NEXT:              (assoc_type req="A" type="Recur")
@@ -166,8 +168,9 @@ struct RecurGeneric<T: P3>: P3 {
 // CHECK-NEXT:   (assoc_type req="A" type="RecurGeneric<Specialize>")
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P3"
 // CHECK-NEXT:     (specialized_conformance type="Specialize.A" protocol="P3"
-// CHECK-NEXT:       (substitution_map generic_signature="<T where T : P3>"
-// CHECK-NEXT:         (substitution "T -> Specialize")
+// CHECK-NEXT:       (substitution_map generic_signature=<T where T : P3>
+// CHECK-NEXT:         (substitution T ->
+// CHECK-NEXT:           (struct_type decl="{{.*}}"))
 // CHECK-NEXT:         (conformance type="T"
 // CHECK-NEXT:           (normal_conformance type="Specialize" protocol="P3" <details printed above>)))
 // CHECK-NEXT:       (normal_conformance type="RecurGeneric<T>" protocol="P3"

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -58,7 +58,7 @@ enum TrailingSemi {
 // CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" "<T : Hashable>" interface type="<T where T : Hashable> (T) -> ()" access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
-// CHECK-AST:         (processed_init=declref_expr type="(Int) -> ()" location={{.*}} range={{.*}} decl="main.(file).generic@{{.*}} [with (substitution_map generic_signature='<T where T : Hashable>' 'T -> Int')]" function_ref=unapplied))
+// CHECK-AST:         (processed_init=declref_expr type="(Int) -> ()" location={{.*}} range={{.*}} decl="main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> T -> Int)]" function_ref=unapplied))
 let _: (Int) -> () = generic
 
 // Closures should be marked as escaping or not.

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -265,3 +265,9 @@ class C8SubRW2: C8Base {
   @objc(custom:) func g(_: Any) // expected-warning {{method 'g' with Objective-C selector 'custom:' conflicts with method 'h()' with the same Objective-C selector; this is an error in Swift 6}}
   @objc(custom:) func h() async // expected-note 2 {{method 'h()' declared here}}
 }
+
+// We forgot to emit diagnostics in the @objc path of StructuralRequirementsRequest.
+struct MyStruct {}
+
+@objc protocol InvalidProtocol where Self: MyStruct {}
+// expected-error@-1 {{type 'Self' constrained to non-protocol, non-class type 'MyStruct'}}


### PR DESCRIPTION
There isn't a whole lot you can actually _state_ in the where clause of an @objc protocol, because there are no associated types. But you can state some invalid things, so make sure they get diagnosed.

While I'm here, clean up RequirementLowering.cpp to make the phase separation between requirement inference and requirement desugaring more explicit.