### PR TITLE
[region-isolation] Ensure that if a var is captured by reference in a closure that we do not allow for later accesses to sendableFields

### DIFF
--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -119,6 +119,8 @@ public:
   using iterator = typename llvm::ArrayRef<T>::iterator;
   iterator begin() const { return Data.begin(); }
   iterator end() const { return Data.end(); }
+  llvm::iterator_range<iterator> range() const { return {begin(), end()}; }
+  llvm::ArrayRef<T> data() const { return Data; }
 
   unsigned size() const { return Data.size(); }
   bool empty() const { return Data.empty(); }

--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -58,19 +58,22 @@
 
 namespace swift {
 
-template <typename PtrTy> class ImmutablePointerSetFactory;
+template <typename T>
+class ImmutablePointerSetFactory;
 
 /// An immutable set of pointers. It is backed by a tail allocated sorted array
 /// ref.
-template <typename T> class ImmutablePointerSet : public llvm::FoldingSetNode {
-  using PtrTy = typename std::add_pointer<T>::type;
+template <typename T>
+class ImmutablePointerSet : public llvm::FoldingSetNode {
   friend class ImmutablePointerSetFactory<T>;
 
+  using PtrTraits = llvm::PointerLikeTypeTraits<T>;
+
   NullablePtr<ImmutablePointerSetFactory<T>> ParentFactory;
-  llvm::ArrayRef<PtrTy> Data;
+  llvm::ArrayRef<T> Data;
 
   ImmutablePointerSet(ImmutablePointerSetFactory<T> *ParentFactory,
-                      llvm::ArrayRef<PtrTy> NewData)
+                      llvm::ArrayRef<T> NewData)
       : ParentFactory(ParentFactory), Data(NewData) {}
 
 public:
@@ -100,7 +103,7 @@ public:
     return !(*this == P);
   }
 
-  unsigned count(PtrTy Ptr) const {
+  unsigned count(T Ptr) const {
     // This returns the first element >= Ptr. Since we know that our array is
     // sorted and uniqued, Ptr must be that element.
     auto LowerBound = std::lower_bound(begin(), end(), Ptr);
@@ -113,7 +116,7 @@ public:
     return *LowerBound == Ptr;
   }
 
-  using iterator = typename llvm::ArrayRef<PtrTy>::iterator;
+  using iterator = typename llvm::ArrayRef<T>::iterator;
   iterator begin() const { return Data.begin(); }
   iterator end() const { return Data.end(); }
 
@@ -122,8 +125,8 @@ public:
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
     assert(!Data.empty() && "Should not profile empty ImmutablePointerSet");
-    for (PtrTy P : Data) {
-      ID.AddPointer(P);
+    for (T P : Data) {
+      ID.AddPointer(PtrTraits::getAsVoidPointer(P));
     }
   }
 
@@ -177,10 +180,11 @@ public:
   }
 };
 
