### PR TITLE
Fixes for -enable-experimental-associated-type-inference

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6796,11 +6796,13 @@ public:
   /// Substitute the base type, looking up our associated type in it if it is
   /// non-dependent. Returns null if the member could not be found in the new
   /// base.
-  Type substBaseType(Type base, LookupConformanceFn lookupConformance);
+  Type substBaseType(Type base, LookupConformanceFn lookupConformance,
+                     SubstOptions options);
 
   /// Substitute the root generic type, looking up the chain of associated types.
   /// Returns null if the member could not be found in the new root.
-  Type substRootParam(Type newRoot, LookupConformanceFn lookupConformance);
+  Type substRootParam(Type newRoot, LookupConformanceFn lookupConformance,
+                      SubstOptions options);
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -346,7 +346,8 @@ static Type substPrefixType(Type type, unsigned suffixLength, Type prefixType,
   auto substBaseType = substPrefixType(memberType->getBase(), suffixLength - 1,
                                        prefixType, sig);
   return memberType->substBaseType(substBaseType,
-                                   LookUpConformanceInSignature(sig.getPointer()));
+                                   LookUpConformanceInSignature(sig.getPointer()),
+                                   llvm::None);
 }
 
 /// Unlike most other queries, the input type can be any type, not just a

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5595,7 +5595,7 @@ TypeBase::getAutoDiffTangentSpace(LookupConformanceFn lookupConformance) {
 
   // Try to get the `TangentVector` associated type of `base`.
   // Return the associated type if it is valid.
-  auto assocTy = dependentType->substBaseType(this, lookupConformance);
+  auto assocTy = dependentType->substBaseType(this, lookupConformance, llvm::None);
   if (!assocTy->hasError())
     return cache(TangentSpace::getTangentVector(assocTy));
 

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -274,30 +274,32 @@ operator()(CanType dependentType, Type conformingReplacementType,
 }
 
 Type DependentMemberType::substBaseType(ModuleDecl *module, Type substBase) {
-  return substBaseType(substBase, LookUpConformanceInModule(module));
+  return substBaseType(substBase, LookUpConformanceInModule(module), llvm::None);
 }
 
 Type DependentMemberType::substBaseType(Type substBase,
-                                        LookupConformanceFn lookupConformance) {
+                                        LookupConformanceFn lookupConformance,
+                                        SubstOptions options) {
   if (substBase.getPointer() == getBase().getPointer() &&
       substBase->hasTypeParameter())
     return this;
 
-  InFlightSubstitution IFS(nullptr, lookupConformance, llvm::None);
+  InFlightSubstitution IFS(nullptr, lookupConformance, options);
   return getMemberForBaseType(IFS, getBase(), substBase,
                               getAssocType(), getName(),
                               /*level=*/0);
 }
 
 Type DependentMemberType::substRootParam(Type newRoot,
-                                         LookupConformanceFn lookupConformance){
+                                         LookupConformanceFn lookupConformance,
+                                         SubstOptions options) {
   auto base = getBase();
   if (base->is<GenericTypeParamType>()) {
-    return substBaseType(newRoot, lookupConformance);
+    return substBaseType(newRoot, lookupConformance, options);
   }
   if (auto depMem = base->getAs<DependentMemberType>()) {
-    return substBaseType(depMem->substRootParam(newRoot, lookupConformance),
-                         lookupConformance);
+    return substBaseType(depMem->substRootParam(newRoot, lookupConformance, options),
+                         lookupConformance, options);
   }
   return Type();
 }

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -136,7 +136,8 @@ mapTypeOutOfOpenedExistentialContext(CanType t) {
         if (auto *dmt =
                 archTy->getInterfaceType()->getAs<DependentMemberType>()) {
           return dmt->substRootParam(params[index],
-                                     MakeAbstractConformanceForGenericType());
+                                     MakeAbstractConformanceForGenericType(),
+                                     llvm::None);
         }
 
         return params[index];

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1360,6 +1360,13 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
     return nullptr;
   }
 
