### PR TITLE
[Compile Time Constant Extraction] Extract from all macro expansions

### DIFF
--- a/test/ConstExtraction/ExtractFromMacroExpansion.swift
+++ b/test/ConstExtraction/ExtractFromMacroExpansion.swift
@@ -1,0 +1,133 @@
+// REQUIRES: swift_swift_parser
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/Macros.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractFromMacroExpansion.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: cat %t/ExtractFromMacroExpansion.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto { }
+
+@freestanding(declaration, names: named(MacroAddedStruct))
+macro AddMacroAddedStruct() = #externalMacro(module: "MacroDefinition", type: "AddStructDeclMacro")
+
+@freestanding(declaration, names: named(macroAddedVar))
+macro AddMacroAddedVar() = #externalMacro(module: "MacroDefinition", type: "AddVarDeclMacro")
+
+@attached(extension, conformances: MyProto, names: prefixed(_extension_))
+macro AddExtension() = #externalMacro(module: "MacroDefinition", type: "AddExtensionMacro")
+
+@attached(peer, names: prefixed(_peer_))
+macro AddPeerVar() = #externalMacro(module: "MacroDefinition", type: "AddPeerVarMacro")
+
+@attached(member, names: prefixed(_member_))
+macro AddMemberVar() = #externalMacro(module: "MacroDefinition", type: "AddMemberMacro")
+
+@attached(memberAttribute)
+macro AddMacro() = #externalMacro(module: "MacroDefinition", type: "AddMemberAttributeMacro")
+
+@attached(accessor)
+macro AddGetter() = #externalMacro(module: "MacroDefinition", type: "GetterMacro")
+
+@attached(peer, names: prefixed(_Peer_))
+macro AddPeerStruct() = #externalMacro(module: "MacroDefinition", type: "AddPeerStructMacro")
+
+
+#AddMacroAddedStruct
+
+@AddExtension
+@AddMemberVar
+@AddPeerStruct
+struct MyStruct {
+  #AddMacroAddedVar
+  
+  @AddPeerVar
+  struct Inner { }
+}
+
+@AddMacro
+extension MyStruct {
+  func fromFunc() { }
+  
+  @AddGetter
+  var fromVar = 123
+}
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MacroAddedStruct",
+// CHECK: "properties": [
+// CHECK:   "label": "macroAddedStructMember",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "1"
+
+// CHECK:   "label": "_extension_MacroAddedStruct",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "3"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct",
+// CHECK: "properties": [
+// CHECK:   "label": "macroAddedVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "2"
+
+// CHECK:   "label": "_peer_Inner",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "4"
+
+// CHECK:   "label": "_member_MyStruct",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "5"
+
+// CHECK:   "label": "_peer_fromFunc",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "4"
+
+// CHECK:   "label": "_peer_fromVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "4"
+
+// CHECK:   "label": "fromVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "123"
+
+// CHECK:   "label": "_extension_MyStruct",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "3"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion._Peer_MyStruct",
+// CHECK: "properties": [
+// CHECK:   "label": "peerMacroVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "7"
+
+// CHECK:   "label": "macroAddedVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "2"
+
+// CHECK:   "label": "_peer_peerMacroVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "4"
+
+// CHECK:   "label": "_member__Peer_MyStruct",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "5"
+
+// CHECK:   "label": "_extension__Peer_MyStruct",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "3"

--- a/test/ConstExtraction/ExtractFromObjcImplementationExtension.swift
+++ b/test/ConstExtraction/ExtractFromObjcImplementationExtension.swift
@@ -1,0 +1,31 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractFromObjcImplementationExtension.swiftconstvalues -const-gather-protocols-file %t/protocols.json %s -import-objc-header %S/Inputs/objc_implementation.h -disable-objc-attr-requires-foundation-module
+// RUN: cat %t/ExtractFromObjcImplementationExtension.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto { }
+
+extension ImplClass: MyProto { 
+    static let notStoredProperty = true
+}
+
+@_objcImplementation extension ImplClass {
+    @objc var defaultIntProperty: CInt = 17
+    final weak var defaultNilProperty: AnyObject?
+}
+
+// CHECK: "typeName": "__ObjC.ImplClass",
+// CHECK: "properties": [
+// CHECK:   "label": "defaultIntProperty",
+// CHECK:   "type": "Swift.Int32",
+// CHECK:   "value": "17"
+
+// CHECK:   "label": "defaultNilProperty",
+// CHECK:   "type": "Swift.Optional<AnyObject>",
+// CHECK:   "value": "nil"
+
+// CHECK:   "label": "notStoredProperty",
+// CHECK:   "type": "Swift.Bool",
+// CHECK:   "value": "true"

