### PR TITLE
[5.10][TypeChecker] Prevent invalid attribute on accessor from failing if i…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -438,29 +438,38 @@ GlobalActorAttributeRequest::evaluate(
             .warnUntilSwiftVersion(6)
             .fixItRemove(globalActorAttr->getRangeWithAt());
 
+        auto &ctx = decl->getASTContext();
         auto *storage = accessor->getStorage();
         // Let's suggest to move the attribute to the storage if
         // this is an accessor/addressor of a property of subscript.
         if (storage->getDeclContext()->isTypeContext()) {
-          // If enclosing declaration has a global actor,
-          // skip the suggestion.
-          if (storage->getGlobalActorAttr())
-            return llvm::None;
+          auto canMoveAttr = [&]() {
+            // If enclosing declaration has a global actor,
+            // skip the suggestion.
+            if (storage->getGlobalActorAttr())
+              return false;
 
-          // Global actor attribute cannot be applied to
-          // an instance stored property of a struct.
-          if (auto *var = dyn_cast<VarDecl>(storage)) {
-            if (isStoredInstancePropertyOfStruct(var))
-              return llvm::None;
+            // Global actor attribute cannot be applied to
+            // an instance stored property of a struct.
+            if (auto *var = dyn_cast<VarDecl>(storage)) {
+              return !isStoredInstancePropertyOfStruct(var);
+            }
+
+            return true;
+          };
+
+          if (canMoveAttr()) {
+            decl->diagnose(diag::move_global_actor_attr_to_storage_decl,
+                           storage)
+                .fixItInsert(
+                    storage->getAttributeInsertionLoc(/*forModifier=*/false),
+                    llvm::Twine("@", result->second->getNameStr()).str());
           }
-
-          decl->diagnose(diag::move_global_actor_attr_to_storage_decl, storage)
-              .fixItInsert(
-                  storage->getAttributeInsertionLoc(/*forModifier=*/false),
-                  llvm::Twine("@", result->second->getNameStr()).str());
         }
 
-        return llvm::None;
+        // In Swift 6, once the diag above is an error, it is disallowed.
+        if (ctx.isSwiftVersionAtLeast(6))
+          return llvm::None;
       }
     }
     // Functions are okay.


### PR DESCRIPTION
…t's a warning

Cherry-pick of https://github.com/apple/swift/pull/70163
Follow-up to https://github.com/apple/swift/pull/69369

--- 

- Explanation:

Pre-Swift 6 use of a global actor attribute on an accessor would be diagnosed as a warning and shouldn't fail `GlobalActorAttributeRequest`.

- Scope: Accessors with global actor attributes in pre-Swift 6 mode.

- Main Branch PR: https://github.com/apple/swift/pull/70163

- Resolves: rdar://118934711

- Risk: Low

- Reviewed By: @hborla 

- Testing: No tests since the behavior is not currently observable.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
