### PR TITLE
[NCGenerics] Serialization for noncopyable generic types.

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -704,6 +704,13 @@ public:
             inherited->isSpecificProtocol(KnownProtocolKind::Actor))
           return TypeWalker::Action::SkipChildren;
 
+        // Do not synthesize an extension to print a conformance to an
+        // invertible protocol, as their conformances are always re-inferred
+        // using the interface itself.
+        if (auto kp = inherited->getKnownProtocolKind())
+          if (getInvertibleProtocolKind(*kp))
+            return TypeWalker::Action::SkipChildren;
+
         if (inherited->isSPI() && printOptions.printPublicInterface())
           return TypeWalker::Action::Continue;
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 827; // apply isolation crossing
+const uint16_t SWIFTMODULE_VERSION_MINOR = 828; // ~Copyable / ~Escapable
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1271,6 +1271,8 @@ namespace decls_block {
   TYPE_LAYOUT(ProtocolCompositionTypeLayout,
     PROTOCOL_COMPOSITION_TYPE,
     BCFixed<1>,          // has AnyObject constraint
+    BCFixed<1>,          // has ~Copyable constraint
+    BCFixed<1>,          // has ~Escapable constraint
     BCArray<TypeIDField> // protocols
   );
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5574,11 +5574,25 @@ public:
     for (auto proto : composition->getMembers())
       protocols.push_back(S.addTypeRef(proto));
 
+    bool inverseCopyable = false, inverseEscapable = false;
+    for (auto ip : composition->getInverses()) {
+      switch (ip) {
+      case InvertibleProtocolKind::Copyable:
+        inverseCopyable = true;
+        break;
+      case InvertibleProtocolKind::Escapable:
+        inverseEscapable = true;
+        break;
+      };
+    }
+
     unsigned abbrCode =
         S.DeclTypeAbbrCodes[ProtocolCompositionTypeLayout::Code];
     ProtocolCompositionTypeLayout::emitRecord(
         S.Out, S.ScratchRecord, abbrCode,
         composition->hasExplicitAnyObject(),
+        inverseCopyable,
+        inverseEscapable,
         protocols);
   }
 

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -1,4 +1,10 @@
 // These are purely to add test coverage of different constructs when emitting modules
+
+public protocol _NoCopyP: ~Copyable {}
+public protocol _NoEscapableP: ~Escapable {}
+
+extension Int: _NoCopyP {}
+
 public struct _Toys {
   static func test_parallelAssignment() {
     var y: Int
@@ -18,5 +24,45 @@ public struct _Toys {
       }
   }
 
-  public static func pickOne<T>(_ a: T, _ b: T) -> T { return a }
+  public static func allCopyable1<T>(_ a: T, _ b: T) -> T { return a }
+
+  public static func allCopyable2<T>(_ s: T)
+                                  where T: _NoCopyP {}
+
+  public static func oneCopyable1<T, V: ~Copyable>(_ s: T, _ v: borrowing V)
+                                  where T: _NoCopyP {}
+
+  public static func oneCopyable2<T, V>(_ s: borrowing T, _ v: V)
+                                  where T: _NoCopyP, T: ~Copyable {}
+
+  public static func oneCopyable3<T, V>(_ s: borrowing T, _ v: V)
+                                  where T: _NoCopyP & ~Copyable {}
+
+  public static func basic_some(_ s: some _NoCopyP) {}
+
+  public static func basic_some_nc(_ s: borrowing some _NoCopyP & ~Copyable) {}
+
+  public static func oneEscapable<T, V>(_ s: T, _ v: V)
+                                    where T: _NoEscapableP, T: ~Escapable {}
+
+  public static func canEscapeButConforms<T: _NoEscapableP>(_ t: T) {}
+
+  public static func opaqueNonEscapable(_ s: some _NoEscapableP & ~Escapable) {}
+
+  public static func opaqueEscapable(_ s: some _NoEscapableP) {}
 }
+
+public struct ExplicitHello<T: ~Copyable>: ~Copyable {
+  let thing: T
+}
+extension ExplicitHello: Copyable where T: Copyable {}
+
+public struct Hello<T: ~Copyable> where T: ~Escapable {}
+
+public protocol TestAssocTypes {
+  associatedtype A: ~Copyable, _NoCopyP = Int
+}
+
+public typealias SomeAlias<G> = Hello<G>
+
+public typealias AliasWithInverse<G> = Hello<G> where G: ~Copyable, G: ~Escapable

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -1,19 +1,5 @@
-
-
-// A Swift × Haskell stdlib flavour.
-
-public struct Vector<T: ~Copyable> {
-
-  subscript(_ i: UInt) -> T {
-    fatalError("todo")
-  }
-}
-
-
-
-
-// These are purely to add test coverage of different constructs
-public struct Toys {
+// These are purely to add test coverage of different constructs when emitting modules
+public struct _Toys {
   static func test_parallelAssignment() {
     var y: Int
     var x: Int
@@ -32,4 +18,5 @@ public struct Toys {
       }
   }
 
+  public static func pickOne<T>(_ a: T, _ b: T) -> T { return a }
 }

--- a/test/ModuleInterface/Inputs/Swiftskell.swift
+++ b/test/ModuleInterface/Inputs/Swiftskell.swift
@@ -31,6 +31,13 @@ public extension Eq where Self: Equatable {
   }
 }
 
