### PR TITLE
build.ps1: Build installer wixproj as bundle

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1594,7 +1594,7 @@ function Build-Installer($Arch) {
     $Properties["SDK_ROOT_$($SDK.VSName.ToUpperInvariant())"] = "$($SDK.SDKInstallRoot)\"
   }
 
-  Build-WiXProject bundle\installer.wixproj -Arch $Arch -Properties $Properties
+  Build-WiXProject bundle\installer.wixproj -Arch $Arch -Bundle -Properties $Properties
 }
 
 function Stage-BuildArtifacts($Arch) {


### PR DESCRIPTION
We were [removing the semantic version suffixes](https://github.com/apple/swift/blob/98e65d015979c7b5a58a6ecf2d8598a6f7c85794/utils/build.ps1#L766) for the whole bundle because we used the logic for individual MSI's, which don't support semantic versioning suffixes. This is now handled in `installer.wixproj` as per the dependent  https://github.com/apple/swift-installer-scripts/pull/252