### PR TITLE
Fix MemoryLifetimeVerifier to ignore thin functions.

### DIFF
--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -763,3 +763,21 @@ bb3:
   return %22 : $()                                
 } 
 
+sil @$testTrivialThinToThickClosure : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+sil @$testTrivialThinToThickApply : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+
+// Test alloc_stack of a non-trivial (thick) function.
+// Initialize by storing a thin function, which as ownership .none.
+// Deallocation does not require a destroy_adr.
+sil [ossa] @testTrivialThinToThick : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @$testTrivialThinToThickClosure : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %1 = thin_to_thick_function %0 : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <Int> to $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %2 = alloc_stack $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  store %1 to [trivial] %2 : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %4 = function_ref @$testTrivialThinToThickApply : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %5 = apply %4<() -> Int>(%2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %2 : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %7 = tuple ()
+  return %7 : $()
+}


### PR DESCRIPTION
SILGen optimizes creation of closure down a thin function when it has no captures:
```
  %1 = thin_to_thick_function %0
  : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
```
ValueOwnership.cpp has a sketchy optimization that treat the result like a trivial type, even though it is not:
```
>  CONSTANT_OWNERSHIP_INST(None, ThinToThickFunction)

commit 8c5737d1d5f87d6d2379e6b074797557561e82aa
Date:   Fri Oct 23 15:12:18 2020 -0700

    [ownership] Change thin_to_thick function to always produce a none value.
```
This creates a mismatch between the SILType and the SILValue ownership. This is not a coherent design--we have a similar problem with enums which is endlessly buggy--but reverting the decision will be hard. Instead, I'll hack the memory verifier to silence this case.

Fixes rdar://115735132 (Lifetime verifier error with opaque return type and closure)
