### PR TITLE
[Profiler] Map regions for error-throwing AST nodes

### DIFF
--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -162,7 +162,16 @@ public:
     return Expressions;
   }
 
-  void printCounter(llvm::raw_ostream &OS, llvm::coverage::Counter C) const;
+  /// Print a given profiling counter expression, given the reference to the
+  /// counter, and the list of counters it may reference.
+  static void
+  printCounter(llvm::raw_ostream &OS, llvm::coverage::Counter C,
+               ArrayRef<llvm::coverage::CounterExpression> Expressions);
+
+  /// Print a given profiling counter expression.
+  void printCounter(llvm::raw_ostream &OS, llvm::coverage::Counter C) const {
+    printCounter(OS, C, getExpressions());
+  }
 
   /// Print the coverage map.
   void print(llvm::raw_ostream &OS, bool Verbose = false,

--- a/include/swift/SIL/SILProfiler.h
+++ b/include/swift/SIL/SILProfiler.h
@@ -36,9 +36,10 @@ class ProfileCounterRef final {
 public:
   enum class Kind : uint8_t {
     /// References an ASTNode.
-    // TODO: This is the currently the only kind, but it will be expanded in
-    // the future for e.g top-level entry and error branches.
-    Node
+    Node,
+
+    /// References the error branch for an apply or access.
+    ErrorBranch
   };
 
 private:
@@ -54,6 +55,12 @@ public:
   static ProfileCounterRef node(ASTNode node) {
     assert(node && "Must have non-null ASTNode");
     return ProfileCounterRef(node, Kind::Node);
+  }
+
+  /// A profile counter that is associated with the error branch of a particular
+  /// error-throwing AST node.
+  static ProfileCounterRef errorBranchOf(ASTNode node) {
+    return ProfileCounterRef(node, Kind::ErrorBranch);
   }
 
   /// Retrieve the corresponding location of the counter.

--- a/include/swift/SIL/SILProfiler.h
+++ b/include/swift/SIL/SILProfiler.h
@@ -142,11 +142,13 @@ public:
   /// Get the number of region counters.
   unsigned getNumRegionCounters() const { return NumRegionCounters; }
 
-  /// Get the mapping from a \c ProfileCounterRef to its corresponding
-  /// profile counter.
-  const llvm::DenseMap<ProfileCounterRef, unsigned> &
-  getRegionCounterMap() const {
-    return RegionCounterMap;
+  /// Retrieve the counter index for a given counter reference, asserting that
+  /// it is present.
+  unsigned getCounterIndexFor(ProfileCounterRef ref);
+
+  /// Whether a counter has been recorded for the given counter reference.
+  bool hasCounterFor(ProfileCounterRef ref) {
+    return RegionCounterMap.contains(ref);
   }
 
 private:

--- a/lib/SIL/IR/SILCoverageMap.cpp
+++ b/lib/SIL/IR/SILCoverageMap.cpp
@@ -100,7 +100,8 @@ struct Printer {
 };
 } // end anonymous namespace
 
-void SILCoverageMap::printCounter(llvm::raw_ostream &OS,
-                                  llvm::coverage::Counter C) const {
-  OS << Printer(C, getExpressions());
+void SILCoverageMap::printCounter(
+    llvm::raw_ostream &OS, llvm::coverage::Counter C,
+    ArrayRef<llvm::coverage::CounterExpression> Expressions) {
+  OS << Printer(C, Expressions);
 }

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -1491,3 +1491,9 @@ llvm::Optional<ASTNode> SILProfiler::getPGOParent(ASTNode Node) {
   }
   return it->getSecond();
 }
+
+unsigned SILProfiler::getCounterIndexFor(ProfileCounterRef ref) {
+  auto result = RegionCounterMap.find(ref);
+  assert(result != RegionCounterMap.end());
+  return result->second;
+}

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -390,163 +390,46 @@ struct MapRegionCounters : public ASTWalker {
   }
 };
 
-struct CounterExprStorage;
-using CounterAllocator = llvm::SpecificBumpPtrAllocator<CounterExprStorage>;
-
-/// A node in an expression tree of counters.
 class CounterExpr {
-  enum class Kind { Leaf, Add, Sub, Zero };
-  Kind K;
-  llvm::Optional<ProfileCounterRef> Counter;
-  const CounterExprStorage *Storage = nullptr;
+  llvm::coverage::Counter Counter;
 
-  CounterExpr(Kind K) : K(K) {
-    assert((K == Kind::Zero) && "only valid for Zero");
-  }
-
-  CounterExpr(Kind K, ProfileCounterRef Counter) : K(K), Counter(Counter) {
-    assert(K == Kind::Leaf && "only valid for Node");
-  }
-
-  CounterExpr(Kind K, const CounterExprStorage *Storage)
-      : K(K), Storage(Storage) {
-    assert((K == Kind::Add || K == Kind::Sub) && "only valid for operators");
-  }
+  explicit CounterExpr(llvm::coverage::Counter Counter) : Counter(Counter) {}
 
 public:
-  static CounterExpr Leaf(ProfileCounterRef Counter) {
-    return CounterExpr(Kind::Leaf, Counter);
+  static CounterExpr Concrete(unsigned Idx) {
+    return CounterExpr(llvm::coverage::Counter::getCounter(Idx));
   }
   static CounterExpr Zero() {
-    return CounterExpr(Kind::Zero);
+    return CounterExpr(llvm::coverage::Counter::getZero());
   }
 
   static CounterExpr Add(CounterExpr LHS, CounterExpr RHS,
-                         CounterAllocator &Alloc);
+                         llvm::coverage::CounterExpressionBuilder &Builder) {
+    return CounterExpr(Builder.add(LHS.getLLVMCounter(), RHS.getLLVMCounter()));
+  }
   static CounterExpr Sub(CounterExpr LHS, CounterExpr RHS,
-                         CounterAllocator &Alloc);
-
-  /// Returns true if this is a Zero node.
-  bool isZero() const { return K == Kind::Zero; }
-
-  /// For an addition or subtraction counter, retrieves the LHS counter.
-  const CounterExpr &getLHS() const;
-
-  /// For an addition or subtraction counter, retrieves the RHS counter.
-  const CounterExpr &getRHS() const;
-
-  /// Returns true if the counter is semantically a Zero node. This considers
-  /// the simplified version of the counter that has eliminated redundant
-  /// operations.
-  bool isSemanticallyZero() const {
-    // Run the counter through the counter builder to simplify it, using a dummy
-    // mapping of unique counter indices for each node reference. The value of
-    // the indices doesn't matter, but we need to ensure that e.g subtraction
-    // of a node from itself cancels out.
-    llvm::coverage::CounterExpressionBuilder Builder;
-    llvm::DenseMap<ProfileCounterRef, unsigned> DummyIndices;
-    unsigned LastIdx = 0;
-    auto Counter = expand(Builder, [&](auto Ref) {
-      if (!DummyIndices.count(Ref)) {
-        DummyIndices[Ref] = LastIdx;
-        LastIdx += 1;
-      }
-      return DummyIndices[Ref];
-    });
-    return Counter.isZero();
+                         llvm::coverage::CounterExpressionBuilder &Builder) {
+    return CounterExpr(
+        Builder.subtract(LHS.getLLVMCounter(), RHS.getLLVMCounter()));
   }
 
-  /// Expand this node into an llvm::coverage::Counter.
-  ///
-  /// Updates \c Builder with any expressions that are needed to represent this
-  /// counter.
-  llvm::coverage::Counter
-  expand(llvm::coverage::CounterExpressionBuilder &Builder,
-         llvm::function_ref<unsigned(ProfileCounterRef)> GetCounterIdx) const {
-    switch (K) {
-    case Kind::Zero:
-      return llvm::coverage::Counter::getZero();
-    case Kind::Leaf:
-      return llvm::coverage::Counter::getCounter(GetCounterIdx(*Counter));
-    case Kind::Add:
-      return Builder.add(getLHS().expand(Builder, GetCounterIdx),
-                         getRHS().expand(Builder, GetCounterIdx));
-    case Kind::Sub:
-      return Builder.subtract(getLHS().expand(Builder, GetCounterIdx),
-                              getRHS().expand(Builder, GetCounterIdx));
-    }
+  /// Returns true if this is a zero counter.
+  bool isZero() const { return Counter.isZero(); }
 
-    llvm_unreachable("Unhandled Kind in switch.");
-  }
+  llvm::coverage::Counter getLLVMCounter() const { return Counter; }
 
-  /// Expand this node into an llvm::coverage::Counter.
-  ///
-  /// Updates \c Builder with any expressions that are needed to represent this
-  /// counter.
-  llvm::coverage::Counter
-  expand(llvm::coverage::CounterExpressionBuilder &Builder,
-         const llvm::DenseMap<ProfileCounterRef, unsigned> &Counters) const {
-    return expand(Builder, [&](auto Ref) {
-      auto Result = Counters.find(Ref);
-      assert(Result != Counters.end() && "Counter not found");
-      return Result->second;
-    });
-  }
-
-  void print(raw_ostream &OS) const {
-    switch (K) {
-    case Kind::Zero:
-      OS << "zero";
-      return;
-    case Kind::Leaf:
-      OS << "leaf(";
-      Counter->dumpSimple(OS);
-      OS << ")";
-      return;
-    case Kind::Add:
-    case Kind::Sub:
-      getLHS().print(OS);
-      OS << ' ' << ((K == Kind::Add) ? '+' : '-') << ' ';
-      getRHS().print(OS);
-      return;
-    }
-    llvm_unreachable("Unhandled Kind in switch.");
+  void print(raw_ostream &OS,
+             const llvm::coverage::CounterExpressionBuilder &Builder) const {
+    SILCoverageMap::printCounter(OS, Counter, Builder.getExpressions());
   }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  LLVM_DUMP_METHOD void dump() const { print(llvm::errs()); }
+  LLVM_DUMP_METHOD
+  void dump(const llvm::coverage::CounterExpressionBuilder &Builder) const {
+    print(llvm::errs(), Builder);
+  }
 #endif
 };
-
-struct CounterExprStorage {
-  CounterExpr LHS;
-  CounterExpr RHS;
-};
-
-inline CounterExpr CounterExpr::Add(CounterExpr LHS, CounterExpr RHS,
-                                    CounterAllocator &Alloc) {
-  auto *Storage = Alloc.Allocate();
-  Storage->LHS = LHS;
-  Storage->RHS = RHS;
-  return CounterExpr(Kind::Add, Storage);
-}
-inline CounterExpr CounterExpr::Sub(CounterExpr LHS, CounterExpr RHS,
-                                    CounterAllocator &Alloc) {
-  auto *Storage = Alloc.Allocate();
-  Storage->LHS = LHS;
-  Storage->RHS = RHS;
-  return CounterExpr(Kind::Sub, Storage);
-}
-
-inline const CounterExpr &CounterExpr::getLHS() const {
-  assert(Storage && "Counter does not have an LHS");
-  return Storage->LHS;
-}
-
-inline const CounterExpr &CounterExpr::getRHS() const {
-  assert(Storage && "Counter does not have an RHS");
-  return Storage->RHS;
-}
 
 /// A region of source code that can be mapped to a counter.
 class SourceMappingRegion {
@@ -873,11 +756,14 @@ private:
   /// The SIL function being profiled.
   SILDeclRef Constant;
 
-  /// Allocator for counter expressions.
-  CounterAllocator CounterAlloc;
+  /// Builder needed to produce CounterExprs.
+  llvm::coverage::CounterExpressionBuilder CounterBuilder;
 
   /// The map of statements to counter expressions.
-  llvm::DenseMap<ProfileCounterRef, CounterExpr> CounterMap;
+  llvm::DenseMap<ProfileCounterRef, CounterExpr> CounterExprs;
+
+  /// The map of counter references to their concrete counter indices.
+  const llvm::DenseMap<ProfileCounterRef, unsigned> &ConcreteCounters;
 
   /// The source mapping regions for this function.
   std::vector<SourceMappingRegion> SourceRegions;
@@ -893,7 +779,7 @@ private:
   Stmt *ImplicitTopLevelBody = nullptr;
 
   /// Return true if \c Ref has an associated counter.
-  bool hasCounter(ProfileCounterRef Ref) { return CounterMap.count(Ref); }
+  bool hasCounter(ProfileCounterRef Ref) { return CounterExprs.count(Ref); }
 
   /// Return true if \c Node has an associated counter.
   bool hasCounter(ASTNode Node) {
@@ -904,8 +790,8 @@ private:
   ///
   /// This should only be called on references that have a dedicated counter.
   CounterExpr getCounter(ProfileCounterRef Ref) {
-    auto Iter = CounterMap.find(Ref);
-    assert(Iter != CounterMap.end() && "No counter found");
+    auto Iter = CounterExprs.find(Ref);
+    assert(Iter != CounterExprs.end() && "No counter found");
     return Iter->second;
   }
 
@@ -918,7 +804,7 @@ private:
 
   /// Create a counter expression for \c Ref and add it to the map.
   void assignCounter(ProfileCounterRef Ref, CounterExpr Expr) {
-    auto Res = CounterMap.insert({Ref, Expr});
+    auto Res = CounterExprs.insert({Ref, Expr});
 
     // Overwrite an existing assignment.
     if (!Res.second)
@@ -933,7 +819,9 @@ private:
   /// Create a counter expression referencing \c Ref's own counter. This must
   /// have been previously mapped by MapRegionCounters.
   CounterExpr assignKnownCounter(ProfileCounterRef Ref) {
-    auto Counter = CounterExpr::Leaf(Ref);
+    auto Iter = ConcreteCounters.find(Ref);
+    assert(Iter != ConcreteCounters.end() && "Should have mapped this counter");
+    auto Counter = CounterExpr::Concrete(Iter->second);
     assignCounter(Ref, Counter);
     return Counter;
   }
@@ -950,7 +838,7 @@ private:
     if (Counter.isZero()) {
       Counter = std::move(Expr);
     } else {
-      Counter = CounterExpr::Add(Counter, std::move(Expr), CounterAlloc);
+      Counter = CounterExpr::Add(Counter, std::move(Expr), CounterBuilder);
     }
     assignCounter(Node, Counter);
   }
@@ -960,11 +848,13 @@ private:
     auto Counter = getCounter(Node);
     assert(!Counter.isZero() && "Cannot create a negative counter");
     assignCounter(Node,
-                  CounterExpr::Sub(Counter, std::move(Expr), CounterAlloc));
+                  CounterExpr::Sub(Counter, std::move(Expr), CounterBuilder));
   }
 
   /// Return the current region's counter.
-  CounterExpr getCurrentCounter() { return getRegion().getCounter(CounterMap); }
+  CounterExpr getCurrentCounter() {
+    return getRegion().getCounter(CounterExprs);
+  }
 
   /// Get the counter from the end of the most recent scope.
   CounterExpr getExitCounter() {
@@ -979,7 +869,7 @@ private:
   llvm::Optional<CounterExpr> setExitCount(ASTNode Node) {
     ExitCounter = getCurrentCounter();
     if (hasCounter(Node) && getRegion().getNode() != Node)
-      return CounterExpr::Sub(getCounter(Node), *ExitCounter, CounterAlloc);
+      return CounterExpr::Sub(getCounter(Node), *ExitCounter, CounterBuilder);
     return llvm::None;
   }
 
@@ -1010,10 +900,10 @@ private:
     auto Count = getCurrentCounter();
     // Add the counts from jumps directly to the label (such as breaks)
     if (JumpsToLabel)
-      Count = CounterExpr::Add(Count, *JumpsToLabel, CounterAlloc);
+      Count = CounterExpr::Add(Count, *JumpsToLabel, CounterBuilder);
     // Now apply any adjustments for control flow.
     if (ControlFlowAdjust)
-      Count = CounterExpr::Sub(Count, *ControlFlowAdjust, CounterAlloc);
+      Count = CounterExpr::Sub(Count, *ControlFlowAdjust, CounterBuilder);
 
     replaceCount(Count, getEndLoc(Scope));
   }
@@ -1038,10 +928,10 @@ private:
   /// \c None, or the counter is semantically zero, an 'incomplete' region is
   /// formed, which is not recorded unless followed by additional AST nodes.
   void replaceCount(CounterExpr Counter, llvm::Optional<SourceLoc> Start) {
-    // If the counter is semantically zero, form an 'incomplete' region with
-    // no starting location. This prevents forming unreachable regions unless
-    // there is a following statement or expression to extend the region.
-    if (Start && Counter.isSemanticallyZero())
+    // If the counter is zero, form an 'incomplete' region with no starting
+    // location. This prevents forming unreachable regions unless there is a
+    // following statement or expression to extend the region.
+    if (Start && Counter.isZero())
       Start = llvm::None;
 
     RegionStack.emplace_back(ASTNode(), Counter, Start, llvm::None);
@@ -1131,8 +1021,10 @@ private:
   }
 
 public:
-  CoverageMapping(const SourceManager &SM, SILDeclRef Constant)
-      : SM(SM), Constant(Constant) {}
+  CoverageMapping(
+      const SourceManager &SM, SILDeclRef Constant,
+      const llvm::DenseMap<ProfileCounterRef, unsigned> &ConcreteCounters)
+      : SM(SM), Constant(Constant), ConcreteCounters(ConcreteCounters) {}
 
   LazyInitializerWalking getLazyInitializerWalkingBehavior() override {
     // We want to walk lazy initializers present in the synthesized getter for
@@ -1146,16 +1038,14 @@ public:
 
   /// Generate the coverage counter mapping regions from collected
   /// source regions.
-  SILCoverageMap *emitSourceRegions(
-      SILModule &M, StringRef Name, StringRef PGOFuncName, uint64_t Hash,
-      llvm::DenseMap<ProfileCounterRef, unsigned> &CounterIndices,
-      SourceFile *SF, StringRef Filename) {
+  SILCoverageMap *emitSourceRegions(SILModule &M, StringRef Name,
+                                    StringRef PGOFuncName, uint64_t Hash,
+                                    SourceFile *SF, StringRef Filename) {
     if (SourceRegions.empty())
       return nullptr;
 
     using MappedRegion = SILCoverageMap::MappedRegion;
 
-    llvm::coverage::CounterExpressionBuilder Builder;
     std::vector<MappedRegion> Regions;
     SourceRange OuterRange;
     for (const auto &Region : SourceRegions) {
@@ -1174,10 +1064,10 @@ public:
       auto End = SM.getLineAndColumnInBuffer(Region.getEndLoc());
       assert(Start.first <= End.first && "region start and end out of order");
 
-      auto Counter = Region.getCounter(CounterMap);
-      Regions.push_back(
-          MappedRegion::code(Start.first, Start.second, End.first, End.second,
-                             Counter.expand(Builder, CounterIndices)));
+      auto Counter = Region.getCounter(CounterExprs);
+      Regions.push_back(MappedRegion::code(Start.first, Start.second, End.first,
+                                           End.second,
+                                           Counter.getLLVMCounter()));
     }
     // Add any skipped regions present in the outer range.
     for (auto IfConfig : SF->getIfConfigsWithin(OuterRange)) {
@@ -1190,7 +1080,7 @@ public:
       }
     }
     return SILCoverageMap::create(M, SF, Filename, Name, PGOFuncName, Hash,
-                                  Regions, Builder.getExpressions());
+                                  Regions, CounterBuilder.getExpressions());
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {
@@ -1238,7 +1128,7 @@ public:
       auto ThenCounter = assignKnownCounter(IS->getThenStmt());
       if (IS->getElseStmt()) {
         auto ElseCounter =
-            CounterExpr::Sub(getCurrentCounter(), ThenCounter, CounterAlloc);
+            CounterExpr::Sub(getCurrentCounter(), ThenCounter, CounterBuilder);
         assignCounter(IS->getElseStmt(), ElseCounter);
       }
     } else if (auto *GS = dyn_cast<GuardStmt>(S)) {
@@ -1432,7 +1322,7 @@ public:
     if (auto *IE = dyn_cast<TernaryExpr>(E)) {
       auto ThenCounter = assignKnownCounter(IE->getThenExpr());
       auto ElseCounter =
-          CounterExpr::Sub(getCurrentCounter(), ThenCounter, CounterAlloc);
+          CounterExpr::Sub(getCurrentCounter(), ThenCounter, CounterBuilder);
       assignCounter(IE->getElseExpr(), ElseCounter);
     }
     auto WalkResult = shouldWalkIntoExpr(E, Parent, Constant);
@@ -1457,7 +1347,7 @@ public:
     if (!RegionStack.empty() && mayExpressionThrow(E)) {
       auto ThrowCount = assignKnownCounter(ProfileCounterRef::errorBranchOf(E));
       replaceCount(
-          CounterExpr::Sub(getCurrentCounter(), ThrowCount, CounterAlloc),
+          CounterExpr::Sub(getCurrentCounter(), ThrowCount, CounterBuilder),
           Lexer::getLocForEndOfToken(SM, E->getEndLoc()));
     }
 
@@ -1530,11 +1420,10 @@ void SILProfiler::assignRegionCounters() {
   PGOFuncHash = 0x0;
 
   if (EmitCoverageMapping) {
-    CoverageMapping Coverage(SM, forDecl);
+    CoverageMapping Coverage(SM, forDecl, RegionCounterMap);
     walkNode(Root, Coverage);
-    CovMap =
-        Coverage.emitSourceRegions(M, CurrentFuncName, PGOFuncName, PGOFuncHash,
-                                   RegionCounterMap, SF, CurrentFileName);
+    CovMap = Coverage.emitSourceRegions(M, CurrentFuncName, PGOFuncName,
+                                        PGOFuncHash, SF, CurrentFileName);
   }
 
   if (llvm::IndexedInstrProfReader *IPR = M.getPGOReader()) {

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -173,7 +173,15 @@ SILLocation ProfileCounterRef::getLocation() const {
 
 void ProfileCounterRef::dumpSimple(raw_ostream &OS) const {
   switch (RefKind) {
-  case Kind::Node: {
+  case Kind::Node:
+    break;
+  case Kind::ErrorBranch:
+    OS << "error branch of: ";
+    break;
+  }
+  switch (RefKind) {
+  case Kind::Node:
+  case Kind::ErrorBranch: {
     OS << Node.getOpaqueValue() << " ";
     if (auto *D = Node.dyn_cast<Decl *>()) {
       OS << Decl::getKindName(D->getKind());
@@ -190,6 +198,11 @@ void ProfileCounterRef::dump(raw_ostream &OS) const {
   switch (RefKind) {
   case Kind::Node:
     Node.dump(OS);
+    break;
+  case Kind::ErrorBranch:
+    OS << "error branch of:\n";
+    Node.dump(OS.indent(2));
+    break;
   }
 }
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1726,11 +1726,7 @@ void SILGenFunction::emitProfilerIncrement(ProfileCounterRef Ref) {
   if (!SP->hasRegionCounters() || !getModule().getOptions().UseProfile.empty())
     return;
 
-  const auto &RegionCounterMap = SP->getRegionCounterMap();
-  auto CounterIt = RegionCounterMap.find(Ref);
-
-  assert(CounterIt != RegionCounterMap.end() &&
-         "cannot increment non-existent counter");
+  auto CounterIdx = SP->getCounterIndexFor(Ref);
 
   // If we're at an unreachable point, the increment can be elided as the
   // counter cannot be incremented.
@@ -1738,7 +1734,7 @@ void SILGenFunction::emitProfilerIncrement(ProfileCounterRef Ref) {
     return;
 
   B.createIncrementProfilerCounter(
-      Ref.getLocation(), CounterIt->second, SP->getPGOFuncName(),
+      Ref.getLocation(), CounterIdx, SP->getPGOFuncName(),
       SP->getNumRegionCounters(), SP->getPGOFuncHash());
 }
 

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -3045,7 +3045,7 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
   auto completionHandler = [&](PatternMatchEmission &emission,
                                ArgArray argArray, ClauseRow &row) {
     auto clause = row.getClientData<CaseStmt>();
-    emitProfilerIncrement(clause->getBody());
+    emitProfilerIncrement(clause);
 
     // Certain catch clauses can be entered along multiple paths because they
     // have multiple labels. When we need multiple entrance path, we factor the

--- a/test/Profiler/coverage_do.swift
+++ b/test/Profiler/coverage_do.swift
@@ -18,26 +18,19 @@
 // CHECK-NEXT:  increment_profiler_counter 1
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s11coverage_do3fooyyF"
-// CHECK-NEXT:  [[@LINE+11]]:12 -> [[@LINE+18]]:2 : 0
-// CHECK-NEXT:  [[@LINE+11]]:9 -> [[@LINE+15]]:4 : 0
-// CHECK-NEXT:  [[@LINE+11]]:8 -> [[@LINE+11]]:17 : 0
-// CHECK-NEXT:  [[@LINE+10]]:18 -> [[@LINE+10]]:28 : 1
-// CHECK-NEXT:  [[@LINE+9]]:28 -> [[@LINE+12]]:4 : (0 - 1)
-// CHECK-NEXT:  [[@LINE+9]]:8 -> [[@LINE+9]]:17 : (0 - 1)
-// CHECK-NEXT:  [[@LINE+8]]:18 -> [[@LINE+8]]:29 : 2
-// CHECK-NEXT:  [[@LINE+7]]:29 -> [[@LINE+8]]:11 : ((0 - 1) - 2)
-// CHECK-NEXT:  [[@LINE+8]]:4 -> [[@LINE+10]]:2 : 2
-// CHECK-NEXT:  [[@LINE+8]]:6 -> [[@LINE+8]]:8 : 2
-// CHECK-NEXT:  [[@LINE+7]]:8 -> [[@LINE+8]]:2 : 2
-func foo() {
-  x: do {
-    if .random() { return }
-    if .random() { break x }
+func foo() {       // CHECK-NEXT: [[@LINE]]:12   -> [[@LINE+11]]:2 : 0
+  x: do {          // CHECK-NEXT: [[@LINE]]:9    -> [[@LINE+8]]:4  : 0
+    if .random() { // CHECK-NEXT: [[@LINE]]:8    -> [[@LINE]]:17   : 0
+      return       // CHECK-NEXT: [[@LINE-1]]:18 -> [[@LINE+1]]:6  : 1
+    }              // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE+4]]:11 : (0 - 1)
+    if .random() { // CHECK-NEXT: [[@LINE]]:8    -> [[@LINE]]:17   : (0 - 1)
+      break x      // CHECK-NEXT: [[@LINE-1]]:18 -> [[@LINE+1]]:6  : 2
+    }              // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE+1]]:11 : ((0 - 1) - 2)
     return
-  }
-  do {}
-}
-// CHECK-NEXT: }
+  }                // CHECK-NEXT: [[@LINE]]:4   -> [[@LINE+2]]:2 : 2
+  do {}            // CHECK-NEXT: [[@LINE]]:6   -> [[@LINE]]:8   : 2
+}                  // CHECK-NEXT: [[@LINE-1]]:8 -> [[@LINE]]:2   : 2
+                   // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s11coverage_do4foobyyF"
 func foob() {

--- a/test/Profiler/coverage_errors.swift
+++ b/test/Profiler/coverage_errors.swift
@@ -3,8 +3,8 @@
 
 struct S {
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.S.init() -> coverage_catch.S
-  init() {     // CHECK: [[@LINE]]:10 -> [[@LINE+6]]:4 : 0
-    do {       // CHECK: [[@LINE]]:8 -> [[@LINE+2]]:6 : 0
+  init() { // CHECK: [[@LINE]]:10 -> [[@LINE+6]]:4 : 0
+    do {   // CHECK: [[@LINE]]:8 -> [[@LINE+2]]:6 : 0
       throw SomeErr.Err1
     } catch {
       // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:6 : 1
@@ -17,14 +17,14 @@ enum SomeErr : Error {
   case Err2
 }
 
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.bar
-func bar() throws {
-  // CHECK-NEXT: [[@LINE-1]]:19 -> [[@LINE+2]]:2 : 0
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test1
+func test1() throws {
+  // CHECK-NEXT: [[@LINE-1]]:21 -> [[@LINE+2]]:2 : 0
   throw SomeErr.Err2
 } // CHECK-NEXT: }
 
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.baz
-func baz(_ fn: () throws -> ()) rethrows {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test2
+func test2(_ fn: () throws -> ()) rethrows {
   do {
     try fn()
   } catch SomeErr.Err1 { // CHECK: [[@LINE]]:24 -> {{[0-9]+}}:4 : 1
@@ -34,8 +34,8 @@ func baz(_ fn: () throws -> ()) rethrows {
   try fn()
 } // CHECK-NEXT: }
 
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.foo
-func foo() -> Int32 {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test3
+func test3() -> Int32 {
   var x : Int32 = 0
 
   do {
@@ -48,41 +48,41 @@ func foo() -> Int32 {
   } // CHECK: [[@LINE]]:4 -> {{[0-9:]+}} : 0
 
   do {
-    try baz(bar)
+    try test2(test1)
   } catch _ {
     // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:4 : 3
   } // CHECK: [[@LINE]]:4 -> {{[0-9:]+}} : 0
 
   do {
-    try baz { () throws -> () in throw SomeErr.Err1 }
+    try test2 { () throws -> () in throw SomeErr.Err1 }
   } catch _ {}
 
-  try! baz { () throws -> () in return }
+  try! test2 { () throws -> () in return }
 
   return x
 }
 
-let _ = foo()
+let _ = test3()
 
 // rdar://34244637 - Coverage after a do-catch is incorrect
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.goo
-func goo(_ b: Bool) -> Int { // CHECK-NEXT: [[@LINE]]:28 {{.*}} : 0
-  do {                       // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE+2]]:4 : 0
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test4
+func test4(_ b: Bool) -> Int { // CHECK-NEXT: [[@LINE]]:30 {{.*}} : 0
+  do {                         // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE+2]]:4 : 0
     throw SomeErr.Err1
-  } catch {                  // CHECK-NEXT: [[@LINE]]:11 {{.*}} : 1
-                             // CHECK-NEXT: [[@LINE+1]]:8 {{.*}} : 1
-    if b {                   // CHECK-NEXT: [[@LINE]]:10 {{.*}} : 2
+  } catch {                    // CHECK-NEXT: [[@LINE]]:11 {{.*}} : 1
+                               // CHECK-NEXT: [[@LINE+1]]:8 {{.*}} : 1
+    if b {                     // CHECK-NEXT: [[@LINE]]:10 {{.*}} : 2
       return 1
-    }                        // CHECK-NEXT: [[@LINE]]:6 {{.*}} : (1 - 2)
-  } // CHECK: [[@LINE]]:4 {{.*}} : (0 - 2)
+    }                          // CHECK-NEXT: [[@LINE]]:6 {{.*}} : (1 - 2)
+  }                            // CHECK: [[@LINE]]:4 {{.*}} : (0 - 2)
   return 0
 }
 
 // Test coverage with nested do-catches
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.hoo
-func hoo() -> Int {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test5
+func test5() -> Int {
   do {
-    try bar()
+    try test1()
     do {
       throw SomeErr.Err1
     } catch {
@@ -96,8 +96,8 @@ func hoo() -> Int {
 }
 
 // Test coverage with a do-catch inside of a repeat-while
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.ioo
-func ioo() -> Int {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test6
+func test6() -> Int {
   repeat { // CHECK: [[@LINE]]:10 {{.*}} : 1
     do {
       throw SomeErr.Err1
@@ -110,11 +110,11 @@ func ioo() -> Int {
 }
 
 // Test coverage with a break inside a do-catch inside of a repeat-while
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.joo
-func joo() -> Int {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test7
+func test7() -> Int {
   repeat { // CHECK: [[@LINE]]:10 {{.*}} : 1
     do {
-      try bar()
+      try test1()
     } catch { // CHECK: [[@LINE]]:13 {{.*}} : 2
       break
     } // CHECK: [[@LINE]]:6 {{.*}} : (1 - 2)
@@ -124,12 +124,12 @@ func joo() -> Int {
 }
 
 // rdar://41010883 – Make sure we don't introduce an empty unreachable region.
-// CHECK-LABEL: sil_coverage_map {{.*}} "$s14coverage_catch3kooSiyKF" {{.*}} // coverage_catch.koo
-func koo() throws -> Int { // CHECK-NEXT: [[@LINE]]:26 -> [[@LINE+7]]:2 : 0
-  do {                     // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE+3]]:4 : 0
-    try bar()
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s14coverage_catch5test8SiyKF"
+func test8() throws -> Int { // CHECK-NEXT: [[@LINE]]:28 -> [[@LINE+7]]:2 : 0
+  do {                       // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE+3]]:4 : 0
+    try test1()
     return 1
-  } catch is SomeErr {     // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+2]]:4 : 1
+  } catch is SomeErr {       // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+2]]:4 : 1
     throw SomeErr.Err1
   }
-}                          // CHECK-NEXT: }
+}                            // CHECK-NEXT: }

--- a/test/Profiler/coverage_errors.swift
+++ b/test/Profiler/coverage_errors.swift
@@ -1,15 +1,24 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_catch %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_errors %s | %FileCheck %s
 // RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
 
 struct S {
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.S.init() -> coverage_catch.S
-  init() { // CHECK: [[@LINE]]:10 -> [[@LINE+6]]:4 : 0
-    do {   // CHECK: [[@LINE]]:8 -> [[@LINE+2]]:6 : 0
-      throw SomeErr.Err1
-    } catch {
-      // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:6 : 1
-    } // CHECK: [[@LINE]]:6 -> [[@LINE+1]]:4 : 0
+  static subscript() -> Int {
+    get throws { 5 }
   }
+  subscript() -> Int {
+    get throws { 5 }
+  }
+  func throwingMethod() throws -> Int { 0 }
+}
+
+func throwingFn() throws -> Int { 0 }
+
+var throwingProp: Int {
+  get throws { 5 }
+}
+
+var throwingS: S {
+  get throws { S() }
 }
 
 enum SomeErr : Error {
@@ -17,56 +26,214 @@ enum SomeErr : Error {
   case Err2
 }
 
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test1
-func test1() throws {
+// Unfortunately due the sorting of the SIL, we have to write the SIL function
+// checks up here.
+
+// func test1() -> Int {
+//   do {
+//     let x = try throwingFn()
+//     return x
+//   } catch {
+//     return 0
+//   }
+// }
+// CHECK-LABEL: sil hidden @$s15coverage_errors5test1SiyF : $@convention(thin) () -> Int
+// CHECK:       bb0:
+// CHECK:       increment_profiler_counter 0
+// CHECK:       [[FN:%[0-9]+]] = function_ref @$s15coverage_errors10throwingFnSiyKF
+// CHECK:       try_apply [[FN]]() : $@convention(thin) () -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 1
+//              FIXME: This next counter is redundant, we ought to be able to
+//                     eliminate this with the SILOptimizer implementation.
+// CHECK:       increment_profiler_counter 2
+
+// func test2() throws -> Int {
+//   let x = try throwingFn()
+//   return x
+// }
+// CHECK-LABEL: sil hidden @$s15coverage_errors5test2SiyKF : $@convention(thin) () -> (Int, @error any Error)
+// CHECK:       bb0:
+// CHECK:       increment_profiler_counter 0
+// CHECK:       [[FN:%[0-9]+]] = function_ref @$s15coverage_errors10throwingFnSiyKF
+// CHECK:       try_apply [[FN]]() : $@convention(thin) () -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 1
+
+// func test3() throws -> Int {
+//   let x = try throwingProp
+//   return x
+// }
+// CHECK-LABEL: sil hidden @$s15coverage_errors5test3SiyKF : $@convention(thin) () -> (Int, @error any Error)
+// CHECK:       bb0:
+// CHECK:       increment_profiler_counter 0
+// CHECK:       [[FN:%[0-9]+]] = function_ref @$s15coverage_errors12throwingPropSivg
+// CHECK:       try_apply [[FN]]() : $@convention(thin) () -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 1
+
+// func test4() throws -> Int {
+//   let x = try S[]
+//   return x
+// }
+// CHECK-LABEL: sil hidden @$s15coverage_errors5test4SiyKF : $@convention(thin) () -> (Int, @error any Error)
+// CHECK:       bb0:
+// CHECK:       increment_profiler_counter 0
+// CHECK:       [[FN:%[0-9]+]] = function_ref @$s15coverage_errors1SVSiycigZ
+// CHECK:       try_apply [[FN]]({{%[0-9]+}}) : $@convention(method) (@thin S.Type) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 1
+
+// func test17(
+//   _ x: S
+// ) throws -> Int {
+//   let y = try x[]
+//   return y
+// }
+// CHECK-LABEL: sil hidden @$s15coverage_errors6test17ySiAA1SVKF : $@convention(thin) (S) -> (Int, @error any Error)
+// CHECK:       bb0(%0 : $S):
+// CHECK:       increment_profiler_counter 0
+// CHECK:       [[FN:%[0-9]+]] = function_ref @$s15coverage_errors1SVSiycig
+// CHECK:       try_apply [[FN]](%0)  : $@convention(method) (S) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 1
+
+// func test18(
+//   _ x: S
+// ) throws -> Int {
+//   let y = try x.throwingMethod()
+//   return y
+// }
+// CHECK-LABEL: sil hidden @$s15coverage_errors6test18ySiAA1SVKF : $@convention(thin) (S) -> (Int, @error any Error)
+// CHECK:       bb0(%0 : $S):
+// CHECK:       increment_profiler_counter 0
+// CHECK:       [[FN:%[0-9]+]] = function_ref @$s15coverage_errors1SV14throwingMethodSiyKF
+// CHECK:       try_apply [[FN]](%0) : $@convention(method) (S) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 1
+
+// func test19() throws -> Int {
+//   let x = try throwingS.throwingMethod()
+//   return x
+// }
+// CHECK-LABEL: sil hidden @$s15coverage_errors6test19SiyKF : $@convention(thin) () -> (Int, @error any Error)
+// CHECK:       bb0:
+// CHECK:       increment_profiler_counter 0
+// CHECK:       [[GETTER:%[0-9]+]] = function_ref @$s15coverage_errors9throwingSAA1SVvg
+// CHECK:       try_apply [[GETTER]]() : $@convention(thin) () -> (S, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 1
+// CHECK:       [[BB_NORMAL]]([[S:%[0-9]+]] : $S):
+// CHECK:       [[FN:%[0-9]+]] = function_ref @$s15coverage_errors1SV14throwingMethodSiyKF
+// CHECK:       try_apply [[FN]]([[S]]) : $@convention(method) (S) -> (Int, @error any Error), normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 2
+
+// func test21() throws -> Int {
+//   try { throw SomeErr.Err1 }()
+//   return 1
+// }
+// CHECK-LABEL: sil hidden @$s15coverage_errors6test21SiyKF : $@convention(thin) () -> (Int, @error any Error)
+// CHECK:       bb0:
+// CHECK:       increment_profiler_counter 0
+// CHECK:       [[FN:%[0-9]+]] = function_ref @$s15coverage_errors6test21SiyKFyyKXEfU_
+// CHECK:       try_apply [[FN]]() : $@convention(thin) () -> @error any Error, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERR:bb[0-9]+]]
+//
+// CHECK:       [[BB_ERR]]
+// CHECK-NEXT:  increment_profiler_counter 1
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test1SiyF"
+func test1() -> Int {        // CHECK-NEXT: [[@LINE]]:21 -> [[@LINE+7]]:2  : 0
+  do {                       // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+3]]:4  : 0
+    let x = try throwingFn() // CHECK-NEXT: [[@LINE]]:29 -> [[@LINE+1]]:13 : (0 - 1)
+    return x
+  } catch {                  // CHECK-NEXT: [[@LINE]]:11 -> [[@LINE+2]]:4 : 2
+    return 0                 // FIXME: The below region shouldn't exist
+  }                          // CHECK-NEXT: [[@LINE]]:4  -> [[@LINE+1]]:2 : (1 - 2)
+}                            // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test2SiyKF"
+func test2() throws -> Int { // CHECK-NEXT: [[@LINE]]:28 -> [[@LINE+3]]:2  : 0
+  let x = try throwingFn()   // CHECK-NEXT: [[@LINE]]:27 -> [[@LINE+1]]:11 : (0 - 1)
+  return x
+}                            // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test3SiyKF"
+func test3() throws -> Int { // CHECK-NEXT: [[@LINE]]:28 -> [[@LINE+3]]:2  : 0
+  let x = try throwingProp   // CHECK-NEXT: [[@LINE]]:27 -> [[@LINE+1]]:11 : (0 - 1)
+  return x
+}                            // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test4SiyKF"
+func test4() throws -> Int { // CHECK-NEXT: [[@LINE]]:28 -> [[@LINE+3]]:2  : 0
+  let x = try S[]            // CHECK-NEXT: [[@LINE]]:18 -> [[@LINE+1]]:11 : (0 - 1)
+  return x
+}                            // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test5yyKF"
+func test5() throws {
   // CHECK-NEXT: [[@LINE-1]]:21 -> [[@LINE+2]]:2 : 0
   throw SomeErr.Err2
 } // CHECK-NEXT: }
 
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test2
-func test2(_ fn: () throws -> ()) rethrows {
-  do {
-    try fn()
-  } catch SomeErr.Err1 { // CHECK: [[@LINE]]:24 -> {{[0-9]+}}:4 : 1
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test6yyyyKXEKF"
+func test6(
+  _ fn: () throws -> ()
+) rethrows {             // CHECK-NEXT: [[@LINE]]:12 -> [[@LINE+8]]:2 : 0
+  do {                   // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+2]]:4 : 0
+    try fn()             // CHECK-NEXT: [[@LINE]]:13 -> [[@LINE+1]]:4 : (0 - 1)
+  } catch SomeErr.Err1 { // CHECK-NEXT: [[@LINE]]:24 -> [[@LINE+2]]:4 : 2
     return
-  } // CHECK-NEXT: [[@LINE]]:4 -> {{[0-9]+}}:2 : (0 - 1)
+  }                      // CHECK-NEXT: [[@LINE]]:4  -> [[@LINE+3]]:2 : (0 - 2)
 
-  try fn()
-} // CHECK-NEXT: }
+  try fn()               // CHECK-NEXT: [[@LINE]]:11 -> [[@LINE+1]]:2 : ((0 - 2) - 3)
+}                        // CHECK-NEXT: }
 
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test3
-func test3() -> Int32 {
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test7s5Int32VyF"
+func test7() -> Int32 {  // CHECK-NEXT: [[@LINE]]:23 -> [[@LINE+31]]:2 : 0
   var x : Int32 = 0
 
-  do {
+  do {                   // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+3]]:4 : 0
     throw SomeErr.Err1
-    x += 2 // [[@LINE]]:5 -> [[@LINE+1]]:4 : zero
-  } catch SomeErr.Err1 {
-    // CHECK: [[@LINE-1]]:24 -> [[@LINE+1]]:4 : 1
-  } catch _ {
-    // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:4 : 2
-  } // CHECK: [[@LINE]]:4 -> {{[0-9:]+}} : 0
+    x += 2               // CHECK-NEXT: [[@LINE]]:5  -> [[@LINE+1]]:4 : zero
+  } catch SomeErr.Err1 { // CHECK-NEXT: [[@LINE]]:24 -> [[@LINE+1]]:4 : 1
+  } catch _ {            // CHECK-NEXT: [[@LINE]]:13 -> [[@LINE+1]]:4 : 2
+  }                      // CHECK-NEXT: [[@LINE]]:4  -> {{[0-9:]+}}   : 0
 
-  do {
-    try test2(test1)
-  } catch _ {
-    // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:4 : 3
-  } // CHECK: [[@LINE]]:4 -> {{[0-9:]+}} : 0
+  do {                   // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+2]]:4 : 0
+    try test6(test5)     // CHECK-NEXT: [[@LINE]]:21 -> [[@LINE+1]]:4 : (0 - 3)
+  } catch _ {            // CHECK-NEXT: [[@LINE]]:13 -> [[@LINE+1]]:4 : 4
+  }                      // CHECK-NEXT: [[@LINE]]:4  -> {{[0-9:]+}}   : 0
 
-  do {
-    try test2 { () throws -> () in throw SomeErr.Err1 }
-  } catch _ {}
+  do {                   // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+5]]:4 : 0
+    try test6 {          // (closures are mapped separately)
+      () throws -> () in
+      throw SomeErr.Err1
+    }                    // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+1]]:4 : (0 - 5)
+  } catch _ {}           // CHECK-NEXT: [[@LINE]]:13 -> [[@LINE]]:15  : 6
+                         // CHECK-NEXT: [[@LINE-1]]:15 -> {{[0-9:]+}} : 0
 
-  try! test2 { () throws -> () in return }
+  // TODO: We ought to realize that everything after try! is unreachable
+  // This is similar issue to rdar://100896177
+  try! test6 {
+    () throws -> () in
+    return
+  }                      // CHECK-NEXT: [[@LINE]]:4  -> [[@LINE+2]]:11 : (0 - 7)
 
   return x
-}
-
-let _ = test3()
+}                        // CHECK-NEXT: }
 
 // rdar://34244637 - Coverage after a do-catch is incorrect
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test4
-func test4(_ b: Bool) -> Int { // CHECK-NEXT: [[@LINE]]:30 {{.*}} : 0
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test8ySiSbF"
+func test8(_ b: Bool) -> Int { // CHECK-NEXT: [[@LINE]]:30 {{.*}} : 0
   do {                         // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE+2]]:4 : 0
     throw SomeErr.Err1
   } catch {                    // CHECK-NEXT: [[@LINE]]:11 {{.*}} : 1
@@ -79,57 +246,120 @@ func test4(_ b: Bool) -> Int { // CHECK-NEXT: [[@LINE]]:30 {{.*}} : 0
 }
 
 // Test coverage with nested do-catches
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test5
-func test5() -> Int {
-  do {
-    try test1()
-    do {
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors5test9SiyF"
+func test9() -> Int {    // CHECK-NEXT: [[@LINE]]:21 -> [[@LINE+12]]:2 : 0
+  do {                   // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+8]]:4 : 0
+    try test5()          // CHECK-NEXT: [[@LINE]]:16 -> [[@LINE+7]]:4 : (0 - 1)
+    do {                 // CHECK-NEXT: [[@LINE]]:8  -> [[@LINE+2]]:6 : (0 - 1)
       throw SomeErr.Err1
-    } catch {
+    } catch {            // CHECK-NEXT: [[@LINE]]:13 -> [[@LINE+3]]:6 : 2
       return 0
-    } // CHECK: [[@LINE]]:6 {{.*}} : (0 - 1)
-
-  } catch {
+                         // FIXME: There shouldn't be region here, it's unreachable (rdar://100470244)
+    }                    // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+1]]:4 : ((0 - 1) - 2)
+  } catch {              // CHECK-NEXT: [[@LINE]]:11 -> [[@LINE+2]]:4 : 3
     return 1
-  } // CHECK: [[@LINE]]:4 {{.*}} : ((0 - 1) - 2)
-
-}
+  }                      // CHECK-NEXT: [[@LINE]]:4 -> [[@LINE+1]]:2 : ((0 - 2) - 3)
+}                        // CHECK-NEXT: }
 
 // Test coverage with a do-catch inside of a repeat-while
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test6
-func test6() -> Int {
-  repeat { // CHECK: [[@LINE]]:10 {{.*}} : 1
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test10SiyF"
+func test10() -> Int {
+  repeat {               // CHECK: [[@LINE]]:10 {{.*}} : 1
     do {
       throw SomeErr.Err1
-    } catch { // CHECK: [[@LINE]]:13 {{.*}} : 2
+    } catch {            // CHECK: [[@LINE]]:13 {{.*}} : 2
       return 0
-    } // CHECK: [[@LINE]]:6 {{.*}} : (1 - 2)
+    }                    // CHECK: [[@LINE]]:6 {{.*}} : (1 - 2)
 
-  } while false // CHECK: [[@LINE]]:11 {{.*}} : (1 - 2)
+  } while false          // CHECK: [[@LINE]]:11 {{.*}} : (1 - 2)
   return 1
 }
 
 // Test coverage with a break inside a do-catch inside of a repeat-while
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.test7
-func test7() -> Int {
-  repeat { // CHECK: [[@LINE]]:10 {{.*}} : 1
-    do {
-      try test1()
-    } catch { // CHECK: [[@LINE]]:13 {{.*}} : 2
-      break
-    } // CHECK: [[@LINE]]:6 {{.*}} : (1 - 2)
-
-  } while false // CHECK: [[@LINE]]:11 {{.*}} : (1 - 2)
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test11SiyF"
+func test11() -> Int { // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+11]]:2 : 0
+  repeat {             // CHECK-NEXT: [[@LINE]]:10 -> [[@LINE+8]]:4 : 1
+    do {               // CHECK-NEXT: [[@LINE]]:8  -> [[@LINE+2]]:6 : 1
+      try test5()      // CHECK-NEXT: [[@LINE]]:18 -> [[@LINE+1]]:6 : (1 - 2)
+    } catch {          // CHECK-NEXT: [[@LINE]]:13 -> [[@LINE+2]]:6 : 3
+      break            // FIXME: This counter should account for the counter 2 (rdar://100470244)
+    }                  // CHECK-NEXT: [[@LINE]]:6   -> [[@LINE+3]]:4  : (1 - 3)
+                       // FIXME: This exit counter is wrong (rdar://118472537)
+                       // CHECK-NEXT: [[@LINE+1]]:4 -> [[@LINE+2]]:11 : (0 - 3)
+  } while false        // CHECK-NEXT: [[@LINE]]:11  -> [[@LINE]]:16   : (1 - 3)
   return 1
-}
+}                      // CHECK-NEXT: }
 
 // rdar://41010883 – Make sure we don't introduce an empty unreachable region.
-// CHECK-LABEL: sil_coverage_map {{.*}} "$s14coverage_catch5test8SiyKF"
-func test8() throws -> Int { // CHECK-NEXT: [[@LINE]]:28 -> [[@LINE+7]]:2 : 0
-  do {                       // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE+3]]:4 : 0
-    try test1()
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test12SiyKF"
+func test12() throws -> Int { // CHECK-NEXT: [[@LINE]]:29 -> [[@LINE+7]]:2  : 0
+  do {                        // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+3]]:4  : 0
+    try test5()               // CHECK-NEXT: [[@LINE]]:16 -> [[@LINE+1]]:13 : (0 - 1)
     return 1
-  } catch is SomeErr {       // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+2]]:4 : 1
-    throw SomeErr.Err1
-  }
-}                            // CHECK-NEXT: }
+  } catch is SomeErr {        // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+2]]:4 : 2
+    throw SomeErr.Err1        // FIXME: The below region shouldn't exist
+  }                           // CHECK-NEXT: [[@LINE]]:4 -> [[@LINE+1]]:2 : 1
+}                             // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test13SiyF"
+func test13() -> Int {      // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+6]]:2 : 0
+  do {                      // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+2]]:4 : 0
+    return try throwingFn() // Note we don't emit a region here because it would be empty.
+  } catch {                 // CHECK-NEXT: [[@LINE]]:11 -> [[@LINE+2]]:4 : 2
+    return 0                // FIXME: The below region shouldn't exist
+  }                         // CHECK-NEXT: [[@LINE]]:4  -> [[@LINE+1]]:2 : (1 - 2)
+}                           // CHECK-NEXT: }
+
+func takesInts(_ x: Int, _ y: Int) {}
+
+// The throwing expr is nested here, the region starts after the throwing expr.
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test14yyKF"
+func test14() throws {           // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+2]]:2 : 0
+  takesInts(try throwingFn(), 0) // CHECK-NEXT: [[@LINE]]:29 -> [[@LINE+1]]:2 : (0 - 1)
+}                                // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test17ySiAA1SVKF"
+func test17(
+  _ x: S
+) throws -> Int { // CHECK-NEXT: [[@LINE]]:17 -> [[@LINE+3]]:2  : 0
+  let y = try x[] // CHECK-NEXT: [[@LINE]]:18 -> [[@LINE+1]]:11 : (0 - 1)
+  return y
+}                 // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test18ySiAA1SVKF"
+func test18(
+  _ x: S
+) throws -> Int {                // CHECK-NEXT: [[@LINE]]:17 -> [[@LINE+3]]:2  : 0
+  let y = try x.throwingMethod() // CHECK-NEXT: [[@LINE]]:33 -> [[@LINE+1]]:11 : (0 - 1)
+  return y
+}                                // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test19SiyKF"
+func test19() throws -> Int {            // CHECK-NEXT: [[@LINE]]:29 -> [[@LINE+3]]:2  : 0
+  let x = try throwingS.throwingMethod() // CHECK-NEXT: [[@LINE]]:24 -> [[@LINE+1]]:11 : (0 - 1)
+  return x                               // CHECK-NEXT: [[@LINE-1]]:41 -> [[@LINE]]:11 : ((0 - 1) - 2)
+}                                        // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test20yyKF"
+func test20() throws { // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+5]]:2 : 0
+  takesInts(
+    try throwingFn(),  // CHECK-NEXT: [[@LINE]]:21 -> [[@LINE+3]]:2 : (0 - 1)
+    try throwingFn()   // CHECK-NEXT: [[@LINE]]:21 -> [[@LINE+2]]:2 : ((0 - 1) - 2)
+  )
+}                      // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test21SiyKF"
+func test21() throws -> Int {  // CHECK-NEXT: [[@LINE]]:29 -> [[@LINE+3]]:2 : 0
+  try { throw SomeErr.Err1 }() // CHECK-NEXT: [[@LINE]]:31 -> [[@LINE+1]]:11 : (0 - 1)
+  return 1
+}                              // CHECK-NEXT: }
+
+struct TestInit {
+  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_errors.TestInit.init() -> coverage_errors.TestInit
+  init() {               // CHECK-NEXT: [[@LINE]]:10 -> [[@LINE+5]]:4 : 0
+    do {                 // CHECK-NEXT: [[@LINE]]:8  -> [[@LINE+2]]:6 : 0
+      throw SomeErr.Err1
+    } catch {            // CHECK-NEXT: [[@LINE]]:13 -> [[@LINE+1]]:6 : 1
+    }                    // CHECK-NEXT: [[@LINE]]:6  -> [[@LINE+1]]:4 : 0
+  }                      // CHECK-NEXT: }
+}

--- a/test/Profiler/coverage_errors_exec.swift
+++ b/test/Profiler/coverage_errors_exec.swift
@@ -1,0 +1,128 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -profile-generate -profile-coverage-mapping -o %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-codesign %t/main
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
+// RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
+// RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck %s
+
+// REQUIRES: profile_runtime
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+struct Err: Error {}
+
+struct S {
+  static subscript() -> Int {
+    get throws { throw Err() }
+  }
+  func throwingMethod() throws -> Int { throw Err() }
+}
+
+func noThrowingFn() throws -> Int { 0 }
+func throwingFn() throws -> Int { throw Err() }
+
+var throwingProp: Int {
+  get throws { throw Err() }
+}
+
+var throwingS: S {
+  get throws { throw Err() }
+}
+
+var noThrowingS: S {
+  get throws { S() }
+}
+
+func test1() -> Int {        // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  do {                       // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    let x = try throwingFn() // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    return x                 // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+  } catch {                  // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    return 0                 // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  }                          // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+}                            // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+_ = test1()                  // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func test2() throws -> Int { // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  let x = try throwingFn()   // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  return x                   // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                            // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+_ = try? test2()             // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func test3() throws -> Int { // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  let x = try throwingProp   // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  return x                   // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                            // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+_ = try? test3()             // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func test4() throws -> Int { // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  let x = try S[]            // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  return x                   // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                            // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+_ = try? test4()             // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+// Note we don't emit a region after the call since it would be empty.
+func test5() -> Int {        // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  do {                       // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    return try throwingFn()  // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  } catch {                  // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    return 0                 // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  }                          // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+}                            // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+_ = test5()                  // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func takesInts(_ x: Int, _ y: Int) {} // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+
+// The throwing expr is nested here, the region starts after the throwing expr.
+func test6() throws {            // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  takesInts(try throwingFn(), 0) // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+}                                // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+try? test6()                     // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func test7() throws {            // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  takesInts(                     // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    try throwingFn(),            // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    0                            // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+  )                              // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                                // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+try? test7()                     // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func test8() throws -> Int {             // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  let x = try throwingS.throwingMethod() // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  return x                               // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                                        // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+_ = try? test8()
+
+func test9() throws -> Int {               // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  let x = try noThrowingS.throwingMethod() // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  return x                                 // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                                          // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+_ = try? test9()                           // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func test10() throws { // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  takesInts(           // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    try throwingFn(),  // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    try throwingFn()   // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+  )                    // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                      // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+try? test10()          // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func test11() throws {  // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  takesInts(            // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    try noThrowingFn(), // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    try throwingFn()    // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  )                     // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                       // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+try? test11()           // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+
+func test21() throws -> Int { // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  try {                       // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+    throw Err()               // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  }()                         // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+  return 1                    // CHECK: {{ *}}[[@LINE]]|{{ *}}0
+}                             // CHECK: {{ *}}[[@LINE]]|{{ *}}1
+_ = try? test21()             // CHECK: {{ *}}[[@LINE]]|{{ *}}1

--- a/test/Profiler/coverage_smoke.swift
+++ b/test/Profiler/coverage_smoke.swift
@@ -150,7 +150,7 @@ func throwError(_ b: Bool) throws {
 func catchError(_ b: Bool) -> Int {
   do {
     try throwError(b) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
-  } catch {           // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
+  } catch {           // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
     return 1          // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
   }                   // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
   let _ = 1 + 1       // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1

--- a/test/Profiler/coverage_switch.swift
+++ b/test/Profiler/coverage_switch.swift
@@ -51,17 +51,18 @@ enum Algebraic {
 func nop() {}
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_switch.f2
-func f2(_ x : Algebraic) -> Int32 { // CHECK-NEXT: [[@LINE]]:35 -> [[@LINE+15]]:2 : 0
+func f2(_ x : Algebraic) -> Int32 { // CHECK-NEXT: [[@LINE]]:35 -> [[@LINE+16]]:2 : 0
   switch(x) {                       // CHECK-NEXT: [[@LINE]]:9 -> [[@LINE]]:12 : 0
   case let .Type1(y, z):            // CHECK-NEXT: [[@LINE]]:3 -> [[@LINE+1]]:10 : 1
     nop()
   case .Type2(let b):               // CHECK-NEXT: [[@LINE]]:3 -> [[@LINE+2]]:16 : 2
     nop()
     fallthrough
-  case .Type3:                      // CHECK-NEXT: [[@LINE]]:3 -> [[@LINE+3]]:6 : (2 + 3)
+  case .Type3:                      // CHECK-NEXT: [[@LINE]]:3 -> [[@LINE+4]]:7 : (2 + 3)
     if (false) {                    // CHECK-NEXT: [[@LINE]]:8 -> [[@LINE]]:15 : (2 + 3)
       fallthrough                   // CHECK-NEXT: [[@LINE-1]]:16 -> [[@LINE+1]]:6 : 4
-    }                               // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE]]:6 : ((2 + 3) - 4)
+    }                               // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE+1]]:7 : ((2 + 3) - 4)
+    () // Here to make sure this region is non empty ^
   case .Type4:                      // CHECK-NEXT: [[@LINE]]:3 -> [[@LINE+1]]:10 : (4 + 5)
     break
   } // CHECK-NEXT: [[@LINE]]:4 -> [[@LINE+1]]:11 : (((1 + 2) + 3) + 5)
@@ -91,23 +92,25 @@ f2(Algebraic.Type3)
 f3(Simple.Second)
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_switch.f4
-func f4(_ x: Int) throws -> Int { // CHECK-NEXT: [[@LINE]]:33 -> [[@LINE+21]]:2 : 0
-  y: do {                         // CHECK-NEXT: [[@LINE]]:9 -> [[@LINE+18]]:4 : 0
+func f4(_ x: Int) throws -> Int { // CHECK-NEXT: [[@LINE]]:33 -> [[@LINE+23]]:2 : 0
+  y: do {                         // CHECK-NEXT: [[@LINE]]:9 -> [[@LINE+20]]:4 : 0
     switch x {                    // CHECK-NEXT: [[@LINE]]:12 -> [[@LINE]]:13 : 0
     case 1, 2, 3:                 // CHECK-NEXT: [[@LINE]]:5 -> [[@LINE+4]]:18 : 1
       if .random() {              // CHECK-NEXT: [[@LINE]]:10 -> [[@LINE]]:19 : 1
         return 5                  // CHECK-NEXT: [[@LINE-1]]:20 -> [[@LINE+1]]:8 : 2
       }                           // CHECK-NEXT: [[@LINE]]:8 -> [[@LINE+1]]:18 : (1 - 2)
       fallthrough
-    case 4:                       // CHECK-NEXT: [[@LINE]]:5 -> [[@LINE+4]]:8 : ((1 + 3) - 2)
+    case 4:                       // CHECK-NEXT: [[@LINE]]:5 -> [[@LINE+5]]:9 : ((1 + 3) - 2)
       if .random() {              // CHECK-NEXT: [[@LINE]]:10 -> [[@LINE]]:19 : ((1 + 3) - 2)
         struct E : Error {}       // CHECK-NEXT: [[@LINE-1]]:20 -> [[@LINE+2]]:8 : 4
         throw E()
-      }                           // CHECK-NEXT: [[@LINE]]:8 -> [[@LINE]]:8 : (((1 + 3) - 2) - 4)
-    default:                      // CHECK-NEXT: [[@LINE]]:5 -> [[@LINE+3]]:8 : 5
+      }                           // CHECK-NEXT: [[@LINE]]:8 -> [[@LINE+1]]:9 : (((1 + 3) - 2) - 4)
+      () // Here to make sure this region is non empty ^
+    default:                      // CHECK-NEXT: [[@LINE]]:5 -> [[@LINE+4]]:9 : 5
       if .random() {              // CHECK-NEXT: [[@LINE]]:10 -> [[@LINE]]:19 : 5
         break y                   // CHECK-NEXT: [[@LINE-1]]:20 -> [[@LINE+1]]:8 : 6
-      }                           // CHECK-NEXT: [[@LINE]]:8 -> [[@LINE]]:8 : (5 - 6)
+      }                           // CHECK-NEXT: [[@LINE]]:8 -> [[@LINE+1]]:9 : (5 - 6)
+      () // Here to make sure this region is non empty ^
     }
     f1(0)                         // CHECK-NEXT: [[@LINE-1]]:6 -> [[@LINE+1]]:4 : (((((1 + 3) + 5) - 2) - 4) - 6)
   }

--- a/test/Profiler/coverage_toplevel.swift
+++ b/test/Profiler/coverage_toplevel.swift
@@ -17,10 +17,9 @@ func f1() {}
 // CHECK-NEXT: [[@LINE+1]]:1 -> [[@LINE+1]]:18 : 1
 var i : Int32 = 0
 
-// CHECK-NEXT: [[@LINE+4]]:1 -> [[@LINE+6]]:2 : 2
-// CHECK-NEXT: [[@LINE+3]]:7 -> [[@LINE+3]]:15 : (2 + 3)
-// CHECK-NEXT: [[@LINE+2]]:16 -> [[@LINE+4]]:2 : 3
-// CHECK-NEXT: [[@LINE+3]]:2 -> [[@LINE+3]]:2 : 2
+// CHECK-NEXT: [[@LINE+3]]:1 -> [[@LINE+5]]:2 : 2
+// CHECK-NEXT: [[@LINE+2]]:7 -> [[@LINE+2]]:15 : (2 + 3)
+// CHECK-NEXT: [[@LINE+1]]:16 -> [[@LINE+3]]:2 : 3
 while (i < 10) {
   i += 1
 }
@@ -30,10 +29,9 @@ while (i < 10) {
 // CHECK-NEXT: [[@LINE+1]]:21 -> [[@LINE+1]]:22 : (4 - 5)
 var i2 = true ? 1 : 0;
 
-// CHECK-NEXT: [[@LINE+4]]:1 -> [[@LINE+6]]:2 : 6
-// CHECK-NEXT: [[@LINE+3]]:4 -> [[@LINE+3]]:10 : 6
-// CHECK-NEXT: [[@LINE+2]]:11 -> [[@LINE+4]]:2 : 7
-// CHECK-NEXT: [[@LINE+3]]:2 -> [[@LINE+3]]:2 : 6
+// CHECK-NEXT: [[@LINE+3]]:1 -> [[@LINE+5]]:2 : 6
+// CHECK-NEXT: [[@LINE+2]]:4 -> [[@LINE+2]]:10 : 6
+// CHECK-NEXT: [[@LINE+1]]:11 -> [[@LINE+3]]:2 : 7
 if (true) {
   i2 = 2
 }

--- a/test/Profiler/coverage_while.swift
+++ b/test/Profiler/coverage_while.swift
@@ -123,6 +123,10 @@ func goo() {
   } while false // CHECK-DAG: [[@LINE]]:11 -> [[@LINE]]:16 : ([[RWS8]] - [[RET1]])
 }
 
-eoo()
-foo()
-goo()
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_while.hoo
+func hoo() {       // CHECK-NEXT: [[@LINE]]:12 -> [[@LINE+5]]:2 : 0
+  var i: Int = 0
+  while (i < 10) { // CHECK-NEXT: [[@LINE]]:9 -> [[@LINE]]:17 : (0 + 1)
+    i += 1         // CHECK-NEXT: [[@LINE-1]]:18 -> [[@LINE+1]]:4 : 1
+  }                // CHECK-NEXT: [[@LINE]]:4 -> [[@LINE+1]]:2 : 0
+}

--- a/test/Profiler/instrprof_basic.swift
+++ b/test/Profiler/instrprof_basic.swift
@@ -37,9 +37,10 @@ func basic(a : Int32) {
 // CHECK: sil hidden [ossa] @[[F_THROWING_NOP:.*throwing_nop.*]] :
 func throwing_nop() throws {}
 // CHECK: sil hidden [ossa] @[[F_EXCEPTIONS:.*exceptions.*]] :
-// CHECK: increment_profiler_counter 0, "{{.*}}instrprof_basic.swift:[[F_EXCEPTIONS]]", num_counters 2, hash
+// CHECK: increment_profiler_counter 0, "{{.*}}instrprof_basic.swift:[[F_EXCEPTIONS]]", num_counters 3, hash
 func exceptions() {
   do {
+    // CHECK: increment_profiler_counter
     try throwing_nop()
   } catch {
     // CHECK: increment_profiler_counter


### PR DESCRIPTION
Map a counter for the error branch of a given potentially-throwing expression, and subtract it from the following region count. This requires also fixing the coverage for do-catch statements, which would have otherwise been regressed.

rdar://34244637
rdar://100470244
rdar://118185163
Resolves #63194
Resolves #61318