### PR TITLE
Fix lit test Python/python_lint.swift

### DIFF
--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -17,7 +17,7 @@ import os
 import sys
 
 from cmpcodesize.compare import \
-    compare_function_sizes, compare_sizes_of_file, list_function_sizes,\
+    compare_function_sizes, compare_sizes_of_file, list_function_sizes, \
     read_sizes
 
 

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -17,8 +17,8 @@ class RoundTripTask(object):
                  skip_bad_syntax):
         assert action == '-round-trip-parse' or action == '-round-trip-lex'
         if sys.version_info[0] < 3:
-            assert type(input_filename) == str
-        assert type(swift_syntax_test) == str
+            assert isinstance(input_filename, str)
+        assert isinstance(swift_syntax_test, str)
 
         assert os.path.isfile(input_filename), \
             "Input file {} is not accessible!".format(input_filename)


### PR DESCRIPTION
./utils/cmpcodesize/cmpcodesize/main.py:20:71: E231 missing whitespace after ','

./utils/round-trip-syntax-test:20:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`

./utils/round-trip-syntax-test:21:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`

I can't find any uses of round-trip-syntax-test, so I don't know if this fix is correct.
