### PR TITLE
[NCGenerics] ensure builtins are Escapable

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1828,13 +1828,20 @@ static ProtocolConformanceRef getBuiltinMetaTypeTypeConformance(
 /// appropriate.
 static ProtocolConformanceRef getBuiltinBuiltinTypeConformance(
     Type type, const BuiltinType *builtinType, ProtocolDecl *protocol) {
-  // All builtin are Sendable and Copyable
-  if (protocol->isSpecificProtocol(KnownProtocolKind::Sendable) ||
-      protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
-    ASTContext &ctx = protocol->getASTContext();
-    return ProtocolConformanceRef(
-        ctx.getBuiltinConformance(type, protocol,
+  // All builtin are Sendable, Copyable, and Escapable
+  if (auto kp = protocol->getKnownProtocolKind()) {
+    switch (*kp) {
+    case KnownProtocolKind::Sendable:
+    case KnownProtocolKind::Copyable:
+    case KnownProtocolKind::Escapable: {
+      ASTContext &ctx = protocol->getASTContext();
+      return ProtocolConformanceRef(
+          ctx.getBuiltinConformance(type, protocol,
                                   BuiltinConformanceKind::Synthesized));
+    }
+    default:
+      break;
+    }
   }
 
   return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -301,8 +301,11 @@ void InverseRequirement::expandDefaults(
   for (auto gp : gps) {
     auto protos = InverseRequirement::expandDefault(gp);
     for (auto ip : protos) {
-      auto protoTy =
-          ctx.getProtocol(getKnownProtocolKind(ip))->getDeclaredInterfaceType();
+      auto proto = ctx.getProtocol(getKnownProtocolKind(ip));
+      if (!proto)
+        llvm_unreachable("failed to load Copyable/Escapable/etc from stdlib!");
+      
+      auto protoTy = proto->getDeclaredInterfaceType();
       result.push_back({{RequirementKind::Conformance, gp, protoTy},
                         SourceLoc(),
                         /*inferred=*/true,

--- a/test/Generics/inverse_generics_stdlib.swift
+++ b/test/Generics/inverse_generics_stdlib.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonEscapableTypes
+
+// REQUIRES: asserts
+
+/// This test specifically covers constructs that are only valid in the stdlib.
+
+import Builtin
+
+@_marker public protocol Copyable: ~Escapable {}
+@_marker public protocol Escapable: ~Copyable {}
+
+struct NC: ~Copyable {}
+
+@frozen public struct UnsafePointer<T: ~Copyable>: Copyable {
+  var value: Builtin.RawPointer
+}
+
+@frozen
+public enum Optional<T: ~Copyable> {
+  case some(T)
+  case none
+}
+
+public func wrapping<T: ~Copyable>(_ t: consuming T) -> T? {
+  return .some(t)
+}
+
+// No ownership required.
+func checkCopyability(_ t: UnsafePointer<NC>) {}


### PR DESCRIPTION
I missed a spot when updating conformance lookups. This led to types from the `Builtin` module not being treated as Escapable.