### PR TITLE
Diagnose *all* cases where a subclass fails to override a required init 

### DIFF
--- a/test/decl/class/inheritance_across_modules.swift
+++ b/test/decl/class/inheritance_across_modules.swift
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module-path %t/MyModule.swiftmodule %t/Inputs/MyModule.swift
+
+// RUN: %target-swift-frontend -typecheck -verify -I %t %t/test.swift
+
+//--- Inputs/MyModule.swift
+open class MySuperclassA {
+  required public init() { }
+  internal init(boop: Bool) {}
+}
+
+//--- test.swift
+import MyModule
+
+class MySubclassA: MySuperclassA {
+// expected-warning{{'required' initializer 'init()' must be provided by subclass of 'MySuperclassA'; this is an error in Swift 6}}
+  var hi: String
+}

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -63,6 +63,7 @@ class DecodableSuper : Decodable {
 
 // expected-note@+1 {{did you mean to override 'init(from:)'?}}{{+1:1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}}}
 class DecodableSubWithoutInitialValue : DecodableSuper { // expected-error {{class 'DecodableSubWithoutInitialValue' has no initializers}}
+// expected-warning{{'required' initializer 'init(from:)' must be provided by subclass of 'DecodableSuper'}}
   var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
 }
 
@@ -78,6 +79,7 @@ class CodableSuper : Codable {
 
 // expected-note@+1 {{did you mean to override 'init(from:)' and 'encode(to:)'?}}{{+1:1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}\n\noverride func encode(to encoder: Encoder) throws {\n    <#code#>\n\}}}
 class CodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'CodableSubWithoutInitialValue' has no initializers}}
+  // expected-warning{{'required' initializer 'init(from:)' must be provided by subclass of 'CodableSuper'; this is an error in Swift 6}}
   var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
 }
 
@@ -86,6 +88,7 @@ class CodableSubWithoutInitialValue : CodableSuper { // expected-error {{class '
 //
 // expected-note@+1 {{did you mean to override 'init(from:)'?}}{{+1:1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}}}
 class EncodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'EncodableSubWithoutInitialValue' has no initializers}}
+  // expected-warning{{'required' initializer 'init(from:)' must be provided by subclass of 'CodableSuper'; this is an error in Swift 6}}
   var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
 
   override func encode(to: Encoder) throws {}


### PR DESCRIPTION
In cases where a subclass was unable to synthesize any initializers (for example, because there were missing designated initializers in the superclass), we were skipping checking of superclass required initializers. This meant that we would silently accept subclasses that cannot be initialized directly (that would produce an error), but could at runtime be initialized via a required initializer... that didn't account for the subclass.

Fixes the original problem from https://github.com/apple/swift/issues/69965.