### PR TITLE
[ASTGen] Move logic in `BridgedASTContext.getIdentifier()` to ASTGen

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -65,7 +65,7 @@ inline const void *_Nullable BridgedIdentifier_raw(BridgedIdentifier ident) {
   return ident.Raw;
 }
 
-struct BridgedIdentifierAndSourceLoc {
+struct BridgedLocatedIdentifier {
   SWIFT_NAME("name")
   BridgedIdentifier Name;
 

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -110,16 +110,7 @@ BridgedDeclNameLoc_createParsed(BridgedSourceLoc cBaseNameLoc) {
 
 BridgedIdentifier BridgedASTContext_getIdentifier(BridgedASTContext cContext,
                                                   BridgedStringRef cStr) {
-  StringRef str = cStr.unbridged();
-  if (str.size() == 1 && str.front() == '_')
-    return BridgedIdentifier();
-
-  // If this was a back-ticked identifier, drop the back-ticks.
-  if (str.size() >= 2 && str.front() == '`' && str.back() == '`') {
-    str = str.drop_front().drop_back();
-  }
-
-  return cContext.unbridged().getIdentifier(str);
+  return cContext.unbridged().getIdentifier(cStr.unbridged());
 }
 
 bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -672,8 +672,7 @@ BridgedNominalTypeDecl BridgedProtocolDecl_createParsed(
 
   auto primaryAssociatedTypeNames =
       context.AllocateTransform<PrimaryAssociatedTypeName>(
-          cPrimaryAssociatedTypeNames
-              .unbridged<BridgedIdentifierAndSourceLoc>(),
+          cPrimaryAssociatedTypeNames.unbridged<BridgedLocatedIdentifier>(),
           [](auto &e) -> PrimaryAssociatedTypeName {
             return {e.Name.unbridged(), e.NameLoc.unbridged()};
           });
@@ -772,15 +771,13 @@ BridgedPrecedenceGroupDecl BridgedPrecedenceGroupDecl_createParsed(
     BridgedSourceLoc cRightBraceLoc) {
 
   SmallVector<PrecedenceGroupDecl::Relation, 2> higherThanNames;
-  for (auto &pair :
-       cHigherThanNames.unbridged<BridgedIdentifierAndSourceLoc>()) {
+  for (auto &pair : cHigherThanNames.unbridged<BridgedLocatedIdentifier>()) {
     higherThanNames.push_back(
         {pair.NameLoc.unbridged(), pair.Name.unbridged(), nullptr});
   }
 
   SmallVector<PrecedenceGroupDecl::Relation, 2> lowerThanNames;
-  for (auto &pair :
-       cLowerThanNames.unbridged<BridgedIdentifierAndSourceLoc>()) {
+  for (auto &pair : cLowerThanNames.unbridged<BridgedLocatedIdentifier>()) {
     lowerThanNames.push_back(
         {pair.NameLoc.unbridged(), pair.Name.unbridged(), nullptr});
   }
@@ -802,7 +799,7 @@ BridgedImportDecl BridgedImportDecl_createParsed(
     BridgedSourceLoc cImportKindLoc, BridgedArrayRef cImportPathElements) {
   ImportPath::Builder builder;
   for (auto &element :
-       cImportPathElements.unbridged<BridgedIdentifierAndSourceLoc>()) {
+       cImportPathElements.unbridged<BridgedLocatedIdentifier>()) {
     builder.push_back(element.Name.unbridged(), element.NameLoc.unbridged());
   }
 

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -167,10 +167,14 @@ extension TokenSyntax {
   /// - Parameter astgen: The visitor providing the `ASTContext`.
   @inline(__always)
   func bridgedIdentifier(in astgen: ASTGenVisitor) -> BridgedIdentifier {
-    var text = self.text
-    return text.withBridgedString { bridged in
-      astgen.ctx.getIdentifier(bridged)
+    var text = self.rawText
+    if rawText == "_" {
+      return nil
     }
+    if rawText.count > 2 && rawText.hasPrefix("`") && rawText.hasSuffix("`") {
+      text = .init(rebasing: text.dropFirst().dropLast())
+    }
+    return astgen.ctx.getIdentifier(rawText.bridged)
   }
 
   /// Obtains a bridged, `ASTContext`-owned copy of this token's text, and its bridged start location in the

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -78,13 +78,6 @@ public extension BridgedSourceLoc {
   }
 }
 
-extension BridgedSourceRange {
-  @inline(__always)
-  init(startToken: TokenSyntax, endToken: TokenSyntax, in astgen: ASTGenVisitor) {
-    self.init(start: startToken.bridgedSourceLoc(in: astgen), end: endToken.bridgedSourceLoc(in: astgen))
-  }
-}
-
 extension String {
   init(bridged: BridgedStringRef) {
     self.init(
@@ -134,92 +127,5 @@ public func freeBridgedString(bridged: BridgedStringRef) {
 extension BridgedStringRef {
   var isEmptyInitialized: Bool {
     return self.data == nil && self.count == 0
-  }
-}
-
-extension SyntaxProtocol {
-  /// Obtains the bridged start location of the node excluding leading trivia in the source buffer provided by `astgen`
-  ///
-  /// - Parameter astgen: The visitor providing the source buffer.
-  @inline(__always)
-  func bridgedSourceLoc(in astgen: ASTGenVisitor) -> BridgedSourceLoc {
-    return BridgedSourceLoc(at: self.positionAfterSkippingLeadingTrivia, in: astgen.base)
-  }
-}
-
-extension Optional where Wrapped: SyntaxProtocol {
-  /// Obtains the bridged start location of the node excluding leading trivia in the source buffer provided by `astgen`.
-  ///
-  /// - Parameter astgen: The visitor providing the source buffer.
-  @inline(__always)
-  func bridgedSourceLoc(in astgen: ASTGenVisitor) -> BridgedSourceLoc {
-    guard let self else {
-      return nil
-    }
-
-    return self.bridgedSourceLoc(in: astgen)
-  }
-}
-
-extension TokenSyntax {
-  /// Obtains a bridged, `ASTContext`-owned copy of this token's text.
-  ///
-  /// - Parameter astgen: The visitor providing the `ASTContext`.
-  @inline(__always)
-  func bridgedIdentifier(in astgen: ASTGenVisitor) -> BridgedIdentifier {
-    var text = self.rawText
-    if rawText == "_" {
-      return nil
-    }
-    if rawText.count > 2 && rawText.hasPrefix("`") && rawText.hasSuffix("`") {
-      text = .init(rebasing: text.dropFirst().dropLast())
-    }
-    return astgen.ctx.getIdentifier(rawText.bridged)
-  }
-
-  /// Obtains a bridged, `ASTContext`-owned copy of this token's text, and its bridged start location in the
-  /// source buffer provided by `astgen`.
-  ///
-  /// - Parameter astgen: The visitor providing the `ASTContext` and source buffer.
-  @inline(__always)
-  func bridgedIdentifierAndSourceLoc(in astgen: ASTGenVisitor) -> (BridgedIdentifier, BridgedSourceLoc) {
-    return (self.bridgedIdentifier(in: astgen), self.bridgedSourceLoc(in: astgen))
-  }
-
-  /// Obtains a bridged, `ASTContext`-owned copy of this token's text, and its bridged start location in the
-  /// source buffer provided by `astgen`.
-  ///
-  /// - Parameter astgen: The visitor providing the `ASTContext` and source buffer.
-  @inline(__always)
-  func bridgedIdentifierAndSourceLoc(in astgen: ASTGenVisitor) -> BridgedIdentifierAndSourceLoc {
-    let (name, nameLoc) = self.bridgedIdentifierAndSourceLoc(in: astgen)
-    return .init(name: name, nameLoc: nameLoc)
-  }
-}
-
-extension Optional<TokenSyntax> {
-  /// Obtains a bridged, `ASTContext`-owned copy of this token's text.
-  ///
-  /// - Parameter astgen: The visitor providing the `ASTContext`.
-  @inline(__always)
-  func bridgedIdentifier(in astgen: ASTGenVisitor) -> BridgedIdentifier {
-    guard let self else {
-      return nil
-    }
-
-    return self.bridgedIdentifier(in: astgen)
-  }
-
-  /// Obtains a bridged, `ASTContext`-owned copy of this token's text, and its bridged start location in the
-  /// source buffer provided by `astgen` excluding leading trivia.
-  ///
-  /// - Parameter astgen: The visitor providing the `ASTContext` and source buffer.
-  @inline(__always)
-  func bridgedIdentifierAndSourceLoc(in astgen: ASTGenVisitor) -> (BridgedIdentifier, BridgedSourceLoc) {
-    guard let self else {
-      return (nil, nil)
-    }
-
-    return self.bridgedIdentifierAndSourceLoc(in: astgen)
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Bridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/Bridge.swift
@@ -129,3 +129,85 @@ extension BridgedStringRef {
     return self.data == nil && self.count == 0
   }
 }
+
+extension SyntaxProtocol {
+  /// Obtains the bridged start location of the node excluding leading trivia in the source buffer provided by `astgen`
+  ///
+  /// - Parameter astgen: The visitor providing the source buffer.
+  @available(*, deprecated, message: "use ASTContext.bridgedSourceLoc(syntax:)")
+  @inline(__always)
+  func bridgedSourceLoc(in astgen: ASTGenVisitor) -> BridgedSourceLoc {
+    astgen.generateSourceLoc(self)
+  }
+}
+
+extension Optional where Wrapped: SyntaxProtocol {
+  /// Obtains the bridged start location of the node excluding leading trivia in the source buffer provided by `astgen`.
+  ///
+  /// - Parameter astgen: The visitor providing the source buffer.
+  @available(*, deprecated, message: "use ASTContext.bridgedSourceLoc(syntax:)")
+  @inline(__always)
+  func bridgedSourceLoc(in astgen: ASTGenVisitor) -> BridgedSourceLoc {
+    astgen.generateSourceLoc(self)
+  }
+}
+
+extension TokenSyntax {
+  /// Obtains a bridged, `ASTContext`-owned copy of this token's text.
+  ///
+  /// - Parameter astgen: The visitor providing the `ASTContext`.
+  @available(*, deprecated, message: "use ASTContext.bridgedIdentifier(token:)")
+  @inline(__always)
+  func bridgedIdentifier(in astgen: ASTGenVisitor) -> BridgedIdentifier {
+    astgen.generateIdentifier(self)
+  }
+
+  /// Obtains a bridged, `ASTContext`-owned copy of this token's text, and its bridged start location in the
+  /// source buffer provided by `astgen`.
+  ///
+  /// - Parameter astgen: The visitor providing the `ASTContext` and source buffer.
+  @available(*, deprecated, message: "use ASTContext.bridgedIdentifierAndSourceLoc(token:)")
+  @inline(__always)
+  func bridgedIdentifierAndSourceLoc(in astgen: ASTGenVisitor) -> (BridgedIdentifier, BridgedSourceLoc) {
+    astgen.generateIdentifierAndSourceLoc(self)
+  }
+
+  /// Obtains a bridged, `ASTContext`-owned copy of this token's text, and its bridged start location in the
+  /// source buffer provided by `astgen`.
+  ///
+  /// - Parameter astgen: The visitor providing the `ASTContext` and source buffer.
+  @available(*, deprecated, message: "use ASTContext.bridgedIdentifierAndSourceLoc(token:)")
+  @inline(__always)
+  func bridgedIdentifierAndSourceLoc(in astgen: ASTGenVisitor) -> BridgedLocatedIdentifier {
+    astgen.generateLocatedIdentifier(self)
+  }
+}
+
+extension Optional<TokenSyntax> {
+  /// Obtains a bridged, `ASTContext`-owned copy of this token's text.
+  ///
+  /// - Parameter astgen: The visitor providing the `ASTContext`.
+  @available(*, deprecated, message: "use ASTContext.bridgedIdentifier(token:)")
+  @inline(__always)
+  func bridgedIdentifier(in astgen: ASTGenVisitor) -> BridgedIdentifier {
+    astgen.generateIdentifier(self)
+  }
+
+  /// Obtains a bridged, `ASTContext`-owned copy of this token's text, and its bridged start location in the
+  /// source buffer provided by `astgen` excluding leading trivia.
+  ///
+  /// - Parameter astgen: The visitor providing the `ASTContext` and source buffer.
+  @available(*, deprecated, message: "use ASTContext.bridgedIdentifierAndSourceLoc(token:)")
+  @inline(__always)
+  func bridgedIdentifierAndSourceLoc(in astgen: ASTGenVisitor) -> (BridgedIdentifier, BridgedSourceLoc) {
+    astgen.generateIdentifierAndSourceLoc(self)
+  }
+}
+
+extension BridgedSourceRange {
+  @available(*, deprecated, message: "use ASTContext.bridgedSourceRange(startToken:endToken:)")
+  @inline(__always)
+  init(startToken: TokenSyntax, endToken: TokenSyntax, in astgen: ASTGenVisitor) {
+    self = astgen.generateSourceRange(start: startToken, end: endToken)
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -73,37 +73,36 @@ extension ASTGenVisitor {
   }
 
   public func generate(typeAliasDecl node: TypeAliasDeclSyntax) -> BridgedTypeAliasDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     return .createParsed(
       self.ctx,
       declContext: self.declContext,
-      typealiasKeywordLoc: node.typealiasKeyword.bridgedSourceLoc(in: self),
+      typealiasKeywordLoc: self.generateSourceLoc(node.typealiasKeyword),
       name: name,
       nameLoc: nameLoc,
       genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
-      equalLoc: node.initializer.equal.bridgedSourceLoc(in: self),
+      equalLoc: self.generateSourceLoc(node.initializer.equal),
       underlyingType: self.generate(type: node.initializer.value),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause)
     )
   }
 
   public func generate(enumDecl node: EnumDeclSyntax) -> BridgedNominalTypeDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedEnumDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
-      enumKeywordLoc: node.enumKeyword.bridgedSourceLoc(in: self),
+      enumKeywordLoc: self.generateSourceLoc(node.enumKeyword),
       name: name,
       nameLoc: nameLoc,
       genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
-      braceRange: BridgedSourceRange(
-        startToken: node.memberBlock.leftBrace,
-        endToken: node.memberBlock.rightBrace,
-        in: self
+      braceRange: self.generateSourceRange(
+        start: node.memberBlock.leftBrace,
+        end: node.memberBlock.rightBrace
       )
     )
 
@@ -115,21 +114,20 @@ extension ASTGenVisitor {
   }
 
   public func generate(structDecl node: StructDeclSyntax) -> BridgedNominalTypeDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedStructDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
-      structKeywordLoc: node.structKeyword.bridgedSourceLoc(in: self),
+      structKeywordLoc: self.generateSourceLoc(node.structKeyword),
       name: name,
       nameLoc: nameLoc,
       genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
-      braceRange: BridgedSourceRange(
-        startToken: node.memberBlock.leftBrace,
-        endToken: node.memberBlock.rightBrace,
-        in: self
+      braceRange: self.generateSourceRange(
+        start: node.memberBlock.leftBrace,
+        end: node.memberBlock.rightBrace
       )
     )
 
@@ -141,21 +139,20 @@ extension ASTGenVisitor {
   }
 
   public func generate(classDecl node: ClassDeclSyntax) -> BridgedNominalTypeDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedClassDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
-      classKeywordLoc: node.classKeyword.bridgedSourceLoc(in: self),
+      classKeywordLoc: self.generateSourceLoc(node.classKeyword),
       name: name,
       nameLoc: nameLoc,
       genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
-      braceRange: BridgedSourceRange(
-        startToken: node.memberBlock.leftBrace,
-        endToken: node.memberBlock.rightBrace,
-        in: self
+      braceRange: self.generateSourceRange(
+        start: node.memberBlock.leftBrace,
+        end: node.memberBlock.rightBrace
       ),
       isActor: false
     )
@@ -168,21 +165,20 @@ extension ASTGenVisitor {
   }
 
   public func generate(actorDecl node: ActorDeclSyntax) -> BridgedNominalTypeDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedClassDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
-      classKeywordLoc: node.actorKeyword.bridgedSourceLoc(in: self),
+      classKeywordLoc: self.generateSourceLoc(node.actorKeyword),
       name: name,
       nameLoc: nameLoc,
       genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
-      braceRange: BridgedSourceRange(
-        startToken: node.memberBlock.leftBrace,
-        endToken: node.memberBlock.rightBrace,
-        in: self
+      braceRange: self.generateSourceRange(
+        start: node.memberBlock.leftBrace,
+        end: node.memberBlock.rightBrace
       ),
       isActor: true
     )
@@ -195,24 +191,23 @@ extension ASTGenVisitor {
   }
 
   func generate(protocolDecl node: ProtocolDeclSyntax) -> BridgedNominalTypeDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
     let primaryAssociatedTypeNames = node.primaryAssociatedTypeClause?.primaryAssociatedTypes.lazy.map {
-      $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
+      self.generateLocatedIdentifier($0.name)
     }
 
     let decl = BridgedProtocolDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
-      protocolKeywordLoc: node.protocolKeyword.bridgedSourceLoc(in: self),
+      protocolKeywordLoc: self.generateSourceLoc(node.protocolKeyword),
       name: name,
       nameLoc: nameLoc,
       primaryAssociatedTypeNames: primaryAssociatedTypeNames.bridgedArray(in: self),
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
-      braceRange: BridgedSourceRange(
-        startToken: node.memberBlock.leftBrace,
-        endToken: node.memberBlock.rightBrace,
-        in: self
+      braceRange: self.generateSourceRange(
+        start: node.memberBlock.leftBrace,
+        end: node.memberBlock.rightBrace
       )
     )
 
@@ -224,12 +219,12 @@ extension ASTGenVisitor {
   }
 
   func generate(associatedTypeDecl node: AssociatedTypeDeclSyntax) -> BridgedAssociatedTypeDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     return .createParsed(
       self.ctx,
       declContext: self.declContext,
-      associatedtypeKeywordLoc: node.associatedtypeKeyword.bridgedSourceLoc(in: self),
+      associatedtypeKeywordLoc: self.generateSourceLoc(node.associatedtypeKeyword),
       name: name,
       nameLoc: nameLoc,
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
@@ -246,14 +241,13 @@ extension ASTGenVisitor {
     let decl = BridgedExtensionDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
-      extensionKeywordLoc: node.extensionKeyword.bridgedSourceLoc(in: self),
+      extensionKeywordLoc: self.generateSourceLoc(node.extensionKeyword),
       extendedType: self.generate(type: node.extendedType),
       inheritedTypes: self.generate(inheritedTypeList: node.inheritanceClause?.inheritedTypes),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
-      braceRange: BridgedSourceRange(
-        startToken: node.memberBlock.leftBrace,
-        endToken: node.memberBlock.rightBrace,
-        in: self
+      braceRange: self.generateSourceRange(
+        start: node.memberBlock.leftBrace,
+        end: node.memberBlock.rightBrace
       )
     )
 
@@ -269,7 +263,7 @@ extension ASTGenVisitor {
 
 extension ASTGenVisitor {
   func generate(enumCaseElement node: EnumCaseElementSyntax) -> BridgedEnumElementDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     return .createParsed(
       self.ctx,
@@ -277,7 +271,7 @@ extension ASTGenVisitor {
       name: name,
       nameLoc: nameLoc,
       parameterList: self.generate(enumCaseParameterClause: node.parameterClause),
-      equalsLoc: (node.rawValue?.equal).bridgedSourceLoc(in: self),
+      equalsLoc: self.generateSourceLoc(node.rawValue?.equal),
       rawValue: self.generate(expr: node.rawValue?.value)
     )
   }
@@ -285,7 +279,7 @@ extension ASTGenVisitor {
   func generate(enumCaseDecl node: EnumCaseDeclSyntax) -> BridgedEnumCaseDecl {
     .createParsed(
       declContext: self.declContext,
-      caseKeywordLoc: node.caseKeyword.bridgedSourceLoc(in: self),
+      caseKeywordLoc: self.generateSourceLoc(node.caseKeyword),
       elements: node.elements.lazy.map(self.generate).bridgedArray(in: self)
     )
   }
@@ -304,7 +298,7 @@ extension ASTGenVisitor {
     return .createParsed(
       self.ctx,
       declContext: self.declContext,
-      bindingKeywordLoc: node.bindingSpecifier.bridgedSourceLoc(in: self),
+      bindingKeywordLoc: self.generateSourceLoc(node.bindingSpecifier),
       pattern: pattern,
       initializer: initializer,
       isStatic: isStatic,
@@ -320,19 +314,19 @@ extension ASTGenVisitor {
     // FIXME: Compute this location
     let staticLoc: BridgedSourceLoc = nil
 
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedFuncDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
       staticLoc: staticLoc,
-      funcKeywordLoc: node.funcKeyword.bridgedSourceLoc(in: self),
+      funcKeywordLoc: self.generateSourceLoc(node.funcKeyword),
       name: name,
       nameLoc: nameLoc,
       genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       parameterList: self.generate(functionParameterClause: node.signature.parameterClause),
-      asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
-      throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
+      asyncSpecifierLoc: self.generateSourceLoc(node.signature.effectSpecifiers?.asyncSpecifier),
+      throwsSpecifierLoc: self.generateSourceLoc(node.signature.effectSpecifiers?.throwsSpecifier),
       thrownType: self.generate(type: node.signature.effectSpecifiers?.thrownError),
       returnType: self.generate(type: node.signature.returnClause?.type),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause)
@@ -351,13 +345,13 @@ extension ASTGenVisitor {
     let decl = BridgedConstructorDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
-      initKeywordLoc: node.initKeyword.bridgedSourceLoc(in: self),
-      failabilityMarkLoc: node.optionalMark.bridgedSourceLoc(in: self),
+      initKeywordLoc: self.generateSourceLoc(node.initKeyword),
+      failabilityMarkLoc: self.generateSourceLoc(node.optionalMark),
       isIUO: node.optionalMark?.tokenKind == .exclamationMark,
       genericParamList: self.generate(genericParameterClause: node.genericParameterClause),
       parameterList: self.generate(functionParameterClause: node.signature.parameterClause),
-      asyncSpecifierLoc: (node.signature.effectSpecifiers?.asyncSpecifier).bridgedSourceLoc(in: self),
-      throwsSpecifierLoc: (node.signature.effectSpecifiers?.throwsSpecifier).bridgedSourceLoc(in: self),
+      asyncSpecifierLoc: self.generateSourceLoc(node.signature.effectSpecifiers?.asyncSpecifier),
+      throwsSpecifierLoc: self.generateSourceLoc(node.signature.effectSpecifiers?.throwsSpecifier),
       thrownType: self.generate(type: node.signature.effectSpecifiers?.thrownError),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause)
     )
@@ -375,7 +369,7 @@ extension ASTGenVisitor {
     let decl = BridgedDestructorDecl.createParsed(
       self.ctx,
       declContext: self.declContext,
-      deinitKeywordLoc: node.deinitKeyword.bridgedSourceLoc(in: self)
+      deinitKeywordLoc: self.generateSourceLoc(node.deinitKeyword)
     )
 
     if let body = node.body {
@@ -403,9 +397,9 @@ extension BridgedOperatorFixity {
 
 extension ASTGenVisitor {
   func generate(operatorDecl node: OperatorDeclSyntax) -> BridgedOperatorDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
-    let (precedenceGroupName, precedenceGroupLoc) = (node.operatorPrecedenceAndTypes?.precedenceGroup)
-      .bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
+    let (precedenceGroupName, precedenceGroupLoc) =
+        self.generateIdentifierAndSourceLoc(node.operatorPrecedenceAndTypes?.precedenceGroup)
 
     let fixity: BridgedOperatorFixity
     if let value = BridgedOperatorFixity(from: node.fixitySpecifier.tokenKind) {
@@ -421,10 +415,10 @@ extension ASTGenVisitor {
       self.ctx,
       declContext: self.declContext,
       fixity: fixity,
-      operatorKeywordLoc: node.operatorKeyword.bridgedSourceLoc(in: self),
+      operatorKeywordLoc: self.generateSourceLoc(node.operatorKeyword),
       name: name,
       nameLoc: nameLoc,
-      colonLoc: (node.operatorPrecedenceAndTypes?.colon).bridgedSourceLoc(in: self),
+      colonLoc: self.generateSourceLoc(node.operatorPrecedenceAndTypes?.colon),
       precedenceGroupName: precedenceGroupName,
       precedenceGroupLoc: precedenceGroupLoc
     )
@@ -446,7 +440,7 @@ extension BridgedAssociativity {
 
 extension ASTGenVisitor {
   func generate(precedenceGroupDecl node: PrecedenceGroupDeclSyntax) -> BridgedPrecedenceGroupDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     struct PrecedenceGroupBody {
       var associativity: PrecedenceGroupAssociativitySyntax? = nil
@@ -522,21 +516,21 @@ extension ASTGenVisitor {
 
     return .createParsed(
       declContext: self.declContext,
-      precedencegroupKeywordLoc: node.precedencegroupKeyword.bridgedSourceLoc(in: self),
+      precedencegroupKeywordLoc: self.generateSourceLoc(node.precedencegroupKeyword),
       name: name,
       nameLoc: nameLoc,
-      leftBraceLoc: node.leftBrace.bridgedSourceLoc(in: self),
-      associativityLabelLoc: (body.associativity?.associativityLabel).bridgedSourceLoc(in: self),
-      associativityValueLoc: (body.associativity?.value).bridgedSourceLoc(in: self),
+      leftBraceLoc: self.generateSourceLoc(node.leftBrace),
+      associativityLabelLoc: self.generateSourceLoc(body.associativity?.associativityLabel),
+      associativityValueLoc: self.generateSourceLoc(body.associativity?.value),
       associativity: associativityValue,
-      assignmentLabelLoc: (body.assignment?.assignmentLabel).bridgedSourceLoc(in: self),
-      assignmentValueLoc: (body.assignment?.value).bridgedSourceLoc(in: self),
+      assignmentLabelLoc: self.generateSourceLoc(body.assignment?.assignmentLabel),
+      assignmentValueLoc: self.generateSourceLoc((body.assignment?.value)),
       isAssignment: assignmentValue,
-      higherThanKeywordLoc: (body.higherThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
+      higherThanKeywordLoc: self.generateSourceLoc((body.higherThanRelation?.higherThanOrLowerThanLabel)),
       higherThanNames: self.generate(precedenceGroupNameList: body.higherThanRelation?.precedenceGroups),
-      lowerThanKeywordLoc: (body.lowerThanRelation?.higherThanOrLowerThanLabel).bridgedSourceLoc(in: self),
+      lowerThanKeywordLoc: self.generateSourceLoc(body.lowerThanRelation?.higherThanOrLowerThanLabel),
       lowerThanNames: self.generate(precedenceGroupNameList: body.lowerThanRelation?.precedenceGroups),
-      rightBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
+      rightBraceLoc: self.generateSourceLoc(node.rightBrace)
     )
   }
 }
@@ -575,11 +569,11 @@ extension ASTGenVisitor {
     return .createParsed(
       self.ctx,
       declContext: self.declContext,
-      importKeywordLoc: node.importKeyword.bridgedSourceLoc(in: self),
+      importKeywordLoc: self.generateSourceLoc(node.importKeyword),
       importKind: importKind,
-      importKindLoc: node.importKindSpecifier.bridgedSourceLoc(in: self),
+      importKindLoc: self.generateSourceLoc(node.importKindSpecifier),
       path: node.path.lazy.map {
-        $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
+        self.generateLocatedIdentifier($0.name)
       }.bridgedArray(in: self)
     )
   }
@@ -599,7 +593,7 @@ extension ASTGenVisitor {
   @inline(__always)
   func generate(precedenceGroupNameList node: PrecedenceGroupNameListSyntax) -> BridgedArrayRef {
     node.lazy.map {
-      $0.name.bridgedIdentifierAndSourceLoc(in: self) as BridgedIdentifierAndSourceLoc
+      self.generateLocatedIdentifier($0.name)
     }.bridgedArray(in: self)
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -17,15 +17,15 @@ extension ASTGenVisitor {
   func generate(genericParameterClause node: GenericParameterClauseSyntax) -> BridgedGenericParamList {
     .createParsed(
       self.ctx,
-      leftAngleLoc: node.leftAngle.bridgedSourceLoc(in: self),
+      leftAngleLoc: self.generateSourceLoc(node.leftAngle),
       parameters: node.parameters.lazy.map(self.generate).bridgedArray(in: self),
       genericWhereClause: self.generate(genericWhereClause: node.genericWhereClause),
-      rightAngleLoc: node.rightAngle.bridgedSourceLoc(in: self)
+      rightAngleLoc: self.generateSourceLoc(node.rightAngle)
     )
   }
 
   func generate(genericParameter node: GenericParameterSyntax) -> BridgedGenericTypeParamDecl {
-    let (name, nameLoc) = node.name.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     var genericParameterIndex: Int?
     for (index, sibling) in (node.parent?.as(GenericParameterListSyntax.self) ?? []).enumerated() {
@@ -41,7 +41,7 @@ extension ASTGenVisitor {
     return .createParsed(
       self.ctx,
       declContext: self.declContext,
-      eachKeywordLoc: node.eachKeyword.bridgedSourceLoc(in: self),
+      eachKeywordLoc: self.generateSourceLoc(node.eachKeyword),
       name: name,
       nameLoc: nameLoc,
       inheritedType: self.generate(type: node.inheritedType),
@@ -54,14 +54,14 @@ extension ASTGenVisitor {
       switch $0.requirement {
       case .conformanceRequirement(let conformance):
         return BridgedRequirementRepr(
-          SeparatorLoc: conformance.colon.bridgedSourceLoc(in: self),
+          SeparatorLoc: self.generateSourceLoc(conformance.colon),
           Kind: .typeConstraint,
           FirstType: self.generate(type: conformance.leftType),
           SecondType: self.generate(type: conformance.rightType)
         )
       case .sameTypeRequirement(let sameType):
         return BridgedRequirementRepr(
-          SeparatorLoc: sameType.equal.bridgedSourceLoc(in: self),
+          SeparatorLoc: self.generateSourceLoc(sameType.equal),
           Kind: .sameType,
           FirstType: self.generate(type: sameType.leftType),
           SecondType: self.generate(type: sameType.rightType)
@@ -74,7 +74,7 @@ extension ASTGenVisitor {
 
     return BridgedTrailingWhereClause.createParsed(
       self.ctx,
-      whereKeywordLoc: node.whereKeyword.bridgedSourceLoc(in: self),
+      whereKeywordLoc: self.generateSourceLoc(node.whereKeyword),
       requirements: requirements.bridgedArray(in: self)
     )
   }

--- a/lib/ASTGen/Sources/ASTGen/LegacyParse.swift
+++ b/lib/ASTGen/Sources/ASTGen/LegacyParse.swift
@@ -24,26 +24,26 @@ extension ASTGenVisitor {
 
     // FIXME: Calculate isExprBasic.
     let isExprBasic = false
-    return legacyParse.parseExpr(node.bridgedSourceLoc(in: self), self.declContext, isExprBasic)
+    return legacyParse.parseExpr(self.generateSourceLoc(node), self.declContext, isExprBasic)
   }
 
   func generateWithLegacy(_ node: DeclSyntax) -> BridgedDecl {
-    legacyParse.parseDecl(node.bridgedSourceLoc(in: self), self.declContext)
+    legacyParse.parseDecl(self.generateSourceLoc(node), self.declContext)
   }
 
   func generateWithLegacy(_ node: StmtSyntax) -> BridgedStmt {
-    legacyParse.parseStmt(node.bridgedSourceLoc(in: self), self.declContext)
+    legacyParse.parseStmt(self.generateSourceLoc(node), self.declContext)
   }
 
   func generateWithLegacy(_ node: TypeSyntax) -> BridgedTypeRepr {
-    legacyParse.parseType(node.bridgedSourceLoc(in: self), self.declContext)
+    legacyParse.parseType(self.generateSourceLoc(node), self.declContext)
   }
 
   func generateMatchingPatternWithLegacy(_ node: some PatternSyntaxProtocol) {
-//    legacyParse.parseMatchingPattern(node.bridgedSourceLoc(in: self), self.declContext)
+//    legacyParse.parseMatchingPattern(self.bridgedSourceLoc(syntax: node), self.declContext)
   }
 
   func generateBindingPatternWithLegacy(_ node: some PatternSyntaxProtocol) {
-//    legacyParse.parseBindingPattern(node.bridgedSourceLoc(in: self), self.declContext)
+//    legacyParse.parseBindingPattern(self.bridgedSourceLoc(syntax: node), self.declContext)
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 
 extension ASTGenVisitor {
   public func generate(stringLiteralExpr node: StringLiteralExprSyntax) -> BridgedStringLiteralExpr {
-    let openDelimiterOrQuoteLoc = (node.openingPounds ?? node.openingQuote).bridgedSourceLoc(in: self)
+    let openDelimiterOrQuoteLoc = self.generateSourceLoc(node.openingPounds ?? node.openingQuote)
 
     // FIXME: Handle interpolated strings.
     // FIXME: Avoid 'String' instantiation
@@ -30,32 +30,43 @@ extension ASTGenVisitor {
     // FIXME: Strip '_'.
     var segment = node.literal.text
     return segment.withBridgedString { bridgedSegment in
-      return .createParsed(ctx, value: bridgedSegment, loc: node.literal.bridgedSourceLoc(in: self))
+      return .createParsed(
+        ctx,
+        value: bridgedSegment,
+        loc: self.generateSourceLoc(node.literal)
+      )
     }
   }
 
   public func generate(booleanLiteralExpr node: BooleanLiteralExprSyntax) -> BridgedBooleanLiteralExpr {
     let value = node.literal.tokenKind == .keyword(.true)
-    return .createParsed(ctx, value: value, loc: node.literal.bridgedSourceLoc(in: self))
+    return .createParsed(
+      ctx,
+      value: value,
+      loc: self.generateSourceLoc(node.literal)
+    )
   }
 
   public func generate(arrayExpr node: ArrayExprSyntax) -> BridgedArrayExpr {
     let expressions = node.elements.lazy.map(self.generate)
 
     let commaLocations = node.elements.compactMap(in: self) {
-      $0.trailingComma.bridgedSourceLoc(in: self)
+      self.generateSourceLoc($0.trailingComma)
     }
 
     return .createParsed(
       self.ctx,
-      lSquareLoc: node.leftSquare.bridgedSourceLoc(in: self),
+      lSquareLoc: self.generateSourceLoc(node.leftSquare),
       elements: expressions.bridgedArray(in: self),
       commaLocs: commaLocations,
-      rSquareLoc: node.rightSquare.bridgedSourceLoc(in: self)
+      rSquareLoc: self.generateSourceLoc(node.rightSquare)
     )
   }
 
   func generate(nilLiteralExpr node: NilLiteralExprSyntax) -> BridgedNilLiteralExpr {
-    .createParsed(self.ctx, nilKeywordLoc: node.nilKeyword.bridgedSourceLoc(in: self))
+    .createParsed(
+      self.ctx,
+      nilKeywordLoc: self.generateSourceLoc(node.nilKeyword)
+    )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
+++ b/lib/ASTGen/Sources/ASTGen/ParameterClause.swift
@@ -73,22 +73,17 @@ extension ASTGenVisitor {
     // FIXME: This location should be derived from the type repr.
     let specifierLoc: BridgedSourceLoc = nil
 
-    let firstName: BridgedIdentifier
-    if node.optionalFirstName?.tokenKind == .wildcard {
-      // Swift AST represents "_" as a null identifier.
-      firstName = nil
-    } else {
-      firstName = node.optionalFirstName.bridgedIdentifier(in: self)
-    }
-
-    let (secondName, secondNameLoc) = node.secondName.bridgedIdentifierAndSourceLoc(in: self)
+    let (firstName, firstNameLoc) =
+        self.generateIdentifierAndSourceLoc(node.optionalFirstName)
+    let (secondName, secondNameLoc) =
+        self.generateIdentifierAndSourceLoc(node.secondName)
 
     var type = node.optionalType.map(generate(type:))
     if let ellipsis = node.ellipsis, let base = type {
       type = BridgedVarargTypeRepr.createParsed(
         self.ctx,
         base: base,
-        ellipsisLoc: ellipsis.bridgedSourceLoc(in: self)
+        ellipsisLoc: self.generateSourceLoc(ellipsis)
       )
     }
 
@@ -97,7 +92,7 @@ extension ASTGenVisitor {
       declContext: self.declContext,
       specifierLoc: specifierLoc,
       firstName: firstName,
-      firstNameLoc: node.optionalFirstName.bridgedSourceLoc(in: self),
+      firstNameLoc: firstNameLoc,
       secondName: secondName,
       secondNameLoc: secondNameLoc,
       type: type.asNullable,
@@ -112,18 +107,18 @@ extension ASTGenVisitor {
   func generate(functionParameterClause node: FunctionParameterClauseSyntax) -> BridgedParameterList {
     BridgedParameterList.createParsed(
       self.ctx,
-      leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
+      leftParenLoc: self.generateSourceLoc(node.leftParen),
       parameters: self.generate(functionParameterList: node.parameters),
-      rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
+      rightParenLoc: self.generateSourceLoc(node.rightParen)
     )
   }
 
   func generate(enumCaseParameterClause node: EnumCaseParameterClauseSyntax) -> BridgedParameterList {
     BridgedParameterList.createParsed(
       self.ctx,
-      leftParenLoc: node.leftParen.bridgedSourceLoc(in: self),
+      leftParenLoc: self.generateSourceLoc(node.leftParen),
       parameters: node.parameters.lazy.map(self.generate).bridgedArray(in: self),
-      rightParenLoc: node.rightParen.bridgedSourceLoc(in: self)
+      rightParenLoc: self.generateSourceLoc(node.rightParen)
     )
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Patterns.swift
+++ b/lib/ASTGen/Sources/ASTGen/Patterns.swift
@@ -38,7 +38,7 @@ extension ASTGenVisitor {
   }
 
   func generate(identifierPattern node: IdentifierPatternSyntax) -> BridgedNamedPattern {
-    let (name, nameLoc) = node.identifier.bridgedIdentifierAndSourceLoc(in: self)
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.identifier)
     return .createParsed(
       ctx, declContext: declContext,
       name: name,

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -57,9 +57,9 @@ extension ASTGenVisitor {
   public func generate(codeBlock node: CodeBlockSyntax) -> BridgedBraceStmt {
     BridgedBraceStmt.createParsed(
       self.ctx,
-      lBraceLoc: node.leftBrace.bridgedSourceLoc(in: self),
+      lBraceLoc: self.generateSourceLoc(node.leftBrace),
       elements: self.generate(codeBlockItemList: node.statements),
-      rBraceLoc: node.rightBrace.bridgedSourceLoc(in: self)
+      rBraceLoc: self.generateSourceLoc(node.rightBrace)
     )
   }
 
@@ -71,10 +71,10 @@ extension ASTGenVisitor {
 
     return .createParsed(
       self.ctx,
-      ifKeywordLoc: node.ifKeyword.bridgedSourceLoc(in: self),
+      ifKeywordLoc: self.generateSourceLoc(node.ifKeyword),
       condition: conditions.first!.castToExpr,
       thenStmt: self.generate(codeBlock: node.body),
-      elseLoc: node.elseKeyword.bridgedSourceLoc(in: self),
+      elseLoc: self.generateSourceLoc(node.elseKeyword),
       elseStmt: node.elseBody.map {
         switch $0 {
         case .codeBlock(let node):
@@ -98,7 +98,7 @@ extension ASTGenVisitor {
   public func generate(returnStmt node: ReturnStmtSyntax) -> BridgedReturnStmt {
     .createParsed(
       self.ctx,
-      returnKeywordLoc: node.returnKeyword.bridgedSourceLoc(in: self),
+      returnKeywordLoc: self.generateSourceLoc(node.returnKeyword),
       expr: self.generate(expr: node.expression)
     )
   }


### PR DESCRIPTION
`getIdentifier()` has some logic includning `_` -> `Identifier()` and stripping escaped identifier. 
Ideally, `ASTBridging` should only do the necessary work for bridging. All non-trivial logic should be in ASTGen.

Also, move-back `getBridgedIdentifier()`, `getBridgedSourceLoc()`, etc to `ASTGenVisitor`.  Now that `getIdentifier()` has some logic, so it's more natural in `ASTGenVisitor`. As for `getBridgedSourceLoc()` this provides syntactic consistency with `generate(xxx:)` functions, e.g.
```swift
    return.createParsed(
      self.ctx,
      leftParenLoc: self.generateSourceLoc(node.leftParen),
      parameters: self.generate(functionParameterList: node.parameters),
      rightParenLoc: self.generateSourceLoc(node.rightParen)
    )
 ```