### PR TITLE
[BitwiseCopyable] Add a marker protocol.

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -137,6 +137,7 @@ PROTOCOL(AsyncIteratorProtocol)
 PROTOCOL(FloatingPoint)
 
 INVERTIBLE_PROTOCOL_WITH_NAME(Copyable, "Copyable")
+PROTOCOL_(BitwiseCopyable)
 
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "Array", false)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByBooleanLiteral, "BooleanLiteralType", true)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -266,6 +266,9 @@ EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)
 /// Enable the @extractConstantsFromMembers attribute.
 EXPERIMENTAL_FEATURE(ExtractConstantsFromMembers, false)
 
+/// Enable bitwise-copyable feature.
+EXPERIMENTAL_FEATURE(BitwiseCopyable, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3694,6 +3694,8 @@ static bool usesFeatureExtractConstantsFromMembers(Decl *decl) {
   return decl->getAttrs().hasAttribute<ExtractConstantsFromMembersAttr>();
 }
 
+static bool usesFeatureBitwiseCopyable(Decl *decl) { return false; }
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6577,6 +6577,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::RangeReplaceableCollection:
   case KnownProtocolKind::GlobalActor:
   case KnownProtocolKind::Copyable:
+  case KnownProtocolKind::BitwiseCopyable:
     return SpecialProtocol::None;
   }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -301,6 +301,7 @@ list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-experimental-concis
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Macros")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "FreestandingMacros")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Extern")
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BitwiseCopyable")
 
 set(swift_core_incorporate_object_libraries)
 list(APPEND swift_core_incorporate_object_libraries swiftRuntime)

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -168,3 +168,7 @@ public func _unsafePerformance<T>(_ c: () -> T) -> T {
 
 
 @_marker public protocol Copyable {}
+
+#if $BitwiseCopyable
+@_marker public protocol _BitwiseCopyable {}
+#endif

--- a/test/Frontend/bitwise-copyable-flag.swift
+++ b/test/Frontend/bitwise-copyable-flag.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend                           \
+// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN:     %s                                           \
+// RUN:     -typecheck -verify
+
+// Verify that the BitwiseCopyable feature flag works both in asserts and noasserts builds.
+
+struct S : _BitwiseCopyable {
+}


### PR DESCRIPTION
Behind the BitwiseCopyable experimental feature flag.
