### PR TITLE
[cxx-interop] Add friend operators to the lookup table properly

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2243,10 +2243,6 @@ namespace {
         if (auto friendDecl = dyn_cast<clang::FriendDecl>(m)) {
           if (friendDecl->getFriendDecl()) {
             m = friendDecl->getFriendDecl();
-
-            auto lookupTable = Impl.findLookupTable(decl);
-            addEntryToLookupTable(*lookupTable, friendDecl->getFriendDecl(),
-                                  Impl.getNameImporter());
           }
         }
 
@@ -2989,7 +2985,11 @@ namespace {
       // This cannot be done when building the lookup table,
       // because templates are instantiated lazily.
       for (auto member : def->decls()) {
-        if (auto method = dyn_cast<clang::CXXMethodDecl>(member)) {
+        if (auto friendDecl = dyn_cast<clang::FriendDecl>(member))
+          if (auto underlyingDecl = friendDecl->getFriendDecl())
+            member = underlyingDecl;
+
+        if (auto method = dyn_cast<clang::FunctionDecl>(member)) {
           if (method->isOverloadedOperator()) {
             addEntryToLookupTable(*Impl.findLookupTable(decl), method,
                                   Impl.getNameImporter());

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1965,6 +1965,10 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
       isa<clang::ObjCCategoryDecl>(named)) {
     clang::DeclContext *dc = cast<clang::DeclContext>(named);
     for (auto member : dc->decls()) {
+      if (auto friendDecl = dyn_cast<clang::FriendDecl>(member))
+        if (auto underlyingDecl = friendDecl->getFriendDecl())
+          member = underlyingDecl;
+
       if (auto namedMember = dyn_cast<clang::NamedDecl>(member))
         addEntryToLookupTable(table, namedMember, nameImporter);
     }

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -45,6 +45,16 @@ struct LoadableIntWrapper {
   }
 };
 
+namespace NS {
+struct IntWrapperInNamespace {
+  int value;
+  friend bool operator==(const IntWrapperInNamespace &lhs,
+                         const IntWrapperInNamespace &rhs) {
+    return lhs.value == rhs.value;
+  }
+};
+} // namespace NS
+
 struct LoadableBoolWrapper {
   bool value;
   LoadableBoolWrapper operator!() {

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -30,7 +30,7 @@ struct LoadableIntWrapper {
   }
 
   // Friend functions
-  friend bool operator==(const LoadableIntWrapper lhs,
+  friend bool operator==(const LoadableIntWrapper &lhs,
                          const LoadableIntWrapper &rhs) {
     return lhs.value == rhs.value;
   }

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -8,6 +8,10 @@
 // CHECK:   mutating func callAsFunction(_ x: Int32) -> Int32
 // CHECK:   mutating func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK: }
+// CHECK: func == (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
+// CHECK: func -= (lhs: inout LoadableIntWrapper, rhs: LoadableIntWrapper)
+
+// CHECK: func == (lhs: NS.IntWrapperInNamespace, rhs: NS.IntWrapperInNamespace) -> Bool
 
 // CHECK: struct LoadableBoolWrapper
 // CHECK:   prefix static func ! (lhs: inout LoadableBoolWrapper) -> LoadableBoolWrapper

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -83,6 +83,15 @@ OperatorsTestSuite.test("LoadableIntWrapper.successor() (inline)") {
   expectEqual(42, wrapper.value)
 }
 
+OperatorsTestSuite.test("IntWrapperInNamespace.equal (inline)") {
+  let lhs = NS.IntWrapperInNamespace(value: 42)
+  let rhs = NS.IntWrapperInNamespace(value: 42)
+
+  let result = lhs == rhs
+
+  expectTrue(result)
+}
+
 OperatorsTestSuite.test("TemplatedWithFriendOperator.equal (inline)") {
   let lhs = TemplatedWithFriendOperatorSpec()
   let rhs = TemplatedWithFriendOperatorSpec()

--- a/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
@@ -3,7 +3,7 @@
 // REQUIRES: OS=macosx
 
 // CHECK: enum std {
-// CHECK-NEXT: enum __1 {
+// CHECK: enum __1 {
 
 // CHECK: typealias string =
 

--- a/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
@@ -8,7 +8,7 @@
 // REQUIRES: OS=macosx
 
 // CHECK: enum std {
-// CHECK-NEXT: enum __1 {
+// CHECK: enum __1 {
 
 // STRING: struct basic_string {
 


### PR DESCRIPTION
Previously, `friend` operators declared in C++ classes were added to the lookup table when the class is being imported.

The operators were added to the wrong lookup table if the class is declared in a C++ namespace. Since a namespace can span across multiple Clang modules, its contents should be added to a translation unit level lookup table, not to a module level lookup table.

This change makes sure we add `friend` operators to the lookup table earlier, when we are actually building the lookup table. Note that this is not possible for class template instantiations, because those are instantiated later, so for templates we still handle `friend` operators when importing the instantiation.

rdar://116349899