### PR TITLE
[embedded] When missing a source location in a PerformanceDiagnostic, at least print the function name

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -181,6 +181,9 @@ bool PerformanceDiagnostics::visitFunction(SILFunction *function,
 
     for (SILInstruction &inst : block) {
       if (visitInst(&inst, perfConstr, parentLoc)) {
+        if (inst.getLoc().getSourceLoc().isInvalid()) {
+          llvm::errs() << "in function " << inst.getFunction()->getName() << "\n";
+        }
         LLVM_DEBUG(llvm::dbgs() << inst << *inst.getFunction());
         return true;
       }
@@ -582,6 +585,9 @@ void PerformanceDiagnostics::checkNonAnnotatedFunction(SILFunction *function) {
       if (function->getModule().getOptions().EmbeddedSwift) {
         auto loc = LocWithParent(inst.getLoc().getSourceLoc(), nullptr);
         if (visitInst(&inst, PerformanceConstraints::None, &loc)) {
+          if (inst.getLoc().getSourceLoc().isInvalid()) {
+            llvm::errs() << "in function " << inst.getFunction()->getName() << "\n";
+          }
           LLVM_DEBUG(llvm::dbgs() << inst << *inst.getFunction());
         }
       }

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -182,7 +182,10 @@ bool PerformanceDiagnostics::visitFunction(SILFunction *function,
     for (SILInstruction &inst : block) {
       if (visitInst(&inst, perfConstr, parentLoc)) {
         if (inst.getLoc().getSourceLoc().isInvalid()) {
-          llvm::errs() << "in function " << inst.getFunction()->getName() << "\n";
+          auto demangledName = Demangle::demangleSymbolAsString(
+              inst.getFunction()->getName(),
+              Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+          llvm::errs() << "in function " << demangledName << "\n";
         }
         LLVM_DEBUG(llvm::dbgs() << inst << *inst.getFunction());
         return true;
@@ -586,7 +589,10 @@ void PerformanceDiagnostics::checkNonAnnotatedFunction(SILFunction *function) {
         auto loc = LocWithParent(inst.getLoc().getSourceLoc(), nullptr);
         if (visitInst(&inst, PerformanceConstraints::None, &loc)) {
           if (inst.getLoc().getSourceLoc().isInvalid()) {
-            llvm::errs() << "in function " << inst.getFunction()->getName() << "\n";
+            auto demangledName = Demangle::demangleSymbolAsString(
+                inst.getFunction()->getName(),
+                Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+            llvm::errs() << "in function " << demangledName << "\n";
           }
           LLVM_DEBUG(llvm::dbgs() << inst << *inst.getFunction());
         }


### PR DESCRIPTION
I know this isn't great, but it's at least something. Turns

```
<unknown>:0: error: cannot use metatype of type 'Int' in embedded Swift
```

into:

```
<unknown>:0: error: cannot use metatype of type 'Int' in embedded Swift
in function $ss17FixedWidthIntegerPsE03bitB0SivgSi_Tg5
```
