### PR TITLE
[SymbolGraphGen] Emit "functionSignature" info for initializers and subscripts

### DIFF
--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -69,6 +69,9 @@ class Symbol {
   void serializeGenericParam(const swift::GenericTypeParamType &Param,
                              llvm::json::OStream &OS) const;
 
+  void serializeParameterList(const swift::ParameterList *ParamList,
+                              llvm::json::OStream &OS) const;
+
   void serializeSwiftGenericMixin(llvm::json::OStream &OS) const;
 
   void serializeSwiftExtensionMixin(llvm::json::OStream &OS) const;

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -69,9 +69,6 @@ class Symbol {
   void serializeGenericParam(const swift::GenericTypeParamType &Param,
                              llvm::json::OStream &OS) const;
 
-  void serializeParameterList(const swift::ParameterList *ParamList,
-                              llvm::json::OStream &OS) const;
-
   void serializeSwiftGenericMixin(llvm::json::OStream &OS) const;
 
   void serializeSwiftExtensionMixin(llvm::json::OStream &OS) const;

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Properties/Subscripts.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Properties/Subscripts.swift
@@ -14,6 +14,8 @@ public struct S {
 }
 
 // FULL-LABEL: "precise": "s:10Subscripts1SVyS2icip"
+// FULL: "functionSignature": {
+// FULL: "returns": [
 // FULL: "declarationFragments": [
 // FULL-NEXT:   {
 // FULL-NEXT:     "kind": "keyword",

--- a/test/SymbolGraph/Symbols/Mixins/FunctionSignature.swift
+++ b/test/SymbolGraph/Symbols/Mixins/FunctionSignature.swift
@@ -1,37 +1,105 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name FunctionSignature -emit-module -emit-module-path %t/
 // RUN: %target-swift-symbolgraph-extract -module-name FunctionSignature -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json
+// RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=FUNC
+// RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=INIT
+// RUN: %FileCheck %s --input-file %t/FunctionSignature.symbols.json --check-prefix=SUBSCRIPT
 
-public func foo(_ noext: Int, ext int: Int) -> String {
-  return "OK"
+public struct MyStruct {
+  public init(_ noext: Int, ext int: Int) {}
+    
+// INIT-LABEL: "precise": "s:17FunctionSignature8MyStructV_3extACSi_Sitcfc",
+// INIT: "name": "noext"
+// INIT-NOT: "internalName": "noext"
+// INIT-NEXT: declarationFragments
+
+// INIT: "kind": "identifier"
+// INIT-NEXT: "spelling": "noext"
+// INIT: "kind": "text"
+// INIT-NEXT: "spelling": ": "
+// INIT: "kind": "typeIdentifier"
+// INIT-NEXT: "spelling": "Int"
+// INIT-NEXT: "preciseIdentifier": "s:Si"
+
+// INIT: "name": "ext"
+// INIT-NEXT: "internalName": "int"
+// INIT-NEXT: declarationFragments
+
+// INIT: "kind": "identifier"
+// INIT-NEXT: "spelling": "int"
+// INIT: "kind": "text"
+// INIT-NEXT: "spelling": ": "
+// INIT: "kind": "typeIdentifier"
+// INIT-NEXT: "spelling": "Int"
+// INIT-NEXT: "preciseIdentifier": "s:Si"
+    
+  public subscript(_ noext: Int, ext int: Int) -> String {
+    get { return "OK" }
+    set { }
+  }
+    
+// SUBSCRIPT-LABEL: "precise": "s:17FunctionSignature8MyStructV_3extSSSi_Sitcip",
+// SUBSCRIPT: "name": "noext"
+// SUBSCRIPT-NOT: "internalName": "noext"
+// SUBSCRIPT-NEXT: declarationFragments
+
+// SUBSCRIPT: "kind": "identifier"
+// SUBSCRIPT-NEXT: "spelling": "noext"
+// SUBSCRIPT: "kind": "text"
+// SUBSCRIPT-NEXT: "spelling": ": "
+// SUBSCRIPT: "kind": "typeIdentifier"
+// SUBSCRIPT-NEXT: "spelling": "Int"
+// SUBSCRIPT-NEXT: "preciseIdentifier": "s:Si"
+
+// SUBSCRIPT: "name": "ext"
+// SUBSCRIPT-NEXT: "internalName": "int"
+// SUBSCRIPT-NEXT: declarationFragments
+
+// SUBSCRIPT: "kind": "identifier"
+// SUBSCRIPT-NEXT: "spelling": "int"
+// SUBSCRIPT: "kind": "text"
+// SUBSCRIPT-NEXT: "spelling": ": "
+// SUBSCRIPT: "kind": "typeIdentifier"
+// SUBSCRIPT-NEXT: "spelling": "Int"
+// SUBSCRIPT-NEXT: "preciseIdentifier": "s:Si"
+
+// SUBSCRIPT: returns
+// SUBSCRIPT: "kind": "typeIdentifier"
+// SUBSCRIPT-NEXT: "spelling": "String"
+// SUBSCRIPT-NEXT: "preciseIdentifier": "s:SS"
+    
+  public func foo(_ noext: Int, ext int: Int) -> String {
+    return "OK"
+  }
+    
+// FUNC-LABEL: "precise": "s:17FunctionSignature8MyStructV3foo_3extSSSi_SitF",
+// FUNC: "name": "noext"
+// FUNC-NOT: "internalName": "noext"
+// FUNC-NEXT: declarationFragments
+
+// FUNC: "kind": "identifier"
+// FUNC-NEXT: "spelling": "noext"
+// FUNC: "kind": "text"
+// FUNC-NEXT: "spelling": ": "
+// FUNC: "kind": "typeIdentifier"
+// FUNC-NEXT: "spelling": "Int"
+// FUNC-NEXT: "preciseIdentifier": "s:Si"
+
+// FUNC: "name": "ext"
+// FUNC-NEXT: "internalName": "int"
+// FUNC-NEXT: declarationFragments
+
+// FUNC: "kind": "identifier"
+// FUNC-NEXT: "spelling": "int"
+// FUNC: "kind": "text"
+// FUNC-NEXT: "spelling": ": "
+// FUNC: "kind": "typeIdentifier"
+// FUNC-NEXT: "spelling": "Int"
+// FUNC-NEXT: "preciseIdentifier": "s:Si"
+
+// FUNC: returns
+// FUNC: "kind": "typeIdentifier"
+// FUNC-NEXT: "spelling": "String"
+// FUNC-NEXT: "preciseIdentifier": "s:SS"
+    
 }
-
-// CHECK: "name": "noext"
-// CHECK-NOT: "internalName": "noext"
-// CHECK-NEXT: declarationFragments
-
-// CHECK: "kind": "identifier"
-// CHECK-NEXT: "spelling": "noext" 
-// CHECK: "kind": "text"
-// CHECK-NEXT: "spelling": ": " 
-// CHECK: "kind": "typeIdentifier"
-// CHECK-NEXT: "spelling": "Int" 
-// CHECK-NEXT: "preciseIdentifier": "s:Si" 
-
-// CHECK: "name": "ext"
-// CHECK-NEXT: "internalName": "int"
-// CHECK-NEXT: declarationFragments
-
-// CHECK: "kind": "identifier"
-// CHECK-NEXT: "spelling": "int" 
-// CHECK: "kind": "text"
-// CHECK-NEXT: "spelling": ": " 
-// CHECK: "kind": "typeIdentifier"
-// CHECK-NEXT: "spelling": "Int" 
-// CHECK-NEXT: "preciseIdentifier": "s:Si" 
-
-// CHECK: returns
-// CHECK: "kind": "typeIdentifier" 
-// CHECK-NEXT: "spelling": "String" 
-// CHECK-NEXT: "preciseIdentifier": "s:SS"


### PR DESCRIPTION
This makes the Swift symbol graph generator emit "functionSignature" information for initializers and subscripts, just like it does for functions.

Resolves <rdar://111072228>.



<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
