### PR TITLE
Fix missing diagnostics about the lack of initializers in cross-module inheritance scenarios

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1372,11 +1372,14 @@ static std::string getFixItStringForDecodable(ClassDecl *CD,
 }
 
 /// Diagnose a class that does not have any initializers.
-static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
+static void diagnoseClassWithoutInitializers(
+    ClassDecl *classDecl, bool downgradeToWarning
+) {
   ASTContext &C = classDecl->getASTContext();
   C.Diags.diagnose(classDecl, diag::class_without_init,
                    classDecl->isExplicitActor(),
-                   classDecl->getDeclaredType());
+                   classDecl->getDeclaredType())
+      .warnUntilSwiftVersionIf(downgradeToWarning, 6);
 
   // HACK: We've got a special case to look out for and diagnose specifically to
   // improve the experience of seeing this, and mitigate some confusion.
@@ -1546,11 +1549,23 @@ static void maybeDiagnoseClassWithoutInitializers(ClassDecl *classDecl) {
       classDecl->inheritsSuperclassInitializers())
     return;
 
+  bool downgradeToWarning = false;
   auto *superclassDecl = classDecl->getSuperclassDecl();
   if (superclassDecl &&
       superclassDecl->getModuleContext() != classDecl->getModuleContext() &&
-      superclassDecl->hasMissingDesignatedInitializers())
-    return;
+      superclassDecl->hasMissingDesignatedInitializers()) {
+    // Objective-C classes might have missing designated initializers because
+    // they couldn't be imported. For historical reasons, we allow the
+    // Swift-defined subclasses to have no
+    if (superclassDecl->hasClangNode() && superclassDecl->isObjC())
+      return;
+
+    // Historically, Swift-defined classes with missing designated
+    // initializers could be subclassed from other modules without defining
+    // any initializers. Downgrade the error to a warning prior to Swift 6
+    // to smooth the transition.
+    downgradeToWarning = true;
+  }
 
   for (auto member : classDecl->lookupDirect(DeclBaseName::createConstructor())) {
     auto ctor = dyn_cast<ConstructorDecl>(member);
@@ -1558,7 +1573,7 @@ static void maybeDiagnoseClassWithoutInitializers(ClassDecl *classDecl) {
       return;
   }
 
-  diagnoseClassWithoutInitializers(classDecl);
+  diagnoseClassWithoutInitializers(classDecl, downgradeToWarning);
 }
 
 /// Determines if a given TypeLoc is module qualified by checking if it's

--- a/test/decl/class/inheritance_across_modules.swift
+++ b/test/decl/class/inheritance_across_modules.swift
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module-path %t/MyModule.swiftmodule %t/Inputs/MyModule.swift
+
+// RUN: %target-swift-frontend -typecheck -verify -I %t %t/test.swift
+
+//--- Inputs/MyModule.swift
+open class MySuperclassA {
+  required public init() { }
+  internal init(boop: Bool) {}
+}
+
+//--- test.swift
+import MyModule
+
+class MySubclassA: MySuperclassA {
+// expected-warning{{'required' initializer 'init()' must be provided by subclass of 'MySuperclassA'; this is an error in Swift 6}}
+  var hi: String
+}

--- a/test/decl/class/inheritance_across_modules.swift
+++ b/test/decl/class/inheritance_across_modules.swift
@@ -11,10 +11,21 @@ open class MySuperclassA {
   internal init(boop: Bool) {}
 }
 
+open class MySuperclassB {
+}
+
 //--- test.swift
 import MyModule
 
 class MySubclassA: MySuperclassA {
-// expected-warning{{'required' initializer 'init()' must be provided by subclass of 'MySuperclassA'; this is an error in Swift 6}}
+  // expected-warning{{'required' initializer 'init()' must be provided by subclass of 'MySuperclassA'; this is an error in Swift 6}}
+  // expected-warning@-2{{class 'MySubclassA' has no initializers; this is an error in Swift 6}}
   var hi: String
+  // expected-note@-1{{stored property 'hi' without initial value prevents synthesized initializers}}
+}
+
+class MySubclassB: MySuperclassB {
+  // expected-warning@-1{{class 'MySubclassB' has no initializers; this is an error in Swift 6}}
+  var hi: String
+  // expected-note@-1{{stored property 'hi' without initial value prevents synthesized initializers}}
 }


### PR DESCRIPTION
When a class inherits a superclass from another module, and that superclass has non-public designated initializers, two important diagnostics were being suppressed:
* The diagnostic about any `required` initializers in the superclass that couldn't be synthesized in the subclass, and
* The diagnostic about the lack of any initializers in the subclass.

Between the two, it became possible to create a class that could not be initialized statically (doing so would produce an error), but that could be dynamically created via the required initializer---without initializing the subclass's storage. Introduce diagnostics for both, staging them in via warnings in Swift 5 and becoming errors in Swift 6.

Fixes https://github.com/apple/swift/issues/69965