### PR TITLE
Prevent modulo in places where we can check the length

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -988,7 +988,10 @@ extension Sequence {
         ringBuffer.append(element)
       } else {
         ringBuffer[i] = element
-        i = (i + 1) % maxLength
+        i += 1
+        if i >= maxLength {
+          i = 0
+        }
       }
     }
 
@@ -1067,7 +1070,10 @@ extension Sequence {
       } else {
         result.append(ringBuffer[i])
         ringBuffer[i] = element
-        i = (i + 1) % k
+        i += 1
+        if i >= k {
+          i = 0
+        }
       }
     }
     return Array(result)


### PR DESCRIPTION
We know maxLength must be positive and non-zero, and therefore, i += 1 will be the next index until we reach maxLength, in which case the result is 0. Rather than perform a modulo, which requires division, every time, we can just reset i when it reaches the end of the buffer.