### PR TITLE
[Dependency Scanning] Avoid looking Clang modules for Swift Overlay dependencies

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -734,8 +734,8 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependencies(
 
     auto moduleDependencies = withDependencyScanningWorker(
         [&cache, moduleName](ModuleDependencyScanningWorker *ScanningWorker) {
-          return ScanningWorker->scanFilesystemForModuleDependency(moduleName,
-                                                                   cache);
+          return ScanningWorker->scanFilesystemForSwiftModuleDependency(moduleName,
+                                                                        cache);
         });
     swiftOverlayLookupResult.insert_or_assign(moduleName, moduleDependencies);
   };


### PR DESCRIPTION
It is far too expensive and will never yield results
