### PR TITLE
[ASTGen] Implement SequenceExpr generation

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -644,6 +644,18 @@ BridgedStringRef BridgedVarDecl_getUserFacingName(BridgedVarDecl decl);
 // MARK: Exprs
 //===----------------------------------------------------------------------===//
 
+SWIFT_NAME(
+    "BridgedArrowExpr.createParsed(_:asyncLoc:throwsLoc:thrownType:arrowLoc:)")
+BridgedArrowExpr BridgedArrowExpr_createParsed(BridgedASTContext cContext,
+                                               BridgedSourceLoc cAsyncLoc,
+                                               BridgedSourceLoc cThrowsLoc,
+                                               BridgedNullableExpr cThrownType,
+                                               BridgedSourceLoc cArrowLoc);
+
+SWIFT_NAME("BridgedAssignExpr.createParsed(_:equalsLoc:)")
+BridgedAssignExpr BridgedAssignExpr_createParsed(BridgedASTContext cContext,
+                                                 BridgedSourceLoc cEqualsLoc);
+
 SWIFT_NAME("BridgedCallExpr.createParsed(_:fn:args:)")
 BridgedCallExpr BridgedCallExpr_createParsed(BridgedASTContext cContext,
                                              BridgedExpr fn,
@@ -655,11 +667,34 @@ BridgedClosureExpr_createParsed(BridgedASTContext cContext,
                                 BridgedDeclContext cDeclContext,
                                 BridgedBraceStmt body);
 
-SWIFT_NAME("BridgedUnresolvedDeclRefExpr.createParsed(_:name:loc:)")
-BridgedUnresolvedDeclRefExpr
-BridgedUnresolvedDeclRefExpr_createParsed(BridgedASTContext cContext,
-                                          BridgedDeclNameRef cName,
-                                          BridgedDeclNameLoc cLoc);
+SWIFT_NAME("BridgedCoerceExpr.createParsed(_:asLoc:type:)")
+BridgedCoerceExpr BridgedCoerceExpr_createParsed(BridgedASTContext cContext,
+                                                 BridgedSourceLoc cAsLoc,
+                                                 BridgedTypeRepr cType);
+
+SWIFT_NAME(
+    "BridgedConditionalCheckedCastExpr.createParsed(_:asLoc:questionLoc:type:)")
+BridgedConditionalCheckedCastExpr
+BridgedConditionalCheckedCastExpr_createParsed(BridgedASTContext cContext,
+                                               BridgedSourceLoc cAsLoc,
+                                               BridgedSourceLoc cQuestionLoc,
+                                               BridgedTypeRepr cType);
+
+SWIFT_NAME("BridgedDiscardAssignmentExpr.createParsed(_:loc:)")
+BridgedDiscardAssignmentExpr
+BridgedDiscardAssignmentExpr_createParsed(BridgedASTContext cContext,
+                                          BridgedSourceLoc cLoc);
+
+SWIFT_NAME(
+    "BridgedForcedCheckedCastExpr.createParsed(_:asLoc:exclaimLoc:type:)")
+BridgedForcedCheckedCastExpr BridgedForcedCheckedCastExpr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cAsLoc,
+    BridgedSourceLoc cExclaimLoc, BridgedTypeRepr cType);
+
+SWIFT_NAME("BridgedIsExpr.createParsed(_:isLoc:type:)")
+BridgedIsExpr BridgedIsExpr_createParsed(BridgedASTContext cContext,
+                                         BridgedSourceLoc cIsLoc,
+                                         BridgedTypeRepr cType);
 
 SWIFT_NAME("BridgedSingleValueStmtExpr.createWithWrappedBranches(_:stmt:"
            "declContext:mustBeExpr:)")
