### PR TITLE
[5.10][Test] Regex tests depend on host Swift compiler

### DIFF
--- a/test/SourceKit/Sema/sema_regex.swift
+++ b/test/SourceKit/Sema/sema_regex.swift
@@ -2,7 +2,8 @@ public func retRegex() -> Regex<Substring> {
   /foo/
 }
 
-// REQUIRES: swift_in_compiler
+// REQUIRES: swift_swift_parser
+
 // RUN: %sourcekitd-test -req=sema %s -- %s -Xfrontend -enable-bare-slash-regex -Xfrontend -disable-availability-checking | %FileCheck %s
 
 // CHECK: [


### PR DESCRIPTION
This test was missed in #69838. Update to depend on swift_swift_parser (ie. "have a host Swift compiler").