### PR TITLE
[5.10] [Serialized diagnostics] Avoid generating filenames that break the reader

### DIFF
--- a/test/diagnostics/Inputs/slash.swift
+++ b/test/diagnostics/Inputs/slash.swift
@@ -1,0 +1,2 @@
+public func /(lhs: String, b: Int) -> Bool { false }
+

--- a/test/diagnostics/bad-generated-filenames.swift
+++ b/test/diagnostics/bad-generated-filenames.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/SlashA.swiftmodule %S/Inputs/slash.swift
+// RUN: %target-swift-frontend -emit-module -o %t/SlashB.swiftmodule %S/Inputs/slash.swift
+// RUN: not %target-swift-frontend -typecheck -I %t -serialize-diagnostics-path %t/serialized.dia %s
+// RUN: c-index-test -read-diagnostics %t/serialized.dia > %t/serialized.txt 2>&1
+// RUN: %FileCheck %s -check-prefix CHECK-DIA < %t/serialized.txt
+
+import SlashA
+import SlashB
+
+func test(a: String, b: Int) -> Bool {
+  // CHECK-DIA: [[@LINE+3]]:5: error: ambiguous use of operator '/'
+  // CHECK-DIA: SlashA./_operator
+  // CHECK-DIA: SlashB./_operator
+  a / b
+}


### PR DESCRIPTION
The serialized diagnostics reader has one very specific limitation it places on filenames: they must not end in `/`, because that makes them look like a directory. This is not documented, and the diagnostics reader will unceremoniously crash when trying to read such a file.

While the reader should be fixed to at least fail gracefully in such cases, Swift also shouldn't generate such filenames. Right now, they can be generated when referencing an entity named `/` that is synthesized or comes from a module. When we encounter such file names, append `_operator` to avoid the problem.

Fixes rdar://118217560.

Cherry-picked from https://github.com/apple/swift/pull/70139