### PR TITLE
Revert "[embedded] Start building embedded support on Linux/ELF, expand archs of the embedded stdlib to cover common embedded targets"

### DIFF
--- a/cmake/modules/SwiftSetIfArchBitness.cmake
+++ b/cmake/modules/SwiftSetIfArchBitness.cmake
@@ -11,14 +11,12 @@ function(set_if_arch_bitness var_name)
      "${SIA_ARCH}" STREQUAL "x86" OR
      "${SIA_ARCH}" STREQUAL "armv5" OR
      "${SIA_ARCH}" STREQUAL "armv6" OR
-     "${SIA_ARCH}" STREQUAL "armv6m" OR
      "${SIA_ARCH}" STREQUAL "armv7" OR
      "${SIA_ARCH}" STREQUAL "armv7k" OR
      "${SIA_ARCH}" STREQUAL "arm64_32" OR
      "${SIA_ARCH}" STREQUAL "armv7m" OR
      "${SIA_ARCH}" STREQUAL "armv7em" OR
      "${SIA_ARCH}" STREQUAL "armv7s" OR
-     "${SIA_ARCH}" STREQUAL "riscv32" OR
      "${SIA_ARCH}" STREQUAL "wasm32" OR
      "${SIA_ARCH}" STREQUAL "powerpc")
     set("${var_name}" "${SIA_CASE_32_BIT}" PARENT_SCOPE)

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -138,7 +138,7 @@ option(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB
       "Enable build of the embedded Swift standard library and runtime"
       TRUE)
 
-if((NOT SWIFT_HOST_VARIANT STREQUAL "macosx") AND (NOT SWIFT_HOST_VARIANT STREQUAL "linux"))
+if(NOT SWIFT_HOST_VARIANT STREQUAL "macosx")
   set(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB FALSE)
 elseif(NOT SWIFT_INCLUDE_TOOLS)
   # Temporarily, only build embedded stdlib when building the compiler, to
@@ -151,36 +151,12 @@ endif()
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   set(EMBEDDED_STDLIB_TARGET_TRIPLES
     # arch    module_name               target triple
-    "armv6    armv6-apple-none-macho    armv6-apple-none-macho"
-    "armv6m   armv6m-apple-none-macho   armv6m-apple-none-macho"
     "armv7    armv7-apple-none-macho    armv7-apple-none-macho"
-    "armv7em  armv7em-apple-none-macho  armv7em-apple-none-macho"
     "arm64    arm64-apple-none-macho    arm64-apple-none-macho"
-
-    # the following are all ELF targets
-    "armv6    armv6-none-none-eabi      armv6-none-none-eabi"
-    "armv6m   armv6m-none-none-eabi     armv6-none-none-eabi"
-    "armv7    armv7-none-none-eabi      armv7-none-none-eabi"
-    "armv7em  armv7em-none-none-eabi    armv7em-none-none-eabi"
-    "aarch64  aarch64-none-none-elf     aarch64-none-none-elf"
-    "riscv32  riscv32-none-none-eabi    riscv32-none-none-eabi"
-    "riscv64  riscv64-none-none-eabi    riscv64-none-none-eabi"
+    "x86_64   x86_64-apple-macos        x86_64-apple-macos10.13"
+    "arm64    arm64-apple-macos         arm64-apple-macos10.13"
+    "arm64e   arm64e-apple-macos        arm64e-apple-macos10.13"
     )
-
-  if (SWIFT_HOST_VARIANT STREQUAL "linux")
-    set(EMBEDDED_STDLIB_TARGET_TRIPLES ${EMBEDDED_STDLIB_TARGET_TRIPLES}
-      "${SWIFT_HOST_VARIANT_ARCH} ${SWIFT_HOST_VARIANT_ARCH}-unknown-linux-gnu ${SWIFT_HOST_VARIANT_ARCH}-unknown-linux-gnu"
-      # In practice this expands to either:
-      # "x86_64   x86_64-unknown-linux-gnu  x86_64-unknown-linux-gnu"
-      # "aarch64  aarch64-unknown-linux-gnu aarch64-unknown-linux-gnu"
-      )
-  elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-    set(EMBEDDED_STDLIB_TARGET_TRIPLES ${EMBEDDED_STDLIB_TARGET_TRIPLES}
-      "x86_64   x86_64-apple-macos        x86_64-apple-macos10.13"
-      "arm64    arm64-apple-macos         arm64-apple-macos10.13"
-      "arm64e   arm64e-apple-macos        arm64e-apple-macos10.13"
-      )
-  endif()
 endif()
 
 if(SWIFT_BUILD_STDLIB)

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -198,18 +198,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     list(GET list 1 mod)
     list(GET list 2 triple)
 
