### PR TITLE
[CSBindings] Unwrap optionals from contextual function type used as a…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -634,8 +634,9 @@ void BindingSet::finalize(
         assert(isKnownKeyPathType(bindingTy) || bindingTy->is<FunctionType>());
 
         // Functions don't have capability so we can simply add them.
-        if (bindingTy->is<FunctionType>())
-          updatedBindings.insert(binding);
+        if (auto *fnType = bindingTy->getAs<FunctionType>()) {
+          updatedBindings.insert(binding.withType(fnType));
+        }
       }
 
       // Note that even though key path literal maybe be invalid it's

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -304,3 +304,17 @@ func test_invalid_argument_to_keypath_subscript() {
     // expected-error@-1 {{cannot use value of type 'A' as a key path subscript index; argument must be a key path}}
   }
 }
+
+extension Collection {
+  func prefix<R: RangeExpression>(
+    _ range: R,
+    while predicate: ((Element) -> Bool)? = nil
+  ) -> SubSequence where R.Bound == Self.Index {
+    fatalError()
+  }
+}
+
+// https://github.com/apple/swift/issues/56393
+func keypathToFunctionWithOptional() {
+  _ = Array("").prefix(1...4, while: \.isNumber) // Ok
+}


### PR DESCRIPTION
… key path type

The key path is going to be implicitly wrapped into a contextual optional type.

Resolves: rdar://72864716
Resolves: https://github.com/apple/swift/issues/56393

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
