### PR TITLE
Teach The AST Demangler About Module ABI Names

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1032,8 +1032,12 @@ ModuleDecl *
 ASTBuilder::findModule(NodePointer node) {
   assert(node->getKind() == Demangle::Node::Kind::Module);
   const auto moduleName = node->getText();
+  // Respect the main module's ABI name when we're trying to resolve
+  // mangled names. But don't touch anything under the Swift stdlib's
+  // umbrella. 
   if (Ctx.MainModule && Ctx.MainModule->getABIName().is(moduleName))
-    return Ctx.MainModule;
+    if (!Ctx.MainModule->getABIName().is(STDLIB_NAME))
+      return Ctx.MainModule;
 
   return Ctx.getModuleByName(moduleName);
 }

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1031,7 +1031,10 @@ ASTBuilder::createTypeDecl(NodePointer node,
 ModuleDecl *
 ASTBuilder::findModule(NodePointer node) {
   assert(node->getKind() == Demangle::Node::Kind::Module);
-  const auto &moduleName = node->getText();
+  const auto moduleName = node->getText();
+  if (Ctx.MainModule && Ctx.MainModule->getABIName().is(moduleName))
+    return Ctx.MainModule;
+
   return Ctx.getModuleByName(moduleName);
 }
 

--- a/test/ModuleInterface/Inputs/opaque-type-abi-name/Bottom.swiftinterface
+++ b/test/ModuleInterface/Inputs/opaque-type-abi-name/Bottom.swiftinterface
@@ -3,16 +3,21 @@
 
 import Swift
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Aspect {
   associatedtype Orientation : Bottom.Aspect
   var orientation: Self.Orientation { get }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct Parameter {
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct ReferencesTop {
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func orientation(of parameter: Bottom.Parameter) -> some Bottom.Aspect
 
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public typealias Orientation = @_opaqueReturnTypeOf("$s3Top13ReferencesTopV11orientation2ofQrAA9ParameterV_tF", 0) __
 }

--- a/test/ModuleInterface/Inputs/opaque-type-abi-name/Bottom.swiftinterface
+++ b/test/ModuleInterface/Inputs/opaque-type-abi-name/Bottom.swiftinterface
@@ -1,0 +1,18 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Bottom -module-abi-name Top -module-interface-preserve-types-as-written
+
+import Swift
+
+public protocol Aspect {
+  associatedtype Orientation : Bottom.Aspect
+  var orientation: Self.Orientation { get }
+}
+
+public struct Parameter {
+}
+
+public struct ReferencesTop {
+  public func orientation(of parameter: Bottom.Parameter) -> some Bottom.Aspect
+
+  public typealias Orientation = @_opaqueReturnTypeOf("$s3Top13ReferencesTopV11orientation2ofQrAA9ParameterV_tF", 0) __
+}

--- a/test/ModuleInterface/Inputs/opaque-type-abi-name/Top.swiftinterface
+++ b/test/ModuleInterface/Inputs/opaque-type-abi-name/Top.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Top -module-interface-preserve-types-as-written
+
+@_exported import Bottom

--- a/test/ModuleInterface/Inputs/opaque-type-abi-name/test.sh
+++ b/test/ModuleInterface/Inputs/opaque-type-abi-name/test.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-/Users/rwidmann/SwiftInternal/build/Ninja-Release/swift-macosx-arm64/bin/swift-frontend -sdk $(xcrun --show-sdk-path) -compile-module-from-interface -module-name Bottom -o Bottom.swiftmodule Bottom.swiftinterface -verify 

--- a/test/ModuleInterface/Inputs/opaque-type-abi-name/test.sh
+++ b/test/ModuleInterface/Inputs/opaque-type-abi-name/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/Users/rwidmann/SwiftInternal/build/Ninja-Release/swift-macosx-arm64/bin/swift-frontend -sdk $(xcrun --show-sdk-path) -compile-module-from-interface -module-name Bottom -o Bottom.swiftmodule Bottom.swiftinterface -verify 

--- a/test/ModuleInterface/verify-opaque-type-abi-name.swift
+++ b/test/ModuleInterface/verify-opaque-type-abi-name.swift
@@ -1,0 +1,4 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-typecheck-module-from-interface(%S/Inputs/opaque-type-abi-name/Bottom.swiftinterface) -module-name Bottom -o %t/Bottom.swiftmodule -verify
+// RUN: %target-swift-typecheck-module-from-interface(%S/Inputs/opaque-type-abi-name/Top.swiftinterface) -module-name Top -o %t/Top.swiftmodule -verify -I %S/Inputs/opaque-type-abi-name


### PR DESCRIPTION
The Swift compiler’s type resolution machinery tries to resolve opaque result types by summoning them out of the ASTBuilder from the mangled name. Unfortunately, it does so by using the ASTContext entrypoint that loads modules. Stop doing that, and also take the module's ABI name into account while I'm here.

Resolves rdar://119212609