### PR TITLE
Disable `InterfaceHash/edited_{method_body|property_getter}.swift`

### DIFF
--- a/test/InterfaceHash/edited_method_body.swift
+++ b/test/InterfaceHash/edited_method_body.swift
@@ -1,4 +1,5 @@
 // REQUIRES: shell
+// REQUIRES: rdar118528453
 // Also uses awk:
 // XFAIL OS=windows
 

--- a/test/InterfaceHash/edited_property_getter.swift
+++ b/test/InterfaceHash/edited_property_getter.swift
@@ -1,4 +1,5 @@
 // REQUIRES: shell
+// REQUIRES: rdar118528453
 // Also uses awk:
 // XFAIL OS=windows
 


### PR DESCRIPTION
These tests are failing due to sometimes registering a dependency on the `_Concurrency` module's swift interface, rather than binary module. Disable while we investigate. 