### PR TITLE
[ConstraintSystem] Implement sendability inference for key path expressions

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6116,6 +6116,11 @@ public:
   /// True if this key path expression has a leading dot.
   bool expectsContextualRoot() const { return HasLeadingDot; }
 
+  BoundGenericType *getKeyPathType() const;
+
+  Type getRootType() const;
+  Type getValueType() const;
+
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::KeyPath;
   }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6101,11 +6101,11 @@ public:
     ParsedPath = path;
   }
 
-  TypeRepr *getRootType() const {
+  TypeRepr *getExplicitRootType() const {
     assert(!isObjC() && "cannot get root type of ObjC keypath");
     return RootType;
   }
-  void setRootType(TypeRepr *rootType) {
+  void setExplicitRootType(TypeRepr *rootType) {
     assert(!isObjC() && "cannot set root type of ObjC keypath");
     RootType = rootType;
   }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3908,6 +3908,8 @@ class KeyPathInst final
   }
   
 public:
+  BoundGenericType *getKeyPathType() const;
+
   KeyPathPattern *getPattern() const;
   bool hasPattern() const { return (bool)Pattern; }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6313,7 +6313,7 @@ public:
 };
 
 /// Determine whether given type is a known one
-/// for a key path `{Writable, ReferenceWritable}KeyPath`.
+/// for a key path `{Any, Partial, Writable, ReferenceWritable}KeyPath`.
 bool isKnownKeyPathType(Type type);
 
 /// Determine whether given declaration is one for a key path

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -339,11 +339,13 @@ enum TypeVariableOptions {
   TVO_PackExpansion = 0x40,
 };
 
-enum class KeyPathCapability : uint8_t {
+enum class KeyPathMutability : uint8_t {
   ReadOnly,
   Writable,
   ReferenceWritable
 };
+
+using KeyPathCapability = std::pair<KeyPathMutability, /*isSendable=*/bool>;
 
 /// The implementation object for a type variable used within the
 /// constraint-solving type checker.

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1280,7 +1280,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     }
 
     if (!E->isObjC()) {
-      auto rootType = E->getRootType();
+      auto rootType = E->getExplicitRootType();
       if (rootType && doIt(rootType))
         return nullptr;
     }

