### PR TITLE
[5.10][Runtime] Fix alignment of tuples in runtime layout string instantiation

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2827,6 +2827,7 @@ void swift::_swift_addRefCountStringForMetatype(LayoutStringWriter &writer,
     previousFieldOffset = offset + fieldType->vw_size();
     fullOffset += fieldType->vw_size();
   } else if (auto *tuple = dyn_cast<TupleTypeMetadata>(fieldType)) {
+    previousFieldOffset = offset;
     for (InProcess::StoredSize i = 0; i < tuple->NumElements; i++) {
       _swift_addRefCountStringForMetatype(writer, flags,
                                           tuple->getElement(i).Type, fullOffset,

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -540,6 +540,17 @@ public enum SinglePayloadEnumExistential {
     case c
 }
 
+public struct TupleLargeAlignment<T> {
+    let x: AnyObject? = nil
+    let x1: AnyObject? = nil
+    let x2: AnyObject? = nil
+    let x3: (T, SIMD4<Int>)
+
+    public init(_ t: T) {
+        self.x3 = (t, .init(Int(Int32.max) + 32, Int(Int32.max) + 32, Int(Int32.max) + 32, Int(Int32.max) + 32))
+    }
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -1059,6 +1059,35 @@ func testSinglePayloadSimpleResolve() {
 
 testSinglePayloadSimpleResolve()
 
+// This is a regression test for rdar://118366415
+func testTupleAlignment() {
+    let ptr = allocateInternalGenericPtr(of: TupleLargeAlignment<TestClass>.self)
+
+    do {
+        let x = TupleLargeAlignment(TestClass())
+        testGenericInit(ptr, to: x)
+    }
+
+    do {
+        let y = TupleLargeAlignment(TestClass())
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: TestClass deinitialized!
+        testGenericAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: TestClass deinitialized!
+    testGenericDestroy(ptr, of: TupleLargeAlignment<TestClass>.self)
+
+    ptr.deallocate()
+}
+
+testTupleAlignment()
+
 #if os(macOS)
 
 import Foundation


### PR DESCRIPTION
5.10 cherry-pick of: https://github.com/apple/swift/pull/69975

- Explanation: Fixes an issue where if a tuple was not already aligned, it would cause a wrong offset to be used in runtime instantiation of layout strings.
- Scope: Layout strings only
- Issue: rdar://118366415
- Risk: Low, only affects layout strings, which is still experimental
- Testing: Added regression test for this issue
- Reviewer: @mikeash 

