### PR TITLE
Make the "typechecked function body" request more central and resilient 

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7245,7 +7245,7 @@ public:
   ///
   /// Note that a true return value does not imply that the body was actually
   /// parsed.
-  bool hasBody() const { return getBodyKind() != BodyKind::None; }
+  bool hasBody() const;
 
   /// Returns true if the text of this function's body can be retrieved either
   /// by extracting the text from the source buffer or reading the inlinable

--- a/include/swift/Basic/MacroRoles.def
+++ b/include/swift/Basic/MacroRoles.def
@@ -16,7 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #ifndef ATTACHED_MACRO_ROLE
-#  define ATTACHED_MACRO_ROLE(Name, Description) MACRO_ROLE(Name, Description)
+#  define ATTACHED_MACRO_ROLE(Name, Description, MangledChar) MACRO_ROLE(Name, Description)
 #endif
 
 #ifndef FREESTANDING_MACRO_ROLE
@@ -24,8 +24,8 @@
 #endif
 
 #ifndef EXPERIMENTAL_ATTACHED_MACRO_ROLE
-#  define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, Feature) \
-     ATTACHED_MACRO_ROLE(Name, Description)
+#  define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, MangledChar, Feature) \
+     ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #endif
 
 #ifndef EXPERIMENTAL_FREESTANDING_MACRO_ROLE
@@ -43,23 +43,23 @@ FREESTANDING_MACRO_ROLE(Declaration, "declaration")
 
 /// An attached macro that declares accessors for a variable or subscript
 /// declaration.
-ATTACHED_MACRO_ROLE(Accessor, "accessor")
+ATTACHED_MACRO_ROLE(Accessor, "accessor", "a")
 
 /// An attached macro that generates attributes for the
 /// members inside the declaration.
-ATTACHED_MACRO_ROLE(MemberAttribute, "memberAttribute")
+ATTACHED_MACRO_ROLE(MemberAttribute, "memberAttribute", "r")
 
 /// An attached macro that generates synthesized members
 /// inside the declaration.
-ATTACHED_MACRO_ROLE(Member, "member")
+ATTACHED_MACRO_ROLE(Member, "member", "m")
 
 /// An attached macro that generates declarations that are peers
 /// of the declaration the macro is attached to.
-ATTACHED_MACRO_ROLE(Peer, "peer")
+ATTACHED_MACRO_ROLE(Peer, "peer", "p")
 
 /// An attached macro that adds conformances to the declaration the
 /// macro is attached to.
-ATTACHED_MACRO_ROLE(Conformance, "conformance")
+ATTACHED_MACRO_ROLE(Conformance, "conformance", "c")
 
 /// A freestanding macro that expands to expressions, statements and
 /// declarations in a code block.
@@ -67,7 +67,7 @@ EXPERIMENTAL_FREESTANDING_MACRO_ROLE(CodeItem, "codeItem", CodeItemMacros)
 
 /// An attached macro that adds extensions to the declaration the
 /// macro is attached to.
