### PR TITLE
Frontend: Temporarily disable stubbing unavailable decls

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -198,7 +198,7 @@ namespace swift {
 
     /// Optimization mode for unavailable declarations.
     UnavailableDeclOptimization UnavailableDeclOptimizationMode =
-        UnavailableDeclOptimization::Stub;
+        UnavailableDeclOptimization::None;
 
     /// Causes the compiler to use weak linkage for symbols belonging to
     /// declarations introduced at the deployment target.

--- a/test/Interpreter/unavailable_decl_optimization_stub.swift
+++ b/test/Interpreter/unavailable_decl_optimization_stub.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -module-name main %s -o %t/a.out
+// RUN: %target-build-swift -module-name main -Xfrontend -unavailable-decl-optimization=stub %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out > %t/output 2>&1 || true
 // RUN: %FileCheck %s < %t/output


### PR DESCRIPTION
This feature should be disabled until rdar://119046537 is solved.
