### PR TITLE
[Runtime] Use malloc_type_posix_memalign().

### DIFF
--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -104,7 +104,13 @@ void *swift::swift_slowAllocTyped(size_t size, size_t alignMask,
       p = malloc_type_malloc(size, typeId);
     } else {
       size_t alignment = computeAlignment(alignMask);
-      p = malloc_type_aligned_alloc(alignment, size, typeId);
+
+      // Do not use malloc_type_aligned_alloc() here, because we want this
+      // to work if `size` is not an integer multiple of `alignment`, which
+      // was a requirement of the latter in C11 (but not C17 and later).
+      int err = malloc_type_posix_memalign(&p, alignment, size);
+      if (err != 0)
+        p = nullptr;
     }
     if (!p) swift::crash("Could not allocate memory.");
     return p;

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -106,6 +106,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     Metadata.cpp
     Enum.cpp
     ExtendedExistential.cpp
+    Heap.cpp
     Refcounting.cpp
     Stdlib.cpp
     StackAllocator.cpp

--- a/unittests/runtime/Heap.cpp
+++ b/unittests/runtime/Heap.cpp
@@ -1,0 +1,72 @@
+//===--- Heap.cpp - Heap tests --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Heap.h"
+
+#include "gtest/gtest.h"
+
+void shouldAlloc(size_t size, size_t alignMask) {
+  void *ptr = swift::swift_slowAlloc(size, alignMask);
+  EXPECT_NE(ptr, (void *)NULL)
+    << "Allocation failed for size " << size << " and alignment mask "
+    << alignMask << ".";
+  swift::swift_slowDealloc(ptr, size, alignMask);
+}
+
+void shouldAlloc(size_t size) {
+  shouldAlloc(size, 0);
+  shouldAlloc(size, 1);
+  shouldAlloc(size, 3);
+  shouldAlloc(size, 7);
+  shouldAlloc(size, 15);
+  shouldAlloc(size, 31);
+  shouldAlloc(size, 63);
+  shouldAlloc(size, 4095);
+}
+
+TEST(HeapTest, slowAlloc) {
+  shouldAlloc(1);
+  shouldAlloc(8);
+  shouldAlloc(32);
+  shouldAlloc(1093);
+}
+
+void shouldAllocTyped(size_t size, size_t alignMask, swift::MallocTypeId typeId) {
+  void *ptr = swift::swift_slowAllocTyped(size, alignMask, typeId);
+  EXPECT_NE(ptr, (void *)NULL)
+    << "Typed allocation failed for size " << size << " and alignment mask "
+    << alignMask << ".";
+  swift::swift_slowDealloc(ptr, size, alignMask);
+}
+
+void shouldAllocTyped(size_t size, swift::MallocTypeId typeId) {
+  shouldAlloc(size, 0);
+  shouldAlloc(size, 1);
+  shouldAlloc(size, 3);
+  shouldAlloc(size, 7);
+  shouldAlloc(size, 15);
+  shouldAlloc(size, 31);
+  shouldAlloc(size, 63);
+  shouldAlloc(size, 4095);
+}
+
+void shouldAllocTyped(size_t size) {
+  shouldAllocTyped(size, 42);
+}
+
+TEST(HeapTest, slowAllocTyped) {
+  shouldAllocTyped(1);
+  shouldAllocTyped(8);
+  shouldAllocTyped(32);
+  shouldAllocTyped(1093);
+}
+


### PR DESCRIPTION
We can't use `malloc_type_aligned_alloc()` because `aligned_alloc()` requires that `size` be a multiple of `alignment`, which isn't something we expect here.

rdar://119137861
