### PR TITLE
[SilOpt] Add new layout type _TrivialStride and add pre-specialization suppport for it

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -948,6 +948,7 @@ now codified into the ABI; the index 0 is therefore reserved.
   LAYOUT-CONSTRAINT ::= 'm' LAYOUT-SIZE  // Trivial of size at most N bits
   LAYOUT-CONSTRAINT ::= 'U'  // Unknown layout
   LAYOUT-CONSTRAINT ::= 'B' // BridgeObject
+  LAYOUT-CONSTRAINT ::= 'S' // TrivialStride
 
   LAYOUT-SIZE ::= INDEX // Size only
   LAYOUT-SIZE-AND-ALIGNMENT ::= INDEX INDEX // Size followed by alignment

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -178,6 +178,7 @@ IDENTIFIER_WITH_NAME(NativeRefCountedObjectLayout, "_NativeRefCountedObject")
 IDENTIFIER_WITH_NAME(ClassLayout, "_Class")
 IDENTIFIER_WITH_NAME(NativeClassLayout, "_NativeClass")
 IDENTIFIER_WITH_NAME(BridgeObjectLayout, "_BridgeObject")
+IDENTIFIER_WITH_NAME(TrivialStrideLayout, "_TrivialStride")
 
 // Operators
 IDENTIFIER_WITH_NAME(MatchOperator, "~=")

--- a/include/swift/AST/LayoutConstraint.h
+++ b/include/swift/AST/LayoutConstraint.h
@@ -114,6 +114,8 @@ class LayoutConstraintInfo
 
   bool isBridgeObject() const { return isBridgeObject(Kind); }
 
