### PR TITLE
[CSBindings] Don't favor unresolved key path type over a conjunction

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1320,6 +1320,14 @@ bool BindingSet::favoredOverConjunction(Constraint *conjunction) const {
     }
   }
 
+  // If key path capability is not yet determined it cannot be favored
+  // over a conjunction because:
+  // 1. There could be no other bindings and that would mean that
+  //    key path would be selected even though it's not yet ready.
+  // 2. A conjunction could be the source of type context for the key path.
+  if (TypeVar->getImpl().isKeyPathType() && isDelayed())
+    return false;
+
   return true;
 }
 

--- a/test/Constraints/rdar119055010.swift
+++ b/test/Constraints/rdar119055010.swift
@@ -1,0 +1,43 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://119055010 - greedy key path type assignment breaks keypath-to-function conversion
+
+protocol Executable {}
+
+final class Wrapper<Value> {
+  func update<Return>(_ work: (inout Value) throws -> Return) rethrows -> Return {
+    fatalError()
+  }
+}
+
+enum Lookup<Value> {
+  func flatMap<T>(_ transform: (Value) throws -> Lookup<T>) rethrows -> Lookup<T> { fatalError() }
+}
+
+protocol Entry {
+}
+
+extension Entry {
+  var executable: Lookup<any Executable> {
+    fatalError()
+  }
+}
+
+func lookup() -> Lookup<any Entry> {
+  fatalError()
+}
+
+struct Test {
+  struct Data {
+  }
+
+  let value = Wrapper<Data>()
+
+  func run() -> Lookup<any Executable> {
+    value.update { data in
+      let _ = 42
+      return lookup()
+    }
+    .flatMap(\.executable)
+  }
+}


### PR DESCRIPTION
If key path capability is not yet determined it cannot be favored over a conjunction because:

1. There could be no other bindings and that would mean that key path would be selected even though it's not yet ready.
2. A conjunction could be the source of type context for the key path.

Resolves: rdar://119055010

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
