### PR TITLE
[cxx-interop] Support C++ default arguments

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -283,6 +283,8 @@ public:
 
   virtual bool isUnsafeCXXMethod(const FuncDecl *func) = 0;
 
+  virtual FuncDecl *getDefaultArgGenerator(const clang::ParmVarDecl *param) = 0;
+
   virtual llvm::Optional<Type>
   importFunctionReturnType(const clang::FunctionDecl *clangDecl,
                            DeclContext *dc) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -587,6 +587,8 @@ public:
 
   bool isUnsafeCXXMethod(const FuncDecl *func) override;
 
+  FuncDecl *getDefaultArgGenerator(const clang::ParmVarDecl *param) override;
+
   bool isAnnotatedWith(const clang::CXXMethodDecl *method, StringRef attr);
 
   /// Find the lookup table that corresponds to the given Clang module.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4199,14 +4199,20 @@ void ClangModuleUnit::getImportedModulesForLookup(
 void ClangImporter::getMangledName(raw_ostream &os,
                                    const clang::NamedDecl *clangDecl) const {
   if (!Impl.Mangler)
-    Impl.Mangler.reset(Impl.getClangASTContext().createMangleContext());
+    Impl.Mangler.reset(getClangASTContext().createMangleContext());
 
+  return Impl.getMangledName(Impl.Mangler.get(), clangDecl, os);
+}
+
+void ClangImporter::Implementation::getMangledName(
+    clang::MangleContext *mangler, const clang::NamedDecl *clangDecl,
+    raw_ostream &os) {
   if (auto ctor = dyn_cast<clang::CXXConstructorDecl>(clangDecl)) {
     auto ctorGlobalDecl =
         clang::GlobalDecl(ctor, clang::CXXCtorType::Ctor_Complete);
-    Impl.Mangler->mangleCXXName(ctorGlobalDecl, os);
+    mangler->mangleCXXName(ctorGlobalDecl, os);
   } else {
-    Impl.Mangler->mangleName(clangDecl, os);
+    mangler->mangleName(clangDecl, os);
   }
 }
 
@@ -7044,6 +7050,14 @@ bool ClangImporter::isAnnotatedWith(const clang::CXXMethodDecl *method,
          });
 }
 
+FuncDecl *
+ClangImporter::getDefaultArgGenerator(const clang::ParmVarDecl *param) {
+  auto it = Impl.defaultArgGenerators.find(param);
+  if (it != Impl.defaultArgGenerators.end())
+    return it->second;
+  return nullptr;
+}
+
 SwiftLookupTable *
 ClangImporter::findLookupTable(const clang::Module *clangModule) {
   return Impl.findLookupTable(clangModule);
@@ -7190,7 +7204,7 @@ static bool hasOwnedValueAttr(const clang::RecordDecl *decl) {
          });
 }
 
-static bool hasUnsafeAPIAttr(const clang::Decl *decl) {
+bool importer::hasUnsafeAPIAttr(const clang::Decl *decl) {
   return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
            if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
              return swiftAttr->getAttribute() == "import_unsafe";
@@ -7254,6 +7268,10 @@ static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {
   }
 
   return false;
+}
+
+bool importer::isViewType(const clang::CXXRecordDecl *decl) {
+  return !hasOwnedValueAttr(decl) && hasPointerInSubobjects(decl);
 }
 
 static bool copyConstructorIsDefaulted(const clang::CXXRecordDecl *decl) {
@@ -7581,8 +7599,7 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
         // A projection of a view type (such as a string_view) from a self
         // contained parent is a proejction (unsafe).
         if (!anySubobjectsSelfContained(cxxRecordReturnType) &&
-            !hasOwnedValueAttr(cxxRecordReturnType) &&
-            hasPointerInSubobjects(cxxRecordReturnType)) {
+            isViewType(cxxRecordReturnType)) {
           return !parentIsSelfContained;
         }
       }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -589,6 +589,10 @@ public:
     return Instance.get();
   }
 
+  /// Writes the mangled name of \p clangDecl to \p os.
+  void getMangledName(clang::MangleContext *mangler,
+                      const clang::NamedDecl *clangDecl, raw_ostream &os);
+
   /// Whether the C++ interoperability compatibility version is at least
   /// 'major'.
   ///