+  bool isTrivialStride() const { return isTrivialStride(Kind); }
+
   unsigned getTrivialSizeInBytes() const {
     assert(isKnownSizeTrivial());
     return (SizeInBits + 7) / 8;
@@ -153,6 +155,11 @@ class LayoutConstraintInfo
 
     // Otherwise assume the alignment of 8 bytes.
     return 8*8;
+  }
+
+  unsigned getTrivialStrideInBits() const {
+    assert(isTrivialStride());
+    return SizeInBits;
   }
 
   operator bool() const {
@@ -203,6 +210,8 @@ class LayoutConstraintInfo
   static bool isNativeRefCounted(LayoutConstraintKind Kind);
 
   static bool isBridgeObject(LayoutConstraintKind Kind);
+
+  static bool isTrivialStride(LayoutConstraintKind Kind);
 
   /// Uniquing for the LayoutConstraintInfo.
   void Profile(llvm::FoldingSetNodeID &ID) {

--- a/include/swift/AST/LayoutConstraintKind.h
+++ b/include/swift/AST/LayoutConstraintKind.h
@@ -41,7 +41,9 @@ enum class LayoutConstraintKind : uint8_t {
   NativeRefCountedObject,
   // It is a layout constraint representing a bridge object
   BridgeObject,
-  LastLayout = BridgeObject,
+  // It is a layout constraint representing a trivial type of a known stride.
+  TrivialStride,
+  LastLayout = TrivialStride,
 };
 
 #endif

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -430,6 +430,7 @@ void decodeRequirement(NodePointer node,
               .Case("B", LayoutConstraintKind::BridgeObject)
               .Cases("E", "e", LayoutConstraintKind::TrivialOfExactSize)
               .Cases("M", "m", LayoutConstraintKind::TrivialOfAtMostSize)
+              .Case("S", LayoutConstraintKind::TrivialStride)
               .Default(llvm::None);
 
       if (!kind)
@@ -438,7 +439,8 @@ void decodeRequirement(NodePointer node,
       BuiltLayoutConstraint layout;
 
       if (kind != LayoutConstraintKind::TrivialOfExactSize &&
-          kind != LayoutConstraintKind::TrivialOfAtMostSize) {
+          kind != LayoutConstraintKind::TrivialOfAtMostSize &&
+          kind != LayoutConstraintKind::TrivialStride) {
         layout = Builder.getLayoutConstraint(*kind);
       } else {
         auto size = child->getChild(2)->getIndex();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6024,7 +6024,8 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
                                                       unsigned SizeInBits,
                                                       unsigned Alignment,
                                                       ASTContext &C) {
-  if (!LayoutConstraintInfo::isKnownSizeTrivial(Kind)) {
+  if (!LayoutConstraintInfo::isKnownSizeTrivial(Kind) &&
+      !LayoutConstraintInfo::isTrivialStride(Kind)) {
     assert(SizeInBits == 0);
     assert(Alignment == 0);
     return getLayoutConstraint(Kind);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3804,6 +3804,9 @@ void ASTMangler::appendOpParamForLayoutConstraint(LayoutConstraint layout) {
   case LayoutConstraintKind::BridgeObject:
     appendOperatorParam("B");
     break;
+  case LayoutConstraintKind::TrivialStride:
+    appendOperatorParam("S", Index(layout->getTrivialSizeInBits()));
+    break;
   }
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7687,6 +7687,7 @@ void LayoutConstraintInfo::print(ASTPrinter &Printer,
     return; // non-parameterized cases
   case LayoutConstraintKind::TrivialOfAtMostSize:
   case LayoutConstraintKind::TrivialOfExactSize:
+  case LayoutConstraintKind::TrivialStride:
     Printer << "(";
     Printer << SizeInBits;
     if (Alignment)

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -527,6 +527,11 @@ GenericSignature GenericSignature::typeErased(ArrayRef<Type> typeErasedParams) c
         requirementsErased.push_back(
             Requirement(RequirementKind::SameType, req.getFirstType(),
                         CanType(BuiltinIntegerType::get(bitWidth, C))));
+      } else if (layout->isTrivialStride()) {
+        unsigned bitWidth = layout->getTrivialStrideInBits();
+        requirementsErased.push_back(
+            Requirement(RequirementKind::SameType, req.getFirstType(),
+                        CanType(BuiltinIntegerType::get(bitWidth, C))));
       } else {
         requirementsErased.push_back(req);
       }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4052,6 +4052,11 @@ NodePointer Demangler::demangleGenericRequirement() {
       if (!size)
         return nullptr;
       name = "m";
+    } else if (c == 'S') {
+      size = demangleIndexAsNode();
+      if (!size)
+        return nullptr;
+      name = "S";
     } else {
       // Unknown layout constraint.
       return nullptr;

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -1664,6 +1664,11 @@ private:
         if (!demangleNatural(size, depth + 1))
           return nullptr;
         name = "m";
+      } else if (Mangled.nextIf('S')) {
+        kind = Node::Kind::Identifier;
+        if (!demangleNatural(size, depth + 1))
+          return nullptr;
+        name = "S";
       } else {
         return nullptr;
       }

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -2239,6 +2239,7 @@ public:
       case LayoutConstraintKind::RefCountedObject:
       case LayoutConstraintKind::TrivialOfAtMostSize:
       case LayoutConstraintKind::BridgeObject:
+      case LayoutConstraintKind::TrivialStride:
         break;
       
       case LayoutConstraintKind::UnknownLayout:

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1185,6 +1185,7 @@ getActualLayoutConstraintKind(uint64_t rawKind) {
   CASE(NativeClass)
   CASE(UnknownLayout)
   CASE(BridgeObject)
+  CASE(TrivialStride)
   }
 #undef CASE
 
@@ -1244,7 +1245,8 @@ llvm::Error ModuleFile::deserializeGenericRequirementsChecked(
       ASTContext &ctx = getContext();
       LayoutConstraint layout;
       if (kind != LayoutConstraintKind::TrivialOfAtMostSize &&
-          kind != LayoutConstraintKind::TrivialOfExactSize)
+          kind != LayoutConstraintKind::TrivialOfExactSize &&
+          kind != LayoutConstraintKind::TrivialStride)
         layout = LayoutConstraint::getLayoutConstraint(kind, ctx);
       else
         layout =

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 824; // LayoutRequirementKindField
+const uint16_t SWIFTMODULE_VERSION_MINOR = 825; // TrivialStride
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -484,6 +484,7 @@ enum LayoutRequirementKind : uint8_t {
   Class = 6,
   NativeClass = 7,
   BridgeObject = 8,
+  TrivialStride = 9,
 };
 using LayoutRequirementKindField = BCFixed<4>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1480,6 +1480,8 @@ void Serializer::serializeGenericRequirements(
       if (layout->isKnownSizeTrivial()) {
         size = layout->getTrivialSizeInBits();
         alignment = layout->getAlignmentInBits();
+      } else if (layout->isTrivialStride()) {
+        size = layout->getTrivialStrideInBits();
       }
       LayoutRequirementKind rawKind = LayoutRequirementKind::UnknownLayout;
       switch (layout->getKind()) {
@@ -1509,6 +1511,9 @@ void Serializer::serializeGenericRequirements(
         break;
       case LayoutConstraintKind::BridgeObject:
         rawKind = LayoutRequirementKind::BridgeObject;
+        break;
+      case LayoutConstraintKind::TrivialStride:
+        rawKind = LayoutRequirementKind::TrivialStride;
         break;
       }
       scratch.push_back(rawKind);

--- a/test/SILOptimizer/Inputs/pre_specialized_module_layouts.swift
+++ b/test/SILOptimizer/Inputs/pre_specialized_module_layouts.swift
@@ -12,6 +12,7 @@ public class SomeClass {
 @_specialize(exported: true, where @_noMetadata T : _Class)
 @_specialize(exported: true, where @_noMetadata T : _BridgeObject)
 @_specialize(exported: true, where @_noMetadata T : _Trivial(64))
+@_specialize(exported: true, where @_noMetadata T : _TrivialStride(128))
 @_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
 public func publicPrespecialized<T>(_ t: T) {
 }

--- a/test/SILOptimizer/pre_specialize_layouts.swift
+++ b/test/SILOptimizer/pre_specialize_layouts.swift
@@ -36,6 +36,11 @@ public struct TwoInt32 {
   let y: Int32 = 0
 }
 
+public struct Stride128 {
+  let x: Int64 = 0
+  let y: Bool = false
+}
+
 // Make sure we generate the public pre-specialized entry points.
 
 // OPT-DAG: sil @$s22pre_specialize_layouts10testPublic1tyx_tlFSf_Ts5 : $@convention(thin) (Float) -> () {
@@ -78,8 +83,8 @@ internal func testEmitIntoClient<T>(t: T) {
   print(t)
 }
 
-// OPT: sil @$s22pre_specialize_layouts28usePrespecializedEntryPoints13wrapperStruct11overaligned5arrayyAA016ReferenceWrapperI0V_AA011OveralignedlmI0VSaySiGtF : $@convention(thin) (@guaranteed ReferenceWrapperStruct, @guaranteed OveralignedReferenceWrapperStruct, @guaranteed Array<Int>) -> () {
-// OPT: bb0([[P1:%.*]] : $ReferenceWrapperStruct, [[P2:%.*]] : $OveralignedReferenceWrapperStruct, [[P3:%.*]] : $Array<Int>):
+// OPT: sil @$s22pre_specialize_layouts28usePrespecializedEntryPoints13wrapperStruct11overaligned5array9stride128yAA016ReferenceWrapperI0V_AA011OveralignedmnI0VSaySiGAA9Stride128VtF : $@convention(thin) (@guaranteed ReferenceWrapperStruct, @guaranteed OveralignedReferenceWrapperStruct, @guaranteed Array<Int>, Stride128) -> () {
+// OPT: bb0([[P1:%.*]] : $ReferenceWrapperStruct, [[P2:%.*]] : $OveralignedReferenceWrapperStruct, [[P3:%.*]] : $Array<Int>, [[P4:%.*]] : $Stride128):
 // OPT:   [[F1:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFSi_Ts5 : $@convention(thin) (Int) -> ()
 // OPT:   apply [[F1]]
 // OPT:   [[F2:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFSd_Ts5 : $@convention(thin) (Double) -> ()
@@ -101,13 +106,16 @@ internal func testEmitIntoClient<T>(t: T) {
 // OPT-macosx: [[F8:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFBb_Ts5 : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
 // OPT-macosx: [[A4:%.*]] = unchecked_bitwise_cast [[P3]] : $Array<Int> to $Builtin.BridgeObject
 // OPT-macosx: apply [[F8]]([[A4]]) : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
+// OPT:   [[F10:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFBi128__Ts5 : $@convention(thin) (Builtin.Int128) -> ()
+// OPT:   [[A6:%.*]] = unchecked_trivial_bit_cast [[P4]] : $Stride128 to $Builtin.Int128
+// OPT:   apply [[F10]]([[A6]]) : $@convention(thin) (Builtin.Int128) -> ()
 // OPT:   [[F3:%.*]] = function_ref @$s30pre_specialized_module_layouts36internalEmitIntoClientPrespecializedyyxlFSi_Ts5 : $@convention(thin) (Int) -> ()
 // OPT:   apply [[F3]]
 // OPT:   [[F4:%.*]] = function_ref @$s30pre_specialized_module_layouts36internalEmitIntoClientPrespecializedyyxlFSd_Ts5 : $@convention(thin) (Double) -> ()
 // OPT:   apply [[F4]]
 // OPT:   [[F5:%.*]] = function_ref @$s30pre_specialized_module_layouts16useInternalThingyyxlFSi_Tg5
 // OPT:   apply [[F5]]({{.*}}) : $@convention(thin) (Int) -> ()
-// OPT: } // end sil function '$s22pre_specialize_layouts28usePrespecializedEntryPoints13wrapperStruct11overaligned5arrayyAA016ReferenceWrapperI0V_AA011OveralignedlmI0VSaySiGtF'
+// OPT: } // end sil function '$s22pre_specialize_layouts28usePrespecializedEntryPoints13wrapperStruct11overaligned5array9stride128yAA016ReferenceWrapperI0V_AA011OveralignedmnI0VSaySiGAA9Stride128VtF'
 
 // OPT: sil {{.*}} @$s30pre_specialized_module_layouts16useInternalThingyyxlFSi_Tg5 : $@convention(thin) (Int) -> () {
 // OPT:   [[F1:%.*]] = function_ref @$s30pre_specialized_module_layouts14InternalThing2V7computexyFSi_Ts5 : $@convention(method) (InternalThing2<Int>) -> Int
@@ -152,7 +160,7 @@ internal func testEmitIntoClient<T>(t: T) {
 // OPT:   [[R10:%.*]] = unchecked_addr_cast [[R9]] : $*AnyObject to $*SomeClass
 // OPT: } // end sil function '$s30pre_specialized_module_layouts16useInternalThingyyxlFAA9SomeClassC_Tg5'
 
-public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, overaligned: OveralignedReferenceWrapperStruct, array: [Int]) {
+public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, overaligned: OveralignedReferenceWrapperStruct, array: [Int], stride128: Stride128) {
   publicPrespecialized(1)
   publicPrespecialized(1.0)
   publicPrespecialized(UInt64(1))
@@ -163,6 +171,7 @@ public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, 
   // should not apply _Class specialization for overaligned struct
   publicPrespecialized(overaligned)
   publicPrespecialized(array)
+  publicPrespecialized(stride128)
   useInternalEmitIntoClientPrespecialized(2)
   useInternalEmitIntoClientPrespecialized(2.0)
   useInternalThing(2)


### PR DESCRIPTION
rdar://119329771

This layout allows adding pre-specializations for trivial types that have a different size, but the same stride. This is especially useful for collections, where the stride is the important factor.
