### PR TITLE
[SIL] Key consume checking off var_decl attr.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -4514,11 +4514,15 @@ live. This makes sense semantically since ``%1`` is modeling a new value with a
 dependent lifetime on ``%0``.
 
 The optional ``lexical`` attribute specifies that the operand corresponds to a
-local variable in the Swift source, so special care must be taken when moving
-the end_borrow.
+local variable with a lexical lifetime in the Swift source, so special care
+must be taken when moving the end_borrow.  Compare to the ``var_decl``
+attribute.
 
 The optional ``pointer_escape`` attribute specifies that a pointer to the
 operand escapes within the borrow scope introduced by this begin_borrow.
+
+The optional ``var_decl`` attribute specifies that the operand corresponds to a
+local variable in the Swift source.
 
 This instruction is only valid in functions in Ownership SSA form.
 
@@ -6376,10 +6380,14 @@ values'. A move_value instruction is an instruction that introduces (or injects)
 a type `T` into the move only value space.
 
 The ``lexical`` attribute specifies that the value corresponds to a local
-variable in the Swift source.
+variable with a lexical lifetime in the Swift source.  Compare to the
+``var_decl`` attribute.
 
 The optional ``pointer_escape`` attribute specifies that a pointer to the
 operand escapes within the scope introduced by this move_value.
+
+The optional ``var_decl`` attribute specifies that the operand corresponds to a
+local variable in the Swift source.
 
 
 drop_deinit

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -4517,6 +4517,9 @@ The optional ``lexical`` attribute specifies that the operand corresponds to a
 local variable in the Swift source, so special care must be taken when moving
 the end_borrow.
 
+The optional ``pointer_escape`` attribute specifies that a pointer to the
+operand escapes within the borrow scope introduced by this begin_borrow.
+
 This instruction is only valid in functions in Ownership SSA form.
 
 end_borrow
@@ -6374,6 +6377,9 @@ a type `T` into the move only value space.
 
 The ``lexical`` attribute specifies that the value corresponds to a local
 variable in the Swift source.
+
+The optional ``pointer_escape`` attribute specifies that a pointer to the
+operand escapes within the scope introduced by this move_value.
 
 
 drop_deinit

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -804,11 +804,13 @@ public:
 
   BeginBorrowInst *createBeginBorrow(SILLocation Loc, SILValue LV,
                                      bool isLexical = false,
-                                     bool hasPointerEscape = false) {
+                                     bool hasPointerEscape = false,
+                                     bool fromVarDecl = false) {
     assert(getFunction().hasOwnership());
     assert(!LV->getType().isAddress());
-    return insert(new (getModule()) BeginBorrowInst(getSILDebugLocation(Loc),
-                                                    LV, isLexical, hasPointerEscape));
+    return insert(new (getModule())
+                      BeginBorrowInst(getSILDebugLocation(Loc), LV, isLexical,
+                                      hasPointerEscape, fromVarDecl));
   }
 
   /// Convenience function for creating a load_borrow on non-trivial values and
@@ -1402,13 +1404,15 @@ public:
 
   MoveValueInst *createMoveValue(SILLocation loc, SILValue operand,
                                  bool isLexical = false,
-                                 bool hasPointerEscape = false) {
+                                 bool hasPointerEscape = false,
+                                 bool fromVarDecl = false) {
     assert(getFunction().hasOwnership());
     assert(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitMoveValueOperation");
-    return insert(new (getModule()) MoveValueInst(
-        getSILDebugLocation(loc), operand, isLexical, hasPointerEscape));
+    return insert(new (getModule())
+                      MoveValueInst(getSILDebugLocation(loc), operand,
+                                    isLexical, hasPointerEscape, fromVarDecl));
   }
 
   DropDeinitInst *createDropDeinit(SILLocation loc, SILValue operand) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1217,10 +1217,11 @@ void SILCloner<ImplClass>::visitBeginBorrowInst(BeginBorrowInst *Inst) {
     return recordFoldedValue(Inst, getOpValue(Inst->getOperand()));
   }
 
-  recordClonedInstruction(
-      Inst, getBuilder().createBeginBorrow(
-                getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
-                Inst->isLexical(), Inst->hasPointerEscape()));
+  recordClonedInstruction(Inst,
+                          getBuilder().createBeginBorrow(
+                              getOpLocation(Inst->getLoc()),
+                              getOpValue(Inst->getOperand()), Inst->isLexical(),
+                              Inst->hasPointerEscape(), Inst->isFromVarDecl()));
 }
 
 template <typename ImplClass>
@@ -1932,7 +1933,7 @@ void SILCloner<ImplClass>::visitMoveValueInst(MoveValueInst *Inst) {
   }
   auto *MVI = getBuilder().createMoveValue(
       getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
-      Inst->isLexical(), Inst->hasPointerEscape());
+      Inst->isLexical(), Inst->hasPointerEscape(), Inst->isFromVarDecl());
   MVI->setAllowsDiagnostics(Inst->getAllowDiagnostics());
   recordClonedInstruction(Inst, MVI);
 }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1218,9 +1218,9 @@ void SILCloner<ImplClass>::visitBeginBorrowInst(BeginBorrowInst *Inst) {
   }
 
   recordClonedInstruction(
-      Inst, getBuilder().createBeginBorrow(getOpLocation(Inst->getLoc()),
-                                           getOpValue(Inst->getOperand()),
-                                           Inst->isLexical()));
+      Inst, getBuilder().createBeginBorrow(
+                getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
+                Inst->isLexical(), Inst->hasPointerEscape()));
 }
 
 template <typename ImplClass>
@@ -1930,9 +1930,9 @@ void SILCloner<ImplClass>::visitMoveValueInst(MoveValueInst *Inst) {
   if (!getBuilder().hasOwnership()) {
     return recordFoldedValue(Inst, getOpValue(Inst->getOperand()));
   }
-  auto *MVI = getBuilder().createMoveValue(getOpLocation(Inst->getLoc()),
-                                           getOpValue(Inst->getOperand()),
-                                           Inst->isLexical());
+  auto *MVI = getBuilder().createMoveValue(
+      getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
+      Inst->isLexical(), Inst->hasPointerEscape());
   MVI->setAllowsDiagnostics(Inst->getAllowDiagnostics());
   recordClonedInstruction(Inst, MVI);
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4398,11 +4398,12 @@ class BeginBorrowInst
   USE_SHARED_UINT8;
 
   BeginBorrowInst(SILDebugLocation DebugLoc, SILValue LValue, bool isLexical,
-                  bool hasPointerEscape)
+                  bool hasPointerEscape, bool fromVarDecl)
       : UnaryInstructionBase(DebugLoc, LValue,
                              LValue->getType().getObjectType()) {
     sharedUInt8().BeginBorrowInst.lexical = isLexical;
     sharedUInt8().BeginBorrowInst.pointerEscape = hasPointerEscape;
+    sharedUInt8().BeginBorrowInst.fromVarDecl = fromVarDecl;
   }
 
 public:
@@ -4426,6 +4427,10 @@ public:
   }
   void setHasPointerEscape(bool pointerEscape) {
     sharedUInt8().BeginBorrowInst.pointerEscape = pointerEscape;
+  }
+
+  bool isFromVarDecl() const {
+    return sharedUInt8().BeginBorrowInst.fromVarDecl;
   }
 
   /// Return a range over all EndBorrow instructions for this BeginBorrow.
@@ -8374,10 +8379,11 @@ class MoveValueInst
   USE_SHARED_UINT8;
 
   MoveValueInst(SILDebugLocation DebugLoc, SILValue operand, bool isLexical,
-                bool hasPointerEscape)
+                bool hasPointerEscape, bool fromVarDecl)
       : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {
     sharedUInt8().MoveValueInst.lexical = isLexical;
     sharedUInt8().MoveValueInst.pointerEscape = hasPointerEscape;
+    sharedUInt8().MoveValueInst.fromVarDecl = fromVarDecl;
   }
 
 public:
@@ -8400,6 +8406,8 @@ public:
   void setHasPointerEscape(bool pointerEscape) {
     sharedUInt8().MoveValueInst.pointerEscape = pointerEscape;
   }
+
+  bool isFromVarDecl() const { return sharedUInt8().MoveValueInst.fromVarDecl; }
 };
 
 class DropDeinitInst

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -241,7 +241,8 @@ protected:
 
     SHARED_FIELD(BeginBorrowInst, uint8_t
                  lexical : 1,
-                 pointerEscape : 1);
+                 pointerEscape : 1,
+                 fromVarDecl : 1);
 
     SHARED_FIELD(CopyAddrInst, uint8_t
       isTakeOfSrc : 1,
@@ -272,7 +273,8 @@ protected:
     SHARED_FIELD(MoveValueInst, uint8_t
                  allowDiagnostics : 1,
                  lexical : 1,
-                 pointerEscape : 1);
+                 pointerEscape : 1,
+                 fromVarDecl : 1);
 
   // Do not use `_sharedUInt8_private` outside of SILNode.
   } _sharedUInt8_private;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1701,6 +1701,9 @@ public:
     if (BBI->hasPointerEscape()) {
       *this << "[pointer_escape] ";
     }
+    if (BBI->isFromVarDecl()) {
+      *this << "[var_decl] ";
+    }
     *this << getIDAndType(BBI->getOperand());
   }
 
@@ -2074,6 +2077,8 @@ public:
       *this << "[lexical] ";
     if (I->hasPointerEscape())
       *this << "[pointer_escape] ";
+    if (I->isFromVarDecl())
+      *this << "[var_decl] ";
     *this << getIDAndType(I->getOperand());
   }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3846,6 +3846,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     bool allowsDiagnostics = false;
     bool isLexical = false;
     bool hasPointerEscape = false;
+    bool fromVarDecl = false;
 
     StringRef AttrName;
     SourceLoc AttrLoc;
@@ -3856,6 +3857,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         isLexical = true;
       else if (AttrName == "pointer_escape")
         hasPointerEscape = true;
