### PR TITLE
[ASTBridging] Avoid temporary SmallVector for 'InheritedEntry' list

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -521,6 +521,18 @@ public:
                               setVector.size());
   }
 
+  template <typename Output, typename Range>
+  ArrayRef<Output> AllocateTransform(
+      Range &&input,
+      llvm::function_ref<Output(typename Range::const_reference)> transform,
+      AllocationArena arena = AllocationArena::Permanent) {
+    auto size = std::distance(std::cbegin(input), std::cend(input));
+    auto storage = AllocateUninitialized<Output>(size, arena);
+    for (auto i : indices(input))
+      new (storage.data() + i) Output(transform(input[i]));
+    return storage;
+  }
+
   /// Set a new stats reporter.
   void setStatsReporter(UnifiedStatsReporter *stats);
 


### PR DESCRIPTION
We know the number of the entries. Allocate the storage in ASTContext directly, then initialize it transforming the bridged values. Add ASTContext::AllocateTransform() helper function.
