### PR TITLE
Require asserts in tests enabling ExtractConstantsFromMembers feature

### DIFF
--- a/test/ConstExtraction/ExtractConstantsFromMembersAttribute.swift
+++ b/test/ConstExtraction/ExtractConstantsFromMembersAttribute.swift
@@ -4,6 +4,8 @@
 // RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractConstantsFromMembersAttribute.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s -enable-experimental-feature ExtractConstantsFromMembers
 // RUN: cat %t/ExtractConstantsFromMembersAttribute.swiftconstvalues 2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
+
 @extractConstantsFromMembers protocol MyProto {}
 public struct TestStruct : MyProto {
     let foo = "foo"

--- a/test/Parse/extractConstantsFromMembers_attr.swift
+++ b/test/Parse/extractConstantsFromMembers_attr.swift
@@ -1,4 +1,6 @@
 // RUN: %target-typecheck-verify-swift -parse -enable-experimental-feature ExtractConstantsFromMembers
 
+// REQUIRES: asserts
+
 @extractConstantsFromMembers
 protocol MyProto {}


### PR DESCRIPTION
The feature is experimental and thus tests using it must require asserts, lest they fail if run with a non assert toolchain.