-template <typename T> class ImmutablePointerSetFactory {
-  using PtrTy = typename std::add_pointer<T>::type;
-
+template <typename T>
+class ImmutablePointerSetFactory {
   using PtrSet = ImmutablePointerSet<T>;
+  using PtrTraits = typename PtrSet::PtrTraits;
+
   // This is computed out-of-line so that ImmutablePointerSetFactory is
   // treated as a complete type.
   static const unsigned AllocAlignment;
@@ -205,7 +209,7 @@ public:
 
   /// Given a sorted and uniqued list \p Array, return the ImmutablePointerSet
   /// containing Array. Asserts if \p Array is not sorted and uniqued.
-  PtrSet *get(llvm::ArrayRef<PtrTy> Array) {
+  PtrSet *get(llvm::ArrayRef<T> Array) {
     if (Array.empty())
       return ImmutablePointerSetFactory::getEmptySet();
 
@@ -215,8 +219,8 @@ public:
     assert(is_sorted_and_uniqued(Array));
 
     llvm::FoldingSetNodeID ID;
-    for (PtrTy Ptr : Array) {
-      ID.AddPointer(Ptr);
+    for (T Ptr : Array) {
+      ID.AddPointer(PtrTraits::getAsVoidPointer(Ptr));
     }
 
     void *InsertPt;
@@ -225,7 +229,7 @@ public:
     }
 
     size_t NumElts = Array.size();
-    size_t MemSize = sizeof(PtrSet) + sizeof(PtrTy) * NumElts;
+    size_t MemSize = sizeof(PtrSet) + sizeof(T) * NumElts;
 
     // Allocate the memory.
     auto *Mem =
@@ -234,8 +238,8 @@ public:
     // Copy in the pointers into the tail allocated memory. We do not need to do
     // any sorting/uniquing ourselves since we assume that our users perform
     // this task for us.
-    llvm::MutableArrayRef<PtrTy> DataMem(reinterpret_cast<PtrTy *>(&Mem[1]),
-                                         NumElts);
+    llvm::MutableArrayRef<void *> DataMem(reinterpret_cast<void **>(&Mem[1]),
+                                          NumElts);
     std::copy(Array.begin(), Array.end(), DataMem.begin());
 
     // Allocate the new node and insert it into the Set.
@@ -244,7 +248,35 @@ public:
     return NewNode;
   }
 
-  PtrSet *merge(PtrSet *S1, llvm::ArrayRef<PtrTy> S2) {
+  PtrSet *get(T value) {
+    llvm::FoldingSetNodeID ID;
+    ID.AddPointer(PtrTraits::getAsVoidPointer(value));
+
+    void *InsertPt;
+    if (auto *PSet = Set.FindNodeOrInsertPos(ID, InsertPt)) {
+      return PSet;
+    }
+
+    size_t NumElts = 1;
+    size_t MemSize = sizeof(PtrSet) + sizeof(T) * NumElts;
+
+    // Allocate the memory.
+    auto *Mem =
+        reinterpret_cast<PtrSet *>(Allocator.Allocate(MemSize, AllocAlignment));
+
+    // Copy in the pointers into the tail allocated memory. We do not need to do
+    // any sorting/uniquing ourselves since we assume that our users perform
+    // this task for us.
+    llvm::MutableArrayRef<T> DataMem(reinterpret_cast<T *>(&Mem[1]), NumElts);
+    DataMem[0] = value;
+
+    // Allocate the new node and insert it into the Set.
+    auto *NewNode = new (Mem) PtrSet(this, DataMem);
+    Set.InsertNode(NewNode, InsertPt);
+    return NewNode;
+  }
+
+  PtrSet *merge(PtrSet *S1, llvm::ArrayRef<T> S2) {
     if (S1->empty())
       return get(S2);
 
@@ -266,7 +298,7 @@ public:
     // perform a sorted set merging algorithm to create the ID. We also count
     // the number of unique elements for allocation purposes.
     unsigned NumElts = 0;
-    set_union_for_each(*S1, S2, [&ID, &NumElts](const PtrTy Ptr) -> void {
+    set_union_for_each(*S1, S2, [&ID, &NumElts](const T Ptr) -> void {
       ID.AddPointer(Ptr);
       NumElts++;
     });
@@ -277,7 +309,7 @@ public:
       return PSet;
     }
 
-    unsigned MemSize = sizeof(PtrSet) + sizeof(PtrTy) * NumElts;
+    unsigned MemSize = sizeof(PtrSet) + sizeof(T) * NumElts;
 
     // Allocate the memory.
     auto *Mem =
@@ -286,8 +318,7 @@ public:
     // Copy in the union of the two pointer sets into the tail allocated
     // memory. Since we know that our sorted arrays are uniqued, we can use
     // set_union to get the uniqued sorted array that we want.
-    llvm::MutableArrayRef<PtrTy> DataMem(reinterpret_cast<PtrTy *>(&Mem[1]),
-                                         NumElts);
+    llvm::MutableArrayRef<T> DataMem(reinterpret_cast<T *>(&Mem[1]), NumElts);
     std::set_union(S1->begin(), S1->end(), S2.begin(), S2.end(),
                    DataMem.begin());
 
@@ -316,8 +347,8 @@ public:
     // perform a sorted set merging algorithm to create the ID. We also count
     // the number of unique elements for allocation purposes.
     unsigned NumElts = 0;
-    set_union_for_each(*S1, *S2, [&ID, &NumElts](const PtrTy Ptr) -> void {
-      ID.AddPointer(Ptr);
+    set_union_for_each(*S1, *S2, [&ID, &NumElts](const T Ptr) -> void {
+      ID.AddPointer(PtrTraits::getAsVoidPointer(Ptr));
       NumElts++;
     });
 
@@ -327,7 +358,7 @@ public:
       return PSet;
     }
 
-    unsigned MemSize = sizeof(PtrSet) + sizeof(PtrTy) * NumElts;
+    unsigned MemSize = sizeof(PtrSet) + sizeof(T) * NumElts;
 
     // Allocate the memory.
     auto *Mem =
@@ -336,8 +367,7 @@ public:
     // Copy in the union of the two pointer sets into the tail allocated
     // memory. Since we know that our sorted arrays are uniqued, we can use
     // set_union to get the uniqued sorted array that we want.
-    llvm::MutableArrayRef<PtrTy> DataMem(reinterpret_cast<PtrTy *>(&Mem[1]),
-                                         NumElts);
+    llvm::MutableArrayRef<T> DataMem(reinterpret_cast<T *>(&Mem[1]), NumElts);
     std::set_union(S1->begin(), S1->end(), S2->begin(), S2->end(),
                    DataMem.begin());
 
@@ -356,8 +386,8 @@ template <typename T>
 #if !defined(_MSC_VER) || defined(__clang__)
 constexpr
 #endif
-const unsigned ImmutablePointerSetFactory<T>::AllocAlignment =
-    (alignof(PtrSet) > alignof(PtrTy)) ? alignof(PtrSet) : alignof(PtrTy);
+    const unsigned ImmutablePointerSetFactory<T>::AllocAlignment =
+        (alignof(PtrSet) > alignof(T)) ? alignof(PtrSet) : alignof(T);
 
 } // end swift namespace
 

--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -240,8 +240,8 @@ public:
     // Copy in the pointers into the tail allocated memory. We do not need to do
     // any sorting/uniquing ourselves since we assume that our users perform
     // this task for us.
-    llvm::MutableArrayRef<void *> DataMem(reinterpret_cast<void **>(&Mem[1]),
-                                          NumElts);
+    llvm::MutableArrayRef<T> DataMem(reinterpret_cast<T *>(&Mem[1]),
+                                     NumElts);
     std::copy(Array.begin(), Array.end(), DataMem.begin());
 
     // Allocate the new node and insert it into the Set.

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -231,6 +231,52 @@ public:
   const_reverse_iterator rbegin() const { return InstList.rbegin(); }
   const_reverse_iterator rend() const { return InstList.rend(); }
 
+  llvm::iterator_range<iterator> getRangeStartingAtInst(SILInstruction *inst) {
+    assert(inst->getParent() == this);
+    return {inst->getIterator(), end()};
+  }
+
+  llvm::iterator_range<iterator> getRangeEndingAtInst(SILInstruction *inst) {
+    assert(inst->getParent() == this);
+    return {begin(), inst->getIterator()};
+  }
+
+  llvm::iterator_range<reverse_iterator>
+  getReverseRangeStartingAtInst(SILInstruction *inst) {
+    assert(inst->getParent() == this);
+    return {inst->getReverseIterator(), rend()};
+  }
+
+  llvm::iterator_range<reverse_iterator>
+  getReverseRangeEndingAtInst(SILInstruction *inst) {
+    assert(inst->getParent() == this);
+    return {rbegin(), inst->getReverseIterator()};
+  }
+
+  llvm::iterator_range<const_iterator>
+  getRangeStartingAtInst(SILInstruction *inst) const {
+    assert(inst->getParent() == this);
+    return {inst->getIterator(), end()};
+  }
+
+  llvm::iterator_range<const_iterator>
+  getRangeEndingAtInst(SILInstruction *inst) const {
+    assert(inst->getParent() == this);
+    return {begin(), inst->getIterator()};
+  }
+
+  llvm::iterator_range<const_reverse_iterator>
+  getReverseRangeStartingAtInst(SILInstruction *inst) const {
+    assert(inst->getParent() == this);
+    return {inst->getReverseIterator(), rend()};
+  }
+
+  llvm::iterator_range<const_reverse_iterator>
+  getReverseRangeEndingAtInst(SILInstruction *inst) const {
+    assert(inst->getParent() == this);
+    return {rbegin(), inst->getReverseIterator()};
+  }
+
   /// Allows deleting instructions while iterating over all instructions of the
   /// block.
   ///

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -88,6 +88,70 @@ struct DenseMapInfo<swift::PartitionPrimitives::Region> {
 
 namespace swift {
 
+struct TransferringOperand {
+  using ValueType = llvm::PointerIntPair<Operand *, 1>;
+  ValueType value;
+
+  TransferringOperand() : value() {}
+  TransferringOperand(Operand *op, bool isClosureCaptured)
+      : value(op, isClosureCaptured) {}
+  explicit TransferringOperand(Operand *op) : value(op, false) {}
+  TransferringOperand(ValueType newValue) : value(newValue) {}
+
+  operator bool() const { return bool(value.getPointer()); }
+
+  Operand *getOperand() const { return value.getPointer(); }
+
+  bool isClosureCaptured() const { return value.getInt(); }
+
+  SILInstruction *getUser() const { return getOperand()->getUser(); }
+};
+
+} // namespace swift
+
+namespace llvm {
+
+template <>
+struct PointerLikeTypeTraits<swift::TransferringOperand> {
+  using TransferringOperand = swift::TransferringOperand;
+
+  static inline void *getAsVoidPointer(TransferringOperand ptr) {
+    return PointerLikeTypeTraits<
+        TransferringOperand::ValueType>::getAsVoidPointer(ptr.value);
+  }
+  static inline TransferringOperand getFromVoidPointer(void *ptr) {
+    return {PointerLikeTypeTraits<
+        TransferringOperand::ValueType>::getFromVoidPointer(ptr)};
+  }
+
+  static constexpr int NumLowBitsAvailable = PointerLikeTypeTraits<
+      TransferringOperand::ValueType>::NumLowBitsAvailable;
+};
+
+template <>
+struct DenseMapInfo<swift::TransferringOperand> {
+  using TransferringOperand = swift::TransferringOperand;
+  using ParentInfo = DenseMapInfo<TransferringOperand::ValueType>;
+
+  static TransferringOperand getEmptyKey() {
+    return TransferringOperand(ParentInfo::getEmptyKey());
+  }
+  static TransferringOperand getTombstoneKey() {
+    return TransferringOperand(ParentInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(TransferringOperand operand) {
+    return ParentInfo::getHashValue(operand.value);
+  }
+  static bool isEqual(TransferringOperand LHS, TransferringOperand RHS) {
+    return ParentInfo::isEqual(LHS.value, RHS.value);
+  }
+};
+
+} // namespace llvm
+
+namespace swift {
+
 /// PartitionOpKind represents the different kinds of PartitionOps that
 /// SILInstructions can be translated to
 enum class PartitionOpKind : uint8_t {
@@ -142,7 +206,7 @@ private:
       : opKind(opKind), opArgs({arg1}), source(sourceOperand) {
     assert(((opKind != PartitionOpKind::Transfer &&
              opKind != PartitionOpKind::UndoTransfer) ||
-            sourceOperand) &&
+            bool(sourceOperand)) &&
            "Transfer needs a sourceInst");
   }
 
@@ -304,7 +368,7 @@ private:
   /// multi map here. The implication of this is that when we are performing
   /// dataflow we use a union operation to combine CFG elements and just take
   /// the first instruction that we see.
-  llvm::SmallDenseMap<Region, Operand *, 2> regionToTransferredOpMap;
+  llvm::SmallDenseMap<Region, TransferringOperand, 2> regionToTransferredOpMap;
 
 public:
   Partition() : elementToRegionMap({}), canonical(true) {}
@@ -358,12 +422,12 @@ public:
 
   /// Mark val as transferred. Returns true if we inserted \p
   /// transferOperand. We return false otherwise.
-  bool markTransferred(Element val, Operand *transferOperand) {
+  bool markTransferred(Element val, TransferringOperand transferredOperand) {
     // First see if our val is tracked. If it is not tracked, insert it and mark
     // its new region as transferred.
     if (!isTracked(val)) {
       elementToRegionMap.insert_or_assign(val, fresh_label);
-      regionToTransferredOpMap.insert({fresh_label, transferOperand});
+      regionToTransferredOpMap.insert({fresh_label, transferredOperand});
       fresh_label = Region(fresh_label + 1);
       canonical = false;
       return true;
@@ -373,7 +437,7 @@ public:
     auto iter1 = elementToRegionMap.find(val);
     assert(iter1 != elementToRegionMap.end());
     auto iter2 =
-        regionToTransferredOpMap.try_emplace(iter1->second, transferOperand);
+        regionToTransferredOpMap.try_emplace(iter1->second, transferredOperand);
     return iter2.second;
   }
 
@@ -532,13 +596,30 @@ public:
 
     os << "[";
     for (auto [regionNo, elementNumbers] : multimap.getRange()) {
-      bool isTransferred = regionToTransferredOpMap.count(regionNo);
-      os << (isTransferred ? "{" : "(");
+      auto iter = regionToTransferredOpMap.find(regionNo);
+      bool isTransferred = iter != regionToTransferredOpMap.end();
+      bool isClosureCaptured =
+          isTransferred ? iter->getSecond().isClosureCaptured() : false;
+
+      if (isTransferred) {
+        os << '{';
+        if (isClosureCaptured)
+          os << '*';
+      } else {
+        os << '(';
+      }
+
       int j = 0;
       for (Element i : elementNumbers) {
         os << (j++ ? " " : "") << i;
       }
-      os << (isTransferred ? "}" : ")");
+      if (isTransferred) {
+        if (isClosureCaptured)
+          os << '*';
+        os << '}';
+      } else {
+        os << ')';
+      }
     }
     os << "]\n";
   }
@@ -552,13 +633,13 @@ public:
 
   /// Return the instruction that transferred \p val's region or nullptr
   /// otherwise.
-  Operand *getTransferred(Element val) const {
+  std::optional<TransferringOperand> getTransferred(Element val) const {
     auto iter = elementToRegionMap.find(val);
     if (iter == elementToRegionMap.end())
-      return nullptr;
+      return std::nullopt;
     auto iter2 = regionToTransferredOpMap.find(iter->second);
     if (iter2 == regionToTransferredOpMap.end())
-      return nullptr;
+      return std::nullopt;
     return iter2->second;
   }
 
@@ -642,7 +723,7 @@ private:
     //
     // TODO: If we just used an array for this, we could just rewrite and
     // re-sort and not have to deal with potential allocations.
-    llvm::SmallDenseMap<Region, Operand *, 2> oldMap =
+    llvm::SmallDenseMap<Region, TransferringOperand, 2> oldMap =
         std::move(regionToTransferredOpMap);
     for (auto &[oldReg, op] : oldMap) {
       auto iter = oldRegionToRelabeledMap.find(oldReg);
@@ -676,8 +757,9 @@ private:
       horizontalUpdate(elementToRegionMap, snd, fstRegion);
       auto iter = regionToTransferredOpMap.find(sndRegion);
       if (iter != regionToTransferredOpMap.end()) {
-        regionToTransferredOpMap.try_emplace(fstRegion, iter->second);
+        auto operand = iter->second;
         regionToTransferredOpMap.erase(iter);
+        regionToTransferredOpMap.try_emplace(fstRegion, operand);
       }
     } else {
       result = sndRegion;
@@ -685,8 +767,9 @@ private:
       horizontalUpdate(elementToRegionMap, fst, sndRegion);
       auto iter = regionToTransferredOpMap.find(fstRegion);
       if (iter != regionToTransferredOpMap.end()) {
-        regionToTransferredOpMap.try_emplace(sndRegion, iter->second);
+        auto operand = iter->second;
         regionToTransferredOpMap.erase(iter);
+        regionToTransferredOpMap.try_emplace(sndRegion, operand);
       }
     }
 
@@ -751,8 +834,8 @@ struct PartitionOpEvaluator {
   /// 3. The operand of the instruction that originally transferred the
   /// region. Can be used to get the immediate value transferred or the
   /// transferring instruction.
-  std::function<void(const PartitionOp &, Element, Operand *)> failureCallback =
-      nullptr;
+  std::function<void(const PartitionOp &, Element, TransferringOperand)>
+      failureCallback = nullptr;
 
   /// A list of elements that cannot be transferred. Whenever we transfer, we
   /// check this list to see if we are transferring the element and then call
@@ -771,11 +854,21 @@ struct PartitionOpEvaluator {
   /// transferred.
   std::function<bool(Element)> isActorDerivedCallback = nullptr;
 
+  /// Check if the representative value of \p elt is closure captured at \p
+  /// op.
+  ///
+  /// NOTE: We actually just use the user of \p op in our callbacks. The reason
+  /// why we do not just pass in that SILInstruction is that then we would need
+  /// to access the instruction in the evaluator which creates a problem when
+  /// since the operand we pass in is a dummy operand.
+  std::function<bool(Element elt, Operand *op)> isClosureCapturedCallback =
+      nullptr;
+
   PartitionOpEvaluator(Partition &p) : p(p) {}
 
   /// A wrapper around the failure callback that checks if it is nullptr.
   void handleFailure(const PartitionOp &op, Element elt,
-                     Operand *transferringOp) const {
+                     TransferringOperand transferringOp) const {
     if (!failureCallback)
       return;
     failureCallback(op, elt, transferringOp);
@@ -795,6 +888,14 @@ struct PartitionOpEvaluator {
   /// isActorDerivedCallback().
   bool isActorDerived(Element elt) const {
     return bool(isActorDerivedCallback) && isActorDerivedCallback(elt);
+  }
+
+  /// A wraper around isClosureCapturedCallback that returns false if
+  /// isClosureCapturedCallback is nullptr and otherwise returns
+  /// isClosureCapturedCallback.
+  bool isClosureCaptured(Element elt, Operand *op) const {
+    return bool(isClosureCapturedCallback) &&
+           isClosureCapturedCallback(elt, op);
   }
 
   /// Apply \p op to the partition op.
@@ -821,8 +922,8 @@ struct PartitionOpEvaluator {
              "Assign PartitionOp's source argument should be already tracked");
       // If we are using a region that was transferred as our assignment source
       // value... emit an error.
-      if (auto *transferringInst = p.getTransferred(op.getOpArgs()[1]))
-        handleFailure(op, op.getOpArgs()[1], transferringInst);
+      if (auto transferredOperand = p.getTransferred(op.getOpArgs()[1]))
+        handleFailure(op, op.getOpArgs()[1], *transferredOperand);
 
       p.elementToRegionMap.insert_or_assign(
           op.getOpArgs()[0], p.elementToRegionMap.at(op.getOpArgs()[1]));
@@ -863,17 +964,22 @@ struct PartitionOpEvaluator {
       if (isActorDerived(op.getOpArgs()[0]))
         return handleTransferNonTransferrable(op, op.getOpArgs()[0]);
 
+      // While we are checking for actor derived, also check if our value or any
+      // value in our region is closure captured and propagate that bit in our
+      // transferred inst.
+      bool isClosureCapturedElt =
+          isClosureCaptured(op.getOpArgs()[0], op.getSourceOp());
+
       Region elementRegion = p.elementToRegionMap.at(op.getOpArgs()[0]);
-      if (llvm::any_of(p.elementToRegionMap,
-                       [&](const std::pair<Element, Region> &pair) -> bool {
-                         if (pair.second != elementRegion)
-                           return false;
-                         return isActorDerived(pair.first);
-                       }))
-        return handleTransferNonTransferrable(op, op.getOpArgs()[0]);
+      for (const auto &pair : p.elementToRegionMap) {
+        if (pair.second == elementRegion && isActorDerived(pair.first))
+          return handleTransferNonTransferrable(op, op.getOpArgs()[0]);
+        isClosureCapturedElt |= isClosureCaptured(pair.first, op.getSourceOp());
+      }
 
       // Mark op.getOpArgs()[0] as transferred.
-      p.markTransferred(op.getOpArgs()[0], op.getSourceOp());
+      p.markTransferred(op.getOpArgs()[0],
+                        {op.getSourceOp(), isClosureCapturedElt});
       return;
     }
     case PartitionOpKind::UndoTransfer: {
@@ -894,10 +1000,10 @@ struct PartitionOpEvaluator {
              "Merge PartitionOp's arguments should already be tracked");
 
       // if attempting to merge a transferred region, handle the failure
-      if (auto *transferringInst = p.getTransferred(op.getOpArgs()[0]))
-        handleFailure(op, op.getOpArgs()[0], transferringInst);
-      if (auto *transferringInst = p.getTransferred(op.getOpArgs()[1]))
-        handleFailure(op, op.getOpArgs()[1], transferringInst);
+      if (auto transferringOp = p.getTransferred(op.getOpArgs()[0]))
+        handleFailure(op, op.getOpArgs()[0], *transferringOp);
+      if (auto transferringOp = p.getTransferred(op.getOpArgs()[1]))
+        handleFailure(op, op.getOpArgs()[1], *transferringOp);
 
       p.merge(op.getOpArgs()[0], op.getOpArgs()[1]);
       return;
@@ -906,8 +1012,8 @@ struct PartitionOpEvaluator {
              "Require PartitionOp should be passed 1 argument");
       assert(p.elementToRegionMap.count(op.getOpArgs()[0]) &&
              "Require PartitionOp's argument should already be tracked");
-      if (auto *transferringInst = p.getTransferred(op.getOpArgs()[0]))
-        handleFailure(op, op.getOpArgs()[0], transferringInst);
+      if (auto transferringOp = p.getTransferred(op.getOpArgs()[0]))
+        handleFailure(op, op.getOpArgs()[0], *transferringOp);
       return;
     }
 

--- a/lib/SILOptimizer/ARC/ARCRegionState.cpp
+++ b/lib/SILOptimizer/ARC/ARCRegionState.cpp
@@ -166,7 +166,7 @@ bool ARCRegionState::processBlockBottomUp(
     EpilogueARCFunctionInfo *EAFI, LoopRegionFunctionInfo *LRFI,
     bool FreezeOwnedArgEpilogueReleases,
     BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory) {
+    ImmutablePointerSetFactory<SILInstruction *> &SetFactory) {
   LLVM_DEBUG(llvm::dbgs() << ">>>> Bottom Up!\n");
 
   SILBasicBlock &BB = *R->getBlock();
@@ -311,7 +311,7 @@ bool ARCRegionState::processBottomUp(
     llvm::DenseSet<SILInstruction *> &UnmatchedRefCountInsts,
     BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
     llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory) {
+    ImmutablePointerSetFactory<SILInstruction *> &SetFactory) {
   const LoopRegion *R = getRegion();
 
   // We only process basic blocks for now. This ensures that we always propagate
@@ -331,7 +331,7 @@ bool ARCRegionState::processBottomUp(
 bool ARCRegionState::processBlockTopDown(
     SILBasicBlock &BB, AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
     BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory) {
+    ImmutablePointerSetFactory<SILInstruction *> &SetFactory) {
   LLVM_DEBUG(llvm::dbgs() << ">>>> Top Down!\n");
 
   bool NestingDetected = false;
@@ -460,7 +460,7 @@ bool ARCRegionState::processTopDown(
     llvm::DenseSet<SILInstruction *> &UnmatchedRefCountInsts,
     BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
     llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory) {
+    ImmutablePointerSetFactory<SILInstruction *> &SetFactory) {
   const LoopRegion *R = getRegion();
 
   // We only process basic blocks for now. This ensures that we always propagate

--- a/lib/SILOptimizer/ARC/ARCRegionState.h
+++ b/lib/SILOptimizer/ARC/ARCRegionState.h
@@ -191,7 +191,7 @@ public:
       llvm::DenseSet<SILInstruction *> &UnmatchedRefCountInsts,
       BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &LoopRegionState,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+      ImmutablePointerSetFactory<SILInstruction *> &SetFactory);
 
   /// If this region is a block, process all instructions bottom up. Otherwise,
   /// apply the summarized bottom up information to the merged bottom up
@@ -204,7 +204,7 @@ public:
       llvm::DenseSet<SILInstruction *> &UnmatchedRefCountInsts,
       BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+      ImmutablePointerSetFactory<SILInstruction *> &SetFactory);
 
   void summarizeBlock(SILBasicBlock *BB);
 
@@ -223,10 +223,10 @@ public:
 private:
   bool processBlockBottomUp(
       const LoopRegion *R, AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
-      EpilogueARCFunctionInfo *EAFI,
-      LoopRegionFunctionInfo *LRFI, bool FreezeOwnedArgEpilogueReleases,
+      EpilogueARCFunctionInfo *EAFI, LoopRegionFunctionInfo *LRFI,
+      bool FreezeOwnedArgEpilogueReleases,
       BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+      ImmutablePointerSetFactory<SILInstruction *> &SetFactory);
   bool processLoopBottomUp(
       const LoopRegion *R, AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI,
       RCIdentityFunctionInfo *RCIA,
@@ -236,7 +236,7 @@ private:
   bool processBlockTopDown(
       SILBasicBlock &BB, AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
       BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+      ImmutablePointerSetFactory<SILInstruction *> &SetFactory);
   bool processLoopTopDown(
       const LoopRegion *R, ARCRegionState *State, AliasAnalysis *AA,
       LoopRegionFunctionInfo *LRFI, RCIdentityFunctionInfo *RCIA,

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
@@ -64,7 +64,7 @@ private:
   BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap;
 
   llvm::BumpPtrAllocator Allocator;
-  ImmutablePointerSetFactory<SILInstruction> SetFactory;
+  ImmutablePointerSetFactory<SILInstruction *> SetFactory;
 
   /// Stashed BB information.
   std::unique_ptr<ARCBBStateInfo> BBStateInfo;

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
@@ -40,7 +40,7 @@ class LoopARCSequenceDataflowEvaluator {
   llvm::BumpPtrAllocator Allocator;
 
   /// The factory that we use to generate immutable pointer sets.
-  ImmutablePointerSetFactory<SILInstruction> SetFactory;
+  ImmutablePointerSetFactory<SILInstruction *> SetFactory;
 
   /// The SILFunction that we are applying the dataflow to.
   SILFunction &F;

--- a/lib/SILOptimizer/ARC/RCStateTransition.h
+++ b/lib/SILOptimizer/ARC/RCStateTransition.h
@@ -73,8 +73,8 @@ class RCStateTransition {
   /// An RCStateTransition can represent either an RC end point (i.e. an initial
   /// or terminal RC transition) or a ptr set of Mutators.
   SILNode *EndPoint;
-  ImmutablePointerSet<SILInstruction> *Mutators =
-      ImmutablePointerSetFactory<SILInstruction>::getEmptySet();
+  ImmutablePointerSet<SILInstruction *> *Mutators =
+      ImmutablePointerSetFactory<SILInstruction *>::getEmptySet();
   RCStateTransitionKind Kind;
 
   // Should only be constructed be default RefCountState.
@@ -84,9 +84,9 @@ public:
   ~RCStateTransition() = default;
   RCStateTransition(const RCStateTransition &R) = default;
 
-  RCStateTransition(ImmutablePointerSet<SILInstruction> *I) {
+  RCStateTransition(ImmutablePointerSet<SILInstruction *> *I) {
     assert(I->size() == 1);
-    SILInstruction *Inst = *I->begin();
+    auto *Inst = *I->begin();
     Kind = getRCStateTransitionKind(Inst->asSILNode());
     if (isRCStateTransitionEndPoint(Kind)) {
       EndPoint = Inst->asSILNode();

--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
@@ -57,7 +57,7 @@ BottomUpDataflowRCStateVisitor<ARCState>::BottomUpDataflowRCStateVisitor(
     RCIdentityFunctionInfo *RCFI, EpilogueARCFunctionInfo *EAFI,
     ARCState &State, bool FreezeOwnedArgEpilogueReleases,
     IncToDecStateMapTy &IncToDecStateMap,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory)
+    ImmutablePointerSetFactory<SILInstruction *> &SetFactory)
     : RCFI(RCFI), EAFI(EAFI), DataflowState(State),
       FreezeOwnedArgEpilogueReleases(FreezeOwnedArgEpilogueReleases),
       IncToDecStateMap(IncToDecStateMap), SetFactory(SetFactory) {}
@@ -184,7 +184,7 @@ template <class ARCState>
 TopDownDataflowRCStateVisitor<ARCState>::TopDownDataflowRCStateVisitor(
     RCIdentityFunctionInfo *RCFI, ARCState &DataflowState,
     DecToIncStateMapTy &DecToIncStateMap,
-    ImmutablePointerSetFactory<SILInstruction> &SetFactory)
+    ImmutablePointerSetFactory<SILInstruction *> &SetFactory)
     : RCFI(RCFI), DataflowState(DataflowState),
       DecToIncStateMap(DecToIncStateMap), SetFactory(SetFactory) {}
 

--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.h
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.h
@@ -120,14 +120,14 @@ public:
   ARCState &DataflowState;
   bool FreezeOwnedArgEpilogueReleases;
   BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap;
-  ImmutablePointerSetFactory<SILInstruction> &SetFactory;
+  ImmutablePointerSetFactory<SILInstruction *> &SetFactory;
 
 public:
   BottomUpDataflowRCStateVisitor(
       RCIdentityFunctionInfo *RCFI, EpilogueARCFunctionInfo *EAFI,
       ARCState &DataflowState, bool FreezeOwnedArgEpilogueReleases,
       IncToDecStateMapTy &IncToDecStateMap,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+      ImmutablePointerSetFactory<SILInstruction *> &SetFactory);
   DataflowResult visitAutoreleasePoolCall(SILNode *N);
   DataflowResult visitStrongDecrement(SILNode *N);
   DataflowResult visitStrongIncrement(SILNode *N);
@@ -156,13 +156,13 @@ class TopDownDataflowRCStateVisitor
   RCIdentityFunctionInfo *RCFI;
   ARCState &DataflowState;
   DecToIncStateMapTy &DecToIncStateMap;
-  ImmutablePointerSetFactory<SILInstruction> &SetFactory;
+  ImmutablePointerSetFactory<SILInstruction *> &SetFactory;
 
 public:
   TopDownDataflowRCStateVisitor(
       RCIdentityFunctionInfo *RCFI, ARCState &State,
       DecToIncStateMapTy &DecToIncStateMap,
-      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+      ImmutablePointerSetFactory<SILInstruction *> &SetFactory);
   DataflowResult visitAutoreleasePoolCall(SILNode *N);
   DataflowResult visitStrongDecrement(SILNode *N);
   DataflowResult visitStrongIncrement(SILNode *N);

--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -82,8 +82,7 @@ MergeTopDownLatticeStates(TopDownRefCountState::LatticeState L1,
 /// Initializes/reinitialized the state for I. If we reinitialize we return
 /// true.
 bool BottomUpRefCountState::initWithMutatorInst(
-    ImmutablePointerSet<SILInstruction> *I,
-    RCIdentityFunctionInfo *RCFI) {
+    ImmutablePointerSet<SILInstruction *> *I, RCIdentityFunctionInfo *RCFI) {
   assert(I->size() == 1);
   SILInstruction *Inst = *I->begin();
   assert((isa<StrongReleaseInst>(Inst) || isa<ReleaseValueInst>(Inst)) &&
@@ -529,8 +528,7 @@ void BottomUpRefCountState::updateForDifferentLoopInst(SILInstruction *I,
 /// Initializes/reinitialized the state for I. If we reinitialize we return
 /// true.
 bool TopDownRefCountState::initWithMutatorInst(
-    ImmutablePointerSet<SILInstruction> *I,
-    RCIdentityFunctionInfo *RCFI) {
+    ImmutablePointerSet<SILInstruction *> *I, RCIdentityFunctionInfo *RCFI) {
   assert(I->size() == 1);
   SILInstruction *Inst = *I->begin();
   (void)Inst;
@@ -563,7 +561,7 @@ void TopDownRefCountState::initWithArg(SILFunctionArgument *Arg) {
 /// Initialize this RefCountState with an instruction which introduces a new
 /// ref count at +1.
 void TopDownRefCountState::initWithEntranceInst(
-    ImmutablePointerSet<SILInstruction> *I, SILValue RCIdentity) {
+    ImmutablePointerSet<SILInstruction *> *I, SILValue RCIdentity) {
   LatState = LatticeState::Incremented;
   Transition = RCStateTransition(I);
   assert(Transition.getKind() == RCStateTransitionKind::StrongEntrance &&

--- a/lib/SILOptimizer/ARC/RefCountState.h
+++ b/lib/SILOptimizer/ARC/RefCountState.h
@@ -64,7 +64,7 @@ public:
 
   /// Initializes/reinitialized the state for I. If we reinitialize we return
   /// true.
-  bool initWithMutatorInst(ImmutablePointerSet<SILInstruction> *I,
+  bool initWithMutatorInst(ImmutablePointerSet<SILInstruction *> *I,
                            RCIdentityFunctionInfo *RCFI) {
     assert(I->size() == 1);
 
@@ -188,7 +188,7 @@ public:
 
   /// Initializes/reinitialized the state for I. If we reinitialize we return
   /// true.
-  bool initWithMutatorInst(ImmutablePointerSet<SILInstruction> *I,
+  bool initWithMutatorInst(ImmutablePointerSet<SILInstruction *> *I,
                            RCIdentityFunctionInfo *RCFI);
 
   /// Update this reference count's state given the instruction \p I.
@@ -327,7 +327,7 @@ public:
 
   /// Initializes/reinitialized the state for I. If we reinitialize we return
   /// true.
-  bool initWithMutatorInst(ImmutablePointerSet<SILInstruction> *I,
+  bool initWithMutatorInst(ImmutablePointerSet<SILInstruction *> *I,
                            RCIdentityFunctionInfo *RCFI);
 
   /// Initialize the state given the consumed argument Arg.
@@ -335,7 +335,7 @@ public:
 
   /// Initialize this RefCountState with an instruction which introduces a new
   /// ref count at +1.
-  void initWithEntranceInst(ImmutablePointerSet<SILInstruction> *I,
+  void initWithEntranceInst(ImmutablePointerSet<SILInstruction *> *I,
                             SILValue RCIdentity);
 
   /// Uninitialize the current state.

--- a/test/Concurrency/sendnonsendable_basic.swift
+++ b/test/Concurrency/sendnonsendable_basic.swift
@@ -752,7 +752,7 @@ func varNonSendableNonTrivialFinalClassFieldTest() async {
 // MARK: StructFieldTests //
 ////////////////////////////
 
-struct StructFieldTests { // expected-complete-note 12 {{}}
+struct StructFieldTests { // expected-complete-note 31 {{}}
   let letSendableTrivial = 0
   let letSendableNonTrivial = SendableKlass()
   let letNonSendableNonTrivial = NonSendableKlass()
@@ -786,31 +786,6 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
   useValue(test)
 }
 
-func varSendableTrivialLetStructFieldTest() async {
-  let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
-}
-
-func varSendableNonTrivialLetStructFieldTest() async {
-  let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableNonTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
-}
-
-func varNonSendableNonTrivialLetStructFieldTest() async {
-  let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
-  _ = z
-  useValue(test)
-}
-
 func letSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests() 
   test = StructFieldTests()
@@ -835,6 +810,52 @@ func letNonSendableNonTrivialVarStructFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = z
+  useValue(test)
+}
+
+// Lets can access sendable let/var even if captured in a closure.
+func letNonSendableNonTrivialLetStructFieldClosureTest() async {
+  let test = StructFieldTests()
+  let cls = {
+    print(test)
+  }
+  _ = cls
+  var cls2 = {}
+  cls2 = {
+    print(test)
+  }
+  _ = cls2
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  let z = test.letSendableNonTrivial
+  _ = z
+  let z2 = test.varSendableNonTrivial
+  _ = z2
+  useValue(test) // expected-tns-note {{access here could race}}
+}
+
+func varSendableTrivialLetStructFieldTest() async {
+  let test = StructFieldTests()
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  _ = test.varSendableTrivial
+  useValue(test) // expected-tns-note {{access here could race}}
+}
+
+func varSendableNonTrivialLetStructFieldTest() async {
+  let test = StructFieldTests()
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  _ = test.varSendableNonTrivial
+  useValue(test) // expected-tns-note {{access here could race}}
+}
+
+func varNonSendableNonTrivialLetStructFieldTest() async {
+  let test = StructFieldTests()
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
 }
@@ -864,6 +885,284 @@ func varNonSendableNonTrivialVarStructFieldTest() async {
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
+  useValue(test)
+}
+
+// vars cannot access sendable let/var if captured in a closure.
+func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  let cls = {
+    test = StructFieldTests()
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = z
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  let cls = {
+    test = StructFieldTests()
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = z
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  let cls = {
+    test = StructFieldTests()
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  useValue(test)
+}
+
+// vars cannot access sendable let/var if captured in a closure.
+func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+  cls = {
+    test = StructFieldTests()
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = z
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+  cls = {
+    test = StructFieldTests()
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = z
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+  cls = {
+    test = StructFieldTests()
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+  cls = {
+    test.varSendableNonTrivial = SendableKlass()
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+  cls = {
+    useInOut(&test)
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+  cls = {
+    useInOut(&test.varSendableNonTrivial)
+  }
+  _ = cls
+  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+
+  if await booleanFlag {
+    cls = {
+      useInOut(&test.varSendableNonTrivial)
+    }
+    _ = cls
+  } else {
+    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+
+    test.varSendableNonTrivial = SendableKlass()
+  }
+
+  useValue(test) // expected-tns-note {{access here could race}}
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+
+  if await booleanFlag {
+    cls = {
+      useInOut(&test.varSendableNonTrivial)
+    }
+    _ = cls
+
+    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  }
+
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  useValue(test)
+}
+
+// We do not error when accessing the sendable field in this example since the
+// transfer is not reachable from the closure. Instead we emit an error on test.
+func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+
+  if await booleanFlag {
+    cls = {
+      useInOut(&test.varSendableNonTrivial)
+    }
+    _ = cls
+  } else {
+    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  }
+
+  test.varSendableNonTrivial = SendableKlass()
+  useValue(test) // expected-tns-note {{access here could race}}
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+
+  for _ in 0..<1024 {
+    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    test = StructFieldTests() // expected-tns-note {{access here could race}}
+    cls = {
+      useInOut(&test.varSendableNonTrivial)
+    }
+    _ = cls
+  }
+
+  test.varSendableNonTrivial = SendableKlass()
+  useValue(test)
+}
+
+func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+
+  // The reason why we error here is that even though we reassign at the end of
+  // the for loop and currently understand that test has a new value different
+  // from the value assigned to test at the beginning of the for loop, when we
+  // merge back through the for loop, we have to merge the regions due to the
+  // union operation we perform. So the conservatism of the dataflow creates
+  // this. This is a case where we are going to need to be able to have the
+  // compiler explain the regions well.
+  for _ in 0..<1024 {
+    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-note @-1 {{access here could race}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    test = StructFieldTests()
+  }
+
+  test.varSendableNonTrivial = SendableKlass()
+  useValue(test)  // expected-tns-note {{access here could race}}
+}
+
+// In this case since we are tracking the transfer from the if statement, we
+// do not track the closure.
+//
+// TODO: Change to track all sets.
+func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+
+  if await booleanFlag {
+    cls = {
+      useInOut(&test.varSendableNonTrivial)
+    }
+    _ = cls
+    await transferToMain(test)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  } else {
+    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  }
+
+  test.varSendableNonTrivial = SendableKlass()
+  useValue(test)  // expected-tns-note {{access here could race}}
+}
+
+// In this case since we are tracking the transfer from the else statement, we
+// track the closure.
+func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
+  var test = StructFieldTests()
+  test = StructFieldTests()
+  var cls = {}
+
+  if await booleanFlag {
+    await transferToMain(test)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  } else {
+    cls = {
+      useInOut(&test.varSendableNonTrivial)
+    }
+    _ = cls
+    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  }
+
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
 }
 

--- a/unittests/Basic/ImmutablePointerSetTest.cpp
+++ b/unittests/Basic/ImmutablePointerSetTest.cpp
@@ -19,7 +19,7 @@ using namespace swift;
 
 TEST(ImmutableSortedSet, OneElementSets) {
   llvm::BumpPtrAllocator BPA;
-  ImmutablePointerSetFactory<unsigned> F(BPA);
+  ImmutablePointerSetFactory<unsigned *> F(BPA);
 
   unsigned *ptr1 = (unsigned *)3;
   auto *OneEltSet1 = F.get(ptr1);
@@ -54,7 +54,7 @@ TEST(ImmutableSortedSet, OneElementSets) {
 
 TEST(ImmutablePointerSet, MultipleElementSets) {
   llvm::BumpPtrAllocator BPA;
-  ImmutablePointerSetFactory<unsigned> F(BPA);
+  ImmutablePointerSetFactory<unsigned *> F(BPA);
 
   unsigned *Ptr1 = (unsigned *)3;
   unsigned *Ptr2 = (unsigned *)4;
@@ -62,8 +62,8 @@ TEST(ImmutablePointerSet, MultipleElementSets) {
   unsigned *Ptr4 = (unsigned *)5;
   unsigned *Ptr5 = (unsigned *)6;
   llvm::SmallVector<unsigned *, 2> Data1 = {Ptr1, Ptr2};
-
-  auto *TwoEltSet = F.get(Data1);
+  llvm::MutableArrayRef<unsigned *> Array = Data1;
+  auto *TwoEltSet = F.get(Array);
   EXPECT_FALSE(TwoEltSet->empty());
   EXPECT_EQ(TwoEltSet->size(), 2u);
   EXPECT_TRUE(TwoEltSet->count(Ptr1));
@@ -110,7 +110,7 @@ TEST(ImmutablePointerSet, MultipleElementSets) {
 
 TEST(ImmutablePointerSet, EmptyIntersectionTests) {
   llvm::BumpPtrAllocator BPA;
-  ImmutablePointerSetFactory<unsigned> F(BPA);
+  ImmutablePointerSetFactory<unsigned *> F(BPA);
 
   unsigned *Ptr1 = (unsigned *)3;
   unsigned *Ptr2 = (unsigned *)4;

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -548,14 +548,13 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
 
   // expected: p: ({0 1 2 6 7 10} (3 4 5) (8 9) (Element(11)))
 
-  auto never_called = [](const PartitionOp &, unsigned, Operand *) {
+  auto never_called = [](const PartitionOp &, unsigned, TransferringOperand) {
     EXPECT_TRUE(false);
   };
 
   int times_called = 0;
-  auto increment_times_called = [&](const PartitionOp &, unsigned, Operand *) {
-    times_called++;
-  };
+  auto increment_times_called = [&](const PartitionOp &, unsigned,
+                                    TransferringOperand) { times_called++; };
 
   {
     PartitionOpEvaluator eval(p);
@@ -623,18 +622,16 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
   {
     bool failure = false;
     PartitionOpEvaluator eval(p1);
-    eval.failureCallback = [&](const PartitionOp &, unsigned, Operand *) {
-      failure = true;
-    };
+    eval.failureCallback = [&](const PartitionOp &, unsigned,
+                               TransferringOperand) { failure = true; };
     eval.apply(PartitionOp::Require(Element(0)));
     EXPECT_TRUE(failure);
   }
 
   {
     PartitionOpEvaluator eval(p2);
-    eval.failureCallback = [](const PartitionOp &, unsigned, Operand *) {
-      EXPECT_TRUE(false);
-    };
+    eval.failureCallback = [](const PartitionOp &, unsigned,
+                              TransferringOperand) { EXPECT_TRUE(false); };
     eval.apply(PartitionOp::Require(Element(0)));
   }
 }
@@ -642,9 +639,8 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
 TEST(PartitionUtilsTest, TestUndoTransfer) {
   Partition p;
   PartitionOpEvaluator eval(p);
-  eval.failureCallback = [&](const PartitionOp &, unsigned, Operand *) {
-    EXPECT_TRUE(false);
-  };
+  eval.failureCallback = [&](const PartitionOp &, unsigned,
+                             TransferringOperand) { EXPECT_TRUE(false); };
 
   // Shouldn't error on this.
   eval.apply({PartitionOp::AssignFresh(Element(0)),

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -63,8 +63,11 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   Partition p2;
   Partition p3;
 
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   {
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
@@ -72,7 +75,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   }
 
   {
-    PartitionOpEvaluator eval(p2);
+    PartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::AssignFresh(Element(5)),
                 PartitionOp::AssignFresh(Element(6)),
                 PartitionOp::AssignFresh(Element(7)),
@@ -80,7 +83,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   }
 
   {
-    PartitionOpEvaluator eval(p3);
+    PartitionOpEvaluator eval(p3, factory);
     eval.apply({PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3)),
                 PartitionOp::AssignFresh(Element(4)),
@@ -92,7 +95,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   EXPECT_FALSE(Partition::equals(p1, p3));
 
   {
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.apply({PartitionOp::AssignFresh(Element(4)),
                 PartitionOp::AssignFresh(Element(5)),
                 PartitionOp::AssignFresh(Element(6)),
@@ -101,7 +104,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   }
 
   {
-    PartitionOpEvaluator eval(p2);
+    PartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3)),
@@ -110,7 +113,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   }
 
   {
-    PartitionOpEvaluator eval(p3);
+    PartitionOpEvaluator eval(p3, factory);
     eval.apply({PartitionOp::AssignFresh(Element(6)),
                 PartitionOp::AssignFresh(Element(7)),
                 PartitionOp::AssignFresh(Element(0)),
@@ -129,12 +132,12 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
 
   auto apply_to_p1_and_p3 = [&](PartitionOp op) {
     {
-      PartitionOpEvaluator eval(p1);
+      PartitionOpEvaluator eval(p1, factory);
       eval.apply(op);
     }
 
     {
-      PartitionOpEvaluator eval(p3);
+      PartitionOpEvaluator eval(p3, factory);
       eval.apply(op);
     }
     expect_join_eq();
@@ -142,12 +145,12 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
 
   auto apply_to_p2_and_p3 = [&](PartitionOp op) {
     {
-      PartitionOpEvaluator eval(p2);
+      PartitionOpEvaluator eval(p2, factory);
       eval.apply(op);
     }
 
     {
-      PartitionOpEvaluator eval(p3);
+      PartitionOpEvaluator eval(p3, factory);
       eval.apply(op);
     }
     expect_join_eq();
@@ -172,12 +175,15 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
 }
 
 TEST(PartitionUtilsTest, Join1) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
   Partition p1 = Partition::separateRegions(llvm::makeArrayRef(data1));
 
   {
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
                 PartitionOp::Assign(Element(1), Element(0)),
                 PartitionOp::Assign(Element(2), Element(2)),
@@ -188,7 +194,7 @@ TEST(PartitionUtilsTest, Join1) {
 
   Partition p2 = Partition::separateRegions(llvm::makeArrayRef(data1));
   {
-    PartitionOpEvaluator eval(p2);
+    PartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
                 PartitionOp::Assign(Element(1), Element(0)),
                 PartitionOp::Assign(Element(2), Element(2)),
@@ -208,12 +214,15 @@ TEST(PartitionUtilsTest, Join1) {
 }
 
 TEST(PartitionUtilsTest, Join2) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
   Partition p1 = Partition::separateRegions(llvm::makeArrayRef(data1));
 
   {
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
                 PartitionOp::Assign(Element(1), Element(0)),
                 PartitionOp::Assign(Element(2), Element(2)),
@@ -226,7 +235,7 @@ TEST(PartitionUtilsTest, Join2) {
                      Element(7), Element(8), Element(9)};
   Partition p2 = Partition::separateRegions(llvm::makeArrayRef(data2));
   {
-    PartitionOpEvaluator eval(p2);
+    PartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(4), Element(4)),
                 PartitionOp::Assign(Element(5), Element(5)),
                 PartitionOp::Assign(Element(6), Element(4)),
@@ -250,12 +259,15 @@ TEST(PartitionUtilsTest, Join2) {
 }
 
 TEST(PartitionUtilsTest, Join2Reversed) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
   Partition p1 = Partition::separateRegions(llvm::makeArrayRef(data1));
 
   {
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
                 PartitionOp::Assign(Element(1), Element(0)),
                 PartitionOp::Assign(Element(2), Element(2)),
@@ -268,7 +280,7 @@ TEST(PartitionUtilsTest, Join2Reversed) {
                      Element(7), Element(8), Element(9)};
   Partition p2 = Partition::separateRegions(llvm::makeArrayRef(data2));
   {
-    PartitionOpEvaluator eval(p2);
+    PartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(4), Element(4)),
                 PartitionOp::Assign(Element(5), Element(5)),
                 PartitionOp::Assign(Element(6), Element(4)),
@@ -292,6 +304,9 @@ TEST(PartitionUtilsTest, Join2Reversed) {
 }
 
 TEST(PartitionUtilsTest, JoinLarge) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   Element data1[] = {
       Element(0),  Element(1),  Element(2),  Element(3),  Element(4),
       Element(5),  Element(6),  Element(7),  Element(8),  Element(9),
@@ -301,7 +316,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
       Element(25), Element(26), Element(27), Element(28), Element(29)};
   Partition p1 = Partition::separateRegions(llvm::makeArrayRef(data1));
   {
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(29)),
                 PartitionOp::Assign(Element(1), Element(17)),
                 PartitionOp::Assign(Element(2), Element(0)),
@@ -343,7 +358,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
       Element(40), Element(41), Element(42), Element(43), Element(44)};
   Partition p2 = Partition::separateRegions(llvm::makeArrayRef(data2));
   {
-    PartitionOpEvaluator eval(p2);
+    PartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(15), Element(31)),
                 PartitionOp::Assign(Element(16), Element(34)),
                 PartitionOp::Assign(Element(17), Element(35)),
@@ -426,23 +441,26 @@ TEST(PartitionUtilsTest, JoinLarge) {
 
 // This test tests the semantics of assignment.
 TEST(PartitionUtilsTest, TestAssign) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   Partition p1;
   Partition p2;
   Partition p3;
 
-  PartitionOpEvaluator evalP1(p1);
+  PartitionOpEvaluator evalP1(p1, factory);
   evalP1.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3))});
 
-  PartitionOpEvaluator evalP2(p2);
+  PartitionOpEvaluator evalP2(p2, factory);
   evalP2.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3))});
 
-  PartitionOpEvaluator evalP3(p3);
+  PartitionOpEvaluator evalP3(p3, factory);
   evalP3.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
@@ -512,10 +530,13 @@ TEST(PartitionUtilsTest, TestAssign) {
 
 // This test tests that consumption consumes entire regions as expected
 TEST(PartitionUtilsTest, TestConsumeAndRequire) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   Partition p;
 
   {
-    PartitionOpEvaluator eval(p);
+    PartitionOpEvaluator eval(p, factory);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
@@ -557,7 +578,7 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
                                     TransferringOperand) { times_called++; };
 
   {
-    PartitionOpEvaluator eval(p);
+    PartitionOpEvaluator eval(p, factory);
     eval.failureCallback = increment_times_called;
     eval.apply({PartitionOp::Require(Element(0)),
                 PartitionOp::Require(Element(1)),
@@ -565,7 +586,7 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
   }
 
   {
-    PartitionOpEvaluator eval(p);
+    PartitionOpEvaluator eval(p, factory);
     eval.failureCallback = never_called;
     eval.apply({PartitionOp::Require(Element(3)),
                 PartitionOp::Require(Element(4)),
@@ -573,27 +594,27 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
   }
 
   {
-    PartitionOpEvaluator eval(p);
+    PartitionOpEvaluator eval(p, factory);
     eval.failureCallback = increment_times_called;
     eval.apply(
         {PartitionOp::Require(Element(6)), PartitionOp::Require(Element(7))});
   }
 
   {
-    PartitionOpEvaluator eval(p);
+    PartitionOpEvaluator eval(p, factory);
     eval.failureCallback = never_called;
     eval.apply(
         {PartitionOp::Require(Element(8)), PartitionOp::Require(Element(9))});
   }
 
   {
-    PartitionOpEvaluator eval(p);
+    PartitionOpEvaluator eval(p, factory);
     eval.failureCallback = increment_times_called;
     eval.apply(PartitionOp::Require(Element(10)));
   }
 
   {
-    PartitionOpEvaluator eval(p);
+    PartitionOpEvaluator eval(p, factory);
     eval.failureCallback = never_called;
     eval.apply(PartitionOp::Require(Element(11)));
   }
@@ -604,9 +625,12 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
 // This test tests that the copy constructor is usable to create fresh
 // copies of partitions
 TEST(PartitionUtilsTest, TestCopyConstructor) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   Partition p1;
   {
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.apply(PartitionOp::AssignFresh(Element(0)));
   }
 
@@ -615,13 +639,13 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
 
   // Change p1 again.
   {
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.apply(PartitionOp::Transfer(Element(0), transferSingletons[0]));
   }
 
   {
     bool failure = false;
-    PartitionOpEvaluator eval(p1);
+    PartitionOpEvaluator eval(p1, factory);
     eval.failureCallback = [&](const PartitionOp &, unsigned,
                                TransferringOperand) { failure = true; };
     eval.apply(PartitionOp::Require(Element(0)));
@@ -629,7 +653,7 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
   }
 
   {
-    PartitionOpEvaluator eval(p2);
+    PartitionOpEvaluator eval(p2, factory);
     eval.failureCallback = [](const PartitionOp &, unsigned,
                               TransferringOperand) { EXPECT_TRUE(false); };
     eval.apply(PartitionOp::Require(Element(0)));
@@ -637,8 +661,11 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
 }
 
 TEST(PartitionUtilsTest, TestUndoTransfer) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+
   Partition p;
-  PartitionOpEvaluator eval(p);
+  PartitionOpEvaluator eval(p, factory);
   eval.failureCallback = [&](const PartitionOp &, unsigned,
                              TransferringOperand) { EXPECT_TRUE(false); };
 


### PR DESCRIPTION
This PR contains two different commits and a utility commit:

1. In the first commit, I change the pass to no longer allow for sendableFields of vars to be used after the var is transferred if the var is captured by reference in a closure. The reason that we must do this is that even if the sendable field is safe, we may race against a load/write to the field itself in the var. I implemented this by adding an early dataflow that the later region dataflow uses to determine if a value is reachable from a closure capture.
2. In this commit, I refactored ImmutablePointerSetFactory to no longer require its generic operand to be an actual pointer. Instead we now require T to have a PointerLikeTypeTraits implementation. This lets one use SILValue and more importantly TransferringOperand (which I need in the next commit). I did this separately from the next commit so that I could use the other places we use ImmutablePointerSetFactory for correctness.
3. In this commit I changed the pass to track all transfer instructions instead of just the first that we saw. Previously I avoided doing this since the only problem would be that in a case where we had two transfer instructions that were in an if-else block, we would just emit an error for one. But in the case where some transfer instructions were impacted by a closure capture and others are not, we actually need to track both since their behaviors are different.

rdar://119048779
rdar://115124361