### PR TITLE
[SIL] Addr-only enums have non-none ownership.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -681,7 +681,7 @@ ManagedValue SILGenBuilder::createManagedOptionalNone(SILLocation loc,
   if (!type.isAddressOnly(getFunction()) ||
       !SGF.silConv.useLoweredAddresses()) {
     SILValue noneValue = createOptionalNone(loc, type);
-    return ManagedValue::forObjectRValueWithoutOwnership(noneValue);
+    return SGF.emitManagedRValueWithCleanup(noneValue);
   }
 
   SILValue tempResult = SGF.emitTemporaryAllocation(loc, type);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1028,8 +1028,8 @@ RValue RValueEmitter::visitNilLiteralExpr(NilLiteralExpr *E, SGFContext C) {
 
     ManagedValue noneValue;
     if (enumTy.isLoadable(SGF.F) || !SGF.silConv.useLoweredAddresses()) {
-      noneValue = ManagedValue::forObjectRValueWithoutOwnership(
-          SGF.B.createEnum(E, SILValue(), noneDecl, enumTy));
+      auto *e = SGF.B.createEnum(E, SILValue(), noneDecl, enumTy);
+      noneValue = SGF.emitManagedRValueWithCleanup(e);
     } else {
       noneValue =
           SGF.B.bufferForExpr(E, enumTy, SGF.getTypeLowering(enumTy), C,

--- a/test/SILGen/Inputs/opaque_values_silgen_resilient.swift
+++ b/test/SILGen/Inputs/opaque_values_silgen_resilient.swift
@@ -1,0 +1,14 @@
+public class ClassEquatable : Equatable {
+  public static func ==(lhs: ClassEquatable, rhs: ClassEquatable) -> Bool { lhs === rhs }
+}
+
+public enum EnumNontrivialWithEmptyCases : Equatable {
+  case empty
+  case other
+  case loaded(ClassEquatable)
+}
+
+public enum EnumTrivial : Equatable {
+  case empty
+  case other
+}

--- a/test/SILGen/opaque_values_silgen_imports_resilient.swift
+++ b/test/SILGen/opaque_values_silgen_imports_resilient.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -disable-availability-checking -o %t -enable-library-evolution -module-name ResilientLibrary %S/Inputs/opaque_values_silgen_resilient.swift
+// RUN: %target-swift-frontend -enable-sil-opaque-values -emit-silgen -disable-availability-checking -I %t %s | %FileCheck %s
+
+import ResilientLibrary
+
+// Verify that an enum instruction producing a trivial is _still_ destroyed if
+// (1) the enum instruction's type is non-trivial
+// (2) the enum is address-only
+// Necessary because such an enum will be lowered to
+// init_enum_data_addr/inject_enum_addr and there isn't generally enough
+// information to determine whether a destroy_addr is required so it is always
+// required.
+// CHECK-LABEL: sil [ossa] @produceSomeEmptyNontrivialAddronlyEnumInstance : {{.*}} {
+// CHECK:         [[EMPTY_CASE:%[^,]+]] = enum $EnumNontrivialWithEmptyCases, #EnumNontrivialWithEmptyCases.empty!enumelt
+// CHECK:         [[SOME_EMPTY_CASE:%[^,]+]] = enum $Optional<EnumNontrivialWithEmptyCases>, #Optional.some!enumelt, [[EMPTY_CASE]]
+// CHECK:         destroy_value [[SOME_EMPTY_CASE]]
+// CHECK-LABEL: } // end sil function 'produceSomeEmptyNontrivialAddronlyEnumInstance'
+@_silgen_name("produceSomeEmptyNontrivialAddronlyEnumInstance")
+public func produceSomeEmptyNontrivialAddronlyEnumInstance(_ one: EnumNontrivialWithEmptyCases?) {
+  if one != .empty {
+  }
+}
+
+// CHECK-LABEL: sil [ossa] @produceNoneEmptyAddronlyEnumInstance : {{.*}} {
+// CHECK:         [[NONE:%[^,]+]] = enum $Optional<EnumNontrivialWithEmptyCases>, #Optional.none!enumelt 
+// CHECK:         return [[NONE]] : $Optional<EnumNontrivialWithEmptyCases> 
+// CHECK-LABEL: } // end sil function 'produceNoneEmptyAddronlyEnumInstance'
+@_silgen_name("produceNoneEmptyAddronlyEnumInstance")
+public func produceNoneEmptyAddronlyEnumInstance() -> EnumNontrivialWithEmptyCases? {
+  return .none
+}


### PR DESCRIPTION
Values produced by address-only `enum` instructions have non-none ownership.  And because `enum` is representation-changing, they have `owned` ownership.

This corresponds at the opaque values SIL stage to the fact that at the address-lowered SIL stage the storage location has non-trivial initialization which must be `destroy_addr`d, regardless of whether an empty case was stored to it.
