### PR TITLE
[5.10] ABCOpts: fix a miscompile in case a value is added to the array index

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -774,13 +774,15 @@ public:
         return nullptr;
       }
 
-      // We don't check if the second argument to the builtin is loop invariant
-      // here, because only induction variables with a +1 incremenent are
-      // considered for bounds check optimization.
       AsArg = dyn_cast<SILArgument>(Builtin->getArguments()[0]);
       if (!AsArg) {
         return nullptr;
       }
+
+      auto *incrVal = dyn_cast<IntegerLiteralInst>(Builtin->getArguments()[1]);
+      if (!incrVal || incrVal->getValue() != 1)
+        return nullptr;
+
       preIncrement = true;
     }
 

--- a/test/SILOptimizer/abcopts_ossa_guaranteed.sil
+++ b/test/SILOptimizer/abcopts_ossa_guaranteed.sil
@@ -61,6 +61,8 @@ bb0(%0: @guaranteed $ArrayInt):
     unreachable
 }
 
+sil [ossa] @nonconst : $@convention(thin) () -> Builtin.Int32
+
 sil [ossa] @unknown_func : $@convention(thin) () -> () {
 bb0:
   unreachable
@@ -1289,3 +1291,41 @@ bb6(%32 : $Builtin.Int32):
   return %33 : $Int32
 }
 
+// CHECK-LABEL: sil [ossa] @non_const_post_increment :
+// CHECK-NOT:     apply
+// CHECK:       bb1({{.*}}):
+// CHECK:         function_ref @nonconst
+// CHECK:         apply
+// CHECK:         function_ref @checkbounds2
+// CHECK:         apply
+// CHECK:       bb2:
+// CHECK:       } // end sil function 'non_const_post_increment'
+sil [ossa] @non_const_post_increment : $@convention(thin) (@guaranteed Array<Int>) -> () {
+bb0(%0 : @guaranteed $Array<Int>):
+  %t = integer_literal $Builtin.Int1, -1
+  %ts = struct $Bool (%t : $Builtin.Int1)
+  %zero = integer_literal $Builtin.Int32, 0
+  %one = integer_literal $Builtin.Int32, 1
+  %ten = integer_literal $Builtin.Int32, 10
+  br bb1(%zero : $Builtin.Int32)
+
+bb1(%i : $Builtin.Int32):
+  %a1 = builtin "sadd_with_overflow_Int32"(%i : $Builtin.Int32, %one : $Builtin.Int32, %t : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %i1 = tuple_extract %a1 : $(Builtin.Int32, Builtin.Int1), 0
+  %nf = function_ref @nonconst : $@convention(thin) () -> Builtin.Int32
+  %nc = apply %nf() : $@convention(thin) () -> Builtin.Int32
+  %a2 = builtin "sadd_with_overflow_Int32"(%i : $Builtin.Int32, %nc : $Builtin.Int32, %t : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %idx = tuple_extract %a2 : $(Builtin.Int32, Builtin.Int1), 0
+  %idxs = struct $Int32 (%idx : $Builtin.Int32)
+  %f2 = function_ref @checkbounds2 : $@convention(method) (Int32, Bool, @guaranteed Array<Int>) -> _DependenceToken
+  apply %f2(%idxs, %ts, %0) : $@convention(method) (Int32, Bool, @guaranteed Array<Int>) -> _DependenceToken
+  %c = builtin "cmp_eq_Int32"(%i1 : $Builtin.Int32, %ten : $Builtin.Int32) : $Builtin.Int1
+  cond_br %c, bb3, bb2
+
+bb2:
+  br bb1(%i1 : $Builtin.Int32)
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
* **Explanation**: When an array is accessed in a loop where the index is an addition of the induction variable and another value, bounds checking optimization miscompiles. For example: `array[i + x]`. In this case the addition of `x` is misinterpreted as pre-increment of the induction variable. The result can be a false bounds checking runtime error.

* **Issue**: rdar://118026862

* **Risk**: Low. The change makes the bounds checking optimization more conservative.

* **Testing**: With regression tests

* **Reviewer**: @meg-gupta 

* **Main branch PR**: https://github.com/apple/swift/pull/69988
