### PR TITLE
[CodeCompletion] Don’t increase score for non-default literal types when performing member completion on a literal

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -88,15 +88,23 @@ static bool shouldIgnoreScoreIncreaseForCodeCompletion(
     return true;
   }
 
-  // The sibling argument is the code completion expression, this allows e.g.
-  // non-default literal values in sibling arguments.
-  // E.g. we allow a 1 to be a double in
-  // foo(1, #^COMPLETE^#)
   if (auto parent = cs.getParentExpr(expr)) {
+    // The sibling argument is the code completion expression, this allows e.g.
+    // non-default literal values in sibling arguments.
+    // E.g. we allow a 1 to be a double in
+    // foo(1, #^COMPLETE^#)
     if (exprHasCodeCompletionAsArgument(parent, cs)) {
       return true;
     }
+    // If we are completing a member of a literal, consider completion results
+    // for all possible literal types. E.g. show completion results for `let a:
+    // Double = 1.#^COMPLETE^#
+    if (isa_and_nonnull<CodeCompletionExpr>(parent) &&
+        kind == SK_NonDefaultLiteral) {
+      return true;
+    }
   }
+
   return false;
 }
 

--- a/test/IDE/complete_non_default_literal.swift
+++ b/test/IDE/complete_non_default_literal.swift
@@ -1,0 +1,22 @@
+// RUN: %batch-code-completion
+
+extension Double {
+  var doubleOnlyMember: Double { self }
+}
+
+struct CustomInt: ExpressibleByIntegerLiteral {
+  public init() {}
+  public init(integerLiteral value: Int) {  }
+  var customIntMember: CustomInt { .init() }
+}
+
+func test() {
+  let double: Double = 2.#^DOUBLE_CONTEXTUAL_TYPE^#
+  // DOUBLE_CONTEXTUAL_TYPE: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: doubleOnlyMember[#Double#];
+
+  let int: Int = 2.#^INT_CONTEXTUAL_TYPE^#
+  // INT_CONTEXTUAL_TYPE: Decl[InstanceVar]/CurrNominal: doubleOnlyMember[#Double#];
+
+  let customInt: CustomInt = 2.#^CUSTOM_INT^#
+  // CUSTOM_INT-NOT: customIntMember
+}


### PR DESCRIPTION
Resolves rdar://118999423
