### PR TITLE
Invalidate stack nesting in keypath silcombine

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -600,6 +600,8 @@ bool SILCombiner::tryOptimizeInoutKeypath(BeginApplyInst *AI) {
     Builder.setInsertionPoint(endApply);
   });
 
+  invalidatedStackNesting = true;
+
   eraseInstFromFunction(*endApply);
   eraseInstFromFunction(*AI);
   ++NumOptimizedKeypaths;

--- a/test/SILOptimizer/optimize_keypath_bug.swift
+++ b/test/SILOptimizer/optimize_keypath_bug.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-sil -O  -enable-ossa-modules -sil-verify-all %s
+// REQUIRES: OS=macosx
+
+import Foundation
+
+// Check the following test does not crash with incorrect stack order
+open class DateFormatter {
+    typealias CFType = CFDateFormatter
+    open func copy(with zone: NSZone? = nil) -> Any {
+        let copied = DateFormatter()
+
+        func __copy<T>(_ keyPath: ReferenceWritableKeyPath<DateFormatter, T>) {
+            copied[keyPath: keyPath] = self[keyPath: keyPath]
+        }
+
+        __copy(\.formattingContext)
+        return copied
+    }
+
+    public enum Context : Int {
+        case unknown
+        case dynamic
+        case standalone
+        case listItem
+        case beginningOfSentence
+        case middleOfSentence
+    }
+    open var formattingContext: Context = .unknown
+}
+


### PR DESCRIPTION
KeyPathProjector creates alloc_stack and dealloc_stack for temporaries. Insertion of new dealloc_stack can modify stack discipline.

Invalidate stack nesting so that it can be fixed up in the pass.

