### PR TITLE
[Parse] Unguard Parser.IsForASTGen for SWIFT_BUILD_SWIFT_SYNTAX

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -159,10 +159,9 @@ public:
   bool InSwiftKeyPath = false;
   bool InFreestandingMacroArgument = false;
 
-#if SWIFT_BUILD_SWIFT_SYNTAX
-  // This Parser is a fallback parser for ASTGen.
+  /// This Parser is a fallback parser for ASTGen.
+  // Note: This doesn't affect anything in non-SWIFT_BUILD_SWIFT_SYNTAX envs.
   bool IsForASTGen = false;
-#endif
 
   // A cached answer to
   //     Context.LangOpts.hasFeature(Feature::NoncopyableGenerics)


### PR DESCRIPTION
Hiding a field depending on `-D` was not a good idea. e.g. https://github.com/apple/swift/pull/69858 https://github.com/apple/swift/pull/69761#discussion_r1392562906

cc: @drodriguez 