### PR TITLE
[Runtime] Fix leak of bridge objects in swift_generic_initWithTake

### DIFF
--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -1214,7 +1214,7 @@ constexpr InitFn initWithTakeTable[] = {
     &copyingInitWithTake,
     &copyingInitWithTake,
     &unknownWeakInitWithTake,
-    &bridgeRetain,
+    &copyingInitWithTake,
     &copyingInitWithTake,
     &copyingInitWithTake,
     nullptr, // Custom

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -416,6 +416,16 @@ public struct SinglePayloadEnumExtraTagBytesWrapper {
     }
 }
 
+public struct NotBitwiseTakableBridge<T> {
+    let x: Int = 0
+    let y: [T]
+    weak var z: AnyObject? = nil
+
+    public init(_ y: [T]) {
+        self.y = y
+    }
+}
+
 public enum SinglePayloadEnumExtraTagBytes {
     case empty0
     case empty1
@@ -590,6 +600,11 @@ public func testAssignCopy<T>(_ ptr: UnsafeMutablePointer<T>, from x: inout T) {
 @inline(never)
 public func testInit<T>(_ ptr: UnsafeMutablePointer<T>, to x: T) {
     ptr.initialize(to: x)
+}
+
+@inline(never)
+public func testInitTake<T>(_ ptr: UnsafeMutablePointer<T>, to x: consuming T) {
+    ptr.initialize(to: consume x)
 }
 
 @inline(never)

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1012,6 +1012,50 @@ func testEnumWithExistential() {
 
 testEnumWithExistential()
 
+// Regression test for rdar://118606044
+func testNotBitwiseTakableBridge() {
+    let ptr = UnsafeMutablePointer<NotBitwiseTakableBridge<SimpleClass>>.allocate(capacity: 1)
+
+    // initWithTake
+    do {
+        let x = NotBitwiseTakableBridge([SimpleClass(x: 23)])
+        testInitTake(ptr, to: consume x)
+    }
+
+    // assignWithTake
+    do {
+        let y = NotBitwiseTakableBridge([SimpleClass(x: 33)])
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // assignWithCopy
+    do {
+        var z = NotBitwiseTakableBridge([SimpleClass(x: 43)])
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // destroy
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testNotBitwiseTakableBridge()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
rdar://118606044

The initWithTakeTable accidentally referenced bridgeRetain instead of copyingInitWithTake, which caused a leak when an object containing a bridge reference was also not bitwise takable.
