### PR TITLE
fix Parse/inverse_escapable_feature.swift

### DIFF
--- a/test/Parse/inverse_escapable_feature.swift
+++ b/test/Parse/inverse_escapable_feature.swift
@@ -1,3 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
 
+// REQUIRES: asserts
+
 struct S: ~Escapable {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonEscapableTypes}}


### PR DESCRIPTION
CI was broken due to missing "requires asserts" due to use of experimental features.

resolves rdar://119554708