### PR TITLE
[Concurrency] Teach `Type::stripConcurrency` about tuples, sugared types, and bound generic types

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1145,6 +1145,25 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
     return anyChanged ? TupleType::get(elts, getASTContext()) : Type(this);
   }
 
+  if (auto *arrayTy = dyn_cast<ArraySliceType>(this)) {
+    auto newBaseTy =
+        arrayTy->getBaseType()->stripConcurrency(recurse, dropGlobalActor);
+    return newBaseTy->isEqual(arrayTy->getBaseType())
+               ? Type(this)
+               : ArraySliceType::get(newBaseTy);
+  }
+
+  if (auto *dictTy = dyn_cast<DictionaryType>(this)) {
+    auto keyTy = dictTy->getKeyType();
+    auto strippedKeyTy = keyTy->stripConcurrency(recurse, dropGlobalActor);
+    auto valueTy = dictTy->getValueType();
+    auto strippedValueTy = valueTy->stripConcurrency(recurse, dropGlobalActor);
+
+    return keyTy->isEqual(strippedKeyTy) && valueTy->isEqual(strippedValueTy)
+               ? Type(this)
+               : DictionaryType::get(strippedKeyTy, strippedValueTy);
+  }
+
   return Type(this);
 }
 

--- a/test/Concurrency/sendable_preconcurrency_erasure.swift
+++ b/test/Concurrency/sendable_preconcurrency_erasure.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-silgen %s -verify -swift-version 5 | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Test erasure in generic arguments
+do {
+  struct S<T> {
+  }
+
+  @preconcurrency func test(_: S<any Sendable>) {}
+  // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure4testL_yyAA1SL_VyypGF
+  @preconcurrency func test(_: S<Array<@Sendable () -> Void>>) {}
+  // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure4testL0_yyAA1SL_VySayyycGGF
+}

--- a/test/Concurrency/sendable_preconcurrency_erasure.swift
+++ b/test/Concurrency/sendable_preconcurrency_erasure.swift
@@ -11,4 +11,11 @@ do {
   // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure4testL_yyAA1SL_VyypGF
   @preconcurrency func test(_: S<Array<@Sendable () -> Void>>) {}
   // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure4testL0_yyAA1SL_VySayyycGGF
+  @preconcurrency func test(_: Array<(any Sendable, @Sendable () -> Void)>) {}
+  // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure4testL1_yySayyp_yyctGF
+}
+
+public struct Data {
+  @preconcurrency var test: (any Sendable, Array<(Int, any Sendable)>)? = nil
+  // CHECK-LABEL: sil [transparent] [ossa] @$s31sendable_preconcurrency_erasure4DataV4testyp_SaySi_yptGtSgvpfi
 }

--- a/test/Concurrency/sendable_preconcurrency_erasure.swift
+++ b/test/Concurrency/sendable_preconcurrency_erasure.swift
@@ -15,6 +15,23 @@ do {
   // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure4testL1_yySayyp_yyctGF
 }
 
+// Test erase in sugared types
+do {
+  @preconcurrency func testArray1(_: [any Sendable]) {}
+  // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure10testArray1L2_yySayypGF
+  @preconcurrency func testArray2(_: [@Sendable () -> Void]) {}
+  // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure10testArray2L2_yySayyycGF
+
+  @preconcurrency func testDictionary(_: [Int: (any Sendable, (String, @Sendable (any Sendable) -> Void))]) {}
+  // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure14testDictionaryL2_yySDySiyp_SS_yypcttGF
+
+  @preconcurrency func testDesugaredDict(_: Dictionary<Int, (any Sendable, (String, @Sendable (any Sendable) -> Void))>) {}
+  // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure17testDesugaredDictL2_yySDySiyp_SS_yypcttGF
+
+  @preconcurrency func testVariadic(_: (any Sendable)...) {}
+  // CHECK-LABEL: sil private [ossa] @$s31sendable_preconcurrency_erasure12testVariadicL2_yyypd_tF
+}
+
 public struct Data {
   @preconcurrency var test: (any Sendable, Array<(Int, any Sendable)>)? = nil
   // CHECK-LABEL: sil [transparent] [ossa] @$s31sendable_preconcurrency_erasure4DataV4testyp_SaySi_yptGtSgvpfi


### PR DESCRIPTION
In recursive mode strip sendable and other concurrency use from all aforementioned types in 
`@preconcurrency` declarations.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
