### PR TITLE
[embedded] Disable building Darwin as embedded, unbreak the build and CI

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -77,7 +77,8 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
     INSTALL_IN_COMPONENT sdk-overlay
     MACCATALYST_BUILD_FLAVOR "zippered")
 
-if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+# TODO(mracek): Disable building Darwin module as embedded pending investigations into a build failure
+if(FALSE)
   set(SWIFT_ENABLE_REFLECTION OFF)
 
   add_custom_target(embedded-darwin ALL)

--- a/test/embedded/darwin-bridging-header.swift
+++ b/test/embedded/darwin-bridging-header.swift
@@ -11,6 +11,9 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
+// Temporarily disabled:
+// REQUIRES: rdar119283700
+
 // BEGIN BridgingHeader.h
 
 #include <unistd.h>

--- a/test/embedded/darwin.swift
+++ b/test/embedded/darwin.swift
@@ -9,6 +9,9 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
+// Temporarily disabled:
+// REQUIRES: rdar119283700
+
 import Darwin
 
 @main


### PR DESCRIPTION
CI is currently failing 

```
<unknown>:0: error: cannot use metatype of type 'Int' in embedded Swift
<unknown>:0: error: cannot use a value of protocol type in embedded Swift
```

https://ci.swift.org/job/oss-swift-incremental-RA-macos/3852/