### PR TITLE
[Diagnostics] Add educational notes into serialized diagnostics

### DIFF
--- a/test/diagnostics/educational_notes_serialization.swift
+++ b/test/diagnostics/educational_notes_serialization.swift
@@ -1,0 +1,22 @@
+// not %target-swift-frontend -no-color-diagnostics -print-educational-notes -diagnostic-documentation-path %S/test-docs/ -typecheck %s
+
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck -no-color-diagnostics -print-educational-notes -diagnostic-documentation-path %S/test-docs/ -serialize-diagnostics-path %t/serialized.dia %s
+// RUN: c-index-test -read-diagnostics %t/serialized.dia > %t/serialized.txt 2>&1
+// RUN: %FileCheck %s < %t/serialized.txt
+
+typealias Fn = () -> ()
+extension Fn {}
+// CHECK: [[@LINE-1]]:1: error: non-nominal type 'Fn' (aka '() -> ()') cannot be extended [{{.*}}nominal-types.md] []
+
+
+// Shares the flag record with `Fn`
+typealias Dup = () -> ()
+extension Dup {}
+// CHECK: [[@LINE-1]]:1: error: non-nominal type 'Dup' (aka '() -> ()') cannot be extended [{{.*}}nominal-types.md] []
+
+do {
+  func noNote(_: Int) {}
+  noNote("Hello")
+  // CHECK: [[@LINE-1]]:10: error: cannot convert value of type 'String' to expected argument type 'Int' [] []
+}


### PR DESCRIPTION
Use flag record (currently unused) to emit semi-colon separated list of paths
to educational notes associated with a diagnostic.

Resolves: rdar://118993780

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
