### PR TITLE
[5.10🍒][test] coverage for bogus exclusivity diagnostic

### DIFF
--- a/test/SILOptimizer/moveonly_correct.swift
+++ b/test/SILOptimizer/moveonly_correct.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend %s -sil-verify-all -c -o /dev/null
+
+// This file is suppose to contain programs that are "correct" through emitting
+// an object file, so no diagnostic tests in here, please!
+
+// rdar://118274699
+struct Env: ~Copyable {
+    var constants: Int
+}
+struct VM: ~Copyable {
+    let env = Env(constants: 0)
+
+    mutating func run() {
+        env.constants
+    }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/70164

Only adds regression test coverage and is otherwise a non-functional change.

resolves rdar://118274699

(cherry picked from commit 85620d6eaf222e687a84fce89325427e915b4f7c)