@@ -664,6 +668,10 @@ private:
       clonedBaseMembers;
 
 public:
+  llvm::DenseMap<const clang::ParmVarDecl*, FuncDecl*> defaultArgGenerators;
+
+  bool isDefaultArgSafeToImport(const clang::ParmVarDecl *param);
+
   ValueDecl *importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext);
 
   static size_t getImportedBaseMemberDeclArity(const ValueDecl *valueDecl);
@@ -1984,6 +1992,10 @@ inline std::string getPrivateOperatorName(const std::string &OperatorToken) {
 #include "clang/Basic/OperatorKinds.def"
   return "None";
 }
+
+bool hasUnsafeAPIAttr(const clang::Decl *decl);
+
+bool isViewType(const clang::CXXRecordDecl *decl);
 
 }
 }

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -18,6 +18,8 @@
 
 namespace swift {
 
+class CallExpr;
+
 enum class MakeStructRawValuedFlags {
   /// whether to also create an unlabeled init
   MakeUnlabeledValueInit = 0x01,
@@ -293,6 +295,10 @@ public:
 
   VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
                                               FuncDecl *setter);
+
+  CallExpr *makeDefaultArgument(const clang::ParmVarDecl *param,
+                                const swift::Type &swiftParamTy,
+                                SourceLoc paramLoc);
 
 private:
   Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -981,6 +981,10 @@ bool SILDeclRef::isForeignToNativeThunk() const {
   // have a foreign-to-native thunk.
   if (!hasDecl())
     return false;
+  // A default argument generator for a C++ function is a Swift function, so no
+  // thunk needed.
+  if (isDefaultArgGenerator())
+    return false;
   if (requiresForeignToNativeThunk(getDecl()))
     return true;
   // ObjC initializing constructors and factories are foreign.
@@ -1103,7 +1107,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
 
   // As a special case, Clang functions and globals don't get mangled at all
   // - except \c objc_direct decls.
-  if (hasDecl()) {
+  if (hasDecl() && !isDefaultArgGenerator()) {
     if (getDecl()->getClangDecl()) {
       if (!isForeignToNativeThunk() && !isNativeToForeignThunk()) {
         auto clangMangling = mangleClangDecl(getDecl(), isForeign);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -719,6 +719,13 @@ static bool isEmittedOnDemand(SILModule &M, SILDeclRef constant) {
   }
   case SILDeclRef::Kind::EnumElement:
     return true;
+  case SILDeclRef::Kind::DefaultArgGenerator: {
+    // Default arguments of C++ functions are only emitted if used.
+    if (isa<ClangModuleUnit>(dc->getModuleScopeContext()))
+      return true;
+
+    break;
+  }
   default:
     break;
   }

--- a/test/Interop/Cxx/foreign-reference/Inputs/pod.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/pod.h
@@ -21,6 +21,8 @@ __attribute__((swift_attr("release:immortal"))) Empty {
   static Empty *create() { return new (malloc(sizeof(Empty))) Empty(); }
 };
 
+void takesConstRefEmpty(const Empty &e) {}
+void takesConstRefEmptyDefaulted(const Empty &e = {}) {}
 void mutateIt(Empty &) {}
 Empty passThroughByValue(Empty x) { return x; }
 

--- a/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
@@ -8,6 +8,8 @@
 // CHECK:   func testMutable() -> Int32
 // CHECK:   class func create() -> Empty
 // CHECK: }
+// CHECK: func takesConstRefEmpty(_ e: Empty)
+// CHECK: func takesConstRefEmptyDefaulted(_ e: Empty)
 // CHECK: func mutateIt(_: Empty)
 // CHECK-NOT: func passThroughByValue(_ x: Empty) -> Empty
 

--- a/test/Interop/Cxx/function/Inputs/default-arguments.cpp
+++ b/test/Interop/Cxx/function/Inputs/default-arguments.cpp
@@ -1,0 +1,10 @@
+#include "default-arguments.h"
+
+ArgTy ArgTy::createZero() { return {0}; }
+
+int HasStaticMethodWithDefaultArg::value = 0;
+int HasStaticMethodWithDefaultArg::counter = 0;
+
+bool HasStaticMethodWithDefaultArg::isNonZero(int v) { return v != 0; }
+bool HasStaticMethodWithDefaultArg::isNonZeroCounter(int v) { return v != 0; }
+bool HasStaticMethodWithDefaultArg::isNonZeroPrivateCounter(int v) { return v != 0; }

--- a/test/Interop/Cxx/function/Inputs/default-arguments.h
+++ b/test/Interop/Cxx/function/Inputs/default-arguments.h
@@ -1,0 +1,148 @@
+inline void unused(int x = 0) {}
+
+inline bool isZero(int value = 0) { return value == 0; }
+inline bool isNonZero(int value = 0) { return value != 0; }
+
+inline bool isNil(int *ptr = nullptr) { return ptr == nullptr; }
+inline bool isStrNil(const char *ptr = "") { return ptr == nullptr; }
+
+static int *globalPtr = nullptr;
+inline bool isGlobalNonNil(int *ptr = globalPtr) { return ptr; }
+
+inline int sum(int a, int b = 1) { return a + b; }
+inline int subtract(int a = 123, int b = 1) { return a - b; }
+
+static int counter = 0;
+inline bool isZeroCounter(int value = counter++) { return value == 0; }
+
+struct ArgTy {
+  int value;
+
+  static ArgTy createNonZero() { return {1}; }
+  static ArgTy createZero();
+};
+struct ArgTyNonPOD {
+  int value;
+
+  static ArgTyNonPOD createNonZero() { return {1}; }
+  ~ArgTyNonPOD() {}
+};
+
+struct ArgTyView {
+  ArgTy *ptr;
+};
+struct __attribute__((swift_attr("import_owned"))) ArgTyOwnedPtr {
+  ArgTy *ptr;
+};
+
+struct __attribute__((swift_attr("import_reference"),
+                      swift_attr("retain:immortal"),
+                      swift_attr("release:immortal"))) ArgFRT {
+  int value;
+  ArgFRT(int value) : value(value) {}
+};
+static ArgFRT *globalFRT;
+inline void createFRT() { globalFRT = new ArgFRT(123); }
+inline void deleteFRT() { delete globalFRT; }
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retainFn")))
+__attribute__((swift_attr("release:releaseFn"))) ArgRefCounted {
+  int value;
+  int refCount = 1;
+  ArgRefCounted(int value) : value(value) {}
+  static ArgRefCounted *create() { return new ArgRefCounted(321); }
+};
+inline void retainFn(ArgRefCounted *a) { a->refCount++; }
+inline void releaseFn(ArgRefCounted *a) { a->refCount--; }
+
+inline bool isArgZero(ArgTy a = {0}) { return a.value == 0; }
+inline bool isArgNonZero(ArgTy a = ArgTy::createNonZero()) { return a.value != 0; }
+inline bool isArgZeroOutOfLine(ArgTy a = ArgTy::createZero()) { return a.value == 0; }
+
+inline bool isArgZeroConstRef(const ArgTy &a = {0}) { return a.value == 0; }
+inline bool isArgNonZeroConstRef(const ArgTy &a = ArgTy::createNonZero()) { return a.value == 0; }
+inline bool isArgNonPODNonZeroConstRef(const ArgTyNonPOD &a = ArgTyNonPOD::createNonZero()) { return a.value == 0; }
+
+inline bool isArgViewNull(ArgTyView a = {nullptr}) { return a.ptr == nullptr; }
+inline bool isArgViewNullAnd(ArgTyView a = {nullptr}, bool second = true) { return a.ptr == nullptr && second; }
+inline bool isArgViewNullAndReversed(bool second = true, ArgTyView a = {nullptr}) { return a.ptr == nullptr && second; }
+inline bool isArgViewNullUnsafeParam(__attribute__((swift_attr("import_unsafe"))) ArgTyView a = {nullptr}) { return a.ptr == nullptr; }
+inline bool isArgViewNullUnsafeFunc(ArgTyView a = {nullptr}) __attribute__((swift_attr("import_unsafe"))) { return a.ptr == nullptr; }
+inline bool isArgOwnedPtrNull(ArgTyOwnedPtr a = {nullptr}) { return a.ptr == nullptr; }
+inline bool isArgFRTNull(ArgFRT *a = nullptr) { return a == nullptr; }
+inline int getArgFRTValue(ArgFRT *a = globalFRT) { return a->value; }
+inline int getArgRefCountedValue(ArgRefCounted *a = ArgRefCounted::create()) { return a->value; }
+
+struct HasMethodWithDefaultArg {
+  bool isZero(int v = 0) const { return v == 0; }
+  bool isNonZero(int v = sizeof(ArgTy)) const { return v != 0; }
+  bool isNilPtr(int *v = nullptr) const { return v == nullptr; }
+  bool isNilConstPtr(const int *v = nullptr) const { return v == nullptr; }
+  bool isZeroConstRef(const int &v = 0) const { return v == 0; }
+};
+
+struct DerivedFromHasMethodWithDefaultArg : public HasMethodWithDefaultArg {};
+struct DerivedFromDerivedFromHasMethodWithDefaultArg : public DerivedFromHasMethodWithDefaultArg {};
+
+struct HasStaticMethodWithDefaultArg {
+  static int value;
+  static bool isNonZero(int v = value);
+
+  static int counter;
+  static bool isNonZeroCounter(int v = counter++);
+
+private:
+  static int privateCounter;
+public:
+  static bool isNonZeroPrivateCounter(int v = privateCounter++);
+
+  // This should not get a default value in Swift:
+  static ArgTy &customTy;
+  static bool isArgZeroRef(ArgTy &a = customTy) { return a.value == 0; }
+};
+
+// TODO: support default arguments of constructors
+// (https://github.com/apple/swift/issues/70124)
+struct HasCtorWithDefaultArg {
+  int value;
+
+  HasCtorWithDefaultArg(int a, int b = 456, int c = 123) : value(a + b + c) {}
+};
+
+template <typename T>
+struct TemplatedHasMethodWithDefaultArg {
+  bool isZero(T v = 0) const { return v == 0; }
+  bool isNonZero(T v = T()) const { return v != 0; }
+};
+typedef TemplatedHasMethodWithDefaultArg<int> TemplatedHasMethodWithDefaultArgInt;
+typedef TemplatedHasMethodWithDefaultArg<float> TemplatedHasMethodWithDefaultArgFloat;
+
+struct DerivedFromTemplatedHasMethodWithDefaultArgFloat : TemplatedHasMethodWithDefaultArgFloat {};
+
+inline int ambiguous(int a, int b = 1) { return a; }
+inline int ambiguous(int a) { return a; }
+
+inline int nonTrailing(int a, int b = 2) { return a + b; }
+inline int nonTrailing(int a = 1, int b);
+
+// MARK: - Un-instantiatable default expressions
+
+class NoDefinition;
+
+template <typename A>
+struct Base {};
+
+template <typename A>
+struct RequiresDef : Base<A> {
+  A value;
+};
+
+template <typename T>
+void invalidDefaultExpr(Base<T> x = RequiresDef<T>()) {}
+
+template <typename T>
+struct InvalidStruct {
+  void invalidDefaultExprMethod(Base<T> x = RequiresDef<T>()) const {}
+};
+typedef InvalidStruct<NoDefinition> InvalidStructNoDef;

--- a/test/Interop/Cxx/function/Inputs/module.modulemap
+++ b/test/Interop/Cxx/function/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module DefaultArguments {
+  header "default-arguments.h"
+  export *
+}

--- a/test/Interop/Cxx/function/default-arguments-irgen.swift
+++ b/test/Interop/Cxx/function/default-arguments-irgen.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s | %FileCheck %s
+
+import DefaultArguments
+
+// Make sure the default argument generator isn't emitted if it isn't used.
+let _ = isZero(0)
+// CHECK-NOT: __cxx__defaultArg_0__Z6isZeroi

--- a/test/Interop/Cxx/function/default-arguments-module-interface.swift
+++ b/test/Interop/Cxx/function/default-arguments-module-interface.swift
@@ -1,0 +1,70 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=DefaultArguments -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: func isZero(_ value: Int32 = cxxDefaultArg) -> Bool
+// CHECK: func isNil(_ ptr: UnsafeMutablePointer<Int32>! = cxxDefaultArg) -> Bool
+// CHECK: func isGlobalNonNil(_ ptr: UnsafeMutablePointer<Int32>! = cxxDefaultArg) -> Bool
+// CHECK: func sum(_ a: Int32, _ b: Int32 = cxxDefaultArg) -> Int32
+// CHECK: func subtract(_ a: Int32 = cxxDefaultArg, _ b: Int32 = cxxDefaultArg) -> Int32
+// CHECK: func isArgZero(_ a: ArgTy = cxxDefaultArg) -> Bool
+// CHECK: func isArgZeroOutOfLine(_ a: ArgTy = cxxDefaultArg) -> Bool
+
+// CHECK: func isArgZeroConstRef(_ a: ArgTy) -> Bool
+// CHECK: func isArgNonZeroConstRef(_ a: ArgTy) -> Bool
+// CHECK: func isArgNonPODNonZeroConstRef(_ a: ArgTyNonPOD) -> Bool
+
+// CHECK: func isArgViewNull(_ a: ArgTyView) -> Bool
+// CHECK: func isArgViewNullAnd(_ a: ArgTyView, _ second: Bool = cxxDefaultArg) -> Bool
+// CHECK: func isArgViewNullAndReversed(_ second: Bool = cxxDefaultArg, _ a: ArgTyView) -> Bool
+// CHECK: func isArgViewNullUnsafeParam(_ a: ArgTyView = cxxDefaultArg) -> Bool
+// CHECK: func isArgViewNullUnsafeFunc(_ a: ArgTyView) -> Bool
+// CHECK: func isArgOwnedPtrNull(_ a: ArgTyOwnedPtr = cxxDefaultArg) -> Bool
+// CHECK: func isArgFRTNull(_ a: ArgFRT! = cxxDefaultArg) -> Bool
+// CHECK: func getArgFRTValue(_ a: ArgFRT! = cxxDefaultArg) -> Int32
+// CHECK: func getArgRefCountedValue(_ a: ArgRefCounted! = cxxDefaultArg) -> Int32
+
+// CHECK: struct HasMethodWithDefaultArg {
+// CHECK:   func isZero(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK:   func isNonZero(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK:   func isNilPtr(_ v: UnsafeMutablePointer<Int32>! = cxxDefaultArg) -> Bool
+// CHECK:   func isNilConstPtr(_ v: UnsafePointer<Int32>! = cxxDefaultArg) -> Bool
+// CHECK:   func isZeroConstRef(_ v: Int32) -> Bool
+// CHECK: }
+
+// CHECK: struct DerivedFromHasMethodWithDefaultArg {
+// CHECK:   func isZero(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK: }
+
+// CHECK: struct DerivedFromDerivedFromHasMethodWithDefaultArg {
+// CHECK:   func isZero(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK: }
+
+// CHECK: struct HasStaticMethodWithDefaultArg {
+// CHECK:   static func isNonZero(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK:   static func isNonZeroCounter(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK:   static func isNonZeroPrivateCounter(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK:   static func isArgZeroRef(_ a: inout ArgTy) -> Bool
+// CHECK: }
+
+// CHECK: struct HasCtorWithDefaultArg {
+// TODO: support default arguments of constructors (https://github.com/apple/swift/issues/70124)
+// TODO:   init(_ a: Int32, _ b: Int32 = cxxDefaultArg, _ c: Int32 = cxxDefaultArg)
+// CHECK: }
+
+// CHECK: struct TemplatedHasMethodWithDefaultArg<CFloat> {
+// CHECK:   func isZero(_ v: Float = cxxDefaultArg) -> Bool
+// CHECK:   func isNonZero(_ v: Float = cxxDefaultArg) -> Bool
+// CHECK: }
+// CHECK: struct TemplatedHasMethodWithDefaultArg<CInt> {
+// CHECK:   func isZero(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK:   func isNonZero(_ v: Int32 = cxxDefaultArg) -> Bool
+// CHECK: }
+
+// CHECK: func ambiguous(_ a: Int32, _ b: Int32 = cxxDefaultArg) -> Int32
+// CHECK: func ambiguous(_ a: Int32) -> Int32
+
+// CHECK: func nonTrailing(_ a: Int32 = cxxDefaultArg, _ b: Int32 = cxxDefaultArg) -> Int32
+
+// CHECK: struct InvalidStruct<NoDefinition> {
+// CHECK:   func invalidDefaultExprMethod(_ x: Base<NoDefinition>)
+// CHECK: }
+// CHECK: typealias InvalidStructNoDef = InvalidStruct<NoDefinition>

--- a/test/Interop/Cxx/function/default-arguments-typechecker.swift
+++ b/test/Interop/Cxx/function/default-arguments-typechecker.swift
@@ -1,0 +1,71 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+
+import DefaultArguments
+
+let _ = isZero()
+let _ = isZero(1)
+
+let _ = isNil()
+let _ = isStrNil()
+let _ = isGlobalNonNil()
+
+let _ = sum(1)
+let _ = sum(1, 2)
+let _ = subtract()
+let _ = subtract(2)
+let _ = subtract(2, 1)
+
+let _ = isArgZero()
+let _ = isArgNonZero()
+let _ = isArgZeroOutOfLine()
+let _ = isArgZeroConstRef() // expected-error {{missing argument for parameter #1 in call}}
+let _ = isArgNonZeroConstRef() // expected-error {{missing argument for parameter #1 in call}}
+let _ = isArgNonPODNonZeroConstRef() // expected-error {{missing argument for parameter #1 in call}}
+
+let _ = isArgViewNull() // expected-error {{missing argument for parameter #1 in call}}
+let _ = isArgViewNullAnd() // expected-error {{missing argument for parameter #1 in call}}
+let _ = isArgViewNullAndReversed() // expected-error {{missing argument for parameter #2 in call}}
+let _ = isArgViewNullUnsafeParam()
+let _ = isArgViewNullUnsafeFunc() // expected-error {{missing argument for parameter #1 in call}}
+let _ = isArgOwnedPtrNull()
+
+let _ = isArgFRTNull()
+let _ = getArgFRTValue()
+let _ = getArgRefCountedValue()
+
+let _ = HasMethodWithDefaultArg().isZero()
+let _ = HasMethodWithDefaultArg().isZero(1)
+let _ = HasMethodWithDefaultArg().isNonZero()
+let _ = HasMethodWithDefaultArg().isNonZero(1)
+let _ = HasMethodWithDefaultArg().isNilPtr()
+let _ = HasMethodWithDefaultArg().isNilConstPtr()
+let _ = HasMethodWithDefaultArg().isZeroConstRef() // expected-error {{missing argument for parameter #1 in call}}
+
+let _ = DerivedFromHasMethodWithDefaultArg().isZero()
+let _ = DerivedFromDerivedFromHasMethodWithDefaultArg().isZero()
+
+let _ = HasStaticMethodWithDefaultArg.isNonZero()
+let _ = HasStaticMethodWithDefaultArg.isNonZero(1)
+let _ = HasStaticMethodWithDefaultArg.isNonZeroPrivateCounter()
+let _ = HasStaticMethodWithDefaultArg.isNonZeroPrivateCounter(1)
+let _ = HasStaticMethodWithDefaultArg.isArgZeroRef() // expected-error {{missing argument for parameter #1 in call}}
+
+let _ = HasCtorWithDefaultArg(1, 2, 3)
+// TODO: support default arguments of constructors (https://github.com/apple/swift/issues/70124)
+//let _ = HasCtorWithDefaultArg(1, 2)
+//let _ = HasCtorWithDefaultArg(1)
+
+let _ = TemplatedHasMethodWithDefaultArgFloat().isZero()
+let _ = TemplatedHasMethodWithDefaultArgFloat().isNonZero()
+let _ = TemplatedHasMethodWithDefaultArgInt().isZero()
+let _ = TemplatedHasMethodWithDefaultArgInt().isNonZero()
+
+let _ = DerivedFromTemplatedHasMethodWithDefaultArgFloat().isZero()
+let _ = DerivedFromTemplatedHasMethodWithDefaultArgFloat().isNonZero()
+
+let _ = ambiguous(1)
+let _ = ambiguous(1, 2)
+
+let _ = nonTrailing()
+let _ = nonTrailing(1)
+let _ = nonTrailing(1, 2)

--- a/test/Interop/Cxx/function/default-arguments.swift
+++ b/test/Interop/Cxx/function/default-arguments.swift
@@ -1,0 +1,193 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clangxx -c %S/Inputs/default-arguments.cpp -I %S/Inputs -o %t/default-arguments.o
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/default-arguments %t/default-arguments.o -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-codesign %t/default-arguments
+// RUN: %target-run %t/default-arguments
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import DefaultArguments
+
+var DefaultArgTestSuite = TestSuite("Functions with Default Arguments")
+
+DefaultArgTestSuite.test("func with integer parameter") {
+  let z0 = isZero()
+  expectTrue(z0)
+
+  let z1 = isZero(1)
+  expectFalse(z1)
+
+  let z2 = isNonZero()
+  expectFalse(z2)
+
+  let s0 = sum(1)
+  expectEqual(2, s0)
+
+  let s1 = sum(3, 4)
+  expectEqual(7, s1)
+
+  let s2 = subtract()
+  expectEqual(122, s2)
+
+  let s3 = subtract(55)
+  expectEqual(54, s3)
+
+  let s4 = subtract(55, 44)
+  expectEqual(11, s4)
+}
+
+DefaultArgTestSuite.test("func with pointer parameter") {
+  let z0 = isNil()
+  expectTrue(z0)
+
+  let z1 = isGlobalNonNil()
+  expectFalse(z1)
+}
+
+DefaultArgTestSuite.test("func with cString parameter") {
+  let z0 = isStrNil()
+  expectFalse(z0)
+}
+
+DefaultArgTestSuite.test("func with mutating integer argument") {
+  let z0 = isZeroCounter()
+  expectTrue(z0)
+
+  let z1 = isZeroCounter()
+  expectFalse(z1)
+}
+
+DefaultArgTestSuite.test("func with non-trailing argument") {
+  let t0 = nonTrailing()
+  expectEqual(3, t0)
+  
+  let t1 = nonTrailing(5, 6)
+  expectEqual(11, t1)
+}
+
+DefaultArgTestSuite.test("method with integer parameter") {
+  let s = HasMethodWithDefaultArg()
+  let z0 = s.isZero()
+  expectTrue(z0)
+
+  let z1 = s.isNonZero()
+  expectTrue(z1)
+}
+
+// TODO: support default args of constructors
+// (https://github.com/apple/swift/issues/70124)
+DefaultArgTestSuite.test("constructor with integer parameter") {
+  let a = HasCtorWithDefaultArg(1, 2, 3)
+  expectEqual(a.value, 6)
+
+//  let b = HasCtorWithDefaultArg(1, 2)
+//  expectEqual(b.value, 126)
+
+//  let c = HasCtorWithDefaultArg(1)
+//  expectEqual(c.value, 580)
+}
+
+DefaultArgTestSuite.test("method in a templated class") {
+  let t = TemplatedHasMethodWithDefaultArgFloat()
+  let z0 = t.isZero()
+  expectTrue(z0)
+
+  let z1 = t.isZero(0.0 as Float)
+  expectTrue(z1)
+
+  let z2 = t.isNonZero()
+  expectFalse(z2)
+}
+
+DefaultArgTestSuite.test("derived method with integer parameter") {
+  let s = DerivedFromHasMethodWithDefaultArg()
+  let z0 = s.isZero()
+  expectTrue(z0)
+
+  let z1 = s.isZero(0)
+  expectTrue(z1)
+
+  let s1 = DerivedFromDerivedFromHasMethodWithDefaultArg()
+  let z2 = s1.isZero()
+  expectTrue(z2)
+
+  let z3 = s1.isZero(0)
+  expectTrue(z3)
+}
+
+DefaultArgTestSuite.test("derived method from a templated class") {
+  let s = DerivedFromTemplatedHasMethodWithDefaultArgFloat()
+  let z0 = s.isZero()
+  expectTrue(z0)
+
+  let z1 = s.isNonZero()
+  expectFalse(z1)
+}
+
+DefaultArgTestSuite.test("func with record parameter") {
+  let z0 = isArgZero()
+  expectTrue(z0)
+
+  let z1 = isArgZero(ArgTy(value: 0))
+  expectTrue(z1)
+
+  let z2 = isArgZero(ArgTy(value: 1))
+  expectFalse(z2)
+
+  let z3 = isArgNonZero()
+  expectTrue(z3)
+
+  let z4 = isArgZeroOutOfLine()
+  expectTrue(z4)
+
+  let z5 = isArgViewNull(ArgTyView(ptr: nil))
+  expectTrue(z5)
+
+  let z6 = isArgOwnedPtrNull()
+  expectTrue(z6)
+}
+
+DefaultArgTestSuite.test("func with immortal FRT parameter") {
+  createFRT()
+
+  let z0 = isArgFRTNull()
+  expectTrue(z0)
+
+  let v0 = getArgFRTValue()
+  expectEqual(123, v0)
+
+  globalFRT.value = 567
+  let v1 = getArgFRTValue()
+  expectEqual(567, v1)
+
+  deleteFRT()
+}
+
+DefaultArgTestSuite.test("func with ref-counted FRT parameter") {
+  let v0 = getArgRefCountedValue()
+  expectEqual(321, v0)
+}
+
+DefaultArgTestSuite.test("func with const reference parameter") {
+  let z0 = isArgZeroConstRef(ArgTy(value: 0))
+  expectTrue(z0)
+}
+
+DefaultArgTestSuite.test("static method with parameter referring to field") {
+  HasStaticMethodWithDefaultArg.value = 0
+  let z0 = HasStaticMethodWithDefaultArg.isNonZero()
+  expectFalse(z0)
+
+  HasStaticMethodWithDefaultArg.value = 123
+  let z1 = HasStaticMethodWithDefaultArg.isNonZero()
+  expectTrue(z1)
+
+  HasStaticMethodWithDefaultArg.counter = 0
+  let z2 = HasStaticMethodWithDefaultArg.isNonZeroCounter()
+  expectFalse(z2)
+  let z3 = HasStaticMethodWithDefaultArg.isNonZeroCounter()
+  expectTrue(z3)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -462,4 +462,9 @@ struct DerivedFromLoadableIntWrapperWithUsingDecl : private LoadableIntWrapper {
   }
 };
 
+struct HasOperatorCallWithDefaultArg {
+  int value;
+  int operator()(int x = 0) const { return value + x; }
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -281,3 +281,7 @@
 // CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT:   mutating func setValue(_ v: Int32)
 // CHECK-NEXT: }
+
+// CHECK: struct HasOperatorCallWithDefaultArg {
+// CHECK:   func callAsFunction(_ x: Int32 = cxxDefaultArg) -> Int32
+// CHECK: }

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -413,4 +413,10 @@ OperatorsTestSuite.test("DerivedFromLoadableIntWrapperWithUsingDecl") {
   expectEqual(666, d.getValue())
 }
 
+OperatorsTestSuite.test("HasOperatorCallWithDefaultArg.call") {
+  let h = HasOperatorCallWithDefaultArg(value: 321)
+  let res = h(123)
+  expectEqual(444, res)
+}
+
 runAllTests()


### PR DESCRIPTION
This allows calling a C++ function with default arguments from Swift without having to explicitly specify the values of all arguments.

For every C++ default argument we mark the corresponding Swift argument as defaulted (`= cxxDefaultArg`). If the default value of the argument is used, the compiler creates a new C++ function `__defaultArg_{argument index}_{mangled name of the function}` that returns the default expression. This function is then imported into Swift and invoked from a default expression of the imported function on the Swift side.

This patch doesn't cover default arguments of C++ constructors (https://github.com/apple/swift/issues/70124).

rdar://103975014