### PR TITLE
Rename instances of “OS X” to “macOS”

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,7 @@ set(SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR "@rpath" CACHE STRING
     "The directory of the install_name for the private standard library dylibs")
 
 set(SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX "10.13" CACHE STRING
-    "Minimum deployment target version for OS X")
+    "Minimum deployment target version for macOS")
 
 set(SWIFT_DARWIN_DEPLOYMENT_VERSION_IOS "11.0" CACHE STRING
     "Minimum deployment target version for iOS")

--- a/docs/CToSwiftNameTranslation.md
+++ b/docs/CToSwiftNameTranslation.md
@@ -55,7 +55,7 @@ enum TimeOfDay __attribute__((enum_extensibility(open))) : long {
 - Case names follow the rules for "enum-style prefix stripping" below.
 - `init?(rawValue:)` currently does not check cases, but probably should for "closed" enums (Clang's equivalent of `@frozen`)
 
-In order to deal with cases with the same underlying value, the importer picks a set of _canonical cases_ by walking the enum and recording the first *available* enumerator with a particular value. (Note that deprecated cases are still considered available unless they were deprecated for a platform older than Swift's earliest deployment targets, OS X 10.9 and iOS 7.) Any "non-canonical" cases are imported as computed properties instead.
+In order to deal with cases with the same underlying value, the importer picks a set of _canonical cases_ by walking the enum and recording the first *available* enumerator with a particular value. (Note that deprecated cases are still considered available unless they were deprecated for a platform older than Swift's earliest deployment targets, macOS 10.9 and iOS 7.) Any "non-canonical" cases are imported as computed properties instead.
 
 ### Error enum structs
 

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -735,7 +735,7 @@ likely, we'd need to wrap them all in an overlay.
 
 In both cases, it is possible to pull these into the Swift error
 handling model, but because this is likely to require massive SDK
-annotations it is considered out of scope for iOS 9/OS X 10.11 & Swift
+annotations it is considered out of scope for iOS 9/macOS 10.11 & Swift
 2.0.
 
 ### Unexpected and universal errors

--- a/docs/LibraryEvolutionManifesto.md
+++ b/docs/LibraryEvolutionManifesto.md
@@ -183,13 +183,13 @@ There's no design yet for how resilience domains should be specified. In today's
 
 ### Deployments
 
-Related to the concept of a resilience domain is a _deployment._ While a resilience domain allows related libraries to be compiled more efficiently, a deployment groups related libraries together to present semantic version information to clients. The simplest example of this might be an OS release: OS X 10.10.0 contains Foundation version 1151.16 and AppKit version 1343. A deployment thus acts as a "virtual dependency": clients that depend on OS X 10.10 can rely on the presence of both of the library versions above.
+Related to the concept of a resilience domain is a _deployment._ While a resilience domain allows related libraries to be compiled more efficiently, a deployment groups related libraries together to present semantic version information to clients. The simplest example of this might be an OS release: macOS 10.10.0 contains Foundation version 1151.16 and AppKit version 1343. A deployment thus acts as a "virtual dependency": clients that depend on macOS 10.10 can rely on the presence of both of the library versions above.
 
 The use of deployments allows clients to only have to think about aggregate dependencies, instead of listing every library they might depend on. It also allows library authors to build [many versions of a library][Foundation version numbers] within a larger release cycle, as well as allowing a vendor to bundle together many libraries with uncoordinated release schedules and release them as a logical unit.
 
 [Foundation version numbers]:  https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Constants/index.html#//apple_ref/doc/constant_group/Foundation_Framework_Version_Numbers		
 
-There are lots of details to figure out here, including how to distribute this information. In particular, just like libraries publish the history of their own APIs, a deployment must publish the history of their included library versions, i.e. not just that OS X 10.10 contains Foundation 1151.16 and AppKit 1343, but also that OS X 10.9 contains Foundation 1056 and AppKit 1265, and that OS X 10.8 contains Foundation 945.0 and AppKit 1187, and so on, back to the earliest version of the deployment that is supported.
+There are lots of details to figure out here, including how to distribute this information. In particular, just like libraries publish the history of their own APIs, a deployment must publish the history of their included library versions, i.e. not just that macOS 10.10 contains Foundation 1151.16 and AppKit 1343, but also that macOS 10.9 contains Foundation 1056 and AppKit 1265, and that macOS 10.8 contains Foundation 945.0 and AppKit 1187, and so on, back to the earliest version of the deployment that is supported.
 
 Obviously, formalizing a model here is probably most useful for people distributing ABI-stable Swift libraries as part of an OS, i.e. Apple.
 

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -374,7 +374,7 @@ to explicitly specify them at link time.
 of headers. See [Clang's Modules](http://clang.llvm.org/docs/Modules.html) documentation for more
 information.
 
-[^framework]: A mechanism for library distribution on OS X. Traditionally 
+[^framework]: A mechanism for library distribution on macOS. Traditionally 
 frameworks contain header files describing the library's API, a binary file containing
 the implementation, and a directory containing any resources the
 library may need. Frameworks are also used on iOS, but as of iOS 7 custom frameworks

--- a/docs/archive/Objective-CInteroperability.rst
+++ b/docs/archive/Objective-CInteroperability.rst
@@ -72,7 +72,7 @@ isa, and any methods declared in an Objective-C protocol will be emitted with
 dual entry points.
 
 
-.. [#] Really, "All Swift objects on OS X and iOS". Presumably a Swift compiler
+.. [#] Really, "All Swift objects on macOS and iOS". Presumably a Swift compiler
    on another system wouldn't bother to emit the Objective-C isa info.
 .. [#] Dave is working out an object and class layout scheme that will minimize
    the performance cost of emitting both the Objective-C isa and a Swift vtable.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1839,11 +1839,11 @@ public:
 /// example, given the following declaration:
 ///
 /// \code
-/// @_originallyDefinedIn(module: "Original", OSX 10.15) var foo: Int
+/// @_originallyDefinedIn(module: "Original", macOS 10.15) var foo: Int
 /// \endcode
 ///
 /// The variable \p foo was originally defined in another module called
-/// \p Original prior to OSX 10.15
+/// \p Original prior to macOS 10.15
 class OriginallyDefinedInAttr: public DeclAttribute {
 public:
   OriginallyDefinedInAttr(SourceLoc AtLoc, SourceRange Range,

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -56,7 +56,7 @@ public:
 };
 
 /// An availability specification that guards execution based on the
-/// run-time platform and version, e.g., OS X >= 10.10.
+/// run-time platform and version, e.g., macOS >= 10.10.
 class PlatformVersionConstraintAvailabilitySpec : public AvailabilitySpec {
   PlatformKind Platform;
   SourceLoc PlatformLoc;

--- a/include/swift/AST/PlatformConditionKinds.def
+++ b/include/swift/AST/PlatformConditionKinds.def
@@ -22,7 +22,7 @@
 #define PLATFORM_CONDITION_(LABEL, IDENTIFIER) PLATFORM_CONDITION(LABEL, "_" IDENTIFIER)
 #endif
 
-/// The active os target (OSX, iOS, Linux, etc.)
+/// The active os target (macOS, iOS, Linux, etc.)
 PLATFORM_CONDITION(OS, "os")
 
 /// The active arch target (x86_64, i386, arm, arm64, etc.)

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -53,10 +53,10 @@ StringRef prettyPlatformString(PlatformKind platform);
 
 /// Returns whether the passed-in platform is active, given the language
 /// options. A platform is active if either it is the target platform or its
-/// AppExtension variant is the target platform. For example, OS X is
-/// considered active when the target operating system is OS X and app extension
-/// restrictions are enabled, but OSXApplicationExtension is not considered
-/// active when the target platform is OS X and app extension restrictions are
+/// AppExtension variant is the target platform. For example, macOS is
+/// considered active when the target operating system is macOS and app extension
+/// restrictions are enabled, but macOSApplicationExtension is not considered
+/// active when the target platform is macOS and app extension restrictions are
 /// disabled. PlatformKind::none is always considered active.
 /// If ForTargetVariant is true then for zippered builds the target-variant
 /// triple will be used rather than the target to determine whether the

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -389,7 +389,7 @@ public:
   
 /// An expression that guards execution based on whether the run-time
 /// configuration supports a given API, e.g.,
-/// #available(OSX >= 10.9, iOS >= 7.0).
+/// #available(macOS >= 10.9, iOS >= 7.0).
 class alignas(8) PoundAvailableInfo final :
     private llvm::TrailingObjects<PoundAvailableInfo, AvailabilitySpec *> {
   friend TrailingObjects;

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -69,7 +69,7 @@ namespace swift {
   /// Returns the platform name for a given target triple.
   ///
   /// For example, the iOS simulator has the name "iphonesimulator", while real
-  /// iOS uses "iphoneos". OS X is "macosx". (These names are intended to be
+  /// iOS uses "iphoneos". macOS is "macosx". (These names are intended to be
   /// compatible with Xcode's SDKs.)
   ///
   /// If the triple does not correspond to a known platform, the empty string is

--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -38,7 +38,7 @@ struct HeapObject;
 
 // Redeclare APIs from the Objective-C runtime.
 // These functions are not available through public headers, but are guaranteed
-// to exist on OS X >= 10.9 and iOS >= 7.0.
+// to exist on macOS >= 10.9 and iOS >= 7.0.
 
 OBJC_EXPORT id objc_retain(id);
 OBJC_EXPORT void objc_release(id);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -500,10 +500,10 @@ static bool isShortFormAvailabilityImpliedByOther(const AvailableAttr *Attr,
 /// Print the short-form @available() attribute for an array of long-form
 /// AvailableAttrs that can be represented in the short form.
 /// For example, for:
-///   @available(OSX, introduced: 10.10)
+///   @available(macOS, introduced: 10.10)
 ///   @available(iOS, introduced: 8.0)
 /// this will print:
-///   @available(OSX 10.10, iOS 8.0, *)
+///   @available(macOS 10.10, iOS 8.0, *)
 static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
                                     ASTPrinter &Printer,
                                     const PrintOptions &Options,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -555,7 +555,7 @@ importer::getNormalInvocationArguments(
   // Set C language options.
   if (triple.isOSDarwin()) {
     invocationArgStrs.insert(invocationArgStrs.end(), {
-      // Avoid including the iso646.h header because some headers from OS X
+      // Avoid including the iso646.h header because some headers from macOS
       // frameworks are broken by it.
       "-D_ISO646_H_", "-D__ISO646_H",
 

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -138,7 +138,7 @@ void EnumInfo::classifyEnum(const clang::EnumDecl *decl,
     }
   }
 
-  // Hardcode a particular annoying case in the OS X headers.
+  // Hardcode a particular annoying case in the macOS headers.
   if (decl->getName() == "DYLD_BOOL") {
     kind = EnumKind::FrozenEnum;
     return;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -998,10 +998,10 @@ bool Parser::parseAvailability(
     // For each platform version spec in the spec list, create an
     // implicit AvailableAttr for the platform with the introduced
     // version from the spec. For example, if we have
-    //   @available(iOS 8.0, OSX 10.10, *):
+    //   @available(iOS 8.0, macOS 10.10, *):
     // we will synthesize:
     //  @available(iOS, introduced: 8.0)
-    //  @available(OSX, introduced: 10.10)
+    //  @available(macOS, introduced: 10.10)
     //
     // Similarly if we have a language version spec or PackageDescription
     // version in the spec list, create an implicit AvailableAttr
@@ -3467,7 +3467,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         }
         return makeParserSuccess();
       }
-      // Parse 'OSX 13.13'.
+      // Parse 'macOS 13.13'.
       case NextSegmentKind::PlatformVersion: {
         ParserStatus ListItemStatus =
             parsePlatformVersionInList(AttrName, PlatformAndVersions);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1369,7 +1369,7 @@ validateAvailabilitySpecList(Parser &P,
     if (!Inserted) {
       // Rule out multiple version specs referring to the same platform.
       // For example, we emit an error for
-      /// #available(OSX 10.10, OSX 10.11, *)
+      /// #available(macOS 10.10, macOS 10.11, *)
       PlatformKind Platform = VersionSpec->getPlatform();
       P.diagnose(VersionSpec->getPlatformLoc(),
                  diag::availability_query_repeated_platform,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1174,9 +1174,9 @@ private:
         continue;
 
       // FIXME: This is not quite right: we want to handle AppExtensions
-      // properly. For example, on the OSXApplicationExtension platform
-      // we want to chose the OS X spec unless there is an explicit
-      // OSXApplicationExtension spec.
+      // properly. For example, on the macOSApplicationExtension platform
+      // we want to chose the macOS spec unless there is an explicit
+      // macOSApplicationExtension spec.
       if (isPlatformActive(VersionSpec->getPlatform(), Context.LangOpts,
                            forTargetVariant)) {
         if (!BestSpec ||

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -398,7 +398,7 @@ public typealias Semaphore = UnsafeMutablePointer<sem_t>
 /// The value returned by `sem_open()` in the case of failure.
 public var SEM_FAILED: Semaphore? {
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-  // The value is ABI.  Value verified to be correct for OS X, iOS, watchOS, tvOS.
+  // The value is ABI.  Value verified to be correct for macOS, iOS, watchOS, tvOS.
   return Semaphore(bitPattern: -1)
 #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku) || os(WASI)
   // The value is ABI.  Value verified to be correct on Glibc.


### PR DESCRIPTION
This is a reworking of #12674, as rebasing became a bit of a dead end. 

Here is @graydon's original PR description: 

It's been pointed out that swiftc still uses 'OSX' or 'OS X' in a lot of places it ought to be saying 'macOS' now. This change switches many, but not all, of those cases. In particular it fixes those cases where the compiler gives feedback about availability guards (the original report was about these) as well as switching internal symbols and docs.

Notably: this change does not eliminate support for 'OSX' in availability checks (it's still a synonym) nor does it change all of the tests that use 'OSX' in those checks; I figured there was no point since the synonym is likely to be supported in perpetuity and it's good to test that fact too. Moreover this change does not alter the terminology in any of the configury or build system; it's my hope that by avoiding that, I can avoid unintentional breakage, though I suspect I'll still be breaking something.

Opinions welcome on how else to stage this.

rdar://35127522

Resolves #54205.