### PR TITLE
[Test] Use split-file rather than split_file.py

### DIFF
--- a/test/embedded/modules-globals-many.swift
+++ b/test/embedded/modules-globals-many.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleA.swiftmodule %t/MyModuleA.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -emit-module -I %t -o %t/MyModuleB.swiftmodule %t/MyModuleB.swift -enable-experimental-feature Embedded -parse-as-library
@@ -16,25 +16,25 @@
 //  ModuleA  ◀──┤                ├───   Main
 //              └───  ModuleC  ◀─┘
 
-// BEGIN MyModuleA.swift
+//--- MyModuleA.swift
 
 public var global = 0
 
 public func foo() { global += 1 }
 
-// BEGIN MyModuleB.swift
+//--- MyModuleB.swift
 
 import MyModuleA
 
 public func foo() { global += 1 }
 
-// BEGIN MyModuleC.swift
+//--- MyModuleC.swift
 
 import MyModuleA
 
 public func foo() { global += 1 }
 
-// BEGIN Main.swift
+//--- Main.swift
 
 import MyModuleB
 import MyModuleC


### PR DESCRIPTION
We've had a bunch of problems with unicode support for Python, `split_file.py` looks to be another one. Just use `split-file` instead.

Resolves rdar://118892583.