### PR TITLE
[Profiler] Fix handling of property wrapper backing inits

### DIFF
--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -295,6 +295,12 @@ struct MapRegionCounters : public ASTWalker {
     return LazyInitializerWalking::InAccessor;
   }
 
+  bool shouldWalkIntoPropertyWrapperPlaceholderValue() override {
+    // Don't walk into PropertyWrapperValuePlaceholderExprs, these should be
+    // mapped as part of the wrapped value initialization.
+    return false;
+  }
+
   void mapRegion(ASTNode N) {
     mapRegion(ProfileCounterRef::node(N));
   }
@@ -681,6 +687,12 @@ struct PGOMapping : public ASTWalker {
     // We want to walk lazy initializers present in the synthesized getter for
     // a lazy variable.
     return LazyInitializerWalking::InAccessor;
+  }
+
+  bool shouldWalkIntoPropertyWrapperPlaceholderValue() override {
+    // Don't walk into PropertyWrapperValuePlaceholderExprs, these should be
+    // mapped as part of the wrapped value initialization.
+    return false;
   }
 
   MacroWalking getMacroWalkingBehavior() const override {
@@ -1100,6 +1112,12 @@ public:
     // We want to walk lazy initializers present in the synthesized getter for
     // a lazy variable.
     return LazyInitializerWalking::InAccessor;
+  }
+
+  bool shouldWalkIntoPropertyWrapperPlaceholderValue() override {
+    // Don't walk into PropertyWrapperValuePlaceholderExprs, these should be
+    // mapped as part of the wrapped value initialization.
+    return false;
   }
 
   MacroWalking getMacroWalkingBehavior() const override {

--- a/test/Profiler/coverage_property_wrapper_backing.swift
+++ b/test/Profiler/coverage_property_wrapper_backing.swift
@@ -25,6 +25,29 @@ struct PassThroughWrapper<T> {
 // CHECK:       [[BB]]:
 // CHECK-NEXT:  increment_profiler_counter 1
 
+// CHECK-LABEL: sil hidden @$s33coverage_property_wrapper_backing1UV1xSivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+// CHECK:       function_ref @$sSb6randomSbyFZ : $@convention(method) (@thin Bool.Type) -> Bool
+// CHECK:       cond_br {{%[0-9]+}}, [[BB_TRUE:bb[0-9]+]], [[BB_FALSE:bb[0-9]+]]
+//
+// CHECK:       [[BB_FALSE]]:
+// CHECK:       integer_literal {{.*}}, 2
+//
+// CHECK:       [[BB_TRUE]]:
+// CHECK:       increment_profiler_counter 1
+// CHECK:       integer_literal {{.*}}, 1
+
+// CHECK-LABEL: sil hidden [transparent] @$s33coverage_property_wrapper_backing1UV2_{{.*}}7WrapperVySiGvpfi : $@convention(thin) () -> Int
+// CHECK:       increment_profiler_counter 0
+// CHECK:       function_ref @$sSb6randomSbyFZ : $@convention(method) (@thin Bool.Type) -> Bool
+// CHECK:       cond_br {{%[0-9]+}}, [[BB_TRUE:bb[0-9]+]], [[BB_FALSE:bb[0-9]+]]
+
+// CHECK:       [[BB_FALSE]]:
+// CHECK:       integer_literal {{.*}}, 4
+//
+// CHECK:       [[BB_TRUE]]:
+// CHECK:       increment_profiler_counter 1
+// CHECK:       integer_literal {{.*}}, 3
+
 struct S {
   // CHECK-LABEL: sil_coverage_map {{.*}} "$s33coverage_property_wrapper_backing1SV1iSivpfP" {{.*}} // property wrapper backing initializer of coverage_property_wrapper_backing.S.i
   // CHECK-NEXT:  [[@LINE+4]]:4 -> [[@LINE+4]]:30 : 0
@@ -55,3 +78,23 @@ struct T {
   @Wrapper(.random() ? 1 : 2)
   var k = 3
 }
+
+// rdar://118939162 - Make sure we don't include the initialization expression
+// in the backing initializer.
+struct U {
+  // CHECK-LABEL: sil_coverage_map {{.*}} // property wrapper backing initializer of coverage_property_wrapper_backing.U.x
+  // CHECK-NEXT:  [[@LINE+4]]:4  -> [[@LINE+4]]:30 : 0
+  // CHECK-NEXT:  [[@LINE+3]]:24 -> [[@LINE+3]]:25 : 1
+  // CHECK-NEXT:  [[@LINE+2]]:28 -> [[@LINE+2]]:29 : (0 - 1)
+  // CHECK-NEXT:  }
+  @Wrapper(.random() ? 1 : 2)
+  var x = if .random() { 3 } else { 4 }
+  // CHECK-LABEL: sil_coverage_map {{.*}} // variable initialization expression of coverage_property_wrapper_backing.U.(_x
+  // CHECK-NEXT:  [[@LINE-2]]:11 -> [[@LINE-2]]:40 : 0
+  // CHECK-NEXT:  [[@LINE-3]]:14 -> [[@LINE-3]]:23 : 0
+  // CHECK-NEXT:  [[@LINE-4]]:24 -> [[@LINE-4]]:29 : 1
+  // CHECK-NEXT:  [[@LINE-5]]:29 -> [[@LINE-5]]:40 : 0
+  // CHECK-NEXT:  [[@LINE-6]]:35 -> [[@LINE-6]]:40 : (0 - 1)
+  // CHECK-NEXT:  }
+}
+


### PR DESCRIPTION
Previously we were walking into the PropertyWrapperValuePlaceholderExpr when generating coverage for a property wrapper backing initializer. This meant that we were duplicating the coverage of the initializer expression, and it could cause crashes if a refined counter was introduced within the top-most expression region, such as with a throwing expression in a `try!`.

rdar://118939162