### PR TITLE
Implement TypeRef::areEqual and TypeInfo::areEqual and fix TypeRef::mangle producing incorrect mangle trees

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -159,6 +159,43 @@ public:
   }
 
   virtual ~TypeInfo() { }
+
+  /// Compares two TypeInfos and returns true if they're equal.
+  /// Since type infos are mostly  behind pointers, this function is implemented
+  /// as a static function instead of being operator==() to avoid having to
+  /// check for null on every call.
+  static bool areEqual(const TypeInfo *LHS, const TypeInfo *RHS) {
+    if (LHS == RHS)
+      return true;
+
+    if ((!LHS && RHS) || (!RHS && LHS))
+      return false;
+
+    if (LHS->Kind != RHS->Kind)
+      return false;
+
+    if (LHS->Kind == TypeInfoKind::Invalid)
+      return true;
+
+    if (LHS->Kind != RHS->Kind || LHS->Size != RHS->Size ||
+        LHS->Alignment != RHS->Alignment ||
+        LHS->Stride != RHS->Alignment ||
+        LHS->NumExtraInhabitants != RHS->NumExtraInhabitants ||
+        LHS->BitwiseTakable != RHS->BitwiseTakable)
+      return false;
+
+
+    return LHS->isEqualImpl(RHS);
+  }
+
+protected:
+  /// Helper function to check if two Type Infos of the same type are equal.
+  /// Should only be called by equals, as it only checks for the subclass
+  /// specific fields.
+  virtual bool isEqualImpl(const TypeInfo *second) const {
+    assert(false && "Should not be called directly!");
+    return false;
+  }
 };
 
 struct FieldInfo {
@@ -167,6 +204,8 @@ struct FieldInfo {
   int Value;
   const TypeRef *TR;
   const TypeInfo &TI;
+
+  bool isEqual(const FieldInfo &RHS) const;
 };
 
 /// Builtins and (opaque) imported value types
@@ -198,6 +237,8 @@ public:
   static bool classof(const TypeInfo *TI) {
     return TI->getKind() == TypeInfoKind::Builtin;
   }
+protected:
+  bool isEqualImpl(const TypeInfo *second) const override;
 };
 
 /// Class instances, structs, tuples
@@ -225,6 +266,8 @@ public:
   static bool classof(const TypeInfo *TI) {
     return TI->getKind() == TypeInfoKind::Record;
   }
+protected:
+  bool isEqualImpl(const TypeInfo *RHS) const override;
 };
 
 /// Enums
@@ -295,6 +338,8 @@ public:
   static bool classof(const TypeInfo *TI) {
     return TI->getKind() == TypeInfoKind::Enum;
   }
+protected:
+  bool isEqualImpl(const TypeInfo *second) const override;
 };
 
 /// References to classes, closure contexts and anything else with an
@@ -333,6 +378,8 @@ public:
   static bool classof(const TypeInfo *TI) {
     return TI->getKind() == TypeInfoKind::Reference;
   }
+protected:
+  bool isEqualImpl(const TypeInfo *second) const override;
 };
 
 /// This class owns the memory for all TypeInfo instances that it vends.

--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -237,6 +237,19 @@ public:
   static bool deriveSubstitutions(GenericArgumentMap &Subs,
                                   const TypeRef *OrigTR,
                                   const TypeRef *SubstTR);
+
+  static bool areEqual(const TypeRef *LHS, const TypeRef *RHS) {
+    if (LHS == RHS)
+      return true;
+    if (!LHS || !RHS)
+      return false;
+    if (LHS->Kind != RHS->Kind)
+      return false;
+    swift::Demangle::Demangler Dem;
+    auto lhsMangledName = LHS->mangle(Dem);
+    auto rhsMangledName = RHS->mangle(Dem);
+    return lhsMangledName == rhsMangledName;
+  }
 };
 
 class BuiltinTypeRef final : public TypeRef {

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -21,6 +21,7 @@
 #if SWIFT_ENABLE_REFLECTION
 
 #include "llvm/Support/MathExtras.h"
+#include "llvm/ADT/STLExtras.h"
 #include "swift/ABI/Enum.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/RemoteInspection/TypeLowering.h"
@@ -2749,6 +2750,50 @@ const RecordTypeInfo *TypeConverter::getClassInstanceTypeInfo(
   swift_unreachable("Unhandled FieldDescriptorKind in switch.");
 }
 
+bool FieldInfo::isEqual(const FieldInfo &RHS) const {
+  return Name == RHS.Name && Offset == RHS.Offset && Value == RHS.Value &&
+         TypeRef::areEqual(TR, RHS.TR) && TypeInfo::areEqual(&TI, &RHS.TI);
+}
+
+bool BuiltinTypeInfo::isEqualImpl(const TypeInfo *RHS) const {
+  auto Other = llvm::cast<BuiltinTypeInfo>(RHS);
+  return Name == Other->Name;
+}
+
+bool RecordTypeInfo::isEqualImpl(const TypeInfo *RHS) const {
+  auto Other = llvm::cast<RecordTypeInfo>(RHS);
+  if (SubKind != Other->SubKind)
+    return false;
+
+  if (Fields.size() != Other->Fields.size())
+    return false;
+
+  for (const auto &[lhsField, rhsField] : llvm::zip(Fields, Other->Fields))
+    if (!lhsField.isEqual(rhsField))
+      return false;
+
+  return true;
+}
+
+bool EnumTypeInfo::isEqualImpl(const TypeInfo *RHS) const {
+  auto Other = llvm::cast<EnumTypeInfo>(RHS);
+  if (SubKind != Other->SubKind)
+    return false;
+
+  if (Cases.size() != Other->Cases.size())
+    return false;
+
+  for (const auto &[lhsCase, rhsCase] : llvm::zip(Cases, Other->Cases))
+    if (!lhsCase.isEqual(rhsCase))
+      return false;
+
+  return true;
+}
+
+bool ReferenceTypeInfo::isEqualImpl(const TypeInfo *RHS) const {
+  auto Other = llvm::cast<ReferenceTypeInfo>(RHS);
+  return SubKind == Other->SubKind && Refcounting == Other->Refcounting;
+}
 } // namespace reflection
 } // namespace swift
 

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -1039,14 +1039,7 @@ llvm::Optional<std::string> TypeRef::mangle(Demangle::Demangler &Dem) const {
   if (!node)
     return {};
 
-  // The mangled tree stored in this typeref implicitly assumes the type and
-  // global mangling, so add those back in.
-  auto typeMangling = Dem.createNode(Node::Kind::TypeMangling);
-  typeMangling->addChild(node, Dem);
-  auto global = Dem.createNode(Node::Kind::Global);
-  global->addChild(node, Dem);
-
-  auto mangling = mangleNode(global);
+  auto mangling = mangleNode(node);
   if (!mangling.isSuccess())
     return {};
   return mangling.result();


### PR DESCRIPTION
There are two commits in this patch.

First:
    Fix TypeRef::mangle producing incorrect mangle trees

    The implementation of TypeRef::mangle was wrong. Replace it with an
    implementation which is just a helper around TypeRef::getDemangling and
    produces a string from a TypeRef.

Second:
    Implement TypeRef::areEqual and TypeInfo::areEqual

    For testing purposes, it would be useful to compare TypeInfos produced
    by different sources to assert they are the same. Implement
    functionality to do that.