### PR TITLE
[PoC] Offer unsafe push/pop APIs for task-locals, for easier macro use

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -246,6 +246,18 @@ struct ResultTypeInfo {
 #endif
 };
 
+/// Result of `localValuePopExpectedKey`.
+struct ExpectedTaskLocalKeyPopResult {
+public:
+  bool hasRemainingBindings;
+  bool keyMatched;
+
+  explicit ExpectedTaskLocalKeyPopResult(
+      bool hasRemainingBindings, bool keyMatched)
+      : hasRemainingBindings(hasRemainingBindings),
+        keyMatched(keyMatched) {}
+};
+
 /// An asynchronous task.  Tasks are the analogue of threads for
 /// asynchronous functions: that is, they are a persistent identity
 /// for the overall async computation.
@@ -420,6 +432,8 @@ public:
 
   /// Returns true if storage has still more bindings.
   bool localValuePop();
+
+  ExpectedTaskLocalKeyPopResult localValuePopExpectedKey(const HeapObject *key);
 
   // ==== Child Fragment -------------------------------------------------------
 

--- a/include/swift/ABI/TaskLocal.h
+++ b/include/swift/ABI/TaskLocal.h
@@ -27,6 +27,7 @@ struct OpaqueValue;
 struct SwiftError;
 class TaskStatusRecord;
 class TaskGroup;
+struct ExpectedTaskLocalKeyPopResult;
 
 // ==== Task Locals Values ---------------------------------------------------
 
@@ -199,6 +200,13 @@ public:
     /// and `false` if the just popped value was the last one and the storage
     /// can be safely disposed of.
     bool popValue(AsyncTask *task);
+
+    /// Pop a value form the task-local bindings chain and compare the popped
+    /// item's key with the expected key.
+    ///
+    /// \param expectedKey the expected key to pop.
+    /// \return `true` if the popped item has matching `key`, `false` otherwise
+    ExpectedTaskLocalKeyPopResult popValueExpectingKey(AsyncTask *task, const HeapObject *expectedKey);
 
     /// Copy all task-local bindings to the target task.
     ///

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -637,6 +637,17 @@ void swift_task_localValuePush(const HeapObject *key,
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_localValuePop();
 
+/// Similar to `swift_task_localValuePop` however validates the popped
+/// task local item's key against the expected key.
+///
+/// Its Swift signature is
+///
+/// \code
+///  public func _taskLocalValuePopExpectedKey(Any.Type)
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_localValuePopExpectedKey(const HeapObject *expectedKey);
+
 /// Copy all task locals from the current context to the target task.
 ///
 /// Its Swift signature is

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -360,6 +360,12 @@ OVERRIDE_TASK_LOCAL(task_localValuePop, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, ,)
 
+OVERRIDE_TASK_LOCAL(task_localValuePopExpectedKey, bool,
+                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+                    swift::,
+                    (const HeapObject *expectedKey),
+                    (expectedKey))
+
 OVERRIDE_TASK_LOCAL(task_localsCopyTo, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::,

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -1130,6 +1130,11 @@ inline bool AsyncTask::localValuePop() {
   return _private().Local.popValue(this);
 }
 
+inline ExpectedTaskLocalKeyPopResult
+AsyncTask::localValuePopExpectedKey(const HeapObject *expectedKey) {
+  return _private().Local.popValueExpectingKey(this, expectedKey);
+}
+
 } // end namespace swift
 
 #endif

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// REQUIRES: libdispatch
 
 // rdar://76038845
 // REQUIRES: concurrency_runtime

--- a/test/Concurrency/Runtime/async_task_locals_unsafe_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_unsafe_basic.swift
@@ -86,11 +86,11 @@ func nested() async {
       printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (2)
       printTaskLocal(TL.$string, "hello") // CHECK: TaskLocal<String>(defaultValue: <undefined>) (hello)
     }
-    TL.$clazz.unsafePopValue() // pop "2"
+    TL.$number.unsafePopValue() // pop "2"
     printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (0)
     printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (hello)
   }
-  TL.$clazz.unsafePopValue() // pop "hello"
+  TL.$string.unsafePopValue() // pop "hello"
   printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (0)
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }

