### PR TITLE
[SwiftCompilerSources] Build without target OS checking

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -75,6 +75,7 @@ function(add_swift_compiler_modules_library name)
   set(swift_compile_options
       "-Xfrontend" "-validate-tbd-against-ir=none"
       "-Xfrontend" "-enable-experimental-cxx-interop"
+      "-Xfrontend" "-disable-target-os-checking"
       "-Xcc" "-std=c++17"
       "-Xcc" "-DCOMPILED_WITH_SWIFT"
       "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")


### PR DESCRIPTION
Temporarily workaround an availability issue with CxxStdlib when building with --bootstrapping=hosttools.

(The same workaround as https://github.com/apple/swift/pull/69577 but for SwiftCompilerSources)