### PR TITLE
[5.10][Macros] Track macro dylib path dependencies when using plugin server

### DIFF
--- a/include/swift/AST/PluginLoader.h
+++ b/include/swift/AST/PluginLoader.h
@@ -86,6 +86,9 @@ public:
   /// NOTE: This method is idempotent. If the plugin is already loaded, the same
   /// instance is simply returned.
   LoadedExecutablePlugin *loadExecutablePlugin(llvm::StringRef path);
+
+  /// Add the specified path to the dependency tracker if needed.
+  void recordDependency(StringRef path);
 };
 
 } // namespace swift

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -168,8 +168,7 @@ LoadedLibraryPlugin *PluginLoader::loadLibraryPlugin(StringRef path) {
   }
 
   // Track the dependency.
-  if (DepTracker)
-    DepTracker->addDependency(resolvedPath, /*IsSystem=*/false);
+  recordDependency(path);
 
   // Load the plugin.
   auto plugin = getRegistry()->loadLibraryPlugin(resolvedPath);
@@ -192,8 +191,7 @@ LoadedExecutablePlugin *PluginLoader::loadExecutablePlugin(StringRef path) {
   }
 
   // Track the dependency.
-  if (DepTracker)
-    DepTracker->addDependency(resolvedPath, /*IsSystem=*/false);
+  recordDependency(path);
 
   // Load the plugin.
   auto plugin =
@@ -205,4 +203,9 @@ LoadedExecutablePlugin *PluginLoader::loadExecutablePlugin(StringRef path) {
   }
 
   return plugin.get();
+}
+
+void PluginLoader::recordDependency(StringRef path) {
+  if (DepTracker)
+    DepTracker->addDependency(path, /*IsSystem=*/false);
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -325,6 +325,9 @@ initializeExecutablePlugin(ASTContext &ctx,
                          executablePlugin->getExecutablePath(), err.message());
       return nullptr;
     }
+
+    ctx.getPluginLoader().recordDependency(resolvedLibraryPath);
+
     std::string resolvedLibraryPathStr(resolvedLibraryPath);
     std::string moduleNameStr(moduleName.str());
 

--- a/test/Macros/macro_swiftdeps.swift
+++ b/test/Macros/macro_swiftdeps.swift
@@ -2,17 +2,25 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/plugin)
+// RUN: %empty-directory(%t/external-plugin)
 // RUN: %empty-directory(%t/lib)
 // RUN: %empty-directory(%t/src)
 
 // RUN: split-file %s %t/src
 
-//#-- Prepare the macro shared library plugin.
+//#-- Prepare the macro shared library plugin for -plugin-path.
 // RUN: %host-build-swift \
 // RUN:   -swift-version 5 \
-// RUN:   -emit-library -o %t/plugin/%target-library-name(MacroDefinition) \
-// RUN:   -module-name MacroDefinition \
-// RUN:   %S/Inputs/syntax_macro_definitions.swift
+// RUN:   -emit-library -o %t/plugin/%target-library-name(StringifyPlugin) \
+// RUN:   -module-name StringifyPlugin \
+// RUN:   %t/src/StringifyPlugin.swift
+
+//#-- Prepare the macro shared library plugin for -external-plugin-path.
+// RUN: %host-build-swift \
+// RUN:   -swift-version 5 \
+// RUN:   -emit-library -o %t/external-plugin/%target-library-name(AssertPlugin) \
+// RUN:   -module-name AssertPlugin \
+// RUN:   %t/src/AssertPlugin.swift
 
 //#-- Prepare the macro executable plugin.
 // RUN: %swift-build-cxx-plugin -o %t/mock-plugin %t/src/plugin.c
@@ -23,6 +31,7 @@
 // RUN:   -emit-module -o %t/lib/MacroLib.swiftmodule \
 // RUN:   -module-name MacroLib \
 // RUN:   -plugin-path %t/plugin \
+// RUN:   -external-plugin-path %t/external-plugin#%swift-plugin-server \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -primary-file %t/src/macro_library.swift \
 // RUN:   -emit-reference-dependencies-path %t/macro_library.swiftdeps \
@@ -35,7 +44,9 @@
 // RUN:   -swift-version 5 -typecheck \
 // RUN:   -primary-file %t/src/test.swift \
 // RUN:   %t/src/other.swift \
-// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -I %t/lib \
+// RUN:   -plugin-path %t/plugin \
+// RUN:   -external-plugin-path %t/external-plugin#%swift-plugin-server \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -emit-reference-dependencies-path %t/without_macro.swiftdeps \
 // RUN:   -emit-dependencies-path %t/without_macro.d
@@ -48,7 +59,9 @@
 // RUN:   -swift-version 5 -typecheck \
 // RUN:   -primary-file %t/src/test.swift \
 // RUN:   %t/src/other.swift \
-// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -I %t/lib \
+// RUN:   -plugin-path %t/plugin \
+// RUN:   -external-plugin-path %t/external-plugin#%swift-plugin-server \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -emit-reference-dependencies-path %t/with_macro_primary.swiftdeps \
 // RUN:   -emit-dependencies-path %t/with_macro_primary.d
@@ -61,21 +74,26 @@
 // RUN:   -swift-version 5 -typecheck \
 // RUN:   %t/src/test.swift \
 // RUN:   -primary-file %t/src/other.swift \
-// RUN:   -I %t/lib -plugin-path %t/plugin \
+// RUN:   -I %t/lib \
+// RUN:   -plugin-path %t/plugin \
+// RUN:   -external-plugin-path %t/external-plugin#%swift-plugin-server \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -emit-reference-dependencies-path %t/with_macro_nonprimary.swiftdeps \
 // RUN:   -emit-dependencies-path %t/with_macro_nonprimary.d
 // RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t/with_macro_nonprimary.swiftdeps > %t/with_macro_nonprimary.swiftdeps.processed
 // RUN: %FileCheck --check-prefix WITHOUT_PLUGIN %s < %t/with_macro_nonprimary.swiftdeps.processed
 
-// WITH_PLUGIN: externalDepend interface '' '{{.*}}mock-plugin' false
-// WITH_PLUGIN: externalDepend interface '' '{{.*}}MacroDefinition.{{(dylib|so|dll)}}' false
+// WITH_PLUGIN-DAG: externalDepend interface '' '{{.*}}mock-plugin' false
+// WITH_PLUGIN-DAG: externalDepend interface '' '{{.*}}StringifyPlugin.{{(dylib|so|dll)}}' false
+// WITH_PLUGIN-DAG: externalDepend interface '' '{{.*}}AssertPlugin.{{(dylib|so|dll)}}' false
 
-// WITHOUT_PLUGIN-NOT:  MacroDefinition
+// WITHOUT_PLUGIN-NOT:  StringifyPlugin
+// WITHOUT_PLUGIN-NOT:  AssertPlugin
 // WITHOUT_PLUGIN-NOT:  mock-plugin
 
 //--- macro_library.swift
-@freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+@freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "StringifyPlugin", type: "StringifyMacro")
+@freestanding(expression) public macro assert(_ value: Bool) = #externalMacro(module: "AssertPlugin", type: "AssertMacro")
 @freestanding(expression) public macro testString(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "TestStringMacro")
 
 public func funcInMacroLib() {}
@@ -90,6 +108,7 @@ func test(a: Int, b: Int) {
 #if USE_MACRO
   _ = #stringify(a + b)
   _ = #testString(123)
+  #assert(true)
 #endif
 }
 
@@ -99,6 +118,42 @@ import MacroLib
 func test() {
   // Just using MacroLib without macro
   funcInMacroLib()
+}
+
+//--- StringifyPlugin.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct StringifyMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.arguments.first?.expression else {
+      fatalError("boom")
+    }
+
+    return "(\(argument), \(StringLiteralExprSyntax(content: argument.description)))"
+  }
+}
+
+//--- AssertPlugin.swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AssertMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.arguments.first?.expression else {
+      fatalError("boom")
+    }
+
+    return "assert(\(argument))"
+  }
 }
 
 //--- plugin.c


### PR DESCRIPTION
Cherry-pick #70305 into release/5.10

* **Explanation**:  Shared library plugin paths were not recorded as dependencies when `swift-plugin-server` was used. Record them when loading libraries in the plugin server.
* **Scope**: Macro plugin loading and dependency tracking
* **Risk**: Low. The fix is simple and straightforward
* **Testing**: Added regression test cases
* **Issues**: rdar://119324830
* **Reviewer**: Doug Gregor (@DougGregor), Ben Barham (@bnbarham)