### PR TITLE
[android] Update to LTS NDK 26c

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -36,8 +36,8 @@ To follow along with this guide, you'll need:
    instructions in the Swift project README.
 2. The latest build of the Swift compiler for your Linux distro, available at
    https://www.swift.org/download/ or sometimes your distro package manager.
-3. The last version of the Android LTS NDK (r25c, the latest LTS NDK 26 at the
-   time of this writing doesn't work yet), available to download here:
+3. The latest version of the Android LTS NDK (r26c at the time of this writing),
+   available to download here:
    https://developer.android.com/ndk/downloads
 4. An Android device with remote debugging enabled or the emulator. We require
    remote debugging in order to deploy built stdlib products to the device. You
@@ -54,7 +54,7 @@ and the prebuilt Swift toolchain (add --skip-early-swift-driver if you already
 have a Swift toolchain in your path):
 
 ```
-$ NDK_PATH=path/to/android-ndk-r25c
+$ NDK_PATH=path/to/android-ndk-r26c
 $ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a-ubuntu20.04/usr/bin
 $ git checkout swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a
 $ utils/build-script \
@@ -83,7 +83,7 @@ Then use the standalone Swift stdlib from the previous step to compile a Swift
 source file, targeting Android:
 
 ```
-$ NDK_PATH="path/to/android-ndk-r25c"
+$ NDK_PATH="path/to/android-ndk-r26c"
 $ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2023-09-30-a-ubuntu20.04/usr/bin
 $ $SWIFT_PATH/swiftc \                                               # The prebuilt Swift compiler you downloaded
                                                                      # The location of the tools used to build Android binaries
@@ -133,7 +133,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libBlo
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r26c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the
@@ -176,7 +176,7 @@ $ utils/build-script \
   -R \                               # Build in ReleaseAssert mode.
   -T \                               # Run all tests, including on the Android device (add --host-test to only run Android tests on the Linux host).
   --android \                        # Build for Android.
-  --android-ndk ~/android-ndk-r25c \  # Path to an Android NDK.
+  --android-ndk ~/android-ndk-r26c \  # Path to an Android NDK.
   --android-arch aarch64 \           # Optionally specify Android architecture, alternately armv7
   --android-api-level 21
 ```

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -530,7 +530,11 @@ function(_add_target_variant_link_flags)
     # We need to add the math library, which is linked implicitly by libc++
     list(APPEND result "-lm")
     if(NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
-      file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib64/clang/*)
+      if("${SWIFT_ANDROID_NDK_PATH}" MATCHES "r26")
+        file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib/clang/*)
+      else()
+        file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib64/clang/*)
+      endif()
       list(APPEND result "-resource-dir=${RESOURCE_DIR}")
     endif()
 

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -132,7 +132,7 @@ public func _stdlib_pipe() -> (readEnd: CInt, writeEnd: CInt, error: CInt) {
 #elseif os(WASI)
     preconditionFailure("No pipes available on WebAssembly/WASI")
 #else
-    return pipe(unsafeFds.baseAddress)
+    return pipe(unsafeFds.baseAddress!)
 #endif
   }
   return (readEnd: fds[0], writeEnd: fds[1], error: ret)

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -318,7 +318,7 @@ internal func sendBytes() {
   var totalBytesWritten = 0
   var pointer = UnsafeMutableRawPointer(bitPattern: address)
   while totalBytesWritten < count {
-    let bytesWritten = Int(fwrite(pointer, 1, Int(count), stdout))
+    let bytesWritten = Int(fwrite(pointer!, 1, Int(count), stdout))
     fflush(stdout)
     if bytesWritten == 0 {
       printErrnoAndExit()


### PR DESCRIPTION
NDK 26 renamed the directory in which it places the Android compiler-rt from `lib64/`, and added a bunch of nullability annotations to the Bionic libc.

@drodriguez, please review. You'll need to update the NDK on the community CI and this will likely break some tests in the compiler validation suite, which I haven't tried with NDK 26b yet. I will submit a separate pull to fix any tests once this is in.