### PR TITLE
[Caching] Fix frontend cache replay for batch mode

### DIFF
--- a/test/CAS/cache_replay_multiple_files.swift
+++ b/test/CAS/cache_replay_multiple_files.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Test compile multiple inputs with batch mode.
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift %t/foo.swift -emit-module -o %t/Test.swiftmodule \
+// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -primary-file %t/test.swift %t/foo.swift -c -o %t/test.o  \
+// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -primary-file %t/foo.swift -c -o %t/foo.o  \
+// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+
+/// Expect cache hit second time
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift %t/foo.swift -emit-module -o %t/Test.swiftmodule \
+// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -primary-file %t/test.swift %t/foo.swift -c -o %t/test.o  \
+// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -primary-file %t/foo.swift -c -o %t/foo.o  \
+// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+
+//--- test.swift
+func testFunc() {}
+
+//--- foo.swift
+func foo() {}
+
+// CACHE-MISS: remark: cache miss for input
+// CACHE-MISS-NOT: remark: replay output file
+// CACHE-HIT: remark: replay output file
+// CACHE-HIT-NOT: remark: cache miss for input

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -110,7 +110,7 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid -Rmodule-loading -Xcc -Rmodule-import %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck %s
 
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution -o %t/Foo.swiftmodule
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %s -cache-compile-job \


### PR DESCRIPTION
Teach swift-frontend to correctly replay cache when using batch-mode/primary-file. Currently, the cache replay logic will try to look up cache key for all the inputs and only replay if all lookups are successful. In batch-mode, not all inputs are producing outputs, which causes lookup for those keys to be a miss and causing a false miss for the compilation.