### PR TITLE
[embedded] Consider 'skipped' decls when SILGen-ing accessors, fix compiler crash on unavailable accessors

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1802,7 +1802,7 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
   if (vd->hasStorage())
     addGlobalVariable(vd);
 
-  vd->visitEmittedAccessors([&](AccessorDecl *accessor) {
+  visitEmittedAccessors(vd, [&](AccessorDecl *accessor) {
     emitFunction(accessor);
   });
 
@@ -1823,6 +1823,16 @@ void SILGenModule::visitMacroDecl(MacroDecl *d) {
 
 void SILGenModule::visitMacroExpansionDecl(MacroExpansionDecl *d) {
   // Expansion already visited as auxiliary decls.
+}
+
+void SILGenModule::visitEmittedAccessors(
+    AbstractStorageDecl *D, llvm::function_ref<void(AccessorDecl *)> callback) {
+  D->visitEmittedAccessors([&](AccessorDecl *accessor) {
+    if (shouldSkipDecl(accessor))
+      return;
+
+    callback(accessor);
+  });
 }
 
 bool

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -301,6 +301,11 @@ public:
   void visitMacroDecl(MacroDecl *d);
   void visitMacroExpansionDecl(MacroExpansionDecl *d);
 
+  // Same as AbstractStorageDecl::visitEmittedAccessors, but skips over skipped
+  // (unavailable) decls.
+  void visitEmittedAccessors(AbstractStorageDecl *D,
+                             llvm::function_ref<void(AccessorDecl *)>);
+
   void emitEntryPoint(SourceFile *SF);
   void emitEntryPoint(SourceFile *SF, SILFunction *TopLevel);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1628,7 +1628,7 @@ void SILGenFunction::visitVarDecl(VarDecl *D) {
   });
 
   // Emit the variable's accessors.
-  D->visitEmittedAccessors([&](AccessorDecl *accessor) {
+  SGM.visitEmittedAccessors(D, [&](AccessorDecl *accessor) {
     SGM.emitFunction(accessor);
   });
 }

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -257,7 +257,7 @@ void SILGenTopLevel::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
 }
 
 void SILGenTopLevel::visitAbstractStorageDecl(AbstractStorageDecl *ASD) {
-  ASD->visitEmittedAccessors(
+  SGF.SGM.visitEmittedAccessors(ASD,
       [this](AccessorDecl *Accessor) { visitAbstractFunctionDecl(Accessor); });
 }
 
@@ -338,7 +338,7 @@ void SILGenTopLevel::TypeVisitor::visitAbstractFunctionDecl(
 
 void SILGenTopLevel::TypeVisitor::visitAbstractStorageDecl(
     AbstractStorageDecl *ASD) {
-  ASD->visitEmittedAccessors(
+  SGF.SGM.visitEmittedAccessors(ASD,
       [this](AccessorDecl *Accessor) { visitAbstractFunctionDecl(Accessor); });
 }
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1242,7 +1242,7 @@ public:
   }
 
   void visitAccessors(AbstractStorageDecl *asd) {
-    asd->visitEmittedAccessors([&](AccessorDecl *accessor) {
+    SGM.visitEmittedAccessors(asd, [&](AccessorDecl *accessor) {
       visitFuncDecl(accessor);
     });
   }
@@ -1422,7 +1422,7 @@ public:
   }
 
   void visitAccessors(AbstractStorageDecl *asd) {
-    asd->visitEmittedAccessors([&](AccessorDecl *accessor) {
+    SGM.visitEmittedAccessors(asd, [&](AccessorDecl *accessor) {
       visitFuncDecl(accessor);
     });
   }

--- a/test/IRGen/unavailable_decl_optimization_complete_struct.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_struct.swift
@@ -21,6 +21,15 @@ public struct AvailableStruct<T> {
     _modify { fatalError() }
   }
 
+  // CHECK-NO-STRIP: s4Test15AvailableStructV45availablePropertyWithSomeUnavailableAccessorsxvg
+  // CHECK-NO-STRIP: s4Test15AvailableStructV45availablePropertyWithSomeUnavailableAccessorsxvs
+  // CHECK-STRIP-NOT: s4Test15AvailableStructV45availablePropertyWithSomeUnavailableAccessorsxvs
+  public var availablePropertyWithSomeUnavailableAccessors: T {
+    get { fatalError() }
+    @available(*, unavailable)
+    set { fatalError() }
+  }
+
   // CHECK-NO-STRIP: s4Test15AvailableStructVyACyxGxcfC
   // CHECK-STRIP-NOT: s4Test15AvailableStructVyACyxGxcfC
   @available(*, unavailable)

--- a/test/embedded/accessor-unavailable.swift
+++ b/test/embedded/accessor-unavailable.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+struct Foo {
+  public subscript(x: Int) -> Int {
+    get {
+      return 0
+    }
+
+    @available(*, unavailable)
+    set { }
+  }
+}
+
+// CHECK: $s4main3FooVyS2icig
+// CHECK-NOT: $s4main3FooVyS2icis


### PR DESCRIPTION
The attached testcase reproduces a compiler crash, which happens when using an unconditional-unavailable annotation on a getter or setter under either `-unavailable-decl-optimization=complete` or embedded Swift mode (which implies the same setting). We need to consider "skipped" accessor decls when emitting functions in SILGen.

```
struct Foo {
  public subscript(x: Int) -> Int {
    get {
      return 0
    }

    @available(*, unavailable)  // <<< (!) this is what triggers the problem
    set { }
  }
}

] ./bin/swift-frontend a.swift -emit-ir -unavailable-decl-optimization=complete
Assertion failed: (!shouldSkipDecl(fd)), function emitFunction, file SILGen.cpp, line 1449.
7  swift-frontend           0x0000000107524dd4 swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) (.cold.2) + 0
8  swift-frontend           0x000000010286b250 swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) + 204
9  swift-frontend           0x0000000102954050 (anonymous namespace)::SILGenType::visitFuncDecl(swift::FuncDecl*) + 28
10 swift-frontend           0x0000000103781124 swift::AbstractStorageDecl::visitEmittedAccessors(llvm::function_ref<void (swift::AccessorDecl*)>) const + 104
11 swift-frontend           0x000000010295421c (anonymous namespace)::SILGenType::visitAbstractStorageDecl(swift::AbstractStorageDecl*) + 148
12 swift-frontend           0x0000000102951354 (anonymous namespace)::SILGenType::emitType() + 244
13 swift-frontend           0x0000000102951254 swift::Lowering::SILGenModule::visitNominalTypeDecl(swift::NominalTypeDecl*) + 24
14 swift-frontend           0x000000010286fbe8 swift::ASTLoweringRequest::evaluate(swift::Evaluator&, swift::ASTLoweringDescriptor) const + 972
15 swift-frontend           0x000000010294394c swift::SimpleRequest<swift::ASTLoweringRequest, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>> (swift::ASTLoweringDescriptor), (swift::RequestFlags)9>::evaluateRequest(swift::ASTLoweringRequest const&, swift::Evaluator&) + 132
16 swift-frontend           0x0000000102872f34 llvm::Expected<swift::ASTLoweringRequest::OutputType> swift::Evaluator::getResultUncached<swift::ASTLoweringRequest>(swift::ASTLoweringRequest const&) + 380
17 swift-frontend           0x00000001028701cc swift::performASTLowering(swift::ModuleDecl*, swift::Lowering::TypeConverter&, swift::SILOptions const&, swift::IRGenOptions const*) + 128
```

Fixes https://github.com/apple/swift/issues/70040