### PR TITLE
[Gardening] Fix typo.

### DIFF
--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -702,7 +702,7 @@ template <class Impl, bool isBitwiseTakable, size_t Size, size_t Alignment,
           bool hasExtraInhabitants>
 struct FixedSizeBufferValueWitnesses;
 
-/// A fixed size buffer value witness that can rely on the presents of the extra
+/// A fixed size buffer value witness that can rely on the presence of the extra
 /// inhabitant functions.
 template <class Impl, bool isBitwiseTakable, size_t Size, size_t Alignment>
 struct FixedSizeBufferValueWitnesses<Impl, isBitwiseTakable, Size, Alignment,
@@ -727,7 +727,7 @@ struct FixedSizeBufferValueWitnesses<Impl, isBitwiseTakable, Size, Alignment,
   }
 };
 
-/// A fixed size buffer value witness that cannot rely on the presents of the
+/// A fixed size buffer value witness that cannot rely on the presence of the
 /// extra inhabitant functions.
 template <class Impl, bool isBitwiseTakable, size_t Size, size_t Alignment>
 struct FixedSizeBufferValueWitnesses<Impl, isBitwiseTakable, Size, Alignment,


### PR DESCRIPTION
Replaced homophone of presence ("presents", i.e. 🎁🎁, 🖥️, etc.) with the word itself.
