### PR TITLE
Enable the use of objective-c protocol symbolic references in type metadata encodings

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -537,7 +537,7 @@ public:
         UseTypeLayoutValueHandling(true), ForceStructTypeLayouts(false),
         EnableLayoutStringValueWitnesses(false),
         EnableLayoutStringValueWitnessesInstantiation(false),
-        EnableObjectiveCProtocolSymbolicReferences(false),
+        EnableObjectiveCProtocolSymbolicReferences(true),
         GenerateProfile(false), EnableDynamicReplacementChaining(false),
         DisableDebuggerShadowCopies(false),
         DisableConcreteTypeMetadataMangledNameAccessors(false),

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -590,7 +590,7 @@ ASTContext::getInitRawStructMetadataAvailability() {
 }
 
 AvailabilityContext ASTContext::getObjCSymbolicReferencesAvailability() {
-  return getSwiftFutureAvailability();
+  return getSwift511Availability();
 }
 
 AvailabilityContext ASTContext::getSwift52Availability() {


### PR DESCRIPTION
rdar://111536582