### PR TITLE
Sema: Associated type inference skips witnesses that might trigger a request cycle [5.10]

### DIFF
--- a/test/decl/protocol/req/assoc_type_inference_cycle.swift
+++ b/test/decl/protocol/req/assoc_type_inference_cycle.swift
@@ -1,0 +1,97 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -module-name Test -experimental-lazy-typecheck
+
+// This file should type check successfully.
+
+// rdar://117442510
+public protocol P1 {
+  associatedtype Value
+
+  func makeValue() -> Value
+  func useProducedValue(_ produceValue: () -> Value)
+}
+
+public typealias A1 = S1.Value
+
+public struct S1: P1 {
+  public func makeValue() -> Int { return 1 }
+  public func useProducedValue(_ produceValue: () -> Value) {
+    _ = produceValue()
+  }
+}
+
+// rdar://56672411
+public protocol P2 {
+  associatedtype X = Int
+  func foo(_ x: X)
+}
+
+public typealias A2 = S2.X
+
+public struct S2: P2 {
+  public func bar(_ x: X) {}
+  public func foo(_ x: X) {}
+}
+
+// https://github.com/apple/swift/issues/57355
+public protocol P3 {
+  associatedtype T
+  var a: T { get }
+  var b: T { get }
+  var c: T { get }
+}
+
+public typealias A3 = S3.T
+
+public struct S3: P3 {
+  public let a: Int
+  public let b: T
+  public let c: T
+}
+
+// Regression tests
+public protocol P4 {
+  associatedtype A
+  func f(_: A)
+}
+
+public typealias A = Int
+
+public typealias A4 = S4.A
+
+public struct S4: P4 {
+  public func f(_: A) {}
+}
+
+public typealias A5 = OuterGeneric<Int>.Inner.A
+
+public struct OuterGeneric<A> {
+  public struct Inner: P4 {
+    public func f(_: A) {  }
+  }
+}
+
+public typealias A6 = OuterNested.Inner.A
+
+public struct OuterNested {
+  public struct A {}
+
+  public struct Inner: P4 {
+    public func f(_: A) {}
+  }
+}
+
+public protocol CaseProtocol {
+  associatedtype A = Int
+  static func a(_: A) -> Self
+  static func b(_: A) -> Self
+  static func c(_: A) -> Self
+}
+
+public typealias A7 = CaseWitness.A
+
+public enum CaseWitness: CaseProtocol {
+  case a(_: A)
+  case b(_: A)
+  case c(_: A)
+}

--- a/validation-test/compiler_crashers_2_fixed/0124-issue-48395.swift
+++ b/validation-test/compiler_crashers_2_fixed/0124-issue-48395.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -emit-ir %s
 
 // https://github.com/apple/swift/issues/48395
 
-struct DefaultAssociatedType {
+public struct DefaultAssociatedType {
 }
 
 protocol Protocol {
@@ -10,9 +10,9 @@ protocol Protocol {
     init(object: AssociatedType)
 }
 
-final class Conformance: Protocol {
+public final class Conformance: Protocol {
     private let object: AssociatedType
-    init(object: AssociatedType) { // expected-error {{reference to invalid associated type 'AssociatedType' of type 'Conformance'}}
+    public init(object: AssociatedType) {
         self.object = object
     }
 }

--- a/validation-test/compiler_crashers_2_fixed/0126-issue-48464.swift
+++ b/validation-test/compiler_crashers_2_fixed/0126-issue-48464.swift
@@ -1,31 +1,30 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -emit-ir %s
 
 // https://github.com/apple/swift/issues/48464
 
-protocol VectorIndex {
+public protocol VectorIndex {
     associatedtype Vector8 : Vector where Vector8.Index == Self, Vector8.Element == UInt8
 }
-enum VectorIndex1 : VectorIndex {
+public enum VectorIndex1 : VectorIndex {
     case i0
-    typealias Vector8 = Vector1<UInt8>
+    public typealias Vector8 = Vector1<UInt8>
 }
-protocol Vector {
+public protocol Vector {
     associatedtype Index: VectorIndex
     associatedtype Element
     init(elementForIndex: (Index) -> Element)
     subscript(index: Index) -> Element { get set }
 }
-struct Vector1<Element> : Vector {
-    //typealias Index = VectorIndex1 // Uncomment this line to workaround bug.
-    var e0: Element
-    init(elementForIndex: (VectorIndex1) -> Element) {
+public struct Vector1<Element> : Vector {
+    public var e0: Element
+    public init(elementForIndex: (VectorIndex1) -> Element) {
         e0 = elementForIndex(.i0)
     }
-    subscript(index: Index) -> Element { // expected-error {{reference to invalid associated type 'Index' of type 'Vector1<Element>'}}
+    public subscript(index: Index) -> Element {
         get { return e0 }
         set { e0 = newValue }
     }
 }
 extension Vector where Index == VectorIndex1 {
-    init(_ e0: Element) { fatalError() }
+    public init(_ e0: Element) { fatalError() }
 }


### PR DESCRIPTION
* Description: Associated type inference would get in trouble if an associated type witness was inferred, but also referenced from inside a type by an unqualified lookup. In this case some declaration checking orders could cause cycles.

* Scope of the issue: Frequently duped issue.

* Origination: Forever.

* Risk: Medium.

* Reviewed by: @tshortli 

* Radars/Issues:
  - rdar://34956654 / https://github.com/apple/swift/issues/48680
  - rdar://38913692 / https://github.com/apple/swift/issues/49066
  - rdar://56672411
  - https://github.com/apple/swift/issues/50010
  - rdar://81587765 / https://github.com/apple/swift/issues/57355
  - rdar://117442510