### PR TITLE
[cxx-interop] Use APINotes to apply `import_owned` attr to `std::string` and `std::vector`

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6956,12 +6956,6 @@ static bool isForeignReferenceType(const clang::QualType type) {
 }
 
 static bool hasOwnedValueAttr(const clang::RecordDecl *decl) {
-  // Hard-coded special cases from the standard library (this will go away once
-  // API notes support namespaces).
-  if (decl->getNameAsString() == "basic_string" ||
-      decl->getNameAsString() == "vector")
-    return true;
-
   return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
            if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
              return swiftAttr->getAttribute() == "import_owned";

--- a/stdlib/public/Cxx/std/std.apinotes
+++ b/stdlib/public/Cxx/std/std.apinotes
@@ -6,3 +6,10 @@ Functions:
 - Name: div
   Availability: nonswift
   AvailabilityMsg: Use the C standard library function
+Namespaces:
+- Name: std
+  Tags:
+  - Name: basic_string
+    SwiftImportAs: owned
+  - Name: vector
+    SwiftImportAs: owned


### PR DESCRIPTION
This removes a special case in the compiler for these types, and applies the `import_owned` attribute to all instantiations of `vector` and `basic_string` via API Notes.