### PR TITLE
[Dependency Scanning] Filter out '-Xcc' search paths from Swift module compilation commands

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1001,6 +1001,16 @@ namespace swift {
 
     std::vector<std::string> getRemappedExtraArgs(
         std::function<std::string(StringRef)> pathRemapCallback) const;
+
+    /// For a swift module dependency, interface build command generation must
+    /// inherit
+    /// `-Xcc` flags used for configuration of the building instance's
+    /// `ClangImporter`. However, we can ignore Clang search path flags because
+    /// explicit Swift module build tasks will not rely on them and they may be
+    /// source-target-context-specific and hinder module sharing across
+    /// compilation source targets.
+    std::vector<std::string>
+    getReducedExtraArgsForSwiftModuleDependency() const;
   };
 
 } // end namespace swift

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1756,17 +1756,32 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     clangImporterOpts.DetailedPreprocessingRecord;
   subClangImporterOpts.CASOpts = clangImporterOpts.CASOpts;
 
-  // If the compiler has been asked to be strict with ensuring downstream dependencies
-  // get the parent invocation's context, or this is an Explicit build, inherit the
-  // extra Clang arguments also.
-  if (LoaderOpts.strictImplicitModuleContext || LoaderOpts.disableImplicitSwiftModule ||
-      LoaderOpts.requestedAction == FrontendOptions::ActionType::ScanDependencies) {
-    // Inherit any clang-specific state of the compilation (macros, clang flags, etc.)
-    subClangImporterOpts.ExtraArgs = clangImporterOpts.ExtraArgs;
-    for (auto arg : subClangImporterOpts.ExtraArgs) {
-      GenericArgs.push_back("-Xcc");
-      GenericArgs.push_back(ArgSaver.save(arg));
-    }
+  std::vector<std::string> inheritedParentContextClangArgs;
+  if (LoaderOpts.requestedAction ==
+      FrontendOptions::ActionType::ScanDependencies) {
+    // For a dependency scanning action, interface build command generation must
+    // inherit
+    // `-Xcc` flags used for configuration of the building instance's
+    // `ClangImporter`. However, we can ignore Clang search path flags because
+    // explicit Swift module build tasks will not rely on them and they may be
+    // source-target-context-specific and hinder module sharing across
+    // compilation source targets.
+    // Clang module dependecies of this Swift dependency will be distinguished by
+    // their context hash for different variants, so would still cause a difference
+    // in the Swift compile commands, when different.
+    inheritedParentContextClangArgs =
+        clangImporterOpts.getReducedExtraArgsForSwiftModuleDependency();
+  } else if (LoaderOpts.strictImplicitModuleContext) {
+    // If the compiler has been asked to be strict with ensuring downstream
+    // dependencies get the parent invocation's context, inherit the extra Clang
+    // arguments also. Inherit any clang-specific state of the compilation
+    // (macros, clang flags, etc.)
+    inheritedParentContextClangArgs = clangImporterOpts.ExtraArgs;
+  }
+  subClangImporterOpts.ExtraArgs = inheritedParentContextClangArgs;
+  for (auto arg : subClangImporterOpts.ExtraArgs) {
+    GenericArgs.push_back("-Xcc");
+    GenericArgs.push_back(ArgSaver.save(arg));
   }
 
   subClangImporterOpts.EnableClangSPI = clangImporterOpts.EnableClangSPI;

--- a/test/ScanDependencies/FilterClangSearchPaths.swift
+++ b/test/ScanDependencies/FilterClangSearchPaths.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -Xcc -fobjc-disable-direct-methods-for-testing -Xcc -I -Xcc /tmp/foo -Xcc -I/tmp/bar
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import C
+
+// CHECK: "mainModuleName": "deps"
+/// --------Main module
+// CHECK-LABEL: "modulePath": "deps.swiftmodule",
+// CHECK-NEXT: sourceFiles
+// CHECK-NEXT: FilterClangSearchPaths.swift
+// CHECK-NEXT: ],
+// CHECK-NEXT: "directDependencies": [
+// CHECK-DAG:     "clang": "C"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK-DAG:     "swift": "_Concurrency"
+// CHECK: ],
+
+// CHECK:     "swift": "A"
+// CHECK:        "swift": {
+// CHECK-NEXT:          "moduleInterfacePath": "{{.*}}{{/|\\}}Inputs{{/|\\}}Swift{{/|\\}}A.swiftinterface",
+// CHECK:          "commandLine": [
+// CHECK:            "-fobjc-disable-direct-methods-for-testing"
+// CHECK:            "-o",
+// CHECK-NEXT:       "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+// CHECK-NOT:        "/tmp/foo"
+// CHECK-NOT:        "-I/tmp/bar"
+// CHECK:          ]


### PR DESCRIPTION
These search paths will not get used during Swift module compilation and can only hinder module sharing among different targets.

Resolves rdar://119217774