### PR TITLE
[5.10][Runtime] Add option to remove override point for retain/release.

### DIFF
--- a/include/swift/Runtime/InstrumentsSupport.h
+++ b/include/swift/Runtime/InstrumentsSupport.h
@@ -23,6 +23,8 @@
 
 namespace swift {
 
+#ifdef SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE
+
 // liboainject patches the function pointers and calls the functions below.
 SWIFT_RUNTIME_EXPORT
 HeapObject *(*SWIFT_RT_DECLARE_ENTRY _swift_allocObject)(
@@ -59,6 +61,8 @@ SWIFT_RUNTIME_EXPORT
 size_t _swift_indexToSize(size_t idx);
 SWIFT_RUNTIME_EXPORT
 void _swift_zone_init(void);
+
+#endif // SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE
 
 }
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -449,6 +449,10 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES")
   endif()
 
+  if(SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE)
+    list(APPEND result "-DSWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE")
+  endif()
+
   list(APPEND result ${SWIFT_STDLIB_EXTRA_C_COMPILE_FLAGS})
 
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -260,6 +260,10 @@ option(SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS
        "Install a parent module map for Swift shims."
        ${SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS_default})
 
+option(SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE
+       "Allow retain/release functions to be overridden by indirecting through function pointers."
+       TRUE)
+
 set(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH "" CACHE STRING
   "If set, provides a fixed path to the swift-backtrace binary.  This
    will disable dynamic determination of the path and will also disable

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -355,6 +355,10 @@ function(_add_target_variant_swift_compile_flags
     list(APPEND result "-D" "SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY")
   endif()
 
+  if(SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE)
+    list(APPEND result "-D" "SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE")
+  endif()
+
   string(TOUPPER "${SWIFT_SDK_${sdk}_THREADING_PACKAGE}" _threading_package)
   list(APPEND result "-D" "SWIFT_THREADING_${_threading_package}")
 

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2675,6 +2675,7 @@ build-swift-stdlib-unicode-data=0
 build-swift-stdlib-static-print=1
 darwin-crash-reporter-client=0
 swift-stdlib-use-relative-protocol-witness-tables=1
+swift-stdlib-overridable-retain-release=0
 
 [preset: stdlib_S_standalone_minimal_macho_x86_64,build]
 mixin-preset=

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -245,6 +245,7 @@ KNOWN_SETTINGS=(
     swift-earlyswiftsyntax                        "0"               "use the early SwiftSyntax"
     swift-enable-backtracing                      "1"               "whether to build the backtracing support"
     swift-runtime-fixed-backtracer-path           ""                "if set, use a fixed path for the backtracer"
+    swift-stdlib-overridable-retain-release       "1"               "whether to allow retain/release functions to be overridden by indirecting through function pointers"
 
     ## FREESTANDING Stdlib Options
     swift-freestanding-flavor                     ""                "when building the FREESTANDING stdlib, which build style to use (options: apple, linux)"
@@ -1876,6 +1877,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLIBDISPATCH_CMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
                     -DSWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE:PATH="${SWIFT_SYNTAX_SOURCE_DIR}"
                     -DSWIFT_ENABLE_BACKTRACING:BOOL=$(true_false "${SWIFT_ENABLE_BACKTRACING}")
+                    -DSWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE:BOOL=$(true_false "${SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE}")
                     "${swift_cmake_options[@]}"
                 )
 

--- a/utils/swift_build_support/swift_build_support/products/minimalstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/minimalstdlib.py
@@ -167,6 +167,8 @@ class MinimalStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define(
             'SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
+        self.cmake_options.define(
+            'SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE:BOOL', 'FALSE')
 
         # Build!
         self.build_with_cmake(["swift-stdlib-freestanding"], build_variant, [],


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/69542 to `release/5.10`.

Add a `SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE` CMake option. When set to true, swift_retain/release and the other functions in InstrumentsSupport.h can be overridden by setting the appropriate global function pointer, as is already the case. When set to false, those function pointers are removed and the functions always go into the default implementation.

Set `SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE` to false when building the minimal stdlib, and set it to true otherwise by default.

rdar://115987924