### PR TITLE
[NCGenerics] add `~Escapable`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2680,19 +2680,12 @@ private:
     /// Whether this declaration produces an implicitly unwrapped
     /// optional result.
     unsigned isIUO : 1;
-
-    /// Whether the "isEscapable" bit has been computed yet.
-    unsigned isEscapable : 1;
-
-    /// Whether this declaration is escapable.
-    unsigned isEscapableComputed : 1;
   } LazySemanticInfo = { };
 
   friend class DynamicallyReplacedDeclRequest;
   friend class OverriddenDeclsRequest;
   friend class IsObjCRequest;
   friend class IsFinalRequest;
-  friend class IsEscapableRequest;
   friend class IsDynamicRequest;
   friend class IsImplicitlyUnwrappedOptionalRequest;
   friend class InterfaceTypeRequest;
@@ -2980,9 +2973,6 @@ public:
   /// Is this declaration 'final'?
   bool isFinal() const;
 
-  /// Is this declaration escapable?
-  bool isEscapable() const;
-
   /// Is this declaration marked with 'dynamic'?
   bool isDynamic() const;
 
@@ -3190,8 +3180,12 @@ public:
   /// Type if it `isNoncopyable` instead of using this.
   bool canBeNoncopyable() const;
 
-  /// Determine how the ~Copyable was applied to this TypeDecl, if at all.
-  InverseMarking getNoncopyableMarking() const;
+  /// Is this declaration escapable?
+  bool isEscapable() const;
+
+  /// Determine how the given invertible protocol was written on this TypeDecl,
+  /// if at all.
+  InverseMarking getMarking(InvertibleProtocolKind ip) const;
 
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_TypeDecl &&

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7555,27 +7555,27 @@ ERROR(accessor_macro_not_single_var, none,
 //------------------------------------------------------------------------------
 // MARK: Noncopyable Types Diagnostics
 //------------------------------------------------------------------------------
-ERROR(noncopyable_but_copyable, none,
-      "%kind0 required to be 'Copyable' but is marked with '~Copyable'",
-      (const ValueDecl *))
-ERROR(noncopyable_generic_but_copyable, none,
+ERROR(inverse_but_also_conforms, none,
+      "%kind0 required to be '%1' but is marked with '~%1'",
+      (const ValueDecl *, StringRef))
+ERROR(inverse_generic_but_also_conforms, none,
       "%0 required to be '%1' but is marked with '~%1'",
       (Type, StringRef))
 WARNING(redundant_inverse_constraint,none,
         "redundant constraint %0 : '~%1'", (Type, StringRef))
-ERROR(noncopyable_class, none,
-      "classes cannot be noncopyable",
-      ())
+ERROR(inverse_on_class, none,
+      "classes cannot be '~%0'",
+      (StringRef))
 ERROR(inverse_extension, none,
       "cannot apply inverse %0 to extension",
       (Type))
 ERROR(copyable_illegal_deinit, none,
       "deinitializer cannot be declared in %kind0 that conforms to 'Copyable'",
       (const ValueDecl *))
-ERROR(noncopyable_type_member_in_copyable,none,
+ERROR(inverse_type_member_in_conforming_type,none,
       "%select{stored property %2|associated value %2}1 of "
-      "'Copyable'-conforming %kind3 has noncopyable type %0",
-      (Type, bool, DeclName, const ValueDecl *))
+      "'%4'-conforming %kind3 has non-%4 type %0",
+      (Type, bool, DeclName, const ValueDecl *, StringRef))
 NOTE(add_inverse,none,
      "consider adding '~%1' to %kind0",
      (const ValueDecl *, StringRef))
@@ -7592,6 +7592,9 @@ NOTE(note_inverse_preventing_conformance_explicit,none,
 NOTE(add_explicit_protocol_for_conformance,none,
      "consider making %kind0 explicitly conform to the '%1' protocol",
      (const ValueDecl *, StringRef))
+ERROR(escapable_requires_feature_flag,none,
+      "type '~Escapable' requires -enable-experimental-feature NonEscapableTypes",
+      ())
 
 // -- older ones below --
 

--- a/include/swift/AST/InverseMarking.h
+++ b/include/swift/AST/InverseMarking.h
@@ -19,7 +19,7 @@
 
 namespace swift {
 
-class NoncopyableAnnotationRequest;
+class InvertibleAnnotationRequest;
 
 /// Describes the way an inverse and its corresponding positive contraint
 /// appears on a TypeDecl, i.e., the way it was marked.
@@ -87,7 +87,7 @@ private:
   Mark positive;
 
   // This friend initializes the marks.
-  friend NoncopyableAnnotationRequest;
+  friend InvertibleAnnotationRequest;
 public:
 
   // Creates an empty marking.

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -137,6 +137,7 @@ PROTOCOL(AsyncIteratorProtocol)
 PROTOCOL(FloatingPoint)
 
 INVERTIBLE_PROTOCOL_WITH_NAME(Copyable, "Copyable")
+INVERTIBLE_PROTOCOL_WITH_NAME(Escapable, "Escapable")
 PROTOCOL_(BitwiseCopyable)
 
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "Array", false)

--- a/include/swift/AST/KnownProtocols.h
+++ b/include/swift/AST/KnownProtocols.h
@@ -73,6 +73,9 @@ llvm::Optional<InvertibleProtocolKind>
 /// Returns the KnownProtocolKind corresponding to an InvertibleProtocolKind.
 KnownProtocolKind getKnownProtocolKind(InvertibleProtocolKind ip);
 
+void simple_display(llvm::raw_ostream &out,
+                    const InvertibleProtocolKind &value);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -428,10 +428,12 @@ public:
   void cacheResult(bool value) const;
 };
 
-/// Determine the kind of noncopyable marking present for this declaration.
-class NoncopyableAnnotationRequest
-    : public SimpleRequest<NoncopyableAnnotationRequest,
-                           InverseMarking(TypeDecl *),
+/// Determine the kind of invertible protocol markings for this declaration,
+/// for example, if a conformance to IP or ~IP was written on it in the
+/// inheritance clause and/or where clause.
+class InvertibleAnnotationRequest
+    : public SimpleRequest<InvertibleAnnotationRequest,
+                           InverseMarking(TypeDecl *, InvertibleProtocolKind),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -440,17 +442,18 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  InverseMarking evaluate(Evaluator &evaluator, TypeDecl *decl) const;
+  InverseMarking evaluate(Evaluator &evaluator,
+                          TypeDecl *decl, InvertibleProtocolKind ip) const;
 
 public:
   // Caching.
   bool isCached() const { return true; }
 };
 
-/// Determine whether the given declaration is escapable.
+/// Determine whether the given type is Escapable.
 class IsEscapableRequest
-    : public SimpleRequest<IsEscapableRequest, bool(ValueDecl *),
-                           RequestFlags::SeparatelyCached> {
+    : public SimpleRequest<IsEscapableRequest, bool(CanType),
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -458,13 +461,11 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  bool evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+  bool evaluate(Evaluator &evaluator, CanType) const;
 
 public:
-  // Separate caching.
+  // Caching.
   bool isCached() const { return true; }
-  llvm::Optional<bool> getCachedResult() const;
-  void cacheResult(bool value) const;
 };
 
 /// Determine whether the given type is noncopyable. Assumes type parameters

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -210,14 +210,15 @@ SWIFT_REQUEST(TypeChecker, IsDynamicRequest, bool(ValueDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached,
               NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, NoncopyableAnnotationRequest,
-              InverseMarking(TypeDecl *),
+SWIFT_REQUEST(TypeChecker, InvertibleAnnotationRequest,
+              InverseMarking(TypeDecl *, InvertibleProtocolKind),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsNoncopyableRequest,
               bool (CanType),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, IsEscapableRequest, bool(ValueDecl *),
-              SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsEscapableRequest,
+              bool (CanType),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsGetterMutatingRequest, bool(AbstractStorageDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsImplicitlyUnwrappedOptionalRequest,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -640,11 +640,13 @@ public:
 
   bool isPlaceholder();
 
-  /// DEPRECIATED: Returns true if this is a noncopyable type.
-  bool isNoncopyable();
+  /// Returns true if this type lacks conformance to Copyable in the context,
+  /// if provided.
+  bool isNoncopyable(const DeclContext *dc = nullptr);
 
-  /// Returns true if this type lacks conformance to Copyable in the context.
-  bool isNoncopyable(const DeclContext *dc);
+  /// Returns true if this type conforms to Escapable in the context,
+  /// if provided.
+  bool isEscapable(const DeclContext *dc = nullptr);
 
   /// Does the type have outer parenthesis?
   bool hasParenSugar() const { return getKind() == TypeKind::Paren; }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -122,6 +122,11 @@ KnownProtocolKind swift::getKnownProtocolKind(InvertibleProtocolKind ip) {
   }
 }
 
+void swift::simple_display(llvm::raw_ostream &out,
+                           const InvertibleProtocolKind &value) {
+  out << getProtocolName(getKnownProtocolKind(value));
+}
+
 namespace {
 enum class SearchPathKind : uint8_t {
   Import = 1 << 0,
@@ -6241,6 +6246,9 @@ BuiltinTupleDecl *ASTContext::getBuiltinTupleDecl() {
     buildFakeExtension(proto);
 
   if (auto *proto = getProtocol(KnownProtocolKind::Copyable))
+    buildFakeExtension(proto);
+
+  if (auto *proto = getProtocol(KnownProtocolKind::Escapable))
     buildFakeExtension(proto);
 
   return result;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4348,6 +4348,9 @@ namespace {
         case InvertibleProtocolKind::Copyable:
           printFlag("inverse_copyable");
           break;
+        case InvertibleProtocolKind::Escapable:
+          printFlag("inverse_escapable");
+          break;
         }
       }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1232,8 +1232,10 @@ static SmallVector<ProtocolConformance *, 2> findSynthesizedConformances(
   if (!isa<ProtocolDecl>(nominal)) {
     trySynthesize(KnownProtocolKind::Sendable);
 
-    if (nominal->getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics))
+    if (nominal->getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
       trySynthesize(KnownProtocolKind::Copyable);
+      trySynthesize(KnownProtocolKind::Escapable);
+    }
   }
 
   /// Distributed actors can synthesize Encodable/Decodable, so look for those

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -161,7 +161,7 @@ bool swift::rewriting::diagnoseRequirementErrors(
       auto inverse = error.getInverse();
       auto protoKind = getKnownProtocolKind(inverse.getKind());
 
-      ctx.Diags.diagnose(loc, diag::noncopyable_generic_but_copyable,
+      ctx.Diags.diagnose(loc, diag::inverse_generic_but_also_conforms,
                          inverse.subject,
                          getProtocolName(protoKind));
       break;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -314,29 +314,6 @@ void IsFinalRequest::cacheResult(bool value) const {
 }
 
 //----------------------------------------------------------------------------//
-// isEscapable computation.
-//----------------------------------------------------------------------------//
-
-llvm::Optional<bool> IsEscapableRequest::getCachedResult() const {
-  auto decl = std::get<0>(getStorage());
-  if (decl->LazySemanticInfo.isEscapableComputed)
-    return static_cast<bool>(decl->LazySemanticInfo.isEscapable);
-
-  return llvm::None;
-}
-
-void IsEscapableRequest::cacheResult(bool value) const {
-  auto decl = std::get<0>(getStorage());
-  decl->LazySemanticInfo.isEscapableComputed = true;
-  decl->LazySemanticInfo.isEscapable = value;
-
-  // Add an attribute for printing
-  if (!value && !decl->getAttrs().hasAttribute<NonEscapableAttr>())
-    decl->getAttrs().add(new (decl->getASTContext())
-                             NonEscapableAttr(/*Implicit=*/true));
-}
-
-//----------------------------------------------------------------------------//
 // isDynamic computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6577,6 +6577,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::RangeReplaceableCollection:
   case KnownProtocolKind::GlobalActor:
   case KnownProtocolKind::Copyable:
+  case KnownProtocolKind::Escapable:
   case KnownProtocolKind::BitwiseCopyable:
     return SpecialProtocol::None;
   }

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1043,6 +1043,10 @@ SILType::getSingletonAggregateFieldType(SILModule &M,
   return SILType();
 }
 
+bool SILType::isEscapable() const {
+  return getASTType()->isEscapable();
+}
+
 bool SILType::isMoveOnly() const {
   // Legacy check.
   if (!getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
@@ -1159,13 +1163,6 @@ bool SILType::isMarkedAsImmortal() const {
     }
   }
   return false;
-}
-
-bool SILType::isEscapable() const {
-  if (auto *nom = getASTType().getAnyNominal())
-    return nom->isEscapable();
-
-  return true;
 }
 
 intptr_t SILType::getFieldIdxOfNominalType(StringRef fieldName) const {

--- a/lib/Sema/TypeCheckInvertible.h
+++ b/lib/Sema/TypeCheckInvertible.h
@@ -34,6 +34,9 @@ public:
 /// \returns true if the conformance to Copyable was successfully validated.
 bool checkCopyableConformance(ProtocolConformance *conformance);
 
+/// \returns true if the conformance to Escapable was successfully validated.
+bool checkEscapableConformance(ProtocolConformance *conformance);
+
 /// You should be using `ImplicitKnownProtocolConformanceRequest` instead
 ProtocolConformance *deriveConformanceForInvertible(Evaluator &evaluator,
                                                     NominalTypeDecl *nominal,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6617,6 +6617,9 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     } else if (NoncopyableGenerics
         && proto->isSpecificProtocol(KnownProtocolKind::Copyable)) {
       checkCopyableConformance(conformance);
+    } else if (NoncopyableGenerics
+        && proto->isSpecificProtocol(KnownProtocolKind::Escapable)) {
+      checkEscapableConformance(conformance);
     }
   }
 

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -169,6 +169,8 @@ public func _unsafePerformance<T>(_ c: () -> T) -> T {
 
 @_marker public protocol Copyable {}
 
+@_marker public protocol Escapable {}
+
 #if $BitwiseCopyable
 @_marker public protocol _BitwiseCopyable {}
 #endif

--- a/test/Generics/inverse_scoping.swift
+++ b/test/Generics/inverse_scoping.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonEscapableTypes
 
 // REQUIRES: asserts
 
@@ -23,7 +23,11 @@ extension U where Self: ~Copyable {} // expected-error {{cannot add inverse cons
 // expected-error@-1 {{'Self' required to be 'Copyable' but is marked with '~Copyable'}}
 
 extension P {
-  func g() where Self: ~Copyable {} // expected-error {{cannot add inverse constraint 'Self: ~Copyable' on generic parameter 'Self' defined in outer scope}}
+  func g() where Self: ~Copyable, // expected-error {{cannot add inverse constraint 'Self: ~Copyable' on generic parameter 'Self' defined in outer scope}}
+                                  // FIXME: why no similar 2nd error as Escapable here on Self?
+
+                 Self: ~Escapable {}  // expected-error {{cannot add inverse constraint 'Self: ~Escapable' on generic parameter 'Self' defined in outer scope}}
+                                      // expected-error@-1 {{'Self' required to be 'Escapable' but is marked with '~Escapable'}}
 
   typealias Me = Self where Self: ~Copyable // expected-error {{cannot add inverse constraint 'Self: ~Copyable' on generic parameter 'Self' defined in outer scope}}
 
@@ -41,6 +45,12 @@ struct S<T> {
           {}
 
   func onlyCopyable() where T: Copyable {}
+
+    func fn<U>(_ u: U)
+      where T: ~Escapable, // expected-error {{cannot add inverse constraint 'T: ~Escapable' on generic parameter 'T' defined in outer scope}}
+                           // expected-error@-1 {{'T' required to be 'Escapable' but is marked with '~Escapable'}}
+            U: ~Escapable
+            {}
 }
 
 extension S where T: NoCopyReq & ~Copyable {} // expected-error {{cannot add inverse constraint 'T: ~Copyable' on generic parameter 'T' defined in outer scope}}

--- a/test/Generics/inverse_signatures.swift
+++ b/test/Generics/inverse_signatures.swift
@@ -1,17 +1,25 @@
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -verify -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s --implicit-check-not "error:"
+// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonEscapableTypes -verify -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s --implicit-check-not "error:"
 
 // REQUIRES: asserts
 
 // CHECK-LABEL: (file).genericFn@
-// CHECK: Generic signature: <T where T : Copyable>
+// CHECK: Generic signature: <T where T : Copyable, T : Escapable>
 func genericFn<T>(_ t: T) {}
 
-// CHECK-LABEL: .withInverse@
+// CHECK-LABEL: .withInverse1@
+// CHECK: Generic signature: <T where T : Escapable>
+func withInverse1<T: ~Copyable>(_ t: borrowing T) {}
+
+// CHECK-LABEL: .withInverse2@
+// CHECK: Generic signature: <T where T : Copyable>
+func withInverse2<T: ~Escapable>(_ t: borrowing T) {}
+
+// CHECK-LABEL: .withInverse3@
 // CHECK: Generic signature: <T>
-func withInverse<T: ~Copyable>(_ t: borrowing T) {}
+func withInverse3<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
 // CHECK-LABEL: .where1@
-// CHECK: Generic signature: <T>
+// CHECK: Generic signature: <T where T : Escapable>
 func where1<T>(_ t: borrowing T) where T: ~Copyable {}
 
 // CHECK-LABEL: .where2@
@@ -19,8 +27,20 @@ func where1<T>(_ t: borrowing T) where T: ~Copyable {}
 func where2<T>(_ t: borrowing T) where T: NoCopyP, T: ~Copyable {}
 
 // CHECK-LABEL: .where3@
-// CHECK: Generic signature: <T where T : Equatable>
+// CHECK: Generic signature: <T where T : Equatable, T : Escapable>
 func where3<T>(_ t: borrowing T) where T: Equatable, T: ~Copyable {}
+
+// CHECK-LABEL: .where4@
+// CHECK: Generic signature: <T where T : Copyable>
+func where4<T>(_ t: borrowing T) where T: ~Escapable {}
+
+// CHECK-LABEL: .where5@
+// CHECK: Generic signature: <T where T : Copyable, T : Empty>
+func where5<T>(_ t: borrowing T) where T: Empty, T: ~Escapable {}
+
+// CHECK-LABEL: .where6@
+// CHECK: Generic signature: <T where T : Equatable, T : Escapable>
+func where6<T>(_ t: borrowing T) where T: Equatable, T: ~Copyable {}
 
 // CHECK-LABEL: .compose1@
 // CHECK: Generic signature: <T where T : NoCopyP>
@@ -35,11 +55,11 @@ func compose3(_ t: inout some NoCopyP & ~Copyable) {}
 func f1<T: NoCopyP>(_ t: T) {}
 
 // CHECK-LABEL: .withSome@
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Copyable>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable>
 func withSome(_ t: some Any) {}
 
 // CHECK-LABEL: .withSomeEquatable@
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Equatable>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Equatable, τ_0_0 : Escapable>
 func withSomeEquatable(_ t: some Equatable) {}
 
 // CHECK-LABEL: .withSomeProto@
@@ -47,35 +67,51 @@ func withSomeEquatable(_ t: some Equatable) {}
 func withSomeProto(_ t: some NoCopyP) {}
 
 // CHECK-LABEL: .withInverseSome@
-// CHECK: Canonical generic signature: <τ_0_0>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Escapable>
 func withInverseSome(_ t: borrowing some ~Copyable) {}
 
 // CHECK-LABEL: .S1@
-// CHECK: Generic signature: <T where T : Copyable>
+// CHECK: Generic signature: <T where T : Copyable, T : Escapable>
 struct S1<T> {}
 
 // CHECK-LABEL: .S1_I@
-// CHECK: Generic signature: <T>
+// CHECK: Generic signature: <T where T : Escapable>
 struct S1_I<T: ~Copyable> {}
 
 // CHECK-LABEL: .C1@
-// CHECK: Generic signature: <T, U where T : Copyable, U : Copyable>
+// CHECK: Generic signature: <T, U where T : Copyable, T : Escapable, U : Copyable, U : Escapable>
 class C1<T, U> {}
 
 // CHECK-LABEL: .C1_IC@
-// CHECK: Generic signature: <T, U where U : Copyable>
+// CHECK: Generic signature: <T, U where T : Escapable, U : Copyable, U : Escapable>
 class C1_IC<T: ~Copyable, U> {}
 
 // CHECK-LABEL: .C1_CI@
-// CHECK: Generic signature: <T, U where T : Copyable>
+// CHECK: Generic signature: <T, U where T : Copyable, T : Escapable, U : Escapable>
 class C1_CI<T, U> where U: ~Copyable {}
 
 // CHECK-LABEL: .C1_II@
-// CHECK: Generic signature: <T, U>
+// CHECK: Generic signature: <T, U where T : Escapable, U : Escapable>
 class C1_II<T: ~Copyable, U: ~Copyable> {}
 
-// CHECK-LABEL: .NoCopyP@
+// CHECK-LABEL: .Empty@
 // CHECK: Requirement signature: <Self>
+protocol Empty: ~Copyable, ~Escapable {}
+
+// CHECK-LABEL: .NoEscapeP@
+// CHECK: Requirement signature: <Self where Self : Copyable>
+protocol NoEscapeP: ~Escapable {}
+
+// CHECK-LABEL: .NoEscapeP2@
+// CHECK: Requirement signature: <Self where Self : NoEscapeP>
+protocol NoEscapeP2 where Self: NoEscapeP & ~Escapable {}
+
+// CHECK-LABEL: .ForgotTildeEscape@
+// CHECK: Requirement signature: <Self where Self : Escapable, Self : NoEscapeP>
+protocol ForgotTildeEscape where Self: NoEscapeP {}
+
+// CHECK-LABEL: .NoCopyP@
+// CHECK: Requirement signature: <Self where Self : Escapable>
 protocol NoCopyP: ~Copyable {}
 
 // CHECK-LABEL: .NoCopyP2@
@@ -83,7 +119,7 @@ protocol NoCopyP: ~Copyable {}
 protocol NoCopyP2 where Self: ~Copyable & NoCopyP {}
 
 // CHECK-LABEL: .CopyP@
-// CHECK: Requirement signature: <Self where Self : Copyable>
+// CHECK: Requirement signature: <Self where Self : Copyable, Self : Escapable>
 protocol CopyP {}
 
 // CHECK-LABEL: .CopyP2@
@@ -95,31 +131,73 @@ protocol CopyP2: CopyP {}
 protocol CopyInheritsNC: NoCopyP {}
 
 // CHECK-LABEL: .P2@
-// CHECK: <Self where Self : Copyable, Self.[P2]A : Copyable>
+// CHECK: <Self where Self : Copyable, Self : Escapable, Self.[P2]A : Copyable, Self.[P2]A : Escapable>
 protocol P2 { associatedtype A }
 
 // CHECK-LABEL: .P2_IC@
-// CHECK: <Self where Self.[P2_IC]A : Copyable>
+// CHECK: <Self where Self : Escapable, Self.[P2_IC]A : Copyable, Self.[P2_IC]A : Escapable>
 protocol P2_IC: ~Copyable { associatedtype A }
 
 // CHECK-LABEL: .P2_CI@
-// CHECK: Requirement signature: <Self where Self : Copyable>
+// CHECK: Requirement signature: <Self where Self : Copyable, Self : Escapable, Self.[P2_CI]A : Escapable>
 protocol P2_CI { associatedtype A: ~Copyable }
 
 // CHECK-LABEL: .P2_II@
-// CHECK: Requirement signature: <Self>
+// CHECK: Requirement signature: <Self where Self : Escapable, Self.[P2_II]A : Escapable>
 protocol P2_II: ~Copyable { associatedtype A: ~Copyable }
 
+// CHECK-LABEL: .P3@
+// CHECK: Requirement signature: <Self where Self.[P3]B : Copyable>
+protocol P3 where Self: (~Copyable & ~Escapable) { associatedtype B: ~Escapable }
+
+// CHECK-LABEL: .P4@
+// CHECK: Requirement signature: <Self where Self : Copyable, Self.[P4]B : Copyable, Self.[P4]C : Escapable>
+protocol P4: ~Escapable {
+  associatedtype B: ~Escapable
+  associatedtype C: ~Copyable
+  associatedtype D: ~Escapable, ~Copyable
+}
+
+// CHECK-LABEL: .Explicit@
+// CHECK: Requirement signature: <Self where Self : Copyable, Self : Escapable, Self.[Explicit]Elm : Copyable, Self.[Explicit]Elm : Escapable>
+protocol Explicit: Copyable, Escapable {
+  associatedtype Elm: Copyable, Escapable
+}
+
 // CHECK-LABEL: .Cond@
-// CHECK: Generic signature: <T>
-// CHECK-NEXT: Canonical generic signature: <τ_0_0>
+// CHECK: Generic signature: <T where T : Escapable>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0 where τ_0_0 : Escapable>
 struct Cond<T: ~Copyable>: ~Copyable {}
 
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Cond
-// CHECK: Generic signature: <T where T : Copyable>
-// CHECK-NEXT: Canonical generic signature: <τ_0_0 where τ_0_0 : Copyable>
+// CHECK: <T where T : Copyable, T : Escapable>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0 where τ_0_0 : Copyable, τ_0_0 : Escapable>
 
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Cond
 // CHECK:       (normal_conformance type="Cond<T>" protocol="Copyable"
 // CHECK-NEXT:       (requirement "T" conforms_to "Copyable"))
 extension Cond: Copyable where T: Copyable {}
+
+
+// CHECK-LABEL: .ImplicitCond@
+// CHECK: Generic signature: <T>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0>
+struct ImplicitCond<T: ~Escapable & ~Copyable> {}
+
+// CHECK-LABEL: StructDecl name=ImplicitCond
+// CHECK-NEXT:    (normal_conformance type="ImplicitCond<T>" protocol="Sendable")
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ImplicitCond
+// CHECK-NEXT: (normal_conformance type="ImplicitCond<T>" protocol="Empty")
+extension ImplicitCond: Empty {}
+
+
+// NOTE: the following extensions were implicitly synthesized, so they appear at the end!
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ImplicitCond
+// CHECK:       (normal_conformance type="ImplicitCond<T>" protocol="Copyable"
+// CHECK-NEXT:       (requirement "T" conforms_to "Copyable"))
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ImplicitCond
+// CHECK:       (normal_conformance type="ImplicitCond<T>" protocol="Escapable"
+// CHECK-NEXT:       (requirement "T" conforms_to "Escapable"))

--- a/test/Parse/inverse_escapable_feature.swift
+++ b/test/Parse/inverse_escapable_feature.swift
@@ -1,0 +1,3 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+
+struct S: ~Escapable {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonEscapableTypes}}

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -46,7 +46,7 @@ protocol Foo: ~Copyable
 
 protocol Sando { func make() }
 
-class C: ~Copyable,  // expected-error {{classes cannot be noncopyable}}
+class C: ~Copyable,  // expected-error {{classes cannot be '~Copyable'}}
          ~Sando // expected-error {{type 'Sando' is not invertible}}
          {}
 

--- a/test/Parse/inverses_legacy.swift
+++ b/test/Parse/inverses_legacy.swift
@@ -2,6 +2,8 @@
 
 protocol Sando { func make() } // expected-note 2{{protocol requires function 'make()'}}
 
+struct BuggerView: ~Escapable {} // expected-error {{can only suppress 'Copyable'}}
+
 struct S: ~U, // expected-error {{can only suppress 'Copyable'}}
               // expected-error@-1 {{inheritance from non-protocol type 'U'}}
           ~Copyable {}


### PR DESCRIPTION
This PR introduces the `Escapable` and `~Escapable` types with support for generics, etc, matching what `~Copyable` is capable of today.

You can now use the `~Escapable` type if you provide both `-enable-experimental-feature NonEscapableTypes` and `-enable-experimental-feature NoncopyableGenerics`.

resolves rdar://119216918