### PR TITLE
SILGen: Mark constant captures for no_consume_or_assign checking instead of may_assign_but_not_consume.

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -771,7 +771,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
           val = B.createMarkUnresolvedNonCopyableValueInst(
               loc, val,
               MarkUnresolvedNonCopyableValueInst::CheckKind::
-                  AssignableButNotConsumable);
+                  NoConsumeOrAssign);
         }
         val = emitLoad(loc, val, tl, SGFContext(), IsNotTake).forward(*this);
       }

--- a/test/Interpreter/Inputs/moveonly_resilient_type.swift
+++ b/test/Interpreter/Inputs/moveonly_resilient_type.swift
@@ -27,3 +27,36 @@ public struct Resilient: ~Copyable {
         return nextValue
     }
 }
+
+func testCapture(_: () -> Bool) {}
+
+public struct ResilientCapturesInDeinit: ~Copyable {
+    static var nextValue: Int = 0
+
+    private(set) public var value: Int
+    public init(nonthrowing: ()) {
+        value = Self.nextValue
+        Self.nextValue += 1
+    }
+    deinit {
+        testCapture { value >= 0 }
+        print("resilient capture in deinit \(value)")
+    }
+    
+    public init(throwing: Bool) throws {
+        if throwing {
+            throw MyError()
+        }
+        self = .init(nonthrowing: ())
+    }
+    public init(throwingAfterInit: Bool) throws {
+        self = .init(nonthrowing: ())
+        if throwingAfterInit {
+            throw MyError()
+        }
+    }
+
+    public static func instanceCount() -> Int {
+        return nextValue
+    }
+}

--- a/test/Interpreter/moveonly_resilient_capture_during_deinit.swift
+++ b/test/Interpreter/moveonly_resilient_capture_during_deinit.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -o %t/a.out -I %t %s %t/moveonly_resilient_type.o
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+import moveonly_resilient_type
+
+// CHECK: start
+
+func test1a() throws {
+    // CHECK-NEXT: resilient capture in deinit 0
+    _ = ResilientCapturesInDeinit(nonthrowing: ())
+}
+func test1b() throws {
+    // CHECK-NEXT: resilient capture in deinit 1
+    let x = ResilientCapturesInDeinit(nonthrowing: ())
+}
+func test2a() throws {
+    // CHECK-NEXT: resilient capture in deinit 2
+    _ = try ResilientCapturesInDeinit(throwing: false)
+}
+func test2b() throws {
+    // CHECK-NEXT: resilient capture in deinit 3
+    let x = try ResilientCapturesInDeinit(throwing: false)
+}
+func test3a() throws {
+    _ = try ResilientCapturesInDeinit(throwing: true)
+}
+func test3b() throws {
+    let x = try ResilientCapturesInDeinit(throwing: true)
+}
+func test4a() throws {
+    // CHECK-NEXT: resilient capture in deinit 4
+    _ = try ResilientCapturesInDeinit(throwingAfterInit: false)
+}
+func test4b() throws {
+    // CHECK-NEXT: resilient capture in deinit 5
+    let x = try ResilientCapturesInDeinit(throwingAfterInit: false)
+}
+func test5a() throws {
+    // CHECK-NEXT: resilient capture in deinit 6
+    _ = try ResilientCapturesInDeinit(throwingAfterInit: true)
+}
+func test5b() throws {
+    // CHECK-NEXT: resilient capture in deinit 7
+    let x = try ResilientCapturesInDeinit(throwingAfterInit: true)
+}
+
+func main() {
+    print("start")
+
+    _ = try? test1a()
+    _ = try? test1b()
+    _ = try? test2a()
+    _ = try? test2b()
+    _ = try? test3a()
+    _ = try? test3b()
+    _ = try? test4a()
+    _ = try? test4b()
+    _ = try? test5a()
+    _ = try? test5b()
+
+    // CHECK-NEXT: total 8
+    print("total \(ResilientCapturesInDeinit.instanceCount())")
+}
+main()

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -913,7 +913,7 @@ func testGlobalAssign() {
 // CHECK:   store [[ARG]] to [init] [[PROJECT]]
 //
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly49checkMarkUnresolvedNonCopyableValueInstOnCaptured1xyAA2FDVn_tFyyXEfU_ : $@convention(thin) @substituted <τ_0_0> (@guaranteed FD) -> @out τ_0_0 for <()>
-// CHECK:   [[MARK:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[PROJECT]]
+// CHECK:   [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT]]
 // CHECK:   [[VALUE:%.*]] = load [copy] [[MARK]]
 // CHECK:   [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]([[VALUE]])
 // CHECK: } // end sil function '$s8moveonly49checkMarkUnresolvedNonCopyableValueInstOnCaptured1xyAA2FDVn_tF'


### PR DESCRIPTION
An immutable noncopyable capture borrows the captured value in-place and can't do anything to modify it, and the may_assign_but_not_consume checking behaves badly with some code patterns generated for resilient types when `self` is captured during a deinit. This change allows for more accurate checking and fixes rdar://118427997.