### PR TITLE
[embedded] Start flagging AllocRefDynamicInst usage in embedded Swift

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -448,7 +448,7 @@ static bool metatypeUsesAreNotRelevant(MetatypeInst *mt) {
 }
 
 static bool allowedMetadataUseInEmbeddedSwift(SILInstruction *inst) {
-  // Only diagnose metatype and value_metatype instructions, for now.
+  // Only diagnose metatype, value_metatype instructions, ...
   if ((isa<ValueMetatypeInst>(inst) || isa<MetatypeInst>(inst))) {
     auto metaTy = cast<SingleValueInstruction>(inst)->getType().castTo<MetatypeType>();
     if (metaTy->getRepresentation() == MetatypeRepresentation::Thick) {
@@ -458,6 +458,9 @@ static bool allowedMetadataUseInEmbeddedSwift(SILInstruction *inst) {
       // Class metadata are supported in embedded Swift
       return instTy->getClassOrBoundGenericClass() ? true : false;
     }
+  // ... and alloc_ref_dynamic, for now.
+  } else if (isa<AllocRefDynamicInst>(inst)) {
+    return false;
   }
 
   return true;


### PR DESCRIPTION
IRGen for AllocRefDynamicInst uses the metadata to look up the size of the instance, but in embedded Swift we either don't have metadata at all (for structs), or they don't contain instance sizes (for class metadata). Let's start flagging AllocRefDynamicInst use in PerformanceDiagnostics to prevent IRGen compiler crashes or miscompiles.