### PR TITLE
Treat package as resilient as non-frozen public by default

### DIFF
--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -75,6 +75,7 @@ public:
   bool isFileScope() const;
   bool isInternal() const;
   bool isPackage() const;
+  bool isPublicOrPackage() const { return isPublic() || isPackage(); }
 
   /// Checks if the DeclContext of this (use site) access scope is more
   /// restrictive than that of the argument (decl site) based on the DeclContext

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2986,7 +2986,7 @@ bool AbstractStorageDecl::isFormallyResilient() const {
   // Non-public global and static variables always have a
   // fixed layout.
   if (!getFormalAccessScope(/*useDC=*/nullptr,
-                            /*treatUsableFromInlineAsPublic=*/true).isPublic())
+                            /*treatUsableFromInlineAsPublic=*/true).isPublicOrPackage())
     return false;
 
   return true;
@@ -4987,10 +4987,10 @@ int TypeDecl::compare(const TypeDecl *type1, const TypeDecl *type2) {
 }
 
 bool NominalTypeDecl::isFormallyResilient() const {
-  // Private, (unversioned) internal, and package types always have a
+  // Private and (unversioned) internal types always have a
   // fixed layout.
   if (!getFormalAccessScope(/*useDC=*/nullptr,
-                            /*treatUsableFromInlineAsPublic=*/true).isPublic())
+                            /*treatUsableFromInlineAsPublic=*/true).isPublicOrPackage())
     return false;
 
   // Check for an explicit @_fixed_layout or @frozen attribute.

--- a/test/IRGen/Inputs/package_types/resilient_class.swift
+++ b/test/IRGen/Inputs/package_types/resilient_class.swift
@@ -65,6 +65,22 @@ package class ResilientGenericOutsideParent<A> {
   }
 }
 
+public class PublicGenericOutsideParent<A> {
+  public var property: A
+  public init(property: A) {
+    self.property = property
+    print("PublicGenericOutsideParent.init()")
+  }
+
+  public func method() {
+    print("PublicGenericOutsideParent.method()")
+  }
+
+  public class func classMethod() {
+    print("PublicGenericOutsideParent.classMethod()")
+  }
+}
+
 
 // Resilient generic subclass
 

--- a/test/IRGen/Inputs/package_types/resilient_enum.swift
+++ b/test/IRGen/Inputs/package_types/resilient_enum.swift
@@ -6,6 +6,11 @@ package enum SimpleShape {
   case Triangle(Size)
 }
 
