### PR TITLE
Sema: Fix a null dereference when diagnosing a call to a renamed function

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2420,12 +2420,12 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
             }
           }
         }
-        // Function names are the same(including context if applicable), so
+        // Function names are the same (including context if applicable), so
         // renaming fix-it doesn't need do be produced.
+        auto calledValue = CE->getCalledValue(/*skipFunctionConversions=*/true);
         if ((parsed.ContextName.empty() ||
              parsed.ContextName == callContextName) &&
-            CE->getCalledValue(/*skipFunctionConversions=*/true)
-                    ->getBaseName() == parsed.BaseName) {
+            calledValue && calledValue->getBaseName() == parsed.BaseName) {
           shouldEmitRenameFixit = false;
         }
       }

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -module-name Test
 
 @available(*, unavailable)
 func unavailable_func() {}
@@ -203,6 +203,9 @@ struct DeprecatedTypeWithRename { }
 func use_deprecated_with_renamed() {
   deprecated_func_with_renamed() // expected-warning{{'deprecated_func_with_renamed()' is deprecated: renamed to 'blarg'}}
   // expected-note@-1{{use 'blarg'}}{{3-31=blarg}}
+
+  Test.deprecated_func_with_renamed() // expected-warning{{'deprecated_func_with_renamed()' is deprecated: renamed to 'blarg'}}
+  // expected-note@-1{{use 'blarg' instead}}
 
   deprecated_func_with_message_renamed() //expected-warning{{'deprecated_func_with_message_renamed()' is deprecated: blarg is your friend}}
   // expected-note@-1{{use 'blarg'}}{{3-39=blarg}}


### PR DESCRIPTION
Resolves rdar://117139757
