### PR TITLE
macros: install the runtime component for Windows

### DIFF
--- a/lib/Macros/CMakeLists.txt
+++ b/lib/Macros/CMakeLists.txt
@@ -60,6 +60,9 @@ function(add_swift_macro_library name)
   set(destination_dir "lib${LLVM_LIBDIR_SUFFIX}/swift/host/plugins")
 
   swift_install_in_component(TARGETS ${name}
+    RUNTIME
+      DESTINATION bin
+      COMPONENT compiler
     LIBRARY
       DESTINATION "${destination_dir}"
       COMPONENT compiler


### PR DESCRIPTION
Windows uses the runtime component for the DLL, the library component for the import library, and archive component for static archives.  This is in contrast to Darwin that uses library for the DLL and archive for static archives.

This is required to enable packaging the ObservableMacros.