### PR TITLE
[Macros] Cache `SourceLocationConverter` in `ExportedSourceFile`

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -386,11 +386,9 @@ extension PluginMessage.Syntax {
     }
 
     let source = syntax.description
-    let sourceStr = String(decoding: sourceFilePtr.pointee.buffer, as: UTF8.self)
     let fileName = sourceFilePtr.pointee.fileName
     let fileID = "\(sourceFilePtr.pointee.moduleName)/\(sourceFilePtr.pointee.fileName.basename)"
-    let converter = SourceLocationConverter(file: fileName, source: sourceStr)
-    let loc = converter.location(for: syntax.position)
+    let loc = sourceFilePtr.pointee.sourceLocationConverter.location(for: syntax.position)
 
     self.init(
       kind: kind,

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -32,6 +32,11 @@ public struct ExportedSourceFile {
   /// The syntax tree for the complete source file.
   public let syntax: SourceFileSyntax
 
+  /// A source location converter to convert `AbsolutePosition`s in `syntax` to line/column locations.
+  /// 
+  /// Cached so we don't need to re-build the line table every time we need to convert a position.
+  let sourceLocationConverter: SourceLocationConverter
+
   public func position(of location: BridgedSourceLoc) -> AbsolutePosition? {
     let sourceFileBaseAddress = UnsafeRawPointer(buffer.baseAddress!)
     guard let opaqueValue = location.getOpaquePointerValue() else {
@@ -75,12 +80,15 @@ public func parseSourceFile(
   let sourceFile = Parser.parse(source: buffer, experimentalFeatures: .init(from: ctx))
 
   let exportedPtr = UnsafeMutablePointer<ExportedSourceFile>.allocate(capacity: 1)
+  let moduleName = String(cString: moduleName)
+  let fileName = String(cString: filename)
   exportedPtr.initialize(
     to: .init(
       buffer: buffer,
-      moduleName: String(cString: moduleName),
-      fileName: String(cString: filename),
-      syntax: sourceFile
+      moduleName: moduleName,
+      fileName: fileName,
+      syntax: sourceFile,
+      sourceLocationConverter: SourceLocationConverter(fileName: fileName, tree: sourceFile)
     )
   )
 


### PR DESCRIPTION
We need a `SourceLocationConverter` every time we create a `PluginMessage.Syntax` to know the source location of that syntax node within the source file. This means that we needed to re-build the line table of the entire source file multiple times for every macro that we expand. Cache it to improve performance.

rdar://119047550
