### PR TITLE
OSLogMandatoryOptTest.swift test REQUIRES: swift_stdlib_no_asserts

### DIFF
--- a/test/SILOptimizer/OSLogMandatoryOptTest.swift
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.swift
@@ -2,6 +2,8 @@
 //
 // REQUIRES: VENDOR=apple
 
+// REQUIRES: swift_stdlib_no_asserts
+
 // Tests for the OSLogOptimization pass that performs compile-time analysis
 // and optimization of the new os log APIs. The tests here check whether specific
 // compile-time constants such as the format string, the size of the byte buffer etc. are


### PR DESCRIPTION
This test began failing when we added begin_borrow [var_decl].

I'm not sure we want to maintain this optimization pass with an asserts stdlib. So here's a quick fix that disables the test.

@nate-chandler you might be interested in knowing why this fails after your begin_borrow changes.

@ravikandhadai do we care if this optimization works with an asserts stdlib?