### PR TITLE
[CodeCompletion] Don't use a metatype's instance type for type relation calculation

### DIFF
--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -347,20 +347,14 @@ public:
   }
 
   static CodeCompletionResultType unknown() {
-    return CodeCompletionResultType(ArrayRef<Type>());
-  }
-
-  explicit CodeCompletionResultType(ArrayRef<Type> Types)
-      : CodeCompletionResultType(
-            /*IsApplicable=*/false,
-            /*ResultType1=*/Types.size() > 0 ? Types[0] : nullptr,
-            /*ResultType2=*/Types.size() > 1 ? Types[1] : nullptr) {
-    assert(Types.size() <= 2 && "Can only store two different result types in "
-                                "CodeCompletionResultType");
+    return CodeCompletionResultType(Type());
   }
 
   explicit CodeCompletionResultType(Type Ty)
-      : CodeCompletionResultType(ArrayRef<Type>(Ty)) {}
+      : CodeCompletionResultType(
+            /*IsApplicable=*/false,
+            /*ResultType1=*/Ty,
+            /*ResultType2=*/nullptr) {}
 
   explicit CodeCompletionResultType(ArrayRef<const USRBasedType *> Types)
       : CodeCompletionResultType(

--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -289,95 +289,50 @@ public:
 /// the following:
 ///  - NotApplicable: The completion result doesn't produce something that's
 ///    valid inside an expression like a keyword
-///  - An empty list of types if the completion result produces something that's
-///    valid inside an expression but the result type isn't known
-///  - A list of proper type if the type produced by this completion result is
-///    known
-/// A \c CodeCompletionResultType does not have a single unique type because for
-/// code completion we consider e.g. the expression \c Int as producing both an
-/// \c Int metatype and an \c Int instance type. Thus we consider both the
-/// instance and the metatype as result types of the expression \c Int.
+///  - An null type if the completion result produces something that's valid
+///    inside an expression but the result type isn't known
+///  - A proper type if the type produced by this completion result is known
 class CodeCompletionResultType {
-  /// \c ResultType1AndIsApplicable and \c ResultType2 store the following
-  /// information:
-  ///  - Whether the type is not applicable (see above). In this case
-  ///    \c ResultType1 and \c ResultType2 should be \c nullptr.
-  ///  - \c ResultType1 and \c ResultType2 form a collection of at most two
-  ///    result types. A \c CodeCompletionResultType cannot have a single unique
-  ///    type because for code completion we consider e.g. \c Int as producing
-  ///    both an \c Int metatype and an \c Int instance.
-  ///    It would be nice if we could use a SmallVector to store those types
-  ///    instead but \c CodeCompletionResultType is allocated in a bump
-  ///    allocator and freeing the bump allocator does not call the
-  ///    SmallVecotor's destructor, leaking potential heap memory. Since we only
-  ///    need two result types at the moment, I decided to implement it in a
-  ///    hacky way with two pointers.
-  /// The \c getResultTypes and \c isApplicable methods mask away this
-  /// implementation detail.
   llvm::PointerIntPair<PointerUnion<Type, const USRBasedType *>, 1, bool>
-      ResultType1AndIsApplicable;
-  PointerUnion<Type, const USRBasedType *> ResultType2;
+      ResultTypeAndIsApplicable;
 
-  llvm::SmallVector<PointerUnion<Type, const USRBasedType *>, 1>
-  getResultTypes() const {
-    if (ResultType1AndIsApplicable.getPointer() && ResultType2) {
-      return {ResultType1AndIsApplicable.getPointer(), ResultType2};
-    } else if (ResultType1AndIsApplicable.getPointer()) {
-      return {ResultType1AndIsApplicable.getPointer()};
-    } else {
-      assert(
-          !ResultType2 &&
-          "We shouldn't have a second result type if there was no first one");
-      return {};
-    }
+  PointerUnion<Type, const USRBasedType *> getResultType() const {
+    return ResultTypeAndIsApplicable.getPointer();
   }
 
   /// Memberwise initializer
   CodeCompletionResultType(bool IsApplicable,
-                           PointerUnion<Type, const USRBasedType *> ResultType1,
-                           PointerUnion<Type, const USRBasedType *> ResultType2)
-      : ResultType1AndIsApplicable(ResultType1, IsApplicable),
-        ResultType2(ResultType2) {}
+                           PointerUnion<Type, const USRBasedType *> ResultType)
+      : ResultTypeAndIsApplicable(ResultType, IsApplicable) {}
 
 public:
   static CodeCompletionResultType notApplicable() {
     return CodeCompletionResultType(/*IsApplicable=*/true,
-                                    /*ResultType1=*/nullptr,
-                                    /*ResultType2=*/nullptr);
+                                    /*ResultType=*/nullptr);
   }
 
   static CodeCompletionResultType unknown() {
     return CodeCompletionResultType(Type());
   }
 
-  explicit CodeCompletionResultType(Type Ty)
-      : CodeCompletionResultType(
-            /*IsApplicable=*/false,
-            /*ResultType1=*/Ty,
-            /*ResultType2=*/nullptr) {}
+  explicit CodeCompletionResultType(Type type)
+      : CodeCompletionResultType(/*IsApplicable=*/false, /*ResultType=*/type) {}
 
-  explicit CodeCompletionResultType(ArrayRef<const USRBasedType *> Types)
-      : CodeCompletionResultType(
-            /*IsApplicable=*/false,
-            /*ResultType1=*/Types.size() > 0 ? Types[0] : nullptr,
-            /*ResultType2=*/Types.size() > 1 ? Types[1] : nullptr) {
-    assert(Types.size() <= 2 && "Can only store two different result types in "
-                                "CodeCompletionResultType");
-  }
+  explicit CodeCompletionResultType(const USRBasedType *type)
+      : CodeCompletionResultType(/*IsApplicable=*/false, type) {}
 
   /// Returns whether the \c CodeCompletionResult type is backed by USRs and
   /// thus not associated with any AST.
   /// Intended to be used in assertions.
-  bool isBackedByUSRs() const;
+  bool isBackedByUSR() const;
 
   /// Returns whether the \c CodeCompletionREsultType is considered not
   /// applicable (see comment on \c CodeCompletionResultType).
-  bool isNotApplicable() const { return ResultType1AndIsApplicable.getInt(); }
+  bool isNotApplicable() const { return ResultTypeAndIsApplicable.getInt(); }
 
-  /// Return the result types as a \c USRBasedTypes, converting an AST-bound
-  /// type to a \c USRBasedTypes if necessary.
-  llvm::SmallVector<const USRBasedType *, 1>
-  getUSRBasedResultTypes(USRBasedTypeArena &Arena) const;
+  /// Return the result type as a \c USRBasedType, converting an AST-bound
+  /// type to a \c USRBasedType if necessary.
+  const USRBasedType *getUSRBasedResultType(USRBasedTypeArena &Arena) const;
 
   /// Return the same \c CodeCompletionResultType with the guarantee that it is
   /// backed by USRs instead of AST-bound types

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -913,7 +913,7 @@ static void addKeywordsAfterReturn(CodeCompletionResultSink &Sink, DeclContext *
       Builder.setLiteralKind(CodeCompletionLiteralKind::NilLiteral);
       Builder.addKeyword("nil");
       Builder.addTypeAnnotation(resultType, {});
-      Builder.setResultTypes(resultType);
+      Builder.setResultType(resultType);
       Builder.setTypeContext(TypeContext, DC);
     }
   }

