### PR TITLE
[ConstraintSystem] Run `salvage` even if diagnostics are suppressed

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1515,14 +1515,6 @@ ConstraintSystem::solve(SyntacticElementTarget &target,
       LLVM_FALLTHROUGH;
 
     case SolutionResult::UndiagnosedError:
-      /// If we have a SolutionCallback, we are inspecting constraint system
-      /// solutions directly and thus also want to receive ambiguous solutions.
-      /// Hence always run the second (salvaging) stage.
-      if (shouldSuppressDiagnostics() && !Context.SolutionCallback) {
-        solution.markAsDiagnosed();
-        return llvm::None;
-      }
-
       if (stage == 1) {
         diagnoseFailureFor(target);
         reportSolutionsToSolutionCallback(solution);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4389,6 +4389,10 @@ SolutionResult ConstraintSystem::salvage() {
       return SolutionResult::forSolved(std::move(viable[0]));
     }
 
+    if (shouldSuppressDiagnostics())
+      return viable.empty() ? SolutionResult::forUndiagnosedError()
+                            : SolutionResult::forAmbiguous(viable);
+
     // FIXME: If we were able to actually fix things along the way,
     // we may have to hunt for the best solution. For now, we don't care.
 
@@ -5228,7 +5232,7 @@ static bool diagnoseContextualFunctionCallGenericAmbiguity(
 
 bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     SmallVectorImpl<Solution> &solutions) {
-  if (solutions.empty())
+  if (solutions.empty() || shouldSuppressDiagnostics())
     return false;
 
   SolutionDiff solutionDiff(solutions);


### PR DESCRIPTION
There are some situations where the solver is able to find a valid
solution only during `salvage` (mostly but not limited to unavailable
declarations), which means that we need to keep running `salvage`
even if the diagnostics are suppressed until the underlying issues
in the normal solving mode are fixed.

One of the issues:

```swift
extension Unmanaged {
   @inline(__always)
   internal static func passRetained(_ instance: __owned Instance?) -> Self? {
     guard let instance = instance else { return nil }
       return .passRetained(instance)
     }
   }
}
 ```

`.passRetained(instance)` is ambiguous during normal solving but
is able to find a solution during `salvage` because it attemtps
more type bindings.

Resolves: rdar://119001449


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
