### PR TITLE
Yet more macro role metaprogramming to reduce boilerplate

### DIFF
--- a/include/swift/Basic/MacroRoles.def
+++ b/include/swift/Basic/MacroRoles.def
@@ -16,7 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #ifndef ATTACHED_MACRO_ROLE
-#  define ATTACHED_MACRO_ROLE(Name, Description) MACRO_ROLE(Name, Description)
+#  define ATTACHED_MACRO_ROLE(Name, Description, MangledChar) MACRO_ROLE(Name, Description)
 #endif
 
 #ifndef FREESTANDING_MACRO_ROLE
@@ -24,8 +24,8 @@
 #endif
 
 #ifndef EXPERIMENTAL_ATTACHED_MACRO_ROLE
-#  define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, Feature) \
-     ATTACHED_MACRO_ROLE(Name, Description)
+#  define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, MangledChar, Feature) \
+     ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #endif
 
 #ifndef EXPERIMENTAL_FREESTANDING_MACRO_ROLE
@@ -43,23 +43,23 @@ FREESTANDING_MACRO_ROLE(Declaration, "declaration")
 
 /// An attached macro that declares accessors for a variable or subscript
 /// declaration.
-ATTACHED_MACRO_ROLE(Accessor, "accessor")
+ATTACHED_MACRO_ROLE(Accessor, "accessor", "a")
 
 /// An attached macro that generates attributes for the
 /// members inside the declaration.
-ATTACHED_MACRO_ROLE(MemberAttribute, "memberAttribute")
+ATTACHED_MACRO_ROLE(MemberAttribute, "memberAttribute", "r")
 
 /// An attached macro that generates synthesized members
 /// inside the declaration.
-ATTACHED_MACRO_ROLE(Member, "member")
+ATTACHED_MACRO_ROLE(Member, "member", "m")
 
 /// An attached macro that generates declarations that are peers
 /// of the declaration the macro is attached to.
-ATTACHED_MACRO_ROLE(Peer, "peer")
+ATTACHED_MACRO_ROLE(Peer, "peer", "p")
 
 /// An attached macro that adds conformances to the declaration the
 /// macro is attached to.
-ATTACHED_MACRO_ROLE(Conformance, "conformance")
+ATTACHED_MACRO_ROLE(Conformance, "conformance", "c")
 
 /// A freestanding macro that expands to expressions, statements and
 /// declarations in a code block.
@@ -67,7 +67,7 @@ EXPERIMENTAL_FREESTANDING_MACRO_ROLE(CodeItem, "codeItem", CodeItemMacros)
 
 /// An attached macro that adds extensions to the declaration the
 /// macro is attached to.