-    if (SWIFT_HOST_VARIANT STREQUAL "linux")
-      if(NOT "${mod}" MATCHES "-linux-gnu$")
-        continue()
-      endif()
-      set(extra_c_compile_flags)
-      set(extra_swift_compile_flags)
-    elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      if(NOT "${mod}" MATCHES "-macos$")
-        continue()
-      endif()
-      set(extra_c_compile_flags -D__MACH__ -D__APPLE__ -ffreestanding)
-      set(extra_swift_compile_flags -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding)
+    # TODO: Only build embedded Swift Concurrency for macOS, for now.
+    if(NOT "${mod}" MATCHES "-macos$")
+      continue()
     endif()
     
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
@@ -251,11 +242,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       TaskCancellation.swift
 
       SWIFT_COMPILE_FLAGS
-        ${extra_swift_compile_flags} -enable-experimental-feature Embedded
+        -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
         -parse-stdlib -DSWIFT_CONCURRENCY_EMBEDDED
         ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
       C_COMPILE_FLAGS
-        ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1
+        -D__MACH__ -D__APPLE__ -ffreestanding
+        ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"

--- a/test/embedded/array-builtins-exec.swift
+++ b/test/embedded/array-builtins-exec.swift
@@ -6,7 +6,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 import Builtin
 

--- a/test/embedded/array-to-pointer.swift
+++ b/test/embedded/array-to-pointer.swift
@@ -7,7 +7,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 @_silgen_name("putchar")
 func putchar(_: UInt8)

--- a/test/embedded/array-zero-size-struct.swift
+++ b/test/embedded/array-zero-size-struct.swift
@@ -2,7 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public struct MyStruct {
 }

--- a/test/embedded/arrays.swift
+++ b/test/embedded/arrays.swift
@@ -7,7 +7,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 @_silgen_name("putchar")
 func putchar(_: UInt8)

