### PR TITLE
[Distributed] Bring back module interface test for DA

### DIFF
--- a/test/ModuleInterface/distributed_actors_module.swift
+++ b/test/ModuleInterface/distributed_actors_module.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/TestResilient.swiftinterface) %s -module-name TestResilient
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestResilient.swiftinterface) -module-name TestResilient
+// RUN: %FileCheck %s < %t/TestResilient.swiftinterface
+// RUN: %target-swift-frontend -compile-module-from-interface -swift-version 5 %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -swift-version 5  -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s
+import Distributed
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) // SwiftStdlib 5.7
+public typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+// CHECK: {{.*}}distributed {{.*}} actor CheckMe
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) // SwiftStdlib 5.7
+public distributed actor CheckMe {
+  distributed func test() {
+    // ...
+  }
+
+}
+
+// CHECK: public struct HasDistributedActors
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) // SwiftStdlib 5.7
+public struct HasDistributedActors {
+  let check: CheckMe
+
+  func test() async throws {
+    try await check.test()
+  }
+}


### PR DESCRIPTION
We had removed the test since it had issues on one specific simulator configuration.

This time I'd like to resolve the root cause, so bringing it back.

resolves rdar://111572280 (Swift CI: ModuleInterface/distributed_actors.swift MacOS failure)

The revert was here: https://github.com/apple/swift/pull/67054