### PR TITLE
Remove SelfAccessKind::ResultDependsOnSelf

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -241,8 +241,7 @@ enum class SelfAccessKind : uint8_t {
   LegacyConsuming,
   Consuming,
   Borrowing,
-  ResultDependsOnSelf,
-  LastSelfAccessKind = ResultDependsOnSelf,
+  LastSelfAccessKind = Borrowing,
 };
 enum : unsigned {
   NumSelfAccessKindBits =

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1559,9 +1559,6 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, ValueDecl *VD)
     case SelfAccessKind::Borrowing:
       FuncSelfKind = "Borrowing";
       break;
-    case SelfAccessKind::ResultDependsOnSelf:
-      FuncSelfKind = "ResultDependsOnSelf";
-      break;
     }
   }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3455,8 +3455,6 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
   case SelfAccessKind::NonMutating:
     // The default flagless state.
     break;
-  case SelfAccessKind::ResultDependsOnSelf:
-    break;
   }
 
   return AnyFunctionType::Param(selfTy, Identifier(), flags);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2150,10 +2150,6 @@ void PrintAST::printSelfAccessKindModifiersIfNeeded(const FuncDecl *FD) {
     if (!Options.excludeAttrKind(DAK_Borrowing))
       Printer.printKeyword("borrowing", Options, " ");
     break;
-  case SelfAccessKind::ResultDependsOnSelf:
-    if (!Options.excludeAttrKind(DAK_ResultDependsOnSelf))
-      Printer.printKeyword("_resultDependsOnSelf", Options, " ");
-    break;
   }
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -603,9 +603,8 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
   case SelfAccessKind::Mutating: return OS << "'mutating'";
   case SelfAccessKind::LegacyConsuming: return OS << "'__consuming'";
   case SelfAccessKind::Consuming: return OS << "'consuming'";
-  case SelfAccessKind::Borrowing: return OS << "'borrowing'";
-  case SelfAccessKind::ResultDependsOnSelf:
-    return OS << "'resultDependsOnSelf'";
+  case SelfAccessKind::Borrowing:
+    return OS << "'borrowing'";
   }
   llvm_unreachable("Unknown SelfAccessKind");
 }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5348,7 +5348,6 @@ bool SILGenModule::shouldEmitSelfAsRValue(FuncDecl *fn, CanType selfType) {
   case SelfAccessKind::LegacyConsuming:
   case SelfAccessKind::Consuming:
   case SelfAccessKind::Borrowing:
-  case SelfAccessKind::ResultDependsOnSelf:
     return true;
   }
   llvm_unreachable("bad self-access kind");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -203,7 +203,14 @@ public:
   void visitConsumingAttr(ConsumingAttr *attr) { visitMutationAttr(attr); }
   void visitLegacyConsumingAttr(LegacyConsumingAttr *attr) { visitMutationAttr(attr); }
   void visitResultDependsOnSelfAttr(ResultDependsOnSelfAttr *attr) {
-    visitMutationAttr(attr);
+    FuncDecl *FD = cast<FuncDecl>(D);
+    if (FD->getDescriptiveKind() != DescriptiveDeclKind::Method) {
+      diagnoseAndRemoveAttr(attr, diag::attr_methods_only, attr);
+    }
+    if (FD->getResultTypeRepr() == nullptr) {
+      diagnoseAndRemoveAttr(attr, diag::result_depends_on_no_result,
+                            attr->getAttrName());
+    }
   }
   void visitDynamicAttr(DynamicAttr *attr);
 
@@ -473,9 +480,6 @@ void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
   case DeclAttrKind::DAK_Borrowing:
     attrModifier = SelfAccessKind::Borrowing;
     break;
-  case DeclAttrKind::DAK_ResultDependsOnSelf:
-    attrModifier = SelfAccessKind::ResultDependsOnSelf;
-    break;
   default:
     llvm_unreachable("unhandled attribute kind");
   }
@@ -490,7 +494,6 @@ void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
       case SelfAccessKind::Consuming:
       case SelfAccessKind::LegacyConsuming:
       case SelfAccessKind::Borrowing:
-      case SelfAccessKind::ResultDependsOnSelf:
         // It's still OK to specify the ownership convention of methods in
         // classes.
         break;
@@ -522,8 +525,7 @@ void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
        FD->getAttrs().hasAttribute<NonMutatingAttr>() +
        FD->getAttrs().hasAttribute<LegacyConsumingAttr>() +
        FD->getAttrs().hasAttribute<ConsumingAttr>() +
