### PR TITLE
Sema: Break request cycle when building TypeRefinementContexts

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -525,13 +525,8 @@ private:
     // get expanded from macros attached to the parent declaration. We must
     // not eagerly expand the attached property wrappers to avoid request
     // cycles.
-    if (auto *pattern = dyn_cast<PatternBindingDecl>(D)) {
-      if (auto firstVar = pattern->getAnchoringVarDecl(0)) {
-        // FIXME: We could narrow this further by detecting whether there are
-        // any macro expansions required to visit the CustomAttrs of the var.
-        if (firstVar->hasInitialValue() && !firstVar->isInitExposedToClients())
-          return true;
-      }
+    if (isa<PatternBindingDecl>(D)) {
+      return true;
     }
 
     return false;

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -16,7 +16,8 @@
 // CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticPropertyInferredType
 // CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=multiPatternStaticPropertyA
 // CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=multiPatternStaticPropertyA
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someComputedProperty
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someComputedProperty
+// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someComputedProperty
 // CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someOtherMethod()
 @available(OSX 10.51, *)
 class SomeClass {
@@ -61,7 +62,8 @@ func someFunction() { }
 
 // CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeProtocol
 // CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=protoMethod()
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=protoProperty
+// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=protoProperty
+// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=protoProperty
 @available(OSX 10.51, *)
 protocol SomeProtocol {
   @available(OSX 10.52, *)
@@ -232,6 +234,8 @@ extension SomeClass {
     return 53
   }()
 }
+
+// CHECK-NEXT: {{^}}  (decl_implicit versions=[10.13,+Inf) decl=wrappedValue
 
 @propertyWrapper
 struct Wrapper<T> {

--- a/test/stdlib/Observation/Inputs/ObservableClass2.swift
+++ b/test/stdlib/Observation/Inputs/ObservableClass2.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Observation
+
+@available(SwiftStdlib 5.9, *)
+@Observable final public class AnotherObservableClass {
+  public var name: String
+
+  init(name: String) {
+    self.name = name
+  }
+}

--- a/test/stdlib/Observation/ObservableAvailabilityCycle2.swift
+++ b/test/stdlib/Observation/ObservableAvailabilityCycle2.swift
@@ -1,0 +1,14 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-swift-frontend -typecheck -parse-as-library -external-plugin-path %swift-plugin-dir#%swift-plugin-server -primary-file %s %S/Inputs/ObservableClass2.swift
+
+// RUN: %target-swift-frontend -typecheck -parse-as-library -external-plugin-path %swift-plugin-dir#%swift-plugin-server %s -primary-file %S/Inputs/ObservableClass2.swift
+
+// REQUIRES: observation
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+@available(SwiftStdlib 5.9, *)
+let x = AnotherObservableClass(name: "Hello")


### PR DESCRIPTION
This fixes a recent regression introduced in the changes to make TRC construction lazier in b33a71d64fbef2a4b6d9c82b91f76a98758dfa5b.

Calling VarDecl::hasInitialValue() can ask for attached property wrappers, which can trigger macro expansion. However, macro expansion can result in TRC construction, causing a cycle.

Instead, just always build a lazy TRC for the initializer. It might not be needed, but it's safest to not ask anything of the VarDecl at all.

Fixes rdar://118452948.