### PR TITLE
[5.10][Concurrency] Downgrade missing `await` error to a warning for synchronous access to isolated global/static `let`s.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -537,10 +537,16 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
 }
 
 bool swift::isLetAccessibleAnywhere(const ModuleDecl *fromModule,
-                                    VarDecl *let) {
+                                    VarDecl *let,
+                                    ActorReferenceResult::Options &options) {
   auto isolation = getActorIsolation(let);
-  ActorReferenceResult::Options options = llvm::None;
   return varIsSafeAcrossActors(fromModule, let, isolation, options);
+}
+
+bool swift::isLetAccessibleAnywhere(const ModuleDecl *fromModule,
+                                    VarDecl *let) {
+  ActorReferenceResult::Options options = llvm::None;
+  return isLetAccessibleAnywhere(fromModule, let, options);
 }
 
 namespace {

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -550,6 +550,13 @@ bool isAccessibleAcrossActors(
     const DeclContext *fromDC,
     llvm::Optional<ReferencedActor> actorInstance = llvm::None);
 
+/// Determines if the 'let' can be read from anywhere within the given module,
+/// regardless of the isolation or async-ness of the context in which
+/// the var is read.
+bool isLetAccessibleAnywhere(const ModuleDecl *fromModule,
+                             VarDecl *let,
+                             ActorReferenceResult::Options &options);
+
 /// Check whether given variable references to a potentially
 /// isolated actor.
 bool isPotentiallyIsolatedActor(


### PR DESCRIPTION
* **Explanation**: https://github.com/apple/swift/pull/69607 fixed an issue where lazily initialized global and static variables with global actor isolation could be accessed synchronously from outside the actor. This caused the effects checker to diagnose missing `await` errors for synchronous access to such variables in `async` contexts. Compiler versions <5.10 allowed this code, so the error should be staged in as a warning until Swift 6.
* **Scope**: The only effect checker diagnostics downgraded by this change are the ones introduced in https://github.com/apple/swift/pull/69607.
* **Risk**: Low; downgrades a newly-diagnosed error to a warning until Swift 6.
* **Testing**: Updated test cases to expect a warning instead of an error.
* **Reviewer**: @ktoso 
* **Main branch PR**: https://github.com/apple/swift/pull/70151. Note that the change in TypeCheckEffects.cpp is slightly different than the `main` version because effects checking has been refactored on `main` for the typed throws implementation.