### PR TITLE
[5.10] Fix miscompiles in client code using resilient noncopyable types.

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -767,7 +767,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
           val = B.createMarkUnresolvedNonCopyableValueInst(
               loc, val,
               MarkUnresolvedNonCopyableValueInst::CheckKind::
-                  AssignableButNotConsumable);
+                  NoConsumeOrAssign);
         }
         val = emitLoad(loc, val, tl, SGFContext(), IsNotTake).forward(*this);
       }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2985,8 +2985,14 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
                                  InitableButNotConsumable)
         continue;
 
-      auto *insertPt = inst->getNextInstruction();
-      assert(insertPt && "def instruction was a terminator");
+      SILInstruction *insertPt;
+      if (auto tryApply = dyn_cast<TryApplyInst>(inst)) {
+        // The dead def is only valid on the success return path.
+        insertPt = &tryApply->getNormalBB()->front();
+      } else {
+        insertPt = inst->getNextInstruction();
+        assert(insertPt && "instruction is a terminator that wasn't handled?");
+      }
       insertDestroyBeforeInstruction(addressUseState, insertPt,
                                      liveness.getRootValue(), defPair.second,
                                      consumes);

--- a/test/Interpreter/Inputs/moveonly_resilient_type.swift
+++ b/test/Interpreter/Inputs/moveonly_resilient_type.swift
@@ -1,0 +1,29 @@
+struct MyError: Error {}
+
+public struct Resilient: ~Copyable {
+    static var nextValue: Int = 0
+
+    private(set) public var value: Int
+    public init(nonthrowing: ()) {
+        value = Self.nextValue
+        Self.nextValue += 1
+    }
+    deinit { print("resilient deinit \(value)") }
+    
+    public init(throwing: Bool) throws {
+        if throwing {
+            throw MyError()
+        }
+        self = .init(nonthrowing: ())
+    }
+    public init(throwingAfterInit: Bool) throws {
+        self = .init(nonthrowing: ())
+        if throwingAfterInit {
+            throw MyError()
+        }
+    }
+
+    public static func instanceCount() -> Int {
+        return nextValue
+    }
+}

--- a/test/Interpreter/Inputs/moveonly_resilient_type.swift
+++ b/test/Interpreter/Inputs/moveonly_resilient_type.swift
@@ -27,3 +27,36 @@ public struct Resilient: ~Copyable {
         return nextValue
     }
 }
+
+func testCapture(_: () -> Bool) {}
+
+public struct ResilientCapturesInDeinit: ~Copyable {
+    static var nextValue: Int = 0
+
+    private(set) public var value: Int
+    public init(nonthrowing: ()) {
+        value = Self.nextValue
+        Self.nextValue += 1
+    }
+    deinit {
+        testCapture { value >= 0 }
+        print("resilient capture in deinit \(value)")
+    }
+    
+    public init(throwing: Bool) throws {
+        if throwing {
+            throw MyError()
+        }
+        self = .init(nonthrowing: ())
+    }
+    public init(throwingAfterInit: Bool) throws {
+        self = .init(nonthrowing: ())
+        if throwingAfterInit {
+            throw MyError()
+        }
+    }
+
+    public static func instanceCount() -> Int {
+        return nextValue
+    }
+}

--- a/test/Interpreter/moveonly_resilient_capture_during_deinit.swift
+++ b/test/Interpreter/moveonly_resilient_capture_during_deinit.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -o %t/a.out -I %t %s %t/moveonly_resilient_type.o
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import moveonly_resilient_type
+
+// CHECK: start
+
+func test1a() throws {
+    // CHECK-NEXT: resilient capture in deinit 0
+    _ = ResilientCapturesInDeinit(nonthrowing: ())
+}
+func test1b() throws {
+    // CHECK-NEXT: resilient capture in deinit 1
+    let x = ResilientCapturesInDeinit(nonthrowing: ())
+}
+func test2a() throws {
+    // CHECK-NEXT: resilient capture in deinit 2
+    _ = try ResilientCapturesInDeinit(throwing: false)
+}
+func test2b() throws {
+    // CHECK-NEXT: resilient capture in deinit 3
+    let x = try ResilientCapturesInDeinit(throwing: false)
+}
+func test3a() throws {
+    _ = try ResilientCapturesInDeinit(throwing: true)
+}
+func test3b() throws {
+    let x = try ResilientCapturesInDeinit(throwing: true)
+}
+func test4a() throws {
+    // CHECK-NEXT: resilient capture in deinit 4
+    _ = try ResilientCapturesInDeinit(throwingAfterInit: false)
+}
+func test4b() throws {
+    // CHECK-NEXT: resilient capture in deinit 5
+    let x = try ResilientCapturesInDeinit(throwingAfterInit: false)
+}
+func test5a() throws {
+    // CHECK-NEXT: resilient capture in deinit 6
+    _ = try ResilientCapturesInDeinit(throwingAfterInit: true)
+}
+func test5b() throws {
+    // CHECK-NEXT: resilient capture in deinit 7
+    let x = try ResilientCapturesInDeinit(throwingAfterInit: true)
+}
+
+func main() {
+    print("start")
+
+    _ = try? test1a()
+    _ = try? test1b()
+    _ = try? test2a()
+    _ = try? test2b()
+    _ = try? test3a()
+    _ = try? test3b()
+    _ = try? test4a()
+    _ = try? test4b()
+    _ = try? test5a()
+    _ = try? test5b()
+
+    // CHECK-NEXT: total 8
+    print("total \(ResilientCapturesInDeinit.instanceCount())")
+}
+main()