+  LLVM_DEBUG(llvm::dbgs() << "Inferring abstract type witnesses for "
+             << "associated types of " << conformance->getProtocol()->getName()
+             << ":\n";);
+  for (auto *assocType : unresolvedAssocTypes) {
+    LLVM_DEBUG(llvm::dbgs() << "- " << assocType->getName() << "\n";);
+  }
+
   // Attempt to compute abstract type witnesses for associated types that could
   // not resolve otherwise.
   llvm::SmallVector<AbstractTypeWitness, 2> abstractTypeWitnesses;
@@ -1429,6 +1436,9 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
   for (const auto &witness : abstractTypeWitnesses) {
     auto *const assocType = witness.getAssocType();
     Type type = witness.getType();
+
+    LLVM_DEBUG(llvm::dbgs() << "Checking witness for " << assocType->getName()
+               << " " << type << "\n";);
 
     // Replace type parameters with other known or tentative type witnesses.
     if (type->hasTypeParameter()) {
@@ -1543,10 +1553,14 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
         return assocType;
 
       type = dc->mapTypeIntoContext(type);
+
+      LLVM_DEBUG(llvm::dbgs() << "Substituted witness type is " << type << "\n";);
     }
 
     if (const auto failed =
             checkTypeWitness(type, assocType, conformance, substOptions)) {
+      LLVM_DEBUG(llvm::dbgs() << "- Type witness does not satisfy requirements\n";);
+
       // We failed to satisfy a requirement. If this is a default type
       // witness failure and we haven't seen one already, write it down.
       auto *defaultedAssocType = witness.getDefaultedAssocType();

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1126,6 +1126,8 @@ void AssociatedTypeInference::collectAbstractTypeWitnesses(
 }
 
 Type AssociatedTypeInference::substCurrentTypeWitnesses(Type type) {
+  auto substOptions = getSubstOptionsWithCurrentTypeWitnesses();
+
   // Local function that folds dependent member types with non-dependent
   // bases into actual member references.
   std::function<Type(Type)> foldDependentMemberTypes;
@@ -1148,7 +1150,8 @@ Type AssociatedTypeInference::substCurrentTypeWitnesses(Type type) {
       auto *module = dc->getParentModule();
 
       // Try to substitute into the base type.
-      Type result = depMemTy->substBaseType(module, baseTy);
+      Type result = depMemTy->substBaseType(
+          baseTy, LookUpConformanceInModule(module), substOptions);
       if (!result->hasError())
         return result;
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1493,8 +1493,10 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
         // If the transformed base has the same nominal as the adoptee, we may
         // need to look up a tentative type witness. Otherwise, just substitute
         // the base.
-        if (substBase->getAnyNominal() != adoptee->getAnyNominal()) {
-          return dmt->substBaseType(dc->getParentModule(), substBase);
+        if (substBase->getAnyNominal() != dc->getSelfNominalTypeDecl()) {
+          return dmt->substBaseType(substBase,
+                                    LookUpConformanceInModule(dc->getParentModule()),
+                                    substOptions);
         }
 
         auto *assocTy = dmt->getAssocType();

--- a/test/decl/protocol/req/associated_type_inference_stdlib.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift
+
+// We would fail here when Indices was explicitly specified, as in X2.
+
+public struct X1: RandomAccessCollection {
+  public var startIndex: Int {
+    return 0
+  }
+
+  public var endIndex: Int {
+    return 0
+  }
+
+  public subscript(position: Int) -> String {
+    return ""
+  }
+}
+
+public struct X2: RandomAccessCollection {
+  public typealias Indices = Range<Int>
+
+  public var startIndex: Int {
+    return 0
+  }
+
+  public var endIndex: Int {
+    return 0
+  }
+
+  public subscript(position: Int) -> String {
+    return ""
+  }
+}

--- a/test/decl/protocol/req/rdar118998138.swift
+++ b/test/decl/protocol/req/rdar118998138.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift
+
+public protocol FakeCopyable {}
+
+extension Int: FakeCopyable {}
+
+// Remove both 'FakeCopyable' requirements below and 
+// inference for Element in Hello succeeds.
+
+public protocol MyIteratorProtocol<Element> {
+  associatedtype Element : FakeCopyable
+
+  mutating func next() -> Element?
+}
+
+public protocol MySequence<Element> {
+  associatedtype Element : FakeCopyable
+
+  associatedtype Iterator: MyIteratorProtocol where Iterator.Element == Element
+
+  __consuming func makeIterator() -> Iterator
+
+  func _customContainsEquatableElement(
+    _ element: Element
+  ) -> Bool?
+}
+
+extension MySequence {
+  @usableFromInline
+  func _customContainsEquatableElement(
+    _ element: Iterator.Element
+  ) -> Bool? { return nil }
+}
+
+extension MySequence where Self.Iterator == Self {
+  @inlinable
+  public __consuming func makeIterator() -> Self {
+    return self
+  }
+}
+
+// ------------
+
+internal struct Hello {}
+
+extension Hello: MySequence, MyIteratorProtocol {
+  // Inferred:
+  // typealias Element = Int
+
+  internal mutating func next() -> Int? {
+    return nil
+  }
+}

--- a/test/decl/protocol/req/rdar90402522.swift
+++ b/test/decl/protocol/req/rdar90402522.swift
@@ -1,0 +1,110 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift
+
+public typealias A = UInt32
+
+public protocol P1: Numeric, Strideable, CustomStringConvertible
+where Magnitude == B.Magnitude,
+      IntegerLiteralType == B.Magnitude,
+      Stride == B.Stride {
+  associatedtype B: BinaryInteger
+  init(_ b: B)
+  init(integerLiteral value: B)
+
+  var rawIndex: B { get set }
+
+  var magnitude: B.Magnitude { get }
+}
+
+public extension P1 {
+  init(integerLiteral value: B) {
+    self.init(value)
+  }
+
+  init<T>(_ value: T) where T: BinaryInteger {
+    self.init(B(value))
+  }
+
+  init?<T>(exactly source: T) where T: BinaryInteger {
+    if let index = B(exactly: source) {
+      self.init(index)
+    } else {
+      return nil
+    }
+  }
+
+  var magnitude: Self.Magnitude {
+    rawIndex.magnitude
+  }
+
+  var description: String {
+    rawIndex.description
+  }
+
+  func distance(to other: Self) -> Stride {
+    rawIndex.distance(to: other.rawIndex)
+  }
+
+  func advanced(by n: Stride) -> Self {
+    Self(rawIndex.advanced(by: n))
+  }
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.rawIndex == rhs.rawIndex
+  }
+
+  static func == <B: BinaryInteger>(lhs: Self, rhs: B) -> Bool {
+    lhs.rawIndex == rhs
+  }
+
+  static func == <B: BinaryInteger>(lhs: B, rhs: Self) -> Bool {
+    lhs == rhs.rawIndex
+  }
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.rawIndex < rhs.rawIndex
+  }
+
+  static func + (lhs: Self, rhs: Self) -> Self {
+    Self(lhs.rawIndex + rhs.rawIndex)
+  }
+
+  static func - (lhs: Self, rhs: Self) -> Self {
+    Self(lhs.rawIndex - rhs.rawIndex)
+  }
+
+  static func * (lhs: Self, rhs: Self) -> Self {
+    Self(lhs.rawIndex * rhs.rawIndex)
+  }
+
+  static func *= (lhs: inout Self, rhs: Self) {
+    lhs.rawIndex *= rhs.rawIndex
+  }
+}
+
+public protocol P2: P1 where B == A {
+  init(b: B)
+  var b: B { get set }
+}
+
+public extension P2 {
+  init(_ b: B) {
+    self.init(b: b)
+  }
+
+  var rawIndex: A {
+    get {
+      b
+    }
+    set(newIndex) {
+      b = newIndex
+    }
+  }
+}
+
+struct S {
+  var b: A
+}
+
+extension S: P2 {}
+


### PR DESCRIPTION
We want to enable this by default since it unblocks some other work that's happening. The stdlib still doesn't build with this flag enabled, but it gets further with the fixes in this PR.