### PR TITLE
Get the standard library to build with -enable-experimental-associated-type-inference

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6798,11 +6798,13 @@ public:
   /// Substitute the base type, looking up our associated type in it if it is
   /// non-dependent. Returns null if the member could not be found in the new
   /// base.
-  Type substBaseType(Type base, LookupConformanceFn lookupConformance);
+  Type substBaseType(Type base, LookupConformanceFn lookupConformance,
+                     SubstOptions options);
 
   /// Substitute the root generic type, looking up the chain of associated types.
   /// Returns null if the member could not be found in the new root.
-  Type substRootParam(Type newRoot, LookupConformanceFn lookupConformance);
+  Type substRootParam(Type newRoot, LookupConformanceFn lookupConformance,
+                      SubstOptions options);
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -151,7 +151,6 @@ EXPERIMENTAL_FEATURE(MoveOnlyTuples, true)
 EXPERIMENTAL_FEATURE(MoveOnlyPartialConsumption, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
-EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, true)
 
 EXPERIMENTAL_FEATURE(AccessLevelOnImport, true)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -585,6 +585,9 @@ namespace swift {
     /// Enable warnings for redundant requirements in generic signatures.
     bool WarnRedundantRequirements = false;
 
+    /// Enable experimental associated type inference improvements.
+    bool EnableExperimentalAssociatedTypeInference = false;
+
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -654,7 +654,11 @@ def disable_experimental_string_processing :
 
 def enable_experimental_associated_type_inference :
   Flag<["-"], "enable-experimental-associated-type-inference">,
-  HelpText<"Enable experimental associated type inference via type witness systems">;
+  HelpText<"Enable experimental associated type inference improvements">;
+
+def disable_experimental_associated_type_inference :
+  Flag<["-"], "disable-experimental-associated-type-inference">,
+  HelpText<"Disable experimental associated type inference improvements">;
 
 def disable_availability_checking : Flag<["-"],
   "disable-availability-checking">,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3479,10 +3479,6 @@ static bool usesFeatureOneWayClosureParameters(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureTypeWitnessSystemInference(Decl *decl) {
-  return false;
-}
-
 static bool usesFeatureOpaqueTypeErasure(Decl *decl) {
   return false;
 }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -548,7 +548,7 @@ NormalProtocolConformance::getAssociatedConformance(Type assocType,
   forEachAssociatedConformance(
       [&](Type t, ProtocolDecl *p, unsigned index) {
         if (t->isEqual(assocType) && p == protocol) {
-          if (!ctx.LangOpts.hasFeature(Feature::TypeWitnessSystemInference)) {
+          if (!ctx.LangOpts.EnableExperimentalAssociatedTypeInference) {
             // Fill in the signature conformances, if we haven't done so yet.
             if (!hasComputedAssociatedConformances()) {
               const_cast<NormalProtocolConformance *>(this)

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -535,27 +535,48 @@ ProtocolConformance::getAssociatedConformance(Type assocType,
 ProtocolConformanceRef
 NormalProtocolConformance::getAssociatedConformance(Type assocType,
                                                  ProtocolDecl *protocol) const {
+  if (Loader)
+    resolveLazyInfo();
+
   assert(assocType->isTypeParameter() &&
          "associated type must be a type parameter");
 
   llvm::Optional<ProtocolConformanceRef> result;
 
+  auto &ctx = getDeclContext()->getASTContext();
+
   forEachAssociatedConformance(
       [&](Type t, ProtocolDecl *p, unsigned index) {
         if (t->isEqual(assocType) && p == protocol) {
-          // Fill in the signature conformances, if we haven't done so yet.
-          if (!hasComputedAssociatedConformances()) {
-            const_cast<NormalProtocolConformance *>(this)
-                ->finishSignatureConformances();
+          if (!ctx.LangOpts.hasFeature(Feature::TypeWitnessSystemInference)) {
+            // Fill in the signature conformances, if we haven't done so yet.
+            if (!hasComputedAssociatedConformances()) {
+              const_cast<NormalProtocolConformance *>(this)
+                  ->finishSignatureConformances();
+            }
           }
 
-          result = getAssociatedConformance(index);
+          // Not strictly necessary, but avoids a bit of request evaluator
+          // overhead in the happy case.
+          if (hasComputedAssociatedConformances()) {
+            result = AssociatedConformances[index];
+            if (result)
+              return true;
+          }
+
+          result = evaluateOrDefault(ctx.evaluator,
+                                     AssociatedConformanceRequest{
+                                       const_cast<NormalProtocolConformance *>(this),
+                                       t->getCanonicalType(), p, index
+                                     }, ProtocolConformanceRef::forInvalid());
           return true;
         }
 
         return false;
       });
 
+  assert(result && "Subject type must be exactly equal to left-hand side of a"
+         "conformance requirement in protocol requirement signature");
   return *result;
 }
 

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -346,7 +346,8 @@ static Type substPrefixType(Type type, unsigned suffixLength, Type prefixType,
   auto substBaseType = substPrefixType(memberType->getBase(), suffixLength - 1,
                                        prefixType, sig);
   return memberType->substBaseType(substBaseType,
-                                   LookUpConformanceInSignature(sig.getPointer()));
+                                   LookUpConformanceInSignature(sig.getPointer()),
+                                   llvm::None);
 }
 
 /// Unlike most other queries, the input type can be any type, not just a

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5595,7 +5595,7 @@ TypeBase::getAutoDiffTangentSpace(LookupConformanceFn lookupConformance) {
 
   // Try to get the `TangentVector` associated type of `base`.
   // Return the associated type if it is valid.
-  auto assocTy = dependentType->substBaseType(this, lookupConformance);
+  auto assocTy = dependentType->substBaseType(this, lookupConformance, llvm::None);
   if (!assocTy->hasError())
     return cache(TangentSpace::getTangentVector(assocTy));
 

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -274,30 +274,32 @@ operator()(CanType dependentType, Type conformingReplacementType,
 }
 
 Type DependentMemberType::substBaseType(ModuleDecl *module, Type substBase) {
-  return substBaseType(substBase, LookUpConformanceInModule(module));
+  return substBaseType(substBase, LookUpConformanceInModule(module), llvm::None);
 }
 
 Type DependentMemberType::substBaseType(Type substBase,
-                                        LookupConformanceFn lookupConformance) {
+                                        LookupConformanceFn lookupConformance,
+                                        SubstOptions options) {
   if (substBase.getPointer() == getBase().getPointer() &&
       substBase->hasTypeParameter())
     return this;
 
-  InFlightSubstitution IFS(nullptr, lookupConformance, llvm::None);
+  InFlightSubstitution IFS(nullptr, lookupConformance, options);
   return getMemberForBaseType(IFS, getBase(), substBase,
                               getAssocType(), getName(),
                               /*level=*/0);
 }
 
 Type DependentMemberType::substRootParam(Type newRoot,
-                                         LookupConformanceFn lookupConformance){
+                                         LookupConformanceFn lookupConformance,
+                                         SubstOptions options) {
   auto base = getBase();
   if (base->is<GenericTypeParamType>()) {
-    return substBaseType(newRoot, lookupConformance);
+    return substBaseType(newRoot, lookupConformance, options);
   }
   if (auto depMem = base->getAs<DependentMemberType>()) {
-    return substBaseType(depMem->substRootParam(newRoot, lookupConformance),
-                         lookupConformance);
+    return substBaseType(depMem->substRootParam(newRoot, lookupConformance, options),
+                         lookupConformance, options);
   }
   return Type();
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -910,8 +910,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
   if (Args.hasArg(OPT_experimental_one_way_closure_params))
     Opts.Features.insert(Feature::OneWayClosureParameters);
-  if (Args.hasArg(OPT_enable_experimental_associated_type_inference))
-    Opts.Features.insert(Feature::TypeWitnessSystemInference);
   if (Args.hasArg(OPT_enable_experimental_forward_mode_differentiation))
     Opts.Features.insert(Feature::ForwardModeDifferentiation);
   if (Args.hasArg(OPT_enable_experimental_additive_arithmetic_derivation))
@@ -1350,6 +1348,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_warn_redundant_requirements))
     Opts.WarnRedundantRequirements = true;
+
+  if (Args.hasArg(OPT_enable_experimental_associated_type_inference))
+    Opts.EnableExperimentalAssociatedTypeInference = true;
+  if (Args.hasArg(OPT_disable_experimental_associated_type_inference))
+    Opts.EnableExperimentalAssociatedTypeInference = false;
 
   Opts.DumpTypeWitnessSystems = Args.hasArg(OPT_dump_type_witness_systems);
 

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -136,7 +136,8 @@ mapTypeOutOfOpenedExistentialContext(CanType t) {
         if (auto *dmt =
                 archTy->getInterfaceType()->getAs<DependentMemberType>()) {
           return dmt->substRootParam(params[index],
-                                     MakeAbstractConformanceForGenericType());
+                                     MakeAbstractConformanceForGenericType(),
+                                     llvm::None);
         }
 
         return params[index];

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -662,6 +662,18 @@ static Type getWitnessTypeForMatching(NormalProtocolConformance *conformance,
                              genericFn->getExtInfo());
   }
 
+  auto &ctx = conformance->getDeclContext()->getASTContext();
+
+  // Get the reduced type of the witness. This rules our certain tautological
+  // inferences below.
+  if (ctx.LangOpts.EnableExperimentalAssociatedTypeInference) {
+    if (auto genericSig = witness->getInnermostDeclContext()
+            ->getGenericSignatureOfContext()) {
+      type = genericSig.getReducedType(type);
+      type = genericSig->getSugaredType(type);
+    }
+  }
+
   // Remap associated types that reference other protocols into this
   // protocol.
   auto proto = conformance->getProtocol();

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1497,8 +1497,10 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
         // If the transformed base has the same nominal as the adoptee, we may
         // need to look up a tentative type witness. Otherwise, just substitute
         // the base.
-        if (substBase->getAnyNominal() != adoptee->getAnyNominal()) {
-          return dmt->substBaseType(dc->getParentModule(), substBase);
+        if (substBase->getAnyNominal() != dc->getSelfNominalTypeDecl()) {
+          return dmt->substBaseType(substBase,
+                                    LookUpConformanceInModule(dc->getParentModule()),
+                                    substOptions);
         }
 
         auto *assocTy = dmt->getAssocType();

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1374,7 +1374,7 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
   // not resolve otherwise.
   llvm::SmallVector<AbstractTypeWitness, 2> abstractTypeWitnesses;
 
-  if (ctx.LangOpts.hasFeature(Feature::TypeWitnessSystemInference)) {
+  if (ctx.LangOpts.EnableExperimentalAssociatedTypeInference) {
     TypeWitnessSystem system(unresolvedAssocTypes);
     collectAbstractTypeWitnesses(system, unresolvedAssocTypes);
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1126,6 +1126,8 @@ void AssociatedTypeInference::collectAbstractTypeWitnesses(
 }
 
 Type AssociatedTypeInference::substCurrentTypeWitnesses(Type type) {
+  auto substOptions = getSubstOptionsWithCurrentTypeWitnesses();
+
   // Local function that folds dependent member types with non-dependent
   // bases into actual member references.
   std::function<Type(Type)> foldDependentMemberTypes;
@@ -1148,7 +1150,8 @@ Type AssociatedTypeInference::substCurrentTypeWitnesses(Type type) {
       auto *module = dc->getParentModule();
 
       // Try to substitute into the base type.
-      Type result = depMemTy->substBaseType(module, baseTy);
+      Type result = depMemTy->substBaseType(
+          baseTy, LookUpConformanceInModule(module), substOptions);
       if (!result->hasError())
         return result;
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1384,6 +1384,19 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
     for (auto *assocType : unresolvedAssocTypes) {
       auto resolvedTy = system.getResolvedTypeWitness(assocType->getName());
 
+      resolvedTy = resolvedTy.transformRec([&](Type ty) -> llvm::Optional<Type> {
+        if (auto *gp = ty->getAs<GenericTypeParamType>()) {
+          // FIXME: 'computeFixedTypeWitness' uses 'getReducedType',
+          // so if a generic parameter is canonical here, it's 'Self'.
+          if (gp->isCanonical() ||
+              isa<ProtocolDecl>(gp->getDecl()->getDeclContext()->getAsDecl())) {
+            return adoptee;
+          }
+        }
+
+        return llvm::None;
+      });
+
       typeWitnesses.insert(assocType, {resolvedTy, reqDepth});
 
       if (auto *defaultedAssocType =
@@ -1399,11 +1412,27 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
       // Try to compute the type without the aid of a specific potential
       // witness.
       if (const auto &typeWitness = computeAbstractTypeWitness(assocType)) {
+        auto resolvedTy = typeWitness->getType();
+
+        resolvedTy = resolvedTy.transformRec([&](Type ty) -> llvm::Optional<Type> {
+          if (auto *gp = ty->getAs<GenericTypeParamType>()) {
+            // FIXME: 'computeFixedTypeWitness' uses 'getReducedType',
+            // so if a generic parameter is canonical here, it's 'Self'.
+            if (gp->isCanonical() ||
+                isa<ProtocolDecl>(gp->getDecl()->getDeclContext()->getAsDecl())) {
+              return adoptee;
+            }
+          }
+
+          return llvm::None;
+        });
+
         // Record the type witness immediately to make it available
         // for substitutions into other tentative type witnesses.
-        typeWitnesses.insert(assocType, {typeWitness->getType(), reqDepth});
+        typeWitnesses.insert(assocType, {resolvedTy, reqDepth});
 
-        abstractTypeWitnesses.push_back(std::move(typeWitness.value()));
+        abstractTypeWitnesses.emplace_back(assocType, resolvedTy,
+                                           typeWitness->getDefaultedAssocType());
         continue;
       }
 
@@ -1431,7 +1460,7 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
     Type type = witness.getType();
 
     // Replace type parameters with other known or tentative type witnesses.
-    if (type->hasTypeParameter()) {
+    if (type->hasDependentMember() || type->hasTypeParameter()) {
       // FIXME: We should find a better way to detect and reason about these
       // cyclic solutions so that we can spot them earlier and express them in
       // diagnostics.
@@ -1440,17 +1469,6 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
 
       std::function<Type(Type)> substCurrentTypeWitnesses;
       substCurrentTypeWitnesses = [&](Type ty) -> Type {
-        if (auto *gp = ty->getAs<GenericTypeParamType>()) {
-          // FIXME: 'computeFixedTypeWitness' uses 'getReducedType',
-          // so if a generic parameter is canonical here, it's 'Self'.
-          if (gp->isCanonical() ||
-              isa<ProtocolDecl>(gp->getDecl()->getDeclContext()->getAsDecl())) {
-            return adoptee;
-          }
-
-          return ty;
-        }
-
         auto *const dmt = ty->getAs<DependentMemberType>();
         if (!dmt) {
           return ty;

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -616,6 +616,8 @@ function(_compile_swift_files
     list(APPEND swift_flags "-Xfrontend" "-disable-preallocated-instantiation-caches")
   endif()
 
+  list(APPEND swift_flags "-Xfrontend" "-enable-experimental-associated-type-inference")
+
   list(APPEND swift_flags ${SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS})
 
   list(APPEND swift_flags ${SWIFT_EXPERIMENTAL_EXTRA_FLAGS})

--- a/test/Generics/rdar116434843.swift
+++ b/test/Generics/rdar116434843.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+
+struct X: P {}
+
+protocol Q {
+  typealias A = X
+}
+
+protocol R {
+  associatedtype A: Q
+  associatedtype B: P
+}
+
+protocol S {}
+
+extension S where Self: R {
+  typealias B = Self.A.A
+}
+
+typealias T<A: Q> = G<A>.B
+
+struct G<A: Q>: R, S {
+  typealias A = A
+}

--- a/test/IDE/complete_member_type.swift
+++ b/test/IDE/complete_member_type.swift
@@ -97,14 +97,14 @@ do {
   let _: [Int].#^SUGARED_ARRAY_MEMBER_DOT?check=ARRAY^#
 
   // ARRAY-LABEL: Begin completions, 8 items
-  // ARRAY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Index[#Int#]; name=Index
-  // ARRAY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Indices[#Range<Int>#]; name=Indices
-  // ARRAY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Iterator[#IndexingIterator<Array<Element>>#]; name=Iterator
-  // ARRAY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: Element[#Element#]; name=Element
-  // ARRAY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: SubSequence[#ArraySlice<Element>#]; name=SubSequence
-  // ARRAY-NEXT: Decl[TypeAlias]/CurrNominal/IsSystem: ArrayLiteralElement[#Element#]; name=ArrayLiteralElement
-  // ARRAY-NEXT: Decl[TypeAlias]/Super/NotRecommended/IsSystem: IndexDistance[#Int#]; name=IndexDistance; diagnostics=warning:'IndexDistance' is deprecated: all index distances are now of type Int
-  // ARRAY-NEXT: Keyword/None: Type[#{{Array<Int>|\[Int\]}}.Type#]; name=Type
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Index[#Int#]; name=Index
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Indices[#Range<Int>#]; name=Indices
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Iterator[#IndexingIterator<Array<Element>>#]; name=Iterator
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: Element[#Element#]; name=Element
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: ArrayLiteralElement[#Element#]; name=ArrayLiteralElement
+  // ARRAY-DAG: Decl[TypeAlias]/CurrNominal/IsSystem: SubSequence[#ArraySlice<Element>#]; name=SubSequence
+  // ARRAY-DAG: Decl[TypeAlias]/Super/NotRecommended/IsSystem: IndexDistance[#Int#]; name=IndexDistance; diagnostics=warning:'IndexDistance' is deprecated: all index distances are now of type Int
+  // ARRAY-DAG: Keyword/None: Type[#{{Array<Int>|\[Int\]}}.Type#]; name=Type
 
   let _: Dictionary<Int, Int>.#^DICTIONARY_MEMBER_DOT?check=DICTIONARY^#
   let _: [Int : Int].#^SUGARED_DICTIONARY_MEMBER_DOT?check=DICTIONARY^#

--- a/test/decl/protocol/req/associated_type_generic_param.swift
+++ b/test/decl/protocol/req/associated_type_generic_param.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+
+protocol P {
+  associatedtype A = Int
+}
+
+struct S<A>: P {}
+
+let x: String.Type = S<String>.A.self

--- a/test/decl/protocol/req/associated_type_inference_fixed_type.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 protocol P1 where A == Never {
   associatedtype A

--- a/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
@@ -230,8 +230,8 @@ do {
   // CHECK-NEXT: }
   struct Conformer1: P17a {} // expected-error {{type 'Conformer1' does not conform to protocol 'P17a'}}
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer2<A> to P17b: {
-  // CHECK-NEXT: A => (unresolved), [[EQUIV_CLASS:0x[0-9a-f]+]]
-  // CHECK-NEXT: B => (unresolved), [[EQUIV_CLASS]]
+  // CHECK-NEXT: A => A, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => (unresolved)
   // CHECK-NEXT: }
   struct Conformer2<A>: P17b {} // expected-error {{type 'Conformer2<A>' does not conform to protocol 'P17b'}}
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer3 to P17c: {
@@ -240,8 +240,8 @@ do {
   // CHECK-NEXT: }
   struct Conformer3: P17c {}
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer4<A> to P17d: {
-  // CHECK-NEXT: A => Int, [[EQUIV_CLASS:0x[0-9a-f]+]]
-  // CHECK-NEXT: B => Int, [[EQUIV_CLASS]]
+  // CHECK-NEXT: A => A, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => Int, [[EQUIV_CLASS:0x[0-9a-f]+]]
   // CHECK-NEXT: }
   struct Conformer4<A>: P17d {}
 }
@@ -674,7 +674,7 @@ protocol P37b {
 }
 do {
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer1<C> to P37b: {
-  // CHECK-NEXT: C => Self.B.A,
+  // CHECK-NEXT: C => C,
   // CHECK-NEXT: }
   struct Conformer1<C>: P37b {
     struct Inner: P37a { typealias A = C }

--- a/test/decl/protocol/req/associated_type_inference_stdlib.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift
+
+// We would fail here when Indices was explicitly specified, as in X2.
+
+public struct X1: RandomAccessCollection {
+  public var startIndex: Int {
+    return 0
+  }
+
+  public var endIndex: Int {
+    return 0
+  }
+
+  public subscript(position: Int) -> String {
+    return ""
+  }
+}
+
+public struct X2: RandomAccessCollection {
+  public typealias Indices = Range<Int>
+
+  public var startIndex: Int {
+    return 0
+  }
+
+  public var endIndex: Int {
+    return 0
+  }
+
+  public subscript(position: Int) -> String {
+    return ""
+  }
+}

--- a/test/decl/protocol/req/associated_type_inference_stdlib.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 // We would fail here when Indices was explicitly specified, as in X2.
 

--- a/test/decl/protocol/req/associated_type_inference_stdlib_2.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib_2.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift
+
+protocol IP {
+  associatedtype E
+
+  func next() -> E?
+}
+
+protocol S {
+  associatedtype I: IP
+  associatedtype E where E == I.E
+
+  func makeI() -> I
+}
+
+struct G: S {
+  struct I: IP {
+    func next() -> Int? {}
+  }
+
+  func makeI() -> I {}
+}

--- a/test/decl/protocol/req/associated_type_inference_stdlib_2.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib_2.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
-// RUN: not %target-typecheck-verify-swift
+// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 protocol IP {
   associatedtype E

--- a/test/decl/protocol/req/associated_type_inference_stdlib_3.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib_3.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+
+struct FooIterator<T: Sequence>: IteratorProtocol {
+  typealias Element = T.Element
+
+  mutating func next() -> Element? { fatalError() }
+}
+
+struct FooSequence<Element>: Sequence {
+  func makeIterator() -> FooIterator<Self> { fatalError() }
+}

--- a/test/decl/protocol/req/rdar118998138.swift
+++ b/test/decl/protocol/req/rdar118998138.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift
+
+public protocol FakeCopyable {}
+
+extension Int: FakeCopyable {}
+
+// Remove both 'FakeCopyable' requirements below and 
+// inference for Element in Hello succeeds.
+
+public protocol MyIteratorProtocol<Element> {
+  associatedtype Element : FakeCopyable
+
+  mutating func next() -> Element?
+}
+
+public protocol MySequence<Element> {
+  associatedtype Element : FakeCopyable
+
+  associatedtype Iterator: MyIteratorProtocol where Iterator.Element == Element
+
+  __consuming func makeIterator() -> Iterator
+
+  func _customContainsEquatableElement(
+    _ element: Element
+  ) -> Bool?
+}
+
+extension MySequence {
+  @usableFromInline
+  func _customContainsEquatableElement(
+    _ element: Iterator.Element
+  ) -> Bool? { return nil }
+}
+
+extension MySequence where Self.Iterator == Self {
+  @inlinable
+  public __consuming func makeIterator() -> Self {
+    return self
+  }
+}
+
+// ------------
+
+internal struct Hello {}
+
+extension Hello: MySequence, MyIteratorProtocol {
+  // Inferred:
+  // typealias Element = Int
+
+  internal mutating func next() -> Int? {
+    return nil
+  }
+}

--- a/test/decl/protocol/req/rdar118998138.swift
+++ b/test/decl/protocol/req/rdar118998138.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
-// RUN: not %target-typecheck-verify-swift
+// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 public protocol FakeCopyable {}
 

--- a/test/decl/protocol/req/rdar90402522.swift
+++ b/test/decl/protocol/req/rdar90402522.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 public typealias A = UInt32
 

--- a/test/decl/protocol/req/rdar90402522.swift
+++ b/test/decl/protocol/req/rdar90402522.swift
@@ -1,0 +1,110 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift
+
+public typealias A = UInt32
+
+public protocol P1: Numeric, Strideable, CustomStringConvertible
+where Magnitude == B.Magnitude,
+      IntegerLiteralType == B.Magnitude,
+      Stride == B.Stride {
+  associatedtype B: BinaryInteger
+  init(_ b: B)
+  init(integerLiteral value: B)
+
+  var rawIndex: B { get set }
+
+  var magnitude: B.Magnitude { get }
+}
+
+public extension P1 {
+  init(integerLiteral value: B) {
+    self.init(value)
+  }
+
+  init<T>(_ value: T) where T: BinaryInteger {
+    self.init(B(value))
+  }
+
+  init?<T>(exactly source: T) where T: BinaryInteger {
+    if let index = B(exactly: source) {
+      self.init(index)
+    } else {
+      return nil
+    }
+  }
+
+  var magnitude: Self.Magnitude {
+    rawIndex.magnitude
+  }
+
+  var description: String {
+    rawIndex.description
+  }
+
+  func distance(to other: Self) -> Stride {
+    rawIndex.distance(to: other.rawIndex)
+  }
+
+  func advanced(by n: Stride) -> Self {
+    Self(rawIndex.advanced(by: n))
+  }
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.rawIndex == rhs.rawIndex
+  }
+
+  static func == <B: BinaryInteger>(lhs: Self, rhs: B) -> Bool {
+    lhs.rawIndex == rhs
+  }
+
+  static func == <B: BinaryInteger>(lhs: B, rhs: Self) -> Bool {
+    lhs == rhs.rawIndex
+  }
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.rawIndex < rhs.rawIndex
+  }
+
+  static func + (lhs: Self, rhs: Self) -> Self {
+    Self(lhs.rawIndex + rhs.rawIndex)
+  }
+
+  static func - (lhs: Self, rhs: Self) -> Self {
+    Self(lhs.rawIndex - rhs.rawIndex)
+  }
+
+  static func * (lhs: Self, rhs: Self) -> Self {
+    Self(lhs.rawIndex * rhs.rawIndex)
+  }
+
+  static func *= (lhs: inout Self, rhs: Self) {
+    lhs.rawIndex *= rhs.rawIndex
+  }
+}
+
+public protocol P2: P1 where B == A {
+  init(b: B)
+  var b: B { get set }
+}
+
+public extension P2 {
+  init(_ b: B) {
+    self.init(b: b)
+  }
+
+  var rawIndex: A {
+    get {
+      b
+    }
+    set(newIndex) {
+      b = newIndex
+    }
+  }
+}
+
+struct S {
+  var b: A
+}
+
+extension S: P2 {}
+

--- a/validation-test/compiler_crashers_2_fixed/issue-53793.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-53793.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -verify -emit-ir %s
+// RUN: %target-swift-frontend -disable-experimental-associated-type-inference -verify -emit-ir %s
 
 // Works with experimental associated type inference.
 // RUN: %target-swift-frontend -enable-experimental-associated-type-inference -emit-ir %s

--- a/validation-test/compiler_crashers_2_fixed/issue-59772.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-59772.swift
@@ -1,0 +1,97 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+private typealias Word = UInt
+
+/// Returns the offset at which the `i`th bit can be found in an array of
+/// `Word`s.
+private func wordOffset(ofBit i: Int) -> Int {
+  precondition(i >= 0)
+  return i / Word.bitWidth
+}
+
+/// Returns a mask that isolates the `i`th bit within its `Word` in an array of
+/// `Word`s.
+private func wordMask(ofBit i: Int) -> Word {
+  precondition(i >= 0)
+  return (1 as Word) << (i % Word.bitWidth)
+}
+
+/// An adapter that presents a base instance of `S` as a sequence of bits packed
+/// into `Word`, where `true` and `false` in the base are represented as `1` and
+/// `0` bits in an element of `self`, respectively.
+private struct PackedIntoWords<S: Sequence>: Sequence where S.Element == Bool {
+  /// The iteration state of a traversal of a `PackedIntoWords`.
+  struct Iterator: IteratorProtocol {
+    var base: S.Iterator
+
+    mutating func next() -> Word? {
+      guard let b = base.next() else { return nil }
+      var r: Word = b ? 1 : 0
+      for i in 1..<Word.bitWidth {
+        guard let b = base.next() else { return r }
+        if b { r |= wordMask(ofBit: i) }
+      }
+      return r
+    }
+  }
+  /// Returns a new iterator over `self`.
+  func makeIterator() -> Iterator { Iterator(base: base.makeIterator()) }
+
+  /// Returns a number no greater than the number of elements in `self`.
+  var underestimatedCount: Int {
+    (base.underestimatedCount + Word.bitWidth - 1) / Word.bitWidth
+  }
+
+  /// The underlying sequence of `Bool`.
+  let base: S
+
+  init(_ base: S) { self.base = base }
+}
+
+struct Bits<Base: Sequence>: Sequence
+  where Base.Element: FixedWidthInteger
+{
+  public var base: Base
+  typealias Element = Bool
+
+  func makeIterator() -> Iterator { Iterator(base: base.makeIterator()) }
+
+  struct Iterator: IteratorProtocol {
+    typealias Element = Bool
+
+    var base: Base.Iterator
+    var buffer: Base.Element.Magnitude = 0
+
+    mutating func next() -> Bool? {
+      let r = buffer & 0x1 != 0
+      buffer >>= 1
+      if buffer != 0 { return r }
+      guard let b = base.next() else { return nil }
+      let r1 = b & 0x1 != 0
+      buffer = Base.Element.Magnitude(truncatingIfNeeded: b)
+      buffer >>= 1
+      buffer |= 1 << (Base.Element.bitWidth - 1)
+      return r1
+    }
+  }
+}
+
+extension Bits: Equatable where Base: Equatable {}
+extension Bits: Hashable where Base: Hashable {}
+
+extension Bits: RandomAccessCollection, BidirectionalCollection, Collection
+  where Base: RandomAccessCollection
+{
+//  typealias Index = Int
+  var startIndex: Int { return 0 }
+  var endIndex: Int { return base.count * Base.Element.bitWidth }
+
+  fileprivate func baseIndex(_ i: Int) -> Base.Index {
+    base.index(base.startIndex, offsetBy: i / Base.Element.bitWidth)
+  }
+
+  subscript(i: Int) -> Bool {
+    base[baseIndex(i)] & (1 << (i % Base.Element.bitWidth)) != 0
+  }
+}
+

--- a/validation-test/compiler_crashers_2_fixed/rdar110806272.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar110806272.swift
@@ -1,5 +1,7 @@
 // RUN: not %target-swift-frontend -typecheck %s -enable-experimental-associated-type-inference
 
+// This code is invalid, but we shouldn't crash.
+
 struct SyntaxCollectionIterator<E: SyntaxProtocol>: IteratorProtocol {
   typealias Element = E
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar110806272.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar110806272.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-swift-frontend -typecheck %s -enable-experimental-associated-type-inference
+
+struct SyntaxCollectionIterator<E: SyntaxProtocol>: IteratorProtocol {
+  typealias Element = E
+}
+
+protocol SyntaxCollection: BidirectionalCollection {}
+
+extension SyntaxCollection {
+  typealias Iterator = SyntaxCollectionIterator<Element>
+}
+
+struct AccessorListSyntax: SyntaxCollection {
+  typealias Element = Int
+}


### PR DESCRIPTION
The new code was briefly enabled by default but then we made it into an experimental feature, and things bitrotted and the standard library stopped building with it on. This PR fixes things up so that the stdlib builds once again, and also adds a bunch of related regression tests.