### PR TITLE
[SILGen] handle TypeExpr in BorrowedBaseVisitor

### DIFF
--- a/test/Interpreter/moveonly.swift
+++ b/test/Interpreter/moveonly.swift
@@ -133,3 +133,29 @@ Tests.test("AddressOnly") {
     }
 }
 
+// coverage for rdar://117082469
+Tests.test("global borrowing access") {
+  class Retainable { var data = 0 }
+
+  struct HasStatic : ~Copyable {
+    var x = 1
+    var y = Retainable()
+
+    static let a = HasStatic()
+    static var b = HasStatic()
+  }
+
+  // test the let 'a'
+  expectEqual(HasStatic.a.x, 1)
+  expectEqual(HasStatic.a.y.data, 0)
+
+  // test the var 'b'
+  expectEqual(HasStatic.b.x, 1)
+  HasStatic.b.x += 10
+  expectEqual(HasStatic.b.x, 11)
+
+  expectEqual(HasStatic.b.y.data, 0)
+  HasStatic.b.y.data += 121
+  expectEqual(HasStatic.b.y.data, 121)
+}
+

--- a/test/SILGen/moveonly_basics.swift
+++ b/test/SILGen/moveonly_basics.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-emit-silgen -module-name test %s | %FileCheck %s --enable-var-scope
+
+class Retainable {}
+
+struct HasStatic : ~Copyable {
+  var x = 1
+  var y = Retainable()
+  static let b = HasStatic()
+}
+
+// coverage for rdar://117082469
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A11HasStatic_1yyF : $@convention(thin) () -> () {
+// CHECK:         [[ADDRESSOR:%.*]] = function_ref @$s4test9HasStaticV1bACvau : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:         [[PTR:%.*]] = apply [[ADDRESSOR]]() : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:         [[ADDR:%.*]] = pointer_to_address [[PTR]] : $Builtin.RawPointer to [strict] $*HasStatic
+// CHECK:         [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ADDR]] : $*HasStatic
+// CHECK:         [[X_ADDR:%.*]] = struct_element_addr [[MARK]] : $*HasStatic, #HasStatic.x
+// CHECK:         = load [trivial] [[X_ADDR]] : $*Int
+func testHasStatic_1() {
+  _ = HasStatic.b.x
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A11HasStatic_2yyF : $@convention(thin) () -> () {
+// CHECK:         [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] {{%.*}} : $*HasStatic
+// CHECK:         [[Y_ADDR:%.*]] = struct_element_addr [[MARK]] : $*HasStatic, #HasStatic.y
+// CHECK:         = load [copy] [[Y_ADDR]] : $*Retainable
+func testHasStatic_2() {
+  _ = HasStatic.b.y
+}


### PR DESCRIPTION
A TypeExpr and other kinds of non-lvalue bases that the borrowed-base visitor doesn't care about can be handled by calling back into the original SILGenLValue instance.

resolves rdar://117082469