### PR TITLE
[embedded] Add a -performance-diagnostics-dump-module-on-failure flag

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -24,6 +24,9 @@
 
 using namespace swift;
 
+static llvm::cl::opt<bool> DumpModuleOnFailure(
+  "performance-diagnostics-dump-module-on-failure", llvm::cl::init(false));
+
 namespace {
 
 class PrettyStackTracePerformanceDiagnostics
@@ -624,6 +627,11 @@ private:
       if (function.getPerfConstraints() == PerformanceConstraints::None) {
         diagnoser.checkNonAnnotatedFunction(&function);
       }
+    }
+
+    if (DumpModuleOnFailure && module->getASTContext().hadError()) {
+      llvm::dbgs() << "In module:\n";
+      module->print(llvm::dbgs());
     }
   }
 };


### PR DESCRIPTION
Sometimes, the performance diagnostics trigger errors that are not clear, missing source locations, or are impossible to diagnose without seeing the full module. Let's add a flag that lets us dump the SILModule at the point where the perf diagnostics are emitted.