### PR TITLE
[5.10] [Macros] Don't apply member attribute macros to accessors

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -508,6 +508,10 @@ ArrayRef<unsigned> ExpandMemberAttributeMacros::evaluate(Evaluator &evaluator,
   if (decl->isImplicit())
     return { };
 
+  // Member attribute macros do not apply to accessors.
+  if (isa<AccessorDecl>(decl))
+    return { };
+
   // Member attribute macros do not apply to macro-expanded members.
   if (decl->isInMacroExpansionInContext())
     return { };

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2077,3 +2077,18 @@ public struct FakeCodeItemMacro: DeclarationMacro, PeerMacro {
     return ["if true { return }"]
   }
 }
+
+public struct AddMemberPeersMacro: MemberAttributeMacro {
+    public static func expansion(of node: AttributeSyntax, attachedTo declaration: some DeclGroupSyntax, providingAttributesFor member: some DeclSyntaxProtocol, in context: some MacroExpansionContext) throws -> [AttributeSyntax] {
+        ["@_AddPeer"]
+    }
+}
+
+public struct _AddPeerMacro: PeerMacro {
+    public static func expansion<Decl: DeclSyntaxProtocol>(of node: AttributeSyntax, providingPeersOf declaration: Decl, in context: some MacroExpansionContext) throws -> [DeclSyntax] {
+        guard let name = declaration.as(VariableDeclSyntax.self)?.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text else {
+            return []
+        }
+        return ["static let \(raw: name)_special = 41"]
+    }
+}

--- a/test/Macros/macro_expand_attributes.swift
+++ b/test/Macros/macro_expand_attributes.swift
@@ -150,3 +150,16 @@ typealias A = Int
 func noMembers() {}
 // expected-error@-2{{'memberAttribute' macro cannot be attached to global function ('noMembers')}}
 #endif
+
+@attached(memberAttribute)
+public macro AddMemberPeers() = #externalMacro(module: "MacroDefinition", type: "AddMemberPeersMacro")
+
+@attached(peer, names: suffixed(_special))
+public macro _AddPeer() = #externalMacro(module: "MacroDefinition", type: "_AddPeerMacro")
+
+@AddMemberPeers
+struct User {
+    var name: String {
+        "mario"
+    }
+}


### PR DESCRIPTION
Accessors are conceptually nested within their property or subscript declarations, so member-attribute macros should only apply to the property or subscript declarations. This eliminates what appears to be redundant macro expansion.

Fixes rdar://118956800.
