### PR TITLE
Deprecate the CommandLine.arguments setter

### DIFF
--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -54,11 +54,44 @@ public enum CommandLine {
     return _unsafeArgv
   }
 
-  /// Access to the Swift command line arguments.
-  // Use lazy initialization of static properties to 
+  // Use lazy initialization of static properties to
   // safely initialize the swift arguments.
-  public static var arguments: [String]
+  @usableFromInline
+  internal static let _arguments: [String]
     = (0..<Int(argc)).map { String(cString: _unsafeArgv[$0]!) }
+ 
+  /// An array that provides access to this program's command line arguments.
+  ///
+  /// Use `CommandLine.arguments` to access the command line arguments used
+  /// when executing the current program. The name of the executed program is
+  /// the first argument.
+  ///
+  /// The following example shows a command line executable that squares the
+  /// integer given as an argument.
+  ///
+  ///     if CommandLine.arguments.count == 2,
+  ///         let number = Int(CommandLine.arguments[1])
+  ///     {
+  ///         print("\(number) x \(number) is \(number * number)")
+  ///     } else {
+  ///         print("""
+  ///           Error: Please provide a number to square.
+  ///           Usage: command <number>
+  ///           """)
+  ///     }
+  ///
+  /// Running the program results in the following output:
+  ///
+  ///     $ command 5
+  ///     5 x 5 is 25
+  ///     $ command ZZZ
+  ///     Error: Please provide a number to square.
+  ///     Usage: command <number>
+  public static var arguments: [String] {
+    get { _arguments }
+    @available(swift, deprecated: 5.10, message: "CommandLine.arguments will be immutable in a future version")
+    set { _arguments = newValue }
+  }
 }
 
 #endif // SWIFT_STDLIB_HAS_COMMANDLINE

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -57,7 +57,7 @@ public enum CommandLine {
   // Use lazy initialization of static properties to
   // safely initialize the swift arguments.
   @usableFromInline
-  internal static let _arguments: [String]
+  internal static var _arguments: [String]
     = (0..<Int(argc)).map { String(cString: _unsafeArgv[$0]!) }
  
   /// An array that provides access to this program's command line arguments.


### PR DESCRIPTION
Accessing `CommandLine.arguments` is a sendability violation, since it's global mutable state. This marks the setter as deprecated, so that we can potentially make it unavailable in Swift 6 mode.

(I also wrote some docs for `CommandLine.arguments`.)