### PR TITLE
Make -Rmodule-loading dump the module search paths

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -555,6 +555,8 @@ public:
   llvm::hash_code getModuleScanningHashComponents() const {
     return getPCHHashComponents();
   }
+
+  void dump(bool isDarwin) const;
 };
 }
 

--- a/lib/AST/SearchPathOptions.cpp
+++ b/lib/AST/SearchPathOptions.cpp
@@ -79,6 +79,35 @@ void ModuleSearchPathLookup::rebuildLookupTable(const SearchPathOptions *Opts,
   State.IsPopulated = true;
 }
 
+void SearchPathOptions::dump(bool isDarwin) const {
+  llvm::errs() << "Module import search paths (non system):\n";
+  for (auto Entry : llvm::enumerate(getImportSearchPaths())) {
+    llvm::errs() << "  [" << Entry.index() << "] " << Entry.value() << "\n";
+  }
+
+  llvm::errs() << "Framework search paths:\n";
+  for (auto Entry : llvm::enumerate(getFrameworkSearchPaths())) {
+    llvm::errs() << "  [" << Entry.index() << "] "
+                 << (Entry.value().IsSystem ? "(system) " : "(non-system) ")
+                 << Entry.value().Path << "\n";
+  }
+
+  if (isDarwin) {
+    llvm::errs() << "Darwin implicit framework search paths:\n";
+    for (auto Entry :
+         llvm::enumerate(getDarwinImplicitFrameworkSearchPaths())) {
+      llvm::errs() << "  [" << Entry.index() << "] " << Entry.value() << "\n";
+    }
+  }
+
+  llvm::errs() << "Runtime library import search paths:\n";
+  for (auto Entry : llvm::enumerate(getRuntimeLibraryImportPaths())) {
+    llvm::errs() << "  [" << Entry.index() << "] " << Entry.value() << "\n";
+  }
+
+  llvm::errs() << "(End of search path lists.)\n";
+}
+
 SmallVector<const ModuleSearchPath *, 4>
 ModuleSearchPathLookup::searchPathsContainingFile(
     const SearchPathOptions *Opts, llvm::ArrayRef<std::string> Filenames,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -538,6 +538,12 @@ bool CompilerInstance::setup(const CompilerInvocation &Invoke,
   // DiagConsumers are added.
   setupCachingDiagnosticsProcessorIfNeeded();
 
+  // Dump module search paths if -Rmodule-loading is on.
+  const auto &LangOpts = Invocation.getLangOptions();
+  if (LangOpts.EnableModuleLoadingRemarks) {
+    Invocation.getSearchPathOptions().dump(LangOpts.Target.isOSDarwin());
+  }
+
   // If we expect an implicit stdlib import, load in the standard library. If we
   // either fail to find it or encounter an error while loading it, bail early. Continuing will at best
   // trigger a bunch of other errors due to the stdlib being missing, or at


### PR DESCRIPTION
It's often useful to understand what are the search paths and what's their order to diagnose module loading issues. This PR adds a dump of search path when -Rmodule-loading is used. Output looks like this (I'm using embedded Swift in this case):

```
Module import search paths (non system):
  [0] /Library/Developer/CommandLineTools/SDKs/MacOSX14.1.sdk/usr/lib/swift
Framework search paths:
Darwin implicit framework search paths:
  [0] /Library/Developer/CommandLineTools/SDKs/MacOSX14.1.sdk/System/Library/Frameworks
  [1] /Library/Developer/CommandLineTools/SDKs/MacOSX14.1.sdk/Library/Frameworks
Runtime library import search paths:
  [0] /Users/kuba/swift-github-main/build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/lib/swift/embedded
  [1] /Library/Developer/CommandLineTools/SDKs/MacOSX14.1.sdk/usr/lib/swift
(End of search path lists.)
```
