### PR TITLE
[embedded] Mark all functions as 'nounwind' in embedded Swift, add dependency tests

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1445,8 +1445,9 @@ void IRGenModule::constructInitialFnAttributes(
     Attrs.addAttribute("stack-protector-buffer-size", llvm::utostr(8));
   }
 
-  if (Context.LangOpts.hasFeature(Feature::Embedded) &&
-      !Context.LangOpts.EnableCXXInterop) {
+  // Mark as 'nounwind' to avoid referencing exception personality symbols, this
+  // is okay even with C++ interop on because the landinpads are trapping.
+  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
     Attrs.addAttribute(llvm::Attribute::NoUnwind);
   }
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1445,7 +1445,8 @@ void IRGenModule::constructInitialFnAttributes(
     Attrs.addAttribute("stack-protector-buffer-size", llvm::utostr(8));
   }
 
-  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+  if (Context.LangOpts.hasFeature(Feature::Embedded) &&
+      !Context.LangOpts.EnableCXXInterop) {
     Attrs.addAttribute(llvm::Attribute::NoUnwind);
   }
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1444,6 +1444,10 @@ void IRGenModule::constructInitialFnAttributes(
     Attrs.addAttribute(llvm::Attribute::StackProtectReq);
     Attrs.addAttribute("stack-protector-buffer-size", llvm::utostr(8));
   }
+
+  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+    Attrs.addAttribute(llvm::Attribute::NoUnwind);
+  }
 }
 
 llvm::AttributeList IRGenModule::constructInitialAttributes() {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1846,8 +1846,9 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
     CurFn->addFnAttr(llvm::Attribute::NoInline);
   }
 
-  if (IGM.Context.LangOpts.hasFeature(Feature::Embedded) &&
-      !IGM.Context.LangOpts.EnableCXXInterop) {
+  // Mark as 'nounwind' to avoid referencing exception personality symbols, this
+  // is okay even with C++ interop on because the landinpads are trapping.
+  if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
     CurFn->addFnAttr(llvm::Attribute::NoUnwind);
   }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1846,7 +1846,8 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
     CurFn->addFnAttr(llvm::Attribute::NoInline);
   }
 
-  if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+  if (IGM.Context.LangOpts.hasFeature(Feature::Embedded) &&
+      !IGM.Context.LangOpts.EnableCXXInterop) {
     CurFn->addFnAttr(llvm::Attribute::NoUnwind);
   }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1846,6 +1846,10 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
     CurFn->addFnAttr(llvm::Attribute::NoInline);
   }
 
+  if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+    CurFn->addFnAttr(llvm::Attribute::NoUnwind);
+  }
+
   auto optMode = f->getOptimizationMode();
   if (optMode != OptimizationMode::NotSet &&
       optMode != f->getModule().getOptions().OptMode) {

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded %s -c -o %t/a.o
+
+// backslash is not doing anything, just to make the grep not match its own line
+// RUN: grep DEP-%target-os %s | sed 's#// DEP-%target-os: ##' | sort > %t/expected-dependencies.txt
+// RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.out | sort > %t/actual-dependencies.txt
+// RUN: diff -u %t/expected-dependencies.txt %t/actual-dependencies.txt
+
+// DEP-macosx: ___stack_chk_fail
+// DEP-macosx: ___stack_chk_guard
+// DEP-macosx: _free
+// DEP-macosx: _posix_memalign
+// DEP-macosx: _printf
+// DEP-macosx: _putchar
+// DEP-macosx: dyld_stub_binder
+
+// DEP-linux-gnu: __stack_chk_fail
+// DEP-linux-gnu: __stack_chk_guard
+// DEP-linux-gnu: free
+// DEP-linux-gnu: posix_memalign
+// DEP-linux-gnu: putchar
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+@_silgen_name("putchar")
+func putchar(_: UInt8)
+
+public func print(_ s: StaticString, terminator: StaticString = "\n") {
+  var p = s.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+  p = terminator.utf8Start
+  while p.pointee != 0 {
+    putchar(p.pointee)
+    p += 1
+  }
+}
+
+print("Hello Embedded Swift!") // CHECK: Hello Embedded Swift!

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -1,5 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded %s -c -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
 
 // backslash is not doing anything, just to make the grep not match its own line
 // RUN: grep DEP-%target-os %s | sed 's#// DEP-%target-os: ##' | sort > %t/expected-dependencies.txt

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -2,6 +2,10 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded %s -c -o %t/a.o
 
 // RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
+
+// Linux/ELF doesn't use the "_" prefix in symbol mangling.
+// RUN: if [ %target-os == "linux-gnu" ]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
+
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
 // Fail if there is any entry in actual-dependencies.txt that's not in allowed-dependencies.txt


### PR DESCRIPTION
Currently, some (not all) IRGen'd functions end up emiting unwind info and referencing exception personality symbols, both of which is undesirable in embedded Swift. Let's mark all functions an NoUnwind and let's add a test that checks that a simple embedded Swift program in Mach-O and ELF files has exactly the expected dependencies.