--- a/test/Concurrency/Runtime/async_task_locals_unsafe_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_unsafe_basic.swift
@@ -1,0 +1,106 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+enum TL {
+
+  @TaskLocal
+  static var string: String = "<undefined>"
+
+  @TaskLocal
+  static var number: Int = 0
+
+  @TaskLocal
+  static var clazz: ClassTaskLocal?
+}
+
+final class ClassTaskLocal: Sendable {
+  init() {
+    print("clazz init \(ObjectIdentifier(self))")
+  }
+
+  deinit {
+    print("clazz deinit \(ObjectIdentifier(self))")
+  }
+}
+
+@discardableResult
+func printTaskLocalAsync<V>(
+    _ key: TaskLocal<V>,
+    _ expected: V? = nil,
+    file: String = #file, line: UInt = #line
+) async -> V? {
+  printTaskLocal(key, expected, file: file, line: line)
+}
+
+@discardableResult
+func printTaskLocal<V>(
+    _ key: TaskLocal<V>,
+    _ expected: V? = nil,
+    file: String = #file, line: UInt = #line
+) -> V? {
+  let value = key.get()
+  print("\(key) (\(value)) at \(file):\(line)")
+  if let expected = expected {
+    assert("\(expected)" == "\(value)",
+        "Expected [\(expected)] but found: \(value), at \(file):\(line)")
+  }
+  return expected
+}
+
+// ==== ------------------------------------------------------------------------
+
+func simple() async {
+  printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
+  TL.$number.unsafePushValue(1)
+  defer { printTaskLocal(TL.$number) }
+  defer { TL.$number.unsafePopValue() }
+  printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (1)
+  // defer: pop
+  // defer: print // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (0)
+}
+
+func simple_deinit() async {
+  TL.$clazz.unsafePushValue(ClassTaskLocal())
+  // CHECK: clazz init [[C:.*]]
+  printTaskLocal(TL.$clazz) // CHECK: TaskLocal<Optional<ClassTaskLocal>>(defaultValue: nil) (Optional(main.ClassTaskLocal))
+  TL.$clazz.unsafePopValue() // release SPECIFICALLY here
+
+  // CHECK: clazz deinit [[C]]
+  printTaskLocal(TL.$clazz) // CHECK: TaskLocal<Optional<ClassTaskLocal>>(defaultValue: nil) (nil)
+}
+
+func nested() async {
+  printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
+  TL.$string.unsafePushValue("hello")
+  do {
+    printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (0)
+    printTaskLocal(TL.$string)// CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (hello)
+    TL.$number.unsafePushValue(2)
+    do {
+      printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (2)
+      printTaskLocal(TL.$string, "hello") // CHECK: TaskLocal<String>(defaultValue: <undefined>) (hello)
+    }
+    TL.$clazz.unsafePopValue() // pop "2"
+    printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (0)
+    printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (hello)
+  }
+  TL.$clazz.unsafePopValue() // pop "hello"
+  printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (0)
+  printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
+}
+
+
+@available(SwiftStdlib 5.1, *)
+@main struct Main {
+  static func main() async {
+    await simple()
+    await simple_deinit()
+    await nested()
+  }
+}

--- a/test/Concurrency/Runtime/async_task_locals_unsafe_crash_pop.swift
+++ b/test/Concurrency/Runtime/async_task_locals_unsafe_crash_pop.swift
@@ -18,6 +18,9 @@ enum TL {
 
   @TaskLocal
   static var number: Int = 0
+
+  @TaskLocal
+  static var other: String = ""
 }
 
 @main struct Main {
@@ -41,6 +44,15 @@ enum TL {
         TL.$number.unsafePopValue()
         TL.$number.unsafePopValue() // BAD ALREADY! tries to pop in parent!
       }.value
+    }
+
+    tests.test("pop unexpected key") {
+      expectCrashLater(withMessage:
+        "unsafePopValue key did not match actually removed binding. This a indicates not well-balanced push/pop pair of calls. Expected key TaskLocal<Int>")
+      TL.$number.unsafePushValue(1)
+      TL.$other.unsafePushValue("hi")
+      // expected order of popping should be reverse of pushing
+      TL.$number.unsafePopValue()
     }
 
     await runAllTestsAsync()

--- a/test/Concurrency/Runtime/async_task_locals_unsafe_crash_pop.swift
+++ b/test/Concurrency/Runtime/async_task_locals_unsafe_crash_pop.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN:  %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+import StdlibUnittest
+
+enum TL {
+
+  @TaskLocal
+  static var number: Int = 0
+}
+
+@main struct Main {
+  static func main() async {
+    let tests = TestSuite("AssertPreconditionActorExecutor")
+
+    tests.test("pop more task-local bindings than were set") {
+      expectCrashLater(withMessage:
+        "Attempted to pop task-local value binding from empty task-local bindings stack. This indicates an un-balanced number of 'unsafePushValue' and 'unsafePopValue' calls.")
+      TL.$number.unsafePushValue(1)
+      TL.$number.unsafePopValue()
+      TL.$number.unsafePopValue() // boom!
+    }
+
+    tests.test("illegal pop from parent") {
+      expectCrashLater(withMessage:
+        "freed pointer was not the last allocation")
+      TL.$number.unsafePushValue(1)
+      _ = await Task {
+        TL.$number.unsafePushValue(2)
+        TL.$number.unsafePopValue()
+        TL.$number.unsafePopValue() // BAD ALREADY! tries to pop in parent!
+      }.value
+    }
+
+    await runAllTestsAsync()
+  }
+}

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -269,6 +269,11 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_localValuePop) {
   swift_task_localValuePop();
 }
 
+TEST_F(CompatibilityOverrideConcurrencyTest,
+       test_swift_task_localValuePopExpectedKey) {
+  swift_task_localValuePopExpectedKey(nullptr);
+}
+
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_localsCopyTo) {
   swift_task_localsCopyTo(nullptr);
 }


### PR DESCRIPTION
We could offer these APIs, which would make it possible to write a "traced" macro like this:

```swift
@SpanPreamble
func hello() {
  print("Hello")
}
```

-> 

```swift
@SpanPreamble
func hello() {
  // let span = Tracing.startSpan(...)
  // ServiceContext.$current.unsafePushValue(span.context)
  // defer { ServiceContext.$current.unsafePopValue() }
  print("Hello")
}```