### PR TITLE
[5.10] Move `swift-parser-cli` to its own package

### DIFF
--- a/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -14,6 +14,7 @@
    <FileRef location = "group:../../../../swift-stress-tester/SwiftEvolve"></FileRef>
    <FileRef location = "group:../../../../swift-syntax"></FileRef>
    <FileRef location = "group:../../../../swift-syntax/Examples"></FileRef>
+   <FileRef location = "group:../../../../swift-syntax/SwiftParserCLI"></FileRef>
    <FileRef location = "group:../../../../swift-system"></FileRef>
    <FileRef location = "group:../../../../swift-tools-support-core"></FileRef>
    <FileRef location = "group:../../../../swiftpm"></FileRef>


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/68120 to release/5.10.

Companion of https://github.com/apple/swift-syntax/pull/2346

* **Explanation**: https://github.com/apple/swift-syntax/pull/2346 moves the `swift-parser-cli` tool to a separate package so that swift-syntax no longer has a dependency on swift-argument-parser. For this to work, the new package needs to be included in the multi root data file.
* **Scope**: Build infrastructure
* **Risk**: Low
* **Testing**: Test that the project still builds
* **Issue**: n/a
* **Reviewer**:  @ahoppen