### PR TITLE
[CMake] Force bootstrapping to HOSTTOOLS if the new parser is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,11 +895,13 @@ elseif(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS" OR SWIFT_BUILD_SWIFT_SYNTAX)
 endif()
 
 if(SWIFT_INCLUDE_TOOLS AND SWIFT_BUILD_SWIFT_SYNTAX)
-  # Only "HOSTTOOLS" is supported in Linux when Swift parser integration is enabled.
-  if(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|OPENBSD|FREEBSD" AND NOT BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+  # HOSTTOOLS is the only supported configuration when Swift parser integration
+  # is enabled.
+  if(NOT BOOTSTRAPPING_MODE STREQUAL "OFF" AND NOT BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
     message(WARNING "Force setting BOOTSTRAPPING=HOSTTOOLS because Swift parser integration is enabled")
     set(BOOTSTRAPPING_MODE "HOSTTOOLS")
   endif()
+
   add_definitions(-DSWIFT_BUILD_SWIFT_SYNTAX)
 endif()
 

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -16,8 +16,6 @@
 
 // -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts
-// rdar://116686158
-// UNSUPPORTED: asan
 
 // NB: Ridiculous formatting to test that we do not include leading trivia in locations.
 

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -2,8 +2,6 @@
 
 // -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts
-// rdar://116686158
-// UNSUPPORTED: asan
 
 protocol P { }
 protocol Q { }


### PR DESCRIPTION
We cannot mix building the Swift libs with a host and new compiler. If the new parser is enabled, force to host tools.

Resolves rdar://116686158.