### PR TITLE
[test] Replace %swift-build-cxx-plugin with %swift-build-c-plugin

### DIFF
--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -14,7 +14,7 @@ if get_target_os() in ['windows-msvc']:
     config.substitutions.insert(
         0,
         (
-            '%swift-build-cxx-plugin',
+            '%swift-build-c-plugin',
             '%clang -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin'
         )
     )
@@ -24,7 +24,7 @@ else:
     config.substitutions.insert(
         0,
         (
-            '%swift-build-cxx-plugin',
+            '%swift-build-c-plugin',
             '%clang %c-flags %exe-linker-flags -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin -Xlinker -rpath -Xlinker %swift-lib-dir'
         )
     )

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %swift-build-cxx-plugin -o %t/mock-plugin %t/plugin.c
+// RUN: %swift-build-c-plugin -o %t/mock-plugin %t/plugin.c
 
 // RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
 // RUN:   -typecheck -verify \

--- a/test/Macros/macro_plugin_disable_sandbox.swift
+++ b/test/Macros/macro_plugin_disable_sandbox.swift
@@ -17,7 +17,7 @@
 // RUN:   %t/MacroDefinition.swift \
 // RUN:   -g -no-toolchain-stdlib-rpath
 
-// RUN: %swift-build-cxx-plugin -o %t/mock-plugin %t/TestPlugin.c
+// RUN: %swift-build-c-plugin -o %t/mock-plugin %t/TestPlugin.c
 
 //== Nested sandbox. Expected to fail because sandbox-exec doesn't support nested sandboxing.
 // RUN: not sandbox-exec -p '(version 1)(allow default)' \

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %swift-build-cxx-plugin -o %t/mock-plugin %t/plugin.c
+// RUN: %swift-build-c-plugin -o %t/mock-plugin %t/plugin.c
 
 // RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
 // RUN:   -typecheck -verify \

--- a/test/Macros/macro_plugin_searchorder.swift
+++ b/test/Macros/macro_plugin_searchorder.swift
@@ -37,7 +37,7 @@
 // RUN:   %t/src/MacroDefinition.swift
 
 //#-- For -load-plugin-executable
-// RUN: %swift-build-cxx-plugin -o %t/libexec/MacroDefinitionPlugin %t/src/MacroDefinition.c
+// RUN: %swift-build-c-plugin -o %t/libexec/MacroDefinitionPlugin %t/src/MacroDefinition.c
 
 //#-- Expect -load-plugin-library
 // RUN: %target-build-swift %t/src/test.swift \

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -15,7 +15,7 @@
 // RUN:   %S/Inputs/syntax_macro_definitions.swift
 
 //#-- Prepare the macro executable plugin.
-// RUN: %swift-build-cxx-plugin -o %t/mock-plugin %t/src/plugin.c
+// RUN: %swift-build-c-plugin -o %t/mock-plugin %t/src/plugin.c
 
 //#-- Prepare the macro library.
 // RUN: %target-swift-frontend \


### PR DESCRIPTION
As pointed out in https://github.com/apple/swift/pull/70136#discussion_r1411417454 the substitution name does not make sense because we are compiling C code, not C++.

This should not introduce any behavioural changes.
