### PR TITLE
[embedded] Run DeadFunctionAndGlobalElimination after MandatoryPerformanceOptimizations

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -255,6 +255,12 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addOnoneSimplification();
   P.addInitializeStaticGlobals();
 
+  // MandatoryPerformanceOptimizations might create specializations that are not
+  // used, and by being unused they are might have unspecialized applies.
+  // Eliminate them via the DeadFunctionAndGlobalElimination in embedded Swift
+  // to avoid getting metadata/existential use errors in them. We don't want to
+  // run this pass in regular Swift: Even unused functions are expected to be
+  // available in debug (-Onone) builds for debugging and development purposes.
   if (P.getOptions().EmbeddedSwift) {
     P.addDeadFunctionAndGlobalElimination();
   }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -254,6 +254,11 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addMandatoryPerformanceOptimizations();
   P.addOnoneSimplification();
   P.addInitializeStaticGlobals();
+
+  if (P.getOptions().EmbeddedSwift) {
+    P.addDeadFunctionAndGlobalElimination();
+  }
+
   P.addPerformanceDiagnostics();
 }
 

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -17,6 +17,9 @@
 
 using namespace swift;
 
+static llvm::cl::opt<bool> LinkEmbeddedRuntime("link-embedded-runtime",
+                                               llvm::cl::init(true));
+
 //===----------------------------------------------------------------------===//
 //                          Top Level Driver
 //===----------------------------------------------------------------------===//
@@ -39,7 +42,7 @@ public:
 
     // In embedded Swift, the stdlib contains all the runtime functions needed
     // (swift_retain, etc.). Link them in so they can be referenced in IRGen.
-    if (M.getOptions().EmbeddedSwift) {
+    if (M.getOptions().EmbeddedSwift && LinkEmbeddedRuntime) {
       linkEmbeddedRuntimeFromStdlib();
     }
   }

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -77,8 +77,7 @@ add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
     INSTALL_IN_COMPONENT sdk-overlay
     MACCATALYST_BUILD_FLAVOR "zippered")
 
-# TODO(mracek): Disable building Darwin module as embedded pending investigations into a build failure
-if(FALSE)
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   set(SWIFT_ENABLE_REFLECTION OFF)
 
   add_custom_target(embedded-darwin ALL)

--- a/test/embedded/darwin-bridging-header.swift
+++ b/test/embedded/darwin-bridging-header.swift
@@ -11,9 +11,6 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
-// Temporarily disabled:
-// REQUIRES: rdar119283700
-
 // BEGIN BridgingHeader.h
 
 #include <unistd.h>

--- a/test/embedded/darwin.swift
+++ b/test/embedded/darwin.swift
@@ -9,9 +9,6 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
-// Temporarily disabled:
-// REQUIRES: rdar119283700
-
 import Darwin
 
 @main

--- a/test/embedded/duration.swift
+++ b/test/embedded/duration.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-emit-ir -Osize %s -enable-experimental-feature Embedded -wmo
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
 
 @available(SwiftStdlib 5.7, *)
 extension Duration {

--- a/test/embedded/duration.swift
+++ b/test/embedded/duration.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo
+// RUN: %target-swift-emit-ir -O %s -enable-experimental-feature Embedded -wmo
+// RUN: %target-swift-emit-ir -Osize %s -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: swift_in_compiler
+
+@available(SwiftStdlib 5.7, *)
+extension Duration {
+  @available(SwiftStdlib 5.7, *)
+  public init() {
+    self = .seconds(10) + .nanoseconds(20)
+  }
+}

--- a/test/embedded/generic-autoclosure.swift
+++ b/test/embedded/generic-autoclosure.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -parse-stdlib -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+public struct UInt23 {
+}
+
+public protocol MyBinaryInteger {
+}
+
+extension UInt23: MyBinaryInteger {
+}
+
+protocol MyProto {
+    static var my_static_var: UInt23 { get }
+    static func foo()
+}
+
+struct MyStruct: MyProto {
+    static let my_static_var = UInt23()
+}
+
+extension MyProto {
+    public static func foo() {
+        bar(Self.my_static_var)
+    }
+}
+
+public func bar<T: MyBinaryInteger>(_ value: @autoclosure () -> T) {
+}


### PR DESCRIPTION
This resolves a problem around building the stdlib and Darwin modules in embedded Swift and getting errors about metadata use. Turns out that in some specialization cases triggered from MandatoryPerformanceOptimizations we end up creating specializations that are not used, and by being unused they are not further processed (apply sites inside are not further specialized) causing the embedded Swift checks to trigger on them. Sounds like we can simply eliminate unused functions after MandatoryPerformanceOptimizations to resolve this problem.

rdar://119276791
rdar://119323139
rdar://119283700
rdar://119343683