### PR TITLE
[ConstraintSystem] A couple of fixes to Sendable inference on functions

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2469,7 +2469,10 @@ bool ConstraintSystem::isPartialApplication(ConstraintLocator *locator) {
 
   auto baseTy =
       simplifyType(getType(UDE->getBase()))->getWithoutSpecifierType();
-  return getApplicationLevel(*this, baseTy, UDE) < 2;
+  auto level = getApplicationLevel(*this, baseTy, UDE);
+  // Static members have base applied implicitly which means that their
+  // application level is lower.
+  return level < (baseTy->is<MetatypeType>() ? 1 : 2);
 }
 
 DeclReferenceType

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -206,3 +206,25 @@ func generic3<T>(_ x: T) async {
 
   await generic3(GenericS<NonSendable>.f)
 }
+
+// Make sure that static members are handled properly
+do {
+  struct X<T> {
+    init(_: T) {
+    }
+
+    static func test(_: T) {}
+  }
+
+  class Test<T> {
+    init(_: T) {
+      _ = X(self) // Ok
+      _ = X.init(self) // Ok
+      _ = Optional.some(self) // Ok
+
+      let _: @Sendable (Int) -> X<Int> = X.init // Ok
+      let _: @Sendable (Test<Int>) -> Void = X.test // Ok
+      let _ = X.test(self) // Ok
+    }
+  }
+}


### PR DESCRIPTION
- Fix `isPartialApplication` to properly handle static members

Only instance members require double-apply to be fully applied,
static members apply the base implicitly.

- Avoid delaying member lookup if:
  - Base is a metatype because static methods are always Sendable
    (because metatype is Sendable)
  - Lookup doesn't have any methods (properties are un-affected by
     the inference changes).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
