### PR TITLE
[Concurrency] Key paths and global actors

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5410,8 +5410,8 @@ ERROR(concurrent_access_local,none,
         "use of local %kind0 in concurrently-executing code",
         (const ValueDecl *))
 ERROR(actor_isolated_keypath_component,none,
-      "cannot form key path to%select{| distributed}0 actor-isolated %kind1",
-      (bool, const ValueDecl *))
+      "cannot form key path to %0 %kind1",
+      (ActorIsolation, const ValueDecl *))
 ERROR(effectful_keypath_component,none,
       "cannot form key path to %0 with 'throws' or 'async'",
       (DescriptiveDeclKind))

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7551,6 +7551,20 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       if (!storage)
         return fail();
 
+      switch (getActorIsolation(storage)) {
+      case ActorIsolation::Unspecified:
+      case ActorIsolation::Nonisolated:
+      case ActorIsolation::NonisolatedUnsafe:
+        break;
+
+      // A reference to an actor isolated state make key path non-Sendable.
+      case ActorIsolation::ActorInstance:
+      case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
+        isSendable = false;
+        break;
+      }
+
       if (isReadOnlyKeyPathComponent(storage, component.getLoc())) {
         mutability = KeyPathMutability::ReadOnly;
         continue;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7494,6 +7494,11 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
           auto *sendable = Context.getProtocol(KnownProtocolKind::Sendable);
 
           for (const auto &arg : *args) {
+            // No need to check more or delay since we already known
+            // that the type is not Sendable.
+            if (!isSendable)
+              break;
+
             auto argTy = simplifyType(getType(arg.getExpr()));
 
             // Sendability cannot be determined until the argument

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3382,7 +3382,7 @@ namespace {
             {
               auto diagnostic = ctx.Diags.diagnose(
                   component.getLoc(), diag::actor_isolated_keypath_component,
-                  isolation.isDistributedActor(), decl);
+                  isolation, decl);
 
               if (isolation == ActorIsolation::ActorInstance)
                 diagnosed = true;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3343,8 +3343,8 @@ namespace {
       for (const auto &component : keyPath->getComponents()) {
         // The decl referred to by the path component cannot be within an actor.
         if (component.hasDeclRef()) {
-          auto concDecl = component.getDeclRef();
-          auto decl = concDecl.getDecl();
+          auto declRef = component.getDeclRef();
+          auto decl = declRef.getDecl();
           auto isolation = getActorIsolationForReference(
               decl, getDeclContext());
           switch (isolation) {
@@ -3354,13 +3354,16 @@ namespace {
             break;
 
           case ActorIsolation::GlobalActor:
-          case ActorIsolation::GlobalActorUnsafe:
-            // Disable global actor checking for now.
-            if (isolation.isGlobalActor() &&
-                !ctx.LangOpts.isSwiftVersionAtLeast(6))
+          case ActorIsolation::GlobalActorUnsafe: {
+            auto result = ActorReferenceResult::forReference(
+                declRef, component.getLoc(), getDeclContext(),
+                kindOfUsage(decl, keyPath));
+
+            if (result == ActorReferenceResult::SameConcurrencyDomain)
               break;
 
             LLVM_FALLTHROUGH;
+          }
 
           case ActorIsolation::ActorInstance:
             // If this entity is always accessible across actors, just check
@@ -3376,11 +3379,17 @@ namespace {
               break;
             }
 
-            ctx.Diags.diagnose(component.getLoc(),
-                               diag::actor_isolated_keypath_component,
-                               isolation.isDistributedActor(),
-                               decl);
-            diagnosed = true;
+            {
+              auto diagnostic = ctx.Diags.diagnose(
+                  component.getLoc(), diag::actor_isolated_keypath_component,
+                  isolation.isDistributedActor(), decl);
+
+              if (isolation == ActorIsolation::ActorInstance)
+                diagnosed = true;
+              else
+                diagnostic.warnUntilSwiftVersion(6);
+            }
+
             break;
           }
         }

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -58,7 +58,7 @@ func tryKeyPathsMisc(d : Door) {
 
 func tryKeyPathsFromAsync() async {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // okay for now
+    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'; this is an error in Swift 6}}
 }
 
 func tryNonSendable() {
@@ -69,7 +69,7 @@ func tryNonSendable() {
 
 func tryKeypaths() {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // okay for now
+    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'; this is an error in Swift 6}}
 
     _ = \Door.immutable
     _ = \Door.globActor_immutable
@@ -84,7 +84,7 @@ func tryKeypaths() {
     let _ : PartialKeyPath<Door> = \.mutable // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
     let _ : AnyKeyPath = \Door.mutable  // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
 
-    _ = \Door.globActor_mutable // okay for now
+    _ = \Door.globActor_mutable // expected-warning {{cannot form key path to actor-isolated property 'globActor_mutable'; this is an error in Swift 6}}
     _ = \Door.[0] // expected-error{{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
-    _ = \Door.["hello"] // okay for now
+    _ = \Door.["hello"] // expected-warning {{cannot form key path to actor-isolated subscript 'subscript(_:)'; this is an error in Swift 6}}
 }

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -58,7 +58,7 @@ func tryKeyPathsMisc(d : Door) {
 
 func tryKeyPathsFromAsync() async {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'; this is an error in Swift 6}}
+    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'unsafeGlobActor_mutable'; this is an error in Swift 6}}
 }
 
 func tryNonSendable() {
@@ -69,7 +69,7 @@ func tryNonSendable() {
 
 func tryKeypaths() {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'; this is an error in Swift 6}}
+    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'unsafeGlobActor_mutable'; this is an error in Swift 6}}
 
     _ = \Door.immutable
     _ = \Door.globActor_immutable
@@ -84,7 +84,7 @@ func tryKeypaths() {
     let _ : PartialKeyPath<Door> = \.mutable // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
     let _ : AnyKeyPath = \Door.mutable  // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
 
-    _ = \Door.globActor_mutable // expected-warning {{cannot form key path to actor-isolated property 'globActor_mutable'; this is an error in Swift 6}}
+    _ = \Door.globActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'globActor_mutable'; this is an error in Swift 6}}
     _ = \Door.[0] // expected-error{{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
-    _ = \Door.["hello"] // expected-warning {{cannot form key path to actor-isolated subscript 'subscript(_:)'; this is an error in Swift 6}}
+    _ = \Door.["hello"] // expected-warning {{cannot form key path to main actor-isolated subscript 'subscript(_:)'; this is an error in Swift 6}}
 }

--- a/test/Concurrency/actor_keypath_isolation_swift6.swift
+++ b/test/Concurrency/actor_keypath_isolation_swift6.swift
@@ -57,7 +57,7 @@ func tryKeyPathsMisc(d : Door) {
 
 func tryKeyPathsFromAsync() async {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // expected-error {{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'}}
+    _ = \Door.unsafeGlobActor_mutable // expected-error {{cannot form key path to main actor-isolated property 'unsafeGlobActor_mutable'}}
 }
 
 func tryNonSendable() {
@@ -68,7 +68,7 @@ func tryNonSendable() {
 
 func tryKeypaths() {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // expected-error {{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'}}
+    _ = \Door.unsafeGlobActor_mutable // expected-error {{cannot form key path to main actor-isolated property 'unsafeGlobActor_mutable'}}
 
     _ = \Door.immutable
     _ = \Door.globActor_immutable
@@ -83,7 +83,7 @@ func tryKeypaths() {
     let _ : PartialKeyPath<Door> = \.mutable // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
     let _ : AnyKeyPath = \Door.mutable  // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
 
-    _ = \Door.globActor_mutable // expected-error{{cannot form key path to actor-isolated property 'globActor_mutable'}}
+    _ = \Door.globActor_mutable // expected-error{{cannot form key path to main actor-isolated property 'globActor_mutable'}}
     _ = \Door.[0] // expected-error{{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
-    _ = \Door.["hello"] // expected-error {{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
+    _ = \Door.["hello"] // expected-error {{cannot form key path to main actor-isolated subscript 'subscript(_:)'}}
 }

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -140,17 +140,62 @@ do {
 }
 
 // Global actor isolated properties.
-do {
+func testGlobalActorIsolatedReferences() {
   @MainActor struct Isolated {
     var data: Int = 42
     subscript(v: Int) -> Bool { false }
   }
 
   let dataKP = \Isolated.data
+  // expected-warning@-1 {{cannot form key path to actor-isolated property 'data'; this is an error in Swift 6}}
   let subscriptKP = \Isolated.[42]
+  // expected-warning@-1 {{cannot form key path to actor-isolated subscript 'subscript(_:)'; this is an error in Swift 6}}
 
   let _: KeyPath<Isolated, Int> & Sendable = dataKP
   // expected-warning@-1 {{type 'WritableKeyPath<Isolated, Int>' does not conform to the 'Sendable' protocol}}
   let _: KeyPath<Isolated, Bool> & Sendable = subscriptKP
   // expected-warning@-1 {{type 'KeyPath<Isolated, Bool>' does not conform to the 'Sendable' protocol}}
+
+  func testNonIsolated() {
+    _ = \Isolated.data
+    // expected-warning@-1 {{cannot form key path to actor-isolated property 'data'; this is an error in Swift 6}}
+  }
+
+  @MainActor func testIsolated() {
+    _ = \Isolated.data // Ok
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor SomeActor {
+}
+
+@available(SwiftStdlib 5.1, *)
+@globalActor
+actor GlobalActor {
+  static let shared: SomeActor = SomeActor()
+}
+
+@available(SwiftStdlib 5.1, *)
+func testReferencesToDifferentGlobalActorIsolatedMembers() {
+  struct Info {
+    @MainActor var name: String  { "" }
+  }
+
+  struct Isolated {
+    @GlobalActor var info: Info { Info() }
+  }
+
+  @MainActor func testIsolatedToMain() {
+    _ = \Info.name // Ok
+    _ = \Isolated.info.name
+    // expected-warning@-1 {{cannot form key path to actor-isolated property 'info'; this is an error in Swift 6}}
+  }
+
+  @GlobalActor func testIsolatedToCustom() {
+    _ = \Info.name // Ok
+    // expected-warning@-1 {{cannot form key path to actor-isolated property 'name'; this is an error in Swift 6}}
+    _ = \Isolated.info.name
+    // expected-warning@-1 {{cannot form key path to actor-isolated property 'name'; this is an error in Swift 6}}
+  }
 }

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -138,3 +138,19 @@ do {
 
   _ = Test(obj: "Hello").utf8.count // Ok
 }
+
+// Global actor isolated properties.
+do {
+  @MainActor struct Isolated {
+    var data: Int = 42
+    subscript(v: Int) -> Bool { false }
+  }
+
+  let dataKP = \Isolated.data
+  let subscriptKP = \Isolated.[42]
+
+  let _: KeyPath<Isolated, Int> & Sendable = dataKP
+  // expected-warning@-1 {{type 'WritableKeyPath<Isolated, Int>' does not conform to the 'Sendable' protocol}}
+  let _: KeyPath<Isolated, Bool> & Sendable = subscriptKP
+  // expected-warning@-1 {{type 'KeyPath<Isolated, Bool>' does not conform to the 'Sendable' protocol}}
+}

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -147,9 +147,9 @@ func testGlobalActorIsolatedReferences() {
   }
 
   let dataKP = \Isolated.data
-  // expected-warning@-1 {{cannot form key path to actor-isolated property 'data'; this is an error in Swift 6}}
+  // expected-warning@-1 {{cannot form key path to main actor-isolated property 'data'; this is an error in Swift 6}}
   let subscriptKP = \Isolated.[42]
-  // expected-warning@-1 {{cannot form key path to actor-isolated subscript 'subscript(_:)'; this is an error in Swift 6}}
+  // expected-warning@-1 {{cannot form key path to main actor-isolated subscript 'subscript(_:)'; this is an error in Swift 6}}
 
   let _: KeyPath<Isolated, Int> & Sendable = dataKP
   // expected-warning@-1 {{type 'WritableKeyPath<Isolated, Int>' does not conform to the 'Sendable' protocol}}
@@ -158,7 +158,7 @@ func testGlobalActorIsolatedReferences() {
 
   func testNonIsolated() {
     _ = \Isolated.data
-    // expected-warning@-1 {{cannot form key path to actor-isolated property 'data'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'data'; this is an error in Swift 6}}
   }
 
   @MainActor func testIsolated() {
@@ -189,13 +189,13 @@ func testReferencesToDifferentGlobalActorIsolatedMembers() {
   @MainActor func testIsolatedToMain() {
     _ = \Info.name // Ok
     _ = \Isolated.info.name
-    // expected-warning@-1 {{cannot form key path to actor-isolated property 'info'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot form key path to global actor 'GlobalActor'-isolated property 'info'; this is an error in Swift 6}}
   }
 
   @GlobalActor func testIsolatedToCustom() {
     _ = \Info.name // Ok
-    // expected-warning@-1 {{cannot form key path to actor-isolated property 'name'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'name'; this is an error in Swift 6}}
     _ = \Isolated.info.name
-    // expected-warning@-1 {{cannot form key path to actor-isolated property 'name'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'name'; this is an error in Swift 6}}
   }
 }


### PR DESCRIPTION
- InferSendableFromCaptures: If key path references a global actor isolated member mark it as non-Sendable
- Diagnose use of the global actor isolated members if the access and declaration
  concurrency domains differ. (This is a warning until Swift 6).

Resolves: https://github.com/apple/swift/issues/66830
Resolves: rdar://117538832

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