+      else if (AttrName == "var_decl")
+        fromVarDecl = true;
       else {
         P.diagnose(InstLoc.getSourceLoc(),
                    diag::sil_invalid_attribute_for_instruction, AttrName,
@@ -3868,7 +3871,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       return true;
     if (parseSILDebugLocation(InstLoc, B))
       return true;
-    auto *MVI = B.createMoveValue(InstLoc, Val, isLexical, hasPointerEscape);
+    auto *MVI = B.createMoveValue(InstLoc, Val, isLexical, hasPointerEscape,
+                                  fromVarDecl);
     MVI->setAllowsDiagnostics(allowsDiagnostics);
     ResultVal = MVI;
     break;
@@ -4077,6 +4081,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
 
     bool isLexical = false;
     bool hasPointerEscape = false;
+    bool fromVarDecl = false;
 
     StringRef AttrName;
     SourceLoc AttrLoc;
@@ -4085,6 +4090,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         isLexical = true;
       else if (AttrName == "pointer_escape")
         hasPointerEscape = true;
+      else if (AttrName == "var_decl")
+        fromVarDecl = true;
       else {
         P.diagnose(InstLoc.getSourceLoc(),
                    diag::sil_invalid_attribute_for_instruction, AttrName,
@@ -4097,7 +4104,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         parseSILDebugLocation(InstLoc, B))
       return true;
 
-    ResultVal = B.createBeginBorrow(InstLoc, Val, isLexical, hasPointerEscape);
+    ResultVal = B.createBeginBorrow(InstLoc, Val, isLexical, hasPointerEscape,
+                                    fromVarDecl);
     break;
   }
 

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -410,7 +410,7 @@ bool ConsumeOperatorCopyableValuesChecker::check() {
   for (auto &block : *fn) {
     for (auto &ii : block) {
       if (auto *bbi = dyn_cast<BeginBorrowInst>(&ii)) {
-        if (bbi->isLexical() && !bbi->getType().isMoveOnly()) {
+        if (bbi->isFromVarDecl() && !bbi->getType().isMoveOnly()) {
           LLVM_DEBUG(llvm::dbgs()
                      << "Found lexical lifetime to check: " << *bbi);
           valuesToCheck.insert(bbi);

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -3028,7 +3028,7 @@ SILValue LifetimeChecker::handleConditionalInitAssign() {
 ///
 ///    %box = alloc_box
 ///    %mark_uninit = mark_uninitialized %box
-///    %lifetime = begin_borrow [lexical] %mark_uninit
+///    %lifetime = begin_borrow [var_decl] %mark_uninit
 ///    %proj_box = project_box %lifetime
 ///
 /// We are replacing a
@@ -3048,7 +3048,7 @@ SILValue LifetimeChecker::handleConditionalInitAssign() {
 /// Consequently, it's not sufficient to just replace the destroy_value
 /// %mark_uninit with a destroy_addr %proj_box (or to replace it with a diamond
 /// where one branch has that destroy_addr) because the destroy_addr is a use
-/// of %proj_box which must be within the lexical lifetime of the box.
+/// of %proj_box which must be within the var_decl lifetime of the box.
 ///
 /// On the other side, we are hemmed in by the fact that the end_borrow must
 /// precede the dealloc_box which will be created in the diamond.  So we
@@ -3084,12 +3084,12 @@ static bool adjustAllocBoxEndBorrow(SILInstruction *previous,
   if (!pbi)
     return false;
 
-  // This fixup only applies if we're destroying a project_box of the lexical
+  // This fixup only applies if we're destroying a project_box of the var_decl
   // lifetime of an alloc_box.
   auto *lifetime = dyn_cast<BeginBorrowInst>(pbi->getOperand());
   if (!lifetime)
     return false;
-  assert(lifetime->isLexical());
+  assert(lifetime->isFromVarDecl());
   assert(isa<AllocBoxInst>(
       cast<MarkUninitializedInst>(lifetime->getOperand())->getOperand()));
 

--- a/lib/SILOptimizer/Mandatory/ReferenceBindingTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/ReferenceBindingTransform.cpp
@@ -173,35 +173,47 @@ CopyAddrInst *ReferenceBindingProcessor::findInit() {
   // Thus to find our initialization, we need to find a project_box use of our
   // target that directly initializes the value.
   CopyAddrInst *initInst = nullptr;
-  for (auto *use : mark->getUses()) {
-    LLVM_DEBUG(llvm::dbgs() << "Visiting use: " << *use->getUser());
+  InstructionWorklist worklist(mark->getFunction());
+  for (auto *user : mark->getUsers()) {
+    worklist.push(user);
+  }
+  while (auto *user = worklist.pop()) {
+    LLVM_DEBUG(llvm::dbgs() << "Visiting use: " << *user);
 
-    if (auto *pbi = dyn_cast<ProjectBoxInst>(use->getUser())) {
-      LLVM_DEBUG(llvm::dbgs() << "    Found project_box! Visiting pbi uses!\n");
-
-      for (auto *pbiUse : pbi->getUses()) {
-        LLVM_DEBUG(llvm::dbgs() << "    Pbi Use: " << *pbiUse->getUser());
-        auto *cai = dyn_cast<CopyAddrInst>(pbiUse->getUser());
-        if (!cai || cai->getDest() != pbi) {
-          LLVM_DEBUG(llvm::dbgs() << "    Either not a copy_addr or dest is "
-                                     "not the project_box! Skipping!\n");
-          continue;
-        }
-
-        if (initInst || !cai->isInitializationOfDest() || cai->isTakeOfSrc()) {
-          LLVM_DEBUG(
-              llvm::dbgs()
-              << "    Either already found an init inst or is an assign of a "
-                 "dest or a take of src... emitting unknown pattern!\n");
-          diagnosticEmitter.diagnoseUnknownPattern(mark);
-          return nullptr;
-        }
-        assert(!initInst && "Init twice?!");
-        assert(!cai->isTakeOfSrc());
-        initInst = cai;
-        LLVM_DEBUG(llvm::dbgs()
-                   << "    Found our init! Checking for other inits!\n");
+    auto *bbi = dyn_cast<BeginBorrowInst>(user);
+    if (bbi && bbi->isFromVarDecl()) {
+      for (auto *user : bbi->getUsers()) {
+        worklist.push(user);
       }
+      continue;
+    }
+    auto *pbi = dyn_cast<ProjectBoxInst>(user);
+    if (!pbi)
+      continue;
+    LLVM_DEBUG(llvm::dbgs() << "    Found project_box! Visiting pbi uses!\n");
+
+    for (auto *pbiUse : pbi->getUses()) {
+      LLVM_DEBUG(llvm::dbgs() << "    Pbi Use: " << *pbiUse->getUser());
+      auto *cai = dyn_cast<CopyAddrInst>(pbiUse->getUser());
+      if (!cai || cai->getDest() != pbi) {
+        LLVM_DEBUG(llvm::dbgs() << "    Either not a copy_addr or dest is "
+                                   "not the project_box! Skipping!\n");
+        continue;
+      }
+
+      if (initInst || !cai->isInitializationOfDest() || cai->isTakeOfSrc()) {
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "    Either already found an init inst or is an assign of a "
+               "dest or a take of src... emitting unknown pattern!\n");
+        diagnosticEmitter.diagnoseUnknownPattern(mark);
+        return nullptr;
+      }
+      assert(!initInst && "Init twice?!");
+      assert(!cai->isTakeOfSrc());
+      initInst = cai;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "    Found our init! Checking for other inits!\n");
     }
   }
   LLVM_DEBUG(llvm::dbgs() << "Final Init: " << *initInst);

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -485,6 +485,11 @@ eliminateSimpleBorrows(BeginBorrowInst *bbi, CanonicalizeInstruction &pass) {
                            !isNestedLexicalBeginBorrow(bbi)))
     return next;
 
+  // Borrow scopes representing a VarDecl can't be eliminated during the raw
+  // stage because they may be needed for diagnostics.
+  if (bbi->isFromVarDecl() && (bbi->getModule().getStage() == SILStage::Raw))
+    return next;
+
   // We know that our borrow is completely within the lifetime of its base value
   // if the borrow is never reborrowed. We check for reborrows and do not
   // optimize such cases. Otherwise, we can eliminate our borrow and instead use

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2154,11 +2154,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
     bool isLexical = Attr & 0x1;
     bool hasPointerEscape = (Attr >> 1) & 0x1;
+    bool fromVarDecl = (Attr >> 2) & 0x1;
     ResultInst = Builder.createBeginBorrow(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID),
                                         (SILValueCategory)TyCategory, Fn)),
-        isLexical, hasPointerEscape);
+        isLexical, hasPointerEscape, fromVarDecl);
     break;
   }
 
@@ -2245,10 +2246,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool AllowsDiagnostics = Attr & 0x1;
     bool IsLexical = (Attr >> 1) & 0x1;
     bool IsEscaping = (Attr >> 2) & 0x1;
+    bool IsFromVarDecl = (Attr >> 3) & 0x1;
     auto *MVI = Builder.createMoveValue(
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        IsLexical, IsEscaping);
+        IsLexical, IsEscaping, IsFromVarDecl);
     MVI->setAllowsDiagnostics(AllowsDiagnostics);
     ResultInst = MVI;
     break;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 819; // _resultDependsOnSelf
+const uint16_t SWIFTMODULE_VERSION_MINOR = 820; // begin_borrow/move_value [var_decl]
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -435,7 +435,7 @@ namespace sil_block {
   // SIL instructions with one typed valueref. (dealloc_stack, return)
   using SILOneOperandLayout =
       BCRecordLayout<SIL_ONE_OPERAND, SILInstOpCodeField,
-                     BCFixed<3>, // Optional attributes
+                     BCFixed<4>, // Optional attributes
                      TypeIDField, SILTypeCategoryField, ValueIDField>;
 
   using SILOneOperandExtraAttributeLayout = BCRecordLayout<

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1525,12 +1525,14 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     } else if (auto *ECMI = dyn_cast<EndCOWMutationInst>(&SI)) {
       Attr = ECMI->doKeepUnique();
     } else if (auto *BBI = dyn_cast<BeginBorrowInst>(&SI)) {
-      Attr =
-          unsigned(BBI->isLexical()) | unsigned(BBI->hasPointerEscape() << 1);
+      Attr = unsigned(BBI->isLexical()) |
+             (unsigned(BBI->hasPointerEscape() << 1)) |
+             (unsigned(BBI->isFromVarDecl() << 2));
     } else if (auto *MVI = dyn_cast<MoveValueInst>(&SI)) {
       Attr = unsigned(MVI->getAllowDiagnostics()) |
              (unsigned(MVI->isLexical() << 1)) |
-             (unsigned(MVI->hasPointerEscape() << 2));
+             (unsigned(MVI->hasPointerEscape() << 2)) |
+             (unsigned(MVI->isFromVarDecl() << 3));
     } else if (auto *I = dyn_cast<MarkUnresolvedNonCopyableValueInst>(&SI)) {
       Attr = unsigned(I->getCheckKind());
     } else if (auto *I = dyn_cast<MarkUnresolvedReferenceBindingInst>(&SI)) {

--- a/test/AutoDiff/SILGen/autodiff_builtins.swift
+++ b/test/AutoDiff/SILGen/autodiff_builtins.swift
@@ -97,7 +97,7 @@ func test_context_builtins_with_type<T>(t: T) {
 // CHECK-LABEL: sil{{.*}}@test_context_builtins_with_type : $@convention(thin) <T> (@in_guaranteed T) -> () {
 // CHECK: bb0({{%.*}} : $*T):
 // CHECK:   [[CTX:%.*]] = builtin "autoDiffCreateLinearMapContextWithType"<T>({{%.*}} : $@thick T.Type) : $Builtin.NativeObject // users: {{.*}}
-// CHECK:   [[BORROWED_CTX:%.*]] = begin_borrow [lexical] [[CTX]] : $Builtin.NativeObject // users: {{.*}}
+// CHECK:   [[BORROWED_CTX:%.*]] = begin_borrow [lexical] [var_decl] [[CTX]] : $Builtin.NativeObject // users: {{.*}}
 // CHECK:   [[BUF:%.*]] = builtin "autoDiffProjectTopLevelSubcontext"([[BORROWED_CTX]] : $Builtin.NativeObject) : $Builtin.RawPointer // users: {{.*}}
 // CHECK:   [[BUF:%.*]] = builtin "autoDiffAllocateSubcontextWithType"<T>([[BORROWED_CTX]] : $Builtin.NativeObject, {{.*}} : $@thick T.Type) : $Builtin.RawPointer // users: {{.*}}
 // CHECK:   destroy_value [[CTX]]

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -350,26 +350,26 @@ func testArrayUninitializedIntrinsicNested(_ x: Float, _ y: Float) -> [Float] {
 // CHECK: [ACTIVE]   [[ARRAY:%.*]] = apply %14<Float>(%7) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 // CHECK: [USEFUL]   [[INT_LIT:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK: [NONE]   // function_ref _allocateUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   [[TUP:%.*]] = apply %18<Float>([[INT_LIT]]) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: [ACTIVE]   [[TUP:%.*]] = apply %19<Float>([[INT_LIT]]) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: [ACTIVE] (**[[LHS:%.*]]**, [[RHS:%.*]]) = destructure_tuple [[TUP]] : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [VARIED] ([[LHS]], **[[RHS]]**) = destructure_tuple [[TUP]] : $(Array<Float>, Builtin.RawPointer)
 // CHECK: [ACTIVE]   [[FLOAT_PTR:%.*]] = pointer_to_address [[RHS]] : $Builtin.RawPointer to [strict] $*Float
 // CHECK: [USEFUL]   [[ZERO_LITERAL:%.*]] = integer_literal $Builtin.IntLiteral, 0
 // CHECK: [USEFUL]   [[META:%.*]] = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   [[RESULT_2:%.*]] = apply %25([[ZERO_LITERAL]], [[META]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [USEFUL]   [[RESULT_2:%.*]] = apply %26([[ZERO_LITERAL]], [[META]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [NONE]   // function_ref Array.subscript.getter
-// CHECK: [NONE]   %28 = apply %27<Float>([[FLOAT_PTR]], [[RESULT_2]], %15) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
+// CHECK: [NONE]   %29 = apply %28<Float>([[FLOAT_PTR]], [[RESULT_2]], %16) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
 // CHECK: [VARIED]   [[ONE_LITERAL:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK: [ACTIVE]   [[INDEX_ADDR:%.*]] = index_addr [[FLOAT_PTR]] : $*Float, [[ONE_LITERAL]] : $Builtin.Word
 // CHECK: [USEFUL]   [[ONE_LITERAL_AGAIN:%.*]] = integer_literal $Builtin.IntLiteral, 1
 // CHECK: [USEFUL]   [[META_AGAIN:%.*]] = metatype $@thin Int.Type
 // CHECK: [NONE]   // function_ref Int.init(_builtinIntegerLiteral:)
-// CHECK: [USEFUL]   %34 = apply %33([[ONE_LITERAL_AGAIN]], [[META_AGAIN]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [USEFUL]   %35 = apply %34([[ONE_LITERAL_AGAIN]], [[META_AGAIN]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK: [NONE]   // function_ref Array.subscript.getter
-// CHECK: [NONE]   %36 = apply %35<Float>(%30, %34, %15) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
+// CHECK: [NONE]   %37 = apply %36<Float>(%31, %35, %16) : $@convention(method) <τ_0_0> (Int, @guaranteed Array<τ_0_0>) -> @out τ_0_0
 // CHECK: [NONE]   // function_ref _finalizeUninitializedArray<A>(_:)
-// CHECK: [ACTIVE]   %38 = apply %37<Float>(%20) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
+// CHECK: [ACTIVE]   %39 = apply %38<Float>([[LHS]]) : $@convention(thin) <τ_0_0> (@owned Array<τ_0_0>) -> @owned Array<τ_0_0>
 
 // TF-978: Test array literal initialized with `apply` indirect results.
 struct Wrapper<T: Differentiable>: Differentiable {

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -52,7 +52,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // CHECK-NEXT: [[REGISTER_4:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_3]]
 // CHECK-NEXT: [[REGISTER_5:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_4]]
 // CHECK-NEXT: [[REGISTER_6:%[^,]+]] = move_value [allows_diagnostics] [lexical] [pointer_escape] [[REGISTER_5]]
-// CHECK-NEXT: return [[REGISTER_6]]
+// CHECK-NEXT: [[REGISTER_7:%[^,]+]] = move_value [var_decl] [[REGISTER_6]]
+// CHECK-NEXT: return [[REGISTER_7]]
 // CHECK-NEXT: } // end sil function 'test_movevalue_parsing'
 sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Builtin.NativeObject):
@@ -62,7 +63,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
   %4 = move_value [allows_diagnostics] [lexical] %3 : $Builtin.NativeObject
   %5 = move_value [lexical] [allows_diagnostics] %4 : $Builtin.NativeObject
   %6 = move_value [pointer_escape] [lexical] [allows_diagnostics] %5 : $Builtin.NativeObject
-  return %6 : $Builtin.NativeObject
+  %7 = move_value [var_decl] %6 : $Builtin.NativeObject
+  return %7 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil [ossa] @test_debug_value_alloc_stack_moved : $@convention(thin) (@owned Builtin.NativeObject) -> () {

--- a/test/SIL/Parser/borrow.sil
+++ b/test/SIL/Parser/borrow.sil
@@ -33,6 +33,7 @@ class C {}
 // CHECK-LABEL: sil [ossa] @foo
 // CHECK: begin_borrow {{%[^,]+}}
 // CHECK: begin_borrow [lexical] {{%[^,]+}}
+// CHECK: begin_borrow [var_decl] {{%[^,]+}}
 // CHECK-LABEL: } // end sil function 'foo'
 sil [ossa] @foo : $@convention(thin) () -> () {
   %instance = alloc_ref $C
@@ -40,6 +41,8 @@ sil [ossa] @foo : $@convention(thin) () -> () {
   end_borrow %guaranteed_c2 : $C
   %guaranteed_c = begin_borrow [lexical] %instance : $C
   end_borrow %guaranteed_c : $C
+  %guaranteed_c3 = begin_borrow [var_decl] %instance : $C
+  end_borrow %guaranteed_c3 : $C
   destroy_value %instance : $C
   %res = tuple ()
   return %res : $()

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -91,7 +91,8 @@ bb0:
 // CHECK-NEXT: [[REGISTER_3:%[^,]+]] = move_value [lexical] [[REGISTER_2]]
 // CHECK-NEXT: [[REGISTER_4:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_3]]
 // CHECK-NEXT: [[REGISTER_5:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_4]]
-// CHECK-NEXT: return [[REGISTER_5]]
+// CHECK-NEXT: [[REGISTER_6:%[^,]+]] = move_value [var_decl] [[REGISTER_5]]
+// CHECK-NEXT: return [[REGISTER_6]]
 // CHECK-NEXT: } // end sil function 'test_movevalue_parsing'
 sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Builtin.NativeObject):
@@ -100,7 +101,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
   %3 = move_value [lexical] %2 : $Builtin.NativeObject
   %4 = move_value [allows_diagnostics] [lexical] %3 : $Builtin.NativeObject
   %5 = move_value [lexical] [allows_diagnostics] %4 : $Builtin.NativeObject
-  return %5 : $Builtin.NativeObject
+  %6 = move_value [var_decl] %5 : $Builtin.NativeObject
+  return %6 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil [no_allocation] [ossa] @test_no_allocation : $@convention(thin) () -> () {

--- a/test/SIL/Serialization/borrow.sil
+++ b/test/SIL/Serialization/borrow.sil
@@ -11,6 +11,7 @@ import Builtin
 // CHECK-LABEL: sil [serialized] [ossa] @begin_borrow_test
 // CHECK: begin_borrow [lexical] {{%[^,]+}}
 // CHECK: begin_borrow {{%[^,]+}}
+// CHECK: begin_borrow [var_decl] {{%[^,]+}}
 // CHECK: } // end sil function 'begin_borrow_test'
 sil [serialized] [ossa] @begin_borrow_test : $@convention(thin) () -> () {
   %instance = alloc_ref $C
@@ -18,6 +19,8 @@ sil [serialized] [ossa] @begin_borrow_test : $@convention(thin) () -> () {
   end_borrow %guaranteed_c : $C
   %guaranteed_c2 = begin_borrow %instance : $C
   end_borrow %guaranteed_c2 : $C
+  %guaranteed_c3 = begin_borrow [var_decl] %instance : $C
+  end_borrow %guaranteed_c3 : $C
   destroy_value %instance : $C
   %res = tuple ()
   return %res : $()

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -28,10 +28,12 @@ bb0:
   return %2 : $()
 }
 
-sil [ossa] [always_inline] @callee_begin_borrow_lexical : $@convention(thin) () -> () {
+sil [ossa] [always_inline] @callee_begin_borrow : $@convention(thin) () -> () {
   %instance = alloc_ref $X
   %guaranteed_c = begin_borrow [lexical] %instance : $X
   end_borrow %guaranteed_c : $X
+  %guaranteed_c2 = begin_borrow [pointer_escape] %instance : $X
+  end_borrow %guaranteed_c2 : $X
   destroy_value %instance : $X
   %res = tuple ()
   return %res : $()
@@ -39,9 +41,10 @@ sil [ossa] [always_inline] @callee_begin_borrow_lexical : $@convention(thin) () 
 
 // CHECK-LABEL: sil [ossa] @caller_begin_borrow_lexical
 // CHECK: begin_borrow [lexical]
+// CHECK: begin_borrow [pointer_escape]
 // CHECK-LABEL: } // end sil function 'caller_begin_borrow_lexical'
 sil [ossa] @caller_begin_borrow_lexical : $@convention(thin) () -> () {
-  %callee_begin_borrow_lexical = function_ref @callee_begin_borrow_lexical : $@convention(thin) () -> ()
+  %callee_begin_borrow_lexical = function_ref @callee_begin_borrow : $@convention(thin) () -> ()
   %res = apply %callee_begin_borrow_lexical() : $@convention(thin) () -> ()
   return %res : $()
 }
@@ -77,7 +80,8 @@ entry(%0 : @owned $Builtin.NativeObject):
   %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
   %3 = move_value [lexical] %2 : $Builtin.NativeObject
   %4 = move_value [allows_diagnostics] [lexical] %3 : $Builtin.NativeObject
-  return %4 : $Builtin.NativeObject
+  %5 = move_value [pointer_escape] %4 : $Builtin.NativeObject
+  return %5 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil [ossa] @caller_move_value {{.*}} {
@@ -86,7 +90,8 @@ entry(%0 : @owned $Builtin.NativeObject):
 // CHECK:       [[REGISTER_2:%[^,]+]] = move_value [allows_diagnostics] [[REGISTER_1]]
 // CHECK:       [[REGISTER_3:%[^,]+]] = move_value [lexical] [[REGISTER_2]]
 // CHECK:       [[REGISTER_4:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_3]]
-// CHECK:       return [[REGISTER_4]]
+// CHECK:       [[REGISTER_5:%[^,]+]] = move_value [pointer_escape] [[REGISTER_4]]
+// CHECK:       return [[REGISTER_5]]
 // CHECK-LABEL: } // end sil function 'caller_move_value'
 sil [ossa] @caller_move_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 entry(%0 : @owned $Builtin.NativeObject):

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -34,6 +34,8 @@ sil [ossa] [always_inline] @callee_begin_borrow : $@convention(thin) () -> () {
   end_borrow %guaranteed_c : $X
   %guaranteed_c2 = begin_borrow [pointer_escape] %instance : $X
   end_borrow %guaranteed_c2 : $X
+  %guaranteed_c3 = begin_borrow [var_decl] %instance : $X
+  end_borrow %guaranteed_c3 : $X
   destroy_value %instance : $X
   %res = tuple ()
   return %res : $()
@@ -42,6 +44,7 @@ sil [ossa] [always_inline] @callee_begin_borrow : $@convention(thin) () -> () {
 // CHECK-LABEL: sil [ossa] @caller_begin_borrow_lexical
 // CHECK: begin_borrow [lexical]
 // CHECK: begin_borrow [pointer_escape]
+// CHECK: begin_borrow [var_decl]
 // CHECK-LABEL: } // end sil function 'caller_begin_borrow_lexical'
 sil [ossa] @caller_begin_borrow_lexical : $@convention(thin) () -> () {
   %callee_begin_borrow_lexical = function_ref @callee_begin_borrow : $@convention(thin) () -> ()
@@ -81,7 +84,8 @@ entry(%0 : @owned $Builtin.NativeObject):
   %3 = move_value [lexical] %2 : $Builtin.NativeObject
   %4 = move_value [allows_diagnostics] [lexical] %3 : $Builtin.NativeObject
   %5 = move_value [pointer_escape] %4 : $Builtin.NativeObject
-  return %5 : $Builtin.NativeObject
+  %6 = move_value [var_decl] %5 : $Builtin.NativeObject
+  return %6 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil [ossa] @caller_move_value {{.*}} {
@@ -91,7 +95,8 @@ entry(%0 : @owned $Builtin.NativeObject):
 // CHECK:       [[REGISTER_3:%[^,]+]] = move_value [lexical] [[REGISTER_2]]
 // CHECK:       [[REGISTER_4:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_3]]
 // CHECK:       [[REGISTER_5:%[^,]+]] = move_value [pointer_escape] [[REGISTER_4]]
-// CHECK:       return [[REGISTER_5]]
+// CHECK:       [[REGISTER_6:%[^,]+]] = move_value [var_decl] [[REGISTER_5]]
+// CHECK:       return [[REGISTER_6]]
 // CHECK-LABEL: } // end sil function 'caller_move_value'
 sil [ossa] @caller_move_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 entry(%0 : @owned $Builtin.NativeObject):

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -12,7 +12,7 @@ public struct S {
 // CHECK: bb0(%0 : @guaranteed $Optional<AnyObject>):
 // CHECK: [[BOX:%.*]] = alloc_box ${ var S }, var, name "s"
 // CHECK: [[MARKED_BOX:%.*]] = mark_uninitialized [var] [[BOX]] : ${ var S }
-// CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_BOX]]
+// CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_BOX]]
 // CHECK: [[ADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var S }, 0
 // CHECK: cond_br %{{.*}}, bb1, bb2
 // CHECK: bb1:
@@ -46,7 +46,7 @@ func takeS(_ s: S) {}
 // CHECK-LABEL: sil [ossa] @$s17access_marker_gen14modifyAndReadSyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
 // CHECK: %[[BOX:.*]] = alloc_box ${ var S }, var, name "s"
-// CHECK: %[[BOX_LIFETIME:[^,]+]] = begin_borrow [lexical] %[[BOX]]
+// CHECK: %[[BOX_LIFETIME:[^,]+]] = begin_borrow [lexical] [var_decl] %[[BOX]]
 // CHECK: %[[ADDRS:.*]] = project_box %[[BOX_LIFETIME]] : ${ var S }, 0
 // CHECK: %[[ACCESS1:.*]] = begin_access [modify] [unknown] %[[ADDRS]] : $*S
 // CHECK: %[[ADDRI:.*]] = struct_element_addr %[[ACCESS1]] : $*S, #S.i

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -166,7 +166,7 @@ func address_only_assignment_from_lv(_ dest: inout Unloadable, v: Unloadable) {
   var v = v
   // CHECK: bb0([[DEST:%[0-9]+]] : $*any Unloadable, [[VARG:%[0-9]+]] : $*any Unloadable):
   // CHECK: [[VBOX:%.*]] = alloc_box ${ var any Unloadable }
-  // CHECK: [[V_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VBOX]]
+  // CHECK: [[V_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[VBOX]]
   // CHECK: [[PBOX:%[0-9]+]] = project_box [[V_LIFETIME]]
   // CHECK: copy_addr [[VARG]] to [init] [[PBOX]] : $*any Unloadable
   dest = v
@@ -212,7 +212,7 @@ func address_only_var() -> Unloadable {
   // CHECK: bb0([[RET:%[0-9]+]] : $*any Unloadable):
   var x = some_address_only_function_1()
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var any Unloadable }
-  // CHECK: [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[XBOX]]
   // CHECK: [[XPB:%.*]] = project_box [[XBOX_LIFETIME]]
   // CHECK: apply {{%.*}}([[XPB]])
   return x

--- a/test/SILGen/async_conversion.swift
+++ b/test/SILGen/async_conversion.swift
@@ -70,7 +70,7 @@ actor AnActor {
     // CHECK: hop_to_executor {{..*}} : $AnActor
     //  [[F:%.*]] = function_ref @$s4test7AnActorC6calleryyYaFySicACYicfu_ : $@convention(thin) (@guaranteed AnActor) -> @owned @callee_guaranteed (Int) -> ()
     //  [[APPLIED_F:%.*]] = apply [[F]]({{.*}}) : $@convention(thin) (@guaranteed AnActor) -> @owned @callee_guaranteed (Int) -> ()
-    //  [[BORROWED_F:%.*]] = begin_borrow [lexical] [[APPLIED_F]] : $@callee_guaranteed (Int) -> ()
+    //  [[BORROWED_F:%.*]] = begin_borrow [lexical] [var_decl] [[APPLIED_F]] : $@callee_guaranteed (Int) -> ()
     //  [[COPIED_F:%.*]] = copy_value [[BORROWED_F]] : $@callee_guaranteed (Int) -> ()
     //  [[THUNK:%.*]] = function_ref @$sSiIegy_SiIegHy_TR : $@convention(thin) @async (Int, @guaranteed @callee_guaranteed (Int) -> ()) -> ()
     //  = partial_apply [callee_guaranteed] [[THUNK]]([[COPIED_F]]) : $@convention(thin) @async (Int, @guaranteed @callee_guaranteed (Int) -> ()) -> ()

--- a/test/SILGen/back_deployed_attr_struct_init.swift
+++ b/test/SILGen/back_deployed_attr_struct_init.swift
@@ -13,7 +13,7 @@ public struct TopLevelStruct<T> {
   // CHECK: bb0([[SELF_OUT:%.*]] : $*TopLevelStruct<T>, [[T_ARG:%.*]] : $*T, [[METATYPE_ARG:%.*]] : $@thin TopLevelStruct<T>.Type):
   // CHECK:   [[SELF:%.*]] = alloc_box $<τ_0_0> { var TopLevelStruct<τ_0_0> } <T>, var, name "self"
   // CHECK:   [[MARKED_SELF:%.*]] = mark_uninitialized [rootself] [[SELF]] : $<τ_0_0> { var TopLevelStruct<τ_0_0> } <T>
-  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [lexical] [[MARKED_SELF]] : $<τ_0_0> { var TopLevelStruct<τ_0_0> } <T>
+  // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF]] : $<τ_0_0> { var TopLevelStruct<τ_0_0> } <T>
   // CHECK:   [[BOX:%.*]] = project_box [[BORROWED_SELF]] : $<τ_0_0> { var TopLevelStruct<τ_0_0> } <T>, 0
   // CHECK:   [[T_STACK:%.*]] = alloc_stack $T
   // CHECK:   copy_addr [[T_ARG]] to [init] [[T_STACK]] : $*T

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -18,7 +18,7 @@ func useD(_ d: D) {}
 // CHECK-LABEL: sil hidden [ossa] @$s6borrow44lvalueBorrowShouldBeAtEndOfFormalAccessScope{{.*}} : $@convention(thin) () -> () {
 // CHECK: bb0:
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var C }, var, name "c"
-// CHECK:   [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PB_BOX:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PB_BOX]] : $*C
 // CHECK:   [[CLASS:%.*]] = load [copy] [[ACCESS]]

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -82,7 +82,7 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK-LABEL: sil hidden [ossa] @$s18boxed_existentials23test_property_of_lvalueySSs5Error_pF :
 // CHECK:       bb0([[ARG:%.*]] : @guaranteed $any Error):
 // CHECK:         [[VAR:%.*]] = alloc_box ${ var any Error }
-// CHECK:         [[VAR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VAR]]
+// CHECK:         [[VAR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[VAR]]
 // CHECK:         [[PVAR:%.*]] = project_box [[VAR_LIFETIME]]
 // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]] : $any Error
 // CHECK:         store [[ARG_COPY]] to [init] [[PVAR]]
@@ -133,10 +133,10 @@ func test_open_existential_semantics(_ guaranteed: Error,
                                      _ immediate: Error) {
   var immediate = immediate
   // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var any Error }
-  // CHECK: [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // CHECK: [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[IMMEDIATE_BOX]]
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
   // GUARANTEED: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var any Error }
-  // GUARANTEED: [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // GUARANTEED: [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[IMMEDIATE_BOX]]
   // GUARANTEED: [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
 
   // CHECK-NOT: copy_value [[ARG0]]
@@ -204,7 +204,7 @@ func test_open_existential_semantics(_ guaranteed: Error,
 func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
   var immediate = immediate
   // CHECK:       [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var any Error }
-  // CHECK:       [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // CHECK:       [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[IMMEDIATE_BOX]]
   // CHECK:       [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
   if true {
     // CHECK-NOT: copy_value [[GUAR]]

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -68,7 +68,7 @@ public func foo(_ x: Double) {
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: [[THUNK:%.*]] = function_ref @$s10cf_members3fooyySdFSo10IAMStruct1VSdcADcfu0_ : $@convention(thin) (Struct1) -> @owned @callee_guaranteed (Double) -> Struct1
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
-  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [lexical] [[C]]
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [lexical] [var_decl] [[C]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
   // CHECK: [[BORROWED_C2:%.*]] = begin_borrow [[C_COPY]]
   let c: (Double) -> Struct1 = z.translate(radians:)
@@ -102,7 +102,7 @@ public func foo(_ x: Double) {
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: [[THUNK:%.*]] = function_ref @$s10cf_members3fooyySdFSo10IAMStruct1VSdcADcfu4_ : $@convention(thin) (Struct1) -> @owned @callee_guaranteed (Double) -> Struct1
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
-  // CHECK: [[BORROWED_F:%.*]] = begin_borrow [lexical] [[F]]
+  // CHECK: [[BORROWED_F:%.*]] = begin_borrow [lexical] [var_decl] [[F]]
   // CHECK: [[F_COPY:%.*]] = copy_value [[BORROWED_F]]
   // CHECK: [[BORROWED_F2:%.*]] = begin_borrow [[F_COPY]]
   let f = z.scale

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -37,7 +37,7 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : @guaranteed $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound> { var τ_0_0 } <T>
-  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_ADDR]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X_ADDR]]
   // CHECK:   [[PB:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
@@ -54,7 +54,7 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : @guaranteed $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound, τ_0_0 : NotClassBound> { var τ_0_0 } <T>
-  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_ADDR]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X_ADDR]]
   // CHECK:   [[PB:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
@@ -69,7 +69,7 @@ func class_bound_protocol(x: ClassBound) -> ClassBound {
   var x = x
   // CHECK: bb0([[X:%.*]] : @guaranteed $any ClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var any ClassBound }
-  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_ADDR]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X_ADDR]]
   // CHECK:   [[PB:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
@@ -85,7 +85,7 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
   var x = x
   // CHECK: bb0([[X:%.*]] : @guaranteed $any ClassBound & NotClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var any ClassBound & NotClassBound }
-  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_ADDR]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X_ADDR]]
   // CHECK:   [[PB:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
@@ -131,7 +131,7 @@ func class_bound_method(x: ClassBound) {
   var x = x
   x.classBoundMethod()
   // CHECK: [[XBOX:%.*]] = alloc_box ${ var any ClassBound }, var, name "x"
-  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[XBOX]]
   // CHECK: [[XBOX_PB:%.*]] = project_box [[XLIFETIME]]
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[XBOX_PB]]

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -34,9 +34,9 @@ func read_only_capture(_ x: Int) -> Int {
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
   // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
   // SEMANTIC ARC TODO: This is incorrect. We need to do the project_box on the copy.
-  // CHECK:   [[PROJECT:%.*]] = project_box [[XBOX]]
+  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [var_decl] [[XBOX]]
+  // CHECK:   [[PROJECT:%.*]] = project_box [[LIFETIME]]
   // CHECK:   store [[X]] to [trivial] [[PROJECT]]
-  // CHECK:   [[XLIFETIME:%[0-9]+]] = begin_borrow [[XBOX]]
 
   func cap() -> Int {
     return x
@@ -46,7 +46,7 @@ func read_only_capture(_ x: Int) -> Int {
   // SEMANTIC ARC TODO: See above. This needs to happen on the copy_valued box.
   // CHECK:   mark_function_escape [[PROJECT]]
   // CHECK:   [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:\$s8closures17read_only_capture.*]] : $@convention(thin) (@guaranteed { var Int }) -> Int
-  // CHECK:   [[RET:%[0-9]+]] = apply [[CAP]]([[XLIFETIME]])
+  // CHECK:   [[RET:%[0-9]+]] = apply [[CAP]]([[LIFETIME]])
   // CHECK:   destroy_value [[XBOX]]
   // CHECK:   return [[RET]]
 }
@@ -66,13 +66,14 @@ func write_to_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
   // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[XBOX_PB:%[0-9]+]] = project_box [[XBOX]]
+  // CHECK:   [[LIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[XBOX]]
+  // CHECK:   [[XBOX_PB:%[0-9]+]] = project_box [[LIFETIME]]
   // CHECK:   store [[X]] to [trivial] [[XBOX_PB]]
   // CHECK:   [[X2BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2BOX]]
+  // CHECK:   [[X2LIFETIME:%.*]] = begin_borrow [var_decl] [[X2BOX]]
+  // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2LIFETIME]]
   // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[XBOX_PB]] : $*Int
   // CHECK:   copy_addr [[ACCESS]] to [init] [[X2BOX_PB]]
-  // CHECK:   [[X2LIFETIME:%[0-9]+]] = begin_borrow [[X2BOX]]
   // CHECK:   mark_function_escape [[X2BOX_PB]]
   var x2 = x
 
@@ -121,14 +122,15 @@ func capture_local_func(_ x: Int) -> () -> () -> Int {
   // CHECK: bb0([[ARG:%.*]] : $Int):
   var x = x
   // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[XBOX_PB:%[0-9]+]] = project_box [[XBOX]]
+  // CHECK:   [[LIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[XBOX]]
+  // CHECK:   [[XBOX_PB:%[0-9]+]] = project_box [[LIFETIME]]
   // CHECK:   store [[ARG]] to [trivial] [[XBOX_PB]]
 
   func aleph() -> Int { return x }
 
   func beth() -> () -> Int { return aleph }
   // CHECK: [[BETH_REF:%.*]] = function_ref @[[BETH_NAME:\$s8closures18capture_local_funcySiycycSiF4bethL_SiycyF]] : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> Int
-  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[LIFETIME]]
   // SEMANTIC ARC TODO: This is incorrect. This should be a project_box from XBOX_COPY.
   // CHECK: mark_function_escape [[XBOX_PB]]
   // CHECK: [[BETH_CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[BETH_REF]]([[XBOX_COPY]])
@@ -158,7 +160,8 @@ func anon_read_only_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%[0-9]+]] = project_box [[XBOX]]
+  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[XBOX]]
+  // CHECK: [[PB:%[0-9]+]] = project_box [[LIFETIME]]
 
   return ({ x })()
   // -- func expression
@@ -180,7 +183,8 @@ func small_closure_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[XBOX]]
+  // CHECK: [[LIFETIME:%.*]] = begin_borrow [var_decl] [[XBOX]]
+  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
 
   return { x }()
   // -- func expression
@@ -202,11 +206,12 @@ func small_closure_capture(_ x: Int) -> Int {
 func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
   var x = x
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
+  // CHECK: [[LIFETIME:%.*]] = begin_borrow [var_decl] [[XBOX]]
 
   return { x + $0 }
   // -- func expression
   // CHECK: [[ANON:%[0-9]+]] = function_ref @[[CLOSURE_NAME:\$s8closures35small_closure_capture_with_argument.*]] : $@convention(thin) (Int, @guaranteed { var Int }) -> Int
-  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[LIFETIME]]
   // CHECK: [[ANON_CLOSURE_APP:%[0-9]+]] = partial_apply [callee_guaranteed] [[ANON]]([[XBOX_COPY]])
   // -- return
   // CHECK: destroy_value [[XBOX]]
@@ -239,7 +244,8 @@ func uncaptured_locals(_ x: Int) -> (Int, Int) {
   // -- locals without captures are stack-allocated
   // CHECK: bb0([[XARG:%[0-9]+]] : $Int):
   // CHECK:   [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[PB:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK:   [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK:   store [[XARG]] to [trivial] [[PB]]
 
   var y = zero
@@ -313,7 +319,7 @@ class SelfCapturedInInit : Base {
   // First create our initial value for self.
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var SelfCapturedInInit }, let, name "self"
   // CHECK:   [[UNINIT_SELF:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
+  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[UNINIT_SELF]]
   // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   store [[SELF]] to [init] [[PB_SELF_BOX]]
   //
@@ -488,7 +494,7 @@ class SuperSub : SuperBase {
   // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:\$s8closures8SuperSubC1c[_0-9a-zA-Z]*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[SELF_COPY]])
-  // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [lexical] [[PA]]
+  // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [lexical] [var_decl] [[PA]]
   // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
   // CHECK:   [[B:%.*]] = begin_borrow [[PA_COPY]]
   // CHECK:   apply [[B]]()
@@ -520,7 +526,7 @@ class SuperSub : SuperBase {
   // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_1:\$s8closures8SuperSubC1d[_0-9a-zA-Z]*]] : $@convention(thin) (@guaranteed SuperSub) -> ()
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[SELF_COPY]])
-  // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [lexical] [[PA]]
+  // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [lexical] [var_decl] [[PA]]
   // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
   // CHECK:   [[B:%.*]] = begin_borrow [[PA_COPY]]
   // CHECK:   apply [[B]]()
@@ -563,7 +569,7 @@ class SuperSub : SuperBase {
     // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_NAME2:\$s8closures8SuperSubC1e.*]] : $@convention(thin)
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[ARG_COPY]])
-    // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [lexical] [[PA]]
+    // CHECK:   [[BORROWED_PA:%.*]] = begin_borrow [lexical] [var_decl] [[PA]]
     // CHECK:   [[PA_COPY:%.*]] = copy_value [[BORROWED_PA]]
     // CHECK:   [[B:%.*]] = begin_borrow [[PA_COPY]]
     // CHECK:   apply [[B]]() : $@callee_guaranteed () -> ()
@@ -656,7 +662,7 @@ class SuperSub : SuperBase {
 // -- We enter with an assumed strong +1.
 // CHECK:  bb0([[SELF:%.*]] : @guaranteed $UnownedSelfNestedCapture):
 // CHECK:         [[OUTER_SELF_CAPTURE:%.*]] = alloc_box ${ var @sil_unowned UnownedSelfNestedCapture }
-// CHECK:         [[OUTER_SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[OUTER_SELF_CAPTURE]]
+// CHECK:         [[OUTER_SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[OUTER_SELF_CAPTURE]]
 // CHECK:         [[PB:%.*]] = project_box [[OUTER_SELF_LIFETIME]]
 // -- strong +2
 // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -7,7 +7,7 @@ class A {
 // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thick A.Type):
 // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var A }
 // CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var A }
-// CHECK:   [[UNINIT_SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT_SELF]]
+// CHECK:   [[UNINIT_SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[UNINIT_SELF]]
 // CHECK:   [[PB:%.*]] = project_box [[UNINIT_SELF_LIFETIME]]
 // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELF_META]] : $@thick A.Type, #A.init!allocator
 // CHECK:   [[INIT_RESULT:%[0-9]+]] = apply [[INIT]]({{%[^,]*}}, [[SELF_META]])

--- a/test/SILGen/consume_operator.swift
+++ b/test/SILGen/consume_operator.swift
@@ -8,7 +8,7 @@ protocol P {
 
 // CHECK-LABEL: sil hidden [ossa] @$s7consume15testLoadableLetyyF : $@convention(thin) () -> () {
 // CHECK: [[ORIG_VALUE:%.*]] = apply {{%.*}}({{%.*}}) : $@convention(method) (@thick Klass.Type) -> @owned Klass
-// CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [lexical] [[ORIG_VALUE]]
+// CHECK: [[BORROWED_VALUE:%.*]] = begin_borrow [lexical] [var_decl] [[ORIG_VALUE]]
 // CHECK: [[COPY:%.*]] = copy_value [[BORROWED_VALUE:%.*]]
 // CHECK: move_value [allows_diagnostics] [[COPY]]
 // CHECK: } // end sil function '$s7consume15testLoadableLetyyF'
@@ -19,7 +19,7 @@ func testLoadableLet() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s7consume15testLoadableVaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW_BOX]]
 //
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
@@ -53,7 +53,7 @@ func testAddressOnlyLet<T : P>(_ t: T.Type) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s7consume18testAddressOnlyVaryyxmAA1PRzlF : $@convention(thin) <T where T : P> (@thick T.Type) -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW_BOX]]
 //
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]

--- a/test/SILGen/consuming_parameter.swift
+++ b/test/SILGen/consuming_parameter.swift
@@ -6,11 +6,12 @@ func bar(_: String) {}
 func foo(y: consuming String, z: String) -> () -> String {
     // CHECK: bb0(%0 : @noImplicitCopy @_eagerMove @owned $String, %1 : @guaranteed $String):
     // CHECK:   [[BOX:%.*]] = alloc_box ${ var @moveOnly String }
-    // CHECK:   [[Y:%.*]] = project_box [[BOX]]
+    // CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+    // CHECK:   [[Y:%.*]] = project_box [[BOX_LIFETIME]]
     // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_addr [[Y]]
     // CHECK:   store %0 to [init] [[UNWRAP]]
 
-    // CHECK:   [[YCAPTURE:%.*]] = copy_value [[BOX]]
+    // CHECK:   [[YCAPTURE:%.*]] = copy_value [[BOX_LIFETIME]]
     // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_box [[YCAPTURE]]
     // CHECK:   partial_apply {{.*}} {{%.*}}([[UNWRAP]])
     let r = { y }
@@ -42,11 +43,12 @@ struct Butt {
     consuming func merged(with other: Butt) -> () -> Butt {
         // CHECK: bb0(%0 : @guaranteed $Butt, %1 : @noImplicitCopy @_eagerMove @owned $Butt):
         // CHECK:   [[BOX:%.*]] = alloc_box ${ var @moveOnly Butt }
-        // CHECK:   [[SELF:%.*]] = project_box [[BOX]]
+        // CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+        // CHECK:   [[SELF:%.*]] = project_box [[BOX_LIFETIME]]
         // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_addr [[SELF]]
         // CHECK:   store %1 to [init] [[UNWRAP]]
 
-        // CHECK:   [[SELFCAPTURE:%.*]] = copy_value [[BOX]]
+        // CHECK:   [[SELFCAPTURE:%.*]] = copy_value [[BOX_LIFETIME]]
         // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_box [[SELFCAPTURE]]
         // CHECK:   partial_apply {{.*}} {{%.*}}([[UNWRAP]])
         let r = { self }

--- a/test/SILGen/copy_expr.swift
+++ b/test/SILGen/copy_expr.swift
@@ -25,7 +25,7 @@ struct ContainKlass {
 
 // CHECK-LABEL: sil hidden [ossa] @$s9copy_expr22testCopyLoadableRValueyyF : $@convention(thin) () -> () {
 // CHECK: [[X:%.*]] = apply {{%.*}}({{%.*}}) : $@convention(method) (@thin ContainKlass.Type) -> @owned ContainKlass
-// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[X]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[X]]
 // CHECK: [[COPY_BORROW:%.*]] = copy_value [[BORROW]]
 // CHECK: explicit_copy_value [[COPY_BORROW]]
 // CHECK: } // end sil function '$s9copy_expr22testCopyLoadableRValueyyF'
@@ -36,7 +36,7 @@ func testCopyLoadableRValue() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s9copy_expr25testCopyLoadableVarLValueyyF : $@convention(thin) () -> () {
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var ContainKlass }, var, name "x"
-// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PROJECT_BOX:%.*]] = project_box [[BORROW_BOX]]
 //
 // CHECK:   [[FINAL_ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT_BOX]]
@@ -88,7 +88,7 @@ func testCopyAddressOnlyRValue<T : P>(_ t: T.Type) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s9copy_expr25testCopyAddressOnlyLValueyyxmAA1PRzlF : $@convention(thin) <T where T : P> (@thick T.Type) -> () {
 // CHECK:   [[BOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : P> { var τ_0_0 } <T>, var, name "x"
-// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PROJECT_BOX:%.*]] = project_box [[BORROW_BOX]]
 //
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT_BOX]]
@@ -114,7 +114,7 @@ func testCopyAddressOnlyLValueArg<T : P>(_ x: inout T) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s9copy_expr31testCallMethodOnLoadableLetCopyyyF : $@convention(thin) () -> () {
 // CHECK: [[ORIG_X:%.*]] = apply {{%.*}}({{%.*}}) : $@convention(method) (@thin ContainKlass.Type) -> @owned ContainKlass
-// CHECK: [[X:%.*]] = begin_borrow [lexical] [[ORIG_X]]
+// CHECK: [[X:%.*]] = begin_borrow [lexical] [var_decl] [[ORIG_X]]
 //
 // Calling consumeFunc.
 // CHECK: [[COPY_X:%.*]] = copy_value [[X]]
@@ -162,7 +162,7 @@ func testCallMethodOnLoadableLetCopy() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s9copy_expr31testCallMethodOnLoadableVarCopyyyF : $@convention(thin) () -> () {
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var ContainKlass }
-// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PROJECT:%.*]] = project_box [[BORROW]]
 //
 // Calling consumeFunc.
@@ -351,7 +351,7 @@ func testCallMethodOnAddressOnlyLetCopy<T : P>(_ t: T.Type) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s9copy_expr34testCallMethodOnAddressOnlyVarCopyyyxmAA1PRzlF : $@convention(thin) <T where T : P> (@thick T.Type) -> () {
 // CHECK:   [[BOX:%.*]] = alloc_box $
-// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PROJECT:%.*]] = project_box [[BORROW]]
 //
 // Calling consumeFunc.

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -9,9 +9,11 @@ func getInt() -> Int { return zero }
 
 // CHECK-LABEL: sil hidden [ossa] @$s21copy_lvalue_peepholes014init_var_from_B0{{[_0-9a-zA-Z]*}}F
 // CHECK:   [[X:%.*]] = alloc_box ${ var Builtin.Int64 }
-// CHECK:   [[PBX:%.*]] = project_box [[X]]
+// CHECK:   [[XLIFE:%.*]] = begin_borrow [var_decl] [[X]]
+// CHECK:   [[PBX:%.*]] = project_box [[XLIFE]]
 // CHECK:   [[Y:%.*]] = alloc_box ${ var Builtin.Int64 }
-// CHECK:   [[PBY:%.*]] = project_box [[Y]]
+// CHECK:   [[YLIFE:%.*]] = begin_borrow [var_decl] [[Y]]
+// CHECK:   [[PBY:%.*]] = project_box [[YLIFE]]
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
 // CHECK:   copy_addr [[READ]] to [init] [[PBY]] : $*Builtin.Int64
 func init_var_from_lvalue(x: Int) {
@@ -38,7 +40,8 @@ func init_var_from_computed_lvalue() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s21copy_lvalue_peepholes021assign_computed_from_B0{{[_0-9a-zA-Z]*}}F
 // CHECK:   [[Y:%.*]] = alloc_box
-// CHECK:   [[PBY:%.*]] = project_box [[Y]]
+// CHECK:   [[YLIFE:%.*]] = begin_borrow [var_decl] [[Y]]
+// CHECK:   [[PBY:%.*]] = project_box [[YLIFE]]
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBY]]
 // CHECK:   [[Y_VAL:%.*]] = load [trivial] [[READ]]
 // CHECK:   [[SETTER:%.*]] = function_ref @$s21copy_lvalue_peepholes8computedBi64_vs

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -33,27 +33,34 @@ func tuple_patterns() {
   var (a, b) : (Int, Float)
   // CHECK: [[ABOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[AADDR:%[0-9]+]] = mark_uninitialized [var] [[ABOX]]
-  // CHECK: [[PBA:%.*]] = project_box [[AADDR]]
+  // CHECK: [[ALIFE:%.*]] = begin_borrow [var_decl] [[AADDR]]
+  // CHECK: [[PBA:%.*]] = project_box [[ALIFE]]
   // CHECK: [[BBOX:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[BADDR:%[0-9]+]] = mark_uninitialized [var] [[BBOX]]
-  // CHECK: [[PBB:%.*]] = project_box [[BADDR]]
+  // CHECK: [[BLIFE:%.*]] = begin_borrow [var_decl] [[BADDR]]
+  // CHECK: [[PBB:%.*]] = project_box [[BLIFE]]
 
   var (c, d) = (a, b)
   // CHECK: [[CADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBC:%.*]] = project_box [[CADDR]]
+  // CHECK: [[CLIFE:%.*]] = begin_borrow [var_decl] [[CADDR]]
+  // CHECK: [[PBC:%.*]] = project_box [[CLIFE]]
   // CHECK: [[DADDR:%[0-9]+]] = alloc_box ${ var Float }
-  // CHECK: [[PBD:%.*]] = project_box [[DADDR]]
+  // CHECK: [[DLIFE:%.*]] = begin_borrow [var_decl] [[DADDR]]
+  // CHECK: [[PBD:%.*]] = project_box [[DLIFE]]
   // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
   // CHECK: copy_addr [[READA]] to [init] [[PBC]]
   // CHECK: [[READB:%.*]] = begin_access [read] [unknown] [[PBB]] : $*Float
   // CHECK: copy_addr [[READB]] to [init] [[PBD]]
   // CHECK: [[EADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBE:%.*]] = project_box [[EADDR]]
+  // CHECK: [[ELIFE:%.*]] = begin_borrow [var_decl] [[EADDR]]
+  // CHECK: [[PBE:%.*]] = project_box [[ELIFE]]
   // CHECK: [[FADDR:%[0-9]+]] = alloc_box ${ var Float }
-  // CHECK: [[PBF:%.*]] = project_box [[FADDR]]
+  // CHECK: [[FLIFE:%.*]] = begin_borrow [var_decl] [[FADDR]]
+  // CHECK: [[PBF:%.*]] = project_box [[FLIFE]]
   // CHECK: [[GADDR:%[0-9]+]] = alloc_box ${ var () }
   // CHECK: [[HADDR:%[0-9]+]] = alloc_box ${ var Double }
-  // CHECK: [[PBH:%.*]] = project_box [[HADDR]]
+  // CHECK: [[HLIFE:%.*]] = begin_borrow [var_decl] [[HADDR]]
+  // CHECK: [[PBH:%.*]] = project_box [[HLIFE]]
   // CHECK: [[EFGH:%[0-9]+]] = apply
   // CHECK: ([[E:%[0-9]+]], [[F:%[0-9]+]], [[H:%[0-9]+]]) = destructure_tuple
   // CHECK: store [[E]] to [trivial] [[PBE]]
@@ -62,7 +69,8 @@ func tuple_patterns() {
   var (e,f,g,h) : (Int, Float, (), Double) = MRV()
 
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
+  // CHECK: [[ILIFE:%.*]] = begin_borrow [var_decl] [[IADDR]]
+  // CHECK: [[PBI:%.*]] = project_box [[ILIFE]]
   // CHECK-NOT: alloc_box ${ var Float }
   // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
   // CHECK: copy_addr [[READA]] to [init] [[PBI]]
@@ -72,7 +80,8 @@ func tuple_patterns() {
   var (i,_) = (a, b)
 
   // CHECK: [[JADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBJ:%.*]] = project_box [[JADDR]]
+  // CHECK: [[JLIFE:%.*]] = begin_borrow [var_decl] [[JADDR]]
+  // CHECK: [[PBJ:%.*]] = project_box [[JLIFE]]
   // CHECK-NOT: alloc_box ${ var Float }
   // CHECK: [[KADDR:%[0-9]+]] = alloc_box ${ var () }
   // CHECK-NOT: alloc_box ${ var Double }
@@ -85,10 +94,12 @@ func tuple_patterns() {
 // CHECK-LABEL: sil hidden [ossa] @$s5decls16simple_arguments{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $Int, %1 : $Int):
 // CHECK: [[X:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
+// CHECK-NEXT: [[XLIFE:%.*]] = begin_borrow [var_decl] [[X]]
+// CHECK-NEXT: [[PBX:%.*]] = project_box [[XLIFE]]
 // CHECK-NEXT: store %0 to [trivial] [[PBX]]
 // CHECK-NEXT: [[Y:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[Y]]
+// CHECK-NEXT: [[YLIFE:%[0-9]+]] = begin_borrow [var_decl] [[Y]]
+// CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[YLIFE]]
 // CHECK-NEXT: store %1 to [trivial] [[PBY]]
 func simple_arguments(x: Int, y: Int) -> Int {
   var x = x
@@ -106,7 +117,8 @@ func tuple_argument(x: (Int, Float, ())) {
 // CHECK-LABEL: sil hidden [ossa] @$s5decls14inout_argument{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Int, %1 : $Int):
 // CHECK: [[X_LOCAL:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK: [[PBX:%.*]] = project_box [[X_LOCAL]]
+// CHECK: [[XLIFE:%.*]] = begin_borrow [var_decl] [[X_LOCAL]]
+// CHECK: [[PBX:%.*]] = project_box [[XLIFE]]
 func inout_argument(x: inout Int, y: Int) {
   var y = y
   x = y
@@ -130,7 +142,8 @@ func store_to_global(x: Int) {
   var x = x
   global = x
   // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBX:%.*]] = project_box [[XADDR]]
+  // CHECK: [[XLIFE:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK: [[PBX:%.*]] = project_box [[XLIFE]]
   // CHECK: [[ACCESSOR:%[0-9]+]] = function_ref @$s5decls6globalSivau
   // CHECK: [[PTR:%[0-9]+]] = apply [[ACCESSOR]]()
   // CHECK: [[ADDR:%[0-9]+]] = pointer_to_address [[PTR]]

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -30,7 +30,8 @@ struct D {
 // CHECK-LABEL: sil hidden [ossa] @$s19default_constructor1DV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin D.Type) -> D
 // CHECK: [[THISBOX:%[0-9]+]] = alloc_box ${ var D }
 // CHECK: [[THIS:%[0-9]+]] = mark_uninit
-// CHECK: [[PB_THIS:%.*]] = project_box [[THIS]]
+// CHECK: [[THIS_LIFE:%.*]] = begin_borrow [var_decl] [[THIS]]
+// CHECK: [[PB_THIS:%.*]] = project_box [[THIS_LIFE]]
 // CHECK: [[IADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.i
 // CHECK: [[JADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.j
 // CHECK: [[INIT:%[0-9]+]] = function_ref @$s19default_constructor1DV1iSivpfi
@@ -71,7 +72,7 @@ class F : E { }
 // CHECK: bb0([[ORIGSELF:%[0-9]+]] : @owned $F)
 // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var F }
 // CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-// CHECK-NEXT: [[SELFLIFE:%[^,]+]] = begin_borrow [lexical] [[SELF]]
+// CHECK-NEXT: [[SELFLIFE:%[^,]+]] = begin_borrow [lexical] [var_decl] [[SELF]]
 // CHECK-NEXT: [[PB:%.*]] = project_box [[SELFLIFE]]
 // CHECK-NEXT: store [[ORIGSELF]] to [init] [[PB]] : $*F
 // CHECK-NEXT: [[SELFP:%[0-9]+]] = load [take] [[PB]] : $*F

--- a/test/SILGen/discard.swift
+++ b/test/SILGen/discard.swift
@@ -89,7 +89,7 @@ func invokedDeinit() {}
 // CHECK-LABEL: sil hidden [ossa] @$s4test11PointerTreeV10tryDestroy9doDiscardySb_tKF : $@convention(method) (Bool, @owned PointerTree) -> @error any Error {
 // CHECK:   bb0{{.*}}:
 // CHECK:     [[SELF_BOX:%.*]] = alloc_box ${ var PointerTree }, var, name "self"
-// CHECK:     [[SELF_BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[SELF_BOX]]
+// CHECK:     [[SELF_BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[SELF_BOX]]
 // CHECK:     [[SELF_PTR:%.*]] = project_box [[SELF_BOX_LIFETIME]] : ${ var PointerTree }, 0
 //            .. skip to the conditional test ..
 // CHECK:     [[SHOULD_FORGET:%.*]] = struct_extract {{.*}} : $Bool, #Bool._value

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -54,7 +54,7 @@ func direct_to_static_method(_ obj: AnyObject) {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
   var obj = obj
   // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK: [[OBJLIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJBOX]]
+  // CHECK: [[OBJLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OBJBOX]]
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJLIFETIME]]
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[PBOBJ]] : $*AnyObject
@@ -76,12 +76,12 @@ func opt_to_class(_ obj: AnyObject) {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
   var obj = obj
   // CHECK:   [[EXISTBOX:%[0-9]+]] = alloc_box ${ var AnyObject } 
-  // CHECK:   [[EXISTLIFETIME:%[^,]+]] = begin_borrow [lexical] [[EXISTBOX]]
+  // CHECK:   [[EXISTLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[EXISTBOX]]
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[EXISTLIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[PBOBJ]]
   // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_guaranteed () -> ()> }
-  // CHECK:   [[OPTLIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPTBOX]]
+  // CHECK:   [[OPTLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OPTBOX]]
   // CHECK:   [[PBOPT:%.*]] = project_box [[OPTLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[EXISTVAL:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
@@ -148,12 +148,12 @@ func opt_to_static_method(_ obj: AnyObject) {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJBOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[OBJLIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJBOX]]
+  // CHECK:   [[OBJLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OBJBOX]]
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJLIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_guaranteed () -> ()> }
-  // CHECK:   [[OPTLIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPTBOX]]
+  // CHECK:   [[OPTLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OPTBOX]]
   // CHECK:   [[PBO:%.*]] = project_box [[OPTLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJCOPY:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
@@ -170,12 +170,13 @@ func opt_to_property(_ obj: AnyObject) {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OBJ_BOX]]
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[INT_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   project_box [[INT_BOX]]
+  // CHECK:   [[INT_LIFETIME:%.*]] = begin_borrow [var_decl] [[INT_BOX]]
+  // CHECK:   project_box [[INT_LIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
@@ -200,12 +201,13 @@ func opt_to_property(_ obj: AnyObject) {
 // GUARANTEED-LABEL: sil hidden [ossa] @$s14dynamic_lookup15opt_to_property{{[_0-9a-zA-Z]*}}F
   // GUARANTEED: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // GUARANTEED:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // GUARANTEED:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // GUARANTEED:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OBJ_BOX]]
   // GUARANTEED:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // GUARANTEED:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // GUARANTEED:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // GUARANTEED:   [[INT_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // GUARANTEED:   project_box [[INT_BOX]]
+  // GUARANTEED:   [[INT_LIFETIME:%.*]] = begin_borrow [var_decl] [[INT_BOX]]
+  // GUARANTEED:   project_box [[INT_LIFETIME]]
   // GUARANTEED:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // GUARANTEED:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // GUARANTEED:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
@@ -230,12 +232,13 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : $Int):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OBJ_BOX]]
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
+  // CHECK:   [[I_LIFETIME:%.*]] = begin_borrow [var_decl] [[I_BOX]]
+  // CHECK:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK:   alloc_box ${ var Int }
   // CHECK:   project_box
@@ -265,12 +268,13 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
 // GUARANTEED-LABEL: sil hidden [ossa] @$s14dynamic_lookup19direct_to_subscript{{[_0-9a-zA-Z]*}}F
   // GUARANTEED: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : $Int):
   // GUARANTEED:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // GUARANTEED:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // GUARANTEED:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OBJ_BOX]]
   // GUARANTEED:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // GUARANTEED:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // GUARANTEED:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // GUARANTEED:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // GUARANTEED:   [[PBI:%.*]] = project_box [[I_BOX]]
+  // GUARANTEED:   [[I_LIFETIME:%.*]] = begin_borrow [var_decl] [[I_BOX]]
+  // GUARANTEED:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
   // GUARANTEED:   store [[I]] to [trivial] [[PBI]] : $*Int
   // GUARANTEED:   alloc_box ${ var Int }
   // GUARANTEED:   project_box
@@ -300,12 +304,13 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : $Int):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OBJ_BOX]]
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
+  // CHECK:   [[I_LIFETIME:%.*]] = begin_borrow [var_decl] [[I_BOX]]
+  // CHECK:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
@@ -334,7 +339,7 @@ func downcast(_ obj: AnyObject) -> X {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OBJ_BOX]]
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -246,7 +246,7 @@ class Z {
     // so that IRGen can recover metadata.
 
     // CHECK:      [[WEAK_SELF:%.*]] = alloc_box ${ var @sil_weak Optional<Z> }
-    // CHECK:      [[WEAK_SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[WEAK_SELF]]
+    // CHECK:      [[WEAK_SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[WEAK_SELF]]
     // CHECK:      [[FN:%.*]] = function_ref @$s12dynamic_self1ZC23testDynamicSelfCaptures1xACXDSi_tFyycfU1_ : $@convention(thin) (@guaranteed { var @sil_weak Optional<Z> }, @thick @dynamic_self Z.Type) -> ()
     // CHECK:      [[WEAK_SELF_COPY:%.*]] = copy_value [[WEAK_SELF_LIFETIME]] : ${ var @sil_weak Optional<Z> }
     // CHECK-NEXT: [[DYNAMIC_SELF:%.*]] = metatype $@thick @dynamic_self Z.Type

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -119,7 +119,8 @@ public enum MyResilientEnum {
   // CHECK-LABEL: sil hidden [ossa] @$s15enum_resilience15MyResilientEnumOACycfC : $@convention(method) (@thin MyResilientEnum.Type) -> @out MyResilientEnum
   // CHECK:       [[SELF_BOX:%.*]] = alloc_box ${ var MyResilientEnum }, var, name "self"
   // CHECK:       [[SELF_TMP:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var MyResilientEnum }
-  // CHECK:       [[SELF_ADDR:%.*]] = project_box [[SELF_TMP]] : ${ var MyResilientEnum }, 0
+  // CHECK:       [[LIFETIME:%.*]] = begin_borrow [var_decl] [[SELF_TMP]]
+  // CHECK:       [[SELF_ADDR:%.*]] = project_box [[LIFETIME]] : ${ var MyResilientEnum }, 0
   // CHECK:       [[NEW_SELF:%.*]] = enum $MyResilientEnum, #MyResilientEnum.loki!enumelt
   // CHECK:       [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*MyResilientEnum
   // CHECK:       assign [[NEW_SELF]] to [[ACCESS]] : $*MyResilientEnum
@@ -147,7 +148,7 @@ public enum MoreHorses {
   // CHECK-LABEL: sil hidden [ossa] @$s15enum_resilience10MoreHorsesOACycfC : $@convention(method) (@thin MoreHorses.Type) -> @out MoreHorses
   // CHECK:       [[SELF_BOX:%.*]] = alloc_box ${ var MoreHorses }, var, name "self"
   // CHECK:       [[SELF_TMP:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var MoreHorses }
-  // CHECK:       [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[SELF_TMP]]
+  // CHECK:       [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[SELF_TMP]]
   // CHECK:       [[SELF_ADDR:%.*]] = project_box [[SELF_LIFETIME]] : ${ var MoreHorses }, 0
   // CHECK:       [[BUILTIN_INT:%.*]] = integer_literal $Builtin.IntLiteral, 0
   // CHECK:       [[INT_METATYPE:%.*]] = metatype $@thin Int.Type

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -107,7 +107,7 @@ func dont_return<T>(_ argument: T) throws -> T {
 
 //   Catch HomeworkError.CatAteIt.
 // CHECK:    [[MATCH]]([[T0:%.*]] : @owned $Cat):
-// CHECK-NEXT: [[BORROWED_T0:%.*]] = begin_borrow [lexical] [[T0]]
+// CHECK-NEXT: [[BORROWED_T0:%.*]] = begin_borrow [lexical] [var_decl] [[T0]]
 // CHECK-NEXT: debug_value [[BORROWED_T0]] : $Cat
 // CHECK-NEXT: [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
 // CHECK-NEXT: end_borrow [[BORROWED_T0]]
@@ -314,7 +314,7 @@ func all_together_now_four(_ flag: Bool) throws -> Cat? {
 
 //   Catch HomeworkError.CatAteIt.
 // CHECK:    [[MATCH_ATE]]([[T0:%.*]] : @owned $Cat):
-// CHECK-NEXT: [[T0_BORROW:%.*]] = begin_borrow [lexical] [[T0]]
+// CHECK-NEXT: [[T0_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[T0]]
 // CHECK-NEXT: [[T0_COPY:%.*]] = copy_value [[T0_BORROW]]
 // CHECK-NEXT: end_borrow [[T0_BORROW]]
 // CHECK-NEXT: destroy_value [[T0]]
@@ -326,7 +326,7 @@ func all_together_now_four(_ flag: Bool) throws -> Cat? {
 
 //   Catch HomeworkError.CatHidIt.
 // CHECK:    [[MATCH_HID]]([[T0:%.*]] : @owned $Cat):
-// CHECK-NEXT: [[T0_BORROW:%.*]] = begin_borrow [lexical] [[T0]]
+// CHECK-NEXT: [[T0_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[T0]]
 // CHECK-NEXT: [[T0_COPY:%.*]] = copy_value [[T0_BORROW]]
 // CHECK-NEXT: end_borrow [[T0_BORROW]]
 // CHECK-NEXT: destroy_value [[T0]]
@@ -695,7 +695,7 @@ class BaseThrowingInit : HasThrowingInit {
 // CHECK: sil hidden [ossa] @$s6errors16BaseThrowingInit{{.*}}c : $@convention(method) (Int, Int, @owned BaseThrowingInit) -> (@owned BaseThrowingInit, @error any Error)
 // CHECK:      [[BOX:%.*]] = alloc_box ${ var BaseThrowingInit }
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]
-// CHECK:      [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_BOX]]
+// CHECK:      [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_BOX]]
 // CHECK:      [[PB:%.*]] = project_box [[BOX_LIFETIME]]
 //   Initialize subField.
 // CHECK:      [[T0:%.*]] = load_borrow [[PB]]
@@ -865,7 +865,7 @@ func testOptionalTryThatNeverThrows() {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors18testOptionalTryVaryyF
 // CHECK-NEXT: bb0:
 // CHECK-NEXT: [[BOX:%.+]] = alloc_box ${ var Optional<Cat> }
-// CHECK-NEXT: [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
+// CHECK-NEXT: [[LIFETIME:%.+]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK-NEXT: [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK: [[FN:%.+]] = function_ref @$s6errors10make_a_catAA3CatCyKF
 // CHECK-NEXT: try_apply [[FN]]() : $@convention(thin) () -> (@owned Cat, @error any Error), normal [[SUCCESS:[^ ]+]], error [[CLEANUPS:[^ ]+]],
@@ -914,7 +914,7 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors29testOptionalTryAddressOnlyVar{{.*}}F
 // CHECK: bb0(%0 : $*T):
 // CHECK: [[BOX:%.+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
-// CHECK: [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[LIFETIME:%.+]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK-NEXT: [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK-NEXT: [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK: [[FN:%.+]] = function_ref @$s6errors11dont_return{{.*}}F
@@ -980,10 +980,12 @@ func testOptionalTryNeverFails() {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors28testOptionalTryNeverFailsVaryyF
 // CHECK: bb0:
 // CHECK-NEXT:   [[BOX:%.+]] = alloc_box ${ var Optional<()> }
-// CHECK-NEXT:   [[PB:%.*]] = project_box [[BOX]]
+// CHECK-NEXT:   [[LIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+// CHECK-NEXT:   [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK-NEXT:   [[VALUE:%.+]] = tuple ()
 // CHECK-NEXT:   [[ENUM:%.+]] = enum $Optional<()>, #Optional.some!enumelt, [[VALUE]]
 // CHECK-NEXT:   store [[ENUM]] to [trivial] [[PB]] :
+// CHECK-NEXT:   end_borrow [[LIFETIME]]
 // CHECK-NEXT:   destroy_value [[BOX]] : ${ var Optional<()> }
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()
@@ -1011,7 +1013,7 @@ func testOptionalTryNeverFailsAddressOnly<T>(_ obj: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors39testOptionalTryNeverFailsAddressOnlyVar{{.*}}F
 // CHECK: bb0(%0 : $*T):
 // CHECK:   [[BOX:%.+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
-// CHECK-NEXT:   [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
+// CHECK-NEXT:   [[LIFETIME:%.+]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK-NEXT:   [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK-NEXT:   [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK-NEXT:   copy_addr %0 to [init] [[BOX_DATA]] : $*T

--- a/test/SILGen/existential_metatypes.swift
+++ b/test/SILGen/existential_metatypes.swift
@@ -65,7 +65,8 @@ func existentialMetatypeUpcast2(_ x: (P & Q).Type) -> P.Type {
 // CHECK-LABEL: sil hidden [ossa] @$s21existential_metatypes0A19MetatypeVarPropertyAA5ValueVyF : $@convention(thin) () -> Value
 func existentialMetatypeVarProperty() -> Value {
   // CHECK:      [[BOX:%.*]] = alloc_box ${ var @thick any P.Type }
-  // CHECK:      [[ADDR:%.*]] = project_box [[BOX]] : ${ var @thick any P.Type }, 0
+  // CHECK:      [[LIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+  // CHECK:      [[ADDR:%.*]] = project_box [[LIFETIME]] : ${ var @thick any P.Type }, 0
   // CHECK:      [[T0:%.*]] = metatype $@thick S.Type
   // CHECK:      [[T1:%.*]] = init_existential_metatype [[T0]]
   // CHECK:      store [[T1]] to [trivial] [[ADDR]] :

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -392,7 +392,8 @@ func tuple() -> (Int, Float) { return (1, 1.0) }
 func tuple_element(_ x: (Int, Float)) {
   var x = x
   // CHECK: [[XADDR:%.*]] = alloc_box ${ var (Int, Float) }
-  // CHECK: [[PB:%.*]] = project_box [[XADDR]]
+  // CHECK: [[XLIFETIME:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK: [[PB:%.*]] = project_box [[XLIFETIME]]
 
   int(x.0)
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
@@ -427,15 +428,20 @@ func ternary_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
   var z = z
   // CHECK: bb0({{.*}}):
   // CHECK: [[AB:%[0-9]+]] = alloc_box ${ var Bool }
-  // CHECK: [[PBA:%.*]] = project_box [[AB]]
+  // CHECK: [[BAL:%.*]] = begin_borrow [var_decl] [[AB]]
+  // CHECK: [[PBA:%.*]] = project_box [[BAL]]
   // CHECK: [[BB:%[0-9]+]] = alloc_box ${ var Bool }
-  // CHECK: [[PBB:%.*]] = project_box [[BB]]
+  // CHECK: [[BBL:%.*]] = begin_borrow [var_decl] [[BB]]
+  // CHECK: [[PBB:%.*]] = project_box [[BBL]]
   // CHECK: [[XB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBX:%.*]] = project_box [[XB]]
+  // CHECK: [[BXL:%.*]] = begin_borrow [var_decl] [[XB]]
+  // CHECK: [[PBX:%.*]] = project_box [[BXL]]
   // CHECK: [[YB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBY:%.*]] = project_box [[YB]]
+  // CHECK: [[BYL:%.*]] = begin_borrow [var_decl] [[YB]]
+  // CHECK: [[PBY:%.*]] = project_box [[BYL]]
   // CHECK: [[ZB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBZ:%.*]] = project_box [[ZB]]
+  // CHECK: [[BZL:%.*]] = begin_borrow [var_decl] [[ZB]]
+  // CHECK: [[PBZ:%.*]] = project_box [[BZL]]
 
   return a
     ? x

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -52,7 +52,7 @@ struct Box<T> {
 // CHECK-LABEL: sil hidden [ossa] @$s10extensions3BoxV1tACyxGx_tcfC : $@convention(method) <T> (@in T, @thin Box<T>.Type) -> @out Box<T>
 // CHECK:      [[SELF_BOX:%.*]] = alloc_box $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK-NEXT: [[UNINIT_SELF_BOX:%.*]] = mark_uninitialized [rootself] [[SELF_BOX]]
-// CHECK-NEXT: [[UNINIT_SELF_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT_SELF_BOX]]
+// CHECK-NEXT: [[UNINIT_SELF_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[UNINIT_SELF_BOX]]
 // CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[UNINIT_SELF_BOX_LIFETIME]] : $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK:      [[RESULT:%.*]] = struct_element_addr [[SELF_ADDR]] : $*Box<T>, #Box.t
 // CHECK:      [[INIT:%.*]] = function_ref @$s10extensions3BoxV1txSgvpfi : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -53,7 +53,8 @@ protocol GenericCollection : Collection {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach13trivialStructyySaySiGF : $@convention(thin) (@guaranteed Array<Int>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : @guaranteed $Array<Int>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<Int>> }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%.*]] = begin_borrow [var_decl] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
@@ -105,7 +106,8 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach26trivialStructContinueBreakyySaySiGF : $@convention(thin) (@guaranteed Array<Int>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : @guaranteed $Array<Int>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<Int>> }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%.*]] = begin_borrow [var_decl] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<Int>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
@@ -205,7 +207,8 @@ func existentialBreak(_ xx: [P]) {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach24existentialContinueBreakyySayAA1P_pGF : $@convention(thin) (@guaranteed Array<any P>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : @guaranteed $Array<any P>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<any P>> }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%.*]] = begin_borrow [var_decl] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<any P>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
@@ -365,7 +368,8 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach26genericStructContinueBreakyySayAA07GenericC0VyxGGlF : $@convention(thin) <T> (@guaranteed Array<GenericStruct<T>>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : @guaranteed $Array<GenericStruct<T>>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box $<τ_0_0> { var IndexingIterator<Array<GenericStruct<τ_0_0>>> } <T>, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%.*]] = begin_borrow [var_decl] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<GenericStruct<T>>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
@@ -473,7 +477,7 @@ func genericCollectionBreak<T : Collection>(_ xx: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach30genericCollectionContinueBreakyyxSlRzlF : $@convention(thin) <T where T : Collection> (@in_guaranteed T) -> () {
 // CHECK: bb0([[COLLECTION:%.*]] : $*T):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : Collection> { var τ_0_0.Iterator } <T>, var, name "$x$generator"
-// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[ITERATOR_BOX]]
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $T, #Sequence.makeIterator :
 // CHECK:   apply [[MAKE_ITERATOR_FUNC]]<T>([[PROJECT_ITERATOR_BOX]], [[COLLECTION_COPY:%.*]])

--- a/test/SILGen/foreach_async.swift
+++ b/test/SILGen/foreach_async.swift
@@ -74,7 +74,8 @@ struct AsyncLazySequence<S: Sequence>: AsyncSequence {
 // CHECK-LABEL: sil hidden [ossa] @$s13foreach_async13trivialStructyyAA17AsyncLazySequenceVySaySiGGYaF : $@convention(thin) @async (@guaranteed AsyncLazySequence<Array<Int>>) -> () {
 // CHECK: bb0([[SOURCE:%.*]] : @guaranteed $AsyncLazySequence<Array<Int>>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var AsyncLazySequence<Array<Int>>.Iterator }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%.*]] = begin_borrow [var_decl] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 
 // CHECK: [[LOOP_DEST]]:
@@ -103,7 +104,8 @@ func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK-LABEL: sil hidden [ossa] @$s13foreach_async21trivialStructContinueyyAA17AsyncLazySequenceVySaySiGGYaF : $@convention(thin) @async (@guaranteed AsyncLazySequence<Array<Int>>) -> () {
 // CHECK: bb0([[SOURCE:%.*]] : @guaranteed $AsyncLazySequence<Array<Int>>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var AsyncLazySequence<Array<Int>>.Iterator }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_LIFETIME:%.*]] = begin_borrow [var_decl] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 
 // CHECK: [[LOOP_DEST]]:
@@ -159,7 +161,8 @@ func trivialStructBreak(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK-LABEL: sil hidden [ossa] @$s13foreach_async26trivialStructContinueBreakyyAA17AsyncLazySequenceVySaySiGGYaF : $@convention(thin) @async (@guaranteed AsyncLazySequence<Array<Int>>) -> ()
 // CHECK: bb0([[SOURCE:%.*]] : @guaranteed $AsyncLazySequence<Array<Int>>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var AsyncLazySequence<Array<Int>>.Iterator }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX_LIFETIME]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 
 // CHECK: [[LOOP_DEST]]:

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -188,7 +188,7 @@ class VeryErrorProne : ErrorProne {
 // CHECK:    bb0([[ARG1:%.*]] : @owned $Optional<AnyObject>, [[ARG2:%.*]] : @owned $VeryErrorProne):
 // CHECK:      [[BOX:%.*]] = alloc_box ${ var VeryErrorProne }
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]
-// CHECK:      [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_BOX]]
+// CHECK:      [[LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_BOX]]
 // CHECK:      [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK:      store [[ARG2]] to [init] [[PB]]
 // CHECK:      [[T0:%.*]] = load [take] [[PB]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -103,11 +103,14 @@ func calls(_ i:Int, j:Int, k:Int) {
   var k = k
   // CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
   // CHECK: [[IBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[IADDR:%.*]] = project_box [[IBOX]]
+  // CHECK: [[ILIFETIME:%.*]] = begin_borrow [var_decl] [[IBOX]]
+  // CHECK: [[IADDR:%.*]] = project_box [[ILIFETIME]]
   // CHECK: [[JBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[JADDR:%.*]] = project_box [[JBOX]]
+  // CHECK: [[JLIFETIME:%.*]] = begin_borrow [var_decl] [[JBOX]]
+  // CHECK: [[JADDR:%.*]] = project_box [[JLIFETIME]]
   // CHECK: [[KBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[KADDR:%.*]] = project_box [[KBOX]]
+  // CHECK: [[KLIFETIME:%.*]] = begin_borrow [var_decl] [[KBOX]]
+  // CHECK: [[KADDR:%.*]] = project_box [[KLIFETIME]]
 
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
@@ -138,7 +141,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- Curry 'self' onto method argument lists dispatched using class_method.
 
   // CHECK: [[CBOX:%[0-9]+]] = alloc_box ${ var SomeClass }
-  // CHECK: [[CLIFETIME:%[^,]+]] = begin_borrow [lexical] [[CBOX]]
+  // CHECK: [[CLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[CBOX]]
   // CHECK: [[CADDR:%.*]] = project_box [[CLIFETIME]]
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeClass.Type
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
@@ -230,7 +233,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- onto protocol type methods dispatched using protocol_method.
 
   // CHECK: [[PBOX:%[0-9]+]] = alloc_box ${ var any SomeProtocol }
-  // CHECK: [[PLIFETIME:%[^,]+]] = begin_borrow [lexical] [[PBOX]]
+  // CHECK: [[PLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[PBOX]]
   // CHECK: [[PADDR:%.*]] = project_box [[PLIFETIME]]
   var p : SomeProtocol = ConformsToSomeProtocol()
 
@@ -263,7 +266,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- Use an apply or partial_apply instruction to bind type parameters of a generic.
 
   // CHECK: [[GBOX:%[0-9]+]] = alloc_box ${ var SomeGeneric<Builtin.Int64> }
-  // CHECK: [[GLIFETIME:%[^,]+]] = begin_borrow [lexical] [[GBOX]]
+  // CHECK: [[GLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[GBOX]]
   // CHECK: [[GADDR:%.*]] = project_box [[GLIFETIME]]
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeGeneric<Builtin.Int64>.Type
   // CHECK: [[CTOR_GEN:%[0-9]+]] = function_ref @$s9functions11SomeGenericC{{[_0-9a-zA-Z]*}}fC : $@convention(method) <τ_0_0> (@thick SomeGeneric<τ_0_0>.Type) -> @owned SomeGeneric<τ_0_0>
@@ -311,7 +314,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // "thick" function values when stored, returned, or passed as arguments.
 
   // CHECK: [[FBOX:%[0-9]+]] = alloc_box ${ var @callee_guaranteed (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 }
-  // CHECK: [[FLIFETIME:%[^,]+]] = begin_borrow [lexical] [[FBOX]]
+  // CHECK: [[FLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[FBOX]]
   // CHECK: [[FADDR:%.*]] = project_box [[FLIFETIME]]
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @$s9functions19standalone_function{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -11,18 +11,19 @@ struct S {}
 // CHECK-LABEL: sil hidden [ossa] @$s26guaranteed_closure_context0A9_capturesyyF
 func guaranteed_captures() {
   // CHECK: [[MUTABLE_TRIVIAL_BOX:%.*]] = alloc_box ${ var S }
+  // CHECK: [[MUTABLE_TRIVIAL_BOX_BORROW:%[^,]+]] = begin_borrow [var_decl] [[MUTABLE_TRIVIAL_BOX]]
   var mutableTrivial = S()
   // CHECK: [[MUTABLE_RETAINABLE_BOX:%.*]] = alloc_box ${ var C }
-  // CHECK: [[MUTABLE_RETAINABLE_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MUTABLE_RETAINABLE_BOX]]
+  // CHECK: [[MUTABLE_RETAINABLE_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MUTABLE_RETAINABLE_BOX]]
   var mutableRetainable = C()
   // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX:%.*]] = alloc_box ${ var any P }
-  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MUTABLE_ADDRESS_ONLY_BOX]]
+  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MUTABLE_ADDRESS_ONLY_BOX]]
   var mutableAddressOnly: P = C()
 
   // CHECK: [[IMMUTABLE_TRIVIAL:%.*]] = apply {{.*}} -> S
   let immutableTrivial = S()
   // CHECK: [[IMMUTABLE_RETAINABLE:%.*]] = apply {{.*}} -> @owned C
-  // CHECK: [[B_IMMUTABLE_RETAINABLE:%.*]] = begin_borrow [lexical] [[IMMUTABLE_RETAINABLE]] : $C
+  // CHECK: [[B_IMMUTABLE_RETAINABLE:%.*]] = begin_borrow [lexical] [var_decl] [[IMMUTABLE_RETAINABLE]] : $C
   let immutableRetainable = C()
   // CHECK: [[IMMUTABLE_ADDRESS_ONLY:%.*]] = alloc_stack [lexical] $any P
   let immutableAddressOnly: P = C()
@@ -37,7 +38,6 @@ func guaranteed_captures() {
   // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]
 
-  // CHECK: [[MUTABLE_TRIVIAL_BOX_BORROW:%[^,]+]] = begin_borrow [[MUTABLE_TRIVIAL_BOX]]
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME:@\$s26guaranteed_closure_context0A9_capturesyyF17captureEverythingL_yyF]]
   // CHECK: apply [[FN]]([[MUTABLE_TRIVIAL_BOX_BORROW]], [[MUTABLE_RETAINABLE_BOX_LIFETIME]], [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]], [[IMMUTABLE_TRIVIAL]], [[B_IMMUTABLE_RETAINABLE]], [[IMMUTABLE_ADDRESS_ONLY]])
   captureEverything()
@@ -49,7 +49,7 @@ func guaranteed_captures() {
 
   // -- partial_apply still takes ownership of its arguments.
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME]]
-  // CHECK: [[MUTABLE_TRIVIAL_BOX_COPY:%.*]] = copy_value [[MUTABLE_TRIVIAL_BOX]]
+  // CHECK: [[MUTABLE_TRIVIAL_BOX_COPY:%.*]] = copy_value [[MUTABLE_TRIVIAL_BOX_BORROW]]
   // CHECK: [[MUTABLE_RETAINABLE_BOX_COPY:%.*]] = copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
   // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_COPY:%.*]] = copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK: [[IMMUTABLE_RETAINABLE_COPY:%.*]] = copy_value [[B_IMMUTABLE_RETAINABLE]]
@@ -58,7 +58,7 @@ func guaranteed_captures() {
   // CHECK: [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE]]
   // CHECK: apply {{.*}}[[CONVERT]]
 
-  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]
+  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX_BORROW]]
   // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -342,7 +342,7 @@ class D: C {
   // CHECK:       bb0([[SELF:%.*]] : @owned $D):
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var D }
   // CHECK-NEXT:    [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK-NEXT:    [[LIFETIME:%.+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK-NEXT:    [[LIFETIME:%.+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK-NEXT:    [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK-NEXT:    store [[SELF]] to [init] [[PB]]
   // CHECK-NOT:     [[PB]]
@@ -458,13 +458,13 @@ class LetFieldClass {
   // CHECK-NEXT: apply [[KRAKEN_METH]]([[KRAKEN]])
   // CHECK: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
   // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
-  // CHECK:      [[REBORROWED_KRAKEN:%.*]] = begin_borrow [lexical] [[KRAKEN]]
+  // CHECK:      [[REBORROWED_KRAKEN:%.*]] = begin_borrow [lexical] [var_decl] [[KRAKEN]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @$s15guaranteed_self11destroyShipyyAA6KrakenCF : $@convention(thin) (@guaranteed Kraken) -> ()
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[REBORROWED_KRAKEN]])
   // CHECK-NEXT: end_borrow [[REBORROWED_KRAKEN]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
-  // CHECK-NEXT: [[KRAKEN_LIFETIME:%.+]] = begin_borrow [lexical] [[KRAKEN_BOX]]
+  // CHECK-NEXT: [[KRAKEN_LIFETIME:%.+]] = begin_borrow [lexical] [var_decl] [[KRAKEN_BOX]]
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_LIFETIME]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
   // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
@@ -505,11 +505,11 @@ class LetFieldClass {
   // CHECK-NEXT: destroy_value [[KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
-  // CHECK:      [[BORROWED_KRAKEN:%.*]] = begin_borrow [lexical] [[KRAKEN]]
+  // CHECK:      [[BORROWED_KRAKEN:%.*]] = begin_borrow [lexical] [var_decl] [[KRAKEN]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @$s15guaranteed_self11destroyShipyyAA6KrakenCF : $@convention(thin) (@guaranteed Kraken) -> ()
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[BORROWED_KRAKEN]])
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
-  // CHECK-NEXT: [[KRAKEN_LIFETIME:%.+]] = begin_borrow [lexical] [[KRAKEN_BOX]]
+  // CHECK-NEXT: [[KRAKEN_LIFETIME:%.+]] = begin_borrow [lexical] [var_decl] [[KRAKEN_BOX]]
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_LIFETIME]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN2:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -219,7 +219,7 @@ actor BlueActorImpl {
 // CHECK:     bb0([[BLUE:%[0-9]+]] : @guaranteed $BlueActorImpl):
 // CHECK:       hop_to_executor [[BLUE]] : $BlueActorImpl
 // CHECK:       [[RED:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@thick RedActorImpl.Type) -> @owned RedActorImpl
-// CHECK:       [[REDBORROW:%[0-9]+]] = begin_borrow [lexical] [[RED]] : $RedActorImpl
+// CHECK:       [[REDBORROW:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[RED]] : $RedActorImpl
 // CHECK:       [[INTARG:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 // CHECK:       [[METH:%[0-9]+]] = class_method [[REDBORROW]] : $RedActorImpl, #RedActorImpl.hello : (isolated RedActorImpl) -> (Int) -> (), $@convention(method) (Int, @guaranteed RedActorImpl) -> ()
 // CHECK:       hop_to_executor [[REDBORROW]] : $RedActorImpl

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -8,7 +8,7 @@ func foo(f f: (() -> ())!) {
 // CHECK: sil hidden [ossa] @{{.*}}foo{{.*}} : $@convention(thin) (@guaranteed Optional<@callee_guaranteed () -> ()>) -> () {
 // CHECK: bb0([[T0:%.*]] : @guaranteed $Optional<@callee_guaranteed () -> ()>):
 // CHECK:   [[F:%.*]] = alloc_box ${ var Optional<@callee_guaranteed () -> ()> }
-// CHECK:   [[F_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[F]]
+// CHECK:   [[F_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[F]]
 // CHECK:   [[PF:%.*]] = project_box [[F_LIFETIME]]
 // CHECK:   [[T0_COPY:%.*]] = copy_value [[T0]]
 // CHECK:   store [[T0_COPY]] to [init] [[PF]]

--- a/test/SILGen/import_as_member.swift
+++ b/test/SILGen/import_as_member.swift
@@ -46,7 +46,7 @@ public func useClass(d: Double, opts: SomeClass.Options) {
   // CHECK: [[OBJ:%[0-9]+]] = apply [[CTOR]]([[D]])
   let o = SomeClass(value: d)
 
-  // CHECK: [[BORROWED_OBJ:%.*]] = begin_borrow [lexical] [[OBJ]]
+  // CHECK: [[BORROWED_OBJ:%.*]] = begin_borrow [lexical] [var_decl] [[OBJ]]
   // CHECK: [[APPLY_FN:%[0-9]+]] = function_ref @IAMSomeClassApplyOptions : $@convention(c) (SomeClass, SomeClass.Options) -> ()
   // CHECK: apply [[APPLY_FN]]([[BORROWED_OBJ]], [[OPTS]])
   // CHECK: end_borrow [[BORROWED_OBJ]]

--- a/test/SILGen/init_delegation_optional.swift
+++ b/test/SILGen/init_delegation_optional.swift
@@ -15,7 +15,7 @@ extension Optional {
     // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Wrapped>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: [[RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Wrapped>
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE12nonFailable1xSgyt_tcfC
@@ -36,7 +36,7 @@ extension Optional {
     // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: [[RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Wrapped>
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE12nonFailable1xSgyt_tcfC
@@ -65,7 +65,7 @@ extension Optional {
     // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE9failable1xSgSgyt_tcfC
@@ -111,7 +111,7 @@ extension Optional {
     // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
     // CHECK-NEXT: [[OPT_RESULT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
@@ -172,7 +172,7 @@ extension Optional {
     // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: [[OPT_OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Optional<Wrapped>>>
     // CHECK-NEXT: [[OPT_OPT_RESULT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OPT_OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
@@ -245,7 +245,7 @@ extension Optional {
     // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
     // CHECK-NEXT: [[OPT_RESULT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
@@ -313,7 +313,7 @@ extension Optional {
     // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE17failableAndThrowsxSgSgyt_tKcfC
@@ -365,7 +365,8 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[MARKED_SELF_LIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_LIFETIME]]
     // CHECK: [[RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Bool>>
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE12nonFailable1xSgyt_tcfC
     // CHECK-NEXT: apply [[DELEG_INIT]]<Bool?>([[RESULT_ADDR]], [[SELF_META]])
@@ -374,6 +375,7 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
     // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
     // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
+    // CHECK-NEXT: end_borrow [[MARKED_SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: br bb2([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
     //
@@ -391,7 +393,8 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[MARKED_SELF_LIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_LIFETIME]]
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalSbSgRszlE13SpecFailable1ABSgSgyt_tcfC
     // CHECK-NEXT: [[OPT_RESULT:%[0-9]+]] = apply [[DELEG_INIT]]([[SELF_META]])
     // CHECK: [[SELECT:%[0-9]+]] = select_enum [[OPT_RESULT]]
@@ -405,10 +408,12 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK-NEXT: assign [[RESULT]] to [[PB]]
     // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
     // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
+    // CHECK-NEXT: end_borrow [[MARKED_SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: br bb4([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
     //
     // CHECK: bb3:
+    // CHECK-NEXT: end_borrow [[MARKED_SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.none!enumelt
     // CHECK-NEXT: br bb4([[NIL]] : $Optional<Optional<Optional<Bool>>>)
@@ -428,7 +433,8 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[MARKED_SELF_LIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_LIFETIME]]
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalSbSgRszlE21SpecFailableAndThrowsABSgSgyt_tKcfC
     // CHECK-NEXT: try_apply [[DELEG_INIT]]([[SELF_META]]) : {{.*}}, normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
     //
@@ -458,10 +464,12 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK-NEXT: assign [[RESULT]] to [[PB]]
     // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
     // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
+    // CHECK-NEXT: end_borrow [[MARKED_SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: br bb9([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
     //
     // CHECK: bb8:
+    // CHECK-NEXT: end_borrow [[MARKED_SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.none!enumelt
     // CHECK-NEXT: br bb9([[NIL]] : $Optional<Optional<Optional<Bool>>>)

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -9,7 +9,8 @@ struct S {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin S.Type):
     // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S }
     // CHECK-NEXT:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK-NEXT:   [[MARKED_SELF_LIFETIME:%.*]] = begin_borrow [var_decl] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT:   [[PB:%.*]] = project_box [[MARKED_SELF_LIFETIME]]
     
     // CHECK-NEXT:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[X_CTOR:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -19,6 +20,7 @@ struct S {
     self.init(x: X())
     // CHECK-NEXT:   assign [[REPLACEMENT_SELF]] to [[PB]] : $*S
     // CHECK-NEXT:   [[SELF_BOX1:%[0-9]+]] = load [trivial] [[PB]] : $*S
+    // CHECK-NEXT:   end_borrow [[MARKED_SELF_LIFETIME]]
     // CHECK-NEXT:   destroy_value [[MARKED_SELF_BOX]] : ${ var S }
     // CHECK-NEXT:   return [[SELF_BOX1]] : $S
   }
@@ -36,7 +38,8 @@ enum E {
     // CHECK: bb0([[E_META:%[0-9]+]] : $@thin E.Type):
     // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box ${ var E }
     // CHECK:   [[MARKED_E_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[E_BOX]]
-    // CHECK:   [[PB:%.*]] = project_box [[MARKED_E_BOX]]
+    // CHECK:   [[MARKED_E_LIFETIME:%.*]] = begin_borrow [var_decl] [[MARKED_E_BOX]]
+    // CHECK:   [[PB:%.*]] = project_box [[MARKED_E_LIFETIME]]
 
     // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[E_DELEG_INIT:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -60,7 +63,8 @@ struct S2 {
     // CHECK: bb0([[S2_META:%[0-9]+]] : $@thin S2.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S2 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   [[MARKED_SELF_LIFETIME:%.*]] = begin_borrow [var_decl] [[MARKED_SELF_BOX]]
+    // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_LIFETIME]]
 
     // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -90,7 +94,7 @@ class C1 {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[SELF_META:%[0-9]+]] : $@thick C1.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C1 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK:   [[PB:%.*]] = project_box [[SELF_LIFETIME]]
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_META]] : $@thick C1.Type, #C1.init!allocator
@@ -114,7 +118,7 @@ class C1 {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[SELF_META:%[0-9]+]] : $@thick C2.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C2 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK:   [[PB_SELF:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_META]] : $@thick C2.Type, #C2.init!allocator
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_META]])

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -491,7 +491,7 @@ class FailableBaseClass {
   // CHECK: bb0([[SELF_META:%.*]] : $@thick FailableBaseClass.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
   // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[SELF_META]])
   // CHECK:   destroy_value [[MARKED_SELF_BOX]]
@@ -511,7 +511,7 @@ class FailableBaseClass {
   // CHECK: bb0([[SELF_META:%.*]] : $@thick FailableBaseClass.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
   // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[SELF_META]])
   // CHECK:   cond_br {{.*}}, [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
@@ -545,7 +545,7 @@ class FailableBaseClass {
   // CHECK: bb0([[SELF_META:%.*]] : $@thick FailableBaseClass.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
   // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[SELF_META]])
   // CHECK:   switch_enum [[NEW_SELF]] : $Optional<FailableBaseClass>, case #Optional.some!enumelt: [[SUCC_BB:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL_BB:bb[0-9]+]]
@@ -573,7 +573,7 @@ class FailableBaseClass {
   // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thick FailableBaseClass.Type):
   // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var FailableBaseClass }, let, name "self"
   // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK-NEXT: [[PB_BOX:%[0-9]+]] = project_box [[SELF_LIFETIME]]
   // CHECK: [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_META]] : $@thick FailableBaseClass.Type, #FailableBaseClass.init!allocator
   // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[DELEG_INIT]]([[SELF_META]])
@@ -619,7 +619,7 @@ class FailableDerivedClass : FailableBaseClass {
   // CHECK: bb0([[OLD_SELF:%.*]] : @owned $FailableDerivedClass):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableDerivedClass }, let, name "self"
   // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
   // CHECK-NEXT: br bb1
@@ -642,7 +642,7 @@ class FailableDerivedClass : FailableBaseClass {
     // First initialize the lvalue for self.
     // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableDerivedClass }, let, name "self"
     // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-    // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
     //
@@ -738,7 +738,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // First initialize.
   // CHECK:   [[REF:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
   // CHECK:   [[MARK_UNINIT:%.*]] = mark_uninitialized [derivedself] [[REF]] : ${ var ThrowDerivedClass }
-  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARK_UNINIT]]
+  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARK_UNINIT]]
   // CHECK:   [[PROJ:%.*]] = project_box [[LIFETIME]]
   // CHECK:   store {{%.*}} to [init] [[PROJ]]
   //
@@ -781,7 +781,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // First initialize.
   // CHECK:   [[REF:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
   // CHECK:   [[MARK_UNINIT:%.*]] = mark_uninitialized [derivedself] [[REF]] : ${ var ThrowDerivedClass }
-  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARK_UNINIT]]
+  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARK_UNINIT]]
   // CHECK:   [[PROJ:%.*]] = project_box [[LIFETIME]]
   // CHECK:   store {{%.*}} to [init] [[PROJ]]
   //
@@ -831,7 +831,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // First initialize.
   // CHECK:   [[REF:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
   // CHECK:   [[MARK_UNINIT:%.*]] = mark_uninitialized [derivedself] [[REF]] : ${ var ThrowDerivedClass }
-  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARK_UNINIT]]
+  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARK_UNINIT]]
   // CHECK:   [[PROJ:%.*]] = project_box [[LIFETIME]]
   // CHECK:   store {{%.*}} to [init] [[PROJ]]
   //
@@ -864,7 +864,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // First initialize.
   // CHECK:   [[REF:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
   // CHECK:   [[MARK_UNINIT:%.*]] = mark_uninitialized [derivedself] [[REF]] : ${ var ThrowDerivedClass }
-  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARK_UNINIT]]
+  // CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARK_UNINIT]]
   // CHECK:   [[PROJ:%.*]] = project_box [[LIFETIME]]
   // CHECK:   store {{%.*}} to [init] [[PROJ]]
   //
@@ -901,7 +901,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // Create our box.
   // CHECK:   [[REF:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
   // CHECK:   [[MARK_UNINIT:%.*]] = mark_uninitialized [derivedself] [[REF]] : ${ var ThrowDerivedClass }
-  // CHECK:   [[MARK_UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARK_UNINIT]]
+  // CHECK:   [[MARK_UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARK_UNINIT]]
   // CHECK:   [[PROJ:%.*]] = project_box [[MARK_UNINIT_LIFETIME]]
   //
   // Perform the unwrap.
@@ -1038,7 +1038,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK: bb0({{.*}}, [[SELF_META:%.*]] : $@thick ThrowDerivedClass.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
   // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   try_apply {{.*}}({{.*}}) : $@convention(thin) (Int) -> (Int, @error any Error), normal [[SUCC_BB1:bb[0-9]+]], error [[ERROR_BB1:bb[0-9]+]]
   //
@@ -1075,7 +1075,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK: bb0({{.*}}, [[SELF_META:%.*]] : $@thick ThrowDerivedClass.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
   // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   try_apply {{.*}}([[SELF_META]]) : {{.*}}, normal [[SUCC_BB1:bb[0-9]+]], error [[ERROR_BB1:bb[0-9]+]]
   //

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -68,10 +68,10 @@ func test3() {
   // CHECK-NEXT: [[STR:%[0-9]+]] = apply [[GETFN]]()
   let o = getAString()
 
+  // CHECK-NEXT: [[STR_BORROW:%.*]] = begin_borrow [var_decl] [[STR]]
   // CHECK-NEXT: debug_value
   // CHECK-NOT: destroy_value
 
-  // CHECK-NEXT: [[STR_BORROW:%.*]] = begin_borrow [[STR]]
   // CHECK: [[USEFN:%[0-9]+]] = function_ref{{.*}}useAString
   // CHECK-NEXT: [[USE:%[0-9]+]] = apply [[USEFN]]([[STR_BORROW]])
   useAString(o)
@@ -233,7 +233,8 @@ struct WeirdPropertyTest {
 func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
   var v = v
   // CHECK: [[VBOX:%[0-9]+]] = alloc_box ${ var WeirdPropertyTest }
-  // CHECK: [[PB:%.*]] = project_box [[VBOX]]
+  // CHECK: [[VLIFETIME:%.*]] = begin_borrow [var_decl] [[VBOX]]
+  // CHECK: [[PB:%.*]] = project_box [[VLIFETIME]]
   // CHECK: store %0 to [trivial] [[PB]]
 
   // The setter isn't mutating, so we need to load the box.
@@ -467,7 +468,8 @@ struct LetPropertyStruct {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testLetPropertyAccessOnLValueBase
 // CHECK: bb0(%0 : $LetPropertyStruct):
 // CHECK:  [[ABOX:%[0-9]+]] = alloc_box ${ var LetPropertyStruct }
-// CHECK:  [[A:%[0-9]+]] = project_box [[ABOX]]
+// CHECK:  [[ALIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[ABOX]]
+// CHECK:  [[A:%[0-9]+]] = project_box [[ALIFETIME]]
 // CHECK:   store %0 to [trivial] [[A]] : $*LetPropertyStruct
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[A]]
 // CHECK:   [[STRUCT:%[0-9]+]] = load [trivial] [[READ]] : $*LetPropertyStruct

--- a/test/SILGen/lexical_lifetime.swift
+++ b/test/SILGen/lexical_lifetime.swift
@@ -44,7 +44,7 @@ struct NonlexicalBox<X> {
 // CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class
 // CHECK:   [[INIT_C:%[^,]+]] = function_ref @$s6borrow1CCACycfC
 // CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_C]]({{%[0-9]+}})
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [var_decl] [[INSTANCE]] : $C
 // CHECK:   end_borrow [[BORROW:%[^,]+]]
 // CHECK-LABEL: } // end sil function 'lexical_borrow_let_class'
 @_silgen_name("lexical_borrow_let_class")
@@ -57,7 +57,7 @@ func lexical_borrow_let_class() {
 // CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_C]]({{%[^,]+}})
 // CHECK:   switch_enum [[INSTANCE]] : $Optional<C>, case #Optional.some!enumelt: [[BASIC_BLOCK2:bb[^,]+]], case #Optional.none!enumelt: {{bb[^,]+}}
 // CHECK: [[BASIC_BLOCK2]]([[INSTANCE:%[^,]+]] : @owned $C):
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [var_decl] [[INSTANCE]] : $C
 // CHECK:   end_borrow [[BORROW]] : $C
 // CHECK-LABEL: // end sil function 'lexical_borrow_if_let_class'
 @_silgen_name("lexical_borrow_if_let_class")
@@ -70,7 +70,7 @@ func lexical_borrow_if_let_class() {
 // CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class_in_struct
 // CHECK:   [[INIT_S:%[^,]+]] = function_ref @$s6borrow1SV1cAcA1CC_tcfC
 // CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_S]]({{%[0-9]+}}, {{%[0-9]+}})
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $S
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [var_decl] [[INSTANCE]] : $S
 // CHECK:   end_borrow [[BORROW:%[^,]+]]
 // CHECK-LABEL: } // end sil function 'lexical_borrow_let_class_in_struct'
 @_silgen_name("lexical_borrow_let_class_in_struct")
@@ -80,7 +80,7 @@ func lexical_borrow_let_class_in_struct() {
 
 // CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class_in_enum
 // CHECK:   [[INSTANCE:%[^,]+]] = enum $E, #E.e!enumelt, {{%[0-9]+}} : $C
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $E
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [var_decl] [[INSTANCE]] : $E
 // CHECK:   end_borrow [[BORROW:%[^,]+]]
 // CHECK-LABEL: } // end sil function 'lexical_borrow_let_class_in_enum'
 @_silgen_name("lexical_borrow_let_class_in_enum")

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -132,7 +132,7 @@ func reftype_return() -> Ref {
 // CHECK-LABEL: sil hidden [ossa] @$s8lifetime11reftype_argyyAA3RefCF : $@convention(thin) (@guaranteed Ref) -> () {
 // CHECK: bb0([[A:%[0-9]+]] : @guaranteed $Ref):
 // CHECK:   [[AADDR:%[0-9]+]] = alloc_box ${ var Ref }
-// CHECK:   [[A_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[AADDR]]
+// CHECK:   [[A_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[AADDR]]
 // CHECK:   [[PA:%[0-9]+]] = project_box [[A_LIFETIME]]
 // CHECK:   [[A_COPY:%.*]] = copy_value [[A]]
 // CHECK:   store [[A_COPY]] to [init] [[PA]]
@@ -157,7 +157,7 @@ func reftype_call_ignore_return() {
 func reftype_call_store_to_local() {
     var a = reftype_func()
     // CHECK: [[A:%[0-9]+]] = alloc_box ${ var Ref }
-    // CHECK: [[A_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[A]]
+    // CHECK: [[A_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[A]]
     // CHECK-NEXT: [[PB:%.*]] = project_box [[A_LIFETIME]]
     // CHECK: = function_ref @$s8lifetime12reftype_funcAA3RefCyF : $@convention(thin) () -> @owned Ref
     // CHECK-NEXT: [[R:%[0-9]+]] = apply
@@ -183,7 +183,7 @@ func reftype_call_arg() {
 // CHECK-LABEL: sil hidden [ossa] @$s8lifetime21reftype_call_with_arg{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0([[A1:%[0-9]+]] : @guaranteed $Ref):
 // CHECK:   [[AADDR:%[0-9]+]] = alloc_box ${ var Ref }
-// CHECK:   [[A_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[AADDR]]
+// CHECK:   [[A_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[AADDR]]
 // CHECK:   [[PB:%.*]] = project_box [[A_LIFETIME]]
 // CHECK:   [[A1_COPY:%.*]] = copy_value [[A1]]
 // CHECK:   store [[A1_COPY]] to [init] [[PB]]
@@ -206,7 +206,7 @@ func reftype_reassign(_ a: inout Ref, b: Ref) {
     var b = b
     // CHECK: bb0([[AADDR:%[0-9]+]] : $*Ref, [[B1:%[0-9]+]] : @guaranteed $Ref):
     // CHECK: [[BADDR:%[0-9]+]] = alloc_box ${ var Ref }
-    // CHECK: [[B_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[BADDR]]
+    // CHECK: [[B_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[BADDR]]
     // CHECK: [[PBB:%.*]] = project_box [[B_LIFETIME]]
     a = b
     // CHECK: destroy_value
@@ -352,13 +352,15 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
   var i = i
   var v = v
   // CHECK: [[RADDR:%[0-9]+]] = alloc_box ${ var RefWithProp }
-  // CHECK: [[R_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[RADDR]]
+  // CHECK: [[R_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[RADDR]]
   // CHECK: [[PR:%[0-9]+]] = project_box [[R_LIFETIME]]
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PI:%[0-9]+]] = project_box [[IADDR]]
+  // CHECK: [[ILIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[IADDR]]
+  // CHECK: [[PI:%[0-9]+]] = project_box [[ILIFETIME]]
   // CHECK: store %1 to [trivial] [[PI]]
   // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
-  // CHECK: [[PV:%[0-9]+]] = project_box [[VADDR]]
+  // CHECK: [[ILIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[VADDR]]
+  // CHECK: [[PV:%[0-9]+]] = project_box [[ILIFETIME]]
 
   // -- Reference types need to be copy_valued as property method args.
   r.int_prop = i
@@ -472,7 +474,8 @@ class Foo<T> {
 
     // -- Then we create a box that we will use to perform a copy_addr into #Foo.x a bit later.
     // CHECK:   [[CHIADDR:%[0-9]+]] = alloc_box ${ var Int }, var, name "chi"
-    // CHECK:   [[PCHI:%[0-9]+]] = project_box [[CHIADDR]]
+    // CHECK:   [[CHILIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[CHIADDR]]
+    // CHECK:   [[PCHI:%[0-9]+]] = project_box [[CHILIFETIME]]
     // CHECK:   store [[CHI]] to [trivial] [[PCHI]]
 
     // -- Then we initialize #Foo.z
@@ -657,7 +660,8 @@ struct Bar {
     // CHECK: bb0([[METATYPE:%[0-9]+]] : $@thin Bar.Type):
     // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Bar }
     // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
-    // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK: [[MARKED_SELF_LIFETIME:%.*]] = begin_borrow [var_decl] [[MARKED_SELF_BOX]]
+    // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_LIFETIME]]
 
     x = bar()
     // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_BOX]]
@@ -685,7 +689,7 @@ struct Bas<T> {
     // CHECK: bb0([[THISADDRPTR:%[0-9]+]] : $*Bas<T>, [[YYADDR:%[0-9]+]] : $*T, [[META:%[0-9]+]] : $@thin Bas<T>.Type):
     // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Bas<τ_0_0> } <T>
     // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
-    // CHECK: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK: [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
 
     x = bar()
@@ -718,14 +722,16 @@ class D : B {
     var y = y
     // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var D }
     // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-    // CHECK: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK: [[PB_BOX:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: store [[SELF]] to [init] [[PB_BOX]]
     // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-    // CHECK: [[PX:%[0-9]+]] = project_box [[XADDR]]
+    // CHECK: [[XLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[XADDR]]
+    // CHECK: [[PX:%[0-9]+]] = project_box [[XLIFETIME]]
     // CHECK: store [[X]] to [trivial] [[PX]]
     // CHECK: [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
-    // CHECK: [[PY:%[0-9]+]] = project_box [[YADDR]]
+    // CHECK: [[YLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[YADDR]]
+    // CHECK: [[PY:%[0-9]+]] = project_box [[YLIFETIME]]
     // CHECK: store [[Y]] to [trivial] [[PY]]
 
     super.init(y: y)
@@ -747,7 +753,7 @@ class D : B {
 func downcast(_ b: B) {
   var b = b
   // CHECK: [[BADDR:%[0-9]+]] = alloc_box ${ var B }
-  // CHECK: [[B_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[BADDR]]
+  // CHECK: [[B_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[BADDR]]
   // CHECK: [[PB:%[0-9]+]] = project_box [[B_LIFETIME]]
   (b as! D).foo()
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]

--- a/test/SILGen/local_recursion.swift
+++ b/test/SILGen/local_recursion.swift
@@ -14,7 +14,7 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[SELF_RECURSIVE_REF:%.*]] = function_ref [[SELF_RECURSIVE]]
   // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[SELF_RECURSIVE_REF]]([[X]])
-  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [lexical] [[CLOSURE]]
+  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [lexical] [var_decl] [[CLOSURE]]
   // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   let sr = self_recursive
   // CHECK: [[B:%.*]] = begin_borrow [[CLOSURE_COPY]]
@@ -50,7 +50,7 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[TRANS_CAPTURE_REF:%.*]] = function_ref [[TRANS_CAPTURE]]
   // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[TRANS_CAPTURE_REF]]([[X]], [[Y]])
-  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [lexical] [[CLOSURE]]
+  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [lexical] [var_decl] [[CLOSURE]]
   // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   let tc = transitive_capture_2
   // CHECK: [[B:%.*]] = begin_borrow [[CLOSURE_COPY]]
@@ -68,7 +68,7 @@ func local_recursion(_ x: Int, y: Int) {
 
   // CHECK: [[CLOSURE_REF:%.*]] = function_ref @$s15local_recursionAA_1yySi_SitFySicfU0_
   // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_REF]]([[X]], [[Y]])
-  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [lexical] [[CLOSURE]]
+  // CHECK: [[BORROWED_CLOSURE:%.*]] = begin_borrow [lexical] [var_decl] [[CLOSURE]]
   // CHECK: [[CLOSURE_COPY:%.*]] = copy_value [[BORROWED_CLOSURE]]
   // CHECK: [[B:%.*]] = begin_borrow [[CLOSURE_COPY]]
   // CHECK: apply [[B]]([[X]])

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -57,7 +57,8 @@ func genericMetatypeFromGenericMetatype<T>(_ x: GenericMetatype<T>)-> T.Type {
 }
 // CHECK-LABEL: sil hidden [ossa] @$ss026dynamicMetatypeFromGenericB0ys1CCms0dB0VyACGF
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var GenericMetatype<C> }
-// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
+// CHECK:         [[XL:%[0-9]+]] = begin_borrow [var_decl] [[XBOX]]
+// CHECK:         [[PX:%[0-9]+]] = project_box [[XL]]
 // CHECK:         [[READ:%.*]] = begin_access [read] [unknown] [[PX]] : $*GenericMetatype<C>
 // CHECK:         [[ADDR:%.*]] = struct_element_addr [[READ]] : $*GenericMetatype<C>, #GenericMetatype.value
 // CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick C.Type
@@ -94,7 +95,8 @@ func dynamicMetatypeToGeneric(_ x: C.Type) {
 }
 // CHECK-LABEL: sil hidden [ossa] @$ss024dynamicMetatypeToGenericB0yys1CCmF
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var @thick C.Type }
-// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
+// CHECK:         [[XL:%[0-9]+]] = begin_borrow [var_decl] [[XBOX]]
+// CHECK:         [[PX:%[0-9]+]] = project_box [[XL]]
 // CHECK:         [[READ:%.*]] = begin_access [read] [unknown] [[PX]] : $*@thick C.Type
 // CHECK:         [[META:%.*]] = load [trivial] [[READ]] : $*@thick C.Type
 // CHECK:         apply {{%.*}}<C>([[META]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -247,7 +247,7 @@ extension AddressOnlyGeneric {
     // CHECK:   [[ARG:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ARG_IN]] :
     //
     // CHECK:   [[ALLOC_X:%.*]] = alloc_box $<τ_0_0> { let AddressOnlyGeneric<τ_0_0> } <T>, let, name "x"
-    // CHECK:   [[X:%.*]] = begin_borrow [lexical] [[ALLOC_X]]
+    // CHECK:   [[X:%.*]] = begin_borrow [lexical] [var_decl] [[ALLOC_X]]
     // CHECK:   [[PROJECT_X:%.*]] = project_box [[X]]
     // CHECK:   copy_addr [[ARG]] to [init] [[PROJECT_X]]
     // CHECK:   [[MARKED_X:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT_X]]
@@ -257,7 +257,7 @@ extension AddressOnlyGeneric {
     // CHECK:   dealloc_stack [[BLACKHOLE_ADDR]]
     //
     // CHECK:   [[ALLOC_Y:%.*]] = alloc_box $<τ_0_0> { let AddressOnlyGeneric<τ_0_0> } <T>, let, name "y"
-    // CHECK:   [[Y:%.*]] = begin_borrow [lexical] [[ALLOC_Y]]
+    // CHECK:   [[Y:%.*]] = begin_borrow [lexical] [var_decl] [[ALLOC_Y]]
     // CHECK:   [[PROJECT_Y:%.*]] = project_box [[Y]]
     // CHECK:   copy_addr [[ARG]] to [init] [[PROJECT_Y]]
     // CHECK:   [[MARKED_Y:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT_Y]]
@@ -281,7 +281,7 @@ extension AddressOnlyProtocol {
     // CHECK:   [[ARG:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ARG_IN]] :
     //
     // CHECK:   [[ALLOC_X:%.*]] = alloc_box ${ let AddressOnlyProtocol }, let, name "x"
-    // CHECK:   [[X:%.*]] = begin_borrow [lexical] [[ALLOC_X]]
+    // CHECK:   [[X:%.*]] = begin_borrow [lexical] [var_decl] [[ALLOC_X]]
     // CHECK:   [[PROJECT_X:%.*]] = project_box [[X]]
     // CHECK:   copy_addr [[ARG]] to [init] [[PROJECT_X]]
     // CHECK:   [[MARKED_X:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT_X]]
@@ -291,7 +291,7 @@ extension AddressOnlyProtocol {
     // CHECK:   dealloc_stack [[BLACKHOLE_ADDR]]
     //
     // CHECK:   [[ALLOC_Y:%.*]] = alloc_box ${ let AddressOnlyProtocol }, let, name "y"
-    // CHECK:   [[Y:%.*]] = begin_borrow [lexical] [[ALLOC_Y]]
+    // CHECK:   [[Y:%.*]] = begin_borrow [lexical] [var_decl] [[ALLOC_Y]]
     // CHECK:   [[PROJECT_Y:%.*]] = project_box [[Y]]
     // CHECK:   copy_addr [[ARG]] to [init] [[PROJECT_Y]]
     // CHECK:   [[MARKED_Y:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT_Y]]
@@ -314,7 +314,7 @@ extension AddressOnlyProtocol {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleLetInitialization1yyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
@@ -331,7 +331,7 @@ func blackHoleLetInitialization1() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleLetInitialization2yyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
@@ -348,7 +348,7 @@ func blackHoleLetInitialization2() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleVarInitialization1yyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
 // CHECK: store {{%.*}} to [init] [[PROJECT_BOX]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
@@ -370,7 +370,7 @@ func blackHoleVarInitialization1() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleVarInitialization2yyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
 // CHECK: store {{%.*}} to [init] [[PROJECT_BOX]]
 //
@@ -393,7 +393,7 @@ func blackHoleVarInitialization2() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleVarInitialization3yyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
 // CHECK: store {{%.*}} to [init] [[PROJECT_BOX]]
 //
@@ -420,7 +420,7 @@ func blackHoleVarInitialization3() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly24borrowObjectFunctionCallyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 //
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW_BOX]]
 // CHECK: store {{%.*}} to [init] [[PROJECT]]
@@ -438,7 +438,7 @@ func borrowObjectFunctionCall() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly29moveOnlyStructNonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 // CHECK: store {{%.*}} to [init] [[PROJECT]]
 //
@@ -462,7 +462,7 @@ func moveOnlyStructNonConsumingUse() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD15NonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW_BOX]]
 //
 // CHECK: store
@@ -485,7 +485,7 @@ func moveOnlyStructMoveOnlyStructNonConsumingUse() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD28CopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 
 // CHECK: store
@@ -509,12 +509,12 @@ func moveOnlyStructMoveOnlyStructCopyableKlassNonConsumingUse() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly021moveOnlyStructSetMoveC5FieldyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ var NonTrivialStruct }
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT1:%.*]] = project_box [[BORROW_BOX]]
 // CHECK: store
 //
 // CHECK: [[BOX2:%.*]] = alloc_box ${ let NonTrivialStruct2 }
-// CHECK: [[BORROW_BOX2:%.*]] = begin_borrow [lexical] [[BOX2]]
+// CHECK: [[BORROW_BOX2:%.*]] = begin_borrow [lexical] [var_decl] [[BOX2]]
 // CHECK: [[PROJECT2:%.*]] = project_box [[BORROW_BOX2]]
 // CHECK: store
 //
@@ -534,7 +534,7 @@ func moveOnlyStructSetMoveOnlyField() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyableD15NonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 //
 // CHECK: store
@@ -557,7 +557,7 @@ func moveOnlyStructCopyableStructNonConsumingUse() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 //
 // CHECK: store
@@ -581,7 +581,7 @@ func moveOnlyStructCopyableStructCopyableKlassNonConsumingUse() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledeD15NonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 //
 // CHECK: store
@@ -605,7 +605,7 @@ func moveOnlyStructCopyableStructCopyableStructNonConsumingUse() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyablededE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 //
 // CHECK: store
@@ -632,7 +632,7 @@ func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
 //
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledede9KlassMovecF15NonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [var_decl]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 //
 // CHECK: store
@@ -721,7 +721,7 @@ var booleanGuard2: Bool { false }
 //
 // CHECK: [[BB_E_2]]([[BBARG:%.*]] : @guaranteed
 // CHECK:   [[NEW_BOX:%.*]] = alloc_box
-// CHECK:   [[NEW_BOX_BORROW:%.*]] = begin_borrow [lexical] [[NEW_BOX]]
+// CHECK:   [[NEW_BOX_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[NEW_BOX]]
 // CHECK:   [[NEW_BOX_PROJECT:%.*]] = project_box [[NEW_BOX_BORROW]]
 // CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
 // CHECK:   store [[BBARG_COPY]] to [init] [[NEW_BOX_PROJECT]]
@@ -731,7 +731,7 @@ var booleanGuard2: Bool { false }
 // This case is copyable
 // CHECK: [[BB_E_3]]([[BBARG:%.*]] : @guaranteed
 // CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
-// CHECK:   begin_borrow [lexical] [[BBARG_COPY]]
+// CHECK:   begin_borrow [lexical] [var_decl] [[BBARG_COPY]]
 // CHECK:   end_borrow [[BORROWED_VALUE]]
 // CHECK:   br [[BB_CONT]]
 //
@@ -749,14 +749,14 @@ var booleanGuard2: Bool { false }
 // Copyable case
 // CHECK: [[BB_E2_LHS]]([[BBARG:%.*]] : @guaranteed
 // CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
-// CHECK:   begin_borrow [lexical] [[BBARG_COPY]]
+// CHECK:   begin_borrow [lexical] [var_decl] [[BBARG_COPY]]
 // CHECK:   end_borrow [[BORROWED_VALUE]]
 // CHECK:   br [[BB_CONT]]
 //
 // Move only case.
 // CHECK: [[BB_E2_RHS]]([[BBARG:%.*]] : @guaranteed
 // CHECK:   [[NEW_BOX:%.*]] = alloc_box
-// CHECK:   [[NEW_BOX_BORROW:%.*]] = begin_borrow [lexical] [[NEW_BOX]]
+// CHECK:   [[NEW_BOX_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[NEW_BOX]]
 // CHECK:   [[NEW_BOX_PROJECT:%.*]] = project_box [[NEW_BOX_BORROW]]
 // CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
 // CHECK:   store [[BBARG_COPY]] to [init] [[NEW_BOX_PROJECT]]
@@ -934,7 +934,7 @@ struct EmptyStruct {
   // CHECK-LABEL: sil hidden [ossa] @$s8moveonly11EmptyStructVACycfC : $@convention(method) (@thin EmptyStruct.Type) -> @owned EmptyStruct {
   // CHECK: [[BOX:%.*]] = alloc_box ${ var EmptyStruct }, var, name "self"
   // CHECK: [[MARKED_UNINIT:%.*]] = mark_uninitialized [rootself] [[BOX]]
-  // CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_UNINIT]]
+  // CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_UNINIT]]
   // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
   // CHECK: [[STRUCT:%.*]] = struct $EmptyStruct ()
   // CHECK: store [[STRUCT]] to [init] [[PROJECT]]
@@ -954,7 +954,7 @@ struct EmptyStruct {
 // CHECK: sil hidden [ossa] @$s8moveonly31testConditionallyInitializedLetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ let NonTrivialStruct }, let, name "x"
 // CHECK: [[MARK_UNINIT:%.*]] = mark_uninitialized [var] [[BOX]]
-// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[MARK_UNINIT]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[MARK_UNINIT]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
 // CHECK: cond_br {{%.*}}, [[LHS_BB:bb[0-9]+]], [[RHS_BB:bb[0-9]+]]
 //
@@ -1041,7 +1041,7 @@ public struct LoadableSubscriptGetOnlyTester : ~Copyable {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE4_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The get call
@@ -1058,7 +1058,7 @@ public struct LoadableSubscriptGetOnlyTester : ~Copyable {
 //
 // Test the assignment
 // CHECK: [[M2_BOX:%.*]] = alloc_box ${
-// CHECK: [[M2_BORROW:%.*]] = begin_borrow [lexical] [[M2_BOX]]
+// CHECK: [[M2_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[M2_BOX]]
 // CHECK: [[M2_PROJECT:%.*]] = project_box [[M2_BORROW]]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS]]
@@ -1080,7 +1080,7 @@ public func testSubscriptGetOnly_BaseLoadable_ResultAddressOnly_Var() {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly047testSubscriptGetOnly_BaseLoadable_ResultAddressE4_LetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The get call
@@ -1144,7 +1144,7 @@ public struct LoadableSubscriptGetOnlyTesterNonCopyableStructParent : ~Copyable 
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The first get call
@@ -1186,7 +1186,7 @@ public func testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_Resu
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly077testSubscriptGetOnlyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressE4_LetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ let L
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT]]
@@ -1250,7 +1250,7 @@ public class LoadableSubscriptGetOnlyTesterClassParent {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly065testSubscriptGetOnlyThroughParentClass_BaseLoadable_ResultAddressE4_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
 //
 // First read.
@@ -1328,7 +1328,7 @@ public struct LoadableSubscriptGetSetTester : ~Copyable {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly54testSubscriptGetSet_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The get call
@@ -1375,7 +1375,7 @@ public func testSubscriptGetSet_BaseLoadable_ResultAddressOnly_Var() {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly54testSubscriptGetSet_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The get call
@@ -1487,7 +1487,7 @@ public struct LoadableSubscriptGetSetTesterNonCopyableStructParent : ~Copyable {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly84testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The first get call
@@ -1542,7 +1542,7 @@ public func testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_Resul
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly84testSubscriptGetSetThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ let L
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT]]
@@ -1635,7 +1635,7 @@ public class LoadableSubscriptGetSetTesterClassParent {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly72testSubscriptGetSetThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
 //
 // First read.
@@ -1777,7 +1777,7 @@ public struct LoadableSubscriptReadModifyTester : ~Copyable {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly58testSubscriptReadModify_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The read call
@@ -1821,7 +1821,7 @@ public func testSubscriptReadModify_BaseLoadable_ResultAddressOnly_Var() {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly58testSubscriptReadModify_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The get call
@@ -1922,7 +1922,7 @@ public struct LoadableSubscriptReadModifyTesterNonCopyableStructParent : ~Copyab
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly88testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The first get call
@@ -1969,7 +1969,7 @@ public func testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_R
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly88testSubscriptReadModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ let L
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT]]
@@ -2049,7 +2049,7 @@ public class LoadableSubscriptReadModifyTesterClassParent {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly76testSubscriptReadModifyThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
 //
 // First read.
@@ -2169,7 +2169,7 @@ public struct LoadableSubscriptGetModifyTester : ~Copyable {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly57testSubscriptGetModify_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The get call
@@ -2214,7 +2214,7 @@ public func testSubscriptGetModify_BaseLoadable_ResultAddressOnly_Var() {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly57testSubscriptGetModify_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The get call
@@ -2322,7 +2322,7 @@ public struct LoadableSubscriptGetModifyTesterNonCopyableStructParent : ~Copyabl
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly87testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // The first get call
@@ -2373,7 +2373,7 @@ public func testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_Re
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly87testSubscriptGetModifyThroughNonCopyableParentStruct_BaseLoadable_ResultAddressOnly_LetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ let L
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 //
 // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[PROJECT]]
@@ -2432,7 +2432,7 @@ public class LoadableSubscriptGetModifyTesterClassParent {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly75testSubscriptGetModifyThroughParentClass_BaseLoadable_ResultAddressOnly_VaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box $
-// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
 //
 // First read.
@@ -2558,7 +2558,7 @@ func testSelfCaptureHandledCorrectly() {
         // CHECK-LABEL: sil private [ossa] @$s8moveonly31testSelfCaptureHandledCorrectlyyyF4TestL_VADycfC : $@convention(method) (@thin Test.Type) -> @owned Test {
         // CHECK: [[BOX:%.*]] = alloc_box ${ var Test }
         // CHECK: [[MARK_UNINIT:%.*]] = mark_uninitialized [rootself] [[BOX]]
-        // CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[MARK_UNINIT]]
+        // CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[MARK_UNINIT]]
         // CHECK: [[PROJECT:%.*]] = project_box [[BORROW]]
         // CHECK: apply {{%.*}}([[PROJECT]])
         // CHECK: } // end sil function '$s8moveonly31testSelfCaptureHandledCorrectlyyyF4TestL_VADycfC'

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -83,7 +83,7 @@ var value: Bool { false }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits24testIntPairWithoutDeinityyF : $@convention(thin) () -> () {
 // SILGEN: [[BOX:%.*]] = alloc_box
-// SILGEN: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// SILGEN: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // SILGEN: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
@@ -133,7 +133,7 @@ public func testIntPairWithoutDeinit() {
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits21testIntPairWithDeinityyF : $@convention(thin) () -> () {
 // SILGEN: [[BOX:%.*]] = alloc_box
-// SILGEN: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// SILGEN: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // SILGEN: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
@@ -181,7 +181,7 @@ public func testIntPairWithDeinit() {
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits26testKlassPairWithoutDeinityyF : $@convention(thin) () -> () {
 // SILGEN: [[BOX:%.*]] = alloc_box
-// SILGEN: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+// SILGEN: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // SILGEN: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
@@ -345,7 +345,7 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
 // SILGEN: [[BOX:%.*]] = alloc_box
-// SILGEN: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// SILGEN: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // SILGEN: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
@@ -394,7 +394,7 @@ public func testIntEnumPairWithoutDeinit() {
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits25testIntEnumPairWithDeinityyF : $@convention(thin) () -> () {
 // SILGEN: [[BOX:%.*]] = alloc_box
-// SILGEN: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// SILGEN: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // SILGEN: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //

--- a/test/SILGen/moveonly_enum_literal.swift
+++ b/test/SILGen/moveonly_enum_literal.swift
@@ -16,7 +16,7 @@ var value: Bool { false }
 
 // CHECK-LABEL: sil hidden [ossa] @$s21moveonly_enum_literal4testyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[VALUE:%.*]] = enum $MoveOnlyIntPair, #MoveOnlyIntPair.lhs!enumelt,
 // CHECK: store [[VALUE]] to [init] [[PROJECT]]

--- a/test/SILGen/moveonly_escaping_closure.swift
+++ b/test/SILGen/moveonly_escaping_closure.swift
@@ -24,7 +24,7 @@ func borrowConsumeVal(_ x: borrowing SingleElt, _ y: consuming SingleElt) {}
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure27testGlobalClosureCaptureVaryyF : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s16moveonly_closure23globalClosureCaptureVaryycvp
 // CHECK: [[BOX:%.*]] = alloc_box ${ var SingleElt }
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure27testGlobalClosureCaptureVaryyFyycfU_ : $@convention(thin) (@guaranteed { var SingleElt }) -> ()
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
@@ -85,12 +85,12 @@ func testGlobalClosureCaptureVar() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure29testLocalLetClosureCaptureVaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
 // CHECK: mark_function_escape [[PROJECT]]
 // CHECK: [[PAI:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[BOX_COPY]])
-// CHECK: [[BORROW_PAI:%.*]] = begin_borrow [lexical] [[PAI]]
+// CHECK: [[BORROW_PAI:%.*]] = begin_borrow [lexical] [var_decl] [[PAI]]
 // CHECK: [[COPY_BORROW_PAI:%.*]] = copy_value [[BORROW_PAI]]
 // CHECK: [[BORROW_COPY_BORROW_PAI:%.*]] = begin_borrow [[COPY_BORROW_PAI]]
 // CHECK: apply [[BORROW_COPY_BORROW_PAI]]()
@@ -153,7 +153,7 @@ func testLocalLetClosureCaptureVar() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure026testLocalVarClosureCaptureE0yyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
 // CHECK: mark_function_escape [[PROJECT]]
@@ -212,7 +212,7 @@ func testLocalVarClosureCaptureVar() {
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure026testInOutVarClosureCaptureF0yyyyczF : $@convention(thin) (@inout @callee_guaranteed () -> ()) -> () {
 // CHECK: bb0([[F:%.*]] : $*@callee_guaranteed () -> ()):
 // CHECK: [[BOX:%.*]] = alloc_box ${ var SingleElt }
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure026testInOutVarClosureCaptureF0yyyyczFyycfU_ : $@convention(thin) (@guaranteed { var SingleElt }) -> ()
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
@@ -274,12 +274,13 @@ func testInOutVarClosureCaptureVar(_ f: inout () -> ()) {
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure36testConsumingEscapeClosureCaptureVaryyyycnF : $@convention(thin) (@owned @callee_guaranteed () -> ()) -> () {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy @_eagerMove @owned
 // CHECK:   [[FUNC_BOX:%.*]] = alloc_box ${ var @moveOnly @callee_guaranteed () -> () }
-// CHECK:   [[FUNC_PROJECT:%.*]] = project_box [[FUNC_BOX]]
+// CHECK:   [[FUNC_LIFETIME:%.*]] = begin_borrow [var_decl] [[FUNC_BOX]]
+// CHECK:   [[FUNC_PROJECT:%.*]] = project_box [[FUNC_LIFETIME]]
 // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_addr [[FUNC_PROJECT]]
 // CHECK:   store [[ARG]] to [init] [[UNWRAP]]
 //
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var SingleElt }
-// CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK:   [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure36testConsumingEscapeClosureCaptureVaryyyycnFyycfU_ : $@convention(thin) (@guaranteed { var SingleElt })
 // CHECK:   [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
@@ -347,7 +348,7 @@ func testConsumingEscapeClosureCaptureVar(_ f: consuming @escaping () -> ()) {
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure27testGlobalClosureCaptureLetyyF : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s16moveonly_closure23globalClosureCaptureLetyycvp
 // CHECK: [[BOX:%.*]] = alloc_box ${ let SingleElt }
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure27testGlobalClosureCaptureLetyyFyycfU_ : $@convention(thin) (@guaranteed { let SingleElt }) -> ()
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
@@ -394,12 +395,12 @@ func testGlobalClosureCaptureLet() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure026testLocalLetClosureCaptureE0yyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
 // CHECK: mark_function_escape [[PROJECT]]
 // CHECK: [[PAI:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[BOX_COPY]])
-// CHECK: [[BORROW_PAI:%.*]] = begin_borrow [lexical] [[PAI]]
+// CHECK: [[BORROW_PAI:%.*]] = begin_borrow [lexical] [var_decl] [[PAI]]
 // CHECK: [[COPY_BORROW_PAI:%.*]] = copy_value [[BORROW_PAI]]
 // CHECK: [[BORROW_COPY_BORROW_PAI:%.*]] = begin_borrow [[COPY_BORROW_PAI]]
 // CHECK: apply [[BORROW_COPY_BORROW_PAI]]()
@@ -444,7 +445,7 @@ func testLocalLetClosureCaptureLet() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure29testLocalVarClosureCaptureLetyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
 // CHECK: mark_function_escape [[PROJECT]]
@@ -490,7 +491,7 @@ func testLocalVarClosureCaptureLet() {
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure29testInOutVarClosureCaptureLetyyyyczF : $@convention(thin) (@inout @callee_guaranteed () -> ()) -> () {
 // CHECK: bb0([[F:%.*]] : $*@callee_guaranteed () -> ()):
 // CHECK: [[BOX:%.*]] = alloc_box ${ let SingleElt }
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure29testInOutVarClosureCaptureLetyyyyczFyycfU_ : $@convention(thin) (@guaranteed { let SingleElt }) -> ()
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
@@ -539,12 +540,13 @@ func testInOutVarClosureCaptureLet(_ f: inout () -> ()) {
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure36testConsumingEscapeClosureCaptureLetyyyycnF : $@convention(thin) (@owned @callee_guaranteed () -> ()) -> () {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy @_eagerMove @owned
 // CHECK:   [[FUNC_BOX:%.*]] = alloc_box ${ var @moveOnly @callee_guaranteed () -> () }
-// CHECK:   [[PROJECT:%.*]] = project_box [[FUNC_BOX]]
+// CHECK:   [[FUNC_LIFETIME:%.*]] = begin_borrow [var_decl] [[FUNC_BOX]]
+// CHECK:   [[PROJECT:%.*]] = project_box [[FUNC_LIFETIME]]
 // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_addr [[FUNC_PROJECT]]
 // CHECK:   store [[ARG]] to [init] [[UNWRAP]]
 //
 // CHECK:   [[BOX:%.*]] = alloc_box ${ let SingleElt }
-// CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK:   [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure36testConsumingEscapeClosureCaptureLetyyyycnFyycfU_ : $@convention(thin) (@guaranteed { let SingleElt })
 // CHECK:   [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
@@ -698,7 +700,7 @@ func testLocalLetClosureCaptureInOut(_ x: inout SingleElt) {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK: [[MARKED:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[ARG]]
 // CHECK: [[FUNC_BOX:%.*]] = alloc_box ${ var @callee_guaranteed () -> () }
-// CHECK: [[FUNC_BOX_BORROW:%.*]] = begin_borrow [lexical] [[FUNC_BOX]]
+// CHECK: [[FUNC_BOX_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[FUNC_BOX]]
 // CHECK: [[FUNC_PROJECT:%.*]] = project_box [[FUNC_BOX_BORROW]]
 // CHECK: [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure31testLocalVarClosureCaptureInOutyyAA9SingleEltVzFyycfU_ : $@convention(thin) (@inout_aliasable SingleElt) -> ()
 // CHECK: [[PAI:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE]]([[MARKED]])
@@ -796,7 +798,8 @@ func testInOutVarClosureCaptureInOut(_ f: inout () -> (), _ x: inout SingleElt) 
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure38testConsumingEscapeClosureCaptureInOutyyyycn_AA9SingleEltVztF : $@convention(thin) (@owned @callee_guaranteed () -> (), @inout SingleElt) -> () {
 // CHECK: bb0([[FUNC_ARG:%.*]] : @noImplicitCopy @_eagerMove @owned $@callee_guaranteed () -> (), [[PROJECT:%.*]] : $*SingleElt):
 // CHECK:   [[FUNC_BOX:%.*]] = alloc_box ${ var @moveOnly @callee_guaranteed () -> () }
-// CHECK:   [[FUNC_PROJECT:%.*]] = project_box [[FUNC_BOX]]
+// CHECK:   [[FUNC_LIFETIME:%.*]] = begin_borrow [var_decl] [[FUNC_BOX]]
+// CHECK:   [[FUNC_PROJECT:%.*]] = project_box [[FUNC_LIFETIME]]
 // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_addr [[FUNC_PROJECT]]
 // CHECK:   store [[FUNC_ARG]] to [init] [[UNWRAP]]
 //
@@ -855,7 +858,7 @@ func testConsumingEscapeClosureCaptureInOut(_ f: consuming @escaping () -> (), _
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure33testGlobalClosureCaptureConsumingyyAA9SingleEltVnF : $@convention(thin) (@owned SingleElt) -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s16moveonly_closure29globalClosureCaptureConsumingyycvp
 // CHECK: [[BOX:%.*]] = alloc_box ${ var SingleElt }
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure33testGlobalClosureCaptureConsumingyyAA9SingleEltVnFyycfU_ : $@convention(thin) (@guaranteed { var SingleElt }) -> ()
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
@@ -914,12 +917,12 @@ func testGlobalClosureCaptureConsuming(_ x: consuming SingleElt) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure35testLocalLetClosureCaptureConsumingyyAA9SingleEltVnF : $@convention(thin) (@owned SingleElt) -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
 // CHECK: mark_function_escape [[PROJECT]]
 // CHECK: [[PAI:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[BOX_COPY]])
-// CHECK: [[BORROW_PAI:%.*]] = begin_borrow [lexical] [[PAI]]
+// CHECK: [[BORROW_PAI:%.*]] = begin_borrow [lexical] [var_decl] [[PAI]]
 // CHECK: [[COPY_BORROW_PAI:%.*]] = copy_value [[BORROW_PAI]]
 // CHECK: [[BORROW_COPY_BORROW_PAI:%.*]] = begin_borrow [[COPY_BORROW_PAI]]
 // CHECK: apply [[BORROW_COPY_BORROW_PAI]]()
@@ -993,7 +996,7 @@ func testLocalLetClosureCaptureConsuming2(_ x: consuming SingleElt) -> (() -> ()
 
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure35testLocalVarClosureCaptureConsumingyyAA9SingleEltVnF : $@convention(thin) (@owned SingleElt) -> () {
 // CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK: [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
 // CHECK: mark_function_escape [[PROJECT]]
@@ -1051,12 +1054,13 @@ func testLocalVarClosureCaptureConsuming(_ x: consuming SingleElt) {
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure033testConsumingEscapeClosureCaptureD0yyyycn_AA9SingleEltVntF : $@convention(thin) (@owned @callee_guaranteed () -> (), @owned SingleElt) -> () {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy @_eagerMove @owned $@callee_guaranteed () -> (),
 // CHECK:   [[FUNC_BOX:%.*]] = alloc_box ${ var @moveOnly @callee_guaranteed () -> () }
-// CHECK:   [[FUNC_PROJECT:%.*]] = project_box [[FUNC_BOX]]
+// CHECK:   [[FUNC_LIFETIME:%.*]] = begin_borrow [var_decl] [[FUNC_BOX]]
+// CHECK:   [[FUNC_PROJECT:%.*]] = project_box [[FUNC_LIFETIME]]
 // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_addr [[FUNC_PROJECT]]
 // CHECK:   store [[ARG]] to [init] [[UNWRAP]]
 //
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var SingleElt }
-// CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PROJECT:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK:   [[CLOSURE:%.*]] = function_ref @$s16moveonly_closure033testConsumingEscapeClosureCaptureD0yyyycn_AA9SingleEltVntFyycfU_ : $@convention(thin) (@guaranteed { var SingleElt }) -> ()
 // CHECK:   [[BOX_COPY:%.*]] = copy_value [[BOX_LIFETIME]]
@@ -1171,7 +1175,7 @@ func testGlobalClosureCaptureOwned(_ x: __owned SingleElt) {
 // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX]]
 // CHECK: mark_function_escape [[PROJECT]]
 // CHECK: [[PAI:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[BOX_COPY]])
-// CHECK: [[BORROW_PAI:%.*]] = begin_borrow [lexical] [[PAI]]
+// CHECK: [[BORROW_PAI:%.*]] = begin_borrow [lexical] [var_decl] [[PAI]]
 // CHECK: [[COPY_BORROW_PAI:%.*]] = copy_value [[BORROW_PAI]]
 // CHECK: [[BORROW_COPY_BORROW_PAI:%.*]] = begin_borrow [[COPY_BORROW_PAI]]
 // CHECK: apply [[BORROW_COPY_BORROW_PAI]]()
@@ -1306,7 +1310,8 @@ func testInOutVarClosureCaptureOwned(_ f: inout () -> (), _ x: __owned SingleElt
 // CHECK-LABEL: sil hidden [ossa] @$s16moveonly_closure38testConsumingEscapeClosureCaptureOwnedyyyycn_AA9SingleEltVntF : $@convention(thin) (@owned @callee_guaranteed () -> (), @owned SingleElt) -> () {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy @_eagerMove @owned $@callee_guaranteed () -> (),
 // CHECK:   [[FUNC_BOX:%.*]] = alloc_box ${ var @moveOnly @callee_guaranteed () -> () }
-// CHECK:   [[FUNC_PROJECT:%.*]] = project_box [[FUNC_BOX]]
+// CHECK:   [[FUNC_LIFETIME:%.*]] = begin_borrow [var_decl] [[FUNC_BOX]]
+// CHECK:   [[FUNC_PROJECT:%.*]] = project_box [[FUNC_LIFETIME]]
 // CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable_addr [[FUNC_PROJECT]]
 // CHECK:   store [[ARG]] to [init] [[UNWRAP]]
 //

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -20,7 +20,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : @owned $String,
 // CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }
 // CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
-// CHECK-RAW: [[SELF_BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+// CHECK-RAW: [[SELF_BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
 // CHECK-RAW: [[PB_BOX:%[0-9]+]] = project_box [[SELF_BOX_LIFETIME]]
 // CHECK-RAW: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
 // CHECK-RAW: [[COPIED_STR:%.*]] = copy_value [[BORROWED_STR]]

--- a/test/SILGen/noimplicitcopy.swift
+++ b/test/SILGen/noimplicitcopy.swift
@@ -100,7 +100,8 @@ func printIntArg(@_noImplicitCopy _ x: Int) {
 // CHECK: apply [[FUNC]]([[VALUE]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
-// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX]]
+// CHECK: [[Y_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y_BOX]]
+// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX_LIFETIME]]
 // CHECK: [[Y_BOX_PROJECT_ACCESS:%.*]] = begin_access [read] [unknown] [[Y_BOX_PROJECT]]
 // CHECK: [[Y_VALUE:%.*]] = load [trivial] [[Y_BOX_PROJECT_ACCESS]]
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy11printIntArgyySiF : $@convention(thin) (Int) -> ()
@@ -149,7 +150,8 @@ func printIntOwnedArg(@_noImplicitCopy _ x: __owned Int) {
 // CHECK: apply [[FUNC]]([[VALUE]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
-// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX]]
+// CHECK: [[Y_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y_BOX]]
+// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX_LIFETIME]]
 // CHECK: [[Y_BOX_PROJECT_ACCESS:%.*]] = begin_access [read] [unknown] [[Y_BOX_PROJECT]]
 // CHECK: [[Y_VALUE:%.*]] = load [trivial] [[Y_BOX_PROJECT_ACCESS]]
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy16printIntOwnedArgyySinF : $@convention(thin) (Int) -> ()
@@ -198,7 +200,8 @@ func printIntArgThrows(@_noImplicitCopy _ x: Int) throws {
 // CHECK: try_apply [[FUNC]]([[VALUE]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
-// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX]]
+// CHECK: [[Y_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y_BOX]]
+// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX_LIFETIME]]
 // CHECK: [[Y_BOX_PROJECT_ACCESS:%.*]] = begin_access [read] [unknown] [[Y_BOX_PROJECT]]
 // CHECK: [[Y_VALUE:%.*]] = load [trivial] [[Y_BOX_PROJECT_ACCESS]]
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy17printIntArgThrowsyySiKF : $@convention(thin) (Int) -> @error any Error
@@ -238,7 +241,8 @@ func printIntOwnedArgThrows(@_noImplicitCopy _ x: __owned Int) throws {
 // CHECK: try_apply [[FUNC]]([[VALUE]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
-// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX]]
+// CHECK: [[Y_BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y_BOX]]
+// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX_LIFETIME]]
 // CHECK: [[Y_BOX_PROJECT_ACCESS:%.*]] = begin_access [read] [unknown] [[Y_BOX_PROJECT]]
 // CHECK: [[Y_VALUE:%.*]] = load [trivial] [[Y_BOX_PROJECT_ACCESS]]
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy22printIntOwnedArgThrowsyySinKF : $@convention(thin) (Int) -> @error any Error
@@ -333,7 +337,7 @@ func callClosureIntOwned() {
 // NOTE: MOW expands to MOVEONLYWRAPPED
 //
 // CHECK-LABEL: sil hidden [ossa] @$s14noimplicitcopy10printKlassyyF : $@convention(thin) () -> () {
-// CHECK:   [[X:%.*]] = begin_borrow [lexical] {{%[0-9]+}} : $Klass
+// CHECK:   [[X:%.*]] = begin_borrow [lexical] [var_decl] {{%[0-9]+}} : $Klass
 // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
 // CHECK:   [[X_MOVEONLYWRAPPED:%.*]] = copyable_to_moveonlywrapper [owned] [[X_COPY]]
 // CHECK:   [[X_MOVEONLYWRAPPED_MARKED:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[X_MOVEONLYWRAPPED]]

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -394,7 +394,7 @@ class Hoozit : Gizmo {
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC7bellsOnACSi_tcfc : $@convention(method) (Int, @owned Hoozit) -> @owned Hoozit {
   // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
   // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK: [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
   // CHECK: [[BORROWED_GIZMO:%.*]] = begin_borrow [[GIZMO]]

--- a/test/SILGen/objc_dealloc.swift
+++ b/test/SILGen/objc_dealloc.swift
@@ -20,7 +20,7 @@ class SwiftGizmo : Gizmo {
   override init() {
     // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var SwiftGizmo }, let, name "self"
     // CHECK:   [[SELF_UNINIT:%.*]] = mark_uninitialized [derivedselfonly] [[SELF_BOX]] : ${ var SwiftGizmo }
-    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[SELF_UNINIT]]
+    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[SELF_UNINIT]]
     // CHECK:   [[SELF_ADDR:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK-NOT: ref_element_addr
     // CHECK:   [[SELF:%.*]] = load [take] [[SELF_ADDR]]

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -113,7 +113,7 @@ class MyNSError : NSError {
 // CHECK:   [[NSERROR_SUBCLASS:%.*]] = apply {{.*}}({{.*}}) : $@convention(method) (@thick MyNSError.Type) -> @owned MyNSError
 // CHECK:   [[UPCAST:%.*]] = upcast [[NSERROR_SUBCLASS]] : $MyNSError to $NSError
 // CHECK:   [[EXISTENTIAL_REF:%.*]] = init_existential_ref [[UPCAST]]
-// CHECK:   [[BORROWED_EXISTENTIAL_REF:%.*]] = begin_borrow [lexical] [[EXISTENTIAL_REF]]
+// CHECK:   [[BORROWED_EXISTENTIAL_REF:%.*]] = begin_borrow [lexical] [var_decl] [[EXISTENTIAL_REF]]
 // CHECK:   [[COPY_BORROWED_EXISTENTIAL_REF:%.*]] = copy_value [[BORROWED_EXISTENTIAL_REF]]
 // CHECK:   end_borrow [[BORROWED_EXISTENTIAL_REF]]
 // CHECK:   destroy_value [[EXISTENTIAL_REF]]

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -81,6 +81,7 @@ extension Sub {
     // CHECK:   [[OLD_NSSTRING:%.*]] = apply [[GET_SUPER_METHOD]]([[BORROWED_UPCAST_SELF_COPY]])
 
     // CHECK: bb3([[OLD_NSSTRING_BRIDGED:%.*]] : @owned $Optional<String>):
+    // CHECK:   [[BORROWED_OLD_NSSTRING_BRIDGED:%.*]] = begin_borrow [var_decl] [[OLD_NSSTRING_BRIDGED]]
     // This next line is completely not needed. But we are emitting it now.
     // CHECK:   destroy_value [[UPCAST_SELF_COPY]]
     // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
@@ -98,7 +99,6 @@ extension Sub {
     // CHECK:    destroy_value [[BRIDGED_NEW_STRING]]
     // CHECK:    destroy_value [[UPCAST_SELF_COPY]]
     // This is an identity cast that should be eliminated by SILGen peepholes.
-    // CHECK:   [[BORROWED_OLD_NSSTRING_BRIDGED:%.*]] = begin_borrow [[OLD_NSSTRING_BRIDGED]]
     // CHECK:    [[DIDSET_NOTIFIER:%.*]] = function_ref @$s15objc_extensions3SubC4propSSSgvW : $@convention(method) (@guaranteed Optional<String>, @guaranteed Sub) -> ()
     // CHECK:    apply [[DIDSET_NOTIFIER]]([[BORROWED_OLD_NSSTRING_BRIDGED]], [[SELF]])
     // CHECK:    end_borrow [[BORROWED_OLD_NSSTRING_BRIDGED]]

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -25,7 +25,7 @@ extension Hive {
   // CHECK: bb0([[QUEEN:%.*]] : @owned $Bee, [[META:%.*]] : $@thick Hive.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var Hive }, let, name "self"
   // CHECK:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MU]]
+  // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MU]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[LIFETIME]] : ${ var Hive }, 0
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
   // CHECK:   [[BORROWED_QUEEN:%.*]] = begin_borrow [[QUEEN]]
@@ -47,7 +47,7 @@ extension Hive {
   // CHECK: bb0([[QUEEN:%.*]] : @owned $Bee, [[META:%.*]] : $@thick Hive.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var Hive }, let, name "self"
   // CHECK-NEXT:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK-NEXT:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MU]]
+  // CHECK-NEXT:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MU]]
   // CHECK-NEXT:   [[PB_BOX:%.*]] = project_box [[LIFETIME]] : ${ var Hive }, 0
   // CHECK:   [[FOREIGN_ERROR_STACK:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
@@ -95,7 +95,7 @@ class SubHive : Hive {
   // CHECK: bb0([[METATYPE:%.*]] : $@thick SubHive.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var SubHive }, let, name "self"
   // CHECK:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var SubHive }
-  // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MU]]
+  // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MU]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[LIFETIME]] : ${ var SubHive }, 0
   // CHECK:   [[UP_METATYPE:%.*]] = upcast [[METATYPE]]
   // CHECK:   [[OBJC_METATYPE:%.*]] = thick_to_objc_metatype [[UP_METATYPE]]

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -8,7 +8,7 @@ extension Gizmo {
     // CHECK: bb0([[I:%[0-9]+]] : $Int, [[SELF_META:%[0-9]+]] : $@thick Gizmo.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Gizmo }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[MARKED_SELF_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[MARKED_SELF_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX_LIFETIME]]
     // CHECK:   [[SELF_OBJC_META:%.*]] = thick_to_objc_metatype [[SELF_META]]
     // CHECK:   [[ORIG_SELF:%.*]] = alloc_ref_dynamic [objc] [[SELF_OBJC_META]]

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -33,7 +33,7 @@ func test5(_ g: Gizmo) {
   Gizmo.inspect(g)
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
   // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
-  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[GIZMO_BOX]]
   // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX_LIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]
@@ -57,7 +57,7 @@ func test6(_ g: Gizmo) {
   Gizmo.consume(g)
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
   // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
-  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[GIZMO_BOX]]
   // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX_LIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]
@@ -83,7 +83,7 @@ func test7(_ g: Gizmo) {
   g.fork()
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
   // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
-  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[GIZMO_BOX]]
   // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX_LIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -233,7 +233,7 @@ extension InformallyFunging: NSFunging { }
 func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializable {
   // CHECK: bb0([[META:%[0-9]+]] : $@thick any Initializable.Type, [[I:%[0-9]+]] : $Int):
   // CHECK:   [[I2_BOX:%[0-9]+]] = alloc_box ${ var any Initializable }
-  // CHECK:   [[I2_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[I2_BOX]]
+  // CHECK:   [[I2_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[I2_BOX]]
   // CHECK:   [[PB:%.*]] = project_box [[I2_LIFETIME]]
   // CHECK:   [[ARCHETYPE_META:%[0-9]+]] = open_existential_metatype [[META]] : $@thick any Initializable.Type to $@thick (@opened([[N:".*"]], any Initializable) Self).Type
   // CHECK:   [[ARCHETYPE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[ARCHETYPE_META]] : $@thick (@opened([[N]], any Initializable) Self).Type to $@objc_metatype (@opened([[N]], any Initializable) Self).Type

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -362,7 +362,7 @@ class Hoozit : Gizmo {
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC7bellsOnACSi_tcfc : $@convention(method) (Int, @owned Hoozit) -> @owned Hoozit {
   // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
   // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK: [[PB_BOX:%.*]] = project_box [[LIFETIME]]
   // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
   // CHECK: [[BORROWED_GIZMO:%.*]] = begin_borrow [[GIZMO]]

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -18,7 +18,8 @@ public struct DidSetWillSetTests {
 
     // CHECK: bb0(%0 : $Int, %1 : $@thin DidSetWillSetTests.Type):
     // CHECK:        [[SELF:%.*]] = mark_uninitialized [rootself]
-    // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF]]
+    // CHECK:        [[SELF_LIFETIME:%.*]] = begin_borrow [var_decl] [[SELF]]
+    // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
     // CHECK:        [[P1:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
     // CHECK-NEXT:   assign %0 to [[P1]]
@@ -317,7 +318,8 @@ func local_observing_property(_ arg: Int) {
   // Alloc and initialize the property to the argument value.
   // CHECK: bb0([[ARG:%[0-9]+]] : $Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[BOX]]
+  // CHECK: [[L:%.*]] = begin_borrow [var_decl] [[BOX]]
+  // CHECK: [[PB:%.*]] = project_box [[L]]
   // CHECK: store [[ARG]] to [trivial] [[PB]]
 }
 

--- a/test/SILGen/opaque_values_closures.swift
+++ b/test/SILGen/opaque_values_closures.swift
@@ -160,8 +160,8 @@ func captureStorageAddress_callee<T>(_ t: (G<T>) -> ()) {}
 // CHECK-LABEL: sil {{.*}}[ossa] @$s22opaque_values_closures46captureImmutableBoxNonopaqueGuaranteedEscapingyyxmlF : {{.*}} {
 // CHECK:       bb0([[T:%[^,]+]] :
 // CHECK:         [[BOX:%[^,]+]] = alloc_box ${ var TakingMOG }, var
-// CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX]]
-// CHECK:         [[BOX_LIFETIME:%[^,]+]] = begin_borrow [[BOX]]
+// CHECK:         [[BOX_LIFETIME:%[^,]+]] = begin_borrow [var_decl] [[BOX]]
+// CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX_LIFETIME]]
 // CHECK:         mark_function_escape [[BOX_ADDR]]
 // CHECK:         [[LOCAL:%[^,]+]] = function_ref @$s22opaque_values_closures46captureImmutableBoxNonopaqueGuaranteedEscapingyyxmlF5localL_yylF
 // CHECK:         apply [[LOCAL]]<T>([[BOX_LIFETIME]], [[T]])
@@ -186,7 +186,7 @@ struct TakingMOG {
 // CaptureKind::ImmutableBox, non-opaque, canGuarantee=false, captureCanEscape=true
 // CHECK-LABEL: sil {{.*}}[ossa] @$s22opaque_values_closures41captureImmutableBoxNonopaqueOwnedEscapingyyxmlF : {{.*}} {
 // CHECK:         [[IMMUTABLEBOX:%[^,]+]] = alloc_box $<τ_0_0> { let MOG<τ_0_0> } <T>, let
-// CHECK:         [[IMMUTABLEBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IMMUTABLEBOX]]
+// CHECK:         [[IMMUTABLEBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[IMMUTABLEBOX]]
 // CHECK:         [[IMMUTABLEBOX_ADDR:%[^,]+]] = project_box [[IMMUTABLEBOX_LIFETIME]]
 // CHECK:         store {{%[^,]+}} to [init] [[IMMUTABLEBOX_ADDR]]
 // CHECK:         [[CLOSURE:%[^,]+]] = function_ref @$s22opaque_values_closures41captureImmutableBoxNonopaqueOwnedEscapingyyxmlFyycfU_ : $@convention(thin) <τ_0_0> (@guaranteed <τ_0_0> { let MOG<τ_0_0> } <τ_0_0>) -> () 
@@ -223,7 +223,8 @@ func captureImmutableBoxNonopaqueOwnedEscaping_callee(_ t: @escaping () -> ()) {
 // CaptureKind::Box, opaque, canGuarantee=true, captureCanEscape=true
 // CHECK-LABEL: sil {{.*}}[ossa] @$s22opaque_values_closures34captureBoxOpaqueGuaranteedEscapingyyF : {{.*}} {
 // CHECK:         [[BOX:%[^,]+]] = alloc_box ${ var @_opaqueReturnTypeOf("$s22opaque_values_closures39captureBoxOpaqueGuaranteedEscaping_vendQryF", 0) __ }, var
-// CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX]]
+// CHECK:         [[BOX_LIFETIME:%[^,]+]] = begin_borrow [var_decl] [[BOX]]
+// CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX_LIFETIME]]
 // CHECK:         [[BOX2:%[^,]+]] = alloc_box ${ var @_opaqueReturnTypeOf("$s22opaque_values_closures39captureBoxOpaqueGuaranteedEscaping_vendQryF", 0) __ } 
 // CHECK:         [[BOX2_ADDR:%[^,]+]] = project_box [[BOX2]]
 // CHECK:         copy_addr [[BOX_ADDR]] to [init] [[BOX2_ADDR]]
@@ -253,7 +254,8 @@ func captureBoxOpaqueGuaranteedEscaping_vend() -> some P { return PImpl() }
 // CaptureKind::Box, opaque, canGuarantee=false, captureCanEscape=true
 // CHECK-LABEL: sil {{.*}}[ossa] @$s22opaque_values_closures29captureBoxOpaqueOwnedEscapingyyF : {{.*}} {
 // CHECK:         [[BOX:%[^,]+]] = alloc_box ${ var @_opaqueReturnTypeOf("$s22opaque_values_closures34captureBoxOpaqueOwnedEscaping_vendQryF", 0) __ }, var
-// CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX]]
+// CHECK:         [[BOX_LIFETIME:%[^,]+]] = begin_borrow [var_decl] [[BOX]]
+// CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX_LIFETIME]]
 // CHECK:         [[BOX_ACCESS:%[^,]+]] = begin_access [read] [unknown] [[BOX_ADDR]]
 // CHECK:         [[FIRST:%[^,]+]] = load [trivial] [[BOX_ACCESS]]
 // CHECK:         end_access [[BOX_ACCESS]]
@@ -304,8 +306,8 @@ func captureBoxOpaqueOwnedEscaping_callee<T : P>(_ t: T, _ c: @escaping (T) -> (
 // CHECK-LABEL: sil {{.*}}[ossa] @$s22opaque_values_closures37captureBoxNonopaqueGuaranteedEscapingyyxyXElF : {{.*}} {
 // CHECK:       bb0([[GET:%[^,]+]] :
 // CHECK:         [[BOX:%[^,]+]] = alloc_box $<τ_0_0> { var Array<τ_0_0> } <U>, var
-// CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX]]
-// CHECK:         [[BOX_LIFETIME:%[^,]+]] = begin_borrow [[BOX]]
+// CHECK:         [[BOX_LIFETIME:%[^,]+]] = begin_borrow [var_decl] [[BOX]]
+// CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX_LIFETIME]]
 // CHECK:         mark_function_escape [[BOX_ADDR]]
 // CHECK:         [[LOCAL:%[^,]+]] = function_ref @$s22opaque_values_closures37captureBoxNonopaqueGuaranteedEscapingyyxyXElF5localL_yylF
 // CHECK:         apply [[LOCAL]]<U>([[BOX_LIFETIME]], [[GET]])
@@ -328,7 +330,7 @@ func captureBoxNonopaqueGuaranteedEscaping<U>(_ get: () -> U) {
 // CaptureKind::Box, non-opaque, canGuarantee=false, captureCanEscape=true
 // CHECK-LABEL: sil {{.*}}[ossa] @$s22opaque_values_closures32captureBoxNonopaqueOwnedEscapingyyF : {{.*}} {
 // CHECK:         [[BOX:%[^,]+]] = alloc_box ${ var C }, var
-// CHECK:         [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+// CHECK:         [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:         [[BOX_ADDR:%[^,]+]] = project_box [[BOX_LIFETIME]]
 // CHECK:         [[BOX_ACCESS:%[^,]+]] = begin_access [read] [unknown] [[BOX_ADDR]]
 // CHECK:         [[INITIAL_VALUE:%[^,]+]] = load [copy] [[BOX_ACCESS]]
@@ -362,7 +364,7 @@ func captureBoxNonopaqueOwnedEscaping_vend() -> C { return C() }
 // CHECK:       bb0([[GET:%[^,]+]] :
 // CHECK:         [[BOX:%[^,]+]] = alloc_box $<τ_0_0> { var BoxWrapper<τ_0_0> } <U>, var
 // CHECK:         [[VAR:%[^,]+]] = mark_uninitialized [var] [[BOX]]
-// CHECK:         [[VAR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VAR]]
+// CHECK:         [[VAR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[VAR]]
 // CHECK:         [[VAR_ADDR:%[^,]+]] = project_box [[VAR_LIFETIME]]
 // TODO: DETERMINE: Considering that captureCanEscape is false, should this mark_function_escape be emitted?
 // CHECK:         mark_function_escape [[VAR_ADDR]]

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -306,7 +306,7 @@ public func unsafeDowncastToAnyObject(fromAny any: Any) -> AnyObject {
 // Test open_existential_box_value in a conversion context.
 // ---
 // CHECK-OSX-LABEL: sil [ossa] @$s20opaque_values_silgen22testOpenExistentialBox1eys5Error_pSg_tF : $@convention(thin) (@guaranteed Optional<Error>) -> () {
-// CHECK-OSX: [[BORROW:%.*]] = begin_borrow [lexical] %{{.*}} : $any Error
+// CHECK-OSX: [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] %{{.*}} : $any Error
 // CHECK-OSX: [[VAL:%.*]] = open_existential_box_value [[BORROW]] : $any Error to $@opened
 // CHECK-OSX: [[COPY:%.*]] = copy_value [[VAL]] : $@opened
 // CHECK-OSX: [[ANY:%.*]] = init_existential_value [[COPY]] : $@opened
@@ -501,11 +501,11 @@ public enum EnumWithTwoSameAddressOnlyPayloads<T> {
 // CHECK-SAME:      case #EnumWithTwoSameAddressOnlyPayloads.yes!enumelt: [[YES_BLOCK:bb[0-9]+]], 
 // CHECK-SAME:      case #EnumWithTwoSameAddressOnlyPayloads.and!enumelt: [[AND_BLOCK:bb[0-9]+]]
 // CHECK:       [[YES_BLOCK]]([[YES_VALUE:%[^,]+]] :
-// CHECK:         [[YES_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[YES_VALUE]]
+// CHECK:         [[YES_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[YES_VALUE]]
 // CHECK:         [[YES_COPY:%[^,]+]] = copy_value [[YES_LIFETIME]]
 // CHECK:         store [[YES_COPY]] to [init] [[RESULT_STORAGE]]
 // CHECK:       [[AND_BLOCK]]([[AND_VALUE:%[^,]+]] :
-// CHECK:         [[AND_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[AND_VALUE]]
+// CHECK:         [[AND_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[AND_VALUE]]
 // CHECK:         [[AND_COPY:%[^,]+]] = copy_value [[AND_LIFETIME]]
 // CHECK:         store [[AND_COPY]] to [init] [[RESULT_STORAGE]]
 // CHECK-LABEL: } // end sil function 'EnumWithTwoSameAddressOnlyPayloads_getPayload'
@@ -805,7 +805,7 @@ func consumeExprOfOwnedAddrOnlyValue<T>(_ t: __owned T) {
 
 // CHECK-LABEL: sil {{.*}}[ossa] @consumeExprOfLoadExprOfOwnedAddrOnlyLValue : {{.*}} {
 // CHECK:         [[VAR:%[^,]+]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
-// CHECK:         [[VAR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VAR]]
+// CHECK:         [[VAR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[VAR]]
 // CHECK:         [[VAR_ADDR:%[^,]+]] = project_box [[VAR_LIFETIME]]
 // CHECK:         store {{%[^,]+}} to [init] [[VAR_ADDR]]
 // CHECK:         [[VAR_ACCESS:%[^,]+]] = begin_access [modify] [unknown] [[VAR_ADDR]]

--- a/test/SILGen/opaque_values_silgen_lib.swift
+++ b/test/SILGen/opaque_values_silgen_lib.swift
@@ -1065,7 +1065,7 @@ public func f530_assignToVar() {
 // HECK:  try_apply [[WT]]<@opened("{{.*}}", any Decoder) Self>([[OPENED]]) : $@convention(witness_method: Decoder) <τ_0_0 where τ_0_0 : Decoder> (@in_guaranteed τ_0_0) -> (@out UnkeyedDecodingContainer, @error any Error), normal bb2, error bb1
 //
 // CHECK:bb{{.*}}([[RET1:%.*]] : @owned $any UnkeyedDecodingContainer):
-// HECK:  [[BORROW2:%.*]] = begin_borrow [lexical] [[RET1]] : $any UnkeyedDecodingContainer
+// HECK:  [[BORROW2:%.*]] = begin_borrow [lexical] [var_decl] [[RET1]] : $any UnkeyedDecodingContainer
 // HECK:  [[OPENED2:%.*]] = open_existential_value [[BORROW2]] : $any UnkeyedDecodingContainer to $@opened("{{.*}}", any UnkeyedDecodingContainer) Self
 // HECK:  [[WT2:%.*]] = witness_method $@opened("{{.*}}", any UnkeyedDecodingContainer) Self, #UnkeyedDecodingContainer.isAtEnd!getter : <Self where Self : UnkeyedDecodingContainer> (Self) -> () -> Builtin.Int1, [[OPENED2]] : $@opened("{{.*}}", UnkeyedDecodingContainer) Self : $@convention(witness_method: UnkeyedDecodingContainer) <τ_0_0 where τ_0_0 : UnkeyedDecodingContainer> (@in_guaranteed τ_0_0) -> Builtin.Int1
 // HECK:  [[RET2:%.*]] = apply [[WT2]]<@opened("{{.*}}", any UnkeyedDecodingContainer) Self>([[OPENED2]]) : $@convention(witness_method: UnkeyedDecodingContainer) <τ_0_0 where τ_0_0 : UnkeyedDecodingContainer> (@in_guaranteed τ_0_0) -> Builtin.Int1

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -7,7 +7,7 @@ class B : A {}
 // CHECK-LABEL: sil hidden [ossa] @$s4main3fooyyAA1ACSgF : $@convention(thin) (@guaranteed Optional<A>) -> () {
 // CHECK:    bb0([[ARG:%.*]] : @guaranteed $Optional<A>):
 // CHECK:      [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
-// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X]]
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X_LIFETIME]]
 //   Check whether the temporary holds a value.
 // CHECK:      [[ARG_COPY:%.*]] = copy_value [[ARG]]
@@ -53,7 +53,7 @@ func foo(_ y : A?) {
 // CHECK-LABEL: sil hidden [ossa] @$s4main3baryyAA1ACSgSgSgSgF : $@convention(thin) (@guaranteed Optional<Optional<Optional<Optional<A>>>>) -> () {
 // CHECK:    bb0([[ARG:%.*]] : @guaranteed $Optional<Optional<Optional<Optional<A>>>>):
 // CHECK:      [[X:%.*]] = alloc_box ${ var Optional<Optional<Optional<B>>> }, var, name "x"
-// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X]]
 // CHECK-NEXT: [[PB:%.*]] = project_box [[X_LIFETIME]]
 // -- Check for some(...)
 // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
@@ -140,7 +140,7 @@ func bar(_ y : A????) {
 // CHECK-LABEL: sil hidden [ossa] @$s4main3bazyyyXlSgF : $@convention(thin) (@guaranteed Optional<AnyObject>) -> () {
 // CHECK:       bb0([[ARG:%.*]] : @guaranteed $Optional<AnyObject>):
 // CHECK:         [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
-// CHECK:         [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK:         [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X]]
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[X_LIFETIME]]
 // CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:         switch_enum [[ARG_COPY]]
@@ -201,8 +201,10 @@ public struct TestAddressOnlyStruct<T> {
 // CHECK: bb0(%0 : $Optional<Int>):
 // CHECK-NEXT: debug_value %0 : $Optional<Int>, let, name "a"
 // CHECK-NEXT: [[X:%.*]] = alloc_box ${ var Optional<Int> }, var, name "x"
-// CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
+// CHECK-NEXT: [[L:%.*]] = begin_borrow [var_decl] [[X]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[L]]
 // CHECK-NEXT: store %0 to [trivial] [[PB]] : $*Optional<Int>
+// CHECK-NEXT: end_borrow [[L]]
 // CHECK-NEXT: destroy_value [[X]] : ${ var Optional<Int> }
 func testContextualInitOfNonAddrOnlyType(_ a : Int?) {
   var x: Int! = a

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -32,12 +32,12 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testAddrOnlyCallResult{{.*}} :
 // CHECK:    bb0([[T0:%.*]] : @guaranteed $Optional<@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>>):
 // CHECK: [[F:%.*]] = alloc_box $<τ_0_0> { var Optional<@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>> } <T>, var, name "f"
-// CHECK: [[F_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[F]]
+// CHECK: [[F_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[F]]
 // CHECK-NEXT: [[PBF:%.*]] = project_box [[F_LIFETIME]]
 // CHECK: [[T0_COPY:%.*]] = copy_value [[T0]]
 // CHECK: store [[T0_COPY]] to [init] [[PBF]]
 // CHECK-NEXT: [[X:%.*]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>, var, name "x"
-// CHECK-NEXT: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK-NEXT: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X]]
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
 // CHECK-NEXT: [[TEMP:%.*]] = init_enum_data_addr [[PBX]]
 // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PBF]]

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -177,7 +177,8 @@ func stringToPointer(_ s: String) {
 func inoutToPointer() {
   var int = 0
   // CHECK: [[INT:%.*]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[INT]]
+  // CHECK: [[L:%.*]] = begin_borrow [var_decl] [[INT]]
+  // CHECK: [[PB:%.*]] = project_box [[L]]
   takesMutablePointer(&int)
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[POINTER:%.*]] = address_to_pointer [stack_protection] [[WRITE]]
@@ -229,7 +230,7 @@ func takesPlusZeroOptionalPointer(_ x: AutoreleasingUnsafeMutablePointer<C?>) {}
 func classInoutToPointer() {
   var c = C()
   // CHECK: [[VAR:%.*]] = alloc_box ${ var C }
-  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VAR]]
+  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[VAR]]
   // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   takesPlusOnePointer(&c)
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
@@ -288,7 +289,8 @@ func functionInoutToPointer() {
 // CHECK-LABEL: sil hidden [ossa] @$s18pointer_conversion20inoutPointerOrderingyyF
 func inoutPointerOrdering() {
   // CHECK: [[ARRAY_BOX:%.*]] = alloc_box ${ var Array<Int> }
-  // CHECK: [[ARRAY:%.*]] = project_box [[ARRAY_BOX]] :
+  // CHECK: [[L:%.*]] = begin_borrow [var_decl] [[ARRAY_BOX]] :
+  // CHECK: [[ARRAY:%.*]] = project_box [[L]] :
   // CHECK: store {{.*}} to [init] [[ARRAY]]
   var array = [Int]()
 

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -13,7 +13,8 @@ func physical_tuple_lvalue(_ c: Int) {
   var x : (Int, Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var (Int, Int) }
   // CHECK: [[MARKED_BOX:%[0-9]+]] = mark_uninitialized [var] [[BOX]]
-  // CHECK: [[XADDR:%.*]] = project_box [[MARKED_BOX]]
+  // CHECK: [[XLIFETIME:%.*]] = begin_borrow [var_decl] [[MARKED_BOX]]
+  // CHECK: [[XADDR:%.*]] = project_box [[XLIFETIME]]
   x.1 = c
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[XADDR]]
   // CHECK: [[X_1:%[0-9]+]] = tuple_element_addr [[WRITE]] : {{.*}}, 1
@@ -343,7 +344,8 @@ func inout_arg(_ x: inout Int) {}
 func physical_inout(_ x: Int) {
   var x = x
   // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[XADDR]]
+  // CHECK: [[XL:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK: [[PB:%.*]] = project_box [[XL]]
   inout_arg(&x)
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[INOUT_ARG:%[0-9]+]] = function_ref @$s10properties9inout_arg{{[_0-9a-zA-Z]*}}F
@@ -369,7 +371,7 @@ func val_subscript_set(_ v: Val, i: Int, x: Float) {
   var v = v
   v[i] = x
   // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
-  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[VADDR]]
+  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[VADDR]]
   // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[SUBSCRIPT_SET_METHOD:%[0-9]+]] = function_ref @$s10properties3ValV{{[_0-9a-zA-Z]*}}is
@@ -666,7 +668,7 @@ class r19254812Derived: r19254812Base{
 // Accessing the "pi" property should not copy_value/release self.
 // CHECK-LABEL: sil hidden [ossa] @$s10properties16r19254812DerivedC{{[_0-9a-zA-Z]*}}fc
 // CHECK: [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself]
-// CHECK: [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+// CHECK: [[LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
 // CHECK: [[PB_BOX:%.*]] = project_box [[LIFETIME]]
 
 // Initialization of the pi field: no copy_values/releases.
@@ -779,7 +781,8 @@ struct MutatingGetterStruct {
 
   // CHECK-LABEL: sil hidden [ossa] @$s10properties20MutatingGetterStructV4test
   // CHECK: [[X:%.*]] = alloc_box ${ var MutatingGetterStruct }, var, name "x"
-  // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
+  // CHECK-NEXT: [[XL:%.*]] = begin_borrow [var_decl] [[X]]
+  // CHECK-NEXT: [[PB:%.*]] = project_box [[XL]]
   // CHECK: store {{.*}} to [trivial] [[PB]] : $*MutatingGetterStruct
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: apply {{%.*}}([[WRITE]]) : $@convention(method) (@inout MutatingGetterStruct) -> Int

--- a/test/SILGen/properties_swift4.swift
+++ b/test/SILGen/properties_swift4.swift
@@ -33,7 +33,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXLIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOXLIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -75,7 +76,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXLIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOXLIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -102,7 +104,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var other = self
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXLIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOXLIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
       // CHECK-NEXT: copy_addr [[READ_SELF]] to [init] [[BOXADDR]] : $*DidSetWillSetTests
       // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests

--- a/test/SILGen/properties_swift5.swift
+++ b/test/SILGen/properties_swift5.swift
@@ -33,7 +33,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXLIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOXLIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -77,7 +78,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXLIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOXLIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -106,7 +108,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var other = self
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXLIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOXLIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
       // CHECK-NEXT: copy_addr [[READ_SELF]] to [init] [[BOXADDR]] : $*DidSetWillSetTests
       // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -38,7 +38,7 @@ func inOutFunc(_ f: inout ((Int) -> Int)) { }
 // CHECK-LABEL: sil hidden [ossa] @$s20property_abstraction6inOutF{{[_0-9a-zA-Z]*}}F : 
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $Foo<Int, Int>):
 // CHECK:   [[XBOX:%.*]] = alloc_box ${ var Foo<Int, Int> }, var, name "x"
-// CHECK:   [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+// CHECK:   [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[XBOX]]
 // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX_LIFETIME]] : ${ var Foo<Int, Int> }, 0
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:   store [[ARG_COPY]] to [init] [[XBOX_PB]]

--- a/test/SILGen/property_wrapper_local.swift
+++ b/test/SILGen/property_wrapper_local.swift
@@ -17,13 +17,14 @@ func testLocalWrapper() {
   @Wrapper var value: Int
   // CHECK: [[A:%.*]] = alloc_box ${ var Wrapper<Int> }, var, name "_value"
   // CHECK: [[W:%.*]] = mark_uninitialized [var] [[A]] : ${ var Wrapper<Int> }
-  // CHECK: [[P:%.*]] = project_box [[W]] : ${ var Wrapper<Int> }
+  // CHECK: [[WLIFETIME:%.*]] = begin_borrow [var_decl] [[W]]
+  // CHECK: [[P:%.*]] = project_box [[WLIFETIME]] : ${ var Wrapper<Int> }
 
   value = 10
   // CHECK: [[I:%.*]] = function_ref @$s22property_wrapper_local16testLocalWrapperyyF5valueL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
   // CHECK: [[IPA:%.*]] = partial_apply [callee_guaranteed] [[I]]() : $@convention(thin) (Int) -> Wrapper<Int>
   // CHECK: [[S:%.*]] = function_ref @$s22property_wrapper_local16testLocalWrapperyyF5valueL_Sivs : $@convention(thin) (Int, @guaranteed { var Wrapper<Int> }) -> ()
-  // CHECK-NEXT: [[C:%.*]] = copy_value [[W]] : ${ var Wrapper<Int> }
+  // CHECK-NEXT: [[C:%.*]] = copy_value [[WLIFETIME]] : ${ var Wrapper<Int> }
   // CHECK-NOT: mark_function_escape
   // CHECK-NEXT: [[SPA:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[S]]([[C]]) : $@convention(thin) (Int, @guaranteed { var Wrapper<Int> }) -> ()
   // CHECK-NEXT: assign_by_wrapper {{%.*}} : $Int to [[P]] : $*Wrapper<Int>, init [[IPA]] : $@callee_guaranteed (Int) -> Wrapper<Int>, set [[SPA]] : $@noescape @callee_guaranteed (Int) -> ()

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -980,12 +980,14 @@ struct S_58201 {
 // CHECK: bb0(%0 : $S_58201):
 // CHECK-NEXT:  debug_value %0 : $S_58201, let, name "self", argno 1, implicit
 // CHECK-NEXT:  [[BOX:%.*]] = alloc_box ${ var BasicComputedIntWrapper }, var, name "_b"
-// CHECK-NEXT:  [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var BasicComputedIntWrapper }, 0
+// CHECK-NEXT:  [[BOX_LIFETIME:%[^,]+]] = begin_borrow [var_decl] [[BOX]]
+// CHECK-NEXT:  [[BOXADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var BasicComputedIntWrapper }, 0
 // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin BasicComputedIntWrapper.Type
 // CHECK-NEXT:  // function_ref BasicComputedIntWrapper.init()
 // CHECK-NEXT:  [[DEFAULTVALUE_FN:%.*]] = function_ref @$s17property_wrappers23BasicComputedIntWrapperVACycfC : $@convention(method) (@thin BasicComputedIntWrapper.Type) -> BasicComputedIntWrapper
 // CHECK-NEXT:  [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin BasicComputedIntWrapper.Type) -> BasicComputedIntWrapper
 // CHECK-NEXT:  store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*BasicComputedIntWrapper
+// CHECK-NEXT:  end_borrow [[BOX_LIFETIME]] : ${ var BasicComputedIntWrapper }
 // CHECK-NEXT:  destroy_value [[BOX]] : ${ var BasicComputedIntWrapper }
 // CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT:  return [[TUPLE]] : $()

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -29,7 +29,7 @@ class Base {}
 func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   var x = x
   // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ObjectUID> { var τ_0_0 } <T>
-  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[XBOX]]
   // CHECK: [[PB:%.*]] = project_box [[XLIFETIME]]
   // -- call x.uid()
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
@@ -84,7 +84,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
 func getBaseObjectUID<T: UID>(x: T) -> (Int, Int, Int) where T: Base {
   var x = x
   // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : Base, τ_0_0 : UID> { var τ_0_0 } <T>
-  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[XBOX]]
   // CHECK: [[PB:%.*]] = project_box [[XLIFETIME]]
   // -- call x.uid()
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -100,7 +100,7 @@ func inout_func(_ n: inout Int) {}
 // CHECK: bb0([[M:%[0-9]+]] : $MetaHolder, [[DD:%[0-9]+]] : $@thick D.Type, [[D:%[0-9]+]] : @guaranteed $D):
 func testD(_ m: MetaHolder, dd: D.Type, d: D) {
   // CHECK: [[D2:%[0-9]+]] = alloc_box ${ var D }
-  // CHECK: [[D2L:%[0-9]+]] = begin_borrow [lexical] [[D2]]
+  // CHECK: [[D2L:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[D2]]
   // CHECK: [[RESULT:%.*]] = project_box [[D2L]]
   // CHECK: [[MATERIALIZED_BORROWED_D:%[0-9]+]] = alloc_stack $D
   // CHECK: [[SB:%.*]] = store_borrow [[D]] to [[MATERIALIZED_BORROWED_D]]
@@ -528,7 +528,7 @@ func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
 // CHECK: bb0([[P:%[0-9]+]] : $*any P1):
 func testExistentials2(_ p1: P1) {
   // CHECK: [[P1A:%[0-9]+]] = alloc_box ${ var any P1 }
-  // CHECK: [[P1AL:%[0-9]+]] = begin_borrow [lexical] [[P1A]]
+  // CHECK: [[P1AL:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[P1A]]
   // CHECK: [[PB:%.*]] = project_box [[P1AL]]
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
   // CHECK: [[FN:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAE11returnsSelf{{[_0-9a-zA-Z]*}}F
@@ -558,7 +558,7 @@ func testExistentialsGetters(_ p1: P1) {
 func testExistentialSetters(_ p1: P1, b: Bool) {
   var p1 = p1
   // CHECK: [[PBOX:%[0-9]+]] = alloc_box ${ var any P1 }
-  // CHECK: [[PLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[PBOX]]
+  // CHECK: [[PLIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[PBOX]]
   // CHECK: [[PBP:%[0-9]+]] = project_box [[PLIFETIME]]
   // CHECK-NEXT: copy_addr [[P]] to [init] [[PBP]] : $*any P1
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBP]]
@@ -592,7 +592,7 @@ struct HasAP1 {
 func testLogicalExistentialSetters(_ hasAP1: HasAP1, _ b: Bool) {
   var hasAP1 = hasAP1
   // CHECK: [[HASP1_BOX:%[0-9]+]] = alloc_box ${ var HasAP1 }
-  // CHECK: [[HASP1_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[HASP1_BOX]]
+  // CHECK: [[HASP1_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[HASP1_BOX]]
   // CHECK: [[PBHASP1:%[0-9]+]] = project_box [[HASP1_LIFETIME]]
   // CHECK-NEXT: copy_addr [[HASP1]] to [init] [[PBHASP1]] : $*HasAP1
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBHASP1]]
@@ -618,7 +618,7 @@ func test_open_existential_semantics_opaque(_ guaranteed: P1,
                                             immediate: P1) {
   var immediate = immediate
   // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var any P1 }
-  // CHECK: [[IMMEDIATE_LIFETIME:%.*]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // CHECK: [[IMMEDIATE_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[IMMEDIATE_BOX]]
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
   // CHECK: [[VALUE:%.*]] = open_existential_addr immutable_access %0
   // CHECK: [[METHOD:%.*]] = function_ref
@@ -661,7 +661,7 @@ func test_open_existential_semantics_class(_ guaranteed: CP1,
                                            immediate: CP1) {
   var immediate = immediate
   // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var any CP1 }
-  // CHECK: [[IMMEDIATE_LIFETIME:%.*]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // CHECK: [[IMMEDIATE_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[IMMEDIATE_BOX]]
   // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
 
   // CHECK-NOT: copy_value [[ARG0]]
@@ -702,7 +702,7 @@ extension InitRequirement {
   init(d: D) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_BOX_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[UNINIT_SELF]]
     // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_BOX_LIFETIME]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
     // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
@@ -726,7 +726,7 @@ extension InitRequirement {
   init(d2: D) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[UNINIT_SELF]]
     // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
     // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
@@ -749,7 +749,7 @@ extension InitRequirement {
   init(c2: C) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [var_decl] [[UNINIT_SELF]]
     // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
     // CHECK-NEXT: [[SELF_TYPE:%.*]] = metatype $@thick Self.Type
@@ -834,7 +834,7 @@ extension ProtoDelegatesToObjC where Self : ObjCInitClass {
   init(string: String) {
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : ObjCInitClass, τ_0_0 : ProtoDelegatesToObjC> { var τ_0_0 } <Self>
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
     // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:   [[SELF_META_C:%[0-9]+]] = upcast [[SELF_META]] : $@thick Self.Type to $@thick ObjCInitClass.Type
     // CHECK:   [[OBJC_INIT:%[0-9]+]] = class_method [[SELF_META_C]] : $@thick ObjCInitClass.Type, #ObjCInitClass.init!allocator
@@ -859,7 +859,7 @@ extension ProtoDelegatesToRequired where Self : RequiredInitClass {
   init(string: String) {
   // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : RequiredInitClass, τ_0_0 : ProtoDelegatesToRequired> { var τ_0_0 } <Self>
   // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:   [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   [[SELF_META_AS_CLASS_META:%[0-9]+]] = upcast [[SELF_META]] : $@thick Self.Type to $@thick RequiredInitClass.Type
   // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELF_META_AS_CLASS_META]] : $@thick RequiredInitClass.Type, #RequiredInitClass.init!allocator : (RequiredInitClass.Type) -> () -> RequiredInitClass, $@convention(method) (@thick RequiredInitClass.Type) -> @owned RequiredInitClass

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -17,12 +17,12 @@ func optionalMethodGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : @guaranteed $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
-  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [[TBOX]]
+  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[TBOX]]
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TLIFETIME]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_guaranteed (Int) -> ()> }
-  // CHECK:   [[OPT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPT_BOX]]
+  // CHECK:   [[OPT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OPT_BOX]]
   // CHECK:   project_box [[OPT_LIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
@@ -36,7 +36,7 @@ func optionalMethodGeneric<T : P1>(t t : T) {
 func optionalStaticMethodRefGeneric<T: P1>(t: T) {
   // CHECK: bb0(%0 : @guaranteed $T):
   // CHECK:   [[BOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_guaranteed (Int) -> ()> }, var
-  // CHECK:   [[BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[BOX]]
+  // CHECK:   [[BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[BOX]]
   // CHECK:   [[UNBOX:%[0-9]+]] = project_box [[BOX_LIFETIME]]
   // CHECK:   [[META:%[0-9]+]] = metatype $@thick T.Type
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]]
@@ -49,7 +49,7 @@ func optionalStaticMethodRefGeneric<T: P1>(t: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s17protocol_optional0B23MethodUnboundRefGeneric1tyx_tAA2P1RzlF : $@convention(thin) <T where T : P1> (@guaranteed T) -> () {
 // CHECK: bb0([[T:%[0-9]+]] : @guaranteed $T):
 // CHECK:   [[BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @owned Optional<@callee_guaranteed (Int) -> ()> for <τ_0_0> } <T>
-// CHECK:   [[BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PBOX:%[0-9]+]] = project_box [[BOX_LIFETIME]]
 // CHECK:   [[THUNK:%[0-9]+]] = function_ref @$[[THUNK_NAME:[_0-9a-zA-Z]+]]
 // CHECK:   [[SPEC_THUNK:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK]]<T>()
@@ -70,7 +70,7 @@ func optionalMethodUnboundRefGeneric<T : P1>(t: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s17protocol_optional0B27MethodUnboundRefExistentialyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
 // CHECK:   [[BOX:%[0-9]+]] = alloc_box ${ var @callee_guaranteed (@guaranteed any P1) -> @owned Optional<@callee_guaranteed () -> @owned any P1> }
-// CHECK:   [[BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [var_decl] [[BOX]]
 // CHECK:   [[PBOX:%[0-9]+]] = project_box [[BOX_LIFETIME]]
 // CHECK:   [[THUNK:%[0-9]+]] = function_ref @$[[THUNK_NAME:[_0-9a-zA-Z]+]]
 // CHECK:   [[THUNK_THICK:%[0-9]+]] = thin_to_thick_function [[THUNK]]
@@ -98,12 +98,13 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : @guaranteed $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
-  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [[TBOX]]
+  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[TBOX]]
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TLIFETIME]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
-  // CHECK:   project_box [[OPT_BOX]]
+  // CHECK:   [[OPT_LIFETIME:%.*]] = begin_borrow [var_decl] [[OPT_BOX]]
+  // CHECK:   project_box [[OPT_LIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   alloc_stack $Optional<Int>
@@ -117,12 +118,13 @@ func optionalSubscriptGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : @guaranteed $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
-  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [[TBOX]]
+  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[TBOX]]
   // CHECK:   [[PT:%[0-9]+]] = project_box [[TLIFETIME]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
-  // CHECK:   project_box [[OPT_BOX]]
+  // CHECK:   [[OPT_LIFETIME:%.*]] = begin_borrow [var_decl] [[OPT_BOX]]
+  // CHECK:   project_box [[OPT_LIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   [[FIVELIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 5

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -26,7 +26,7 @@ class Box<T> {
 // CHECK:   // function_ref Box.__allocating_init(_:)
 // CHECK:   [[INIT_F:%.*]] = function_ref @$s4main3BoxCyACyxGxcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
 // CHECK:   [[CALL:%.*]] = apply [[INIT_F]]<(Int, () -> ())>(%{{.*}}, %{{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, @thick Box<τ_0_0>.Type) -> @owned Box<τ_0_0>
-// CHECK:   [[BORROW_CALL:%.*]] = begin_borrow [lexical] [[CALL]] : $Box<(Int, () -> ())> 
+// CHECK:   [[BORROW_CALL:%.*]] = begin_borrow [lexical] [var_decl] [[CALL]] : $Box<(Int, () -> ())> 
 // CHECK:   [[REF:%.*]] = ref_element_addr [[BORROW_CALL]] : $Box<(Int, () -> ())>, #Box.value
 // CHECK:   [[TUPLEC:%.*]] = load [copy] [[REF]] : $*(Int, @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>)
 // CHECK:   ([[TUPLEC_0:%.*]], [[TUPLEC_1:%.*]]) = destructure_tuple [[TUPLEC]]

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -14,7 +14,7 @@ func transform(_ i: Int) -> Double {
 // CHECK-LABEL: sil hidden [ossa] @$s17reabstract_lvalue0A13FunctionInOutyyF : $@convention(thin) () -> ()
 func reabstractFunctionInOut() {
   // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_guaranteed (Int) -> Double }
-  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[BOX]]
   // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK: [[ARG:%.*]] = function_ref @$s17reabstract_lvalue9transformySdSiF
   // CHECK: [[THICK_ARG:%.*]] = thin_to_thick_function [[ARG]]

--- a/test/SILGen/reference_bindings.swift
+++ b/test/SILGen/reference_bindings.swift
@@ -13,10 +13,12 @@ func doSomething() {}
 //
 // CHECK-LABEL: sil hidden [ossa] @$s18reference_bindings13testBindToVaryyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = alloc_box ${ var Int }, var, name "x"
-// CHECK: [[PROJECT:%.*]] = project_box %0
+// CHECK: [[LIFETIME:%.*]] = begin_borrow [var_decl] %0
+// CHECK: [[PROJECT:%.*]] = project_box [[LIFETIME]]
 // CHECK: [[INOUT_BOX:%.*]] = alloc_box ${ var Int }, var, name "x2"
 // CHECK: [[UNRESOLVED_BINDING:%.*]] = mark_unresolved_reference_binding [inout] [[INOUT_BOX]]
-// CHECK: [[INOUT_PROJECT:%.*]] = project_box [[UNRESOLVED_BINDING]]
+// CHECK: [[INOUT_LIFETIME:%.*]] = begin_borrow [var_decl] [[UNRESOLVED_BINDING]]
+// CHECK: [[INOUT_PROJECT:%.*]] = project_box [[INOUT_LIFETIME]]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
 // CHECK: copy_addr [[ACCESS]] to [init] [[INOUT_PROJECT]]
 // CHECK: end_access [[ACCESS]]
@@ -47,7 +49,8 @@ func testBindToVar() {
 // CHECK: bb0([[ARG:%.*]] : $*String):
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var String }
 // CHECK:   [[MARK:%.*]] = mark_unresolved_reference_binding [inout] [[BOX]]
-// CHECK:   [[PROJECT:%.*]] = project_box [[MARK]]
+// CHECK:   [[LIFETIME:%.*]] = begin_borrow [var_decl] [[MARK]]
+// CHECK:   [[PROJECT:%.*]] = project_box [[LIFETIME]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[ARG]]
 // CHECK:   copy_addr [[ACCESS]] to [init] [[PROJECT]]
 // CHECK:   end_access [[ACCESS]]

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -526,7 +526,8 @@ func defer_mutable(_ x: Int) {
   var x = x
   // expected-warning@-1 {{variable 'x' was never mutated; consider changing to 'let' constant}}
   // CHECK: [[BOX:%.*]] = alloc_box ${ var Int }
-  // CHECK-NEXT: project_box [[BOX]]
+  // CHECK-NEXT: [[BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+  // CHECK-NEXT: project_box [[BOX_LIFETIME]]
   // CHECK-NOT: [[BOX]]
   // CHECK: function_ref @$s10statements13defer_mutableyySiF6$deferL_yyF : $@convention(thin) (@inout_aliasable Int) -> ()
   // CHECK-NOT: [[BOX]]
@@ -603,8 +604,8 @@ func testRequireOptional2(_ a : String?) -> String {
   guard let t = a else { abort() }
 
   // CHECK:  [[SOME_BB]]([[STR:%.*]] : @owned $String):
-  // CHECK-NEXT:   debug_value [[STR]] : $String, let, name "t"
-  // CHECK-NEXT:   [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
+  // CHECK-NEXT:   [[BORROWED_STR:%.*]] = begin_borrow [var_decl] [[STR]]
+  // CHECK-NEXT:   debug_value [[BORROWED_STR]] : $String, let, name "t"
   // CHECK-NEXT:   [[RETURN:%.*]] = copy_value [[BORROWED_STR]]
   // CHECK-NEXT:   end_borrow [[BORROWED_STR]]
   // CHECK-NEXT:   destroy_value [[STR]] : $String
@@ -647,7 +648,7 @@ func test_as_pattern(_ y : BaseClass) -> DerivedClass {
 
 
   // CHECK: bb{{.*}}([[PTR:%[0-9]+]] : @owned $DerivedClass):
-  // CHECK-NEXT: [[BORROWED_PTR:%.*]] = begin_borrow [lexical] [[PTR]]
+  // CHECK-NEXT: [[BORROWED_PTR:%.*]] = begin_borrow [lexical] [var_decl] [[PTR]]
   // CHECK-NEXT: debug_value [[BORROWED_PTR]] : $DerivedClass, let, name "result"
   // CHECK-NEXT: [[RESULT:%.*]] = copy_value [[BORROWED_PTR]]
   // CHECK-NEXT: end_borrow [[BORROWED_PTR]]

--- a/test/SILGen/stored_property_init_reabstraction.swift
+++ b/test/SILGen/stored_property_init_reabstraction.swift
@@ -25,7 +25,7 @@ struct Struct<T> {
 
 // CHECK-LABEL: sil hidden [ossa] @$s34stored_property_init_reabstraction6StructVyACySiGSicSiRszlufC : $@convention(method) (Int, @thin Struct<Int>.Type) -> @owned Struct<Int> {
 // CHECK: [[SELF_BOX:%.*]] = mark_uninitialized [rootself] {{%.*}} : ${ var Struct<Int> }
-// CHECK: [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[SELF_BOX]]
+// CHECK: [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[SELF_BOX]]
 // CHECK: [[SELF:%.*]] = project_box [[SELF_LIFETIME]] : ${ var Struct<Int> }, 0
 // CHECK: [[ADDR:%.*]] = struct_element_addr [[SELF]] : $*Struct<Int>, #Struct.fn
 // CHECK: [[INIT:%.*]] = function_ref @$s34stored_property_init_reabstraction6StructV2fnyxcSgvpfi : $@convention(thin) <τ_0_0> () -> @owned Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -11,7 +11,7 @@ class Bar: Foo {
   // CHECK: bb0([[INPUT_SELF:%.*]] : @owned $Bar):
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Bar }
   // CHECK:         [[MARKED_SELF_BOX:%.*]] =  mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:         store [[INPUT_SELF]] to [init] [[PB_SELF_BOX]]
   // CHECK:         [[ORIG_SELF:%.*]] = load [take] [[PB_SELF_BOX]]
@@ -31,7 +31,7 @@ extension Foo {
   // CHECK-LABEL: sil hidden [ossa] @$s22super_init_refcounting3FooC{{[_0-9a-zA-Z]*}}fC
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Foo }
   // CHECK:         [[MARKED_SELF_BOX:%.*]] =  mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:         [[SELF_INIT:%.*]] = class_method
   // CHECK:         [[NEW_SELF:%.*]] = apply [[SELF_INIT]](%1)
@@ -76,7 +76,7 @@ class Good: Foo {
   // CHECK-LABEL: sil hidden [ossa] @$s22super_init_refcounting4GoodC{{[_0-9a-zA-Z]*}}fc
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Good }
   // CHECK:         [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_SELF_BOX]]
   // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:         store %0 to [init] [[PB_SELF_BOX]]
   // CHECK:         [[SELF_OBJ:%.*]] = load_borrow [[PB_SELF_BOX]]

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -543,7 +543,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   case let y as D1 where runced():
   // CHECK: [[IS_D1]]([[CAST_D1:%.*]] : @guaranteed $D1):
   // CHECK:   [[CAST_D1_COPY:%.*]] = copy_value [[CAST_D1]]
-  // CHECK:   [[BORROWED_CAST_D1_COPY:%.*]] = begin_borrow [lexical] [[CAST_D1_COPY]]
+  // CHECK:   [[BORROWED_CAST_D1_COPY:%.*]] = begin_borrow [lexical] [var_decl] [[CAST_D1_COPY]]
   // CHECK:   function_ref @$s6switch6runcedSbyF
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
 
@@ -569,7 +569,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   case let y as D2:
   // CHECK: [[CASE2]]([[CAST_D2:%.*]] : @guaranteed $D2):
   // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
-  // CHECK:   [[BORROWED_CAST_D2_COPY:%.*]] = begin_borrow [lexical] [[CAST_D2_COPY]]
+  // CHECK:   [[BORROWED_CAST_D2_COPY:%.*]] = begin_borrow [lexical] [var_decl] [[CAST_D2_COPY]]
   // CHECK:   function_ref @$s6switch1byyF
   // CHECK:   [[CAST_D2_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_D2_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D2_COPY_COPY]]
@@ -584,7 +584,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   case let y as E where funged():
   // CHECK: [[IS_E]]([[CAST_E:%.*]] : @guaranteed $E):
   // CHECK:   [[CAST_E_COPY:%.*]] = copy_value [[CAST_E]]
-  // CHECK:   [[BORROWED_CAST_E_COPY:%.*]] = begin_borrow [lexical] [[CAST_E_COPY]]
+  // CHECK:   [[BORROWED_CAST_E_COPY:%.*]] = begin_borrow [lexical] [var_decl] [[CAST_E_COPY]]
   // CHECK:   function_ref @$s6switch6fungedSbyF
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
 
@@ -610,7 +610,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   case let y as C:
   // CHECK: [[CASE4]]([[CAST_C:%.*]] : @guaranteed $C):
   // CHECK:   [[CAST_C_COPY:%.*]] = copy_value [[CAST_C]]
-  // CHECK:   [[BORROWED_CAST_C_COPY:%.*]] = begin_borrow [lexical] [[CAST_C_COPY]]
+  // CHECK:   [[BORROWED_CAST_C_COPY:%.*]] = begin_borrow [lexical] [var_decl] [[CAST_C_COPY]]
   // CHECK:   function_ref @$s6switch1dyyF
   // CHECK:   [[CAST_C_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_C_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_C_COPY_COPY]]
@@ -1538,14 +1538,14 @@ func addressOnlyFallthroughCaller() {
 //
 // CHECK: [[BB_A]]([[BB_A_ARG:%.*]] : @guaranteed
 // CHECK:   [[BB_A_ARG_COPY:%.*]] = copy_value [[BB_A_ARG]]
-// CHECK:   [[BB_A_ARG_COPY_BORROW:%.*]] = begin_borrow [lexical] [[BB_A_ARG_COPY]]
+// CHECK:   [[BB_A_ARG_COPY_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BB_A_ARG_COPY]]
 // CHECK:   apply {{%.*}}([[BB_A_ARG_COPY_BORROW]])
 // CHECK:   [[RESULT:%.*]] = copy_value [[BB_A_ARG_COPY_BORROW]]
 // CHECK:   br [[BB_AB:bb[0-9]+]]([[RESULT]] :
 //
 // CHECK: [[BB_B]]([[BB_B_ARG:%.*]] : @guaranteed
 // CHECK:   [[BB_B_ARG_COPY:%.*]] = copy_value [[BB_B_ARG]]
-// CHECK:   [[BB_B_ARG_COPY_BORROW:%.*]] = begin_borrow [lexical] [[BB_B_ARG_COPY]]
+// CHECK:   [[BB_B_ARG_COPY_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[BB_B_ARG_COPY]]
 // CHECK:   [[RESULT:%.*]] = copy_value [[BB_B_ARG_COPY_BORROW]]
 // CHECK:   br [[BB_AB:bb[0-9]+]]([[RESULT]] :
 //
@@ -1557,7 +1557,7 @@ func addressOnlyFallthroughCaller() {
 //
 // CHECK: [[BB_C]]([[BB_C_ARG:%.*]] : @guaranteed
 // CHECK:   [[BB_C_COPY:%.*]] = copy_value [[BB_C_ARG]]
-// CHECK:   [[BB_C_BORROWED_COPY:%.*]] = begin_borrow [lexical] [[BB_C_COPY]]
+// CHECK:   [[BB_C_BORROWED_COPY:%.*]] = begin_borrow [lexical] [var_decl] [[BB_C_COPY]]
 // CHECK:   [[RESULT:%.*]] = copy_value [[BB_C_BORROWED_COPY]]
 // CHECK:   br [[BB_ABC]]([[RESULT]] :
 //

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -139,7 +139,8 @@ func test5() {
   case (var n, foo()):
     // Check that the var is boxed and unboxed and the final value is the one that falls through into the next case
     // CHECK:   [[BOX:%.*]] = alloc_box ${ var Int }, var, name "n"
-    // CHECK:   [[N_BOX:%.*]] = project_box [[BOX]] : ${ var Int }, 0
+    // CHECK:   [[N_LIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+    // CHECK:   [[N_BOX:%.*]] = project_box [[N_LIFETIME]] : ${ var Int }, 0
     // CHECK:   function_ref @$s18switch_fallthrough1ayyF
     // CHECK:   [[N:%.*]] = load [trivial] [[N_BOX]] : $*Int
     // CHECK:   destroy_value [[BOX]] : ${ var Int }

--- a/test/SILGen/switch_isa.swift
+++ b/test/SILGen/switch_isa.swift
@@ -65,8 +65,8 @@ func guardFn(_ l: D, _ r: D) -> Bool { return true }
 //
 // CHECK:       [[L_CAST_YES]]([[L:%.*]] : @guaranteed $D):
 // CHECK:         [[L2:%.*]] = copy_value [[L]]
-// CHECK:         [[BORROWED_R2:%.*]] = begin_borrow [lexical] [[R2]]
-// CHECK:         [[BORROWED_L2:%.*]] = begin_borrow [lexical] [[L2]]
+// CHECK:         [[BORROWED_R2:%.*]] = begin_borrow [lexical] [var_decl] [[R2]]
+// CHECK:         [[BORROWED_L2:%.*]] = begin_borrow [lexical] [var_decl] [[L2]]
 // CHECK:         function_ref @$s10switch_isa7guardFnySbAA1DC_ADtF
 // CHECK:         cond_br {{%.*}}, [[GUARD_YES:bb[0-9]+]], [[GUARD_NO:bb[0-9]+]]
 //

--- a/test/SILGen/switch_multiple_entry_address_only.swift
+++ b/test/SILGen/switch_multiple_entry_address_only.swift
@@ -93,7 +93,7 @@ func multipleLabelsVar(e: E) {
   // CHECK:      bb3:
   // CHECK-NEXT: debug_value [[X_PHI]] : $*Any, var, name "x"
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_box ${ var Any }, var, name "x"
-  // CHECK-NEXT: [[ANY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ANY_BOX]]
+  // CHECK-NEXT: [[ANY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[ANY_BOX]]
   // CHECK-NEXT: [[BOX_PAYLOAD:%.*]] = project_box [[ANY_BOX_LIFETIME]] : ${ var Any }, 0
   // CHECK-NEXT: copy_addr [take] [[X_PHI]] to [init] [[BOX_PAYLOAD]]
   // CHECK-NEXT: [[ACCESS:%.*]] = begin_access [read] [unknown] [[BOX_PAYLOAD]]

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -47,7 +47,8 @@ func test_var_1() {
   // CHECK:   function_ref @$s10switch_var3fooSiyF
   switch foo() {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK-NOT: br bb
   case var x:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
@@ -65,7 +66,8 @@ func test_var_2() {
   // CHECK:   function_ref @$s10switch_var3fooSiyF
   switch foo() {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6runced1xSbSi_tF
@@ -81,7 +83,8 @@ func test_var_2() {
     a(x: x)
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
+  // CHECK:   [[YLIFETIME:%.*]] = begin_borrow [var_decl] [[YADDR]]
+  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6funged1xSbSi_tF
@@ -97,7 +100,8 @@ func test_var_2() {
   case var z:
   // CHECK: [[NO_CASE2]]:
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
+  // CHECK:   [[ZLIFETIME:%.*]] = begin_borrow [var_decl] [[ZADDR]]
+  // CHECK:   [[Z:%.*]] = project_box [[ZLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1c1xySi_tF
@@ -116,7 +120,8 @@ func test_var_3() {
   // CHECK:   function_ref @$s10switch_var3barSiyF
   switch (foo(), bar()) {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK:   function_ref @$s10switch_var6runced1xSbSi_tF
@@ -132,9 +137,11 @@ func test_var_3() {
 
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
+  // CHECK:   [[YLIFETIME:%.*]] = begin_borrow [var_decl] [[YADDR]]
+  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
+  // CHECK:   [[ZLIFETIME:%.*]] = begin_borrow [var_decl] [[ZADDR]]
+  // CHECK:   [[Z:%.*]] = project_box [[ZLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6funged1xSbSi_tF
@@ -154,7 +161,8 @@ func test_var_3() {
     b(x: z)
   // CHECK: [[NO_CASE2]]:
   // CHECK:   [[WADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[W:%.*]] = project_box [[WADDR]]
+  // CHECK:   [[WLIFETIME:%.*]] = begin_borrow [var_decl] [[WADDR]]
+  // CHECK:   [[W:%.*]] = project_box [[WLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK:   function_ref @$s10switch_var5ansed1xSbSi_tF
@@ -170,7 +178,8 @@ func test_var_3() {
   // CHECK:   destroy_value [[WADDR]]
   case var v:
   // CHECK:   [[VADDR:%.*]] = alloc_box ${ var (Int, Int) } 
-  // CHECK:   [[V:%.*]] = project_box [[VADDR]]
+  // CHECK:   [[VLIFETIME:%.*]] = begin_borrow [var_decl] [[VADDR]]
+  // CHECK:   [[V:%.*]] = project_box [[VLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[V]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var2cc1xySi_Sit_tF
@@ -204,7 +213,8 @@ func test_var_4(p p: P) {
   // CHECK: [[IS_X]]:
   // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*X
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[X]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
@@ -235,7 +245,8 @@ func test_var_4(p p: P) {
   // CHECK: [[IS_Y]]:
   // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*Y
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
+  // CHECK:   [[YLIFETIME:%.*]] = begin_borrow [var_decl] [[YADDR]]
+  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[Y]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
@@ -264,7 +275,7 @@ func test_var_4(p p: P) {
 
   // CHECK: [[NEXT]]:
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var (any P, Int) }
-  // CHECK:   [[ZLIFETIME:%.+]] = begin_borrow [lexical] [[ZADDR]]
+  // CHECK:   [[ZLIFETIME:%.+]] = begin_borrow [lexical] [var_decl] [[ZADDR]]
   // CHECK:   [[Z:%.*]] = project_box [[ZLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 1
@@ -289,7 +300,8 @@ func test_var_4(p p: P) {
   case (_, var w):
   // CHECK:   [[PAIR_0:%.*]] = tuple_element_addr [[PAIR]] : $*(any P, Int), 0
   // CHECK:   [[WADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[W:%.*]] = project_box [[WADDR]]
+  // CHECK:   [[WLIFETIME:%.*]] = begin_borrow [var_decl] [[WADDR]]
+  // CHECK:   [[W:%.*]] = project_box [[WLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1d1xySi_tF
@@ -309,7 +321,8 @@ func test_var_5() {
   // CHECK:   function_ref @$s10switch_var3barSiyF
   switch (foo(), bar()) {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [var_decl] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   case var x where runced(x: x.0):
   // CHECK: [[CASE1]]:
@@ -317,9 +330,11 @@ func test_var_5() {
     a()
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[Y:%[0-9]+]] = project_box [[YADDR]]
+  // CHECK:   [[YLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[YADDR]]
+  // CHECK:   [[Y:%[0-9]+]] = project_box [[YLIFETIME]]
   // CHECK:   [[ZADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[Z:%[0-9]+]] = project_box [[ZADDR]]
+  // CHECK:   [[ZLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[ZADDR]]
+  // CHECK:   [[Z:%[0-9]+]] = project_box [[ZLIFETIME]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case (var y, var z) where funged(x: y):
   // CHECK: [[CASE2]]:
@@ -349,16 +364,19 @@ func test_var_return() {
   switch (foo(), bar()) {
   case var x where runced():
     // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[X:%[0-9]+]] = project_box [[XADDR]]
+    // CHECK: [[XLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[XADDR]]
+    // CHECK: [[X:%[0-9]+]] = project_box [[XLIFETIME]]
     // CHECK: function_ref @$s10switch_var1ayyF
     // CHECK: destroy_value [[XADDR]]
     // CHECK: br [[EPILOG:bb[0-9]+]]
     a()
     return
   // CHECK: [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[Y:%[0-9]+]] = project_box [[YADDR]]
+  // CHECK: [[YLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[YADDR]]
+  // CHECK: [[Y:%[0-9]+]] = project_box [[YLIFETIME]]
   // CHECK: [[ZADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[Z:%[0-9]+]] = project_box [[ZADDR]]
+  // CHECK: [[ZLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[ZADDR]]
+  // CHECK: [[Z:%[0-9]+]] = project_box [[ZLIFETIME]]
   case (var y, var z) where funged():
     // CHECK: function_ref @$s10switch_var1byyF
     // CHECK: destroy_value [[ZADDR]]
@@ -368,7 +386,8 @@ func test_var_return() {
     return
   case var w where ansed():
     // CHECK: [[WADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[W:%[0-9]+]] = project_box [[WADDR]]
+    // CHECK: [[WLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[WADDR]]
+    // CHECK: [[W:%[0-9]+]] = project_box [[WLIFETIME]]
     // CHECK: function_ref @$s10switch_var1cyyF
     // CHECK-NOT: destroy_value [[ZADDR]]
     // CHECK-NOT: destroy_value [[YADDR]]
@@ -378,7 +397,8 @@ func test_var_return() {
     return
   case var v:
     // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[V:%[0-9]+]] = project_box [[VADDR]]
+    // CHECK: [[VLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[VADDR]]
+    // CHECK: [[V:%[0-9]+]] = project_box [[VLIFETIME]]
     // CHECK: function_ref @$s10switch_var1dyyF
     // CHECK-NOT: destroy_value [[ZADDR]]
     // CHECK-NOT: destroy_value [[YADDR]]
@@ -397,14 +417,14 @@ func test_let() {
   // CHECK: [[VAL:%.*]] = apply [[FOOS]]()
   // CHECK: [[BORROWED_VAL:%.*]] = begin_borrow [[VAL]]
   // CHECK: [[VAL_COPY:%.*]] = copy_value [[BORROWED_VAL]]
+  // CHECK: [[VAL_LIFETIME:%.*]] = begin_borrow [var_decl] [[VAL_COPY]]
   // CHECK: function_ref @$s10switch_var6runcedSbyF
   // CHECK: cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   switch foos() {
   case let x where runced():
   // CHECK: [[CASE1]]:
-  // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [[VAL_COPY]]
   // CHECK:   [[A:%.*]] = function_ref @$s10switch_var1a1xySS_tF
-  // CHECK:   apply [[A]]([[BORROWED_VAL_COPY]])
+  // CHECK:   apply [[A]]([[VAL_LIFETIME]])
   // CHECK:   destroy_value [[VAL_COPY]]
   // CHECK:   destroy_value [[VAL]]
   // CHECK:   br [[CONT:bb[0-9]+]]
@@ -413,11 +433,11 @@ func test_let() {
   // CHECK:   destroy_value [[VAL_COPY]]
   // CHECK:   [[BORROWED_VAL_2:%.*]] = begin_borrow [[VAL]]
   // CHECK:   [[VAL_COPY_2:%.*]] = copy_value [[BORROWED_VAL_2]]
+  // CHECK:   [[BORROWED_VAL_COPY_2:%.*]] = begin_borrow [var_decl] [[VAL_COPY_2]]
   // CHECK:   function_ref @$s10switch_var6fungedSbyF
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case let y where funged():
   // CHECK: [[CASE2]]:
-  // CHECK:   [[BORROWED_VAL_COPY_2:%.*]] = begin_borrow [[VAL_COPY_2]]
   // CHECK:   [[B:%.*]] = function_ref @$s10switch_var1b1xySS_tF
   // CHECK:   apply [[B]]([[BORROWED_VAL_COPY_2]])
   // CHECK:   destroy_value [[VAL_COPY_2]]
@@ -428,8 +448,8 @@ func test_let() {
   // CHECK:   destroy_value [[VAL_COPY_2]]
   // CHECK:   [[BORROWED_VAL_3:%.*]] = begin_borrow [[VAL]]
   // CHECK:   [[VAL_COPY_3:%.*]] = copy_value [[BORROWED_VAL_3]]
+  // CHECK:   [[BORROWED_VAL_COPY_3:%.*]] = begin_borrow [var_decl] [[VAL_COPY_3]]
   // CHECK:   function_ref @$s10switch_var4barsSSyF
-  // CHECK:   [[BORROWED_VAL_COPY_3:%.*]] = begin_borrow [[VAL_COPY_3]]
   // CHECK:   [[SB:%.*]] = store_borrow [[BORROWED_VAL_COPY_3]] to [[IN_ARG:%.*]] :
   // CHECK:   apply {{%.*}}<String>({{.*}}, [[SB]])
   // CHECK:   cond_br {{%.*}}, [[YES_CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
@@ -467,7 +487,8 @@ func test_mixed_let_var() {
 
   // First pattern.
   // CHECK:   [[BOX:%.*]] = alloc_box ${ var String }, var, name "x"
-  // CHECK:   [[PBOX:%.*]] = project_box [[BOX]]
+  // CHECK:   [[PLIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+  // CHECK:   [[PBOX:%.*]] = project_box [[PLIFETIME]]
   // CHECK:   [[VAL_COPY:%.*]] = copy_value [[BORROWED_VAL]]
   // CHECK:   store [[VAL_COPY]] to [init] [[PBOX]]
   // CHECK:   cond_br {{.*}}, [[CASE1:bb[0-9]+]], [[NOCASE1:bb[0-9]+]]
@@ -485,11 +506,11 @@ func test_mixed_let_var() {
   // CHECK:   destroy_value [[BOX]]
   // CHECK:   [[BORROWED_VAL:%.*]] = begin_borrow [[VAL]]
   // CHECK:   [[VAL_COPY:%.*]] = copy_value [[BORROWED_VAL]]
+  // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [var_decl] [[VAL_COPY]]
   // CHECK:   cond_br {{.*}}, [[CASE2:bb[0-9]+]], [[NOCASE2:bb[0-9]+]]
   case let y where funged():
 
   // CHECK: [[CASE2]]:
-  // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [[VAL_COPY]]
   // CHECK:   [[B:%.*]] = function_ref @$s10switch_var1b1xySS_tF
   // CHECK:   apply [[B]]([[BORROWED_VAL_COPY]])
   // CHECK:   end_borrow [[BORROWED_VAL_COPY]]
@@ -503,7 +524,7 @@ func test_mixed_let_var() {
 
   // CHECK:   [[BORROWED_VAL:%.*]] = begin_borrow [[VAL]]
   // CHECK:   [[VAL_COPY:%.*]] = copy_value [[BORROWED_VAL]]
-  // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [[VAL_COPY]]
+  // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [var_decl] [[VAL_COPY]]
   // CHECK:   [[SB:%.*]] = store_borrow [[BORROWED_VAL_COPY]] to [[TMP_VAL_COPY_ADDR:%.*]] :
   // CHECK:   apply {{.*}}<String>({{.*}}, [[SB]])
   // CHECK:   cond_br {{.*}}, [[CASE3:bb[0-9]+]], [[NOCASE3:bb[0-9]+]]
@@ -707,7 +728,7 @@ func test_multiple_patterns_value_semantics(_ y: C) {
   switch y {
     // CHECK:   checked_cast_br C in {{%.*}} : $C to D, [[AS_D:bb[0-9]+]], [[NOT_AS_D:bb[0-9]+]]
     // CHECK: [[AS_D]]({{.*}}):
-    // CHECK:   [[ORIG_BORROW:%.*]] = begin_borrow [lexical] [[ORIG:%.*]] :
+    // CHECK:   [[ORIG_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[ORIG:%.*]] :
     // CHECK:   cond_br {{%.*}}, [[F_TRUE:bb[0-9]+]], [[F_FALSE:bb[0-9]+]]
     // CHECK: [[F_TRUE]]:
     // CHECK:   [[BINDING:%.*]] = copy_value [[ORIG_BORROW]] :

--- a/test/SILGen/ternary_expr.swift
+++ b/test/SILGen/ternary_expr.swift
@@ -33,11 +33,11 @@ func consumeAddressOnly(_: AddressOnly) {}
 func addr_only_ternary_1(x: Bool) -> AddressOnly {
   // CHECK: bb0([[RET:%.*]] : $*any AddressOnly, {{.*}}):
   // CHECK: [[a:%[0-9]+]] = alloc_box ${ var any AddressOnly }, var, name "a"
-  // CHECK: [[a_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[a]]
+  // CHECK: [[a_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[a]]
   // CHECK: [[PBa:%.*]] = project_box [[a_LIFETIME]]
   var a : AddressOnly = A()
   // CHECK: [[b:%[0-9]+]] = alloc_box ${ var any AddressOnly }, var, name "b"
-  // CHECK: [[b_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[b]]
+  // CHECK: [[b_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[b]]
   // CHECK: [[PBb:%.*]] = project_box [[b_LIFETIME]]
   var b : AddressOnly = B()
 

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -25,10 +25,11 @@ func make_xy() -> (x: Int, y: P) { return (make_int(), make_p()) }
 // CHECK-LABEL: sil hidden [ossa] @$s6tuples17testShuffleOpaqueyyF
 func testShuffleOpaque() {
   // CHECK: [[X:%.*]] = alloc_box ${ var any P }
-  // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+  // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X]]
   // CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK: [[Y:%.*]] = alloc_box ${ var Int }
-  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
+  // CHECK-NEXT: [[Y_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y]]
+  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y_LIFETIME]]
   // CHECK-NEXT: [[TMP:%.*]] = alloc_stack $any P
 
   // CHECK:      [[T0:%.*]] = function_ref @$s6tuples7make_xySi1x_AA1P_p1ytyF
@@ -39,7 +40,7 @@ func testShuffleOpaque() {
   var (x,y) : (y:P, x:Int) = make_xy()
 
   // CHECK-NEXT: [[PAIR:%.*]] = alloc_box ${ var (y: any P, x: Int) }
-  // CHECK-NEXT: [[PAIR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[PAIR]]
+  // CHECK-NEXT: [[PAIR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[PAIR]]
   // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR_LIFETIME]]
   // CHECK-NEXT: [[TMP:%.*]] = alloc_stack $any P
   // CHECK-NEXT: // function_ref
@@ -66,10 +67,11 @@ func testShuffleOpaque() {
 // CHECK-LABEL: testShuffleTuple
 func testShuffleTuple() {
   // CHECK: [[X:%.*]] = alloc_box ${ var any P }
-  // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+  // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X]]
   // CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK: [[Y:%.*]] = alloc_box ${ var Int }
-  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
+  // CHECK-NEXT: [[Y_LIFETIME:%.*]] = begin_borrow [var_decl] [[Y]]
+  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y_LIFETIME]]
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples8make_intSiyF
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]()
@@ -83,7 +85,7 @@ func testShuffleTuple() {
   var (x,y) : (y:P, x:Int) = (x: make_int(), y: make_p())
 
   // CHECK-NEXT: [[PAIR:%.*]] = alloc_box ${ var (y: any P, x: Int) }
-  // CHECK-NEXT: [[PAIR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[PAIR]]
+  // CHECK-NEXT: [[PAIR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[PAIR]]
   // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR_LIFETIME]]
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples8make_intSiyF
@@ -189,7 +191,7 @@ public func testTupleAssign(x: inout [Int]) {
 // CHECK:     [[X:%.*]] = copy_value %0 : $C
 // CHECK:     [[Z:%.*]] = copy_value %2 : $String
 // CHECK:     [[INPUT:%.*]] = tuple $(x: C, y: Int, z: String) ([[X]], %1, [[Z]])
-// CHECK:     [[INPUT_BORROW:%.*]] = begin_borrow [lexical] [[INPUT]] : $(x: C, y: Int, z: String)
+// CHECK:     [[INPUT_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[INPUT]] : $(x: C, y: Int, z: String)
 // CHECK:     [[OUTPUT:%.*]] = alloc_stack [lexical] $(y: Optional<Int>, z: Any, x: AnyObject)
 // CHECK:     [[INPUT_COPY:%.*]] = copy_value [[INPUT_BORROW]] : $(x: C, y: Int, z: String)
 // CHECK:     ([[X:%.*]], [[Y:%.*]], [[Z:%.*]]) = destructure_tuple %12 : $(x: C, y: Int, z: String)

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -28,7 +28,8 @@ struct S {
     // CHECK: bb0([[X:%[0-9]+]] : $Int, [[THIS:%[0-9]+]] : $*S):
     member = x
     // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-    // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
+    // CHECK: [[XLIFETIME:%[0-9]+]] = begin_borrow [var_decl] [[XBOX]]
+    // CHECK: [[XADDR:%[0-9]+]] = project_box [[XLIFETIME]]
     // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[XADDR]] : $*Int
     // CHECK: [[X:%.*]] = load [trivial] [[READ]] : $*Int
     // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[THIS]] : $*S

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -44,12 +44,12 @@ func test0(c c: C) {
   var a: A
   // CHECK:   [[A1:%.*]] = alloc_box ${ var A }, var, name "a"
   // CHECK:   [[MARKED_A1:%.*]] = mark_uninitialized [var] [[A1]]
-  // CHECK:   [[MARKED_A1_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_A1]]
+  // CHECK:   [[MARKED_A1_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_A1]]
   // CHECK:   [[PBA:%.*]] = project_box [[MARKED_A1_LIFETIME]]
 
   unowned var x = c
   // CHECK:   [[X:%.*]] = alloc_box ${ var @sil_unowned C }
-  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X]]
   // CHECK:   [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C  to $@sil_unowned C
@@ -89,9 +89,9 @@ func testunowned_local() -> C {
   // CHECK: [[C:%.*]] = apply
   let c = C()
 
-  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [lexical] [[C]]
+  // CHECK: [[BORROWED_C:%.*]] = begin_borrow [lexical] [var_decl] [[C]]
   // CHECK: [[UC:%.*]] = alloc_box ${ var @sil_unowned C }, let, name "uc"
-  // CHECK: [[UC_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UC]]
+  // CHECK: [[UC_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[UC]]
   // CHECK: [[PB_UC:%.*]] = project_box [[UC_LIFETIME]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
   // CHECK: [[tmp1:%.*]] = ref_to_unowned [[C_COPY]] : $C to $@sil_unowned C

--- a/test/SILGen/unsafevalue.swift
+++ b/test/SILGen/unsafevalue.swift
@@ -29,7 +29,8 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK: bb0([[INPUT_ELEMENT:%.*]] : @guaranteed $Element,
   // CHECK:   [[BOX:%.*]] = alloc_box
   // CHECK:   [[UNINIT_BOX:%.*]] = mark_uninitialized [rootself] [[BOX]]
-  // CHECK:   [[PROJECT_UNINIT_BOX:%.*]] = project_box [[UNINIT_BOX]]
+  // CHECK:   [[BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[UNINIT_BOX]]
+  // CHECK:   [[PROJECT_UNINIT_BOX:%.*]] = project_box [[BOX_LIFETIME]]
   // CHECK:   [[COPY_INPUT_ELEMENT:%.*]] = copy_value [[INPUT_ELEMENT]]
   // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT_UNINIT_BOX]]
   // CHECK:   [[STRUCT_ACCESS:%.*]] = struct_element_addr [[ACCESS]]
@@ -70,7 +71,8 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s11unsafevalue11UnsafeValueV20withGuaranteeingBase4base_qd_0_qd___qd_0_xXEtr0_lF :
   // CHECK: bb0([[RESULT:%.*]] : $*Result, [[BASE:%.*]] : $*Base, [[CLOSURE:%.*]] : @guaranteed $@noescape @callee_guaranteed {{.*}}, [[UNSAFE_VALUE:%.*]] : $UnsafeValue<Element>):
   // CHECK:  [[COPY_BOX:%.*]] = alloc_box
-  // CHECK:  [[COPY_PROJ:%.*]] = project_box [[COPY_BOX]]
+  // CHECK:  [[BOX_LIFETIME:%.*]] = begin_borrow [var_decl] [[COPY_BOX]]
+  // CHECK:  [[COPY_PROJ:%.*]] = project_box [[BOX_LIFETIME]]
   // CHECK:  store [[UNSAFE_VALUE]] to [trivial] [[COPY_PROJ]]
   // CHECK:  [[CLOSUREC:%.*]] = copy_value [[CLOSURE]]
   // CHECK:  [[VALUE_ADDR:%.*]] = begin_access [read] [unknown] [[COPY_PROJ]]

--- a/test/SILGen/variadic-generic-results.swift
+++ b/test/SILGen/variadic-generic-results.swift
@@ -126,7 +126,8 @@ func copyOrThrowIntoTuple<each T>(_ args: repeat each T) throws -> (repeat each 
 // CHECK-NEXT:    debug_value [[A]] : $Int
 // CHECK-NEXT:    [[B:%.*]] = load [take] [[R1]] : $*String
 // CHECK-NEXT:    [[C:%.*]] = load [take] [[R2]] : $*String
-// CHECK-NEXT:    debug_value [[C]] : $String
+// CHECK-NEXT:    [[C_LIFETIME:%.*]] = begin_borrow [var_decl] [[C]]
+// CHECK-NEXT:    debug_value [[C_LIFETIME]] : $String
 // CHECK-NEXT:    destroy_value [[B]] : $String
 //   End of statement.
 // CHECK-NEXT:    dealloc_stack [[R2]] : $*String
@@ -138,6 +139,7 @@ func copyOrThrowIntoTuple<each T>(_ args: repeat each T) throws -> (repeat each 
 // CHECK-NEXT:    [[SEQUENCE_FN:%.*]] = function_ref @$s4main8sequenceyyF
 // CHECK-NEXT:    apply [[SEQUENCE_FN]]()
 //   Leave the function.
+// CHECK-NEXT:    end_borrow [[C_LIFETIME]] : $String
 // CHECK-NEXT:    destroy_value [[C]] : $String
 // CHECK-NEXT:    [[RET:%.*]] = tuple ()
 // CHECK-NEXT:    return [[RET]] : $()

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -16,18 +16,18 @@ func test0(c c: C) {
   var c = c
 // CHECK:    bb0(%0 : @guaranteed $C):
 // CHECK:      [[C:%.*]] = alloc_box ${ var C }
-// CHECK:      [[C_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[C]]
+// CHECK:      [[C_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[C]]
 // CHECK-NEXT: [[PBC:%.*]] = project_box [[C_LIFETIME]]
 
   var a: A
 // CHECK:      [[A1:%.*]] = alloc_box ${ var A }
 // CHECK:      [[MARKED_A1:%.*]] = mark_uninitialized [var] [[A1]]
-// CHECK:      [[A1_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_A1]]
+// CHECK:      [[A1_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[MARKED_A1]]
 // CHECK-NEXT: [[PBA:%.*]] = project_box [[A1_LIFETIME]]
 
   weak var x = c
 // CHECK:      [[X:%.*]] = alloc_box ${ var @sil_weak Optional<C> }, var, name "x"
-// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[X]]
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
 //   Implicit conversion
 // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PBC]]
@@ -74,7 +74,7 @@ class CC {
   // CHECK:  bb0([[SELF:%.*]] : @owned $CC):
   // CHECK:    [[UNINIT_SELF:%.*]] = mark_uninitialized [rootself] [[SELF]] : $CC
   // CHECK:    [[FOO:%.*]] = alloc_box ${ var Optional<CC> }, var, name "foo"
-  // CHECK:    [[FOO_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[FOO]]
+  // CHECK:    [[FOO_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[FOO]]
   // CHECK:    [[PB:%.*]] = project_box [[FOO_LIFETIME]]
   // CHECK:    [[BORROWED_UNINIT_SELF:%.*]] = begin_borrow [[UNINIT_SELF]]
   // CHECK:    [[X:%.*]] = ref_element_addr [[BORROWED_UNINIT_SELF]] : $CC, #CC.x

--- a/test/SILGen/without_actually_escaping.swift
+++ b/test/SILGen/without_actually_escaping.swift
@@ -88,7 +88,7 @@ func modifyAndPerform<T>(_ _: UnsafeMutablePointer<T>, closure: () ->()) {
 // CHECK-LABEL: sil hidden [ossa] @$s25without_actually_escaping0A24ActuallyEscapingConflictyyF : $@convention(thin) () -> () {
 // CHECK: [[CLOSURE_1_FUN:%.*]] = function_ref @$s25without_actually_escaping0A24ActuallyEscapingConflictyyFyycfU_ :
 // CHECK: [[CLOSURE_1:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_1_FUN]](
-// CHECK: [[BORROWED_CLOSURE_1:%.*]] = begin_borrow [lexical] [[CLOSURE_1]]
+// CHECK: [[BORROWED_CLOSURE_1:%.*]] = begin_borrow [lexical] [var_decl] [[CLOSURE_1]]
 // CHECK: [[COPY_BORROWED_CLOSURE_1:%.*]] = copy_value [[BORROWED_CLOSURE_1]]
 // CHECK: [[COPY_2_BORROWED_CLOSURE_1:%.*]] = copy_value [[COPY_BORROWED_CLOSURE_1]]
 // CHECK: [[THUNK_FUNC:%.*]] = function_ref @$sIeg_Ieg_TR :

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -53,7 +53,8 @@ struct StructOfInt {
 // CHECK: bb0(%0 : $@thin StructOfInt.Type):
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var StructOfInt }, var, name "self"
 // CHECK:   [[UNINIT:%.*]] = mark_uninitialized [rootself] [[BOX]] : ${ var StructOfInt }
-// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT]] : ${ var StructOfInt }, 0
+// CHECK:   [[LIFETIME:%.*]] = begin_borrow [var_decl] [[UNINIT]]
+// CHECK:   [[PROJ:%.*]] = project_box [[LIFETIME]] : ${ var StructOfInt }, 0
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]] : $*StructOfInt
 // CHECK:   [[ADR:%.*]] = struct_element_addr [[ACCESS]] : $*StructOfInt, #StructOfInt.i
 // CHECK:   assign %{{.*}} to [[ADR]] : $*Int
@@ -105,7 +106,7 @@ class SubHasInt : SuperHasInt {
 // CHECK: bb0(%0 : @owned $SubHasInt):
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var SubHasInt }, let, name "self"
 // CHECK:   [[UNINIT:%.*]] = mark_uninitialized [derivedself] [[BOX]] : ${ var SubHasInt }
-// CHECK:   [[UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT]]
+// CHECK:   [[UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[UNINIT]]
 // CHECK:   [[PROJ:%.*]] = project_box [[UNINIT_LIFETIME]] : ${ var SubHasInt }, 0
 // CHECK-NOT: begin_access
 // CHECK:   store %0 to [init] [[PROJ]] : $*SubHasInt
@@ -134,7 +135,7 @@ class SubHasInt : SuperHasInt {
 // CHECK: bb0(%0 : $Int, %1 : @owned $SubHasInt):
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var SubHasInt }, let, name "self"
 // CHECK:   [[UNINIT:%.*]] = mark_uninitialized [derivedself] [[BOX]] : ${ var SubHasInt }
-// CHECK:   [[UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT]]
+// CHECK:   [[UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[UNINIT]]
 // CHECK:   [[PROJ:%.*]] = project_box [[UNINIT_LIFETIME]] : ${ var SubHasInt }, 0
 // CHECK-NOT: begin_access
 // CHECK:   store %{{.*}} to [init] [[PROJ]] : $*SubHasInt
@@ -220,11 +221,12 @@ func testCaptureLocal() -> ()->() {
 // CHECK-LABEL: sil hidden [ossa] @$s20access_marker_verify16testCaptureLocalyycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
 // CHECK: bb0:
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var Int }, var, name "x"
-// CHECK:   [[PROJ:%.*]] = project_box [[BOX]]
+// CHECK:   [[LIFETIME:%.*]] = begin_borrow [var_decl] [[BOX]]
+// CHECK:   [[PROJ:%.*]] = project_box [[LIFETIME]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]] : $*Int
 // CHECK:   store %{{.*}} to [trivial] [[ACCESS]]
 // CHECK:   end_access
-// CHECK:   [[CAPTURE:%.*]] = copy_value [[BOX]] : ${ var Int }
+// CHECK:   [[CAPTURE:%.*]] = copy_value [[LIFETIME]] : ${ var Int }
 // CHECK:   partial_apply [callee_guaranteed] %{{.*}}([[CAPTURE]]) : $@convention(thin) (@guaranteed { var Int }) -> ()
 // CHECK:   begin_access [read] [unknown] [[PROJ]]
 // CHECK:   [[VAL:%.*]] = load [trivial]

--- a/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
+++ b/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
@@ -5,20 +5,21 @@
 // CHECK: sil hidden [ossa] @$s4null19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> Int {
 // CHECK: bb0:
 // CHECK:   [[BOX:%[^,]+]] = alloc_box ${ var Int }, var, name "x", loc {{.*}}:32:7, scope 3
-// CHECK:   [[BOX_ADDR:%[^,]+]] = project_box [[BOX]] : ${ var Int }, 0, loc {{.*}}:32:7, scope 3
+// CHECK:   [[BOX_LIFETIME:%[^,]+]] = begin_borrow [var_decl] [[BOX]]
+// CHECK:   [[BOX_ADDR:%[^,]+]] = project_box [[BOX_LIFETIME]] : ${ var Int }, 0, loc {{.*}}:32:7, scope 3
 // CHECK:   [[ONE:%[^,]+]] = integer_literal $Builtin.IntLiteral, 1, loc {{.*}}:32:11, scope 4
 // CHECK:   [[THIN_INT_TYPE:%[^,]+]] = metatype $@thin Int.Type, loc {{.*}}:32:11, scope 4
 // CHECK:   [[INTEGER_LITERAL:%[^,]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 4
 // CHECK:   [[ONE_INT:%[^,]+]] = apply [[INTEGER_LITERAL]]([[ONE]], [[THIN_INT_TYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 4
 // CHECK:   store [[ONE_INT]] to [trivial] [[BOX_ADDR]] : $*Int, loc {{.*}}:32:11, scope 4
-// CHECK:   [[BOX_COPY:%[^,]+]] = copy_value [[BOX]] : ${ var Int }, loc {{.*}}:33:11, scope 4
+// CHECK:   [[BOX_COPY:%[^,]+]] = copy_value [[BOX_LIFETIME]] : ${ var Int }, loc {{.*}}:33:11, scope 4
 // CHECK:   [[BOX_COPY_ADDR:%[^,]+]] = project_box [[BOX_COPY]] : ${ var Int }, 0, loc {{.*}}:33:11, scope 4
 // CHECK:   mark_function_escape [[BOX_ADDR]] : $*Int, loc {{.*}}:33:11, scope 4
 // CHECK:   [[SPECIALIZED_F:%[^,]+]] = function_ref @$s4null19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 4
 // CHECK:   [[REGISTER_11:%[^,]+]] = load [trivial] [[BOX_COPY_ADDR]] : $*Int, loc {{.*}}:33:11, scope 4
 // CHECK:   destroy_value [[BOX_COPY]] : ${ var Int }, loc {{.*}}:33:11, scope 4
 // CHECK:   [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[SPECIALIZED_F]]([[REGISTER_11]]) : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 4
-// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] [[CLOSURE]]
+// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[CLOSURE]]
 // CHECK:   debug_value [[BORROW]] : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:33:7, scope 6
 // CHECK:   [[CLOSURE_COPY:%[^,]+]] = copy_value [[BORROW]] : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 6
 // There used to be an end_borrow here. We leave an emptyline here to preserve line numbers.
@@ -26,7 +27,6 @@
 // CHECK:   destroy_value [[BOX]] : ${ var Int }, loc {{.*}}:35:1, scope 6
 // CHECK:   return [[CLOSURE_COPY]] : $@callee_guaranteed () -> Int, loc {{.*}}:34:3, scope 6
 // CHECK: }
-
 
 func captureStackPromote() -> () -> Int {
   var x = 1

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.sil
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.sil
@@ -22,7 +22,7 @@ case some(T)
 sil [ossa] @useInLoopWithDestroyOutOfLoop : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   debug_value %0 : $Klass, let, name "x", argno 1
-  %2 = begin_borrow [lexical] %0 : $Klass // expected-error {{'y' used after consume}}
+  %2 = begin_borrow [lexical] [var_decl] %0 : $Klass // expected-error {{'y' used after consume}}
   debug_value %2 : $Klass, let, name "y"
   %4 = copy_value %2 : $Klass
   %5 = move_value [allows_diagnostics] %4 : $Klass // expected-note {{consumed here}}
@@ -34,7 +34,7 @@ bb1:
 
 bb2(%58 : $Int):
   %59 = copy_value %2 : $Klass
-  %60 = begin_borrow [lexical] %59 : $Klass // expected-note {{used here}}
+  %60 = begin_borrow [lexical] [var_decl] %59 : $Klass // expected-note {{used here}}
   debug_value %60 : $Klass, let, name "m"
   end_borrow %60 : $Klass
   destroy_value %59 : $Klass

--- a/test/SILOptimizer/lexical_lifetime_elim.swift
+++ b/test/SILOptimizer/lexical_lifetime_elim.swift
@@ -14,7 +14,7 @@ func getOwned() -> AnyObject
 
 // CHECK-LABEL: // testLexical()
 // CHECK: [[A:%.*]] = apply %{{.*}}()
-// CHECK: [[B:%.*]] = begin_borrow [lexical] [[A]]
+// CHECK: [[B:%.*]] = begin_borrow [lexical] [var_decl] [[A]]
 // CHECK: apply %{{.*}}([[B]])
 // CHECK: apply
 // CHECK: end_borrow [[B]]
@@ -28,7 +28,7 @@ func getOwned() -> AnyObject
 // CHECK-LABEL: *** SIL function after {{.*}} (sil-lexical-lifetime-eliminator)
 // CHECK-LABEL: // testLexical()
 // CHECK: [[A:%.*]] = apply %{{.*}}()
-// CHECK: [[B:%.*]] = begin_borrow [[A]]
+// CHECK: [[B:%.*]] = begin_borrow [var_decl] [[A]]
 // CHECK: apply %{{.*}}([[B]])
 // CHECK: apply
 // CHECK: end_borrow [[B]]

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -26,6 +26,7 @@ public func borrowVal(_ x: borrowing KlassPair) {}
 public func borrowVal(_ x: borrowing AggGenericStruct<String>) {}
 public func borrowVal<T>(_ x: borrowing AggGenericStruct<T>) {}
 public func borrowVal(_ x: borrowing EnumTy) {}
+public func borrowVal(_ x: borrowing String) {}
 
 public func consumeVal(_ x: __owned Klass) {}
 public func consumeVal(_ x: __owned FinalKlass) {}
@@ -4261,4 +4262,23 @@ func testMyEnum() {
       _ = y
     }
   }
+}
+
+
+func rdar_118059326_example1() {
+  @_noEagerMove let thinger = "hello" // expected-error {{'thinger' used after consume}}
+  _ = consume thinger // expected-note {{consumed}}
+  borrowVal(thinger) // expected-note {{used}}
+}
+
+func withSadness<T>(_ execute: () throws -> T) rethrows -> T {
+  try execute()
+}
+
+func rdar_118059326_example2(_ path: String) {
+  let decoded = withSadness { // expected-error {{'decoded' used after consume}}
+      return path
+  }
+  _ = consume decoded // expected-note {{consumed}}
+  borrowVal(decoded) // expected-note {{used}}
 }


### PR DESCRIPTION
Previously, the `lexical` attribute on `begin_borrow` instructions was used to determine the roots of values for which consume checking should be performed. This doesn't work for values without lexical lifetimes which are consumed, e.g. stdlib CoW types.  Here, the new `var_decl` attribute on `begin_borrow` is keyed off of instead.  This flag encodes exactly that a value corresponds to a source-level VarDecl, which is the condition under which checking needs to run.

rdar://118059326
