### PR TITLE
[embedded] Make deserialized specializations fragile if needed, fix SIL verification failure

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -407,6 +407,16 @@ SILFunction *SILDeserializer::getFuncForReference(StringRef name,
     }
   }
 
+  // A deserialized function might reference a non-fragile function (e.g. in
+  // embedded Swift if we deserialize a specialized function, which references
+  // something that has already been specialized in the current module). Make
+  // the referenced function serialized in that case.
+  if (SILMod.getOptions().EmbeddedSwift &&
+      !fn->hasValidLinkageForFragileRef()) {
+    fn->setSerialized(IsSerialized_t(IsSerialized));
+    assert(fn->hasValidLinkageForFragileRef() && "invalid non-fragile ref");
+  }
+
   // FIXME: check for matching types.
 
   // At this point, if fn is set, we know that we have a good function to use.

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+@main
+public struct Application {
+    public static func main() {
+        var x: UInt64 = 0
+        x <<= 8
+    }
+}
+
+enum MyEnum: UInt8 {
+    case a = 0
+}
+
+// CHECK: define {{.*}}@main(


### PR DESCRIPTION
This might not be the right fix, please advise if there's a better option.

The problem: The attached testcase crashes the compiler (SIL verification failure due to a non-fragile function being called from a fragile one). The actual crash happens when the MandatoryPerfOptimization loop is specializing, discovering and deserializing more SIL functions. While deserializing a function (a UInt64 specialization of `Hasher._hash` in this case), one of its callees is already present in the module (a specialization of `FixedWidthInteger._truncatingInit` in this case) and is not fragile because the specialization was created in the current compilation. This situation of a deserialized fragile function having a non-fragile callee is invalid SIL and the verifier flags it.

I think this is in practice only a problem in embedded Swift, because we serialize everything from the stdlib, including specializations.

The backtrace of the verification failure:

