### PR TITLE
Fix test methods-this-and-indirect-return-irgen-msvc.swift for windows/aarch64

### DIFF
--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-irgen -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-irgen -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-cpu
 
 // REQUIRES: OS=windows-msvc
 
@@ -14,4 +14,5 @@ public func use() -> CInt {
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
 // CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr sret(%struct.NonTrivialInWrapper) %[[result]], i32 42)
 
-// CHECK: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})
+// CHECK-x86_64: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})
+// CHECK-aarch64: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr inreg noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})


### PR DESCRIPTION
Handle a slight LLVM IR difference in the second parameter (inreg) of a function between x86_64 and aarch64. These are how Clang on windows emits the code.
