### PR TITLE
[embedded] Disable embedded/dependencies.swift test on Linux/AArch64

### DIFF
--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -26,6 +26,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
 @_silgen_name("putchar")
 func putchar(_: UInt8)


### PR DESCRIPTION
To unbreak this CI job: https://ci.swift.org/job/oss-swift-package-ubi-9-aarch64/