### PR TITLE
AST: DeclExportabilityVisitor fixes

### DIFF
--- a/include/swift/AST/DeclExportabilityVisitor.h
+++ b/include/swift/AST/DeclExportabilityVisitor.h
@@ -150,7 +150,6 @@ public:
   }
   UNREACHABLE(Module);
   UNREACHABLE(TopLevelCode);
-  UNREACHABLE(PoundDiagnostic);
   UNREACHABLE(Missing);
   UNREACHABLE(MissingMember);
   UNREACHABLE(GenericTypeParam);
@@ -168,6 +167,7 @@ public:
   bool visit##KIND##Decl(const KIND##Decl *D) { return true; }
   UNINTERESTING(IfConfig);
   UNINTERESTING(Import);
+  UNINTERESTING(PoundDiagnostic);
   UNINTERESTING(PrecedenceGroup);
   UNINTERESTING(EnumCase);
   UNINTERESTING(Operator);

--- a/include/swift/AST/DeclExportabilityVisitor.h
+++ b/include/swift/AST/DeclExportabilityVisitor.h
@@ -153,7 +153,6 @@ public:
   UNREACHABLE(PoundDiagnostic);
   UNREACHABLE(Missing);
   UNREACHABLE(MissingMember);
-  UNREACHABLE(MacroExpansion);
   UNREACHABLE(GenericTypeParam);
   UNREACHABLE(Param);
 
@@ -172,6 +171,7 @@ public:
   UNINTERESTING(PrecedenceGroup);
   UNINTERESTING(EnumCase);
   UNINTERESTING(Operator);
+  UNINTERESTING(MacroExpansion);
 
 #undef UNINTERESTING
 };

--- a/include/swift/AST/DeclExportabilityVisitor.h
+++ b/include/swift/AST/DeclExportabilityVisitor.h
@@ -149,7 +149,6 @@ public:
     return true;                                                               \
   }
   UNREACHABLE(Module);
-  UNREACHABLE(TopLevelCode);
   UNREACHABLE(Missing);
   UNREACHABLE(MissingMember);
   UNREACHABLE(GenericTypeParam);
@@ -165,6 +164,7 @@ public:
   // context has already been checked.
 #define UNINTERESTING(KIND)                                                    \
   bool visit##KIND##Decl(const KIND##Decl *D) { return true; }
+  UNINTERESTING(TopLevelCode);
   UNINTERESTING(IfConfig);
   UNINTERESTING(Import);
   UNINTERESTING(PoundDiagnostic);

--- a/test/Macros/skip_non_exportable_decls.swift
+++ b/test/Macros/skip_non_exportable_decls.swift
@@ -1,0 +1,17 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
+
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/freestanding_macro_library.swiftmodule %S/Inputs/freestanding_macro_library.swift -module-name freestanding_macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
+
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -load-plugin-library %t/%target-library-name(MacroDefinition) %s -module-name MacroUser -experimental-skip-non-exportable-decls | %FileCheck %s
+
+@freestanding(declaration)
+macro anonymousTypes(public: Bool = false, causeErrors: Bool = false, _: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
+
+// CHECK: sil @$s9MacroUser03$s9A70User33_B2D49A1BE4DC7AF5CC327EB8EE2214BDLl14anonymousTypesfMf_4namefMu_C5helloSSyF : $@convention(method) (@guaranteed $s9MacroUser33_B2D49A1BE4DC7AF5CC327EB8EE2214BDLl14anonymousTypesfMf_4namefMu_) -> @owned String {
+#anonymousTypes(public: true) { "hello" }
+
+// CHECK-NOT: s9MacroUser03$s9A71User33_B2D49A1BE4DC7AF5CC327EB8EE2214BDLl14anonymousTypesfMf_4namefMu0_O5helloSSyF
+#anonymousTypes(public: false) { "goodbye" }

--- a/test/SILGen/skip_non_exportable_decls.swift
+++ b/test/SILGen/skip_non_exportable_decls.swift
@@ -4,6 +4,8 @@
 
 import Swift
 
+#warning("!")
+
 // CHECK-NO-SKIP: sil_global private @$s4Test17internalGlobalVar_Wz : $Builtin.Word
 // CHECK-SKIP-NOT: s4Test17internalGlobalVar_Wz
 

--- a/test/SILGen/skip_non_exportable_decls_top_level.swift
+++ b/test/SILGen/skip_non_exportable_decls_top_level.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-silgen %s -module-name Test | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-SKIP
+// RUN: %target-swift-frontend -emit-silgen %s -module-name Test -experimental-skip-non-exportable-decls | %FileCheck %s --check-prefixes=CHECK,CHECK-SKIP
+
+// CHECK-NO-SKIP: sil_global hidden @$s4Test1xSivp : $Int
+// CHECK-SKIP: sil_global hidden_external @$s4Test1xSivp : $Int
+var x = foo()
+
+// CHECK-NO-SKIP: sil hidden{{.*}} @$s4Test3fooSiyF : $@convention(thin) () -> Int {
+// CHECK-SKIP: sil hidden_external @$s4Test3fooSiyF : $@convention(thin) () -> Int
+func foo() -> Int { return 1 }


### PR DESCRIPTION
`DeclExportabilityVisitor` wasn't handling macro expansion, pound diagnostics, and top-level code declarations which lead to crashes when emitting SIL with `-experimental-skip-non-exportable-decls` for some modules.

Resolves rdar://119449439