### PR TITLE
[TBDGen][Tests] Add apple vendor requirement on package test

### DIFF
--- a/test/TBD/package_symbol_with_default_arg.swift
+++ b/test/TBD/package_symbol_with_default_arg.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
TBD files only encode darwin based platforms. This fixes up failing linux bots.

resolves: rdar://118461540