### PR TITLE
[Distributed] Remove redundant isa check in getting SR

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -110,7 +110,7 @@ Type swift::getSerializationRequirementTypesForMember(
   auto SerReqAssocType = DA->getAssociatedType(C.Id_SerializationRequirement)
       ->getDeclaredInterfaceType();
 
-  if (DC->getSelfProtocolDecl() || isa<ExtensionDecl>(DC)) {
+  if (DC->getSelfProtocolDecl()) {
     GenericSignature signature;
     if (auto *genericContext = member->getAsGenericContext()) {
       signature = genericContext->getGenericSignature();

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -88,6 +88,13 @@ extension NoSerializationRequirementYet
   }
 }
 
+extension ProtocolWithChecksSeqReqDA {
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test4' does not conform to serialization requirement 'Codable'}}
+  distributed func test4() -> NotCodable {
+    .init()
+  }
+}
+
 // FIXME(distributed): remove the -verify-ignore-unknown
 // <unknown>:0: error: unexpected error produced: instance method 'recordReturnType' requires that 'NotCodable' conform to 'Decodable'
 // <unknown>:0: error: unexpected error produced: instance method 'recordReturnType' requires that 'NotCodable' conform to 'Encodable'


### PR DESCRIPTION
Minor follow up -- the isa<ExtensionDecl> check is redundant here.