### PR TITLE
Teach AST verifier about thrown error contexts

### DIFF
--- a/include/swift/Basic/MacroRoles.def
+++ b/include/swift/Basic/MacroRoles.def
@@ -13,6 +13,11 @@
 // This file defines all of the kinds of macro roles. Clients should define
 // either MACRO_ROLE or both ATTACHED_MACRO_ROLE and FREESTANDING_MACRO_ROLE.
 //
+// The order of the macro roles in this file is significant for the
+// serialization of module files. Please do not re-order the entries without
+// also bumping the module format version. When introducing new macro roles,
+// please add them to the end of the file.
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef ATTACHED_MACRO_ROLE

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1025,16 +1025,14 @@ public:
       SourceLoc loc = S->getThrowLoc();
       if (loc.isValid()) {
         auto catchNode = ASTScope::lookupCatchNode(getModuleContext(), loc);
-
-        if (!catchNode) {
-          Out << "No catch context for throw statement\n";
-          abort();
-        }
-
-        if (auto thrown = catchNode.getThrownErrorTypeInContext(Ctx)) {
-          thrownError = *thrown;
+	if (catchNode) {
+          if (auto thrown = catchNode.getThrownErrorTypeInContext(Ctx)) {
+            thrownError = *thrown;
+          } else {
+            thrownError = Ctx.getNeverType();
+          }
         } else {
-          thrownError = Ctx.getNeverType();
+          thrownError = checkExceptionTypeExists("throw expression");
         }
       } else {
         return;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/MacroDiscriminatorContext.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrettyStackTrace.h"
@@ -1021,13 +1022,24 @@ public:
 
     void verifyChecked(ThrowStmt *S) {
       Type thrownError;
-      if (!Functions.empty()) {
-        if (auto fn = AnyFunctionRef::fromDeclContext(Functions.back()))
-          thrownError = fn->getThrownErrorType();
+      SourceLoc loc = S->getThrowLoc();
+      if (loc.isValid()) {
+        auto catchNode = ASTScope::lookupCatchNode(getModuleContext(), loc);
+
+        if (!catchNode) {
+          Out << "No catch context for throw statement\n";
+          abort();
+        }
+
+        if (auto thrown = catchNode.getThrownErrorTypeInContext(Ctx)) {
+          thrownError = *thrown;
+        } else {
+          thrownError = Ctx.getNeverType();
+        }
+      } else {
+        return;
       }
 
-      if (!thrownError)
-        thrownError = checkExceptionTypeExists("throw expression");
       checkSameType(S->getSubExpr()->getType(), thrownError, "throw operand");
       verifyCheckedBase(S);
     }

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -130,6 +130,23 @@ open class MyClass {
   func f() throws { }
 }
 
+
+struct Foo: Error { }
+struct Bar: Error { }
+
+// CHECK-LABEL: sil hidden [ossa] @$s12typed_throws0B22DifferentFromEnclosingyyAA3FooVYKF : $@convention(thin) () -> @error Foo
+func throwsDifferentFromEnclosing() throws(Foo) {
+  do {
+    throw Bar()
+  } catch {
+    print("Bar was barred")
+  }
+
+  // CHECK: throw [[ERROR:%.*]] : $Foo
+  throw Foo()
+}
+
+
 // CHECK-LABEL:      sil_vtable MySubclass {
 // CHECK-NEXT:   #MyClass.init!allocator: <E where E : Error> (MyClass.Type) -> (() throws(E) -> ()) throws(E) -> MyClass : @$s12typed_throws10MySubclassC4bodyACyyxYKXE_txYKcs5ErrorRzlufC [override]
 // CHECK-NEXT:  #MyClass.f: (MyClass) -> () throws -> () : @$s12typed_throws10MySubclassC1fyyAA0C5ErrorOYKFAA0C5ClassCADyyKFTV [override]


### PR DESCRIPTION
The AST verifier was only correctly extracting thrown error types from
enclosing functions, without account for do...catch bodies. Switch it
over to using ASTScope's lookup to find the innermost enclosing caught
error context.

Fixes a AST verifier error reported by Paul Cantrell