### PR TITLE
[SILOpt] Fix mutable state in EagerSpecializer

### DIFF
--- a/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
@@ -746,7 +746,7 @@ SILValue EagerDispatch::emitArgumentConversion(
 
 namespace {
 class EagerSpecializerTransform : public SILFunctionTransform {
-  bool onlyCreatePrespecializations;
+  const bool onlyCreatePrespecializations;
 public:
   EagerSpecializerTransform(bool onlyPrespecialize)
       : onlyCreatePrespecializations(onlyPrespecialize) {}
@@ -833,6 +833,8 @@ void EagerSpecializerTransform::run() {
   // TODO: Use a decision-tree to reduce the amount of dynamic checks being
   // performed.
   SmallVector<SILSpecializeAttr *, 8> attrsToRemove;
+
+  bool onlyCreatePrespecializations = this->onlyCreatePrespecializations;
 
   for (auto *SA : F.getSpecializeAttrs()) {
     if (onlyCreatePrespecializations && !SA->isExported()) {

--- a/test/SILOptimizer/pre_specialize_rdar118554892.swift
+++ b/test/SILOptimizer/pre_specialize_rdar118554892.swift
@@ -1,13 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-stdlib -O -Xllvm -sil-disable-pass=function-signature-opts -emit-sil %s | %FileCheck %s
 
+// Regression test for rdar://118554892
+
 import Swift
 
 public struct Foo {}
 
 @_specializeExtension
 extension Array {
-
+  // The `target:` here triggered the bug we are testing for here. So while we don't test this
+  // specialization itself, it has to remain here for the test to properly function.
   @_specialize(exported: true,
                target: _endMutation(),
                where Element == Foo)
@@ -16,10 +19,11 @@ extension Array {
 }
 
 extension Sequence where Element: StringProtocol {
-  // CHECK-DAG: sil shared @$sST28pre_specialize_rdar118554892Sy7ElementRpzrlE3xxxSSyFSaySSG_Tg5 : $@convention(method) (@guaranteed Array<String>)
-  // CHECK-DAG: sil shared @$sST28pre_specialize_rdar118554892Sy7ElementRpzrlE3xxxSSyFSaySsG_Tg5 : $@convention(method) (@guaranteed Array<Substring>)
+  // CHECK-DAG: sil shared [noinline] @$sST28pre_specialize_rdar118554892Sy7ElementRpzrlE3xxxSSyFSaySSG_Tg5 : $@convention(method) (@guaranteed Array<String>)
+  // CHECK-DAG: sil shared [noinline] @$sST28pre_specialize_rdar118554892Sy7ElementRpzrlE3xxxSSyFSaySsG_Tg5 : $@convention(method) (@guaranteed Array<Substring>)
   @_specialize(where Self == Array<Substring>)
   @_specialize(where Self == Array<String>)
+  @inline(never) // prevent inlining the specialization into the function body
   public func xxx() -> String {
     return _xxx()
   }

--- a/test/SILOptimizer/pre_specialize_rdar118554892.swift
+++ b/test/SILOptimizer/pre_specialize_rdar118554892.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-stdlib -O -Xllvm -sil-disable-pass=function-signature-opts -emit-sil %s | %FileCheck %s
+
+import Swift
+
+public struct Foo {}
+
+@_specializeExtension
+extension Array {
+
+  @_specialize(exported: true,
+               target: _endMutation(),
+               where Element == Foo)
+  @usableFromInline
+  mutating func rdar118554892__specialize_class__endMutation(){ Builtin.unreachable() }
+}
+
+extension Sequence where Element: StringProtocol {
+  // CHECK-DAG: sil shared @$sST28pre_specialize_rdar118554892Sy7ElementRpzrlE3xxxSSyFSaySSG_Tg5 : $@convention(method) (@guaranteed Array<String>)
+  // CHECK-DAG: sil shared @$sST28pre_specialize_rdar118554892Sy7ElementRpzrlE3xxxSSyFSaySsG_Tg5 : $@convention(method) (@guaranteed Array<Substring>)
+  @_specialize(where Self == Array<Substring>)
+  @_specialize(where Self == Array<String>)
+  public func xxx() -> String {
+    return _xxx()
+  }
+
+  @inline(__always)
+  internal func _xxx() -> String {
+    var result = ""
+    for x in self {
+      result.append(x._ephemeralString)
+    }
+    return result
+  }
+}


### PR DESCRIPTION
rdar://118554892

On the first occurance of a `@_specialize` attribute with `target:` argument, `onlyCreatePrespecializations` would be set to `true`, preventing any subsequent pre-specializations with `exported: false`