### PR TITLE
[Concurrency] Make actor-isolated witness diagnostics more discoverable.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4912,6 +4912,14 @@ bool swift::contextRequiresStrictConcurrencyChecking(
       if (hasExplicitIsolationAttribute(decl))
         return true;
 
+      // Extensions of explicitly isolated types are using concurrency
+      // features.
+      if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
+        auto *nominal = extension->getExtendedNominal();
+        if (nominal && hasExplicitIsolationAttribute(nominal))
+          return true;
+      }
+
       if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
         // Async and concurrent functions use concurrency features.
         if (func->hasAsync() || func->isSendable())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3225,9 +3225,10 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
       refResult.isolation.isGlobalActor() ||
       requirementIsolation.isGlobalActor()) {
     // If the witness or requirement has global actor isolation, downgrade
-    // based on context.
+    // based on context. Use the witness itself as the context, because
+    // an explicitly isolated witness should not suppress diagnostics.
     behavior = SendableCheckContext(
-        Conformance->getDeclContext()).defaultDiagnosticBehavior();
+        witness->getInnermostDeclContext()).defaultDiagnosticBehavior();
   }
 
   // Complain that this witness cannot conform to the requirement due to

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -20,8 +20,7 @@ actor SomeGlobalActor {
 // Witnessing and unsafe global actor
 // ----------------------------------------------------------------------
 protocol P1 {
-  @MainActor(unsafe) func onMainActor() // expected-note{{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
-  // expected-complete-tns-note @-1 {{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
+  @MainActor(unsafe) func onMainActor() // expected-note 2{{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
 }
 
 struct S1_P1: P1 {
@@ -36,9 +35,9 @@ struct S3_P1: P1 {
   nonisolated func onMainActor() { }
 }
 
-struct S4_P1_quietly: P1 {
+struct S4_P1_not_quietly: P1 {
   @SomeGlobalActor func onMainActor() { }
-  // expected-complete-tns-warning @-1 {{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated protocol requirement}}
+  // expected-warning @-1 {{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated protocol requirement}}
 }
 
 @SomeGlobalActor

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+
 // REQUIRES: concurrency
 
 actor SomeActor { }
@@ -41,4 +42,17 @@ class C1 : P1, P2 {
   func asyncMethod1() async { }
   @GenericGlobalActor<String> func asyncMethod2() async { }
   @GlobalActor func asyncMethod3() async { }
+}
+
+protocol NonIsolatedRequirement {
+  // expected-note@+1 {{mark the protocol requirement 'requirement()' 'async' to allow actor-isolated conformances}}
+  func requirement()
+}
+
+@MainActor class OnMain {}
+
+extension OnMain: NonIsolatedRequirement {
+  // expected-warning@+2 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated protocol requirement}}
+  // expected-note@+1 {{add 'nonisolated' to 'requirement()' to make this instance method not isolated to the actor}}
+  func requirement() {}
 }


### PR DESCRIPTION
This changes the witness checker to diagnose actor isolation mismatches between witnesses and requirements more readily under minimal concurrency checking. Previously, a warning was only emitted if the conformance was stated at the primary declaration and the conforming type was explicitly isolated. Now, minimal checking will emit warnings in the following cases:
* The conforming type is explicitly isolated, regardless of whether the conformance is stated at the primary declaration or in an extension.
* The witness itself is explicitly isolated.

Resolves rdar://100321259