### PR TITLE
Frontend: Add -experimental-skip-non-inlinable-function-bodies-is-lazy

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1130,6 +1130,11 @@ def experimental_skip_all_function_bodies:
   Flag<["-"], "experimental-skip-all-function-bodies">,
   HelpText<"Skip type-checking function bodies and all SIL generation">;
 
+def experimental_skip_non_inlinable_function_bodies_is_lazy
+  : Flag<["-"], "experimental-skip-non-inlinable-function-bodies-is-lazy">,
+  HelpText<"Infer lazy typechecking for "
+           "-experimental-skip-non-inlinable-function-bodies">;
+
 def experimental_allow_module_with_compiler_errors:
   Flag<["-"], "experimental-allow-module-with-compiler-errors">,
   Flags<[HelpHidden]>,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -322,6 +322,10 @@ bool ArgsToFrontendOptionsConverter::convert(
 
   Opts.SkipNonExportableDecls |=
       Args.hasArg(OPT_experimental_skip_non_exportable_decls);
+  Opts.SkipNonExportableDecls |=
+      Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
+      Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
+
   Opts.DebugPrefixSerializedDebuggingOptions |=
       Args.hasArg(OPT_prefix_serialized_debugging_options);
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -325,6 +325,12 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.SkipNonExportableDecls |=
       Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
       Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
+  // HACK: The driver currently erroneously passes all flags to module interface
+  // verification jobs. -experimental-skip-non-exportable-decls is not
+  // appropriate for verification tasks and should be ignored, though.
+  if (Opts.RequestedAction ==
+      FrontendOptions::ActionType::TypecheckModuleFromInterface)
+    Opts.SkipNonExportableDecls = false;
 
   Opts.DebugPrefixSerializedDebuggingOptions |=
       Args.hasArg(OPT_prefix_serialized_debugging_options);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1503,6 +1503,9 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);
 
   Opts.EnableLazyTypecheck |= Args.hasArg(OPT_experimental_lazy_typecheck);
+  Opts.EnableLazyTypecheck |=
+      Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
+      Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
 
   return HadError;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1506,6 +1506,12 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.EnableLazyTypecheck |=
       Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
       Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
+  // HACK: The driver currently erroneously passes all flags to module interface
+  // verification jobs. -experimental-skip-non-exportable-decls is not
+  // appropriate for verification tasks and should be ignored, though.
+  if (FrontendOpts.RequestedAction ==
+      FrontendOptions::ActionType::TypecheckModuleFromInterface)
+    Opts.EnableLazyTypecheck = false;
 
   return HadError;
 }

--- a/test/ModuleInterface/verify-module-interfaces-no-lazy-typecheck.swift
+++ b/test/ModuleInterface/verify-module-interfaces-no-lazy-typecheck.swift
@@ -1,0 +1,12 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 5.11
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name Test
+// expected-error @-3 {{failed to verify module interface of 'Test'}}
+import Swift
+public struct S {
+  @inlinable public func foo() {
+    doesNotExist() // expected-error {{cannot find 'doesNotExist' in scope}}
+  }
+}
+
+// RUN: %target-swift-typecheck-module-from-interface(%s) -module-name Test -verify -verify-ignore-unknown -experimental-lazy-typecheck

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -15,3 +15,8 @@
 //     and -experimental-skip-non-exportable-decls can be used by the same client as in (1).
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-exportable-decls
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-non-inlinable
+
+// (4) Verify that a module built with -experimental-skip-non-inlinable-function-bodies-is-lazy implies
+//     -experimental-lazy-typecheck and -experimental-skip-non-exportable-decls.
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable-is-lazy/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-inlinable-function-bodies-is-lazy
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-non-inlinable-is-lazy

--- a/test/Serialization/lazy-typecheck.swift
+++ b/test/Serialization/lazy-typecheck.swift
@@ -11,4 +11,7 @@
 // RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-all/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls
 // RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-all
 
-// FIXME: Re-run the test with -experimental-skip-non-inlinable-function-bodies
+// (3) Verify that a module built with -experimental-lazy-typecheck, -experimental-skip-non-inlinable-function-bodies,
+//     and -experimental-skip-non-exportable-decls can be used by the same client as in (1).
+// RUN: %target-swift-frontend -swift-version 5 %S/../Inputs/lazy_typecheck.swift -module-name lazy_typecheck -enable-library-evolution -parse-as-library -package-name Package -DFLAG -emit-module -emit-module-path %t/lazy-skip-non-inlinable/lazy_typecheck.swiftmodule -debug-forbid-typecheck-prefix NoTypecheck -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-exportable-decls
+// RUN: %target-swift-frontend -package-name Package -typecheck -verify %S/../Inputs/lazy_typecheck_client.swift -DFLAG -I %t/lazy-skip-non-inlinable


### PR DESCRIPTION
This option causes the `-experimental-lazy-typecheck` and `-experimental-skip-non-exportable-decls` options to be inferred from the presence of `-experimental-skip-non-inlinable-function-bodies`. This new option is meant to be a temporary testing aid that allows lazy typechecking to be tested on projects without full build system support for passing the other flags to the right jobs.

Also, ignore `-experimental-lazy-typecheck` during interface verification jobs, since the flag does not make sense during that action but the driver will pass the flag down regardless.
    
Resolves rdar://118938251