-       FD->getAttrs().hasAttribute<BorrowingAttr>() +
-       FD->getAttrs().hasAttribute<ResultDependsOnSelfAttr>()) > 1) {
+       FD->getAttrs().hasAttribute<BorrowingAttr>()) > 1) {
     if (auto *NMA = FD->getAttrs().getAttribute<NonMutatingAttr>()) {
       if (attrModifier != SelfAccessKind::NonMutating) {
         diagnoseAndRemoveAttr(NMA, diag::functions_mutating_and_not,
@@ -557,24 +559,6 @@ void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
         diagnoseAndRemoveAttr(BSA, diag::functions_mutating_and_not,
                               SelfAccessKind::Borrowing, attrModifier);
       }
-    }
-
-    if (auto *RDSA = FD->getAttrs().getAttribute<ResultDependsOnSelfAttr>()) {
-      if (attrModifier != SelfAccessKind::ResultDependsOnSelf) {
-        diagnoseAndRemoveAttr(RDSA, diag::functions_mutating_and_not,
-                              SelfAccessKind::ResultDependsOnSelf,
-                              attrModifier);
-      }
-    }
-  }
-
-  if (auto *RDSA = FD->getAttrs().getAttribute<ResultDependsOnSelfAttr>()) {
-    if (FD->getResultTypeRepr() == nullptr) {
-      diagnoseAndRemoveAttr(RDSA, diag::result_depends_on_no_result,
-                            attr->getAttrName());
-    }
-    if (FD->getDescriptiveKind() != DescriptiveDeclKind::Method) {
-      diagnoseAndRemoveAttr(RDSA, diag::attr_methods_only, attr);
     }
   }
   // Verify that we don't have a static function.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2392,7 +2392,6 @@ ParamSpecifierRequest::evaluate(Evaluator &evaluator,
       case SelfAccessKind::Mutating:
         return ParamSpecifier::InOut;
       case SelfAccessKind::NonMutating:
-      case SelfAccessKind::ResultDependsOnSelf:
         return ParamSpecifier::Default;
       }
       llvm_unreachable("nonexhaustive switch");

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1342,7 +1342,6 @@ public:
         case SelfAccessKind::Borrowing:
         case SelfAccessKind::NonMutating:
         case SelfAccessKind::Mutating:
-        case SelfAccessKind::ResultDependsOnSelf:
           ctx.Diags.diagnose(DS->getDiscardLoc(),
                              diag::discard_wrong_context_nonconsuming,
                              fn->getDescriptiveKind());

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2837,8 +2837,6 @@ getActualSelfAccessKind(uint8_t raw) {
     return swift::SelfAccessKind::Consuming;
   case serialization::SelfAccessKind::Borrowing:
     return swift::SelfAccessKind::Borrowing;
-  case serialization::SelfAccessKind::ResultDependsOnSelf:
-    return swift::SelfAccessKind::ResultDependsOnSelf;
   }
   return llvm::None;
 }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -429,7 +429,6 @@ enum class SelfAccessKind : uint8_t {
   LegacyConsuming,
   Consuming,
   Borrowing,
-  ResultDependsOnSelf,
 };
 using SelfAccessKindField = BCFixed<3>;
   

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2334,8 +2334,6 @@ getStableSelfAccessKind(swift::SelfAccessKind MM) {
     return serialization::SelfAccessKind::Consuming;
   case swift::SelfAccessKind::Borrowing:
     return serialization::SelfAccessKind::Borrowing;
-  case swift::SelfAccessKind::ResultDependsOnSelf:
-    return serialization::SelfAccessKind::ResultDependsOnSelf;
   }
 
   llvm_unreachable("Unhandled StaticSpellingKind in switch.");

--- a/test/Sema/result_depends_on_errors.swift
+++ b/test/Sema/result_depends_on_errors.swift
@@ -4,8 +4,13 @@
 import Builtin
 
 class Klass {}
+
+struct View {
+  var pointer: UnsafeRawPointer?
+}
+
 class MethodModifiers {
     _resultDependsOnSelf func testAttrOnMethod() { } // expected-error{{Incorrect use of _resultDependsOnSelf with no result}}
 }
 
-_resultDependsOnSelf func testAttrOnFunc () { } // expected-error{{'resultDependsOnSelf' is only valid on methods}}
+_resultDependsOnSelf func testAttrOnFunc () -> View { return View(pointer:nil) } // expected-error{{only methods can be declared '_resultDependsOnSelf'}}


### PR DESCRIPTION
`@_resultDependsOnSelf` is not a self access kind like borrowing etc.