### PR TITLE
[Concurrency] Downgrade missing `await` errors to warnings when referencing `@preconcurrency` declarations.

### DIFF
--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -154,7 +154,7 @@ class Sub: Super {
 
   func g2() {
     Task.detached {
-      self.f() // expected-error{{expression is 'async' but is not marked with 'await'}}
+      self.f() // expected-warning{{expression is 'async' but is not marked with 'await'}}
       // expected-note@-1{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
     }
   }

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -108,14 +108,14 @@ func testCalls(x: X) {
 }
 
 func testCallsWithAsync() async {
-  onMainActorAlways() // expected-error{{expression is 'async' but is not marked with 'await'}}
+  onMainActorAlways() // expected-warning{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
 
   let _: () -> Void = onMainActorAlways // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
-  let c = MyModelClass() // expected-error{{expression is 'async' but is not marked with 'await'}}
+  let c = MyModelClass() // expected-warning{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
-  c.f() // expected-error{{expression is 'async' but is not marked with 'await'}}
+  c.f() // expected-warning{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 }
 


### PR DESCRIPTION
Otherwise, libraries cannot isolate existing APIs using `@preconcurrency` without potentially breaking clients with effects checker errors.

Resolves rdar://116209687