### PR TITLE
ConsumeOperator: handle lack of `borrow [lexical]`

### DIFF
--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -26,6 +26,7 @@ public func borrowVal(_ x: borrowing KlassPair) {}
 public func borrowVal(_ x: borrowing AggGenericStruct<String>) {}
 public func borrowVal<T>(_ x: borrowing AggGenericStruct<T>) {}
 public func borrowVal(_ x: borrowing EnumTy) {}
+public func borrowVal(_ x: borrowing String) {}
 
 public func consumeVal(_ x: __owned Klass) {}
 public func consumeVal(_ x: __owned FinalKlass) {}
@@ -4261,4 +4262,22 @@ func testMyEnum() {
       _ = y
     }
   }
+}
+
+func rdar_118059326_example1() {
+  let thinger = "hello" // expected-error {{'thinger' used after consume}}
+  _ = consume thinger // expected-note {{consumed}}
+  borrowVal(thinger) // expected-note {{used}}
+}
+
+func withSadness<T>(_ execute: () throws -> T) rethrows -> T {
+  try execute()
+}
+
+func rdar_118059326_example2(_ path: String) {
+  let decoded = withSadness { // expected-error {{'decoded' used after consume}}
+      return path
+  }
+  _ = consume decoded // expected-note {{consumed}}
+  borrowVal(decoded) // expected-note {{used}}
 }


### PR DESCRIPTION
A subtle change was made in what was being emitted by SILGen / upstream passes, in that a `begin_borrow [lexical]` wasn't always present when a lexical value that had `consume` applied to it. This led to the `ConsumeOperatorCopyableValuesChecker` missing diagnosis of illegal consumes, and for legal ones, leaving behind a `move_value` that still `[allows_diagnostics]`, which is a kind of indicator that it hasn't been
 checked yet.

Somehow that subtle change wasn't caught by existing regression tests.

resolves rdar://118059326