### PR TITLE
[embedded] Mark embedded/no-allocations.swift test as REQUIRES: optimized_stdlib

### DIFF
--- a/test/embedded/no-allocations.swift
+++ b/test/embedded/no-allocations.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -no-allocations -wmo -verify -verify-ignore-unknown
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 public class X {} // expected-error {{cannot use allocating type 'X' in -no-allocations mode}}


### PR DESCRIPTION
To resolve a test failure on this bot: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators/3614/