+/// MARK: Iteration
+
+public protocol Generator: ~Copyable {
+  associatedtype Element: ~Copyable
+  func next() -> Element
+}
+
 
 public struct Vector<T: ~Copyable> {
 

--- a/test/ModuleInterface/Inputs/Swiftskell.swift
+++ b/test/ModuleInterface/Inputs/Swiftskell.swift
@@ -1,0 +1,88 @@
+// --------------------------------
+// A Swift × Haskell stdlib flavour
+// --------------------------------
+
+/// MARK: GHC.Show
+
+public protocol Show: ~Copyable {
+  borrowing func show() -> String
+}
+
+public func print(_ s: borrowing some Show & ~Copyable) {
+  print(s.show())
+}
+
+/// MARK: Data.Eq
+
+public protocol Eq: ~Copyable {
+  static func ==(_ a: borrowing Self, _ b: borrowing Self) -> Bool
+  static func /=(_ a: borrowing Self, _ b: borrowing Self) -> Bool
+}
+
+public extension Eq {
+  static func /=(_ a: borrowing Self, _ b: borrowing Self) -> Bool {
+    return !(a == b)
+  }
+}
+
+public extension Eq where Self: Equatable {
+  static func ==(_ a: borrowing Self, _ b: borrowing Self) -> Bool {
+    return a == b
+  }
+}
+
+
+public struct Vector<T: ~Copyable> {
+
+  subscript(_ i: UInt) -> T {
+    fatalError("todo")
+  }
+}
+
+
+/// MARK: Data.Maybe
+
+public enum Maybe<Value: ~Copyable> {
+  case just(Value)
+  case nothing
+}
+
+extension Maybe: Show {
+  public borrowing func show() -> String {
+    fatalError("need borrowing switches")
+  }
+}
+
+extension Maybe: Eq where Value: Eq {
+  public static func ==(_ a: borrowing Self, _ b: borrowing Self) -> Bool {
+    fatalError("need borrowing switches")
+  }
+}
+
+public func maybe<A: ~Copyable, B>(_ defaultVal: B,
+                                   _ fn: (consuming A) -> B)
+                                   -> (consuming Maybe<A>) -> B {
+  return { (_ mayb: consuming Maybe<A>) -> B in
+    switch consume mayb {
+      case .just(_):
+        fatalError("waiting for bugfix here")
+        // return fn(val)
+      case .nothing:
+        return defaultVal
+    }
+  }
+}
+
+@inlinable
+public func fromMaybe<A>(_ defaultVal: A) -> (Maybe<A>) -> A {
+  return maybe(defaultVal, {$0})
+}
+
+public func isJust<A: ~Copyable>(_ m: borrowing Maybe<A>) -> Bool {
+  fatalError("need borrowing switches")
+}
+
+@inlinable
+public func isNothing<A: ~Copyable>(_ m: borrowing Maybe<A>) -> Bool {
+  return !isJust(m)
+}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -2,12 +2,14 @@
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature NonEscapableTypes \
 // RUN:     -o %t/NoncopyableGenerics_Misc.swiftmodule \
 // RUN:     -emit-module-interface-path %t/NoncopyableGenerics_Misc.swiftinterface \
 // RUN:     %S/Inputs/NoncopyableGenerics_Misc.swift
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature NonEscapableTypes \
 // RUN:     -o %t/Swiftskell.swiftmodule \
 // RUN:     -emit-module-interface-path %t/Swiftskell.swiftinterface \
 // RUN:     %S/Inputs/Swiftskell.swift
@@ -17,28 +19,101 @@
 // RUN: %FileCheck %s --check-prefix=CHECK-MISC < %t/NoncopyableGenerics_Misc.swiftinterface
 // RUN: %FileCheck %s < %t/Swiftskell.swiftinterface
 
+// See if we can compile a module through just the interface and typecheck using it.
+
+// RUN: %target-swift-frontend -compile-module-from-interface \
+// RUN:    -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature NonEscapableTypes \
+// RUN:    %t/NoncopyableGenerics_Misc.swiftinterface -o %t/NoncopyableGenerics_Misc.swiftmodule
+
+// RUN: %target-swift-frontend -compile-module-from-interface \
+// RUN:    -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature NonEscapableTypes \
+// RUN:    %t/Swiftskell.swiftinterface -o %t/Swiftskell.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -I %t %s \
+// RUN:    -enable-experimental-feature NoncopyableGenerics \
+// RUN:    -enable-experimental-feature NonEscapableTypes
+
 // REQUIRES: asserts
 
 import NoncopyableGenerics_Misc
 
-// CHECK-MISC: public struct rdar118697289_S1<Element> where Element : Swift.Copyable {
-// CHECK-MISC: public struct rdar118697289_S2<Element> where Element : Swift.Copyable {
-// CHECK-MISC: public static func pickOne<T>(_ a: T, _ b: T) -> T where T : Swift.Copyable
+// CHECK-MISC: public struct _Toys {
+// CHECK-MISC: public struct rdar118697289_S1<Element> {
+// CHECK-MISC: public struct rdar118697289_S2<Element> {
+// CHECK-MISC: public static func allCopyable1<T>(_ a: T, _ b: T) -> T
 
-// CHECK-MISC: extension NoncopyableGenerics_Misc._Toys : Swift.Copyable {}
-// CHECK-MISC: extension NoncopyableGenerics_Misc._Toys.rdar118697289_S1 : Swift.Copyable {}
-// CHECK-MISC: extension NoncopyableGenerics_Misc._Toys.rdar118697289_S2 : Swift.Copyable {}
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func allCopyable2<T>(_ s: T) where T : NoncopyableGenerics_Misc._NoCopyP
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func oneCopyable1<T, V>(_ s: T, _ v: borrowing V) where T : {{.*}}._NoCopyP, V : ~Copyable
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func oneCopyable2<T, V>(_ s: borrowing T, _ v: V) where T : {{.*}}._NoCopyP, T : ~Copyable
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func oneCopyable3<T, V>(_ s: borrowing T, _ v: V) where T : {{.*}}._NoCopyP, T : ~Copyable
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func basic_some(_ s: some _NoCopyP)
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func basic_some_nc(_ s: borrowing some _NoCopyP & ~Copyable)
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func oneEscapable<T, V>(_ s: T, _ v: V) where T : NoncopyableGenerics_Misc._NoEscapableP, T : ~Escapable
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func canEscapeButConforms<T>(_ t: T) where T : {{.*}}._NoEscapableP
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func opaqueNonEscapable(_ s: some _NoEscapableP & ~Escapable)
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public static func opaqueEscapable(_ s: some _NoEscapableP)
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public struct ExplicitHello<T> : ~Copyable where T : ~Copyable {
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: extension {{.*}}.ExplicitHello : Swift.Copyable where T : Swift.Copyable {
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public struct Hello<T> where T : ~Copyable, T : ~Escapable {
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public protocol TestAssocTypes {
+// CHECK-MISC-NEXT:   associatedtype A : {{.*}}._NoCopyP, ~Copyable
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public typealias SomeAlias<G> = {{.*}}.Hello<G>
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public typealias AliasWithInverse<G> = {{.*}}.Hello<G> where G : ~Copyable, G : ~Escapable
+
+///////////////////////////////////////////////////////////////////////
+// Synthesized conditional conformances are next
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: extension {{.*}}.Hello : Swift.Copyable where T : Swift.Copyable {
+
+////////////////////////////////////////////////////////////////////////
+//    At the end, ensure there are no synthesized Copyable extensions
+
+// CHECK-MISC-NOT: extension {{.*}}_Toys : Swift.Copyable
 
 import Swiftskell
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public protocol Show {
+// CHECK-NEXT: public protocol Show : ~Copyable {
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-NEXT: public func print(_ s: borrowing some Show & ~Copyable)
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public protocol Eq {
+// CHECK-NEXT: public protocol Eq : ~Copyable {
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-NEXT: extension Swiftskell.Eq {
@@ -47,10 +122,14 @@ import Swiftskell
 // CHECK-NEXT: extension Swiftskell.Eq where Self : Swift.Equatable {
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public struct Vector<T> {
+// CHECK-NEXT: public protocol Generator : ~Copyable {
+// CHECK-NEXT:   associatedtype Element : ~Copyable
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public enum Maybe<Value> {
+// CHECK-NEXT: public struct Vector<T> where T : ~Copyable {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public enum Maybe<Value> where Value : ~Copyable {
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-NEXT: extension Swiftskell.Maybe : Swiftskell.Show {
@@ -59,13 +138,13 @@ import Swiftskell
 // CHECK-NEXT: extension Swiftskell.Maybe : Swiftskell.Eq where Value : Swiftskell.Eq {
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public func maybe<A, B>(_ defaultVal: B, _ fn: (consuming A) -> B) -> (consuming Swiftskell.Maybe<A>) -> B where B : Swift.Copyable
+// CHECK-NEXT: public func maybe<A, B>(_ defaultVal: B, _ fn: (consuming A) -> B) -> (consuming Swiftskell.Maybe<A>) -> B where A : ~Copyable
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: @inlinable public func fromMaybe<A>(_ defaultVal: A) -> (Swiftskell.Maybe<A>) -> A where A : Swift.Copyable {
+// CHECK-NEXT: @inlinable public func fromMaybe<A>(_ defaultVal: A) -> (Swiftskell.Maybe<A>) -> A {
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public func isJust<A>(_ m: borrowing Swiftskell.Maybe<A>) -> Swift.Bool
+// CHECK-NEXT: public func isJust<A>(_ m: borrowing Swiftskell.Maybe<A>) -> Swift.Bool where A : ~Copyable
 
 
 struct FileDescriptor: ~Copyable, Eq, Show {

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -1,8 +1,81 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-library-evolution -emit-module -o %t/NoncopyableGenerics.swiftmodule -emit-module-interface-path %t/NoncopyableGenerics.swiftinterface -enable-experimental-feature NoncopyableGenerics %S/Inputs/NoncopyableGenerics.swift
-// RUN: %target-swift-frontend -emit-sil -sil-verify-all -I %t %s > /dev/null
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -o %t/NoncopyableGenerics_Misc.swiftmodule \
+// RUN:     -emit-module-interface-path %t/NoncopyableGenerics_Misc.swiftinterface \
+// RUN:     %S/Inputs/NoncopyableGenerics_Misc.swift
+
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -o %t/Swiftskell.swiftmodule \
+// RUN:     -emit-module-interface-path %t/Swiftskell.swiftinterface \
+// RUN:     %S/Inputs/Swiftskell.swift
+
+// Check the interfaces
+
+// RUN: %FileCheck %s --check-prefix=CHECK-MISC < %t/NoncopyableGenerics_Misc.swiftinterface
+// RUN: %FileCheck %s < %t/Swiftskell.swiftinterface
 
 // REQUIRES: asserts
 
-import NoncopyableGenerics
+import NoncopyableGenerics_Misc
+
+// CHECK-MISC: public struct rdar118697289_S1<Element> where Element : Swift.Copyable {
+// CHECK-MISC: public struct rdar118697289_S2<Element> where Element : Swift.Copyable {
+// CHECK-MISC: public static func pickOne<T>(_ a: T, _ b: T) -> T where T : Swift.Copyable
+
+// CHECK-MISC: extension NoncopyableGenerics_Misc._Toys : Swift.Copyable {}
+// CHECK-MISC: extension NoncopyableGenerics_Misc._Toys.rdar118697289_S1 : Swift.Copyable {}
+// CHECK-MISC: extension NoncopyableGenerics_Misc._Toys.rdar118697289_S2 : Swift.Copyable {}
+
+import Swiftskell
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public protocol Show {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public func print(_ s: borrowing some Show & ~Copyable)
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public protocol Eq {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: extension Swiftskell.Eq {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: extension Swiftskell.Eq where Self : Swift.Equatable {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public struct Vector<T> {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public enum Maybe<Value> {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: extension Swiftskell.Maybe : Swiftskell.Show {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: extension Swiftskell.Maybe : Swiftskell.Eq where Value : Swiftskell.Eq {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public func maybe<A, B>(_ defaultVal: B, _ fn: (consuming A) -> B) -> (consuming Swiftskell.Maybe<A>) -> B where B : Swift.Copyable
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: @inlinable public func fromMaybe<A>(_ defaultVal: A) -> (Swiftskell.Maybe<A>) -> A where A : Swift.Copyable {
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-NEXT: public func isJust<A>(_ m: borrowing Swiftskell.Maybe<A>) -> Swift.Bool
+
+
+struct FileDescriptor: ~Copyable, Eq, Show {
+  let id: Int
+
+  func show() -> String {
+    return "FileDescriptor(id:\(id))"
+  }
+
+  static func ==(_ a: borrowing Self, _ b: borrowing Self) -> Bool {
+    return a.id == b.id
+  }
+}


### PR DESCRIPTION
This PR covers serialization and deserialization of ~Copyable types when NoncopyableGenerics is enabled. This means that you can now write:

```
public protocol P: ~Copyable {}
```

and emit Swift module containing that type, to be imported by another module.

resolves rdar://118947007&119531975