### PR TITLE
[lit] Use CMAKE_C_FLAGS and CMAKE_EXE_LINKER_FLAGS when compiling test plugin

### DIFF
--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -25,6 +25,8 @@ else:
         0,
         (
             '%swift-build-cxx-plugin',
-            '%clang -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin -Xlinker -rpath -Xlinker %swift-lib-dir'
+            '%clang %c-flags %exe-linker-flags -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin -Xlinker -rpath -Xlinker %swift-lib-dir'
         )
     )
+    config.substitutions.append(('%c-flags', config.c_flags))
+    config.substitutions.append(('%exe-linker-flags', config.exe_linker_flags))

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -44,6 +44,9 @@ config.swift_driver_test_options = "@SWIFT_DRIVER_TEST_OPTIONS@"
 config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
 config.swift_ide_test_test_options = "@SWIFT_IDE_TEST_TEST_OPTIONS@"
 
+config.c_flags = r'''@CMAKE_C_FLAGS@'''
+config.exe_linker_flags = r'''@CMAKE_EXE_LINKER_FLAGS@'''
+
 # --- Darwin ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"
 


### PR DESCRIPTION
In cases where the swift-plugin-server is built with specialized `CMAKE_C_FLAGS` and/or `CMAKE_EXE_LINKER_FLAGS`, if one wants to load a plugin in it, one needs to build with a compatible set of flags, or the plugin will not be able to be loaded.

Most of the time the tests can build against the `/` sysroot and be fine, but in the case of these test plugins, since they have to be loaded into the swift-plugin-server process, they need to compiled and linked in a compatible way. Using `CMAKE_C_FLAGS` and `CMAKE_EXE_LINKER_FLAGS` uses the same set of flags in both cases, and allow loading these test plugins during testing and avoid failures.

The change in `lit.site.cfg.in` embeds the values of `CMAKE_C_FLAGS` and `CMAKE_EXE_LINKER_FLAGS` from CMake into the Lit configuration. The usage of raw triple quoted strings allow single and double quoted arguments to survive the interpolation.

The change in `lit.local.cfg` creates two substitutions for them, and uses those substitutions in `swift-build-cxx-plugin`.