### PR TITLE
[Runtime] Assert the correct name when retrieving standard Concurrency type descriptors.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -815,6 +815,10 @@ descriptorFromStandardMangling(Demangle::NodePointer symbolicNode) {
   // we will be able to reference those symbols directly as well.
 #define STANDARD_TYPE_CONCURRENCY(KIND, MANGLING, TYPENAME)                    \
   if (concurrencyDescriptors && name.equals(#TYPENAME)) {                      \
+    assert(isa<TypeContextDescriptor>(concurrencyDescriptors->TYPENAME));      \
+    assert(name == reinterpret_cast<const TypeContextDescriptor *>(            \
+                       concurrencyDescriptors->TYPENAME)                       \
+                       ->Name.get());                                          \
     return concurrencyDescriptors->TYPENAME;                                   \
   }
 #if !SWIFT_OBJC_INTEROP


### PR DESCRIPTION
If the runtime and Concurrency runtime are mismatched and have different, we can end up grabbing the wrong descriptor when looking up a standard Concurrency type. If they have different declarations of ConcurrencyStandardTypeDescriptors then the fields can be misaligned, causing us to retrieve the wrong one. This can cause extremely confusing type lookup failures or other crashes.

To better detect this problem in asserts builds, add an assert that the descriptor we got from concurrencyDescriptors actually has the right name.