### PR TITLE
AST: Refactor pattern binding initializer expression state representation

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -68,11 +68,10 @@ protected:
   // clang-format off
   union { uint64_t OpaqueBits;
 
-  SWIFT_INLINE_BITFIELD_BASE(Pattern, bitmax(NumPatternKindBits,8)+1+1+1,
+  SWIFT_INLINE_BITFIELD_BASE(Pattern, bitmax(NumPatternKindBits,8)+1+1,
     Kind : bitmax(NumPatternKindBits,8),
     isImplicit : 1,
-    hasInterfaceType : 1,
-    executableInitChecked : 1
+    hasInterfaceType : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(TuplePattern, Pattern, 32,
@@ -105,7 +104,6 @@ protected:
     Bits.Pattern.Kind = unsigned(kind);
     Bits.Pattern.isImplicit = false;
     Bits.Pattern.hasInterfaceType = false;
-    Bits.Pattern.executableInitChecked = false;
   }
 
 private:
@@ -137,11 +135,6 @@ public:
   /// exists no source code for it.
   bool isImplicit() const { return Bits.Pattern.isImplicit; }
   void setImplicit() { Bits.Pattern.isImplicit = true; }
-
-  bool executableInitChecked() const {
-    return Bits.Pattern.executableInitChecked;
-  }
-  void setExecutableInitChecked() { Bits.Pattern.executableInitChecked = true; }
 
   /// Find the smallest subpattern which obeys the property that matching it is
   /// equivalent to matching this pattern.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2347,8 +2347,8 @@ public:
   void cacheResult(const PatternBindingEntry *value) const;
 };
 
-class PatternBindingCheckedExecutableInitRequest
-    : public SimpleRequest<PatternBindingCheckedExecutableInitRequest,
+class PatternBindingCheckedAndContextualizedInitRequest
+    : public SimpleRequest<PatternBindingCheckedAndContextualizedInitRequest,
                            Expr *(PatternBindingDecl *, unsigned),
                            RequestFlags::SeparatelyCached> {
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -258,7 +258,7 @@ SWIFT_REQUEST(TypeChecker, OverriddenDeclsRequest,
 SWIFT_REQUEST(TypeChecker, PatternBindingEntryRequest,
               const PatternBindingEntry *(PatternBindingDecl *, unsigned, bool),
               SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, PatternBindingCheckedExecutableInitRequest,
+SWIFT_REQUEST(TypeChecker, PatternBindingCheckedAndContextualizedInitRequest,
               Expr *(PatternBindingDecl *, unsigned),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PrimarySourceFilesRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2072,7 +2072,7 @@ void PatternBindingEntry::setInit(Expr *E) {
   } else {
     PatternAndFlags.setInt(F | Flags::Removed);
   }
-  InitExpr.initAfterSynthesis = E;
+  InitExpr.initAfterSynthesis.setPointer(E);
   InitContextAndFlags.setInt(InitContextAndFlags.getInt() -
                              PatternFlags::IsText);
 }
@@ -2198,11 +2198,17 @@ PatternBindingDecl::getInitializerIsolation(unsigned i) const {
   return var->getInitializerIsolation();
 }
 
-Expr *PatternBindingDecl::getCheckedExecutableInit(unsigned i) const {
+Expr *PatternBindingDecl::getCheckedAndContextualizedInit(unsigned i) const {
   return evaluateOrDefault(getASTContext().evaluator,
-                           PatternBindingCheckedExecutableInitRequest{
+                           PatternBindingCheckedAndContextualizedInitRequest{
                                const_cast<PatternBindingDecl *>(this), i},
                            nullptr);
+}
+
+Expr *PatternBindingDecl::getCheckedAndContextualizedExecutableInit(
+    unsigned i) const {
+  (void)getCheckedAndContextualizedInit(i);
+  return getExecutableInit(i);
 }
 
 bool PatternBindingDecl::hasStorage() const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1023,23 +1023,24 @@ void PatternBindingEntryRequest::cacheResult(
 }
 
 //----------------------------------------------------------------------------//
-// PatternCheckedExecutableInitRequest computation.
+// PatternBindingCheckedAndContextualizedInitRequest computation.
 //----------------------------------------------------------------------------//
 
 llvm::Optional<Expr *>
-PatternBindingCheckedExecutableInitRequest::getCachedResult() const {
+PatternBindingCheckedAndContextualizedInitRequest::getCachedResult() const {
   auto *PBD = std::get<0>(getStorage());
   auto idx = std::get<1>(getStorage());
-  if (!PBD->getPattern(idx)->executableInitChecked())
+  if (!PBD->getPatternList()[idx].isInitializerCheckedAndContextualized())
     return llvm::None;
-  return PBD->getExecutableInit(idx);
+  return PBD->getInit(idx);
 }
 
-void PatternBindingCheckedExecutableInitRequest::cacheResult(Expr *expr) const {
+void PatternBindingCheckedAndContextualizedInitRequest::cacheResult(
+    Expr *expr) const {
   auto *PBD = std::get<0>(getStorage());
   auto idx = std::get<1>(getStorage());
-  assert(expr == PBD->getExecutableInit(idx));
-  PBD->getPattern(idx)->setExecutableInitChecked();
+  assert(expr == PBD->getInit(idx));
+  PBD->getMutablePatternList()[idx].setInitializerCheckedAndContextualized();
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1657,7 +1657,7 @@ emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
     return;
 
   // Force the executable init to be type checked before emission.
-  if (!pbd->getCheckedExecutableInit(i))
+  if (!pbd->getCheckedAndContextualizedExecutableInit(i))
     return;
 
   auto *var = pbd->getAnchoringVarDecl(i);

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -220,7 +220,7 @@ void SILGenModule::emitGlobalInitialization(PatternBindingDecl *pd,
   }
 
   // Force the executable init to be type checked before emission.
-  if (!pd->getCheckedExecutableInit(pbdEntry))
+  if (!pd->getCheckedAndContextualizedExecutableInit(pbdEntry))
     return;
 
   Mangle::ASTMangler TokenMangler;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2664,7 +2664,7 @@ public:
 
         // Trigger a request that will complete typechecking for the
         // initializer.
-        (void)PBD->getCheckedExecutableInit(i);
+        (void)PBD->getCheckedAndContextualizedInit(i);
       }
     }
 


### PR DESCRIPTION
As a follow up to https://github.com/apple/swift/pull/69841, clarify the possible states that initializer expression of a pattern can be in. The possible states are not checked, checked, and "checked and contextualized" (which is the new state that was introduced and requestified in the previous PR). This refactoring encodes the states more explicitly and renames a few compiler APIs to better align with the new naming. NFC.