--- a/test/embedded/class-func.swift
+++ b/test/embedded/class-func.swift
@@ -3,7 +3,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 @main
 struct Main {

--- a/test/embedded/classes-arrays.swift
+++ b/test/embedded/classes-arrays.swift
@@ -6,7 +6,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 class MyClass {
   init() { print("MyClass.init") }

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -7,7 +7,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public class MyClass {
   public init() { print("MyClass.init") }

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -6,7 +6,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 class MyClass {
   init() { print("MyClass.init") }

--- a/test/embedded/closures-heap.swift
+++ b/test/embedded/closures-heap.swift
@@ -6,7 +6,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public class MyClass {
   var handler: (()->())? = nil

--- a/test/embedded/collection.swift
+++ b/test/embedded/collection.swift
@@ -7,7 +7,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 @_silgen_name("putchar")
 func putchar(_: UInt8)

--- a/test/embedded/concurrency-actors.swift
+++ b/test/embedded/concurrency-actors.swift
@@ -7,6 +7,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
 import _Concurrency

--- a/test/embedded/concurrency-async-let.swift
+++ b/test/embedded/concurrency-async-let.swift
@@ -7,6 +7,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
 import _Concurrency

--- a/test/embedded/concurrency-builtins.swift
+++ b/test/embedded/concurrency-builtins.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
 import Builtin

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -7,6 +7,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
+// REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
 import _Concurrency

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -5,7 +5,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 @_silgen_name("putchar")
 func putchar(_: UInt8)

--- a/test/embedded/debuginfo.swift
+++ b/test/embedded/debuginfo.swift
@@ -7,7 +7,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func foo<T>(_ array: inout [T]) {
     array.withUnsafeMutableBytes {

--- a/test/embedded/deserialize-vtables.swift
+++ b/test/embedded/deserialize-vtables.swift
@@ -5,7 +5,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 @main
 struct Main {

--- a/test/embedded/dynamic-self.swift
+++ b/test/embedded/dynamic-self.swift
@@ -1,7 +1,8 @@
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -parse-as-library -module-name main | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 class MyClass {
      init() {

--- a/test/embedded/fno-builtin.swift
+++ b/test/embedded/fno-builtin.swift
@@ -3,7 +3,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func foo() -> [Int] {
 	var a = [1, 2, 3]

--- a/test/embedded/generic-classes-debuginfo.swift
+++ b/test/embedded/generic-classes-debuginfo.swift
@@ -3,7 +3,8 @@
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 struct User {
   let o: BaseClass

--- a/test/embedded/generic-classes.swift
+++ b/test/embedded/generic-classes.swift
@@ -4,7 +4,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 protocol Fooable {
   func foo()

--- a/test/embedded/lto.swift
+++ b/test/embedded/lto.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
 // For LTO, the linker dlopen()'s the libLTO library, which is a scenario that

--- a/test/embedded/metatypes.swift
+++ b/test/embedded/metatypes.swift
@@ -2,7 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func sink<T>(t: T) {}
 

--- a/test/embedded/modules-classes.swift
+++ b/test/embedded/modules-classes.swift
@@ -9,7 +9,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // BEGIN MyModule.swift
 

--- a/test/embedded/modules-globals-exec.swift
+++ b/test/embedded/modules-globals-exec.swift
@@ -9,7 +9,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // BEGIN MyModule.swift
 

--- a/test/embedded/modules-globals-many.swift
+++ b/test/embedded/modules-globals-many.swift
@@ -7,7 +7,8 @@
 // RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // Dependencies look like this:
 //
@@ -43,4 +44,4 @@ public func main() {
   MyModuleC.foo()
 }
 
-// CHECK: @"$s9MyModuleA6globalSivp" = {{.*}}global %TSi zeroinitializer
+// CHECK: @"$s9MyModuleA6globalSivp" = global %TSi zeroinitializer

--- a/test/embedded/modules-globals.swift
+++ b/test/embedded/modules-globals.swift
@@ -5,7 +5,8 @@
 // RUN: %target-swift-frontend -emit-ir -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // BEGIN MyModule.swift
 
@@ -30,7 +31,7 @@ public func main() {
   foo()
 }
 
-// CHECK: @"$s4Main022global_in_client_used_c1_D0Sivp" = {{.*}}global %TSi zeroinitializer
-// CHECK: @"$s4Main024global_in_client_unused_c1_D0Sivp" = {{.*}}global %TSi zeroinitializer
-// CHECK: @"$s8MyModule022global_in_module_used_d1_E0Sivp" = {{.*}}global %TSi zeroinitializer
-// CHECK: @"$s8MyModule024global_in_module_unused_d1_E0Sivp" = {{.*}}global %TSi zeroinitializer
+// CHECK: @"$s4Main022global_in_client_used_c1_D0Sivp" = global %TSi zeroinitializer
+// CHECK: @"$s4Main024global_in_client_unused_c1_D0Sivp" = global %TSi zeroinitializer
+// CHECK: @"$s8MyModule022global_in_module_used_d1_E0Sivp" = global %TSi zeroinitializer
+// CHECK: @"$s8MyModule024global_in_module_unused_d1_E0Sivp" = global %TSi zeroinitializer

--- a/test/embedded/modules-print-exec.swift
+++ b/test/embedded/modules-print-exec.swift
@@ -9,7 +9,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // BEGIN MyModule.swift
 

--- a/test/embedded/no-autolink.swift
+++ b/test/embedded/no-autolink.swift
@@ -1,7 +1,8 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func staticstring() -> StaticString {
   return "hello"

--- a/test/embedded/once-dependent.swift
+++ b/test/embedded/once-dependent.swift
@@ -5,7 +5,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public struct MyStructA {
   static var singleton = MyStructA()

--- a/test/embedded/once-multithreaded.swift
+++ b/test/embedded/once-multithreaded.swift
@@ -2,13 +2,14 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %target-swift-frontend %t/Main.swift %S/Inputs/print.swift -import-bridging-header %t/BridgingHeader.h -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip -pthreads
+// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // BEGIN BridgingHeader.h
 

--- a/test/embedded/once.swift
+++ b/test/embedded/once.swift
@@ -5,7 +5,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // For LTO, the linker dlopen()'s the libLTO library, which is a scenario that
 // ASan cannot work in ("Interceptors are not working, AddressSanitizer is

--- a/test/embedded/osize-genericspecializer.swift
+++ b/test/embedded/osize-genericspecializer.swift
@@ -1,7 +1,8 @@
 // RUN: %target-swift-emit-ir -Osize %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func foo<T>(n: T) {
     bar(n: 42)

--- a/test/embedded/osize-releasedevirt.swift
+++ b/test/embedded/osize-releasedevirt.swift
@@ -2,7 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func foo() {
     bar([42])

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -7,6 +7,7 @@
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
 // REQUIRES: optimized_stdlib
 
 public func test() {}

--- a/test/embedded/ptrauth-fieldptr1.swift
+++ b/test/embedded/ptrauth-fieldptr1.swift
@@ -4,7 +4,8 @@
 // RUN: %target-swift-frontend -enable-import-ptrauth-field-function-pointers -O -emit-ir %t/Main.swift -enable-experimental-feature Embedded -import-objc-header %t/header.h | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 // REQUIRES: CPU=arm64e
 
 // BEGIN header.h

--- a/test/embedded/ptrauth-fieldptr2.swift
+++ b/test/embedded/ptrauth-fieldptr2.swift
@@ -6,7 +6,8 @@
 // RUN: %target-swift-frontend -enable-import-ptrauth-field-function-pointers -O -emit-ir %t/Main.swift -I%t -enable-experimental-feature Embedded -import-objc-header %t/header.h
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 // REQUIRES: CPU=arm64e
 
 // BEGIN header.h

--- a/test/embedded/runtime-release.swift
+++ b/test/embedded/runtime-release.swift
@@ -5,7 +5,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 @main
 struct Main {

--- a/test/embedded/runtime.swift
+++ b/test/embedded/runtime.swift
@@ -5,7 +5,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 @_silgen_name("putchar")
 func putchar(_: UInt8)

--- a/test/embedded/shared-linkage.swift
+++ b/test/embedded/shared-linkage.swift
@@ -11,7 +11,8 @@
 // RUN: %target-swift-frontend -Osize -emit-ir %t/Main.swift -I%t -enable-experimental-feature Embedded
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 // BEGIN Module.swift
 

--- a/test/embedded/static-object.swift
+++ b/test/embedded/static-object.swift
@@ -4,7 +4,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func stringArray() -> [StaticString] {
   return ["a", "b", "c", "d"]

--- a/test/embedded/static-string-interpolation.swift
+++ b/test/embedded/static-string-interpolation.swift
@@ -3,7 +3,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public struct MyInterpolation : StringInterpolationProtocol {
     public typealias StringLiteralType = StaticString

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
 
 public func bool() -> Bool {
   return true

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
 // REQUIRES: optimized_stdlib
 
 class MyClass {}

--- a/test/embedded/throw-trap-stdlib.swift
+++ b/test/embedded/throw-trap-stdlib.swift
@@ -1,7 +1,8 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func test() {
   withUnsafeTemporaryAllocation(byteCount: MemoryLayout<Int>.size, alignment: MemoryLayout<Int>.alignment) { p in

--- a/test/embedded/throw-trap.swift
+++ b/test/embedded/throw-trap.swift
@@ -3,7 +3,8 @@
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -throws-as-traps | %FileCheck %s --check-prefix CHECK-TRAPS-IR
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 enum MyError : Error {
   case a

--- a/test/embedded/throw-typed.swift
+++ b/test/embedded/throw-typed.swift
@@ -5,7 +5,8 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public enum MyError : Error, Equatable {
   case a

--- a/test/embedded/typeof.swift
+++ b/test/embedded/typeof.swift
@@ -2,7 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 
 public func unsafeWriteArray<T, R>(_ elementType: R.Type, array: inout T, index n: Int, value: R) {
   precondition(_isPOD(elementType))


### PR DESCRIPTION
Reverts apple/swift#69973. It's causing buildbot failures. We'll only merge this if my attempted proper fix (https://github.com/apple/swift/pull/70057) fails.