### PR TITLE
[swift-inspect] Add JSON output option for dump-generic-metadata

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -20,6 +20,8 @@ internal final class DarwinRemoteProcess: RemoteProcess {
   public typealias ProcessHandle = task_t
 
   private var task: task_t
+  internal var processIdentifier: ProcessIdentifier
+  internal lazy var processName = getProcessName(processId: processIdentifier) ?? "<unknown process>"
 
   public var process: ProcessHandle { task }
   public private(set) var context: SwiftReflectionContextRef!
@@ -114,20 +116,32 @@ internal final class DarwinRemoteProcess: RemoteProcess {
   }
 
   init?(processId: ProcessIdentifier, forkCorpse: Bool) {
+    processIdentifier = processId
     var task: task_t = task_t()
     let taskResult = task_for_pid(mach_task_self_, processId, &task)
     guard taskResult == KERN_SUCCESS else {
-      print("unable to get task for pid \(processId): \(String(cString: mach_error_string(taskResult))) \(hex: taskResult)")
+      print("unable to get task for pid \(processId): \(String(cString: mach_error_string(taskResult))) \(hex: taskResult)",
+        to: &Std.err)
       return nil
     }
 
     if forkCorpse {
       var corpse = task_t()
-      let corpseResult = task_generate_corpse(task, &corpse)
-      if corpseResult == KERN_SUCCESS {
-        task = corpse
-      } else {
-        print("unable to fork corpse for pid \(processId): \(String(cString: mach_error_string(corpseResult))) \(hex: corpseResult)")
+      let maxRetry = 6
+      for retry in 0..<maxRetry {
+        let corpseResult = task_generate_corpse(task, &corpse)
+        if corpseResult == KERN_SUCCESS {
+          task_stop_peeking(task)
+          mach_port_deallocate(mach_task_self_, task)
+          task = corpse
+          break
+        }
+        if corpseResult != KERN_RESOURCE_SHORTAGE || retry == maxRetry {
+          print("unable to fork corpse for pid \(processId): \(String(cString: mach_error_string(corpseResult))) \(hex: corpseResult)",
+            to: &Std.err)
+          return nil
+        }
+        sleep(UInt32(1 << retry))
       }
     }
 
@@ -161,6 +175,7 @@ internal final class DarwinRemoteProcess: RemoteProcess {
   deinit {
     task_stop_peeking(self.task)
     mach_port_deallocate(mach_task_self_, self.task)
+    mach_port_mod_refs(mach_task_self_, self.task, MACH_PORT_RIGHT_SEND, -1);
   }
 
   func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?) {

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpGenericMetadata.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpGenericMetadata.swift
@@ -12,15 +12,47 @@
 
 import ArgumentParser
 import SwiftRemoteMirror
+import Foundation
 
-private struct Metadata {
+private struct Metadata: Encodable {
   let ptr: swift_reflection_ptr_t
   var allocation: swift_metadata_allocation_t?
-
   let name: String
   let isArrayOfClass: Bool
-
+  var garbage: Bool = false
   var offset: Int? { allocation.map { Int(self.ptr - $0.ptr) } }
+  var backtrace: String?
+
+  enum CodingKeys: String, CodingKey {
+    case ptr = "address"
+    case allocation
+    case name
+    case isArrayOfClass
+    case garbage
+    case offset
+    case backtrace
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(ptr, forKey: .ptr)
+    try container.encode(name, forKey: .name)
+    if isArrayOfClass {
+      try container.encode(isArrayOfClass, forKey: .isArrayOfClass)
+    }
+    if garbage {
+      try container.encode(garbage, forKey: .garbage)
+    }
+    if let offset {
+      try container.encode(offset, forKey: .offset)
+    }
+    if let backtrace {
+      try container.encode(backtrace, forKey: .backtrace)
+    }
+    if let allocation {
+      try container.encode(allocation, forKey: .allocation)
+    }
+  }
 }
 
 internal struct DumpGenericMetadata: ParsableCommand {
@@ -41,52 +73,79 @@ internal struct DumpGenericMetadata: ParsableCommand {
       let allocations: [swift_metadata_allocation_t] =
           try process.context.allocations.sorted()
 
-      let generics: [Metadata] = allocations.compactMap { allocation -> Metadata? in
+      let stacks: [swift_reflection_ptr_t:[swift_reflection_ptr_t]] =
+          backtraceOptions.style == nil
+          ? [swift_reflection_ptr_t:[swift_reflection_ptr_t]]()
+          : try process.context.allocationStacks
+
+      let generics: [Metadata] = allocations.compactMap { allocation in
         let pointer = swift_reflection_allocationMetadataPointer(process.context, allocation)
         if pointer == 0 { return nil }
+        let allocation = allocations.last(where: { pointer >= $0.ptr && pointer < $0.ptr + UInt64($0.size) })
+        let garbage = (allocation == nil && swift_reflection_ownsAddressStrict(process.context, UInt(pointer)) == 0)
+        var currentBacktrace: String?
+        if let style = backtraceOptions.style, let allocation, let stack = stacks[allocation.ptr] {
+          currentBacktrace = backtrace(stack, style: style, process.symbolicate)
+        }
 
         return Metadata(ptr: pointer,
-                        allocation: allocations.last(where: { pointer >= $0.ptr && pointer < $0.ptr + swift_reflection_ptr_t($0.size) }),
-                        name: (process.context.name(type: pointer, mangled: genericMetadataOptions.mangled) ?? "<unknown>"),
-                        isArrayOfClass: process.context.isArrayOfClass(pointer))
+                        allocation: allocation,
+                        name: process.context.name(type: pointer, mangled: genericMetadataOptions.mangled) ?? "<unknown>",
+                        isArrayOfClass: process.context.isArrayOfClass(pointer),
+                        garbage: garbage,
+                        backtrace: currentBacktrace)
       }
 
-      let stacks: [swift_reflection_ptr_t:[swift_reflection_ptr_t]]? =
-          backtraceOptions.style == nil
-              ? nil
-              : try process.context.allocationStacks
-
-      var errorneousMetadata: [(ptr: swift_reflection_ptr_t, name: String)] = []
-
-      print("Address", "Allocation", "Size", "Offset", "isArrayOfClass", "Name", separator: "\t")
-      generics.forEach {
-        print("\(hex: $0.ptr)", terminator: "\t")
-        if let allocation = $0.allocation, let offset = $0.offset {
-          print("\(hex: allocation.ptr)\t\(allocation.size)\t\(offset)", terminator: "\t")
-        } else {
-          if (swift_reflection_ownsAddressStrict(process.context, UInt($0.ptr))) == 0 {
-            errorneousMetadata.append((ptr: $0.ptr, name: $0.name))
-          }
-          print("???\t??\t???", terminator: "\t")
-        }
-        print($0.isArrayOfClass, terminator: "\t")
-        print($0.name)
-        if let style = backtraceOptions.style, let allocation = $0.allocation {
-          if let stack = stacks?[allocation.ptr] {
-            print(backtrace(stack, style: style, process.symbolicate))
-          } else {
-            print("  No stacktrace available")
-          }
-        }
+      if let outputFile = genericMetadataOptions.outputJson {
+        try dumpToJson(process: process, generics: generics,
+                       outputPath: outputFile)
+      } else {
+        try dumpToStdout(process: process, generics: generics)
       }
-
-      if errorneousMetadata.count > 0 {
-        print("Error: The following metadata was not found in any DATA or AUTH segments, may be garbage.")
-        errorneousMetadata.forEach {
-          print("\(hex: $0.ptr)\t\($0.name)")
-        }
-      }
-
     }
   }
+
+  private func dumpToStdout(process: any RemoteProcess, generics: [Metadata]) throws {
+    var errorneousMetadata: [(ptr: swift_reflection_ptr_t, name: String)] = []
+
+    print("Address", "Allocation", "Size", "Offset", "isArrayOfClass", "Name", separator: "\t")
+    generics.forEach {
+      print("\(hex: $0.ptr)", terminator: "\t")
+      if let allocation = $0.allocation, let offset = $0.offset {
+        print("\(hex: allocation.ptr)\t\(allocation.size)\t\(offset)", terminator: "\t")
+      } else {
+        if $0.garbage {
+          errorneousMetadata.append((ptr: $0.ptr, name: $0.name))
+        }
+        print("???\t??\t???", terminator: "\t")
+      }
+      print($0.isArrayOfClass, terminator: "\t")
+      print($0.name)
+      if let _ = backtraceOptions.style, let _ = $0.allocation {
+        print($0.backtrace ?? "  No stacktrace available")
+      }
+    }
+
+    if errorneousMetadata.count > 0 {
+      print("Error: The following metadata was not found in any DATA or AUTH segments, may be garbage.")
+      errorneousMetadata.forEach {
+        print("\(hex: $0.ptr)\t\($0.name)")
+      }
+    }
+  }
+
+  private func dumpToJson(process: any RemoteProcess,
+                          generics: [Metadata],
+                          outputPath: String) throws {
+    struct AllMetadataEntries: Encodable {
+      var metadata: [Metadata]
+    }
+    let allMetadataEntries = AllMetadataEntries(metadata: generics)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .prettyPrinted
+    let data = try encoder.encode(allMetadataEntries)
+    try String(data: data, encoding: .utf8)!
+      .write(toFile: outputPath, atomically: true, encoding: .utf8)
+  }
+
 }

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
@@ -12,10 +12,21 @@
 
 import SwiftRemoteMirror
 
-extension swift_metadata_allocation_t {
+extension swift_metadata_allocation_t: Encodable {
   internal var tag: swift_metadata_allocation_tag_t { return self.Tag }
   internal var ptr: swift_reflection_ptr_t { return self.Ptr }
   internal var size: Int { return Int(self.Size) }
+  enum CodingKeys: String, CodingKey {
+      case tag
+      case ptr = "address"
+      case size
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(tag, forKey: .tag)
+      try container.encode(ptr, forKey: .ptr)
+      try container.encode(size, forKey: .size)
+  }
 }
 
 extension swift_metadata_allocation_t: Comparable {

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -18,6 +18,8 @@ internal protocol RemoteProcess: AnyObject {
 
   var process: ProcessHandle { get }
   var context: SwiftReflectionContextRef! { get }
+  var processIdentifier: ProcessIdentifier { get }
+  var processName: String { get }
 
   typealias QueryDataLayoutFunction =
       @convention(c) (UnsafeMutableRawPointer?, DataLayoutQueryType,

--- a/tools/swift-inspect/Sources/swift-inspect/String+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/String+Extensions.swift
@@ -11,10 +11,27 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftRemoteMirror
+import Foundation
 
 extension DefaultStringInterpolation {
   mutating func appendInterpolation<T>(hex: T) where T: BinaryInteger {
     appendInterpolation("0x")
     appendInterpolation(String(hex, radix: 16))
   }
+}
+
+enum Std {
+  struct File: TextOutputStream {
+    var underlying: UnsafeMutablePointer<FILE>
+
+    mutating func write(_ string: String) {
+      fputs(string, underlying)
+    }
+  }
+
+  static var err = File(underlying: stderr)
+}
+
+internal func disableStdErrBuffer() {
+  setvbuf(stderr, nil, Int32(_IONBF), 0)
 }

--- a/tools/swift-inspect/Sources/swift-inspect/Symbolication+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Symbolication+Extensions.swift
@@ -15,18 +15,6 @@
 import Foundation
 import SymbolicationShims
 
-enum Std {
-  struct File: TextOutputStream {
-    var underlying: UnsafeMutablePointer<FILE>
-
-    mutating func write(_ string: String) {
-      fputs(string, underlying)
-    }
-  }
-
-  static var err = File(underlying: stderr)
-}
-
 private let symbolicationPath =
   "/System/Library/PrivateFrameworks/Symbolication.framework/Symbolication"
 private let symbolicationHandle = dlopen(symbolicationPath, RTLD_LAZY)!
@@ -133,7 +121,7 @@ func CSSymbolOwnerForeachSymbol(
 }
 
 func CSSymbolOwnerGetSymbolWithMangledName(
-  _ owner: CSTypeRef, 
+  _ owner: CSTypeRef,
   _ name: String
 ) -> CSTypeRef {
   Sym.CSSymbolOwnerGetSymbolWithMangledName(owner, name)
@@ -196,7 +184,7 @@ func task_start_peeking(_ task: task_t) -> Bool {
   if result == KERN_SUCCESS {
     return true
   }
-  
+
   print("task_start_peeking failed: \(machErrStr(result))", to: &Std.err)
   return false
 }

--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -23,6 +23,8 @@ internal final class WindowsRemoteProcess: RemoteProcess {
 
   public private(set) var process: ProcessHandle
   public private(set) var context: SwiftReflectionContextRef!
+  public private(set) var processIdentifier: ProcessIdentifier
+  public private(set) var processName: String = "<unknown process>"
 
   private var hSwiftCore: HMODULE = HMODULE(bitPattern: -1)!
 
@@ -136,6 +138,7 @@ internal final class WindowsRemoteProcess: RemoteProcess {
   }
 
   init?(processId: ProcessIdentifier) {
+    self.processIdentifier = processId
     // Get process handle.
     self.process =
       OpenProcess(

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -45,6 +45,9 @@ internal struct BacktraceOptions: ParsableArguments {
 internal struct GenericMetadataOptions: ParsableArguments {
   @Flag(help: "Show allocations in mangled form")
   var mangled: Bool = false
+
+  @Option(help: "Path to output JSON file")
+  var outputJson: String? = nil
 }
 
 internal func inspect(options: UniversalOptions,

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -46,8 +46,11 @@ internal struct GenericMetadataOptions: ParsableArguments {
   @Flag(help: "Show allocations in mangled form")
   var mangled: Bool = false
 
-  @Option(help: "Path to output JSON file")
-  var outputJson: String? = nil
+  @Flag(help: "Output JSON")
+  var json: Bool = false
+
+  @Option(help: "Output to a file")
+  var outputFile: String? = nil
 }
 
 internal func inspect(options: UniversalOptions,

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -12,11 +12,12 @@
 
 import ArgumentParser
 import SwiftRemoteMirror
+import Foundation
 
 
 internal struct UniversalOptions: ParsableArguments {
   @Argument(help: "The pid or partial name of the target process")
-  var nameOrPid: String
+  var nameOrPid: String?
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   @Flag(help: ArgumentHelp(
@@ -24,8 +25,27 @@ internal struct UniversalOptions: ParsableArguments {
       discussion: "Creates a low-level copy of the target process, allowing " +
                   "the target to immediately resume execution before " +
                   "swift-inspect has completed its work."))
-  var forkCorpse: Bool = false
 #endif
+  var forkCorpse: Bool = false
+
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+  @Flag(help: "Run on all processes")
+#endif
+  var all: Bool = false
+
+  mutating func validate() throws {
+    if nameOrPid != nil && all || nameOrPid == nil && !all {
+      #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        throw ValidationError("Please specify partial process name, pid or --all")
+      #else
+        throw ValidationError("Please specify partial process name or pid")
+      #endif
+    }
+    if all {
+      // Fork corpse is enabled if all is specified
+      forkCorpse = true
+    }
+  }
 }
 
 internal struct BacktraceOptions: ParsableArguments {
@@ -49,33 +69,58 @@ internal struct GenericMetadataOptions: ParsableArguments {
   @Flag(help: "Output JSON")
   var json: Bool = false
 
+  #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+  @Flag(help: "Print out a summary from all process output")
+  #endif
+  var summary: Bool = false
+
   @Option(help: "Output to a file")
   var outputFile: String? = nil
 }
 
 internal func inspect(options: UniversalOptions,
                       _ body: (any RemoteProcess) throws -> Void) throws {
-  guard let processId = process(matching: options.nameOrPid) else {
-    print("No process found matching \(options.nameOrPid)")
-    return
+  if let nameOrPid = options.nameOrPid {
+    guard let processId = process(matching: nameOrPid) else {
+      print("No process found matching \(nameOrPid)", to: &Std.err)
+      return
+    }
+    guard let process = getRemoteProcess(processId: processId,
+                                         options: options) else {
+      print("Failed to create inspector for process id \(processId)", to: &Std.err)
+      return
+    }
+    try body(process)
   }
-
+  else {
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-  guard let process = DarwinRemoteProcess(processId: processId,
-                                          forkCorpse: options.forkCorpse) else {
-    print("Failed to create inspector for process id \(processId)")
-    return
-  }
-#elseif os(Windows)
-  guard let process = WindowsRemoteProcess(processId: processId) else {
-    print("Failed to create inspector for process id \(processId)")
-    return
-  }
-#else
-#error("Unsupported platform")
+    if let processIdentifiers = getAllProcesses(options: options) {
+      let totalCount = processIdentifiers.count
+      var successfulCount = 0
+      for (index, processIdentifier) in processIdentifiers.enumerated() {
+        let progress = "[\(successfulCount)/\(index + 1)/\(totalCount)]"
+        if let remoteProcess = getRemoteProcess(processId: processIdentifier, options: options) {
+          do {
+            print(progress, "\(remoteProcess.processName)(\(remoteProcess.processIdentifier))",
+              terminator: "", to: &Std.err)
+            try body(remoteProcess)
+            successfulCount += 1
+          } catch {
+            print(" - \(error)", terminator: "", to: &Std.err)
+          }
+          remoteProcess.release() // break retain cycle
+        } else {
+          print(progress, " - failed to create inspector for process id \(processIdentifier)",
+            terminator: "\n", to: &Std.err)
+        }
+        print("\u{01B}[0K", terminator: "\r", to: &Std.err)
+      }
+      print("", to: &Std.err)
+    } else {
+      print("Failed to get list of processes", to: &Std.err)
+    }
 #endif
-
-  try body(process)
+  }
 }
 
 @main


### PR DESCRIPTION
This change adds JSON output option to `--dump-generic-metadata` for swift-inspect for easier read and consumption, when needed. We are now also able to see more allocation details, and the backtrace entry per metadata in the JSON output if option is selected. `nil` or commonly `false` fields are omitted in the output to keep size compact. The second commit changes arguments so that `--json` is now a flag, and `--output-file` is an option. The third commit adds macOS platform to inspect all processes, expands json and text output, and `--summary` option provides total size and popularity per generic metadata.

```
[swift-inspect] Add json output option for dump-generic-metadata
    This change adds json output option to dump-generic-metadata for swift-inspect.

[swift-inspect] Change argument options to select between file or standard output
    With this change we make --json flag to toggle between JSON and text output. If --output-file option is given, then the output stream is forwarded to the file specified.

[swift-inspect] Inspect all processes and add summary option   
    With this change swift-inspect can inspect all processes to see if metadata allocation iteration is enabled. We also added summary option that sorts metadata to popularity.
```