### PR TITLE
[IRGen] Use memcpy for BitwiseCopyable archetypes.

### DIFF
--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -275,6 +275,13 @@ public:
         size.getValue());
   }
 
+  llvm::CallInst *CreateMemCpy(Address dest, Address src, llvm::Value *size) {
+    return CreateMemCpy(dest.getAddress(),
+                        llvm::MaybeAlign(dest.getAlignment().getValue()),
+                        src.getAddress(),
+                        llvm::MaybeAlign(src.getAlignment().getValue()), size);
+  }
+
   using IRBuilderBase::CreateMemSet;
   llvm::CallInst *CreateMemSet(Address dest, llvm::Value *value, Size size) {
     return CreateMemSet(dest.getAddress(), value, size.getValue(),

--- a/test/IRGen/bitwise-copyable-derived-loadRaw.swift
+++ b/test/IRGen/bitwise-copyable-derived-loadRaw.swift
@@ -1,0 +1,41 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature BuiltinModule -enable-experimental-feature BitwiseCopyable) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Execute an unaligned load of SIMD16<UInt8> which conforms to a protocol derived from BitwiseCopyable.
+
+public protocol MyBitwiseCopyable : _BitwiseCopyable {}
+
+extension SIMD16 : MyBitwiseCopyable {}
+
+func doit() {
+  let bytes: [UInt8] = Array(repeating: 0, count: 64)
+  bytes.withUnsafeBufferPointer { bytes in
+      let rawBytes = UnsafeRawPointer(bytes.baseAddress!) + 1
+      let vector = rawBytes.myLoadUnaligned(as: SIMD16<UInt8>.self)
+      //CHECK: SIMD16<UInt8>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+      blackhole(vector)
+  }
+}
+
+import Builtin
+
+extension UnsafeRawPointer {
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func myLoadUnaligned<T : MyBitwiseCopyable>(
+    fromByteOffset offset: Int = 0,
+    as type: T.Type
+  ) -> T {
+    return Builtin.loadRaw((self + offset)._rawValue)
+  }
+}
+
+doit()
+
+@_silgen_name("blackhole")
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func blackhole<T>(_ t: T) {
+  print(t) 
+}

--- a/test/IRGen/bitwise-copyable-loadRaw.swift
+++ b/test/IRGen/bitwise-copyable-loadRaw.swift
@@ -1,0 +1,39 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature BuiltinModule -enable-experimental-feature BitwiseCopyable -Xfrontend -disable-availability-checking) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Execute an unaligned load of SIMD16<UInt8> which retroactively conforms directly to BitwiseCopyable.
+
+extension SIMD16 : @retroactive _BitwiseCopyable {}
+
+func doit() {
+  let bytes: [UInt8] = Array(repeating: 0, count: 64)
+  bytes.withUnsafeBufferPointer { bytes in
+      let rawBytes = UnsafeRawPointer(bytes.baseAddress!) + 1
+      let vector = rawBytes.myLoadUnaligned(as: SIMD16<UInt8>.self)
+      //CHECK: SIMD16<UInt8>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+      blackhole(vector)
+  }
+}
+
+import Builtin
+
+extension UnsafeRawPointer {
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func myLoadUnaligned<T : _BitwiseCopyable>(
+    fromByteOffset offset: Int = 0,
+    as type: T.Type
+  ) -> T {
+    return Builtin.loadRaw((self + offset)._rawValue)
+  }
+}
+
+doit()
+
+@_silgen_name("blackhole")
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func blackhole<T>(_ t: T) {
+  print(t) 
+}


### PR DESCRIPTION
Based on https://github.com/apple/swift/pull/69938 .  This PR adds two new commits.

Besides being an optimization, using memcpy directly rather than a value witness is required in order to interact with unaligned instances of such types: the value witness functions expect their arguments to be aligned.

rdar://96919870

