### PR TITLE
[Typed throws] Cleanups for the caught error type computation

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -124,24 +124,6 @@ public:
     return TheFunction.get<AbstractClosureExpr *>()->getType();
   }
 
-  Type getThrownErrorType() const {
-    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
-      if (Type thrownError = AFD->getThrownInterfaceType())
-        return AFD->mapTypeIntoContext(thrownError);
-
-      return Type();
-    }
-
-    Type closureType = TheFunction.get<AbstractClosureExpr *>()->getType();
-    if (!closureType)
-      return Type();
-
-    if (auto closureFnType = closureType->getAs<AnyFunctionType>())
-      return closureFnType->getThrownError();
-
-    return Type();
-  }
-
   Type getBodyResultType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
       if (auto *FD = dyn_cast<FuncDecl>(AFD))

--- a/include/swift/AST/CatchNode.h
+++ b/include/swift/AST/CatchNode.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_CATCHNODE_H
 #define SWIFT_AST_CATCHNODE_H
 
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "swift/AST/Decl.h"
@@ -36,7 +37,14 @@ public:
   /// Returns the thrown error type for a throwing context, or \c llvm::None
   /// if this is a non-throwing context.
   llvm::Optional<Type> getThrownErrorTypeInContext(DeclContext *dc) const;
+
+  friend llvm::hash_code hash_value(CatchNode catchNode) {
+    using llvm::hash_value;
+    return hash_value(catchNode.getOpaqueValue());
+  }
 };