--- a/lib/IDE/KeyPathCompletion.cpp
+++ b/lib/IDE/KeyPathCompletion.cpp
@@ -37,8 +37,8 @@ void KeyPathTypeCheckCompletionCallback::sawSolutionImpl(
   if (ComponentIndex == 0) {
     // We are completing on the root and need to extract the key path's root
     // type.
-    if (KeyPath->getRootType()) {
-      BaseType = S.getResolvedType(KeyPath->getRootType());
+    if (auto *rootTy = KeyPath->getExplicitRootType()) {
+      BaseType = S.getResolvedType(rootTy);
     } else {
       // The key path doesn't have a root TypeRepr set, so we can't look the key
       // path's root up through it. Build a constraint locator and look the

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7123,7 +7123,8 @@ void IRGenSILFunction::visitKeyPathInst(swift::KeyPathInst *I) {
     emitDeallocateDynamicAlloca(*dynamicArgsBuf);
   }
 
-  auto resultStorageTy = IGM.getTypeInfo(I->getType()).getStorageType();
+  auto loweredKeyPathTy = IGM.getLoweredType(I->getKeyPathType());
+  auto resultStorageTy = IGM.getTypeInfo(loweredKeyPathTy).getStorageType();
 
   Explosion e;
   e.add(Builder.CreateBitCast(call, resultStorageTy));

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/AssertImplements.h"
@@ -2964,6 +2965,18 @@ KeyPathInst::~KeyPathInst() {
   // Destroy operands.
   for (auto &operand : getAllOperands())
     operand.~Operand();
+}
+
+BoundGenericType *KeyPathInst::getKeyPathType() const {
+  auto kpTy = getType();
+
+  if (auto existential = kpTy.getAs<ExistentialType>()) {
+    auto containedTy = existential->getConstraintType();
+    return containedTy->getExistentialLayout()
+        .explicitSuperclass->castTo<BoundGenericType>();
+  }
+
+  return kpTy.getAs<BoundGenericType>();
 }
 
 KeyPathPattern *KeyPathInst::getPattern() const {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2971,8 +2971,7 @@ BoundGenericType *KeyPathInst::getKeyPathType() const {
   auto kpTy = getType();
 
   if (auto existential = kpTy.getAs<ExistentialType>()) {
-    auto containedTy = existential->getConstraintType();
-    return containedTy->getExistentialLayout()
+    return existential->getExistentialLayout()
         .explicitSuperclass->castTo<BoundGenericType>();
   }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5423,8 +5423,9 @@ public:
     auto kpTy = KPI->getType();
     
     require(kpTy.isObject(), "keypath result must be an object type");
-    
-    auto kpBGT = kpTy.getAs<BoundGenericType>();
+
+    auto *kpBGT = KPI->getKeyPathType();
+
     require(kpBGT, "keypath result must be a generic type");
     require(kpBGT->isKeyPath() ||
             kpBGT->isWritableKeyPath() ||

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4140,9 +4140,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
   SmallVector<KeyPathPatternComponent, 4> loweredComponents;
   auto loweredTy = SGF.getLoweredType(E->getType());
 
-  CanType rootTy = E->getType()->castTo<BoundGenericType>()->getGenericArgs()[0]
-    ->getCanonicalType();
-  
+  CanType rootTy = E->getRootType()->getCanonicalType();
+
   bool needsGenericContext = false;
   if (rootTy->hasArchetype()) {
     needsGenericContext = true;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5010,8 +5010,7 @@ namespace {
         leafTy = fnTy->getResult();
         isFunctionType = true;
       } else if (auto *existential = exprType->getAs<ExistentialType>()) {
-        auto constrainedTy = existential->getConstraintType();
-        auto layout = constrainedTy->getExistentialLayout();
+        auto layout = existential->getExistentialLayout();
         auto keyPathTy = layout.explicitSuperclass->castTo<BoundGenericType>();
         baseTy = keyPathTy->getGenericArgs()[0];
         leafTy = keyPathTy->getGenericArgs()[1];

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5009,6 +5009,12 @@ namespace {
         baseTy = fnTy->getParams()[0].getParameterType();
         leafTy = fnTy->getResult();
         isFunctionType = true;
+      } else if (auto *existential = exprType->getAs<ExistentialType>()) {
+        auto constrainedTy = existential->getConstraintType();
+        auto layout = constrainedTy->getExistentialLayout();
+        auto keyPathTy = layout.explicitSuperclass->castTo<BoundGenericType>();
+        baseTy = keyPathTy->getGenericArgs()[0];
+        leafTy = keyPathTy->getGenericArgs()[1];
       } else {
         auto keyPathTy = exprType->castTo<BoundGenericType>();
         baseTy = keyPathTy->getGenericArgs()[0];

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -534,16 +534,16 @@ void BindingSet::inferTransitiveBindings(
 static BoundGenericType *getKeyPathType(ASTContext &ctx,
                                         KeyPathCapability capability,
                                         Type rootType, Type valueType) {
-  switch (capability) {
-  case KeyPathCapability::ReadOnly:
+  switch (capability.first) {
+  case KeyPathMutability::ReadOnly:
     return BoundGenericType::get(ctx.getKeyPathDecl(), /*parent=*/Type(),
                                  {rootType, valueType});
 
-  case KeyPathCapability::Writable:
+  case KeyPathMutability::Writable:
     return BoundGenericType::get(ctx.getWritableKeyPathDecl(),
                                  /*parent=*/Type(), {rootType, valueType});
 
-  case KeyPathCapability::ReferenceWritable:
+  case KeyPathMutability::ReferenceWritable:
     return BoundGenericType::get(ctx.getReferenceWritableKeyPathDecl(),
                                  /*parent=*/Type(), {rootType, valueType});
   }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -531,22 +531,41 @@ void BindingSet::inferTransitiveBindings(
   }
 }
 
-static BoundGenericType *getKeyPathType(ASTContext &ctx,
-                                        KeyPathCapability capability,
-                                        Type rootType, Type valueType) {
-  switch (capability.first) {
+static Type getKeyPathType(ASTContext &ctx, KeyPathCapability capability,
+                           Type rootType, Type valueType) {
+  KeyPathMutability mutability;
+  bool isSendable;
+
+  std::tie(mutability, isSendable) = capability;
+
+  Type keyPathTy;
+  switch (mutability) {
   case KeyPathMutability::ReadOnly:
-    return BoundGenericType::get(ctx.getKeyPathDecl(), /*parent=*/Type(),
-                                 {rootType, valueType});
+    keyPathTy = BoundGenericType::get(ctx.getKeyPathDecl(), /*parent=*/Type(),
+                                      {rootType, valueType});
+    break;
 
   case KeyPathMutability::Writable:
-    return BoundGenericType::get(ctx.getWritableKeyPathDecl(),
-                                 /*parent=*/Type(), {rootType, valueType});
+    keyPathTy = BoundGenericType::get(ctx.getWritableKeyPathDecl(),
+                                      /*parent=*/Type(), {rootType, valueType});
+    break;
 
   case KeyPathMutability::ReferenceWritable:
-    return BoundGenericType::get(ctx.getReferenceWritableKeyPathDecl(),
-                                 /*parent=*/Type(), {rootType, valueType});
+    keyPathTy = BoundGenericType::get(ctx.getReferenceWritableKeyPathDecl(),
+                                      /*parent=*/Type(), {rootType, valueType});
+    break;
   }
+
+  if (isSendable &&
+      ctx.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
+    auto *sendable = ctx.getProtocol(KnownProtocolKind::Sendable);
+    keyPathTy = ProtocolCompositionType::get(
+        ctx, {keyPathTy, sendable->getDeclaredInterfaceType()},
+        /*hasExplicitAnyObject=*/false);
+    return ExistentialType::get(keyPathTy);
+  }
+
+  return keyPathTy;
 }
 
 void BindingSet::finalize(

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1426,7 +1426,7 @@ SourceRange MemberAccessOnOptionalBaseFailure::getSourceRange() const {
     auto anchor = getAnchor();
     auto keyPathExpr = castToExpr<KeyPathExpr>(anchor);
     if (componentPathElt->getIndex() == 0) {
-      if (auto rootType = keyPathExpr->getRootType()) {
+      if (auto rootType = keyPathExpr->getExplicitRootType()) {
         return rootType->getSourceRange();
       } else {
         return keyPathExpr->getComponents().front().getLoc();
@@ -1483,7 +1483,7 @@ bool MemberAccessOnOptionalBaseFailure::diagnoseAsError() {
     // For members where the base type is an optional key path root
     // let's emit a tailored note suggesting to use its unwrapped type.
     auto *keyPathExpr = castToExpr<KeyPathExpr>(getAnchor());
-    if (auto rootType = keyPathExpr->getRootType()) {
+    if (auto rootType = keyPathExpr->getExplicitRootType()) {
       emitDiagnostic(diag::optional_base_not_unwrapped, baseType, Member,
                      unwrappedBaseType);
 
@@ -6134,7 +6134,7 @@ SourceLoc AnyObjectKeyPathRootFailure::getLoc() const {
   auto anchor = getAnchor();
 
   if (auto *KPE = getAsExpr<KeyPathExpr>(anchor)) {
-    if (auto rootTyRepr = KPE->getRootType())
+    if (auto rootTyRepr = KPE->getExplicitRootType())
       return rootTyRepr->getLoc();
   }
 
@@ -6145,7 +6145,7 @@ SourceRange AnyObjectKeyPathRootFailure::getSourceRange() const {
   auto anchor = getAnchor();
 
   if (auto *KPE = getAsExpr<KeyPathExpr>(anchor)) {
-    if (auto rootTyRepr = KPE->getRootType())
+    if (auto rootTyRepr = KPE->getExplicitRootType())
       return rootTyRepr->getSourceRange();
   }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3732,7 +3732,7 @@ namespace {
                                                           TVO_CanBindToHole);
 
       // If a root type was explicitly given, then resolve it now.
-      if (auto rootRepr = E->getRootType()) {
+      if (auto rootRepr = E->getExplicitRootType()) {
         const auto rootObjectTy = resolveTypeReferenceInExpression(
             rootRepr, TypeResolverContext::InExpression, locator);
         if (!rootObjectTy || rootObjectTy->hasError())

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12195,6 +12195,12 @@ ConstraintSystem::simplifyKeyPathConstraint(
     if (contextualTy->isPlaceholder())
       return true;
 
+    // Situations like `any KeyPath<...> & Sendable`.
+    if (contextualTy->isExistentialType()) {
+      contextualTy = contextualTy->getExistentialLayout().explicitSuperclass;
+      assert(contextualTy);
+    }
+
     // If there are no other options the solver might end up picking
     // `AnyKeyPath` or `PartialKeyPath` based on a contextual conversion.
     // This is an error during normal type-checking but okay in

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2222,7 +2222,7 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
 
   std::reverse(components.begin(), components.end());
 
-  KPE->setRootType(rootType);
+  KPE->setExplicitRootType(rootType);
   KPE->setComponents(getASTContext(), components);
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3365,18 +3365,21 @@ namespace {
           }
         }
 
-        // Captured values in a path component must conform to Sendable.
-        // These captured values appear in Subscript, such as \Type.dict[k]
-        // where k is a captured dictionary key.
-        if (auto *args = component.getSubscriptArgs()) {
-          for (auto arg : *args) {
-            auto type = getType(arg.getExpr());
-            if (type &&
-                shouldDiagnoseExistingDataRaces(getDeclContext()) &&
-                diagnoseNonSendableTypes(
-                    type, getDeclContext(), component.getLoc(),
-                    diag::non_sendable_keypath_capture))
-              diagnosed = true;
+        // With `InferSendableFromCaptures` feature enabled the solver is
+        // responsible for inferring `& Sendable` for sendable key paths.
+        if (!ctx.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
+          // Captured values in a path component must conform to Sendable.
+          // These captured values appear in Subscript, such as \Type.dict[k]
+          // where k is a captured dictionary key.
+          if (auto *args = component.getSubscriptArgs()) {
+            for (auto arg : *args) {
+              auto type = getType(arg.getExpr());
+              if (type && shouldDiagnoseExistingDataRaces(getDeclContext()) &&
+                  diagnoseNonSendableTypes(type, getDeclContext(),
+                                           component.getLoc(),
+                                           diag::non_sendable_keypath_capture))
+                diagnosed = true;
+            }
           }
         }
       }

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -1,0 +1,126 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature InferSendableFromCaptures -strict-concurrency=complete
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+class NonSendable : Hashable {
+  var data: Int
+
+  init(data: Int = 42) {
+    self.data = data
+  }
+
+  init(data: [Int]) {
+    self.data = data.first!
+  }
+
+  static func == (x: NonSendable, y: NonSendable) -> Bool { false }
+  func hash(into hasher: inout Hasher) {}
+}
+
+final class CondSendable<T> : Hashable {
+  init(_: T) {}
+  init(_: Int) {}
+  init(_: T, other: T = 42) {}
+  init<Q>(_: [Q] = []) {}
+
+  static func == (x: CondSendable, y: CondSendable) -> Bool { false }
+  func hash(into hasher: inout Hasher) {}
+}
+
+extension CondSendable : Sendable where T: Sendable {
+}
+
+// Test forming sendable key paths without context
+do {
+  class K {
+    var data: String = ""
+
+    subscript<T>(_: T) -> Bool {
+      get { false }
+    }
+
+    subscript<Q>(_: Int, _: Q) -> Int {
+      get { 42 }
+      set {}
+    }
+  }
+
+  let kp = \K.data // Marked as  `& Sendable`
+
+  let _: KeyPath<K, String> = kp // Ok
+  let _: KeyPath<K, String> & Sendable = kp // Ok
+
+  func test<V>(_: KeyPath<K, V> & Sendable) {
+  }
+
+  test(kp) // Ok
+
+  let nonSendableKP = \K.[NonSendable()]
+
+  let _: KeyPath<K, Bool> = \.[NonSendable()] // ok
+  let _: KeyPath<K, Bool> & Sendable = \.[NonSendable()] // expected-warning {{type 'KeyPath<K, Bool>' does not conform to the 'Sendable' protocol}}
+  let _: KeyPath<K, Int> & Sendable = \.[42, NonSendable(data: [-1, 0, 1])] // expected-warning {{type 'ReferenceWritableKeyPath<K, Int>' does not conform to the 'Sendable' protocol}}
+  let _: KeyPath<K, Int> & Sendable = \.[42, -1] // Ok
+
+  test(nonSendableKP) // expected-warning {{type 'KeyPath<K, Bool>' does not conform to the 'Sendable' protocol}}
+}
+
+// Test using sendable and non-sendable key paths.
+do {
+  class V {
+    var i: Int = 0
+
+    subscript<T>(_: T) -> Int {
+      get { 42 }
+    }
+
+    subscript<Q>(_: Int, _: Q) -> Int {
+      get { 42 }
+      set {}
+    }
+  }
+
+  func testSendableKP<T, U>(v: T, _ kp: any KeyPath<T, U> & Sendable) {}
+  func testSendableFn<T, U>(v: T, _: @Sendable (T) -> U) {}
+
+  func testNonSendableKP<T, U>(v: T, _ kp: KeyPath<T, U>) {}
+  func testNonSendableFn<T, U>(v: T, _ kp: (T) -> U) {}
+
+  let v = V()
+
+  testSendableKP(v: v, \.i) // Ok
+  testSendableFn(v: v, \.i) // Ok
+
+  testSendableKP(v: v, \.[42]) // Ok
+  testSendableFn(v: v, \.[42]) // Ok
+
+  testSendableKP(v: v, \.[NonSendable()]) // expected-warning {{type 'KeyPath<V, Int>' does not conform to the 'Sendable' protocol}}
+  // Note that there is no warning here because the key path is wrapped in a closure and not captured by it: `{ $0[keyPath: \.[NonSendable()]] }`
+  testSendableFn(v: v, \.[NonSendable()]) // Ok
+
+  testNonSendableKP(v: v, \.[NonSendable()]) // Ok
+  testNonSendableFn(v: v, \.[NonSendable()]) // Ok
+
+  let _: @Sendable (V) -> Int = \.[NonSendable()] // Ok
+
+  let _: KeyPath<V, Int> & Sendable = \.[42, CondSendable(NonSendable(data: [1, 2, 3]))]
+  // expected-warning@-1 {{type 'ReferenceWritableKeyPath<V, Int>' does not conform to the 'Sendable' protocol}}
+  let _: KeyPath<V, Int> & Sendable = \.[42, CondSendable(42)] // Ok
+
+  struct Root {
+    let v: V
+  }
+
+  testSendableKP(v: v, \.[42, CondSendable(NonSendable(data: [1, 2, 3]))])
+  // expected-warning@-1 {{type 'ReferenceWritableKeyPath<V, Int>' does not conform to the 'Sendable' protocol}}
+  testSendableFn(v: v, \.[42, CondSendable(NonSendable(data: [1, 2, 3]))]) // Ok
+  testSendableKP(v: v, \.[42, CondSendable(42)]) // Ok
+
+  let nonSendable = NonSendable()
+  testSendableKP(v: v, \.[42, CondSendable(nonSendable)])
+  // expected-warning@-1 {{type 'ReferenceWritableKeyPath<V, Int>' does not conform to the 'Sendable' protocol}}
+
+  // TODO: This should be diagnosed by the isolation checker because implicitly synthesized closures captures a non-Sendable value.
+  testSendableFn(v: v, \.[42, CondSendable(nonSendable)])
+}

--- a/test/Interpreter/keypath.swift
+++ b/test/Interpreter/keypath.swift
@@ -121,3 +121,16 @@ print(\Controller[[42], [42]])
 print(\Controller[array: [42]])
 // CHECK: \Controller.
 print(\Controller[array: [42], array2: [42]])
+
+do {
+  struct S {
+    var i: Int
+  }
+
+  func test<T, U>(v: T, _ kp: any KeyPath<T, U> & Sendable) {
+    print(v[keyPath: kp])
+  }
+
+  // CHECK: 42
+  test(v: S(i: 42), \.i)
+}


### PR DESCRIPTION
Gated by `InferSendableFromCaptures` experimental flag.

Swift forums pitch - https://forums.swift.org/t/pitch-inferring-sendable-for-methods-and-key-path-literals/68011

Sendability of key path expressions is expressed by means of protocol composition
between key path type and `Sendable` protocol i.e. `KeyPath<String, Int> & Sendable`.

Augment the key path capability inference to include sendability checking based 
on whether subscript component arguments captured by a key path are sendable
or not or, if there are subscript components a key path expression is always sendable.

Resolves: rdar://75861003

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
