### PR TITLE
[SourceKit] Fix a build failure if `SWIFT_BUILD_SWIFT_SYNTAX` is not set

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2523,8 +2523,11 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
 
     // FIXME: Don't silently eat errors here.
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
+      using ResultType = RequestResult<ArrayRef<RelatedIdentInfo>>;
 #if !SWIFT_BUILD_SWIFT_SYNTAX
-      Receiver(RequestResult<RelatedIdentsInfo>::fromError("relatedidents is not supported because sourcekitd was built without swift-syntax"));
+      Receiver(
+          ResultType::fromError("relatedidents is not supported because "
+                                "sourcekitd was built without swift-syntax"));
       return;
 #else
       auto &CompInst = AstUnit->getCompilerInstance();
@@ -2597,7 +2600,7 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
         }
       };
       Action();
-      Receiver(RequestResult<ArrayRef<RelatedIdentInfo>>::fromResult(Ranges));
+      Receiver(ResultType::fromResult(Ranges));
 #endif
     }
 


### PR DESCRIPTION
Fixes https://github.com/apple/swift/pull/70269#issuecomment-1844778242