### PR TITLE
[swift-inspect] Deallocate symbolicator after inspecting a process

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -174,8 +174,8 @@ internal final class DarwinRemoteProcess: RemoteProcess {
 
   deinit {
     task_stop_peeking(self.task)
+    CSRelease(self.symbolicator)
     mach_port_deallocate(mach_task_self_, self.task)
-    mach_port_mod_refs(mach_task_self_, self.task, MACH_PORT_RIGHT_SEND, -1);
   }
 
   func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?) {

--- a/tools/swift-inspect/Sources/swift-inspect/Symbolication+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Symbolication+Extensions.swift
@@ -33,6 +33,8 @@ private func symbol<T>(_ handle: UnsafeMutableRawPointer, _ name: String) -> T {
 enum Sym {
   static let pidFromHint: @convention(c) (AnyObject) -> pid_t =
     symbol(symbolicationHandle, "pidFromHint")
+  static let CSRelease: @convention(c) (CSTypeRef) -> Void =
+    symbol(coreSymbolicationHandle, "CSRelease")
   static let CSSymbolicatorCreateWithTask: @convention(c) (task_t) -> CSTypeRef =
     symbol(coreSymbolicationHandle, "CSSymbolicatorCreateWithTask")
   static let CSSymbolicatorGetSymbolOwnerWithNameAtTime:
@@ -98,6 +100,10 @@ typealias CSSymbolOwnerRef = CSTypeRef
 func pidFromHint(_ hint: String) -> pid_t? {
   let result = Sym.pidFromHint(hint as NSString)
   return result == 0 ? nil : result
+}
+
+func CSRelease(_ sym: CSTypeRef) -> Void {
+  Sym.CSRelease(sym)
 }
 
 func CSSymbolicatorCreateWithTask(_ task: task_t) -> CSTypeRef {


### PR DESCRIPTION
This change deallocates the symbolicator. Added CSRelease to symbolication extensions.