### PR TITLE
deinit-devirtualization: correctly handle drop_deinit for address types

### DIFF
--- a/test/SILOptimizer/devirt_deinits.sil
+++ b/test/SILOptimizer/devirt_deinits.sil
@@ -235,18 +235,6 @@ bb0(%0 : $*E2):
   return %r : $()
 }
 
-// CHECK-LABEL: sil [ossa] @test_drop_deinit_addr :
-// CHECK:         %1 = drop_deinit %0
-// CHECK:         end_lifetime %1
-// CHECK:       } // end sil function 'test_drop_deinit_addr'
-sil [ossa] @test_drop_deinit_addr : $@convention(thin) (@in S1) -> () {
-bb0(%0 : $*S1):
-  %1 = drop_deinit %0 : $*S1
-  destroy_addr %1 : $*S1
-  %r = tuple()
-  return %r : $()
-}
-
 // CHECK-LABEL: sil [ossa] @test_two_field_drop_deinit_addr :
 // CHECK:         %1 = drop_deinit %0
 // CHECK:         [[A1:%.*]] = struct_element_addr %1 : $*S4, #S4.a
@@ -261,7 +249,10 @@ bb0(%0 : $*S1):
 sil [ossa] @test_two_field_drop_deinit_addr : $@convention(thin) (@in S4) -> () {
 bb0(%0 : $*S4):
   %1 = drop_deinit %0 : $*S4
-  destroy_addr %1 : $*S4
+  %2 = struct_element_addr %1 : $*S4, #S4.a
+  destroy_addr %2 : $*S1
+  %4 = struct_element_addr %1 : $*S4, #S4.b
+  destroy_addr %4 : $*S2
   %r = tuple()
   return %r : $()
 }

--- a/test/SILOptimizer/moveonly_deinit_devirtualization.sil
+++ b/test/SILOptimizer/moveonly_deinit_devirtualization.sil
@@ -329,18 +329,6 @@ bb0(%0 : @owned $StructDeinit):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in StructDeinit) -> () {
-// CHECK:         %1 = drop_deinit %0
-// CHECK-NEXT:    end_lifetime %1
-// CHECK:       } // end sil function 'dropDeinitOnIndirectStruct'
-sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in StructDeinit) -> () {
-bb0(%0 : $*StructDeinit):
-  %1 = drop_deinit %0 : $*StructDeinit
-  destroy_addr %1 : $*StructDeinit
-  %9999 = tuple()
-  return %9999 : $()
-}
-
 sil @$s4main5KlassCfD : $@convention(method) (@owned Klass) -> ()
 sil @$s4main5KlassCACycfc : $@convention(method) (@owned Klass) -> @owned Klass
 sil @$s4main5KlassCfd : $@convention(method) (@guaranteed Klass) -> @owned Builtin.NativeObject

--- a/test/SILOptimizer/moveonly_deinit_devirtualization_library_evolution.sil
+++ b/test/SILOptimizer/moveonly_deinit_devirtualization_library_evolution.sil
@@ -331,18 +331,6 @@ bb0(%0 : @owned $StructDeinit):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in StructDeinit) -> () {
-// CHECK:         %1 = drop_deinit %0
-// CHECK-NEXT:    end_lifetime %1
-// CHECK:       } // end sil function 'dropDeinitOnIndirectStruct'
-sil [ossa] @dropDeinitOnIndirectStruct : $@convention(thin) (@in StructDeinit) -> () {
-bb0(%0 : $*StructDeinit):
-  %1 = drop_deinit %0 : $*StructDeinit
-  destroy_addr %1 : $*StructDeinit
-  %9999 = tuple()
-  return %9999 : $()
-}
-
 sil @$s4main5KlassCfD : $@convention(method) (@owned Klass) -> ()
 sil @$s4main5KlassCACycfc : $@convention(method) (@owned Klass) -> @owned Klass
 sil @$s4main5KlassCfd : $@convention(method) (@guaranteed Klass) -> @owned Builtin.NativeObject


### PR DESCRIPTION
Make it clear that drop_deinit cannot be used to prevent a deinit called from a destroy_addr. This is more a refactoring and clarification than a bug fix, because a destroy_addr cannot have a drop_deinit as operand, anyway.

This is a follow-up on https://github.com/apple/swift/pull/69955