### PR TITLE
[Profiler] Improve if statement coverage

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -734,7 +734,8 @@ SWIFT_NAME("BridgedIfStmt.createParsed(_:ifKeywordLoc:condition:thenStmt:"
            "elseLoc:elseStmt:)")
 BridgedIfStmt BridgedIfStmt_createParsed(BridgedASTContext cContext,
                                          BridgedSourceLoc cIfLoc,
-                                         BridgedExpr cond, BridgedStmt then,
+                                         BridgedExpr cond,
+                                         BridgedBraceStmt then,
                                          BridgedSourceLoc cElseLoc,
                                          BridgedNullableStmt elseStmt);
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -757,20 +757,25 @@ public:
 class IfStmt : public LabeledConditionalStmt {
   SourceLoc IfLoc;
   SourceLoc ElseLoc;
-  Stmt *Then;
+  BraceStmt *Then;
   Stmt *Else;
   
 public:
   IfStmt(LabeledStmtInfo LabelInfo, SourceLoc IfLoc, StmtCondition Cond,
-         Stmt *Then, SourceLoc ElseLoc, Stmt *Else,
+         BraceStmt *Then, SourceLoc ElseLoc, Stmt *Else,
          llvm::Optional<bool> implicit = llvm::None)
       : LabeledConditionalStmt(StmtKind::If,
                                getDefaultImplicitFlag(implicit, IfLoc),
                                LabelInfo, Cond),
-        IfLoc(IfLoc), ElseLoc(ElseLoc), Then(Then), Else(Else) {}
+        IfLoc(IfLoc), ElseLoc(ElseLoc), Then(Then), Else(Else) {
+    assert(Then && "Must have non-null 'then' statement");
+    assert(!Else || isa<BraceStmt>(Else) ||
+           isa<IfStmt>(Else) &&
+               "Else statement must either be BraceStmt or IfStmt");
+  }
 
-  IfStmt(SourceLoc IfLoc, Expr *Cond, Stmt *Then, SourceLoc ElseLoc, Stmt *Else,
-         llvm::Optional<bool> implicit, ASTContext &Ctx);
+  IfStmt(SourceLoc IfLoc, Expr *Cond, BraceStmt *Then, SourceLoc ElseLoc,
+         Stmt *Else, llvm::Optional<bool> implicit, ASTContext &Ctx);
 
   SourceLoc getIfLoc() const { return IfLoc; }
   SourceLoc getElseLoc() const { return ElseLoc; }
@@ -782,8 +787,8 @@ public:
     return (Else ? Else->getEndLoc() : Then->getEndLoc());
   }
 
