### PR TITLE
[cxx-interop] Allow imported subscript to have generic parameters.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6865,7 +6865,9 @@ public:
                                        SourceLoc SubscriptLoc,
                                        ParameterList *Indices,
                                        SourceLoc ArrowLoc, Type ElementTy,
-                                       DeclContext *Parent, ClangNode ClangN);
+                                       DeclContext *Parent,
+                                       GenericParamList *GenericParams,
+                                       ClangNode ClangN);
   
   /// \returns the way 'static'/'class' was spelled in the source.
   StaticSpellingKind getStaticSpelling() const {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2644,17 +2644,12 @@ public:
         abort();
       }
 
-      // FIXME: Workaround for invalid AST for imported C++ templates.
-      if (!var->hasClangNode()) {
-        // If we are performing pack iteration, variables have to carry the
-        // generic environment. Catching the missing environment here will prevent
-        // the code from being lowered.
-        if (var->getTypeInContext()->is<ErrorType>()) {
-          Out << "VarDecl is missing a Generic Environment: ";
-          var->getInterfaceType().print(Out);
-          Out << "\n";
-          abort();
-        }
+      // Catch cases where there's a missing generic environment.
+      if (var->getTypeInContext()->is<ErrorType>()) {
+        Out << "VarDecl is missing a Generic Environment: ";
+        var->getInterfaceType().print(Out);
+        Out << "\n";
+        abort();
       }
 
       // The fact that this is *directly* be a reference storage type

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8831,6 +8831,7 @@ SubscriptDecl *SubscriptDecl::createImported(ASTContext &Context, DeclName Name,
                                              ParameterList *Indices,
                                              SourceLoc ArrowLoc, Type ElementTy,
                                              DeclContext *Parent,
+                                             GenericParamList *GenericParams,
                                              ClangNode ClangN) {
   assert(ClangN && ElementTy);
   auto *DeclPtr = allocateMemoryForDecl<SubscriptDecl>(
@@ -8839,7 +8840,7 @@ SubscriptDecl *SubscriptDecl::createImported(ASTContext &Context, DeclName Name,
   auto *const SD = ::new (DeclPtr)
       SubscriptDecl(Name, SourceLoc(), StaticSpellingKind::None, SubscriptLoc,
                     Indices, ArrowLoc, /*ElementTyR=*/nullptr, Parent,
-                    /*GenericParams=*/nullptr);
+                    GenericParams);
   SD->setElementInterfaceType(ElementTy);
   SD->setClangNode(ClangN);
   return SD;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7151,6 +7151,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
                                                         name, decl->getLoc(),
                                                         bodyParams, decl->getLoc(),
                                                         elementTy, dc,
+                                                        /*genericParams=*/nullptr,
                                                         getter->getClangNode());
 
   bool IsObjCDirect = false;

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1683,7 +1683,8 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
 
   SubscriptDecl *subscript = SubscriptDecl::createImported(
       ctx, name, getterImpl->getLoc(), bodyParams, getterImpl->getLoc(),
-      elementTy, dc, getterImpl->getClangNode());
+      elementTy, dc, getterImpl->getGenericParams(),
+      getterImpl->getClangNode());
   subscript->setAccess(AccessLevel::Public);
 
   AccessorDecl *getterDecl = AccessorDecl::create(

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -151,7 +151,7 @@
 // CHECK-NEXT: }
 
 // CHECK: struct TemplatedOperatorArrayByVal {
-// CHECK:   subscript(i: T) -> T { mutating get }
+// CHECK:   subscript<T>(i: T) -> T { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscriptConst<T>(_ i: T) -> T
 // CHECK-NOT: mutating func __operatorPlus<T>(_ i: T) -> UnsafeMutablePointer<T>


### PR DESCRIPTION
Subscripts imported from C++ can have generic parameter lists, but the Clang Importer was assuming that imported subscripts always have a null generic parameter list. Propagate generic parameters from the getter in `SwiftDeclSynthesizer`.

Thanks to @simanerush for adding the ASTVerifier change that surfaced this bug!

Resolves rdar://119406160, https://github.com/apple/swift/issues/70328