### PR TITLE
[ClangImporter] Add support for `swift_attr(“@Sendable”)` on ObjC protocols

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5110,11 +5110,14 @@ bool swift::checkSendableConformance(
       // we allow `NSObject` for Objective-C interoperability.
       if (auto superclassDecl = classDecl->getSuperclassDecl()) {
         if (!superclassDecl->isNSObject()) {
-          classDecl->diagnose(
-              diag::concurrent_value_inherit,
-              nominal->getASTContext().LangOpts.EnableObjCInterop,
-              classDecl->getName());
-          return true;
+          classDecl
+              ->diagnose(diag::concurrent_value_inherit,
+                         nominal->getASTContext().LangOpts.EnableObjCInterop,
+                         classDecl->getName())
+              .limitBehavior(behavior);
+
+          if (behavior == DiagnosticBehavior::Unspecified)
+            return true;
         }
       }
     }

--- a/test/Concurrency/sendable_objc_protocol_attr.swift
+++ b/test/Concurrency/sendable_objc_protocol_attr.swift
@@ -22,6 +22,9 @@ NS_SWIFT_SENDABLE
 @property (readonly, nonatomic) NSString *test;
 @end
 
+@protocol MyRefinedObjCProtocol <MyObjCProtocol>
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -37,4 +40,31 @@ extension MyObjCProtocol {
   func test() {
     compute() // Ok
   }
+}
+
+class K : NSObject, MyObjCProtocol {
+  // expected-warning@-1 {{non-final class 'K' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+  let test: String = "k"
+}
+
+class UncheckedK : NSObject, MyObjCProtocol, @unchecked Sendable { // ok
+  let test: String = "unchecked"
+}
+
+class KRefined : NSObject, MyRefinedObjCProtocol {
+  // expected-warning@-1 {{non-final class 'KRefined' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+  let test: String = "refined"
+}
+
+class KUncheckedRefined : NSObject, MyRefinedObjCProtocol, @unchecked Sendable { // Ok
+  let test: String = "refined unchecked"
+}
+
+do {
+  func testSendable<T: Sendable>(_: T) {}
+
+  testSendable(K()) // Ok
+  testSendable(UncheckedK()) // Ok
+  testSendable(KRefined()) // Ok
+  testSendable(KUncheckedRefined()) // Ok
 }

--- a/test/Concurrency/sendable_objc_protocol_attr.swift
+++ b/test/Concurrency/sendable_objc_protocol_attr.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -strict-concurrency=complete \
+// RUN:   -module-name main -I %t -verify
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+//--- Test.h
+#define NS_SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+
+#pragma clang assume_nonnull begin
+
+@import Foundation;
+
+NS_SWIFT_SENDABLE
+@protocol MyObjCProtocol <NSObject>
+@property (readonly, nonatomic) NSString *test;
+@end
+
+#pragma clang assume_nonnull end
+
+//--- main.swift
+struct MyStruct: Sendable {
+  let value: any MyObjCProtocol // Ok
+}
+
+extension Sendable {
+  func compute() {}
+}
+
+extension MyObjCProtocol {
+  func test() {
+    compute() // Ok
+  }
+}

--- a/test/Concurrency/sendable_objc_protocol_attr.swift
+++ b/test/Concurrency/sendable_objc_protocol_attr.swift
@@ -60,6 +60,42 @@ class KUncheckedRefined : NSObject, MyRefinedObjCProtocol, @unchecked Sendable {
   let test: String = "refined unchecked"
 }
 
+@preconcurrency
+protocol P : Sendable {
+}
+
+protocol Q : Sendable {
+}
+
+do {
+  class A : NSObject {}
+
+  final class B : A, P {
+    // expected-warning@-1 {{'Sendable' class 'B' cannot inherit from another class other than 'NSObject'}}
+  }
+
+  final class UncheckedB : A, P, @unchecked Sendable { // Ok
+  }
+
+  class C : A, MyObjCProtocol {
+    // expected-warning@-1 {{non-final class 'C' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+    // expected-warning@-2 {{'Sendable' class 'C' cannot inherit from another class other than 'NSObject'}}
+    let test: String = "c"
+  }
+
+  class UncheckedC : A, MyObjCProtocol, @unchecked Sendable { // Ok
+    let test: String = "c"
+  }
+
+  // A warning until `-swift-version 6`
+  final class D : A, Q {
+    // expected-warning@-1 {{'Sendable' class 'D' cannot inherit from another class other than 'NSObject'}}
+  }
+
+  final class UncheckedD : A, Q, @unchecked Sendable { // Ok
+  }
+}
+
 do {
   func testSendable<T: Sendable>(_: T) {}
 

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -43,6 +43,9 @@ import _Concurrency
 // CHECK: @available(*, unavailable)
 // CHECK-NEXT: extension AuditedBoth : @unchecked Sendable {
 
+// CHECK-LABEL: public protocol SendableProtocol
+// CHECK-SAME: : Sendable
+
 // CHECK-LABEL: enum SendableEnum :
 // CHECK-SAME: @unchecked Sendable
 

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -225,6 +225,9 @@ SENDABLE @interface AuditedSendable : NSObject @end
 @interface AuditedNonSendable : NSObject @end
 NONSENDABLE SENDABLE @interface AuditedBoth : NSObject @end
 
+SENDABLE @protocol SendableProtocol @end
+@protocol SendableProtocolRefined <SendableProtocol> @end
+
 typedef NS_ENUM(unsigned, SendableEnum) {
   SendableEnumFoo, SendableEnumBar
 };


### PR DESCRIPTION
When ClangImporter imports a nominal type with `@Sendable` attached,
it adds a `SynthesizedProtocolAttr` to the type. That did the right thing 
for concrete types, but protocols currently ignore these attributes. 

Manually add them where necessary.

Resolves: rdar://99758612

Partially based on https://github.com/apple/swift/pull/66188 (which I discovered later :))

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
