### PR TITLE
Allow preamble macros to introduce declarations with documented names

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -155,7 +155,7 @@ private:
   /// Child scopes, sorted by source range.
   Children storedChildren;
 
-  mutable llvm::Optional<CharSourceRange> cachedCharSourceRange;
+  mutable llvm::Optional<SourceRange> cachedCharSourceRange;
 
 #pragma mark - constructor / destructor
 public:
@@ -194,8 +194,17 @@ public:
 #pragma mark - source ranges
 
 public:
-  CharSourceRange getCharSourceRangeOfScope(SourceManager &SM,
-                                            bool omitAssertions = false) const;
+  /// Retrieve the source range of the given scope, where the end location
+  /// is adjusted to refer to the end of the token.
+  ///
+  /// Since the adjustment to the end of the token requires lexing, this
+  /// routine also caches the result.
+  ///
+  /// Note that the start and end locations might be in different source
+  /// buffers, so we represent the result as SourceRange rather than
+  /// CharSourceRange.
+  SourceRange getCharSourceRangeOfScope(SourceManager &SM,
+                                        bool omitAssertions = false) const;
   bool isCharSourceRangeCached() const;
 
   /// Returns source range of this node alone, without factoring in any

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/FileSystem.h"
 #include "swift/Basic/SourceLoc.h"
 #include "clang/Basic/FileManager.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/None.h"
 #include "llvm/ADT/Optional.h"
@@ -69,6 +70,10 @@ public:
   /// The name of the source file on disk that was created to hold the
   /// contents of this file for external clients.
   StringRef onDiskBufferCopyFileName = StringRef();
+
+  /// Contains the ancestors of this source buffer, starting with the root source
+  /// buffer and ending at this source buffer.
+  mutable llvm::ArrayRef<unsigned> ancestors = llvm::ArrayRef<unsigned>();
 };
 
 /// This class manages and owns source buffers.
@@ -205,6 +210,15 @@ public:
   llvm::Optional<GeneratedSourceInfo>
   getGeneratedSourceInfo(unsigned bufferID) const;
 
+  /// Retrieve the list of ancestors of the given source buffer, starting with
+  /// the root buffer and proceding to the given buffer ID at the end.
+  ///
+  /// The scratch parameter will be used to avoid allocation in the case where
+  /// the given buffer ID is the top-level buffer, in which case bufferID will
+  /// be written into scratch at the returned array will contain that one
+  /// element.
+  ArrayRef<unsigned> getAncestors(unsigned bufferID, unsigned &scratch) const;
+
   /// Record the starting source location of a regex literal.
   void recordRegexLiteralStartLoc(SourceLoc loc) {
     RegexLiteralStartLocs.insert(loc);
@@ -216,13 +230,35 @@ public:
     return RegexLiteralStartLocs.contains(loc);
   }
 
-  /// Returns true if \c LHS is before \c RHS in the source buffer.
+  /// Returns true if \c first is before \c second in the same source file,
+  /// accounting for the possibility that first and second are in different
+  /// source buffers that are conceptually within the same source file,
+  /// due to macro expansion.
+  bool isBefore(SourceLoc first, SourceLoc second) const;
+
+  /// Returns true if \c first is at or before \c second in the same source
+  /// file, accounting for the possibility that first and second are in
+  /// different source buffers that are conceptually within the same source
+  /// file, due to macro expansion.
+  bool isAtOrBefore(SourceLoc first, SourceLoc second) const;
+
+  /// Returns true if \c LHS is before \c RHS in the same source buffer.
   bool isBeforeInBuffer(SourceLoc LHS, SourceLoc RHS) const {
     return LHS.Value.getPointer() < RHS.Value.getPointer();
   }
 
