### PR TITLE
[C++20] Make `operator==` const.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -128,7 +128,7 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
     uint16_t Column = 0;
     llvm::DIFile *File = nullptr;
     StringRef getFilename() const { return File ? File->getFilename() : ""; }
-    bool operator==(const FileAndLocation &other) {
+    bool operator==(const FileAndLocation &other) const {
       return Line == other.Line && Column == other.Column && File == other.File;
     }
   };


### PR DESCRIPTION
C++20 considers calls to `operator==` ambiguous with calls that have the arguments reversed if the argument is const but `this` is not.
