### PR TITLE
[cxx-interop] Adjust detection of C++ modules after changes in libc++

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7626,6 +7626,11 @@ bool importer::requiresCPlusPlus(const clang::Module *module) {
   // The libc++ modulemap doesn't currently declare the requirement.
   if (module->getTopLevelModuleName() == "std")
     return true;
+  // In recent libc++ versions the module is split into multiple top-level
+  // modules (std_vector, std_utility, etc).
+  if (module->getTopLevelModule()->IsSystem &&
+      module->getTopLevelModuleName().starts_with("std_"))
+    return true;
 
   // Modulemaps often declare the requirement for the top-level module only.
   if (auto parent = module->Parent) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3389,7 +3389,10 @@ namespace {
                     ->getTopLevelModule()
                     ->getFullModuleName() == n;
         };
-        if (topLevelModuleEq(decl, "std")) {
+        if (topLevelModuleEq(decl, "std") ||
+            (decl->getOwningModule() && decl->getOwningModule()->IsSystem &&
+             StringRef(decl->getOwningModule()->getTopLevelModule()->Name)
+                 .starts_with("std_"))) {
           if (isAlternativeCStdlibFunctionFromTextualHeader(decl)) {
             return nullptr;
           }


### PR DESCRIPTION
libc++ recently split the `std` module into many top-level modules: https://github.com/llvm/llvm-project/commit/571178a21a8bc105bf86cf4bf92f842e07792e1a

This prevented the conformances to `CxxSet`, `CxxVector`, etc. from being synthesized with a fresh libc++ version.

rdar://119270491