### PR TITLE
[5.10] Devirtualizer: be less restrictive when checking for correct types to enable witness method devirtualization

### DIFF
--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -1201,6 +1201,17 @@ static bool canDevirtualizeWitnessMethod(ApplySite applySite, bool isMandatory) 
   if (!interfaceTy->hasTypeParameter())
     return true;
 
+  auto subs = getWitnessMethodSubstitutions(f->getModule(), applySite,
+                                            f, wmi->getConformance());
+  CanSILFunctionType substCalleTy = f->getLoweredFunctionType()->substGenericArgs(
+      f->getModule(), subs,
+      applySite.getFunction()->getTypeExpansionContext());
+  CanSILFunctionType applySubstCalleeTy = applySite.getSubstCalleeType();
+
+  // If the function types match, there is no problem.
+  if (substCalleTy == applySubstCalleeTy)
+    return true;
+
   auto selfGP = wmi->getLookupProtocol()->getSelfInterfaceType();
   auto isSelfRootedTypeParameter = [selfGP](Type T) -> bool {
     if (!T->hasTypeParameter())

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -344,3 +344,33 @@ public func testNoDevirt() {
   p.assoc3 { _ in }
   p.assoc4 { _ in }
 }
+
+protocol MyProtocol {
+    associatedtype Element
+    var array: [Element] { get }
+    var foo: Bool { get }
+}
+
+extension Array {
+    var isThisACoolArray: Bool {
+        return true
+    }
+}
+
+extension MyProtocol {
+    var foo: Bool { array.isThisACoolArray }
+}
+
+public struct MyStruct {
+    var array: [Int] = []
+}
+
+extension MyStruct: MyProtocol {}
+
+// CHECK-LABEL: sil @$s34devirt_protocol_method_invocations15testArrayReturn1xSbAA8MyStructVz_tF :
+// CHECK-NOT:     witness_method
+// CHECK:       } // end sil function '$s34devirt_protocol_method_invocations15testArrayReturn1xSbAA8MyStructVz_tF'
+public func testArrayReturn(x: inout MyStruct) -> Bool {
+    return x.foo
+}
+


### PR DESCRIPTION
* **Explanation**:  In the de-virtualizer, the check for correct function types was too restrictive for witness methods. If the function type of the call exactly matches the type of the witness methods, the call can be safely de-virtualized. This fixes a (pretty significant) performance problem.

* **Issue**: rdar://114202760

* **Risk**: Low. It's a small change. The fix landed on main more than 2 months ago and therefore went through extensive testing already.

* **Reviewer**: @zoecarver

* **Main branch PR**: https://github.com/apple/swift/pull/68703
