### PR TITLE
[ConstraintSystem] Key path literals with completion tokens should be…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -641,6 +641,7 @@ void BindingSet::finalize(
           updatedBindings.insert(
               {keyPathTy, AllowedBindingKind::Exact, keyPathLoc});
         } else if (CS.shouldAttemptFixes()) {
+          auto fixedRootTy = CS.getFixedType(rootTy);
           // If key path is structurally correct and has a resolved root
           // type, let's promote the fallback type into a binding because
           // root would have been inferred from explicit type already and
@@ -648,7 +649,7 @@ void BindingSet::finalize(
           // type to key path literal to propagate root/value to the context.
           if (!keyPath->hasSingleInvalidComponent() &&
               (keyPath->getParsedRoot() ||
-               !CS.getFixedType(rootTy)->isTypeVariableOrMember())) {
+               (fixedRootTy && !fixedRootTy->isTypeVariableOrMember()))) {
             auto fallback = llvm::find_if(Defaults, [](const auto &entry) {
               return entry.second->getKind() == ConstraintKind::FallbackType;
             });

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7469,8 +7469,7 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       break;
 
     case KeyPathExpr::Component::Kind::CodeCompletion: {
-      capability = KeyPathCapability::ReadOnly;
-      break;
+      return fail();
     }
     case KeyPathExpr::Component::Kind::Property:
     case KeyPathExpr::Component::Kind::Subscript:

--- a/test/IDE/complete_issue-69936.swift
+++ b/test/IDE/complete_issue-69936.swift
@@ -1,0 +1,13 @@
+// RUN: %batch-code-completion
+
+struct Test {
+  var currentHeight: Int
+
+  func subscribeToKeyboardEvents() {
+    objectAndKeyPath(object: self, keyPath: \.#^COMPLETE^#)
+  }
+}
+
+func objectAndKeyPath<Root, Input>(object: Root, keyPath: WritableKeyPath<Root, Input>) {}
+
+// COMPLETE: Decl[InstanceVar]/CurrNominal:      currentHeight[#Int#]; name=currentHeight


### PR DESCRIPTION
… marked as invalid

Capability couldn't be determined for expressions like that 
which means that inference should be delayed until root 
becomes available.

Resolves: https://github.com/apple/swift/issues/69936

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