-ATTACHED_MACRO_ROLE(Extension, "extension")
+ATTACHED_MACRO_ROLE(Extension, "extension", "e")
 
 #undef ATTACHED_MACRO_ROLE
 #undef FREESTANDING_MACRO_ROLE

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3892,7 +3892,7 @@ void ASTMangler::appendMacroExpansionContext(
   // Freestanding macros
 #define FREESTANDING_MACRO_ROLE(Name, Description) \
   case GeneratedSourceInfo::Name##MacroExpansion:
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
   {
     auto parent = ASTNode::getFromOpaqueValue(generatedSourceInfo->astNode);
@@ -3914,7 +3914,7 @@ void ASTMangler::appendMacroExpansionContext(
 
   // Attached macros
 #define FREESTANDING_MACRO_ROLE(Name, Description)
-#define ATTACHED_MACRO_ROLE(Name, Description)      \
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)      \
     case GeneratedSourceInfo::Name##MacroExpansion:
 #include "swift/Basic/MacroRoles.def"
   {
@@ -3956,34 +3956,17 @@ void ASTMangler::appendMacroExpansionOperator(
 
   switch (role) {
 #define FREESTANDING_MACRO_ROLE(Name, Description) case MacroRole::Name:
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
     appendOperator("fMf", Index(discriminator));
     break;
 
-  case MacroRole::Accessor:
-    appendOperator("fMa", Index(discriminator));
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar) \
+  case MacroRole::Name:                                     \
+    appendOperator("fM" MangledChar, Index(discriminator)); \
     break;
-
-  case MacroRole::MemberAttribute:
-    appendOperator("fMr", Index(discriminator));
-    break;
-
-  case MacroRole::Member:
-    appendOperator("fMm", Index(discriminator));
-    break;
-
-  case MacroRole::Peer:
-    appendOperator("fMp", Index(discriminator));
-    break;
-
-  case MacroRole::Conformance:
-    appendOperator("fMc", Index(discriminator));
-    break;
-
-  case MacroRole::Extension:
-    appendOperator("fMe", Index(discriminator));
-    break;
+#include "swift/Basic/MacroRoles.def"
   }
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11049,7 +11049,7 @@ bool swift::isMacroSupported(MacroRole role, ASTContext &ctx) {
   switch (role) {
 #define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, FeatureName) \
   case MacroRole::Name: \
-    return ctx.LangOpts.hasFeature(FeatureName::CodeItemMacros);
+    return ctx.LangOpts.hasFeature(Feature::FeatureName);
 
 #define EXPERIMENTAL_FREESTANDING_MACRO_ROLE(Name, Description, FeatureName) \
   case MacroRole::Name: return ctx.LangOpts.hasFeature(Feature::FeatureName);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9102,6 +9102,24 @@ bool AbstractFunctionDecl::isSendable() const {
   return getAttrs().hasAttribute<SendableAttr>();
 }
 
+bool AbstractFunctionDecl::hasBody() const {
+  switch (getBodyKind()) {
+  case BodyKind::Deserialized:
+  case BodyKind::Parsed:
+  case BodyKind::SILSynthesize:
+  case BodyKind::Synthesize:
+  case BodyKind::Unparsed:
+    return true;
+
+  case BodyKind::None:
+    return false;
+
+  case BodyKind::TypeChecked:
+    return BodyAndFP.getBody() != nullptr;
+  }
+}
+
+
 BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {
   if ((getBodyKind() == BodyKind::Synthesize ||
        getBodyKind() == BodyKind::Unparsed) &&
@@ -10857,13 +10875,13 @@ void ParseAbstractFunctionBodyRequest::cacheResult(
   switch (afd->getBodyKind()) {
   case BodyKind::Deserialized:
   case BodyKind::SILSynthesize:
-  case BodyKind::None:
     // The body is always empty, so don't cache anything.
     assert(!value.getFingerprint().has_value() && value.getBody() == nullptr);
     return;
 
   case BodyKind::Parsed:
   case BodyKind::TypeChecked:
+  case BodyKind::None:
     afd->BodyAndFP = value;
     return;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11019,12 +11019,12 @@ StringRef swift::getMacroIntroducedDeclNameString(
 static MacroRoles freestandingMacroRoles =
   (MacroRoles()
 #define FREESTANDING_MACRO_ROLE(Name, Description) | MacroRole::Name
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
    );
 static MacroRoles attachedMacroRoles = 
   (MacroRoles()
-#define ATTACHED_MACRO_ROLE(Name, Description) | MacroRole::Name
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar) | MacroRole::Name
 #define FREESTANDING_MACRO_ROLE(Name, Description)
 #include "swift/Basic/MacroRoles.def"
    );
@@ -11506,7 +11506,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
   // Attached macros
 #define FREESTANDING_MACRO_ROLE(Name, Description)  \
   case GeneratedSourceInfo::Name##MacroExpansion:
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
   {
     auto node = ASTNode::getFromOpaqueValue(generatedSourceInfo->astNode);
@@ -11525,7 +11525,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
 
   // Attached macros
 #define FREESTANDING_MACRO_ROLE(Name, Description)
-#define ATTACHED_MACRO_ROLE(Name, Description)      \
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)      \
   case GeneratedSourceInfo::Name##MacroExpansion:
 #include "swift/Basic/MacroRoles.def"
   case GeneratedSourceInfo::PrettyPrinted:

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1540,7 +1540,6 @@ TypeCheckFunctionBodyRequest::getCachedResult() const {
   switch (afd->getBodyKind()) {
   case BodyKind::Deserialized:
   case BodyKind::SILSynthesize:
-  case BodyKind::None:
     // These cases don't have any body available.
     return nullptr;
 
@@ -1550,6 +1549,7 @@ TypeCheckFunctionBodyRequest::getCachedResult() const {
   case BodyKind::Synthesize:
   case BodyKind::Parsed:
   case BodyKind::Unparsed:
+  case BodyKind::None:
     return llvm::None;
   }
   llvm_unreachable("Unhandled BodyKind in switch");

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -412,11 +412,13 @@ extractTypePropertyInfo(VarDecl *propertyDecl) {
   }
 
   if (auto accessorDecl = propertyDecl->getAccessor(AccessorKind::Get)) {
-    auto node = accessorDecl->getTypecheckedBody()->getFirstElement();
-    if (auto *stmt = node.dyn_cast<Stmt *>()) {
-      if (stmt->getKind() == StmtKind::Return) {
-        return {propertyDecl,
-                extractCompileTimeValue(cast<ReturnStmt>(stmt)->getResult())};
+    if (auto body = accessorDecl->getTypecheckedBody()) {
+      auto node = body->getFirstElement();
+      if (auto *stmt = node.dyn_cast<Stmt *>()) {
+        if (stmt->getKind() == StmtKind::Return) {
+          return {propertyDecl,
+                  extractCompileTimeValue(cast<ReturnStmt>(stmt)->getResult())};
+        }
       }
     }
   }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4109,46 +4109,19 @@ NodePointer Demangler::demangleMacroExpansion() {
   bool isAttached;
   bool isFreestanding;
   switch (nextChar()) {
-  case 'a':
-    kind = Node::Kind::AccessorAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)    \
+  case MangledChar[0]:                                         \
+    kind = Node::Kind::Name##AttachedMacroExpansion;           \
+    isAttached = true;                                         \
+    isFreestanding = false;                                    \
     break;
-
-  case 'r':
-    kind = Node::Kind::MemberAttributeAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
-    break;
+#include "swift/Basic/MacroRoles.def"
 
   case 'f':
     kind = Node::Kind::FreestandingMacroExpansion;
     isAttached = false;
     isFreestanding = true;
-    break;
-
-  case 'm':
-    kind = Node::Kind::MemberAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
-    break;
-
-  case 'p':
-    kind = Node::Kind::PeerAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
-    break;
-
-  case 'c':
-    kind = Node::Kind::ConformanceAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
-    break;
-
-  case 'e':
-    kind = Node::Kind::ExtensionAttachedMacroExpansion;
-    isAttached = true;
-    isFreestanding = false;
     break;
 
   case 'u':

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1080,47 +1080,15 @@ ManglingError Remangler::mangleFreestandingMacroExpansion(
   return mangleChildNodes(node, depth + 1);
 }
 
-ManglingError Remangler::mangleAccessorAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMa";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)    \
+ManglingError Remangler::mangle##Name##AttachedMacroExpansion( \
+    Node *node, unsigned depth) {                              \
+  Buffer << "fM" MangledChar;                                  \
+  RETURN_IF_ERROR(mangleIndex(node, depth + 1));               \
+  return mangleChildNodes(node, depth + 1);                    \
 }
-
-ManglingError Remangler::mangleMemberAttributeAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMr";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
-
-ManglingError Remangler::mangleMemberAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMm";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
-
-ManglingError Remangler::manglePeerAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMp";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
-
-ManglingError Remangler::mangleConformanceAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMc";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
-
-ManglingError Remangler::mangleExtensionAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  Buffer << "fMe";
-  RETURN_IF_ERROR(mangleIndex(node, depth + 1));
-  return mangleChildNodes(node, depth + 1);
-}
+#include "swift/Basic/MacroRoles.def"
 
 ManglingError Remangler::mangleMacroExpansionUniqueName(
     Node *node, unsigned depth) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2930,59 +2930,17 @@ ManglingError Remangler::mangleFreestandingMacroExpansion(
   return mangleChildNode(node, 2, depth + 1);
 }
 
-ManglingError Remangler::mangleAccessorAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMa";
-  return mangleChildNode(node, 3, depth + 1);
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)    \
+ManglingError Remangler::mangle##Name##AttachedMacroExpansion( \
+    Node *node, unsigned depth) {                              \
+  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));        \
+  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));        \
+  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));        \
+  Buffer << "fM" MangledChar;                                  \
+  return mangleChildNode(node, 3, depth + 1);                  \
 }
-
-ManglingError Remangler::mangleMemberAttributeAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMr";
-  return mangleChildNode(node, 3, depth + 1);
-}
-
-ManglingError Remangler::mangleMemberAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMm";
-  return mangleChildNode(node, 3, depth + 1);
-}
-
-ManglingError Remangler::manglePeerAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMp";
-  return mangleChildNode(node, 3, depth + 1);
-}
-
-ManglingError Remangler::mangleConformanceAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMc";
-  return mangleChildNode(node, 3, depth + 1);
-}
-
-ManglingError Remangler::mangleExtensionAttachedMacroExpansion(
-    Node *node, unsigned depth) {
-  RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1));
-  Buffer << "fMe";
-  return mangleChildNode(node, 3, depth + 1);
-}
+#include "swift/Basic/MacroRoles.def"
 
 ManglingError Remangler::mangleMacroExpansionUniqueName(
     Node *node, unsigned depth) {

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -88,7 +88,7 @@ public:
     // Whitelist the kinds of decls to transform.
     // TODO: Expand the set of decls visited here.
     if (auto *FD = dyn_cast<AbstractFunctionDecl>(D))
-      return Action::VisitChildrenIf(FD->getBody());
+      return Action::VisitChildrenIf(FD->getTypecheckedBody());
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       return Action::VisitChildrenIf(TLCD->getBody());
     if (isa<NominalTypeDecl>(D))

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -336,7 +336,7 @@ public:
     if (D->isImplicit())
       return D;
     if (auto *FD = dyn_cast<FuncDecl>(D)) {
-      if (BraceStmt *B = FD->getBody()) {
+      if (BraceStmt *B = FD->getTypecheckedBody()) {
         const ParameterList *PL = FD->getParameters();
         BraceStmt *NB = transformBraceStmt(B, PL);
         // Since it would look strange going straight to the first line in a

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -308,7 +308,7 @@ public:
     if (D->isImplicit())
       return D;
     if (auto *FD = dyn_cast<FuncDecl>(D)) {
-      if (BraceStmt *B = FD->getBody()) {
+      if (BraceStmt *B = FD->getTypecheckedBody()) {
         const ParameterList *PL = FD->getParameters();
         TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Return);
         BraceStmt *NB = transformBraceStmt(B, PL);

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -570,7 +570,7 @@ bool swift::isInvalidAttachedMacro(MacroRole role,
                                    Decl *attachedTo) {
   switch (role) {
 #define FREESTANDING_MACRO_ROLE(Name, Description) case MacroRole::Name:
-#define ATTACHED_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)
 #include "swift/Basic/MacroRoles.def"
     llvm_unreachable("Invalid macro role for attached macro");
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2343,20 +2343,11 @@ getStableSelfAccessKind(swift::SelfAccessKind MM) {
 
 static uint8_t getRawStableMacroRole(swift::MacroRole context) {
   switch (context) {
-#define CASE(NAME) \
-  case swift::MacroRole::NAME: \
-    return static_cast<uint8_t>(serialization::MacroRole::NAME);
-  CASE(Expression)
-  CASE(Declaration)
-  CASE(Accessor)
-  CASE(MemberAttribute)
-  CASE(Member)
-  CASE(Peer)
-  CASE(Conformance)
-  CASE(CodeItem)
-  CASE(Extension)
+#define MACRO_ROLE(Name, Description) \
+  case swift::MacroRole::Name: \
+    return static_cast<uint8_t>(serialization::MacroRole::Name);
+#include "swift/Basic/MacroRoles.def"
   }
-#undef CASE
   llvm_unreachable("bad result declaration macro kind");
 }
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -580,9 +580,8 @@ class С_43383 {
 extension С_43383 {
     print("The room where it happened, the room where it happened")
     // expected-error @-1 {{expected 'func' keyword in instance method declaration}}
-    // expected-error @-2 {{expected '{' in body of function declaration}}
-    // expected-error @-3 {{invalid redeclaration of 'print()'}}
-    // expected-error @-4 {{expected parameter name followed by ':'}}
+    // expected-error @-2 {{invalid redeclaration of 'print()'}}
+    // expected-error @-3 {{expected parameter name followed by ':'}}
 }
 
 

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -223,7 +223,6 @@ extension X6 {
   var k: Int { return 0 } // expected-note{{previously declared here}}
   func k()
   // expected-error@-1{{invalid redeclaration of 'k()'}}
-  // expected-error@-2{{expected '{' in body of function declaration}}
 }
 
 // Subscripting


### PR DESCRIPTION
The "typechecked function body" request was defined to type-check a
function body that is known to be present, and not skipped, and would
assert these conditions, requiring its users to check whether a body
was expected. Often, this means that callers would use `getBody()`
instead, which retrieves the underlying value in whatever form it
happens to be, and assume it has been mutated appropriately.

Make the "typechecked function body" request, triggered by
`getTypecheckedBody()`, more resilient and central. A `NULL` result is
now acceptable, signifying that there is no body. Clients will need to
tolerate NULL results.

* When there is no body but should be one, produce an appropriate
error.
* When there shouldn't be a body but is, produce an appropriate error
* Handle skipping of function bodies here, rather than elsewhere.

Over time, we should move clients off of `getBody` and `hasBody`
entirely, and toward `getTypecheckedBody` or some yet-to-be-introduced
forms like `getBodyAsWritten` for the pre-typechecked body.