### PR TITLE
[ASTGen] Small cleanups

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -18,12 +18,6 @@ import ParseBridging
 
 import struct SwiftDiagnostics.Diagnostic
 
-extension UnsafePointer {
-  public var raw: UnsafeMutableRawPointer {
-    UnsafeMutableRawPointer(mutating: self)
-  }
-}
-
 enum ASTNode {
   case decl(BridgedDecl)
   case stmt(BridgedStmt)
@@ -102,7 +96,7 @@ struct ASTGenVisitor {
     self.legacyParse = legacyParser
   }
 
-  public func generate(sourceFile node: SourceFileSyntax) -> [BridgedDecl] {
+  func generate(sourceFile node: SourceFileSyntax) -> [BridgedDecl] {
     var out = [BridgedDecl]()
 
     for element in node.statements {
@@ -129,8 +123,6 @@ struct ASTGenVisitor {
           endLoc: loc
         )
         out.append(topLevelDecl.asDecl)
-      default:
-        fatalError("Top level nodes must be decls, stmts, or exprs.")
       }
     }
 
@@ -241,15 +233,15 @@ extension ASTGenVisitor {
 // Misc visits.
 // TODO: Some of these are called within a single file/method; we may want to move them to the respective files.
 extension ASTGenVisitor {
-  public func generate(memberBlockItem node: MemberBlockItemSyntax) -> BridgedDecl {
+  func generate(memberBlockItem node: MemberBlockItemSyntax) -> BridgedDecl {
     generate(decl: node.decl)
   }
 
-  public func generate(initializerClause node: InitializerClauseSyntax) -> BridgedExpr {
+  func generate(initializerClause node: InitializerClauseSyntax) -> BridgedExpr {
     generate(expr: node.value)
   }
 
-  public func generate(conditionElement node: ConditionElementSyntax) -> ASTNode {
+  func generate(conditionElement node: ConditionElementSyntax) -> ASTNode {
     // FIXME: returning ASTNode is wrong, non-expression conditions are not ASTNode.
     switch node.condition {
     case .availability(_):
@@ -264,7 +256,7 @@ extension ASTGenVisitor {
     fatalError("unimplemented")
   }
 
-  public func generate(codeBlockItem node: CodeBlockItemSyntax) -> ASTNode {
+  func generate(codeBlockItem node: CodeBlockItemSyntax) -> ASTNode {
     switch node.item {
     case .decl(let node):
       return .decl(self.generate(decl: node))
@@ -275,7 +267,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(arrayElement node: ArrayElementSyntax) -> BridgedExpr {
+  func generate(arrayElement node: ArrayElementSyntax) -> BridgedExpr {
     generate(expr: node.expression)
   }
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -72,7 +72,7 @@ extension ASTGenVisitor {
     return self.generateWithLegacy(node)
   }
 
-  public func generate(typeAliasDecl node: TypeAliasDeclSyntax) -> BridgedTypeAliasDecl {
+  func generate(typeAliasDecl node: TypeAliasDeclSyntax) -> BridgedTypeAliasDecl {
     let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     return .createParsed(
@@ -88,7 +88,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(enumDecl node: EnumDeclSyntax) -> BridgedNominalTypeDecl {
+  func generate(enumDecl node: EnumDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedEnumDecl.createParsed(
@@ -113,7 +113,7 @@ extension ASTGenVisitor {
     return decl
   }
 
-  public func generate(structDecl node: StructDeclSyntax) -> BridgedNominalTypeDecl {
+  func generate(structDecl node: StructDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedStructDecl.createParsed(
@@ -138,7 +138,7 @@ extension ASTGenVisitor {
     return decl
   }
 
-  public func generate(classDecl node: ClassDeclSyntax) -> BridgedNominalTypeDecl {
+  func generate(classDecl node: ClassDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedClassDecl.createParsed(
@@ -164,7 +164,7 @@ extension ASTGenVisitor {
     return decl
   }
 
-  public func generate(actorDecl node: ActorDeclSyntax) -> BridgedNominalTypeDecl {
+  func generate(actorDecl node: ActorDeclSyntax) -> BridgedNominalTypeDecl {
     let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
     let decl = BridgedClassDecl.createParsed(
@@ -288,7 +288,7 @@ extension ASTGenVisitor {
 // MARK: - AbstractStorageDecl
 
 extension ASTGenVisitor {
-  public func generate(variableDecl node: VariableDeclSyntax) -> BridgedPatternBindingDecl {
+  func generate(variableDecl node: VariableDeclSyntax) -> BridgedPatternBindingDecl {
     let pattern = generate(pattern: node.bindings.first!.pattern)
     let initializer = generate(initializerClause: node.bindings.first!.initializer!)
 
@@ -310,7 +310,7 @@ extension ASTGenVisitor {
 // MARK: - AbstractFunctionDecl
 
 extension ASTGenVisitor {
-  public func generate(functionDecl node: FunctionDeclSyntax) -> BridgedFuncDecl {
+  func generate(functionDecl node: FunctionDeclSyntax) -> BridgedFuncDecl {
     // FIXME: Compute this location
     let staticLoc: BridgedSourceLoc = nil
 

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -199,7 +199,7 @@ extension ASTGenVisitor {
     preconditionFailure("isExprMigrated() mismatch")
   }
 
-  public func generate(arrowExpr node: ArrowExprSyntax) -> BridgedArrowExpr {
+  func generate(arrowExpr node: ArrowExprSyntax) -> BridgedArrowExpr {
     let asyncLoc: BridgedSourceLoc
     let throwsLoc: BridgedSourceLoc
     let thrownTypeExpr: BridgedNullableExpr
@@ -231,15 +231,15 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(assignmentExpr node: AssignmentExprSyntax) -> BridgedAssignExpr {
+  func generate(assignmentExpr node: AssignmentExprSyntax) -> BridgedAssignExpr {
     return .createParsed(self.ctx, equalsLoc: self.generateSourceLoc(node.equal))
   }
 
-  public func generate(binaryOperatorExpr node: BinaryOperatorExprSyntax) -> BridgedUnresolvedDeclRefExpr {
+  func generate(binaryOperatorExpr node: BinaryOperatorExprSyntax) -> BridgedUnresolvedDeclRefExpr {
     return createOperatorRefExpr(token: node.operator, kind: .binaryOperator)
   }
 
-  public func generate(closureExpr node: ClosureExprSyntax) -> BridgedClosureExpr {
+  func generate(closureExpr node: ClosureExprSyntax) -> BridgedClosureExpr {
     let body = BridgedBraceStmt.createParsed(
       self.ctx,
       lBraceLoc: self.generateSourceLoc(node.leftBrace),
@@ -251,7 +251,7 @@ extension ASTGenVisitor {
     return .createParsed(self.ctx, declContext: self.declContext, body: body)
   }
 
-  public func generate(functionCallExpr node: FunctionCallExprSyntax) -> BridgedCallExpr {
+  func generate(functionCallExpr node: FunctionCallExprSyntax) -> BridgedCallExpr {
     if !node.arguments.isEmpty || node.trailingClosure == nil {
       if node.leftParen == nil {
         self.diagnose(
@@ -333,7 +333,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(declReferenceExpr node: DeclReferenceExprSyntax) -> BridgedUnresolvedDeclRefExpr {
+  func generate(declReferenceExpr node: DeclReferenceExprSyntax) -> BridgedUnresolvedDeclRefExpr {
     let nameAndLoc = createDeclNameRef(declReferenceExpr: node)
     return .createParsed(
       self.ctx,
@@ -343,11 +343,11 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(discardAssignmentExpr node: DiscardAssignmentExprSyntax) -> BridgedDiscardAssignmentExpr {
+  func generate(discardAssignmentExpr node: DiscardAssignmentExprSyntax) -> BridgedDiscardAssignmentExpr {
     return .createParsed(self.ctx, loc: self.generateSourceLoc(node.wildcard))
   }
 
-  public func generate(memberAccessExpr node: MemberAccessExprSyntax) -> BridgedExpr {
+  func generate(memberAccessExpr node: MemberAccessExprSyntax) -> BridgedExpr {
     let nameAndLoc = createDeclNameRef(declReferenceExpr: node.declName)
 
     if let base = node.base {
@@ -368,7 +368,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(ifExpr node: IfExprSyntax) -> BridgedSingleValueStmtExpr {
+  func generate(ifExpr node: IfExprSyntax) -> BridgedSingleValueStmtExpr {
     let stmt = makeIfStmt(node).asStmt
 
     // Wrap in a SingleValueStmtExpr to embed as an expression.
@@ -380,7 +380,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(postfixOperatorExpr node: PostfixOperatorExprSyntax) -> BridgedPostfixUnaryExpr {
+  func generate(postfixOperatorExpr node: PostfixOperatorExprSyntax) -> BridgedPostfixUnaryExpr {
     return .createParsed(
       self.ctx,
       operator: self.createOperatorRefExpr(
@@ -391,7 +391,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(prefixOperatorExpr node: PrefixOperatorExprSyntax) -> BridgedPrefixUnaryExpr {
+  func generate(prefixOperatorExpr node: PrefixOperatorExprSyntax) -> BridgedPrefixUnaryExpr {
     return .createParsed(
       self.ctx,
       operator: self.createOperatorRefExpr(
@@ -402,7 +402,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(sequenceExpr node: SequenceExprSyntax) -> BridgedExpr {
+  func generate(sequenceExpr node: SequenceExprSyntax) -> BridgedExpr {
     assert(
       !node.elements.count.isMultiple(of: 2),
       "SequenceExpr must have odd number of elements"
@@ -458,18 +458,18 @@ extension ASTGenVisitor {
     ).asExpr
   }
 
-  public func generate(tupleExpr node: TupleExprSyntax) -> BridgedTupleExpr {
+  func generate(tupleExpr node: TupleExprSyntax) -> BridgedTupleExpr {
     return self.generate(labeledExprList: node.elements, leftParen: node.leftParen, rightParen: node.rightParen)
   }
 
-  public func generate(typeExpr node: TypeExprSyntax) -> BridgedTypeExpr {
+  func generate(typeExpr node: TypeExprSyntax) -> BridgedTypeExpr {
     return .createParsed(
       self.ctx,
       type: self.generate(type: node.type)
     )
   }
 
-  public func generate(unresolvedAsExpr node: UnresolvedAsExprSyntax, typeExpr typeNode: TypeExprSyntax) -> BridgedExpr {
+  func generate(unresolvedAsExpr node: UnresolvedAsExprSyntax, typeExpr typeNode: TypeExprSyntax) -> BridgedExpr {
     let type = self.generate(type: typeNode.type)
     let asLoc = self.generateSourceLoc(node.asKeyword)
 
@@ -499,7 +499,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(unresolvedIsExpr node: UnresolvedIsExprSyntax, typeExpr typeNode: TypeExprSyntax) -> BridgedIsExpr {
+  func generate(unresolvedIsExpr node: UnresolvedIsExprSyntax, typeExpr typeNode: TypeExprSyntax) -> BridgedIsExpr {
     return .createParsed(
       self.ctx,
       isLoc: self.generateSourceLoc(node.isKeyword),
@@ -507,7 +507,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(unresolvedTernaryExpr node: UnresolvedTernaryExprSyntax) -> BridgedTernaryExpr {
+  func generate(unresolvedTernaryExpr node: UnresolvedTernaryExprSyntax) -> BridgedTernaryExpr {
     return .createParsed(
       self.ctx,
       questionLoc: self.generateSourceLoc(node.questionMark),

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -14,7 +14,7 @@ import ASTBridging
 import SwiftSyntax
 
 extension ASTGenVisitor {
-  public func generate(stringLiteralExpr node: StringLiteralExprSyntax) -> BridgedStringLiteralExpr {
+  func generate(stringLiteralExpr node: StringLiteralExprSyntax) -> BridgedStringLiteralExpr {
     let openDelimiterOrQuoteLoc = self.generateSourceLoc(node.openingPounds ?? node.openingQuote)
 
     // FIXME: Handle interpolated strings.
@@ -25,7 +25,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(integerLiteralExpr node: IntegerLiteralExprSyntax) -> BridgedIntegerLiteralExpr {
+  func generate(integerLiteralExpr node: IntegerLiteralExprSyntax) -> BridgedIntegerLiteralExpr {
     // FIXME: Avoid 'String' instantiation
     // FIXME: Strip '_'.
     var segment = node.literal.text
@@ -38,7 +38,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(booleanLiteralExpr node: BooleanLiteralExprSyntax) -> BridgedBooleanLiteralExpr {
+  func generate(booleanLiteralExpr node: BooleanLiteralExprSyntax) -> BridgedBooleanLiteralExpr {
     let value = node.literal.tokenKind == .keyword(.true)
     return .createParsed(
       ctx,
@@ -47,7 +47,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(arrayExpr node: ArrayExprSyntax) -> BridgedArrayExpr {
+  func generate(arrayExpr node: ArrayExprSyntax) -> BridgedArrayExpr {
     let expressions = node.elements.lazy.map(self.generate)
 
     let commaLocations = node.elements.compactMap(in: self) {

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -54,7 +54,7 @@ extension ASTGenVisitor {
     return self.generateWithLegacy(node)
   }
 
-  public func generate(codeBlock node: CodeBlockSyntax) -> BridgedBraceStmt {
+  func generate(codeBlock node: CodeBlockSyntax) -> BridgedBraceStmt {
     BridgedBraceStmt.createParsed(
       self.ctx,
       lBraceLoc: self.generateSourceLoc(node.leftBrace),
@@ -86,7 +86,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(expressionStmt node: ExpressionStmtSyntax) -> BridgedStmt {
+  func generate(expressionStmt node: ExpressionStmtSyntax) -> BridgedStmt {
     switch Syntax(node.expression).as(SyntaxEnum.self) {
     case .ifExpr(let e):
       return makeIfStmt(e).asStmt
@@ -95,7 +95,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(returnStmt node: ReturnStmtSyntax) -> BridgedReturnStmt {
+  func generate(returnStmt node: ReturnStmtSyntax) -> BridgedReturnStmt {
     .createParsed(
       self.ctx,
       returnKeywordLoc: self.generateSourceLoc(node.returnKeyword),

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -102,7 +102,7 @@ extension ASTGenVisitor {
     preconditionFailure("isTypeMigrated() mismatch")
   }
 
-  public func generate(identifierType node: IdentifierTypeSyntax) -> BridgedTypeRepr {
+  func generate(identifierType node: IdentifierTypeSyntax) -> BridgedTypeRepr {
     let loc = self.generateSourceLoc(node.name)
 
     // If this is the bare 'Any' keyword, produce an empty composition type.
@@ -130,7 +130,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(memberType node: MemberTypeSyntax) -> BridgedTypeRepr {
+  func generate(memberType node: MemberTypeSyntax) -> BridgedTypeRepr {
     // Gather the member components, in decreasing depth order.
     var reverseMemberComponents = [BridgedTypeRepr]()
 
@@ -172,7 +172,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(arrayType node: ArrayTypeSyntax) -> BridgedTypeRepr {
+  func generate(arrayType node: ArrayTypeSyntax) -> BridgedTypeRepr {
     let elementType = generate(type: node.element)
     let lSquareLoc = self.generateSourceLoc(node.leftSquare)
     let rSquareLoc = self.generateSourceLoc(node.rightSquare)
@@ -184,7 +184,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(dictionaryType node: DictionaryTypeSyntax) -> BridgedTypeRepr {
+  func generate(dictionaryType node: DictionaryTypeSyntax) -> BridgedTypeRepr {
     let keyType = self.generate(type: node.key)
     let valueType = self.generate(type: node.value)
     let colonLoc = self.generateSourceLoc(node.colon)
@@ -200,7 +200,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(metatypeType node: MetatypeTypeSyntax) -> BridgedTypeRepr {
+  func generate(metatypeType node: MetatypeTypeSyntax) -> BridgedTypeRepr {
     let baseType = generate(type: node.baseType)
     let tyLoc = self.generateSourceLoc(node.metatypeSpecifier)
     if node.metatypeSpecifier.rawText == "Type" {
@@ -219,7 +219,7 @@ extension ASTGenVisitor {
     }
   }
 
-  public func generate(implicitlyUnwrappedOptionalType node: ImplicitlyUnwrappedOptionalTypeSyntax) -> BridgedTypeRepr {
+  func generate(implicitlyUnwrappedOptionalType node: ImplicitlyUnwrappedOptionalTypeSyntax) -> BridgedTypeRepr {
     let base = generate(type: node.wrappedType)
     let exclaimLoc = self.generateSourceLoc(node.exclamationMark)
     return BridgedImplicitlyUnwrappedOptionalTypeRepr.createParsed(
@@ -229,7 +229,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(optionalType node: OptionalTypeSyntax) -> BridgedTypeRepr {
+  func generate(optionalType node: OptionalTypeSyntax) -> BridgedTypeRepr {
     let base = generate(type: node.wrappedType)
     let questionLoc = self.generateSourceLoc(node.questionMark)
     return BridgedOptionalTypeRepr.createParsed(
@@ -239,7 +239,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(packExpansionType node: PackExpansionTypeSyntax) -> BridgedTypeRepr {
+  func generate(packExpansionType node: PackExpansionTypeSyntax) -> BridgedTypeRepr {
     let base = generate(type: node.repetitionPattern)
     let repeatLoc = self.generateSourceLoc(node.repeatKeyword)
     return BridgedPackExpansionTypeRepr.createParsed(
@@ -249,7 +249,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(tupleType node: TupleTypeSyntax) -> BridgedTypeRepr {
+  func generate(tupleType node: TupleTypeSyntax) -> BridgedTypeRepr {
     BridgedTupleTypeRepr.createParsed(
       self.ctx,
       elements: self.generate(tupleTypeElementList: node.elements),
@@ -258,7 +258,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(compositionType node: CompositionTypeSyntax) -> BridgedTypeRepr {
+  func generate(compositionType node: CompositionTypeSyntax) -> BridgedTypeRepr {
     assert(node.elements.count > 1)
 
     let types = node.elements.lazy.map {
@@ -272,7 +272,7 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(functionType node: FunctionTypeSyntax) -> BridgedTypeRepr {
+  func generate(functionType node: FunctionTypeSyntax) -> BridgedTypeRepr {
     BridgedFunctionTypeRepr.createParsed(
       self.ctx,
       // FIXME: Why does `FunctionTypeSyntax` not have a `TupleTypeSyntax` child?
@@ -290,12 +290,12 @@ extension ASTGenVisitor {
     )
   }
 
-  public func generate(namedOpaqueReturnType node: NamedOpaqueReturnTypeSyntax) -> BridgedTypeRepr {
+  func generate(namedOpaqueReturnType node: NamedOpaqueReturnTypeSyntax) -> BridgedTypeRepr {
     let baseTy = generate(type: node.type)
     return BridgedNamedOpaqueReturnTypeRepr.createParsed(self.ctx, base: baseTy)
   }
 
-  public func generate(someOrAnyType node: SomeOrAnyTypeSyntax) -> BridgedTypeRepr {
+  func generate(someOrAnyType node: SomeOrAnyTypeSyntax) -> BridgedTypeRepr {
     let someOrAnyLoc = self.generateSourceLoc(node.someOrAnySpecifier)
     let baseTy = generate(type: node.constraint)
     if node.someOrAnySpecifier.rawText == "some" {
@@ -335,7 +335,7 @@ extension BridgedAttributedTypeSpecifier {
 }
 
 extension ASTGenVisitor {
-  public func generate(attributedType node: AttributedTypeSyntax) -> BridgedTypeRepr {
+  func generate(attributedType node: AttributedTypeSyntax) -> BridgedTypeRepr {
     var type = generate(type: node.baseType)
 
     // Handle specifiers.


### PR DESCRIPTION
* Remove `public` from the functions, those were remnants of when `ASTGenVisitor` conformed to `SyntaxTransformVisitor`.
* Remove an unreachable `default:` from a switch.
* Remove unused `UnsafePointer.raw`.
