### PR TITLE
[Debug] Conditional _DebugDescription macro declaration

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -12,7 +12,7 @@
 
 import SwiftShims
 
-// Swift can be built without swift-syntax, which disables macros support.
+// Macros are disabled when Swift is built without swift-syntax.
 #if $Macros && hasAttribute(attached)
 
 /// Converts description definitions to a debugger type summary.

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -12,6 +12,7 @@
 
 import SwiftShims
 
+// Swift can be built without swift-syntax, which disables macros support.
 #if $Macros && hasAttribute(attached)
 
 /// Converts description definitions to a debugger type summary.

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -12,6 +12,8 @@
 
 import SwiftShims
 
+#if $Macros && hasAttribute(attached)
+
 /// Converts description definitions to a debugger type summary.
 ///
 /// This macro converts compatible `debugDescription` (or `description`)
@@ -41,6 +43,8 @@ public macro _DebugDescription() =
 @attached(peer, names: named(_lldb_summary))
 public macro _DebugDescriptionProperty(_ debugIdentifier: String, _ computedProperties: [String]) =
   #externalMacro(module: "SwiftMacros", type: "_DebugDescriptionPropertyMacro")
+
+#endif
 
 #if SWIFT_ENABLE_REFLECTION
 


### PR DESCRIPTION
Make `_DebugDescription` macro conditional upon macro availability in the build.

The `Macros` feature is based on the value of `SWIFT_BUILD_SWIFT_SYNTAX`.

See https://github.com/apple/swift/pull/69626#issuecomment-1848221971