### PR TITLE
[Profiler] Avoid crashing on redundant break in repeat-while

### DIFF
--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -907,6 +907,9 @@ private:
 
   /// Subtract \c Expr from \c Node's counter.
   void subtractFromCounter(ASTNode Node, CounterExpr Expr) {
+    if (Expr.isZero())
+      return;
+
     auto Counter = getCounter(Node);
     assert(!Counter.isZero() && "Cannot create a negative counter");
     assignCounter(Node,

--- a/test/Profiler/coverage_while.swift
+++ b/test/Profiler/coverage_while.swift
@@ -130,3 +130,12 @@ func hoo() {       // CHECK-NEXT: [[@LINE]]:12 -> [[@LINE+5]]:2 : 0
     i += 1         // CHECK-NEXT: [[@LINE-1]]:18 -> [[@LINE+1]]:4 : 1
   }                // CHECK-NEXT: [[@LINE]]:4 -> [[@LINE+1]]:2 : 0
 }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_while.ioo
+func ioo() {   // CHECK-NEXT: [[@LINE]]:12   -> [[@LINE+6]]:2  : 0
+  repeat {     // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+3]]:4  : 1
+    break      // CHECK-NEXT: [[@LINE+1]]:5  -> [[@LINE+1]]:10 : zero
+    break      // FIXME: This next region seems wrong, we exit the loop the same number of times we enter (rdar://118472537).
+  } while true // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+2]]:2  : (0 - 1)
+               // CHECK-NEXT: [[@LINE-1]]:11 -> [[@LINE-1]]:15 : zero
+}              // CHECK-NEXT: }


### PR DESCRIPTION
Treat subtracting zero as a no-op, avoiding the assertion guarding against creating negative counters.