### PR TITLE
[cxx-interop] Propagate `CONFORMS_TO` attribute to derived classes

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2812,13 +2812,24 @@ namespace {
       }
 
       if (auto *ntd = dyn_cast<NominalTypeDecl>(result))
-        addExplicitProtocolConformances(ntd);
+        addExplicitProtocolConformances(ntd, decl);
 
       return result;
     }
 
-    void addExplicitProtocolConformances(NominalTypeDecl *decl) {
-      auto clangDecl = decl->getClangDecl();
+    void
+    addExplicitProtocolConformances(NominalTypeDecl *decl,
+                                    const clang::CXXRecordDecl *clangDecl) {
+      if (Impl.isCxxInteropCompatVersionAtLeast(
+              version::getUpcomingCxxInteropCompatVersion())) {
+        // Propagate conforms_to attribute from public base classes.
+        for (auto base : clangDecl->bases()) {
+          if (base.getAccessSpecifier() != clang::AccessSpecifier::AS_public)
+            continue;
+          if (auto *baseClangDecl = base.getType()->getAsCXXRecordDecl())
+            addExplicitProtocolConformances(decl, baseClangDecl);
+        }
+      }
 
       if (!clangDecl->hasAttrs())
         return;

--- a/test/Interop/Cxx/class/Inputs/conforms-to.h
+++ b/test/Interop/Cxx/class/Inputs/conforms-to.h
@@ -22,4 +22,19 @@ struct
   void testImported() const;
 };
 
+struct DerivedFromHasTest : HasTest {};
+struct DerivedFromDerivedFromHasTest : HasTest {};
+
+struct __attribute__((swift_attr("conforms_to:SwiftTest.Testable")))
+DerivedFromDerivedFromHasTestWithDuplicateArg : HasTest {};
+
+struct DerivedFromHasPlay : HasPlay {};
+struct DerivedFromDerivedFromHasPlay : HasPlay {};
+
+struct HasTestAndPlay : HasPlay, HasTest {};
+struct DerivedFromHasTestAndPlay : HasPlay, HasTest {};
+
+struct DerivedFromHasImportedConf : HasImportedConf {};
+struct DerivedFromDerivedFromHasImportedConf : HasImportedConf {};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_H

--- a/test/Interop/Cxx/class/conforms-to.swift
+++ b/test/Interop/Cxx/class/conforms-to.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend %S/Inputs/conforms-to-imported.swift -module-name ImportedModule -emit-module -emit-module-path %t/ImportedModule.swiftmodule
 
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %t -I %S/Inputs -module-name SwiftTest -enable-experimental-cxx-interop
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=upcoming-swift -D UPCOMING_SWIFT
 
 import ConformsTo
 import ImportedModule
@@ -21,6 +22,11 @@ func callee(_ _: Testable) {
 func caller(_ x: HasTest) {
     callee(x)
 }
+#if UPCOMING_SWIFT
+func caller(_ x: DerivedFromHasTest) { callee(x) }
+func caller(_ x: DerivedFromDerivedFromHasTest) { callee(x) }
+func caller(_ x: DerivedFromDerivedFromHasTestWithDuplicateArg) { callee(x) }
+#endif
 
 func callee(_ _: Playable) {
 
@@ -29,6 +35,19 @@ func callee(_ _: Playable) {
 func caller(_ x: Playable) {
     callee(x)
 }
+#if UPCOMING_SWIFT
+func caller(_ x: DerivedFromHasPlay) { callee(x) }
+func caller(_ x: DerivedFromDerivedFromHasPlay) { callee(x) }
+
+func caller(_ x: HasTestAndPlay) {
+    callee(x as Testable)
+    callee(x as Playable)
+}
+func caller(_ x: DerivedFromHasTestAndPlay) {
+    callee(x as Testable)
+    callee(x as Playable)
+}
+#endif
 
 func callee(_ _: ProtocolFromImportedModule) {
 }
@@ -36,3 +55,7 @@ func callee(_ _: ProtocolFromImportedModule) {
 func caller(_ x: HasImportedConf) {
     callee(x)
 }
+#if UPCOMING_SWIFT
+func caller(_ x: DerivedFromHasImportedConf) { callee(x) }
+func caller(_ x: DerivedFromDerivedFromHasImportedConf) { callee(x) }
+#endif


### PR DESCRIPTION
If `struct Base` is a public base class of `struct Derived`, and `Base` is annotated with `__attribute__((swift_attr("conforms_to:MyModule.MyProto")))`, `Derived` will now also get a conformance to `MyProto`.

rdar://113971944