### PR TITLE
[TypeChecker] Update `@dynamicMemberLookup` to specify sendability of the parameter

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2350,11 +2350,10 @@ namespace {
     /// Build an implicit argument for keypath based dynamic lookup,
     /// which consists of KeyPath expression and a single component.
     ///
-    /// \param keyPathTy The type of the keypath argument.
+    /// \param argType The type of the keypath subscript argument.
     /// \param dotLoc The location of the '.' preceding member name.
     /// \param memberLoc The locator to be associated with new argument.
-    Expr *buildKeyPathDynamicMemberArgExpr(BoundGenericType *keyPathTy,
-                                           SourceLoc dotLoc,
+    Expr *buildKeyPathDynamicMemberArgExpr(Type argType, SourceLoc dotLoc,
                                            ConstraintLocator *memberLoc) {
       using Component = KeyPathExpr::Component;
       auto &ctx = cs.getASTContext();
@@ -2363,7 +2362,7 @@ namespace {
       auto makeKeyPath = [&](ArrayRef<Component> components) -> Expr * {
         auto *kp = KeyPathExpr::createImplicit(ctx, /*backslashLoc*/ dotLoc,
                                                components, anchor->getEndLoc());
-        kp->setType(keyPathTy);
+        kp->setType(argType);
         cs.cacheExprTypes(kp);
 
         // See whether there's an equivalent ObjC key path string we can produce
@@ -2371,6 +2370,10 @@ namespace {
         checkAndSetObjCKeyPathString(kp);
         return kp;
       };
+
+      Type keyPathTy = argType;
+      if (auto *existential = keyPathTy->getAs<ExistentialType>())
+        keyPathTy = existential->getExistentialLayout().explicitSuperclass;
 
       SmallVector<Component, 2> components;
       auto *componentLoc = cs.getConstraintLocator(
@@ -3482,8 +3485,8 @@ namespace {
         auto fieldName = overload.choice.getName().getBaseIdentifier().str();
         argExpr = buildDynamicMemberLookupArgExpr(fieldName, nameLoc, paramTy);
       } else {
-        argExpr = buildKeyPathDynamicMemberArgExpr(
-            paramTy->castTo<BoundGenericType>(), dotLoc, memberLocator);
+        argExpr =
+            buildKeyPathDynamicMemberArgExpr(paramTy, dotLoc, memberLocator);
       }
 
       if (!argExpr)

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2372,8 +2372,10 @@ namespace {
       };
 
       Type keyPathTy = argType;
-      if (auto *existential = keyPathTy->getAs<ExistentialType>())
-        keyPathTy = existential->getExistentialLayout().explicitSuperclass;
+      if (auto *existential = keyPathTy->getAs<ExistentialType>()) {
+        keyPathTy = existential->getSuperclass();
+        assert(isKnownKeyPathType(keyPathTy));
+      }
 
       SmallVector<Component, 2> components;
       auto *componentLoc = cs.getConstraintLocator(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3487,8 +3487,10 @@ void ConstraintSystem::bindOverloadType(
     // and U is a leaf type (aka member type).
     auto paramTy = fnType->getParams()[0].getPlainType();
 
-    if (auto *existential = paramTy->getAs<ExistentialType>())
-      paramTy = existential->getExistentialLayout().explicitSuperclass;
+    if (auto *existential = paramTy->getAs<ExistentialType>()) {
+      paramTy = existential->getSuperclass();
+      assert(isKnownKeyPathType(paramTy));
+    }
 
     auto keyPathTy = paramTy->castTo<BoundGenericType>();
 

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -124,3 +124,17 @@ do {
   // TODO: This should be diagnosed by the isolation checker because implicitly synthesized closures captures a non-Sendable value.
   testSendableFn(v: v, \.[42, CondSendable(nonSendable)])
 }
+
+// @dynamicMemberLookup with Sendable requirement
+do {
+  @dynamicMemberLookup
+  struct Test<T> {
+    var obj: T
+
+    subscript<U>(dynamicMember member: KeyPath<T, U> & Sendable) -> U {
+      get { obj[keyPath: member] }
+    }
+  }
+
+  _ = Test(obj: "Hello").utf8.count // Ok
+}

--- a/test/Interpreter/keypath.swift
+++ b/test/Interpreter/keypath.swift
@@ -134,3 +134,17 @@ do {
   // CHECK: 42
   test(v: S(i: 42), \.i)
 }
+
+do {
+  @dynamicMemberLookup
+  struct Test<T> {
+    var obj: T
+
+    subscript<U>(dynamicMember member: KeyPath<T, U> & Sendable) -> U {
+      get { obj[keyPath: member] }
+    }
+  }
+
+  // CHECK: 5
+  print(Test(obj: "Hello").utf8.count)
+}


### PR DESCRIPTION
Allow to compose key path type with protocol(s) as a way to express
additional requirements on the parameter for `subscript(dynamicMember: ...)`. 

For example:

```
struct Test<R> {
  subscript<V>(dynamicMember member: KeyPath<R, V> & Sendable) -> V {
    ...
  }
}
```

Resolves: rdar://102827975

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
