### PR TITLE
Use explicit checks for the 'store' instruction

### DIFF
--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -266,7 +266,7 @@ bb0(%0 : $Bool):
   return %6 : $Bool
 
   // CHECK: alloc_stack $Bool
-  // CHECK-NEXT: store %0 to %1 : $*Bool
+  // CHECK-NEXT: store {{%[0-9]+}}
   // CHECK-NEXT: tuple ()
   // CHECK-NEXT: load
   // CHECK-NEXT: dealloc_stack
@@ -803,7 +803,7 @@ bb5(%25 : $Error):                                // Preds: bb4 bb3
 // CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK:      bb2:
-// CHECK:        store %0 to %1 : $*Int
+// CHECK:        store {{%[0-9]+}}
 // CHECK:        [[STACK2:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   dealloc_stack [[STACK2]] : $*Bool, loc "testloc":27:27
 // CHECK-NEXT:   dealloc_stack [[BOX]] : $*Int, loc "testloc":27:27
@@ -841,7 +841,7 @@ bb3:
 // CHECK:      bb0(%0 : $Int):
 // CHECK-NEXT:   [[REF:%[0-9]+]] = alloc_ref [stack] $SomeClass
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
-// CHECK:        store %0 to %1 : $*Int
+// CHECK:        store {{%[0-9]+}}
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack_ref [[REF]]
 // CHECK-NEXT:   tuple
@@ -868,7 +868,7 @@ bb0(%0 : $Int):
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store %0 to %1 : $*Int
+// CHECK:        store {{%[0-9]+}}
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   tuple
@@ -904,7 +904,7 @@ bb2:
 // CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store %0 to %1 : $*Int
+// CHECK:        store {{%[0-9]+}}
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   tuple
@@ -938,7 +938,7 @@ bb2:
 // CHECK:      bb1:
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store %0 to %1 : $*Int
+// CHECK:        store {{%[0-9]+}}
 // CHECK:        dealloc_stack [[STACK]]
 // CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   tuple
@@ -969,7 +969,7 @@ bb2:
 // CHECK:      bb1:
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store %0 to %1 : $*Int
+// CHECK:        store {{%[0-9]+}}
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
@@ -998,7 +998,7 @@ bb2:
 // CHECK-NEXT:   {{.*}} = alloc_stack $Bool
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store %0 to %1 : $*Int
+// CHECK:        store {{%[0-9]+}}
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
@@ -1065,7 +1065,7 @@ bb3:
 // CHECK-NEXT:   dealloc_stack [[AI]]
 // CHECK-NEXT:   br bb3
 // CHECK:      bb3:
