### PR TITLE
tests: fix and re-enable the performance-annotations.swift test

### DIFF
--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -1,6 +1,4 @@
-// REQUIRES: rdar119075334
-
-// RUN: %target-swift-frontend -parse-as-library -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -emit-sil %s -o /dev/null -verify
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: swift_in_compiler
 


### PR DESCRIPTION
The use of opaque return types requires `-disable-availability-checking`. Otherwise the test will fail when run for old targets.

rdar://119075334