-  Stmt *getThenStmt() const { return Then; }
-  void setThenStmt(Stmt *s) { Then = s; }
+  BraceStmt *getThenStmt() const { return Then; }
+  void setThenStmt(BraceStmt *s) { Then = s; }
 
   Stmt *getElseStmt() const { return Else; }
   void setElseStmt(Stmt *s) { Else = s; }

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -1051,7 +1051,8 @@ BridgedBraceStmt BridgedBraceStmt_createParsed(BridgedASTContext cContext,
 
 BridgedIfStmt BridgedIfStmt_createParsed(BridgedASTContext cContext,
                                          BridgedSourceLoc cIfLoc,
-                                         BridgedExpr cond, BridgedStmt then,
+                                         BridgedExpr cond,
+                                         BridgedBraceStmt then,
                                          BridgedSourceLoc cElseLoc,
                                          BridgedNullableStmt elseStmt) {
   ASTContext &context = cContext.unbridged();

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1813,8 +1813,8 @@ Stmt *Traversal::visitIfStmt(IfStmt *IS) {
   if (doIt(IS->getCond()))
     return nullptr;
 
-  if (Stmt *S2 = doIt(IS->getThenStmt()))
-    IS->setThenStmt(S2);
+  if (auto *S2 = doIt(IS->getThenStmt()))
+    IS->setThenStmt(cast<BraceStmt>(S2));
   else
     return nullptr;
 

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -661,7 +661,7 @@ static StmtCondition exprToCond(Expr *C, ASTContext &Ctx) {
   return Ctx.AllocateCopy(Arr);
 }
 
-IfStmt::IfStmt(SourceLoc IfLoc, Expr *Cond, Stmt *Then, SourceLoc ElseLoc,
+IfStmt::IfStmt(SourceLoc IfLoc, Expr *Cond, BraceStmt *Then, SourceLoc ElseLoc,
                Stmt *Else, llvm::Optional<bool> implicit, ASTContext &Ctx)
     : IfStmt(LabeledStmtInfo(), IfLoc, exprToCond(Cond, Ctx), Then, ElseLoc,
              Else, implicit) {}

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -73,7 +73,7 @@ extension ASTGenVisitor {
       self.ctx,
       ifKeywordLoc: node.ifKeyword.bridgedSourceLoc(in: self),
       condition: conditions.first!.castToExpr,
-      thenStmt: self.generate(codeBlock: node.body).asStmt,
+      thenStmt: self.generate(codeBlock: node.body),
       elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
       elseStmt: node.elseBody.map {
         switch $0 {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -494,7 +494,7 @@ protected:
         availabilityCond && builder.supports(ctx.Id_buildLimitedAvailability);
 
     NullablePtr<Expr> thenVarRef;
-    NullablePtr<Stmt> thenBranch;
+    NullablePtr<BraceStmt> thenBranch;
     {
       SmallVector<ASTNode, 4> thenBody;
 

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -1803,7 +1803,7 @@ private:
     else
       hadError = true;
 
-    ifStmt->setThenStmt(visit(ifStmt->getThenStmt()).get<Stmt *>());
+    ifStmt->setThenStmt(castToStmt<BraceStmt>(visit(ifStmt->getThenStmt())));
 
     if (auto elseStmt = ifStmt->getElseStmt()) {
       ifStmt->setElseStmt(visit(elseStmt).get<Stmt *>());

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -142,10 +142,10 @@ public:
     transformStmtCondition(SC, IS->getStartLoc());
     IS->setCond(SC); // FIXME: is setting required?..
 
-    if (Stmt *TS = IS->getThenStmt()) {
-      Stmt *NTS = transformStmt(TS);
+    if (auto *TS = IS->getThenStmt()) {
+      auto *NTS = transformStmt(TS);
       if (NTS != TS) {
-        IS->setThenStmt(NTS);
+        IS->setThenStmt(cast<BraceStmt>(NTS));
       }
     }
 

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -205,10 +205,10 @@ public:
   // transform*() return their input if it's unmodified,
   // or a modified copy of their input otherwise.
   IfStmt *transformIfStmt(IfStmt *IS) {
-    if (Stmt *TS = IS->getThenStmt()) {
-      Stmt *NTS = transformStmt(TS);
+    if (auto *TS = IS->getThenStmt()) {
+      auto *NTS = transformStmt(TS);
       if (NTS != TS) {
-        IS->setThenStmt(NTS);
+        IS->setThenStmt(cast<BraceStmt>(NTS));
       }
     }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1377,15 +1377,15 @@ public:
     auto sourceFile = DC->getParentSourceFile();
     checkLabeledStmtShadowing(getASTContext(), sourceFile, IS);
 
-    Stmt *S = IS->getThenStmt();
-    typeCheckStmt(S);
-    IS->setThenStmt(S);
+    auto *TS = IS->getThenStmt();
+    typeCheckStmt(TS);
+    IS->setThenStmt(TS);
 
-    if ((S = IS->getElseStmt())) {
-      typeCheckStmt(S);
-      IS->setElseStmt(S);
+    if (auto *ES = IS->getElseStmt()) {
+      typeCheckStmt(ES);
+      IS->setElseStmt(ES);
     }
-    
+
     return IS;
   }
   

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1641,14 +1641,13 @@ synthesizeLazyGetterBody(AccessorDecl *Get, VarDecl *VD, VarDecl *Storage,
   Tmp1DRE->setType(Tmp1VD->getTypeInContext());
   auto *Return = new (Ctx) ReturnStmt(SourceLoc(), Tmp1DRE,
                                       /*implicit*/true);
-
+  auto *ReturnBranch = BraceStmt::createImplicit(Ctx, {Return});
 
   // Build the "if" around the early return.
-  Body.push_back(new (Ctx) IfStmt(LabeledStmtInfo(),
-                                  SourceLoc(), Ctx.AllocateCopy(Cond), Return,
-                                  /*elseloc*/SourceLoc(), /*else*/nullptr,
-                                  /*implicit*/ true));
-
+  Body.push_back(new (Ctx) IfStmt(LabeledStmtInfo(), SourceLoc(),
+                                  Ctx.AllocateCopy(Cond), ReturnBranch,
+                                  /*elseloc*/ SourceLoc(),
+                                  /*else*/ nullptr, /*implicit*/ true));
 
   auto *Tmp2VD = new (Ctx) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Let,
                                    SourceLoc(), Ctx.getIdentifier("tmp2"),

--- a/test/Profiler/coverage_deinit.swift
+++ b/test/Profiler/coverage_deinit.swift
@@ -21,4 +21,4 @@ public class Foo {
 // CHECK-NEXT: [[@LINE-8]]:10 -> [[@LINE-4]]:4 : 0
 // CHECK-NEXT: [[@LINE-8]]:8 -> [[@LINE-8]]:17 : 0
 // CHECK-NEXT: [[@LINE-9]]:18 -> [[@LINE-7]]:6 : 1
-// CHECK-NEXT: [[@LINE-8]]:6 -> [[@LINE-7]]:4 : 0
+// CHECK-NEXT: }

--- a/test/Profiler/coverage_errors.swift
+++ b/test/Profiler/coverage_errors.swift
@@ -658,62 +658,58 @@ func test49() throws -> Int { // CHECK-NEXT: [[@LINE]]:29   -> [[@LINE+6]]:2  : 
 }                             // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test50SiyKF"
-func test50() throws -> Int {     // CHECK-NEXT: [[@LINE]]:29   -> [[@LINE+8]]:2  : 0
+func test50() throws -> Int {     // CHECK-NEXT: [[@LINE]]:29   -> [[@LINE+7]]:2  : 0
   let x = if try throwingBool() { // CHECK-NEXT: [[@LINE]]:14   -> [[@LINE]]:32   : 0
     try throwingFn()              // CHECK-NEXT: [[@LINE-1]]:32 -> [[@LINE+4]]:11 : (0 - 2)
   } else {                        // CHECK-NEXT: [[@LINE-2]]:33 -> [[@LINE]]:4    : 1
     1                             // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4  : (1 - 3)
-  }                               // CHECK-NEXT: [[@LINE-2]]:4  -> [[@LINE+1]]:11 : ((0 - 2) - 3)
-  return x                        // CHECK-NEXT: [[@LINE-3]]:10 -> [[@LINE-1]]:4  : ((0 - 1) - 2)
-                                  // CHECK-NEXT: [[@LINE-2]]:4  -> [[@LINE-1]]:11 : ((0 - 2) - 3)
+  }                               // CHECK-NEXT: [[@LINE-2]]:10 -> [[@LINE]]:4    : ((0 - 1) - 2)
+  return x                        // CHECK-NEXT: [[@LINE-1]]:4  -> [[@LINE]]:11   : ((0 - 2) - 3)
 }                                 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test51SiyKF"
-func test51() throws -> Int {     // CHECK-NEXT: [[@LINE]]:29   -> [[@LINE+9]]:2  : 0
+func test51() throws -> Int {     // CHECK-NEXT: [[@LINE]]:29   -> [[@LINE+8]]:2  : 0
   let x = if try throwingBool() { // CHECK-NEXT: [[@LINE]]:14   -> [[@LINE]]:32   : 0
     try throwingFn()              // CHECK-NEXT: [[@LINE-1]]:32 -> [[@LINE+4]]:11 : (0 - 2)
   } else {                        // CHECK-NEXT: [[@LINE-2]]:33 -> [[@LINE]]:4    : 1
     try throwingFn()              // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4  : (1 - 3)
-  }                               // CHECK-NEXT: [[@LINE-2]]:4  -> [[@LINE+1]]:11 : ((0 - 2) - 3)
-  return x                        // CHECK-NEXT: [[@LINE-3]]:10 -> [[@LINE-1]]:4  : ((0 - 1) - 2)
-                                  // CHECK-NEXT: [[@LINE-3]]:21 -> [[@LINE-2]]:4  : (((0 - 1) - 2) - 4)
-                                  // CHECK-NEXT: [[@LINE-3]]:4  -> [[@LINE-2]]:11 : (((0 - 2) - 3) - 4)
+  }                               // CHECK-NEXT: [[@LINE-2]]:10 -> [[@LINE]]:4    : ((0 - 1) - 2)
+  return x                        // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4  : (((0 - 1) - 2) - 4)
+                                  // CHECK-NEXT: [[@LINE-2]]:4  -> [[@LINE-1]]:11 : (((0 - 2) - 3) - 4)
 }                                 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test52SiyKF"
-func test52() throws -> Int {     // CHECK-NEXT: [[@LINE]]:29   -> [[@LINE+10]]:2  : 0
-  let x = if try throwingBool(),  // CHECK-NEXT: [[@LINE]]:14   -> [[@LINE]]:32    : 0
-             try throwingBool() { // CHECK-NEXT: [[@LINE-1]]:32 -> [[@LINE+5]]:11  : (0 - 2)
-    try throwingFn()              // CHECK-NEXT: [[@LINE-1]]:32 -> [[@LINE+4]]:11  : ((0 - 2) - 3)
-  } else {                        // CHECK-NEXT: [[@LINE-2]]:33 -> [[@LINE]]:4     : 1
-    try throwingFn()              // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4   : (1 - 4)
-  }                               // CHECK-NEXT: [[@LINE-2]]:4  -> [[@LINE+1]]:11  : (((0 - 2) - 3) - 4)
-  return x                        // CHECK-NEXT: [[@LINE-3]]:10 -> [[@LINE-1]]:4   : (((0 - 1) - 2) - 3)
-                                  // CHECK-NEXT: [[@LINE-3]]:21 -> [[@LINE-2]]:4   : ((((0 - 1) - 2) - 3) - 5)
-                                  // CHECK-NEXT: [[@LINE-3]]:4  -> [[@LINE-2]]:11  : ((((0 - 2) - 3) - 4) - 5)
+func test52() throws -> Int {     // CHECK-NEXT: [[@LINE]]:29   -> [[@LINE+9]]:2  : 0
+  let x = if try throwingBool(),  // CHECK-NEXT: [[@LINE]]:14   -> [[@LINE]]:32   : 0
+             try throwingBool() { // CHECK-NEXT: [[@LINE-1]]:32 -> [[@LINE+5]]:11 : (0 - 2)
+    try throwingFn()              // CHECK-NEXT: [[@LINE-1]]:32 -> [[@LINE+4]]:11 : ((0 - 2) - 3)
+  } else {                        // CHECK-NEXT: [[@LINE-2]]:33 -> [[@LINE]]:4    : 1
+    try throwingFn()              // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4  : (1 - 4)
+  }                               // CHECK-NEXT: [[@LINE-2]]:10 -> [[@LINE]]:4    : (((0 - 1) - 2) - 3)
+  return x                        // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4  : ((((0 - 1) - 2) - 3) - 5)
+                                  // CHECK-NEXT: [[@LINE-2]]:4  -> [[@LINE-1]]:11 : ((((0 - 2) - 3) - 4) - 5)
 }                                 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test53yyKF"
-func test53() throws {     // CHECK-NEXT: [[@LINE]]:22   -> [[@LINE+10]]:2  : 0
-  if try throwingBool(),   // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE]]:24    : 0
-      try throwingBool() { // CHECK-NEXT: [[@LINE-1]]:24 -> [[@LINE+8]]:2   : (0 - 2)
-    try throwingFn()       // CHECK-NEXT: [[@LINE-1]]:25 -> [[@LINE+7]]:2   : ((0 - 2) - 3)
-  } else {                 // CHECK-NEXT: [[@LINE-2]]:26 -> [[@LINE]]:4     : 1
-    try throwingFn()       // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4   : (1 - 4)
-  }                        // CHECK-NEXT: [[@LINE-2]]:4  -> [[@LINE+4]]:2   : (((0 - 2) - 3) - 4)
-                           // CHECK-NEXT: [[@LINE-3]]:10 -> [[@LINE-1]]:4   : (((0 - 1) - 2) - 3)
-                           // CHECK-NEXT: [[@LINE-3]]:21 -> [[@LINE-2]]:4   : ((((0 - 1) - 2) - 3) - 5)
-                           // CHECK-NEXT: [[@LINE-3]]:4  -> [[@LINE+1]]:2   : ((((0 - 2) - 3) - 4) - 5)
+func test53() throws {     // CHECK-NEXT: [[@LINE]]:22   -> [[@LINE+9]]:2 : 0
+  if try throwingBool(),   // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE]]:24  : 0
+      try throwingBool() { // CHECK-NEXT: [[@LINE-1]]:24 -> [[@LINE+7]]:2 : (0 - 2)
+    try throwingFn()       // CHECK-NEXT: [[@LINE-1]]:25 -> [[@LINE+6]]:2 : ((0 - 2) - 3)
+  } else {                 // CHECK-NEXT: [[@LINE-2]]:26 -> [[@LINE]]:4   : 1
+    try throwingFn()       // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4 : (1 - 4)
+  }                        // CHECK-NEXT: [[@LINE-2]]:10 -> [[@LINE]]:4   : (((0 - 1) - 2) - 3)
+                           // CHECK-NEXT: [[@LINE-2]]:21 -> [[@LINE-1]]:4 : ((((0 - 1) - 2) - 3) - 5)
+                           // CHECK-NEXT: [[@LINE-2]]:4  -> [[@LINE+1]]:2 : ((((0 - 2) - 3) - 4) - 5)
 }                          // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test54SiSgyF"
-func test54()-> Int? {            // CHECK-NEXT: [[@LINE]]:22   -> [[@LINE+7]]:2 : 0
+func test54()-> Int? {            // CHECK-NEXT: [[@LINE]]:22 -> [[@LINE+7]]:2 : 0
   if let x = try? throwingFn(),
-      let y = try? throwingFn() { // CHECK-NEXT: [[@LINE]]:33   -> [[@LINE+2]]:4 : 1
-    x + y                         // FIXME: This region is redundant, and not really accurate since we have implicit returns (rdar://118653218)
-  } else {                        // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+3]]:2 : 0
-    try? throwingFn()             // CHECK-NEXT: [[@LINE-1]]:10 -> [[@LINE+1]]:4 : (0 - 1)
-  }                               // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+1]]:2 : 0
+      let y = try? throwingFn() { // CHECK-NEXT: [[@LINE]]:33 -> [[@LINE+2]]:4 : 1
+    x + y
+  } else {                        // CHECK-NEXT: [[@LINE]]:10 -> [[@LINE+2]]:4 : (0 - 1)
+    try? throwingFn()
+  }
 }                                 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s15coverage_errors6test55yyKF"

--- a/test/Profiler/coverage_if.swift
+++ b/test/Profiler/coverage_if.swift
@@ -21,15 +21,14 @@ foo(x: false);
 // rdar://29390569 – Make sure we don't add a spurious unreachable empty region.
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo1
-func foo1() -> Int {    // CHECK: [[@LINE]]:20 -> {{[0-9]+}}:2 : 0
-  if .random() {        // CHECK: [[@LINE]]:6 -> [[@LINE]]:15 : 0
-    return 0            // CHECK: [[@LINE-1]]:16 -> [[@LINE+2]]:4 : 1
-                        // CHECK: [[@LINE+1]]:4 -> {{[0-9]+}}:2 : (0 - 1)
-  } else if .random() { // CHECK: [[@LINE]]:13 -> [[@LINE]]:22 : (0 - 1)
-    return 1            // CHECK: [[@LINE-1]]:23 -> [[@LINE+1]]:4 : 2
-  } else {              // CHECK: [[@LINE]]:4 -> {{[0-9]+}}:2 : ((0 - 1) - 2)
-    return 2            // CHECK: [[@LINE-1]]:10 -> [[@LINE+1]]:4 : ((0 - 1) - 2)
-  }                     // CHECK-NOT: zero
+func foo1() -> Int {    // CHECK-NEXT: [[@LINE]]:20   -> {{[0-9]+}}:2  : 0
+  if .random() {        // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE]]:15  : 0
+    return 0            // CHECK-NEXT: [[@LINE-1]]:16 -> [[@LINE+1]]:4 : 1
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22  : (0 - 1)
+    return 1            // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4 : 2
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4 : ((0 - 1) - 2)
+    return 2
+  }                     // CHECK-NEXT: }
 }
 
 // ...but we will add an unreachable region if you write code there.
@@ -47,16 +46,17 @@ func foo2() -> Int {
 
 // Make sure we don't add unreachable regions for a labeled jump either.
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo3
-func foo3() -> Int { // CHECK: [[@LINE]]:20 -> {{[0-9]+}}:2 : 0
-  x: do {            // CHECK: [[@LINE]]:9 -> [[@LINE+6]]:4 : 0
-    if .random() {   // CHECK: [[@LINE]]:8 -> [[@LINE]]:17 : 0
-      return 0       // CHECK: [[@LINE-1]]:18 -> [[@LINE+1]]:6 : 1
-    } else {         // CHECK: [[@LINE]]:6 -> [[@LINE+3]]:4 : (0 - 1)
-      break x        // CHECK: [[@LINE-1]]:12 -> [[@LINE+1]]:6 : (0 - 1)
-    }                // CHECK-NOT: zero
-  }
+func foo3() -> Int { // CHECK-NEXT: [[@LINE]]:20   -> {{[0-9]+}}:2   : 0
+  x: do {            // CHECK-NEXT: [[@LINE]]:9    -> [[@LINE+6]]:4  : 0
+    if .random() {   // CHECK-NEXT: [[@LINE]]:8    -> [[@LINE]]:17   : 0
+      return 0       // CHECK-NEXT: [[@LINE-1]]:18 -> [[@LINE+1]]:6  : 1
+    } else {         // CHECK-NEXT: [[@LINE]]:12   -> [[@LINE+2]]:6  : (0 - 1)
+      break x
+    }
+  }                  // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+1]]:11 : (0 - 1)
   return 2
-}
+}                    // CHECK-NEXT: }
+
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo4
 func foo4() -> Int {
   x: do {
@@ -71,20 +71,161 @@ func foo4() -> Int {
 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo5
-func foo5() throws -> Int { // CHECK: [[@LINE]]:27 -> {{[0-9]+}}:2 : 0
-  if .random() {            // CHECK: [[@LINE]]:6 -> [[@LINE]]:15 : 0
-    return 0                // CHECK: [[@LINE-1]]:16 -> [[@LINE+1]]:4 : 1
-  } else {                  // CHECK: [[@LINE]]:4 -> {{[0-9]+}}:2 : (0 - 1)
-    struct S: Error {}      // CHECK: [[@LINE-1]]:10 -> [[@LINE+2]]:4 : (0 - 1)
+func foo5() throws -> Int { // CHECK-NEXT: [[@LINE]]:27   -> {{[0-9]+}}:2  : 0
+  if .random() {            // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE]]:15  : 0
+    return 0                // CHECK-NEXT: [[@LINE-1]]:16 -> [[@LINE+1]]:4 : 1
+  } else {                  // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+3]]:4 : (0 - 1)
+    struct S: Error {}
     throw S()
-  }                         // CHECK-NOT: zero
-}
+  }
+}                           // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo6
-func foo6(_ x: Int?) -> Int? { // CHECK: [[@LINE]]:30 -> {{[0-9]+}}:2 : 0
-  if let x = x {
-    return x                   // CHECK: [[@LINE-1]]:16 -> [[@LINE+1]]:4 : 1
-  } else {                     // CHECK: [[@LINE]]:4 -> {{[0-9]+}}:2 : (0 - 1)
-    return nil                 // CHECK: [[@LINE-1]]:10 -> [[@LINE+1]]:4 : (0 - 1)
-  }                            // CHECK-NOT: zero
-}
+func foo6(_ x: Int?) -> Int? { // CHECK-NEXT: [[@LINE]]:30 -> {{[0-9]+}}:2  : 0
+  if let x = x {               // CHECK-NEXT: [[@LINE]]:16 -> [[@LINE+2]]:4 : 1
+    return x
+  } else {                     // CHECK-NEXT: [[@LINE]]:10 -> [[@LINE+2]]:4 : (0 - 1)
+    return nil
+  }
+}                              // CHECK-NEXT: }
+
+// rdar://104078910, rdar://104079242 - Make sure the else if condition and the
+// else gets a correct counter here.
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo7
+func foo7() -> Int {    // CHECK-NEXT: [[@LINE]]:20   -> [[@LINE+12]]:2 : 0
+  let x: Int
+  if .random() {        // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE]]:15   : 0
+    x = 0               // CHECK-NEXT: [[@LINE-1]]:16 -> [[@LINE+1]]:4  : 1
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : (0 - 1)
+    x = 1               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 2
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : ((0 - 1) - 2)
+    x = 2               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 3
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4  : (((0 - 1) - 2) - 3)
+    x = 3
+  }
+  return x
+}                       // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo8
+func foo8() -> Int {    // CHECK-NEXT: [[@LINE]]:20   -> [[@LINE+12]]:2 : 0
+  let x: Int            // CHECK-NEXT: [[@LINE+1]]:6  -> [[@LINE+1]]:15 : 0
+  if .random() {        // CHECK-NEXT: [[@LINE]]:16   -> [[@LINE+2]]:4  : 1
+    return 0
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : (0 - 1)
+    x = 1               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 2
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : ((0 - 1) - 2)
+    x = 2               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 3
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4  : (((0 - 1) - 2) - 3)
+    x = 3
+  }                     // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+1]]:11 : (0 - 1)
+  return x
+}                       // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo9
+func foo9() -> Int {    // CHECK-NEXT: [[@LINE]]:20   -> [[@LINE+12]]:2 : 0
+  let x: Int            // CHECK-NEXT: [[@LINE+1]]:6  -> [[@LINE+1]]:15 : 0
+  if .random() {        // CHECK-NEXT: [[@LINE]]:16   -> [[@LINE+2]]:4  : 1
+    return 0
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : (0 - 1)
+    return 1            // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 2
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : ((0 - 1) - 2)
+    x = 2               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 3
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4  : (((0 - 1) - 2) - 3)
+    x = 3
+  }                     // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+1]]:11 : ((0 - 1) - 2)
+  return x
+}                       // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo10
+func foo10() -> Int {   // CHECK-NEXT: [[@LINE]]:21   -> [[@LINE+12]]:2 : 0
+  let x: Int            // CHECK-NEXT: [[@LINE+1]]:6  -> [[@LINE+1]]:15 : 0
+  if .random() {        // CHECK-NEXT: [[@LINE]]:16   -> [[@LINE+2]]:4  : 1
+    return 0
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : (0 - 1)
+    return 1            // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 2
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : ((0 - 1) - 2)
+    x = 2               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 3
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4  : (((0 - 1) - 2) - 3)
+    return 3
+  }                     // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+1]]:11 : 3
+  return x
+}                       // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo11
+func foo11() -> Int {   // CHECK-NEXT: [[@LINE]]:21   -> [[@LINE+12]]:2 : 0
+  let x: Int            // CHECK-NEXT: [[@LINE+1]]:6  -> [[@LINE+1]]:15 : 0
+  if .random() {        // CHECK-NEXT: [[@LINE]]:16   -> [[@LINE+2]]:4  : 1
+    x = 0
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : (0 - 1)
+    x = 1               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 2
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : ((0 - 1) - 2)
+    x = 2               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 3
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4  : (((0 - 1) - 2) - 3)
+    return 3
+  }                     // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+1]]:11 : ((1 + 2) + 3)
+  return x
+}                       // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo12
+func foo12() -> Int { // CHECK-NEXT: [[@LINE]]:21   -> [[@LINE+9]]:2  : 0
+  let x: Int
+  y: if .random() {   // CHECK-NEXT: [[@LINE]]:9    -> [[@LINE]]:18   : 0
+    x = 0             // CHECK-NEXT: [[@LINE-1]]:19 -> [[@LINE+2]]:4  : 1
+    break y
+  } else {
+    x = 1             // CHECK-NEXT: [[@LINE-1]]:10 -> [[@LINE+1]]:4  : (0 - 1)
+  }
+  return x
+}                     // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo13
+func foo13() -> Int { // CHECK-NEXT: [[@LINE]]:21   -> [[@LINE+10]]:2 : 0
+  let x: Int
+  y: if .random() {   // CHECK-NEXT: [[@LINE]]:9    -> [[@LINE]]:18   : 0
+    x = 0             // CHECK-NEXT: [[@LINE-1]]:19 -> [[@LINE+2]]:4  : 1
+    break y
+  } else {
+    x = 1             // CHECK-NEXT: [[@LINE-1]]:10 -> [[@LINE+2]]:4  : (0 - 1)
+    break y
+  }
+  return x
+}                     // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo14
+func foo14() -> Int {   // CHECK-NEXT: [[@LINE]]:21   -> [[@LINE+14]]:2 : 0
+  let x: Int            // CHECK-NEXT: [[@LINE+1]]:9  -> [[@LINE+1]]:18 : 0
+  y: if .random() {     // CHECK-NEXT: [[@LINE]]:19   -> [[@LINE+3]]:4  : 1
+    x = 0
+    break y
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : (0 - 1)
+    return 1            // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4  : 2
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : ((0 - 1) - 2)
+    x = 2               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+2]]:4  : 3
+    break y
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4  : (((0 - 1) - 2) - 3)
+    return 3
+  }                     // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+1]]:11 : (1 + 3)
+  return x
+}                       // CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_if.foo15
+func foo15() -> Int {   // CHECK-NEXT: [[@LINE]]:21   -> [[@LINE+19]]:2 : 0
+  let x: Int            // CHECK-NEXT: [[@LINE+1]]:9  -> [[@LINE+1]]:18 : 0
+  y: if .random() {     // CHECK-NEXT: [[@LINE]]:19   -> [[@LINE+5]]:4  : 1
+    x = 0
+    if .random() {      // CHECK-NEXT: [[@LINE]]:8    -> [[@LINE]]:17   : 1
+      break y           // CHECK-NEXT: [[@LINE-1]]:18 -> [[@LINE+1]]:6  : 2
+    }                   // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE+1]]:4  : (1 - 2)
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : (0 - 1)
+    x = 1               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+4]]:4  : 3
+    if .random() {      // CHECK-NEXT: [[@LINE]]:8    -> [[@LINE]]:17   : 3
+      return 1          // CHECK-NEXT: [[@LINE-1]]:18 -> [[@LINE+1]]:6  : 4
+    }                   // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE+1]]:4  : (3 - 4)
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22   : ((0 - 1) - 3)
+    x = 2               // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+2]]:4  : 5
+    break y
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4  : (((0 - 1) - 3) - 5)
+    return 3
+  }                     // CHECK-NEXT: [[@LINE]]:4    -> [[@LINE+1]]:11 : (((1 + 3) + 5) - 4)
+  return x
+}                       // CHECK-NEXT: }

--- a/test/Profiler/coverage_if_expr.swift
+++ b/test/Profiler/coverage_if_expr.swift
@@ -2,20 +2,12 @@
 // RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
 
 // CHECK-LABEL: sil_coverage_map {{.*}} "$s16coverage_if_expr0b1_C0SiyF"
-func if_expr() -> Int { // CHECK:      [[@LINE]]:23 -> {{[0-9]+}}:2 : 0
-  if .random() {        // CHECK-NEXT: [[@LINE]]:6 -> [[@LINE]]:15 : 0
-    0                   // CHECK-NEXT: [[@LINE-1]]:16 -> [[@LINE+4]]:4 : 1
-                        // CHECK-NEXT: [[@LINE+3]]:4 -> {{[0-9]+}}:2 : 0
-
-                        // FIXME: The below line is incorrect, it should be (0 - 1), but that's an existing bug with else ifs.
-  } else if .random() { // CHECK-NEXT: [[@LINE]]:13 -> [[@LINE]]:22 : 0
+func if_expr() -> Int { // CHECK:      [[@LINE]]:23   -> {{[0-9]+}}:2  : 0
+  if .random() {        // CHECK-NEXT: [[@LINE]]:6    -> [[@LINE]]:15  : 0
+    0                   // CHECK-NEXT: [[@LINE-1]]:16 -> [[@LINE+1]]:4 : 1
+  } else if .random() { // CHECK-NEXT: [[@LINE]]:13   -> [[@LINE]]:22  : (0 - 1)
     1                   // CHECK-NEXT: [[@LINE-1]]:23 -> [[@LINE+1]]:4 : 2
-  } else {              // CHECK-NEXT: [[@LINE]]:4 -> {{[0-9]+}}:2 : 0
-
-                        // FIXME: The below line is incorrect, it should be ((0 - 1) - 2), but that's an existing bug with else ifs.
-    2                   // CHECK-NEXT: [[@LINE-3]]:10 -> [[@LINE+4]]:4 : (0 - 2)
-
-                        // FIXME: Also incorrect
-                        // CHECK-NEXT: [[@LINE+1]]:4 -> [[@LINE+2]]:2 : 0
+  } else {              // CHECK-NEXT: [[@LINE]]:10   -> [[@LINE+2]]:4 : ((0 - 1) - 2)
+    2
   }                     // CHECK-NEXT: }
 }

--- a/test/Profiler/coverage_optimized_report.swift
+++ b/test/Profiler/coverage_optimized_report.swift
@@ -14,7 +14,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
-// CHECK: "lines":{"count":9,"covered":6{{.*}}"functions":{"count":5,"covered":3
+// CHECK: "lines":{"count":9,"covered":5{{.*}}"functions":{"count":5,"covered":3
 
 // The functions 'unused' and 'optimizedOut' will be optimized out, but
 // make sure we still emit coverage records for them, using name data emitted

--- a/test/Profiler/coverage_property_wrapper_backing.swift
+++ b/test/Profiler/coverage_property_wrapper_backing.swift
@@ -93,8 +93,7 @@ struct U {
   // CHECK-NEXT:  [[@LINE-2]]:11 -> [[@LINE-2]]:40 : 0
   // CHECK-NEXT:  [[@LINE-3]]:14 -> [[@LINE-3]]:23 : 0
   // CHECK-NEXT:  [[@LINE-4]]:24 -> [[@LINE-4]]:29 : 1
-  // CHECK-NEXT:  [[@LINE-5]]:29 -> [[@LINE-5]]:40 : 0
-  // CHECK-NEXT:  [[@LINE-6]]:35 -> [[@LINE-6]]:40 : (0 - 1)
+  // CHECK-NEXT:  [[@LINE-5]]:35 -> [[@LINE-5]]:40 : (0 - 1)
   // CHECK-NEXT:  }
 }
 


### PR DESCRIPTION
Fix counters for regions following `else if`s, fix the counters for `else if` conditions, and fix handling of `break` statements. Also while here, clean up the handling of branch exit regions such that we don't generate multiple overlapping regions for each branch, but a single region at the end of the entire `if` statement that accounts for all exiting control flow.

rdar://104078910
rdar://104079242
Resolves #62943
Resolves #62944