### PR TITLE
[embedded] Avoid compiler crash when using an opaque result type

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1636,6 +1636,9 @@ void IRGenModule::emitStructDecl(StructDecl *st) {
 }
 
 void IRGenModule::maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *opaque) {
+  if (opaque->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return;
+
   if (!opaque->isAvailableDuringLowering())
     return;
 

--- a/test/embedded/opaque-return-types.swift
+++ b/test/embedded/opaque-return-types.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+protocol Proto { }
+
+struct MyStruct: Proto { }
+
+func foo() -> some Proto {
+  MyStruct()
+}
+
+// CHECK: define {{.*}}@main(

--- a/test/embedded/opaque-return-types.swift
+++ b/test/embedded/opaque-return-types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: VENDOR=apple


### PR DESCRIPTION
We currently crash in IRGen when emitting metadata for an opaque type decl. We should not emit that in embedded Swift.

```
Assertion failed: (!isEmbedded(decl)), function forOpaqueTypeDescriptor, file Linking.h, line 928.
 #7 0x00000001083d8950 swift::irgen::IRGenModule::emitOpaqueTypeDecl(swift::OpaqueTypeDecl*) (.cold.3)
 #8 0x00000001035e5b80 swift::irgen::IRGenModule::emitOpaqueTypeDecl(swift::OpaqueTypeDecl*)
 #9 0x000000010362574c swift::irgen::IRGenModule::maybeEmitOpaqueTypeDecl(swift::OpaqueTypeDecl*)
#10 0x000000010355b0c0 swift::irgen::IRGenModule::emitSourceFile(swift::SourceFile&)
#11 0x0000000103660898 swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const
#12 0x00000001036a69bc swift::GeneratedModule swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)9>::callDerived<0ul>(swift::Evaluator&, std::__1::integer_sequence<unsigned long, 0ul>) const
#13 0x0000000103668dbc llvm::Expected<swift::IRGenRequest::OutputType> swift::Evaluator::getResultUncached<swift::IRGenRequest>(swift::IRGenRequest const&)
#14 0x000000010366184c swift::performIRGeneration(swift::ModuleDecl*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm::GlobalVariable**)
#15 0x00000001031aefa8 generateIR(swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, swift::PrimarySpecificPaths const&, llvm::StringRef, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, llvm::GlobalVariable*&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>)
#16 0x00000001031ab6c4 performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*)
#17 0x00000001031aadd4 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*)
#18 0x00000001031bb10c withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool)
#19 0x00000001031ad010 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*)
```
