### PR TITLE
[ASTGen] Generalize BridgedNullable

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -214,55 +214,37 @@ extension ASTGenVisitor {
 extension ASTGenVisitor {
   @inline(__always)
   func generate(type node: TypeSyntax?) -> BridgedNullableTypeRepr {
-    self.map(node, generate(type:))
+    node.map(generate(type:)).asNullable
   }
 
   @inline(__always)
   func generate(expr node: ExprSyntax?) -> BridgedNullableExpr {
-    self.map(node, generate(expr:))
+    node.map(generate(expr:)).asNullable
   }
 
   @inline(__always)
   func generate(genericParameterClause node: GenericParameterClauseSyntax?) -> BridgedNullableGenericParamList {
-    self.map(node, generate(genericParameterClause:))
+    node.map(generate(genericParameterClause:)).asNullable
   }
 
   @inline(__always)
   func generate(genericWhereClause node: GenericWhereClauseSyntax?) -> BridgedNullableTrailingWhereClause {
-    self.map(node, generate(genericWhereClause:))
+    node.map(generate(genericWhereClause:)).asNullable
   }
 
   @inline(__always)
   func generate(enumCaseParameterClause node: EnumCaseParameterClauseSyntax?) -> BridgedNullableParameterList {
-    self.map(node, generate(enumCaseParameterClause:))
+    node.map(generate(enumCaseParameterClause:)).asNullable
   }
 
   @inline(__always)
   func generate(inheritedTypeList node: InheritedTypeListSyntax?) -> BridgedArrayRef {
-    self.map(node, generate(inheritedTypeList:))
+    node.map(generate(inheritedTypeList:)) ?? .init()
   }
 
   @inline(__always)
   func generate(precedenceGroupNameList node: PrecedenceGroupNameListSyntax?) -> BridgedArrayRef {
-    self.map(node, generate(precedenceGroupNameList:))
-  }
-
-  // Helper function for `generate(foo: FooSyntax?)` methods.
-  @inline(__always)
-  private func map<Node: SyntaxProtocol, Result: HasNullable>(
-    _ node: Node?,
-    _ body: (Node) -> Result
-  ) -> Result.Nullable {
-    return Result.asNullable(node.map(body))
-  }
-
-  // Helper function for `generate(barList: BarListSyntax?)` methods for collection nodes.
-  @inline(__always)
-  private func map<Node: SyntaxCollection>(
-    _ node: Node?,
-    _ body: (Node) -> BridgedArrayRef
-  ) -> BridgedArrayRef {
-    return node.map(body) ?? .init()
+    node.map(generate(precedenceGroupNameList:)) ?? .init()
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -14,69 +14,57 @@ import ASTBridging
 import BasicBridging
 import SwiftSyntax
 
-extension BridgedSourceLoc: ExpressibleByNilLiteral {
+protocol BridgedNullable: ExpressibleByNilLiteral {
+  associatedtype RawPtr
+  init(raw: RawPtr?)
+}
+extension BridgedNullable {
   public init(nilLiteral: ()) {
     self.init(raw: nil)
   }
 }
 
-extension BridgedIdentifier: ExpressibleByNilLiteral {
-  public init(nilLiteral: ()) {
-    self.init(raw: nil)
-  }
-}
+extension BridgedSourceLoc: BridgedNullable {}
+extension BridgedIdentifier: BridgedNullable {}
+extension BridgedNullableExpr: BridgedNullable {}
+extension BridgedNullableStmt: BridgedNullable {}
+extension BridgedNullableTypeRepr: BridgedNullable {}
+extension BridgedNullablePattern: BridgedNullable {}
+extension BridgedNullableGenericParamList: BridgedNullable {}
+extension BridgedNullableTrailingWhereClause: BridgedNullable {}
+extension BridgedNullableParameterList: BridgedNullable {}
 
 /// Protocol that declares that there's a "Nullable" variation of the type.
 ///
 /// E.g. BridgedExpr vs BridgedNullableExpr.
-protocol HasNullable {
-  associatedtype Nullable
-
-  /// Convert an `Optional<Self>` to `Nullable`.
-  static func asNullable(_ node: Self?) -> Nullable
+protocol BridgedHasNullable {
+  associatedtype Nullable: BridgedNullable
+  var raw: Nullable.RawPtr { get }
 }
-
-extension Optional where Wrapped: HasNullable {
+extension Optional where Wrapped: BridgedHasNullable {
   /// Convert an Optional to Nullable variation of the wrapped type.
   var asNullable: Wrapped.Nullable {
-    Wrapped.asNullable(self)
+    Wrapped.Nullable(raw: self?.raw)
   }
 }
 
-extension BridgedStmt: HasNullable {
-  static func asNullable(_ node: Self?) -> BridgedNullableStmt {
-    .init(raw: node?.raw)
-  }
+extension BridgedStmt: BridgedHasNullable {
+  typealias Nullable = BridgedNullableStmt
 }
-
-extension BridgedExpr: HasNullable {
-  static func asNullable(_ node: Self?) -> BridgedNullableExpr {
-    .init(raw: node?.raw)
-  }
+extension BridgedExpr: BridgedHasNullable {
+  typealias Nullable = BridgedNullableExpr
 }
-
-extension BridgedTypeRepr: HasNullable {
-  static func asNullable(_ node: Self?) -> BridgedNullableTypeRepr {
-    .init(raw: node?.raw)
-  }
+extension BridgedTypeRepr: BridgedHasNullable {
+  typealias Nullable = BridgedNullableTypeRepr
 }
-
-extension BridgedGenericParamList: HasNullable {
-  static func asNullable(_ node: Self?) -> BridgedNullableGenericParamList {
-    .init(raw: node?.raw)
-  }
+extension BridgedGenericParamList: BridgedHasNullable {
+  typealias Nullable = BridgedNullableGenericParamList
 }
-
-extension BridgedTrailingWhereClause: HasNullable {
-  static func asNullable(_ node: Self?) -> BridgedNullableTrailingWhereClause {
-    .init(raw: node?.raw)
-  }
+extension BridgedTrailingWhereClause: BridgedHasNullable {
+  typealias Nullable = BridgedNullableTrailingWhereClause
 }
-
-extension BridgedParameterList: HasNullable {
-  static func asNullable(_ node: Self?) -> BridgedNullableParameterList {
-    .init(raw: node?.raw)
-  }
+extension BridgedParameterList: BridgedHasNullable {
+  typealias Nullable = BridgedNullableParameterList
 }
 
 public extension BridgedSourceLoc {


### PR DESCRIPTION
Declare `BridgedNullable` protocol for `ExpressibleByNilLiteral`.
Simplify `HasNullable` implementation using `BridgedNullable`, and rename it to `BridgedHasNullable`.
