### PR TITLE
Fix ModuleInterface/noncopyable_generics.swift

### DIFF
--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -3,5 +3,6 @@
 // RUN: %target-swift-frontend -enable-library-evolution -emit-module -o %t/NoncopyableGenerics.swiftmodule -emit-module-interface-path %t/NoncopyableGenerics.swiftinterface -enable-experimental-feature NoncopyableGenerics %S/Inputs/NoncopyableGenerics.swift
 // RUN: %target-swift-frontend -emit-sil -sil-verify-all -I %t %s > /dev/null
 
+// REQUIRES: asserts
 
 import NoncopyableGenerics


### PR DESCRIPTION
Experimental features are disabled in no-asserts compilers.
