### PR TITLE
AST: Desugar typed patterns in swiftinterfaces consistently.

### DIFF
--- a/test/Inputs/lazy_typecheck.swift
+++ b/test/Inputs/lazy_typecheck.swift
@@ -16,6 +16,10 @@ public func publicFunc() -> Int {
   return NoTypecheck.int
 }
 
+public func publicFuncReturnsTypealias() -> PublicIntAlias {
+  return NoTypecheck.int
+}
+
 public func publicFuncWithDefaultArg(_ x: Int = 1) -> Int {
   return NoTypecheck.int
 }
@@ -88,11 +92,15 @@ struct InternalWrapper {
 // MARK: - Global vars
 
 public var publicGlobalVar: Int = NoTypecheck.int
+public var publicGlobalVarTypealias: PublicIntAlias = 1
 public var publicGlobalVarInferredType = ""
+public var publicGlobalVarInferredInferredGeneric: [_] = [1]
+public var publicGlobalVarTypealiasGeneric: PublicIntAlias? = 1
 public var (publicGlobalVarInferredTuplePatX, publicGlobalVarInferredTuplePatY) = (0, 1)
 
 var internalGlobalVar: NoTypecheck = NoTypecheck()
 var internalGlobalVarInferredType = NoTypecheck()
+var internalGlobalTypealiasVar: PublicIntAlias = NoTypecheck.int
 
 // MARK: - Nominal types
 
@@ -132,6 +140,7 @@ protocol InternalProtoConformingToPublicProto: PublicProto {
 
 public struct PublicStruct {
   public var publicProperty: Int = NoTypecheck.int
+  public var publicTypealiasProperty: PublicIntAlias = 1
   public var publicPropertyInferredType = ""
   public var publicLazyProperty: Int = NoTypecheck.int
   public var publicLazyPropertyInferred = 1
@@ -334,6 +343,7 @@ extension PublicGenericStruct: EmptyPublicProto where T == InternalStructForCons
 
 // MARK: - Type aliases
 
+public typealias PublicIntAlias = Int
 public typealias PublicStructAlias = PublicStruct
 typealias InternalTypeAlias = NoTypecheck
 

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -12,17 +12,17 @@ struct ConformsToMainActorProto: MainActorProtocol {
 }
 
 func testGlobalFunctions() {
-  _ = publicFunc()
-  _ = publicFuncWithDefaultArg()
+  let _: Int = publicFunc()
+  let _: Int = publicFuncWithDefaultArg()
   #if TEST_PACKAGE
-  _ = packageFunc()
+  let _: Int = packageFunc()
   #endif
   constrainedGenericPublicFunction(ConformsToPublicProto())
-  _ = publicSpecializedFunc(4)
-  _ = publicSpecializedFunc(ConformsToPublicProto())
+  let _: Int = publicSpecializedFunc(4)
+  let _: ConformsToPublicProto = publicSpecializedFunc(ConformsToPublicProto())
   if #available(SwiftStdlib 5.1, *) {
-    _ = publicFuncWithOpaqueReturnType()
-    _ = publicAEICFuncWithOpaqueReturnType()
+    let _: any PublicProto = publicFuncWithOpaqueReturnType()
+    let _: Any = publicAEICFuncWithOpaqueReturnType()
   }
 }
 

--- a/test/Inputs/lazy_typecheck_client.swift
+++ b/test/Inputs/lazy_typecheck_client.swift
@@ -13,6 +13,7 @@ struct ConformsToMainActorProto: MainActorProtocol {
 
 func testGlobalFunctions() {
   let _: Int = publicFunc()
+  let _: Int = publicFuncReturnsTypealias()
   let _: Int = publicFuncWithDefaultArg()
   #if TEST_PACKAGE
   let _: Int = packageFunc()
@@ -28,7 +29,10 @@ func testGlobalFunctions() {
 
 func testGobalVars() {
   let _: Int = publicGlobalVar
+  let _: Int = publicGlobalVarTypealias
   let _: String = publicGlobalVarInferredType
+  let _: [Int] = publicGlobalVarInferredInferredGeneric
+  let _: Int? = publicGlobalVarTypealiasGeneric
   let _: (Int, Int) = (publicGlobalVarInferredTuplePatX, publicGlobalVarInferredTuplePatY)
 }
 
@@ -36,6 +40,7 @@ func testPublicStructs() {
   let s = PublicStruct(x: 1)
   let _: Int = s.publicMethod()
   let _: Int = s.publicProperty
+  let _: Int = s.publicTypealiasProperty
   let _: String = s.publicPropertyInferredType
   let _: Int = s.publicLazyProperty
   let _: Int = s.publicLazyPropertyInferred


### PR DESCRIPTION
To match the swiftinterfaces that are emitted for eagerly typechecked ASTs, lazily trigger initializer expression typechecking for typed patterns that were written using a typealias.

Resolves rdar://118698233