-  /// Returns true if range \c R contains the location \c Loc.  The location
-  /// \c Loc should point at the beginning of the token.
+  /// Returns true if \c range contains the location \c loc.  The location
+  /// \c loc should point at the beginning of the token.
+  ///
+  /// This function accounts for the possibility that the source locations
+  /// provided might come from different source buffers that are conceptually
+  /// part of the same source file, for example due to macro expansion.
+  bool containsTokenLoc(SourceRange range, SourceLoc loc) const;
+
+  /// Returns true if range \c R contains the location \c Loc, where all
+  /// locations are known to be in the same source buffer.
+  ///
+  /// The location \c Loc should point at the beginning of the token.
   bool rangeContainsTokenLoc(SourceRange R, SourceLoc Loc) const {
     return Loc == R.Start || Loc == R.End ||
            (isBeforeInBuffer(R.Start, Loc) && isBeforeInBuffer(Loc, R.End));

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -255,6 +255,20 @@ public:
   /// part of the same source file, for example due to macro expansion.
   bool containsTokenLoc(SourceRange range, SourceLoc loc) const;
 
+  /// Returns true if \c range contains the location \c loc.
+  ///
+  /// This function accounts for the possibility that the source locations
+  /// provided might come from different source buffers that are conceptually
+  /// part of the same source file, for example due to macro expansion.
+  bool containsLoc(SourceRange range, SourceLoc loc) const;
+
+  /// Returns true if \c enclosing contains the whole range \c inner.
+  ///
+  /// This function accounts for the possibility that the source locations
+  /// provided might come from different source buffers that are conceptually
+  /// part of the same source file, for example due to macro expansion.
+  bool encloses(SourceRange enclosing, SourceRange inner) const;
+
   /// Returns true if range \c R contains the location \c Loc, where all
   /// locations are known to be in the same source buffer.
   ///

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1323,7 +1323,7 @@ AbstractPatternEntryScope::AbstractPatternEntryScope(
 #pragma mark - expandBody
 
 void FunctionBodyScope::expandBody(ScopeCreator &scopeCreator) {
-  scopeCreator.addToScopeTree(decl->getBody(), this);
+  scopeCreator.addToScopeTree(decl->getMacroExpandedBody(), this);
 }
 
 void GenericTypeOrExtensionScope::expandBody(ScopeCreator &) {}

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -120,20 +120,16 @@ ASTScopeImpl::findChildContaining(ModuleDecl *parentModule,
   auto *const *child = llvm::lower_bound(
       getChildren(), loc,
       [&](const ASTScopeImpl *scope, SourceLoc loc) {
-        auto rangeOfScope = scope->getSourceRangeOfThisASTNode();
-        auto endOfScope =
-            Lexer::getLocForEndOfToken(sourceMgr, rangeOfScope.End);
-
+        auto rangeOfScope = scope->getCharSourceRangeOfScope(sourceMgr);
         loc = translateLocForReplacedRange(sourceMgr, rangeOfScope.Start, loc);
-        return sourceMgr.isAtOrBefore(endOfScope, loc);
+        return sourceMgr.isAtOrBefore(rangeOfScope.End, loc);
       });
 
   if (child != getChildren().end()) {
-    auto rangeOfScope = (*child)->getSourceRangeOfThisASTNode();
-    auto endOfScope = Lexer::getLocForEndOfToken(sourceMgr, rangeOfScope.End);
+    auto rangeOfScope = (*child)->getCharSourceRangeOfScope(sourceMgr);
     loc = translateLocForReplacedRange(sourceMgr, rangeOfScope.Start, loc);
     if (sourceMgr.isAtOrBefore(rangeOfScope.Start, loc) &&
-        sourceMgr.isBefore(loc, endOfScope))
+        sourceMgr.isBefore(loc, rangeOfScope.End))
       return *child;
   }
 

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -38,6 +38,14 @@ using namespace ast_scope;
 
 static SourceLoc getLocAfterExtendedNominal(const ExtensionDecl *);
 
+/// Retrieve the character-based source range for the given source range.
+static SourceRange getCharSourceRange(
+    SourceManager &sourceMgr, SourceRange range
+){
+  range.End = Lexer::getLocForEndOfToken(sourceMgr, range.End);
+  return range;
+}
+
 void ASTScopeImpl::checkSourceRangeBeforeAddingChild(ASTScopeImpl *child,
                                                      const ASTContext &ctx) const {
   // Ignore debugger bindings - they're a special mix of user code and implicit
@@ -51,35 +59,18 @@ void ASTScopeImpl::checkSourceRangeBeforeAddingChild(ASTScopeImpl *child,
 
   auto range = getCharSourceRangeOfScope(sourceMgr);
 
-  std::function<bool(CharSourceRange)> containedInParent;
-  containedInParent = [&](CharSourceRange childCharRange) {
+  std::function<bool(SourceRange)> containedInParent;
+  containedInParent = [&](SourceRange childCharRange) {
     // HACK: For code completion. Handle replaced range.
     for (const auto &pair : sourceMgr.getReplacedRanges()) {
-      auto originalRange =
-          Lexer::getCharSourceRangeFromSourceRange(sourceMgr, pair.first);
-      auto newRange =
-          Lexer::getCharSourceRangeFromSourceRange(sourceMgr, pair.second);
-      if (range.contains(originalRange) &&
-          newRange.contains(childCharRange))
+      auto originalRange = getCharSourceRange(sourceMgr, pair.first);
+      auto newRange = getCharSourceRange(sourceMgr, pair.second);
+      if (sourceMgr.encloses(range, originalRange) &&
+          sourceMgr.encloses(newRange, childCharRange))
         return true;
     }
 
-    if (range.contains(childCharRange))
-      return true;
-
-    // If this is from a macro expansion, look at the where the expansion
-    // occurred.
-    auto childBufferID =
-      sourceMgr.findBufferContainingLoc(childCharRange.getStart());
-    auto generatedInfo = sourceMgr.getGeneratedSourceInfo(childBufferID);
-    if (!generatedInfo)
-      return false;
-
-    CharSourceRange expansionRange = generatedInfo->originalSourceRange;
-    if (expansionRange.isInvalid())
-      return false;
-
-    return containedInParent(expansionRange);
+    return sourceMgr.encloses(range, childCharRange);
   };
 
   auto childCharRange = child->getCharSourceRangeOfScope(sourceMgr);
@@ -95,11 +86,9 @@ void ASTScopeImpl::checkSourceRangeBeforeAddingChild(ASTScopeImpl *child,
   if (!storedChildren.empty()) {
     auto previousChild = storedChildren.back();
     auto endOfPreviousChild = previousChild->getCharSourceRangeOfScope(
-        sourceMgr).getEnd();
+        sourceMgr).End;
 
-    if (childCharRange.getStart() != endOfPreviousChild &&
-        !sourceMgr.isBeforeInBuffer(endOfPreviousChild,
-                                    childCharRange.getStart())) {
+    if (!sourceMgr.isAtOrBefore(endOfPreviousChild, childCharRange.Start)) {
       auto &out = verificationError() << "child overlaps previous child:\n";
       child->print(out);
       out << "\n***Previous child\n";
@@ -384,18 +373,19 @@ SourceRange GuardStmtBodyScope::getSourceRangeOfThisASTNode(
 
 #pragma mark source range caching
 
-CharSourceRange
+SourceRange
 ASTScopeImpl::getCharSourceRangeOfScope(SourceManager &SM,
                                         bool omitAssertions) const {
   if (!isCharSourceRangeCached()) {
     auto range = getSourceRangeOfThisASTNode(omitAssertions);
     ASTScopeAssert(range.isValid(), "scope has invalid source range");
-    ASTScopeAssert(SM.isBeforeInBuffer(range.Start, range.End) ||
+    ASTScopeAssert(SM.isBefore(range.Start, range.End) ||
                    range.Start == range.End,
                    "scope source range ends before start");
 
-    cachedCharSourceRange =
-      Lexer::getCharSourceRangeFromSourceRange(SM, range);
+    range.End = Lexer::getLocForEndOfToken(SM, range.End);
+
+    cachedCharSourceRange = range;
   }
 
   return *cachedCharSourceRange;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9117,24 +9117,74 @@ bool AbstractFunctionDecl::hasBody() const {
   }
 }
 
+/// Expand all preamble macros attached to the given function declaration.
+static std::vector<ASTNode> expandPreamble(AbstractFunctionDecl *func) {
+  std::vector<ASTNode> preamble;
 
+  ASTContext &ctx = func->getASTContext();
+  ExpandPreambleMacroRequest request{func};
+  auto module = func->getParentModule();
+  for (auto bufferID : evaluateOrDefault(ctx.evaluator, request, { })) {
+    auto bufferStart = ctx.SourceMgr.getLocForBufferStart(bufferID);
+    auto preambleSF = module->getSourceFileContainingLocation(bufferStart);
+    preamble.insert(preamble.end(),
+                    preambleSF->getTopLevelItems().begin(),
+                    preambleSF->getTopLevelItems().end());
+  }
+
+  return preamble;
+}
+
+/// Expand body macros and produce the resulting body.
 static BraceStmt *expandBodyMacro(AbstractFunctionDecl *fn) {
   ASTContext &ctx = fn->getASTContext();
 
-  auto bufferID = evaluateOrDefault(
-      ctx.evaluator, ExpandBodyMacroRequest{fn}, llvm::None);
-  if (!bufferID) {
+  // Expand the preamble.
+  auto preamble = expandPreamble(fn);
+
+  // Expand a body macro, if there is one.
+  if (auto bufferID = evaluateOrDefault(
+          ctx.evaluator, ExpandBodyMacroRequest{fn}, llvm::None)) {
+    CharSourceRange bufferRange = ctx.SourceMgr.getRangeForBuffer(*bufferID);
+    auto bufferStart = bufferRange.getStart();
+    auto module = fn->getParentModule();
+    auto macroSourceFile = module->getSourceFileContainingLocation(bufferStart);
+
+    // When there is no preamble, adopt the body itself.
+    if (preamble.empty()) {
+      return BraceStmt::create(
+          ctx, bufferRange.getStart(), macroSourceFile->getTopLevelItems(),
+          bufferRange.getEnd());
+    }
+
+    // Merge the preamble into the macro-produced body.
+    auto contents = std::move(preamble);
+    contents.insert(
+        contents.end(),
+        macroSourceFile->getTopLevelItems().begin(),
+        macroSourceFile->getTopLevelItems().end());
+    return BraceStmt::create(
+        ctx, bufferRange.getStart(), contents, bufferRange.getEnd());
+  }
+
+  // There is no body macro. If there's no preamble, either, then there is
+  // nothing to do.
+  if (preamble.empty())
+    return nullptr;
+
+  // If there is no body, the preamble has nowhere to go.
+  auto body = fn->getBody(/*canSynthesize=*/true);
+  if (!body) {
+    // FIXME: diagnose this
     return nullptr;
   }
 
-  CharSourceRange bufferRange = ctx.SourceMgr.getRangeForBuffer(*bufferID);
-  auto bufferStart = bufferRange.getStart();
-  auto module = fn->getParentModule();
-  auto macroSourceFile = module->getSourceFileContainingLocation(bufferStart);
-
+  // Merge the preamble into the existing body.
+  auto contents = std::move(preamble);
+  contents.insert(
+      contents.end(), body->getElements().begin(), body->getElements().end());
   return BraceStmt::create(
-      ctx, bufferRange.getStart(), macroSourceFile->getTopLevelItems(),
-      bufferRange.getEnd());
+      ctx, body->getLBraceLoc(), contents, body->getRBraceLoc());
 }
 
 BraceStmt *AbstractFunctionDecl::getMacroExpandedBody() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1026,16 +1026,7 @@ void IterableDeclContext::addMemberSilently(Decl *member, Decl *hint,
     assert(nextStart.isValid() &&
            "Only implicit decls can have invalid source location");
 
-    if (getASTContext().SourceMgr.isBeforeInBuffer(prevEnd, nextStart))
-      return;
-
-    // Synthesized member macros can add new members in a macro expansion buffer.
-    SourceFile *memberSourceFile = member->getLoc()
-        ? member->getModuleContext()
-                ->getSourceFileContainingLocation(member->getLoc())
-        : member->getInnermostDeclContext()->getParentSourceFile();
-    if (memberSourceFile->getFulfilledMacroRole() == MacroRole::Member ||
-        memberSourceFile->getFulfilledMacroRole() == MacroRole::Peer)
+    if (getASTContext().SourceMgr.isAtOrBefore(prevEnd, nextStart))
       return;
 
     llvm::errs() << "Source ranges out of order in addMember():\n";

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1665,6 +1665,15 @@ bool
 namelookup::isInMacroArgument(SourceFile *sourceFile, SourceLoc loc) {
   bool inMacroArgument = false;
 
+  // Make sure that the source location is actually within the given source
+  // file.
+  if (sourceFile && loc.isValid()) {
+    sourceFile =
+        sourceFile->getParentModule()->getSourceFileContainingLocation(loc);
+    if (!sourceFile)
+      return false;
+  }
+
   ASTScope::lookupEnclosingMacroScope(
       sourceFile, loc,
       [&](auto potentialMacro) -> bool {

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -817,3 +817,12 @@ bool SourceManager::isAtOrBefore(SourceLoc first, SourceLoc second) const {
 bool SourceManager::containsTokenLoc(SourceRange range, SourceLoc loc) const {
   return isAtOrBefore(range.Start, loc) && isAtOrBefore(loc, range.End);
 }
+
+bool SourceManager::containsLoc(SourceRange range, SourceLoc loc) const {
+  return isAtOrBefore(range.Start, loc) && isBefore(loc, range.End);
+}
+
+bool SourceManager::encloses(SourceRange enclosing, SourceRange inner) const {
+  return containsLoc(enclosing, inner.Start) &&
+      isAtOrBefore(inner.End, enclosing.End);
+}

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -216,6 +216,10 @@ SourceManager::getIDForBufferIdentifier(StringRef BufIdentifier) const {
 SourceManager::~SourceManager() {
   for (auto &generated : GeneratedSourceInfos) {
     free((void*)generated.second.onDiskBufferCopyFileName.data());
+
+    if (generated.second.ancestors.size() > 0) {
+      delete [] generated.second.ancestors.data();
+    }
   }
 }
 
@@ -716,4 +720,100 @@ SourceManager::getLocForForeignLoc(SourceLoc otherLoc,
   }
 
   return SourceLoc();
+}
+
+/// Populate the ancestors list for this buffer, with the root source buffer
+/// at the beginning and the given source buffer at the end.
+static void populateAncestors(
+    const SourceManager &sourceMgr, unsigned bufferID,
+    SmallVectorImpl<unsigned> &ancestors) {
+  if (auto info = sourceMgr.getGeneratedSourceInfo(bufferID)) {
+    auto ancestorLoc = info->originalSourceRange.getStart();
+    if (ancestorLoc.isValid()) {
+      auto ancestorBufferID = sourceMgr.findBufferContainingLoc(ancestorLoc);
+      populateAncestors(sourceMgr, ancestorBufferID, ancestors);
+    }
+  }
+
+  ancestors.push_back(bufferID);
+}
+
+ArrayRef<unsigned> SourceManager::getAncestors(
+    unsigned bufferID, unsigned &scratch
+) const {
+  // If there is no generated source information for this buffer, then this is
+  // the only buffer here. Avoid memory allocation by using the scratch space
+  // we were given.
+  auto knownInfo = GeneratedSourceInfos.find(bufferID);
+  if (knownInfo == GeneratedSourceInfos.end()) {
+    scratch = bufferID;
+    return ArrayRef<unsigned>(&scratch, 1);
+  }
+
+  // If we already have the ancestors cached, use them.
+  if (!knownInfo->second.ancestors.empty())
+    return knownInfo->second.ancestors;
+
+  // Compute all of the ancestors. We only do this once for a given buffer.
+  SmallVector<unsigned, 4> ancestors;
+  populateAncestors(*this, bufferID, ancestors);
+
+  // Cache the ancestors in the generated source info record.
+  unsigned *ancestorsPtr = new unsigned [ancestors.size()];
+  std::copy(ancestors.begin(), ancestors.end(), ancestorsPtr);
+  knownInfo->second.ancestors = llvm::makeArrayRef(ancestorsPtr, ancestors.size());
+  return knownInfo->second.ancestors;
+}
+
+
+/// Determine whether the first source location precedes the second, accounting
+/// for macro expansions.
+static bool isBeforeInSource(
+    const SourceManager &sourceMgr, SourceLoc firstLoc, SourceLoc secondLoc,
+    bool allowEqual) {
+  // If the two locations are in the same source buffer, compare their pointers.
+  unsigned firstBufferID = sourceMgr.findBufferContainingLoc(firstLoc);
+  unsigned secondBufferID = sourceMgr.findBufferContainingLoc(secondLoc);
+  if (firstBufferID == secondBufferID) {
+    return sourceMgr.isBeforeInBuffer(firstLoc, secondLoc) ||
+        (allowEqual && firstLoc == secondLoc);
+  }
+
+  // If the two locations are in different source buffers, we need to compute
+  // the least common ancestor.
+  unsigned firstScratch, secondScratch;
+  auto firstAncestors = sourceMgr.getAncestors(firstBufferID, firstScratch);
+  auto secondAncestors = sourceMgr.getAncestors(secondBufferID, secondScratch);
+
+  // Find the first mismatch between the two ancestor lists; this is the
+  // point of divergence.
+  auto [firstMismatch, secondMismatch] = std::mismatch(
+      firstAncestors.begin(), firstAncestors.end(),
+      secondAncestors.begin(), secondAncestors.end());
+  assert(firstMismatch != firstAncestors.begin() &&
+         secondMismatch != secondAncestors.begin() &&
+         "Ancestors don't have the same root source file");
+
+  SourceLoc firstLocInLCA = firstMismatch == firstAncestors.end()
+      ? firstLoc
+      : sourceMgr.getGeneratedSourceInfo(*firstMismatch)
+          ->originalSourceRange.getStart();
+  SourceLoc secondLocInLCA = secondMismatch == secondAncestors.end()
+      ? secondLoc
+      : sourceMgr.getGeneratedSourceInfo(*secondMismatch)
+          ->originalSourceRange.getStart();
+  return sourceMgr.isBeforeInBuffer(firstLocInLCA, secondLocInLCA) ||
+    (allowEqual && firstLocInLCA == secondLocInLCA);
+}
+
+bool SourceManager::isBefore(SourceLoc first, SourceLoc second) const {
+  return isBeforeInSource(*this, first, second, /*allowEqual=*/false);
+}
+
+bool SourceManager::isAtOrBefore(SourceLoc first, SourceLoc second) const {
+  return isBeforeInSource(*this, first, second, /*allowEqual=*/true);
+}
+
+bool SourceManager::containsTokenLoc(SourceRange range, SourceLoc loc) const {
+  return isAtOrBefore(range.Start, loc) && isAtOrBefore(loc, range.End);
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7146,7 +7146,6 @@ void AttributeChecker::visitMacroRoleAttr(MacroRoleAttr *attr) {
       // TODO: Check property observer names?
       break;
     case MacroRole::MemberAttribute:
-    case MacroRole::Preamble:
     case MacroRole::Body:
       if (!attr->getNames().empty())
         diagnoseAndRemoveAttr(attr, diag::macro_cannot_introduce_names,
@@ -7168,6 +7167,7 @@ void AttributeChecker::visitMacroRoleAttr(MacroRoleAttr *attr) {
       break;
     }
     case MacroRole::Extension:
+    case MacroRole::Preamble:
       break;
     default:
       diagnoseAndRemoveAttr(attr, diag::invalid_macro_role_for_macro_syntax,

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2183,7 +2183,7 @@ public struct TracedPreambleMacro: PreambleMacro {
 }
 
 @_spi(ExperimentalLanguageFeature)
-public struct Log2PreambleMacro: PreambleMacro {
+public struct LoggerMacro: PreambleMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingPreambleFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
@@ -2203,16 +2203,19 @@ public struct Log2PreambleMacro: PreambleMacro {
     let passedArgs = paramNames.map { "\($0): \\(\($0))" }.joined(separator: ", ")
 
     let entry: CodeBlockItemSyntax = """
-      log2("Entering \(funcBaseName)(\(raw: passedArgs))")
+      logger.log(entering: "\(funcBaseName)(\(raw: passedArgs))")
       """
 
     let argLabels = paramNames.map { "\($0):" }.joined()
 
     let exit: CodeBlockItemSyntax = """
-      log2("Exiting \(funcBaseName)(\(raw: argLabels))")
+      logger.log(exiting: "\(funcBaseName)(\(raw: argLabels))")
       """
 
     return [
+      """
+      let logger = Logger()
+      """,
       entry,
       """
       defer {

--- a/test/Macros/macro_expand_body.swift
+++ b/test/Macros/macro_expand_body.swift
@@ -16,8 +16,8 @@ macro Remote() = #externalMacro(module: "MacroDefinition", type: "RemoteBodyMacr
 @attached(preamble)
 macro Traced() = #externalMacro(module: "MacroDefinition", type: "TracedPreambleMacro")
 
-@attached(preamble)
-macro Log2() = #externalMacro(module: "MacroDefinition", type: "Log2PreambleMacro")
+@attached(preamble, names: named(logger))
+macro Logged() = #externalMacro(module: "MacroDefinition", type: "LoggerMacro")
 
 protocol ConjureRemoteValue {
   static func conjureValue() -> Self
@@ -27,36 +27,53 @@ extension String: ConjureRemoteValue {
   static func conjureValue() -> String { "" }
 }
 
+struct Logger {
+  func log(entering function: String) {
+    print("Logger entering \(function)")
+  }
+
+  func log(_ message: String) {
+    print("--- \(message)")
+  }
+
+  func log(exiting function: String) {
+    print("Logger exiting \(function)")
+  }
+}
+
+func log(_ message: String) {
+  print(message)
+}
+
 @available(SwiftStdlib 5.1, *)
 func remoteCall<Result: ConjureRemoteValue>(function: String, arguments: [String: Any]) async throws -> Result {
-  let printedArgs = arguments.keys.sorted().map { key in 
+  let printedArgs = arguments.keys.sorted().map { key in
     "\(key): \(arguments[key]!)"
   }.joined(separator: ", ")
   print("Remote call \(function)(\(printedArgs))")
   return Result.conjureValue()
 }
 
-func log(_ value: String) {
-  print(value)
-}
-
-func log2(_ value: String) {
-  print("log2(\(value))")
-}
+@available(SwiftStdlib 5.1, *)
+@Remote
+func f(a: Int, b: String) async throws -> String
 
 @Traced
 func doubleTheValue(value: Int) -> Int {
   return value * 2
 }
 
-@available(SwiftStdlib 5.1, *)
-@Remote
-func f(a: Int, b: String) async throws -> String
+@Logged
+func useLogger() {
+  let x = 1
+  logger.log("use it")
+  print(x)
+}
 
 @available(SwiftStdlib 5.1, *)
 @Remote
 @Traced
-@Log2
+@Logged
 func g(a: Int, b: String) async throws -> String {
   doesNotTypeCheck()
 }
@@ -80,9 +97,14 @@ if #available(SwiftStdlib 5.1, *) {
   print(try await f(a: 5, b: "Hello"))
 
   // CHECK: Entering g(a: 5, b: World)
-  // CHECK: log2(Entering g(a: 5, b: World))
+  // CHECK: Logger entering g(a: 5, b: World)
   // CHECK: Remote call g(a: 5, b: World)
-  // CHECK: log2(Exiting g(a:b:))
+  // CHECK: Logger exiting g(a:b:)
   // CHECK: Exiting g(a:b:)
   print(try await g(a: 5, b: "World"))
 }
+
+// CHECK: Logger entering useLogger()
+// CHECK: --- use it
+// CHECK: Logger exiting useLogger()
+useLogger()

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -587,7 +587,7 @@ build-subdir=buildbot_incremental
 release
 assertions
 
-llvm-targets-to-build=X86;ARM;AArch64;PowerPC
+llvm-targets-to-build=X86;ARM;AArch64;PowerPC;RISCV
 
 libcxx
 llbuild


### PR DESCRIPTION
Preamble macros introduce code at the beginning of a function body.
Allow them to introduce declarations as well, so long as the macro
declaration properly declares the names it introduces. This allows all
sorts of exciting macros that introduce (e.g.) new local variables
that one can use.