### PR TITLE
[swift-ide-test] Add -enable-upcoming-feature ImportObjcForwardDeclarations support

### DIFF
--- a/test/ClangImporter/incomplete_objc_types_swift_ide_test.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_ide_test.swift
@@ -1,0 +1,35 @@
+// This test checks that swift-ide-test output under either -swift-version 6 or 
+// -enable-upcoming-feature ImportObjCForwardDeclarations the output matches the
+// import capabilities of the compiler.
+
+// (1) Print the interface with -enable-upcoming-feature ImportObjCForwardDeclarations
+// RUN: %target-swift-ide-test -print-module -module-to-print IncompleteTypeLibrary1 -I %S/Inputs/custom-modules/IncompleteTypes \
+// RUN:     -enable-objc-interop -enable-upcoming-feature ImportObjcForwardDeclarations -source-filename x | %FileCheck %s
+
+// (2) Print the interface with -swift-version 6
+// RUN: %target-swift-ide-test -print-module -module-to-print IncompleteTypeLibrary1 -I %S/Inputs/custom-modules/IncompleteTypes \
+// RUN:     -enable-objc-interop -swift-version 6 -source-filename x | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: asserts
+
+// CHECK: import Foundation
+// CHECK: @available(*, unavailable, message: "This Objective-C class has only been forward-declared; import its owning module to use it")
+// CHECK: class ForwardDeclaredInterface {
+// CHECK: }
+// CHECK: @available(*, unavailable, message: "This Objective-C protocol has only been forward-declared; import its owning module to use it")
+// CHECK: protocol ForwardDeclaredProtocol {
+// CHECK: }
+// CHECK: class IncompleteTypeConsumer1 : NSObject {
+// CHECK:   var propertyUsingAForwardDeclaredProtocol1: (any ForwardDeclaredProtocol)!
+// CHECK:   var propertyUsingAForwardDeclaredInterface1: ForwardDeclaredInterface!
+// CHECK:   init!()
+// CHECK:   func methodReturningForwardDeclaredProtocol1() -> (any ForwardDeclaredProtocol & NSObjectProtocol)!
+// CHECK:   func methodReturningForwardDeclaredInterface1() -> ForwardDeclaredInterface!
+// CHECK:   func methodTakingAForwardDeclaredProtocol1(_ param: (any ForwardDeclaredProtocol)!)
+// CHECK:   func methodTakingAForwardDeclaredInterface1(_ param: ForwardDeclaredInterface!)
+// CHECK: }
+// CHECK: func CFunctionReturningAForwardDeclaredInterface1() -> ForwardDeclaredInterface!
+// CHECK: func CFunctionTakingAForwardDeclaredInterface1(_ param: ForwardDeclaredInterface!)
+// CHECK: func CFunctionReturningAForwardDeclaredProtocol1() -> (any ForwardDeclaredProtocol & NSObjectProtocol)!
+// CHECK: func CFunctionTakingAForwardDeclaredProtocol1(_ param: (any ForwardDeclaredProtocol)!)

--- a/test/ClangImporter/objc_forward_declarations.swift
+++ b/test/ClangImporter/objc_forward_declarations.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t -I %S/Inputs/custom-modules -enable-objc-interop %s
-// RUN: %target-swift-ide-test -print-module -module-to-print objc_forward_declarations -I %t -I %S/Inputs/custom-modules -enable-objc-interop -enable-objc-forward-declarations -source-filename x | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print objc_forward_declarations -I %t -I %S/Inputs/custom-modules -enable-objc-interop -enable-upcoming-feature ImportObjcForwardDeclarations -source-filename x | %FileCheck %s
 
 // CHECK: class Innocuous : Confusing {
 

--- a/test/IDE/print_clang_ObjectiveC.swift
+++ b/test/IDE/print_clang_ObjectiveC.swift
@@ -4,7 +4,7 @@
 // RUN: %FileCheck -input-file %t/ObjectiveC.NSObject.printed.txt %s
 // RUN: %FileCheck -input-file %t/ObjectiveC.NSObject.printed.txt -check-prefix=NEGATIVE -check-prefix=NEGATIVE-WITHOUT-FORWARD-DECLS %s
 
-// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=ObjectiveC.NSObject -function-definitions=false -enable-objc-forward-declarations > %t/ObjectiveC.NSObject.forward-decls.txt
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=ObjectiveC.NSObject -function-definitions=false -enable-upcoming-feature ImportObjcForwardDeclarations > %t/ObjectiveC.NSObject.forward-decls.txt
 // RUN: %FileCheck -input-file %t/ObjectiveC.NSObject.forward-decls.txt -check-prefix=CHECK -check-prefix=CHECK-WITH-FORWARD-DECLS %s
 // RUN: %FileCheck -input-file %t/ObjectiveC.NSObject.forward-decls.txt -check-prefix=NEGATIVE %s
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -414,12 +414,6 @@ static llvm::cl::opt<bool> CodeCompleteCallPatternHeuristics(
     llvm::cl::cat(Category));
 
 static llvm::cl::opt<bool>
-ObjCForwardDeclarations("enable-objc-forward-declarations",
-    llvm::cl::desc("Import Objective-C forward declarations when possible"),
-    llvm::cl::cat(Category),
-    llvm::cl::init(false));
-
-static llvm::cl::opt<bool>
 EnableSwift3ObjCInference("enable-swift3-objc-inference",
     llvm::cl::desc("Enable Swift 3's @objc inference rules"),
     llvm::cl::cat(Category),
@@ -4486,8 +4480,13 @@ int main(int argc, char *argv[]) {
     options::EnableDeserializationSafety;
   InitInvok.getLangOptions().EnableSwift3ObjCInference =
     options::EnableSwift3ObjCInference;
+  // The manner in which swift-ide-test constructs its CompilerInvocation does
+  // not hit the codepath in arg parsing that would normally construct
+  // ClangImporter options based on enabled language features etc. Explicitly
+  // enable them here.
   InitInvok.getClangImporterOptions().ImportForwardDeclarations |=
-    options::ObjCForwardDeclarations;
+      InitInvok.getLangOptions().hasFeature(
+          Feature::ImportObjcForwardDeclarations);
   if (!options::ResourceDir.empty()) {
     InitInvok.setRuntimeResourcePath(options::ResourceDir);
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -866,6 +866,11 @@ static llvm::cl::list<std::string>
                              llvm::cl::cat(Category));
 
 static llvm::cl::list<std::string>
+  EnableUpcomingFeatures("enable-upcoming-feature",
+      llvm::cl::desc("Enable a feature that will be introduced in an upcoming language version"),
+      llvm::cl::cat(Category));
+
+static llvm::cl::list<std::string>
 AccessNotesPath("access-notes-path", llvm::cl::desc("Path to access notes file"),
                 llvm::cl::cat(Category));
 
@@ -4417,6 +4422,12 @@ int main(int argc, char *argv[]) {
 
   for (const auto &featureArg : options::EnableExperimentalFeatures) {
     if (auto feature = getExperimentalFeature(featureArg)) {
+      InitInvok.getLangOptions().Features.insert(*feature);
+    }
+  }
+
+  for (const auto &featureArg : options::EnableUpcomingFeatures) {
+    if (auto feature = getUpcomingFeature(featureArg)) {
       InitInvok.getLangOptions().Features.insert(*feature);
     }
   }


### PR DESCRIPTION
In this first commit we add support for the -enable-upcoming-feature flag in general.

In the second commit we make sure that the ClangImporter constructed for use in swift-ide-test is configured appropriately when the ImportObjcForwardDeclarations upcoming language feature is enabled, or the language version is recent enough to enable it by default.