### PR TITLE
initializeStaticGlobalsPass: don't crash if there was a preceding error

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
@@ -44,6 +44,11 @@ import SIL
 let initializeStaticGlobalsPass = FunctionPass(name: "initialize-static-globals") {
   (function: Function, context: FunctionPassContext) in
 
+  if context.hadError {
+    // In case of a preceding error, there is no guarantee that the SIL is valid.
+    return
+  }
+
   if !function.isGlobalInitOnceFunction {
     return
   }

--- a/test/SILOptimizer/init_static_globals_crash.swift
+++ b/test/SILOptimizer/init_static_globals_crash.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -parse-as-library -emit-sil %s -o /dev/null -verify
+
+// Don't crash in the initializeStaticGlobalsPass when the global is not valid.
+
+let f: @convention(c) () -> Void = { // expected-error {{a C function pointer cannot be formed from a closure that captures generic parameters}}
+    func g<T>(_ x: T) {}
+}


### PR DESCRIPTION
In case of a preceding error, there is no guarantee that the SIL is valid. Therefore just bail in this case.

rdar://118521842
