### PR TITLE
[CMake] In LLVM unified builds, depend on the generation of Clang headers

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -263,6 +263,15 @@ else()
   add_library(importedHeaderDependencies "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp")
   target_include_directories(importedHeaderDependencies PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../include/swift")
 
+  # When building unified, we need to make sure all the Clang headers are
+  # generated before we try to use them.
+  # When building Swift against an already compiled LLVM/Clang, like
+  # build-script does, this target does not exist, but the headers
+  # are already completely generated at that point.
+  if(TARGET clang-tablegen-targets)
+    add_dependencies(importedHeaderDependencies clang-tablegen-targets)
+  endif()
+
   if(BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|CROSSCOMPILE")
 
     if (NOT SWIFT_EXEC_FOR_SWIFT_MODULES)


### PR DESCRIPTION
If one is building a LLVM unified build, with Swift as an external project, SwiftCompilerSources can compile before the `.td` files that generate Clang headers are finished, which will make the compilation fail to find some files (the `.inc` files derived from those `.td`). Make the library that uses the header depend on `clang-tablegen-targets` to ensure those are done before the library is tried to be used.

This is not a problem in the normal `build-script` builds because in those cases, the LLVM/Clang headers are build way before Swift is started to be build.
