### PR TITLE
[Test] Avoid LSAN report of leaked FunctionTest.

### DIFF
--- a/include/swift/SIL/Test.h
+++ b/include/swift/SIL/Test.h
@@ -151,7 +151,10 @@ public:
   ///     } // end namespace swift::test
   FunctionTest(StringRef name, Invocation invocation);
 
-  FunctionTest(StringRef name, NativeSwiftInvocation invocation);
+  /// Creates a test that will run \p invocation and stores it in the global
+  /// registry.
+  static void createNativeSwiftFunctionTest(StringRef name,
+                                            NativeSwiftInvocation invocation);
 
   /// Computes and returns the function's dominance tree.
   DominanceInfo *getDominanceInfo();
@@ -254,6 +257,11 @@ private:
   /// The vendor for dependencies provided to the test by TestRunner.  Only
   /// non-null when FunctionTest::run is executing.
   Dependencies *dependencies;
+
+public:
+  /// Creates a test that will run \p invocation.  For use by
+  /// createNativeSwiftFunctionTest.
+  FunctionTest(StringRef name, NativeSwiftInvocation invocation);
 };
 
 /// Thunks for delaying template instantiation.

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -145,7 +145,8 @@ void registerBridgedClass(BridgedStringRef bridgedClassName, SwiftMetatype metat
 //===----------------------------------------------------------------------===//
 
 void registerFunctionTest(BridgedStringRef name, void *nativeSwiftInvocation) {
-  new swift::test::FunctionTest(name.unbridged(), nativeSwiftInvocation);
+  swift::test::FunctionTest::createNativeSwiftFunctionTest(
+      name.unbridged(), nativeSwiftInvocation);
 }
 
 bool BridgedTestArguments::hasUntaken() const {

--- a/lib/SIL/Utils/Test.cpp
+++ b/lib/SIL/Utils/Test.cpp
@@ -80,8 +80,14 @@ FunctionTest::FunctionTest(StringRef name, Invocation invocation)
 }
 FunctionTest::FunctionTest(StringRef name, NativeSwiftInvocation invocation)
     : invocation(invocation), pass(nullptr), function(nullptr),
-      dependencies(nullptr) {
-  Registry::get().registerFunctionTest(this, name);
+      dependencies(nullptr) {}
+
+void FunctionTest::createNativeSwiftFunctionTest(
+    StringRef name, NativeSwiftInvocation invocation) {
+  /// Statically allocate the tests to avoid triggering LSAN's "leak" detection.
+  static SmallVector<FunctionTest, 4> tests;
+  auto &test = tests.emplace_back(name, invocation);
+  Registry::get().registerFunctionTest(&test, name);
 }
 
 FunctionTest *FunctionTest::get(StringRef name) {


### PR DESCRIPTION
Avoid heap-allocating an immortal FunctionTest with `new` because it results in LSAN reporting a leak.

In fact, the "leaked" value wasn't leaked: a reference to it was stored in a global map when the type's constructor ran.  It was only a leak in the sense that it was never freed, not that there was a dangling allocation which couldn't be freed.

Work around this by storing the global instances themselves in a second static structure.  Store pointers to the instances into the global map as before.

rdar://118134637
