### PR TITLE
[Explicit Moduele Builds] Look through forwarding modules for `canImport` version check.

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2246,6 +2246,21 @@ bool ExplicitSwiftModuleLoader::canImportModule(
                        it->second.modulePath);
     return false;
   }
+
+  // If it's a forwarding module, load the YAML file from disk and get the path
+  // to the actual module for the version check.
+  if (!serialization::isSerializedAST((*moduleBuf)->getBuffer())) {
+    if (auto forwardingModule = ForwardingModule::load(**moduleBuf)) {
+      moduleBuf = fs.getBufferForFile(forwardingModule->underlyingModulePath);
+      if (!moduleBuf) {
+        Ctx.Diags.diagnose(SourceLoc(),
+                           diag::error_opening_explicit_module_file,
+                           forwardingModule->underlyingModulePath);
+        return false;
+      }
+    }
+  }
+
   auto metaData = serialization::validateSerializedAST(
       (*moduleBuf)->getBuffer(), Ctx.SILOpts.EnableOSSAModules,
       Ctx.LangOpts.SDKName, !Ctx.LangOpts.DebuggerSupport);

--- a/test/ScanDependencies/can_import_explicit_versioned_forwarding.swift
+++ b/test/ScanDependencies/can_import_explicit_versioned_forwarding.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+// RUN: mkdir -p %t/barinputs
+// RUN: echo "public func foo() {}" >> %t/foo.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo -user-module-version 9001
+// RUN: echo "public func bar() {}" >> %t/bar.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/barinputs/Bar.swiftmodule -emit-module-doc-path %t/barinputs/Bar.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/barinputs/Bar.swiftsourceinfo -module-cache-path %t.module-cache %t/bar.swift -module-name Bar
+
+// RUN: echo "---"                                  >> %t/inputs/ForwardingFoo.swiftmodule
+// RUN: echo "path: '%/t/inputs/Foo.swiftmodule'" >> %t/inputs/ForwardingFoo.swiftmodule
+// RUN: echo "dependencies:    []"                  >> %t/inputs/ForwardingFoo.swiftmodule
+// RUN: echo "version:         1 "                  >> %t/inputs/ForwardingFoo.swiftmodule
+// RUN: echo "..."                                  >> %t/inputs/ForwardingFoo.swiftmodule
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/ForwardingFoo.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: not %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -disable-implicit-swift-modules
+// RUN: %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -I %t/barinputs -Rmodule-loading 2>&1 | %FileCheck -check-prefix=POSITIVE-CHECK %s
+
+#if canImport(Foo, _version: 9000)
+import Bar
+#endif
+
+// 'Bar' can only be imported if the explicitly-loaded 'Foo' is known to be over 9000
+// POSITIVE-CHECK: remark: loaded module 'Bar'
+
+// Re-build Foo with a lower version and ensure we do not import `Bar` 
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo -user-module-version 7000
+// RUN: %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -I %t/barinputs -Rmodule-loading 2>&1 | %FileCheck -check-prefix=NEGATIVE-CHECK %s
+
+// 'Bar' can only be imported if the explicitly-loaded 'Foo' is known to be over 9000
+// NEGATIVE-CHECK-NOT: remark: loaded module 'Bar'


### PR DESCRIPTION
Otherwise we default to version **0** for all modules which get forwarded.

Resolves rdar://119346213