### PR TITLE
Sema: Strip off LValueType from opened existential accesses with an erased result type [5.10]

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -569,6 +569,15 @@ Type TypeBase::typeEraseOpenedArchetypesWithRoot(
         }
       }
 
+      if (auto lvalue = dyn_cast<LValueType>(type)) {
+        auto objTy = lvalue->getObjectType();
+        auto erased = transformFn(objTy);
+        if (erased.getPointer() == objTy.getPointer())
+          return Type(lvalue);
+
+        return erased;
+      }
+
       auto *const archetype = dyn_cast<OpenedArchetypeType>(ty);
       if (!archetype) {
         // Recurse.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2167,6 +2167,15 @@ static Type typeEraseExistentialSelfReferences(Type refTy, Type baseTy,
             }
           }
 
+          if (auto lvalue = dyn_cast<LValueType>(t)) {
+            auto objTy = lvalue->getObjectType();
+            auto erased = transformFn(objTy, currPos);
+            if (erased.getPointer() == objTy.getPointer())
+              return Type(lvalue);
+
+            return erased;
+          }
+
           if (!t->isTypeParameter()) {
             // Recurse.
             return llvm::None;

--- a/test/Sema/open_existential_lvalue.swift
+++ b/test/Sema/open_existential_lvalue.swift
@@ -1,0 +1,65 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Q {}
+
+protocol P {
+  associatedtype T: Q
+  var member: T { get set }
+  var otherMember: any Q { get set }
+  subscript(_: Int) -> T { get set }
+}
+
+func takesAny(x: any Q) {}
+func takesRValue(x: any Q) {}
+func takesInOut(x: inout any Q) {}
+
+func f(data: inout any P) {
+  takesAny(x: data.member)
+  takesAny(x: data[0])
+
+  takesRValue(x: data.member)
+  takesRValue(x: data[0])
+
+  takesInOut(x: &data.member) // expected-error {{cannot pass immutable value as inout argument: 'data' is immutable}}
+  takesInOut(x: &data[0]) // expected-error {{cannot pass immutable value as inout argument: 'data' is immutable}}
+
+  takesInOut(x: &data.otherMember) // okay
+}
+
+struct S {
+  subscript<T: Q>(_ ct: T.Type) -> T {
+    get { fatalError() }
+    set { fatalError() }
+  }
+}
+
+func f(s: inout S, t: any Q.Type) -> (any Q) {
+  takesAny(x: s[t])
+  takesRValue(x: s[t])
+  takesInOut(x: &s[t]) // expected-error {{cannot pass immutable value as inout argument: 's' is immutable}}
+}
+
+// https://github.com/apple/swift/issues/62219
+do {
+  struct Action {
+      var intVar: Int
+      var strVar: String
+  }
+
+  protocol TestDelegate: AnyObject {
+      associatedtype ActionType
+      var actions: [ActionType] { get set }
+  }
+
+  class TestDelegateImpl: TestDelegate {
+      typealias ActionType = Action
+      var actions: [Action] = []
+  }
+
+  class TestViewController {
+      var testDelegate: (any TestDelegate)?
+      func testFunc() {
+          testDelegate?.actions.removeAll() // expected-error {{cannot use mutating member on immutable value: 'self' is immutable}}
+      }
+  }
+}


### PR DESCRIPTION
* Description: A member access `foo.bar` where `foo` has existential type will open the existential. If the return type of `bar` contains `Self`, `foo` is an lvalue, and `bar` has a setter, we would try to form an lvalue of existential type and crash. Since `foo.bar` cannot be safely used as an lvalue of existential type in these circumstances, fix it by converting the type into an rvalue first.

* Scope of the issue: Lots of reproducers where changing a 'let' to a 'var' causes a crash, etc.

* Origination: The bug has been there since https://github.com/apple/swift-evolution/blob/main/proposals/0352-implicit-open-existentials.md was first implemented.

* Risk: Low.

* Reviewed by: @hborla

* Radars/Issues:
  - Fixes https://github.com/apple/swift/issues/62219
  - Fixes https://github.com/apple/swift/issues/60619,
  - Fixes rdar://104230391
  - Fixes rdar://118247162.