### PR TITLE
[ASTGen] TokenSyntax.keyworkKind to directly get Keyword kind

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -12,7 +12,7 @@
 
 import ASTBridging
 import SwiftDiagnostics
-@_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+@_spi(ExperimentalLanguageFeatures) @_spi(RawSyntax) import SwiftSyntax
 
 /// Check if an `ExprSyntax` can be generated using ASTGen.
 ///
@@ -292,12 +292,12 @@ extension ASTGenVisitor {
 
   private func createDeclNameRef(declReferenceExpr node: DeclReferenceExprSyntax) -> (name: BridgedDeclNameRef, loc: BridgedDeclNameLoc) {
     let baseName: BridgedDeclBaseName
-    switch node.baseName.tokenKind {
-    case .keyword(.`init`):
+    switch node.baseName.keywordKind {
+    case .`init`:
       baseName = .createConstructor()
-    case .keyword(.deinit):
+    case .deinit:
       baseName = .createDestructor()
-    case .keyword(.subscript):
+    case .subscript:
       baseName = .createSubscript()
     default:
       baseName = .createIdentifier(self.generateIdentifier(node.baseName))
@@ -480,14 +480,14 @@ extension ASTGenVisitor {
         asLoc: asLoc,
         type: type
       ).asExpr
-    case let question? where question.text == "?":
+    case let question? where question.rawTokenKind == .postfixQuestionMark:
       return BridgedConditionalCheckedCastExpr.createParsed(
         self.ctx,
         asLoc: asLoc,
         questionLoc: self.generateSourceLoc(question),
         type: type
       ).asExpr
-    case let exclaim? where exclaim.text == "!":
+    case let exclaim? where exclaim.rawTokenKind == .exclamationMark:
       return BridgedForcedCheckedCastExpr.createParsed(
         self.ctx,
         asLoc: asLoc,

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -39,7 +39,7 @@ extension ASTGenVisitor {
   }
 
   func generate(booleanLiteralExpr node: BooleanLiteralExprSyntax) -> BridgedBooleanLiteralExpr {
-    let value = node.literal.tokenKind == .keyword(.true)
+    let value = node.literal.keywordKind == .true
     return .createParsed(
       ctx,
       value: value,

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -106,7 +106,7 @@ extension ASTGenVisitor {
     let loc = self.generateSourceLoc(node.name)
 
     // If this is the bare 'Any' keyword, produce an empty composition type.
-    if node.name.rawText == "Any" && node.genericArgumentClause == nil {
+    if node.name.keywordKind == .Any && node.genericArgumentClause == nil {
       return BridgedCompositionTypeRepr.createEmpty(self.ctx, anyKeywordLoc: loc)
     }
 
@@ -203,14 +203,14 @@ extension ASTGenVisitor {
   func generate(metatypeType node: MetatypeTypeSyntax) -> BridgedTypeRepr {
     let baseType = generate(type: node.baseType)
     let tyLoc = self.generateSourceLoc(node.metatypeSpecifier)
-    if node.metatypeSpecifier.rawText == "Type" {
+    if node.metatypeSpecifier.keywordKind == .Type {
       return BridgedMetatypeTypeRepr.createParsed(
         self.ctx,
         base: baseType,
         typeKeywordLoc: tyLoc
       )
     } else {
-      assert(node.metatypeSpecifier.rawText == "Protocol")
+      assert(node.metatypeSpecifier.keywordKind == .Protocol)
       return BridgedProtocolTypeRepr.createParsed(
         self.ctx,
         base: baseType,
@@ -298,14 +298,14 @@ extension ASTGenVisitor {
   func generate(someOrAnyType node: SomeOrAnyTypeSyntax) -> BridgedTypeRepr {
     let someOrAnyLoc = self.generateSourceLoc(node.someOrAnySpecifier)
     let baseTy = generate(type: node.constraint)
-    if node.someOrAnySpecifier.rawText == "some" {
+    if node.someOrAnySpecifier.keywordKind == .some {
       return BridgedOpaqueReturnTypeRepr.createParsed(
         self.ctx,
         someKeywordLoc: someOrAnyLoc,
         base: baseTy
       )
     } else {
-      assert(node.someOrAnySpecifier.text == "any")
+      assert(node.someOrAnySpecifier.keywordKind == .any)
       return BridgedExistentialTypeRepr.createParsed(
         self.ctx,
         anyKeywordLoc: someOrAnyLoc,
@@ -320,16 +320,16 @@ extension ASTGenVisitor {
 // MARK: - SpecifierTypeRepr/AttributedTypeRepr
 
 extension BridgedAttributedTypeSpecifier {
-  fileprivate init?(from tokenKind: TokenKind) {
-    switch tokenKind {
-    case .keyword(.inout): self = .inOut
-    case .keyword(.borrowing): self = .borrowing
-    case .keyword(.consuming): self = .consuming
-    case .keyword(.__shared): self = .legacyShared
-    case .keyword(.__owned): self = .legacyOwned
-    case .keyword(._const): self = .const
-    case .keyword(.isolated): self = .isolated
-    case .keyword(._resultDependsOn): self = .resultDependsOn
+  fileprivate init?(from keyword: Keyword?) {
+    switch keyword {
+    case .inout: self = .inOut
+    case .borrowing: self = .borrowing
+    case .consuming: self = .consuming
+    case .__shared: self = .legacyShared
+    case .__owned: self = .legacyOwned
+    case ._const: self = .const
+    case .isolated: self = .isolated
+    case ._resultDependsOn: self = .resultDependsOn
     default: return nil
     }
   }
@@ -341,7 +341,7 @@ extension ASTGenVisitor {
 
     // Handle specifiers.
     if let specifier = node.specifier {
-      if let kind = BridgedAttributedTypeSpecifier(from: specifier.tokenKind) {
+      if let kind = BridgedAttributedTypeSpecifier(from: specifier.keywordKind) {
         type = BridgedSpecifierTypeRepr.createParsed(
           self.ctx,
           base: type,


### PR DESCRIPTION
This should be faster than e.g. `token.tokenKind == .keyword(.true)`.
