### PR TITLE
SIL linker: delay function verification to end of linking

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -91,7 +91,7 @@ void SILLinkerVisitor::deserializeAndPushToWorklist(SILFunction *F) {
          "the de-serializer did set the wrong serialized flag");
   
   F->setBare(IsBare);
-  F->verify();
+  toVerify.push_back(F);
   Worklist.push_back(F);
   Changed = true;
   ++NumFuncLinked;
@@ -462,5 +462,10 @@ void SILLinkerVisitor::process() {
         visit(&I);
       }
     }
+  }
+
+  while (!toVerify.empty()) {
+    auto *fn = toVerify.pop_back_val();
+    fn->verify();
   }
 }

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -83,6 +83,8 @@ class SILLinkerVisitor : public SILInstructionVisitor<SILLinkerVisitor, void> {
   /// Worklist of SILFunctions we are processing.
   llvm::SmallVector<SILFunction *, 128> Worklist;
 
+  llvm::SmallVector<SILFunction *, 32> toVerify;
+
   /// The current linking mode.
   LinkingMode Mode;
 

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+@main
+public struct Application {
+    public static func main() {
+        var x: UInt64 = 0
+        x <<= 8
+    }
+}
+
+enum MyEnum: UInt8 {
+    case a = 0
+}
+
+// CHECK: define {{.*}}@main(
+


### PR DESCRIPTION
The SIL linker de-serializes functions. Immediately after de-serialization some `[serialized]` flags of referenced functions may not be set correctly, yet. This is fixed by the linker. But it also means that the SIL is only valid after the linker has finished processing all functions.

Fixes a SIL verifier error.
