### PR TITLE
[5.10] Fix LetPropertiesOpt crash on @_objcImplementation extensions

### DIFF
--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -239,7 +239,8 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
     return;
 
   auto *Ty = dyn_cast<NominalTypeDecl>(Property->getDeclContext());
-  if (SkipTypeProcessing.count(Ty))
+  // Ty is null for properties declared inside an extension of an ObjC type.
+  if (!Ty || SkipTypeProcessing.count(Ty))
     return;
 
   LLVM_DEBUG(llvm::dbgs() << "Replacing access to property '" << *Property

--- a/test/SILOptimizer/Inputs/let_properties_opts.h
+++ b/test/SILOptimizer/Inputs/let_properties_opts.h
@@ -3,3 +3,5 @@
 @interface ObjcInterface: NSObject
 @end
 
+@interface ObjcInterfaceConstInit: NSObject
+@end

--- a/test/SILOptimizer/let_properties_opts_objc.swift
+++ b/test/SILOptimizer/let_properties_opts_objc.swift
@@ -16,3 +16,14 @@ public func testObjcInterface(_ x: ObjcInterface) -> Int {
   return x.i
 }
 
+// Test optimization of a private constant. This constant must be declared in a separate type without other fields.
+@_objcImplementation extension ObjcInterfaceConstInit {
+  private let constant: Int = 0
+
+  // CHECK-LABEL: sil hidden @$sSo22ObjcInterfaceConstInitC4testE0E15PrivateConstantSiyF : $@convention(method) (@guaranteed ObjcInterfaceConstInit) -> Int {
+  // CHECK: ref_element_addr %0 : $ObjcInterfaceConstInit, #ObjcInterfaceConstInit.constant
+  // CHECK-LABEL: } // end sil function '$sSo22ObjcInterfaceConstInitC4testE0E15PrivateConstantSiyF'
+  final func testPrivateConstant() -> Int {
+    return constant
+  }
+}


### PR DESCRIPTION
Fixes rdar://115139065 (Swift Compiler; @_objcImplementation; crash in LetPropertiesOpt)

(cherry picked from commit 98dabf9a2b29ed8fc3023bd392b5d100931349b4)

--- CCC ---
Explanation: LetPropertiesOpts assumes that each property is declared in a nominal type. This is not true with `@_objcImplementation`. The previous fix was incomplete: rdar://103381746.

Scope: -O build; private @_objcImplementation extension; constant private property

Issue: rdar://115139065 (Swift Compiler Crash; @_objcImplementation; crash in LetPropertiesOpt)

Risk: Zero. Bypass optimization on a condition that would always crash.

PR to main: https://github.com/apple/swift/pull/70113

Testing: Added regression test to the test suite

Reviewer: @eeckstein