### PR TITLE
SILVerifier: Fix crashes when verifying type dependent arguments

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -473,7 +473,7 @@ public:
   SingleValueInstruction *
   getRootLocalArchetypeDefInst(CanLocalArchetypeType archetype,
                                SILFunction *inFunction) {
-    return cast<SingleValueInstruction>(
+    return dyn_cast<SingleValueInstruction>(
         getRootLocalArchetypeDef(archetype, inFunction));
   }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1703,6 +1703,8 @@ public:
         // the current function.
         auto *openingInst = F.getModule().getRootLocalArchetypeDefInst(
             root, AI->getFunction());
+        require(openingInst,
+                "Root opened archetype should be registered in SILModule");
         require(openingInst == AI || properlyDominates(openingInst, AI),
                 "Use of a local archetype should be dominated by a "
                 "definition of this root opened archetype");


### PR DESCRIPTION
`getRootLocalArchetypeDef()` may return a `PlaceholderValue` which makes the `cast<SingleValueInstruction>` invalid. Use `dyn_cast` and then update the callers of `getRootLocalArchetypeDefInst()` to handle `nullptr`.