### PR TITLE
[stdlib] Performance improvements for reading keypaths

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/KeyPath.h
+++ b/stdlib/public/SwiftShims/swift/shims/KeyPath.h
@@ -32,8 +32,10 @@ static const __swift_uint32_t _SwiftKeyPathBufferHeader_TrivialFlag
   = 0x80000000U;
 static const __swift_uint32_t _SwiftKeyPathBufferHeader_HasReferencePrefixFlag
   = 0x40000000U;
+static const __swift_uint32_t _SwiftKeyPathBufferHeader_IsSingleComponentFlag
+  = 0x20000000U;
 static const __swift_uint32_t _SwiftKeyPathBufferHeader_ReservedMask
-  = 0x3F000000U;
+  = 0x1F000000U;
   
 // Bitfields for a key path component header.
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -340,8 +340,6 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
       }
     }
 
-    var currentType = rootType
-
     return withBuffer {
       var buffer = $0
 
@@ -379,6 +377,8 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
         currentValueBuffer.withMemoryRebound(to: Root.self) {
           $0.initializeElement(at: 0, to: root)
         }
+
+        var currentType = rootType
 
         while true {
           let (rawComponent, optNextType) = buffer.next()

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -4108,14 +4108,20 @@ internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
     sizeVisitor.finish()
     instantiateVisitor.finish()
     isPureStruct.append(contentsOf: instantiateVisitor.isPureStruct)
-    checkSizeConsistency()
+    checkSizeConsistency(checkMaxSize: true)
   }
 
-  func checkSizeConsistency() {
+  func checkSizeConsistency(checkMaxSize: Bool = false) {
     let nextDest = instantiateVisitor.destData.baseAddress._unsafelyUnwrappedUnchecked
     let curSize = nextDest - origDest + MemoryLayout<Int>.size
 
-    _internalInvariant(curSize == sizeVisitor.sizeWithMaxSize,
+    let sizeVisitorSize = if checkMaxSize {
+      sizeVisitor.sizeWithMaxSize
+    } else {
+      sizeVisitor.size
+    }
+
+    _internalInvariant(curSize == sizeVisitorSize,
                  "size and instantiation visitors out of sync")
   }
 }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3725,6 +3725,16 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
                             leafMetadataRef: MetadataReference,
                             kvcCompatibilityString: UnsafeRawPointer?) {
     self.genericEnvironment = genericEnvironment
+
+    let leaf = _resolveKeyPathMetadataReference(
+              leafMetadataRef,
+              genericEnvironment: genericEnvironment,
+              arguments: patternArgs
+    )
+
+    let size = _openExistential(leaf, do: _getTypeSize(_:))
+
+    maxSize = Swift.max(maxSize, size)
   }
 
   mutating func visitStoredComponent(kind: KeyPathStructOrClass,

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -68,52 +68,51 @@ public class AnyKeyPath: _AppendKeyPath {
   TODO: Find a better method of refactoring this variable if possible.
   */
 
-  func assignOffsetToStorage(offset: Int) {
+  final func assignOffsetToStorage(offset: Int) {
     let maximumOffsetOn32BitArchitecture = 4094
 
     guard offset >= 0 else {
       return
     }
-    // TODO: This just gets the architecture size (32 or 64 bits).
-    // Is there a more efficient way? Something in Builtin maybe?
-    let architectureSize = MemoryLayout<Int>.size
-    if architectureSize == 8 {
-      _kvcKeyPathStringPtr = UnsafePointer<CChar>(bitPattern: -offset - 1)
+
+#if _pointerBitWidth(_64)
+    _kvcKeyPathStringPtr = UnsafePointer<CChar>(bitPattern: -offset - 1)
+#elseif _pointerBitWidth(_32)
+    if offset <= maximumOffsetOn32BitArchitecture {
+      _kvcKeyPathStringPtr = UnsafePointer<CChar>(bitPattern: (offset + 1))
+    } else {
+      _kvcKeyPathStringPtr = nil
     }
-    else {
-      if offset <= maximumOffsetOn32BitArchitecture {
-        _kvcKeyPathStringPtr = UnsafePointer<CChar>(bitPattern: (offset + 1))
-      }
-      else {
-        _kvcKeyPathStringPtr = nil
-      }
-    }
+#else
+#error("Unsupported platform")
+#endif
   }
 
-  func getOffsetFromStorage() -> Int? {
+  final func getOffsetFromStorage() -> Int? {
     let maximumOffsetOn32BitArchitecture = 4094
     guard _kvcKeyPathStringPtr != nil else {
       return nil
     }
 
-    let architectureSize = MemoryLayout<Int>.size
-    if architectureSize == 8 {
-      let offset = -Int(bitPattern: _kvcKeyPathStringPtr) - 1
-      guard offset >= 0 else {
-        // This happens to be an actual _kvcKeyPathStringPtr, not an offset, if we get here.
-        return nil
-      }
-      return offset
-    }
-    else {
-      let offset = Int(bitPattern: _kvcKeyPathStringPtr) - 1
-      // Pointers above 0x7fffffff will come in as negative numbers which are
-      // less than maximumOffsetOn32BitArchitecture, be sure to reject them.
-      if (offset >= 0 && offset <= maximumOffsetOn32BitArchitecture) {
-        return offset
-      }
+#if _pointerBitWidth(_64)
+    let offset = (0 &- Int(bitPattern: _kvcKeyPathStringPtr)) &- 1
+    guard _fastPath(offset >= 0) else {
+      // This happens to be an actual _kvcKeyPathStringPtr, not an offset, if
+      // we get here.
       return nil
     }
+    return offset
+#elseif _pointerBitWidth(_32)
+    let offset = Int(bitPattern: _kvcKeyPathStringPtr) &- 1
+    // Pointers above 0x7fffffff will come in as negative numbers which are
+    // less than maximumOffsetOn32BitArchitecture, be sure to reject them.
+    if offset >= 0, offset <= maximumOffsetOn32BitArchitecture {
+      return offset
+    }
+    return nil
+#else
+#error("Unsupported platform")
+#endif
   }
 
   // SPI for the Foundation overlay to allow interop with KVC keypath-based
@@ -330,63 +329,106 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   @usableFromInline
   @_unavailableInEmbedded
   internal final func _projectReadOnly(from root: Root) -> Value {
-      
+    let (rootType, valueType) = Self._rootAndValueType
+
     // One performance improvement is to skip right to Value
     // if this keypath traverses through structs only.
     if let offset = getOffsetFromStorage() {
-      return withUnsafeBytes(of: root) {
-        let pointer = $0.baseAddress.unsafelyUnwrapped.advanced(by: offset)
+      return _withUnprotectedUnsafeBytes(of: root) {
+        let pointer = $0.baseAddress._unsafelyUnwrappedUnchecked + offset
         return pointer.assumingMemoryBound(to: Value.self).pointee
       }
     }
-      
-    // TODO: For perf, we could use a local growable buffer instead of Any
-    var curBase: Any = root
+
+    var currentType = rootType
+
     return withBuffer {
       var buffer = $0
-      if buffer.data.isEmpty {
-        return unsafeBitCast(root, to: Value.self)
+
+      if _slowPath(buffer.data.isEmpty) {
+        return Builtin.reinterpretCast(root)
       }
-      while true {
-        let (rawComponent, optNextType) = buffer.next()
-        let valueType = optNextType ?? Value.self
-        let isLast = optNextType == nil
-        
-        func project<CurValue>(_ base: CurValue) -> Value? {
-          func project2<NewValue>(_: NewValue.Type) -> Value? {
-            switch rawComponent._projectReadOnly(base,
-              to: NewValue.self, endingWith: Value.self) {
-            case .continue(let newBase):
-              if isLast {
-                _internalInvariant(NewValue.self == Value.self,
-                             "key path does not terminate in correct type")
-                return unsafeBitCast(newBase, to: Value.self)
-              } else {
-                curBase = newBase
-                return nil
+
+      let bufferPtr = buffer.data.baseAddress._unsafelyUnwrappedUnchecked
+      let endOfBuffer = bufferPtr + buffer.data.count
+      let maxSize = Int(truncatingIfNeeded:
+        endOfBuffer.load(as: UInt32.self)
+      )
+      let roundedMaxSize = 1 &<< (Int.bitWidth &- maxSize.leadingZeroBitCount)
+
+      // 16 is the max alignment allowed on practically every platform we deploy
+      // to.
+      return _withUnprotectedUnsafeTemporaryAllocation(
+        byteCount: roundedMaxSize,
+        alignment: 16
+      ) {
+        let currentValueBuffer = $0
+
+        currentValueBuffer.withMemoryRebound(to: Root.self) {
+          $0.initializeElement(at: 0, to: root)
+        }
+
+        while true {
+          let (rawComponent, optNextType) = buffer.next()
+          let newType = optNextType ?? valueType
+          let isLast = optNextType == nil
+
+          func projectCurrent<Current>(_: Current.Type) -> Value {
+            func projectNew<New>(_: New) -> Value {
+              var isBreak = false
+
+              let newBase = currentValueBuffer.withMemoryRebound(
+                to: Current.self
+              ) {
+                return rawComponent._projectReadOnly(
+                  $0[0],
+                  to: New.self,
+                  endingWith: Value.self,
+                  &isBreak
+                )
               }
-            case .break(let result):
-              return result
+
+              // If we've broken from the projection, it means we found nil
+              // while optional chaining.
+              guard _fastPath(!isBreak) else {
+                var value: Value = Builtin.zeroInitializer()
+
+                // Optional.none has a tag of 1
+                let tag: UInt32 = 1
+                Builtin.injectEnumTag(&value, tag._value)
+
+                return value
+              }
+
+              if isLast {
+                _internalInvariant(
+                  New.self == Value.self,
+                  "key path does not terminate in correct type"
+                )
+
+                return Builtin.reinterpretCast(newBase) as Value
+              }
+
+              currentValueBuffer.withMemoryRebound(to: Current.self) {
+                $0.deinitializeElement(at: 0)
+              }
+
+              currentValueBuffer.withMemoryRebound(to: New.self) {
+                $0.initializeElement(at: 0, to: newBase)
+              }
+
+              currentType = newType
+              return Builtin.reinterpretCast(newBase) as Value
             }
+
+            return _openExistential(newType, do: projectNew(_:))
           }
 
-          return _openExistential(valueType, do: project2)
-        }
+          let result = _openExistential(currentType, do: projectCurrent(_:))
 
-        let result = _openExistential(curBase, do: project)
-
-        if let result = result {
-          return result
-        }
-
-        // Note: This should never be taken. The only time this will occur is if
-        // the API keypath is referencing has a nullability violation.
-        // In certain cases, `Value` has the same layout as `Value?` and the
-        // "nullptr" representation of `Value` is represented as `nil` for
-        // `Value?`. If we're returning a `Value`, but manage to get its `nil`
-        // representation, then the above check will fail.
-        if _slowPath(isLast) {
-          _preconditionFailure("Could not resolve KeyPath")
+          if isLast {
+            return result
+          }
         }
       }
     }
@@ -486,23 +528,78 @@ public class ReferenceWritableKeyPath<
     var keepAlive: AnyObject?
     let address: UnsafeMutablePointer<Value> = withBuffer {
       var buffer = $0
+
       // Project out the reference prefix.
-      var base: Any = origBase
-      while buffer.hasReferencePrefix {
-        let (rawComponent, optNextType) = buffer.next()
-        _internalInvariant(optNextType != nil,
-                     "reference prefix should not go to end of buffer")
-        let nextType = optNextType.unsafelyUnwrapped
-        
-        func project<NewValue>(_: NewValue.Type) -> Any {
-          func project2<CurValue>(_ base: CurValue) -> Any {
-            return rawComponent._projectReadOnly(
-              base, to: NewValue.self, endingWith: Value.self)
-              .assumingContinue
-          }
-          return _openExistential(base, do: project2)
+
+      let bufferPtr = buffer.data.baseAddress._unsafelyUnwrappedUnchecked
+      let endOfBuffer = bufferPtr + buffer.data.count
+      let maxSize = Int(truncatingIfNeeded:
+        endOfBuffer.load(as: UInt32.self)
+      )
+      let roundedMaxSize = 1 &<< (Int.bitWidth &- maxSize.leadingZeroBitCount)
+
+      // 16 is the max alignment allowed on practically every platform we deploy
+      // to.
+      let base: Any = _withUnprotectedUnsafeTemporaryAllocation(
+        byteCount: roundedMaxSize,
+        alignment: 16
+      ) {
+        var currentType: Any.Type = Root.self
+        let currentValueBuffer = $0
+
+        currentValueBuffer.withMemoryRebound(to: Root.self) {
+          $0.initializeElement(at: 0, to: origBase)
         }
-        base = _openExistential(nextType, do: project)
+
+        while buffer.hasReferencePrefix {
+          let (rawComponent, optNextType) = buffer.next()
+          _internalInvariant(optNextType != nil,
+                     "reference prefix should not go to end of buffer")
+          let nextType = optNextType._unsafelyUnwrappedUnchecked
+
+          func projectNew<New>(_: New.Type) {
+            func projectCurrent<Current>(_: Current.Type) {
+              var isBreak = false
+
+              let newBase = currentValueBuffer.withMemoryRebound(
+                to: Current.self
+              ) {
+                return rawComponent._projectReadOnly(
+                  $0[0],
+                  to: New.self,
+                  endingWith: Value.self,
+                  &isBreak
+                )
+              }
+
+              guard _fastPath(!isBreak) else {
+                _internalInvariantFailure("should not have stopped key path projection")
+              }
+
+              currentValueBuffer.withMemoryRebound(to: Current.self) {
+                $0.deinitializeElement(at: 0)
+              }
+
+              currentValueBuffer.withMemoryRebound(to: New.self) {
+                $0.initializeElement(at: 0, to: newBase)
+              }
+
+              currentType = nextType
+            }
+
+            _openExistential(currentType, do: projectCurrent(_:))
+          }
+
+          _openExistential(nextType, do: projectNew(_:))
+        }
+
+        func projectCurrent<Current>(_: Current.Type) -> Any {
+          return currentValueBuffer.withMemoryRebound(to: Current.self) {
+            $0[0]
+          }
+        }
+
+        return _openExistential(currentType, do: projectCurrent(_:))
       }
       
       // Start formal access to the mutable value, based on the final base
@@ -535,7 +632,7 @@ public class ReferenceWritableKeyPath<
           return UnsafeMutablePointer(mutating: typedPointer)
         }
       }
-      return _openExistential(base, do: formalMutation)
+      return _openExistential(base, do: formalMutation(_:))
     }
     
     return (address, keepAlive)
@@ -1044,10 +1141,10 @@ internal struct RawKeyPathComponent {
 
     internal var discriminator: UInt32 {
       get {
-        return (_value & Header.discriminatorMask) >> Header.discriminatorShift
+        return (_value & Header.discriminatorMask) &>> Header.discriminatorShift
       }
       set {
-        let shifted = newValue << Header.discriminatorShift
+        let shifted = newValue &<< Header.discriminatorShift
         _internalInvariant(shifted & Header.discriminatorMask == shifted,
                      "discriminator doesn't fit")
         _value = _value & ~Header.discriminatorMask | shifted
@@ -1276,7 +1373,7 @@ internal struct RawKeyPathComponent {
     // The component header is 4 bytes, but may be followed by an aligned
     // pointer field for some kinds of component, forcing padding.
     internal static var pointerAlignmentSkew: Int {
-      return MemoryLayout<Int>.size - MemoryLayout<Int32>.size
+      return MemoryLayout<Int>.size &- MemoryLayout<Int32>.size
     }
 
     internal var isTrivialPropertyDescriptor: Bool {
@@ -1313,20 +1410,20 @@ internal struct RawKeyPathComponent {
         // The body holds a pointer to the external property descriptor,
         // and some number of substitution arguments, the count of which is
         // in the payload.
-        return 4 * (1 + Int(payload))
+        return 4 &* (1 &+ Int(payload))
 
       case .computed:
         // The body holds at minimum the id and getter.
         var size = 8
         // If settable, it also holds the setter.
         if isComputedSettable {
-          size += 4
+          size &+= 4
         }
         // If there are arguments, there's also a layout function,
         // witness table, and initializer function.
         // Property descriptors never carry argument information, though.
         if !forPropertyDescriptor && hasComputedArguments {
-          size += 12
+          size &+= 12
         }
 
         return size
@@ -1422,19 +1519,19 @@ internal struct RawKeyPathComponent {
       return 0
     case .computed:
       // align to pointer, minimum two pointers for id and get
-      var total = Header.pointerAlignmentSkew + ptrSize * 2
+      var total = Header.pointerAlignmentSkew &+ ptrSize &* 2
       // additional word for a setter
       if header.isComputedSettable {
-        total += ptrSize
+        total &+= ptrSize
       }
       // include the argument size
       if header.hasComputedArguments {
         // two words for argument header: size, witnesses
-        total += ptrSize * 2
+        total &+= ptrSize &* 2
         // size of argument area
-        total += _computedArgumentSize
+        total &+= _computedArgumentSize
         if header.isComputedInstantiatedFromExternalWithArguments {
-          total += Header.externalWithArgumentsExtraSize
+          total &+= Header.externalWithArgumentsExtraSize
         }
       }
       return total
@@ -1450,9 +1547,9 @@ internal struct RawKeyPathComponent {
       // Offset overflowed into body
       _internalInvariant(body.count >= MemoryLayout<UInt32>.size,
                    "component not big enough")
-      return Int(body.load(as: UInt32.self))
+      return Int(truncatingIfNeeded: body.load(as: UInt32.self))
     }
-    return Int(header.storedOffsetPayload)
+    return Int(truncatingIfNeeded: header.storedOffsetPayload)
   }
 
   internal var _computedIDValue: Int {
@@ -1477,16 +1574,16 @@ internal struct RawKeyPathComponent {
 
     return ComputedAccessorsPtr(
       header: header,
-      value: body.baseAddress.unsafelyUnwrapped +
+      value: body.baseAddress._unsafelyUnwrappedUnchecked +
               Header.pointerAlignmentSkew + MemoryLayout<Int>.size)
   }
 
   internal var _computedArgumentHeaderPointer: UnsafeRawPointer {
     _internalInvariant(header.hasComputedArguments, "no arguments")
 
-    return body.baseAddress.unsafelyUnwrapped
+    return body.baseAddress._unsafelyUnwrappedUnchecked
       + Header.pointerAlignmentSkew
-      + MemoryLayout<Int>.size *
+      + MemoryLayout<Int>.size &*
          (header.isComputedSettable ? 3 : 2)
   }
 
@@ -1501,7 +1598,7 @@ internal struct RawKeyPathComponent {
   }
 
   internal var _computedArguments: UnsafeRawPointer {
-    var base = _computedArgumentHeaderPointer + MemoryLayout<Int>.size * 2
+    var base = _computedArgumentHeaderPointer + MemoryLayout<Int>.size &* 2
     // If the component was instantiated from an external property descriptor
     // with its own arguments, we include some additional capture info to
     // be able to map to the original argument context by adjusting the size
@@ -1517,7 +1614,7 @@ internal struct RawKeyPathComponent {
   internal var _computedArgumentWitnessSizeAdjustment: Int {
     if header.isComputedInstantiatedFromExternalWithArguments {
       return _computedArguments.load(
-        fromByteOffset: -Header.externalWithArgumentsExtraSize,
+        fromByteOffset: 0 &- Header.externalWithArgumentsExtraSize,
         as: Int.self)
     }
     return 0
@@ -1586,7 +1683,7 @@ internal struct RawKeyPathComponent {
       if header.hasComputedArguments,
          let destructor = _computedArgumentWitnesses.destroy {
         destructor(_computedMutableArguments,
-                 _computedArgumentSize - _computedArgumentWitnessSizeAdjustment)
+                 _computedArgumentSize &- _computedArgumentWitnessSizeAdjustment)
       }
     case .external:
       _internalInvariantFailure("should have been instantiated away")
@@ -1705,22 +1802,25 @@ internal struct RawKeyPathComponent {
   internal func _projectReadOnly<CurValue, NewValue, LeafValue>(
     _ base: CurValue,
     to: NewValue.Type,
-    endingWith: LeafValue.Type
-  ) -> ProjectionResult<NewValue, LeafValue> {
+    endingWith: LeafValue.Type,
+    _ isBreak: inout Bool
+  ) -> NewValue {
     switch value {
     case .struct(let offset):
-      var base2 = base
-      return .continue(withUnsafeBytes(of: &base2) {
-        let p = $0.baseAddress.unsafelyUnwrapped.advanced(by: offset)
+      let newValue = _withUnprotectedUnsafeBytes(of: base) {
+        let p = $0.baseAddress._unsafelyUnwrappedUnchecked + offset
+
         // The contents of the struct should be well-typed, so we can assume
         // typed memory here.
         return p.assumingMemoryBound(to: NewValue.self).pointee
-      })
+      }
+
+      return newValue
 
     case .class(let offset):
       _internalInvariant(CurValue.self is AnyObject.Type,
                    "base is not a class")
-      let baseObj = unsafeBitCast(base, to: AnyObject.self)
+      let baseObj: AnyObject = Builtin.reinterpretCast(base)
       let basePtr = UnsafeRawPointer(Builtin.bridgeToRawPointer(baseObj))
       defer { _fixLifetime(baseObj) }
 
@@ -1731,40 +1831,65 @@ internal struct RawKeyPathComponent {
       // 'modify' access.
       Builtin.performInstantaneousReadAccess(offsetAddress._rawValue,
         NewValue.self)
-      return .continue(offsetAddress
-        .assumingMemoryBound(to: NewValue.self)
-        .pointee)
+      return offsetAddress.assumingMemoryBound(to: NewValue.self).pointee
 
     case .get(id: _, accessors: let accessors, argument: let argument),
          .mutatingGetSet(id: _, accessors: let accessors, argument: let argument),
          .nonmutatingGetSet(id: _, accessors: let accessors, argument: let argument):
-      return .continue(accessors.getter()(base,
-                               argument?.data.baseAddress ?? accessors._value,
-                               argument?.data.count ?? 0))
+      let getter: ComputedAccessorsPtr.Getter<CurValue, NewValue> = accessors.getter()
+
+      let newValue = getter(
+        base,
+        argument?.data.baseAddress ?? accessors._value,
+        argument?.data.count ?? 0
+      )
+
+      return newValue
 
     case .optionalChain:
       _internalInvariant(CurValue.self == Optional<NewValue>.self,
                    "should be unwrapping optional value")
       _internalInvariant(_isOptional(LeafValue.self),
                    "leaf result should be optional")
-      if let baseValue = unsafeBitCast(base, to: Optional<NewValue>.self) {
-        return .continue(baseValue)
-      } else {
-        // TODO: A more efficient way of getting the `none` representation
-        // of a dynamically-optional type...
-        return .break((Optional<()>.none as Any) as! LeafValue)
+
+      // Optional's tags are some = 0, none = 1
+      let tag = UInt32(Builtin.getEnumTag(base))
+
+      if _fastPath(tag == 0) {
+        // Optional "shares" a layout with its Wrapped type meaning we can
+        // reinterpret the base address as an address to its Wrapped value.
+        return Builtin.reinterpretCast(base)
       }
+
+      // We found nil.
+      isBreak = true
+
+      // Return some zeroed out value for NewValue if we break. The caller will
+      // handle returning nil. We do this to prevent allocating metadata in this
+      // function because returning something like 'NewValue?' would need to
+      // allocate the optional metadata for 'NewValue'.
+      return Builtin.zeroInitializer()
 
     case .optionalForce:
       _internalInvariant(CurValue.self == Optional<NewValue>.self,
                    "should be unwrapping optional value")
-      return .continue(unsafeBitCast(base, to: Optional<NewValue>.self)!)
+
+      // Optional's tags are some = 0, none = 1
+      let tag = UInt32(Builtin.getEnumTag(base))
+
+      if _fastPath(tag == 0) {
+        // Optional "shares" a layout with its Wrapped type meaning we can
+        // reinterpret the base address as an address to its Wrapped value.
+        return Builtin.reinterpretCast(base)
+      }
+
+      _internalInvariantFailure("unwrapped nil optional")
 
     case .optionalWrap:
       _internalInvariant(NewValue.self == Optional<CurValue>.self,
                    "should be wrapping optional value")
-      return .continue(
-        unsafeBitCast(base as Optional<CurValue>, to: NewValue.self))
+
+      return Builtin.reinterpretCast(base)
     }
   }
 
@@ -1858,7 +1983,7 @@ internal struct RawKeyPathComponent {
 internal func _pop<T : BitwiseCopyable>(from: inout UnsafeRawBufferPointer,
                       as type: T.Type) -> T {
   let buffer = _pop(from: &from, as: type, count: 1)
-  return buffer.baseAddress.unsafelyUnwrapped.pointee
+  return buffer.baseAddress._unsafelyUnwrappedUnchecked.pointee
 }
 internal func _pop<T : BitwiseCopyable>(from: inout UnsafeRawBufferPointer,
                       as: T.Type,
@@ -1866,11 +1991,11 @@ internal func _pop<T : BitwiseCopyable>(from: inout UnsafeRawBufferPointer,
   from = MemoryLayout<T>._roundingUpBaseToAlignment(from)
   let byteCount = MemoryLayout<T>.stride * count
   let result = UnsafeBufferPointer(
-    start: from.baseAddress.unsafelyUnwrapped.assumingMemoryBound(to: T.self),
+    start: from.baseAddress._unsafelyUnwrappedUnchecked.assumingMemoryBound(to: T.self),
     count: count)
 
   from = UnsafeRawBufferPointer(
-    start: from.baseAddress.unsafelyUnwrapped + byteCount,
+    start: from.baseAddress._unsafelyUnwrappedUnchecked + byteCount,
     count: from.count - byteCount)
   return result
 }
@@ -1909,7 +2034,7 @@ internal struct KeyPathBuffer {
     }
     internal mutating func pushRaw(size: Int, alignment: Int)
         -> UnsafeMutableRawBufferPointer {
-      var baseAddress = buffer.baseAddress.unsafelyUnwrapped
+      var baseAddress = buffer.baseAddress._unsafelyUnwrappedUnchecked
       var misalign = Int(bitPattern: baseAddress) & (alignment - 1)
       if misalign != 0 {
         misalign = alignment - misalign
@@ -2506,7 +2631,7 @@ internal func _appendingKeyPaths<
 
         // Remember where the tail-allocated KVC string buffer begins.
         if appendedKVCLength > 0 {
-          kvcStringBuffer = destBuffer.baseAddress.unsafelyUnwrapped
+          kvcStringBuffer = destBuffer.baseAddress._unsafelyUnwrappedUnchecked
             .advanced(by: resultSize)
 
           destBuffer = .init(start: destBuffer.baseAddress,
@@ -2577,8 +2702,8 @@ internal func _appendingKeyPaths<
       if root.getOffsetFromStorage() == nil,
         leaf.getOffsetFromStorage() == nil {
         if let kvcStringBuffer = kvcStringBuffer {
-          let rootPtr = root._kvcKeyPathStringPtr.unsafelyUnwrapped
-          let leafPtr = leaf._kvcKeyPathStringPtr.unsafelyUnwrapped
+          let rootPtr = root._kvcKeyPathStringPtr._unsafelyUnwrappedUnchecked
+          let leafPtr = leaf._kvcKeyPathStringPtr._unsafelyUnwrappedUnchecked
           _memcpy(
             dest: kvcStringBuffer,
             src: rootPtr,
@@ -2684,19 +2809,22 @@ public func _swift_getKeyPath(pattern: UnsafeMutableRawPointer,
   // Instantiate a new key path object modeled on the pattern.
   // Do a pass to determine the class of the key path we'll be instantiating
   // and how much space we'll need for it.
-  let (keyPathClass, rootType, size, _)
+  let (keyPathClass, rootType, size, sizeWithMaxSize, _)
     = _getKeyPathClassAndInstanceSizeFromPattern(patternPtr, arguments)
 
   var pureStructOffset: UInt32? = nil
         
   // Allocate the instance.
-  let instance = keyPathClass._create(capacityInBytes: size) { instanceData in
+  let instance = keyPathClass._create(
+    capacityInBytes: sizeWithMaxSize
+  ) { instanceData in
     // Instantiate the pattern into the instance.
     pureStructOffset = _instantiateKeyPathBuffer(
       patternPtr,
       instanceData,
       rootType,
-      arguments
+      arguments,
+      size
     )
   }
 
@@ -2914,7 +3042,7 @@ internal func _resolveRelativeAddress(_ base: UnsafeRawPointer,
                                       _ offset: Int32) -> UnsafeRawPointer {
   // Sign-extend the offset to pointer width and add with wrap on overflow.
   return UnsafeRawPointer(bitPattern: Int(bitPattern: base) &+ Int(offset))
-    .unsafelyUnwrapped
+    ._unsafelyUnwrappedUnchecked
 }
 internal func _resolveRelativeIndirectableAddress(_ base: UnsafeRawPointer,
                                                   _ offset: Int32)
@@ -2930,7 +3058,7 @@ internal func _resolveRelativeIndirectableAddress(_ base: UnsafeRawPointer,
 internal func _resolveCompactFunctionPointer(_ base: UnsafeRawPointer, _ offset: Int32)
     -> UnsafeRawPointer {
 #if SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER
-  return UnsafeRawPointer(bitPattern: Int(offset)).unsafelyUnwrapped
+  return UnsafeRawPointer(bitPattern: Int(offset))._unsafelyUnwrappedUnchecked
 #else
   return _resolveRelativeAddress(base, offset)
 #endif
@@ -2977,7 +3105,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
       offset = .unresolvedFieldOffset(_pop(from: &componentBuffer,
                                            as: UInt32.self))
     case RawKeyPathComponent.Header.unresolvedIndirectOffsetPayload:
-      let base = componentBuffer.baseAddress.unsafelyUnwrapped
+      let base = componentBuffer.baseAddress._unsafelyUnwrappedUnchecked
       let relativeOffset = _pop(from: &componentBuffer,
                                 as: Int32.self)
       let ptr = _resolveRelativeIndirectableAddress(base, relativeOffset)
@@ -2999,14 +3127,14 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
           idValue: Int32,
           getter: UnsafeRawPointer,
           setter: UnsafeRawPointer?) {
-    let idValueBase = componentBuffer.baseAddress.unsafelyUnwrapped
+    let idValueBase = componentBuffer.baseAddress._unsafelyUnwrappedUnchecked
     let idValue = _pop(from: &componentBuffer, as: Int32.self)
-    let getterBase = componentBuffer.baseAddress.unsafelyUnwrapped
+    let getterBase = componentBuffer.baseAddress._unsafelyUnwrappedUnchecked
     let getterRef = _pop(from: &componentBuffer, as: Int32.self)
     let getter = _resolveCompactFunctionPointer(getterBase, getterRef)
     let setter: UnsafeRawPointer?
     if header.isComputedSettable {
-      let setterBase = componentBuffer.baseAddress.unsafelyUnwrapped
+      let setterBase = componentBuffer.baseAddress._unsafelyUnwrappedUnchecked
       let setterRef = _pop(from: &componentBuffer, as: Int32.self)
       setter = _resolveCompactFunctionPointer(setterBase, setterRef)
     } else {
@@ -3020,7 +3148,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
                             componentBuffer: inout UnsafeRawBufferPointer)
       -> KeyPathPatternComputedArguments? {
     if header.hasComputedArguments {
-      let getLayoutBase = componentBuffer.baseAddress.unsafelyUnwrapped
+      let getLayoutBase = componentBuffer.baseAddress._unsafelyUnwrappedUnchecked
       let getLayoutRef = _pop(from: &componentBuffer, as: Int32.self)
       let getLayoutRaw = _resolveCompactFunctionPointer(getLayoutBase, getLayoutRef)
       let getLayoutSigned = _PtrAuth.sign(pointer: getLayoutRaw,
@@ -3029,7 +3157,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
       let getLayout = unsafeBitCast(getLayoutSigned,
                                     to: KeyPathComputedArgumentLayoutFn.self)
 
-      let witnessesBase = componentBuffer.baseAddress.unsafelyUnwrapped
+      let witnessesBase = componentBuffer.baseAddress._unsafelyUnwrappedUnchecked
       let witnessesRef = _pop(from: &componentBuffer, as: Int32.self)
       let witnesses: UnsafeRawPointer
       if witnessesRef == 0 {
@@ -3038,7 +3166,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
         witnesses = _resolveRelativeAddress(witnessesBase, witnessesRef)
       }
 
-      let initializerBase = componentBuffer.baseAddress.unsafelyUnwrapped
+      let initializerBase = componentBuffer.baseAddress._unsafelyUnwrappedUnchecked
       let initializerRef = _pop(from: &componentBuffer, as: Int32.self)
       let initializerRaw = _resolveCompactFunctionPointer(initializerBase,
                                                           initializerRef)
@@ -3111,7 +3239,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
       // Look at the external property descriptor to see if we should take it
       // over the component given in the pattern.
       let genericParamCount = Int(header.payload)
-      let descriptorBase = buffer.baseAddress.unsafelyUnwrapped
+      let descriptorBase = buffer.baseAddress._unsafelyUnwrappedUnchecked
       let descriptorOffset = _pop(from: &buffer,
                                   as: Int32.self)
       let descriptor =
@@ -3221,7 +3349,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
 
     // Otherwise, pop the intermediate component type accessor and
     // go around again.
-    let componentTypeBase = buffer.baseAddress.unsafelyUnwrapped
+    let componentTypeBase = buffer.baseAddress._unsafelyUnwrappedUnchecked
     let componentTypeOffset = _pop(from: &buffer, as: Int32.self)
     let componentTypeRef = _resolveRelativeAddress(componentTypeBase,
                                                    componentTypeOffset)
@@ -3237,7 +3365,10 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
 @_unavailableInEmbedded
 internal struct GetKeyPathClassAndInstanceSizeFromPattern
     : KeyPathPatternVisitor {
-  var size: Int = MemoryLayout<Int>.size // start with one word for the header
+  // start with one word for the header
+  var size: Int = MemoryLayout<Int>.size
+  var sizeWithMaxSize: Int = 0
+
   var capability: KeyPathKind = .value
   var didChain: Bool = false
   var root: Any.Type!
@@ -3405,6 +3536,9 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
   }
 
   mutating func finish() {
+    sizeWithMaxSize = size
+    roundUpToPointerAlignment()
+    sizeWithMaxSize &+= MemoryLayout<Int>.size
   }
 }
 
@@ -3416,6 +3550,7 @@ internal func _getKeyPathClassAndInstanceSizeFromPattern(
   keyPathClass: AnyKeyPath.Type,
   rootType: Any.Type,
   size: Int,
+  sizeWithMaxSize: Int,
   alignmentMask: Int
 ) {
   var walker = GetKeyPathClassAndInstanceSizeFromPattern(patternArgs: arguments)
@@ -3445,8 +3580,13 @@ internal func _getKeyPathClassAndInstanceSizeFromPattern(
   return (keyPathClass: classTy,
           rootType: walker.root!,
           size: walker.size,
+          sizeWithMaxSize: walker.sizeWithMaxSize,
           // FIXME: Handle overalignment
           alignmentMask: MemoryLayout<Int>._alignmentMask)
+}
+
+internal func _getTypeSize<Type>(_: Type.Type) -> Int {
+  MemoryLayout<Type>.size
 }
 
 @_unavailableInEmbedded
@@ -3457,6 +3597,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
   var base: Any.Type
   var structOffset: UInt32 = 0
   var isPureStruct: [Bool] = []
+  var maxSize: Int = 0
 
   init(destData: UnsafeMutableRawBufferPointer,
        patternArgs: UnsafeRawPointer?,
@@ -3464,6 +3605,17 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
     self.destData = destData
     self.patternArgs = patternArgs
     self.base = root
+
+    // FIXME: This will not work on arm64e.
+    let metadataPtr = unsafeBitCast(root, to: UnsafeRawPointer.self)
+    let vwtPtr = metadataPtr.load(
+      fromByteOffset: 0 &- MemoryLayout<Int>.size,
+      as: UnsafeRawPointer.self
+    )
+    self.maxSize = vwtPtr.load(fromByteOffset: 0x40, as: Int.self)
+
+    // FIXME: The following doesn't work as it crashes the compiler in IRGen.
+    //self.maxSize = _openExistential(root, do: _getTypeSize(_:))
   }
 
   // Track the triviality of the resulting object data.
@@ -3478,7 +3630,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
     misalign: Int
   ) {
     let alignment = MemoryLayout<T>.alignment
-    var baseAddress = destData.baseAddress.unsafelyUnwrapped
+    var baseAddress = destData.baseAddress._unsafelyUnwrappedUnchecked
     var misalign = Int(bitPattern: baseAddress) & (alignment - 1)
     if misalign != 0 {
       misalign = alignment - misalign
@@ -3490,7 +3642,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
     let size = MemoryLayout<T>.size
     let (baseAddress, misalign) = adjustDestForAlignment(of: T.self)
     _withUnprotectedUnsafeBytes(of: value) {
-      _memcpy(dest: baseAddress, src: $0.baseAddress.unsafelyUnwrapped,
+      _memcpy(dest: baseAddress, src: $0.baseAddress._unsafelyUnwrappedUnchecked,
               size: UInt(size))
     }
     destData = UnsafeMutableRawBufferPointer(
@@ -3513,7 +3665,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
 
   mutating func updatePreviousComponentAddr() -> UnsafeMutableRawPointer? {
     let oldValue = previousComponentAddr
-    previousComponentAddr = destData.baseAddress.unsafelyUnwrapped
+    previousComponentAddr = destData.baseAddress._unsafelyUnwrappedUnchecked
     return oldValue
   }
 
@@ -3709,10 +3861,10 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
       _internalInvariant(Int(bitPattern: destData.baseAddress) & alignmentMask == 0,
                    "argument destination not aligned")
       arguments.initializer(patternArgs,
-                            destData.baseAddress.unsafelyUnwrapped)
+                            destData.baseAddress._unsafelyUnwrappedUnchecked)
 
       destData = UnsafeMutableRawBufferPointer(
-        start: destData.baseAddress.unsafelyUnwrapped + baseSize,
+        start: destData.baseAddress._unsafelyUnwrappedUnchecked + baseSize,
         count: destData.count - baseSize)
     }
     
@@ -3729,7 +3881,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
       // Write the descriptor's generic arguments, which should all be relative
       // references to metadata accessor functions.
       for i in externalArgs.indices {
-        let base = externalArgs.baseAddress.unsafelyUnwrapped + i
+        let base = externalArgs.baseAddress._unsafelyUnwrappedUnchecked + i
         let offset = base.pointee
         let metadataRef = _resolveRelativeAddress(UnsafeRawPointer(base), offset)
         let result = _resolveKeyPathGenericArgReference(
@@ -3768,9 +3920,24 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
                      arguments: patternArgs)
     pushDest(metadata)
     base = metadata
+
+    // FIXME: This will not work on arm64e.
+    let metadataPtr = unsafeBitCast(metadata, to: UnsafeRawPointer.self)
+    let vwtPtr = metadataPtr.load(
+      fromByteOffset: 0 &- MemoryLayout<Int>.size,
+      as: UnsafeRawPointer.self
+    )
+    let size = vwtPtr.load(fromByteOffset: 0x40, as: Int.self)
+    //let size = _openExistential(metadata, do: _getTypeSize(_:))
+
+    maxSize = Swift.max(maxSize, size)
   }
   
   mutating func finish() {
+    // Finally, push our max size at the end of the buffer (and round up if
+    // necessary).
+    pushDest(maxSize)
+
     // Should have filled the entire buffer by the time we reach the end of the
     // pattern.
     _internalInvariant(destData.isEmpty,
@@ -3793,7 +3960,7 @@ internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
        instantiateVisitor: InstantiateKeyPathBuffer) {
     self.sizeVisitor = sizeVisitor
     self.instantiateVisitor = instantiateVisitor
-    origDest = self.instantiateVisitor.destData.baseAddress.unsafelyUnwrapped
+    origDest = self.instantiateVisitor.destData.baseAddress._unsafelyUnwrappedUnchecked
   }
 
   mutating func visitHeader(genericEnvironment: UnsafeRawPointer?,
@@ -3886,7 +4053,7 @@ internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
   }
 
   func checkSizeConsistency() {
-    let nextDest = instantiateVisitor.destData.baseAddress.unsafelyUnwrapped
+    let nextDest = instantiateVisitor.destData.baseAddress._unsafelyUnwrappedUnchecked
     let curSize = nextDest - origDest + MemoryLayout<Int>.size
 
     _internalInvariant(curSize == sizeVisitor.size,
@@ -3900,12 +4067,13 @@ internal func _instantiateKeyPathBuffer(
   _ pattern: UnsafeRawPointer,
   _ origDestData: UnsafeMutableRawBufferPointer,
   _ rootType: Any.Type,
-  _ arguments: UnsafeRawPointer
+  _ arguments: UnsafeRawPointer,
+  _ sizeBeforeMaxSize: Int
 ) -> UInt32? {
-  let destHeaderPtr = origDestData.baseAddress.unsafelyUnwrapped
+  let destHeaderPtr = origDestData.baseAddress._unsafelyUnwrappedUnchecked
   var destData = UnsafeMutableRawBufferPointer(
     start: destHeaderPtr.advanced(by: MemoryLayout<Int>.size),
-    count: origDestData.count - MemoryLayout<Int>.size)
+    count: origDestData.count &- MemoryLayout<Int>.size)
 
 #if INTERNAL_CHECKS_ENABLED
   // If checks are enabled, use a validating walker that ensures that the
@@ -3939,7 +4107,7 @@ internal func _instantiateKeyPathBuffer(
 
   // Write out the header.
   let destHeader = KeyPathBuffer.Header(
-    size: origDestData.count - MemoryLayout<Int>.size,
+    size: sizeBeforeMaxSize &- MemoryLayout<Int>.size,
     trivial: isTrivial,
     hasReferencePrefix: endOfReferencePrefixComponent != nil)
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3537,7 +3537,7 @@ internal struct GetKeyPathClassAndInstanceSizeFromPattern
 
   mutating func finish() {
     sizeWithMaxSize = size
-    roundUpToPointerAlignment()
+    sizeWithMaxSize = MemoryLayout<Int>._roundingUpToAlignment(sizeWithMaxSize)
     sizeWithMaxSize &+= MemoryLayout<Int>.size
   }
 }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -84,7 +84,7 @@ public class AnyKeyPath: _AppendKeyPath {
       _kvcKeyPathStringPtr = nil
     }
 #else
-#error("Unsupported platform")
+    // Don't assign anything.
 #endif
   }
 
@@ -111,7 +111,8 @@ public class AnyKeyPath: _AppendKeyPath {
     }
     return nil
 #else
-#error("Unsupported platform")
+    // Otherwise, we assigned nothing so return nothing.
+    return nil
 #endif
   }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3665,16 +3665,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
     self.patternArgs = patternArgs
     self.base = root
 
-    // FIXME: This will not work on arm64e.
-    let metadataPtr = unsafeBitCast(root, to: UnsafeRawPointer.self)
-    let vwtPtr = metadataPtr.load(
-      fromByteOffset: 0 &- MemoryLayout<Int>.size,
-      as: UnsafeRawPointer.self
-    )
-    self.maxSize = vwtPtr.load(fromByteOffset: 0x40, as: Int.self)
-
-    // FIXME: The following doesn't work as it crashes the compiler in IRGen.
-    //self.maxSize = _openExistential(root, do: _getTypeSize(_:))
+    self.maxSize = _openExistential(root, do: _getTypeSize(_:))
   }
 
   // Track the triviality of the resulting object data.
@@ -3980,14 +3971,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
     pushDest(metadata)
     base = metadata
 
-    // FIXME: This will not work on arm64e.
-    let metadataPtr = unsafeBitCast(metadata, to: UnsafeRawPointer.self)
-    let vwtPtr = metadataPtr.load(
-      fromByteOffset: 0 &- MemoryLayout<Int>.size,
-      as: UnsafeRawPointer.self
-    )
-    let size = vwtPtr.load(fromByteOffset: 0x40, as: Int.self)
-    //let size = _openExistential(metadata, do: _getTypeSize(_:))
+    let size = _openExistential(metadata, do: _getTypeSize(_:))
 
     maxSize = Swift.max(maxSize, size)
   }

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -362,7 +362,8 @@ public func _forEachFieldWithKeyPath<Root>(
       destBuilder.pushHeader(KeyPathBuffer.Header(
         size: resultSize - MemoryLayout<Int>.size,
         trivial: true,
-        hasReferencePrefix: false
+        hasReferencePrefix: false,
+        isSingleComponent: true
       ))
       let component = RawKeyPathComponent(
            header: RawKeyPathComponent.Header(stored: .struct,

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -178,8 +178,7 @@ internal func _withUnprotectedUnsafeTemporaryAllocation<
   _ body: (Builtin.RawPointer) throws -> R
 ) rethrows -> R {
   // How many bytes do we need to allocate?
-  //let byteCount = _byteCountForTemporaryAllocation(of: type, capacity: capacity)
-  let byteCount = MemoryLayout<T>.stride &* capacity
+  let byteCount = _byteCountForTemporaryAllocation(of: type, capacity: capacity)
 
   guard _isStackAllocationSafe(byteCount: byteCount, alignment: alignment) else {
     return try _fallBackToHeapAllocation(byteCount: byteCount, alignment: alignment, body)
@@ -295,7 +294,7 @@ public func _withUnprotectedUnsafeTemporaryAllocation<R: ~Copyable>(
     alignment: alignment
   ) { pointer in
     let buffer = UnsafeMutableRawBufferPointer(
-      _uncheckedStart: .init(pointer),
+      start: .init(pointer),
       count: byteCount
     )
     return try body(buffer)
@@ -375,7 +374,7 @@ public func _withUnprotectedUnsafeTemporaryAllocation<
   ) { pointer in
     Builtin.bindMemory(pointer, capacity._builtinWordValue, type)
     let buffer = UnsafeMutableBufferPointer<T>(
-      _uncheckedStart: .init(pointer),
+      start: .init(pointer),
       count: capacity
     )
     return try body(buffer)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -116,6 +116,21 @@ public struct Unsafe${Mutable}RawBufferPointer {
     _debugPrecondition(count >= 0, "${Self} with negative count")
     _debugPrecondition(count == 0 || start != nil,
       "${Self} has a nil start and nonzero count")
+
+    self.init(_uncheckedStart: start, count: count)
+  }
+
+  @_alwaysEmitIntoClient
+  internal init(
+    _uncheckedStart start: Unsafe${Mutable}RawPointer?,
+    count: Int
+  ) {
+    _internalInvariant(count >= 0, "${Self} with negative count")
+    _internalInvariant(
+      count == 0 || start != nil,
+      "${Self} has a nil start and nonzero count"
+    )
+
     _position = start
     _end = start.map { $0 + _assumeNonNegative(count) }
   }
@@ -1382,7 +1397,10 @@ public func _withUnprotectedUnsafeBytes<
 #else
   let addr = UnsafeRawPointer(Builtin.addressOfBorrow(value))
 #endif
-  let buffer = UnsafeRawBufferPointer(start: addr, count: MemoryLayout<T>.size)
+  let buffer = UnsafeRawBufferPointer(
+    _uncheckedStart: addr,
+    count: MemoryLayout<T>.size
+  )
   return try body(buffer)
 }
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -117,20 +117,6 @@ public struct Unsafe${Mutable}RawBufferPointer {
     _debugPrecondition(count == 0 || start != nil,
       "${Self} has a nil start and nonzero count")
 
-    self.init(_uncheckedStart: start, count: count)
-  }
-
-  @_alwaysEmitIntoClient
-  internal init(
-    _uncheckedStart start: Unsafe${Mutable}RawPointer?,
-    count: Int
-  ) {
-    _internalInvariant(count >= 0, "${Self} with negative count")
-    _internalInvariant(
-      count == 0 || start != nil,
-      "${Self} has a nil start and nonzero count"
-    )
-
     _position = start
     _end = start.map { $0 + _assumeNonNegative(count) }
   }
@@ -1397,10 +1383,7 @@ public func _withUnprotectedUnsafeBytes<
 #else
   let addr = UnsafeRawPointer(Builtin.addressOfBorrow(value))
 #endif
-  let buffer = UnsafeRawBufferPointer(
-    _uncheckedStart: addr,
-    count: MemoryLayout<T>.size
-  )
+  let buffer = UnsafeRawBufferPointer(start: addr, count: MemoryLayout<T>.size)
   return try body(buffer)
 }
 


### PR DESCRIPTION
This patch includes some performance improvements for reading out a value from a key path. Essentially I've cut out all metadata allocations within the projection loop as well as getting rid of the intermediate `Any` value we were using to traffic intermediate values. Instead, we calculate the largest type we'll ever store during instantiation and stuff that value at the end of the buffer. We'll read this value when we project and create a temporary allocation and constantly re-view this memory for components.

Partially resolves: rdar://116587442