### PR TITLE
[embedded] Add Set to the embedded stdlib

### DIFF
--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -74,7 +74,11 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
   @inlinable
   @inline(__always)
   internal init(taggedPayload: UInt) {
+    #if !$Embedded
+    rawValue = _bridgeObject(taggingPayload: taggedPayload)
+    #else
     rawValue = Builtin.reinterpretCast(taggedPayload)
+    #endif
   }
 #endif
 
@@ -134,7 +138,11 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
   internal var nativeInstance: Native {
     @inline(__always) get {
       _internalInvariant(isNative)
+      #if !$Embedded
+      return Builtin.castReferenceFromBridgeObject(rawValue)
+      #else
       return rawValue
+      #endif
     }
   }
 
@@ -145,7 +153,11 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
       #if !$Embedded
       _internalInvariant(_nonPointerBits(rawValue) == 0)
       #endif
+      #if !$Embedded
+      return Builtin.reinterpretCast(rawValue)
+      #else
       return rawValue
+      #endif
     }
   }
 

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -179,16 +179,8 @@ internal struct _BridgeStorage<NativeClass: AnyObject> {
   @inline(__always)
   internal init(native: Native) {
     _internalInvariant(_usesNativeSwiftReferenceCounting(NativeClass.self))
-    rawValue = Builtin.reinterpretCast(native)
+    rawValue = native
   }
-
-#if _pointerBitWidth(_64)
-  @inlinable
-  @inline(__always)
-  internal init(taggedPayload: UInt) {
-    rawValue = Builtin.reinterpretCast(taggedPayload)
-  }
-#endif
 
   @inlinable
   @inline(__always)

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -725,9 +725,11 @@ func _isUnique_native<T>(_ object: inout T) -> Bool {
   // This could be a bridge object, single payload enum, or plain old
   // reference. Any case it's non pointer bits must be zero, so
   // force cast it to BridgeObject and check the spare bits.
+  #if !$Embedded
   _internalInvariant(
     (_bitPattern(Builtin.reinterpretCast(object)) & _objectPointerSpareBits)
     == 0)
+  #endif
   _internalInvariant(_usesNativeSwiftReferenceCounting(
       type(of: Builtin.reinterpretCast(object) as AnyObject)))
   return Bool(Builtin.isUnique_native(&object))

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -43,10 +43,10 @@ split_embedded_sources(
   EMBEDDED Assert.swift
   EMBEDDED AssertCommon.swift
   EMBEDDED BidirectionalCollection.swift
-    NORMAL Bitset.swift
+  EMBEDDED Bitset.swift
   EMBEDDED Bool.swift
     NORMAL BridgeObjectiveC.swift
-    NORMAL BridgeStorage.swift
+  EMBEDDED BridgeStorage.swift
     NORMAL BridgingBuffer.swift
   EMBEDDED Builtin.swift
   EMBEDDED BuiltinMath.swift
@@ -89,7 +89,7 @@ split_embedded_sources(
   # END WORKAROUND
   EMBEDDED Hasher.swift
     NORMAL Hashing.swift
-    NORMAL HashTable.swift
+  EMBEDDED HashTable.swift
   EMBEDDED Identifiable.swift
   EMBEDDED Indices.swift
     NORMAL InputStream.swift
@@ -111,7 +111,7 @@ split_embedded_sources(
   EMBEDDED Misc.swift
   EMBEDDED MutableCollection.swift
     NORMAL NativeDictionary.swift
-    NORMAL NativeSet.swift
+  EMBEDDED NativeSet.swift
     NORMAL NewtypeWrapper.swift
     NORMAL NFC.swift
     NORMAL NFD.swift
@@ -139,15 +139,15 @@ split_embedded_sources(
   EMBEDDED SipHash.swift
   EMBEDDED Sequence.swift
   EMBEDDED SequenceAlgorithms.swift
-    NORMAL Set.swift
+  EMBEDDED Set.swift
   EMBEDDED SetAlgebra.swift
     NORMAL SetAnyHashableExtensions.swift
     NORMAL SetBridging.swift
-    NORMAL SetBuilder.swift
-    NORMAL SetCasting.swift
-    NORMAL SetStorage.swift
-    NORMAL SetVariant.swift
-    NORMAL ShadowProtocols.swift
+  EMBEDDED SetBuilder.swift
+  EMBEDDED SetCasting.swift
+  EMBEDDED SetStorage.swift
+  EMBEDDED SetVariant.swift
+  EMBEDDED ShadowProtocols.swift
     NORMAL Shims.swift
   EMBEDDED Slice.swift
     NORMAL SmallString.swift

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -64,6 +64,12 @@ internal final class __EmptyArrayStorage
 }
 
 #if $Embedded
+// In embedded Swift, the stdlib is a .swiftmodule only without any .o/.a files,
+// to allow consuming it by clients with different LLVM codegen setting (-mcpu
+// flags, etc.), which means we cannot declare the singleton in a C/C++ file.
+//
+// TODO: We should figure out how to make this a constant so that it's placed in
+// non-writable memory (can't be a let, Builtin.addressof below requires a var).
 public var _swiftEmptyArrayStorage: (Int, Int, Int, Int) =
     (/*isa*/0, /*refcount*/-1, /*count*/0, /*flags*/1)
 #endif

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -473,7 +473,7 @@ extension _DictionaryStorage {
         truncatingIfNeeded: ObjectIdentifier(storage).hashValue)
     }
 
-    storage._seed = seed ?? _HashTable.hashSeed(for: storage, scale: scale)
+    storage._seed = seed ?? _HashTable.hashSeed(for: Builtin.castToNativeObject(storage), scale: scale)
     storage._rawKeys = UnsafeMutableRawPointer(keysAddr)
     storage._rawValues = UnsafeMutableRawPointer(valuesAddr)
 

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -275,10 +275,9 @@ public func swift_deletedMethodError() -> Never {
 public func swift_willThrow() throws {
 }
 
-@_silgen_name("arc4random_buf")
+@_extern(c, "arc4random_buf")
 public func arc4random_buf(buf: UnsafeMutableRawPointer, nbytes: Int)
 
-@_silgen_name("swift_stdlib_random")
 public func swift_stdlib_random(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
   arc4random_buf(buf: buf, nbytes: nbytes)
 }

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -275,3 +275,10 @@ public func swift_deletedMethodError() -> Never {
 public func swift_willThrow() throws {
 }
 
+@_silgen_name("arc4random_buf")
+public func arc4random_buf(buf: UnsafeMutableRawPointer, nbytes: Int)
+
+@_silgen_name("swift_stdlib_random")
+public func swift_stdlib_random(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
+  arc4random_buf(buf: buf, nbytes: nbytes)
+}

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -276,7 +276,7 @@ public func swift_willThrow() throws {
 }
 
 @_extern(c, "arc4random_buf")
-public func arc4random_buf(buf: UnsafeMutableRawPointer, nbytes: Int)
+func arc4random_buf(buf: UnsafeMutableRawPointer, nbytes: Int)
 
 public func swift_stdlib_random(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
   arc4random_buf(buf: buf, nbytes: nbytes)

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -102,7 +102,7 @@ extension _HashTable {
   }
 
   internal static func hashSeed(
-    for object: AnyObject,
+    for object: Builtin.NativeObject,
     scale: Int8
   ) -> Int {
     // We generate a new hash seed whenever a new hash table is allocated and

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -251,6 +251,16 @@ extension Hasher {
   }
 }
 
+#if $Embedded
+@usableFromInline
+var _swift_stdlib_Hashing_parameters: _SwiftHashingParameters = {
+  var seed0: UInt64 = 0, seed1: UInt64 = 0
+  swift_stdlib_random(&seed0, MemoryLayout<UInt64>.size)
+  swift_stdlib_random(&seed1, MemoryLayout<UInt64>.size)
+  return .init(seed0: seed0, seed1: seed1, deterministic: false)
+}()
+#endif
+
 /// The universal hash function used by `Set` and `Dictionary`.
 ///
 /// `Hasher` can be used to map an arbitrary sequence of bytes to an integer

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -351,6 +351,7 @@ extension _NativeSet: _SetBuffer {
 // This function has a highly visible name to make it stand out in stack traces.
 @usableFromInline
 @inline(never)
+@_unavailableInEmbedded
 internal func ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(
   _ elementType: Any.Type
 ) -> Never {
@@ -379,7 +380,11 @@ extension _NativeSet { // Insertions
       // because we'll need to compare elements in case of hash collisions.
       let (bucket, found) = find(element, hashValue: hashValue)
       guard !found else {
+        #if !$Embedded
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
+        #else
+        fatalError("duplicate elements in a Set")
+        #endif
       }
       hashTable.insert(bucket)
       uncheckedInitialize(at: bucket, to: element)
@@ -418,7 +423,11 @@ extension _NativeSet { // Insertions
     if rehashed {
       let (b, f) = find(element)
       if f {
+        #if !$Embedded
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
+        #else
+        fatalError("duplicate elements in a Set")
+        #endif
       }
       bucket = b
     }
@@ -437,7 +446,11 @@ extension _NativeSet { // Insertions
     if rehashed {
       let (b, f) = find(element)
       if f != found {
+        #if !$Embedded
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
+        #else
+        fatalError("duplicate elements in a Set")
+        #endif
       }
       bucket = b
     }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -448,12 +448,14 @@ extension Set: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 extension Set: _HasCustomAnyHashableRepresentation {
   public __consuming func _toCustomAnyHashable() -> AnyHashable? {
     return AnyHashable(_box: _SetAnyHashableBox(self))
   }
 }
 
+@_unavailableInEmbedded
 internal struct _SetAnyHashableBox<Element: Hashable>: _AnyHashableBox {
   internal let _value: Set<Element>
   internal let _canonical: Set<AnyHashable>
@@ -1034,6 +1036,7 @@ extension Set: SetAlgebra {
   }
 }
 
+@_unavailableInEmbedded
 extension Set: CustomStringConvertible, CustomDebugStringConvertible {
   /// A string that represents the contents of the set.
   public var description: String {

--- a/stdlib/public/core/SetCasting.swift
+++ b/stdlib/public/core/SetCasting.swift
@@ -41,6 +41,7 @@ extension Set {
 /// - Precondition: `BaseValue` is a base class or base `@objc`
 ///   protocol (such as `AnyObject`) of `DerivedValue`.
 @inlinable
+@_unavailableInEmbedded
 public func _setUpCast<DerivedValue, BaseValue>(
   _ source: Set<DerivedValue>
 ) -> Set<BaseValue> {
@@ -57,6 +58,7 @@ public func _setUpCast<DerivedValue, BaseValue>(
 
 /// Called by the casting machinery.
 @_silgen_name("_swift_setDownCastIndirect")
+@_unavailableInEmbedded
 internal func _setDownCastIndirect<SourceValue, TargetValue>(
   _ source: UnsafePointer<Set<SourceValue>>,
   _ target: UnsafeMutablePointer<Set<TargetValue>>) {
@@ -71,6 +73,7 @@ internal func _setDownCastIndirect<SourceValue, TargetValue>(
 /// - Precondition: `DerivedValue` is a subtype of `BaseValue` and both
 ///   are reference types.
 @inlinable
+@_unavailableInEmbedded
 public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
   -> Set<DerivedValue> {
 
@@ -99,6 +102,7 @@ public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
 
 /// Called by the casting machinery.
 @_silgen_name("_swift_setDownCastConditionalIndirect")
+@_unavailableInEmbedded
 internal func _setDownCastConditionalIndirect<SourceValue, TargetValue>(
   _ source: UnsafePointer<Set<SourceValue>>,
   _ target: UnsafeMutablePointer<Set<TargetValue>>
@@ -118,6 +122,7 @@ internal func _setDownCastConditionalIndirect<SourceValue, TargetValue>(
 /// - Precondition: `DerivedValue` is a subtype of `BaseValue` and both
 ///   are reference types.
 @inlinable
+@_unavailableInEmbedded
 public func _setDownCastConditional<BaseValue, DerivedValue>(
   _ source: Set<BaseValue>
 ) -> Set<DerivedValue>? {

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -127,6 +127,22 @@ internal class __EmptySetSingleton: __RawSetStorage {
 #endif
 }
 
+#if $Embedded
+public var _swiftEmptySetSingleton: (Int, Int, Int, Int, UInt8, UInt8, UInt16, UInt32, Int, Int, Int) =
+    (
+      /*isa*/0, /*refcount*/-1, // HeapObject header
+      /*count*/0, 
+      /*capacity*/0, 
+      /*scale*/0, 
+      /*reservedScale*/0, 
+      /*extra*/0, 
+      /*age*/0, 
+      /*seed*/0, 
+      /*rawElements*/1, 
+      /*metadata*/-1
+    )
+#endif
+
 extension __RawSetStorage {
   /// The empty singleton that is used for every single Set that is created
   /// without any elements. The contents of the storage must never be mutated.
@@ -364,7 +380,7 @@ extension _SetStorage {
         truncatingIfNeeded: ObjectIdentifier(storage).hashValue)
     }
 
-    storage._seed = seed ?? _HashTable.hashSeed(for: storage, scale: scale)
+    storage._seed = seed ?? _HashTable.hashSeed(for: Builtin.castToNativeObject(storage), scale: scale)
     storage._rawElements = UnsafeMutableRawPointer(elementsAddr)
 
     // Initialize hash table metadata.

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -128,6 +128,12 @@ internal class __EmptySetSingleton: __RawSetStorage {
 }
 
 #if $Embedded
+// In embedded Swift, the stdlib is a .swiftmodule only without any .o/.a files,
+// to allow consuming it by clients with different LLVM codegen setting (-mcpu
+// flags, etc.), which means we cannot declare the singleton in a C/C++ file.
+//
+// TODO: We should figure out how to make this a constant so that it's placed in
+// non-writable memory (can't be a let, Builtin.addressof below requires a var).
 public var _swiftEmptySetSingleton: (Int, Int, Int, Int, UInt8, UInt8, UInt16, UInt32, Int, Int, Int) =
     (
       /*isa*/0, /*refcount*/-1, // HeapObject header

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -36,9 +36,9 @@ extension Set {
     @inlinable
     @inline(__always)
     init(dummy: ()) {
-#if _pointerBitWidth(_64)
+#if _pointerBitWidth(_64) && !$Embedded
       self.object = _BridgeStorage(taggedPayload: 0)
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || $Embedded
       self.init(native: _NativeSet())
 #else
 #error("Unknown platform")

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -88,6 +88,7 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
     return true
   }
 
+#if !$Embedded
   // Finally, take a slow path through the standard library to see if the
   // current environment can accept a larger stack allocation.
   guard #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) //SwiftStdlib 5.6
@@ -95,6 +96,10 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
     return false
   }
   return swift_stdlib_isStackAllocationSafe(byteCount, alignment)
+#else
+  return false
+#endif
+
 #else
   fatalError("unsupported compiler")
 #endif

--- a/test/embedded/set-runtime.swift
+++ b/test/embedded/set-runtime.swift
@@ -1,0 +1,30 @@
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+@main
+struct Main {
+  static func main() {
+    var s: Set<Int> = [1, 2, 3]
+    s.insert(42)
+    s.sorted()
+    s.allSatisfy { $0 > 0 }
+    s.contains { $0 > 0 }
+    s.map { $0 * 2 }
+    s.filter { $0 > 0 }
+    s.firstIndex(of: 42)
+    s.min()
+    s.max()
+    s.reduce(0, +)
+    // s.shuffled()
+    // s.randomElement()
+    print("OK!")
+  }
+}
+
+// CHECK: OK!

--- a/test/embedded/set-runtime.swift
+++ b/test/embedded/set-runtime.swift
@@ -5,7 +5,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx
 
 @main
 struct Main {

--- a/test/embedded/stdlib-array.swift
+++ b/test/embedded/stdlib-array.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+
+public func test() {
+  var array: [Int] = [1, 2, 3]
+  array.append(42)
+  array.append(contentsOf: [4, 5, 6])
+  array = array.sorted()
+  array.sort()
+  array.allSatisfy { $0 > 0 }
+  array.contains { $0 > 0 }
+  array.map { $0 * 2 }
+  array.filter { $0 > 0 }
+  array.dropFirst().dropLast().drop(while: { $0 < 0 })
+  array.firstIndex(of: 42)
+  array.min()
+  array.max()
+  array.partition(by: { $0 > 0 })
+  array.reduce(0, +)
+  // array.shuffle()
+  // array = array.shuffled()
+  // array.randomElement()
+}
+
+test()
+
+// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)

--- a/test/embedded/stdlib-set.swift
+++ b/test/embedded/stdlib-set.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+
+public func test() {
+  var s: Set<Int> = [1, 2, 3]
+  s.insert(42)
+  s.sorted()
+  s.allSatisfy { $0 > 0 }
+  s.contains { $0 > 0 }
+  s.map { $0 * 2 }
+  s.filter { $0 > 0 }
+  s.firstIndex(of: 42)
+  s.min()
+  s.max()
+  s.reduce(0, +)
+  // s.shuffled()
+  // s.randomElement()
+}
+
+test()
+
+// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -36,6 +36,7 @@ public func test() {
   let opaque = unmanaged.toOpaque()
   let unmanaged2 = Unmanaged<MyClass>.fromOpaque(opaque)
   let o = unmanaged2.takeUnretainedValue()
+  var s1: Set<Int> = [1, 2, 3]
 }
 
 test()


### PR DESCRIPTION
Mostly a straightforward addition of the Set-implementing source files to the embedded stdlib, except:
- `Builtin.BridgeObject` in BridgeStorage causes usage of swift_bridgeObjectRelease/swift_bridgeObjectRetain, which we could probably implement in the embedded runtime, but it looks like a better idea to just avoid using `Builtin.BridgeObject` altogether
- `_swift_stdlib_Hashing_parameters` are now needed, so they need to be initialized
- `ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS` cannot be used in embedded Swift because it uses a metatype as an argument
- `_swiftEmptySetSingleton` needs to be defined