### PR TITLE
[5.10] [Profiler] Remove an assertion

### DIFF
--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -781,7 +781,8 @@ private:
   /// Subtract \c Expr from \c Node's counter.
   void subtractFromCounter(ASTNode Node, CounterExpr Expr) {
     auto Counter = getCounter(Node);
-    assert(!Counter.isZero() && "Cannot create a negative counter");
+    // FIXME: This assertion ought to be restored (rdar://100470244)
+    // assert(!Counter.isZero() && "Cannot create a negative counter");
     assignCounter(Node,
                   CounterExpr::Sub(Counter, std::move(Expr), CounterBuilder));
   }

--- a/test/Profiler/rdar118896974.swift
+++ b/test/Profiler/rdar118896974.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
+
+// rdar://118896974 - Make sure we don't crash.
+func foo() {
+  do {
+    return
+  } catch {
+    return
+  }
+}


### PR DESCRIPTION
- Explanation: Due to the recent change to how we simplify counters (rdar://118185163), we can now end up hitting this assertion for certain do-catch statements. The counter has always been wrong here, and previously would have underflowed at runtime (rdar://100470244). This issue has been properly fixed on main, but we haven't cherry-picked that fix to 5.10 since it requires a bunch of other changes. For now, just remove the assertion to maintain the previous behavior.
- Scope: Affects code coverage for do-catch statements
- Issue: rdar://118896974
- Risk: Low, this just removes an assertion
- Testing: Added test to test suite
- Reviewer: Ben Barham

Resolves #70072