### PR TITLE
[5.10][Runtime] Fix findBridgeWitness when building for the shared cache.

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -208,9 +208,8 @@ PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable);
 
 static const _ObjectiveCBridgeableWitnessTable *
 findBridgeWitness(const Metadata *T) {
-  static const auto bridgeableProtocol
-    = &PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable);
-  auto w = swift_conformsToProtocolCommon(T, bridgeableProtocol);
+  auto w = swift_conformsToProtocolCommon(
+      T, &PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable));
   return reinterpret_cast<const _ObjectiveCBridgeableWitnessTable *>(w);
 }
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/70156 to `release/5.10`.

The static bridgeableProtocol inherits the ptrauth_struct attribute which uses the B key, and that's not allowed on global data in the shared cache. Pass the value directly as a parameter instead.