### PR TITLE
[Typed throws] Implement support for do throws(...) syntax 

### DIFF
--- a/include/swift/AST/CatchNode.h
+++ b/include/swift/AST/CatchNode.h
@@ -35,7 +35,7 @@ public:
   ///
   /// Returns the thrown error type for a throwing context, or \c llvm::None
   /// if this is a non-throwing context.
-  llvm::Optional<Type> getThrownErrorTypeInContext(ASTContext &ctx) const;
+  llvm::Optional<Type> getThrownErrorTypeInContext(DeclContext *dc) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1196,6 +1196,9 @@ ERROR(expected_catch_where_expr,PointsToFirstBadToken,
 ERROR(docatch_not_trycatch,PointsToFirstBadToken,
       "the 'do' keyword is used to specify a 'catch' region",
       ())
+ERROR(do_throws_without_catch,none,
+      "a 'do' statement with a 'throws' clause must have at least one 'catch'",
+      ())
 
 // C-Style For Stmt
 ERROR(c_style_for_stmt_removed,none,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -46,6 +46,7 @@ class ContextualPattern;
 class ContinueStmt;
 class DefaultArgumentExpr;
 class DefaultArgumentType;
+class DoCatchStmt;
 struct ExternalMacroDefinition;
 class ClosureExpr;
 class GenericParamList;
@@ -2299,6 +2300,27 @@ private:
 public:
   // Separate caching.
   bool isCached() const { return true; }
+  llvm::Optional<Type> getCachedResult() const;
+  void cacheResult(Type value) const;
+};
+
+/// Determines the explicitly-written thrown error type in a do..catch block.
+class DoCatchExplicitThrownTypeRequest
+    : public SimpleRequest<DoCatchExplicitThrownTypeRequest,
+                           Type(DeclContext *, DoCatchStmt *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Type evaluate(Evaluator &evaluator, DeclContext *dc, DoCatchStmt *stmt) const;
+
+public:
+  // Separate caching.
+  bool isCached() const;
   llvm::Optional<Type> getCachedResult() const;
   void cacheResult(Type value) const;
 };

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -360,6 +360,9 @@ SWIFT_REQUEST(TypeChecker, ParamSpecifierRequest,
               ParamDecl::Specifier(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ThrownTypeRequest,
               Type(AbstractFunctionDecl *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DoCatchExplicitThrownTypeRequest,
+              Type(DeclContext *, DoCatchStmt *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResultTypeRequest,
               Type(ValueDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AreAllStoredPropertiesDefaultInitableRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11691,7 +11691,7 @@ MacroDiscriminatorContext::getParentOf(FreestandingMacroExpansion *expansion) {
 }
 
 llvm::Optional<Type>
-CatchNode::getThrownErrorTypeInContext(ASTContext &ctx) const {
+CatchNode::getThrownErrorTypeInContext(DeclContext *dc) const {
   if (auto func = dyn_cast<AbstractFunctionDecl *>()) {
     if (auto thrownError = func->getEffectiveThrownErrorType())
       return func->mapTypeIntoContext(*thrownError);
@@ -11708,7 +11708,7 @@ CatchNode::getThrownErrorTypeInContext(ASTContext &ctx) const {
   }
 
   auto doCatch = get<DoCatchStmt *>();
-  if (auto thrownError = doCatch->getCaughtErrorType()) {
+  if (auto thrownError = doCatch->getCaughtErrorType(dc)) {
     if (thrownError->isNever())
       return llvm::None;
 
@@ -11716,5 +11716,5 @@ CatchNode::getThrownErrorTypeInContext(ASTContext &ctx) const {
   }
 
   // If we haven't computed the error type yet, do so now.
-  return ctx.getErrorExistentialType();
+  return dc->getASTContext().getErrorExistentialType();
 }

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -450,12 +450,15 @@ Expr *ForEachStmt::getTypeCheckedSequence() const {
 }
 
 DoCatchStmt *DoCatchStmt::create(ASTContext &ctx, LabeledStmtInfo labelInfo,
-                                 SourceLoc doLoc, Stmt *body,
+                                 SourceLoc doLoc,
+                                 SourceLoc throwsLoc, TypeLoc thrownType,
+                                 Stmt *body,
                                  ArrayRef<CaseStmt *> catches,
                                  llvm::Optional<bool> implicit) {
   void *mem = ctx.Allocate(totalSizeToAlloc<CaseStmt *>(catches.size()),
                            alignof(DoCatchStmt));
-  return ::new (mem) DoCatchStmt(labelInfo, doLoc, body, catches, implicit);
+  return ::new (mem) DoCatchStmt(labelInfo, doLoc, throwsLoc, thrownType, body,
+                                 catches, implicit);
 }
 
 bool CaseLabelItem::isSyntacticallyExhaustive() const {
@@ -472,7 +475,17 @@ bool DoCatchStmt::isSyntacticallyExhaustive() const {
   return false;
 }
 
-Type DoCatchStmt::getCaughtErrorType() const {
+Type DoCatchStmt::getExplicitlyThrownType(DeclContext *dc) const {
+  ASTContext &ctx = dc->getASTContext();
+  DoCatchExplicitThrownTypeRequest request{dc, const_cast<DoCatchStmt *>(this)};
+  return evaluateOrDefault(ctx.evaluator, request, Type());
+}
+
+Type DoCatchStmt::getCaughtErrorType(DeclContext *dc) const {
+  // Check for an explicitly-specified error type.
+  if (Type explicitError = getExplicitlyThrownType(dc))
+    return explicitError;
+
   auto firstPattern = getCatches()
     .front()
     ->getCaseLabelItems()

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -970,6 +970,29 @@ void ThrownTypeRequest::cacheResult(Type type) const {
 }
 
 //----------------------------------------------------------------------------//
+// DoCatchExplicitThrownTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+bool DoCatchExplicitThrownTypeRequest::isCached() const {
+  auto *const stmt = std::get<1>(getStorage());
+  return stmt->getThrowsLoc().isValid();
+}
+
+llvm::Optional<Type> DoCatchExplicitThrownTypeRequest::getCachedResult() const {
+  auto *const stmt = std::get<1>(getStorage());
+  Type thrownType = stmt->ThrownType.getType();
+  if (thrownType.isNull())
+    return llvm::None;
+
+  return thrownType;
+}
+
+void DoCatchExplicitThrownTypeRequest::cacheResult(Type type) const {
+  auto *const stmt = std::get<1>(getStorage());
+  stmt->ThrownType.setType(type);
+}
+
+//----------------------------------------------------------------------------//
 // ResultTypeRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2191,8 +2191,8 @@ ParserResult<Stmt> Parser::parseStmtRepeat(LabeledStmtInfo labelInfo) {
 
 /// 
 ///   stmt-do:
-///     (identifier ':')? 'do' stmt-brace
-///     (identifier ':')? 'do' stmt-brace stmt-catch+
+///     (identifier ':')? 'do' throws-clause? stmt-brace
+///     (identifier ':')? 'do' throws-clause? stmt-brace stmt-catch+
 ParserResult<Stmt> Parser::parseStmtDo(LabeledStmtInfo labelInfo,
                                        bool shouldSkipDoTokenConsume) {
   SourceLoc doLoc;
@@ -2204,6 +2204,25 @@ ParserResult<Stmt> Parser::parseStmtDo(LabeledStmtInfo labelInfo,
   }
 
   ParserStatus status;
+
+  // Parse the optional 'throws' clause.
+  SourceLoc throwsLoc;
+  TypeRepr *thrownType = nullptr;
+  if (consumeIf(tok::kw_throws, throwsLoc)) {
+    // Parse the thrown error type.
+    SourceLoc lParenLoc;
+    if (consumeIf(tok::l_paren, lParenLoc)) {
+      ParserResult<TypeRepr> parsedThrownTy =
+          parseType(diag::expected_thrown_error_type);
+      thrownType = parsedThrownTy.getPtrOrNull();
+      status |= parsedThrownTy;
+
+      SourceLoc rParenLoc;
+      parseMatchingToken(
+          tok::r_paren, rParenLoc,
+          diag::expected_rparen_after_thrown_error_type, lParenLoc);
+    }
+  }
 
   ParserResult<BraceStmt> body =
       parseBraceItemList(diag::expected_lbrace_after_do);
@@ -2236,7 +2255,12 @@ ParserResult<Stmt> Parser::parseStmtDo(LabeledStmtInfo labelInfo,
     }
 
     return makeParserResult(status,
-      DoCatchStmt::create(Context, labelInfo, doLoc, body.get(), allClauses));
+      DoCatchStmt::create(Context, labelInfo, doLoc, throwsLoc, thrownType,
+                          body.get(), allClauses));
+  }
+
+  if (throwsLoc.isValid()) {
+    diagnose(throwsLoc, diag::do_throws_without_catch);
   }
 
   // If we dont see a 'while' or see a 'while' that starts

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1117,7 +1117,7 @@ void StmtEmitter::visitDoStmt(DoStmt *S) {
 }
 
 void StmtEmitter::visitDoCatchStmt(DoCatchStmt *S) {
-  Type formalExnType = S->getCaughtErrorType();
+  Type formalExnType = S->getCaughtErrorType(SGF.FunctionDC);
   auto &exnTL = SGF.getTypeLowering(formalExnType);
 
   SILValue exnArg;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1195,8 +1195,7 @@ public:
         DC->getParentModule(), TS->getThrowLoc());
     Type errorType;
     if (catchNode) {
-      errorType = catchNode.getThrownErrorTypeInContext(getASTContext())
-          .value_or(Type());
+      errorType = catchNode.getThrownErrorTypeInContext(DC).value_or(Type());
     }
 
     // If there was no error type, use 'any Error'. We'll check it later.
@@ -1679,7 +1678,7 @@ public:
     // Do-catch statements always limit exhaustivity checks.
     bool limitExhaustivityChecks = true;
 
-    Type caughtErrorType = TypeChecker::catchErrorType(Ctx, S);
+    Type caughtErrorType = TypeChecker::catchErrorType(DC, S);
     auto catches = S->getCatches();
     checkSiblingCaseStmts(catches.begin(), catches.end(),
                           CaseParentKind::DoCatch, limitExhaustivityChecks,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1176,7 +1176,7 @@ llvm::Optional<Type> canThrow(ASTContext &ctx, Expr *expr);
 ///
 /// The error type is used in the catch clauses and, for a nonexhausive
 /// do-catch, is implicitly rethrown out of the do...catch block.
-Type catchErrorType(ASTContext &ctx, DoCatchStmt *stmt);
+Type catchErrorType(DeclContext *dc, DoCatchStmt *stmt);
 
 /// Given two error types, merge them into the "union" of both error types
 /// that is a supertype of both error types.

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -146,3 +146,27 @@ func rethrowsLike<E>(_ body: () throws(E) -> Void) throws(E) { }
 func fromRethrows(body: () throws -> Void) rethrows {
   try rethrowsLike(body) // expected-error{{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
 }
+
+// Explicit specification of the thrown type within a `do..catch` block.
+func testDoCatchExplicitTyped() {
+  do throws {
+    try doHomework() // would normally infer HomeworkError
+  } catch {
+    let _: Int = error // expected-error{{cannot convert value of type 'any Error' to specified type 'Int'}}
+  }
+
+  do throws(any Error) {
+    try doHomework() // would normally infer HomeworkError
+  } catch {
+    let _: Int = error // expected-error{{cannot convert value of type 'any Error' to specified type 'Int'}}
+  }
+
+  do throws(HomeworkError) {
+    throw .forgot // okay, HomeworkError.forgot based on context
+  } catch {
+    let _: Int = error // expected-error{{cannot convert value of type 'HomeworkError' to specified type 'Int'}}
+  }
+
+  do throws(HomeworkError) { // expected-error{{a 'do' statement with a 'throws' clause must have at least one 'catch'}}
+  }
+}


### PR DESCRIPTION
During the review of [SE-0413](https://apple.github.io/swift-evolution/#?proposal=SE-0413), typed throws, the notion of a `do throws` syntax for `do..catch` blocks came up. Implement that syntax and semantics, as a way to explicitly specify the type of error that is thrown from the `do` body in `do..catch` statement.