### PR TITLE
IRGen: Allocate an address for the result of zero sized typed error results

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4751,6 +4751,13 @@ Address IRGenFunction::createErrorResultSlot(SILType errorType, bool isAsync,
   auto errorAlignment  = isTypedError ? IGM.getPointerAlignment() :
     cast<FixedTypeInfo>(getTypeInfo(errorType)).getFixedAlignment();
 
+  // Pass an address for zero sized types.
+  if (!isTypedError && !setSwiftErrorFlag &&
+      cast<FixedTypeInfo>(getTypeInfo(errorType)).getFixedSize() == Size(0)) {
+    errorStorageType = IGM.Int8PtrTy;
+    errorAlignment = IGM.getPointerAlignment();
+  }
+
   // Create the alloca.  We don't use allocateStack because we're
   // not allocating this in stack order.
   auto addr = createAlloca(errorStorageType,

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -66,3 +66,15 @@ func reabstractAsConcreteThrowing() throws -> Int {
 // CHECK-LABEL: define {{.*}} swiftcc void @"$sSi12typed_throws10MyBigErrorOIgdzo_SiACIegrzr_TR"(ptr noalias nocapture sret(%TSi) %0, ptr %1, ptr %2, ptr swiftself %3, ptr noalias nocapture swifterror dereferenceable(8) %4, ptr %5)
 // CHECK: call swiftcc {{i32|i64}} %1
 // CHECK: br i1 %8, label %typed.error.load, label %10
+
+
+struct S : Error { }
+
+func callee() throws (S) {
+  throw S()
+}
+
+// This used to crash at compile time.
+func testit() throws (S) {
+  try callee()
+}


### PR DESCRIPTION
rdar://118657904