```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x00000001035ae3c4 swift-frontend`(anonymous namespace)::SILVerifier::_require(this=0x000000016d884918, condition=false, complaint=0x000000016d883fa8, extraContext=0x000000016d883f88) at SILVerifier.cpp:804:9 [opt]
    frame #1: 0x00000001035cc56c swift-frontend`(anonymous namespace)::SILVerifier::checkFunctionRefBaseInst(this=0x000000016d884918, FRI=<unavailable>) at SILVerifier.cpp:2197:7 [opt]
    frame #2: 0x00000001035b3074 swift-frontend`swift::SILVisitorBase<(anonymous namespace)::SILVerifier, void>::visitSILBasicBlock(swift::SILBasicBlock*) [inlined] swift::SILInstructionVisitor<(anonymous namespace)::SILVerifier, void>::visit(this=0x000000016d884918, inst=0x0000600003f29260) at SILVisitor.h:0:5 [opt]
    frame #3: 0x00000001035b3018 swift-frontend`swift::SILVisitorBase<(anonymous namespace)::SILVerifier, void>::visitSILBasicBlock(this=<unavailable>, BB=<unavailable>) at SILVisitor.h:38:16 [opt]
    frame #4: 0x00000001035b29c4 swift-frontend`(anonymous namespace)::SILVerifier::visitSILBasicBlock(this=0x000000016d884918, BB=0x000000013acae5a8) at SILVerifier.cpp:6651:28 [opt]
    frame #5: 0x00000001035b13d0 swift-frontend`(anonymous namespace)::SILVerifier::visitSILFunction(swift::SILFunction*) at SILVerifier.cpp:6671:7 [opt]
    frame #6: 0x00000001035b1310 swift-frontend`(anonymous namespace)::SILVerifier::visitSILFunction(this=0x000000016d884918, F=0x000000013acad688) at SILVerifier.cpp:6794:5 [opt]
    frame #7: 0x00000001035ab1c8 swift-frontend`swift::SILFunction::verify(swift::SILPassManager*, bool, bool, bool) const [inlined] (anonymous namespace)::SILVerifier::verify(this=0x000000016d884918, isCompleteOSSA=<unavailable>) at SILVerifier.cpp:6806:5 [opt]
    frame #8: 0x00000001035ab148 swift-frontend`swift::SILFunction::verify(this=<unavailable>, passManager=<unavailable>, SingleFunction=<unavailable>, isCompleteOSSA=<unavailable>, checkLinearLifetime=<unavailable>) const at SILVerifier.cpp:6848:12 [opt]
    frame #9: 0x000000010346c944 swift-frontend`swift::SILLinkerVisitor::deserializeAndPushToWorklist(this=0x000000016d884f08, F=0x000000013acad688) at Linker.cpp:94:6 [opt]
    frame #10: 0x000000010346cb88 swift-frontend`swift::SILLinkerVisitor::maybeAddFunctionToWorklist(this=<unavailable>, F=<unavailable>, setToSerializable=<unavailable>) at Linker.cpp:0:7 [opt] [artificial]
    frame #11: 0x000000010346d6a8 swift-frontend`swift::SILInstructionVisitor<swift::SILLinkerVisitor, void>::visit(this=<unavailable>, inst=<unavailable>) at SILNodes.def:0 [opt] [artificial]
    frame #12: 0x000000010346ce74 swift-frontend`swift::SILLinkerVisitor::process(this=0x000000016d884f08) at Linker.cpp:462:9 [opt]
    frame #13: 0x000000010346cec4 swift-frontend`swift::SILLinkerVisitor::processConformance(this=0x000000016d884f08, conformanceRef=<unavailable>) at Linker.cpp:162:3 [opt]
    frame #14: 0x00000001034e15c8 swift-frontend`swift::SILModule::lookUpFunctionInWitnessTable(this=0x000000013aa4c600, C=ProtocolConformanceRef @ 0x000000016d885348, Requirement=SILDeclRef @ 0x000000016d8853c0, linkingMode=LinkAll) at SILModule.cpp:594:12 [opt]
    frame #15: 0x00000001031de088 swift-frontend`canDevirtualizeWitnessMethod(applySite=ApplySite @ 0x000000016d8853e0, isMandatory=false) at Devirtualize.cpp:1166:43 [opt]
    frame #16: 0x00000001031dd72c swift-frontend`swift::tryDevirtualizeWitnessMethod(applySite=ApplySite @ 0x000000016d885498, ore=0x0000000000000000, isMandatory=<unavailable>) at Devirtualize.cpp:1270:8 [opt]
    frame #17: 0x00000001031de4b0 swift-frontend`swift::tryDevirtualizeApply(applySite=ApplySite @ 0x000000016d885ad8, cha=0x0000600003f65b00, ore=0x0000000000000000, isMandatory=false) at Devirtualize.cpp:1304:12 [opt]
    frame #18: 0x0000000103067090 swift-frontend`BridgedPassContext::tryDevirtualizeApply(this=<unavailable>, apply=<unavailable>, isMandatory=<unavailable>) const at PassManager.cpp:1495:17 [opt]
    frame #19: 0x00000001026f2ed4 swift-frontend`merged generic specialization <SIL.ApplyInst> of function signature specialization <Arg[0] = Existential To Protocol Constrained Generic> of generic specialization <Optimizer.SimplifyContext> of Optimizer.MutatingContext.tryDevirtualize(apply: SIL.FullApplySite, isMandatory: Swift.Bool) -> Swift.Optional<SIL.ApplySite> + 80
    frame #20: 0x0000000102654138 swift-frontend`protocol witness for Optimizer.Simplifyable.simplify(Optimizer.SimplifyContext) -> () in conformance SIL.ApplyInst : Optimizer.Simplifyable in Optimizer + 112
    frame #21: 0x00000001026652bc swift-frontend`function signature specialization <Arg[3] = [Closure Propagated : closure #1 (SIL.Instruction, Optimizer.SimplifyContext) -> () in Optimizer.(optimize in _CE57200F4F5437FCCF0DE2E3922F96F5)(function: SIL.Function, _: Optimizer.FunctionPassContext, _: inout Optimizer.(FunctionWorklist in _CE57200F4F5437FCCF0DE2E3922F96F5)) -> (), Argument Types : [Swift.Set<Optimizer.PathFunctionTuple>Optimizer.FunctionPassContextSIL.FunctionOptimizer.FunctionWorklist]> of Optimizer.runSimplification(on: SIL.Function, _: Optimizer.FunctionPassContext, preserveDebugInfo: Swift.Bool, _: (SIL.Instruction, Optimizer.SimplifyContext) -> ()) -> Swift.Bool + 828
    frame #22: 0x0000000102664270 swift-frontend`closure #1 (Optimizer.ModulePassContext) -> () in variable initialization expression of Optimizer.mandatoryPerformanceOptimizations : Optimizer.ModulePass + 1392
    frame #23: 0x0000000103063e34 swift-frontend`swift::SILPassManager::runModulePass(this=0x000000016d885f28, TransIdx=36) at PassManager.cpp:793:8 [opt]
    frame #24: 0x0000000103065fa8 swift-frontend`swift::SILPassManager::execute(this=0x000000016d885f28) at PassManager.cpp:896:7 [opt]
    frame #25: 0x00000001030610cc swift-frontend`swift::SILPassManager::executePassPipelinePlan(this=0x000000016d885f28, Plan=0x000000016d8864c8) at PassManager.cpp:861:5 [opt]
    frame #26: 0x0000000103061068 swift-frontend`swift::ExecuteSILPipelineRequest::evaluate(this=<unavailable>, evaluator=<unavailable>, desc=SILPipelineExecutionDescriptor @ 0x000000016d886380) const at PassManager.cpp:362:6 [opt]
    frame #27: 0x0000000103098824 swift-frontend`swift::SimpleRequest<swift::ExecuteSILPipelineRequest, std::__1::tuple<> (swift::SILPipelineExecutionDescriptor), (swift::RequestFlags)1>::evaluateRequest(swift::ExecuteSILPipelineRequest const&, swift::Evaluator&) [inlined] std::__1::tuple<> swift::SimpleRequest<swift::ExecuteSILPipelineRequest, std::__1::tuple<> (swift::SILPipelineExecutionDescriptor), (swift::RequestFlags)1>::callDerived<0ul>(this=<unavailable>, evaluator=<unavailable>, (null)=<unavailable>) const at SimpleRequest.h:267:24 [opt]
    frame #28: 0x0000000103098814 swift-frontend`swift::SimpleRequest<swift::ExecuteSILPipelineRequest, std::__1::tuple<> (swift::SILPipelineExecutionDescriptor), (swift::RequestFlags)1>::evaluateRequest(request=<unavailable>, evaluator=<unavailable>) at SimpleRequest.h:290:20 [opt]
    frame #29: 0x000000010307a004 swift-frontend`llvm::Expected<swift::ExecuteSILPipelineRequest::OutputType> swift::Evaluator::getResultUncached<swift::ExecuteSILPipelineRequest>(this=0x000000013a80c870, request=0x000000016d886460) at Evaluator.h:368:21 [opt]
    frame #30: 0x00000001030612ac swift-frontend`swift::executePassPipelinePlan(swift::SILModule*, swift::SILPassPipelinePlan const&, bool, swift::irgen::IRGenModule*) [inlined] llvm::Expected<swift::ExecuteSILPipelineRequest::OutputType> swift::Evaluator::operator()<swift::ExecuteSILPipelineRequest, (void*)0>(this=<unavailable>, request=0x000000016d886460) at Evaluator.h:273:12 [opt]
    frame #31: 0x00000001030612a0 swift-frontend`swift::executePassPipelinePlan(SM=0x000000013aa4c600, plan=0x000000016d8864c8, isMandatory=<unavailable>, IRMod=0x0000000000000000) at PassManager.cpp:372:24 [opt]
    frame #32: 0x000000010307c2e8 swift-frontend`swift::runSILDiagnosticPasses(Module=0x000000013aa4c600) at Passes.cpp:64:3 [opt]
    frame #33: 0x000000010293b690 swift-frontend`swift::CompilerInstance::performSILProcessing(swift::SILModule*) [inlined] performMandatorySILPasses(Invocation=0x0000000139833800, SM=<unavailable>) at Frontend.cpp:1670:10 [opt]
    frame #34: 0x000000010293b688 swift-frontend`swift::CompilerInstance::performSILProcessing(this=0x0000000139833800, silModule=0x000000013aa4c600) at Frontend.cpp:1714:7 [opt]
    frame #35: 0x0000000102714ba0 swift-frontend`performCompileStepsPostSILGen(Instance=0x0000000139833800, SM=swift::SILModule @ 0x000000013aa4c600, MSF=swift::ModuleOrSourceFile @ 0x000000016d886620, PSPs=0x000000016d886cc8, ReturnValue=0x000000016d8873f4, observer=0x0000000000000000) at FrontendTool.cpp:1827:16 [opt]
    frame #36: 0x000000010271451c swift-frontend`swift::performCompileStepsPostSema(Instance=0x0000000139833800, ReturnValue=0x000000016d8873f4, observer=0x0000000000000000) at FrontendTool.cpp:874:12 [opt]
    frame #37: 0x0000000102725318 swift-frontend`bool llvm::function_ref<bool (swift::CompilerInstance&)>::callback_fn<performAction(swift::CompilerInstance&, int&, swift::FrontendObserver*)::$_30>(long, swift::CompilerInstance&) [inlined] performAction(swift::CompilerInstance&, int&, swift::FrontendObserver*)::$_30::operator()(this=<unavailable>, Instance=<unavailable>) const at FrontendTool.cpp:1436:18 [opt] [artificial]
    frame #38: 0x0000000102724af8 swift-frontend`withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) [inlined] llvm::function_ref<bool (swift::CompilerInstance&)>::operator()(this=<unavailable>, params=0x0000000139833800) const at STLFunctionalExtras.h:68:12 [opt]
    frame #39: 0x0000000102724aec swift-frontend`withSemanticAnalysis(Instance=0x0000000139833800, observer=<unavailable>, cont=function_ref<bool (swift::CompilerInstance &)> @ 0x0000600003651330, runDespiteErrors=false) at FrontendTool.cpp:1296:10 [opt]
    frame #40: 0x0000000102716758 swift-frontend`performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*) [inlined] performAction(Instance=0x0000000139833800, ReturnValue=0x000000016d8873f4, observer=0x0000000000000000) at FrontendTool.cpp:0 [opt]
    frame #41: 0x0000000102716708 swift-frontend`performCompile(Instance=0x0000000139833800, ReturnValue=0x000000016d8873f4, observer=0x0000000000000000) at FrontendTool.cpp:1507:19 [opt]
    frame #42: 0x00000001027157f8 swift-frontend`swift::performFrontend(Args=ArrayRef<const char *> @ 0x000000016d888f18, Argv0=<unavailable>, MainAddr=<unavailable>, observer=0x0000000000000000) at FrontendTool.cpp:2465:19 [opt]
    frame #43: 0x00000001025a9034 swift-frontend`swift::mainEntry(int, char const**) at driver.cpp:0 [opt]
    frame #44: 0x00000001025a8c74 swift-frontend`swift::mainEntry(argc_=<unavailable>, argv_=<unavailable>) at driver.cpp:505:10 [opt]
    frame #45: 0x0000000183cc10e0 dyld`start + 2360
```
