### PR TITLE
[CodeCompletion] Add keyword completion for 'some', 'any', 'repeat', and 'each'

### DIFF
--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -199,6 +199,8 @@ enum class CompletionKind : uint8_t {
   KeyPathExprObjC,
   KeyPathExprSwift,
   TypeDeclResultBeginning,
+  TypeBeginning,
+  TypeSimpleOrComposition,
   TypeSimpleBeginning,
   TypeSimpleWithDot,
   TypeSimpleWithoutDot,

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -185,6 +185,13 @@ public:
   /// Complete the beginning of the type of result of func/var/let/subscript.
   virtual void completeTypeDeclResultBeginning() {};
 
+  /// Same as `completeTypeSimpleOrComposition` but also allows `repeat`.
+  virtual void completeTypeBeginning(){};
+
+  /// Same as `completeTypeSimpleBeginning` but also allows `any`, `some` and
+  /// `each`.
+  virtual void completeTypeSimpleOrComposition(){};
+
   /// Complete the beginning of type-simple -- no tokens provided
   /// by user.
   virtual void completeTypeSimpleBeginning() {};

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -632,6 +632,12 @@ Parser::parseType(Diag<> MessageID, ParseTypeReason reason, bool fromASTGen) {
 
     return makeParserResult(ty,
         new (Context) PackExpansionTypeRepr(repeatLoc, ty.get()));
+  } else if (Tok.is(tok::code_complete)) {
+    if (CodeCompletionCallbacks) {
+      CodeCompletionCallbacks->completeTypeBeginning();
+    }
+    return makeParserCodeCompletionResult<TypeRepr>(
+        ErrorTypeRepr::create(Context, consumeToken(tok::code_complete)));
   }
 
   ty = parseTypeScalar(MessageID, reason);
@@ -954,6 +960,12 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason) {
 
     auto *typeRepr = new (Context) PackElementTypeRepr(eachLoc, packElt.get());
     return makeParserResult(ParserStatus(packElt), typeRepr);
+  } else if (Tok.is(tok::code_complete)) {
+    if (CodeCompletionCallbacks) {
+      CodeCompletionCallbacks->completeTypeSimpleOrComposition();
+    }
+    return makeParserCodeCompletionResult<TypeRepr>(
+        ErrorTypeRepr::create(Context, consumeToken(tok::code_complete)));
   }
 
   auto applyOpaque = [&](TypeRepr *type) -> TypeRepr * {

--- a/test/IDE/complete_generic_param.swift
+++ b/test/IDE/complete_generic_param.swift
@@ -1,13 +1,4 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT1 | %FileCheck %s -check-prefix=INHERIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT2 | %FileCheck %s -check-prefix=INHERIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT3 | %FileCheck %s -check-prefix=INHERIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT4 | %FileCheck %s -check-prefix=INHERIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT5 | %FileCheck %s -check-prefix=INHERIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT6 | %FileCheck %s -check-prefix=INHERIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPE_PARAM
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SECOND_GENERIC_TYPE_PARAM | %FileCheck %s -check-prefix=GENERIC_TYPE_PARAM
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_PARAM_ON_NESTED_TYPE_GLOBAL_VAR | %FileCheck %s -check-prefix=GENERIC_PARAM_ON_NESTED_TYPE
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_PARAM_ON_NESTED_TYPE_LOCAL_VAR | %FileCheck %s -check-prefix=GENERIC_PARAM_ON_NESTED_TYPE
+// RUN: %batch-code-completion
 
 class C1{}
 protocol P1{}
@@ -17,17 +8,17 @@ let ValueInt1 = 1
 let ValueString2 = ""
 func TopLevelFunc() {}
 
-func f1<S : #^INHERIT1^#>(p : S) {}
-func f2<S : #^INHERIT2^#
+func f1<S : #^INHERIT1?check=INHERIT^#>(p : S) {}
+func f2<S : #^INHERIT2?check=INHERIT^#
 
 class C2 {
-  func f1<S : #^INHERIT3^#>(p : S) {}
-  func f2<S : #^INHERIT4^#
+  func f1<S : #^INHERIT3?check=INHERIT^#>(p : S) {}
+  func f2<S : #^INHERIT4?check=INHERIT^#
 }
 
 class C3 {
-  func f1<S1: P1, S2 : #^INHERIT5^#>(p : S1) {}
-  func f2<S1: P1, S2 : #^INHERIT6^#
+  func f1<S1: P1, S2 : #^INHERIT5?check=INHERIT^#>(p : S1) {}
+  func f2<S1: P1, S2 : #^INHERIT6?check=INHERIT^#
 }
 
 // INHERIT-DAG: Decl[Class]/CurrModule:             C1[#C1#]{{; name=.+$}}
@@ -44,7 +35,7 @@ class C3 {
 class C4<T, U> {}
 
 _ = C4<#^GENERIC_TYPE_PARAM^# >()
-_ = C4<SomeType, #^SECOND_GENERIC_TYPE_PARAM^# >()
+_ = C4<SomeType, #^SECOND_GENERIC_TYPE_PARAM?check=GENERIC_TYPE_PARAM^# >()
 // GENERIC_TYPE_PARAM-DAG: Decl[Class]/CurrModule:             C1[#C1#];
 
 // https://github.com/apple/swift/issues/56979
@@ -55,10 +46,10 @@ struct S2 {
   }
 }
 
-var s2_globalVar = S2.Nested< #^GENERIC_PARAM_ON_NESTED_TYPE_GLOBAL_VAR^#>()
+var s2_globalVar = S2.Nested< #^GENERIC_PARAM_ON_NESTED_TYPE_GLOBAL_VAR?check=GENERIC_PARAM_ON_NESTED_TYPE^#>()
 
 func someFunction() {
-  var s2_localVar = S2.Nested< #^GENERIC_PARAM_ON_NESTED_TYPE_LOCAL_VAR^#>()
+  var s2_localVar = S2.Nested< #^GENERIC_PARAM_ON_NESTED_TYPE_LOCAL_VAR?check=GENERIC_PARAM_ON_NESTED_TYPE^#>()
 }
 
 // GENERIC_PARAM_ON_NESTED_TYPE-DAG: Decl[Struct]/CurrModule:            S2[#S2#];

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -12,29 +12,21 @@ struct ConcreteMyProtocol : MyProtocol {
 
 // MARK: 'some' keyword.
 
-// BEGINNING_WITH_SOME-DAG: Keyword/None:                       some[#some#]; name=some
+// BEGINNING_WITH_SOME-DAG: Keyword/None:                       some; name=some
 // BEGINNING_WITH_SOME-DAG: Keyword/None:                       Any[#Any#]; name=Any
 // BEGINNING_WITH_SOME-DAG: Decl[Enum]/CurrModule:              MyEnum[#MyEnum#]; name=MyEnum
 // BEGINNING_WITH_SOME-DAG: Decl[Class]/CurrModule:             MyClass[#MyClass#]; name=MyClass
 // BEGINNING_WITH_SOME-DAG: Decl[Protocol]/CurrModule:          MyProtocol[#MyProtocol#]; name=MyProtocol
 // BEGINNING_WITH_SOME-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 
-// BEGINNING_WITHOUT_SOME-NOT: Keyword/None: some
-// BEGINNING_WITHOUT_SOME-DAG: Keyword/None:                       Any[#Any#]; name=Any
-// BEGINNING_WITHOUT_SOME-DAG: Decl[Enum]/CurrModule:              MyEnum[#MyEnum#]; name=MyEnum
-// BEGINNING_WITHOUT_SOME-DAG: Decl[Class]/CurrModule:             MyClass[#MyClass#]; name=MyClass
-// BEGINNING_WITHOUT_SOME-DAG: Decl[Protocol]/CurrModule:          MyProtocol[#MyProtocol#]; name=MyProtocol
-// BEGINNING_WITHOUT_SOME-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
-// BEGINNING_WITHOUT_SOME-NOT: Keyword/None: some
-
 func gloabalFunc() -> #^GLOBAL_FUNC?check=BEGINNING_WITH_SOME^#
-var globalVar: #^GLOBAL_VAR?check=BEGINNING_WITHOUT_SOME^#
+var globalVar: #^GLOBAL_VAR?check=BEGINNING_WITH_SOME^#
 
 protocol SomeProto {
-  associatedtype protoAssocTy: #^PROTOCOL_ASSOCIATEDTYPE?check=BEGINNING_WITHOUT_SOME^#
-  func protoMethodReq() -> #^PROTOCOL_METHOD_REQUIREMENT?check=BEGINNING_WITHOUT_SOME^#
-  var protoVarReq: #^PROTOCOL_VAR_REQUIREMENT?check=BEGINNING_WITHOUT_SOME^#
-  subscript(req: Int) -> #^PROTOCOL_SUBSCRIPT_REQUIREMENT?check=BEGINNING_WITHOUT_SOME^#
+  associatedtype protoAssocTy: #^PROTOCOL_ASSOCIATEDTYPE?check=BEGINNING_WITH_SOME^#
+  func protoMethodReq() -> #^PROTOCOL_METHOD_REQUIREMENT?check=BEGINNING_WITH_SOME^#
+  var protoVarReq: #^PROTOCOL_VAR_REQUIREMENT?check=BEGINNING_WITH_SOME^#
+  subscript(req: Int) -> #^PROTOCOL_SUBSCRIPT_REQUIREMENT?check=BEGINNING_WITH_SOME^#
 }
 
 extension SomeProto {
@@ -44,7 +36,7 @@ extension SomeProto {
 }
 
 struct SomeStruct {
-  typealias TyAlias = #^STRUCT_TYPEALIAS_RHS?check=BEGINNING_WITHOUT_SOME^#
+  typealias TyAlias = #^STRUCT_TYPEALIAS_RHS?check=BEGINNING_WITH_SOME^#
   func structMethodExt() -> #^STRUCT_METHOD?check=BEGINNING_WITH_SOME^#
   var structVarExt: #^STRUCT_VAR?check=BEGINNING_WITH_SOME^#
   subscript(struct: Int) -> #^STRUCT_SUBSCRIPT?check=BEGINNING_WITH_SOME^#

--- a/test/IDE/complete_some_any.swift
+++ b/test/IDE/complete_some_any.swift
@@ -1,0 +1,25 @@
+// RUN: %batch-code-completion
+
+func test1(x: #^PARAM?check=HAS_SOME_ANY;check=HAS_REPEAT^#) {}
+
+func test2() -> #^RESULT?check=HAS_SOME_ANY;check=NO_REPEAT^# {}
+
+func test3() {
+  // FIXME: 'repeat' is not valid here semantically but we allow it syntactically and can't (easily) tell in the parser whether 'repeat' is valid. Not worth fixing in the old parser.
+  let a: [#^ARRAY_TYPE?check=HAS_SOME_ANY;check=HAS_REPEAT^#]
+  let b: any #^AFTER_ANY?check=NO_SOME_ANY;check=NO_REPEAT^#
+}
+
+func test4(x: repeat #^AFTER_REPEAT?check=HAS_SOME_ANY;check=NO_REPEAT^#) {}
+
+// HAS_SOME_ANY-DAG: Keyword/None: some; name=some
+// HAS_SOME_ANY-DAG: Keyword/None: any; name=any
+// HAS_SOME_ANY-DAG: Keyword/None: each; name=each
+
+// NO_SOME_ANY-NOT: Keyword/None: some; name=some
+// NO_SOME_ANY-NOT: Keyword/None: any; name=any
+// NO_SOME_ANY-NOT: Keyword/None: each; name=each
+
+// HAS_REPEAT-DAG: Keyword/None: repeat; name=repeat
+
+// NO_REPEAT-NOT: Keyword/None: repeat; name=repeat

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -176,6 +176,8 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
       }
       break;
     case CompletionKind::TypeDeclResultBeginning:
+    case CompletionKind::TypeBeginning:
+    case CompletionKind::TypeSimpleOrComposition:
     case CompletionKind::TypeSimpleBeginning:
       if (custom.Contexts.contains(CustomCompletionInfo::Type)) {
         changed = true;
@@ -451,6 +453,8 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
     bool hideLowPriority =
         options.hideLowPriority &&
         completionKind != CompletionKind::TypeDeclResultBeginning &&
+        completionKind != CompletionKind::TypeBeginning &&
+        completionKind != CompletionKind::TypeSimpleOrComposition &&
         completionKind != CompletionKind::TypeSimpleBeginning &&
         completionKind != CompletionKind::PostfixExpr;
     for (Completion *completion : completions) {


### PR DESCRIPTION
The implementation is not 100% perfect (it suggests `repeat` and `each` in places where they aren’t semantically valid) but I don’t think it’s worth putting too much effort into it passing more information down in the parser if 'repeat' and 'each' are valid if we are going to remove the current parser anyway.

rdar://95725895