### PR TITLE
[build] Only link `swiftIDEUtilsBridging` when `SWIFT_BUILD_SWIFT_SYNTAX` is set

### DIFF
--- a/lib/Refactoring/CMakeLists.txt
+++ b/lib/Refactoring/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_libraries(swiftRefactoring PRIVATE
   swiftAST
   swiftClangImporter
   swiftIDE
-  swiftIDEUtilsBridging
   swiftIndex
   swiftParse
   swiftSema)
@@ -54,6 +53,9 @@ if(SWIFT_BUILD_SWIFT_SYNTAX)
   target_compile_definitions(swiftRefactoring
     PRIVATE
     SWIFT_BUILD_SWIFT_SYNTAX
+  )
+  target_link_libraries(swiftRefactoring PRIVATE
+    swiftIDEUtilsBridging
   )
 endif()
 


### PR DESCRIPTION
https://github.com/apple/swift/pull/70174 change swift-refactor and sourcekitd to not use `NameMatcher` from swift-syntax but it did not remove the link dependency from swiftRefactoring on `swiftIDEUtilsBridging` if `SWIFT_BUILD_SWIFT_SYNTAX` is false. Do so now.