### PR TITLE
Add DirectX WinSDK modulemap changes from main

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -213,8 +213,6 @@ module WinSDK [system] {
       export *
 
       link "xaudio2.lib"
-
-      requires cplusplus
     }
 
     // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was
@@ -230,7 +228,7 @@ module WinSDK [system] {
       header "dinput.h"
       export *
 
-      link "dinput.lib"
+      link "dinput8.lib"
     }
 
     link "dxguid.lib"


### PR DESCRIPTION
Adds the following 2 pull requests already merged into main.

Fix incorrect library name
https://github.com/apple/swift/pull/68888

Platform: remove cplusplus requirement on XAudio29
https://github.com/apple/swift/pull/70195