### PR TITLE
[Dependency Scanning] Remove/move mutable state from parallel scanner workers

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -915,10 +915,6 @@ public:
     return Mapper->mapToString(Path);
   }
 
-  /// Wrap the filesystem on the specified `CompilerInstance` with a
-  /// caching `DependencyScanningWorkerFilesystem`
-  void overlaySharedFilesystemCacheForCompilation(CompilerInstance &Instance);
-
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);
 private:

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -341,7 +341,7 @@ public:
   /// Retrieve the dependencies for the given, named module, or \c None
   /// if no such module exists.
   virtual llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
-  getModuleDependencies(StringRef moduleName,
+  getModuleDependencies(Identifier moduleName,
                         StringRef moduleOutputPath,
                         llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -440,7 +440,7 @@ public:
       StringRef moduleOutputPath, RemapPathCallback remapPath = nullptr);
 
   llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
-  getModuleDependencies(StringRef moduleName, StringRef moduleOutputPath,
+  getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath,
                         llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/Identifier.h"
 #include "swift/AST/ModuleDependencies.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
@@ -36,18 +37,18 @@ public:
 private:
   /// Retrieve the module dependencies for the module with the given name.
   ModuleDependencyVector
-  scanFilesystemForModuleDependency(StringRef moduleName,
+  scanFilesystemForModuleDependency(Identifier moduleName,
                                     const ModuleDependenciesCache &cache,
                                     bool isTestableImport = false);
 
   /// Retrieve the module dependencies for the Clang module with the given name.
   ModuleDependencyVector
-  scanFilesystemForClangModuleDependency(StringRef moduleName,
+  scanFilesystemForClangModuleDependency(Identifier moduleName,
                                          const ModuleDependenciesCache &cache);
 
   /// Retrieve the module dependencies for the Swift module with the given name.
   ModuleDependencyVector
-  scanFilesystemForSwiftModuleDependency(StringRef moduleName,
+  scanFilesystemForSwiftModuleDependency(Identifier moduleName,
                                          const ModuleDependenciesCache &cache);
 
   // An AST delegate for interface scanning.
@@ -134,6 +135,8 @@ private:
   /// available to this scanner.
   template <typename Function, typename... Args>
   auto withDependencyScanningWorker(Function &&F, Args &&...ArgList);
+
+  Identifier getModuleImportIdentifier(StringRef moduleName);
 
 private:
   const CompilerInvocation &ScanCompilerInvocation;

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -98,7 +98,7 @@ public:
   }
 
   llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
-  getModuleDependencies(StringRef moduleName, StringRef moduleOutputPath,
+  getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath,
                         llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -250,7 +250,7 @@ public:
   virtual void verifyAllModules() override;
 
   virtual llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
-  getModuleDependencies(StringRef moduleName, StringRef moduleOutputPath,
+  getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath,
                         llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -480,17 +480,6 @@ SwiftDependencyTracker::createTreeFromDependencies() {
       });
 }
 
-void SwiftDependencyScanningService::overlaySharedFilesystemCacheForCompilation(
-    CompilerInstance &Instance) {
-  auto existingFS = Instance.getSourceMgr().getFileSystem();
-  llvm::IntrusiveRefCntPtr<
-      clang::tooling::dependencies::DependencyScanningWorkerFilesystem>
-      depFS =
-          new clang::tooling::dependencies::DependencyScanningWorkerFilesystem(
-              getSharedFilesystemCache(), existingFS);
-  Instance.getSourceMgr().setFileSystem(depFS);
-}
-
 bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     CompilerInstance &Instance) {
   if (!Instance.getInvocation().getFrontendOptions().EnableCaching)

--- a/lib/AST/SearchPathOptions.cpp
+++ b/lib/AST/SearchPathOptions.cpp
@@ -101,10 +101,12 @@ ModuleSearchPathLookup::searchPathsContainingFile(
   llvm::SmallSet<std::pair<ModuleSearchPathKind, unsigned>, 4> ResultIds;
 
   for (auto &Filename : Filenames) {
-    for (auto &Entry : LookupTable.lookup(Filename)) {
-      if (ResultIds.insert(std::make_pair(Entry->getKind(), Entry->getIndex()))
-              .second) {
-        Result.push_back(Entry.get());
+    if (LookupTable.contains(Filename)) {
+      for (auto &Entry : LookupTable.at(Filename)) {
+        if (ResultIds.insert(std::make_pair(Entry->getKind(), Entry->getIndex()))
+                .second) {
+          Result.push_back(Entry.get());
+        }
       }
     }
   }

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -407,7 +407,7 @@ computeClangWorkingDirectory(const std::vector<std::string> &commandLineArgs,
 }
 
 ModuleDependencyVector
-ClangImporter::getModuleDependencies(StringRef moduleName,
+ClangImporter::getModuleDependencies(Identifier moduleName,
                                      StringRef moduleOutputPath,
                                      llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
                                      const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
@@ -435,14 +435,14 @@ ClangImporter::getModuleDependencies(StringRef moduleName,
 
   auto clangModuleDependencies =
       clangScanningTool.getModuleDependencies(
-          moduleName, commandLineArgs, workingDir,
+          moduleName.str(), commandLineArgs, workingDir,
           alreadySeenClangModules, lookupModuleOutput);
   if (!clangModuleDependencies) {
     auto errorStr = toString(clangModuleDependencies.takeError());
     // We ignore the "module 'foo' not found" error, the Swift dependency
     // scanner will report such an error only if all of the module loaders
     // fail as well.
-    if (errorStr.find("fatal error: module '" + moduleName.str() +
+    if (errorStr.find("fatal error: module '" + moduleName.str().str() +
                       "' not found") == std::string::npos)
       ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
                          errorStr);

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1448,8 +1448,6 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
   if (opts.ReuseDependencyScannerCache)
     deserializeDependencyCache(instance, service);
 
-  // Wrap the filesystem with a caching `DependencyScanningWorkerFilesystem`
-  service.overlaySharedFilesystemCacheForCompilation(instance);
   if (service.setupCachingDependencyScanningService(instance))
     return true;
 
@@ -1520,7 +1518,6 @@ bool swift::dependencies::batchScanDependencies(
   // we have created
 
   SwiftDependencyScanningService singleUseService;
-  singleUseService.overlaySharedFilesystemCacheForCompilation(instance);
   if (singleUseService.setupCachingDependencyScanningService(instance))
     return true;
 

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -155,7 +155,7 @@ void SourceLoader::loadExtensions(NominalTypeDecl *nominal,
 }
 
 ModuleDependencyVector
-SourceLoader::getModuleDependencies(StringRef moduleName,
+SourceLoader::getModuleDependencies(Identifier moduleName,
                                     StringRef moduleOutputPath,
                                     llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
                                     const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -305,14 +305,14 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
 }
 
 ModuleDependencyVector SerializedModuleLoaderBase::getModuleDependencies(
-    StringRef moduleName, StringRef moduleOutputPath,
+    Identifier moduleName, StringRef moduleOutputPath,
     llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> CacheFS,
     const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
         &alreadySeenClangModules,
     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
     InterfaceSubContextDelegate &delegate, llvm::TreePathPrefixMapper *mapper,
     bool isTestableDependencyLookup) {
-  ImportPath::Module::Builder builder(Ctx, moduleName, /*separator=*/'.');
+  ImportPath::Module::Builder builder(moduleName);
   auto modulePath = builder.get();
   auto moduleId = modulePath.front().Item;
   llvm::Optional<SwiftDependencyTracker> tracker = llvm::None;
@@ -344,7 +344,7 @@ ModuleDependencyVector SerializedModuleLoaderBase::getModuleDependencies(
 
       ModuleDependencyVector moduleDependnecies;
       moduleDependnecies.push_back(
-          std::make_pair(ModuleDependencyID{moduleName.str(),
+          std::make_pair(ModuleDependencyID{moduleName.str().str(),
                                             scanner->dependencies->getKind()},
                          *(scanner->dependencies)));
       return moduleDependnecies;


### PR DESCRIPTION
- Move generation of a named import path `Identifier` out of the individual scanning workers up into the parent scanner. This operation mutates the scanner `ASTContext` by potentially adding new identifiers to it and is therefore not thread-safe.
- Remove `overlaySharedFilesystemCacheForCompilation` from the scanner. It overlays a non-thread-safe filesystem on shared compilation instances and is no longer valid with parallel scanning.