### PR TITLE
[5.10][Runtime] Use threaded code in compact value witness runtime

### DIFF
--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -97,6 +97,141 @@ static uint64_t readTagBytes(const uint8_t *addr, uint8_t byteCount) {
   }
 }
 
+#if defined(__APPLE__) && defined(__arm64__)
+
+#define CONTINUE_WITH_COPY(METADATA, READER, ADDR_OFFSET, DEST, SRC)           \
+  do {                                                                         \
+    TAG = READER.readBytes<uint64_t>();                                        \
+    OFFSET = (TAG & ~(0xFFULL << 56));                                         \
+    if (OFFSET) {                                                              \
+      memcpy(DEST + ADDR_OFFSET, SRC + ADDR_OFFSET, OFFSET);                   \
+    }                                                                          \
+    ADDR_OFFSET += OFFSET;                                                     \
+    TAG >>= 56;                                                                \
+    goto *dispatchTable[TAG];                                                  \
+  } while (false)
+
+#define CONTINUE_NO_COPY(METADATA, READER, ADDR_OFFSET, ADDR)                  \
+  do {                                                                         \
+    TAG = READER.readBytes<uint64_t>();                                        \
+    OFFSET = (TAG & ~(0xFFULL << 56));                                         \
+    ADDR_OFFSET += OFFSET;                                                     \
+    TAG >>= 56;                                                                \
+    goto *dispatchTable[TAG];                                                  \
+  } while (false)
+
+#define handleRefCounts(FN_TABLE, CONTINUE, METADATA, READER, ADDR_OFFSET,     \
+                        ...)                                                   \
+  do {                                                                         \
+    while (true) {                                                             \
+      uint64_t TAG = 0;                                                        \
+      uintptr_t OFFSET = 0;                                                    \
+                                                                               \
+      _Pragma("clang diagnostic push")                                         \
+          _Pragma("clang diagnostic ignored \"-Wgnu-label-as-value\"")         \
+              const void *dispatchTable[] = {                                  \
+                  &&done,       &&Error,   &&NativeStrong,   &&NativeUnowned,  \
+                  &&NativeWeak, &&Unknown, &&UnknownUnowned, &&UnknownWeak,    \
+                  &&Bridge,     &&Block,   &&ObjC,           &&Custom,         \
+                  &&Metatype,   &&Generic, &&Existential,    &&Resilient,      \
+                  &&Default,    &&Default, &&Default,        &&Default,        \
+                  &&Default,    &&Default, &&Default,                          \
+      };                                                                       \
+                                                                               \
+      [[clang::nomerge]] {                                                     \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+                                                                               \
+      [[clang::nomerge]] {                                                     \
+      Error:                                                                   \
+                                                                               \
+        FN_TABLE[1](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      NativeStrong:                                                            \
+        FN_TABLE[2](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      NativeUnowned:                                                           \
+        FN_TABLE[3](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      NativeWeak:                                                              \
+        FN_TABLE[4](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Unknown:                                                                 \
+        FN_TABLE[5](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      UnknownUnowned:                                                          \
+        FN_TABLE[6](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      UnknownWeak:                                                             \
+        FN_TABLE[7](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Bridge:                                                                  \
+        FN_TABLE[8](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Block:                                                                   \
+        FN_TABLE[9](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);               \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      ObjC:                                                                    \
+        FN_TABLE[10](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);              \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Custom:                                                                  \
+        swift_unreachable("");                                                 \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Metatype:                                                                \
+        FN_TABLE[12](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);              \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Generic:                                                                 \
+        swift_unreachable("");                                                 \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Existential:                                                             \
+        FN_TABLE[14](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);              \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Resilient:                                                               \
+        FN_TABLE[15](METADATA, READER, ADDR_OFFSET, __VA_ARGS__);              \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      [[clang::nomerge]] {                                                     \
+      Default:                                                                 \
+        uintptr_t _ADDR_OFFSET = ADDR_OFFSET;                                  \
+        LayoutStringReader1 _READER = READER;                                  \
+        FN_TABLE[TAG](METADATA, _READER, _ADDR_OFFSET, __VA_ARGS__);           \
+        READER = _READER;                                                      \
+        ADDR_OFFSET = _ADDR_OFFSET;                                            \
+        CONTINUE(METADATA, READER, ADDR_OFFSET, __VA_ARGS__);                  \
+      }                                                                        \
+      _Pragma("clang diagnostic pop")                                          \
+    }                                                                          \
+  done:                                                                        \
+    break;                                                                     \
+  } while (false)
+#endif
+
 static void handleRefCountsDestroy(const Metadata *metadata,
                           LayoutStringReader1 &reader,
                           uintptr_t &addrOffset,
@@ -111,82 +246,70 @@ static void handleEnd(const Metadata *metadata,
   return;
 }
 
-static void errorDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void errorDestroy(const Metadata *metadata, LayoutStringReader1 &reader,
+                         uintptr_t &addrOffset, uint8_t *addr) {
   SwiftError *error = *(SwiftError**)(addr + addrOffset);
   addrOffset += sizeof(SwiftError*);
   swift_errorRelease(error);
 }
 
-static void nativeStrongDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void nativeStrongDestroy(const Metadata *metadata,
+                                LayoutStringReader1 &reader,
+                                uintptr_t &addrOffset, uint8_t *addr) {
   HeapObject *object = (HeapObject*)((*(uintptr_t *)(addr + addrOffset)) & ~_swift_abi_SwiftSpareBitsMask);
   addrOffset += sizeof(HeapObject*);
   swift_release(object);
 }
 
-static void unownedDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void unownedDestroy(const Metadata *metadata,
+                           LayoutStringReader1 &reader, uintptr_t &addrOffset,
+                           uint8_t *addr) {
   HeapObject *object = (HeapObject*)((*(uintptr_t *)(addr + addrOffset)) & ~_swift_abi_SwiftSpareBitsMask);
   addrOffset += sizeof(HeapObject*);
   swift_unownedRelease(object);
 }
 
-static void weakDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void weakDestroy(const Metadata *metadata, LayoutStringReader1 &reader,
+                        uintptr_t &addrOffset, uint8_t *addr) {
   auto *object = (WeakReference *)(addr + addrOffset);
   addrOffset += sizeof(WeakReference);
   swift_weakDestroy(object);
 }
 
-static void unknownDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void unknownDestroy(const Metadata *metadata,
+                           LayoutStringReader1 &reader, uintptr_t &addrOffset,
+                           uint8_t *addr) {
   void *object = *(void**)(addr + addrOffset);
   addrOffset += sizeof(void*);
   swift_unknownObjectRelease(object);
 }
 
-static void unknownUnownedDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void unknownUnownedDestroy(const Metadata *metadata,
+                                  LayoutStringReader1 &reader,
+                                  uintptr_t &addrOffset, uint8_t *addr) {
   UnownedReference *object = (UnownedReference*)(addr + addrOffset);
   addrOffset += sizeof(UnownedReference);
   swift_unknownObjectUnownedDestroy(object);
 }
 
-static void unknownWeakDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void unknownWeakDestroy(const Metadata *metadata,
+                               LayoutStringReader1 &reader,
+                               uintptr_t &addrOffset, uint8_t *addr) {
   auto *object = (WeakReference *)(addr + addrOffset);
   addrOffset += sizeof(WeakReference);
   swift_unknownObjectWeakDestroy(object);
 }
 
-static void bridgeDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void bridgeDestroy(const Metadata *metadata, LayoutStringReader1 &reader,
+                          uintptr_t &addrOffset, uint8_t *addr) {
   auto *object = *(void **)(addr + addrOffset);
   addrOffset += sizeof(void*);
   swift_bridgeObjectRelease(object);
 }
 
-static void singlePayloadEnumSimpleBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void singlePayloadEnumSimple(const Metadata *metadata,
+                                    LayoutStringReader1 &reader,
+                                    uintptr_t &addrOffset, uint8_t *addr) {
   reader.modify([&](LayoutStringReader1 &reader) {
     uint64_t byteCountsAndOffset;
     size_t payloadSize;
@@ -228,10 +351,9 @@ static void singlePayloadEnumSimpleBranchless(const Metadata *metadata,
 
 typedef unsigned (*GetEnumTagFn)(const uint8_t *);
 
-static void singlePayloadEnumFNBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void singlePayloadEnumFN(const Metadata *metadata,
+                                LayoutStringReader1 &reader,
+                                uintptr_t &addrOffset, uint8_t *addr) {
   reader.modify([&](LayoutStringReader1 &reader) {
     GetEnumTagFn getEnumTag = readRelativeFunctionPointer<GetEnumTagFn>(reader);
 
@@ -249,10 +371,9 @@ static void singlePayloadEnumFNBranchless(const Metadata *metadata,
   });
 }
 
-static void singlePayloadEnumFNResolvedBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void singlePayloadEnumFNResolved(const Metadata *metadata,
+                                        LayoutStringReader1 &reader,
+                                        uintptr_t &addrOffset, uint8_t *addr) {
   reader.modify([&](LayoutStringReader1 &reader) {
     GetEnumTagFn getEnumTag;
     size_t refCountBytes;
@@ -268,10 +389,9 @@ static void singlePayloadEnumFNResolvedBranchless(const Metadata *metadata,
   });
 }
 
-static void singlePayloadEnumGenericBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void singlePayloadEnumGeneric(const Metadata *metadata,
+                                     LayoutStringReader1 &reader,
+                                     uintptr_t &addrOffset, uint8_t *addr) {
   reader.modify([&](LayoutStringReader1 &reader) {
     auto tagBytesAndOffset = reader.readBytes<uint64_t>();
     auto payloadSize = reader.readBytes<size_t>();
@@ -307,11 +427,10 @@ static void singlePayloadEnumGenericBranchless(const Metadata *metadata,
   });
 }
 
-template<auto HandlerFn>
-static void multiPayloadEnumFNBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+template <auto HandlerFn>
+static void multiPayloadEnumFN(const Metadata *metadata,
+                               LayoutStringReader1 &reader,
+                               uintptr_t &addrOffset, uint8_t *addr) {
   size_t numPayloads;
   size_t refCountBytes;
   size_t enumSize;
@@ -339,11 +458,10 @@ static void multiPayloadEnumFNBranchless(const Metadata *metadata,
   }
 }
 
-template<auto HandlerFn>
-static void multiPayloadEnumFNResolvedBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+template <auto HandlerFn>
+static void multiPayloadEnumFNResolved(const Metadata *metadata,
+                                       LayoutStringReader1 &reader,
+                                       uintptr_t &addrOffset, uint8_t *addr) {
   size_t numPayloads;
   size_t refCountBytes;
   size_t enumSize;
@@ -371,11 +489,10 @@ static void multiPayloadEnumFNResolvedBranchless(const Metadata *metadata,
   }
 }
 
-template<auto HandlerFn>
-static void multiPayloadEnumGenericBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+template <auto HandlerFn>
+static void multiPayloadEnumGeneric(const Metadata *metadata,
+                                    LayoutStringReader1 &reader,
+                                    uintptr_t &addrOffset, uint8_t *addr) {
   size_t tagBytes;
   size_t numPayloads;
   size_t refCountBytes;
@@ -405,11 +522,10 @@ static void multiPayloadEnumGenericBranchless(const Metadata *metadata,
   }
 }
 
-static void singlePayloadEnumSimpleBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void singlePayloadEnumSimple(const Metadata *metadata,
+                                    LayoutStringReader1 &reader,
+                                    uintptr_t &addrOffset, uint8_t *dest,
+                                    uint8_t *src) {
   reader.modify([&](LayoutStringReader1 &reader) {
     uint64_t byteCountsAndOffset;
     size_t payloadSize;
@@ -450,11 +566,10 @@ static void singlePayloadEnumSimpleBranchless(const Metadata *metadata,
   });
 }
 
-static void singlePayloadEnumFNBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void singlePayloadEnumFN(const Metadata *metadata,
+                                LayoutStringReader1 &reader,
+                                uintptr_t &addrOffset, uint8_t *dest,
+                                uint8_t *src) {
   reader.modify([&](LayoutStringReader1 &reader) {
     GetEnumTagFn getEnumTag = readRelativeFunctionPointer<GetEnumTagFn>(reader);
 
@@ -473,11 +588,10 @@ static void singlePayloadEnumFNBranchless(const Metadata *metadata,
   });
 }
 
-static void singlePayloadEnumFNResolvedBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void singlePayloadEnumFNResolved(const Metadata *metadata,
+                                        LayoutStringReader1 &reader,
+                                        uintptr_t &addrOffset, uint8_t *dest,
+                                        uint8_t *src) {
   reader.modify([&](LayoutStringReader1 &reader) {
     GetEnumTagFn getEnumTag;
     size_t refCountBytes;
@@ -494,11 +608,10 @@ static void singlePayloadEnumFNResolvedBranchless(const Metadata *metadata,
   });
 }
 
-static void singlePayloadEnumGenericBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void singlePayloadEnumGeneric(const Metadata *metadata,
+                                     LayoutStringReader1 &reader,
+                                     uintptr_t &addrOffset, uint8_t *dest,
+                                     uint8_t *src) {
   reader.modify([&](LayoutStringReader1 &reader) {
     auto tagBytesAndOffset = reader.readBytes<uint64_t>();
     auto payloadSize = reader.readBytes<size_t>();
@@ -535,12 +648,10 @@ static void singlePayloadEnumGenericBranchless(const Metadata *metadata,
   });
 }
 
-template<auto HandlerFn>
-static void multiPayloadEnumFNBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+template <auto HandlerFn>
+static void
+multiPayloadEnumFN(const Metadata *metadata, LayoutStringReader1 &reader,
+                   uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   size_t numPayloads;
   size_t refCountBytes;
   size_t enumSize;
@@ -572,12 +683,11 @@ static void multiPayloadEnumFNBranchless(const Metadata *metadata,
   }
 }
 
-template<auto HandlerFn>
-static void multiPayloadEnumFNResolvedBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+template <auto HandlerFn>
+static void multiPayloadEnumFNResolved(const Metadata *metadata,
+                                       LayoutStringReader1 &reader,
+                                       uintptr_t &addrOffset, uint8_t *dest,
+                                       uint8_t *src) {
   size_t numPayloads;
   size_t refCountBytes;
   size_t enumSize;
@@ -609,12 +719,10 @@ static void multiPayloadEnumFNResolvedBranchless(const Metadata *metadata,
   }
 }
 
-template<auto HandlerFn>
-static void multiPayloadEnumGenericBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+template <auto HandlerFn>
+static void
+multiPayloadEnumGeneric(const Metadata *metadata, LayoutStringReader1 &reader,
+                        uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   size_t tagBytes;
   size_t numPayloads;
   size_t refCountBytes;
@@ -648,20 +756,21 @@ static void multiPayloadEnumGenericBranchless(const Metadata *metadata,
   }
 }
 
+static void blockDestroy(const Metadata *metadata, LayoutStringReader1 &reader,
+                         uintptr_t &addrOffset, uint8_t *addr) {
 #if SWIFT_OBJC_INTEROP
-static void blockDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
   void* object = (void *)(addr + addrOffset);
   addrOffset += sizeof(void*);
   _Block_release(object);
+#else
+  swift_unreachable("Blocks are not available on this platform");
+#endif
 }
 
-static void objcStrongDestroyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *addr) {
+static void objcStrongDestroy(const Metadata *metadata,
+                              LayoutStringReader1 &reader,
+                              uintptr_t &addrOffset, uint8_t *addr) {
+#if SWIFT_OBJC_INTEROP
   uintptr_t object = *(uintptr_t *)(addr + addrOffset);
   addrOffset += sizeof(objc_object*);
   if (object & _swift_abi_ObjCReservedBitsMask)
@@ -669,23 +778,23 @@ static void objcStrongDestroyBranchless(const Metadata *metadata,
 
   object &= ~_swift_abi_SwiftSpareBitsMask;
   objc_release((objc_object *)object);
-}
+#else
+  swift_unreachable("ObjC interop is not available on this platform");
 #endif
+}
 
-static void metatypeDestroyBranchless(const Metadata *metadata,
-                               LayoutStringReader1 &reader,
-                               uintptr_t &addrOffset,
-                               uint8_t *addr) {
+static void metatypeDestroy(const Metadata *metadata,
+                            LayoutStringReader1 &reader, uintptr_t &addrOffset,
+                            uint8_t *addr) {
   auto *type = reader.readBytes<const Metadata *>();
   auto *object = (OpaqueValue *)(addr + addrOffset);
   addrOffset += type->vw_size();
   type->vw_destroy(object);
 }
 
-static void existentialDestroyBranchless(const Metadata *metadata,
+static void existentialDestroy(const Metadata *metadata,
                                LayoutStringReader1 &reader,
-                               uintptr_t &addrOffset,
-                               uint8_t *addr) {
+                               uintptr_t &addrOffset, uint8_t *addr) {
   OpaqueValue *object = (OpaqueValue *)(addr + addrOffset);
   auto* type = getExistentialTypeMetadata(object);
   addrOffset += sizeof(uintptr_t) * NumWords_ValueBuffer;
@@ -696,50 +805,42 @@ static void existentialDestroyBranchless(const Metadata *metadata,
   }
 }
 
-static void resilientDestroyBranchless(const Metadata *metadata,
-                               LayoutStringReader1 &reader,
-                               uintptr_t &addrOffset,
-                               uint8_t *addr) {
+static void resilientDestroy(const Metadata *metadata,
+                             LayoutStringReader1 &reader, uintptr_t &addrOffset,
+                             uint8_t *addr) {
   auto *type = getResilientTypeMetadata(metadata, reader);
   auto *object = (OpaqueValue *)(addr + addrOffset);
   addrOffset += type->vw_size();
   type->vw_destroy(object);
 }
 
-typedef void (*DestrFnBranchless)(const Metadata *metadata,
-                                  LayoutStringReader1 &reader,
-                                  uintptr_t &addrOffset,
-                                  uint8_t *addr);
+typedef void (*DestrFn)(const Metadata *metadata, LayoutStringReader1 &reader,
+                        uintptr_t &addrOffset, uint8_t *addr);
 
-const DestrFnBranchless destroyTableBranchless[] = {
-  &handleEnd,
-  &errorDestroyBranchless,
-  &nativeStrongDestroyBranchless,
-  &unownedDestroyBranchless,
-  &weakDestroyBranchless,
-  &unknownDestroyBranchless,
-  &unknownUnownedDestroyBranchless,
-  &unknownWeakDestroyBranchless,
-  &bridgeDestroyBranchless,
-#if SWIFT_OBJC_INTEROP
-  &blockDestroyBranchless,
-  &objcStrongDestroyBranchless,
-#else
-  nullptr,
-  nullptr,
-#endif
-  nullptr, // Custom
-  &metatypeDestroyBranchless,
-  nullptr, // Generic
-  &existentialDestroyBranchless,
-  &resilientDestroyBranchless,
-  &singlePayloadEnumSimpleBranchless,
-  &singlePayloadEnumFNBranchless,
-  &singlePayloadEnumFNResolvedBranchless,
-  &singlePayloadEnumGenericBranchless,
-  &multiPayloadEnumFNBranchless<handleRefCountsDestroy>,
-  &multiPayloadEnumFNResolvedBranchless<handleRefCountsDestroy>,
-  &multiPayloadEnumGenericBranchless<handleRefCountsDestroy>,
+constexpr DestrFn destroyTable[] = {
+    &handleEnd,
+    &errorDestroy,
+    &nativeStrongDestroy,
+    &unownedDestroy,
+    &weakDestroy,
+    &unknownDestroy,
+    &unknownUnownedDestroy,
+    &unknownWeakDestroy,
+    &bridgeDestroy,
+    &blockDestroy,
+    &objcStrongDestroy,
+    nullptr, // Custom
+    &metatypeDestroy,
+    nullptr, // Generic
+    &existentialDestroy,
+    &resilientDestroy,
+    &singlePayloadEnumSimple,
+    &singlePayloadEnumFN,
+    &singlePayloadEnumFNResolved,
+    &singlePayloadEnumGeneric,
+    &multiPayloadEnumFN<handleRefCountsDestroy>,
+    &multiPayloadEnumFNResolved<handleRefCountsDestroy>,
+    &multiPayloadEnumGeneric<handleRefCountsDestroy>,
 };
 
 static void handleRefCountsDestroy(const Metadata *metadata,
@@ -754,7 +855,7 @@ static void handleRefCountsDestroy(const Metadata *metadata,
       return;
     }
 
-    destroyTableBranchless[tag](metadata, reader, addrOffset, addr);
+    destroyTable[tag](metadata, reader, addrOffset, addr);
   }
 }
 
@@ -763,15 +864,29 @@ swift_generic_destroy(swift::OpaqueValue *address, const Metadata *metadata) {
   const uint8_t *layoutStr = metadata->getLayoutString();
   LayoutStringReader1 reader{layoutStr + layoutStringHeaderSize};
   uintptr_t addrOffset = 0;
-  handleRefCountsDestroy(metadata, reader, addrOffset, (uint8_t *)address);
+  uint8_t *addr = (uint8_t *)address;
+
+#if defined(__APPLE__) && defined(__arm64__)
+  handleRefCounts(destroyTable, CONTINUE_NO_COPY, metadata, reader, addrOffset,
+                  addr);
+#else
+  handleRefCountsDestroy(metadata, reader, addrOffset, addr);
+#endif
 }
 
 void swift::swift_generic_arrayDestroy(swift::OpaqueValue *address, size_t count, size_t stride, const Metadata *metadata) {
   const uint8_t *layoutStr = metadata->getLayoutString();
+  uint8_t *addr = (uint8_t *)address;
   for (size_t i = 0; i < count; i++) {
     LayoutStringReader1 reader{layoutStr + layoutStringHeaderSize};
     uintptr_t addrOffset = i * stride;
-    handleRefCountsDestroy(metadata, reader, addrOffset, (uint8_t *)address);
+
+#if defined(__APPLE__) && defined(__arm64__)
+    handleRefCounts(destroyTable, CONTINUE_NO_COPY, metadata, reader,
+                    addrOffset, addr);
+#else
+    handleRefCountsDestroy(metadata, reader, addrOffset, addr);
+#endif
   }
 }
 
@@ -781,11 +896,8 @@ static void handleRefCountsInitWithCopy(const Metadata *metadata,
                           uint8_t *dest,
                           uint8_t *src);
 
-static void errorRetainBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void errorRetain(const Metadata *metadata, LayoutStringReader1 &reader,
+                        uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   SwiftError *object = *(SwiftError **)(src + _addrOffset);
   memcpy(dest + addrOffset, &object, sizeof(SwiftError*));
@@ -793,11 +905,10 @@ static void errorRetainBranchless(const Metadata *metadata,
   swift_errorRetain(object);
 }
 
-static void nativeStrongRetainBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void nativeStrongRetain(const Metadata *metadata,
+                               LayoutStringReader1 &reader,
+                               uintptr_t &addrOffset, uint8_t *dest,
+                               uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   uintptr_t object = *(uintptr_t *)(src + _addrOffset);
   memcpy(dest + _addrOffset, &object, sizeof(HeapObject*));
@@ -806,11 +917,8 @@ static void nativeStrongRetainBranchless(const Metadata *metadata,
   swift_retain((HeapObject *)object);
 }
 
-static void unownedRetainBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void unownedRetain(const Metadata *metadata, LayoutStringReader1 &reader,
+                          uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   uintptr_t object = *(uintptr_t *)(src + _addrOffset);
   memcpy(dest + _addrOffset, &object, sizeof(HeapObject*));
@@ -819,11 +927,8 @@ static void unownedRetainBranchless(const Metadata *metadata,
   swift_unownedRetain((HeapObject *)object);
 }
 
-static void weakCopyInitBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void weakCopyInit(const Metadata *metadata, LayoutStringReader1 &reader,
+                         uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   auto *destObject = (WeakReference *)(dest + _addrOffset);
   auto *srcObject = (WeakReference *)(src + _addrOffset);
@@ -831,11 +936,8 @@ static void weakCopyInitBranchless(const Metadata *metadata,
   swift_weakCopyInit(destObject, srcObject);
 }
 
-static void unknownRetainBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void unknownRetain(const Metadata *metadata, LayoutStringReader1 &reader,
+                          uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   void *object = *(void **)(src + _addrOffset);
   memcpy(dest + _addrOffset, &object, sizeof(void*));
@@ -843,11 +945,10 @@ static void unknownRetainBranchless(const Metadata *metadata,
   swift_unknownObjectRetain(object);
 }
 
-static void unknownUnownedCopyInitBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void unknownUnownedCopyInit(const Metadata *metadata,
+                                   LayoutStringReader1 &reader,
+                                   uintptr_t &addrOffset, uint8_t *dest,
+                                   uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   UnownedReference *objectDest = (UnownedReference*)(dest + _addrOffset);
   UnownedReference *objectSrc = (UnownedReference*)(src + _addrOffset);
@@ -855,11 +956,10 @@ static void unknownUnownedCopyInitBranchless(const Metadata *metadata,
   swift_unknownObjectUnownedCopyInit(objectDest, objectSrc);
 }
 
-static void unknownWeakCopyInitBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void unknownWeakCopyInit(const Metadata *metadata,
+                                LayoutStringReader1 &reader,
+                                uintptr_t &addrOffset, uint8_t *dest,
+                                uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   auto *destObject = (WeakReference *)(dest + _addrOffset);
   auto *srcObject = (WeakReference *)(src + _addrOffset);
@@ -867,11 +967,8 @@ static void unknownWeakCopyInitBranchless(const Metadata *metadata,
   swift_unknownObjectWeakCopyInit(destObject, srcObject);
 }
 
-static void bridgeRetainBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void bridgeRetain(const Metadata *metadata, LayoutStringReader1 &reader,
+                         uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   void *object = *(void **)(src + _addrOffset);
   memcpy(dest + _addrOffset, &object, sizeof(void*));
@@ -879,23 +976,22 @@ static void bridgeRetainBranchless(const Metadata *metadata,
   swift_bridgeObjectRetain(object);
 }
 
+static void blockCopy(const Metadata *metadata, LayoutStringReader1 &reader,
+                      uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
 #if SWIFT_OBJC_INTEROP
-static void blockCopyBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   auto *copy = _Block_copy(*(void**)(src + _addrOffset));
   memcpy(dest + _addrOffset, &copy, sizeof(void*));
   addrOffset = _addrOffset + sizeof(void*);
+#else
+  swift_unreachable("Blocks are not available on this platform");
+#endif
 }
 
-static void objcStrongRetainBranchless(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void objcStrongRetain(const Metadata *metadata,
+                             LayoutStringReader1 &reader, uintptr_t &addrOffset,
+                             uint8_t *dest, uint8_t *src) {
+#if SWIFT_OBJC_INTEROP
   uintptr_t _addrOffset = addrOffset;
   uintptr_t object = *(uintptr_t *)(src + _addrOffset);
   memcpy(dest + _addrOffset, &object, sizeof(objc_object *));
@@ -904,14 +1000,15 @@ static void objcStrongRetainBranchless(const Metadata *metadata,
     return;
   object &= ~_swift_abi_SwiftSpareBitsMask;
   objc_retain((objc_object *)object);
-}
+#else
+  swift_unreachable("ObjC interop is not available on this platform");
 #endif
+}
 
-static void metatypeInitWithCopyBranchless(const Metadata *metadata,
-                               LayoutStringReader1 &reader,
-                               uintptr_t &addrOffset,
-                               uint8_t *dest,
-                               uint8_t *src) {
+static void metatypeInitWithCopy(const Metadata *metadata,
+                                 LayoutStringReader1 &reader,
+                                 uintptr_t &addrOffset, uint8_t *dest,
+                                 uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   auto *type = reader.readBytes<const Metadata *>();
   auto *destObject = (OpaqueValue *)(dest + _addrOffset);
@@ -920,11 +1017,10 @@ static void metatypeInitWithCopyBranchless(const Metadata *metadata,
   type->vw_initializeWithCopy(destObject, srcObject);
 }
 
-static void existentialInitWithCopyBranchless(const Metadata *metadata,
-                               LayoutStringReader1 &reader,
-                               uintptr_t &addrOffset,
-                               uint8_t *dest,
-                               uint8_t *src) {
+static void existentialInitWithCopy(const Metadata *metadata,
+                                    LayoutStringReader1 &reader,
+                                    uintptr_t &addrOffset, uint8_t *dest,
+                                    uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   auto *type = getExistentialTypeMetadata((OpaqueValue*)(src + _addrOffset));
   auto *destObject = (ValueBuffer *)(dest + _addrOffset);
@@ -933,11 +1029,10 @@ static void existentialInitWithCopyBranchless(const Metadata *metadata,
   type->vw_initializeBufferWithCopyOfBuffer(destObject, srcObject);
 }
 
-static void resilientInitWithCopyBranchless(const Metadata *metadata,
-                               LayoutStringReader1 &reader,
-                               uintptr_t &addrOffset,
-                               uint8_t *dest,
-                               uint8_t *src) {
+static void resilientInitWithCopy(const Metadata *metadata,
+                                  LayoutStringReader1 &reader,
+                                  uintptr_t &addrOffset, uint8_t *dest,
+                                  uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   auto *type = getResilientTypeMetadata(metadata, reader);
   auto *destObject = (OpaqueValue *)(dest + _addrOffset);
@@ -952,35 +1047,30 @@ typedef void (*InitFn)(const Metadata *metadata,
                                  uint8_t *dest,
                                  uint8_t *src);
 
-static const InitFn initWithCopyTable[] = {
-  &handleEnd,
-  &errorRetainBranchless,
-  &nativeStrongRetainBranchless,
-  &unownedRetainBranchless,
-  &weakCopyInitBranchless,
-  &unknownRetainBranchless,
-  &unknownUnownedCopyInitBranchless,
-  &unknownWeakCopyInitBranchless,
-  &bridgeRetainBranchless,
-#if SWIFT_OBJC_INTEROP
-  &blockCopyBranchless,
-  &objcStrongRetainBranchless,
-#else
-  nullptr,
-  nullptr,
-#endif
-  nullptr, // Custom
-  &metatypeInitWithCopyBranchless,
-  nullptr, // Generic
-  &existentialInitWithCopyBranchless,
-  &resilientInitWithCopyBranchless,
-  &singlePayloadEnumSimpleBranchless,
-  &singlePayloadEnumFNBranchless,
-  &singlePayloadEnumFNResolvedBranchless,
-  &singlePayloadEnumGenericBranchless,
-  &multiPayloadEnumFNBranchless<handleRefCountsInitWithCopy>,
-  &multiPayloadEnumFNResolvedBranchless<handleRefCountsInitWithCopy>,
-  &multiPayloadEnumGenericBranchless<handleRefCountsInitWithCopy>,
+constexpr InitFn initWithCopyTable[] = {
+    &handleEnd,
+    &errorRetain,
+    &nativeStrongRetain,
+    &unownedRetain,
+    &weakCopyInit,
+    &unknownRetain,
+    &unknownUnownedCopyInit,
+    &unknownWeakCopyInit,
+    &bridgeRetain,
+    &blockCopy,
+    &objcStrongRetain,
+    nullptr, // Custom
+    &metatypeInitWithCopy,
+    nullptr, // Generic
+    &existentialInitWithCopy,
+    &resilientInitWithCopy,
+    &singlePayloadEnumSimple,
+    &singlePayloadEnumFN,
+    &singlePayloadEnumFNResolved,
+    &singlePayloadEnumGeneric,
+    &multiPayloadEnumFN<handleRefCountsInitWithCopy>,
+    &multiPayloadEnumFNResolved<handleRefCountsInitWithCopy>,
+    &multiPayloadEnumGeneric<handleRefCountsInitWithCopy>,
 };
 
 static void handleRefCountsInitWithCopy(const Metadata *metadata,
@@ -1006,28 +1096,42 @@ static void handleRefCountsInitWithCopy(const Metadata *metadata,
 }
 
 extern "C" swift::OpaqueValue *
-swift_generic_initWithCopy(swift::OpaqueValue *dest, swift::OpaqueValue *src,
+swift_generic_initWithCopy(swift::OpaqueValue *_dest, swift::OpaqueValue *_src,
                            const Metadata *metadata) {
   const uint8_t *layoutStr = metadata->getLayoutString();
   LayoutStringReader1 reader{layoutStr + layoutStringHeaderSize};
   uintptr_t addrOffset = 0;
-  handleRefCountsInitWithCopy(metadata, reader, addrOffset, (uint8_t *)dest, (uint8_t *)src);
+  uint8_t *dest = (uint8_t *)_dest;
+  uint8_t *src = (uint8_t *)_src;
+
+#if defined(__APPLE__) && defined(__arm64__)
+  handleRefCounts(initWithCopyTable, CONTINUE_WITH_COPY, metadata, reader,
+                  addrOffset, dest, src);
+#else
+  handleRefCountsInitWithCopy(metadata, reader, addrOffset, dest, src);
+#endif
 
   assert(addrOffset == metadata->vw_size());
 
-  return dest;
+  return _dest;
 }
 
-void swift::swift_generic_arrayInitWithCopy(swift::OpaqueValue *dest,
-                                     swift::OpaqueValue *src,
-                                     size_t count,
-                                     size_t stride,
-                                     const Metadata *metadata) {
+void swift::swift_generic_arrayInitWithCopy(swift::OpaqueValue *_dest,
+                                            swift::OpaqueValue *_src,
+                                            size_t count, size_t stride,
+                                            const Metadata *metadata) {
   const uint8_t *layoutStr = metadata->getLayoutString();
+  uint8_t *dest = (uint8_t *)_dest;
+  uint8_t *src = (uint8_t *)_src;
   for (size_t i = 0; i < count; i++) {
     LayoutStringReader1 reader{layoutStr + layoutStringHeaderSize};
     uintptr_t addrOffset = i * stride;
-    handleRefCountsInitWithCopy(metadata, reader, addrOffset, (uint8_t *)dest, (uint8_t *)src);
+#if defined(__APPLE__) && defined(__arm64__)
+    handleRefCounts(initWithCopyTable, CONTINUE_WITH_COPY, metadata, reader,
+                    addrOffset, dest, src);
+#else
+    handleRefCountsInitWithCopy(metadata, reader, addrOffset, dest, src);
+#endif
   }
 }
 
@@ -1093,30 +1197,38 @@ static void resilientInitWithTake(const Metadata *metadata,
   type->vw_initializeWithTake(destObject, srcObject);
 }
 
-static const InitFn initWithTakeTable[] = {
-  &handleEnd,
-  nullptr,
-  nullptr,
-  nullptr,
-  nullptr,
-  nullptr,
-  nullptr,
-  &unknownWeakInitWithTake,
-  nullptr,
-  nullptr,
-  nullptr,
-  nullptr, // Custom
-  &metatypeInitWithTake,
-  nullptr, // Generic
-  &existentialInitWithTake,
-  &resilientInitWithTake,
-  &singlePayloadEnumSimpleBranchless,
-  &singlePayloadEnumFNBranchless,
-  &singlePayloadEnumFNResolvedBranchless,
-  &singlePayloadEnumGenericBranchless,
-  &multiPayloadEnumFNBranchless<handleRefCountsInitWithTake>,
-  &multiPayloadEnumFNResolvedBranchless<handleRefCountsInitWithTake>,
-  &multiPayloadEnumGenericBranchless<handleRefCountsInitWithTake>,
+static void copyingInitWithTake(const Metadata *metadata,
+                                LayoutStringReader1 &reader,
+                                uintptr_t &addrOffset, uint8_t *dest,
+                                uint8_t *src) {
+  memcpy(dest + addrOffset, src + addrOffset, sizeof(uintptr_t));
+  addrOffset += sizeof(uintptr_t);
+}
+
+constexpr InitFn initWithTakeTable[] = {
+    &handleEnd,
+    &copyingInitWithTake,
+    &copyingInitWithTake,
+    &copyingInitWithTake,
+    &copyingInitWithTake,
+    &copyingInitWithTake,
+    &copyingInitWithTake,
+    &unknownWeakInitWithTake,
+    &copyingInitWithTake,
+    &copyingInitWithTake,
+    &copyingInitWithTake,
+    nullptr, // Custom
+    &metatypeInitWithTake,
+    nullptr, // Generic
+    &existentialInitWithTake,
+    &resilientInitWithTake,
+    &singlePayloadEnumSimple,
+    &singlePayloadEnumFN,
+    &singlePayloadEnumFNResolved,
+    &singlePayloadEnumGeneric,
+    &multiPayloadEnumFN<handleRefCountsInitWithTake>,
+    &multiPayloadEnumFNResolved<handleRefCountsInitWithTake>,
+    &multiPayloadEnumGeneric<handleRefCountsInitWithTake>,
 };
 
 static void handleRefCountsInitWithTake(const Metadata *metadata,
@@ -1131,52 +1243,52 @@ static void handleRefCountsInitWithTake(const Metadata *metadata,
     if (SWIFT_UNLIKELY(offset)) {
       memcpy(dest + _addrOffset, src + _addrOffset, offset);
     }
-    _addrOffset += offset;
+    addrOffset += offset;
     tag >>= 56;
     if (SWIFT_UNLIKELY(tag == 0)) {
-      addrOffset = _addrOffset;
       return;
     }
 
-    if (auto handler = initWithTakeTable[tag]) {
-      addrOffset = _addrOffset;
-      handler(metadata, reader, addrOffset, dest, src);
-    } else {
-      memcpy(dest + _addrOffset, src + _addrOffset, sizeof(uintptr_t));
-      addrOffset = _addrOffset + sizeof(uintptr_t);
-    }
+    initWithTakeTable[tag](metadata, reader, addrOffset, dest, src);
   }
 }
 
 extern "C" swift::OpaqueValue *
-swift_generic_initWithTake(swift::OpaqueValue *dest, swift::OpaqueValue *src,
+swift_generic_initWithTake(swift::OpaqueValue *_dest, swift::OpaqueValue *_src,
                            const Metadata *metadata) {
   if (SWIFT_LIKELY(metadata->getValueWitnesses()->isBitwiseTakable())) {
     size_t size = metadata->vw_size();
-    memcpy(dest, src, size);
-    return dest;
+    memcpy(_dest, _src, size);
+    return _dest;
   }
+
+  uint8_t *dest = (uint8_t *)_dest;
+  uint8_t *src = (uint8_t *)_src;
 
   const uint8_t *layoutStr = metadata->getLayoutString();
   LayoutStringReader1 reader{layoutStr + layoutStringHeaderSize};
   uintptr_t addrOffset = 0;
 
-  handleRefCountsInitWithTake(metadata, reader, addrOffset, (uint8_t *)dest, (uint8_t *)src);
+#if defined(__APPLE__) && defined(__arm64__)
+  handleRefCounts(initWithTakeTable, CONTINUE_WITH_COPY, metadata, reader,
+                  addrOffset, dest, src);
+#else
+  handleRefCountsInitWithTake(metadata, reader, addrOffset, dest, src);
+#endif
 
   assert(addrOffset == metadata->vw_size());
 
-  return dest;
+  return _dest;
 }
 
 static void errorAssignWithCopy(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+                                LayoutStringReader1 &reader,
+                                uintptr_t &addrOffset, uint8_t *dest,
+                                uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   SwiftError *destObject = *(SwiftError **)(dest + _addrOffset);
   SwiftError *srcObject = *(SwiftError **)(src + _addrOffset);
-  memcpy(dest + addrOffset, &srcObject, sizeof(SwiftError*));
+  memcpy(dest + _addrOffset, &srcObject, sizeof(SwiftError *));
   addrOffset = _addrOffset + sizeof(SwiftError *);
   swift_errorRelease(destObject);
   swift_errorRetain(srcObject);
@@ -1214,30 +1326,41 @@ static void unownedAssignWithCopy(const Metadata *metadata,
   swift_unownedRetain((HeapObject *)srcObject);
 }
 
-static void weakAssignWithCopy(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void unknownAssignWithCopy(const Metadata *metadata,
+                                  LayoutStringReader1 &reader,
+                                  uintptr_t &addrOffset, uint8_t *dest,
+                                  uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
-  auto *destObject = (WeakReference *)(dest + _addrOffset);
-  auto *srcObject = (WeakReference *)(src + _addrOffset);
-  addrOffset = _addrOffset + sizeof(WeakReference);
-  swift_weakCopyAssign(destObject, srcObject);
+  void *destObject = *(void **)(dest + _addrOffset);
+  void *srcObject = *(void **)(src + _addrOffset);
+  memcpy(dest + _addrOffset, &srcObject, sizeof(void *));
+  addrOffset = _addrOffset + sizeof(void *);
+  swift_unknownObjectRelease(destObject);
+  swift_unknownObjectRetain(srcObject);
 }
 
-static void unknownAssignWithCopy(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void bridgeAssignWithCopy(const Metadata *metadata,
+                                 LayoutStringReader1 &reader,
+                                 uintptr_t &addrOffset, uint8_t *dest,
+                                 uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
   void *destObject = *(void **)(dest + _addrOffset);
   void *srcObject = *(void **)(src + _addrOffset);
   memcpy(dest + _addrOffset, &srcObject, sizeof(void*));
   addrOffset = _addrOffset + sizeof(void *);
-  swift_unknownObjectRelease(destObject);
-  swift_unknownObjectRetain(srcObject);
+  swift_bridgeObjectRelease(destObject);
+  swift_bridgeObjectRetain(srcObject);
+}
+
+static void weakAssignWithCopy(const Metadata *metadata,
+                               LayoutStringReader1 &reader,
+                               uintptr_t &addrOffset, uint8_t *dest,
+                               uint8_t *src) {
+  uintptr_t _addrOffset = addrOffset;
+  auto *destObject = (WeakReference *)(dest + _addrOffset);
+  auto *srcObject = (WeakReference *)(src + _addrOffset);
+  addrOffset = _addrOffset + sizeof(WeakReference);
+  swift_weakCopyAssign(destObject, srcObject);
 }
 
 static void unknownUnownedAssignWithCopy(const Metadata *metadata,
@@ -1264,31 +1387,20 @@ static void unknownWeakAssignWithCopy(const Metadata *metadata,
   swift_unknownObjectWeakCopyAssign(destObject, srcObject);
 }
 
-static void bridgeAssignWithCopy(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
-  uintptr_t _addrOffset = addrOffset;
-  void *destObject = *(void **)(dest + _addrOffset);
-  void *srcObject = *(void **)(src + _addrOffset);
-  memcpy(dest + _addrOffset, &srcObject, sizeof(void*));
-  addrOffset = _addrOffset + sizeof(void*);
-  swift_bridgeObjectRelease(destObject);
-  swift_bridgeObjectRetain(srcObject);
-}
-
-#if SWIFT_OBJC_INTEROP
 static void blockAssignWithCopy(const Metadata *metadata,
                              LayoutStringReader1 &reader,
                              uintptr_t &addrOffset,
                              uint8_t *dest,
                              uint8_t *src) {
+#if SWIFT_OBJC_INTEROP
   uintptr_t _addrOffset = addrOffset;
   _Block_release(*(void **)(dest + _addrOffset));
   auto *copy = _Block_copy(*(void **)(src + _addrOffset));
   memcpy(dest + _addrOffset, &copy, sizeof(void*));
   addrOffset = _addrOffset + sizeof(void*);
+#else
+  swift_unreachable("Blocks are not available on this platform");
+#endif
 }
 
 static void objcStrongAssignWithCopy(const Metadata *metadata,
@@ -1296,6 +1408,7 @@ static void objcStrongAssignWithCopy(const Metadata *metadata,
                              uintptr_t &addrOffset,
                              uint8_t *dest,
                              uint8_t *src) {
+#if SWIFT_OBJC_INTEROP
   uintptr_t _addrOffset = addrOffset;
   uintptr_t destObject = *(uintptr_t *)(dest + _addrOffset);
   uintptr_t srcObject = *(uintptr_t *)(src + _addrOffset);
@@ -1311,20 +1424,9 @@ static void objcStrongAssignWithCopy(const Metadata *metadata,
     srcObject &= ~_swift_abi_SwiftSpareBitsMask;
     objc_retain((objc_object *)srcObject);
   }
-}
+#else
+  swift_unreachable("ObjC interop is not available on this platform");
 #endif
-
-static void metatypeAssignWithCopy(const Metadata *metadata,
-                               LayoutStringReader1 &reader,
-                               uintptr_t &addrOffset,
-                               uint8_t *dest,
-                               uint8_t *src) {
-  uintptr_t _addrOffset = addrOffset;
-  auto *type = reader.readBytes<const Metadata *>();
-  auto *destObject = (OpaqueValue *)(dest + _addrOffset);
-  auto *srcObject = (OpaqueValue *)(src + _addrOffset);
-  addrOffset = _addrOffset + type->vw_size();
-  type->vw_assignWithCopy(destObject, srcObject);
 }
 
 static void existentialAssignWithCopy(const Metadata *metadata,
@@ -1344,6 +1446,18 @@ static void existentialAssignWithCopy(const Metadata *metadata,
     memcpy(destObject, srcObject, sizeof(uintptr_t));
     swift_retain(*(HeapObject**)srcObject);
   }
+}
+
+static void metatypeAssignWithCopy(const Metadata *metadata,
+                                   LayoutStringReader1 &reader,
+                                   uintptr_t &addrOffset, uint8_t *dest,
+                                   uint8_t *src) {
+  uintptr_t _addrOffset = addrOffset;
+  auto *type = reader.readBytes<const Metadata *>();
+  auto *destObject = (OpaqueValue *)(dest + _addrOffset);
+  auto *srcObject = (OpaqueValue *)(src + _addrOffset);
+  addrOffset = _addrOffset + type->vw_size();
+  type->vw_assignWithCopy(destObject, srcObject);
 }
 
 static void resilientAssignWithCopy(const Metadata *metadata,
@@ -1369,7 +1483,7 @@ static void handleSingleRefCountDestroy(const Metadata *metadata,
   if (SWIFT_UNLIKELY(tag == 0)) {
     return;
   }
-  destroyTableBranchless[tag](metadata, reader, addrOffset, addr);
+  destroyTable[tag](metadata, reader, addrOffset, addr);
 }
 
 static void handleSingleRefCountInitWithCopy(const Metadata *metadata,
@@ -1392,10 +1506,10 @@ static void handleSingleRefCountInitWithCopy(const Metadata *metadata,
 }
 
 static void singlePayloadEnumSimpleAssignWithCopy(const Metadata *metadata,
-                               LayoutStringReader1 &reader,
-                               uintptr_t &addrOffset,
-                               uint8_t *dest,
-                               uint8_t *src) {
+                                                  LayoutStringReader1 &reader,
+                                                  uintptr_t &_addrOffset,
+                                                  uint8_t *dest, uint8_t *src) {
+  uintptr_t addrOffset = _addrOffset;
   reader.modify([&](LayoutStringReader1 &reader) {
     uint64_t srcTagBytes = 0;
     uint64_t destTagBytes = 0;
@@ -1430,7 +1544,8 @@ static void singlePayloadEnumSimpleAssignWithCopy(const Metadata *metadata,
           zeroTagValue;
     }
 
-    if (srcTagBytes >= xiTagValues && destTagBytes >= xiTagValues) {
+    if (SWIFT_LIKELY(srcTagBytes >= xiTagValues &&
+                     destTagBytes >= xiTagValues)) {
       return;
     } else if (srcTagBytes >= xiTagValues) {
       const uint8_t *end = (reader.layoutStr + refCountBytes);
@@ -1451,6 +1566,8 @@ static void singlePayloadEnumSimpleAssignWithCopy(const Metadata *metadata,
     memcpy(dest + addrOffset, src + addrOffset, skip);
     addrOffset += skip;
   });
+
+  _addrOffset = addrOffset;
 }
 
 static void singlePayloadEnumFNAssignWithCopy(const Metadata *metadata,
@@ -1590,68 +1707,13 @@ static void singlePayloadEnumGenericAssignWithCopy(const Metadata *metadata,
 }
 
 static void multiPayloadEnumFNAssignWithCopy(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
-  size_t numPayloads;
-  size_t refCountBytes;
-  size_t enumSize;
-  LayoutStringReader1 nestedReader;
-  uintptr_t nestedAddrOffset;
-  unsigned srcTag;
-  unsigned destTag;
+                                             LayoutStringReader1 &reader,
+                                             uintptr_t &addrOffset,
+                                             uint8_t *dest, uint8_t *src);
 
-  reader.modify([&](LayoutStringReader1 &reader) {
-    GetEnumTagFn getEnumTag = readRelativeFunctionPointer<GetEnumTagFn>(reader);
-    reader.readBytes(numPayloads, refCountBytes, enumSize);
-    nestedReader = reader;
-    nestedAddrOffset = addrOffset;
-
-    srcTag = getEnumTag(src + addrOffset);
-    destTag = getEnumTag(dest + addrOffset);
-    reader.skip(refCountBytes + (numPayloads * sizeof(size_t)));
-  });
-
-  if (SWIFT_LIKELY(srcTag < numPayloads && destTag < numPayloads)) {
-    addrOffset += enumSize;
-    size_t srcRefCountOffset = nestedReader.peekBytes<size_t>(srcTag * sizeof(size_t));
-    size_t destRefCountOffset = nestedReader.peekBytes<size_t>(destTag * sizeof(size_t));
-    LayoutStringReader1 nestedReaderDest = nestedReader;
-    nestedReader.skip((numPayloads * sizeof(size_t)) + srcRefCountOffset);
-    nestedReaderDest.skip((numPayloads * sizeof(size_t)) + destRefCountOffset);
-    auto nestedAddrOffsetDest = nestedAddrOffset;
-    handleRefCountsDestroy(metadata, nestedReaderDest, nestedAddrOffsetDest, dest);
-    handleRefCountsInitWithCopy(metadata, nestedReader, nestedAddrOffset, dest, src);
-    auto trailingBytes = addrOffset - nestedAddrOffset;
-    if (trailingBytes)
-      memcpy(dest + nestedAddrOffset, src + nestedAddrOffset, trailingBytes);
-    return;
-  } else if (srcTag < numPayloads) {
-    addrOffset += enumSize;
-    size_t refCountOffset = nestedReader.peekBytes<size_t>(srcTag * sizeof(size_t));
-    nestedReader.skip((numPayloads * sizeof(size_t)) + refCountOffset);
-    handleRefCountsInitWithCopy(metadata, nestedReader, nestedAddrOffset, dest, src);
-    auto trailingBytes = addrOffset - nestedAddrOffset;
-    if (trailingBytes)
-      memcpy(dest + nestedAddrOffset, src + nestedAddrOffset, trailingBytes);
-    return;
-  } else if (destTag < numPayloads) {
-    size_t refCountOffset =
-        nestedReader.peekBytes<size_t>(destTag * sizeof(size_t));
-    nestedReader.skip((numPayloads * sizeof(size_t)) + refCountOffset);
-    handleRefCountsDestroy(metadata, nestedReader, nestedAddrOffset, dest);
-  }
-
-  memcpy(dest + addrOffset, src + addrOffset, enumSize);
-  addrOffset += enumSize;
-}
-
-static void multiPayloadEnumFNResolvedAssignWithCopy(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+static void multiPayloadEnumFNResolvedAssignWithCopy(
+    const Metadata *metadata, LayoutStringReader1 &reader,
+    uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   size_t numPayloads;
   size_t refCountBytes;
   size_t enumSize;
@@ -1706,10 +1768,9 @@ static void multiPayloadEnumFNResolvedAssignWithCopy(const Metadata *metadata,
 }
 
 static void multiPayloadEnumGenericAssignWithCopy(const Metadata *metadata,
-                             LayoutStringReader1 &reader,
-                             uintptr_t &addrOffset,
-                             uint8_t *dest,
-                             uint8_t *src) {
+                                                  LayoutStringReader1 &reader,
+                                                  uintptr_t &addrOffset,
+                                                  uint8_t *dest, uint8_t *src) {
   size_t tagBytes;
   size_t numPayloads;
   size_t refCountBytes;
@@ -1765,42 +1826,40 @@ static void multiPayloadEnumGenericAssignWithCopy(const Metadata *metadata,
   addrOffset += enumSize;
 }
 
-static const InitFn assignWithCopyTable[] = {
-  &handleEnd,
-  &errorAssignWithCopy,
-  &nativeStrongAssignWithCopy,
-  &unownedAssignWithCopy,
-  &weakAssignWithCopy,
-  &unknownAssignWithCopy,
-  &unknownUnownedAssignWithCopy,
-  &unknownWeakAssignWithCopy,
-  &bridgeAssignWithCopy,
-#if SWIFT_OBJC_INTEROP
-  &blockAssignWithCopy,
-  &objcStrongAssignWithCopy,
-#else
-  nullptr,
-  nullptr,
-#endif
-  nullptr, // Custom
-  &metatypeAssignWithCopy,
-  nullptr, // Generic
-  &existentialAssignWithCopy,
-  &resilientAssignWithCopy,
-  &singlePayloadEnumSimpleAssignWithCopy,
-  &singlePayloadEnumFNAssignWithCopy,
-  &singlePayloadEnumFNResolvedAssignWithCopy,
-  &singlePayloadEnumGenericAssignWithCopy,
-  &multiPayloadEnumFNAssignWithCopy,
-  &multiPayloadEnumFNResolvedAssignWithCopy,
-  &multiPayloadEnumGenericAssignWithCopy,
+typedef void (*AssignCPFn)(const Metadata *metadata, uint8_t *dest,
+                           uint8_t *src);
+
+constexpr InitFn assignWithCopyTable[] = {
+    &handleEnd,
+    &errorAssignWithCopy,
+    &nativeStrongAssignWithCopy,
+    &unownedAssignWithCopy,
+    &weakAssignWithCopy,
+    &unknownAssignWithCopy,
+    &unknownUnownedAssignWithCopy,
+    &unknownWeakAssignWithCopy,
+    &bridgeAssignWithCopy,
+    &blockAssignWithCopy,
+    &objcStrongAssignWithCopy,
+    nullptr, // Custom
+    &metatypeAssignWithCopy,
+    nullptr, // Generic
+    &existentialAssignWithCopy,
+    &resilientAssignWithCopy,
+    &singlePayloadEnumSimpleAssignWithCopy,
+    &singlePayloadEnumFNAssignWithCopy,
+    &singlePayloadEnumFNResolvedAssignWithCopy,
+    &singlePayloadEnumGenericAssignWithCopy,
+    &multiPayloadEnumFNAssignWithCopy,
+    &multiPayloadEnumFNResolvedAssignWithCopy,
+    &multiPayloadEnumGenericAssignWithCopy,
 };
 
+#if !(defined(__APPLE__) && defined(__arm64__))
 static void handleRefCountsAssignWithCopy(const Metadata *metadata,
-                          LayoutStringReader1 &reader,
-                          uintptr_t &addrOffset,
-                          uint8_t *dest,
-                          uint8_t *src) {
+                                          LayoutStringReader1 &reader,
+                                          uintptr_t &addrOffset, uint8_t *dest,
+                                          uint8_t *src) {
   while (true) {
     uintptr_t _addrOffset = addrOffset;
     auto tag = reader.readBytes<uint64_t>();
@@ -1817,31 +1876,125 @@ static void handleRefCountsAssignWithCopy(const Metadata *metadata,
     assignWithCopyTable[tag](metadata, reader, addrOffset, dest, src);
   }
 }
+#endif // !(defined(__APPLE__) && defined(__arm64__))
+
+static void multiPayloadEnumFNAssignWithCopy(const Metadata *metadata,
+                                             LayoutStringReader1 &reader,
+                                             uintptr_t &addrOffset,
+                                             uint8_t *dest, uint8_t *src) {
+  size_t numPayloads;
+  size_t refCountBytes;
+  size_t enumSize;
+  LayoutStringReader1 nestedReader;
+  uintptr_t nestedAddrOffset;
+  unsigned srcTag;
+  unsigned destTag;
+
+  reader.modify([&](LayoutStringReader1 &reader) {
+    GetEnumTagFn getEnumTag = readRelativeFunctionPointer<GetEnumTagFn>(reader);
+    reader.readBytes(numPayloads, refCountBytes, enumSize);
+    nestedReader = reader;
+    nestedAddrOffset = addrOffset;
+
+    srcTag = getEnumTag(src + addrOffset);
+    destTag = getEnumTag(dest + addrOffset);
+    reader.skip(refCountBytes + (numPayloads * sizeof(size_t)));
+  });
+
+  if (SWIFT_LIKELY(srcTag < numPayloads && destTag < numPayloads)) {
+    addrOffset += enumSize;
+    size_t srcRefCountOffset = nestedReader.peekBytes<size_t>(srcTag * sizeof(size_t));
+    size_t destRefCountOffset = nestedReader.peekBytes<size_t>(destTag * sizeof(size_t));
+
+    if (srcTag == destTag) {
+      nestedReader.skip((numPayloads * sizeof(size_t)) + srcRefCountOffset);
+#if defined(__APPLE__) && defined(__arm64__)
+      auto nestedAddrOffsetDest = nestedAddrOffset;
+      LayoutStringReader1 nestedReaderDest = nestedReader;
+
+      handleRefCounts(assignWithCopyTable, CONTINUE_WITH_COPY, metadata,
+                      nestedReaderDest, nestedAddrOffsetDest, dest, src);
+      nestedAddrOffset = nestedAddrOffsetDest;
+#else
+      handleRefCountsAssignWithCopy(metadata, nestedReader, nestedAddrOffset,
+                                    dest, src);
+#endif
+    } else {
+      LayoutStringReader1 nestedReaderDest = nestedReader;
+      nestedReader.skip((numPayloads * sizeof(size_t)) + srcRefCountOffset);
+      nestedReaderDest.skip((numPayloads * sizeof(size_t)) +
+                            destRefCountOffset);
+      auto nestedAddrOffsetDest = nestedAddrOffset;
+      handleRefCountsDestroy(metadata, nestedReaderDest, nestedAddrOffsetDest,
+                             dest);
+      handleRefCountsInitWithCopy(metadata, nestedReader, nestedAddrOffset,
+                                  dest, src);
+    }
+    auto trailingBytes = addrOffset - nestedAddrOffset;
+    if (trailingBytes) {
+      memcpy(dest + nestedAddrOffset, src + nestedAddrOffset, trailingBytes);
+    }
+    return;
+  } else if (srcTag < numPayloads) {
+    addrOffset += enumSize;
+    size_t refCountOffset = nestedReader.peekBytes<size_t>(srcTag * sizeof(size_t));
+    nestedReader.skip((numPayloads * sizeof(size_t)) + refCountOffset);
+    handleRefCountsInitWithCopy(metadata, nestedReader, nestedAddrOffset, dest, src);
+    auto trailingBytes = addrOffset - nestedAddrOffset;
+    if (trailingBytes) {
+      memcpy(dest + nestedAddrOffset, src + nestedAddrOffset, trailingBytes);
+    }
+    return;
+  } else if (destTag < numPayloads) {
+    size_t refCountOffset =
+        nestedReader.peekBytes<size_t>(destTag * sizeof(size_t));
+    nestedReader.skip((numPayloads * sizeof(size_t)) + refCountOffset);
+    handleRefCountsDestroy(metadata, nestedReader, nestedAddrOffset, dest);
+  }
+
+  memcpy(dest + addrOffset, src + addrOffset, enumSize);
+  addrOffset += enumSize;
+}
 
 extern "C" swift::OpaqueValue *
-swift_generic_assignWithCopy(swift::OpaqueValue *dest, swift::OpaqueValue *src,
+swift_generic_assignWithCopy(swift::OpaqueValue *_dest,
+                             swift::OpaqueValue *_src,
                              const Metadata *metadata) {
+  uint8_t *dest = (uint8_t *)_dest;
+  uint8_t *src = (uint8_t *)_src;
   const uint8_t *layoutStr = metadata->getLayoutString();
   LayoutStringReader1 reader{layoutStr + layoutStringHeaderSize};
   uintptr_t addrOffset = 0;
-  handleRefCountsAssignWithCopy(metadata, reader, addrOffset, (uint8_t *)dest,
-                                (uint8_t *)src);
+
+#if defined(__APPLE__) && defined(__arm64__)
+  handleRefCounts(assignWithCopyTable, CONTINUE_WITH_COPY, metadata, reader,
+                  addrOffset, dest, src);
+#else
+  handleRefCountsAssignWithCopy(metadata, reader, addrOffset, dest, src);
+#endif
 
   assert(addrOffset == metadata->vw_size());
 
-  return dest;
+  return _dest;
 }
 
-void swift::swift_generic_arrayAssignWithCopy(swift::OpaqueValue *dest,
-                                              swift::OpaqueValue *src,
+void swift::swift_generic_arrayAssignWithCopy(swift::OpaqueValue *_dest,
+                                              swift::OpaqueValue *_src,
                                               size_t count, size_t stride,
                                               const Metadata *metadata) {
+  uint8_t *dest = (uint8_t *)_dest;
+  uint8_t *src = (uint8_t *)_src;
   const uint8_t *layoutStr = metadata->getLayoutString();
   for (size_t i = 0; i < count; i++) {
     LayoutStringReader1 reader{layoutStr + layoutStringHeaderSize};
     uintptr_t addrOffset = i * stride;
-    handleRefCountsAssignWithCopy(metadata, reader, addrOffset, (uint8_t *)dest,
-                                  (uint8_t *)src);
+
+#if defined(__APPLE__) && defined(__arm64__)
+    handleRefCounts(assignWithCopyTable, CONTINUE_WITH_COPY, metadata, reader,
+                    addrOffset, dest, src);
+#else
+    handleRefCountsAssignWithCopy(metadata, reader, addrOffset, dest, src);
+#endif
   }
 }
 

--- a/stdlib/public/runtime/BytecodeLayouts.h
+++ b/stdlib/public/runtime/BytecodeLayouts.h
@@ -52,7 +52,7 @@ enum class RefCountingKind : uint8_t {
   MultiPayloadEnumFNResolved = 0x15,
   MultiPayloadEnumGeneric = 0x16,
 
-  Skip = 0x80,
+  // Skip = 0x80,
   // We may use the MSB as flag that a count follows,
   // so all following values are reserved
   // Reserved: 0x81 - 0xFF
@@ -245,9 +245,10 @@ void swift_generic_arrayInitWithCopy(swift::OpaqueValue *dest,
                                      size_t stride,
                                      const Metadata *metadata);
 
-void swift_generic_arrayAssignWithCopy(swift::OpaqueValue *dest,
-                                       swift::OpaqueValue *src, size_t count,
-                                       size_t stride, const Metadata *metadata);
+extern "C" void swift_generic_arrayAssignWithCopy(swift::OpaqueValue *dest,
+                                                  swift::OpaqueValue *src,
+                                                  size_t count, size_t stride,
+                                                  const Metadata *metadata);
 
 constexpr size_t layoutStringHeaderSize = sizeof(uint64_t) + sizeof(size_t);
 

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -380,6 +380,12 @@ public struct MultiPayloadEnumWrapper {
     }
 }
 
+public enum MultiPayloadEnumMultiLarge {
+    case empty
+    case nonEmpty(Int, SimpleClass, Int, SimpleClass, Int, Bool, SimpleClass, Bool, SimpleClass, Bool)
+    case nonEmpty2(SimpleClass, Int, Int, SimpleClass, Int, Bool, SimpleClass, Bool, SimpleClass, Bool)
+}
+
 public struct MixedEnumWrapper {
     let x: SinglePayloadSimpleClassEnum
     let y: MultiPayloadEnum
@@ -598,10 +604,6 @@ public func testAssign<T>(_ ptr: UnsafeMutablePointer<T>, from x: T) {
 }
 
 @inline(never)
-public func testAssign<T>(_ ptr: UnsafeMutablePointer<T>, from x: UnsafeMutablePointer<T>) {
-    ptr.assign(from: x, count: 1)
-}
-
 public func testAssignCopy<T>(_ ptr: UnsafeMutablePointer<T>, from x: inout T) {
     ptr.update(from: &x, count: 1)
 }
@@ -654,10 +656,10 @@ public func testGenericArrayDestroy<T>(_ buffer: UnsafeMutableBufferPointer<T>) 
 
 @inline(never)
 public func testGenericArrayInitWithCopy<T>(dest: UnsafeMutableBufferPointer<T>, src: UnsafeMutableBufferPointer<T>) {
-    dest.initialize(fromContentsOf: src)
+    _ = dest.initialize(fromContentsOf: src)
 }
 
 @inline(never)
 public func testGenericArrayAssignWithCopy<T>(dest: UnsafeMutableBufferPointer<T>, src: UnsafeMutableBufferPointer<T>) {
-    dest.update(fromContentsOf: src)
+    _ = dest.update(fromContentsOf: src)
 }

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -31,6 +31,7 @@ class TestClass {
 func testSimple() {
     let ptr = UnsafeMutablePointer<Simple>.allocate(capacity: 1)
 
+    // initWithCopy
     do {
         let x = Simple(x: 3, y: SimpleClass(x: 23), z: SimpleBig())
         testInit(ptr, to: x)
@@ -39,6 +40,7 @@ func testSimple() {
     // CHECK: 3 - 23
     print("\(ptr.pointee.x) - \(ptr.pointee.y.x)")
 
+    // assignWithTake
     do {
         let y = Simple(x: 2, y: SimpleClass(x: 1), z: SimpleBig())
 
@@ -52,10 +54,24 @@ func testSimple() {
     // CHECK-NEXT: 2 - 1
     print("\(ptr.pointee.x) - \(ptr.pointee.y.x)")
 
+    // assignWithCopy
+    do {
+        var z = Simple(x: 23, y: SimpleClass(x: 5), z: SimpleBig())
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: 23 - 5
+    print("\(ptr.pointee.x) - \(ptr.pointee.y.x)")
+
     // CHECK-NEXT: Before deinit
     print("Before deinit")
 
-
+    // destroy
     // CHECK-NEXT: SimpleClass deinitialized!
     testDestroy(ptr)
 
@@ -106,6 +122,28 @@ func testWeakNative() {
         }
     }
 
+    do {
+        let ref = SimpleClass(x: 23)
+
+        withExtendedLifetime(ref) {
+
+            // CHECK-NEXT: SimpleClass deinitialized!
+            var wrapper = WeakNativeWrapper(x: ref)
+            testAssignCopy(ptr, from: &wrapper)
+
+            guard let x = ptr.pointee.x else {
+                fatalError("Weak reference prematurely destroyed")
+            }
+
+            // CHECK-NEXT: value: 23
+            print("value: \(x.x)")
+
+            // NOTE: There is still a strong reference to it here
+            // CHECK-NEXT: Before deinit
+            print("Before deinit")
+        }
+    }
+
     // CHECK-NEXT: SimpleClass deinitialized!
     testDestroy(ptr)
 
@@ -147,6 +185,23 @@ func testUnownedNative() {
         }
     }
 
+    do {
+        let ref = SimpleClass(x: 23)
+
+        withExtendedLifetime(ref) {
+            // CHECK-NEXT: SimpleClass deinitialized!
+            var wrapper = UnownedNativeWrapper(x: ref)
+            testAssignCopy(ptr, from: &wrapper)
+
+            // CHECK-NEXT: value: 23
+            print("value: \(ptr.pointee.x.x)")
+
+            // NOTE: There is still a strong reference to it here
+            // CHECK-NEXT: Before deinit
+            print("Before deinit")
+        }
+    }
+
     // CHECK-NEXT: SimpleClass deinitialized!
     testDestroy(ptr)
 
@@ -175,6 +230,19 @@ func testClosure() {
         testAssign(ptr, from: ClosureWrapper(f: { print("value: \(ref.x)") }))
 
         // CHECK-NEXT: value: 34
+        ptr.pointee.f()
+    }
+
+    do {
+        let ref = SimpleClass(x: 23)
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        var wrapper = ClosureWrapper(f: { print("value: \(ref.x)") })
+        testAssignCopy(ptr, from: &wrapper)
+
+        // CHECK-NEXT: value: 23
         ptr.pointee.f()
     }
 
@@ -213,6 +281,17 @@ func testExistentialClass() {
         testAssign(ptr, from: ExistentialWrapper(x: y))
     }
 
+    do {
+        let z = ClassWithSomeProtocol()
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: ClassWithSomeProtocol deinitialized!
+        var wrapper = ExistentialWrapper(x: z)
+        testAssignCopy(ptr, from: &wrapper)
+    }
+
     // CHECK-NEXT: Before deinit
     print("Before deinit")
 
@@ -245,6 +324,17 @@ func testExistentialStructInline() {
 
         // CHECK-NEXT: SimpleClass deinitialized!
         testAssign(ptr, from: createExistentialWrapper(y))
+    }
+
+    do {
+        let z = StructWithSomeProtocolInline(x: SimpleClass(x: 32))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        var wrapper = createExistentialWrapper(z)
+        testAssignCopy(ptr, from: &wrapper)
     }
 
     // CHECK-NEXT: Before deinit
@@ -284,6 +374,17 @@ func testExistentialStructBox() {
         testAssign(ptr, from: createExistentialWrapper(y))
     }
 
+    do {
+        let z = StructWithSomeProtocolBox(x: SimpleClass(x: 32))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        var wrapper = createExistentialWrapper(z)
+        testAssignCopy(ptr, from: &wrapper)
+    }
+
     // CHECK-NEXT: Before deinit
     print("Before deinit")
 
@@ -312,6 +413,18 @@ func testAnyWrapper() {
         // CHECK-NEXT: TestClass deinitialized!
         // CHECK-NEXT: SimpleClass deinitialized!
         testAssign(ptr, from: AnyWrapper(y: y, z: SimpleClass(x: 32)))
+    }
+
+    do {
+        let z = TestClass()
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: TestClass deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        var wrapper = AnyWrapper(y: z, z: SimpleClass(x: 32))
+        testAssignCopy(ptr, from: &wrapper)
     }
 
     // CHECK-NEXT: Before deinit
@@ -351,6 +464,18 @@ func testMultiProtocolExistential() {
         testAssign(ptr, from: MultiProtocolExistentialWrapper(y: y, z: SimpleClass(x: 32)))
     }
 
+    do {
+        let z = ClassWithABC()
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: ClassWithABC deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        var wrapper = MultiProtocolExistentialWrapper(y: z, z: SimpleClass(x: 32))
+        testAssignCopy(ptr, from: &wrapper)
+    }
+
     // CHECK-NEXT: Before deinit
     print("Before deinit")
 
@@ -387,6 +512,17 @@ func testExistentialReference() {
         testAssign(ptr, from: ExistentialRefWrapper(x: y))
     }
 
+    do {
+        let z = ClassWithSomeClassProtocol()
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: ClassWithSomeClassProtocol deinitialized!
+        var wrapper = ExistentialRefWrapper(x: z)
+        testAssignCopy(ptr, from: &wrapper)
+    }
+
     // CHECK-NEXT: Before deinit
     print("Before deinit")
 
@@ -421,7 +557,22 @@ func testSinglePayloadSimpleClassEnum() {
         testAssign(ptr, from: y)
     }
 
-    // CHECK-NEXT: Value: 28
+    do {
+        // CHECK: Value: 28
+        if case .nonEmpty(let c) = ptr.pointee {
+            print("Value: \(c.x)")
+        }
+
+        var z = SinglePayloadSimpleClassEnum.nonEmpty(SimpleClass(x: 32))
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: Value: 32
     if case .nonEmpty(let c) = ptr.pointee {
         print("Value: \(c.x)")
     }
@@ -593,6 +744,60 @@ func testMultiPayloadEnum() {
 }
 
 testMultiPayloadEnum()
+
+func testMultiPayloadEnumMultiLarge() {
+    let ptr = UnsafeMutablePointer<MultiPayloadEnumMultiLarge>.allocate(capacity: 1)
+
+    do {
+        let x = MultiPayloadEnumMultiLarge.nonEmpty(
+            0, SimpleClass(x: 1), 2, SimpleClass(x: 3), 4, true,
+            SimpleClass(x: 6), false, SimpleClass(x: 8), true)
+        testInit(ptr, to: x)
+    }
+
+    do {
+        var y = MultiPayloadEnumMultiLarge.nonEmpty(
+            10, SimpleClass(x: 11), 12, SimpleClass(x: 13), 14, false,
+            SimpleClass(x: 6), true, SimpleClass(x: 8), false)
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &y)
+    }
+
+    do {
+        var z = MultiPayloadEnumMultiLarge.nonEmpty2(
+            SimpleClass(x: 20), 21, 22, SimpleClass(x: 23), 24, true,
+            SimpleClass(x: 26), false, SimpleClass(x: 28), true)
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    // CHECK-NEXT: SimpleClass deinitialized!
+    // CHECK-NEXT: SimpleClass deinitialized!
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadEnumMultiLarge()
 
 func testNullableRefEnum() {
     let ptr = UnsafeMutablePointer<NullableRefEnum>.allocate(capacity: 1)
@@ -875,6 +1080,18 @@ func testObjc() {
         print("value: \(ptr.pointee.x.x)")
     }
 
+    do {
+        var x = ObjcWrapper(x: ObjcClass(x: 34))
+        // CHECK-macosx-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-macosx-NEXT: ObjcClass deinitialized!
+        testAssignCopy(ptr, from: &x)
+
+        // CHECK-macosx-NEXT: value: 34
+        print("value: \(ptr.pointee.x.x)")
+    }
+
     // CHECK-macosx-NEXT: Before deinit
     print("Before deinit")
 
@@ -900,6 +1117,28 @@ func testWeakObjc() {
             }
 
             // CHECK-macosx: value: 2
+            print("value: \(x.x)")
+
+            // NOTE: There is still a strong reference to it here
+            // CHECK-macosx-NEXT: Before deinit
+            print("Before deinit")
+        }
+    }
+
+    do {
+        let ref = ObjcClass(x: 23)
+
+        withExtendedLifetime(ref) {
+
+            // CHECK-macosx-NEXT: ObjcClass deinitialized!
+            var wrapper = WeakObjcWrapper(x: ref)
+            testAssignCopy(ptr, from: &wrapper)
+
+            guard let x = ptr.pointee.x else {
+                fatalError("Weak reference prematurely destroyed")
+            }
+
+            // CHECK-macosx-NEXT: value: 23
             print("value: \(x.x)")
 
             // NOTE: There is still a strong reference to it here
@@ -962,6 +1201,23 @@ func testUnownedObjc() {
             testAssign(ptr, from: UnownedObjcWrapper(x: ref))
 
             // CHECK-macosx-NEXT: value: 34
+            print("value: \(ptr.pointee.x.x)")
+
+            // NOTE: There is still a strong reference to it here
+            // CHECK-macosx-NEXT: Before deinit
+            print("Before deinit")
+        }
+    }
+
+    do {
+        let ref = ObjcClass(x: 23)
+
+        withExtendedLifetime(ref) {
+            // CHECK-macosx-NEXT: ObjcClass deinitialized!
+            var wrapper = UnownedObjcWrapper(x: ref)
+            testAssignCopy(ptr, from: &wrapper)
+
+            // CHECK-macosx-NEXT: value: 23
             print("value: \(ptr.pointee.x.x)")
 
             // NOTE: There is still a strong reference to it here


### PR DESCRIPTION
5.10 cherry-pick of: https://github.com/apple/swift/pull/69756

- Explanation: Significantly improves performance of layout strings runtime functions
- Scope: Layout strings only
- Issue: rdar://118606762
- Risk: Low, only affects layout strings, which is still experimental
- Testing: Added tests to the test suite, existing tests still succeed
- Reviewer: @mikeash