### PR TITLE
[Backtracing][Android] Fix armv7 build

### DIFF
--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -243,7 +243,11 @@ handle_fatal_signal(int signum,
 #elif defined(__arm64__) || defined(__aarch64__)
   pc = (void *)(ctx->uc_mcontext.pc);
 #elif defined(__arm__)
+#if defined(__ANDROID__)
+  pc = (void *)(ctx->uc_mcontext.arm_pc);
+#else
   pc = (void *)(ctx->uc_mcontext.gprs[15]);
+#endif
 #endif
 
   _swift_displayCrashMessage(signum, pc);


### PR DESCRIPTION
Cherrypick of #69913

__Explanation:__ Add [the correct name of this field for Android armv7](https://android.googlesource.com/platform/bionic/+/180edefbd287c39caeb9d48784a9a10ac35f3636/libc/kernel/uapi/asm-arm/asm/sigcontext.h#28), which gets the build working again.

__Scope:__ backtracing fix that only affects one platform

__Issue:__ none

__Risk:__ none, since it only affects that niche platform

__Testing:__ I apply this patch on my daily Android CI to get the build working, finagolfin/swift-android-sdk@48c4993.

__Reviewer:__ @al45tair