--- a/test/ConstExtraction/Inputs/Macros.swift
+++ b/test/ConstExtraction/Inputs/Macros.swift
@@ -1,0 +1,156 @@
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AddStructDeclMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+    """
+    @AddExtension
+    struct MacroAddedStruct {
+      var macroAddedStructMember = 1
+    }
+    """
+    ]
+  }
+}
+
+public struct AddVarDeclMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+    """
+    static let macroAddedVar = 2
+    """
+    ]
+  }
+}
+
+public struct AddExtensionMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let typeName = declaration.declGroupName
+    return protocols.map {
+      ("extension \(typeName): \($0) { }" as DeclSyntax)
+        .cast(ExtensionDeclSyntax.self)
+    } + [
+    ("""
+    extension \(typeName) {
+      static let _extension_\(typeName) = 3
+    }
+    """ as DeclSyntax).cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
+public struct AddPeerVarMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let name = declaration.declName
+    return [
+    """
+    static var _peer_\(name) = 4
+    """
+    ]
+  }
+}
+
+public struct AddMemberMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let typeName = declaration.declGroupName
+    return [
+    """
+    static let _member_\(typeName) = 5
+    """
+    ]
+  }
+}
+
+public struct AddMemberAttributeMacro: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    if member.isProtocol(DeclGroupSyntax.self) {
+      return ["@AddExtension"]
+    }
+    return ["@AddPeerVar"]
+  }
+}
+
+public struct GetterMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    return ["get { 6 }"]
+  }
+}
+
+public struct AddPeerStructMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let name = declaration.declName
+    return [
+    """
+    @AddExtension
+    @AddMemberVar
+    struct _Peer_\(name) {
+      #AddMacroAddedVar
+      
+      @AddPeerVar
+      var peerMacroVar = 7
+    }
+    """
+    ]
+  }
+}
+
+extension DeclGroupSyntax {
+  var declGroupName: TokenSyntax {
+    if let structDecl = self.as(StructDeclSyntax.self) {
+      return structDecl.name.trimmed
+    }
+    fatalError("Not implemented")
+  }
+}
+
+extension DeclSyntaxProtocol {
+  var declName: TokenSyntax {
+    if let varDecl = self.as(VariableDeclSyntax.self),
+       let first = varDecl.bindings.first,
+       let pattern = first.pattern.as(IdentifierPatternSyntax.self) {
+      return pattern.identifier.trimmed
+    } else if let funcDecl = self.as(FunctionDeclSyntax.self) {
+      return funcDecl.name.trimmed
+    } else if let structDecl = self.as(StructDeclSyntax.self) {
+      return structDecl.name.trimmed
+    }
+    fatalError("Not implemented")
+  }
+}

--- a/test/ConstExtraction/Inputs/objc_implementation.h
+++ b/test/ConstExtraction/Inputs/objc_implementation.h
@@ -1,0 +1,8 @@
+@interface NSObject
+@end
+
+@interface ImplClass : NSObject
+
+@property int defaultIntProperty;
+
+@end


### PR DESCRIPTION
Extend constant extraction to extract:

1. members introduced by freestanding declaration macros and peer macros
2. from types introduced by peer macros

For example:

```swift
// expands to _Peer_MyStruct confomring to MyProto
@AddPeerStruct
struct MyStruct: MyProto {
  // expands to var macroAddedVar
  #AddMacroAddedVar

  // expands to var _peer_Inner
  @AddPeerVar
  struct Inner { }
}
```



Fix rdar://118948638