### PR TITLE
[Caching] Fix a typo in legacy layout file name

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -459,7 +459,7 @@ void SwiftDependencyTracker::addCommonSearchPathDeps(
     std::error_code EC;
     for (auto &Arch : AllSupportedArches) {
       SmallString<256> LayoutFile(RuntimeLibPath);
-      llvm::sys::path::append(LayoutFile, "layout-" + Arch + ".yaml");
+      llvm::sys::path::append(LayoutFile, "layouts-" + Arch + ".yaml");
       FS->status(LayoutFile);
     }
   }

--- a/test/CAS/deps_cas_fs.swift
+++ b/test/CAS/deps_cas_fs.swift
@@ -1,0 +1,32 @@
+// REQUIRES: objc_interop, OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/cas
+
+// RUN: mkdir -p %t/resource/macosx
+// RUN: cp %S/../IRGen/Inputs/legacy_type_info/a.yaml %t/resource/macosx/layouts-x86_64.yaml
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/../ScanDependencies/Inputs/CHeaders -I %S/../ScanDependencies/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/../ScanDependencies/Inputs/CHeaders/Bridging.h -swift-version 4 -cache-compile-job -cas-path %t/cas -module-name Test -resource-dir %t/resource
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json &>/dev/null
+
+/// check cas-fs content
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json E casFSRootID > %t/E_fs.casid
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/E_fs.casid | %FileCheck %s -check-prefix FS_ROOT_E
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json F casFSRootID > %t/F_fs.casid
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/F_fs.casid | %FileCheck %s -check-prefix FS_ROOT_F
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json Test casFSRootID > %t/Test_fs.casid
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/Test_fs.casid | %FileCheck %s -check-prefix FS_ROOT_TEST
+
+// FS_ROOT_E-DAG: layouts-x86_64.yaml
+// FS_ROOT_E-DAG: E.swiftinterface
+
+// FS_ROOT_F-DAG: layouts-x86_64.yaml
+// FS_ROOT_F-DAG: F.swiftinterface
+
+// FS_ROOT_TEST-DAG: layouts-x86_64.yaml
+// FS_ROOT_TEST-DAG: deps_cas_fs.swift
+
+import E
+import SubE


### PR DESCRIPTION
Fix a typo in the name of legacy layout file name that causes the legacy layouts are not ingested into the CASFS for cached compilation.

rdar://119622429