### PR TITLE
[SIL] Fix computation of substituted error type against an abstraction pattern

### DIFF
--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -177,6 +177,27 @@ func forceTryErased() {
   try! mightThrowAny(arg: throwsMyBigErrorOrReturnsInt())
 }
 
+func takesClosureThrowingConcrete(_ body: () throws(MyError) -> ()) throws(MyError) {
+}
+
+// CHECK-LABEL: sil private [ossa] @$s12typed_throws30passesClosureWithReabstraction5countySi_tFyyXEfU_ : $@convention(thin) () -> @error MyError
+// CHECK: bb0:
+// CHECK-NEXT: debug_value undef : $MyError, var, name "$error", argno 1
+func passesClosureWithReabstraction(count: Int) {
+    try! takesClosureThrowingConcrete { }
+}
+
+func takesClosureThrowingConcreteAndRethrows(_ body: () throws(MyError) -> ()) rethrows {
+}
+
+// CHECK-LABEL: sil private [ossa] @$s12typed_throws42passesClosureWithReabstractionToRethrowing5countySi_tFyyXEfU_ : $@convention(thin) () -> @error MyError {
+// CHECK: bb0:
+// CHECK-NEXT:  debug_value undef : $MyError, var, name "$error", argno 1
+func passesClosureWithReabstractionToRethrowing(count: Int) {
+    try! takesClosureThrowingConcrete { }
+}
+
+
 // CHECK-LABEL:      sil_vtable MySubclass {
 // CHECK-NEXT:   #MyClass.init!allocator: <E where E : Error> (MyClass.Type) -> (() throws(E) -> ()) throws(E) -> MyClass : @$s12typed_throws10MySubclassC4bodyACyyxYKXE_txYKcs5ErrorRzlufC [override]
 // CHECK-NEXT:  #MyClass.f: (MyClass) -> () throws -> () : @$s12typed_throws10MySubclassC1fyyAA0C5ErrorOYKFAA0C5ClassCADyyKFTV [override]

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -310,8 +310,8 @@ struct UntypedRes<Success>: P {
 }
 
 struct InfallibleRes<Success>: P {
-  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s20typed_throws_generic13InfallibleResVyxGAA1PA2aEP1fyy1EQzYKFTW : $@convention(witness_method: P) <τ_0_0> (@in_guaranteed InfallibleRes<τ_0_0>) -> @error_indirect any Error
-  // CHECK: bb0(%0 : $*any Error, %1 : $*InfallibleRes<τ_0_0>):
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s20typed_throws_generic13InfallibleResVyxGAA1PA2aEP1fyy1EQzYKFTW : $@convention(witness_method: P) <τ_0_0> (@in_guaranteed InfallibleRes<τ_0_0>) -> @error_indirect τ_0_0.E
+  // CHECK: bb0(%0 : $*@error_type τ_0_0.E, %1 : $*InfallibleRes<τ_0_0>):
   // CHECK: [[SELF:%.*]] = load [trivial] %1 : $*InfallibleRes<τ_0_0>
   // CHECK: [[WITNESS:%.*]] = function_ref @$s20typed_throws_generic13InfallibleResV1fyyF : $@convention(method) <τ_0_0> (InfallibleRes<τ_0_0>) -> ()
   // CHECK: = apply [[WITNESS]]<τ_0_0>([[SELF]]) : $@convention(method) <τ_0_0> (InfallibleRes<τ_0_0>)


### PR DESCRIPTION
We were attempting to perform substitution against the original pattern even when it didn't have a substitution map, and then trying to cover for the resulting errors by adjusting to `any Error`... which isn't always correct. Do the substitution only when it makes sense.

Fixes rdar://119217570 & rdar://119219214.
