### PR TITLE
[CSBindings] keypath-to-function conversion should respect sendabilit…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -668,6 +668,14 @@ void BindingSet::finalize(
 
         // Functions don't have capability so we can simply add them.
         if (auto *fnType = bindingTy->getAs<FunctionType>()) {
+          auto extInfo = fnType->getExtInfo();
+
+          bool isKeyPathSendable = capability && capability->second;
+          if (!isKeyPathSendable && extInfo.isSendable()) {
+            fnType = FunctionType::get(fnType->getParams(), fnType->getResult(),
+                                       extInfo.withConcurrent(false));
+          }
+
           updatedBindings.insert(binding.withType(fnType));
         }
       }


### PR DESCRIPTION
…y of the key path

If the underlying key path is not Sendable, the compiler generated closure 
that captures the key path expression (as `{ [$kp$ = ...] in $0[keyPath: $kp$] }`) 
cannot be marked as Sendable either.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