--- a/lib/IDE/CodeCompletionContext.cpp
+++ b/lib/IDE/CodeCompletionContext.cpp
@@ -157,7 +157,7 @@ void CodeCompletionContext::addResultsFromModules(
       // back the contextual results.
       for (auto Result : Sink.Results) {
         assert(
-            Result->getContextFreeResult().getResultType().isBackedByUSRs() &&
+            Result->getContextFreeResult().getResultType().isBackedByUSR() &&
             "Results stored in the cache should have their result types backed "
             "by a USR because the cache might outlive the ASTContext the "
             "results were created from.");

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -145,8 +145,8 @@ public:
   /// This is not a single unique type because for code completion we consider
   /// e.g. \c Int as producing both an \c Int metatype and an \c Int instance
   /// type.
-  void setResultTypes(ArrayRef<Type> ResultTypes) {
-    this->ResultType = CodeCompletionResultType(ResultTypes);
+  void setResultType(Type ResultType) {
+    this->ResultType = CodeCompletionResultType(ResultType);
   }
 
   /// Set context in which this code completion item occurs. Used to compute the

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -383,7 +383,7 @@ calculateMaxTypeRelation(Type Ty, const ExpectedTypeContext &typeContext,
   if (Ty->isVoid() && typeContext.requiresNonVoid())
     return TypeRelation::Invalid;
   if (typeContext.getExpectedCustomAttributeKinds()) {
-    return (getCustomAttributeKinds(Ty) &
+    return (getCustomAttributeKinds(Ty->getMetatypeInstanceType()) &
             typeContext.getExpectedCustomAttributeKinds())
                ? TypeRelation::Convertible
                : TypeRelation::Unrelated;

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -420,34 +420,26 @@ calculateMaxTypeRelation(Type Ty, const ExpectedTypeContext &typeContext,
   return Result;
 }
 
-bool CodeCompletionResultType::isBackedByUSRs() const {
-  return llvm::all_of(
-      getResultTypes(),
-      [](const PointerUnion<Type, const USRBasedType *> &ResultType) {
-        return ResultType.is<const USRBasedType *>();
-      });
+bool CodeCompletionResultType::isBackedByUSR() const {
+  return getResultType().isNull() || getResultType().is<const USRBasedType *>();
 }
 
-llvm::SmallVector<const USRBasedType *, 1>
-CodeCompletionResultType::getUSRBasedResultTypes(
+const USRBasedType *CodeCompletionResultType::getUSRBasedResultType(
     USRBasedTypeArena &Arena) const {
   llvm::SmallVector<const USRBasedType *, 1> USRBasedTypes;
-  auto ResultTypes = getResultTypes();
-  USRBasedTypes.reserve(ResultTypes.size());
-  for (auto ResultType : ResultTypes) {
-    if (auto USRType = ResultType.dyn_cast<const USRBasedType *>()) {
-      USRBasedTypes.push_back(USRType);
-    } else {
-      USRBasedTypes.push_back(
-          USRBasedType::fromType(ResultType.get<Type>(), Arena));
-    }
+  auto ResultType = getResultType();
+  if (ResultType.isNull()) {
+    return nullptr;
+  } else if (auto USRType = ResultType.dyn_cast<const USRBasedType *>()) {
+    return USRType;
+  } else {
+    return USRBasedType::fromType(ResultType.get<Type>(), Arena);
   }
-  return USRBasedTypes;
 }
 
 CodeCompletionResultType
 CodeCompletionResultType::usrBasedType(USRBasedTypeArena &Arena) const {
-  return CodeCompletionResultType(this->getUSRBasedResultTypes(Arena));
+  return CodeCompletionResultType(this->getUSRBasedResultType(Arena));
 }
 
 TypeRelation CodeCompletionResultType::calculateTypeRelation(
@@ -461,19 +453,19 @@ TypeRelation CodeCompletionResultType::calculateTypeRelation(
     return TypeRelation::Unknown;
   }
 
+  auto ResultType = getResultType();
   TypeRelation Res = TypeRelation::Unknown;
-  for (auto Ty : getResultTypes()) {
-    if (auto USRType = Ty.dyn_cast<const USRBasedType *>()) {
-      if (!USRTypeContext) {
-        assert(false && "calculateTypeRelation must have a USRBasedTypeContext "
-                        "passed if it contains a USR-based result type");
-        continue;
-      }
-      Res = std::max(Res, USRTypeContext->typeRelation(USRType));
-    } else {
-      Res = std::max(
-          Res, calculateMaxTypeRelation(Ty.get<Type>(), *TypeContext, *DC));
+  if (ResultType.isNull()) {
+    return Res;
+  } else if (auto USRType = ResultType.dyn_cast<const USRBasedType *>()) {
+    if (!USRTypeContext) {
+      assert(false && "calculateTypeRelation must have a USRBasedTypeContext "
+                      "passed if it contains a USR-based result type");
     }
+    Res = std::max(Res, USRTypeContext->typeRelation(USRType));
+  } else {
+    Res = std::max(Res, calculateMaxTypeRelation(ResultType.get<Type>(),
+                                                 *TypeContext, *DC));
   }
   return Res;
 }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -517,7 +517,7 @@ void CompletionLookup::addTypeAnnotation(CodeCompletionResultBuilder &Builder,
   if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
     PO.setBaseType(typeContext->getDeclaredTypeInContext());
   Builder.addTypeAnnotation(eraseArchetypes(T, genericSig), PO);
-  Builder.setResultTypes(T);
+  Builder.setResultType(T);
 }
 
 void CompletionLookup::addTypeAnnotationForImplicitlyUnwrappedOptional(
@@ -539,7 +539,7 @@ void CompletionLookup::addTypeAnnotationForImplicitlyUnwrappedOptional(
   if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
     PO.setBaseType(typeContext->getDeclaredTypeInContext());
   Builder.addTypeAnnotation(eraseArchetypes(T, genericSig), PO, suffix);
-  Builder.setResultTypes(T);
+  Builder.setResultType(T);
   Builder.setTypeContext(expectedTypeContext, CurrDeclContext);
 }
 
@@ -1129,7 +1129,7 @@ void CompletionLookup::addPoundSelector(bool needPound) {
   Builder.addRightParen();
   Builder.addTypeAnnotation("Selector");
   // This function is called only if the context type is 'Selector'.
-  Builder.setResultTypes(Ctx.getSelectorType());
+  Builder.setResultType(Ctx.getSelectorType());
   Builder.setTypeContext(expectedTypeContext, CurrDeclContext);
 }
 
@@ -1149,7 +1149,7 @@ void CompletionLookup::addPoundKeyPath(bool needPound) {
                                   /*IsVarArg=*/false);
   Builder.addRightParen();
   Builder.addTypeAnnotation("String");
-  Builder.setResultTypes(Ctx.getStringType());
+  Builder.setResultType(Ctx.getStringType());
   Builder.setTypeContext(expectedTypeContext, CurrDeclContext);
 }
 
@@ -1472,7 +1472,7 @@ void CompletionLookup::addMethodCall(const FuncDecl *FD,
       Builder.addTypeAnnotation(TypeStr);
     }
 
-    Builder.setResultTypes(ResultType);
+    Builder.setResultType(ResultType);
     Builder.setTypeContext(expectedTypeContext, CurrDeclContext);
 
     if (isUnresolvedMemberIdealType(ResultType))
@@ -1711,15 +1711,7 @@ void CompletionLookup::addNominalTypeRef(const NominalTypeDecl *NTD,
     addTypeAnnotation(Builder, NTD->getDeclaredType());
   }
 
-  // Override the type relation for NominalTypes. Use the better relation
-  // for the metatypes and the instance type. For example,
-  //
-  //   func receiveInstance(_: Int) {}
-  //   func receiveMetatype(_: Int.Type) {}
-  //
-  // We want to suggest 'Int' as 'Identical' for both arguments.
-  Builder.setResultTypes(
-      {NTD->getInterfaceType(), NTD->getDeclaredInterfaceType()});
+  Builder.setResultType(NTD->getInterfaceType());
   Builder.setTypeContext(expectedTypeContext, CurrDeclContext);
 }
 
@@ -2596,7 +2588,7 @@ void CompletionLookup::addTypeRelationFromProtocol(
   }
   if (literalType) {
     addTypeAnnotation(builder, literalType);
-    builder.setResultTypes(literalType);
+    builder.setResultType(literalType);
     builder.setTypeContext(expectedTypeContext, CurrDeclContext);
   }
 }
@@ -2696,7 +2688,7 @@ void CompletionLookup::addValueLiteralCompletions() {
     for (auto T : expectedTypeContext.getPossibleTypes()) {
       if (T && T->is<TupleType>() && !T->isVoid()) {
         addTypeAnnotation(builder, T);
-        builder.setResultTypes(T);
+        builder.setResultType(T);
         builder.setTypeContext(expectedTypeContext, CurrDeclContext);
         break;
       }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -107,7 +107,7 @@ class C1 {
 // EXPECT_INT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: intGen()[#Int#]; name=intGen()
 // EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i1[#Int#]; name=i1
 // EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i2[#Int#]; name=i2
-// EXPECT_INT-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: Int[#Int#]
+// EXPECT_INT-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem: Int[#Int#]
 // EXPECT_INT-DAG: Decl[FreeFunction]/CurrModule:      ointGen()[#Int?#]; name=ointGen()
 // EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule:         oi1[#Int?#]; name=oi1
 // EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule:         os2[#String?#]; name=os2
@@ -152,7 +152,7 @@ class C2 {
 // EXPECT_STRING-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
 // EXPECT_STRING-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f2()[#Void#]; name=f2()
 // EXPECT_STRING-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: stringGen()[#String#]; name=stringGen()
-// EXPECT_STRING-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: String[#String#]
+// EXPECT_STRING-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem: String[#String#]
 // EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s1[#String#]; name=s1
 // EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s2[#String#]; name=s2
 // EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule:         os1[#String?#]; name=os1
@@ -205,12 +205,12 @@ class C3 {
 // OVERLOAD3-DAG: Decl[InstanceVar]/CurrNominal:      C1I[#C1#]; name=C1I
 // OVERLOAD3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
 // OVERLOAD3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: C2I[#C2#]; name=C2I
-// OVERLOAD3-DAG: Decl[Class]/CurrModule/TypeRelation[Convertible]: C2[#C2#]
+// OVERLOAD3-DAG: Decl[Class]/CurrModule: C2[#C2#]
 
 // OVERLOAD4-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: C1I[#C1#]; name=C1I
 // OVERLOAD4-DAG: Decl[InstanceVar]/CurrNominal:      C2I[#C2#]; name=C2I
 // OVERLOAD4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
-// OVERLOAD4-DAG: Decl[Class]/CurrModule/TypeRelation[Convertible]: C1[#C1#]
+// OVERLOAD4-DAG: Decl[Class]/CurrModule: C1[#C1#]
 
 // OVERLOAD5-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ['(']{#(a): C1#}, {#b1: C2#}[')'][#Void#]; name=:b1:
 // OVERLOAD5-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ['(']{#(a): C2#}, {#b2: C1#}[')'][#Void#]; name=:b2:
@@ -555,7 +555,7 @@ func testStaticMemberCall() {
   let _ = TestStaticMemberCall.create2(#^STATIC_METHOD_AFTERPAREN_2^#)
 // STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
 // STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
-// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: Int[#Int#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem: Int[#Int#];
 // STATIC_METHOD_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Int#];
 
   let _ = TestStaticMemberCall.create2(1, #^STATIC_METHOD_SECOND^#)
@@ -581,7 +581,7 @@ func testImplicitMember() {
   let _: TestStaticMemberCall = .create2(#^IMPLICIT_MEMBER_AFTERPAREN_2^#)
 // IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
 // IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
-// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: Int[#Int#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem: Int[#Int#];
 // IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Int#];
 
   let _: TestStaticMemberCall? = .create1(#^IMPLICIT_MEMBER_AFTERPAREN_3^#)

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -1,24 +1,4 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AVAILABILITY1 | %FileCheck %s -check-prefix=AVAILABILITY1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AVAILABILITY2 | %FileCheck %s -check-prefix=AVAILABILITY2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD2 | %FileCheck %s -check-prefix=KEYWORD2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD3 | %FileCheck %s -check-prefix=KEYWORD3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD3_2 | %FileCheck %s -check-prefix=KEYWORD3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD4 | %FileCheck %s -check-prefix=KEYWORD4
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD5 | %FileCheck %s -check-prefix=KEYWORD5
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_GLOBALVAR | %FileCheck %s -check-prefix=ON_GLOBALVAR
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_INIT | %FileCheck %s -check-prefix=ON_INIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PROPERTY | %FileCheck %s -check-prefix=ON_PROPERTY
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_METHOD | %FileCheck %s -check-prefix=ON_METHOD
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PARAM_1 | %FileCheck %s -check-prefix=ON_PARAM
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PARAM_2 | %FileCheck %s -check-prefix=ON_PARAM
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_INDEPENDENT_1 | %FileCheck %s -check-prefix=ON_MEMBER_LAST
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_INDEPENDENT_2 | %FileCheck %s -check-prefix=ON_MEMBER_LAST
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_LAST | %FileCheck %s -check-prefix=ON_MEMBER_LAST
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE | %FileCheck %s -check-prefix=IN_CLOSURE
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT_1 | %FileCheck %s -check-prefix=KEYWORD_LAST
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT_2 | %FileCheck %s -check-prefix=KEYWORD_LAST
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_LAST | %FileCheck %s -check-prefix=KEYWORD_LAST
-
+// RUN: %batch-code-completion
 struct MyStruct {}
 
 @propertyWrapper
@@ -134,7 +114,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD3-NEXT:             Keyword/None:                       globalActor[#Class Attribute#]; name=globalActor
 // KEYWORD3-NEXT:             Keyword/None:                       preconcurrency[#Class Attribute#]; name=preconcurrency
 
-@#^KEYWORD3_2^#IB class C2 {}
+@#^KEYWORD3_2?check=KEYWORD3^#IB class C2 {}
 // Same as KEYWORD3.
 
 @#^KEYWORD4^# enum E {}
@@ -259,7 +239,7 @@ struct _S {
 
 
 
-  func bar(@#^ON_PARAM_1^#)
+  func bar(@#^ON_PARAM_1?check=ON_PARAM^#)
 // ON_PARAM-NOT: Keyword
 // ON_PARAM-DAG: Decl[Struct]/CurrModule:             MyStruct[#MyStruct#]; name=MyStruct
 // ON_PARAM-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -268,18 +248,18 @@ struct _S {
 // ON_PARAM-NOT: Keyword
 
   func bar(
-    @#^ON_PARAM_2^#
+    @#^ON_PARAM_2?check=ON_PARAM^#
 
     arg: Int
   )
 // Same as ON_PARAM.
 
-  @#^ON_MEMBER_INDEPENDENT_1^#
+  @#^ON_MEMBER_INDEPENDENT_1?check=ON_MEMBER_LAST^#
 
   func dummy1() {}
 // Same as ON_MEMBER_LAST.
 
-  @#^ON_MEMBER_INDEPENDENT_2^#
+  @#^ON_MEMBER_INDEPENDENT_2?check=ON_MEMBER_LAST^#
   func dummy2() {}
 // Same as ON_MEMBER_LAST.
 
@@ -344,12 +324,12 @@ func takeClosure(_: () -> Void) {
 // IN_CLOSURE-DAG: Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#Global Actor#]; name=MyGlobalActor
 
 
-@#^KEYWORD_INDEPENDENT_1^#
+@#^KEYWORD_INDEPENDENT_1?check=KEYWORD_LAST^#
 
 func dummy1() {}
 // Same as KEYWORD_LAST.
 
-@#^KEYWORD_INDEPENDENT_2^#
+@#^KEYWORD_INDEPENDENT_2?check=KEYWORD_LAST^#
 func dummy2() {}
 // Same as KEYWORD_LAST.
 

--- a/test/IDE/complete_exception.swift
+++ b/test/IDE/complete_exception.swift
@@ -71,10 +71,10 @@ func getNSError() -> NSError { return NSError(domain: "", code: 1, userInfo: [:]
 func test001() {
   do {} catch #^CATCH1^#
 
-// CATCH1-DAG:  Decl[Enum]/CurrModule/TypeRelation[Convertible]:              Error4[#Error4#]; name=Error4{{$}}
-// CATCH1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error3[#Error3#]; name=Error3{{$}}
-// CATCH1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error2[#Error2#]; name=Error2{{$}}
-// CATCH1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error1[#Error1#]; name=Error1{{$}}
+// CATCH1-DAG:  Decl[Enum]/CurrModule:              Error4[#Error4#]; name=Error4{{$}}
+// CATCH1-DAG:  Decl[Class]/CurrModule:             Error3[#Error3#]; name=Error3{{$}}
+// CATCH1-DAG:  Decl[Class]/CurrModule:             Error2[#Error2#]; name=Error2{{$}}
+// CATCH1-DAG:  Decl[Class]/CurrModule:             Error1[#Error1#]; name=Error1{{$}}
 // CATCH1-DAG:  Keyword[let]/None:                  let{{; name=.+$}}
 // CATCH1-DAG:  Decl[Class]/CurrModule:             NoneError1[#NoneError1#]; name=NoneError1{{$}}
 // CATCH1-DAG:  Decl[Class]/OtherModule[Foundation]/IsSystem: NSError[#NSError#]{{; name=.+$}}
@@ -86,11 +86,11 @@ func test002() {
   let e2 = Error2()
   throw #^THROW1^#
 
-// THROW1-DAG:  Decl[Enum]/CurrModule/TypeRelation[Convertible]:              Error4[#Error4#]; name=Error4{{$}}
-// THROW1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error3[#Error3#]; name=Error3{{$}}
-// THROW1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error2[#Error2#]; name=Error2{{$}}
-// THROW1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error1[#Error1#]; name=Error1{{$}}
-// THROW1-DAG:  Decl[Protocol]/CurrModule/Flair[RareType]/TypeRelation[Convertible]: ErrorPro1[#ErrorPro1#]; name=ErrorPro1{{$}}
+// THROW1-DAG:  Decl[Enum]/CurrModule:              Error4[#Error4#]; name=Error4{{$}}
+// THROW1-DAG:  Decl[Class]/CurrModule:             Error3[#Error3#]; name=Error3{{$}}
+// THROW1-DAG:  Decl[Class]/CurrModule:             Error2[#Error2#]; name=Error2{{$}}
+// THROW1-DAG:  Decl[Class]/CurrModule:             Error1[#Error1#]; name=Error1{{$}}
+// THROW1-DAG:  Decl[Protocol]/CurrModule/Flair[RareType]: ErrorPro1[#ErrorPro1#]; name=ErrorPro1{{$}}
 // THROW1-DAG:  Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]:      getError1()[#Error1#]{{; name=.+$}}
 // THROW1-DAG:  Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]:      getNSError()[#NSError#]{{; name=.+$}}
 

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -221,7 +221,7 @@ func testTypeRelationInResultBuilder() {
     @ViewBuilder2 var body: some View2 {
       #^SINGLE_ELEMENT^#
     }
-    // SINGLE_ELEMENT-DAG: Decl[Struct]/Local/TypeRelation[Convertible]: MyText[#MyText#];
+    // SINGLE_ELEMENT-DAG: Decl[Struct]/Local: MyText[#MyText#];
 
     @ViewBuilder2 var body2: some View2 {
       MyText()
@@ -276,7 +276,7 @@ func testCompleteGlobalInResultBuilderIf() {
     }
   }
 
-  // GLOBAL_IN_RESULT_BUILDER_IF-DAG: Decl[Struct]/Local/TypeRelation[Convertible]: MyView[#MyView#]; name=MyView
+  // GLOBAL_IN_RESULT_BUILDER_IF-DAG: Decl[Struct]/Local: MyView[#MyView#]; name=MyView
 }
 
 func testInStringLiteralInResultBuilder() {

--- a/test/IDE/complete_type_relation_global_results.swift
+++ b/test/IDE/complete_type_relation_global_results.swift
@@ -69,10 +69,10 @@ func test() -> MyProto {
 	return #^COMPLETE^#
 }
 
-// CHECK-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// CHECK-DAG: Decl[Struct]/OtherModule[Lib]: Foo[#Foo#];
 // CHECK-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
 // CHECK-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
-// CHECK-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: MyProto[#MyProto#];
+// CHECK-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
 // CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
 // CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: returnSomeMyProto()[#MyProto#];
 
@@ -91,7 +91,7 @@ func testOpaqueComposition() -> some MyProto & MyOtherProto {
 // COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
 // COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
 // COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeFoo()[#Foo#];
-// COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: FooBar[#FooBar#];
+// COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[Struct]/OtherModule[Lib]: FooBar[#FooBar#];
 
 // RUN: %empty-directory(%t/completion-cache)
 // RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token ALSO_CONSIDER_METATYPE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=ALSO_CONSIDER_METATYPE
@@ -129,12 +129,12 @@ func testGenericReturn<T: MyProto>() -> T {
   return #^GENERIC_RETURN^#
 }
 
-// GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]: Foo[#Foo#];
 // GENERIC_RETURN-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
 // GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
-// GENERIC_RETURN-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: MyProto[#MyProto#];
+// GENERIC_RETURN-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
 // GENERIC_RETURN-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
-// GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: FooBar[#FooBar#];
+// GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]: FooBar[#FooBar#];
 // GENERIC_RETURN-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: returnSomeMyProto()[#MyProto#];
 
 // RUN: %empty-directory(%t/completion-cache)
@@ -147,7 +147,7 @@ func testGenericReturn() -> some MyClass & MyProto {
 
 // OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeMySubclass()[#MySubclass#];
 // OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[Class]/OtherModule[Lib]:       MySubclass[#MySubclass#];
-// OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Convertible]: MySubclassConformingToMyProto[#MySubclassConformingToMyProto#];
+// OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[Class]/OtherModule[Lib]: MySubclassConformingToMyProto[#MySubclassConformingToMyProto#];
 // OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeMyClass()[#MyClass#];
 // OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
 // OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[FreeFunction]/OtherModule[Lib]: returnSomeMyProto()[#MyProto#];
@@ -163,15 +163,15 @@ func testGenericReturn() -> MyBaseProto {
 // TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyOtherProto[#MyOtherProto#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[Class]/OtherModule[Lib]:       MyClass[#MyClass#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
-// TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]: Foo[#Foo#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: returnSomeMyProto()[#MyProto#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
-// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: MyBaseProto[#MyBaseProto#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyBaseProto[#MyBaseProto#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
-// TRANSITIVE_CONFORMANCE-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Convertible]: MySubclassConformingToMyProto[#MySubclassConformingToMyProto#];
-// TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: FooBar[#FooBar#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Class]/OtherModule[Lib]: MySubclassConformingToMyProto[#MySubclassConformingToMyProto#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]: FooBar[#FooBar#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeMyClass()[#MyClass#];
-// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: MyProto[#MyProto#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
 
 
 // RUN: %empty-directory(%t/completion-cache)
@@ -182,9 +182,9 @@ func protoWithAssocType() -> ProtoWithAssocType {
   return #^PROTO_WITH_ASSOC_TYPE^#
 }
 
-// PROTO_WITH_ASSOC_TYPE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: StructWithAssocType[#StructWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE-DAG: Decl[Struct]/OtherModule[Lib]: StructWithAssocType[#StructWithAssocType#];
 // PROTO_WITH_ASSOC_TYPE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeProtoWithAssocType()[#ProtoWithAssocType#];
-// PROTO_WITH_ASSOC_TYPE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: ProtoWithAssocType[#ProtoWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: ProtoWithAssocType[#ProtoWithAssocType#];
 
 // RUN: %empty-directory(%t/completion-cache)
 // RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE_OPAQUE_CONTEXT -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROTO_WITH_ASSOC_TYPE
@@ -202,9 +202,9 @@ func protoWithAssocTypeInGenericContext<T: ProtoWithAssocType>() -> T {
   return #^PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT^#
 }
 
-// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: StructWithAssocType[#StructWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]: StructWithAssocType[#StructWithAssocType#];
 // PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeProtoWithAssocType()[#ProtoWithAssocType#];
-// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: ProtoWithAssocType[#ProtoWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: ProtoWithAssocType[#ProtoWithAssocType#];
 
 
 // RUN: %empty-directory(%t/completion-cache)
@@ -216,5 +216,5 @@ struct TestPropertyWrapper {
   @#^PROPERTY_WRAPPER^# var foo: String
 }
 
-// PROPERTY_WRAPPER-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: MyPropertyWrapper[#Property Wrapper#];
+// PROPERTY_WRAPPER-DAG: Decl[Struct]/OtherModule[Lib]: MyPropertyWrapper[#Property Wrapper#];
 // PROPERTY_WRAPPER-DAG: Decl[Struct]/OtherModule[Lib]: StructWithAssocType[#StructWithAssocType#];

--- a/test/IDE/complete_unresolved_chains.swift
+++ b/test/IDE/complete_unresolved_chains.swift
@@ -1,11 +1,4 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_CHAIN_1 | %FileCheck %s -check-prefix=UNRESOLVED_CHAIN_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_CHAIN_2 | %FileCheck %s -check-prefix=UNRESOLVED_CHAIN_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_CHAIN_3 | %FileCheck %s -check-prefix=UNRESOLVED_CHAIN_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_CHAIN_4 | %FileCheck %s -check-prefix=UNRESOLVED_CHAIN_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_CHAIN_5 | %FileCheck %s -check-prefix=UNRESOLVED_CHAIN_2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_CHAIN_6 | %FileCheck %s -check-prefix=UNRESOLVED_CHAIN_3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_CHAIN_7 | %FileCheck %s -check-prefix=UNRESOLVED_CHAIN_3
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DOUBLY_NESTED| %FileCheck %s -check-prefix=DOUBLY_NESTED
+// RUN: %batch-code-completion
 
 struct ChainStruct1 {
   static var chain2 = ChainStruct2()
@@ -27,12 +20,12 @@ enum ChainEnum {
 
 func testChains() {
   let _: ChainStruct1 = .chain2.#^UNRESOLVED_CHAIN_1^#
-  let _: ChainStruct1 = .chain2.chainStruct2.#^UNRESOLVED_CHAIN_2^#
-  let _: ChainStruct1 = .chain2Func().#^UNRESOLVED_CHAIN_3^#
-  let _: ChainStruct1 = .chain2Func().#^UNRESOLVED_CHAIN_4^#
+  let _: ChainStruct1 = .chain2.chainStruct2.#^UNRESOLVED_CHAIN_2?check=UNRESOLVED_CHAIN_1^#
+  let _: ChainStruct1 = .chain2Func().#^UNRESOLVED_CHAIN_3?check=UNRESOLVED_CHAIN_1^#
+  let _: ChainStruct1 = .chain2Func().#^UNRESOLVED_CHAIN_4?check=UNRESOLVED_CHAIN_1^#
   let _: ChainEnum = .case1.#^UNRESOLVED_CHAIN_5^#
   let _: ChainEnum = .case1.chainStruct2.#^UNRESOLVED_CHAIN_6^#
-  let _: ChainEnum = .case1.chainStruct2.#^UNRESOLVED_CHAIN_7^#
+  let _: ChainEnum = .case1.chainStruct2.#^UNRESOLVED_CHAIN_7?check=UNRESOLVED_CHAIN_6^#
 }
 
 // UNRESOLVED_CHAIN_1: Begin completions, 5 items
@@ -42,18 +35,18 @@ func testChains() {
 // UNRESOLVED_CHAIN_1-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct2[#ChainStruct2#];
 // UNRESOLVED_CHAIN_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: chainStruct1Func()[#ChainStruct1#];
 
-// UNRESOLVED_CHAIN_2: Begin completions, 5 items
-// UNRESOLVED_CHAIN_2-DAG: Keyword[self]/CurrNominal:          self[#ChainEnum#]; name=self
-// UNRESOLVED_CHAIN_2-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct2[#ChainStruct2#]; name=chainStruct2
-// UNRESOLVED_CHAIN_2-DAG: Decl[InstanceMethod]/CurrNominal:   chainStruct2Func()[#ChainStruct2#]; name=chainStruct2Func()
-// UNRESOLVED_CHAIN_2-DAG: Decl[InstanceVar]/CurrNominal:      hashValue[#Int#]; name=hashValue
-// UNRESOLVED_CHAIN_2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#into: &Hasher#})[#Void#]; name=hash(into:)
+// UNRESOLVED_CHAIN_5: Begin completions, 5 items
+// UNRESOLVED_CHAIN_5-DAG: Keyword[self]/CurrNominal:          self[#ChainEnum#]; name=self
+// UNRESOLVED_CHAIN_5-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct2[#ChainStruct2#]; name=chainStruct2
+// UNRESOLVED_CHAIN_5-DAG: Decl[InstanceMethod]/CurrNominal:   chainStruct2Func()[#ChainStruct2#]; name=chainStruct2Func()
+// UNRESOLVED_CHAIN_5-DAG: Decl[InstanceVar]/CurrNominal:      hashValue[#Int#]; name=hashValue
+// UNRESOLVED_CHAIN_5-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#into: &Hasher#})[#Void#]; name=hash(into:)
 
-// UNRESOLVED_CHAIN_3: Begin completions, 5 items
-// UNRESOLVED_CHAIN_3-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct1[#ChainStruct1#]; name=chainStruct1
-// UNRESOLVED_CHAIN_3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: chainEnum[#ChainEnum#]; name=chainEnum
-// UNRESOLVED_CHAIN_3-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct2[#ChainStruct2#]; name=chainStruct2
-// UNRESOLVED_CHAIN_3-DAG: Decl[InstanceMethod]/CurrNominal:   chainStruct1Func()[#ChainStruct1#]; name=chainStruct1Func()
+// UNRESOLVED_CHAIN_6: Begin completions, 5 items
+// UNRESOLVED_CHAIN_6-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct1[#ChainStruct1#]; name=chainStruct1
+// UNRESOLVED_CHAIN_6-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: chainEnum[#ChainEnum#]; name=chainEnum
+// UNRESOLVED_CHAIN_6-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct2[#ChainStruct2#]; name=chainStruct2
+// UNRESOLVED_CHAIN_6-DAG: Decl[InstanceMethod]/CurrNominal:   chainStruct1Func()[#ChainStruct1#]; name=chainStruct1Func()
 
 class Outer {
   class Inner: Outer {
@@ -71,11 +64,11 @@ func testDoublyNestedType() {
 
 // DOUBLY_NESTED: Begin completions, 8 items
 // DOUBLY_NESTED-DAG: Keyword[self]/CurrNominal:          self[#Outer.Inner.Type#]; name=self
-// DOUBLY_NESTED-DAG: Decl[Class]/CurrNominal/TypeRelation[Convertible]: InnerInner[#Outer.Inner.InnerInner#];
+// DOUBLY_NESTED-DAG: Decl[Class]/CurrNominal: InnerInner[#Outer.Inner.InnerInner#];
 // DOUBLY_NESTED-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: outer[#Outer#];
 // DOUBLY_NESTED-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: inner[#Outer.Inner#];
 // DOUBLY_NESTED-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: makeOuter()[#Outer#];
 // DOUBLY_NESTED-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: makeInner()[#Outer.Inner#];
 // DOUBLY_NESTED-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#Outer.Inner#];
-// DOUBLY_NESTED-DAG: Decl[Class]/Super/TypeRelation[Convertible]: Inner[#Outer.Inner#];
+// DOUBLY_NESTED-DAG: Decl[Class]/Super: Inner[#Outer.Inner#];
 

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -434,7 +434,7 @@ func testSubType() {
 }
 // SUBTYPE_1: Begin completions, 6 items
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#BaseClass#];
-// SUBTYPE_1-DAG: Decl[Class]/CurrNominal/TypeRelation[Convertible]: SubClass[#BaseClass.SubClass#];
+// SUBTYPE_1-DAG: Decl[Class]/CurrNominal: SubClass[#BaseClass.SubClass#];
 // SUBTYPE_1-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: subInstance[#BaseClass.SubClass#];
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal:      init({#failable: Void#})[#BaseClass?#];
 // SUBTYPE_1-DAG: Decl[TypeAlias]/Super/TypeRelation[Convertible]: Concrete1[#BaseClass#];

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1857,6 +1857,6 @@ func testProtocolMetatype(protoProto: MetaProto.Protocol, protoType: MetaProto.T
 func testRdar90136020() {
     let a: Int64 = #^RDAR90136020^#
 // RDAR90136020-NOT: name=Int64{{$}}
-// RDAR90136020: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: Int64[#Int64#]; name=Int64
+// RDAR90136020: Decl[Struct]/OtherModule[Swift]/IsSystem: Int64[#Int64#]; name=Int64
 // RDAR90136020-NOT: name=Int64{{$}}
 }

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift
@@ -68,7 +68,7 @@ func testUnknown() {
 // OPTIONALCONTEXT-LABEL: }
 // OPTIONALCONTEXT-LABEL: key.name: "Int",
 // OPTIONALCONTEXT:       key.typename: "Int",
-// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.convertible,
+// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // OPTIONALCONTEXT-LABEL: }
 // OPTIONALCONTEXT-LABEL: key.name: "nil",
 // OPTIONALCONTEXT:       key.typename: "Int?",


### PR DESCRIPTION
AFAICT we used to suggest e.g. `Int` as `Convertible` in a context that requires an instance of type `Int` because didn’t use to suggest calls to the initializer of `Int`. Since we do now, there’s no need to report `Int` as convertible anymore. This also simplifies `CodeCompletionResultType`.

rdar://81035837