### PR TITLE
Tighten CatchNode from an AbstractClosureExpr to a ClosureExpr.

### DIFF
--- a/include/swift/AST/CatchNode.h
+++ b/include/swift/AST/CatchNode.h
@@ -25,7 +25,7 @@ namespace swift {
 /// An AST node that represents a point where a thrown error can be caught and
 /// or rethrown, which includes functions do...catch statements.
 class CatchNode: public llvm::PointerUnion<
-    AbstractFunctionDecl *, AbstractClosureExpr *, DoCatchStmt *, AnyTryExpr *
+    AbstractFunctionDecl *, ClosureExpr *, DoCatchStmt *, AnyTryExpr *
   > {
 public:
   using PointerUnion::PointerUnion;

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -684,8 +684,9 @@ static std::pair<CatchNode, const BraceStmtScope *>
 getCatchNode(const ASTScopeImpl *scope) {
   // Closures introduce a catch scope for errors initiated in their body.
   if (auto closureParams = dyn_cast<ClosureParametersScope>(scope)) {
-    return getCatchNodeBody(
-        scope, const_cast<AbstractClosureExpr *>(closureParams->closureExpr));
+    if (auto closure = dyn_cast<ClosureExpr>(closureParams->closureExpr)) {
+      return getCatchNodeBody(scope, const_cast<ClosureExpr *>(closure));
+    }
   }
 
   // Functions introduce a catch scope for errors initiated in their body.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11702,17 +11702,15 @@ CatchNode::getThrownErrorTypeInContext(DeclContext *dc) const {
     return llvm::None;
   }
 
-  if (auto abstractClosure = dyn_cast<AbstractClosureExpr *>()) {
-    if (abstractClosure->getType())
-      return abstractClosure->getEffectiveThrownType();
+  if (auto closure = dyn_cast<ClosureExpr *>()) {
+    if (closure->getType())
+      return closure->getEffectiveThrownType();
 
-    if (auto closure = llvm::dyn_cast<ClosureExpr>(abstractClosure)) {
-      if (Type thrownType = closure->getExplicitThrownType()) {
-        if (thrownType->isNever())
-          return llvm::None;
+    if (Type thrownType = closure->getExplicitThrownType()) {
+      if (thrownType->isNever())
+        return llvm::None;
 
-        return thrownType;
-      }
+      return thrownType;
     }
 
     return llvm::None;
@@ -11770,12 +11768,8 @@ bool ExplicitCaughtTypeRequest::isCached() const {
   }
 
   // Closures with explicitly-written thrown types need the result cached.
-  if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
-    if (auto closure = dyn_cast<ClosureExpr>(abstractClosure)) {
-      return closure->ThrownType != nullptr;
-    }
-
-    return false;
+  if (auto closure = catchNode.dyn_cast<ClosureExpr *>()) {
+    return closure->ThrownType != nullptr;
   }
 
   // Do..catch with explicitly-written thrown types need the result cached.
@@ -11801,8 +11795,7 @@ llvm::Optional<Type> ExplicitCaughtTypeRequest::getCachedResult() const {
     return nonnullTypeOrNone(func->ThrownType.getType());
   }
 
-  if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
-    auto closure = cast<ClosureExpr>(abstractClosure);
+  if (auto closure = catchNode.dyn_cast<ClosureExpr *>()) {
     if (closure->ThrownType) {
       return nonnullTypeOrNone(closure->ThrownType->getInstanceType());
     }
@@ -11825,8 +11818,7 @@ void ExplicitCaughtTypeRequest::cacheResult(Type type) const {
     return;
   }
 
-  if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
-    auto closure = cast<ClosureExpr>(abstractClosure);
+  if (auto closure = catchNode.dyn_cast<ClosureExpr *>()) {
     if (closure->ThrownType)
       closure->ThrownType->setType(MetatypeType::get(type));
     else

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -927,10 +927,8 @@ private:
     if (catchNode) {
       // FIXME: Introduce something like getThrownErrorTypeInContext() for the
       // constraint solver.
-      if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
-        if (auto closure = dyn_cast<ClosureExpr>(abstractClosure)) {
-          errorType = cs.getClosureType(closure)->getThrownError();
-        }
+      if (auto closure = catchNode.dyn_cast<ClosureExpr *>()) {
+        errorType = cs.getClosureType(closure)->getThrownError();
       }
 
       if (!errorType)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5697,28 +5697,26 @@ Type ExplicitCaughtTypeRequest::evaluate(
   }
 
   // Closures
-  if (auto abstractClosure = catchNode.dyn_cast<AbstractClosureExpr *>()) {
-    if (auto closure = dyn_cast<ClosureExpr>(abstractClosure)) {
-      assert(dc == closure && "Key mismatch for explicit caught type request");
+  if (auto closure = catchNode.dyn_cast<ClosureExpr *>()) {
+    assert(dc == closure && "Key mismatch for explicit caught type request");
 
-      // Explicit thrown error type.
-      if (auto thrownTypeRepr = closure->getExplicitThrownTypeRepr()) {
-        if (!ctx.LangOpts.hasFeature(Feature::TypedThrows)) {
-          ctx.Diags.diagnose(thrownTypeRepr->getLoc(),
-                             diag::experimental_typed_throws);
-        }
-
-        return TypeResolution::resolveContextualType(
-                 thrownTypeRepr, dc,
-                 TypeResolutionOptions(TypeResolverContext::None),
-                 /*unboundTyOpener*/ nullptr, PlaceholderType::get,
-                 /*packElementOpener*/ nullptr);
+    // Explicit thrown error type.
+    if (auto thrownTypeRepr = closure->getExplicitThrownTypeRepr()) {
+      if (!ctx.LangOpts.hasFeature(Feature::TypedThrows)) {
+        ctx.Diags.diagnose(thrownTypeRepr->getLoc(),
+                           diag::experimental_typed_throws);
       }
 
-      // Explicit 'throws' implies that this throws 'any Error'.
-      if (closure->getThrowsLoc().isValid()) {
-        return ctx.getErrorExistentialType();
-      }
+      return TypeResolution::resolveContextualType(
+               thrownTypeRepr, dc,
+               TypeResolutionOptions(TypeResolverContext::None),
+               /*unboundTyOpener*/ nullptr, PlaceholderType::get,
+               /*packElementOpener*/ nullptr);
+    }
+
+    // Explicit 'throws' implies that this throws 'any Error'.
+    if (closure->getThrowsLoc().isValid()) {
+      return ctx.getErrorExistentialType();
     }
 
     // Thrown error type will be inferred.


### PR DESCRIPTION
Only real closures can have thrown error types, so we can use the tighter bound for closures and simplify various CatchNode operations.
