### PR TITLE
[5.10][Test] Fix integer overflow in layout_string_witnesses_dynamic.swift …

### DIFF
--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -569,10 +569,10 @@ public struct TupleLargeAlignment<T> {
     let x: AnyObject? = nil
     let x1: AnyObject? = nil
     let x2: AnyObject? = nil
-    let x3: (T, SIMD4<Int>)
+    let x3: (T, SIMD4<Int64>)
 
     public init(_ t: T) {
-        self.x3 = (t, .init(Int(Int32.max) + 32, Int(Int32.max) + 32, Int(Int32.max) + 32, Int(Int32.max) + 32))
+        self.x3 = (t, .init(Int64(Int32.max) + 32, Int64(Int32.max) + 32, Int64(Int32.max) + 32, Int64(Int32.max) + 32))
     }
 }
 


### PR DESCRIPTION
…on 32 bit targets

Cherry-pick of: https://github.com/apple/swift/pull/70290

- **Explanation**: A test used an Int, when it should have been Int64, which caused an overflow on 32 bit targets
- **Issue**: rdar://119268608
- **Risk**: Low. Only fixes a test.
- **Reviewer**: @beccadax 
