### PR TITLE
Add RISCV to standard set of architectures for incremental buildbots

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -587,7 +587,7 @@ build-subdir=buildbot_incremental
 release
 assertions
 
-llvm-targets-to-build=X86;ARM;AArch64;PowerPC
+llvm-targets-to-build=X86;ARM;AArch64;PowerPC;RISCV
 
 libcxx
 llbuild
@@ -1492,7 +1492,7 @@ mixin-preset=
 [preset: LLDB_Nested]
 skip-build-benchmarks
 install-destdir=%(swift_install_destdir)s
-llvm-targets-to-build=X86;ARM;AArch64;PowerPC;SystemZ;Mips
+llvm-targets-to-build=X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV
 
 [preset: LLDB_Swift_DebugAssert]
 mixin-preset=


### PR DESCRIPTION
I think this will unbreak the incremental buildbots