### PR TITLE
[Parse] Restore accidentally deleted code

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7958,6 +7958,9 @@ void Parser::parseTopLevelAccessors(
     consumeTokenWithoutFeedingReceiver();
 
   ParameterList *indices = nullptr;
+  if (auto subscript = dyn_cast<SubscriptDecl>(storage))
+    indices = subscript->getIndices();
+
   bool hadLBrace = consumeIf(tok::l_brace);
 
   // Prepopulate the field for any accessors that were already parsed parsed accessors


### PR DESCRIPTION
I accidentally deleted this in #70326, restore it. I would add a test, but unfortunately it seems there are a couple of other issues with accessor macros on subscripts (#70368, #70369).