-// CHECK-NEXT:   store %0 to %as1 : $*Bool
+// CHECK-NEXT:   store {{%[0-9]+}}
 // CHECK-NEXT:   load
 // CHECK-NEXT:   unreachable
 sil @nesting_and_unreachable7 : $@convention(thin) (Bool) -> Bool {
@@ -1100,7 +1100,7 @@ bb3:
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
 // CHECK-NEXT:   br bb4
 // CHECK:      bb3:
-// CHECK:        store %0 to %1 : $*Int
+// CHECK:        store {{%[0-9]+}}
 // CHECK:        dealloc_stack [[STACK2]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   dealloc_stack [[BOX]]

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -841,7 +841,7 @@ bb3:
 // CHECK:      bb0(%0 : $Int):
 // CHECK-NEXT:   [[REF:%[0-9]+]] = alloc_ref [stack] $SomeClass
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
-// CHECK:         store %0 to %1 : $*Int
+// CHECK:        store %0 to %1 : $*Int
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack_ref [[REF]]
 // CHECK-NEXT:   tuple
@@ -1065,7 +1065,7 @@ bb3:
 // CHECK-NEXT:   dealloc_stack [[AI]]
 // CHECK-NEXT:   br bb3
 // CHECK:      bb3:
-// CHECK:        store %0 to %as1 : $*Bool
+// CHECK-NEXT:   store %0 to %as1 : $*Bool
 // CHECK-NEXT:   load
 // CHECK-NEXT:   unreachable
 sil @nesting_and_unreachable7 : $@convention(thin) (Bool) -> Bool {

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -266,7 +266,7 @@ bb0(%0 : $Bool):
   return %6 : $Bool
 
   // CHECK: alloc_stack $Bool
-  // CHECK-NEXT: store
+  // CHECK-NEXT: store %0 to %1 : $*Bool
   // CHECK-NEXT: tuple ()
   // CHECK-NEXT: load
   // CHECK-NEXT: dealloc_stack
@@ -803,7 +803,7 @@ bb5(%25 : $Error):                                // Preds: bb4 bb3
 // CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK:      bb2:
-// CHECK:        store
+// CHECK:        store %0 to %1 : $*Int
 // CHECK:        [[STACK2:%[0-9]+]] = alloc_stack $Bool
 // CHECK-NEXT:   dealloc_stack [[STACK2]] : $*Bool, loc "testloc":27:27
 // CHECK-NEXT:   dealloc_stack [[BOX]] : $*Int, loc "testloc":27:27
@@ -841,7 +841,7 @@ bb3:
 // CHECK:      bb0(%0 : $Int):
 // CHECK-NEXT:   [[REF:%[0-9]+]] = alloc_ref [stack] $SomeClass
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
-// CHECK:        store
+// CHECK:         store %0 to %1 : $*Int
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack_ref [[REF]]
 // CHECK-NEXT:   tuple
@@ -868,7 +868,7 @@ bb0(%0 : $Int):
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store
+// CHECK:        store %0 to %1 : $*Int
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   tuple
@@ -904,7 +904,7 @@ bb2:
 // CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store
+// CHECK:        store %0 to %1 : $*Int
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   tuple
@@ -938,7 +938,7 @@ bb2:
 // CHECK:      bb1:
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store
+// CHECK:        store %0 to %1 : $*Int
 // CHECK:        dealloc_stack [[STACK]]
 // CHECK-NEXT:   dealloc_stack [[BOX]]
 // CHECK-NEXT:   tuple
@@ -969,7 +969,7 @@ bb2:
 // CHECK:      bb1:
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store
+// CHECK:        store %0 to %1 : $*Int
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
@@ -998,7 +998,7 @@ bb2:
 // CHECK-NEXT:   {{.*}} = alloc_stack $Bool
 // CHECK-NEXT:   unreachable
 // CHECK:      bb2:
-// CHECK:        store
+// CHECK:        store %0 to %1 : $*Int
 // CHECK:        dealloc_stack [[BOX]]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
@@ -1065,7 +1065,7 @@ bb3:
 // CHECK-NEXT:   dealloc_stack [[AI]]
 // CHECK-NEXT:   br bb3
 // CHECK:      bb3:
-// CHECK-NEXT:   store
+// CHECK:        store %0 to %as1 : $*Bool
 // CHECK-NEXT:   load
 // CHECK-NEXT:   unreachable
 sil @nesting_and_unreachable7 : $@convention(thin) (Bool) -> Bool {
@@ -1100,7 +1100,7 @@ bb3:
 // CHECK-NEXT:   dealloc_stack [[STACK2]]
 // CHECK-NEXT:   br bb4
 // CHECK:      bb3:
-// CHECK:        store
+// CHECK:        store %0 to %1 : $*Int
 // CHECK:        dealloc_stack [[STACK2]]
 // CHECK-NEXT:   dealloc_stack [[STACK1]]
 // CHECK-NEXT:   dealloc_stack [[BOX]]

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -568,7 +568,7 @@ bb3:
 // CHECK-NEXT: alloc_stack
 // CHECK-NEXT: tuple
 // CHECK-NEXT: init_enum_data_addr
-// CHECK-NEXT: store
+// CHECK-NEXT: store %11 to %2 : $*(Int, Unicode.Scalar)
 // CHECK-NEXT: inject_enum_addr
 // CHECK-NEXT: br bb1
 // CHECK: } // end sil function 'constant_fold_switch_enum_addr_with_payload'
@@ -596,7 +596,7 @@ bb2:
 // CHECK: bb0(
 // CHECK-NEXT: alloc_stack
 // CHECK-NEXT: init_enum_data_addr
-// CHECK-NEXT: store
+// CHECK-NEXT: store %0 to %2 : $*Builtin.NativeObject
 // CHECK-NEXT: inject_enum_addr
 // CHECK-NEXT: br bb1
 // CHECK: } // end sil function 'constant_fold_switch_enum_addr_with_nontrivial_payload'
@@ -627,7 +627,7 @@ bb3:
 // CHECK: bb0(
 // CHECK-NEXT: alloc_stack
 // CHECK-NEXT: init_enum_data_addr
-// CHECK-NEXT: store
+// CHECK-NEXT: store %0 to %2 : $*Builtin.NativeObject
 // CHECK-NEXT: inject_enum_addr
 // CHECK-NEXT: br bb1
 // CHECK: } // end sil function 'constant_fold_switch_enum_addr_with_nontrivial_payload_2'

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -148,7 +148,7 @@ sil @removeTriviallyDeadInstructions : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <B>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <B>, 0
-  store %0 to %1a : $*B                 // CHECK: store
+  store %0 to %1a : $*B                 // CHECK: store {{%[0-9]+}}
   %3 = load %1a : $*B
   strong_retain %3 : $B                         // CHECK: strong_retain
   %5 = unchecked_ref_cast %3 : $B to $Builtin.NativeObject     // CHECK-NOT: unchecked_ref_cast
@@ -568,7 +568,7 @@ bb3:
 // CHECK-NEXT: alloc_stack
 // CHECK-NEXT: tuple
 // CHECK-NEXT: init_enum_data_addr
-// CHECK-NEXT: store %11 to %2 : $*(Int, Unicode.Scalar)
+// CHECK-NEXT: store {{%[0-9]+}}
 // CHECK-NEXT: inject_enum_addr
 // CHECK-NEXT: br bb1
 // CHECK: } // end sil function 'constant_fold_switch_enum_addr_with_payload'
@@ -596,7 +596,7 @@ bb2:
 // CHECK: bb0(
 // CHECK-NEXT: alloc_stack
 // CHECK-NEXT: init_enum_data_addr
-// CHECK-NEXT: store %0 to %2 : $*Builtin.NativeObject
+// CHECK-NEXT: store {{%[0-9]+}}
 // CHECK-NEXT: inject_enum_addr
 // CHECK-NEXT: br bb1
 // CHECK: } // end sil function 'constant_fold_switch_enum_addr_with_nontrivial_payload'
@@ -627,7 +627,7 @@ bb3:
 // CHECK: bb0(
 // CHECK-NEXT: alloc_stack
 // CHECK-NEXT: init_enum_data_addr
-// CHECK-NEXT: store %0 to %2 : $*Builtin.NativeObject
+// CHECK-NEXT: store {{%[0-9]+}}
 // CHECK-NEXT: inject_enum_addr
 // CHECK-NEXT: br bb1
 // CHECK: } // end sil function 'constant_fold_switch_enum_addr_with_nontrivial_payload_2'


### PR DESCRIPTION
## In This PR
* Tweak Filechecks for `store` to be more explicit. This would cause our tests to fail on `https://ci-external.swift.org/job/indexstore-db-PR-windows/25/console` because some lines in the generated SIL would have the file path in them, and that path contains `store`