### PR TITLE
Add concrete overload for `!=` on all stdlib integer types.

### DIFF
--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1715,6 +1715,27 @@ ${operatorComment(x.operator, True)}
 
 %   end
 
+  // IMPORTANT: The following four apparently unnecessary overloads of
+  // comparison operations are necessary for literal comparands to be
+  // inferred as the desired type.
+  //
+  // Absent these, an expression like `Int8.min != 1 << 7` would have
+  // two candidates for `!=`: the heterogeneous generic operator defined
+  // on BinaryInteger, and the homogeneous generic operator defined on
+  // Equatable. The heterogeneous one is chosen because it is "more
+  // specialized," which results in `1 << 7` being given the type `Int`
+  // and the value 128, which compares not-equal to `Int8.min`.
+  //
+  // However, there is necessarily a homogeneous concrete `==` operator
+  // because it is a customization point for Equatable, so the expression
+  // `Int8.min == 1 << 7` types `1 << 7` as `Int8` with value -128, which
+  // compares equal to `Int8.min`.
+  //
+  // This inconsistency can be resolved by ensuring that we have
+  // concrete overloads of every comparison operation. It's still possible
+  // to get literal expression comparands typed Int in generic contexts,
+  // but there's also a pretty straightforward workaround (adding an
+  // explicit type).
   @_transparent @_alwaysEmitIntoClient
   public static func !=(lhs: ${Self}, rhs: ${Self}) -> Bool {
     return !(lhs == rhs)

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1715,6 +1715,11 @@ ${operatorComment(x.operator, True)}
 
 %   end
 
+  @_transparent @_alwaysEmitIntoClient
+  public static func !=(lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs == rhs)
+  }
+
   @_transparent
   public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return !(rhs < lhs)

--- a/test/stdlib/integer_comparison_typeinference.swift
+++ b/test/stdlib/integer_comparison_typeinference.swift
@@ -1,0 +1,17 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+let ComparisonTypeInferenceTests = TestSuite("Comparison type inference")
+
+ComparisonTypeInferenceTests.test("Int8") {
+  expectTrue( Int8.min == 1 << 7)
+  expectFalse(Int8.min != 1 << 7)
+  expectTrue( Int8.max >  1 << 7)
+  expectTrue( Int8.max >= 1 << 7)
+  expectTrue( 1 << 7 <  Int8.max)
+  expectTrue( 1 << 7 <= Int8.max)
+}
+
+runAllTests()


### PR DESCRIPTION
Sometime between 4.2 and 5.0 this overload was lost, introducing https://github.com/apple/swift/issues/70041.

Note that programs will have to be recompiled to see the effects of this change, as the bug is in the type inferred for the comparands, rather than the implementation of the comparison itself.