### PR TITLE
[5.10] PredictableMemOpt: fix wrong handling of re-borrows of a load_borrow

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -2177,6 +2177,12 @@ bool AllocOptimize::promoteLoadBorrow(LoadBorrowInst *lbi) {
   if (!result.has_value())
     return false;
 
+  // Bail if the load_borrow has reborrows. In this case it's not so easy to
+  // find the insertion points for the destroys.
+  if (!lbi->getUsersOfType<BranchInst>().empty()) {
+    return false;
+  }
+
   ++NumLoadPromoted;
 
   SILType loadTy = result->first;

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -1341,6 +1341,25 @@ bbEnd(%8 : @owned $Optional<Builtin.NativeObject>):
   return %8 : $Optional<Builtin.NativeObject>
 }
 
+// CHECK-LABEL: sil [ossa] @dont_promote_load_borrow_with_reborrows :
+// CHECK:         load_borrow
+// CHECK:       } // end sil function 'dont_promote_load_borrow_with_reborrows'
+sil [ossa] @dont_promote_load_borrow_with_reborrows : $@convention(thin) (@owned SomeClass) -> () {
+bb0(%0 : @owned $SomeClass):
+  %1 = alloc_stack $SomeClass
+  store %0 to [init] %1 : $*SomeClass
+  %3 = load_borrow %1 : $*SomeClass
+  br bb1(%3 : $SomeClass)
+
+bb1(%5 : @reborrow @guaranteed $SomeClass):
+  end_borrow %5 : $SomeClass
+  destroy_addr %1 : $*SomeClass
+  dealloc_stack %1 : $*SomeClass
+  %9 = tuple ()
+  return %9 : $()
+}
+
+
 class Foo {}
 struct MyInt {
   var _value: Builtin.Int64


### PR DESCRIPTION
* **Explanation**:  When promoting a load_borrow, the PredictableMemOpt pass doesn't consider re-borrows. This can lead an ownership verifier error or a mis-compile resulting in leaked values.

* **Issue**: rdar://118402432

* **Risk**: Low. It's a trivial change which makes the optimization more conservative.

* **Reviewer**: @atrick

* **Main branch PR**: https://github.com/apple/swift/pull/69886