### PR TITLE
[Macros/Tests] Build test plugins with the same compiler as the dylib 

### DIFF
--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -21,11 +21,12 @@ if get_target_os() in ['windows-msvc']:
 else:
     # FIXME(compnerd) do all the targets we currently support use SysV ABI?
     config.substitutions.insert(0, ('%target-abi', 'SYSV'))
+    config.substitutions.insert(0, ('%cmake-c-compiler', config.cmake_c_compiler))
     config.substitutions.insert(
         0,
         (
             '%swift-build-c-plugin',
-            '%clang %c-flags %exe-linker-flags -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin -Xlinker -rpath -Xlinker %swift-lib-dir'
+            '%cmake-c-compiler %c-flags %exe-linker-flags -target %host_triple -isysroot %host_sdk -I %swift_src_root/include -L %swift-lib-dir -l_swiftMockPlugin -Xlinker -rpath -Xlinker %swift-lib-dir'
         )
     )
     config.substitutions.append(('%c-flags', config.c_flags))

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -1,6 +1,3 @@
-// FIXME: Failing in ASAN (rdar://119141141)
-// UNSUPPORTED: asan_runtime
-
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)

--- a/test/Macros/macro_plugin_disable_sandbox.swift
+++ b/test/Macros/macro_plugin_disable_sandbox.swift
@@ -1,6 +1,3 @@
-// FIXME: Failing in ASAN (rdar://119141141)
-// UNSUPPORTED: asan_runtime
-
 // REQUIRES: swift_swift_parser
 
 // sandbox-exec is only avaiable in Darwin

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -1,6 +1,3 @@
-// FIXME: Failing in ASAN (rdar://119141141)
-// UNSUPPORTED: asan_runtime
-
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)

--- a/test/Macros/macro_plugin_searchorder.swift
+++ b/test/Macros/macro_plugin_searchorder.swift
@@ -1,5 +1,3 @@
-// FIXME: Failing in ASAN (rdar://119141141)
-// UNSUPPORTED: asan_runtime
 
 // REQUIRES: swift_swift_parser, executable_test
 

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -1,6 +1,3 @@
-// FIXME: Failing in ASAN (rdar://119141141)
-// UNSUPPORTED: asan_runtime
-
 // REQUIRES: swift_swift_parser
 
 // RUN: %empty-directory(%t)

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -44,6 +44,8 @@ config.swift_driver_test_options = "@SWIFT_DRIVER_TEST_OPTIONS@"
 config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
 config.swift_ide_test_test_options = "@SWIFT_IDE_TEST_TEST_OPTIONS@"
 
+config.cmake_c_compiler = r'''@CMAKE_C_COMPILER@'''
+config.cmake_cxx_compiler = r'''@CMAKE_CXX_COMPILER@'''
 config.c_flags = r'''@CMAKE_C_FLAGS@'''
 config.exe_linker_flags = r'''@CMAKE_EXE_LINKER_FLAGS@'''
 

--- a/tools/libMockPlugin/CMakeLists.txt
+++ b/tools/libMockPlugin/CMakeLists.txt
@@ -16,4 +16,4 @@ add_llvm_symbol_exports(libMockPlugin ${LLVM_EXPORTED_SYMBOL_FILE})
 
 add_dependencies(tools libMockPlugin)
 # Adds -dead_strip option
-add_link_opts(libStaticMirror)
+add_link_opts(libMockPlugin)


### PR DESCRIPTION
Sanitizer ABI are apparently not stable. We need to build the executable with the same compiler as the linking dylib.

rdar://119141141