### PR TITLE
[AST] Make `StmtConditionElement` a single `PointerIntPair`

### DIFF
--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -571,6 +571,21 @@ bool StmtConditionElement::rebindsSelf(ASTContext &Ctx,
   return false;
 }
 
+SourceRange ConditionalPatternBindingInfo::getSourceRange() const {
+  SourceLoc Start;
+  if (IntroducerLoc.isValid())
+    Start = IntroducerLoc;
+  else
+    Start = ThePattern->getStartLoc();
+
+  SourceLoc End = Initializer->getEndLoc();
+  if (Start.isValid() && End.isValid()) {
+    return SourceRange(Start, End);
+  } else {
+    return SourceRange();
+  }
+}
+
 PoundAvailableInfo *
 PoundAvailableInfo::create(ASTContext &ctx, SourceLoc PoundLoc,
                            SourceLoc LParenLoc,
@@ -603,18 +618,7 @@ SourceRange StmtConditionElement::getSourceRange() const {
   case StmtConditionElement::CK_HasSymbol:
     return getHasSymbolInfo()->getSourceRange();
   case StmtConditionElement::CK_PatternBinding:
-    SourceLoc Start;
-    if (IntroducerLoc.isValid())
-      Start = IntroducerLoc;
-    else
-      Start = getPattern()->getStartLoc();
-    
-    SourceLoc End = getInitializer()->getEndLoc();
-    if (Start.isValid() && End.isValid()) {
-      return SourceRange(Start, End);
-    } else {
-      return SourceRange();
-    }
+    return getPatternBinding()->getSourceRange();
   }
 
   llvm_unreachable("Unhandled StmtConditionElement in switch.");
@@ -636,7 +640,7 @@ SourceLoc StmtConditionElement::getStartLoc() const {
   case StmtConditionElement::CK_Availability:
     return getAvailability()->getStartLoc();
   case StmtConditionElement::CK_PatternBinding:
-    return getSourceRange().Start;
+    return getPatternBinding()->getStartLoc();
   case StmtConditionElement::CK_HasSymbol:
     return getHasSymbolInfo()->getStartLoc();
   }
@@ -651,7 +655,7 @@ SourceLoc StmtConditionElement::getEndLoc() const {
   case StmtConditionElement::CK_Availability:
     return getAvailability()->getEndLoc();
   case StmtConditionElement::CK_PatternBinding:
-    return getSourceRange().End;
+    return getPatternBinding()->getEndLoc();
   case StmtConditionElement::CK_HasSymbol:
     return getHasSymbolInfo()->getEndLoc();
   }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1862,7 +1862,8 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
                                 ErrorExpr(ThePattern.get()->getEndLoc()));
   }
 
-  result.push_back({IntroducerLoc, ThePattern.get(), Init.get()});
+  result.push_back(ConditionalPatternBindingInfo::create(
+      Context, IntroducerLoc, ThePattern.get(), Init.get()));
   return Status;
 }
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1676,8 +1676,8 @@ deriveBodyDecodable_enum_init(AbstractFunctionDecl *initDecl, void *) {
           C, VarDecl::Introducer::Let,
           NamedPattern::createImplicit(C, theKeyDecl));
 
