### PR TITLE
[5.10][Macros] Cache `SourceLocationConverter` in `ExportedSourceFile`

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -379,11 +379,9 @@ extension PluginMessage.Syntax {
     }
 
     let source = syntax.description
-    let sourceStr = String(decoding: sourceFilePtr.pointee.buffer, as: UTF8.self)
     let fileName = sourceFilePtr.pointee.fileName
     let fileID = "\(sourceFilePtr.pointee.moduleName)/\(sourceFilePtr.pointee.fileName.basename)"
-    let converter = SourceLocationConverter(file: fileName, source: sourceStr)
-    let loc = converter.location(for: syntax.position)
+    let loc = sourceFilePtr.pointee.sourceLocationConverter.location(for: syntax.position)
 
     self.init(
       kind: kind,

--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -102,15 +102,6 @@ extension SourceManager.MacroExpansionContext: MacroExpansionContext {
       return nil
     }
 
-    // Determine the filename to use in the resulting location.
-    let fileName: String
-    switch filePathMode {
-    case .fileID:
-      fileName = "\(exportedSourceFile.moduleName)/\(exportedSourceFile.fileName.basename)"
-
-    case .filePath:
-      fileName = exportedSourceFile.fileName
-    }
 
     // Find the node's offset relative to its root.
     let rawPosition: AbsolutePosition
@@ -131,8 +122,37 @@ extension SourceManager.MacroExpansionContext: MacroExpansionContext {
     let offsetWithinSyntaxNode =
       rawPosition.utf8Offset - node.position.utf8Offset
 
+    var location = exportedSourceFile.sourceLocationConverter.location(
+      for: rootPosition.advanced(by: offsetWithinSyntaxNode)
+    )
+
+    switch filePathMode {
+    case .fileID:
+      // The `SourceLocationConverter` in `exportedSourceFile` uses `filePath` as the file mode. When the `fileID` mode
+      // is requested, we need to adjust the file and presumed file to the `fileID`.
+      let fileID = "\(exportedSourceFile.moduleName)/\(exportedSourceFile.fileName.basename)"
+      var adjustedFile = location.file
+      if adjustedFile == exportedSourceFile.fileName {
+        adjustedFile = fileID
+      }
+      var adjustePresumedFile = location.presumedFile
+      if adjustePresumedFile == exportedSourceFile.fileName {
+        adjustePresumedFile = fileID
+      }
+      location = SourceLocation(
+        line: location.line,
+        column: location.column,
+        offset: location.offset,
+        file: adjustedFile,
+        presumedLine: location.presumedLine,
+        presumedFile: adjustePresumedFile
+      )
+
+    case .filePath:
+      break
+    }
+
     // Do the location lookup.
-    let converter = SourceLocationConverter(file: fileName, tree: sourceFile)
-    return AbstractSourceLocation(converter.location(for: rootPosition.advanced(by: offsetWithinSyntaxNode)))
+    return AbstractSourceLocation(location)
   }
 }


### PR DESCRIPTION
* **Explanation**: We need a `SourceLocationConverter` every time we create a `PluginMessage.Syntax` to know the source location of that syntax node within the source file. This means that we needed to re-build the line table of the entire source file multiple times for every macro that we expand. Cache it to improve performance.
* **Scope**: Macro expansions
* **Risk**: Low
* **Testing**: Verified manually that this improves performance of files with many macros
* **Issue**: rdar://119047550
* **Reviewer**:  @bnbarham on https://github.com/apple/swift/pull/70415