--- a/test/Interpreter/moveonly_resilient_deinit_on_throw.swift
+++ b/test/Interpreter/moveonly_resilient_deinit_on_throw.swift
@@ -1,0 +1,88 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -o %t/a.out -I %t %s %t/moveonly_resilient_type.o
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// CHECK: starting
+
+import moveonly_resilient_type
+
+func makeItem1() throws -> Resilient {
+    return Resilient(nonthrowing: ())
+}
+
+func test1a() throws {
+    // CHECK-NEXT: resilient deinit 0
+    _ = try makeItem1()
+}
+func test1b() throws {
+    // CHECK-NEXT: resilient deinit 1
+    let x = try makeItem1()
+}
+
+func makeItem2(throwing: Bool) throws -> Resilient {
+    return try Resilient(throwing: throwing)
+}
+
+func test2aa() throws {
+    // CHECK-NEXT: resilient deinit 2
+    _ = try makeItem2(throwing: false)
+}
+
+func test2ab() throws {
+    _ = try makeItem2(throwing: true)
+}
+
+func test2ba() throws {
+    // CHECK-NEXT: resilient deinit 3
+    let x = try makeItem2(throwing: false)
+}
+
+func test2bb() throws {
+    let x = try makeItem2(throwing: true)
+}
+
+func makeItem3(throwing: Bool) throws -> Resilient {
+    return try Resilient(throwingAfterInit: throwing)
+}
+
+func test3aa() throws {
+    // CHECK-NEXT: resilient deinit 4
+    _ = try makeItem3(throwing: false)
+}
+
+func test3ab() throws {
+    // CHECK-NEXT: resilient deinit 5
+    _ = try makeItem3(throwing: true)
+}
+
+func test3ba() throws {
+    // CHECK-NEXT: resilient deinit 6
+    let x = try makeItem3(throwing: false)
+}
+
+func test3bb() throws {
+    // CHECK-NEXT: resilient deinit 7
+    let x = try makeItem3(throwing: true)
+}
+
+func main() {
+    print("starting")
+    _ = try? test1a()
+    _ = try? test1b()
+    _ = try? test2aa()
+    _ = try? test2ab()
+    _ = try? test2ba()
+    _ = try? test2bb()
+    _ = try? test3aa()
+    _ = try? test3ab()
+    _ = try? test3ba()
+    _ = try? test3bb()
+
+    // CHECK-NEXT: 8 instances in total
+    print("\(Resilient.instanceCount()) instances in total")
+}
+main()

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -913,7 +913,7 @@ func testGlobalAssign() {
 // CHECK:   store [[ARG]] to [init] [[PROJECT]]
 //
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly49checkMarkUnresolvedNonCopyableValueInstOnCaptured1xyAA2FDVn_tFyyXEfU_ : $@convention(thin) @substituted <τ_0_0> (@guaranteed FD) -> @out τ_0_0 for <()>
-// CHECK:   [[MARK:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[PROJECT]]
+// CHECK:   [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT]]
 // CHECK:   [[VALUE:%.*]] = load [copy] [[MARK]]
 // CHECK:   [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]([[VALUE]])
 // CHECK: } // end sil function '$s8moveonly49checkMarkUnresolvedNonCopyableValueInstOnCaptured1xyAA2FDVn_tF'


### PR DESCRIPTION
• Explanation: Fixes a compiler crash when a function that can throw tries to return a resilient noncopyable type, as well as an over-destroy of a resilient noncopyable value that is captured into a closure.
• Scope of Issue: Bug fixes.
• Origination: Noncopyable feature work.
• Risk: Low. Two small fixes that only affect code using resilient noncopyable types.
• Cherry-pick from main URLs: https://github.com/apple/swift/pull/69887, https://github.com/apple/swift/pull/69899
• Reviewed By: @gottesmm 
• Automated Testing: Swift CI
• Issues: rdar://118255228, rdar://118427997