+
+void simple_display(llvm::raw_ostream &out, CatchNode catchNode);
 
 } // end namespace swift
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6989,7 +6989,7 @@ void simple_display(llvm::raw_ostream &out, BodyAndFingerprint value);
 /// Base class for function-like declarations.
 class AbstractFunctionDecl : public GenericContext, public ValueDecl {
   friend class NeedsNewVTableEntryRequest;
-  friend class ThrownTypeRequest;
+  friend class ExplicitCaughtTypeRequest;
 
 public:
   /// records the kind of SILGen-synthesized body this decl represents

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3987,6 +3987,8 @@ public:
 ///     { [weak c] (a : Int) -> Int in a + c!.getFoo() }
 /// \endcode
 class ClosureExpr : public AbstractClosureExpr {
+  friend class ExplicitCaughtTypeRequest;
+
 public:
   enum class BodyState {
     /// The body was parsed, but not ready for type checking because
@@ -4034,7 +4036,7 @@ private:
   /// The location of the "in", if present.
   SourceLoc InLoc;
 
-  /// The explcitly-specified thrown type.
+  /// The explicitly-specified thrown type.
   TypeExpr *ThrownType;
 
   /// The explicitly-specified result type.
@@ -4149,14 +4151,7 @@ public:
   }
 
   /// Retrieve the explicitly-thrown type.
-  Type getExplicitThrownType() const {
-    if (ThrownType)
-      return ThrownType->getInstanceType();
-
-    return nullptr;
-  }
-
-  void setExplicitThrownType(Type thrownType);
+  Type getExplicitThrownType() const;
 
   /// Retrieve the explicitly-thrown type representation.
   TypeRepr *getExplicitThrownTypeRepr() const {

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1387,7 +1387,7 @@ class DoCatchStmt final
     : public LabeledStmt,
       private llvm::TrailingObjects<DoCatchStmt, CaseStmt *> {
   friend TrailingObjects;
-  friend class DoCatchExplicitThrownTypeRequest;
+  friend class ExplicitCaughtTypeRequest;
 
   SourceLoc DoLoc;
 
@@ -1429,13 +1429,13 @@ public:
   SourceLoc getStartLoc() const { return getLabelLocOrKeywordLoc(DoLoc); }
   SourceLoc getEndLoc() const { return getCatches().back()->getEndLoc(); }
 
-  /// Retrieves the type representation for the thrown type.
-  TypeRepr *getThrownTypeRepr() const {
+  /// Retrieves the type representation for the caught type.
+  TypeRepr *getCaughtTypeRepr() const {
     return ThrownType.getTypeRepr();
   }
 
-  // Get the explicitly-specified thrown error type.
-  Type getExplicitlyThrownType(DeclContext *dc) const;
+  // Get the explicitly-specified caught error type.
+  Type getExplicitCaughtType(DeclContext *dc) const;
 
   Stmt *getBody() const { return Body; }
   void setBody(Stmt *s) { Body = s; }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -20,6 +20,7 @@
 #include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/ASTTypeIDs.h"
+#include "swift/AST/CatchNode.h"
 #include "swift/AST/Effects.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/GenericSignature.h"
@@ -2283,10 +2284,16 @@ public:
   void cacheResult(ParamSpecifier value) const;
 };
 
-/// Determines the explicitly-written thrown result type of a function.
-class ThrownTypeRequest
-    : public SimpleRequest<ThrownTypeRequest,
-                           Type(AbstractFunctionDecl *),
+/// Determines the explicitly-written caught result type for any catch node,
+/// including functions/closures and do..catch statements.
+///
+/// Returns the caught result type for the catch node, which will be
+/// `Never` if no error can be thrown from within the context (e.g., a
+/// non-throwing function). Returns a NULL type if the caught error type
+/// requires type inference.
+class ExplicitCaughtTypeRequest
+    : public SimpleRequest<ExplicitCaughtTypeRequest,
+                           Type(DeclContext *, CatchNode),
                            RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2295,28 +2302,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  Type evaluate(Evaluator &evaluator, AbstractFunctionDecl *func) const;
-
-public:
-  // Separate caching.
-  bool isCached() const { return true; }
-  llvm::Optional<Type> getCachedResult() const;
-  void cacheResult(Type value) const;
-};
-
-/// Determines the explicitly-written thrown error type in a do..catch block.
-class DoCatchExplicitThrownTypeRequest
-    : public SimpleRequest<DoCatchExplicitThrownTypeRequest,
-                           Type(DeclContext *, DoCatchStmt *),
-                           RequestFlags::SeparatelyCached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  Type evaluate(Evaluator &evaluator, DeclContext *dc, DoCatchStmt *stmt) const;
+  Type evaluate(Evaluator &evaluator, DeclContext *dc, CatchNode catchNode) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -358,11 +358,8 @@ SWIFT_REQUEST(TypeChecker, NeedsNewVTableEntryRequest,
               bool(AbstractFunctionDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ParamSpecifierRequest,
               ParamDecl::Specifier(ParamDecl *), SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, ThrownTypeRequest,
-              Type(AbstractFunctionDecl *), SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, DoCatchExplicitThrownTypeRequest,
-              Type(DeclContext *, DoCatchStmt *), SeparatelyCached,
-              NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ExplicitCaughtTypeRequest,
+              Type(DeclContext *, CatchNode), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResultTypeRequest,
               Type(ValueDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AreAllStoredPropertiesDefaultInitableRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -979,9 +979,13 @@ bool Decl::preconcurrency() const {
 }
 
 Type AbstractFunctionDecl::getThrownInterfaceType() const {
+  if (!getThrownTypeRepr())
+    return ThrownType.getType();
+
+  auto mutableThis = const_cast<AbstractFunctionDecl *>(this);
   return evaluateOrDefault(
       getASTContext().evaluator,
-      ThrownTypeRequest{const_cast<AbstractFunctionDecl *>(this)},
+      ExplicitCaughtTypeRequest{mutableThis, mutableThis},
       Type());
 }
 
@@ -11736,4 +11740,97 @@ CatchNode::getThrownErrorTypeInContext(DeclContext *dc) const {
   }
 
   llvm_unreachable("Unhandled catch node kind");
+}
+
+void swift::simple_display(llvm::raw_ostream &out, CatchNode catchNode) {
+  out << "catch node";
+}
+
+//----------------------------------------------------------------------------//
+// ExplicitCaughtTypeRequest computation.
+//----------------------------------------------------------------------------//
+bool ExplicitCaughtTypeRequest::isCached() const {
+  auto catchNode = std::get<1>(getStorage());
+
+  // try? and try! never need to be cached.
+  if (catchNode.is<AnyTryExpr *>())
+    return false;
+
+  // Functions with explicitly-written thrown types need the result cached.
+  if (auto func = catchNode.dyn_cast<AbstractFunctionDecl *>()) {
+    return func->ThrownType.getTypeRepr() != nullptr;
+  }
+
+  // Closures with explicitly-written thrown types need the result cached.
+  if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
+    if (auto closure = dyn_cast<ClosureExpr>(abstractClosure)) {
+      return closure->ThrownType != nullptr;
+    }
+
+    return false;
+  }
+
+  // Do..catch with explicitly-written thrown types need the result cached.
+  if (auto doCatch = catchNode.dyn_cast<DoCatchStmt *>()) {
+    return doCatch->getThrowsLoc().isValid();
+  }
+
+  llvm_unreachable("Unhandled catch node");
+}
+
+llvm::Optional<Type> ExplicitCaughtTypeRequest::getCachedResult() const {
+  // Map a possibly-null Type to llvm::Optional<Type>.
+  auto nonnullTypeOrNone = [](Type type) -> llvm::Optional<Type> {
+    if (type.isNull())
+      return llvm::None;
+
+    return type;
+  };
+
+  auto catchNode = std::get<1>(getStorage());
+
+  if (auto func = catchNode.dyn_cast<AbstractFunctionDecl *>()) {
+    return nonnullTypeOrNone(func->ThrownType.getType());
+  }
+
+  if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
+    auto closure = cast<ClosureExpr>(abstractClosure);
+    if (closure->ThrownType) {
+      return nonnullTypeOrNone(closure->ThrownType->getInstanceType());
+    }
+
+    return llvm::None;
+  }
+
+  if (auto doCatch = catchNode.dyn_cast<DoCatchStmt *>()) {
+    return nonnullTypeOrNone(doCatch->ThrownType.getType());
+  }
+
+  llvm_unreachable("Unhandled catch node");
+}
+
+void ExplicitCaughtTypeRequest::cacheResult(Type type) const {
+  auto catchNode = std::get<1>(getStorage());
+
+  if (auto func = catchNode.dyn_cast<AbstractFunctionDecl *>()) {
+    func->ThrownType.setType(type);
+    return;
+  }
+
+  if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
+    auto closure = cast<ClosureExpr>(abstractClosure);
+    if (closure->ThrownType)
+      closure->ThrownType->setType(MetatypeType::get(type));
+    else
+      closure->ThrownType =
+          TypeExpr::createImplicit(type, type->getASTContext());
+    return;
+  }
+
+  if (auto doCatch = catchNode.dyn_cast<DoCatchStmt *>()) {
+    doCatch->ThrownType.setType(type);
+    return;
+  }
+
+  llvm_unreachable("Unhandled catch node");
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11702,11 +11702,19 @@ CatchNode::getThrownErrorTypeInContext(DeclContext *dc) const {
     return llvm::None;
   }
 
-  if (auto closure = dyn_cast<AbstractClosureExpr *>()) {
-    if (closure->getType())
-      return closure->getEffectiveThrownType();
+  if (auto abstractClosure = dyn_cast<AbstractClosureExpr *>()) {
+    if (abstractClosure->getType())
+      return abstractClosure->getEffectiveThrownType();
 
-    // FIXME: Should we lazily compute this?
+    if (auto closure = llvm::dyn_cast<ClosureExpr>(abstractClosure)) {
+      if (Type thrownType = closure->getExplicitThrownType()) {
+        if (thrownType->isNever())
+          return llvm::None;
+
+        return thrownType;
+      }
+    }
+
     return llvm::None;
   }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2046,11 +2046,14 @@ bool ClosureExpr::hasEmptyBody() const {
   return getBody()->empty();
 }
 
-void ClosureExpr::setExplicitThrownType(Type thrownType) {
-  assert(thrownType && !thrownType->hasTypeVariable() &&
-         !thrownType->hasPlaceholder());
-  assert(ThrownType);
-  ThrownType->setType(MetatypeType::get(thrownType));
+Type ClosureExpr::getExplicitThrownType() const {
+  if (getThrowsLoc().isInvalid())
+    return Type();
+  
+  ASTContext &ctx = getASTContext();
+  auto mutableThis = const_cast<ClosureExpr *>(this);
+  ExplicitCaughtTypeRequest request{mutableThis, mutableThis};
+  return evaluateOrDefault(ctx.evaluator, request, Type());
 }
 
 void ClosureExpr::setExplicitResultType(Type ty) {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1937,8 +1937,10 @@ Type AbstractClosureExpr::getResultType(
 }
 
 llvm::Optional<Type> AbstractClosureExpr::getEffectiveThrownType() const {
-  return getType()->castTo<AnyFunctionType>()
-      ->getEffectiveThrownErrorType();
+  if (auto fnType = getType()->getAs<AnyFunctionType>())
+    return fnType->getEffectiveThrownErrorType();
+
+  return llvm::None;
 }
 
 bool AbstractClosureExpr::isBodyThrowing() const {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -478,15 +478,15 @@ bool DoCatchStmt::isSyntacticallyExhaustive() const {
   return false;
 }
 
-Type DoCatchStmt::getExplicitlyThrownType(DeclContext *dc) const {
+Type DoCatchStmt::getExplicitCaughtType(DeclContext *dc) const {
   ASTContext &ctx = dc->getASTContext();
-  DoCatchExplicitThrownTypeRequest request{dc, const_cast<DoCatchStmt *>(this)};
+  ExplicitCaughtTypeRequest request{dc, const_cast<DoCatchStmt *>(this)};
   return evaluateOrDefault(ctx.evaluator, request, Type());
 }
 
 Type DoCatchStmt::getCaughtErrorType(DeclContext *dc) const {
   // Check for an explicitly-specified error type.
-  if (Type explicitError = getExplicitlyThrownType(dc))
+  if (Type explicitError = getExplicitCaughtType(dc))
     return explicitError;
 
   auto firstPattern = getCatches()

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -952,47 +952,6 @@ void ParamSpecifierRequest::cacheResult(ParamSpecifier specifier) const {
 }
 
 //----------------------------------------------------------------------------//
-// ThrownTypeRequest computation.
-//----------------------------------------------------------------------------//
-
-llvm::Optional<Type> ThrownTypeRequest::getCachedResult() const {
-  auto *const func = std::get<0>(getStorage());
-  Type thrownType = func->ThrownType.getType();
-  if (thrownType.isNull())
-    return llvm::None;
-
-  return thrownType;
-}
-
-void ThrownTypeRequest::cacheResult(Type type) const {
-  auto *const func = std::get<0>(getStorage());
-  func->ThrownType.setType(type);
-}
-
-//----------------------------------------------------------------------------//
-// DoCatchExplicitThrownTypeRequest computation.
-//----------------------------------------------------------------------------//
-
-bool DoCatchExplicitThrownTypeRequest::isCached() const {
-  auto *const stmt = std::get<1>(getStorage());
-  return stmt->getThrowsLoc().isValid();
-}
-
-llvm::Optional<Type> DoCatchExplicitThrownTypeRequest::getCachedResult() const {
-  auto *const stmt = std::get<1>(getStorage());
-  Type thrownType = stmt->ThrownType.getType();
-  if (thrownType.isNull())
-    return llvm::None;
-
-  return thrownType;
-}
-
-void DoCatchExplicitThrownTypeRequest::cacheResult(Type type) const {
-  auto *const stmt = std::get<1>(getStorage());
-  stmt->ThrownType.setType(type);
-}
-
-//----------------------------------------------------------------------------//
 // ResultTypeRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6502,7 +6502,7 @@ static ValueDecl *rewriteIntegerTypes(SubstitutionMap subst, ValueDecl *oldDecl,
           func->getASTContext(), func->getNameLoc(),
           func->getName(), func->getNameLoc(),
           func->hasAsync(), func->hasThrows(),
-          /*FIXME:ThrownType=*/func->getThrownInterfaceType(),
+          func->getThrownInterfaceType(),
           fixedParams, originalFnSubst->getResult(),
           /*genericParams=*/nullptr, func->getDeclContext(), newDecl->getClangDecl());
       if (func->isStatic()) newFnDecl->setStatic();

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2459,13 +2459,8 @@ namespace {
       // Determine the thrown error type, when appropriate.
       Type thrownErrorTy = [&] {
         // Explicitly-specified thrown type.
-        if (auto thrownTypeRepr = closure->getExplicitThrownTypeRepr()) {
-          Type resolvedTy = resolveTypeReferenceInExpression(
-              thrownTypeRepr, TypeResolverContext::InExpression,
-              thrownErrorLocator);
-          if (resolvedTy)
-            return resolvedTy;
-        }
+        if (Type explicitType = closure->getExplicitThrownType())
+          return explicitType;
 
         // Thrown type inferred from context.
         if (auto contextualType = CS.getContextualType(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2459,8 +2459,10 @@ namespace {
       // Determine the thrown error type, when appropriate.
       Type thrownErrorTy = [&] {
         // Explicitly-specified thrown type.
-        if (Type explicitType = closure->getExplicitThrownType())
-          return explicitType;
+        if (closure->getExplicitThrownTypeRepr()) {
+          if (Type explicitType = closure->getExplicitThrownType())
+            return explicitType;
+        }
 
         // Thrown type inferred from context.
         if (auto contextualType = CS.getContextualType(

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2564,11 +2564,6 @@ SolutionApplicationToFunctionResult ConstraintSystem::applySolution(
     if (llvm::is_contained(solution.preconcurrencyClosures, closure))
       closure->setIsolatedByPreconcurrency();
 
-    // Coerce the thrown type, if it was written explicitly.
-    if (closure->getExplicitThrownType()) {
-      closure->setExplicitThrownType(closureFnType->getThrownError());
-    }
-
     // Coerce the result type, if it was written explicitly.
     if (closure->hasExplicitResultType()) {
       closure->setExplicitResultType(closureFnType->getResult());

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -925,7 +925,16 @@ private:
         dc->getParentModule(), throwStmt->getThrowLoc());
     Type errorType;
     if (catchNode) {
-      errorType = catchNode.getThrownErrorTypeInContext(dc).value_or(Type());
+      // FIXME: Introduce something like getThrownErrorTypeInContext() for the
+      // constraint solver.
+      if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
+        if (auto closure = dyn_cast<ClosureExpr>(abstractClosure)) {
+          errorType = cs.getClosureType(closure)->getThrownError();
+        }
+      }
+
+      if (!errorType)
+        errorType = catchNode.getThrownErrorTypeInContext(dc).value_or(Type());
     }
 
     if (!errorType) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2287,34 +2287,6 @@ static Type buildAddressorResultType(AccessorDecl *addressor,
 }
 
 Type
-ThrownTypeRequest::evaluate(
-    Evaluator &evaluator, AbstractFunctionDecl *func
-) const {
-  ASTContext &ctx = func->getASTContext();
-
-  TypeRepr *typeRepr = func->getThrownTypeRepr();
-  if (!typeRepr) {
-    // There is no explicit thrown type, so return a NULL type.
-    return Type();
-  }
-
-  if (!ctx.LangOpts.hasFeature(Feature::TypedThrows)) {
-    ctx.Diags.diagnose(typeRepr->getLoc(), diag::experimental_typed_throws);
-  }
-
-  auto options = TypeResolutionOptions(TypeResolverContext::None);
-  if (func->preconcurrency())
-    options |= TypeResolutionFlags::Preconcurrency;
-
-  auto *const dc = func->getInnermostDeclContext();
-  return TypeResolution::forInterface(dc, options,
-                                      /*unboundTyOpener*/ nullptr,
-                                      PlaceholderType::get,
-                                      /*packElementOpener*/ nullptr)
-      .resolveType(typeRepr);
-}
-
-Type
 ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   auto &ctx = decl->getASTContext();
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3584,16 +3584,9 @@ llvm::Optional<Type> TypeChecker::canThrow(ASTContext &ctx, Expr *expr) {
 Type TypeChecker::catchErrorType(DeclContext *dc, DoCatchStmt *stmt) {
   ASTContext &ctx = dc->getASTContext();
 
-  // When typed throws is disabled, this is always "any Error".
-  // FIXME: When we distinguish "precise" typed throws from normal typed
-  // throws, we'll be able to compute a more narrow catch error type in some
-  // case, e.g., from a `try` but not a `throws`.
-  if (!ctx.LangOpts.hasFeature(Feature::TypedThrows))
-    return ctx.getErrorExistentialType();
-
   // If the do..catch statement explicitly specifies that it throws, use
   // that type.
-  if (Type explicitError = stmt->getExplicitlyThrownType(dc)) {
+  if (Type explicitError = stmt->getExplicitCaughtType(dc)) {
     return explicitError;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5680,7 +5680,7 @@ Type ExplicitCaughtTypeRequest::evaluate(
       return ctx.getNeverType();
     }
 
-    // We have an explici thrown error type, so resolve it.
+    // We have an explicit thrown error type, so resolve it.
     if (!ctx.LangOpts.hasFeature(Feature::TypedThrows)) {
       ctx.Diags.diagnose(thrownTypeRepr->getLoc(), diag::experimental_typed_throws);
     }
@@ -5719,20 +5719,10 @@ Type ExplicitCaughtTypeRequest::evaluate(
       if (closure->getThrowsLoc().isValid()) {
         return ctx.getErrorExistentialType();
       }
-
-      // If there is no potential throw site (based on syntactic analysis),
-      // then this closure is non-throwing.
-      auto effects = evaluateOrDefault(
-          evaluator, ClosureEffectsRequest{closure}, FunctionType::ExtInfo());
-      if (!effects.isThrowing())
-        return ctx.getNeverType();
     }
 
-    // TODO: A throwing closure with no explicit 'throws' annotation will infer
-    // the thrown error type in Swift 6 and under FullTypedThrows.
-
-    // Otherwise, we throw 'any Error'.
-    return ctx.getErrorExistentialType();
+    // Thrown error type will be inferred.
+    return Type();
   }
 
   // do..catch statements.

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -176,3 +176,18 @@ func tryBangQuestionMismatchingContext() throws(MyError) {
   try? doHomework()
   try doHomework() // expected-error{{thrown expression type 'HomeworkError' cannot be converted to error type 'MyError'}}
 }
+
+func apply<T, E: Error>(body: () throws(E) -> T) throws(E) -> T {
+  return try body()
+}
+
+func testDoCatchErrorTypedInClosure(cond: Bool) {
+  apply {
+    do throws(MyError) {
+      throw .failed
+    } catch {
+      assert(error == .failed)
+      processMyError(error)
+    }
+  }
+}


### PR DESCRIPTION
Unify `ThrownTypeRequest` and `DoCatchExplicitThrownTypeRequest`.  These two requests are effectively doing the same thing to two different cases within `CatchNode`. Unify the requests into a single
request, `ExplicitCaughtTypeRequest`, which operates on a CatchNode.

This also moves the logic for closures with explicitly-specified throws
clauses into the same request, taking it out of the constraint system.

Also unify some of the computation of the "caught" type for a `CatchNode`, fixing an issue where
explicitly-specified types on a `do..catch` weren't getting used within a closure.