### PR TITLE
[5.10][Features] Update upcoming feature flags for Swift 6.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -115,9 +115,10 @@ LANGUAGE_FEATURE(FreestandingMacros, 397, "freestanding declaration macros", tru
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
 UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
 UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
-UPCOMING_FEATURE(ExistentialAny, 335, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
 UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
+
+UPCOMING_FEATURE(ExistentialAny, 335, 7)
 
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -115,6 +115,7 @@ LANGUAGE_FEATURE(FreestandingMacros, 397, "freestanding declaration macros", tru
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
 UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
 UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
+UPCOMING_FEATURE(DeprecateApplicationMain, 383, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
 UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3220,6 +3220,10 @@ static bool usesFeatureStrictConcurrency(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureDeprecateApplicationMain(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureImportObjcForwardDeclarations(Decl *decl) {
   ClangNode clangNode = decl->getClangNode();
   if (!clangNode)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2346,15 +2346,16 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
     attr->setInvalid();
   }
 
-  diagnose(attr->getLocation(),
-           diag::attr_ApplicationMain_deprecated,
-           applicationMainKind)
-    .warnUntilSwiftVersion(6);
+  if (C.LangOpts.hasFeature(Feature::DeprecateApplicationMain)) {
+    diagnose(attr->getLocation(),
+             diag::attr_ApplicationMain_deprecated,
+             applicationMainKind)
+      .warnUntilSwiftVersion(6);
 
-  diagnose(attr->getLocation(),
-           diag::attr_ApplicationMain_deprecated_use_attr_main)
-    .fixItReplace(attr->getRange(), "@main");
-
+    diagnose(attr->getLocation(),
+             diag::attr_ApplicationMain_deprecated_use_attr_main)
+      .fixItReplace(attr->getRange(), "@main");
+  }
 
   if (attr->isInvalid())
     return;

--- a/test/TBD/objc-entry-point.swift
+++ b/test/TBD/objc-entry-point.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o /dev/null -validate-tbd-against-ir=all -parse-as-library -verify -enable-testing %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o /dev/null -validate-tbd-against-ir=all -parse-as-library -verify %s
 
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o /dev/null -validate-tbd-against-ir=all -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- -enable-testing %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-upcoming-feature DeprecateApplicationMain -emit-ir -o /dev/null -validate-tbd-against-ir=all -parse-as-library -verify -verify-additional-prefix deprecated- %s
+
 // REQUIRES: objc_interop
 import AppKit
 
@@ -9,7 +12,7 @@ import AppKit
 // present in the TBD.
 let globalConstantWithLazyInitializer: String = "hello, world"
 
-@NSApplicationMain // expected-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-1 {{use @main instead}} {{1-19=@main}}
+@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain.swift
@@ -1,10 +1,11 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- %s
 
 // REQUIRES: objc_interop
 
 import AppKit
 
-@NSApplicationMain // expected-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-1 {{use @main instead}} {{1-19=@main}}
+@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_inherited.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_inherited.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- %s
 
 // REQUIRES: objc_interop
 
@@ -6,7 +7,7 @@ import AppKit
 
 class DelegateBase : NSObject, NSApplicationDelegate { }
 
-@NSApplicationMain // expected-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-1 {{use @main instead}} {{1-19=@main}}
+@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate : DelegateBase { }
 

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
@@ -4,13 +4,15 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name main -emit-module-path %t.swiftmodule -primary-file %s %S/delegate.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name main -parse-as-library -typecheck %t.swiftmodule -primary-file %S/delegate.swift -verify -verify-ignore-unknown
 
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name main -parse-as-library -typecheck -enable-upcoming-feature DeprecateApplicationMain %t.swiftmodule -primary-file %S/delegate.swift -verify -verify-ignore-unknown -verify-additional-prefix deprecated-
+
 // REQUIRES: objc_interop
 
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class EvilDelegate: NSObject, NSApplicationDelegate {
 }
 

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/delegate.swift
@@ -8,8 +8,8 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }
 

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multiple.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multiple.swift
@@ -1,23 +1,25 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- %s
+
 
 // REQUIRES: objc_interop
 
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate1: NSObject, NSApplicationDelegate {
 }
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate2: NSObject, NSApplicationDelegate {
 }
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate3: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_not_NSApplicationDelegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_not_NSApplicationDelegate.swift
@@ -1,11 +1,12 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- %s
 
 // REQUIRES: objc_interop
 
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' class must conform to the 'NSApplicationDelegate' protocol}}
-// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyNonDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_with_main/delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_with_main/delegate.swift
@@ -8,8 +8,8 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute cannot be used in a module that contains top-level code}}
-// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }
 

--- a/test/attr/ApplicationMain/attr_UIApplicationMain.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain.swift
@@ -1,10 +1,11 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- %s
 
 // REQUIRES: objc_interop
 
 import UIKit
 
-@UIApplicationMain // expected-warning {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-1 {{use @main instead}} {{1-19=@main}}
+@UIApplicationMain // expected-deprecated-warning {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, UIApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_inherited.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_inherited.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- %s
 
 // REQUIRES: objc_interop
 
@@ -6,7 +7,7 @@ import UIKit
 
 class DelegateBase : NSObject, UIApplicationDelegate { }
 
-@UIApplicationMain // expected-warning {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-1 {{use @main instead}} {{1-19=@main}}
+@UIApplicationMain // expected-deprecated-warning {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate : DelegateBase { }
 

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_multiple.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_multiple.swift
@@ -1,23 +1,24 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- %s
 
 // REQUIRES: objc_interop
 
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
-// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate1: NSObject, UIApplicationDelegate {
 }
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
-// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate2: NSObject, UIApplicationDelegate {
 }
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
-// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate3: NSObject, UIApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_not_UIApplicationDelegate.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_not_UIApplicationDelegate.swift
@@ -1,11 +1,12 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-upcoming-feature DeprecateApplicationMain -verify -verify-additional-prefix deprecated- %s
 
 // REQUIRES: objc_interop
 
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' class must conform to the 'UIApplicationDelegate' protocol}}
-// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyNonDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_with_main/delegate.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_with_main/delegate.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute cannot be used in a module that contains top-level code}}
-// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
-// expected-note@-2 {{use @main instead}} {{1-19=@main}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, UIApplicationDelegate {
 }
 


### PR DESCRIPTION
* **Explanation**: Changes and additions to upcoming feature flags for Swift 6 as described in https://forums.swift.org/t/progress-toward-the-swift-6-language-mode/68315.
  - Don't enable `ExistentialAny` by default in Swift 6.
  - Gate [SE-0383](https://apple.github.io/swift-evolution/#?proposal=SE-0383) behind an upcoming feature flag.

Note that the first point has no functional impact on `release/5.10`. I only included it to make the second commit cherry pick cleanly.
* **Scope**: Does not impact any existing code. This change gates the deprecation warning for SE-0383 behind the upcoming feature flag, which is currently unconditional on the `release/5.10` branch.
* **Risk**: Low; the only functional impact is adding an upcoming feature flag and gating a diagnostic behind it.
* **Testing**: Updated test cases.
* **Main branch PR**: First two commits of https://github.com/apple/swift/pull/70123.