### PR TITLE
swift-inspect: clean up event creation on Windows

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/WinSDK+Extentions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WinSDK+Extentions.swift
@@ -14,8 +14,21 @@
 
 import WinSDK
 
-internal let FILE_MAP_ALL_ACCESS = DWORD(
-  STANDARD_RIGHTS_REQUIRED | SECTION_QUERY | SECTION_MAP_WRITE | SECTION_MAP_READ
-    | SECTION_MAP_EXECUTE | SECTION_EXTEND_SIZE)
+internal var FILE_MAP_ALL_ACCESS: DWORD {
+  DWORD(STANDARD_RIGHTS_REQUIRED | SECTION_QUERY |
+        SECTION_MAP_WRITE | SECTION_MAP_READ | SECTION_MAP_EXECUTE |
+        SECTION_EXTEND_SIZE)
+}
+
+internal func CreateEvent(_ name: String, bManualReset: Bool = false,
+                          bInitialState: Bool = false) -> HANDLE? {
+  let hEvent: HANDLE = CreateEventA(LPSECURITY_ATTRIBUTES(bitPattern: 0),
+                                    bManualReset, bInitialState, name)
+  if hEvent == HANDLE(bitPattern: 0) {
+    print("CreateEvent failed \(GetLastError())")
+    return nil
+  }
+  return hEvent
+}
 
 #endif

--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -529,30 +529,12 @@ internal final class WindowsRemoteProcess: RemoteProcess {
   }
 
   private func createEventPair(_ dwProcessId: DWORD) -> (HANDLE, HANDLE)? {
-    let readEventName = READ_EVENT_NAME_PREFIX + "-" + String(dwProcessId)
-    let writeEventName = WRITE_EVENT_NAME_PREFIX + "-" + String(dwProcessId)
-    let hReadEvent: HANDLE = CreateEventA(
-      LPSECURITY_ATTRIBUTES(bitPattern: 0),
-      false,  // Auto-reset
-      false,  // Initial state is nonsignaled
-      readEventName)
-    if hReadEvent == HANDLE(bitPattern: 0) {
-      print("CreateEvent failed \(GetLastError())")
-      return nil
-    }
-    let hWriteEvent: HANDLE = CreateEventA(
-      LPSECURITY_ATTRIBUTES(bitPattern: 0),
-      false,  // Auto-reset
-      false,  // Initial state is nonsignaled
-      writeEventName)
-    if hWriteEvent == HANDLE(bitPattern: 0) {
-      print("CreateEvent failed \(GetLastError())")
-      CloseHandle(hReadEvent)
-      return nil
-    }
+    let hReadEvent = CreateEvent("\(READ_EVENT_NAME_PREFIX)-\(dwProcessId)")
+    guard let hReadEvent else { return nil }
+    let hWriteEvent = CreateEvent("\(WRITE_EVENT_NAME_PREFIX)-\(dwProcessId)")
+    guard let hWriteEvent else { CloseHandle(hReadEvent);  return nil }
     return (hReadEvent, hWriteEvent)
   }
-
 }
 
 #endif


### PR DESCRIPTION
Create a Swiftier interface for `CreateEvent` from the Windows SDK and use that to simplify the implementation of the remote process interface.