### PR TITLE
[stdlib] BitwiseCopyable loadUnaligned overloads.

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -433,16 +433,14 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
             : IsNotABIAccessible;
   }
 
-  auto &ASTContext = IGM.getSwiftModule()->getASTContext();
-  if (ASTContext.LangOpts.hasFeature(Feature::BitwiseCopyable)) {
-    // TODO: Should this conformance imply isAddressOnlyTrivial is true?
-    auto *proto = ASTContext.getProtocol(KnownProtocolKind::BitwiseCopyable);
-    // It's possible for the protocol not to exist if the stdlib is built
-    // no_asserts.
-    if (proto && IGM.getSwiftModule()->lookupConformance(archetype, proto)) {
-      return BitwiseCopyableArchetypeTypeInfo::create(storageType,
-                                                      abiAccessible);
-    }
+  // TODO: Should this conformance imply isAddressOnlyTrivial is true?
+  auto *bitwiseCopyableProtocol =
+      IGM.getSwiftModule()->getASTContext().getProtocol(
+          KnownProtocolKind::BitwiseCopyable);
+  // The protocol won't be present in swiftinterfaces from older SDKs.
+  if (bitwiseCopyableProtocol && IGM.getSwiftModule()->lookupConformance(
+                                     archetype, bitwiseCopyableProtocol)) {
+    return BitwiseCopyableArchetypeTypeInfo::create(storageType, abiAccessible);
   }
 
   return OpaqueArchetypeTypeInfo::create(storageType, abiAccessible);

--- a/stdlib/public/core/UnsafeBufferPointerSlice.swift
+++ b/stdlib/public/core/UnsafeBufferPointerSlice.swift
@@ -378,6 +378,17 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///     with `type`.
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
+#if $BitwiseCopyable
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func loadUnaligned<T : _BitwiseCopyable>(
+    fromByteOffset offset: Int = 0,
+    as type: T.Type
+  ) -> T {
+    let buffer = Base(rebasing: self)
+    return buffer.loadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+#endif
   @inlinable
   @_alwaysEmitIntoClient
   public func loadUnaligned<T>(
@@ -606,6 +617,17 @@ extension Slice where Base == UnsafeRawBufferPointer {
   ///     with `type`.
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
+#if $BitwiseCopyable
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func loadUnaligned<T : _BitwiseCopyable>(
+    fromByteOffset offset: Int = 0,
+    as type: T.Type
+  ) -> T {
+    let buffer = Base(rebasing: self)
+    return buffer.loadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+#endif
   @inlinable
   @_alwaysEmitIntoClient
   public func loadUnaligned<T>(

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -430,6 +430,18 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     with `type`.
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
+#if $BitwiseCopyable
+  @_alwaysEmitIntoClient
+  public func loadUnaligned<T : _BitwiseCopyable>(
+    fromByteOffset offset: Int = 0,
+    as type: T.Type
+  ) -> T {
+    _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
+    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+      "${Self}.load out of bounds")
+    return baseAddress!.loadUnaligned(fromByteOffset: offset, as: T.self)
+  }
+#endif
   @_alwaysEmitIntoClient
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -456,6 +456,16 @@ public struct UnsafeRawPointer: _Pointer {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///   `offset`. The returned instance isn't associated
   ///   with the value in the range of memory referenced by this pointer.
+#if $BitwiseCopyable
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func loadUnaligned<T : _BitwiseCopyable>(
+    fromByteOffset offset: Int = 0,
+    as type: T.Type
+  ) -> T {
+    return Builtin.loadRaw((self + offset)._rawValue)
+  }
+#endif
   @inlinable
   @_alwaysEmitIntoClient
   public func loadUnaligned<T>(
@@ -473,8 +483,6 @@ public struct UnsafeRawPointer: _Pointer {
       )
       return temporary.pointee
     }
-    //FIXME: reimplement with `loadRaw` when supported in SIL (rdar://96956089)
-    // e.g. Builtin.loadRaw((self + offset)._rawValue)
   }
 }
 
@@ -1238,6 +1246,16 @@ public struct UnsafeMutableRawPointer: _Pointer {
   /// - Returns: A new instance of type `T`, read from the raw bytes at
   ///   `offset`. The returned instance isn't associated
   ///   with the value in the range of memory referenced by this pointer.
+#if $BitwiseCopyable
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func loadUnaligned<T : _BitwiseCopyable>(
+    fromByteOffset offset: Int = 0,
+    as type: T.Type
+  ) -> T {
+    return Builtin.loadRaw((self + offset)._rawValue)
+  }
+#endif
   @inlinable
   @_alwaysEmitIntoClient
   public func loadUnaligned<T>(
@@ -1255,8 +1273,6 @@ public struct UnsafeMutableRawPointer: _Pointer {
       )
       return temporary.pointee
     }
-    //FIXME: reimplement with `loadRaw` when supported in SIL (rdar://96956089)
-    // e.g. Builtin.loadRaw((self + offset)._rawValue)
   }
 
   /// Stores the given value's bytes into raw memory at the specified offset.

--- a/test/IRGen/bitwise-copyable-loadRaw.swift
+++ b/test/IRGen/bitwise-copyable-loadRaw.swift
@@ -10,24 +10,13 @@ func doit() {
   let bytes: [UInt8] = Array(repeating: 0, count: 64)
   bytes.withUnsafeBufferPointer { bytes in
       let rawBytes = UnsafeRawPointer(bytes.baseAddress!) + 1
-      let vector = rawBytes.myLoadUnaligned(as: SIMD16<UInt8>.self)
+      let vector = rawBytes.loadUnaligned(as: SIMD16<UInt8>.self)
       //CHECK: SIMD16<UInt8>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
       blackhole(vector)
   }
 }
 
 import Builtin
-
-extension UnsafeRawPointer {
-  @inlinable
-  @_alwaysEmitIntoClient
-  public func myLoadUnaligned<T : _BitwiseCopyable>(
-    fromByteOffset offset: Int = 0,
-    as type: T.Type
-  ) -> T {
-    return Builtin.loadRaw((self + offset)._rawValue)
-  }
-}
 
 doit()
 


### PR DESCRIPTION
The new overloads will make use of the new `BitwiseCopyableArchetypeTypeInfo` to avoid the extra copy that is currently done.
