### PR TITLE
[Frontend] Drop self-assignment of IRGenOpts.DWARFVersion (NFC)

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2253,10 +2253,6 @@ int swift::performFrontend(ArrayRef<const char *> Args,
              trace.emplace(*buffer);
            });
 
-  // Setting DWARF Version based on frontend options.
-  IRGenOptions &IRGenOpts = Invocation.getIRGenOptions();
-  IRGenOpts.DWARFVersion = IRGenOpts.DWARFVersion;
-
   // The compiler invocation is now fully configured; notify our observer.
   if (observer) {
     observer->parsedArgs(Invocation);


### PR DESCRIPTION
Looks like a no-op that's not required anymore? It was introduced with the recent [DWARF version](https://github.com/apple/swift/commit/5d978b44ca6cc859f3451ab670b5e434fc10c99c) change.