+public enum PublicSimpleShape {
+  case pbKleinBottle
+  case pbTriangle(PublicSize)
+}
+
 // Fixed-layout enum with resilient members
 package enum Shape {
   case Point
@@ -17,6 +22,11 @@ package enum Shape {
 package enum FunnyShape {
   indirect case Parallelogram(Size)
   indirect case Trapezoid(Size)
+}
+
+public enum PublicFunnyShape {
+  indirect case Parallelogram(PublicSize)
+  indirect case Trapezoid(PublicSize)
 }
 
 package enum FullyFixedLayout {
@@ -52,6 +62,18 @@ package enum Medium {
 
   // Case with resilient payload
   case Postcard(Size)             // -2
+
+  // Empty cases
+  case Paper                      // 0
+  case Canvas                     // 1
+}
+
+public enum PublicMedium {
+  // Indirect case
+  indirect case Pamphlet(PublicMedium)  // -1
+
+  // Case with resilient payload
+  case Postcard(PublicSize)             // -2
 
   // Empty cases
   case Paper                      // 0

--- a/test/IRGen/Inputs/package_types/resilient_struct.swift
+++ b/test/IRGen/Inputs/package_types/resilient_struct.swift
@@ -1,4 +1,3 @@
-// Fixed-layout struct
 package struct Point {
   package var x: Int // read-write stored property
   package let y: Int // read-only stored property
@@ -12,7 +11,6 @@ package struct Point {
   package mutating func mutantMethod() {}
 }
 
-// Resilient-layout struct
 package struct Size {
   package var w: Int // should have getter and setter
   package let h: Int // getter only
@@ -26,7 +24,6 @@ package struct Size {
   package mutating func mutantMethod() {}
 }
 
-// Fixed-layout struct with resilient members
 package struct Rectangle {
   package let p: Point
   package let s: Size
@@ -116,6 +113,69 @@ package struct UnavailableResilientInt {
   package let i: Int
 
   package init(i: Int) {
+    self.i = i
+  }
+}
+
+
+public struct PublicPoint {
+  public var x: Int // read-write stored property
+  public let y: Int // read-only stored property
+
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  public func method() {}
+  public mutating func mutantMethod() {}
+}
+
+@frozen
+public struct FrozenPublicPoint {
+  public var x: Int // read-write stored property
+  public let y: Int // read-only stored property
+
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  public func method() {}
+  public mutating func mutantMethod() {}
+}
+
+public struct PublicSize {
+  public var w: Int // should have getter and setter
+  public let h: Int // getter only
+
+  public init(w: Int, h: Int) {
+    self.w = w
+    self.h = h
+  }
+
+  public func method() {}
+  public mutating func mutantMethod() {}
+}
+
+@frozen
+public struct FrozenPublicSize {
+  public var w: Int // should have getter and setter
+  public let h: Int // getter only
+
+  public init(w: Int, h: Int) {
+    self.w = w
+    self.h = h
+  }
+
+  public func method() {}
+  public mutating func mutantMethod() {}
+}
+
+public struct PublicResilientInt {
+  public let i: Int
+
+  public init(i: Int) {
     self.i = i
   }
 }

--- a/test/IRGen/package_resilience.swift
+++ b/test/IRGen/package_resilience.swift
@@ -5,6 +5,8 @@
 // possible.
 //
 
+// REQUIRES: rdar118947451
+
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/package_resilience.swift
 // RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/Inputs/package_types/resilient_struct.swift

--- a/test/IRGen/package_resilient_as_public_by_default.swift
+++ b/test/IRGen/package_resilient_as_public_by_default.swift
@@ -1,0 +1,677 @@
+//
+// Unlike its counterparts in the other *_resilience.swift files, the goal is
+// for the package's component modules to all be considered within the same
+// resilience domain. This file ensures that we use direct access as much as
+// possible.
+//
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/chex.py < %s > %t/package_resilience.swift
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/Inputs/package_types/resilient_struct.swift
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/Inputs/package_types/resilient_enum.swift
+// RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/Inputs/package_types/resilient_class.swift
+
+// RUN: %target-swift-frontend -package-name MyPkg -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift > %t/ir-result
+// RUN: %FileCheck %t/package_resilience.swift --check-prefixes=CHECK -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment < %t/ir-result
+
+// RUN: %target-swift-frontend -package-name MyPkg -I %t -emit-ir -enable-library-evolution -O %t/package_resilience.swift -package-name MyPkg
+// REQUIRES: objc_codegen
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+// REQUIRES: CPU=x86_64 || CPU=arm64
+
+// CHECK: @"$s18package_resilience27PublicClassWithPbPropertiesC1p16resilient_struct0C5PointVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience27PublicClassWithPbPropertiesC1s16resilient_struct0C4SizeVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience27PublicClassWithPbPropertiesC5colors5Int32VvpWvd" = hidden global
+// CHECK: @"$s18package_resilience28PkgClassWithPublicPropertiesC1p16resilient_struct0F5PointVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience28PkgClassWithPublicPropertiesC1s16resilient_struct0F4SizeVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience28PkgClassWithPublicPropertiesC5colors5Int32VvpWvd" = hidden global
+// CHECK: @"$s18package_resilience24PkgWithPackagePropertiesC1p16resilient_struct5PointVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience24PkgWithPackagePropertiesC1s16resilient_struct4SizeVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience24PkgWithPackagePropertiesC5colors5Int32VvpWvd" = hidden global 
+// CHECK: @"$s18package_resilience32PublicClassWithEnumIndirectCasesC1s14resilient_enum0C10FunnyShapeOvpWvd" = hidden global
+// CHECK: @"$s18package_resilience32PublicClassWithEnumIndirectCasesC5colors5Int32VvpWvd" = hidden global 
+// CHECK: @"$s18package_resilience29PkgClassWithEnumIndirectCasesC1s14resilient_enum10FunnyShapeOvpWvd" = hidden global
+// CHECK: @"$s18package_resilience29PkgClassWithEnumIndirectCasesC5colors5Int32VvpWvd" = hidden global 
+
+// CHECK: @"$s18package_resilience33PublicClassWithEmptyThenResilientC9resilient0I7_struct0cH3IntVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience33PublicClassWithResilientThenEmptyC9resilient0I7_struct0cF3IntVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience30PkgClassWithEmptyThenResilientC9resilient0I7_struct0H3IntVvpWvd" = hidden global
+// CHECK: @"$s18package_resilience30PkgClassWithResilientThenEmptyC9resilient0I7_struct0F3IntVvpWvd" = hidden global
+
+// CHECK: @"$s18package_resilience33PublicClassWithFrozenPbPropertiesC1p16resilient_struct0fC5PointVvpWvd" = hidden constant
+// CHECK: @"$s18package_resilience33PublicClassWithFrozenPbPropertiesC1s16resilient_struct0fC4SizeVvpWvd" = hidden constant
+// CHECK: @"$s18package_resilience33PublicClassWithFrozenPbPropertiesC5colors5Int32VvpWvd" = hidden constant
+
+// CHECK: @"$s18package_resilience17PublicClassParentC1sAA0C12StructSimpleVvpWvd" = hidden constant 
+// CHECK: @"$s18package_resilience16PublicClassChildC5fields5Int32VvpWvd" = hidden constant 
+// CHECK: @"$s18package_resilience24PublicClassConcreteChildC1xSivpWvd" = hidden constant 
+// CHECK: @"$s18package_resilience14PkgClassParentC1sAA0C12StructSimpleVvpWvd" = hidden constant 
+// CHECK: @"$s18package_resilience13PkgClassChildC5fields5Int32VvpWvd" = hidden constant 
+// CHECK: @"$s18package_resilience21PkgClassConcreteChildC1xSivpWvd" = hidden constant 
+
+// CHECK: @"$s18package_resilience33PublicClassWithEmptyThenResilientC5emptyAA0cF0VvpWvd" = hidden constant 
+// CHECK: @"$s18package_resilience33PublicClassWithResilientThenEmptyC5emptyAA0cH0VvpWvd" = hidden constant 
+// CHECK: @"$s18package_resilience30PkgClassWithEmptyThenResilientC5emptyAA0c6StructF0VvpWvd" = hidden constant
+// CHECK: @"$s18package_resilience30PkgClassWithResilientThenEmptyC5emptyAA0c6StructH0VvpWvd" = hidden constant
+
+import resilient_class
+import resilient_struct
+import resilient_enum
+
+public class PublicClassWithPbProperties {
+  public let p: PublicPoint
+  public let s: PublicSize
+  public let color: Int32
+
+  public init(p: PublicPoint, s: PublicSize, color: Int32) {
+    self.p = p
+    self.s = s
+    self.color = color
+  }
+}
+
+
+// PublicClassWithPbProperties.p getter
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s18package_resilience27PublicClassWithPbPropertiesC1p16resilient_struct0C5PointVvg"(ptr noalias sret(%swift.opaque) %0, ptr swiftself %1)
+// CHECK:       [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience27PublicClassWithPbPropertiesC1p16resilient_struct0C5PointVvpWvd"
+// CHECK-NEXT:  [[FIELD_PTR:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT:  [[A:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct11PublicPointVMa"
+// CHECK-NEXT:  [[B:%.*]] = extractvalue %swift.metadata_response [[A]], 0
+// CHECK-NEXT:  [[C:%.*]] = getelementptr inbounds ptr, ptr [[B]],
+// CHECK-NEXT:  [[FIELD_VW:%.*]] = load ptr, ptr [[C]]
+// CHECK-NEXT:  [[D:%.*]] = getelementptr inbounds ptr, ptr [[FIELD_VW]]
+// CHECK-NEXT:  [[FIELD_PAYLOAD:%.*]] = load ptr, ptr [[D]]
+// CHECK-NEXT:  [[E:%.*]] = call ptr [[FIELD_PAYLOAD]](ptr noalias
+// CHECK-NEXT:  ret void
+
+// PublicClassWithPbProperties.color getter
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience27PublicClassWithPbPropertiesC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:       [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience27PublicClassWithPbPropertiesC5colors5Int32VvpWvd"
+// CHECK-NEXT:  [[PTR:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT:  [[VALUE:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[PTR]]
+// CHECK-NEXT:  [[RET:%.*]] = load {{i32|i64}}, ptr [[VALUE]]
+// CHECK-NEXT:  ret {{i32|i64}} [[RET]]
+
+
+
+
+// PkgClassWithPublicProperties.p getter
+
+// CHECK: define{{.*}} swiftcc void @"$s18package_resilience28PkgClassWithPublicPropertiesC1p16resilient_struct0F5PointVvg"(ptr noalias sret(%swift.opaque) %0, ptr swiftself %1)
+// CHECK:       [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience28PkgClassWithPublicPropertiesC1p16resilient_struct0F5PointVvpWvd"
+// CHECK-NEXT:  [[FIELD_PTR:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT:  [[A:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct11PublicPointVMa"(i64 0)
+// CHECK-NEXT:  [[B:%.*]] = extractvalue %swift.metadata_response [[A]], 0
+// CHECK-NEXT:  [[C:%.*]] = getelementptr inbounds ptr, ptr [[B]]
+// CHECK-NEXT:  [[FIELD_VW:%.*]] = load ptr, ptr [[C]]
+// CHECK-NEXT:  [[D:%.*]] = getelementptr inbounds ptr, ptr [[FIELD_VW]]
+// CHECK-NEXT:  [[FIELD_PAYLOAD:%.*]] = load ptr, ptr [[D]]
+// CHECK-NEXT:  [[E:%.*]] = call ptr [[FIELD_PAYLOAD]](ptr noalias
+// CHECK-NEXT:  ret void
+
+package class PkgClassWithPublicProperties {
+  package let p: PublicPoint
+  package let s: PublicSize
+  package let color: Int32
+
+  package init(p: PublicPoint, s: PublicSize, color: Int32) {
+    self.p = p
+    self.s = s
+    self.color = color
+  }
+}
+
+
+// PkgClassWithPublicProperties.color getter
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience28PkgClassWithPublicPropertiesC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:       [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience28PkgClassWithPublicPropertiesC5colors5Int32VvpWvd"
+// CHECK-NEXT:  [[PTR:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT:  [[VALUE:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[PTR]]
+// CHECK-NEXT:  [[RET:%.*]] = load {{i32|i64}}, ptr [[VALUE]]
+// CHECK-NEXT:  ret {{i32|i64}} [[RET]]
+
+package class PkgWithPackageProperties {
+  package let p: Point
+  package let s: Size
+  package let color: Int32
+
+  package init(p: Point, s: Size, color: Int32) {
+    self.p = p
+    self.s = s
+    self.color = color
+  }
+}
+
+
+// PkgWithPackageProperties.p getter
+
+// CHECK: define{{.*}} swiftcc void @"$s18package_resilience24PkgWithPackagePropertiesC1p16resilient_struct5PointVvg"(ptr noalias sret(%swift.opaque) %0, ptr swiftself %1)
+// CHECK:       [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience24PkgWithPackagePropertiesC1p16resilient_struct5PointVvpWvd"
+// CHECK:       [[FIELD_PTR:%.*]] = getelementptr inbounds i8, ptr {{.*}}, i64 [[OFFSET]]
+// CHECK-NEXT:  [[A:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct5PointVMa"
+// CHECK-NEXT:  [[B:%.*]] = extractvalue %swift.metadata_response [[A]], 0
+// CHECK-NEXT:  [[C:%.*]] = getelementptr inbounds ptr, ptr [[B]]
+// CHECK-NEXT:  [[FIELD_VW:%.*]] = load ptr, ptr [[C]]
+// CHECK-NEXT:  [[D:%.*]] = getelementptr inbounds ptr, ptr [[FIELD_VW]]
+// CHECK-NEXT:  [[FIELD_PAYLOAD:%.*]] = load ptr, ptr [[D]]
+// CHECK-NEXT:  [[E:%.*]] = call ptr [[FIELD_PAYLOAD]](ptr noalias
+// CHECK-NEXT:  ret void
+
+// PkgWithPackageProperties.color getter
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience24PkgWithPackagePropertiesC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:       [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience24PkgWithPackagePropertiesC5colors5Int32VvpWvd"
+// CHECK-NEXT:  [[PTR:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT:  [[VALUE:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[PTR]]
+// CHECK-NEXT:  [[RET:%.*]] = load {{i32|i64}}, ptr [[VALUE]]
+// CHECK-NEXT:  ret {{i32|i64}} [[RET]]
+
+
+public class PublicClassWithFrozenPbProperties {
+  public let p: FrozenPublicPoint
+  public let s: FrozenPublicSize
+  public let color: Int32
+
+  public init(p: FrozenPublicPoint, s: FrozenPublicSize, color: Int32) {
+    self.p = p
+    self.s = s
+    self.color = color
+  }
+}
+
+// PublicClassWithFrozenPbProperties.p getter
+
+// CHECK: define{{.*}} swiftcc { {{i32|i64}}, {{i32|i64}} } @"$s18package_resilience33PublicClassWithFrozenPbPropertiesC1p16resilient_struct0fC5PointVvg"(ptr swiftself %0)
+// CHECK:      [[T1:%.*]] = getelementptr inbounds %T18package_resilience33PublicClassWithFrozenPbPropertiesC, ptr {{.*}}
+// CHECK-NEXT: [[X:%.*]] = getelementptr inbounds %T16resilient_struct17FrozenPublicPointV, ptr [[T1]]
+// CHECK-NEXT: [[XVAL:%.*]] = getelementptr inbounds %TSi, ptr [[X]]
+// CHECK-NEXT: [[T2:%.*]] = load {{i32|i64}}, ptr [[XVAL]]
+// CHECK-NEXT: [[Y:%.*]] = getelementptr inbounds %T16resilient_struct17FrozenPublicPointV, ptr [[T1]]
+// CHECK-NEXT: [[YVAL:%.*]] = getelementptr inbounds %TSi, ptr [[Y]]
+// CHECK-NEXT: [[T3:%.*]] = load {{i32|i64}}, ptr [[YVAL]]
+// CHECK-NEXT: [[T4:%.*]] = insertvalue {{.*}} undef, {{i32|i64}} [[T2]], 0
+// CHECK-NEXT: [[T5:%.*]] = insertvalue {{.*}} [[T4]], {{i32|i64}} [[T3]], 1
+// CHECK-NEXT: ret { {{i32|i64}}, {{i32|i64}} } [[T5]]
+
+
+// PublicClassWithFrozenPbProperties.color getter
+
+// CHECK: define{{.*}} swiftcc {{i32|64}} @"$s18package_resilience33PublicClassWithFrozenPbPropertiesC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:      [[T1:%.*]] = getelementptr inbounds %T18package_resilience33PublicClassWithFrozenPbPropertiesC, ptr {{.*}}
+// CHECK-NEXT: [[VAL:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[T1]]
+// CHECK-NEXT: [[T2:%.*]] = load {{i32|i64}}, ptr [[VAL]]
+// CHECK-NEXT: ret {{i32|i64}} [[T2]]
+
+
+package class PkgClassWithFrozenPublicProperties {
+  package let p: FrozenPublicPoint
+  package let s: FrozenPublicSize
+  package let color: Int32
+
+  package init(p: FrozenPublicPoint, s: FrozenPublicSize, color: Int32) {
+    self.p = p
+    self.s = s
+    self.color = color
+  }
+}
+
+
+// PkgClassWithFrozenPublicProperties.p getter
+
+// CHECK: define{{.*}} swiftcc { i64, i64 } @"$s18package_resilience34PkgClassWithFrozenPublicPropertiesC1p16resilient_struct0fG5PointVvg"(ptr swiftself %0)
+// CHECK:      [[T1:%.*]] = getelementptr inbounds %T18package_resilience34PkgClassWithFrozenPublicPropertiesC, ptr {{.*}}
+// CHECK-NEXT: [[X:%.*]] = getelementptr inbounds %T16resilient_struct17FrozenPublicPointV, ptr [[T1]]
+// CHECK-NEXT: [[XVAL:%.*]] = getelementptr inbounds %TSi, ptr [[X]]
+// CHECK-NEXT: [[T2:%.*]] = load {{i32|i64}}, ptr [[XVAL]]
+// CHECK-NEXT: [[Y:%.*]] = getelementptr inbounds %T16resilient_struct17FrozenPublicPointV, ptr [[T1]]
+// CHECK-NEXT: [[YVAL:%.*]] = getelementptr inbounds %TSi, ptr [[Y]]
+// CHECK-NEXT: [[T3:%.*]] = load {{i32|i64}}, ptr [[YVAL]]
+// CHECK-NEXT: [[T4:%.*]] = insertvalue { i64, i64 } undef, i64 [[T2]], 0
+// CHECK-NEXT: [[T5:%.*]] = insertvalue { i64, i64 } %4, i64 [[T3]], 1
+// CHECK-NEXT: ret { {{i32|i64}}, {{i32|i64}} } [[T5]]
+
+// PkgClassWithFrozenPublicProperties.color getter
+
+// CHECK: define{{.*}} swiftcc {{i32|64}} @"$s18package_resilience34PkgClassWithFrozenPublicPropertiesC5colors5Int32Vvg"(ptr swiftself %0) #0 {
+// CHECK:      [[T1:%.*]] = getelementptr inbounds %T18package_resilience34PkgClassWithFrozenPublicPropertiesC, ptr {{.*}}
+// CHECK-NEXT: [[VAL:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[T1]]
+// CHECK-NEXT: [[T2:%.*]] = load {{i32|i64}}, ptr [[VAL]]
+// CHECK-NEXT: ret {{i32|i64}} [[T2]]
+
+
+// Enums with indirect payloads are fixed-size
+public class PublicClassWithEnumIndirectCases {
+  public let s: PublicFunnyShape
+  public let color: Int32
+
+  public init(s: PublicFunnyShape, color: Int32) {
+    self.s = s
+    self.color = color
+  }
+}
+
+// PublicClassWithEnumIndirectCases.s getter
+
+// CHECK: define{{.*}} swiftcc void @"$s18package_resilience32PublicClassWithEnumIndirectCasesC1s14resilient_enum0C10FunnyShapeOvg"(ptr noalias sret(%swift.opaque) %0, ptr swiftself %1)
+// CHECK:      [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience32PublicClassWithEnumIndirectCasesC1s14resilient_enum0C10FunnyShapeOvpWvd"
+// CHECK-NEXT: [[A:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT: [[B:%.*]] = call swiftcc %swift.metadata_response @"$s14resilient_enum16PublicFunnyShapeOMa"
+// CHECK-NEXT: [[C:%.*]] = extractvalue %swift.metadata_response [[B]], 0
+// CHECK-NEXT: [[D:%.*]] = getelementptr inbounds ptr, ptr [[C]]
+// CHECK-NEXT: [[VW:%.*]] = load ptr, ptr [[D]]
+// CHECK-NEXT: [[E:%.*]] = getelementptr inbounds ptr, ptr [[VW]]
+// CHECK-NEXT: [[PAYLOAD:%.*]] = load ptr, ptr [[E]]
+// CHECK-NEXT: [[RET:%.*]] = call ptr [[PAYLOAD]](ptr noalias
+// CHECK-NEXT: ret void
+
+// PublicClassWithEnumIndirectCases.color getter
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc {{.*}} @"$s18package_resilience32PublicClassWithEnumIndirectCasesC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:      [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience32PublicClassWithEnumIndirectCasesC5colors5Int32VvpWvd",
+// CHECK-NEXT: [[PTR:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT: [[VALUE:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[PTR]]
+// CHECK-NEXT: [[RET:%.*]] = load {{i32|i64}}, ptr [[VALUE]]
+// CHECK-NEXT: ret {{i32|i64}} [[RET]]
+
+package class PkgClassWithEnumIndirectCases {
+  package let s: FunnyShape
+  package let color: Int32
+
+  package init(s: FunnyShape, color: Int32) {
+    self.s = s
+    self.color = color
+  }
+}
+
+// PkgClassWithEnumIndirectCases.s getter
+
+// CHECK: define{{.*}} swiftcc void @"$s18package_resilience29PkgClassWithEnumIndirectCasesC1s14resilient_enum10FunnyShapeOvg"(ptr noalias sret(%swift.opaque) %0, ptr swiftself %1)
+// CHECK:      [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience29PkgClassWithEnumIndirectCasesC1s14resilient_enum10FunnyShapeOvpWvd"
+// CHECK-NEXT: [[A:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT: [[B:%.*]] = call swiftcc %swift.metadata_response @"$s14resilient_enum10FunnyShapeOMa"
+// CHECK-NEXT: [[C:%.*]] = extractvalue %swift.metadata_response [[B]], 0
+// CHECK-NEXT: [[D:%.*]] = getelementptr inbounds ptr, ptr [[C]]
+// CHECK-NEXT: [[VW:%.*]] = load ptr, ptr [[D]]
+// CHECK-NEXT: [[E:%.*]] = getelementptr inbounds ptr, ptr [[VW]]
+// CHECK-NEXT: [[PAYLOAD:%.*]] = load ptr, ptr [[E]]
+// CHECK-NEXT: [[RET:%.*]] = call ptr [[PAYLOAD]](ptr noalias
+// CHECK-NEXT: ret void
+
+// PkgClassWithEnumIndirectCases.color getter
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i32|64}} @"$s18package_resilience29PkgClassWithEnumIndirectCasesC5colors5Int32Vvg"(ptr swiftself %0)
+// CHECK:      [[OFFSET:%.*]] = load {{i32|i64}}, ptr @"$s18package_resilience29PkgClassWithEnumIndirectCasesC5colors5Int32VvpWvd",
+// CHECK-NEXT: [[PTR:%.*]] = getelementptr inbounds i8, ptr {{.*}}, {{i32|i64}} [[OFFSET]]
+// CHECK-NEXT: [[VALUE:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[PTR]]
+// CHECK-NEXT: [[RET:%.*]] = load {{i32|i64}}, ptr [[VALUE]]
+// CHECK-NEXT: ret {{i32|i64}} [[RET]]
+
+
+public struct PublicStructSimple {
+  public let x: Int32
+}
+
+public class PublicClassParent {
+  public let s: PublicStructSimple = PublicStructSimple(x: 0)
+}
+
+public class PublicClassChild : PublicClassParent {
+  public let field: Int32 = 0
+}
+
+public class PublicClassGenericParent<T> {
+  package let t: T
+
+  package init(t: T) {
+    self.t = t
+  }
+}
+
+public class PublicClassConcreteChild : PublicClassGenericParent<Int> {
+  public let x: Int
+
+  public init(x: Int) {
+    self.x = x
+    super.init(t: x)
+  }
+}
+
+// PublicClassConcreteChild.x getter
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc {{.*}} @"$s18package_resilience24PublicClassConcreteChildC1xSivg"(ptr swiftself %0)
+// CHECK:      [[PTR:%.*]] = getelementptr inbounds %T18package_resilience24PublicClassConcreteChildC, ptr {{.*}}
+// CHECK-NEXT: [[VAL:%.*]] = getelementptr inbounds %TSi, ptr [[PTR]]
+// CHECK-NEXT: [[RET:%.*]] = load {{i32|i64}}, ptr [[VAL]]
+// CHECK-NEXT: ret {{i32|i64}} [[RET]]
+
+
+
+package struct PkgStructSimple {
+  package let x: Int32
+}
+
+package class PkgClassParent {
+  package let s: PkgStructSimple = PkgStructSimple(x: 0)
+}
+
+package class PkgClassChild : PkgClassParent {
+  package let field: Int32 = 0
+}
+
+package class PkgClassGenericParent<T> {
+  package let t: T
+
+  package init(t: T) {
+    self.t = t
+  }
+}
+
+package class PkgClassConcreteChild : PkgClassGenericParent<Int> {
+  package let x: Int
+
+  package init(x: Int) {
+    self.x = x
+    super.init(t: x)
+  }
+}
+
+
+// PkgClassConcreteChild.x getter
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc {{.*}} @"$s18package_resilience21PkgClassConcreteChildC1xSivg"(ptr swiftself %0)
+// CHECK:      [[PTR:%.*]] = getelementptr inbounds %T18package_resilience21PkgClassConcreteChildC, ptr {{.*}}
+// CHECK-NEXT: [[VAL:%.*]] = getelementptr inbounds %TSi, ptr [[PTR]]
+// CHECK-NEXT: [[RET:%.*]] = load {{i32|i64}}, ptr [[VAL]]
+// CHECK-NEXT: ret {{i32|i64}} [[RET]]
+
+
+
+extension PublicGenericOutsideParent {
+  public func publicGenericExtensionMethod() -> A.Type {
+    return A.self
+  }
+}
+
+// PublicGenericOutsideParent.publicGenericExtensionMethod()
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s15resilient_class26PublicGenericOutsideParentC18package_resilienceE06publicD15ExtensionMethodxmyF"(ptr swiftself %0)
+// CHECK: [[ISA:%.*]] = load ptr, ptr {{.*}}
+// CHECK:      [[BASE:%.*]] = load {{i32|i64}}, ptr @"$s15resilient_class26PublicGenericOutsideParentCMo"
+// CHECK-NEXT: [[GENERIC_PARAM_OFFSET:%.*]] = add {{i32|i64}} [[BASE]], 0
+// CHECK-NEXT: [[GENERIC_PARAM_TMP:%.*]] = getelementptr inbounds i8, ptr [[ISA]], {{i32|i64}} [[GENERIC_PARAM_OFFSET]]
+// CHECK-NEXT: [[GENERIC_PARAM:%.*]] = load ptr, ptr [[GENERIC_PARAM_TMP]]
+
+extension ResilientGenericOutsideParent {
+  package func pkgGenericExtensionMethod() -> A.Type {
+    return A.self
+  }
+}
+
+// ResilientGenericOutsideParent.pkgGenericExtensionMethod()
+
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s15resilient_class29ResilientGenericOutsideParentC18package_resilienceE03pkgD15ExtensionMethodxmyF"(ptr swiftself %0)
+// CHECK: [[ISA:%.*]] = load ptr, ptr {{.*}}
+// CHECK:      [[BASE:%.*]] = load {{i32|i64}}, ptr @"$s15resilient_class29ResilientGenericOutsideParentCMo"
+// CHECK-NEXT: [[GENERIC_PARAM_OFFSET:%.*]] = add {{i32|i64}} [[BASE]], 0
+// CHECK-NEXT: [[GENERIC_PARAM_TMP:%.*]] = getelementptr inbounds i8, ptr [[ISA]], {{i32|i64}} [[GENERIC_PARAM_OFFSET]]
+// CHECK-NEXT: [[GENERIC_PARAM:%.*]] = load ptr, ptr [[GENERIC_PARAM_TMP]]
+
+
+
+// rdar://48031465
+// Field offsets for empty fields in resilient classes should be initialized
+// to their best-known value and made non-constant if that value might
+// disagree with the dynamic value.
+
+public struct PublicEmpty {}
+
+public class PublicClassWithEmptyThenResilient {
+  public let empty: PublicEmpty
+  public let resilient: PublicResilientInt
+
+  public init(empty: PublicEmpty, resilient: PublicResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+public class PublicClassWithResilientThenEmpty {
+  public let resilient: PublicResilientInt
+  public let empty: PublicEmpty
+
+  public init(empty: PublicEmpty, resilient: PublicResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+package struct PkgStructEmpty {}
+
+package class PkgClassWithEmptyThenResilient {
+  package let empty: PkgStructEmpty
+  package let resilient: ResilientInt
+
+  package init(empty: PkgStructEmpty, resilient: ResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+package class PkgClassWithResilientThenEmpty {
+  package let resilient: ResilientInt
+  package let empty: PkgStructEmpty
+
+  package init(empty: PkgStructEmpty, resilient: ResilientInt) {
+    self.empty = empty
+    self.resilient = resilient
+  }
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience35memoryLayoutDotSizeWithPublicStructSiyF"()
+public func memoryLayoutDotSizeWithPublicStruct() -> Int {
+  // CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+  // CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[FIELD_VALUE]],
+  // CHECK-NEXT: [[SIZE:%.*]] = load {{i32|i64}}, ptr [[FIELD_PTR]],
+  // CHECK-NEXT: ret {{i32|i64}} [[SIZE]]
+  return MemoryLayout<PublicSize>.size
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience32memoryLayoutDotSizeWithPkgStructSiyF"()
+package func memoryLayoutDotSizeWithPkgStruct() -> Int {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[FIELD_VALUE]],
+// CHECK-NEXT: [[SIZE:%.*]] = load {{i32|i64}}, ptr [[FIELD_PTR]],
+// CHECK-NEXT: ret {{i32|i64}} [[SIZE]]
+  return MemoryLayout<Size>.size
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience41memoryLayoutDotSizeWithFrozenPublicStructSiyF"()
+public func memoryLayoutDotSizeWithFrozenPublicStruct() -> Int {
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret {{i32|i64}} {{.*}}
+  return MemoryLayout<FrozenPublicSize>.size
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience37memoryLayoutDotStrideWithPublicStructSiyF"()
+public func memoryLayoutDotStrideWithPublicStruct() -> Int {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[FIELD_VALUE]],
+// CHECK-NEXT: [[STRIDE:%.*]] = load {{i32|i64}}, ptr [[FIELD_PTR]],
+// CHECK-NEXT: ret {{i32|i64}} [[STRIDE]]
+  return MemoryLayout<PublicSize>.stride
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience34memoryLayoutDotStrideWithPkgStructSiyF"()
+package func memoryLayoutDotStrideWithPkgStruct() -> Int {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[FIELD_VALUE]],
+// CHECK-NEXT: [[STRIDE:%.*]] = load {{i32|i64}}, ptr [[FIELD_PTR]],
+// CHECK-NEXT: ret {{i32|i64}} [[STRIDE]]
+  return MemoryLayout<Size>.stride
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience43memoryLayoutDotStrideWithFrozenPublicStructSiyF"()
+public func memoryLayoutDotStrideWithFrozenPublicStruct() -> Int {
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret {{i32|i64}} {{.*}}
+  return MemoryLayout<FrozenPublicSize>.stride
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience40memoryLayoutDotAlignmentWithPublicStructSiyF"()
+public func memoryLayoutDotAlignmentWithPublicStruct() -> Int {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[FIELD_VALUE]],
+// CHECK-NEXT:  [[FIELD_FLAGS:%.*]] = load {{i32|i64}}, ptr [[FIELD_PTR]],
+// CHECK-NEXT:  [[FIELD_ADDR:%.*]] = zext {{i32|i64}} [[FIELD_FLAGS]] to {{i32|i64}}
+// CHECK-NEXT:  [[FIELD_MASK:%.*]] = and {{i32|i64}} [[FIELD_ADDR]]
+// CHECK-NEXT:  [[FIELD_PAYLOAD:%.*]] = add {{i32|i64}} [[FIELD_MASK]], 1
+// CHECK-NEXT:  ret {{i32|i64}} [[FIELD_PAYLOAD]]
+  return MemoryLayout<PublicSize>.alignment
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience43memoryLayoutDotAlignmentWithResilientStructSiyF"()
+package func memoryLayoutDotAlignmentWithResilientStruct() -> Int {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds %swift.vwtable, ptr [[FIELD_VALUE]],
+// CHECK-NEXT:  [[FIELD_FLAGS:%.*]] = load {{i32|i64}}, ptr [[FIELD_PTR]],
+// CHECK-NEXT:  [[FIELD_ADDR:%.*]] = zext {{i32|i64}} [[FIELD_FLAGS]] to {{i32|i64}}
+// CHECK-NEXT:  [[FIELD_MASK:%.*]] = and {{i32|i64}} [[FIELD_ADDR]]
+// CHECK-NEXT:  [[FIELD_PAYLOAD:%.*]] = add {{i32|i64}} [[FIELD_MASK]], 1
+// CHECK-NEXT:  ret {{i32|i64}} [[FIELD_PAYLOAD]]
+  return MemoryLayout<Size>.alignment
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience46memoryLayoutDotAlignmentWithFrozenPublicStructSiyF"()
+public func memoryLayoutDotAlignmentWithFrozenPublicStruct() -> Int {
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret {{i32|i64}} {{.*}}
+  return MemoryLayout<FrozenPublicSize>.alignment
+}
+
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience37constructPublicResilientEnumNoPayload14resilient_enum0D6MediumOyF"(ptr noalias
+public func constructPublicResilientEnumNoPayload() -> PublicMedium {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds ptr, ptr [[FIELD_VALUE]],
+// CHECK-NEXT: [[TAG:%.*]] = load ptr, ptr [[FIELD_PTR]],
+// CHECK-NEXT: call void [[TAG]]
+// CHECK-NEXT: ret void
+  return PublicMedium.Paper
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience34constructPkgResilientEnumNoPayload14resilient_enum6MediumOyF"
+package func constructPkgResilientEnumNoPayload() -> Medium {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds ptr, ptr [[FIELD_VALUE]],
+// CHECK-NEXT: [[TAG:%.*]] = load ptr, ptr [[FIELD_PTR]],
+// CHECK-NEXT: call void [[TAG]]
+// CHECK-NEXT: ret void
+  return Medium.Paper
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience43pub_constructExhaustiveWithResilientMembers14resilient_enum17PublicSimpleShapeOyF"
+public func pub_constructExhaustiveWithResilientMembers() -> PublicSimpleShape {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds ptr, ptr [[FIELD_VALUE]],
+// CHECK-NEXT: [[TAG:%.*]] = load ptr, ptr [[FIELD_PTR]],
+// CHECK-NEXT: call void [[TAG]]
+// CHECK-NEXT: ret void
+  return .pbKleinBottle
+}
+
+// CHECK: define{{.*}} swiftcc {{.*}} @"$s18package_resilience43pkg_constructExhaustiveWithResilientMembers14resilient_enum11SimpleShapeOyF"
+package func pkg_constructExhaustiveWithResilientMembers() -> SimpleShape {
+// CHECK: [[FIELD_VALUE:%.*]] = load ptr, ptr {{.*}},
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = getelementptr inbounds ptr, ptr [[FIELD_VALUE]],
+// CHECK-NEXT: [[TAG:%.*]] = load ptr, ptr [[FIELD_PTR]],
+// CHECK-NEXT: call void [[TAG]]
+// CHECK-NEXT: ret void
+  return .KleinBottle
+}
+
+
+// PublicClassWithPbProperties metadata accessor
+//3535
+// CHECK: define{{.*}} swiftcc %swift.metadata_response @"$s18package_resilience27PublicClassWithPbPropertiesCMa"
+// CHECK-NEXT: entry:
+// CHECK-NEXT: [[PTR:%.*]] = load ptr, ptr @"$s18package_resilience27PublicClassWithPbPropertiesCMl"
+// CHECK-NEXT: [[RET:%.*]] = icmp eq ptr [[PTR]]
+// CHECK-NEXT: br i1 [[RET]], label %cacheIsNull, label %cont
+
+
+
+// PublicClassWithPbProperties method lookup function
+
+// 3606
+// CHECK: define{{.*}} swiftcc ptr @"$s18package_resilience27PublicClassWithPbPropertiesCMu"(ptr {{.*}}, ptr {{.*}})
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   [[RESULT:%.*]] = call ptr @swift_lookUpClassMethod(ptr {{.*}}, ptr {{.*}}, ptr @"$s18package_resilience27PublicClassWithPbPropertiesCMn")
+// CHECK-NEXT:   ret ptr [[RESULT]]
+
+
+
+// PkgClassWithPublicProperties metadata accessor
+//3630
+// CHECK: define{{.*}} swiftcc %swift.metadata_response @"$s18package_resilience28PkgClassWithPublicPropertiesCMa"
+// CHECK:      [[T1:%.*]] = load ptr, ptr @"$s18package_resilience28PkgClassWithPublicPropertiesCMl"
+// CHECK-NEXT: [[T2:%.*]] = icmp eq ptr [[T1]], null
+// CHECK-NEXT: br i1 [[T2]], label %cacheIsNull, label %cont
+
+
+
+// PkgClassWithPublicProperties method lookup
+// 3701
+// CHECK: define{{.*}} swiftcc ptr @"$s18package_resilience28PkgClassWithPublicPropertiesCMu"(ptr {{.*}}, ptr {{.*}})
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   [[RESULT:%.*]] = call ptr @swift_lookUpClassMethod(ptr {{.*}}, ptr {{.*}}, ptr @"$s18package_resilience28PkgClassWithPublicPropertiesCMn")
+// CHECK-NEXT:   ret ptr [[RESULT]]
+
+
+// PkgWithPackageProperties metadata accessor
+//3716
+// CHECK: define{{.*}} swiftcc %swift.metadata_response @"$s18package_resilience24PkgWithPackagePropertiesCMa"
+// CHECK:      [[T1:%.*]] = load ptr, ptr @"$s18package_resilience24PkgWithPackagePropertiesCMl"
+// CHECK-NEXT: [[T2:%.*]] = icmp eq ptr [[T1]], null
+// CHECK-NEXT: br i1 [[T2]], label %cacheIsNull, label %cont
+
+
+// PkgWithPackageProperties method lookup
+//3787
+// CHECK: define{{.*}} swiftcc ptr @"$s18package_resilience24PkgWithPackagePropertiesCMu"(ptr {{.*}}, ptr {{.*}})
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   [[RESULT:%.*]] = call ptr @swift_lookUpClassMethod(ptr {{.*}}, ptr {{.*}}, ptr @"$s18package_resilience24PkgWithPackagePropertiesCMn")
+// CHECK-NEXT:   ret ptr [[RESULT]]
+
+// PublicClassWithFrozenPbProperties metadata accessor
+//3802
+// CHECK: define{{.*}} swiftcc %swift.metadata_response @"$s18package_resilience33PublicClassWithFrozenPbPropertiesCMa"
+// CHECK:      [[A:%.*]] = insertvalue %swift.metadata_response undef, ptr {{.*}}, 0
+// CHECK-NEXT: [[B:%.*]] = insertvalue %swift.metadata_response [[A]]
+// CHECK-NEXT: ret %swift.metadata_response [[B]]
+
+
+
+// PublicClassWithFrozenPbProperties method lookup
+//3810
+// CHECK: define{{.*}} swiftcc ptr @"$s18package_resilience33PublicClassWithFrozenPbPropertiesCMu"(ptr {{.*}}, ptr {{.*}})
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   [[RESULT:%.*]] = call ptr @swift_lookUpClassMethod(ptr {{.*}}, ptr {{.*}}, ptr @"$s18package_resilience33PublicClassWithFrozenPbPropertiesCMn")
+// CHECK-NEXT:   ret ptr [[RESULT]]
+
+// PkgClassWithFrozenPublicProperties metadata accessor
+//3828
+// CHECK: define{{.*}} swiftcc %swift.metadata_response @"$s18package_resilience34PkgClassWithFrozenPublicPropertiesCMa"
+// CHECK:      [[A:%.*]] = insertvalue %swift.metadata_response undef, ptr {{.*}}, 0
+// CHECK-NEXT: [[B:%.*]] = insertvalue %swift.metadata_response [[A]]
+// CHECK-NEXT: ret %swift.metadata_response [[B]]
+
+// PkgClassWithFrozenPublicProperties method lookup
+//3836
+// CHECK: define{{.*}} swiftcc ptr @"$s18package_resilience34PkgClassWithFrozenPublicPropertiesCMu"(ptr {{.*}}, ptr {{.*}})
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   [[RESULT:%.*]] = call ptr @swift_lookUpClassMethod(ptr {{.*}}, ptr {{.*}}, ptr @"$s18package_resilience34PkgClassWithFrozenPublicPropertiesCMn")
+// CHECK-NEXT:   ret ptr [[RESULT]]
+
+

--- a/test/SILGen/witness_tables_serialized.swift
+++ b/test/SILGen/witness_tables_serialized.swift
@@ -26,11 +26,6 @@ internal struct UsableFromInlineStruct : PublicProtocol, UsableFromInlineProtoco
 // CHECK-DAG: sil_witness_table PublicFrozenStruct: PackageProtocol
 // CHECK-DAG: sil_witness_table hidden PublicFrozenStruct: InternalProtocol
 
-// CHECK-DAG: sil_witness_table [serialized] PackageStruct: PublicProtocol
-// CHECK-DAG: sil_witness_table [serialized] PackageStruct: UsableFromInlineProtocol
-// CHECK-DAG: sil_witness_table PackageStruct: PackageProtocol
-// CHECK-DAG: sil_witness_table hidden PackageStruct: InternalProtocol
-
 // CHECK-RESILIENT-DAG: sil_witness_table UsableFromInlineStruct: UsableFromInlineProtocol
 // CHECK-RESILIENT-DAG: sil_witness_table UsableFromInlineStruct: PublicProtocol
 // CHECK-RESILIENT-DAG: sil_witness_table UsableFromInlineStruct: PackageProtocol
@@ -41,6 +36,11 @@ internal struct UsableFromInlineStruct : PublicProtocol, UsableFromInlineProtoco
 // CHECK-RESILIENT-DAG: sil_witness_table PublicResilientStruct: PackageProtocol
 // CHECK-RESILIENT-DAG: sil_witness_table hidden PublicResilientStruct: InternalProtocol
 
+// CHECK-RESILIENT-DAG: sil_witness_table PackageStruct: PublicProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table PackageStruct: UsableFromInlineProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table PackageStruct: PackageProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table hidden PackageStruct: InternalProtocol
+
 // CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] UsableFromInlineStruct: UsableFromInlineProtocol
 // CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] UsableFromInlineStruct: PublicProtocol
 // CHECK-NONRESILIENT-DAG: sil_witness_table UsableFromInlineStruct: PackageProtocol
@@ -50,3 +50,8 @@ internal struct UsableFromInlineStruct : PublicProtocol, UsableFromInlineProtoco
 // CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PublicResilientStruct: UsableFromInlineProtocol
 // CHECK-NONRESILIENT-DAG: sil_witness_table PublicResilientStruct: PackageProtocol
 // CHECK-NONRESILIENT-DAG: sil_witness_table hidden PublicResilientStruct: InternalProtocol
+
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PackageStruct: PublicProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PackageStruct: UsableFromInlineProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table PackageStruct: PackageProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table hidden PackageStruct: InternalProtocol

--- a/test/Sema/package_resilience_access.swift
+++ b/test/Sema/package_resilience_access.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+/// Build Utils module resiliently.
 // RUN: %target-swift-frontend -emit-module %t/Utils.swift \
 // RUN:   -module-name Utils -swift-version 5 -I %t \
 // RUN:   -package-name mypkg \
@@ -9,51 +10,273 @@
 
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t -swift-version 5 -package-name mypkg -verify
 
-// RUN: %target-swift-frontend -emit-sil %t/Client.swift -package-name mypkg -I %t > %t/Client.sil
-// RUN: %FileCheck %s < %t/Client.sil
+/// Check serialization in SILGEN with resilience enabled.
+// RUN: %target-swift-emit-silgen -emit-verbose-sil -enable-library-evolution -module-name Utils %t/Utils.swift -package-name mypkg -I %t > %t/Utils-Res.sil
+// RUN: %FileCheck %s --check-prefixes=UTILS-RES,UTILS-COMMON < %t/Utils-Res.sil
+
+/// Check for indirect access with a resiliently built module dependency.
+// RUN: %target-swift-emit-silgen %t/Client.swift -package-name mypkg -I %t > %t/Client-Res.sil
+// RUN: %FileCheck %s --check-prefixes=CLIENT-RES,CLIENT-COMMON < %t/Client-Res.sil
+
+// RUN: rm -rf %t/Utils.swiftmodule
+
+/// Build Utils module non-resiliently
+// RUN: %target-swift-frontend -emit-module %t/Utils.swift \
+// RUN:   -module-name Utils -swift-version 5 -I %t \
+// RUN:   -package-name mypkg \
+// RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t -swift-version 5 -package-name mypkg -verify
+
+/// Check serialization in SILGEN with resilience not enabled.
+// RUN: %target-swift-emit-silgen -emit-verbose-sil -module-name Utils %t/Utils.swift -package-name mypkg -I %t > %t/Utils-NonRes.sil
+// RUN: %FileCheck %s --check-prefixes=UTILS-NONRES,UTILS-COMMON < %t/Utils-NonRes.sil
+
+/// Check for indirect access with a non-resiliently built module dependency.
+// RUN: %target-swift-emit-silgen %t/Client.swift -package-name mypkg -I %t > %t/Client-NonRes.sil
+// RUN: %FileCheck %s --check-prefixes=CLIENT-NONRES,CLIENT-COMMON < %t/Client-NonRes.sil
 
 
 //--- Utils.swift
 
-// Resilient; public. Acessed indirectly.
+public protocol PublicProto {
+  var data: Int { get set }
+  func pfunc(_ arg: Int) -> Int
+}
+
+public class PublicKlass: PublicProto {
+    public var data: Int
+    public init(data: Int = 1) {
+        self.data = data
+    }
+    public func pfunc(_ arg: Int) -> Int {
+        return data + arg
+    }
+}
+
+// UTILS-RES-LABEL: // PublicKlass.data.getter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils11PublicKlassC4dataSivg : $@convention(method) (@guaranteed PublicKlass) -> Int
+
+// UTILS-NONRES-LABEL: // PublicKlass.data.getter
+// UTILS-NONRES-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils11PublicKlassC4dataSivg : $@convention(method) (@guaranteed PublicKlass) -> Int {
+
+// UTILS-RES-LABEL: // PublicKlass.data.setter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils11PublicKlassC4dataSivs : $@convention(method) (Int, @guaranteed PublicKlass) -> () {
+
+// UTILS-NONRES-LABEL: // PublicKlass.data.setter
+// UTILS-NONRES-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils11PublicKlassC4dataSivs : $@convention(method) (Int, @guaranteed PublicKlass) -> () {
+
+// UTILS-RES-LABEL: // PublicKlass.data.modify
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils11PublicKlassC4dataSivM : $@yield_once @convention(method) (@guaranteed PublicKlass) -> @yields @inout Int {
+
+// UTILS-NONRES-LABEL: // PublicKlass.data.modify
+// UTILS-NONRES-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils11PublicKlassC4dataSivM : $@yield_once @convention(method) (@guaranteed PublicKlass) -> @yields @inout Int {
+
+// UTILS-COMMON-LABEL: // default argument 0 of PublicKlass.init(data:)
+// UTILS-COMMON-NEXT: sil non_abi [serialized] [ossa] @$s5Utils11PublicKlassC4dataACSi_tcfcfA_ : $@convention(thin) () -> Int {
+
+// UTILS-COMMON-LABEL: // PublicKlass.__allocating_init(data:)
+// UTILS-COMMON-NEXT: sil [serialized] [exact_self_class] [ossa] @$s5Utils11PublicKlassC4dataACSi_tcfC : $@convention(method) (Int, @thick PublicKlass.Type) -> @owned PublicKlass {
+
+// UTILS-RES-LABEL: // protocol witness for PublicProto.data.getter in conformance PublicKlass
+// UTILS-RES-NEXT: sil private [transparent] [thunk] [ossa] @$s5Utils11PublicKlassCAA0B5ProtoA2aDP4dataSivgTW : $@convention(witness_method: PublicProto) (@in_guaranteed PublicKlass) -> Int {
+
+// UTILS-NONRES-LABEL: // protocol witness for PublicProto.data.getter in conformance PublicKlass
+// UTILS-NONRES-NEXT: sil shared [transparent] [serialized] [thunk] [ossa] @$s5Utils11PublicKlassCAA0B5ProtoA2aDP4dataSivgTW : $@convention(witness_method: PublicProto) (@in_guaranteed PublicKlass) -> Int {
+
+// UTILS-RES-LABEL: // protocol witness for PublicProto.data.setter in conformance PublicKlass
+// UTILS-RES-NEXT: sil private [transparent] [thunk] [ossa] @$s5Utils11PublicKlassCAA0B5ProtoA2aDP4dataSivsTW : $@convention(witness_method: PublicProto) (Int, @inout PublicKlass) -> () {
+
+// UTILS-NONRES-LABEL: // protocol witness for PublicProto.data.setter in conformance PublicKlass
+// UTILS-NONRES-NEXT: sil shared [transparent] [serialized] [thunk] [ossa] @$s5Utils11PublicKlassCAA0B5ProtoA2aDP4dataSivsTW : $@convention(witness_method: PublicProto) (Int, @inout PublicKlass) -> () {
+
+
+// UTILS-RES-LABEL: // protocol witness for PublicProto.data.modify in conformance PublicKlass
+// UTILS-RES-NEXT: sil private [transparent] [thunk] [ossa] @$s5Utils11PublicKlassCAA0B5ProtoA2aDP4dataSivMTW : $@yield_once @convention(witness_method: PublicProto) @substituted <τ_0_0> (@inout τ_0_0) -> @yields @inout Int for <PublicKlass> {
+
+// UTILS-NONRES-LABEL: // protocol witness for PublicProto.data.modify in conformance PublicKlass
+// UTILS-NONRES-NEXT: sil shared [transparent] [serialized] [thunk] [ossa] @$s5Utils11PublicKlassCAA0B5ProtoA2aDP4dataSivMTW : $@yield_once @convention(witness_method: PublicProto) @substituted <τ_0_0> (@inout τ_0_0) -> @yields @inout Int for <PublicKlass> {
+
+// UTILS-RES-LABEL: // protocol witness for PublicProto.pfunc(_:) in conformance PublicKlass
+// UTILS-RES-NEXT: sil private [transparent] [thunk] [ossa] @$s5Utils11PublicKlassCAA0B5ProtoA2aDP5pfuncyS2iFTW : $@convention(witness_method: PublicProto) (Int, @in_guaranteed PublicKlass) -> Int {
+
+// UTILS-NONRES-LABEL: // protocol witness for PublicProto.pfunc(_:) in conformance PublicKlass
+// UTILS-NONRES-NEXT: sil shared [transparent] [serialized] [thunk] [ossa] @$s5Utils11PublicKlassCAA0B5ProtoA2aDP5pfuncyS2iFTW : $@convention(witness_method: PublicProto) (Int, @in_guaranteed PublicKlass) -> Int {
+
+package protocol PkgProto {
+  var data: Int { get set }
+  func pkgfunc(_ arg: Int) -> Int
+}
+
+package class PkgKlass: PkgProto {
+    package var data: Int
+    package init(data: Int = 1) {
+        self.data = data
+    }
+    package func pkgfunc(_ arg: Int) -> Int {
+        return data + arg
+    }
+}
+
+// UTILS-COMMON-LABEL: // key path getter for PkgKlass.data : PkgKlass
+// UTILS-COMMON-NEXT: sil shared [thunk] [ossa] @$s5Utils8PkgKlassC4dataSivpACTK : $@convention(keypath_accessor_getter) (@in_guaranteed PkgKlass) -> @out Int {
+
+// UTILS-COMMON-LABEL: // key path setter for PkgKlass.data : PkgKlass
+// UTILS-COMMON-NEXT: sil shared [thunk] [ossa] @$s5Utils8PkgKlassC4dataSivpACTk : $@convention(keypath_accessor_setter) (@in_guaranteed Int, @in_guaranteed PkgKlass) -> () {
+
+// UTILS-RES-LABEL: // PkgKlass.data.getter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils8PkgKlassC4dataSivg : $@convention(method) (@guaranteed PkgKlass) -> Int {
+// UTILS-NONRES-LABEL: // PkgKlass.data.getter
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils8PkgKlassC4dataSivg : $@convention(method) (@guaranteed PkgKlass) -> Int {
+
+// UTILS-RES-LABEL: // PkgKlass.data.setter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils8PkgKlassC4dataSivs : $@convention(method) (Int, @guaranteed PkgKlass) -> () {
+// UTILS-NONRES-LABEL: // PkgKlass.data.setter
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils8PkgKlassC4dataSivs : $@convention(method) (Int, @guaranteed PkgKlass) -> () {
+
+
+// UTILS-RES-LABEL: // PkgKlass.data.modify
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils8PkgKlassC4dataSivM : $@yield_once @convention(method) (@guaranteed PkgKlass) -> @yields @inout Int {
+// UTILS-NONRES-LABEL: // PkgKlass.data.modify
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils8PkgKlassC4dataSivM : $@yield_once @convention(method) (@guaranteed PkgKlass) -> @yields @inout Int {
+
+// UTILS-COMMON-LABEL: // default argument 0 of PkgKlass.init(data:)
+// UTILS-COMMON-NEXT: sil [ossa] @$s5Utils8PkgKlassC4dataACSi_tcfcfA_ : $@convention(thin) () -> Int {
+
+// FIXME: __allocating_init for a `package` class should not be serialized in resilient Utils.
+// UTILS-COMMON-LABEL: // PkgKlass.__allocating_init(data:)
+// UTILS-COMMON-NEXT: sil [serialized] [exact_self_class] [ossa] @$s5Utils8PkgKlassC4dataACSi_tcfC : $@convention(method) (Int, @thick PkgKlass.Type) -> @owned PkgKlass {
+
+// UTILS-COMMON-LABEL: // PkgKlass.init(data:)
+// UTILS-COMMON-NEXT: sil [ossa] @$s5Utils8PkgKlassC4dataACSi_tcfc : $@convention(method) (Int, @owned PkgKlass) -> @owned PkgKlass {
+
+// UTILS-COMMON-LABEL: // PkgKlass.pkgfunc(_:)
+// UTILS-COMMON-NEXT: sil [ossa] @$s5Utils8PkgKlassC7pkgfuncyS2iF : $@convention(method) (Int, @guaranteed PkgKlass) -> Int {
+
+// UTILS-COMMON-LABEL: // PkgKlass.deinit
+// UTILS-COMMON-NEXT: sil [ossa] @$s5Utils8PkgKlassCfd : $@convention(method) (@guaranteed PkgKlass) -> @owned Builtin.NativeObject {
+
+// UTILS-COMMON-LABEL: // PkgKlass.__deallocating_deinit
+// UTILS-COMMON-NEXT: sil [ossa] @$s5Utils8PkgKlassCfD : $@convention(method) (@owned PkgKlass) -> () {
+
+// UTILS-COMMON-LABEL: // protocol witness for PkgProto.data.getter in conformance PkgKlass
+// UTILS-COMMON-NEXT: sil private [transparent] [thunk] [ossa] @$s5Utils8PkgKlassCAA0B5ProtoA2aDP4dataSivgTW : $@convention(witness_method: PkgProto) (@in_guaranteed PkgKlass) -> Int {
+
+// UTILS-COMMON-LABEL: // protocol witness for PkgProto.data.setter in conformance PkgKlass
+// UTILS-COMMON-NEXT: sil private [transparent] [thunk] [ossa] @$s5Utils8PkgKlassCAA0B5ProtoA2aDP4dataSivsTW : $@convention(witness_method: PkgProto) (Int, @inout PkgKlass) -> () {
+
+// UTILS-COMMON-LABEL: // protocol witness for PkgProto.pkgfunc(_:) in conformance PkgKlass
+// UTILS-COMMON-NEXT: sil private [transparent] [thunk] [ossa] @$s5Utils8PkgKlassCAA0B5ProtoA2aDP7pkgfuncyS2iFTW : $@convention(witness_method: PkgProto) (Int, @in_guaranteed PkgKlass) -> Int {
+
 public struct PublicStruct {
   public var data: Int
 }
 
-// Non-resilient; non-public. Accessed directly.
+// UTILS-RES-LABEL: // PublicStruct.data.getter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils12PublicStructV4dataSivg : $@convention(method) (@in_guaranteed PublicStruct) -> Int {
+
+// UTILS-NONRES-LABEL: // PublicStruct.data.getter
+// UTILS-NONRES-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils12PublicStructV4dataSivg : $@convention(method) (PublicStruct) -> Int {
+
+// UTILS-RES-LABEL: // PublicStruct.data.setter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils12PublicStructV4dataSivs : $@convention(method) (Int, @inout PublicStruct) -> () {
+
+// UTILS-NONRES-LABEL: // PublicStruct.data.setter
+// UTILS-NONRES-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils12PublicStructV4dataSivs : $@convention(method) (Int, @inout PublicStruct) -> () {
+
+// UTILS-RES-LABEL: // PublicStruct.data.modify
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils12PublicStructV4dataSivM : $@yield_once @convention(method) (@inout PublicStruct) -> @yields @inout Int {
+
+// UTILS-NONRES-LABEL: // PublicStruct.data.modify
+// UTILS-NONRES-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils12PublicStructV4dataSivM : $@yield_once @convention(method) (@inout PublicStruct) -> @yields @inout Int {
+
+@_frozen
+public struct FrozenPublicStruct {
+  public var data: Int
+}
+
+// UTILS-COMMON-LABEL: // FrozenPublicStruct.data.getter
+// UTILS-COMMON-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils18FrozenPublicStructV4dataSivg : $@convention(method) (FrozenPublicStruct) -> Int {
+
+// UTILS-COMMON-LABEL: // FrozenPublicStruct.data.setter
+// UTILS-COMMON-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils18FrozenPublicStructV4dataSivs : $@convention(method) (Int, @inout FrozenPublicStruct) -> () {
+
+// UTILS-COMMON-LABEL: // FrozenPublicStruct.data.modify
+// UTILS-COMMON-NEXT: sil [transparent] [serialized] [ossa] @$s5Utils18FrozenPublicStructV4dataSivM : $@yield_once @convention(method) (@inout FrozenPublicStruct) -> @yields @inout Int {
+
 package struct PkgStruct {
   package var data: Int
 }
 
-// Non-resilient but accessed indirectly since generic.
+// UTILS-RES-LABEL: // PkgStruct.data.getter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils9PkgStructV4dataSivg : $@convention(method) (@in_guaranteed PkgStruct) -> Int {
+
+// UTILS-NONRES-LABEL: // PkgStruct.data.getter
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils9PkgStructV4dataSivg : $@convention(method) (PkgStruct) -> Int {
+
+// UTILS-RES-LABEL: // PkgStruct.data.setter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils9PkgStructV4dataSivs : $@convention(method) (Int, @inout PkgStruct) -> () {
+
+// UTILS-NONRES-LABEL: // PkgStruct.data.setter
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils9PkgStructV4dataSivs : $@convention(method) (Int, @inout PkgStruct) -> () {
+
+// UTILS-RES-LABEL: // PkgStruct.data.modify
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils9PkgStructV4dataSivM : $@yield_once @convention(method) (@inout PkgStruct) -> @yields @inout Int {
+
+// UTILS-NONRES-LABEL: // PkgStruct.data.modify
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils9PkgStructV4dataSivM : $@yield_once @convention(method) (@inout PkgStruct) -> @yields @inout Int {
+
+@usableFromInline
+package struct UfiPkgStruct {
+  package var data: Int
+}
+
+// UTILS-RES-LABEL: // UfiPkgStruct.data.getter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils12UfiPkgStructV4dataSivg : $@convention(method) (@in_guaranteed UfiPkgStruct) -> Int {
+
+// UTILS-NONRES-LABEL: // UfiPkgStruct.data.getter
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils12UfiPkgStructV4dataSivg : $@convention(method) (UfiPkgStruct) -> Int {
+
+// UTILS-RES-LABEL: // UfiPkgStruct.data.setter
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils12UfiPkgStructV4dataSivs : $@convention(method) (Int, @inout UfiPkgStruct) -> () {
+
+// UTILS-NONRES-LABEL: // UfiPkgStruct.data.setter
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils12UfiPkgStructV4dataSivs : $@convention(method) (Int, @inout UfiPkgStruct) -> () {
+
+// UTILS-RES-LABEL: // UfiPkgStruct.data.modify
+// UTILS-RES-NEXT: sil [ossa] @$s5Utils12UfiPkgStructV4dataSivM : $@yield_once @convention(method) (@inout UfiPkgStruct) -> @yields @inout Int {
+
+// UTILS-NONRES-LABEL: // UfiPkgStruct.data.modify
+// UTILS-NONRES-NEXT: sil [transparent] [ossa] @$s5Utils12UfiPkgStructV4dataSivM : $@yield_once @convention(method) (@inout UfiPkgStruct) -> @yields @inout Int {
+
 package struct PkgStructGeneric<T> {
   package var data: T
 }
 
-// Non-resilient but accessed indirectly; member is of a resilient type.
 package struct PkgStructWithPublicMember {
   package var member: PublicStruct
 }
 
-// Non-resilient but accessed indirectly; contains existential.
 package struct PkgStructWithPublicExistential {
   package var member: any PublicProto
 }
 
-// Non-resilient but accessed indirectly; contains existential.
 package struct PkgStructWithPkgExistential {
   package var member: any PkgProto
 }
 
-// Resilient; public. Acessed indirectly.
-public protocol PublicProto {
-  var data: Int { get set }
+struct InternalStruct {
+    var data: Int
 }
 
-// Non-resilient but acessed indirectly; existential.
-package protocol PkgProto {
-  var data: Int { get set }
-}
+// UTILS-RES-LABEL: sil_vtable PublicKlass {
+// UTILS-NONRES-LABEL: sil_vtable [serialized] PublicKlass {
+// UTILS-COMMON-LABEL: sil_vtable PkgKlass {
+
+// UTILS-RES-LABEL: sil_witness_table PublicKlass: PublicProto module Utils {
+// UTILS-NONRES-LABEL: sil_witness_table [serialized] PublicKlass: PublicProto module Utils {
+// UTILS-COMMON-LABEL: sil_witness_table PkgKlass: PkgProto module Utils {
+
 
 
 //--- Client.swift
@@ -63,141 +286,263 @@ package func f(_ arg: PublicStruct) -> Int {
   return arg.data
 }
 
-// CHECK: // f(_:)
-// CHECK-NEXT: sil @$s6Client1fySi5Utils12PublicStructVF : $@convention(thin) (@in_guaranteed PublicStruct) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %3, %1
-// CHECK-NEXT: bb0(%0 : $*PublicStruct):
-// CHECK-NEXT:   debug_value %0 : $*PublicStruct, let, name "arg", argno 1, expr op_deref // id: %1
-// CHECK-NEXT:   %2 = alloc_stack $PublicStruct                  // users: %7, %6, %5, %3
-// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PublicStruct      // id: %3
-// CHECK-NEXT:   // function_ref PublicStruct.data.getter
-// CHECK-NEXT:   %4 = function_ref @$s5Utils12PublicStructV4dataSivg : $@convention(method) (@in_guaranteed PublicStruct) -> Int // user: %5
-// CHECK-NEXT:   %5 = apply %4(%2) : $@convention(method) (@in_guaranteed PublicStruct) -> Int // user: %8
-// CHECK-NEXT:   destroy_addr %2 : $*PublicStruct                // id: %6
-// CHECK-NEXT:   dealloc_stack %2 : $*PublicStruct               // id: %7
-// CHECK-NEXT:   return %5 : $Int                                // id: %8
-// CHECK-NEXT: } // end sil function '$s6Client1fySi5Utils12PublicStructVF'
+// CLIENT-RES-LABEL: // f(_:)
+// CLIENT-RES-NEXT: sil [ossa] @$s6Client1fySi5Utils12PublicStructVF : $@convention(thin) (@in_guaranteed PublicStruct) -> Int
+// CLIENT-RES-LABEL: // PublicStruct.data.getter
+// CLIENT-RES-NEXT: sil @$s5Utils12PublicStructV4dataSivg : $@convention(method) (@in_guaranteed PublicStruct) -> Int
 
+// CLIENT-NONRES-LABEL: // f(_:)
+// CLIENT-NONRES-NEXT: sil [ossa] @$s6Client1fySi5Utils12PublicStructVF : $@convention(thin) (PublicStruct) -> Int
+
+public func ff(_ arg: PublicStruct) -> Int {
+  return arg.data
+}
+
+// CLIENT-RES-LABEL: // ff(_:)
+// CLIENT-RES-NEXT: sil [ossa] @$s6Client2ffySi5Utils12PublicStructVF : $@convention(thin) (@in_guaranteed PublicStruct) -> Int
+
+// CLIENT-NONRES-LABEL: // ff(_:)
+// CLIENT-NONRES-NEXT: sil [ossa] @$s6Client2ffySi5Utils12PublicStructVF : $@convention(thin) (PublicStruct) -> Int
+
+
+public func fx(_ arg: FrozenPublicStruct) -> Int {
+  return arg.data
+}
+
+// CLIENT-COMMON-LABEL: // fx(_:)
+// CLIENT-COMMON-LABEL: sil [ossa] @$s6Client2fxySi5Utils18FrozenPublicStructVF : $@convention(thin) (FrozenPublicStruct) -> Int {
+// CLIENT-COMMON-LABEL: // %0 "arg"
+// CLIENT-COMMON-LABEL: bb0(%0 : $FrozenPublicStruct):
+// CLIENT-COMMON-LABEL:   debug_value %0 : $FrozenPublicStruct, let, name "arg", argno 1
+// CLIENT-COMMON-LABEL:   %2 = struct_extract %0 : $FrozenPublicStruct, #FrozenPublicStruct.data
+// CLIENT-COMMON-LABEL:   return %2 : $Int
+// CLIENT-COMMON-LABEL: } // end sil function '$s6Client2fxySi5Utils18FrozenPublicStructVF'
+
+package func fy(_ arg: FrozenPublicStruct) -> Int {
+  return arg.data
+}
+
+// CLIENT-COMMON-LABEL: // fy(_:)
+// CLIENT-COMMON-LABEL: sil [ossa] @$s6Client2fyySi5Utils18FrozenPublicStructVF : $@convention(thin) (FrozenPublicStruct) -> Int {
+// CLIENT-COMMON-LABEL: // %0 "arg"
+// CLIENT-COMMON-LABEL: bb0(%0 : $FrozenPublicStruct):
+// CLIENT-COMMON-LABEL:   debug_value %0 : $FrozenPublicStruct, let, name "arg", argno 1
+// CLIENT-COMMON-LABEL:   %2 = struct_extract %0 : $FrozenPublicStruct, #FrozenPublicStruct.data
+// CLIENT-COMMON-LABEL:   return %2 : $Int
+// CLIENT-COMMON-LABEL: } // end sil function '$s6Client2fyySi5Utils18FrozenPublicStructVF'
 
 package func g(_ arg: PkgStruct) -> Int {
   return arg.data
 }
 
-// CHECK: // g(_:)
-// CHECK-NEXT: sil @$s6Client1gySi5Utils9PkgStructVF : $@convention(thin) (PkgStruct) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
-// CHECK-NEXT: bb0(%0 : $PkgStruct):
-// CHECK-NEXT:   debug_value %0 : $PkgStruct, let, name "arg", argno 1 // id: %1
-// CHECK-NEXT:   %2 = struct_extract %0 : $PkgStruct, #PkgStruct.data // user: %3
-// CHECK-NEXT:   return %2 : $Int                                // id: %3
-// CHECK-NEXT: } // end sil function '$s6Client1gySi5Utils9PkgStructVF'
+// CLIENT-RES-LABEL: // g(_:)
+// CLIENT-RES-NEXT: sil [ossa] @$s6Client1gySi5Utils9PkgStructVF : $@convention(thin) (@in_guaranteed PkgStruct) -> Int
+// CLIENT-RES-LABEL: // PkgStruct.data.getter
+// CLIENT-RES-NEXT: sil @$s5Utils9PkgStructV4dataSivg : $@convention(method) (@in_guaranteed PkgStruct) -> Int
+
+// CLIENT-NONRES-LABEL: // g(_:)
+// CLIENT-NONRES-NEXT: sil [ossa] @$s6Client1gySi5Utils9PkgStructVF : $@convention(thin) (PkgStruct) -> Int
+
+package func gx(_ arg: UfiPkgStruct) -> Int {
+  return arg.data
+}
+
+// CLIENT-RES-LABEL: // gx(_:)
+// CLIENT-RES-NEXT: sil [ossa] @$s6Client2gxySi5Utils12UfiPkgStructVF : $@convention(thin) (@in_guaranteed UfiPkgStruct) -> Int
+// CLIENT-RES-LABEL: // UfiPkgStruct.data.getter
+// CLIENT-RES-NEXT: sil @$s5Utils12UfiPkgStructV4dataSivg : $@convention(method) (@in_guaranteed UfiPkgStruct) -> Int
+
+// CLIENT-NONRES-LABEL: // gx(_:)
+// CLIENT-NONRES-NEXT: sil [ossa] @$s6Client2gxySi5Utils12UfiPkgStructVF : $@convention(thin) (UfiPkgStruct) -> Int
 
 package func m<T>(_ arg: PkgStructGeneric<T>) -> T {
   return arg.data
 }
 
-// CHECK: // m<A>(_:)
-// CHECK-NEXT: sil @$s6Client1myx5Utils16PkgStructGenericVyxGlF : $@convention(thin) <T> (@in_guaranteed PkgStructGeneric<T>) -> @out T {
-// CHECK-NEXT: // %0 "$return_value"                             // user: %4
-// CHECK-NEXT: // %1 "arg"                                       // users: %3, %2
-// CHECK-NEXT: bb0(%0 : $*T, %1 : $*PkgStructGeneric<T>):
-// CHECK-NEXT:   debug_value %1 : $*PkgStructGeneric<T>, let, name "arg", argno 1, expr op_deref // id: %2
-// CHECK-NEXT:   %3 = struct_element_addr %1 : $*PkgStructGeneric<T>, #PkgStructGeneric.data // user: %4
-// CHECK-NEXT:   copy_addr %3 to [init] %0 : $*T                 // id: %4
-// CHECK-NEXT:   %5 = tuple ()                                   // user: %6
-// CHECK-NEXT:   return %5 : $()                                 // id: %6
-// CHECK-NEXT: } // end sil function '$s6Client1myx5Utils16PkgStructGenericVyxGlF'
+// CLIENT-RES-LABEL: // m<A>(_:)
+// CLIENT-RES-NEXT: sil [ossa] @$s6Client1myx5Utils16PkgStructGenericVyxGlF : $@convention(thin) <T> (@in_guaranteed PkgStructGeneric<T>) -> @out T {
+// CLIENT-RES-NEXT: // %0 "$return_value"
+// CLIENT-RES-NEXT: // %1 "arg"
+// CLIENT-RES-NEXT: bb0(%0 : $*T, %1 : $*PkgStructGeneric<T>):
+// CLIENT-RES-NEXT:   debug_value %1 : $*PkgStructGeneric<T>, let, name "arg", argno 1, expr op_deref
+// CLIENT-RES-NEXT:   %3 = alloc_stack $PkgStructGeneric<T>
+// CLIENT-RES-NEXT:   copy_addr %1 to [init] %3 : $*PkgStructGeneric<T>
+// CLIENT-RES-NEXT:   // function_ref PkgStructGeneric.data.getter
+// CLIENT-RES-NEXT:   %5 = function_ref @$s5Utils16PkgStructGenericV4dataxvg : $@convention(method) <τ_0_0> (@in_guaranteed PkgStructGeneric<τ_0_0>) -> @out τ_0_0
+// CLIENT-RES-NEXT:   %6 = apply %5<T>(%0, %3) : $@convention(method) <τ_0_0> (@in_guaranteed PkgStructGeneric<τ_0_0>) -> @out τ_0_0
+// CLIENT-RES-NEXT:   destroy_addr %3 : $*PkgStructGeneric<T>
+// CLIENT-RES-NEXT:   dealloc_stack %3 : $*PkgStructGeneric<T>
+// CLIENT-RES-NEXT:   %9 = tuple ()
+// CLIENT-RES-NEXT:   return %9 : $()
+// CLIENT-RES-NEXT: } // end sil function '$s6Client1myx5Utils16PkgStructGenericVyxGlF'
+
+// CLIENT-RES-LABEL: // PkgStructGeneric.data.getter
+// CLIENT-RES-NEXT: sil @$s5Utils16PkgStructGenericV4dataxvg : $@convention(method) <τ_0_0> (@in_guaranteed PkgStructGeneric<τ_0_0>) -> @out τ_0_0
+
+// CLIENT-NONRES-LABEL: // m<A>(_:)
+// CLIENT-NONRES-NEXT: sil [ossa] @$s6Client1myx5Utils16PkgStructGenericVyxGlF : $@convention(thin) <T> (@in_guaranteed PkgStructGeneric<T>) -> @out T {
+// CLIENT-NONRES-NEXT: // %0 "$return_value"
+// CLIENT-NONRES-NEXT: // %1 "arg"
+// CLIENT-NONRES-NEXT: bb0(%0 : $*T, %1 : $*PkgStructGeneric<T>):
+// CLIENT-NONRES-NEXT:   debug_value %1 : $*PkgStructGeneric<T>, let, name "arg", argno 1, expr op_deref
+// CLIENT-NONRES-NEXT:   %3 = struct_element_addr %1 : $*PkgStructGeneric<T>, #PkgStructGeneric.data
+// CLIENT-NONRES-NEXT:   copy_addr %3 to [init] %0 : $*T
+// CLIENT-NONRES-NEXT:   %5 = tuple ()
+// CLIENT-NONRES-NEXT:   return %5 : $()
+// CLIENT-NONRES-NEXT: } // end sil function '$s6Client1myx5Utils16PkgStructGenericVyxGlF'
+
 
 package func n(_ arg: PkgStructWithPublicMember) -> Int {
   return arg.member.data
 }
 
-// CHECK: // n(_:)
-// CHECK-NEXT: sil @$s6Client1nySi5Utils25PkgStructWithPublicMemberVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicMember) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
-// CHECK-NEXT: bb0(%0 : $*PkgStructWithPublicMember):
-// CHECK-NEXT:   debug_value %0 : $*PkgStructWithPublicMember, let, name "arg", argno 1, expr op_deref // id: %1
-// CHECK-NEXT:   %2 = struct_element_addr %0 : $*PkgStructWithPublicMember, #PkgStructWithPublicMember.member // user: %4
-// CHECK-NEXT:   %3 = alloc_stack $PublicStruct                  // users: %12, %10, %6, %4
-// CHECK-NEXT:   copy_addr %2 to [init] %3 : $*PublicStruct      // id: %4
-// CHECK-NEXT:   %5 = alloc_stack $PublicStruct                  // users: %11, %9, %8, %6
-// CHECK-NEXT:   copy_addr %3 to [init] %5 : $*PublicStruct      // id: %6
-// CHECK-NEXT:   // function_ref PublicStruct.data.getter
-// CHECK-NEXT:   %7 = function_ref @$s5Utils12PublicStructV4dataSivg : $@convention(method) (@in_guaranteed PublicStruct) -> Int // user: %8
-// CHECK-NEXT:   %8 = apply %7(%5) : $@convention(method) (@in_guaranteed PublicStruct) -> Int // user: %13
-// CHECK-NEXT:   destroy_addr %5 : $*PublicStruct                // id: %9
-// CHECK-NEXT:   destroy_addr %3 : $*PublicStruct                // id: %10
-// CHECK-NEXT:   dealloc_stack %5 : $*PublicStruct               // id: %11
-// CHECK-NEXT:   dealloc_stack %3 : $*PublicStruct               // id: %12
-// CHECK-NEXT:   return %8 : $Int                                // id: %13
-// CHECK-NEXT: } // end sil function '$s6Client1nySi5Utils25PkgStructWithPublicMemberVF'
+// CLIENT-RES-LABEL: // n(_:)
+// CLIENT-RES-NEXT: sil [ossa] @$s6Client1nySi5Utils25PkgStructWithPublicMemberVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicMember) -> Int
+// CLIENT-RES-LABEL: // PkgStructWithPublicMember.member.getter
+// CLIENT-RES-NEXT: sil @$s5Utils25PkgStructWithPublicMemberV6memberAA0eC0Vvg : $@convention(method) (@in_guaranteed PkgStructWithPublicMember) -> @out PublicStruct
+
+
+// CLIENT-NONRES-LABEL: // n(_:)
+// CLIENT-NONRES-NEXT: sil [ossa] @$s6Client1nySi5Utils25PkgStructWithPublicMemberVF : $@convention(thin) (PkgStructWithPublicMember) -> Int
 
 package func p(_ arg: PkgStructWithPublicExistential) -> any PublicProto {
   return arg.member
 }
 
-// CHECK: // p(_:)
-// CHECK-NEXT: sil @$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto {
-// CHECK-NEXT: // %0 "$return_value"                             // user: %4
-// CHECK-NEXT: // %1 "arg"                                       // users: %3, %2
-// CHECK-NEXT: bb0(%0 : $*any PublicProto, %1 : $*PkgStructWithPublicExistential):
-// CHECK-NEXT:   debug_value %1 : $*PkgStructWithPublicExistential, let, name "arg", argno 1, expr op_deref // id: %2
-// CHECK-NEXT:   %3 = struct_element_addr %1 : $*PkgStructWithPublicExistential, #PkgStructWithPublicExistential.member // user: %4
-// CHECK-NEXT:   copy_addr %3 to [init] %0 : $*any PublicProto   // id: %4
-// CHECK-NEXT:   %5 = tuple ()                                   // user: %6
-// CHECK-NEXT:   return %5 : $()                                 // id: %6
-// CHECK-NEXT: } // end sil function '$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF'
+// CLIENT-RES-LABEL: // p(_:)
+// CLIENT-RES-NEXT: sil [ossa] @$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto {
+// CLIENT-RES-NEXT: // %0 "$return_value"
+// CLIENT-RES-NEXT: // %1 "arg"
+// CLIENT-RES-NEXT: bb0(%0 : $*any PublicProto, %1 : $*PkgStructWithPublicExistential):
+// CLIENT-RES-NEXT:   debug_value %1 : $*PkgStructWithPublicExistential, let, name "arg", argno 1, expr op_deref
+// CLIENT-RES-NEXT:   %3 = alloc_stack $PkgStructWithPublicExistential
+// CLIENT-RES-NEXT:   copy_addr %1 to [init] %3 : $*PkgStructWithPublicExistential
+// CLIENT-RES-NEXT:   // function_ref PkgStructWithPublicExistential.member.getter
+// CLIENT-RES-NEXT:   %5 = function_ref @$s5Utils30PkgStructWithPublicExistentialV6memberAA0E5Proto_pvg : $@convention(method) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto
+// CLIENT-RES-NEXT:   %6 = apply %5(%0, %3) : $@convention(method) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto
+// CLIENT-RES-NEXT:   destroy_addr %3 : $*PkgStructWithPublicExistential
+// CLIENT-RES-NEXT:   dealloc_stack %3 : $*PkgStructWithPublicExistential
+// CLIENT-RES-NEXT:   %9 = tuple ()
+// CLIENT-RES-NEXT:   return %9 : $()
+// CLIENT-RES-NEXT: } // end sil function '$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF'
+
+// CLIENT-RES-LABEL: // PkgStructWithPublicExistential.member.getter
+// CLIENT-RES-NEXT: sil @$s5Utils30PkgStructWithPublicExistentialV6memberAA0E5Proto_pvg : $@convention(method) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto
+
+
+// CLIENT-NONRES-LABEL: // p(_:)
+// CLIENT-NONRES-NEXT: sil [ossa] @$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPublicExistential) -> @out any PublicProto {
+// CLIENT-NONRES-NEXT: // %0 "$return_value"
+// CLIENT-NONRES-NEXT: // %1 "arg"
+// CLIENT-NONRES-NEXT: bb0(%0 : $*any PublicProto, %1 : $*PkgStructWithPublicExistential):
+// CLIENT-NONRES-NEXT:   debug_value %1 : $*PkgStructWithPublicExistential, let, name "arg", argno 1, expr op_deref
+// CLIENT-NONRES-NEXT:   %3 = struct_element_addr %1 : $*PkgStructWithPublicExistential, #PkgStructWithPublicExistential.member
+// CLIENT-NONRES-NEXT:   copy_addr %3 to [init] %0 : $*any PublicProto
+// CLIENT-NONRES-NEXT:   %5 = tuple ()
+// CLIENT-NONRES-NEXT:   return %5 : $()
+// CLIENT-NONRES-NEXT: } // end sil function '$s6Client1py5Utils11PublicProto_pAC013PkgStructWithC11ExistentialVF'
+
 
 package func q(_ arg: PkgStructWithPkgExistential) -> any PkgProto {
   return arg.member
 }
 
-// CHECK: // q(_:)
-// CHECK-NEXT: sil @$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto {
-// CHECK-NEXT: // %0 "$return_value"                             // user: %4
-// CHECK-NEXT: // %1 "arg"                                       // users: %3, %2
-// CHECK-NEXT: bb0(%0 : $*any PkgProto, %1 : $*PkgStructWithPkgExistential):
-// CHECK-NEXT:   debug_value %1 : $*PkgStructWithPkgExistential, let, name "arg", argno 1, expr op_deref // id: %2
-// CHECK-NEXT:   %3 = struct_element_addr %1 : $*PkgStructWithPkgExistential, #PkgStructWithPkgExistential.member // user: %4
-// CHECK-NEXT:   copy_addr %3 to [init] %0 : $*any PkgProto      // id: %4
-// CHECK-NEXT:   %5 = tuple ()                                   // user: %6
-// CHECK-NEXT:   return %5 : $()                                 // id: %6
-// CHECK-NEXT: } // end sil function '$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF'
+// CLIENT-RES-LABEL: // q(_:)
+// CLIENT-RES-NEXT: sil [ossa] @$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto {
+// CLIENT-RES-NEXT: // %0 "$return_value"
+// CLIENT-RES-NEXT: // %1 "arg"
+// CLIENT-RES-NEXT: bb0(%0 : $*any PkgProto, %1 : $*PkgStructWithPkgExistential):
+// CLIENT-RES-NEXT:   debug_value %1 : $*PkgStructWithPkgExistential, let, name "arg", argno 1, expr op_deref
+// CLIENT-RES-NEXT:   %3 = alloc_stack $PkgStructWithPkgExistential
+// CLIENT-RES-NEXT:   copy_addr %1 to [init] %3 : $*PkgStructWithPkgExistential
+// CLIENT-RES-NEXT:   // function_ref PkgStructWithPkgExistential.member.getter
+// CLIENT-RES-NEXT:   %5 = function_ref @$s5Utils013PkgStructWithB11ExistentialV6memberAA0B5Proto_pvg : $@convention(method) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto
+// CLIENT-RES-NEXT:   %6 = apply %5(%0, %3) : $@convention(method) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto
+// CLIENT-RES-NEXT:   destroy_addr %3 : $*PkgStructWithPkgExistential
+// CLIENT-RES-NEXT:   dealloc_stack %3 : $*PkgStructWithPkgExistential
+// CLIENT-RES-NEXT:   %9 = tuple ()
+// CLIENT-RES-NEXT:   return %9 : $()
+// CLIENT-RES-NEXT: } // end sil function '$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF'
+
+// CLIENT-RES-LABEL: // PkgStructWithPkgExistential.member.getter
+// CLIENT-RES-NEXT: sil @$s5Utils013PkgStructWithB11ExistentialV6memberAA0B5Proto_pvg : $@convention(method) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto
+
+
+// CLIENT-NONRES-LABEL: // q(_:)
+// CLIENT-NONRES-NEXT: sil [ossa] @$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF : $@convention(thin) (@in_guaranteed PkgStructWithPkgExistential) -> @out any PkgProto {
+// CLIENT-NONRES-NEXT: // %0 "$return_value"
+// CLIENT-NONRES-NEXT: // %1 "arg"
+// CLIENT-NONRES-NEXT: bb0(%0 : $*any PkgProto, %1 : $*PkgStructWithPkgExistential):
+// CLIENT-NONRES-NEXT:   debug_value %1 : $*PkgStructWithPkgExistential, let, name "arg", argno 1, expr op_deref
+// CLIENT-NONRES-NEXT:   %3 = struct_element_addr %1 : $*PkgStructWithPkgExistential, #PkgStructWithPkgExistential.member
+// CLIENT-NONRES-NEXT:   copy_addr %3 to [init] %0 : $*any PkgProto
+// CLIENT-NONRES-NEXT:   %5 = tuple ()
+// CLIENT-NONRES-NEXT:   return %5 : $()
+// CLIENT-NONRES-NEXT: } // end sil function '$s6Client1qy5Utils8PkgProto_pAC0c10StructWithC11ExistentialVF'
+
 
 package func r(_ arg: PublicProto) -> Int {
   return arg.data
 }
 
-// CHECK: // r(_:)
-// CHECK-NEXT: sil @$s6Client1rySi5Utils11PublicProto_pF : $@convention(thin) (@in_guaranteed any PublicProto) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
-// CHECK-NEXT: bb0(%0 : $*any PublicProto):
-// CHECK-NEXT:   debug_value %0 : $*any PublicProto, let, name "arg", argno 1, expr op_deref // id: %1
-// CHECK-NEXT:   %2 = open_existential_addr immutable_access %0 : $*any PublicProto
-// CHECK-NEXT:   %3 = alloc_stack $@opened
-// CHECK-NEXT:   copy_addr %2 to [init] %3 : $*@opened
-// CHECK-NEXT:   %5 = witness_method $@opened
-// CHECK-NEXT:   %6 = apply %5<@opened
-// CHECK-NEXT:   destroy_addr %3 : $*@opened
-// CHECK-NEXT:   dealloc_stack %3 : $*@opened
-// CHECK-NEXT:   return %6 : $Int
-// CHECK-NEXT: } // end sil function '$s6Client1rySi5Utils11PublicProto_pF'
+// CLIENT-COMMON-LABEL: // r(_:)
+// CLIENT-COMMON-NEXT: sil [ossa] @$s6Client1rySi5Utils11PublicProto_pF : $@convention(thin) (@in_guaranteed any PublicProto) -> Int {
+// CLIENT-COMMON-NEXT: // %0 "arg"
+// CLIENT-COMMON-NEXT: bb0(%0 : $*any PublicProto):
+// CLIENT-COMMON-NEXT:   debug_value %0 : $*any PublicProto, let, name "arg", argno 1, expr op_deref
+// CLIENT-COMMON-NEXT:   %2 = open_existential_addr immutable_access %0 : $*any PublicProto to $*@opened({{.*}}, any PublicProto) Self
+// CLIENT-COMMON-NEXT:   %3 = alloc_stack $@opened("{{.*}}", any PublicProto) Self
+// CLIENT-COMMON-NEXT:   copy_addr %2 to [init] %3 : $*@opened("{{.*}}", any PublicProto) Self
+// CLIENT-COMMON-NEXT:   %5 = witness_method $@opened("{{.*}}", any PublicProto) Self, #PublicProto.data!getter : <Self where Self : Utils.PublicProto> (Self) -> () -> Int, %2 : $*@opened("{{.*}}", any PublicProto) Self : $@convention(witness_method: PublicProto) <τ_0_0 where τ_0_0 : PublicProto> (@in_guaranteed τ_0_0) -> Int
+// CLIENT-COMMON-NEXT:   %6 = apply %5<@opened("{{.*}}", any PublicProto) Self>(%3) : $@convention(witness_method: PublicProto) <τ_0_0 where τ_0_0 : PublicProto> (@in_guaranteed τ_0_0) -> Int
+// CLIENT-COMMON-NEXT:   destroy_addr %3 : $*@opened("{{.*}}", any PublicProto) Self
+// CLIENT-COMMON-NEXT:   dealloc_stack %3 : $*@opened("{{.*}}", any PublicProto) Self
+// CLIENT-COMMON-NEXT:   return %6 : $Int
+// CLIENT-COMMON-NEXT: } // end sil function '$s6Client1rySi5Utils11PublicProto_pF'
 
 package func s(_ arg: PkgProto) -> Int {
   return arg.data
 }
-// CHECK: // s(_:)
-// CHECK-NEXT: sil @$s6Client1sySi5Utils8PkgProto_pF : $@convention(thin) (@in_guaranteed any PkgProto) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
-// CHECK-NEXT: bb0(%0 : $*any PkgProto):
-// CHECK-NEXT:   debug_value %0 : $*any PkgProto, let, name "arg", argno 1, expr op_deref // id: %1
-// CHECK-NEXT:   %2 = open_existential_addr immutable_access %0 : $*any PkgProto to $*@opened
-// CHECK-NEXT:   %3 = alloc_stack $@opened
-// CHECK-NEXT:   copy_addr %2 to [init] %3 : $*@opened
-// CHECK-NEXT:   %5 = witness_method $@opened
-// CHECK-NEXT:   %6 = apply %5<@opened
-// CHECK-NEXT:   destroy_addr %3 : $*@opened
-// CHECK-NEXT:   dealloc_stack %3 : $*@opened
-// CHECK-NEXT:   return %6 : $Int
-// CHECK-NEXT: } // end sil function '$s6Client1sySi5Utils8PkgProto_pF'
 
+// CLIENT-COMMON-LABEL: // s(_:)
+// CLIENT-COMMON-NEXT: sil [ossa] @$s6Client1sySi5Utils8PkgProto_pF : $@convention(thin) (@in_guaranteed any PkgProto) -> Int {
+// CLIENT-COMMON-NEXT: // %0 "arg"
+// CLIENT-COMMON-NEXT: bb0(%0 : $*any PkgProto):
+// CLIENT-COMMON-NEXT:   debug_value %0 : $*any PkgProto, let, name "arg", argno 1, expr op_deref
+// CLIENT-COMMON-NEXT:   %2 = open_existential_addr immutable_access %0 : $*any PkgProto to $*@opened("{{.*}}", any PkgProto) Self
+// CLIENT-COMMON-NEXT:   %3 = alloc_stack $@opened("{{.*}}", any PkgProto) Self
+// CLIENT-COMMON-NEXT:   copy_addr %2 to [init] %3 : $*@opened("{{.*}}", any PkgProto) Self
+// CLIENT-COMMON-NEXT:   %5 = witness_method $@opened("{{.*}}", any PkgProto) Self, #PkgProto.data!getter : <Self where Self : Utils.PkgProto> (Self) -> () -> Int, %2 : $*@opened("{{.*}}", any PkgProto) Self : $@convention(witness_method: PkgProto) <τ_0_0 where τ_0_0 : PkgProto> (@in_guaranteed τ_0_0) -> Int
+// CLIENT-COMMON-NEXT:   %6 = apply %5<@opened("{{.*}}", any PkgProto) Self>(%3) : $@convention(witness_method: PkgProto) <τ_0_0 where τ_0_0 : PkgProto> (@in_guaranteed τ_0_0) -> Int
+// CLIENT-COMMON-NEXT:   destroy_addr %3 : $*@opened("{{.*}}", any PkgProto) Self
+// CLIENT-COMMON-NEXT:   dealloc_stack %3 : $*@opened("{{.*}}", any PkgProto) Self
+// CLIENT-COMMON-NEXT:   return %6 : $Int
+// CLIENT-COMMON-NEXT: } // end sil function '$s6Client1sySi5Utils8PkgProto_pF'
+
+
+public func t(_ arg: any PublicProto) -> Int {
+    return arg.pfunc(arg.data)
+}
+// CLIENT-COMMON-LABEL: // t(_:)
+// CLIENT-COMMON-LABEL: sil [ossa] @$s6Client1tySi5Utils11PublicProto_pF : $@convention(thin) (@in_guaranteed any PublicProto) -> Int
+
+public func u(_ arg: PublicKlass) -> Int {
+    return arg.pfunc(arg.data)
+}
+
+// CLIENT-COMMON-LABEL: // u(_:)
+// CLIENT-COMMON-LABEL: sil [ossa] @$s6Client1uySi5Utils11PublicKlassCF : $@convention(thin) (@guaranteed PublicKlass) -> Int
+
+package func v(_ arg: any PkgProto) -> Int {
+   return arg.pkgfunc(arg.data)
+}
+
+// CLIENT-COMMON-LABEL: // v(_:)
+// CLIENT-COMMON-LABEL: sil [ossa] @$s6Client1vySi5Utils8PkgProto_pF : $@convention(thin) (@in_guaranteed any PkgProto) -> Int
+
+package func w(_ arg: PkgKlass) -> Int {
+   return arg.pkgfunc(arg.data)
+}
+
+// CLIENT-COMMON-LABEL: // w(_:)
+// CLIENT-COMMON-NEXT: sil [ossa] @$s6Client1wySi5Utils8PkgKlassCF : $@convention(thin) (@guaranteed PkgKlass) -> Int

--- a/test/Sema/package_resilience_bypass_exhaustive_switch.swift
+++ b/test/Sema/package_resilience_bypass_exhaustive_switch.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar118947451
+
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
Currently `package` types are treated non-resilient by default. This PR changes that to treat them as 
resilient as non-frozen `public` by default. If the defining module is built resiliently, treat the package 
decl as resilient, just as we do for `public` decls. Access methods to `package` should be the same 
as for non-frozen `public`, i.e. indirect. 
Added tests for SIL/IR wrt serialization and indirect access with/out resilience enabled.

Resolves rdar://118947451