### PR TITLE
[Test] Disable some runtime tests in back deployment testing.

### DIFF
--- a/test/Casting/CastTraps.swift.gyb
+++ b/test/Casting/CastTraps.swift.gyb
@@ -105,7 +105,7 @@ CastTrapsTestSuite.test("${t1}__${t2}")
 % end
 
 protocol P2 {}
-if #available(SwiftStdlib 5.5, *) {
+if #available(SwiftStdlib 5.11, *) {
 CastTrapsTestSuite.test("Unexpected null")
   .crashOutputMatches("Found a null pointer in a value of type '")
   .crashOutputMatches("Foo'")
@@ -125,7 +125,7 @@ CastTrapsTestSuite.test("Unexpected null")
 
 
 #if _runtime(_ObjC)
-if #available(SwiftStdlib 5.5, *) {
+if #available(SwiftStdlib 5.11, *) {
 CastTrapsTestSuite.test("Unexpected Obj-C null")
   .crashOutputMatches("Found a null pointer in a value of type 'NSObject'")
   .crashOutputMatches("(Detected while casting to '")

--- a/test/stdlib/BridgeEquatableToObjC.swift
+++ b/test/stdlib/BridgeEquatableToObjC.swift
@@ -6,6 +6,9 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import StdlibUnittest
 import Foundation
 

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -25,6 +25,9 @@
 // rdar://problem/56959761
 // UNSUPPORTED: OS=watchos
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import Foundation
 
 class C { 

--- a/test/stdlib/SwiftValueNSObject.swift
+++ b/test/stdlib/SwiftValueNSObject.swift
@@ -22,6 +22,9 @@
 
 // REQUIRES: objc_interop
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import Foundation
 
 struct C: CustomDebugStringConvertible {


### PR DESCRIPTION
These tests are testing changes that aren't present in older runtimes:

test/stdlib/SwiftValueNSObject.swift
test/stdlib/SwiftObjectNSObject.swift
test/stdlib/BridgeEquatableToObjC.swift

And this test looks for some wording that's different on older runtimes. This one already does availability checks, so we change the requirements to SwiftStdlib 5.11:

test/Casting/CastTraps.swift.gyb

rdar://116339747