### PR TITLE
SwiftCompilerSources: remove the redundant `BridgedPassContext.Feature` enum

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
@@ -32,7 +32,7 @@ struct Options {
     _bridged.hasFeature(.Embedded)
   }
 
-  func hasFeature(_ feature: BridgedPassContext.Feature) -> Bool {
+  func hasFeature(_ feature: BridgedFeature) -> Bool {
     _bridged.hasFeature(feature)
   }
 

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -169,12 +169,6 @@ struct BridgedPassContext {
     Lowered
   };
 
-  /// Enumeration describing all of the named features.
-  enum class Feature {
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) FeatureName,
-#include "swift/Basic/Features.def"
-  };
-
   SWIFT_IMPORT_UNSAFE BridgedOwnedString getModuleDescription() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedChangeNotificationHandler asNotificationHandler() const;
   BRIDGED_INLINE SILStage getSILStage() const;
@@ -307,7 +301,7 @@ struct BridgedPassContext {
   };
 
   BRIDGED_INLINE bool enableStackProtection() const;
-  BRIDGED_INLINE bool hasFeature(Feature feature) const;
+  BRIDGED_INLINE bool hasFeature(BridgedFeature feature) const;
   BRIDGED_INLINE bool enableMoveInoutStackProtection() const;
   BRIDGED_INLINE AssertConfiguration getAssertConfiguration() const;
   bool enableSimplificationFor(BridgedInstruction inst) const;

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -414,7 +414,7 @@ bool BridgedPassContext::enableStackProtection() const {
   return mod->getOptions().EnableStackProtection;
 }
 
-bool BridgedPassContext::hasFeature(Feature feature) const {
+bool BridgedPassContext::hasFeature(BridgedFeature feature) const {
   swift::SILModule *mod = invocation->getPassManager()->getModule();
   return mod->getASTContext().LangOpts.hasFeature((swift::Feature)feature);
 }


### PR DESCRIPTION
And replace it with the existing BridgedFeature
