### PR TITLE
AST: Specify the module name in errors on ambiguities across modules

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4239,6 +4239,9 @@ WARNING(warn_use_async_alternative,none,
 
 NOTE(found_candidate,none,
      "found this candidate", ())
+NOTE(found_candidate_in_module,none,
+     "found this candidate %select{|in module %1}0",
+     (bool, const ModuleDecl *))
 NOTE(found_candidate_type,none,
      "found candidate with type %0", (Type))
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5598,12 +5598,17 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
       case OverloadChoiceKind::Decl:
       case OverloadChoiceKind::DeclViaDynamic:
       case OverloadChoiceKind::DeclViaBridge:
-      case OverloadChoiceKind::DeclViaUnwrappedOptional:
+      case OverloadChoiceKind::DeclViaUnwrappedOptional: {
         // FIXME: show deduced types, etc, etc.
-        if (EmittedDecls.insert(choice.getDecl()).second)
-          DE.diagnose(choice.getDecl(), diag::found_candidate);
+        auto decl = choice.getDecl();
+        if (EmittedDecls.insert(decl).second) {
+          auto declModule = decl->getDeclContext()->getParentModule();
+          bool printModuleName = declModule != DC->getParentModule();
+          DE.diagnose(decl, diag::found_candidate_in_module,
+                      printModuleName, declModule);
+        }
         break;
-
+      }
       case OverloadChoiceKind::KeyPathApplication:
       case OverloadChoiceKind::DynamicMemberLookup:
       case OverloadChoiceKind::KeyPathDynamicMemberLookup:

--- a/test/diagnostics/ambiguity-across-modules.swift
+++ b/test/diagnostics/ambiguity-across-modules.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Compile the exact same source file into 2 different modules.
+// RUN: %target-swift-frontend -emit-module -o %t/A.swiftmodule %t/Lib.swift \
+// RUN:    -emit-module-source-info -module-name A -package-name pkg \
+// RUN:    -enable-testing
+// RUN: %target-swift-frontend -emit-module -o %t/B.swiftmodule %t/Lib.swift \
+// RUN:    -emit-module-source-info -module-name B -package-name pkg \
+// RUN:    -enable-testing
+
+// Build a client importing both modules and hitting the ambiguities.
+// RUN: not %target-swift-frontend -typecheck -I %t %t/Client.swift -package-name pkg 2> %t/out
+// RUN: cat %t/out | %FileCheck %s
+
+//--- Lib.swift
+public func publicAmbiguity() {}
+package func packageAmbiguity() {}
+internal func internalAmbiguity() {}
+
+//--- Client.swift
+@testable import A
+@testable import B
+
+func foo() {
+  publicAmbiguity()
+// CHECK: error: ambiguous use of 'publicAmbiguity()'
+// CHECK-NEXT:  publicAmbiguity()
+// CHECK-NEXT:  ^
+// CHECK-NEXT: Lib.swift:1:13: note: found this candidate in module 'A'
+// CHECK-NEXT: public func publicAmbiguity() {}
+// CHECK-NEXT:             ^
+// CHECK-NEXT: Lib.swift:1:13: note: found this candidate in module 'B'
+// CHECK-NEXT: public func publicAmbiguity() {}
+// CHECK-NEXT:             ^
+
+  packageAmbiguity()
+// CHECK: error: ambiguous use of 'packageAmbiguity()'
+// CHECK-NEXT:  packageAmbiguity()
+// CHECK-NEXT:  ^
+// CHECK-NEXT: Lib.swift:2:14: note: found this candidate in module 'A'
+// CHECK-NEXT: package func packageAmbiguity() {}
+// CHECK-NEXT:             ^
+// CHECK-NEXT: Lib.swift:2:14: note: found this candidate in module 'B'
+// CHECK-NEXT: package func packageAmbiguity() {}
+// CHECK-NEXT:             ^
+
+  internalAmbiguity()
+// CHECK: error: ambiguous use of 'internalAmbiguity()'
+// CHECK-NEXT:  internalAmbiguity()
+// CHECK-NEXT:  ^
+// CHECK-NEXT: Lib.swift:3:15: note: found this candidate in module 'A'
+// CHECK-NEXT: internal func internalAmbiguity() {}
+// CHECK-NEXT:             ^
+// CHECK-NEXT: Lib.swift:3:15: note: found this candidate in module 'B'
+// CHECK-NEXT: internal func internalAmbiguity() {}
+// CHECK-NEXT:             ^
+}

--- a/test/diagnostics/testable-printast-locations.swift
+++ b/test/diagnostics/testable-printast-locations.swift
@@ -9,5 +9,5 @@
 ambiguous()
 
 // CHECK: testable-printast-locations.swift:[[@LINE-2]]:1: error: ambiguous use of 'ambiguous()'
-// CHECK: ModuleA.ambiguous (internal):1:15: note: found this candidate
-// CHECK: ModuleB.ambiguous (internal):1:15: note: found this candidate
+// CHECK: ModuleA.ambiguous (internal):1:15: note: found this candidate in module 'ModuleA'
+// CHECK: ModuleB.ambiguous (internal):1:15: note: found this candidate in module 'ModuleB'


### PR DESCRIPTION
When a file defining an API is included in two modules, clients calling that API may get an error about the ambiguity on the duplicated API. That error is not very helpful when it takes into account the swiftsourceinfo data and points to the source file instead of the module. In such a case the notes point twice to the same file and line of code.

Improve this situation by appending the module name to the notes when a candidate is found outside of the module.

rdar://116255141