### PR TITLE
[Backtracing] Improve warning message about thread suspension failure.

### DIFF
--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -531,9 +531,10 @@ suspend_other_threads(struct thread *self)
           tgkill(our_pid, tid, sig_to_use);
           ++pending;
         } else {
-          warn("swift-runtime: unable to suspend thread ");
+          warn("swift-runtime: failed to suspend thread ");
           warn(dp->d_name);
-          warn("\n");
+          warn(" while processing a crash; backtraces will be missing "
+               "information\n");
         }
       }
     }


### PR DESCRIPTION
In the event that the backtracer fails to suspend a thread, it emits a warning message.  Unfortunately the exact meaning of this message isn't obvious and it doesn't make clear that it's a secondary problem (that is, you've already crashed at this point).

Update the message to make things clearer.

rdar://116593541
