### PR TITLE
GenericSpecializer: support specializing typed throws

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -55,9 +55,9 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     blocks.reversed().lazy.flatMap { $0.instructions.reversed() }
   }
 
-  /// The number of indirect result arguments.
   public var numIndirectResultArguments: Int { bridged.getNumIndirectFormalResults() }
-  
+  public var hasIndirectErrorArgument: Bool { bridged.hasIndirectErrorResult() }
+
   /// The number of arguments which correspond to parameters (and not to indirect results).
   public var numParameterArguments: Int { bridged.getNumParameters() }
 
@@ -66,7 +66,9 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
   /// This is the sum of indirect result arguments and parameter arguments.
   /// If the function is a definition (i.e. it has at least an entry block), this is the
   /// number of arguments of the function's entry block.
-  public var numArguments: Int { numIndirectResultArguments + numParameterArguments }
+  public var numArguments: Int {
+    numIndirectResultArguments + (hasIndirectErrorArgument ? 1 : 0) + numParameterArguments
+  }
 
   public var hasSelfArgument: Bool {
     bridged.getSelfArgumentIndex() >= 0

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4785,6 +4785,9 @@ public:
   unsigned getNumPackResults() const {
     return isCoroutine() ? 0 : NumPackResults;
   }
+  bool hasIndirectErrorResult() const {
+    return hasErrorResult() && getErrorResult().isFormalIndirect();
+  }
 
   struct IndirectFormalResultFilter {
     bool operator()(SILResultInfo result) const {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -295,6 +295,7 @@ struct BridgedFunction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedBasicBlock getFirstBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedBasicBlock getLastBlock() const;
   BRIDGED_INLINE SwiftInt getNumIndirectFormalResults() const;
+  BRIDGED_INLINE bool hasIndirectErrorResult() const;
   BRIDGED_INLINE SwiftInt getNumParameters() const;
   BRIDGED_INLINE SwiftInt getSelfArgumentIndex() const;
   BRIDGED_INLINE SwiftInt getNumSILArguments() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -413,6 +413,10 @@ SwiftInt BridgedFunction::getNumIndirectFormalResults() const {
   return (SwiftInt)getFunction()->getLoweredFunctionType()->getNumIndirectFormalResults();
 }
 
+bool BridgedFunction::hasIndirectErrorResult() const {
+  return (SwiftInt)getFunction()->getLoweredFunctionType()->hasIndirectErrorResult();
+}
+
 SwiftInt BridgedFunction::getNumParameters() const {
   return (SwiftInt)getFunction()->getLoweredFunctionType()->getNumParameters();
 }

--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -242,6 +242,12 @@ public:
     return 0;
   }
 
+  bool isArgumentIndexOfIndirectErrorResult(unsigned idx) {
+    unsigned indirectResults = getNumIndirectSILResults();
+    return idx >= indirectResults &&
+           idx < indirectResults + getNumIndirectSILErrorResults();
+  }
+
   /// Are any SIL results passed as address-typed arguments?
   bool hasIndirectSILResults() const { return getNumIndirectSILResults() != 0; }
   bool hasIndirectSILErrorResults() const { return getNumIndirectSILErrorResults() != 0; }

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -42,7 +42,6 @@ class GenericCloner
 
   llvm::SmallVector<AllocStackInst *, 8> AllocStacks;
   llvm::SmallVector<StoreBorrowInst *, 8> StoreBorrowsToCleanup;
-  llvm::SmallVector<TermInst *, 8> FunctionExits;
   AllocStackInst *ReturnValueAddr = nullptr;
 
 public:
@@ -94,11 +93,6 @@ protected:
     if (Callback)
       Callback(Orig, Cloned);
 
-    if (auto *termInst = dyn_cast<TermInst>(Cloned)) {
-      if (termInst->isFunctionExiting()) {
-        FunctionExits.push_back(termInst);
-      }
-    }
     SILClonerWithScopes<GenericCloner>::postProcess(Orig, Cloned);
   }
 

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -43,6 +43,7 @@ class GenericCloner
   llvm::SmallVector<AllocStackInst *, 8> AllocStacks;
   llvm::SmallVector<StoreBorrowInst *, 8> StoreBorrowsToCleanup;
   AllocStackInst *ReturnValueAddr = nullptr;
+  AllocStackInst *ErrorValueAddr = nullptr;
 
 public:
   friend class SILCloner<GenericCloner>;

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -192,8 +192,7 @@ void GenericCloner::visitTerminator(SILBasicBlock *BB) {
       getBuilder().createDeallocStack(ASI->getLoc(), ASI);
     }
     if (ReturnValue) {
-      auto *NewReturn = getBuilder().createReturn(RI->getLoc(), ReturnValue);
-      FunctionExits.push_back(NewReturn);
+      getBuilder().createReturn(RI->getLoc(), ReturnValue);
       return;
     }
   } else if (OrigTermInst->isFunctionExiting()) {

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -62,6 +62,7 @@ SILFunction *GenericCloner::createDeclaration(
 void GenericCloner::populateCloned() {
   assert(AllocStacks.empty() && "Stale cloner state.");
   assert(!ReturnValueAddr && "Stale cloner state.");
+  assert(!ErrorValueAddr && "Stale cloner state.");
 
   SILFunction *Cloned = getCloned();
   // Create arguments for the entry block.
@@ -95,17 +96,33 @@ void GenericCloner::populateCloned() {
         return false;
 
       if (ArgIdx < origConv.getSILArgIndexOfFirstParam()) {
-        // Handle result arguments.
-        unsigned formalIdx =
-            origConv.getIndirectFormalResultIndexForSILArg(ArgIdx);
-        if (ReInfo.isFormalResultConverted(formalIdx)) {
-          // This result is converted from indirect to direct. The return inst
-          // needs to load the value from the alloc_stack. See below.
-          createAllocStack();
-          assert(!ReturnValueAddr);
-          ReturnValueAddr = ASI;
-          entryArgs.push_back(ASI);
-          return true;
+        if (ArgIdx < origConv.getNumIndirectSILResults()) {
+          // Handle result arguments.
+          unsigned formalIdx =
+              origConv.getIndirectFormalResultIndexForSILArg(ArgIdx);
+          if (ReInfo.isFormalResultConverted(formalIdx)) {
+            // This result is converted from indirect to direct. The return inst
+            // needs to load the value from the alloc_stack. See below.
+            createAllocStack();
+            assert(!ReturnValueAddr);
+            ReturnValueAddr = ASI;
+            entryArgs.push_back(ASI);
+            return true;
+          }
+        } else {
+          assert(origConv.getNumIndirectSILErrorResults() == 1 &&
+                 "only a single indirect error result is supported");
+          assert(ArgIdx == origConv.getNumIndirectSILResults());
+
+          if (ReInfo.isErrorResultConverted()) {
+            // This error result is converted from indirect to direct. The throw
+            // instruction needs to load the value from the alloc_stack. See below.
+            createAllocStack();
+            assert(!ErrorValueAddr);
+            ErrorValueAddr = ASI;
+            entryArgs.push_back(ASI);
+            return true;
+          }
         }
       } else if (ReInfo.isDroppedMetatypeArg(ArgIdx)) {
         // Replace the metatype argument with an `metatype` instruction in the
@@ -195,6 +212,17 @@ void GenericCloner::visitTerminator(SILBasicBlock *BB) {
       getBuilder().createReturn(RI->getLoc(), ReturnValue);
       return;
     }
+  } else if (isa<ThrowAddrInst>(OrigTermInst) && ErrorValueAddr) {
+      // The result is converted from indirect to direct. We have to load the
+      // returned value from the alloc_stack.
+      SILValue errorValue = getBuilder().emitLoadValueOperation(
+            ErrorValueAddr->getLoc(), ErrorValueAddr,
+            LoadOwnershipQualifier::Take);
+      for (AllocStackInst *ASI : reverse(AllocStacks)) {
+        getBuilder().createDeallocStack(ASI->getLoc(), ASI);
+      }
+      getBuilder().createThrow(OrigTermInst->getLoc(), errorValue);
+      return;
   } else if (OrigTermInst->isFunctionExiting()) {
     for (AllocStackInst *ASI : reverse(AllocStacks)) {
       getBuilder().createDeallocStack(ASI->getLoc(), ASI);

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -1788,3 +1788,58 @@ bb6(%14 : $FakeBool):
   return %14 : $FakeBool
 }
 
+struct Err: Error {
+  var i: Int
+}
+
+sil @callee1 : $@convention(thin) (Int) -> @out Int
+sil @callee2 : $@convention(thin) (Int) -> (@out Int, @error_indirect Err)
+
+// CHECK-LABEL: sil [ossa] @try_apply_to_apply_with_indirect_error1 :
+// CHECK:         [[OUT:%.*]] = alloc_stack $Int
+// CHECK:         apply {{%[0-9]+}}([[OUT]], %0)
+// CHECK:       } // end sil function 'try_apply_to_apply_with_indirect_error1'
+sil [ossa] @try_apply_to_apply_with_indirect_error1 : $@convention(method) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = function_ref @callee1 : $@convention(thin) (Int) -> @out Int
+  %2 = thin_to_thick_function %1 : $@convention(thin) (Int) -> @out Int to $@noescape @callee_guaranteed (Int) -> @out Int
+  %3 = convert_function %2 : $@noescape @callee_guaranteed (Int) -> @out Int to $@noescape @callee_guaranteed (Int) -> (@out Int, @error_indirect Err), forwarding: @owned
+  %4 = alloc_stack $Int
+  %5 = alloc_stack $Err
+  try_apply %3(%4, %5, %0) : $@noescape @callee_guaranteed (Int) -> (@out Int, @error_indirect Err), normal bb10, error bb11
+
+bb10(%7 : $()):
+  dealloc_stack %5 : $*Err
+  dealloc_stack %4 : $*Int
+  destroy_value %3 : $@noescape @callee_guaranteed (Int) -> (@out Int, @error_indirect Err)
+  %r = tuple ()
+  return  %r : $()
+
+bb11:
+  dealloc_stack %5 : $*Err
+  dealloc_stack %4 : $*Int
+  destroy_value %3 : $@noescape @callee_guaranteed (Int) -> (@out Int, @error_indirect Err)
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @try_apply_to_apply_with_indirect_error2 :
+// CHECK:         [[OUT:%.*]] = alloc_stack $Int
+// CHECK:         [[ERR:%.*]] = alloc_stack $Err
+// CHECK:         apply [nothrow] {{%[0-9]+}}([[OUT]], [[ERR]], %0)
+// CHECK:       } // end sil function 'try_apply_to_apply_with_indirect_error2'
+sil [ossa] @try_apply_to_apply_with_indirect_error2 : $@convention(method) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = function_ref @callee2 : $@convention(thin) (Int) -> (@out Int, @error_indirect Err)
+  %4 = alloc_stack $Int
+  %5 = alloc_stack $Err
+  try_apply %1(%4, %5, %0) : $@convention(thin) (Int) -> (@out Int, @error_indirect Err), normal bb10, error bb11
+
+bb10(%7 : $()):
+  dealloc_stack %5 : $*Err
+  dealloc_stack %4 : $*Int
+  %r = tuple ()
+  return  %r : $()
+
+bb11:
+  unreachable
+}

--- a/test/SILOptimizer/specialize_reabstraction_ossa.sil
+++ b/test/SILOptimizer/specialize_reabstraction_ossa.sil
@@ -34,6 +34,18 @@ public struct Val<T> : ValProto {
   init()
 }
 
+struct Err : Error {
+  init()
+}
+
+protocol P {}
+
+struct NonLoadableErr : Error {
+  @_hasStorage var p: P
+  init()
+}
+
+
 sil @coerce : $@convention(thin) <T, U, V> (@owned @callee_owned (@owned Ref<T>) -> @owned @callee_owned (@owned Ref<U>) -> @owned Ref<V>) -> @owned @callee_owned (Val<U>) -> Val<V>
 
 sil [ossa] @merge : $@convention(method) <Self where Self : RefProto><U> (@owned Ref<U>, @in_guaranteed Self) -> @owned Ref<(Self.T, U)> {
@@ -130,3 +142,125 @@ bb0(%0 : $Bool):
   %rv = tuple ()
   return %rv : $()
 }
+
+// CHECK-LABEL: sil [ossa] @test_indirect_error :
+// CHECK:         [[F:%.*]] = function_ref @$s14indirect_error4main3ErrV_Tg5 : $@convention(thin) (Err) -> (Int, @error Err)
+// CHECK:         try_apply [[F]]({{%[0-9]+}}) : $@convention(thin) (Err) -> (Int, @error Err), normal bb1, error bb2
+// CHECK:       bb1(%8 : $Int):
+// CHECK:       bb2({{%[0-9]+}} : $Err):
+// CHECK:       } // end sil function 'test_indirect_error'
+sil [ossa] @test_indirect_error : $@convention(thin) (Err) -> @error Err {
+bb0(%0 : $Err):
+  %3 = alloc_stack $Err
+  store %0 to [trivial] %3 : $*Err
+  %5 = function_ref @indirect_error : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  %6 = alloc_stack $Err
+  %7 = alloc_stack $Int
+  try_apply %5<Err>(%7, %6, %3) : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0), normal bb1, error bb2
+
+bb1(%8 : $()):
+  dealloc_stack %7 : $*Int
+  dealloc_stack %6 : $*Err
+  dealloc_stack %3 : $*Err
+  %11 = tuple ()
+  return %11 : $()
+
+bb2:
+  %13 = load [trivial] %6 : $*Err
+  dealloc_stack %7 : $*Int
+  dealloc_stack %6 : $*Err
+  dealloc_stack %3 : $*Err
+  throw %13 : $Err
+}
+
+// CHECK-LABEL: sil shared [ossa] @$s14indirect_error4main3ErrV_Tg5 : $@convention(thin) (Err) -> (Int, @error Err) {
+// CHECK:         throw {{%[0-9]+}} : $Err
+// CHECK:       } // end sil function '$s14indirect_error4main3ErrV_Tg5'
+
+// CHECK-LABEL: sil shared [ossa] @$s14indirect_error4main14NonLoadableErrV_Tg5 : $@convention(thin) (@in_guaranteed NonLoadableErr) -> (Int, @error_indirect NonLoadableErr) {
+// CHECK:         throw_addr
+// CHECK:       } // end sil function '$s14indirect_error4main14NonLoadableErrV_Tg5'
+
+sil [ossa] @indirect_error : $@convention(thin) <E where E : Error> (@in_guaranteed E) -> (@out Int, @error_indirect E) {
+bb0(%0 : $*Int, %1 : $*E, %2 : $*E):
+  copy_addr %2 to [init] %1 : $*E
+  throw_addr
+}
+
+// CHECK-LABEL: sil [ossa] @test_indirect_error_nothrow :
+// CHECK:         [[F:%.*]] = function_ref @$s14indirect_error4main3ErrV_Tg5 : $@convention(thin) (Err) -> (Int, @error Err)
+// CHECK:         apply [nothrow] [[F]]({{%[0-9]+}}) : $@convention(thin) (Err) -> (Int, @error Err)
+// CHECK:       } // end sil function 'test_indirect_error_nothrow'
+sil [ossa] @test_indirect_error_nothrow : $@convention(thin) (Err) -> @error Err {
+bb0(%0 : $Err):
+  %3 = alloc_stack $Err
+  store %0 to [trivial] %3 : $*Err
+  %5 = function_ref @indirect_error : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  %6 = alloc_stack $Err
+  %7 = alloc_stack $Int
+  apply [nothrow] %5<Err>(%7, %6, %3) : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  dealloc_stack %7 : $*Int
+  dealloc_stack %6 : $*Err
+  dealloc_stack %3 : $*Err
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_indirect_non_loadable_error_nothrow :
+// CHECK:         [[F:%.*]] = function_ref @$s14indirect_error4main14NonLoadableErrV_Tg5 : $@convention(thin) (@in_guaranteed NonLoadableErr) -> (Int, @error_indirect NonLoadableErr)
+// CHECK:         apply [nothrow] [[F]]({{%[0-9]+}}, %0) : $@convention(thin) (@in_guaranteed NonLoadableErr) -> (Int, @error_indirect NonLoadableErr)
+// CHECK:       } // end sil function 'test_indirect_non_loadable_error_nothrow'
+sil [ossa] @test_indirect_non_loadable_error_nothrow : $@convention(thin) (@in_guaranteed NonLoadableErr) -> @error NonLoadableErr {
+bb0(%0 : $*NonLoadableErr):
+  %5 = function_ref @indirect_error : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  %6 = alloc_stack $NonLoadableErr
+  %7 = alloc_stack $Int
+  apply [nothrow] %5<NonLoadableErr>(%7, %6, %0) : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  dealloc_stack %7 : $*Int
+  destroy_addr %6 : $*NonLoadableErr
+  dealloc_stack %6 : $*NonLoadableErr
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_indirect_error_thunk :
+// CHECK:         [[F:%.*]] = function_ref @$s14indirect_error4main3ErrV_TG5 : $@convention(thin) (@in_guaranteed Err) -> (@out Int, @error_indirect Err)
+// CHECK:         partial_apply [callee_guaranteed] [[F]]() : $@convention(thin) (@in_guaranteed Err) -> (@out Int, @error_indirect Err)
+// CHECK:       } // end sil function 'test_indirect_error_thunk'
+sil [ossa] @test_indirect_error_thunk : $@convention(thin) () -> @owned (@callee_guaranteed (@in_guaranteed Err) -> (@out Int, @error_indirect Err)) {
+bb0:
+  %5 = function_ref @indirect_error : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  %15 = partial_apply [callee_guaranteed] %5<Err>() : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  return %15 : $@callee_guaranteed (@in_guaranteed Err) -> (@out Int, @error_indirect Err)
+}
+
+// CHECK-LABEL: sil [ossa] @test_indirect_non_loadable_error_thunk :
+// CHECK:         [[F:%.*]] = function_ref @$s14indirect_error4main14NonLoadableErrV_TG5 : $@convention(thin) (@in_guaranteed NonLoadableErr) -> (@out Int, @error_indirect NonLoadableErr)
+// CHECK:         partial_apply [callee_guaranteed] [[F]]() : $@convention(thin) (@in_guaranteed NonLoadableErr) -> (@out Int, @error_indirect NonLoadableErr)
+// CHECK:       } // end sil function 'test_indirect_non_loadable_error_thunk'
+sil [ossa] @test_indirect_non_loadable_error_thunk : $@convention(thin) () -> @owned (@callee_guaranteed (@in_guaranteed NonLoadableErr) -> (@out Int, @error_indirect NonLoadableErr)) {
+bb0:
+  %5 = function_ref @indirect_error : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  %15 = partial_apply [callee_guaranteed] %5<NonLoadableErr>() : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
+  return %15 : $@callee_guaranteed (@in_guaranteed NonLoadableErr) -> (@out Int, @error_indirect NonLoadableErr)
+}
+
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s14indirect_error4main3ErrV_TG5 : $@convention(thin) (@in_guaranteed Err) -> (@out Int, @error_indirect Err) {
+// CHECK:         [[F:%.*]] = function_ref @$s14indirect_error4main3ErrV_Tg5 : $@convention(thin) (Err) -> (Int, @error Err)
+// CHECK:         try_apply [[F]]({{%[0-9]+}}) : $@convention(thin) (Err) -> (Int, @error Err), normal bb1, error bb2
+// CHECK:       bb1([[I:%.*]] : $Int):
+// CHECK:         store [[I]] to [trivial] %0 : $*Int
+// CHECK:       bb2([[E:%.*]] : $Err):
+// CHECK:         store %10 to [trivial] %1 : $*Err
+// CHECK:         throw_addr
+// CHECK:       } // end sil function '$s14indirect_error4main3ErrV_TG5'
+
+// CHECK-LABEL: sil shared [transparent] [thunk] [ossa] @$s14indirect_error4main14NonLoadableErrV_TG5 : $@convention(thin) (@in_guaranteed NonLoadableErr) -> (@out Int, @error_indirect NonLoadableErr) {
+// CHECK:         [[F:%.*]]3 = function_ref @$s14indirect_error4main14NonLoadableErrV_Tg5 : $@convention(thin) (@in_guaranteed NonLoadableErr) -> (Int, @error_indirect NonLoadableErr)
+// CHECK:         try_apply %3(%1, %2) : $@convention(thin) (@in_guaranteed NonLoadableErr) -> (Int, @error_indirect NonLoadableErr), normal bb1, error bb2
+// CHECK:       bb1([[I:%.*]] : $Int):
+// CHECK:         store [[I]] to [trivial] %0 : $*Int
+// CHECK:       bb2:
+// CHECK-NEXT:    throw_addr
+// CHECK:       } // end sil function '$s14indirect_error4main14NonLoadableErrV_TG5'
+


### PR DESCRIPTION
This means to support specializing functions with indirect error results.
Also, when specializing (and the concrete error type is loadable), convert the indirect error to a direct error.

rdar://118532113

Also, fix try_apply -> apply transformation for indirect error results in SimplifyCFG