### PR TITLE
[SourceKit] Support building sourcekitd without building swift-syntax

### DIFF
--- a/include/swift/Refactoring/Refactoring.h
+++ b/include/swift/Refactoring/Refactoring.h
@@ -100,6 +100,7 @@ public:
 ///   - valueDecl: The declaration that should be renamed
 RenameLocs localRenameLocs(SourceFile *sourceFile, const ValueDecl *valueDecl);
 
+#if SWIFT_BUILD_SWIFT_SYNTAX
 /// Given a list of `RenameLoc`s, get the corresponding `ResolveLoc`s.
 ///
 /// These resolve locations contain more structured information, such as the
@@ -112,6 +113,7 @@ std::vector<ResolvedLoc> resolveRenameLocations(ArrayRef<RenameLoc> renameLocs,
                                                 StringRef newName,
                                                 SourceFile &sourceFile,
                                                 DiagnosticEngine &diags);
+#endif
 
 struct RangeConfig {
   unsigned BufferID;

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -808,6 +808,7 @@ public:
                     getBuffer());
     RewriteBuf.Initialize(Input);
     removeCommentLines(RewriteBuf, Input, "RUN");
+    removeCommentLines(RewriteBuf, Input, "REQUIRES");
     removeCommentLines(RewriteBuf, Input, "CHECK");
   }
 

