### PR TITLE
remove the default value for the keepUnique argument of Builder.createEndCOWMutation

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -346,7 +346,7 @@ public struct Builder {
     return notifyNew(metatype.getAs(MetatypeInst.self))
   }
 
-  public func createEndCOWMutation(instance: Value, keepUnique: Bool = false) -> EndCOWMutationInst {
+  public func createEndCOWMutation(instance: Value, keepUnique: Bool) -> EndCOWMutationInst {
     let endMutation = bridged.createEndCOWMutation(instance.bridged, keepUnique)
     return notifyNew(endMutation.getAs(EndCOWMutationInst.self))
   }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2287,7 +2287,7 @@ public:
                                         Int1Ty, getFunction(), isNative));
   }
   EndCOWMutationInst *createEndCOWMutation(SILLocation Loc, SILValue operand,
-                                           bool keepUnique = false) {
+                                           bool keepUnique) {
     return insert(new (getModule()) EndCOWMutationInst(getSILDebugLocation(Loc),
                                                   operand, keepUnique));
   }

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1019,7 +1019,7 @@ emitBuiltinEndCOWMutation(SILGenFunction &SGF,
 
   SILValue refAddr = args[0].getValue();
   auto ref = SGF.B.createLoad(loc, refAddr, LoadOwnershipQualifier::Take);
-  auto endRef = SGF.B.createEndCOWMutation(loc, ref);
+  auto endRef = SGF.B.createEndCOWMutation(loc, ref, /*keepUnique=*/ false);
   SGF.B.createStore(loc, endRef, refAddr, StoreOwnershipQualifier::Init);
   return ManagedValue::forObjectRValueWithoutOwnership(SGF.emitEmptyTuple(loc));
 }


### PR DESCRIPTION
This avoids bugs because the default value false is sometimes not the right choice.
NFC
