### PR TITLE
Use preprocessor metaprogramming for macro roles in the demangle node printer

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11065,7 +11065,7 @@ MacroRoles swift::getAttachedMacroRoles() {
 
 bool swift::isMacroSupported(MacroRole role, ASTContext &ctx) {
   switch (role) {
-#define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, FeatureName) \
+#define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, MangledChar, FeatureName) \
   case MacroRole::Name: \
     return ctx.LangOpts.hasFeature(Feature::FeatureName);
 
@@ -11076,7 +11076,7 @@ bool swift::isMacroSupported(MacroRole role, ASTContext &ctx) {
 
 #include "swift/Basic/MacroRoles.def"
 
-#define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, FeatureName)
+#define EXPERIMENTAL_ATTACHED_MACRO_ROLE(Name, Description, MangledChar, FeatureName)
 #define EXPERIMENTAL_FREESTANDING_MACRO_ROLE(Name, Description, FeatureName)
 #define MACRO_ROLE(Name, Description) case MacroRole::Name:
 #include "swift/Basic/MacroRoles.def"

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1448,46 +1448,19 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
                        Node->getNumChildren() == 3? TypePrinting::WithColon
                                                   : TypePrinting::FunctionStyle,
                        /*hasName*/ true);
-  case Node::Kind::AccessorAttachedMacroExpansion:
-    return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true,
-                       ("accessor macro @" +
-                        nodeToString(Node->getChild(2)) + " expansion #"),
+#define FREESTANDING_MACRO_ROLE(Name, Description)
+#define ATTACHED_MACRO_ROLE(Name, Description, MangledChar)                \
+  case Node::Kind::Name##AttachedMacroExpansion:                           \
+    return printEntity(Node, depth, asPrefixContext,                       \
+                       TypePrinting::NoType, /*hasName*/true,              \
+                       (Description " macro @" +                           \
+                        nodeToString(Node->getChild(2)) + " expansion #"), \
                        (int)Node->getChild(3)->getIndex() + 1);
+#include "swift/Basic/MacroRoles.def"
   case Node::Kind::FreestandingMacroExpansion:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
                        /*hasName*/true, "freestanding macro expansion #",
                        (int)Node->getChild(2)->getIndex() + 1);
-  case Node::Kind::MemberAttributeAttachedMacroExpansion:
-    return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true,
-                       ("member attribute macro @" +
-                        nodeToString(Node->getChild(2)) + " expansion #"),
-                       (int)Node->getChild(3)->getIndex() + 1);
-  case Node::Kind::MemberAttachedMacroExpansion:
-    return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true,
-                       ("member macro @" + nodeToString(Node->getChild(2)) +
-                        " expansion #"),
-                       (int)Node->getChild(3)->getIndex() + 1);
-  case Node::Kind::PeerAttachedMacroExpansion:
-    return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true,
-                       ("peer macro @" + nodeToString(Node->getChild(2)) +
-                        " expansion #"),
-                       (int)Node->getChild(3)->getIndex() + 1);
-  case Node::Kind::ConformanceAttachedMacroExpansion:
-    return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true,
-                       ("conformance macro @" + nodeToString(Node->getChild(2)) +
-                        " expansion #"),
-                       (int)Node->getChild(3)->getIndex() + 1);
-  case Node::Kind::ExtensionAttachedMacroExpansion:
-    return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                       /*hasName*/true,
-                       ("extension macro @" + nodeToString(Node->getChild(2)) +
-                        " expansion #"),
-                       (int)Node->getChild(3)->getIndex() + 1);
   case Node::Kind::MacroExpansionUniqueName:
     return printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
                        /*hasName*/true, "unique name #",


### PR DESCRIPTION
Yet more preprocessor metaprogramming for macro roles