@@ -676,6 +711,11 @@ BridgedStringLiteralExpr_createParsed(BridgedASTContext cContext,
 SWIFT_NAME("BridgedSequenceExpr.createParsed(_:exprs:)")
 BridgedSequenceExpr BridgedSequenceExpr_createParsed(BridgedASTContext cContext,
                                                      BridgedArrayRef exprs);
+
+SWIFT_NAME("BridgedTernaryExpr.createParsed(_:questionLoc:thenExpr:colonLoc:)")
+BridgedTernaryExpr BridgedTernaryExpr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cQuestionLoc,
+    BridgedExpr cThenExpr, BridgedSourceLoc cColonLoc);
 
 SWIFT_NAME("BridgedTupleExpr.createParsed(_:leftParenLoc:exprs:labels:"
            "labelLocs:rightParenLoc:)")
@@ -706,6 +746,32 @@ BridgedArrayExpr BridgedArrayExpr_createParsed(BridgedASTContext cContext,
                                                BridgedArrayRef elements,
                                                BridgedArrayRef commas,
                                                BridgedSourceLoc cRLoc);
+
+SWIFT_NAME("BridgedPostfixUnaryExpr.createParsed(_:operator:operand:)")
+BridgedPostfixUnaryExpr
+BridgedPostfixUnaryExpr_createParsed(BridgedASTContext cContext,
+                                     BridgedExpr oper, BridgedExpr operand);
+
+SWIFT_NAME("BridgedPrefixUnaryExpr.createParsed(_:operator:operand:)")
+BridgedPrefixUnaryExpr
+BridgedPrefixUnaryExpr_createParsed(BridgedASTContext cContext,
+                                    BridgedExpr oper, BridgedExpr operand);
+
+SWIFT_NAME("BridgedTypeExpr.createParsed(_:type:)")
+BridgedTypeExpr BridgedTypeExpr_createParsed(BridgedASTContext cContext,
+                                             BridgedTypeRepr cType);
+
+enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDeclRefKind : size_t {
+  BridgedDeclRefKindOrdinary,
+  BridgedDeclRefKindBinaryOperator,
+  BridgedDeclRefKindPostfixOperator,
+  BridgedDeclRefKindPrefixOperator,
+};
+
+SWIFT_NAME("BridgedUnresolvedDeclRefExpr.createParsed(_:name:kind:loc:)")
+BridgedUnresolvedDeclRefExpr BridgedUnresolvedDeclRefExpr_createParsed(
+    BridgedASTContext cContext, BridgedDeclNameRef cName,
+    BridgedDeclRefKind cKind, BridgedDeclNameLoc cLoc);
 
 SWIFT_NAME("BridgedUnresolvedDotExpr.createParsed(_:base:dotLoc:name:nameLoc:)")
 BridgedUnresolvedDotExpr BridgedUnresolvedDotExpr_createParsed(

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1698,8 +1698,7 @@ public:
   ParserResult<Expr> parseExprBasic(Diag<> ID) {
     return parseExprImpl(ID, /*isExprBasic=*/true);
   }
-  ParserResult<Expr> parseExprImpl(Diag<> ID, bool isExprBasic,
-                                   bool fromASTGen = false);
+  ParserResult<Expr> parseExprImpl(Diag<> ID, bool isExprBasic);
   ParserResult<Expr> parseExprIs();
   ParserResult<Expr> parseExprAs();
   ParserResult<Expr> parseExprArrow();

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -869,6 +869,21 @@ bool BridgedNominalTypeDecl_isStructWithUnreferenceableStorage(
 // MARK: Exprs
 //===----------------------------------------------------------------------===//
 
+BridgedArrowExpr BridgedArrowExpr_createParsed(BridgedASTContext cContext,
+                                               BridgedSourceLoc cAsyncLoc,
+                                               BridgedSourceLoc cThrowsLoc,
+                                               BridgedNullableExpr cThrownType,
+                                               BridgedSourceLoc cArrowLoc) {
+  return new (cContext.unbridged())
+      ArrowExpr(cAsyncLoc.unbridged(), cThrowsLoc.unbridged(),
+                cThrownType.unbridged(), cArrowLoc.unbridged());
+}
+
+BridgedAssignExpr BridgedAssignExpr_createParsed(BridgedASTContext cContext,
+                                                 BridgedSourceLoc cEqualsLoc) {
+  return new (cContext.unbridged()) AssignExpr(cEqualsLoc.unbridged());
+}
+
 BridgedClosureExpr
 BridgedClosureExpr_createParsed(BridgedASTContext cContext,
                                 BridgedDeclContext cDeclContext,
@@ -891,6 +906,45 @@ BridgedClosureExpr_createParsed(BridgedASTContext cContext,
   out->setBody(body.unbridged(), true);
   out->setParameterList(params);
   return out;
+}
+
+BridgedCoerceExpr BridgedCoerceExpr_createParsed(BridgedASTContext cContext,
+                                                 BridgedSourceLoc cAsLoc,
+                                                 BridgedTypeRepr cType) {
+  return CoerceExpr::create(cContext.unbridged(), cAsLoc.unbridged(),
+                            cType.unbridged());
+}
+
+BridgedConditionalCheckedCastExpr
+BridgedConditionalCheckedCastExpr_createParsed(BridgedASTContext cContext,
+                                               BridgedSourceLoc cAsLoc,
+                                               BridgedSourceLoc cQuestionLoc,
+                                               BridgedTypeRepr cType) {
+  return ConditionalCheckedCastExpr::create(
+      cContext.unbridged(), cAsLoc.unbridged(), cQuestionLoc.unbridged(),
+      cType.unbridged());
+}
+
+BridgedDiscardAssignmentExpr
+BridgedDiscardAssignmentExpr_createParsed(BridgedASTContext cContext,
+                                          BridgedSourceLoc cLoc) {
+  return new (cContext.unbridged())
+      DiscardAssignmentExpr(cLoc.unbridged(), /*Implicit=*/false);
+}
+
+BridgedForcedCheckedCastExpr BridgedForcedCheckedCastExpr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cAsLoc,
+    BridgedSourceLoc cExclaimLoc, BridgedTypeRepr cType) {
+  return ForcedCheckedCastExpr::create(cContext.unbridged(), cAsLoc.unbridged(),
+                                       cExclaimLoc.unbridged(),
+                                       cType.unbridged());
+}
+
+BridgedIsExpr BridgedIsExpr_createParsed(BridgedASTContext cContext,
+                                         BridgedSourceLoc cIsLoc,
+                                         BridgedTypeRepr cType) {
+  return IsExpr::create(cContext.unbridged(), cIsLoc.unbridged(),
+                        cType.unbridged());
 }
 
 BridgedSequenceExpr BridgedSequenceExpr_createParsed(BridgedASTContext cContext,
@@ -928,13 +982,26 @@ BridgedCallExpr BridgedCallExpr_createParsed(BridgedASTContext cContext,
                           /*implicit*/ false);
 }
 
-BridgedUnresolvedDeclRefExpr
-BridgedUnresolvedDeclRefExpr_createParsed(BridgedASTContext cContext,
-                                          BridgedDeclNameRef cName,
-                                          BridgedDeclNameLoc cLoc) {
-  ASTContext &context = cContext.unbridged();
-  return new (context) UnresolvedDeclRefExpr(
-      cName.unbridged(), DeclRefKind::Ordinary, cLoc.unbridged());
+BridgedUnresolvedDeclRefExpr BridgedUnresolvedDeclRefExpr_createParsed(
+    BridgedASTContext cContext, BridgedDeclNameRef cName,
+    BridgedDeclRefKind cKind, BridgedDeclNameLoc cLoc) {
+  DeclRefKind kind;
+  switch (cKind) {
+  case BridgedDeclRefKindOrdinary:
+    kind = DeclRefKind::Ordinary;
+    break;
+  case BridgedDeclRefKindBinaryOperator:
+    kind = DeclRefKind::BinaryOperator;
+    break;
+  case BridgedDeclRefKindPostfixOperator:
+    kind = DeclRefKind::PostfixOperator;
+    break;
+  case BridgedDeclRefKindPrefixOperator:
+    kind = DeclRefKind::PrefixOperator;
+    break;
+  }
+  return new (cContext.unbridged())
+      UnresolvedDeclRefExpr(cName.unbridged(), kind, cLoc.unbridged());
 }
 
 BridgedStringLiteralExpr
@@ -979,6 +1046,20 @@ BridgedNilLiteralExpr_createParsed(BridgedASTContext cContext,
   return new (cContext.unbridged()) NilLiteralExpr(cNilKeywordLoc.unbridged());
 }
 
+BridgedPostfixUnaryExpr
+BridgedPostfixUnaryExpr_createParsed(BridgedASTContext cContext,
+                                     BridgedExpr oper, BridgedExpr operand) {
+  return PostfixUnaryExpr::create(cContext.unbridged(), oper.unbridged(),
+                                  operand.unbridged());
+}
+
+BridgedPrefixUnaryExpr
+BridgedPrefixUnaryExpr_createParsed(BridgedASTContext cContext,
+                                    BridgedExpr oper, BridgedExpr operand) {
+  return PrefixUnaryExpr::create(cContext.unbridged(), oper.unbridged(),
+                                 operand.unbridged());
+}
+
 BridgedSingleValueStmtExpr BridgedSingleValueStmtExpr_createWithWrappedBranches(
     BridgedASTContext cContext, BridgedStmt S, BridgedDeclContext cDeclContext,
     bool mustBeExpr) {
@@ -986,6 +1067,13 @@ BridgedSingleValueStmtExpr BridgedSingleValueStmtExpr_createWithWrappedBranches(
   DeclContext *declContext = cDeclContext.unbridged();
   return SingleValueStmtExpr::createWithWrappedBranches(
       context, S.unbridged(), declContext, mustBeExpr);
+}
+
+BridgedTernaryExpr BridgedTernaryExpr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cQuestionLoc,
+    BridgedExpr cThenExpr, BridgedSourceLoc cColonLoc) {
+  return new (cContext.unbridged()) TernaryExpr(
+      cQuestionLoc.unbridged(), cThenExpr.unbridged(), cColonLoc.unbridged());
 }
 
 BridgedTypeExpr BridgedTypeExpr_createParsed(BridgedASTContext cContext,

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -27,6 +27,12 @@ import SwiftDiagnostics
 /// `generateWithLegacy(_:)` only receives the parser position, it eagerly
 /// parses the outer expressions.
 func isExprMigrated(_ node: ExprSyntax) -> Bool {
+  if node.is(SequenceExprSyntax.self) {
+    // 'generate(sequenceExpr:)' is implemented.
+    // Since `generateWithLegacy()` only calls `parseExprSequenceElement()`
+    // in C++, we don't have to worry about over parsing in the legacy parser.
+    return true
+  }
   var current: Syntax = Syntax(node)
   if let firstToken = node.firstToken(viewMode: .sourceAccurate) {
     current = firstToken.parent!
@@ -34,9 +40,12 @@ func isExprMigrated(_ node: ExprSyntax) -> Bool {
   while true {
     switch current.kind {
     case // Known implemented kinds.
-        .closureExpr, .functionCallExpr, .declReferenceExpr, .memberAccessExpr,
-        .tupleExpr, .ifExpr, .booleanLiteralExpr, .integerLiteralExpr,
-        .arrayExpr, .nilLiteralExpr, .stringLiteralExpr:
+        .arrayExpr, .arrowExpr, .assignmentExpr, .binaryOperatorExpr,
+        .booleanLiteralExpr, .closureExpr, .discardAssignmentExpr,
+        .declReferenceExpr, .functionCallExpr, .ifExpr, .integerLiteralExpr,
+        .memberAccessExpr,  .nilLiteralExpr, .postfixOperatorExpr,
+        .prefixOperatorExpr, .sequenceExpr, .stringLiteralExpr, .tupleExpr,
+        .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedTernaryExpr:
 
       // `generate(stringLiteralExpr:)` doesn't support interpolations.
       if let str = current.as(StringLiteralExprSyntax.self) {
@@ -46,26 +55,17 @@ func isExprMigrated(_ node: ExprSyntax) -> Bool {
         assert(str.segments.first!.is(StringSegmentSyntax.self))
       }
 
-      // NOTE: When SequenceExpr is implemented, we need some special handling.
-      // E.g.
-      //   <implemented> + <unimplemented> + <implemented>
-      // If we delegate `<unimplemented>` part to the legacy parser, it would
-      // eagerly parse the rest of the expression, instead of just the
-      // <unimplemented> part.
-      // Maybe call 'Parser::parseExprSequenceElement' directly.
       break
     case // Known unimplemented kinds.
-        .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr,
+        .asExpr, .awaitExpr,
         .borrowExpr, .canImportExpr, .canImportVersionInfo, .dictionaryExpr,
-        .discardAssignmentExpr, .doExpr, .editorPlaceholderExpr,
+        .doExpr, .editorPlaceholderExpr,
         .floatLiteralExpr, .forceUnwrapExpr, .inOutExpr, .infixOperatorExpr,
         .isExpr, .keyPathExpr, .macroExpansionExpr, .consumeExpr, .copyExpr,
         .optionalChainingExpr, .packElementExpr, .packExpansionExpr,
-        .postfixIfConfigExpr, .postfixOperatorExpr, .prefixOperatorExpr,
-        .regexLiteralExpr, .sequenceExpr, .genericSpecializationExpr,
+        .postfixIfConfigExpr, .regexLiteralExpr, .genericSpecializationExpr,
         .simpleStringLiteralExpr, .subscriptCallExpr, .superExpr, .switchExpr,
-        .ternaryExpr, .tryExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr,
-        .patternExpr, .unresolvedTernaryExpr:
+        .ternaryExpr, .tryExpr, .patternExpr:
       return false
     case // Unknown expr kinds.
       _ where current.is(ExprSyntax.self):
@@ -91,15 +91,15 @@ extension ASTGenVisitor {
     case .arrayExpr(let node):
       return self.generate(arrayExpr: node).asExpr
     case .arrowExpr:
-      break
+      preconditionFailure("should be handled in generate(sequenceExpr:)")
     case .asExpr:
       break
     case .assignmentExpr:
-      break
+      preconditionFailure("should be handled in generate(sequenceExpr:)")
     case .awaitExpr:
       break
     case .binaryOperatorExpr:
-      break
+      preconditionFailure("should be handled in generate(sequenceExpr:)")
     case .booleanLiteralExpr(let node):
       return self.generate(booleanLiteralExpr: node).asExpr
     case .borrowExpr:
@@ -118,8 +118,8 @@ extension ASTGenVisitor {
       return self.generate(declReferenceExpr: node).asExpr
     case .dictionaryExpr:
       break
-    case .discardAssignmentExpr:
-      break
+    case .discardAssignmentExpr(let node):
+      return self.generate(discardAssignmentExpr: node).asExpr
     case .doExpr:
       break
     case .editorPlaceholderExpr:
@@ -163,14 +163,14 @@ extension ASTGenVisitor {
       break
     case .postfixIfConfigExpr:
       break
-    case .postfixOperatorExpr:
-      break
-    case .prefixOperatorExpr:
-      break
+    case .postfixOperatorExpr(let node):
+      return self.generate(postfixOperatorExpr: node).asExpr
+    case .prefixOperatorExpr(let node):
+      return self.generate(prefixOperatorExpr: node).asExpr
     case .regexLiteralExpr:
       break
-    case .sequenceExpr:
-      break
+    case .sequenceExpr(let node):
+      return self.generate(sequenceExpr: node)
     case .simpleStringLiteralExpr:
       break
     case .stringLiteralExpr(let node):
@@ -187,16 +187,56 @@ extension ASTGenVisitor {
       break
     case .tupleExpr(let node):
       return self.generate(tupleExpr: node).asExpr
-    case .typeExpr:
-      break
+    case .typeExpr(let node):
+      return self.generate(typeExpr: node).asExpr
     case .unresolvedAsExpr:
-      break
+      preconditionFailure("should be handled in generate(sequenceExpr:)")
     case .unresolvedIsExpr:
-      break
+      preconditionFailure("should be handled in generate(sequenceExpr:)")
     case .unresolvedTernaryExpr:
-      break
+      preconditionFailure("should be handled in generate(sequenceExpr:)")
     }
     preconditionFailure("isExprMigrated() mismatch")
+  }
+
+  public func generate(arrowExpr node: ArrowExprSyntax) -> BridgedArrowExpr {
+    let asyncLoc: BridgedSourceLoc
+    let throwsLoc: BridgedSourceLoc
+    let thrownTypeExpr: BridgedNullableExpr
+
+    if let effectSpecifiers = node.effectSpecifiers {
+      asyncLoc = effectSpecifiers.asyncSpecifier.bridgedSourceLoc(in: self)
+      throwsLoc = (effectSpecifiers.throwsClause?.throwsSpecifier).bridgedSourceLoc(in: self)
+      if let thrownTypeNode = effectSpecifiers.thrownError {
+        let typeExpr = BridgedTypeExpr.createParsed(
+          self.ctx,
+          type: self.generate(type: thrownTypeNode)
+        )
+        thrownTypeExpr = BridgedNullableExpr(raw: typeExpr.raw)
+      } else {
+        thrownTypeExpr = nil
+      }
+    } else {
+      asyncLoc = nil
+      throwsLoc = nil
+      thrownTypeExpr = nil
+    }
+
+    return .createParsed(
+      self.ctx,
+      asyncLoc: asyncLoc,
+      throwsLoc: throwsLoc,
+      thrownType: thrownTypeExpr,
+      arrowLoc: node.arrow.bridgedSourceLoc(in: self)
+    )
+  }
+
+  public func generate(assignmentExpr node: AssignmentExprSyntax) -> BridgedAssignExpr {
+    return .createParsed(self.ctx, equalsLoc: node.equal.bridgedSourceLoc(in: self))
+  }
+
+  public func generate(binaryOperatorExpr node: BinaryOperatorExprSyntax) -> BridgedUnresolvedDeclRefExpr {
+    return createOperatorRefExpr(token: node.operator, kind: .binaryOperator)
   }
 
   public func generate(closureExpr node: ClosureExprSyntax) -> BridgedClosureExpr {
@@ -298,8 +338,13 @@ extension ASTGenVisitor {
     return .createParsed(
       self.ctx,
       name: nameAndLoc.name,
+      kind: .ordinary,
       loc: nameAndLoc.loc
     )
+  }
+
+  public func generate(discardAssignmentExpr node: DiscardAssignmentExprSyntax) -> BridgedDiscardAssignmentExpr {
+    return .createParsed(self.ctx, loc: node.wildcard.bridgedSourceLoc(in: self))
   }
 
   public func generate(memberAccessExpr node: MemberAccessExprSyntax) -> BridgedExpr {
@@ -335,14 +380,158 @@ extension ASTGenVisitor {
     )
   }
 
+  public func generate(postfixOperatorExpr node: PostfixOperatorExprSyntax) -> BridgedPostfixUnaryExpr {
+    return .createParsed(
+      self.ctx,
+      operator: self.createOperatorRefExpr(
+        token: node.operator,
+        kind: .postfixOperator
+      ).asExpr,
+      operand: self.generate(expr: node.expression)
+    )
+  }
+
+  public func generate(prefixOperatorExpr node: PrefixOperatorExprSyntax) -> BridgedPrefixUnaryExpr {
+    return .createParsed(
+      self.ctx,
+      operator: self.createOperatorRefExpr(
+        token: node.operator,
+        kind: .prefixOperator
+      ).asExpr,
+      operand: self.generate(expr: node.expression)
+    )
+  }
+
+  public func generate(sequenceExpr node: SequenceExprSyntax) -> BridgedExpr {
+    assert(
+      !node.elements.count.isMultiple(of: 2),
+      "SequenceExpr must have odd number of elements"
+    )
+
+    guard node.elements.count > 1 else {
+      // Should be unreachable if the `node` is a parsed by `SwiftParser`.
+      return self.generate(expr: node.elements.first!)
+    }
+
+    // NOTE: we can't just generate(expr:) for each elements because
+    // SwiftSyntax.SequenceExprSyntax and swift::SequenceExpr has mismatch in the
+    // element representations. e.g. 'as' and 'is'.
+
+    // FIXME: Avoid Swift.Array.
+    var elements: [BridgedExpr] = []
+    elements.reserveCapacity(node.elements.count)
+
+    var iter = node.elements.makeIterator()
+    while let node = iter.next() {
+      switch node.as(ExprSyntaxEnum.self) {
+      case .arrowExpr(let node):
+        elements.append(self.generate(arrowExpr: node).asExpr)
+      case .assignmentExpr(let node):
+        elements.append(self.generate(assignmentExpr: node).asExpr)
+      case .binaryOperatorExpr(let node):
+        elements.append(self.generate(binaryOperatorExpr: node).asExpr)
+      case .unresolvedAsExpr(let node):
+        let oper = self.generate(
+          unresolvedAsExpr: node,
+          typeExpr: iter.next()!.cast(TypeExprSyntax.self)
+        )
+        elements.append(oper)
+        elements.append(oper)
+      case .unresolvedIsExpr(let node):
+        let oper = self.generate(
+          unresolvedIsExpr: node,
+          typeExpr: iter.next()!.cast(TypeExprSyntax.self)
+        )
+        elements.append(oper.asExpr)
+        elements.append(oper.asExpr)
+      case .unresolvedTernaryExpr(let node):
+        elements.append(self.generate(unresolvedTernaryExpr: node).asExpr)
+      default:
+        // Operand.
+        elements.append(self.generate(expr: node))
+      }
+    }
+
+    return BridgedSequenceExpr.createParsed(
+      self.ctx,
+      exprs: elements.lazy.bridgedArray(in: self)
+    ).asExpr
+  }
+
   public func generate(tupleExpr node: TupleExprSyntax) -> BridgedTupleExpr {
     return self.generate(labeledExprList: node.elements, leftParen: node.leftParen, rightParen: node.rightParen)
+  }
+
+  public func generate(typeExpr node: TypeExprSyntax) -> BridgedTypeExpr {
+    return .createParsed(
+      self.ctx,
+      type: self.generate(type: node.type)
+    )
+  }
+
+  public func generate(unresolvedAsExpr node: UnresolvedAsExprSyntax, typeExpr typeNode: TypeExprSyntax) -> BridgedExpr {
+    let type = self.generate(type: typeNode.type)
+    let asLoc = node.asKeyword.bridgedSourceLoc(in: self)
+
+    switch node.questionOrExclamationMark {
+    case nil:
+      return BridgedCoerceExpr.createParsed(
+        self.ctx,
+        asLoc: asLoc,
+        type: type
+      ).asExpr
+    case let question? where question.text == "?":
+      return BridgedConditionalCheckedCastExpr.createParsed(
+        self.ctx,
+        asLoc: asLoc,
+        questionLoc: question.bridgedSourceLoc(in: self),
+        type: type
+      ).asExpr
+    case let exclaim? where exclaim.text == "!":
+      return BridgedForcedCheckedCastExpr.createParsed(
+        self.ctx,
+        asLoc: asLoc,
+        exclaimLoc: exclaim.bridgedSourceLoc(in: self),
+        type: type
+      ).asExpr
+    case _?:
+      preconditionFailure("UnresolvedAsExprSyntax must have '?' or '!'")
+    }
+  }
+
+  public func generate(unresolvedIsExpr node: UnresolvedIsExprSyntax, typeExpr typeNode: TypeExprSyntax) -> BridgedIsExpr {
+    return .createParsed(
+      self.ctx,
+      isLoc: node.isKeyword.bridgedSourceLoc(in: self),
+      type: self.generate(type: typeNode.type)
+    )
+  }
+
+  public func generate(unresolvedTernaryExpr node: UnresolvedTernaryExprSyntax) -> BridgedTernaryExpr {
+    return .createParsed(
+      self.ctx,
+      questionLoc: node.questionMark.bridgedSourceLoc(in: self),
+      thenExpr: self.generate(expr: node.thenExpression),
+      colonLoc: node.colon.bridgedSourceLoc(in: self)
+    )
   }
 
   // NOTE: When implementing new `generate(expr:)`, please update `isExprMigrated(_:)`.
 }
 
 extension ASTGenVisitor {
+  fileprivate func createOperatorRefExpr(token node: TokenSyntax, kind: BridgedDeclRefKind) -> BridgedUnresolvedDeclRefExpr {
+    let (name, nameLoc) = node.bridgedIdentifierAndSourceLoc(in: self)
+
+    return .createParsed(
+      self.ctx,
+      name: .createParsed(.createIdentifier(name)),
+      kind: kind,
+      loc: .createParsed(nameLoc)
+    );
+  }
+
+
   /// Generate a tuple expression from a ``LabeledExprListSyntax`` and parentheses.
   func generate(labeledExprList node: LabeledExprListSyntax, leftParen: TokenSyntax?, rightParen: TokenSyntax?) -> BridgedTupleExpr {
     let expressions = node.lazy.map {

--- a/lib/ASTGen/Sources/ASTGen/LegacyParse.swift
+++ b/lib/ASTGen/Sources/ASTGen/LegacyParse.swift
@@ -18,10 +18,9 @@ import ParseBridging
 extension ASTGenVisitor {
 
   func generateWithLegacy(_ node: ExprSyntax) -> BridgedExpr {
-    // NOTE: Postfix expressions and sequence expressions share the same start
-    // location with the inner expression. This function must only be called on
-    // the outermost expression that shares the same position.
-    // See also `isExprMigrated(_:)`
+    // NOTE: Postfix expressions share the same start location with the inner
+    // expression. This function must only be called on the outermost expression
+    // that shares the same position. See also `isExprMigrated(_:)`
 
     // FIXME: Calculate isExprBasic.
     let isExprBasic = false

--- a/lib/Parse/ParseBridging.cpp
+++ b/lib/Parse/ParseBridging.cpp
@@ -27,8 +27,10 @@ BridgedExpr BridgedLegacyParser_parseExpr(BridgedLegacyParser p,
       P.getParserPosition(loc.unbridged(), /*PreviousLoc=*/loc.unbridged());
   P.CurDeclContext = DC.unbridged();
   P.restoreParserPosition(PP);
+  // Since `SequenceExpr` is implemented in ASTGen, it only delegates sequence
+  // elements parsing.
   ParserResult<Expr> result =
-      P.parseExprImpl(diag::expected_expr, isExprBasic, /*fromASTGen=*/true);
+      P.parseExprSequenceElement(diag::expected_expr, isExprBasic);
   return result.getPtrOrNull();
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -38,12 +38,9 @@ using namespace swift;
 ///     expr-sequence(basic | trailing-closure)
 ///
 /// \param isExprBasic Whether we're only parsing an expr-basic.
-/// \param fromASTGen If true , this function in called from ASTGen as the
-/// fallback, so do not attempt a callback to ASTGen.
-ParserResult<Expr> Parser::parseExprImpl(Diag<> Message, bool isExprBasic,
-                                         bool fromASTGen) {
+ParserResult<Expr> Parser::parseExprImpl(Diag<> Message, bool isExprBasic) {
 #if SWIFT_BUILD_SWIFT_SYNTAX
-  if (IsForASTGen && !fromASTGen)
+  if (IsForASTGen)
     return parseExprFromSyntaxTree();
 #endif
   // If we are parsing a refutable pattern, check to see if this is the start

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -224,3 +224,12 @@ struct TestStruct {
 //    return .instance(arg:)(12)
 //  }
 }
+
+func testSequence(arg1: Int, arg2: () -> Int, arg3: Any) {
+  _ = arg1 + arg2()
+  _ = arg3 as? Int ?? 31 as Int
+  _ = false ? arg2() : Int(1)
+  _ = [() -> Int]()
+  _ = [@Sendable () -> Int]().count +  [any Collection]().count
+  _ = arg3 is Double || !(arg3 is Int, 0).0
+}


### PR DESCRIPTION
Implement `arrowExpr`, `assignmentExpr`, `binaryOperatorExpr`, `discardAssignmentExpr`, `postfixOperatorExpr `, `prefixOperatorExpr `, `sequenceExpr`, `typeExpr` `unresolvedAsExpr`, `unresolvedIsExpr`, and `unresolvedTernaryExpr`.