### PR TITLE
[region-isolation] Add support for async let

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -877,16 +877,19 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 
 // Warnings arising from the flow-sensitive checking of Sendability of
 // non-Sendable values
-WARNING(arg_region_transferred, none,
+WARNING(regionbasedisolation_selforargtransferred, none,
         "call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller", ())
-WARNING(transfer_yields_race, none,
-        "non-sendable value sent across isolation domains that could be concurrently accessed later in this function (%0 access site%select{|s}1 displayed%select{|, %3 more hidden}2)",
-        (unsigned, bool, bool, unsigned))
-WARNING(call_site_transfer_yields_race, none,
+WARNING(regionbasedisolation_transfer_yields_race_no_isolation, none,
+        "transferred value of non-Sendable type %0 that could race with later accesses",
+        (Type))
+WARNING(regionbasedisolation_transfer_yields_race_with_isolation, none,
         "passing argument of non-sendable type %0 from %1 context to %2 context at this call site could yield a race with accesses later in this function",
         (Type, ActorIsolation, ActorIsolation))
-NOTE(possible_racy_access_site, none,
+NOTE(regionbasedisolation_maybe_race, none,
      "access here could race", ())
+ERROR(regionbasedisolation_unknown_pattern, none,
+      "pattern that the region based isolation checker does not understand how to check. Please file a bug",
+      ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/SIL/OperandBits.h
+++ b/include/swift/SIL/OperandBits.h
@@ -1,0 +1,72 @@
+//===--- OperandBits.h ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_OPERANDBITS_H
+#define SWIFT_SIL_OPERANDBITS_H
+
+#include "swift/SIL/SILBitfield.h"
+#include "swift/SIL/SILValue.h"
+
+namespace swift {
+
+class OperandBitfield : public SILBitfield<OperandBitfield, Operand> {
+  template <class, class>
+  friend class SILBitfield;
+
+  OperandBitfield *insertInto(SILFunction *function) {
+    assert(function && "OperandBitField constructed with a null function");
+    OperandBitfield *oldParent = function->newestAliveOperandBitfield;
+    function->newestAliveOperandBitfield = this;
+    return oldParent;
+  }
+
+public:
+  OperandBitfield(SILFunction *function, int size)
+      : SILBitfield(function, size, insertInto(function)) {}
+
+  ~OperandBitfield() {
+    assert(function->newestAliveOperandBitfield == this &&
+           "BasicBlockBitfield destructed too early");
+    function->newestAliveOperandBitfield = parent;
+  }
+};
+
+/// A set of Operands.
+///
+/// For details see OperandBitfield.
+class OperandSet {
+  OperandBitfield bit;
+
+public:
+  OperandSet(SILFunction *function) : bit(function, 1) {}
+
+  SILFunction *getFunction() const { return bit.getFunction(); }
+
+  bool contains(Operand *node) const { return (bool)bit.get(node); }
+
+  /// Returns true if \p node was not contained in the set before inserting.
+  bool insert(Operand *node) {
+    bool wasContained = contains(node);
+    if (!wasContained) {
+      bit.set(node, 1);
+    }
+    return !wasContained;
+  }
+
+  void erase(Operand *node) { bit.set(node, 0); }
+};
+
+using OperandSetWithSize = KnownSizeSet<OperandSet>;
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/OperandDatastructures.h
+++ b/include/swift/SIL/OperandDatastructures.h
@@ -1,0 +1,145 @@
+//===--- OperanDatastructures.h -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines efficient data structures for working with Operands.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_OPERANDDATASTRUCTURES_H
+#define SWIFT_SIL_OPERANDDATASTRUCTURES_H
+
+#include "swift/SIL/OperandBits.h"
+#include "swift/SIL/StackList.h"
+
+namespace swift {
+
+/// An implementation of `llvm::SetVector<Operand *,
+///                                       StackList<Operand *>,
+///                                       OperandSet>`.
+///
+/// Unfortunately it's not possible to use `llvm::SetVector` directly because
+/// the OperandSet and StackList constructors needs a `SILFunction`
+/// argument.
+///
+/// Note: This class does not provide a `remove` method intentionally, because
+/// it would have a O(n) complexity.
+class OperandSetVector {
+  StackList<Operand *> vector;
+  OperandSet set;
+
+public:
+  using iterator = typename StackList<Operand *>::iterator;
+
+  OperandSetVector(SILFunction *function) : vector(function), set(function) {}
+
+  iterator begin() const { return vector.begin(); }
+  iterator end() const { return vector.end(); }
+
+  llvm::iterator_range<iterator> getRange() const {
+    return llvm::make_range(begin(), end());
+  }
+
+  bool empty() const { return vector.empty(); }
+
+  bool contains(Operand *instruction) const {
+    return set.contains(instruction);
+  }
+
+  /// Returns true if \p instruction was not contained in the set before
+  /// inserting.
+  bool insert(Operand *instruction) {
+    if (set.insert(instruction)) {
+      vector.push_back(instruction);
+      return true;
+    }
+    return false;
+  }
+};
+
+/// A utility for processing instructions in a worklist.
+///
+/// It is basically a combination of an instruction vector and an instruction
+/// set. It can be used for typical worklist-processing algorithms.
+class OperandWorklist {
+  StackList<Operand *> worklist;
+  OperandSet visited;
+
+public:
+  /// Construct an empty worklist.
+  OperandWorklist(SILFunction *function)
+      : worklist(function), visited(function) {}
+
+  /// Initialize the worklist with \p initialOperand.
+  OperandWorklist(Operand *initialOperand)
+      : OperandWorklist(initialOperand->getUser()->getFunction()) {
+    push(initialOperand);
+  }
+
+  /// Pops the last added element from the worklist or returns null, if the
+  /// worklist is empty.
+  Operand *pop() {
+    if (worklist.empty())
+      return nullptr;
+    return worklist.pop_back_val();
+  }
+
+  /// Pushes \p operand onto the worklist if \p operand has never been
+  /// push before.
+  bool pushIfNotVisited(Operand *operand) {
+    if (visited.insert(operand)) {
+      worklist.push_back(operand);
+      return true;
+    }
+    return false;
+  }
+
+  /// Pushes the operands of all uses of \p instruction onto the worklist if the
+  /// operands have never been pushed before. Returns \p true if we inserted
+  /// /any/ values.
+  ///
+  /// This is a bulk convenience API.
+  bool pushResultOperandsIfNotVisited(SILInstruction *inst) {
+    bool insertedOperand = false;
+    for (auto result : inst->getResults()) {
+      for (auto *use : result->getUses()) {
+        insertedOperand |= pushIfNotVisited(use);
+      }
+    }
+    return insertedOperand;
+  }
+
+  /// Like `pushIfNotVisited`, but requires that \p operand has never been
+  /// on the worklist before.
+  void push(Operand *operand) {
+    assert(!visited.contains(operand));
+    visited.insert(operand);
+    worklist.push_back(operand);
+  }
+
+  /// Like `pop`, but marks the returned operand as "unvisited". This means,
+  /// that the operand can be pushed onto the worklist again.
+  Operand *popAndForget() {
+    if (worklist.empty())
+      return nullptr;
+    Operand *operand = worklist.pop_back_val();
+    visited.erase(operand);
+    return operand;
+  }
+
+  /// Returns true if \p operand was visited, i.e. has been added to the
+  /// worklist.
+  bool isVisited(Operand *operand) const { return visited.contains(operand); }
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -38,6 +38,7 @@ class SILFunctionBuilder;
 class SILProfiler;
 class BasicBlockBitfield;
 class NodeBitfield;
+class OperandBitfield;
 class SILPassManager;
 
 namespace Lowering {
@@ -203,6 +204,7 @@ private:
   template <class, class> friend class SILBitfield;
   friend class BasicBlockBitfield;
   friend class NodeBitfield;
+  friend class OperandBitfield;
 
   /// Module - The SIL module that the function belongs to.
   SILModule &Module;
@@ -278,9 +280,12 @@ private:
   /// The head of a single-linked list of currently alive NodeBitfield.
   NodeBitfield *newestAliveNodeBitfield = nullptr;
 
+  /// The head of a single-linked list of currently alive OperandBitfields.
+  OperandBitfield *newestAliveOperandBitfield = nullptr;
+
   /// A monotonically increasing ID which is incremented whenever a
-  /// BasicBlockBitfield or NodeBitfield is constructed.
-  /// For details see SILBitfield::bitfieldID;
+  /// BasicBlockBitfield, NodeBitfield, or OperandBitfield is constructed.  For
+  /// details see SILBitfield::bitfieldID;
   int64_t currentBitfieldID = 1;
 
   /// Unique identifier for vector indexing and deterministic sorting.

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1019,26 +1019,38 @@ ValueOwnershipKind::getForwardingOperandOwnership(bool allowUnowned) const {
 /// A formal SIL reference to a value, suitable for use as a stored
 /// operand.
 class Operand {
-  /// The value used as this operand.
-  SILValue TheValue;
+  template <class, class> friend class SILBitfield;
 
-  /// The next operand in the use-chain.  Note that the chain holds
-  /// every use of the current ValueBase, not just those of the
-  /// designated result.
-  Operand *NextUse = nullptr;
+  /// The value used as this operand combined with three bits we use for
+  /// `customBits`.
+  llvm::PointerIntPair<SILValue, 3> TheValueAndThreeBits = {SILValue(), 0};
+
+  /// The next operand in the use-chain. Note that the chain holds every use of
+  /// the current ValueBase, not just those of the designated result.
+  ///
+  /// We use 3 bits of the pointer for customBits.
+  llvm::PointerIntPair<Operand *, 3> NextUseAndThreeBits = {nullptr, 0};
 
   /// A back-pointer in the use-chain, required for fast patching
   /// of use-chains.
-  Operand **Back = nullptr;
+  ///
+  /// We use 2 bits of the pointer for customBits.
+  llvm::PointerIntPair<Operand **, 3> BackAndThreeBits = {nullptr, 0};
 
   /// The owner of this operand.
   /// FIXME: this could be space-compressed.
   SILInstruction *Owner;
 
+  /// Used by `OperandBitfield`
+  enum { numCustomBits = 8 };
+
+  /// Used by `OperandBitfield`
+  int64_t lastInitializedBitfieldID = 0;
+
 public:
   Operand(SILInstruction *owner) : Owner(owner) {}
   Operand(SILInstruction *owner, SILValue theValue)
-      : TheValue(theValue), Owner(owner) {
+      : TheValueAndThreeBits(theValue), Owner(owner) {
     insertIntoCurrent();
   }
 
@@ -1050,14 +1062,14 @@ public:
   Operand &operator=(Operand &&) = default;
 
   /// Return the current value being used by this operand.
-  SILValue get() const { return TheValue; }
+  SILValue get() const { return TheValueAndThreeBits.getPointer(); }
 
   /// Set the current value being used by this operand.
   void set(SILValue newValue) {
     // It's probably not worth optimizing for the case of switching
     // operands on a single value.
     removeFromCurrent();
-    TheValue = newValue;
+    TheValueAndThreeBits.setPointer(newValue);
     insertIntoCurrent();
   }
 
@@ -1071,9 +1083,9 @@ public:
   /// Remove this use of the operand.
   void drop() {
     removeFromCurrent();
-    TheValue = SILValue();
-    NextUse = nullptr;
-    Back = nullptr;
+    TheValueAndThreeBits = {SILValue(), 0};
+    NextUseAndThreeBits = {nullptr, 0};
+    BackAndThreeBits = {nullptr, 0};
     Owner = nullptr;
   }
 
@@ -1085,7 +1097,7 @@ public:
   SILInstruction *getUser() { return Owner; }
   const SILInstruction *getUser() const { return Owner; }
 
-  Operand *getNextUse() const { return NextUse; }
+  Operand *getNextUse() const { return NextUseAndThreeBits.getPointer(); }
 
   /// Return true if this operand is a type dependent operand.
   ///
@@ -1135,25 +1147,62 @@ public:
   SILBasicBlock *getParentBlock() const;
   SILFunction *getParentFunction() const;
 
+  unsigned getCustomBits() const {
+    unsigned bits = 0;
+    bits |= TheValueAndThreeBits.getInt();
+    bits |= NextUseAndThreeBits.getInt() << 3;
+    bits |= BackAndThreeBits.getInt() << 2;
+    return bits;
+  }
+
+  void setCustomBits(unsigned bits) {
+    assert(bits < 256 && "Can only store a byte?!");
+    TheValueAndThreeBits.setInt(bits & 0x7);
+    NextUseAndThreeBits.setInt((bits >> 3) & 0x7);
+    BackAndThreeBits.setInt((bits >> 6) & 0x3);
+  }
+
+  // Called when transferring basic blocks from one function to another.
+  void resetBitfields() {
+    lastInitializedBitfieldID = 0;
+  }
+
+  void markAsDeleted() {
+    lastInitializedBitfieldID = -1;
+  }
+
+  bool isMarkedAsDeleted() const { return lastInitializedBitfieldID < 0; }
+
+  SILFunction *getFunction() const;
+
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP;
 
 private:
   void removeFromCurrent() {
-    if (!Back)
+    auto *back = getBack();
+    if (!back)
       return;
-    *Back = NextUse;
-    if (NextUse)
-      NextUse->Back = Back;
+    auto *nextUse = getNextUse();
+    *back = nextUse;
+    if (nextUse)
+      nextUse->setBack(back);
   }
 
   void insertIntoCurrent() {
-    Back = &TheValue->FirstUse;
-    NextUse = TheValue->FirstUse;
-    if (NextUse)
-      NextUse->Back = &NextUse;
-    TheValue->FirstUse = this;
+    auto **firstUse = &get()->FirstUse;
+    setBack(firstUse);
+    setNextUse(*firstUse);
+    if (auto *nextUse = getNextUse())
+      nextUse->setBack(NextUseAndThreeBits.getAddrOfPointer());
+    get()->FirstUse = this;
   }
+
+  void setNextUse(Operand *op) { NextUseAndThreeBits.setPointer(op); }
+
+  Operand **getBack() const { return BackAndThreeBits.getPointer(); }
+
+  void setBack(Operand **newValue) { BackAndThreeBits.setPointer(newValue); }
 
   friend class ValueBase;
   friend class ValueBaseUseIterator;
@@ -1196,7 +1245,7 @@ public:
 
   ValueBaseUseIterator &operator++() {
     assert(Cur && "incrementing past end()!");
-    Cur = Cur->NextUse;
+    Cur = Cur->getNextUse();
     return *this;
   }
 
@@ -1231,7 +1280,7 @@ public:
   ConsumingUseIterator &operator++() {
     assert(Cur && "incrementing past end()!");
     assert(Cur->isLifetimeEnding());
-    while ((Cur = Cur->NextUse)) {
+    while ((Cur = Cur->getNextUse())) {
       if (Cur->isLifetimeEnding())
         break;
     }
@@ -1249,7 +1298,7 @@ inline ValueBase::consuming_use_iterator
 ValueBase::consuming_use_begin() const {
   auto cur = FirstUse;
   while (cur && !cur->isLifetimeEnding()) {
-    cur = cur->NextUse;
+    cur = cur->getNextUse();
   }
   return ValueBase::consuming_use_iterator(cur);
 }
@@ -1264,7 +1313,7 @@ public:
   NonConsumingUseIterator &operator++() {
     assert(Cur && "incrementing past end()!");
     assert(!Cur->isLifetimeEnding());
-    while ((Cur = Cur->NextUse)) {
+    while ((Cur = Cur->getNextUse())) {
       if (!Cur->isLifetimeEnding())
         break;
     }
@@ -1282,7 +1331,7 @@ inline ValueBase::non_consuming_use_iterator
 ValueBase::non_consuming_use_begin() const {
   auto cur = FirstUse;
   while (cur && cur->isLifetimeEnding()) {
-    cur = cur->NextUse;
+    cur = cur->getNextUse();
   }
   return ValueBase::non_consuming_use_iterator(cur);
 }
@@ -1297,7 +1346,7 @@ public:
   explicit TypeDependentUseIterator(Operand *cur) : ValueBaseUseIterator(cur) {}
   TypeDependentUseIterator &operator++() {
     assert(Cur && "incrementing past end()!");
-    while ((Cur = Cur->NextUse)) {
+    while ((Cur = Cur->getNextUse())) {
       if (Cur->isTypeDependent())
         break;
     }
@@ -1315,7 +1364,7 @@ inline ValueBase::typedependent_use_iterator
 ValueBase::typedependent_use_begin() const {
   auto cur = FirstUse;
   while (cur && !cur->isTypeDependent()) {
-    cur = cur->NextUse;
+    cur = cur->getNextUse();
   }
   return ValueBase::typedependent_use_iterator(cur);
 }
@@ -1332,7 +1381,7 @@ public:
   NonTypeDependentUseIterator &operator++() {
     assert(Cur && "incrementing past end()!");
     assert(!Cur->isTypeDependent());
-    while ((Cur = Cur->NextUse)) {
+    while ((Cur = Cur->getNextUse())) {
       if (!Cur->isTypeDependent())
         break;
     }
@@ -1350,7 +1399,7 @@ inline ValueBase::non_typedependent_use_iterator
 ValueBase::non_typedependent_use_begin() const {
   auto cur = FirstUse;
   while (cur && cur->isTypeDependent()) {
-    cur = cur->NextUse;
+    cur = cur->getNextUse();
   }
   return ValueBase::non_typedependent_use_iterator(cur);
 }

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -248,6 +248,8 @@ SILFunction::~SILFunction() {
          "Not all BasicBlockBitfields deleted at function destruction");
   assert(!newestAliveNodeBitfield &&
          "Not all NodeBitfields deleted at function destruction");
+  assert(!newestAliveOperandBitfield &&
+         "Not all OperandBitfields deleted at function destruction");
 
   if (destroyFunction)
     destroyFunction({this}, &libswiftSpecificData, sizeof(libswiftSpecificData));

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -474,6 +474,10 @@ void Operand::print(llvm::raw_ostream &os) const {
      << "Is Type Dependent: " << (isTypeDependent() ? "yes" : "no") << '\n';
 }
 
+SILFunction *Operand::getFunction() const {
+  return getUser()->getFunction();
+}
+
 //===----------------------------------------------------------------------===//
 //                             OperandConstraint
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Type.h"
@@ -19,6 +20,7 @@
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/NodeDatastructures.h"
+#include "swift/SIL/OperandDatastructures.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBuilder.h"
@@ -241,6 +243,55 @@ static bool isProjectedFromAggregate(SILValue value) {
   return visitor.isMerge;
 }
 
+static PartialApplyInst *findAsyncLetPartialApplyFromStart(BuiltinInst *bi) {
+  // If our operand is Sendable then we want to return nullptr. We only want to
+  // return a value if we are not
+  SILValue value = bi->getOperand(1);
+  auto fType = value->getType().castTo<SILFunctionType>();
+  if (fType->isSendable())
+    return nullptr;
+
+  SILValue temp = value;
+  while (true) {
+    if (isa<ConvertEscapeToNoEscapeInst>(temp) ||
+        isa<ConvertFunctionInst>(temp)) {
+      temp = cast<SingleValueInstruction>(temp)->getOperand(0);
+    }
+    if (temp == value)
+      break;
+    value = temp;
+  }
+
+  return cast<PartialApplyInst>(value);
+}
+
+static PartialApplyInst *findAsyncLetPartialApplyFromGet(ApplyInst *ai) {
+  auto *bi = cast<BuiltinInst>(FullApplySite(ai).getArgument(0));
+  assert(*bi->getBuiltinKind() ==
+         BuiltinValueKind::StartAsyncLetWithLocalBuffer);
+  return findAsyncLetPartialApplyFromStart(bi);
+}
+
+static bool isAsyncLetBeginPartialApply(PartialApplyInst *pai) {
+  auto *cfi = pai->getSingleUserOfType<ConvertFunctionInst>();
+  if (!cfi)
+    return false;
+
+  auto *cvt = cfi->getSingleUserOfType<ConvertEscapeToNoEscapeInst>();
+  if (!cvt)
+    return false;
+
+  auto *bi = cvt->getSingleUserOfType<BuiltinInst>();
+  if (!bi)
+    return false;
+
+  auto kind = bi->getBuiltinKind();
+  if (!kind)
+    return false;
+
+  return *kind == BuiltinValueKind::StartAsyncLetWithLocalBuffer;
+}
+
 //===----------------------------------------------------------------------===//
 //                             MARK: Diagnostics
 //===----------------------------------------------------------------------===//
@@ -282,34 +333,51 @@ static InFlightDiagnostic diagnose(const SILInstruction *inst, Diag<T...> diag,
 namespace {
 
 struct InferredCallerArgumentTypeInfo {
-  Type inferredType;
-  ApplyExpr *sourceApply;
-  ApplyIsolationCrossing isolationCrossing;
-  Expr *foundExpr;
+  Type baseInferredType;
+  SmallVector<std::pair<Type, std::optional<ApplyIsolationCrossing>>, 4>
+      applyUses;
 
-  InferredCallerArgumentTypeInfo(const Operand *op);
+  void init(const Operand *op);
+
+  void initForApply(const Operand *op, ApplyExpr *expr);
+  void initForAutoclosure(const Operand *op, AutoClosureExpr *expr);
+
+  Expr *getFoundExprForSelf(ApplyExpr *sourceApply) {
+    if (auto callExpr = dyn_cast<CallExpr>(sourceApply))
+      if (auto calledExpr =
+              dyn_cast<DotSyntaxCallExpr>(callExpr->getDirectCallee()))
+        return calledExpr->getBase();
+    return nullptr;
+  }
+
+  Expr *getFoundExprForParam(ApplyExpr *sourceApply, unsigned argNum) {
+    auto *expr = sourceApply->getArgs()->getExpr(argNum);
+
+    // If we have an erasure expression, lets use the original type. We do
+    // this since we are not saying the specific parameter that is the
+    // issue and we are using the type to explain it to the user.
+    if (auto *erasureExpr = dyn_cast<ErasureExpr>(expr))
+      expr = erasureExpr->getSubExpr();
+
+    return expr;
+  }
 };
 
 } // namespace
 
-InferredCallerArgumentTypeInfo::InferredCallerArgumentTypeInfo(
-    const Operand *op)
-    : inferredType(op->get()->getType().getASTType()), sourceApply(nullptr),
-      isolationCrossing(), foundExpr(nullptr) {
-  sourceApply = op->getUser()->getLoc().getAsASTNode<ApplyExpr>();
-  assert(sourceApply);
-  isolationCrossing = *sourceApply->getIsolationCrossing();
+void InferredCallerArgumentTypeInfo::initForApply(const Operand *op,
+                                                  ApplyExpr *sourceApply) {
+  auto isolationCrossing = *sourceApply->getIsolationCrossing();
 
   // Grab out full apply site and see if we can find a better expr.
   SILInstruction *i = const_cast<SILInstruction *>(op->getUser());
   auto fai = FullApplySite::isa(i);
 
+  Expr *foundExpr = nullptr;
+
   // If we have self, then infer it.
   if (fai.hasSelfArgument() && op == &fai.getSelfArgumentOperand()) {
-    if (auto callExpr = dyn_cast<CallExpr>(sourceApply))
-      if (auto calledExpr =
-              dyn_cast<DotSyntaxCallExpr>(callExpr->getDirectCallee()))
-        foundExpr = calledExpr->getBase();
+    foundExpr = getFoundExprForSelf(sourceApply);
   } else {
     // Otherwise, try to infer using the operand of the ApplyExpr.
     unsigned argNum = [&]() -> unsigned {
@@ -317,20 +385,112 @@ InferredCallerArgumentTypeInfo::InferredCallerArgumentTypeInfo(
         return op->getOperandNumber();
       return fai.getAppliedArgIndex(*op);
     }();
-    if (argNum < sourceApply->getArgs()->size()) {
-      auto *expr = sourceApply->getArgs()->getExpr(argNum);
+    assert(argNum < sourceApply->getArgs()->size());
+    foundExpr = getFoundExprForParam(sourceApply, argNum);
+  }
 
-      // If we have an erasure expression, lets use the original type. We do
-      // this since we are not saying the specific parameter that is the
-      // issue and we are using the type to explain it to the user.
-      if (auto *erasureExpr = dyn_cast<ErasureExpr>(expr))
-        expr = erasureExpr->getSubExpr();
-      foundExpr = expr;
+  auto inferredArgType =
+      foundExpr ? foundExpr->findOriginalType() : baseInferredType;
+  applyUses.emplace_back(inferredArgType, isolationCrossing);
+}
+
+namespace {
+
+struct Walker : ASTWalker {
+  InferredCallerArgumentTypeInfo &foundTypeInfo;
+  ValueDecl *targetDecl;
+  SmallPtrSet<Expr *, 8> visitedCallExprDeclRefExprs;
+
+  Walker(InferredCallerArgumentTypeInfo &foundTypeInfo, ValueDecl *targetDecl)
+      : foundTypeInfo(foundTypeInfo), targetDecl(targetDecl) {}
+
+  Expr *lookThroughExpr(Expr *expr) {
+    while (true) {
+      if (auto *memberRefExpr = dyn_cast<MemberRefExpr>(expr)) {
+        expr = memberRefExpr->getBase();
+        continue;
+      }
+
+      if (auto *cvt = dyn_cast<ImplicitConversionExpr>(expr)) {
+        expr = cvt->getSubExpr();
+        continue;
+      }
+
+      if (auto *e = dyn_cast<ForceValueExpr>(expr)) {
+        expr = e->getSubExpr();
+        continue;
+      }
+
+      if (auto *t = dyn_cast<TupleElementExpr>(expr)) {
+        expr = t->getBase();
+        continue;
+      }
+
+      return expr;
     }
   }
 
-  if (foundExpr)
-    inferredType = foundExpr->findOriginalType();
+  PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
+    if (auto *declRef = dyn_cast<DeclRefExpr>(expr)) {
+      // If this decl ref expr was not visited as part of a callExpr, add it as
+      // something without isolation crossing.
+      if (!visitedCallExprDeclRefExprs.count(declRef)) {
+        if (declRef->getDecl() == targetDecl) {
+          visitedCallExprDeclRefExprs.insert(declRef);
+          foundTypeInfo.applyUses.emplace_back(declRef->findOriginalType(),
+                                               std::nullopt);
+          return Action::Continue(expr);
+        }
+      }
+    }
+
+    if (auto *callExpr = dyn_cast<CallExpr>(expr)) {
+      if (auto isolationCrossing = callExpr->getIsolationCrossing()) {
+        // Search callExpr's arguments to see if we have our targetDecl.
+        auto *argList = callExpr->getArgs();
+        for (auto pair : llvm::enumerate(argList->getArgExprs())) {
+          auto *arg = lookThroughExpr(pair.value());
+          if (auto *declRef = dyn_cast<DeclRefExpr>(arg)) {
+            if (declRef->getDecl() == targetDecl) {
+              // Found our target!
+              visitedCallExprDeclRefExprs.insert(declRef);
+              foundTypeInfo.applyUses.emplace_back(declRef->findOriginalType(),
+                                                   isolationCrossing);
+              return Action::Continue(expr);
+            }
+          }
+        }
+      }
+    }
+
+    return Action::Continue(expr);
+  }
+};
+
+} // namespace
+
+void InferredCallerArgumentTypeInfo::init(const Operand *op) {
+  baseInferredType = op->get()->getType().getASTType();
+
+  auto loc = op->getUser()->getLoc();
+  if (auto *sourceApply = loc.getAsASTNode<ApplyExpr>()) {
+    initForApply(op, sourceApply);
+  } else {
+    auto *autoClosureExpr = loc.getAsASTNode<AutoClosureExpr>();
+    if (!autoClosureExpr) {
+      llvm::report_fatal_error("Unknown node");
+    }
+
+    SILInstruction *i = const_cast<SILInstruction *>(op->getUser());
+    auto pai = ApplySite::isa(i);
+    unsigned captureIndex = pai.getAppliedArgIndex(*op);
+
+    auto captureInfo =
+        autoClosureExpr->getCaptureInfo().getCaptures()[captureIndex];
+    auto *captureDecl = captureInfo.getDecl();
+    Walker walker(*this, captureDecl);
+    autoClosureExpr->walk(walker);
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -509,6 +669,15 @@ struct PartitionOpBuilder {
         PartitionOp::Transfer(lookupValueID(representative), op));
   }
 
+  void addUndoTransfer(SILValue representative,
+                       SILInstruction *untransferringInst) {
+    assert(valueHasID(representative) &&
+           "transferred value should already have been encountered");
+
+    currentInstPartitionOps.emplace_back(PartitionOp::UndoTransfer(
+        lookupValueID(representative), untransferringInst));
+  }
+
   void addMerge(SILValue fst, SILValue snd) {
     assert(valueHasID(fst, /*dumpIfHasNoID=*/true) &&
            valueHasID(snd, /*dumpIfHasNoID=*/true) &&
@@ -655,13 +824,17 @@ class PartitionOpTranslator {
     return true;
   }
 
-  void initCapturedUniquelyIdentifiedValues() {
-    LLVM_DEBUG(llvm::dbgs()
-               << ">>> Begin Captured Uniquely Identified addresses for "
-               << function->getName() << ":\n");
+  void gatherFlowInsensitiveInformationBeforeDataflow() {
+    LLVM_DEBUG(llvm::dbgs() << ">>> Performing pre-dataflow scan to gather "
+                               "flow insensitive information "
+                            << function->getName() << ":\n");
 
     for (auto &block : *function) {
       for (auto &inst : block) {
+        // See if this instruction is a partial apply whose non-sendable address
+        // operands we need to mark as captured_uniquely identified. Importantly
+        // this does not affect the result of the partial apply so there isn't
+        // any problems with the builtin section earlier.
         if (auto *pai = dyn_cast<PartialApplyInst>(&inst)) {
           // If we find an address or a box of a non-Sendable type that is
           // passed to a partial_apply, mark the value's representative as being
@@ -693,7 +866,7 @@ public:
   PartitionOpTranslator(SILFunction *function)
       : function(function), functionArgPartition(), builder() {
     builder.translator = this;
-    initCapturedUniquelyIdentifiedValues();
+    gatherFlowInsensitiveInformationBeforeDataflow();
 
     LLVM_DEBUG(llvm::dbgs() << "Initializing Function Args:\n");
     auto functionArguments = function->getArguments();
@@ -703,20 +876,42 @@ public:
       return;
     }
 
-    llvm::SmallVector<Element, 8> nonSendableIndices;
+    llvm::SmallVector<Element, 8> nonSendableJoinedIndices;
+    llvm::SmallVector<Element, 8> nonSendableSeparateIndices;
     for (SILArgument *arg : functionArguments) {
       if (auto state = tryToTrackValue(arg)) {
-        // If we have an arg that is an actor, we allow for it to be
-        // transfer... value ids derived from it though cannot be transferred.
         LLVM_DEBUG(llvm::dbgs() << "    %%" << state->getID() << ": ");
-        neverTransferredValueIDs.push_back(state->getID());
-        nonSendableIndices.push_back(state->getID());
+
+        // If we have a function argument that is closure captured by a Sendable
+        // closure, allow for the argument to be transferred.
+        //
+        // DISCUSSION: The reason that we do this is that in the case of us
+        // having an actual Sendable closure there are two cases we can see:
+        //
+        // 1. If we have an actual Sendable closure, the AST will emit an
+        // earlier error saying that we are capturing a non-Sendable value in a
+        // Sendable closure. So we want to squelch the error that we would emit
+        // otherwise. This only occurs when we are not in swift-6 mode since in
+        // swift-6 mode we will error on the earlier error... but in the case of
+        // us not being in swift 6 mode lets not emit extra errors.
+        //
+        // 2. If we have an async-let based Sendable closure, we want to allow
+        // for the value to be transferred and not emit an error.
+        if (!cast<SILFunctionArgument>(arg)->isClosureCapture() ||
+            !function->getLoweredFunctionType()->isSendable()) {
+          neverTransferredValueIDs.push_back(state->getID());
+          nonSendableJoinedIndices.push_back(state->getID());
+        } else {
+          nonSendableSeparateIndices.push_back(state->getID());
+        }
         LLVM_DEBUG(llvm::dbgs() << *arg);
       }
     }
 
-    // All non actor values are in the same partition.
-    functionArgPartition = Partition::singleRegion(nonSendableIndices);
+    functionArgPartition = Partition::singleRegion(nonSendableJoinedIndices);
+    for (Element elt : nonSendableSeparateIndices) {
+      functionArgPartition->addElement(elt);
+    }
   }
 
   std::optional<TrackableValue> getValueForId(TrackableValueID id) const {
@@ -885,46 +1080,145 @@ public:
     }
   }
 
-  void translateSILApply(SILInstruction *applyInst) {
+  void translateAsyncLetStart(BuiltinInst *bi) {
+    // Just track the result of the builtin inst as an assign fresh. We do this
+    // so we properly track the partial_apply get. We already transferred the
+    // parameters.
+    builder.addAssignFresh(bi);
+  }
+
+  void translateAsyncLetGet(ApplyInst *ai) {
+    auto *pai = findAsyncLetPartialApplyFromGet(ai);
+
+    // We should always be able to derive a partial_apply since we pattern
+    // matched against the actual function call to swift_asyncLet_get in our
+    // caller.
+    assert(pai && "AsyncLet Get should always have a derivable partial_apply");
+
+    ApplySite applySite(pai);
+
+    // For each of our partial apply operands...
+    for (auto pair : llvm::enumerate(applySite.getArgumentOperands())) {
+      Operand &op = pair.value();
+
+      // If we are tracking the value...
+      if (auto trackedArgValue = tryToTrackValue(op.get())) {
+
+        // Gather the isolation info from the AST for this operand...
+        InferredCallerArgumentTypeInfo typeInfo;
+        typeInfo.init(&op);
+
+        // Then see if /any/ of our uses are passed to over a isolation boundary
+        // that is actor isolated... if we find one continue so we do not undo
+        // the transfer for that element.
+        if (llvm::any_of(
+                typeInfo.applyUses,
+                [](const std::pair<Type, std::optional<ApplyIsolationCrossing>>
+                       &data) {
+                  // If we do not have an apply isolation crossing, we just use
+                  // undefined crossing since that is considered nonisolated.
+                  ApplyIsolationCrossing crossing;
+                  return data.second.value_or(crossing)
+                      .CalleeIsolation.isActorIsolated();
+                }))
+          continue;
+
+        builder.addUndoTransfer(trackedArgValue->getRepresentative(), ai);
+      }
+    }
+  }
+
+  void translateSILPartialApplyAsyncLetBegin(PartialApplyInst *pai) {
+    // Grab our partial apply and transfer all of its non-sendable
+    // parameters. We do not merge the parameters since each individual capture
+    // of the async let at the program level is viewed as still being in
+    // separate regions. Otherwise, we would need to error on the following
+    // code:
+    //
+    // let x = NonSendable(), x2 = NonSendable()
+    // async let y = transferToActor(x) + transferToNonIsolated(x2)
+    // _ = await y
+    // useValue(x2)
+    for (auto &op : ApplySite(pai).getArgumentOperands()) {
+      if (auto trackedArgValue = tryToTrackValue(op.get())) {
+        builder.addRequire(trackedArgValue->getRepresentative());
+        builder.addTransfer(trackedArgValue->getRepresentative(), &op);
+      }
+    }
+  }
+
+  void translateSILPartialApply(PartialApplyInst *pai) {
+    assert(!isIsolationBoundaryCrossingApply(pai));
+
+    // First check if our partial_apply is fed into an async let begin. If so,
+    // handle it especially.
+    if (isAsyncLetBeginPartialApply(pai)) {
+      return translateSILPartialApplyAsyncLetBegin(pai);
+    }
+
+    SILMultiAssignOptions options;
+    for (auto arg : pai->getOperandValues()) {
+      if (auto value = tryToTrackValue(arg)) {
+        if (value->isActorDerived()) {
+          options |= SILMultiAssignFlags::PropagatesActorSelf;
+        }
+      } else {
+        // NOTE: One may think that only sendable things can enter
+        // here... but we treat things like function_ref/class_method which
+        // are non-Sendable as sendable for our purposes.
+        if (arg->getType().isActor()) {
+          options |= SILMultiAssignFlags::PropagatesActorSelf;
+        }
+      }
+    }
+
+    SmallVector<SILValue, 8> applyResults;
+    getApplyResults(pai, applyResults);
+    translateSILMultiAssign(applyResults, pai->getOperandValues(), options);
+  }
+
+  void translateSILApply(SILInstruction *inst) {
+    if (auto *bi = dyn_cast<BuiltinInst>(inst)) {
+      if (auto kind = bi->getBuiltinKind()) {
+        if (kind == BuiltinValueKind::StartAsyncLetWithLocalBuffer) {
+          return translateAsyncLetStart(bi);
+        }
+      }
+    }
+
+    if (auto fas = FullApplySite::isa(inst)) {
+      if (auto *f = fas.getCalleeFunction()) {
+        // Check against the actual SILFunction.
+        if (f->getName() == "swift_asyncLet_get") {
+          return translateAsyncLetGet(cast<ApplyInst>(*fas));
+        }
+      }
+    }
+
     // If this apply does not cross isolation domains, it has normal
     // non-transferring multi-assignment semantics
-    if (!isIsolationBoundaryCrossingApply(applyInst)) {
+    if (!isIsolationBoundaryCrossingApply(inst)) {
       SILMultiAssignOptions options;
-      if (auto fas = FullApplySite::isa(applyInst)) {
+      if (auto fas = FullApplySite::isa(inst)) {
         if (fas.hasSelfArgument()) {
           if (auto self = fas.getSelfArgument()) {
             if (self->getType().isActor())
               options |= SILMultiAssignFlags::PropagatesActorSelf;
           }
         }
-      } else if (auto *pai = dyn_cast<PartialApplyInst>(applyInst)) {
-        for (auto arg : pai->getOperandValues()) {
-          if (auto value = tryToTrackValue(arg)) {
-            if (value->isActorDerived()) {
-              options |= SILMultiAssignFlags::PropagatesActorSelf;
-            }
-          } else {
-            // NOTE: One may think that only sendable things can enter
-            // here... but we treat things like function_ref/class_method which
-            // are non-Sendable as sendable for our purposes.
-            if (arg->getType().isActor()) {
-              options |= SILMultiAssignFlags::PropagatesActorSelf;
-            }
-          }
-        }
       }
 
       SmallVector<SILValue, 8> applyResults;
-      getApplyResults(applyInst, applyResults);
-      return translateSILMultiAssign(
-          applyResults, applyInst->getOperandValues(), options);
+      getApplyResults(inst, applyResults);
+      return translateSILMultiAssign(applyResults, inst->getOperandValues(),
+                                     options);
     }
 
-    if (auto cast = dyn_cast<ApplyInst>(applyInst))
+    if (auto cast = dyn_cast<ApplyInst>(inst))
       return translateIsolationCrossingSILApply(cast);
-    if (auto cast = dyn_cast<BeginApplyInst>(applyInst))
+    if (auto cast = dyn_cast<BeginApplyInst>(inst))
       return translateIsolationCrossingSILApply(cast);
-    if (auto cast = dyn_cast<TryApplyInst>(applyInst))
+    if (auto cast = dyn_cast<TryApplyInst>(inst))
       return translateIsolationCrossingSILApply(cast);
 
     llvm_unreachable("Only ApplyInst, BeginApplyInst, and TryApplyInst should "
@@ -1306,11 +1600,13 @@ public:
       return translateSILTupleAddrConstructor(
           cast<TupleAddrConstructorInst>(inst));
 
+    case SILInstructionKind::PartialApplyInst:
+      return translateSILPartialApply(cast<PartialApplyInst>(inst));
+
     // Applies are handled specially since we need to merge their results.
     case SILInstructionKind::ApplyInst:
     case SILInstructionKind::BeginApplyInst:
     case SILInstructionKind::BuiltinInst:
-    case SILInstructionKind::PartialApplyInst:
     case SILInstructionKind::TryApplyInst:
       return translateSILApply(inst);
 
@@ -1937,6 +2233,7 @@ class PartitionAnalysis {
         transferOpToRequireInstMultiMap;
 
     // Then for each block...
+    LLVM_DEBUG(llvm::dbgs() << "Walking blocks for diagnostics.\n");
     for (auto [block, blockState] : blockStates) {
       LLVM_DEBUG(llvm::dbgs() << "|--> Block bb" << block.getDebugID() << "\n");
 
@@ -1955,6 +2252,8 @@ class PartitionAnalysis {
                 << "        ID:  %%" << transferredVal << "\n"
                 << "        Rep: " << *rep
                 << "        Require Inst: " << *partitionOp.getSourceInst()
+                << "        Transferring Op Num: "
+                << transferringOp->getOperandNumber() << '\n'
                 << "        Transferring Inst: " << *transferringOp->getUser());
             transferOpToRequireInstMultiMap.insert(transferringOp,
                                                    partitionOp.getSourceInst());
@@ -1967,7 +2266,8 @@ class PartitionAnalysis {
                        << "        Rep: "
                        << *translator.getValueForId(transferredVal)
                                ->getRepresentative());
-            diagnose(partitionOp, diag::arg_region_transferred);
+            diagnose(partitionOp,
+                     diag::regionbasedisolation_selforargtransferred);
           };
       eval.nonTransferrableElements = translator.getNeverTransferredValues();
       eval.isActorDerivedCallback = [&](Element element) -> bool {
@@ -1991,45 +2291,75 @@ class PartitionAnalysis {
     // since we cannot clear it without iterating over it.
     unsigned blockLivenessInfoGeneration = 0;
 
+    if (transferOpToRequireInstMultiMap.empty())
+      return;
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "Visiting found transfer+[requireInsts] for diagnostics.\n");
     for (auto [transferOp, requireInsts] :
          transferOpToRequireInstMultiMap.getRange()) {
 
-      LLVM_DEBUG(llvm::dbgs() << "Transfer Inst: " << *transferOp->getUser());
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Transfer Op. Number: " << transferOp->getOperandNumber()
+                 << ". User: " << *transferOp->getUser());
 
       RequireLiveness liveness(blockLivenessInfoGeneration, transferOp,
                                blockLivenessInfo);
       ++blockLivenessInfoGeneration;
       liveness.process(requireInsts);
 
-      InferredCallerArgumentTypeInfo argTypeInfo(transferOp);
-      diagnose(transferOp, diag::call_site_transfer_yields_race,
-               argTypeInfo.inferredType,
-               argTypeInfo.isolationCrossing.getCallerIsolation(),
-               argTypeInfo.isolationCrossing.getCalleeIsolation())
-          .highlight(transferOp->get().getLoc().getSourceRange());
+      InferredCallerArgumentTypeInfo argTypeInfo;
+      argTypeInfo.init(transferOp);
 
-      // Ok, we now have our requires... emit the errors.
-      bool didEmitRequire = false;
-
-      InstructionSet requireInstsUnique(function);
-      for (auto *require : requireInsts) {
-        // We can have multiple of the same require insts if we had a require
-        // and an assign from the same instruction. Our liveness checking above
-        // doesn't care about that, but we still need to make sure we do not
-        // emit twice.
-        if (!requireInstsUnique.insert(require))
-          continue;
-
-        // If this was not a last require, do not emit an error.
-        if (!liveness.finalRequires.contains(require))
-          continue;
-
-        diagnose(require, diag::possible_racy_access_site)
-            .highlight(require->getLoc().getSourceRange());
-        didEmitRequire = true;
+      // If we were supposed to emit an error and we failed to do so, emit a
+      // hard error so that the user knows to file a bug.
+      //
+      // DISCUSSION: We do this rather than asserting since users often times do
+      // not know what to do if the compiler crashes. This at least shows up in
+      // editor UIs providing a more actionable error message.
+      if (argTypeInfo.applyUses.empty()) {
+        diagnose(transferOp, diag::regionbasedisolation_unknown_pattern);
+        continue;
       }
 
-      assert(didEmitRequire && "Should have a require for all errors?!");
+      for (auto &info : argTypeInfo.applyUses) {
+        if (auto isolation = info.second) {
+          diagnose(
+              transferOp,
+              diag::regionbasedisolation_transfer_yields_race_with_isolation,
+              info.first, isolation->getCallerIsolation(),
+              isolation->getCalleeIsolation())
+              .highlight(transferOp->get().getLoc().getSourceRange());
+        } else {
+          diagnose(transferOp,
+                   diag::regionbasedisolation_transfer_yields_race_no_isolation,
+                   info.first)
+              .highlight(transferOp->get().getLoc().getSourceRange());
+        }
+
+        // Ok, we now have our requires... emit the errors.
+        bool didEmitRequire = false;
+
+        InstructionSet requireInstsUnique(function);
+        for (auto *require : requireInsts) {
+          // We can have multiple of the same require insts if we had a require
+          // and an assign from the same instruction. Our liveness checking
+          // above doesn't care about that, but we still need to make sure we do
+          // not emit twice.
+          if (!requireInstsUnique.insert(require))
+            continue;
+
+          // If this was not a last require, do not emit an error.
+          if (!liveness.finalRequires.contains(require))
+            continue;
+
+          diagnose(require, diag::regionbasedisolation_maybe_race)
+              .highlight(require->getLoc().getSourceRange());
+          didEmitRequire = true;
+        }
+
+        assert(didEmitRequire && "Should have a require for all errors?!");
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2329,9 +2329,14 @@ namespace {
         if (closure && closure->isImplicit()) {
           auto *patternBindingDecl = getTopPatternBindingDecl();
           if (patternBindingDecl && patternBindingDecl->isAsyncLet()) {
-            diagnoseNonSendableTypes(
-                type, getDeclContext(), capture.getLoc(),
-                diag::implicit_async_let_non_sendable_capture, decl->getName());
+            // Defer diagnosing checking of non-Sendable types that are passed
+            // into async let to SIL level region based isolation.
+            if (!ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation)) {
+              diagnoseNonSendableTypes(
+                  type, getDeclContext(), capture.getLoc(),
+                  diag::implicit_async_let_non_sendable_capture,
+                  decl->getName());
+            }
           } else {
             // Fallback to a generic implicit capture missing sendable
             // conformance diagnostic.
@@ -3204,8 +3209,8 @@ namespace {
             unsatisfiedIsolation, setThrows, usesDistributedThunk);
       }
 
-      // check if language features ask us to defer sendable diagnostics
-      // if so, don't check for sendability of arguments here
+      // Check if language features ask us to defer sendable diagnostics if so,
+      // don't check for sendability of arguments here.
       if (!ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation)) {
         diagnoseApplyArgSendability(apply, getDeclContext());
       }

--- a/test/Concurrency/issue-57376.swift
+++ b/test/Concurrency/issue-57376.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -disable-availability-checking -strict-concurrency=targeted %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -disable-availability-checking -strict-concurrency=targeted %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-and-complete-
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix targeted-and-complete-
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -verify-additional-prefix tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -25,35 +25,37 @@ func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws whe
    async let _ = seq.reduce(0) { $0 + $1 } // OK
 }
 
-func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
-   async let result: Int = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
-   // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
+   async let result: Int = seq.reduce(0) { $0 + $1 } // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+   // expected-warning @-1 {{immutable value 'result' was never used; consider replacing with '_' or removing it}}
+   // expected-targeted-and-complete-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
-func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
-   async let _: Int = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
+   async let _: Int = seq.reduce(0) { $0 + $1 } // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
-func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
-   async let result = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
-   // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
+   async let result = seq.reduce(0) { $0 + $1 } // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+   // expected-warning @-1 {{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
+   // expected-targeted-and-complete-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
-func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
-   async let _ = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
+   async let _ = seq.reduce(0) { $0 + $1 } // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
-func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
-   async let result = seq // expected-warning{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
-   //expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
+func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
+  async let result = seq // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+   //expected-warning @-2 {{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
 }
 
-func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
-   async let _ = seq // expected-warning{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
+  async let _ = seq // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func search(query: String, entities: [String]) async throws -> [String] {

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -251,12 +251,11 @@ final class NonSendable {
   func call() async {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning@-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-    // expected-tns-warning@-3 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-note @-2 {{access here could race}}
+    // expected-tns-warning @-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
 
     _ = await x
     // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
@@ -292,14 +291,14 @@ func callNonisolatedAsyncClosure(
   g: (NonSendable) async -> Void
 ) async {
   await g(ns)
-  // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning@-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-  // expected-tns-warning@-3 {{passing argument of non-sendable type 'NonSendable' from main actor-isolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-tns-warning @-3 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-note@-2 {{access here could race}}
+  // expected-tns-warning @-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
 
 }
 

--- a/test/Concurrency/sendnonsendable_asynclet.swift
+++ b/test/Concurrency/sendnonsendable_asynclet.swift
@@ -1,0 +1,737 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+/// Classes are always non-sendable, so this is non-sendable
+class NonSendableKlass { // expected-complete-note 92{{}}
+  var field: NonSendableKlass? = nil
+  var field2: NonSendableKlass? = nil
+
+  func asyncCall() async {}
+}
+
+class SendableKlass : @unchecked Sendable {}
+
+actor Actor {
+  var klass = NonSendableKlass()
+  final var finalKlass = NonSendableKlass()
+
+  func useKlass(_ x: NonSendableKlass) {}
+
+  func useSendableFunction(_: @Sendable () -> Void) {}
+  func useNonSendableFunction(_: () -> Void) {}
+}
+
+final actor FinalActor {
+  var klass = NonSendableKlass()
+  func useKlass(_ x: NonSendableKlass) {}
+}
+
+func useInOut<T>(_ x: inout T) {}
+@discardableResult
+func useValue<T>(_ x: T) -> T { x }
+func useValueWrapInOptional<T>(_ x: T) -> T? { x }
+
+@MainActor func transferToMain<T>(_ t: T) async {}
+@MainActor func transferToMainInt<T>(_ t: T) async -> Int { 5 }
+@MainActor func transferToMainIntOpt<T>(_ t: T) async -> Int? { 5 }
+
+func transferToNonIsolated<T>(_ t: T) async {}
+func transferToNonIsolatedInt<T>(_ t: T) async -> Int { 5 }
+func transferToNonIsolatedIntOpt<T>(_ t: T) async -> Int? { 5 }
+
+var booleanFlag: Bool { false }
+
+struct SingleFieldKlassBox {
+  var k = NonSendableKlass()
+}
+
+struct TwoFieldKlassBox { // expected-complete-note 24{{}}
+  var k1 = NonSendableKlass()
+  var k2 = NonSendableKlass()
+}
+
+/////////////////////////////////////
+// MARK: Async Let Let Actor Tests //
+/////////////////////////////////////
+
+func asyncLet_Let_ActorIsolated_Simple1() async {
+  let x = NonSendableKlass()
+  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_Simple2() async {
+  let x = NonSendableKlass()
+  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  let _ = await y
+  useValue(x) // expected-tns-note {{access here could race}}
+}
+
+func asyncLet_Let_ActorIsolated_Simple3() async {
+  let x = NonSendableKlass()
+  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  // TODO: We shouldn't emit the 2nd error here given the current implementation
+  // since it is only accessible along the else path but we already hit
+  // useValue. But when we search for requires that we want to emit, we do not
+  // take into account awaits. That being said, even though this is
+  // inconsistent, a race does occur here.
+  if await booleanFlag {
+    let _ = await y
+  } else {
+    useValue(x) // expected-tns-note {{access here could race}}
+  }
+  useValue(x) // expected-tns-note {{access here could race}}
+}
+
+func asyncLet_Let_ActorIsolated_Simple4() async {
+  let x = NonSendableKlass()
+  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  if await booleanFlag {
+    useValue(x) // expected-tns-note {{access here could race}}
+    let _ = await y
+  } else {
+    useValue(x) // expected-tns-note {{access here could race}}
+  }
+}
+
+func asyncLet_Let_ActorIsolated_Simple5() async {
+  let x = NonSendableKlass()
+  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  if await booleanFlag {
+    let _ = await y
+    useValue(x) // expected-tns-note {{access here could race}}
+  } else {
+    useValue(x) // expected-tns-note {{access here could race}}
+  }
+}
+
+// Make sure we error appropriately when accessing a field of a class in the
+// async let rather than the base class.
+func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
+  let x = NonSendableKlass()
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
+  let x = NonSendableKlass()
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  useValue(x.field) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
+  let x = NonSendableKlass()
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  useValue(x.field2) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+// Make sure we error appropriately when accessing a field of a struct in the
+// async let rather than the base struct.
+func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
+  let x = TwoFieldKlassBox()
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{passing argument of non-sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
+  let x = TwoFieldKlassBox()
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{passing argument of non-sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  useValue(x.k1) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
+  let x = TwoFieldKlassBox()
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{passing argument of non-sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  useValue(x.k2) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
+  let x = TwoFieldKlassBox()
+  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{passing argument of non-sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  useValue(x.k1.field) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+// Make sure we error appropriately when accessing a field of a struct in the
+// async let rather than the base struct.
+func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
+  let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{passing argument of non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
+  let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{passing argument of non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  useValue(x.1) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
+  let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{passing argument of non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  useValue(x.1.k2) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
+  let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
+  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{passing argument of non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  useValue(x.0.k2.field) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+  useValue(x2) // expected-tns-note {{access here could race}}
+}
+
+func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  useValue(x2) // expected-tns-note {{access here could race}}
+  let _ = await y
+  useValue(x) // expected-tns-note {{access here could race}}
+}
+
+// Make sure we emit separate errors for x and x2.
+func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  // We only error on the first value captured if multiple values are captured
+  // since we track a single partial_apply as a transfer instruction.
+  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+// Make sure that we emit an error for transferToMainInt in the async val
+// function itself.
+func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
+  let x = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-note @-1:67 {{access here could race}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  let _ = await y
+}
+
+// Make sure that we emit an error when the same value is used by two async let
+// as part of one statement.
+func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
+  let x = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-note @-1:53 {{access here could race}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  let _ = await y
+  let _ = await z
+}
+
+// Make sure we don't error when we use different values in different async let.
+func asyncLet_Let_ActorIsolated_MultipleAsyncLet2() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  let _ = await y
+  let _ = await z
+}
+
+func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
+  // expected-tns-warning @-1:53 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  useValue(x2) // expected-tns-note {{access here could race}}
+  let _ = await y
+  let _ = await z
+}
+
+func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
+  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  let _ = await y
+  let _ = await z
+  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{access here could race}}
+}
+
+func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
+  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  let _ = await y
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await z
+  useValue(x2) // expected-tns-note {{access here could race}}
+}
+
+func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
+  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+
+  let _ = await y
+  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{access here could race}}
+  let _ = await z
+}
+
+///////////////////////////////////////
+// MARK: SendNonSendable NonIsolated //
+///////////////////////////////////////
+
+func asyncLet_Let_NonIsolated_Simple1() async {
+  let x = NonSendableKlass()
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_Simple2() async {
+  let x = NonSendableKlass()
+  async let y = transferToNonIsolatedInt(x)
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  let _ = await y
+  useValue(x)
+}
+
+func asyncLet_Let_NonIsolated_Simple3() async {
+  let x = NonSendableKlass()
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  // TODO: We shouldn't emit the 2nd error here given the current implementation
+  // since it is only accessible along the else path but we already hit
+  // useValue. But when we search for requires that we want to emit, we do not
+  // take into account awaits. That being said, even though this is
+  // inconsistent, a race does occur here.
+  if await booleanFlag {
+    let _ = await y
+  } else {
+    useValue(x) // expected-tns-note {{access here could race}}
+  }
+  useValue(x) // expected-tns-note {{access here could race}}
+}
+
+func asyncLet_Let_NonIsolated_Simple4() async {
+  let x = NonSendableKlass()
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  if await booleanFlag {
+    useValue(x) // expected-tns-note {{access here could race}}
+    let _ = await y
+  } else {
+    useValue(x) // expected-tns-note {{access here could race}}
+  }
+}
+
+func asyncLet_Let_NonIsolated_Simple5() async {
+  let x = NonSendableKlass()
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  if await booleanFlag {
+    let _ = await y
+    useValue(x)
+  } else {
+    useValue(x) // expected-tns-note {{access here could race}}
+  }
+}
+
+// Make sure we error appropriately when accessing a field of a class in the
+// async let rather than the base class.
+func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
+  let x = NonSendableKlass()
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
+  let x = NonSendableKlass()
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  useValue(x.field) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
+  let x = NonSendableKlass()
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  useValue(x.field2) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+// Make sure we error appropriately when accessing a field of a struct in the
+// async let rather than the base struct.
+func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
+  let x = TwoFieldKlassBox()
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferred value of non-Sendable type 'TwoFieldKlassBox' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
+  let x = TwoFieldKlassBox()
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferred value of non-Sendable type 'TwoFieldKlassBox' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+
+  useValue(x.k1) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
+  let x = TwoFieldKlassBox()
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferred value of non-Sendable type 'TwoFieldKlassBox' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+
+  useValue(x.k2) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
+  let x = TwoFieldKlassBox()
+  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{transferred value of non-Sendable type 'TwoFieldKlassBox' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+
+  useValue(x.k1.field) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+// Make sure we error appropriately when accessing a field of a struct in the
+// async let rather than the base struct.
+func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
+  let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferred value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
+  let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferred value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  useValue(x.1) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
+  let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferred value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+
+  useValue(x.1.k2) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_AccessFieldsTuple4() async {
+  let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
+  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{transferred value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  useValue(x.0.k2.field) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr1() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+  useValue(x2)
+}
+
+func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr2() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  useValue(x2) // expected-tns-note {{access here could race}}
+  let _ = await y
+  useValue(x)
+}
+
+// Make sure we emit separate errors for x and x2.
+func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr3() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-tns-warning @-1 {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  // We only error on the first value captured if multiple values are captured
+  // since we track a single partial_apply as a transfer instruction.
+  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{access here could race}}
+  let _ = await y
+}
+
+// Make sure that we emit an error for transferToNonIsolatedInt in the async val
+// function itself.
+func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr4() async {
+  let x = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x))
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  let _ = await y
+}
+
+// Make sure that we emit an error when the same value is used by two async let
+// as part of one statement.
+func asyncLet_Let_NonIsolated_MultipleAsyncLet1() async {
+  let x = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-tns-note @-1:60 {{access here could race}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  let _ = await y
+  let _ = await z
+}
+
+// Make sure we don't error when we use different values in different async let.
+func asyncLet_Let_NonIsolated_MultipleAsyncLet2() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  let _ = await y
+  let _ = await z
+}
+
+func asyncLet_Let_NonIsolated_MultipleAsyncLet3() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
+  // expected-tns-warning @-1:60 {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  useValue(x2) // expected-tns-note {{access here could race}}
+  let _ = await y
+  let _ = await z
+}
+
+func asyncLet_Let_NonIsolated_MultipleAsyncLet4() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  let _ = await y
+  let _ = await z
+  useValue(x)
+  useValue(x2)
+}
+
+func asyncLet_Let_NonIsolated_MultipleAsyncLet5() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  let _ = await y
+  useValue(x)
+  let _ = await z
+  useValue(x2)
+}
+
+func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
+  let x = NonSendableKlass()
+  let x2 = NonSendableKlass()
+
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
+  // expected-tns-warning @-1 {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+
+  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+
+  let _ = await y
+  useValue(x)
+  useValue(x2) // expected-tns-note {{access here could race}}
+  let _ = await z
+}
+
+////////////////////////////
+// MARK: Normal Value Use //
+////////////////////////////
+
+func asyncLet_Let_NormalUse_Simple1() async {
+  let x = NonSendableKlass()
+  async let y = x // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  useValue(x) // expected-tns-note {{access here could race}}
+  let _ = await y
+
+}
+
+func asyncLet_Let_NormalUse_Simple2() async {
+  let x = NonSendableKlass()
+  async let y = x
+  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  let _ = await y
+  useValue(x)
+}

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -49,6 +49,12 @@ Operand *transferSingletons[5] = {
     (Operand *)0xFEDA0000, (Operand *)0xFBDA0000,
 };
 
+SILInstruction *instSingletons[5] = {
+    (SILInstruction *)0xBEAD0000, (SILInstruction *)0xBEAD0000,
+    (SILInstruction *)0xBEDF0000, (SILInstruction *)0xBEDA0000,
+    (SILInstruction *)0xBBDA0000,
+};
+
 // This test tests that if a series of merges is split between two partitions
 // p1 and p2, but also applied in its entirety to p3, then joining p1 and p2
 // yields p3.
@@ -631,4 +637,18 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
     };
     eval.apply(PartitionOp::Require(Element(0)));
   }
+}
+
+TEST(PartitionUtilsTest, TestUndoTransfer) {
+  Partition p;
+  PartitionOpEvaluator eval(p);
+  eval.failureCallback = [&](const PartitionOp &, unsigned, Operand *) {
+    EXPECT_TRUE(false);
+  };
+
+  // Shouldn't error on this.
+  eval.apply({PartitionOp::AssignFresh(Element(0)),
+              PartitionOp::Transfer(Element(0), transferSingletons[0]),
+              PartitionOp::UndoTransfer(Element(0), instSingletons[0]),
+              PartitionOp::Require(Element(0), instSingletons[0])});
 }


### PR DESCRIPTION
[region-isolation] Add support for async let.

Specifically:

1. If the value is transferred such that it becomes part of an actor region, the
value is permanently part of the actor region as one would normally have.

2. If the value is transferred into a function that is nonisolated then once the
async let has been awaited upon, the value is now allowed to be used again. This
is safe since there isn't any isolated state that the value could escape into in
the nonisolated function.

rdar://117506395

