### PR TITLE
[ASTGen] Give argument labels to all generate(_:) functions

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -188,7 +188,7 @@ extension ASTGenVisitor {
 }
 
 extension ASTGenVisitor {
-  /// Generate AST from a Syntax node. The node must be a decl, stmt, expr, or
+  /// Generate ASTNode from a Syntax node. The node must be a decl, stmt, expr, or
   /// type.
   func generate(_ node: Syntax) -> ASTNode {
     if let decl = node.as(DeclSyntax.self) {
@@ -222,6 +222,8 @@ extension ASTGenVisitor {
 // Misc visits.
 // TODO: Some of these are called within a single file/method; we may want to move them to the respective files.
 extension ASTGenVisitor {
+
+  /// Do NOT introduce another usage of this. Not all choices can produce 'ASTNode'.
   func generate(choices node: some SyntaxChildChoices) -> ASTNode {
     return self.generate(Syntax(node))
   }
@@ -273,6 +275,7 @@ extension ASTGenVisitor {
     return self.generate(expr: node)
   }
 
+  /// DO NOT introduce another usage of this. Not all choices can produce 'ASTNode'.
   @inline(__always)
   func generate(optional node: (some SyntaxChildChoices)?) -> ASTNode? {
     guard let node else {

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -127,15 +127,15 @@ struct ASTGenVisitor {
     self.legacyParse = legacyParser
   }
 
-  public func generate(_ node: SourceFileSyntax) -> [UnsafeMutableRawPointer] {
-    var out = [UnsafeMutableRawPointer]()
+  public func generate(sourceFile node: SourceFileSyntax) -> [BridgedDecl] {
+    var out = [BridgedDecl]()
 
     for element in node.statements {
       let loc = element.bridgedSourceLoc(in: self)
       let swiftASTNodes = generate(codeBlockItem: element)
       switch swiftASTNodes {
       case .decl(let d):
-        out.append(d.raw)
+        out.append(d)
       case .stmt(let s):
         let topLevelDecl = BridgedTopLevelCodeDecl.createParsed(
           self.ctx,
@@ -144,7 +144,7 @@ struct ASTGenVisitor {
           stmt: s,
           endLoc: loc
         )
-        out.append(topLevelDecl.raw)
+        out.append(topLevelDecl.asDecl)
       case .expr(let e):
         let topLevelDecl = BridgedTopLevelCodeDecl.createParsed(
           self.ctx,
@@ -153,7 +153,7 @@ struct ASTGenVisitor {
           expr: e,
           endLoc: loc
         )
-        out.append(topLevelDecl.raw)
+        out.append(topLevelDecl.asDecl)
       default:
         fatalError("Top level nodes must be decls, stmts, or exprs.")
       }
@@ -222,32 +222,32 @@ extension ASTGenVisitor {
 // Misc visits.
 // TODO: Some of these are called within a single file/method; we may want to move them to the respective files.
 extension ASTGenVisitor {
-  func generate(_ node: some SyntaxChildChoices) -> ASTNode {
+  func generate(choices node: some SyntaxChildChoices) -> ASTNode {
     return self.generate(Syntax(node))
   }
 
-  public func generate(_ node: MemberBlockItemSyntax) -> BridgedDecl {
+  public func generate(memberBlockItem node: MemberBlockItemSyntax) -> BridgedDecl {
     generate(decl: node.decl)
   }
 
-  public func generate(_ node: InitializerClauseSyntax) -> BridgedExpr {
+  public func generate(initializerClause node: InitializerClauseSyntax) -> BridgedExpr {
     generate(expr: node.value)
   }
 
-  public func generate(_ node: ConditionElementSyntax) -> ASTNode {
-    generate(node.condition)
+  public func generate(conditionElement node: ConditionElementSyntax) -> ASTNode {
+    generate(choices: node.condition)
   }
 
   public func generate(codeBlockItem node: CodeBlockItemSyntax) -> ASTNode {
-    generate(node.item)
+    generate(choices: node.item)
   }
 
-  public func generate(_ node: ArrayElementSyntax) -> BridgedExpr {
+  public func generate(arrayElement node: ArrayElementSyntax) -> BridgedExpr {
     generate(expr: node.expression)
   }
 
   @inline(__always)
-  func generate(_ node: CodeBlockItemListSyntax) -> BridgedArrayRef {
+  func generate(codeBlockItemList node: CodeBlockItemListSyntax) -> BridgedArrayRef {
     node.lazy.map { self.generate(codeBlockItem: $0).bridged }.bridgedArray(in: self)
   }
 }
@@ -256,7 +256,7 @@ extension ASTGenVisitor {
 // 'self.visit(<expr>)' recursion pattern between optional and non-optional inputs.
 extension ASTGenVisitor {
   @inline(__always)
-  func generate(_ node: TypeSyntax?) -> BridgedTypeRepr? {
+  func generate(optional node: TypeSyntax?) -> BridgedTypeRepr? {
     guard let node else {
       return nil
     }
@@ -265,7 +265,7 @@ extension ASTGenVisitor {
   }
 
   @inline(__always)
-  func generate(_ node: ExprSyntax?) -> BridgedExpr? {
+  func generate(optional node: ExprSyntax?) -> BridgedExpr? {
     guard let node else {
       return nil
     }
@@ -274,58 +274,57 @@ extension ASTGenVisitor {
   }
 
   @inline(__always)
-  func generate(_ node: (some SyntaxChildChoices)?) -> ASTNode? {
+  func generate(optional node: (some SyntaxChildChoices)?) -> ASTNode? {
     guard let node else {
       return nil
     }
 
-    // This call recurses without disambiguation.
-    return self.generate(node) as ASTNode
+    return self.generate(choices: node)
   }
 
   @inline(__always)
-  func generate(_ node: GenericParameterClauseSyntax?) -> BridgedGenericParamList? {
+  func generate(optional node: GenericParameterClauseSyntax?) -> BridgedGenericParamList? {
     guard let node else {
       return nil
     }
 
-    return self.generate(node)
+    return self.generate(genericParameterClause: node)
   }
 
   @inline(__always)
-  func generate(_ node: GenericWhereClauseSyntax?) -> BridgedTrailingWhereClause? {
+  func generate(optional node: GenericWhereClauseSyntax?) -> BridgedTrailingWhereClause? {
     guard let node else {
       return nil
     }
 
-    return self.generate(node)
+    return self.generate(genericWhereClause: node)
   }
 
   @inline(__always)
-  func generate(_ node: EnumCaseParameterClauseSyntax?) -> BridgedParameterList? {
+  func generate(optional node: EnumCaseParameterClauseSyntax?) -> BridgedParameterList? {
     guard let node else {
       return nil
     }
 
-    return self.generate(node)
+    return self.generate(enumCaseParameterClause: node)
   }
 
   @inline(__always)
-  func generate(_ node: InheritedTypeListSyntax?) -> BridgedArrayRef {
+  func generate(optional node: InheritedTypeListSyntax?) -> BridgedArrayRef {
     guard let node else {
       return .init()
     }
 
-    return self.generate(node)
+    return self.generate(inheritedTypeList: node)
   }
 
   @inline(__always)
-  func generate(_ node: PrecedenceGroupNameListSyntax?) -> BridgedArrayRef {
+  func generate(optional node: PrecedenceGroupNameListSyntax?) -> BridgedArrayRef {
     guard let node else {
       return .init()
     }
 
-    return self.generate(node)
+    return self.generate(precedenceGroupNameList: node)
   }
 }
 
@@ -414,8 +413,8 @@ public func buildTopLevelASTNodes(
     astContext: ctx,
     legacyParser: legacyParser
   )
-  .generate(sourceFile.pointee.syntax)
-  .forEach { callback($0, outputContext) }
+  .generate(sourceFile: sourceFile.pointee.syntax)
+  .forEach { callback($0.raw, outputContext) }
 }
 
 /// Generate an AST node at the given source location. Returns the generated

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -23,29 +23,29 @@ extension ASTGenVisitor {
     case .accessorDecl:
       break
     case .actorDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(actorDecl: node).asDecl
     case .associatedTypeDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(associatedTypeDecl: node).asDecl
     case .classDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(classDecl: node).asDecl
     case .deinitializerDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(deinitializerDecl: node).asDecl
     case .editorPlaceholderDecl:
       break
     case .enumCaseDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(enumCaseDecl: node).asDecl
     case .enumDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(enumDecl: node).asDecl
     case .extensionDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(extensionDecl: node).asDecl
     case .functionDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(functionDecl: node).asDecl
     case .ifConfigDecl:
       break
     case .importDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(importDecl: node).asDecl
     case .initializerDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(initializerDecl: node).asDecl
     case .macroDecl:
       break
     case .macroExpansionDecl:
@@ -53,26 +53,26 @@ extension ASTGenVisitor {
     case .missingDecl:
       break
     case .operatorDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(operatorDecl: node).asDecl
     case .poundSourceLocation:
       break
     case .precedenceGroupDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(precedenceGroupDecl: node).asDecl
     case .protocolDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(protocolDecl: node).asDecl
     case .structDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(structDecl: node).asDecl
     case .subscriptDecl:
       break
     case .typeAliasDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(typeAliasDecl: node).asDecl
     case .variableDecl(let node):
-      return self.generate(node).asDecl
+      return self.generate(variableDecl: node).asDecl
     }
     return self.generateWithLegacy(node)
   }
 
-  public func generate(_ node: TypeAliasDeclSyntax) -> BridgedTypeAliasDecl {
+  public func generate(typeAliasDecl node: TypeAliasDeclSyntax) -> BridgedTypeAliasDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     return .createParsed(
@@ -81,14 +81,14 @@ extension ASTGenVisitor {
       typealiasKeywordLoc: node.typealiasKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause).asNullable,
+      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
       equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
       underlyingType: self.generate(type: node.initializer.value),
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable
     )
   }
 
-  public func generate(_ node: EnumDeclSyntax) -> BridgedNominalTypeDecl {
+  public func generate(enumDecl node: EnumDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     let decl = BridgedEnumDecl.createParsed(
@@ -97,9 +97,9 @@ extension ASTGenVisitor {
       enumKeywordLoc: node.enumKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause).asNullable,
-      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
+      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -108,13 +108,13 @@ extension ASTGenVisitor {
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(node.memberBlock.members))
+      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members))
     }
 
     return decl
   }
 
-  public func generate(_ node: StructDeclSyntax) -> BridgedNominalTypeDecl {
+  public func generate(structDecl node: StructDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     let decl = BridgedStructDecl.createParsed(
@@ -123,9 +123,9 @@ extension ASTGenVisitor {
       structKeywordLoc: node.structKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause).asNullable,
-      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
+      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -134,13 +134,13 @@ extension ASTGenVisitor {
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(node.memberBlock.members))
+      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members))
     }
 
     return decl
   }
 
-  public func generate(_ node: ClassDeclSyntax) -> BridgedNominalTypeDecl {
+  public func generate(classDecl node: ClassDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     let decl = BridgedClassDecl.createParsed(
@@ -149,9 +149,9 @@ extension ASTGenVisitor {
       classKeywordLoc: node.classKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause).asNullable,
-      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
+      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -161,13 +161,13 @@ extension ASTGenVisitor {
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(node.memberBlock.members))
+      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members))
     }
 
     return decl
   }
 
-  public func generate(_ node: ActorDeclSyntax) -> BridgedNominalTypeDecl {
+  public func generate(actorDecl node: ActorDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     let decl = BridgedClassDecl.createParsed(
@@ -176,9 +176,9 @@ extension ASTGenVisitor {
       classKeywordLoc: node.actorKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause).asNullable,
-      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
+      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -188,13 +188,13 @@ extension ASTGenVisitor {
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(node.memberBlock.members))
+      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members))
     }
 
     return decl
   }
 
-  func generate(_ node: ProtocolDeclSyntax) -> BridgedNominalTypeDecl {
+  func generate(protocolDecl node: ProtocolDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
     let primaryAssociatedTypeNames = node.primaryAssociatedTypeClause?.primaryAssociatedTypes.lazy.map {
       $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
@@ -207,8 +207,8 @@ extension ASTGenVisitor {
       name: name,
       nameLoc: nameLoc,
       primaryAssociatedTypeNames: primaryAssociatedTypeNames.bridgedArray(in: self),
-      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
+      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -217,13 +217,13 @@ extension ASTGenVisitor {
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(node.memberBlock.members))
+      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members))
     }
 
     return decl
   }
 
-  func generate(_ node: AssociatedTypeDeclSyntax) -> BridgedAssociatedTypeDecl {
+  func generate(associatedTypeDecl node: AssociatedTypeDeclSyntax) -> BridgedAssociatedTypeDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     return .createParsed(
@@ -232,9 +232,9 @@ extension ASTGenVisitor {
       associatedtypeKeywordLoc: node.associatedtypeKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      defaultType: self.generate(node.initializer?.value).asNullable,
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable
+      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
+      defaultType: self.generate(optional: node.initializer?.value).asNullable,
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable
     )
   }
 }
@@ -242,14 +242,14 @@ extension ASTGenVisitor {
 // MARK: - ExtensionDecl
 
 extension ASTGenVisitor {
-  func generate(_ node: ExtensionDeclSyntax) -> BridgedExtensionDecl {
+  func generate(extensionDecl node: ExtensionDeclSyntax) -> BridgedExtensionDecl {
     let decl = BridgedExtensionDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
       extensionKeywordLoc: node.extensionKeyword.bridgedSourceLoc(in: self),
       extendedType: self.generate(type: node.extendedType),
-      inheritedTypes: self.generate(node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
+      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -258,7 +258,7 @@ extension ASTGenVisitor {
     )
 
     self.withDeclContext(decl.asDeclContext) {
-      decl.setParsedMembers(self.generate(node.memberBlock.members))
+      decl.setParsedMembers(self.generate(memberBlockItemList: node.memberBlock.members))
     }
 
     return decl
@@ -268,7 +268,7 @@ extension ASTGenVisitor {
 // MARK: - EnumCaseDecl
 
 extension ASTGenVisitor {
-  func generate(_ node: EnumCaseElementSyntax) -> BridgedEnumElementDecl {
+  func generate(enumCaseElement node: EnumCaseElementSyntax) -> BridgedEnumElementDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     return .createParsed(
@@ -276,13 +276,13 @@ extension ASTGenVisitor {
       declContext: self.declContext,
       name: name,
       nameLoc: nameLoc,
-      parameterList: self.generate(node.parameterClause).asNullable,
+      parameterList: self.generate(optional: node.parameterClause).asNullable,
       equalsLoc: (node.rawValue?.equal).bridgedSourceLoc(in: self),
-      rawValue: self.generate(node.rawValue?.value).asNullable
+      rawValue: self.generate(optional: node.rawValue?.value).asNullable
     )
   }
 
-  func generate(_ node: EnumCaseDeclSyntax) -> BridgedEnumCaseDecl {
+  func generate(enumCaseDecl node: EnumCaseDeclSyntax) -> BridgedEnumCaseDecl {
     .createParsed(
       declContext: self.declContext,
       caseKeywordLoc: node.caseKeyword.bridgedSourceLoc(in: self),
@@ -294,9 +294,9 @@ extension ASTGenVisitor {
 // MARK: - AbstractStorageDecl
 
 extension ASTGenVisitor {
-  public func generate(_ node: VariableDeclSyntax) -> BridgedPatternBindingDecl {
+  public func generate(variableDecl node: VariableDeclSyntax) -> BridgedPatternBindingDecl {
     let pattern = generate(pattern: node.bindings.first!.pattern)
-    let initializer = generate(node.bindings.first!.initializer!)
+    let initializer = generate(initializerClause: node.bindings.first!.initializer!)
 
     let isStatic = false  // TODO: compute this
     let isLet = node.bindingSpecifier.tokenKind == .keyword(.let)
@@ -316,7 +316,7 @@ extension ASTGenVisitor {
 // MARK: - AbstractFunctionDecl
 
 extension ASTGenVisitor {
-  public func generate(_ node: FunctionDeclSyntax) -> BridgedFuncDecl {
+  public func generate(functionDecl node: FunctionDeclSyntax) -> BridgedFuncDecl {
     // FIXME: Compute this location
     let staticLoc: BridgedSourceLoc = nil
 
@@ -329,13 +329,13 @@ extension ASTGenVisitor {
       funcKeywordLoc: node.funcKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(node.genericParameterClause).asNullable,
-      parameterList: self.generate(node.signature.parameterClause),
+      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      parameterList: self.generate(functionParameterClause: node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type).asNullable,
-      returnType: self.generate(node.signature.returnClause?.type).asNullable,
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable
+      thrownType: self.generate(optional: node.signature.effectSpecifiers?.thrownError?.type).asNullable,
+      returnType: self.generate(optional: node.signature.returnClause?.type).asNullable,
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable
     )
 
     if let body = node.body {
@@ -347,19 +347,19 @@ extension ASTGenVisitor {
     return decl
   }
 
-  func generate(_ node: InitializerDeclSyntax) -> BridgedConstructorDecl {
+  func generate(initializerDecl node: InitializerDeclSyntax) -> BridgedConstructorDecl {
     let decl = BridgedConstructorDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
       initKeywordLoc: node.initKeyword.bridgedSourceLoc(in: self),
       failabilityMarkLoc: node.optionalMark.bridgedSourceLoc(in: self),
       isIUO: node.optionalMark?.tokenKind == .exclamationMark,
-      genericParamList: self.generate(node.genericParameterClause).asNullable,
-      parameterList: self.generate(node.signature.parameterClause),
+      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      parameterList: self.generate(functionParameterClause: node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(node.signature.effectSpecifiers?.thrownError?.type).asNullable,
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable
+      thrownType: self.generate(optional: node.signature.effectSpecifiers?.thrownError?.type).asNullable,
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable
     )
 
     if let body = node.body {
@@ -371,7 +371,7 @@ extension ASTGenVisitor {
     return decl
   }
 
-  func generate(_ node: DeinitializerDeclSyntax) -> BridgedDestructorDecl {
+  func generate(deinitializerDecl node: DeinitializerDeclSyntax) -> BridgedDestructorDecl {
     let decl = BridgedDestructorDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
@@ -402,7 +402,7 @@ extension BridgedOperatorFixity {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: OperatorDeclSyntax) -> BridgedOperatorDecl {
+  func generate(operatorDecl node: OperatorDeclSyntax) -> BridgedOperatorDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
     let (precedenceGroupName, precedenceGroupLoc) = (node.operatorPrecedenceAndTypes?.precedenceGroup)
       .bridgedIdentifierAndSourceLoc(in: self)
@@ -445,7 +445,7 @@ extension BridgedAssociativity {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: PrecedenceGroupDeclSyntax) -> BridgedPrecedenceGroupDecl {
+  func generate(precedenceGroupDecl node: PrecedenceGroupDeclSyntax) -> BridgedPrecedenceGroupDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     struct PrecedenceGroupBody {
@@ -533,9 +533,9 @@ extension ASTGenVisitor {
       assignmentValueLoc: (body.assignment?.value).bridgedSourceLoc(in: self),
       isAssignment: assignmentValue,
       higherThanKeywordLoc: (body.higherThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-      higherThanNames: self.generate(body.higherThanRelation?.precedenceGroups),
+      higherThanNames: self.generate(optional: body.higherThanRelation?.precedenceGroups),
       lowerThanKeywordLoc: (body.lowerThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-      lowerThanNames: self.generate(body.lowerThanRelation?.precedenceGroups),
+      lowerThanNames: self.generate(optional: body.lowerThanRelation?.precedenceGroups),
       rightBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
     )
   }
@@ -559,7 +559,7 @@ extension BridgedImportKind {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: ImportDeclSyntax) -> BridgedImportDecl {
+  func generate(importDecl node: ImportDeclSyntax) -> BridgedImportDecl {
     let importKind: BridgedImportKind
     if let specifier = node.importKindSpecifier {
       if let value = BridgedImportKind(from: specifier.tokenKind) {
@@ -587,17 +587,17 @@ extension ASTGenVisitor {
 
 extension ASTGenVisitor {
   @inline(__always)
-  func generate(_ node: MemberBlockItemListSyntax) -> BridgedArrayRef {
+  func generate(memberBlockItemList node: MemberBlockItemListSyntax) -> BridgedArrayRef {
     node.lazy.map(self.generate).bridgedArray(in: self)
   }
 
   @inline(__always)
-  func generate(_ node: InheritedTypeListSyntax) -> BridgedArrayRef {
+  func generate(inheritedTypeList node: InheritedTypeListSyntax) -> BridgedArrayRef {
     node.lazy.map { self.generate(type: $0.type) }.bridgedArray(in: self)
   }
 
   @inline(__always)
-  func generate(_ node: PrecedenceGroupNameListSyntax) -> BridgedArrayRef {
+  func generate(precedenceGroupNameList node: PrecedenceGroupNameListSyntax) -> BridgedArrayRef {
     node.lazy.map {
       $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
     }.bridgedArray(in: self)

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -14,17 +14,17 @@ import ASTBridging
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  func generate(_ node: GenericParameterClauseSyntax) -> BridgedGenericParamList {
+  func generate(genericParameterClause node: GenericParameterClauseSyntax) -> BridgedGenericParamList {
     .createParsed(
       self.ctx,
       leftAngleLoc: node.leftAngle.bridgedSourceLoc(in: self),
       parameters: node.parameters.lazy.map(self.generate).bridgedArray(in: self),
-      genericWhereClause: self.generate(node.genericWhereClause).asNullable,
+      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
       rightAngleLoc: node.rightAngle.bridgedSourceLoc(in: self)
     )
   }
 
-  func generate(_ node: GenericParameterSyntax) -> BridgedGenericTypeParamDecl {
+  func generate(genericParameter node: GenericParameterSyntax) -> BridgedGenericTypeParamDecl {
     let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
 
     var genericParameterIndex: Int?
@@ -44,12 +44,12 @@ extension ASTGenVisitor {
       eachKeywordLoc: node.eachKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      inheritedType: self.generate(node.inheritedType).asNullable,
+      inheritedType: self.generate(optional: node.inheritedType).asNullable,
       index: genericParameterIndex
     )
   }
 
-  func generate(_ node: GenericWhereClauseSyntax) -> BridgedTrailingWhereClause {
+  func generate(genericWhereClause node: GenericWhereClauseSyntax) -> BridgedTrailingWhereClause {
     let requirements = node.requirements.lazy.map {
       switch $0.requirement {
       case .conformanceRequirement(let conformance):

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -14,7 +14,7 @@ import ASTBridging
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func generate(_ node: StringLiteralExprSyntax) -> BridgedStringLiteralExpr {
+  public func generate(stringLiteralExpr node: StringLiteralExprSyntax) -> BridgedStringLiteralExpr {
     let openDelimiterOrQuoteLoc = (node.openingPounds ?? node.openingQuote).bridgedSourceLoc(in: self)
 
     // FIXME: Handle interpolated strings.
@@ -24,19 +24,19 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(_ node: IntegerLiteralExprSyntax) -> BridgedIntegerLiteralExpr {
+  public func generate(integerLiteralExpr node: IntegerLiteralExprSyntax) -> BridgedIntegerLiteralExpr {
     var segment = node.literal.text
     return segment.withBridgedString { bridgedSegment in
       return .createParsed(ctx, value: bridgedSegment, loc: node.literal.bridgedSourceLoc(in: self))
     }
   }
 
-  public func generate(_ node: BooleanLiteralExprSyntax) -> BridgedBooleanLiteralExpr {
+  public func generate(booleanLiteralExpr node: BooleanLiteralExprSyntax) -> BridgedBooleanLiteralExpr {
     let value = node.literal.tokenKind == .keyword(.true)
     return .createParsed(ctx, value: value, loc: node.literal.bridgedSourceLoc(in: self))
   }
 
-  public func generate(_ node: ArrayExprSyntax) -> BridgedArrayExpr {
+  public func generate(arrayExpr node: ArrayExprSyntax) -> BridgedArrayExpr {
     let expressions = node.elements.lazy.map(self.generate)
 
     let commaLocations = node.elements.compactMap(in: self) {
@@ -52,7 +52,7 @@ extension ASTGenVisitor {
     )
   }
 
-  func generate(_ node: NilLiteralExprSyntax) -> BridgedNilLiteralExpr {
+  func generate(nilLiteralExpr node: NilLiteralExprSyntax) -> BridgedNilLiteralExpr {
     .createParsed(self.ctx, nilKeywordLoc: node.nilKeyword.bridgedSourceLoc(in: self))
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
+++ b/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
@@ -61,11 +61,11 @@ extension EnumCaseParameterSyntax: ValueParameterSyntax {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: FunctionParameterSyntax) -> BridgedParamDecl {
+  func generate(functionParameter node: FunctionParameterSyntax) -> BridgedParamDecl {
     self.makeParamDecl(node)
   }
 
-  func generate(_ node: EnumCaseParameterSyntax) -> BridgedParamDecl {
+  func generate(enumCaseParameter node: EnumCaseParameterSyntax) -> BridgedParamDecl {
     self.makeParamDecl(node)
   }
 
@@ -83,7 +83,7 @@ extension ASTGenVisitor {
 
     let (secondName, secondNameLoc) = node.secondName.bridgedIdentifierAndSourceLoc(in: self)
 
-    var type = self.generate(node.optionalType)
+    var type = self.generate(optional: node.optionalType)
     if let ellipsis = node.ellipsis, let base = type {
       type = BridgedVarargTypeRepr.createParsed(
         self.ctx,
@@ -101,7 +101,7 @@ extension ASTGenVisitor {
       secondName: secondName,
       secondNameLoc: secondNameLoc,
       type: type.asNullable,
-      defaultValue: self.generate(node.defaultValue?.value).asNullable
+      defaultValue: self.generate(optional: node.defaultValue?.value).asNullable
     )
   }
 }
@@ -109,16 +109,16 @@ extension ASTGenVisitor {
 // MARK: - ParameterList
 
 extension ASTGenVisitor {
-  func generate(_ node: FunctionParameterClauseSyntax) -> BridgedParameterList {
+  func generate(functionParameterClause node: FunctionParameterClauseSyntax) -> BridgedParameterList {
     BridgedParameterList.createParsed(
       self.ctx,
       leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
-      parameters: self.generate(node.parameters),
+      parameters: self.generate(functionParameterList: node.parameters),
       rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
     )
   }
 
-  func generate(_ node: EnumCaseParameterClauseSyntax) -> BridgedParameterList {
+  func generate(enumCaseParameterClause node: EnumCaseParameterClauseSyntax) -> BridgedParameterList {
     BridgedParameterList.createParsed(
       self.ctx,
       leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
@@ -130,7 +130,7 @@ extension ASTGenVisitor {
 
 extension ASTGenVisitor {
   @inline(__always)
-  func generate(_ node: FunctionParameterListSyntax) -> BridgedArrayRef {
+  func generate(functionParameterList node: FunctionParameterListSyntax) -> BridgedArrayRef {
     node.lazy.map(self.generate).bridgedArray(in: self)
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -64,8 +64,10 @@ extension ASTGenVisitor {
   }
 
   func makeIfStmt(_ node: IfExprSyntax) -> BridgedIfStmt {
+    // FIXME: handle multiple coniditons.
+    // FIXME: handle non-expression conditions.
     let conditions = node.conditions.map(self.generate)
-    assert(conditions.count == 1)  // TODO: handle multiple conditions.
+    assert(conditions.count == 1)
 
     return .createParsed(
       self.ctx,

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -27,7 +27,7 @@ extension ASTGenVisitor {
     case .doStmt:
       break
     case .expressionStmt(let node):
-      return self.generate(node)
+      return self.generate(expressionStmt: node)
     case .fallThroughStmt:
       break
     case .forStmt:
@@ -41,7 +41,7 @@ extension ASTGenVisitor {
     case .repeatStmt:
       break
     case .returnStmt(let node):
-      return self.generate(node).asStmt
+      return self.generate(returnStmt: node).asStmt
     case .thenStmt:
       break
     case .throwStmt:
@@ -58,7 +58,7 @@ extension ASTGenVisitor {
     BridgedBraceStmt.createParsed(
       self.ctx,
       lBraceLoc: node.leftBrace.bridgedSourceLoc(in: self),
-      elements: self.generate(node.statements),
+      elements: self.generate(codeBlockItemList: node.statements),
       rBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
     )
   }
@@ -73,11 +73,11 @@ extension ASTGenVisitor {
       condition: conditions.first!.castToExpr,
       thenStmt: self.generate(codeBlock: node.body).asStmt,
       elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
-      elseStmt: (self.generate(node.elseBody)?.castToStmt).asNullable
+      elseStmt: (self.generate(optional: node.elseBody)?.castToStmt).asNullable
     )
   }
 
-  public func generate(_ node: ExpressionStmtSyntax) -> BridgedStmt {
+  public func generate(expressionStmt node: ExpressionStmtSyntax) -> BridgedStmt {
     switch Syntax(node.expression).as(SyntaxEnum.self) {
     case .ifExpr(let e):
       return makeIfStmt(e).asStmt
@@ -86,11 +86,11 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(_ node: ReturnStmtSyntax) -> BridgedReturnStmt {
+  public func generate(returnStmt node: ReturnStmtSyntax) -> BridgedReturnStmt {
     .createParsed(
       self.ctx,
       returnKeywordLoc: node.returnKeyword.bridgedSourceLoc(in: self),
-      expr: self.generate(node.expression).asNullable
+      expr: self.generate(optional: node.expression).asNullable
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -57,46 +57,46 @@ extension ASTGenVisitor {
     }
     switch node.as(TypeSyntaxEnum.self) {
     case .arrayType(let node):
-      return self.generate(node)
+      return self.generate(arrayType: node)
     case .attributedType(let node):
-      return self.generate(node)
+      return self.generate(attributedType: node)
     case .classRestrictionType:
       break
     case .compositionType(let node):
-      return self.generate(node)
+      return self.generate(compositionType: node)
     case .dictionaryType(let node):
-      return self.generate(node)
+      return self.generate(dictionaryType: node)
     case .functionType(let node):
-      return self.generate(node)
+      return self.generate(functionType: node)
     case .identifierType(let node):
-      return self.generate(node)
+      return self.generate(identifierType: node)
     case .implicitlyUnwrappedOptionalType(let node):
-      return self.generate(node)
+      return self.generate(implicitlyUnwrappedOptionalType: node)
     case .memberType(let node):
-      return self.generate(node)
+      return self.generate(memberType: node)
     case .metatypeType(let node):
-      return self.generate(node)
+      return self.generate(metatypeType: node)
     case .missingType:
       break
     case .namedOpaqueReturnType(let node):
-      return self.generate(node)
+      return self.generate(namedOpaqueReturnType: node)
     case .optionalType(let node):
-      return self.generate(node)
+      return self.generate(optionalType: node)
     case .packElementType:
       break
     case .packExpansionType(let node):
-      return self.generate(node)
+      return self.generate(packExpansionType: node)
     case .someOrAnyType(let node):
-      return self.generate(node)
+      return self.generate(someOrAnyType: node)
     case .suppressedType:
       break
     case .tupleType(let node):
-      return self.generate(node)
+      return self.generate(tupleType: node)
     }
     preconditionFailure("isTypeMigrated() mismatch")
   }
 
-  public func generate(_ node: IdentifierTypeSyntax) -> BridgedTypeRepr {
+  public func generate(identifierType node: IdentifierTypeSyntax) -> BridgedTypeRepr {
     let loc = node.bridgedSourceLoc(in: self)
 
     // If this is the bare 'Any' keyword, produce an empty composition type.
@@ -124,7 +124,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(_ node: MemberTypeSyntax) -> BridgedTypeRepr {
+  public func generate(memberType node: MemberTypeSyntax) -> BridgedTypeRepr {
     // Gather the member components, in decreasing depth order.
     var reverseMemberComponents = [BridgedTypeRepr]()
 
@@ -166,7 +166,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(_ node: ArrayTypeSyntax) -> BridgedTypeRepr {
+  public func generate(arrayType node: ArrayTypeSyntax) -> BridgedTypeRepr {
     let elementType = generate(type: node.element)
     let lSquareLoc = node.leftSquare.bridgedSourceLoc(in: self)
     let rSquareLoc = node.rightSquare.bridgedSourceLoc(in: self)
@@ -178,7 +178,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(_ node: DictionaryTypeSyntax) -> BridgedTypeRepr {
+  public func generate(dictionaryType node: DictionaryTypeSyntax) -> BridgedTypeRepr {
     let keyType = generate(type: node.key)
     let valueType = generate(type: node.value)
     let colonLoc = node.colon.bridgedSourceLoc(in: self)
@@ -194,7 +194,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(_ node: MetatypeTypeSyntax) -> BridgedTypeRepr {
+  public func generate(metatypeType node: MetatypeTypeSyntax) -> BridgedTypeRepr {
     let baseType = generate(type: node.baseType)
     let tyLoc = node.metatypeSpecifier.bridgedSourceLoc(in: self)
     if node.metatypeSpecifier.text == "Type" {
@@ -213,7 +213,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) -> BridgedTypeRepr {
+  public func generate(implicitlyUnwrappedOptionalType node: ImplicitlyUnwrappedOptionalTypeSyntax) -> BridgedTypeRepr {
     let base = generate(type: node.wrappedType)
     let exclaimLoc = node.exclamationMark.bridgedSourceLoc(in: self)
     return BridgedImplicitlyUnwrappedOptionalTypeRepr.createParsed(
@@ -223,7 +223,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(_ node: OptionalTypeSyntax) -> BridgedTypeRepr {
+  public func generate(optionalType node: OptionalTypeSyntax) -> BridgedTypeRepr {
     let base = generate(type: node.wrappedType)
     let questionLoc = node.questionMark.bridgedSourceLoc(in: self)
     return BridgedOptionalTypeRepr.createParsed(
@@ -233,7 +233,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(_ node: PackExpansionTypeSyntax) -> BridgedTypeRepr {
+  public func generate(packExpansionType node: PackExpansionTypeSyntax) -> BridgedTypeRepr {
     let base = generate(type: node.repetitionPattern)
     let repeatLoc = node.repeatKeyword.bridgedSourceLoc(in: self)
     return BridgedPackExpansionTypeRepr.createParsed(
@@ -243,16 +243,16 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(_ node: TupleTypeSyntax) -> BridgedTypeRepr {
+  public func generate(tupleType node: TupleTypeSyntax) -> BridgedTypeRepr {
     BridgedTupleTypeRepr.createParsed(
       self.ctx,
-      elements: self.generate(node.elements),
+      elements: self.generate(tupleTypeElementList: node.elements),
       leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
       rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
     )
   }
 
-  public func generate(_ node: CompositionTypeSyntax) -> BridgedTypeRepr {
+  public func generate(compositionType node: CompositionTypeSyntax) -> BridgedTypeRepr {
     assert(node.elements.count > 1)
 
     let types = node.elements.lazy.map {
@@ -266,30 +266,30 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(_ node: FunctionTypeSyntax) -> BridgedTypeRepr {
+  public func generate(functionType node: FunctionTypeSyntax) -> BridgedTypeRepr {
     BridgedFunctionTypeRepr.createParsed(
       self.ctx,
       // FIXME: Why does `FunctionTypeSyntax` not have a `TupleTypeSyntax` child?
       argsType: BridgedTupleTypeRepr.createParsed(
         self.ctx,
-        elements: self.generate(node.parameters),
+        elements: self.generate(tupleTypeElementList: node.parameters),
         leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
         rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
       ),
       asyncLoc: (node.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsLoc: (node.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(node.effectSpecifiers?.thrownError?.type).asNullable,
+      thrownType: self.generate(optional: node.effectSpecifiers?.thrownError?.type).asNullable,
       arrowLoc: node.returnClause.arrow.bridgedSourceLoc(in: self),
       resultType: generate(type: node.returnClause.type)
     )
   }
 
-  public func generate(_ node: NamedOpaqueReturnTypeSyntax) -> BridgedTypeRepr {
+  public func generate(namedOpaqueReturnType node: NamedOpaqueReturnTypeSyntax) -> BridgedTypeRepr {
     let baseTy = generate(type: node.type)
     return BridgedNamedOpaqueReturnTypeRepr.createParsed(self.ctx, base: baseTy)
   }
 
-  public func generate(_ node: SomeOrAnyTypeSyntax) -> BridgedTypeRepr {
+  public func generate(someOrAnyType node: SomeOrAnyTypeSyntax) -> BridgedTypeRepr {
     let someOrAnyLoc = node.someOrAnySpecifier.bridgedSourceLoc(in: self)
     let baseTy = generate(type: node.constraint)
     if node.someOrAnySpecifier.text == "some" {
@@ -308,7 +308,7 @@ extension ASTGenVisitor {
     }
   }
 
-  // NOTE: When implementing new `generate(_:)`, please update  `isTypeMigrated(_:)`.
+  // NOTE: When implementing new `generate(type:)`, please update  `isTypeMigrated(_:)`.
 }
 
 // MARK: - SpecifierTypeRepr/AttributedTypeRepr
@@ -329,7 +329,7 @@ extension BridgedAttributedTypeSpecifier {
 }
 
 extension ASTGenVisitor {
-  public func generate(_ node: AttributedTypeSyntax) -> BridgedTypeRepr {
+  public func generate(attributedType node: AttributedTypeSyntax) -> BridgedTypeRepr {
     var type = generate(type: node.baseType)
 
     // Handle specifiers.
@@ -406,7 +406,7 @@ extension ASTGenVisitor {
 }
 
 extension ASTGenVisitor {
-  func generate(_ node: TupleTypeElementListSyntax) -> BridgedArrayRef {
+  func generate(tupleTypeElementList node: TupleTypeElementListSyntax) -> BridgedArrayRef {
     node.lazy.map { element in
       let (firstName, firstNameLoc) = element.firstName.bridgedIdentifierAndSourceLoc(in: self)
       let (secondName, secondNameLoc) = element.secondName.bridgedIdentifierAndSourceLoc(in: self)


### PR DESCRIPTION
Explicit argument labels are useful for "Open Quickly..." in Xcode, reduce the fear of miss overload resolution, and better crash backtrace as they might not show parameter types.

notes:
* `generate(xxxExpr:)` instead of `generateXXXExpr(_:)` because it's an argument information. It's' possible that we'd need to generate different things from the same argument. I'd like to reserve the base name for the return value. For example:
  ```swift
    func generateExpr(tupleExpr: TupleExprSyntax) -> BridgedTupleExpr
    func generatePattern(tupleExpr: TupleExprSyntax) -> BridgedTuplePattern
  ```
* I haven't decided what todo with `generate(_: Syntax) -> ASTNode` maybe `generateASTNode(syntax:)`?
* All `generate(_: T?)` are now `generate(optional:)` It's still overloaded, but probably enough for disambiguation
