### PR TITLE
Fix compiler crash when emitting objc header with C++ interop enabled

### DIFF
--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -391,8 +391,10 @@ void LoweredFunctionSignature::visitParameterList(
       if (!schema.requiresIndirect()) {
         // Skip ABI parameters with empty native representation, as they're not
         // emitted in the LLVM IR signature.
-        if (schema.empty())
+        if (schema.empty()) {
+          ++currentSilParam;
           continue;
+        }
         isIndirect = false;
       }
     }

--- a/test/Driver/issue-70016-emit-objc-header-with-empty-struct.swift
+++ b/test/Driver/issue-70016-emit-objc-header-with-empty-struct.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend %s -emit-module -emit-objc-header-path %t/Issue70016-Swift.h -module-name Issue70016 -cxx-interoperability-mode=default
+
+public struct Struct {}
+public func foo(_ x: Struct) {}


### PR DESCRIPTION
This was because `LoweredFunctionSignature::visitParameterList` has a special case for parameters with an empty LLVM representation (e.g. an empty struct) but forgot to increment the counter, which then tripped the assertion.

Resolves #70016.