--- a/lib/Refactoring/CMakeLists.txt
+++ b/lib/Refactoring/CMakeLists.txt
@@ -1,8 +1,3 @@
-if (NOT SWIFT_BUILD_SWIFT_SYNTAX)
-  # swiftRefactoring requires SwiftIDEUtilsBriding, which isn't built if SWIFT_BUILD_SWIFT_SYNTAX is `NO`.
-  return()
-endif()
-
 add_swift_host_library(swiftRefactoring STATIC
   AddEquatableConformance.cpp
   AddExplicitCodableImplementation.cpp
@@ -55,5 +50,11 @@ target_link_libraries(swiftRefactoring PRIVATE
   swiftParse
   swiftSema)
 
-set_swift_llvm_is_available(swiftRefactoring)
+if(SWIFT_BUILD_SWIFT_SYNTAX)
+  target_compile_definitions(swiftRefactoring
+    PRIVATE
+    SWIFT_BUILD_SWIFT_SYNTAX
+  )
+endif()
 
+set_swift_llvm_is_available(swiftRefactoring)

--- a/lib/Refactoring/SyntacticRename.cpp
+++ b/lib/Refactoring/SyntacticRename.cpp
@@ -21,6 +21,7 @@
 using namespace swift;
 using namespace swift::ide;
 
+#if SWIFT_BUILD_SWIFT_SYNTAX
 std::vector<ResolvedLoc>
 swift::ide::resolveRenameLocations(ArrayRef<RenameLoc> RenameLocs,
                                    StringRef NewName, SourceFile &SF,
@@ -105,6 +106,7 @@ swift::ide::resolveRenameLocations(ArrayRef<RenameLoc> RenameLocs,
   }
   return resolvedLocsInRequestedOrder;
 }
+#endif
 
 CancellableResult<std::vector<SyntacticRenameRangeDetails>>
 swift::ide::findSyntacticRenameRanges(SourceFile *SF,
@@ -112,6 +114,9 @@ swift::ide::findSyntacticRenameRanges(SourceFile *SF,
                                       StringRef NewName) {
   using ResultType =
       CancellableResult<std::vector<SyntacticRenameRangeDetails>>;
+#if !SWIFT_BUILD_SWIFT_SYNTAX
+  return ResultType::failure("find-syntactic-rename-ranges is not supported because sourcekitd was built without swift-syntax");
+#else
   assert(SF && "null source file");
 
   SourceManager &SM = SF->getASTContext().SourceMgr;
@@ -146,4 +151,5 @@ swift::ide::findSyntacticRenameRanges(SourceFile *SF,
     return ResultType::failure(ErrBuffer);
 
   return ResultType::success(Result);
+#endif
 }

--- a/test/SourceKit/CursorInfo/cursor_callargs.swift
+++ b/test/SourceKit/CursorInfo/cursor_callargs.swift
@@ -6,6 +6,7 @@ class C1 {
 var c1 = C1(passInt: 0, andThis: 0)
 c1.meth(0, passFloat: 0)
 
+// REQUIRES: swift_swift_parser
 // RUN: %sourcekitd-test -req=cursor -pos=6:11 %s -- %s | %FileCheck -check-prefix=CHECK-CLASS %s
 // CHECK-CLASS: source.lang.swift.ref.class (2:7-2:9)
 // CHECK-CLASS: s:15cursor_callargs2C1C

--- a/test/SourceKit/Misc/stats.swift
+++ b/test/SourceKit/Misc/stats.swift
@@ -1,5 +1,6 @@
 func foo() {}
 
+// REQUIRES: swift_swift_parser
 // RUN: %sourcekitd-test -req=syntax-map %s == -req=stats | %FileCheck %s -check-prefix=SYNTAX_1
 
 // SYNTAX_1:   {{.*}} source.statistic.instruction-count

--- a/test/SourceKit/Refactoring/find-rename-ranges.swift
+++ b/test/SourceKit/Refactoring/find-rename-ranges.swift
@@ -117,6 +117,8 @@ struct Foo {
   static var test: Int = 10
 }
 
+// REQUIRES: swift_swift_parser
+
 // RUN: %empty-directory(%t.result)
 
 // Ensure that a syntactic rename request does not require the stdlib

--- a/test/SourceKit/Refactoring/ordering.swift
+++ b/test/SourceKit/Refactoring/ordering.swift
@@ -35,6 +35,7 @@ func test(c: C) {
                             /*C_foo3_call_arg2*/b: 2)
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/ordering/ordering.in.json %s >> %t.result/ordering.expected
 // RUN: %diff -u %S/ordering/ordering.expected %t.result/ordering.expected

--- a/test/SourceKit/Refactoring/rename-mismatch.swift
+++ b/test/SourceKit/Refactoring/rename-mismatch.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
 
@@ -17,11 +18,11 @@ _ = Sss()
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %t/rename-spec.json %t/input.swift | %FileCheck %s
 
 // CHECK: source.edit.kind.active:
-// CHECK:   5:8-5:11 source.refactoring.range.kind.basename
+// CHECK:   6:8-6:11 source.refactoring.range.kind.basename
 // CHECK: source.edit.kind.unknown:
 // CHECK: source.edit.kind.mismatch:
 // CHECK: source.edit.kind.active:
-// CHECK:   10:5-10:8 source.refactoring.range.kind.basename
+// CHECK:   11:5-11:8 source.refactoring.range.kind.basename
 
 //--- rename-spec.json
 
@@ -33,14 +34,9 @@ _ = Sss()
     "key.is_non_protocol_type": 1,
     "key.locations": [
       {
-        "key.line": 5,
+        "key.line": 6,
         "key.column": 8,
         "key.nametype": source.syntacticrename.definition
-      },
-      {
-        "key.line": 8,
-        "key.column": 5,
-        "key.nametype": source.syntacticrename.unknown
       },
       {
         "key.line": 9,
@@ -49,6 +45,11 @@ _ = Sss()
       },
       {
         "key.line": 10,
+        "key.column": 5,
+        "key.nametype": source.syntacticrename.unknown
+      },
+      {
+        "key.line": 11,
         "key.column": 5,
         "key.nametype": source.syntacticrename.reference
       }

--- a/test/SourceKit/Refactoring/rename-with-location-directive.swift
+++ b/test/SourceKit/Refactoring/rename-with-location-directive.swift
@@ -2,5 +2,6 @@
 func test() {}
 #sourceLocation()
 
+// REQUIRES: swift_swift_parser
 // RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=2:6 %s -- %s | %FileCheck %s
 // CHECK: 2:6-2:10 source.refactoring.range.kind.basename

--- a/test/SourceKit/Refactoring/semantic-refactoring/line-col-conversion.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/line-col-conversion.swift
@@ -1,7 +1,8 @@
-// RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=4:7 %s -- %s | %FileCheck %s
+// REQUIRES: swift_swift_parser
+// RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=5:7 %s -- %s | %FileCheck %s
 
 var Foo: Int {
 	var missingNewlineAtEndOfFile
 
 // CHECK: source.edit.kind.active:
-// CHECK:   4:6-4:31 source.refactoring.range.kind.basename
+// CHECK:   5:6-5:31 source.refactoring.range.kind.basename

--- a/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
@@ -11,6 +11,7 @@ func foo() {
   return 1
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=2:8 %s -- %s | %FileCheck %s --check-prefix CHECK-aa
 

--- a/test/SourceKit/RelatedIdents/implicit_vis.swift
+++ b/test/SourceKit/RelatedIdents/implicit_vis.swift
@@ -16,6 +16,7 @@ class B {
 
 //--- dummy.swift
 
+// REQUIRES: swift_swift_parser
 // RUN: %sourcekitd-test -req=related-idents -pos=3:10 %t/a.swift -- %t/a.swift %t/b.swift -o implicit_vis.o | %FileCheck -check-prefix=CHECK1 %s
 
 // CHECK1: START RANGES

--- a/test/SourceKit/RelatedIdents/invalid_loc.swift
+++ b/test/SourceKit/RelatedIdents/invalid_loc.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: %sourcekitd-test -req=related-idents -pos=%(line + 1):1 %s -- %s | %FileCheck %s
 
 // CHECK: START RANGES

--- a/test/SourceKit/RelatedIdents/multiple_occurrences_on_same_line.swift
+++ b/test/SourceKit/RelatedIdents/multiple_occurrences_on_same_line.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: %sourcekitd-test -req=related-idents -pos=%(line + 1):5 %s -- %s | %FileCheck %s
 let asd = [0]
 let index = asd.firstIndex(of: 0)!
@@ -5,9 +6,9 @@ print(asd[asd.firstIndex(of: 0)!...])
 
 
 // CHECK: START RANGES
-// CHECK: 2:5 - 3
-// CHECK: 3:13 - 3
-// CHECK: 4:7 - 3
-// CHECK: 4:11 - 3
+// CHECK: 3:5 - 3
+// CHECK: 4:13 - 3
+// CHECK: 5:7 - 3
+// CHECK: 5:11 - 3
 // CHECK: END RANGES
 

--- a/test/SourceKit/RelatedIdents/pound_if.swift
+++ b/test/SourceKit/RelatedIdents/pound_if.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: %sourcekitd-test -req=related-idents -pos=%(line + 1):10 %s -- %s | %FileCheck %s
 func foo(x: Int) {
 #if true
@@ -8,6 +9,6 @@ func foo(x: Int) {
 }
 
 // CHECK: START RANGES
-// CHECK-NEXT: 2:10 - 1
-// CHECK-NEXT: 4:9 - 1
+// CHECK-NEXT: 3:10 - 1
+// CHECK-NEXT: 5:9 - 1
 // CHECK-NEXT: END RANGES

--- a/test/SourceKit/RelatedIdents/related_idents.swift
+++ b/test/SourceKit/RelatedIdents/related_idents.swift
@@ -105,6 +105,8 @@ func ifLet(test: Int?) {
   }
 }
 
+// REQUIRES: swift_swift_parser
+
 // RUN: %sourcekitd-test -req=related-idents -pos=6:17 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: START RANGES
 // CHECK1-NEXT: 1:7 - 2

--- a/test/SourceKit/RelatedIdents/system_symbol.swift
+++ b/test/SourceKit/RelatedIdents/system_symbol.swift
@@ -1,9 +1,10 @@
+// REQUIRES: swift_swift_parser
 // RUN: %sourcekitd-test -req=related-idents -pos=%(line + 1):13 %s -- %s | %FileCheck %s
 func foo(x: String) {
   let a: String = "abc"
 }
 
 // CHECK: START RANGES
-// CHECK-NEXT: 2:13 - 6
-// CHECK-NEXT: 3:10 - 6
+// CHECK-NEXT: 3:13 - 6
+// CHECK-NEXT: 4:10 - 6
 // CHECK-NEXT: END RANGES

--- a/test/refactoring/SyntacticRename/backticks-noncollapsible-separate-arglabel.swift
+++ b/test/refactoring/SyntacticRename/backticks-noncollapsible-separate-arglabel.swift
@@ -3,6 +3,7 @@ struct Foo {
 }
 Foo()/*test:ref*/[`x`: 10]
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "subscript(x:)" >> %t.ranges/backticks-noncollapsible-separate-arglabel.swift.expected
 // RUN: diff -u %S/Outputs/backticks-noncollapsible-separate-arglabel.swift.expected %t.ranges/backticks-noncollapsible-separate-arglabel.swift.expected

--- a/test/refactoring/SyntacticRename/backticks-noncollapsible.swift
+++ b/test/refactoring/SyntacticRename/backticks-noncollapsible.swift
@@ -3,6 +3,7 @@ struct Foo {
 }
 Foo()/*test:ref*/[10]
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "subscript(_:)" >> %t.ranges/backticks-noncollapsible.swift.expected
 // RUN: diff -u %S/Outputs/backticks-noncollapsible.swift.expected %t.ranges/backticks-noncollapsible.swift.expected

--- a/test/refactoring/SyntacticRename/backticks-separate-arglabel.swift
+++ b/test/refactoring/SyntacticRename/backticks-separate-arglabel.swift
@@ -2,6 +2,7 @@ func /*test:def*/`foo`(`x` `y`: Int) {}
 /*test:call*/`foo`(`x`: 2)
 _ = /*test:ref*/`foo`(`x`:)
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "foo(x:)" >> %t.ranges/backticks-separate-arglabel.swift.expected
 // RUN: diff -u %S/Outputs/backticks-separate-arglabel.swift.expected %t.ranges/backticks-separate-arglabel.swift.expected

--- a/test/refactoring/SyntacticRename/backticks.swift
+++ b/test/refactoring/SyntacticRename/backticks.swift
@@ -2,6 +2,7 @@ func /*test:def*/`foo`(`x`: Int) {}
 /*test:call*/`foo`(`x`: 2)
 _ = /*test:ref*/`foo`(`x`:)
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "foo(x:)" >> %t.ranges/backticks.swift.expected
 // RUN: diff -u %S/Outputs/backticks.swift.expected %t.ranges/backticks.swift.expected

--- a/test/refactoring/SyntacticRename/call-as-function-base.swift
+++ b/test/refactoring/SyntacticRename/call-as-function-base.swift
@@ -10,6 +10,7 @@ let /*test:def*/add3 = Adder(base: 3)
 /*test:ref*/add3(x: 10, y: 11)
 let blah = /*test:ref*/add3.callAsFunction(x:y:)
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -old-name "add3" >> %t.ranges/call-as-function-base.swift.expected
 // RUN: diff -u %S/Outputs/call-as-function-base.swift.expected %t.ranges/call-as-function-base.swift.expected

--- a/test/refactoring/SyntacticRename/call-as-function-paren-arg.swift
+++ b/test/refactoring/SyntacticRename/call-as-function-paren-arg.swift
@@ -11,6 +11,7 @@ _ = add3 . /*test:call*/callAsFunction(10)
 _ = add3 . /*test:ref*/callAsFunction(_:)
 _ = add3 . /*test:ref*/callAsFunction
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "callAsFunction(_:)" >> %t.ranges/call-as-function-paren-arg.swift.expected
 // RUN: diff -u %S/Outputs/call-as-function-paren-arg.swift.expected %t.ranges/call-as-function-paren-arg.swift.expected

--- a/test/refactoring/SyntacticRename/call-as-function.swift
+++ b/test/refactoring/SyntacticRename/call-as-function.swift
@@ -12,6 +12,7 @@ _ = add3 . /*test:ref*/callAsFunction(x:y:)
 _ = add3 . /*test:ref*/callAsFunction
 _ = (add3 . /*test:call*/callAsFunction())/*test:call*/(x: 10, y: 11)
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "callAsFunction(x:y:)" >> %t.ranges/call-as-function.swift.expected
 // RUN: diff -u %S/Outputs/call-as-function.swift.expected %t.ranges/call-as-function.swift.expected

--- a/test/refactoring/SyntacticRename/callsites.swift
+++ b/test/refactoring/SyntacticRename/callsites.swift
@@ -67,6 +67,7 @@ func /*mixed:def*/withAllOfTheAbove(x: Int = 2, _: Int..., z: Int = 2, c: () -> 
 // false positives
 /*mixed:call*/withAllOfTheAbove(z: 1, 2, c: {return 1})
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="defaults" -is-function-like -old-name "withDefaults(_:y:x:)" -new-name "betterName(x:y:z:)" >> %t.result/callsites_defaults.swift
 // RUN: diff -u %S/Outputs/callsites/defaults.swift.expected %t.result/callsites_defaults.swift

--- a/test/refactoring/SyntacticRename/custom-attrs.swift
+++ b/test/refactoring/SyntacticRename/custom-attrs.swift
@@ -57,6 +57,7 @@ struct Bar {
 }
 
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="wrapper" -is-non-protocol-type -old-name "Foo" >> %t.ranges/custom-attrs-Foo.swift

--- a/test/refactoring/SyntacticRename/fixed_crashes.swift
+++ b/test/refactoring/SyntacticRename/fixed_crashes.swift
@@ -2,5 +2,6 @@ enum AnEnum {
 	case /*last-enum-element:def*/lastOccurrence(a: Int)
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="last-enum-element" -is-function-like -old-name "lastOccurrence(a:)" -new-name "lastOccurrence(b:)"
 // REQUIRES asserts

--- a/test/refactoring/SyntacticRename/functions.swift
+++ b/test/refactoring/SyntacticRename/functions.swift
@@ -83,6 +83,7 @@ _ = Memberwise(/*memberwise-x:ref*/x: 1, z: 3)
 let memberwise = Memberwise.init(/*memberwise-x:ref*/x:z:)
 _ = memberwise . /*memberwise-x:ref*/x
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="import" -is-function-like -old-name "someFunc(a:)" >> %t.ranges/functions_import.swift
 // RUN: diff -u %S/Outputs/functions/import.swift.expected %t.ranges/functions_import.swift

--- a/test/refactoring/SyntacticRename/init.swift
+++ b/test/refactoring/SyntacticRename/init.swift
@@ -9,6 +9,7 @@ _ = Test . /*test:ref*/init
 _ = Test . /*test:ref*/init(base:)
 
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "init(base:)" >> %t.ranges/init.swift.expected
 // RUN: diff -u %S/Outputs/init.swift.expected %t.ranges/init.swift.expected

--- a/test/refactoring/SyntacticRename/invalid-newname.swift
+++ b/test/refactoring/SyntacticRename/invalid-newname.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: not %refactor -find-rename-ranges -source-filename %s -pos="ignore" -old-name "a" -new-name " "
 // RUN: not %refactor -find-rename-ranges -source-filename %s -pos="ignore" -is-function-like -old-name "foo(a:)" -new-name "foo( :)"
 // RUN: not %refactor -find-rename-ranges -source-filename %s -pos="ignore" -is-function-like -old-name "foo" -new-name "foo( )"

--- a/test/refactoring/SyntacticRename/macro-definition.swift
+++ b/test/refactoring/SyntacticRename/macro-definition.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "StringifyMacro" | %FileCheck %s
 

--- a/test/refactoring/SyntacticRename/multiple-trailing-closures-defaulted.swift
+++ b/test/refactoring/SyntacticRename/multiple-trailing-closures-defaulted.swift
@@ -7,6 +7,7 @@ func /*test:def*/test(x: () -> () = {}, _ xx: () -> () = {}, y: () -> () = {}, z
 /*test:call*/test(y: {}) {}
 
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "test(x:_:y:z:)" >> %t.ranges/multiple-trailing-closures-defaulted.swift.expected
 // RUN: diff -u %S/Outputs/multiple-trailing-closures-defaulted.swift.expected %t.ranges/multiple-trailing-closures-defaulted.swift.expected

--- a/test/refactoring/SyntacticRename/multiple-trailing-closures.swift
+++ b/test/refactoring/SyntacticRename/multiple-trailing-closures.swift
@@ -6,6 +6,7 @@ func /*test:def*/test(x: () -> (), _ xx: () -> (), y: () -> (), z: ()->()) {}
 /*test:call*/test {} _: {} y: {} z: {}
 
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="test" -is-function-like -old-name "test(x:_:y:z:)" >> %t.ranges/multiple-trailing-closures.swift.expected
 // RUN: diff -u %S/Outputs/multiple-trailing-closures.swift.expected %t.ranges/multiple-trailing-closures.swift.expected

--- a/test/refactoring/SyntacticRename/objc-keypath.swift
+++ b/test/refactoring/SyntacticRename/objc-keypath.swift
@@ -24,6 +24,7 @@ _ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array[0] . hashValue)
 // FIXME: Invalid and not resolved
 _ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="Outer" -old-name "Outer" >> %t/outer.swift
 // RUN: diff -u %S/Outputs/objc-keypath/outer.swift.expected %t/outer.swift

--- a/test/refactoring/SyntacticRename/property-wrapper-init.swift
+++ b/test/refactoring/SyntacticRename/property-wrapper-init.swift
@@ -35,6 +35,7 @@ func uses() {
 }
 
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="init" -is-function-like -old-name "init(initialValue:)" >> %t.ranges/property-wrapper-init.swift

--- a/test/refactoring/SyntacticRename/property-wrapper-split.swift
+++ b/test/refactoring/SyntacticRename/property-wrapper-split.swift
@@ -19,6 +19,7 @@ struct User {
 }
 
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="someValue" -old-name "someValue" >> %t.ranges/property-wrapper-split-someValue.swift
 // RUN: diff -u %S/Outputs/property-wrapper-split/someValue.swift.expected %t.ranges/property-wrapper-split-someValue.swift

--- a/test/refactoring/SyntacticRename/textual.swift
+++ b/test/refactoring/SyntacticRename/textual.swift
@@ -36,6 +36,7 @@ _ = /*MyClass:unknown*/Mismatch()
 _ = /*MyClass:unknown*/MyClass()
 #endif
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="foo" -is-function-like -old-name "foo" >> %t.ranges/textual_foo.swift
 // RUN: diff -u %S/Outputs/textual/foo.swift.expected %t.ranges/textual_foo.swift

--- a/test/refactoring/SyntacticRename/types.swift
+++ b/test/refactoring/SyntacticRename/types.swift
@@ -52,6 +52,7 @@ enum /*enum-WithValue:def*/WithValue: Int {
 }
 var _ = /*enum-WithValue*/WithValue . /*case-one*/one
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="class-Foo" -is-non-protocol-type -old-name "Foo" > %t.result/types_class-Foo.swift
 // RUN: diff -u %S/Outputs/types/class-Foo.swift.expected %t.result/types_class-Foo.swift

--- a/test/refactoring/SyntacticRename/variables.swift
+++ b/test/refactoring/SyntacticRename/variables.swift
@@ -38,6 +38,7 @@ struct S {
 	}()
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="var-y" -old-name "y" -new-name "yack" >> %t.result/variables_var-y.swift
 // RUN: diff -u %S/Outputs/variables/var-y.swift.expected %t.result/variables_var-y.swift

--- a/test/refactoring/rename/basic.swift
+++ b/test/refactoring/rename/basic.swift
@@ -27,6 +27,7 @@ struct Test {
   }
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t)
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=2:15 > %t/S1.swift
 // RUN: diff -u %S/Outputs/basic_ranges/S1.swift.expected %t/S1.swift

--- a/test/refactoring/rename/enum.swift
+++ b/test/refactoring/rename/enum.swift
@@ -9,6 +9,7 @@ func test() {
   let _ = Foo.second
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=2:8 > %t.result/first_def.swift
 // RUN: diff -u %S/Outputs/enum/first.swift.expected %t.result/first_def.swift

--- a/test/refactoring/rename/local.swift
+++ b/test/refactoring/rename/local.swift
@@ -55,6 +55,7 @@ func testCaptureVariable() {
   }
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=3:9 -new-name="xRenamed" > %t.result/localvar_1.swift
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=7:11 -new-name="xRenamed" > %t.result/localvar_2.swift

--- a/test/refactoring/rename/localEnum.swift
+++ b/test/refactoring/rename/localEnum.swift
@@ -7,6 +7,7 @@ func boop() {
   print(LocalEnum.north)
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=3:10 -new-name east > %t.result/north_def.swift
 // RUN: diff -u %S/Outputs/localEnum/north.swift.expected %t.result/north_def.swift

--- a/test/refactoring/rename/prefix_operator.swift
+++ b/test/refactoring/rename/prefix_operator.swift
@@ -2,6 +2,7 @@ let foo: Int = 12
 let negfoo = -foo
 print("opposite of \(foo) is \(negfoo)")
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=1:5 -new-name bar >> %t.result/def.swift

--- a/test/refactoring/rename/property.swift
+++ b/test/refactoring/rename/property.swift
@@ -3,6 +3,7 @@ var foo: String {
   return name
 }
 
+// REQUIRES: swift_swift_parser
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=2:7 > %t.result/computed_property.swift
 // RUN: diff -u %S/Outputs/property/computed_property.swift.expected %t.result/computed_property.swift

--- a/test/refactoring/rename/shorthand_shadow.swift
+++ b/test/refactoring/rename/shorthand_shadow.swift
@@ -1,3 +1,4 @@
+// REQUIRES: swift_swift_parser
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=%(line+2):29 | %FileCheck %s --check-prefix=OPTIONAL
 // OPTIONAL: func renameShorthandBinding(<base>opt</base>: Int?) {
 func renameShorthandBinding(opt: Int?) {

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -68,3 +68,10 @@ target_link_libraries(SourceKitSwiftLang PRIVATE
   clangAPINotes
   clangBasic)
 add_dependencies(SourceKitSwiftLang clang-tablegen-targets)
+
+if(SWIFT_BUILD_SWIFT_SYNTAX)
+  target_compile_definitions(SourceKitSwiftLang
+    PRIVATE
+    SWIFT_BUILD_SWIFT_SYNTAX
+  )
+endif()

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2520,6 +2520,10 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
 
     // FIXME: Don't silently eat errors here.
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
+#if !SWIFT_BUILD_SWIFT_SYNTAX
+      Receiver(RequestResult<RelatedIdentsInfo>::fromError("relatedidents is not supported because sourcekitd was built without swift-syntax"));
+      return;
+#else
       auto &CompInst = AstUnit->getCompilerInstance();
 
       auto *SrcFile = retrieveInputFile(InputFile, CompInst);
@@ -2592,6 +2596,7 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
       RelatedIdentsInfo Info;
       Info.Ranges = Ranges;
       Receiver(RequestResult<RelatedIdentsInfo>::fromResult(Info));
+#endif
     }
 
     void cancelled() override {


### PR DESCRIPTION
This allows building sourcekitd and swift-refactor with `SWIFT_BUILD_SWIFT_SYNTAX=NO`. In these builds, the `relatedidents` and `find-syntactic-rename-ranges` requests will always return an error.