### PR TITLE
[cxx-interop] Fix incorrect diagnostic for non-imported functions

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3202,13 +3202,16 @@ namespace {
 
       if (auto recordType = dyn_cast<clang::RecordType>(
               decl->getReturnType().getCanonicalType())) {
-        Impl.addImportDiagnostic(
-            decl, Diagnostic(diag::reference_passed_by_value,
-                             Impl.SwiftContext.AllocateCopy(
-                                 recordType->getDecl()->getNameAsString()),
-                             "the return"),
-            decl->getLocation());
-        return recordHasReferenceSemantics(recordType->getDecl());
+        if (recordHasReferenceSemantics(recordType->getDecl())) {
+          Impl.addImportDiagnostic(
+              decl,
+              Diagnostic(diag::reference_passed_by_value,
+                         Impl.SwiftContext.AllocateCopy(
+                             recordType->getDecl()->getNameAsString()),
+                         "the return"),
+              decl->getLocation());
+          return true;
+        }
       }
 
       return false;


### PR DESCRIPTION
If a C++ function cannot be imported into Swift, we try to emit a diagnostic that explains why. This diagnostic wasn't always correct: for functions that return a C++ struct, we emitted a note saying "function uses foreign reference type in a return type which breaks 'swift_shared_reference' contract" even if the return type is a trivial struct without any attributes. This was emitted unless there was another diagnostic that we also provided for the same function.