### PR TITLE
AST: fix isEscapable in case the experimental feature NoncopyableGenerics is _not_ enabled

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -214,7 +214,7 @@ bool TypeBase::isEscapable(const DeclContext *dc) {
     if (auto nom = canType.getAnyNominal())
       return nom->isEscapable();
     else
-      return false;
+      return true;
   }
 
   IsEscapableRequest request{canType};

--- a/test/embedded/FixedArray.swift
+++ b/test/embedded/FixedArray.swift
@@ -12,9 +12,6 @@
 // REQUIRES: VENDOR=apple
 // REQUIRES: OS=macosx
 
-
-// REQUIRES: needsfixing
-
 func simpleStackAllocated() {
   var a = FixedArray<Int>(capacity: 10)
   a.append(27)


### PR DESCRIPTION
This fixes the FixedArrays test.
