### PR TITLE
[ConstraintSystem] A couple of NFC code cleanups

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9536,9 +9536,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // where the base type has a conditional Sendable conformance
   if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
     if (isPartialApplication(memberLocator)) {
-      auto sendableProtocol =
-          Context.getProtocol(
-              KnownProtocolKind::Sendable);
+      auto sendableProtocol = Context.getProtocol(KnownProtocolKind::Sendable);
       auto baseConformance = DC->getParentModule()->lookupConformance(
           instanceTy, sendableProtocol);
 
@@ -9548,9 +9546,11 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
                 if (req.getKind() != RequirementKind::Conformance)
                   return false;
 
-                if (auto protocolTy = req.getSecondType()->template getAs<ProtocolType>()) {
+                if (auto protocolTy =
+                        req.getSecondType()->template getAs<ProtocolType>()) {
                   return req.getFirstType()->hasTypeVariable() &&
-                         protocolTy->getDecl()->isSpecificProtocol(KnownProtocolKind::Sendable);
+                         protocolTy->getDecl()->isSpecificProtocol(
+                             KnownProtocolKind::Sendable);
                 }
                 return false;
               })) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1665,8 +1665,6 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
                                      FunctionRefKind functionRefKind,
                                      ConstraintLocatorBuilder locator,
                                      DeclContext *useDC) {
-  auto &ctx = getASTContext();
-
   if (value->getDeclContext()->isTypeContext() && isa<FuncDecl>(value)) {
     // Unqualified lookup can find operator names within nominal types.
     auto func = cast<FuncDecl>(value);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1713,7 +1713,8 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
 
     if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
       // All global functions should be @Sendable
-      if (!funcDecl->getDeclContext()->isTypeContext() && !funcDecl->getDeclContext()->isLocalContext() ) {
+      if (!funcDecl->getDeclContext()->isTypeContext() &&
+          !funcDecl->getDeclContext()->isLocalContext()) {
         funcType =
             funcType->withExtInfo(funcType->getExtInfo().withConcurrent());
       }
@@ -1722,7 +1723,9 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
     auto openedType = openFunctionType(funcType, locator, replacements,
                                        funcDecl->getDeclContext())
                           ->removeArgumentLabels(numLabelsToRemove);
-    openedType = unwrapPropertyWrapperParameterTypes(*this, funcDecl, functionRefKind, openedType->castTo<FunctionType>(), locator);
+    openedType = unwrapPropertyWrapperParameterTypes(
+        *this, funcDecl, functionRefKind, openedType->castTo<FunctionType>(),
+        locator);
 
     auto origOpenedType = openedType;
     if (!isRequirementOrWitness(locator)) {
@@ -2677,7 +2680,10 @@ ConstraintSystem::getTypeOfMemberReference(
       if (isPartialApplication(locator) &&
           isSendableType(DC->getParentModule(), baseOpenedTy)) {
         // Add @Sendable to functions without conditional conformances
-        functionType = functionType->withExtInfo(functionType->getExtInfo().withConcurrent())->getAs<FunctionType>();
+        functionType =
+            functionType
+                ->withExtInfo(functionType->getExtInfo().withConcurrent())
+                ->getAs<FunctionType>();
       }
       // Unapplied values should always be Sendable
       info = info.withConcurrent();


### PR DESCRIPTION
- Unify logic in `isInvalidPartialApplication` and `isPartialApplicaiotn`
- Remove unused reference to ASTContext
- Format code related to `InferSendableFromCaptures` feature

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
