### PR TITLE
Platform: remove cplusplus requirement on XAudio29

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -219,8 +219,6 @@ module WinSDK [system] {
       export *
 
       link "xaudio2.lib"
-
-      requires cplusplus
     }
 
     // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was


### PR DESCRIPTION
The header is usable without C++ interop.  This should make it easier to use the module in many cases.