### PR TITLE
[CodeComplete] Prefer function call if both reference and call are possible

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1972,10 +1972,11 @@ bool CompletionLookup::addCompoundFunctionNameIfDesiable(
   if (!useFunctionReference && funcTy) {
     // We know that the CodeCompletionResultType is AST-based so we can pass
     // nullptr for USRTypeContext.
-    auto maxRel = CodeCompletionResultType(funcTy).calculateTypeRelation(
+    auto maxFuncTyRel = CodeCompletionResultType(funcTy).calculateTypeRelation(
         &expectedTypeContext, CurrDeclContext, /*USRTypeContext=*/nullptr);
-    useFunctionReference =
-        maxRel >= CodeCompletionResultTypeRelation::Convertible;
+    auto maxResultTyRel = CodeCompletionResultType(funcTy->getResult()).calculateTypeRelation(
+        &expectedTypeContext, CurrDeclContext, /*USRTypeContext=*/nullptr);
+    useFunctionReference = maxFuncTyRel > maxResultTyRel;
   }
   if (!useFunctionReference)
     return false;

--- a/test/IDE/complete_prefer_function_call_if_both_reference_and_call_are_possible.swift
+++ b/test/IDE/complete_prefer_function_call_if_both_reference_and_call_are_possible.swift
@@ -1,0 +1,30 @@
+// RUN: %batch-code-completion
+
+struct Route {
+  func makeDetailView() -> Int {
+    return 52
+  }
+}
+
+@resultBuilder struct ViewBuilder {
+    static func buildBlock(_ x: Int) -> Int { return x }
+}
+
+func foo(@ViewBuilder destination: () -> Int) {}
+func foo(destination: Int) {}
+
+func test(route: Route?) {
+  route.map { route in
+    foo(destination: route.#^COMPLETE^#)
+  }
+}
+
+
+// COMPLETE-DAG: Keyword[self]/CurrNominal:          self[#Route#];
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: makeDetailView()[#Int#];
+
+func testTask(route: Route) {
+  Task {
+    route.#^IN_TASK?check=COMPLETE^#
+  }
+}

--- a/test/IDE/complete_prefer_function_call_if_both_reference_and_call_are_possible.swift
+++ b/test/IDE/complete_prefer_function_call_if_both_reference_and_call_are_possible.swift
@@ -28,3 +28,16 @@ func testTask(route: Route) {
     route.#^IN_TASK?check=COMPLETE^#
   }
 }
+
+protocol Builder {
+  func recv<T>(_: (T) throws -> Void)
+}
+
+struct S {
+  func foo(x: Int) throws {}
+  func test(builder: Builder) {
+    builder.recv(#^IN_CONTEXT_FOR_UNAPPLIED_REF^#)
+  }
+}
+// IN_CONTEXT_FOR_UNAPPLIED_REF-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: foo(x:)[#(Int) throws -> ()#]; name=foo(x:)
+// IN_CONTEXT_FOR_UNAPPLIED_REF-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: test(builder:)[#(any Builder) -> ()#]; name=test(builder:)


### PR DESCRIPTION
The real-world use case here is the `Task` initializer in the added test case. In general, we should only prefer to insert an unapplied function reference if it has a better type relation than calling the function because, in most cases, you want to call functions and not get unapplied references to them.

rdar://90456105