### PR TITLE
[stdlib] add missing `Element` type witnesses

### DIFF
--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -309,6 +309,12 @@ extension _UnsafeBitset.Word {
 // problems in normal use, because `next()` is usually called on a separate
 // iterator, not the original word.
 extension _UnsafeBitset.Word: Sequence, IteratorProtocol {
+
+#if $NoncopyableGenerics
+  @usableFromInline
+  typealias Element = Int
+#endif
+
   @inlinable
   internal var count: Int {
     return value.nonzeroBitCount

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -1231,6 +1231,11 @@ internal struct _ClosureBasedSequence<Iterator: IteratorProtocol> {
 }
 
 extension _ClosureBasedSequence: Sequence {
+
+#if $NoncopyableGenerics
+  public typealias Element = Iterator.Element
+#endif
+
   @inlinable
   internal func makeIterator() -> Iterator {
     return _makeUnderlyingIterator()

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1241,6 +1241,11 @@ public struct IteratorSequence<Base: IteratorProtocol> {
 }
 
 extension IteratorSequence: IteratorProtocol, Sequence {
+
+  #if $NoncopyableGenerics
+    public typealias Element = Base.Element
+  #endif
+
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
   ///


### PR DESCRIPTION
With `NoncopyableGenerics` enabled, we currently lose some ability for associatedtype inference to find a suitable type witness based on a value witness. (rdar://118998138)

The stdlib accidentally uses that inference for Sequence.Element, due to the default witness for `_customContainsEquatableElement` mentioning `Iterator.Element` whereas the requirement only states `Element`.