### PR TITLE
[C++20] Two very minor C++20 fixes.

### DIFF
--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -200,7 +200,7 @@
 #if defined(__cplusplus)
 #if defined(__cpp_char8_t)
 inline constexpr char operator""_swift_u8(char8_t c) { return c; }
-inline const char *operator""_swift_u8(const char8_t *p, std::size_t) {
+inline const char *operator""_swift_u8(const char8_t *p, size_t) {
   return reinterpret_cast<const char *>(p);
 }
 #define SWIFT_UTF8(literal) u8##literal##_swift_u8

--- a/include/swift/RemoteInspection/MetadataSource.h
+++ b/include/swift/RemoteInspection/MetadataSource.h
@@ -29,6 +29,7 @@ using llvm::cast;
 
 #include <cerrno>
 #include <climits>
+#include <cstdlib>
 #include <string>
 
 namespace swift {


### PR DESCRIPTION
- Remove `std::` from `std::size_t` where we're importing `stddef.h` instead of `cstddef`.
- Add an inclusion of `<cstdlib>` where needed because libc++ has cleaned up some of their transitive inclusions.