-      guardElements.emplace_back(SourceLoc(), theKeyPattern,
-                                 allKeysPopFirstCallExpr);
+      guardElements.emplace_back(ConditionalPatternBindingInfo::create(
+          C, SourceLoc(), theKeyPattern, allKeysPopFirstCallExpr));
 
       // generate: allKeys.isEmpty;
       auto *allKeysIsEmptyExpr =

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1644,7 +1644,8 @@ synthesizeLazyGetterBody(AccessorDecl *Get, VarDecl *VD, VarDecl *Storage,
     createPropertyLoadOrCallSuperclassGetter(Get, Storage,
                                              TargetImpl::Storage, Ctx);
   SmallVector<StmtConditionElement, 1> Cond;
-  Cond.emplace_back(SourceLoc(), Some, StoredValueExpr);
+  Cond.emplace_back(ConditionalPatternBindingInfo::create(
+      Ctx, SourceLoc(), Some, StoredValueExpr));
 
   // Build the early return inside the if.
   auto *Tmp1DRE = new (Ctx) DeclRefExpr(Tmp1VD, DeclNameLoc(), /*Implicit*/true,

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -162,17 +162,18 @@ TEST(SourceLoc, StmtConditionElement) {
                                             , false);
   
   // Case a, when the IntroducerLoc is valid.
-  auto introducer = StmtConditionElement( start.getAdvancedLoc(3)
-                                        , pattern, init);
-  
+  auto introducer = StmtConditionElement(ConditionalPatternBindingInfo::create(
+      C.Ctx, start.getAdvancedLoc(3), pattern, init));
+
   EXPECT_EQ(start.getAdvancedLoc(3), introducer.getStartLoc());
   EXPECT_EQ(start.getAdvancedLoc(25), introducer.getEndLoc());
   EXPECT_EQ( SourceRange(start.getAdvancedLoc(3), start.getAdvancedLoc(25))
            , introducer.getSourceRange());
   
   // Case b, when the IntroducerLoc is invalid, but the pattern has a valid loc.
-  auto patternStmtCond = StmtConditionElement(SourceLoc(), pattern, init);
-  
+  auto patternStmtCond = StmtConditionElement(
+      ConditionalPatternBindingInfo::create(C.Ctx, SourceLoc(), pattern, init));
+
   EXPECT_EQ(start.getAdvancedLoc(7), patternStmtCond.getStartLoc());
   EXPECT_EQ(start.getAdvancedLoc(25), patternStmtCond.getEndLoc());
   EXPECT_EQ( SourceRange(start.getAdvancedLoc(7), start.getAdvancedLoc(25))
@@ -180,18 +181,20 @@ TEST(SourceLoc, StmtConditionElement) {
   
   // If the IntroducerLoc is valid but the stmt cond init is invalid.
   auto invalidInit = new (C.Ctx) IntegerLiteralExpr("1", SourceLoc(), false);
-  auto introducerStmtInvalid = StmtConditionElement( start.getAdvancedLoc(3)
-                                                   , pattern, invalidInit);
-  
+  auto introducerStmtInvalid =
+      StmtConditionElement(ConditionalPatternBindingInfo::create(
+          C.Ctx, start.getAdvancedLoc(3), pattern, invalidInit));
+
   EXPECT_EQ(SourceLoc(), introducerStmtInvalid.getStartLoc());
   EXPECT_EQ(SourceLoc(), introducerStmtInvalid.getEndLoc());
   EXPECT_EQ(SourceRange(), introducerStmtInvalid.getSourceRange());
   
   // If the IntroducerLoc is invalid, the pattern is valid, but the stmt cond 
   // init is invalid.
-  auto patternStmtInvalid = StmtConditionElement( SourceLoc(), pattern
-                                                , invalidInit);
-  
+  auto patternStmtInvalid =
+      StmtConditionElement(ConditionalPatternBindingInfo::create(
+          C.Ctx, SourceLoc(), pattern, invalidInit));
+
   EXPECT_EQ(SourceLoc(), patternStmtInvalid.getStartLoc());
   EXPECT_EQ(SourceLoc(), patternStmtInvalid.getEndLoc());
   EXPECT_EQ(SourceRange(), patternStmtInvalid.getSourceRange());


### PR DESCRIPTION
Previously, '`IntroducerLoc` and `ThePattern` were only used for pattern binding cases. Create a new `ConditionalPatternBindingInfo` type to cover such cases, and make `StmtConditionElement` a pure `PointerUnion` type.

This makes it clear which fields are used in which condition kind. Also, we can expect overall size reduction of `StmtCondition` when the majority of the conditions are simple boolean expressions.

Also, fix the doc-comment as the implicit subsequent `let` is not supported in the current Swift ([SE-0099](https://github.com/apple/swift-evolution/blob/main/proposals/0099-conditionclauses.md)):
```swift
if let a = thing, b = other { ... }
```