### PR TITLE
[embedded] Make embedded target triples conditional on LLVM support

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -149,23 +149,42 @@ elseif(BOOTSTRAPPING_MODE STREQUAL "OFF")
 endif()
 
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
-  set(EMBEDDED_STDLIB_TARGET_TRIPLES
-    # arch    module_name               target triple
-    "armv6    armv6-apple-none-macho    armv6-apple-none-macho"
-    "armv6m   armv6m-apple-none-macho   armv6m-apple-none-macho"
-    "armv7    armv7-apple-none-macho    armv7-apple-none-macho"
-    "armv7em  armv7em-apple-none-macho  armv7em-apple-none-macho"
-    "arm64    arm64-apple-none-macho    arm64-apple-none-macho"
-
-    # the following are all ELF targets
-    "armv6    armv6-none-none-eabi      armv6-none-none-eabi"
-    "armv6m   armv6m-none-none-eabi     armv6-none-none-eabi"
-    "armv7    armv7-none-none-eabi      armv7-none-none-eabi"
-    "armv7em  armv7em-none-none-eabi    armv7em-none-none-eabi"
-    "aarch64  aarch64-none-none-elf     aarch64-none-none-elf"
-    "riscv32  riscv32-none-none-eabi    riscv32-none-none-eabi"
-    "riscv64  riscv64-none-none-eabi    riscv64-none-none-eabi"
+  set(EMBEDDED_STDLIB_TARGET_TRIPLES)
+  if("ARM" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      # arch    module_name               target triple
+      "armv6    armv6-apple-none-macho    armv6-apple-none-macho"
+      "armv6m   armv6m-apple-none-macho   armv6m-apple-none-macho"
+      "armv7    armv7-apple-none-macho    armv7-apple-none-macho"
+      "armv7em  armv7em-apple-none-macho  armv7em-apple-none-macho"
     )
+  endif()
+  if("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "arm64    arm64-apple-none-macho    arm64-apple-none-macho"
+    )
+  endif()
+
+  # the following are all ELF targets
+  if("ARM" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "armv6    armv6-none-none-eabi      armv6-none-none-eabi"
+      "armv6m   armv6m-none-none-eabi     armv6-none-none-eabi"
+      "armv7    armv7-none-none-eabi      armv7-none-none-eabi"
+      "armv7em  armv7em-none-none-eabi    armv7em-none-none-eabi"
+    )
+  endif()
+  if("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "aarch64  aarch64-none-none-elf     aarch64-none-none-elf"
+    )
+  endif()
+  if("RISCV" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "riscv32  riscv32-none-none-eabi    riscv32-none-none-eabi"
+      "riscv64  riscv64-none-none-eabi    riscv64-none-none-eabi"
+    )
+  endif()
 
   if (SWIFT_HOST_VARIANT STREQUAL "linux")
     set(EMBEDDED_STDLIB_TARGET_TRIPLES ${EMBEDDED_STDLIB_TARGET_TRIPLES}


### PR DESCRIPTION
LLVM might not be build with support for all architectures to save time. The changes in this commit check the value of LLVM_TARGETS_TO_BUILD provided by LLVMConfig.cmake to add or skip the different embedded targets if LLVM happens to not build with support for that target.

While x86_64 and ARM/AArch64 are very common in `LLVM_TARGETS_TO_BUILD`, targets like RISCV are more specialized and might not be always enabled.

This is not a problem for builds using the `build-script` because of the changes introduced in #70057, but it is still a problem for other builds that do not use `build-script`. This solution should work for any build.

