### PR TITLE
[embedded] Port and start building Darwin.swiftmodule as embedded

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -260,7 +260,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       SDK "embedded"
       ARCHITECTURE "${mod}"
       DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT "never_install"
+      INSTALL_IN_COMPONENT stdlib
       )
     set_property(TARGET embedded-concurrency-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
 

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -120,11 +120,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       SDK "embedded"
       ARCHITECTURE "${arch}"
       DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT "never_install"
+      INSTALL_IN_COMPONENT stdlib
       )
-    set_property(TARGET embedded-darwin-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-
     add_dependencies(embedded-darwin embedded-darwin-${mod})
   endforeach()
 endif()

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -77,6 +77,58 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
     INSTALL_IN_COMPONENT sdk-overlay
     MACCATALYST_BUILD_FLAVOR "zippered")
 
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+  set(SWIFT_ENABLE_REFLECTION OFF)
+
+  add_custom_target(embedded-darwin ALL)
+  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
+    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
+    list(GET list 0 arch)
+    list(GET list 1 mod)
+    list(GET list 2 triple)
+
+    if(NOT "${mod}" MATCHES "-macos$")
+      continue()
+    endif()
+
+    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
+    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
+    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
+    set(SWIFT_SDK_embedded_PATH ${SWIFT_SDK_OSX_PATH})
+    set(SWIFT_SDK_embedded_ARCH_${arch}_PATH ${SWIFT_SDK_OSX_PATH})
+    set(SWIFT_SDK_embedded_USE_ISYSROOT TRUE)
+    add_swift_target_library_single(
+      embedded-darwin-${mod}
+      swiftDarwin
+      ONLY_SWIFTMODULE
+      IS_SDK_OVERLAY IS_FRAGILE
+
+      Platform.swift
+      TiocConstants.swift
+      POSIXError.swift
+      MachError.swift
+
+      GYB_SOURCES
+        tgmath.swift.gyb
+        Darwin.swift.gyb
+      
+      SWIFT_COMPILE_FLAGS
+        -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
+      C_COMPILE_FLAGS
+        -D__MACH__ -D__APPLE__ -ffreestanding
+      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+      SDK "embedded"
+      ARCHITECTURE "${arch}"
+      DEPENDS embedded-stdlib-${mod}
+      INSTALL_IN_COMPONENT "never_install"
+      )
+    set_property(TARGET embedded-darwin-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
+
+
+    add_dependencies(embedded-darwin embedded-darwin-${mod})
+  endforeach()
+endif()
+
 set(swiftGlibc_target_sdks ANDROID CYGWIN FREEBSD OPENBSD LINUX HAIKU)
 if(SWIFT_FREESTANDING_FLAVOR STREQUAL "linux")
   set(swiftGlibc_target_sdks ANDROID CYGWIN FREEBSD OPENBSD LINUX HAIKU FREESTANDING)

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -55,6 +55,7 @@ extension DarwinBoolean : CustomReflectable {
 }
 #endif
 
+@_unavailableInEmbedded
 extension DarwinBoolean : CustomStringConvertible {
   /// A textual representation of `self`.
   public var description: String {
@@ -129,6 +130,7 @@ public var stderr : UnsafeMutablePointer<FILE> {
   }
 }
 
+#if !$Embedded
 public func dprintf(_ fd: Int, _ format: UnsafePointer<Int8>, _ args: CVarArg...) -> Int32 {
   return withVaList(args) { va_args in
     vdprintf(Int32(fd), format, va_args)
@@ -140,6 +142,8 @@ public func snprintf(ptr: UnsafeMutablePointer<Int8>, _ len: Int, _ format: Unsa
     return vsnprintf(ptr, len, format, va_args)
   }
 }
+#endif
+
 #elseif os(OpenBSD)
 public var stdin: UnsafeMutablePointer<FILE> { return _swift_stdlib_stdin() }
 public var stdout: UnsafeMutablePointer<FILE> { return _swift_stdlib_stdout() }

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -329,6 +329,7 @@ public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
 @available(swift, deprecated: 4.2/*, obsoleted: 5.1*/, message:
            "use ${T}(nan: ${T}.RawSignificand).")
 @_transparent
+@_unavailableInEmbedded
 public func nan(_ tag: String) -> ${T} {
   return ${T}(nan${f}(tag))
 }

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -49,7 +49,7 @@ split_embedded_sources(
     NORMAL BridgeStorage.swift
     NORMAL BridgingBuffer.swift
   EMBEDDED Builtin.swift
-    NORMAL BuiltinMath.swift
+  EMBEDDED BuiltinMath.swift
     NORMAL Character.swift
     NORMAL CocoaArray.swift
     NORMAL Codable.swift

--- a/test/embedded/darwin-bridging-header.swift
+++ b/test/embedded/darwin-bridging-header.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend %t/Main.swift %S/Inputs/print.swift -import-bridging-header %t/BridgingHeader.h -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// BEGIN BridgingHeader.h
+
+#include <unistd.h>
+
+// BEGIN Main.swift
+
+@main
+struct Main {
+  static func main() {
+    let x = getuid()
+    print("User id: ")
+    print(x)
+  }
+}
+
+// CHECK: User id:

--- a/test/embedded/darwin.swift
+++ b/test/embedded/darwin.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -throws-as-traps -enable-builtin-module -c -o %t/main.o
+// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+import Darwin
+
+@main
+struct Main {
+  static func main() {
+    let x = getuid()
+    print("User id: ")
+    print(x)
+  }
+}
+
+// CHECK: User id:


### PR DESCRIPTION
Building in embedded Swift mode is useful even for non-standalone environments/targets, like Darwin, at least for testing but also possibly for writing userspace library code that wants to get the no-runtime no-metadata guarantees on embedded Swift. Let's make a step towards that by porting and providing an embedded build of the Darwin overlay (Darwin.swiftmodule).