### PR TITLE
[DebugInfo][SILGen] Ensure "guard let" is lowered with a non-implicit…

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -404,7 +404,7 @@ void SILGenFunction::emitExprInto(Expr *E, Initialization *I,
     FormalEvaluationScope writeback(*this);
     auto lv = emitLValue(load->getSubExpr(),
                          SGFAccessKind::BorrowedAddressRead);
-    emitCopyLValueInto(E, std::move(lv), I);
+    emitCopyLValueInto(L ? *L : E, std::move(lv), I);
     return;
   }
 

--- a/test/SILGen/guardlet_debuginfo.swift
+++ b/test/SILGen/guardlet_debuginfo.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen -g -Xllvm -sil-print-debuginfo %s | %FileCheck %s
+
+class A {
+    func foo() {
+        { [weak self] in
+// Check that column 14 -- the start "guard" -- is used as the debug location,
+// as other locations are considered implicit.
+// CHECK:       switch_enum
+// CHECK-SAME:  guardlet_debuginfo.swift":[[@LINE+1]]:13
+            guard let self else { return }
+            print(self)
+        }()
+    }
+}
+
+let a = A()
+a.foo()


### PR DESCRIPTION
… location

Prior to this patch, a "guard let" was being lowered with an implicit debug location, causing it to be dropped in later stages of the compiler, and making it impossible to set a breakpoint in that line.

This was tracked down to a piece of code in `SILGenFunction::emitExprInto`, which takes an optional Location parameter that was being ignored in one code path.

(cherry picked from commit 8baf9331140b3a9ce94835ee7f899e3846e90659)

rdar://116462520