### PR TITLE
[Backtracing][Android] Fix armv7 build

### DIFF
--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -243,7 +243,11 @@ handle_fatal_signal(int signum,
 #elif defined(__arm64__) || defined(__aarch64__)
   pc = (void *)(ctx->uc_mcontext.pc);
 #elif defined(__arm__)
+#if defined(__ANDROID__)
+  pc = (void *)(ctx->uc_mcontext.arm_pc);
+#else
   pc = (void *)(ctx->uc_mcontext.gprs[15]);
+#endif
 #endif
 
   _swift_displayCrashMessage(signum, pc);


### PR DESCRIPTION
@al45tair, this [broke the Android armv7 CI](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/5899/console) in #69697, because [Android names this differently](https://android.googlesource.com/platform/bionic/+/180edefbd287c39caeb9d48784a9a10ac35f3636/libc/kernel/uapi/asm-arm/asm/sigcontext.h#28):
```
/home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android/swift/stdlib/public/runtime/CrashHandlerLinux.cpp:246:34: error: no member named 'gprs' in 'sigcontext'
  246 |   pc = (void *)(ctx->uc_mcontext.gprs[15]);
      |                 ~~~~~~~~~~~~~~~~ ^
```
I used [this patch to fix it on my daily Android CI](https://github.com/finagolfin/swift-android-sdk/pull/126/files#diff-b7b92d458c8b4b0b16b26556a6e5db085369bb9e658f791038d0ccb37b1ec0d1).