-ATTACHED_MACRO_ROLE(Extension, "extension")
+ATTACHED_MACRO_ROLE(Extension, "extension", "e")
 
 #undef ATTACHED_MACRO_ROLE
 #undef FREESTANDING_MACRO_ROLE

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3892,7 +3892,7 @@ void ASTMangler::appendMacroExpansionContext(
   // Freestanding macros
 #define FREESTANDING_MACRO_ROLE(Name, Description) \
   case GeneratedSourceInfo::Name##MacroExpansion:
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
   {
     auto parent = ASTNode::getFromOpaqueValue(generatedSourceInfo->astNode);
@@ -3914,7 +3914,7 @@ void ASTMangler::appendMacroExpansionContext(
 
   // Attached macros
 #define FREESTANDING_MACRO_ROLE(Name, Description)
-#define ATTACHED_MACRO_ROLE(Name, Description)      \
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)      \
     case GeneratedSourceInfo::Name##MacroExpansion:
 #include "swift/Basic/MacroRoles.def"
   {
@@ -3956,34 +3956,17 @@ void ASTMangler::appendMacroExpansionOperator(
 
   switch (role) {
 #define FREESTANDING_MACRO_ROLE(Name, Description) case MacroRole::Name:
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
     appendOperator("fMf", Index(discriminator));
     break;
 
-  case MacroRole::Accessor:
-    appendOperator("fMa", Index(discriminator));
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar) \
+  case MacroRole::Name:                                     \
+    appendOperator("fM" MangledChar, Index(discriminator)); \
     break;
-
-  case MacroRole::MemberAttribute:
-    appendOperator("fMr", Index(discriminator));
-    break;
-
-  case MacroRole::Member:
-    appendOperator("fMm", Index(discriminator));
-    break;
-
-  case MacroRole::Peer:
-    appendOperator("fMp", Index(discriminator));
-    break;
-
-  case MacroRole::Conformance:
-    appendOperator("fMc", Index(discriminator));
-    break;
-
-  case MacroRole::Extension:
-    appendOperator("fMe", Index(discriminator));
-    break;
+#include "swift/Basic/MacroRoles.def"
   }
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11049,7 +11049,7 @@ bool swift::isMacroSupported(MacroRole role, ASTContext &ctx) {
   switch (role) {
 #define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, FeatureName) \
   case MacroRole::Name: \
-    return ctx.LangOpts.hasFeature(FeatureName::CodeItemMacros);
+    return ctx.LangOpts.hasFeature(Feature::FeatureName);
 
 #define EXPERIMENTAL_FREESTANDING_MACRO_ROLE(Name, Description, FeatureName) \
   case MacroRole::Name: return ctx.LangOpts.hasFeature(Feature::FeatureName);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11019,12 +11019,12 @@ StringRef swift::getMacroIntroducedDeclNameString(
 static MacroRoles freestandingMacroRoles =
   (MacroRoles()
 #define FREESTANDING_MACRO_ROLE(Name, Description) | MacroRole::Name
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
    );
 static MacroRoles attachedMacroRoles = 
   (MacroRoles()
-#define ATTACHED_MACRO_ROLE(Name, Description) | MacroRole::Name
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar) | MacroRole::Name
 #define FREESTANDING_MACRO_ROLE(Name, Description)
 #include "swift/Basic/MacroRoles.def"
    );
@@ -11506,7 +11506,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
   // Attached macros
 #define FREESTANDING_MACRO_ROLE(Name, Description)  \
   case GeneratedSourceInfo::Name##MacroExpansion:
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
   {
     auto node = ASTNode::getFromOpaqueValue(generatedSourceInfo->astNode);
@@ -11525,7 +11525,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
 
   // Attached macros
 #define FREESTANDING_MACRO_ROLE(Name, Description)
-#define ATTACHED_MACRO_ROLE(Name, Description)      \
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)      \
   case GeneratedSourceInfo::Name##MacroExpansion:
 #include "swift/Basic/MacroRoles.def"
   case GeneratedSourceInfo::PrettyPrinted:

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4109,46 +4109,19 @@ NodePointer Demangler::demangleMacroExpansion() {
   bool isAttached;
   bool isFreestanding;
   switch (nextChar()) {
-  case 'a':
-    kind = Node::Kind::AccessorAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)    \
+  case MangledChar[0]:                                         \
+    kind = Node::Kind::Name##AttachedMacroExpansion;           \
+    isAttached = true;                                         \
+    isFreestanding = false;                                    \
     break;
-
-  case 'r':
-    kind = Node::Kind::MemberAttributeAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
-    break;
+#include "swift/Basic/MacroRoles.def"
 
   case 'f':
     kind = Node::Kind::FreestandingMacroExpansion;
     isAttached = false;
     isFreestanding = true;
-    break;
-
-  case 'm':
-    kind = Node::Kind::MemberAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
-    break;
-
-  case 'p':
-    kind = Node::Kind::PeerAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
-    break;
-
-  case 'c':
-    kind = Node::Kind::ConformanceAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
-    break;
-
-  case 'e':
-    kind = Node::Kind::ExtensionAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
     break;
 
   case 'u':

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1080,47 +1080,15 @@ ManglingError Remangler::mangleFreestandingMacroExpansion(
   return mangleChildNodes(node, depth + 1);
 }
 
-ManglingError Remangler::mangleAccessorAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMa";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)    \
+ManglingError Remangler::mangle##Name##AttachedMacroExpansion( \
+    Node *node, unsigned depth) {                              \
+  Buffer << "fM" MangledChar;                                  \
+  RETURN_IF_ERROR(mangleIndex(node, depth + 1));               \
+  return mangleChildNodes(node, depth + 1);                    \
 }
-
-ManglingError Remangler::mangleMemberAttributeAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMr";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
-
-ManglingError Remangler::mangleMemberAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMm";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
-
-ManglingError Remangler::manglePeerAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMp";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
-
-ManglingError Remangler::mangleConformanceAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMc";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
-
-ManglingError Remangler::mangleExtensionAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMe";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
+#include "swift/Basic/MacroRoles.def"
 
 ManglingError Remangler::mangleMacroExpansionUniqueName(
     Node *node, unsigned depth) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2930,59 +2930,17 @@ ManglingError Remangler::mangleFreestandingMacroExpansion(
   return mangleChildNode(node, 2, depth + 1);
 }
 
-ManglingError Remangler::mangleAccessorAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMa";
-  return mangleChildNode(node, 3, depth + 1);
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)    \
+ManglingError Remangler::mangle##Name##AttachedMacroExpansion( \
+    Node *node, unsigned depth) {                              \
+  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));        \
+  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));        \
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));        \
+  Buffer << "fM" MangledChar;                                  \
+  return mangleChildNode(node, 3, depth + 1);                  \
 }
