### PR TITLE
[Runtime] Fix alignment of tuples in runtime layout string instantiation

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2933,6 +2933,7 @@ void swift::_swift_addRefCountStringForMetatype(LayoutStringWriter &writer,
     previousFieldOffset = offset + fieldType->vw_size();
     fullOffset += fieldType->vw_size();
   } else if (auto *tuple = dyn_cast<TupleTypeMetadata>(fieldType)) {
+    previousFieldOffset = offset;
     for (InProcess::StoredSize i = 0; i < tuple->NumElements; i++) {
       _swift_addRefCountStringForMetatype(writer, flags,
                                           tuple->getElement(i).Type, fullOffset,

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -555,6 +555,17 @@ public enum SinglePayloadEnumExistential {
     case c
 }
 
+public struct TupleLargeAlignment<T> {
+    let x: AnyObject? = nil
+    let x1: AnyObject? = nil
+    let x2: AnyObject? = nil
+    let x3: (T, SIMD4<Int>)
+
+    public init(_ t: T) {
+        self.x3 = (t, .init(Int(Int32.max) + 32, Int(Int32.max) + 32, Int(Int32.max) + 32, Int(Int32.max) + 32))
+    }
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -1132,6 +1132,35 @@ func testArrayAssignWithCopy() {
 
 testArrayAssignWithCopy()
 
+// This is a regression test for rdar://118366415
+func testTupleAlignment() {
+    let ptr = allocateInternalGenericPtr(of: TupleLargeAlignment<TestClass>.self)
+
+    do {
+        let x = TupleLargeAlignment(TestClass())
+        testGenericInit(ptr, to: x)
+    }
+
+    do {
+        let y = TupleLargeAlignment(TestClass())
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: TestClass deinitialized!
+        testGenericAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: TestClass deinitialized!
+    testGenericDestroy(ptr, of: TupleLargeAlignment<TestClass>.self)
+
+    ptr.deallocate()
+}
+
+testTupleAlignment()
+
 #if os(macOS)
 
 import Foundation


### PR DESCRIPTION
rdar://118366415

If a tuple was not already aligned, this would cause a wrong offset to be used in the layout string.
