### PR TITLE
[Concurrency] correct AbstractFunction::isPreconcurrency logic

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1076,6 +1076,10 @@ public:
   /// global or static 'let' variables, which was previously accepted in
   /// compiler versions before 5.10, or for declarations marked preconcurrency.
   bool downgradeAsyncAccessToWarning(Decl *decl) {
+    if (decl->preconcurrency()) {
+      return true;
+    }
+
     if (auto *var = dyn_cast<VarDecl>(decl)) {
       ActorReferenceResult::Options options = llvm::None;
       // The newly-diagnosed cases are invalid regardless of the module context
@@ -1086,7 +1090,7 @@ public:
       }
     }
 
-    return decl->preconcurrency();
+    return false;
   }
 
   Classification classifyLookup(LookupExpr *E) {

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -23,7 +23,7 @@ func nonIsolatedAsync() async {
     await print(a)
     a = a + 10
     // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
-    // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
+    // expected-warning@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
     // expected-note@-3:9 {{property access is 'async'}}
 }
 


### PR DESCRIPTION
correction to the logic in https://github.com/apple/swift/pull/70261

Without this change, `preconcurrency` will fail to factor in the logic if `options.contains(ActorReferenceResult::flags::Preconcurrency)` is false.