-
-ManglingError Remangler::mangleMemberAttributeAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMr";
-  return mangleChildNode(node, 3, depth + 1);
-}
-
-ManglingError Remangler::mangleMemberAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMm";
-  return mangleChildNode(node, 3, depth + 1);
-}
-
-ManglingError Remangler::manglePeerAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMp";
-  return mangleChildNode(node, 3, depth + 1);
-}
-
-ManglingError Remangler::mangleConformanceAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMc";
-  return mangleChildNode(node, 3, depth + 1);
-}
-
-ManglingError Remangler::mangleExtensionAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMe";
-  return mangleChildNode(node, 3, depth + 1);
-}
+#include "swift/Basic/MacroRoles.def"
 
 ManglingError Remangler::mangleMacroExpansionUniqueName(
     Node *node, unsigned depth) {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -570,7 +570,7 @@ bool swift::isInvalidAttachedMacro(MacroRole role,
                                    Decl *attachedTo) {
   switch (role) {
 #define FREESTANDING_MACRO_ROLE(Name, Description) case MacroRole::Name:
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
     llvm_unreachable("Invalid macro role for attached macro");
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2343,20 +2343,11 @@ getStableSelfAccessKind(swift::SelfAccessKind MM) {
 
 static uint8_t getRawStableMacroRole(swift::MacroRole context) {
   switch (context) {
-#define CASE(NAME) \
-  case swift::MacroRole::NAME: \
-    return static_cast<uint8_t>(serialization::MacroRole::NAME);
-  CASE(Expression)
-  CASE(Declaration)
-  CASE(Accessor)
-  CASE(MemberAttribute)
-  CASE(Member)
-  CASE(Peer)
-  CASE(Conformance)
-  CASE(CodeItem)
-  CASE(Extension)
+#define MACRO_ROLE(Name, Description) \
+  case swift::MacroRole::Name: \
+    return static_cast<uint8_t>(serialization::MacroRole::Name);
+#include "swift/Basic/MacroRoles.def"
   }
-#undef CASE
   llvm_unreachable("bad result declaration macro kind");
 }
 


### PR DESCRIPTION
Introduce yet more preprocessor metaprogramming for macro roles, to simplify the process of adding a new macro role and reduce boilerplate. This includes:
* Fixing a bug with experimental attached macros, which weren't used (yet) and didn't actually work
* Macro role metaprogramming for (de-)serialization
* Macro role metaprogramming for mangling / demangling / remangling