### PR TITLE
[test] Add dependency to the embedded-stdlib

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -311,6 +311,10 @@ foreach(SDK ${SWIFT_SDKS})
         endif()
       endif()
 
+      if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND TARGET "embedded-stdlib")
+        list(APPEND test_dependencies "embedded-stdlib")
+      endif()
+
       if(NOT "${COVERAGE_DB}" STREQUAL "")
         list(APPEND test_dependencies "touch-covering-tests")
       endif()


### PR DESCRIPTION
When not building `all`, like the `build-script` does in CI, the tests did not have a dependency on `embedded-stdlib`, and those tests will fail to pass if one was using CMake/Ninja to execute the tests after something like `ninja clean`.

The dependency is added if the embedded stdlib is being built.
