### PR TITLE
[ASTGen] Several improvements to generalize node handling

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -28,7 +28,6 @@ enum ASTNode {
   case decl(BridgedDecl)
   case stmt(BridgedStmt)
   case expr(BridgedExpr)
-  case type(BridgedTypeRepr)
 
   var castToExpr: BridgedExpr {
     guard case .expr(let bridged) = self else {
@@ -51,13 +50,6 @@ enum ASTNode {
     return bridged
   }
 
-  var castToType: BridgedTypeRepr {
-    guard case .type(let bridged) = self else {
-      fatalError("Expected a type")
-    }
-    return bridged
-  }
-
   var bridged: BridgedASTNode {
     switch self {
     case .expr(let e):
@@ -66,8 +58,6 @@ enum ASTNode {
       return BridgedASTNode(raw: s.raw, kind: .stmt)
     case .decl(let d):
       return BridgedASTNode(raw: d.raw, kind: .decl)
-    default:
-      fatalError("Must be expr, stmt, or decl.")
     }
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -209,27 +209,56 @@ extension ASTGenVisitor {
   }
 }
 
-// Optional node handling.
+// Forwarding overloads that take optional syntax nodes. These are defined on demand to achieve a consistent
+// 'self.generate(foo: FooSyntax)' recursion pattern between optional and non-optional inputs.
 extension ASTGenVisitor {
-  /// Generate an AST node from an optional node using the generator function.
-  ///
-  /// Usage:
-  ///   self.map(node.initializer, generate(expr:))
   @inline(__always)
-  func map<Node: SyntaxProtocol, Result: HasNullable>(
+  func generate(type node: TypeSyntax?) -> BridgedNullableTypeRepr {
+    self.map(node, generate(type:))
+  }
+
+  @inline(__always)
+  func generate(expr node: ExprSyntax?) -> BridgedNullableExpr {
+    self.map(node, generate(expr:))
+  }
+
+  @inline(__always)
+  func generate(genericParameterClause node: GenericParameterClauseSyntax?) -> BridgedNullableGenericParamList {
+    self.map(node, generate(genericParameterClause:))
+  }
+
+  @inline(__always)
+  func generate(genericWhereClause node: GenericWhereClauseSyntax?) -> BridgedNullableTrailingWhereClause {
+    self.map(node, generate(genericWhereClause:))
+  }
+
+  @inline(__always)
+  func generate(enumCaseParameterClause node: EnumCaseParameterClauseSyntax?) -> BridgedNullableParameterList {
+    self.map(node, generate(enumCaseParameterClause:))
+  }
+
+  @inline(__always)
+  func generate(inheritedTypeList node: InheritedTypeListSyntax?) -> BridgedArrayRef {
+    self.map(node, generate(inheritedTypeList:))
+  }
+
+  @inline(__always)
+  func generate(precedenceGroupNameList node: PrecedenceGroupNameListSyntax?) -> BridgedArrayRef {
+    self.map(node, generate(precedenceGroupNameList:))
+  }
+
+  // Helper function for `generate(foo: FooSyntax?)` methods.
+  @inline(__always)
+  private func map<Node: SyntaxProtocol, Result: HasNullable>(
     _ node: Node?,
     _ body: (Node) -> Result
   ) -> Result.Nullable {
     return Result.asNullable(node.map(body))
   }
 
-  /// Generate an AST node array from an optional collection node using the
-  /// generator function. If `nil`, returns an empty array.
-  ///
-  /// Usage:
-  ///   self.map(node.genericWhereClasuse, generate(genericWhereClause:))
+  // Helper function for `generate(barList: BarListSyntax?)` methods for collection nodes.
   @inline(__always)
-  func map<Node: SyntaxCollection>(
+  private func map<Node: SyntaxCollection>(
     _ node: Node?,
     _ body: (Node) -> BridgedArrayRef
   ) -> BridgedArrayRef {

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -26,39 +26,56 @@ extension BridgedIdentifier: ExpressibleByNilLiteral {
   }
 }
 
-extension BridgedStmt? {
-  var asNullable: BridgedNullableStmt {
-    .init(raw: self?.raw)
+/// Protocol that declares that there's a "Nullable" variation of the type.
+///
+/// E.g. BridgedExpr vs BridgedNullableExpr.
+protocol HasNullable {
+  associatedtype Nullable
+
+  /// Convert an `Optional<Self>` to `Nullable`.
+  static func asNullable(_ node: Self?) -> Nullable
+}
+
+extension Optional where Wrapped: HasNullable {
+  /// Convert an Optional to Nullable variation of the wrapped type.
+  var asNullable: Wrapped.Nullable {
+    Wrapped.asNullable(self)
   }
 }
 
-extension BridgedExpr? {
-  var asNullable: BridgedNullableExpr {
-    .init(raw: self?.raw)
+extension BridgedStmt: HasNullable {
+  static func asNullable(_ node: Self?) -> BridgedNullableStmt {
+    .init(raw: node?.raw)
   }
 }
 
-extension BridgedTypeRepr? {
-  var asNullable: BridgedNullableTypeRepr {
-    .init(raw: self?.raw)
+extension BridgedExpr: HasNullable {
+  static func asNullable(_ node: Self?) -> BridgedNullableExpr {
+    .init(raw: node?.raw)
   }
 }
 
-extension BridgedGenericParamList? {
-  var asNullable: BridgedNullableGenericParamList {
-    .init(raw: self?.raw)
+extension BridgedTypeRepr: HasNullable {
+  static func asNullable(_ node: Self?) -> BridgedNullableTypeRepr {
+    .init(raw: node?.raw)
   }
 }
 
-extension BridgedTrailingWhereClause? {
-  var asNullable: BridgedNullableTrailingWhereClause {
-    .init(raw: self?.raw)
+extension BridgedGenericParamList: HasNullable {
+  static func asNullable(_ node: Self?) -> BridgedNullableGenericParamList {
+    .init(raw: node?.raw)
   }
 }
 
-extension BridgedParameterList? {
-  var asNullable: BridgedNullableParameterList {
-    .init(raw: self?.raw)
+extension BridgedTrailingWhereClause: HasNullable {
+  static func asNullable(_ node: Self?) -> BridgedNullableTrailingWhereClause {
+    .init(raw: node?.raw)
+  }
+}
+
+extension BridgedParameterList: HasNullable {
+  static func asNullable(_ node: Self?) -> BridgedNullableParameterList {
+    .init(raw: node?.raw)
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -81,10 +81,10 @@ extension ASTGenVisitor {
       typealiasKeywordLoc: node.typealiasKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
       equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
       underlyingType: self.generate(type: node.initializer.value),
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:))
     )
   }
 
@@ -97,9 +97,9 @@ extension ASTGenVisitor {
       enumKeywordLoc: node.enumKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
-      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
+      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
+      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -123,9 +123,9 @@ extension ASTGenVisitor {
       structKeywordLoc: node.structKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
-      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
+      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
+      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -149,9 +149,9 @@ extension ASTGenVisitor {
       classKeywordLoc: node.classKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
-      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
+      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
+      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -176,9 +176,9 @@ extension ASTGenVisitor {
       classKeywordLoc: node.actorKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
-      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
+      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
+      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -207,8 +207,8 @@ extension ASTGenVisitor {
       name: name,
       nameLoc: nameLoc,
       primaryAssociatedTypeNames: primaryAssociatedTypeNames.bridgedArray(in: self),
-      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
+      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -232,9 +232,9 @@ extension ASTGenVisitor {
       associatedtypeKeywordLoc: node.associatedtypeKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
-      defaultType: self.generate(optional: node.initializer?.value).asNullable,
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable
+      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
+      defaultType: self.map(node.initializer?.value, generate(type:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:))
     )
   }
 }
@@ -248,8 +248,8 @@ extension ASTGenVisitor {
       declContext: self.declContext,
       extensionKeywordLoc: node.extensionKeyword.bridgedSourceLoc(in: self),
       extendedType: self.generate(type: node.extendedType),
-      inheritedTypes: self.generate(optional: node.inheritanceClause?.inheritedTypes),
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
+      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -276,9 +276,9 @@ extension ASTGenVisitor {
       declContext: self.declContext,
       name: name,
       nameLoc: nameLoc,
-      parameterList: self.generate(optional: node.parameterClause).asNullable,
+      parameterList: self.map(node.parameterClause, generate(enumCaseParameterClause:)),
       equalsLoc: (node.rawValue?.equal).bridgedSourceLoc(in: self),
-      rawValue: self.generate(optional: node.rawValue?.value).asNullable
+      rawValue: self.map(node.rawValue?.value, generate(expr:))
     )
   }
 
@@ -329,13 +329,13 @@ extension ASTGenVisitor {
       funcKeywordLoc: node.funcKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
       parameterList: self.generate(functionParameterClause: node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(optional: node.signature.effectSpecifiers?.thrownError?.type).asNullable,
-      returnType: self.generate(optional: node.signature.returnClause?.type).asNullable,
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable
+      thrownType: self.map(node.signature.effectSpecifiers?.thrownError?.type, generate(type:)),
+      returnType: self.map(node.signature.returnClause?.type, generate(type:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:))
     )
 
     if let body = node.body {
@@ -354,12 +354,12 @@ extension ASTGenVisitor {
       initKeywordLoc: node.initKeyword.bridgedSourceLoc(in: self),
       failabilityMarkLoc: node.optionalMark.bridgedSourceLoc(in: self),
       isIUO: node.optionalMark?.tokenKind == .exclamationMark,
-      genericParamList: self.generate(optional: node.genericParameterClause).asNullable,
+      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
       parameterList: self.generate(functionParameterClause: node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(optional: node.signature.effectSpecifiers?.thrownError?.type).asNullable,
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable
+      thrownType: self.map(node.signature.effectSpecifiers?.thrownError?.type, generate(type:)),
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:))
     )
 
     if let body = node.body {
@@ -533,9 +533,9 @@ extension ASTGenVisitor {
       assignmentValueLoc: (body.assignment?.value).bridgedSourceLoc(in: self),
       isAssignment: assignmentValue,
       higherThanKeywordLoc: (body.higherThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-      higherThanNames: self.generate(optional: body.higherThanRelation?.precedenceGroups),
+      higherThanNames: self.map(body.higherThanRelation?.precedenceGroups, generate(precedenceGroupNameList:)),
       lowerThanKeywordLoc: (body.lowerThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-      lowerThanNames: self.generate(optional: body.lowerThanRelation?.precedenceGroups),
+      lowerThanNames: self.map(body.lowerThanRelation?.precedenceGroups, generate(precedenceGroupNameList:)),
       rightBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
     )
   }

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -81,10 +81,10 @@ extension ASTGenVisitor {
       typealiasKeywordLoc: node.typealiasKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
+      genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
       underlyingType: self.generate(type: node.initializer.value),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:))
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause)
     )
   }
 
@@ -97,9 +97,9 @@ extension ASTGenVisitor {
       enumKeywordLoc: node.enumKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
-      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
+      genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
+      inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -123,9 +123,9 @@ extension ASTGenVisitor {
       structKeywordLoc: node.structKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
-      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
+      genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
+      inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -149,9 +149,9 @@ extension ASTGenVisitor {
       classKeywordLoc: node.classKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
-      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
+      genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
+      inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -176,9 +176,9 @@ extension ASTGenVisitor {
       classKeywordLoc: node.actorKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
-      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
+      genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
+      inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -207,8 +207,8 @@ extension ASTGenVisitor {
       name: name,
       nameLoc: nameLoc,
       primaryAssociatedTypeNames: primaryAssociatedTypeNames.bridgedArray(in: self),
-      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
+      inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -232,9 +232,9 @@ extension ASTGenVisitor {
       associatedtypeKeywordLoc: node.associatedtypeKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
-      defaultType: self.map(node.initializer?.value, generate(type:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:))
+      inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
+      defaultType: self.generate(type: node.initializer?.value),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause)
     )
   }
 }
@@ -248,8 +248,8 @@ extension ASTGenVisitor {
       declContext: self.declContext,
       extensionKeywordLoc: node.extensionKeyword.bridgedSourceLoc(in: self),
       extendedType: self.generate(type: node.extendedType),
-      inheritedTypes: self.map(node.inheritanceClause?.inheritedTypes, generate(inheritedTypeList:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
+      inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       braceRange: BridgedSourceRange(
         startToken: node.memberBlock.leftBrace,
         endToken: node.memberBlock.rightBrace,
@@ -276,9 +276,9 @@ extension ASTGenVisitor {
       declContext: self.declContext,
       name: name,
       nameLoc: nameLoc,
-      parameterList: self.map(node.parameterClause, generate(enumCaseParameterClause:)),
+      parameterList: self.generate(enumCaseParameterClause: node.parameterClause),
       equalsLoc: (node.rawValue?.equal).bridgedSourceLoc(in: self),
-      rawValue: self.map(node.rawValue?.value, generate(expr:))
+      rawValue: self.generate(expr: node.rawValue?.value)
     )
   }
 
@@ -329,13 +329,13 @@ extension ASTGenVisitor {
       funcKeywordLoc: node.funcKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
+      genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       parameterList: self.generate(functionParameterClause: node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.map(node.signature.effectSpecifiers?.thrownError?.type, generate(type:)),
-      returnType: self.map(node.signature.returnClause?.type, generate(type:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:))
+      thrownType: self.generate(type: node.signature.effectSpecifiers?.thrownError?.type),
+      returnType: self.generate(type: node.signature.returnClause?.type),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause)
     )
 
     if let body = node.body {
@@ -354,12 +354,12 @@ extension ASTGenVisitor {
       initKeywordLoc: node.initKeyword.bridgedSourceLoc(in: self),
       failabilityMarkLoc: node.optionalMark.bridgedSourceLoc(in: self),
       isIUO: node.optionalMark?.tokenKind == .exclamationMark,
-      genericParamList: self.map(node.genericParameterClause, generate(genericParameterClause:)),
+      genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       parameterList: self.generate(functionParameterClause: node.signature.parameterClause),
       asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.map(node.signature.effectSpecifiers?.thrownError?.type, generate(type:)),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:))
+      thrownType: self.generate(type: node.signature.effectSpecifiers?.thrownError?.type),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause)
     )
 
     if let body = node.body {
@@ -533,9 +533,9 @@ extension ASTGenVisitor {
       assignmentValueLoc: (body.assignment?.value).bridgedSourceLoc(in: self),
       isAssignment: assignmentValue,
       higherThanKeywordLoc: (body.higherThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-      higherThanNames: self.map(body.higherThanRelation?.precedenceGroups, generate(precedenceGroupNameList:)),
+      higherThanNames: self.generate(precedenceGroupNameList: body.higherThanRelation?.precedenceGroups),
       lowerThanKeywordLoc: (body.lowerThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
-      lowerThanNames: self.map(body.lowerThanRelation?.precedenceGroups, generate(precedenceGroupNameList:)),
+      lowerThanNames: self.generate(precedenceGroupNameList: body.lowerThanRelation?.precedenceGroups),
       rightBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
     )
   }

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -19,7 +19,7 @@ extension ASTGenVisitor {
       self.ctx,
       leftAngleLoc: node.leftAngle.bridgedSourceLoc(in: self),
       parameters: node.parameters.lazy.map(self.generate).bridgedArray(in: self),
-      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
+      genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
       rightAngleLoc: node.rightAngle.bridgedSourceLoc(in: self)
     )
   }
@@ -44,7 +44,7 @@ extension ASTGenVisitor {
       eachKeywordLoc: node.eachKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      inheritedType: self.map(node.inheritedType, generate(type:)),
+      inheritedType: self.generate(type: node.inheritedType),
       index: genericParameterIndex
     )
   }

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -19,7 +19,7 @@ extension ASTGenVisitor {
       self.ctx,
       leftAngleLoc: node.leftAngle.bridgedSourceLoc(in: self),
       parameters: node.parameters.lazy.map(self.generate).bridgedArray(in: self),
-      genericWhereClause: self.generate(optional: node.genericWhereClause).asNullable,
+      genericWhereClause: self.map(node.genericWhereClause, generate(genericWhereClause:)),
       rightAngleLoc: node.rightAngle.bridgedSourceLoc(in: self)
     )
   }
@@ -44,7 +44,7 @@ extension ASTGenVisitor {
       eachKeywordLoc: node.eachKeyword.bridgedSourceLoc(in: self),
       name: name,
       nameLoc: nameLoc,
-      inheritedType: self.generate(optional: node.inheritedType).asNullable,
+      inheritedType: self.map(node.inheritedType, generate(type:)),
       index: genericParameterIndex
     )
   }

--- a/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
+++ b/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
@@ -101,7 +101,7 @@ extension ASTGenVisitor {
       secondName: secondName,
       secondNameLoc: secondNameLoc,
       type: type.asNullable,
-      defaultValue: self.map(node.defaultValue?.value, generate(expr:))
+      defaultValue: self.generate(expr: node.defaultValue?.value)
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
+++ b/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
@@ -83,7 +83,7 @@ extension ASTGenVisitor {
 
     let (secondName, secondNameLoc) = node.secondName.bridgedIdentifierAndSourceLoc(in: self)
 
-    var type = self.generate(optional: node.optionalType)
+    var type = node.optionalType.map(generate(type:))
     if let ellipsis = node.ellipsis, let base = type {
       type = BridgedVarargTypeRepr.createParsed(
         self.ctx,
@@ -101,7 +101,7 @@ extension ASTGenVisitor {
       secondName: secondName,
       secondNameLoc: secondNameLoc,
       type: type.asNullable,
-      defaultValue: self.generate(optional: node.defaultValue?.value).asNullable
+      defaultValue: self.map(node.defaultValue?.value, generate(expr:))
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -75,14 +75,14 @@ extension ASTGenVisitor {
       condition: conditions.first!.castToExpr,
       thenStmt: self.generate(codeBlock: node.body).asStmt,
       elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
-      elseStmt: self.generate(optional: node.elseBody) {
+      elseStmt: self.map(node.elseBody) {
         switch $0 {
         case .codeBlock(let node):
           return self.generate(codeBlock: node).asStmt
         case .ifExpr(let node):
           return self.makeIfStmt(node).asStmt
         }
-      }.asNullable
+      }
     )
   }
 
@@ -99,7 +99,7 @@ extension ASTGenVisitor {
     .createParsed(
       self.ctx,
       returnKeywordLoc: node.returnKeyword.bridgedSourceLoc(in: self),
-      expr: self.generate(optional: node.expression).asNullable
+      expr: self.map(node.expression, generate(expr:))
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -75,7 +75,14 @@ extension ASTGenVisitor {
       condition: conditions.first!.castToExpr,
       thenStmt: self.generate(codeBlock: node.body).asStmt,
       elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
-      elseStmt: (self.generate(optional: node.elseBody)?.castToStmt).asNullable
+      elseStmt: self.generate(optional: node.elseBody) {
+        switch $0 {
+        case .codeBlock(let node):
+          return self.generate(codeBlock: node).asStmt
+        case .ifExpr(let node):
+          return self.makeIfStmt(node).asStmt
+        }
+      }.asNullable
     )
   }
 

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -75,14 +75,14 @@ extension ASTGenVisitor {
       condition: conditions.first!.castToExpr,
       thenStmt: self.generate(codeBlock: node.body).asStmt,
       elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
-      elseStmt: self.map(node.elseBody) {
+      elseStmt: node.elseBody.map {
         switch $0 {
         case .codeBlock(let node):
           return self.generate(codeBlock: node).asStmt
         case .ifExpr(let node):
           return self.makeIfStmt(node).asStmt
         }
-      }
+      }.asNullable
     )
   }
 
@@ -99,7 +99,7 @@ extension ASTGenVisitor {
     .createParsed(
       self.ctx,
       returnKeywordLoc: node.returnKeyword.bridgedSourceLoc(in: self),
-      expr: self.map(node.expression, generate(expr:))
+      expr: self.generate(expr: node.expression)
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -66,7 +66,7 @@ extension ASTGenVisitor {
   func makeIfStmt(_ node: IfExprSyntax) -> BridgedIfStmt {
     // FIXME: handle multiple coniditons.
     // FIXME: handle non-expression conditions.
-    let conditions = node.conditions.map(self.generate)
+    let conditions = node.conditions.map(self.generate(conditionElement:))
     assert(conditions.count == 1)
 
     return .createParsed(

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -278,7 +278,7 @@ extension ASTGenVisitor {
       ),
       asyncLoc: (node.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsLoc: (node.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.generate(optional: node.effectSpecifiers?.thrownError?.type).asNullable,
+      thrownType: self.map(node.effectSpecifiers?.thrownError?.type, generate(type:)),
       arrowLoc: node.returnClause.arrow.bridgedSourceLoc(in: self),
       resultType: generate(type: node.returnClause.type)
     )

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -278,7 +278,7 @@ extension ASTGenVisitor {
       ),
       asyncLoc: (node.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
       throwsLoc: (node.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
-      thrownType: self.map(node.effectSpecifiers?.thrownError?.type, generate(type:)),
+      thrownType: self.generate(type: node.effectSpecifiers?.thrownError?.type),
       arrowLoc: node.returnClause.arrow.bridgedSourceLoc(in: self),
       resultType: generate(type: node.returnClause.type)
     )

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -76,8 +76,8 @@ func test5(_ b: Swift.Bool) -> Int {
   return if b { 0 } else { 1 }
 }
 
-func test6(_ b: Bool) -> Int {
-  let x = if b { 0 } else { 1 }
+func test6(_ b1: Bool, b2: Bool) -> Int {
+  let x = if b1 { 0 } else if b2 { 1 } else { 2 }
   return x
 }
 


### PR DESCRIPTION
* Remove `generate(choices:)` because it was expecting all the choices can generate `ASTNode` which is not the case.
* Remove `generate(_:) -> ASTNode` because, again, not all syntax kind can generate `ASTNode`
* Only `generate(codeBlockItem:)` now returns `ASTNode` and `ASTNode` is now `.decl`, `.stmt`, or `.expr` only. That resembles C++ `swift::ASTNode`.
* Generalize optional node handling.
  * Bridged types that has `Nullable` variation can now have `HasNullable` conformance, that teaches how to convert `Optional<BridgedT>` to `BridgedNullableT`
  * `ASTGenVisitor.map(_: T?, _: (T) -> BridgedU) -> BridgedNullableU` for optional node handling.
  * `ASTGenVisitor.map(_: TCollection?, _: (TCollection) -> BridgedArrayRef) -> BridgedArrayRef)` for optional collection node handling
