### PR TITLE
Group actor isolation errors

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5258,11 +5258,10 @@ NOTE(note_add_async_and_throws_to_decl,none,
 NOTE(note_add_distributed_to_decl,none,
      "add 'distributed' to %0 to make this %kindonly0 satisfy the protocol requirement",
      (const ValueDecl *))
-NOTE(note_add_globalactor_to_function,none,
+ERROR(add_globalactor_to_function,none,
      "add '@%0' to make %kind1 part of global actor %2",
      (StringRef, const ValueDecl *, Type))
 FIXIT(insert_globalactor_attr, "@%0 ", (Type))
-
 ERROR(main_function_must_be_mainActor,none,
       "main() must be '@MainActor'", ())
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -278,6 +278,9 @@ EXPERIMENTAL_FEATURE(BitwiseCopyable, true)
 /// Enables the FixedArray data type.
 EXPERIMENTAL_FEATURE(FixedArrays, false)
 
+// Group Main Actor Isolation Errors by Scope
+EXPERIMENTAL_FEATURE(GroupActorErrors, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3300,6 +3300,10 @@ static bool usesFeatureDeprecateApplicationMain(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureGroupActorErrors(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureImportObjcForwardDeclarations(Decl *decl) {
   ClangNode clangNode = decl->getClangNode();
   if (!clangNode)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2080,7 +2080,9 @@ namespace {
         // Add Fix-it for missing @SomeActor annotation
         if (isolation.isGlobalActor()) {
           if (missingGlobalActorOnContext(
-                                          const_cast<DeclContext*>(getDeclContext()), isolation.getGlobalActor(), behavior)) {
+                  const_cast<DeclContext *>(getDeclContext()),
+                  isolation.getGlobalActor(), behavior) &&
+              errors.size() > 1) {
             behavior= DiagnosticBehavior::Note;
           }
         }
@@ -2103,7 +2105,9 @@ namespace {
         // Add Fix-it for missing @SomeActor annotation
         if (isolation.isGlobalActor()) {
           if (missingGlobalActorOnContext(
-                                          const_cast<DeclContext*>(getDeclContext()), isolation.getGlobalActor(), behavior)) {
+                  const_cast<DeclContext *>(getDeclContext()),
+                  isolation.getGlobalActor(), behavior) &&
+              errors.size() > 1) {
             behavior= DiagnosticBehavior::Note;
           }
         }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -259,8 +259,6 @@ public:
 
 };
 
-static bool diagnoseIsolationErrors(DeclContext *dc, ArrayRef<IsolationError> errors);
-
 /// Individual options used with \c FunctionCheckOptions
 enum class FunctionCheckKind {
   /// Check params

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -248,6 +248,19 @@ public:
   operator Kind() const { return kind; }
 };
 
+struct IsolationError {
+
+  SourceLoc loc;
+
+  Diagnostic diag;
+
+public:
+  IsolationError(SourceLoc loc, Diagnostic diag) : loc(loc), diag(diag) {}
+
+};
+
+static bool diagnoseIsolationErrors(DeclContext *dc, ArrayRef<IsolationError> errors);
+
 /// Individual options used with \c FunctionCheckOptions
 enum class FunctionCheckKind {
   /// Check params
@@ -579,5 +592,50 @@ bool diagnoseApplyArgSendability(
     swift::ApplyExpr *apply, const DeclContext *declContext);
 
 } // end namespace swift
+
+namespace llvm {
+
+template <>
+struct DenseMapInfo<swift::ReferencedActor::Kind> {
+  using RefActorKind = swift::ReferencedActor::Kind;
+
+  static RefActorKind getEmptyKey() {
+   return RefActorKind::NonIsolatedContext;
+  }
+
+  static RefActorKind getTombstoneKey() {
+   return RefActorKind::NonIsolatedContext;
+  }
+
+  static unsigned getHashValue(RefActorKind Val) {
+   return static_cast<unsigned>(Val);
+  }
+
+  static bool isEqual(const RefActorKind &LHS, const RefActorKind &RHS) {
+   return LHS == RHS;
+  }
+ };
+
+  template <>
+  struct DenseMapInfo<swift::ActorIsolation> {
+    using RefActor = swift::ActorIsolation;
+
+    static RefActor getEmptyKey() {
+      return RefActor(swift::ActorIsolation::Kind::Unspecified);
+    }
+
+    static RefActor getTombstoneKey() {
+     return RefActor(swift::ActorIsolation::Kind::Unspecified);
+    }
+
+    static unsigned getHashValue(RefActor Val) {
+     return static_cast<unsigned>(Val.getKind());
+    }
+
+    static bool isEqual(const RefActor &LHS, const RefActor &RHS) {
+     return LHS == RHS;
+    }
+  };
+} // end namespace llvm
 
 #endif /* SWIFT_SEMA_TYPECHECKCONCURRENCY_H */

--- a/test/Concurrency/grouped_actor_isolation_diagnostics.swift
+++ b/test/Concurrency/grouped_actor_isolation_diagnostics.swift
@@ -1,0 +1,77 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature GroupActorErrors
+// REQUIRES: concurrency
+
+
+@MainActor
+protocol P {
+  func f()
+  nonisolated func g()
+}
+
+struct S_P: P {
+  func f() { }
+  // expected-complete-sns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  func g() { }
+}
+
+func testP2(x: S_P, p: P) { // expected-error{{add '@MainActor' to make global function 'testP2(x:p:)' part of global actor 'MainActor'}}
+  p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  p.g() // OKAY
+  x.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  x.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  x.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  x.g() // OKAY
+}
+
+actor SomeActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+@propertyWrapper
+struct WrapperOnActor<Wrapped: Sendable> {
+  private var stored: Wrapped
+
+  nonisolated init(wrappedValue: Wrapped) {
+    stored = wrappedValue
+  }
+
+  @MainActor var wrappedValue: Wrapped {
+    get { }
+    set { }
+  }
+
+  @SomeGlobalActor var projectedValue: Wrapped {
+    get {  }
+    set { }
+  }
+}
+
+struct HasWrapperOnActor {
+  @WrapperOnActor var x: Int = 0
+  @WrapperOnActor var y: String = ""
+  @WrapperOnActor var z: (Double, Double) = (1.0,2.0)
+
+  func testWrapped() { // expected-error{{add '@MainActor' to make instance method 'testWrapped()' part of global actor 'MainActor'}}
+    _ = x // expected-note{{main actor-isolated property 'x' can not be referenced from a non-isolated context}}
+    _ = y // expected-note{{main actor-isolated property 'y' can not be referenced from a non-isolated context}}
+    _ = z // expected-note{{main actor-isolated property 'z' can not be referenced from a non-isolated context}}
+  }
+  func testProjected(){ // expected-error{{add '@SomeGlobalActor' to make instance method 'testProjected()' part of global actor 'SomeGlobalActor'}}
+    _ = $x // expected-note{{global actor 'SomeGlobalActor'-isolated property '$x' can not be referenced from a non-isolated context}}
+    _ = $y // expected-note{{global actor 'SomeGlobalActor'-isolated property '$y' can not be referenced from a non-isolated context}}
+    _ = $z // expected-note{{global actor 'SomeGlobalActor'-isolated property '$z' can not be referenced from a non-isolated context}}
+  }
+
+  @MainActor
+  func testMA(){ }
+
+  func testErrors() { // expected-error{{add '@MainActor' to make instance method 'testErrors()' part of global actor 'MainActor'}}
+    testMA() // expected-note{{call to main actor-isolated instance method 'testMA()' in a synchronous nonisolated context}}
+    testMA() // expected-note{{call to main actor-isolated instance method 'testMA()' in a synchronous nonisolated context}}
+  }
+}

--- a/test/Concurrency/grouped_actor_isolation_diagnostics.swift
+++ b/test/Concurrency/grouped_actor_isolation_diagnostics.swift
@@ -1,7 +1,6 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature GroupActorErrors
 // REQUIRES: concurrency
 
-
 @MainActor
 protocol P {
   func f()
@@ -14,7 +13,7 @@ struct S_P: P {
   func g() { }
 }
 
-func testP2(x: S_P, p: P) { // expected-error{{add '@MainActor' to make global function 'testP2(x:p:)' part of global actor 'MainActor'}}
+func testP(x: S_P, p: P) { // expected-error{{add '@MainActor' to make global function 'testP(x:p:)' part of global actor 'MainActor'}}
   p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
@@ -71,7 +70,6 @@ struct HasWrapperOnActor {
   func testMA(){ }
 
   func testErrors() { // expected-error{{add '@MainActor' to make instance method 'testErrors()' part of global actor 'MainActor'}}
-    testMA() // expected-note{{call to main actor-isolated instance method 'testMA()' in a synchronous nonisolated context}}
-    testMA() // expected-note{{call to main actor-isolated instance method 'testMA()' in a synchronous nonisolated context}}
+    testMA() // expected-error{{call to main actor-isolated instance method 'testMA()' in a synchronous nonisolated context}}
   }
 }


### PR DESCRIPTION
To improve user experience, we should only display one error message for actor isolation errors within a function scope. No matter how many actor isolation errors exist within a function scope, the fix-it will be the same -  add  the global actor to the function declaration. i.e. `@MainActor`. Removing the redundant errors and fix-its will ease the Swift 6 migration.

rdar://112228022