### PR TITLE
[cxx-interop] Fix assertion failure when emitting a module interface

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2710,13 +2710,13 @@ namespace {
                       ctorUsingShadowDecl->getTargetDecl());
                   if (!baseCtorDecl || baseCtorDecl->isDeleted())
                     continue;
+                  auto loc = ctorUsingShadowDecl->getLocation();
+
                   auto derivedCtorDecl = clangSema.findInheritingConstructor(
-                      clang::SourceLocation(), baseCtorDecl,
-                      ctorUsingShadowDecl);
+                      loc, baseCtorDecl, ctorUsingShadowDecl);
                   if (!derivedCtorDecl->isDefined() &&
                       !derivedCtorDecl->isDeleted())
-                    clangSema.DefineInheritingConstructor(
-                        clang::SourceLocation(), derivedCtorDecl);
+                    clangSema.DefineInheritingConstructor(loc, derivedCtorDecl);
                 }
               }
             }


### PR DESCRIPTION
```
Assertion failed: (LHS.isValid() && RHS.isValid() && "Passed invalid source location!"), function isBeforeInTranslationUnit, file SourceManager.cpp, line 1991.
```

rdar://118572078