### PR TITLE
[CMake] Fix SWIFT_TARGET redefinition warning

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -272,7 +272,6 @@ else()
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp.tmp"
        "
 #define COMPILED_WITH_SWIFT
-#define SWIFT_TARGET
 
 #include \"Basic/BasicBridging.h\"
 #include \"SIL/SILBridging.h\"


### PR DESCRIPTION
`HeaderDependencies.cpp` is (as in the name) C++, which means it receives `-DSWIFT_TARGET` from the top level `add_definitions`. No need to add it again.