### PR TITLE
[NCGenerics] fix type lowering

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -647,11 +647,19 @@ public:
 
   /// Returns true if this type lacks conformance to Copyable in the context,
   /// if provided.
-  bool isNoncopyable(const DeclContext *dc = nullptr);
+  bool isNoncopyable(GenericEnvironment *env = nullptr);
+  bool isNoncopyable(const DeclContext *dc) {
+    assert(dc);
+    return isNoncopyable(dc->getGenericEnvironmentOfContext());
+  };
 
   /// Returns true if this type conforms to Escapable in the context,
   /// if provided.
-  bool isEscapable(const DeclContext *dc = nullptr);
+  bool isEscapable(GenericEnvironment *env = nullptr);
+  bool isEscapable(const DeclContext *dc) {
+    assert(dc);
+    return isEscapable(dc->getGenericEnvironmentOfContext());
+  };
 
   /// Does the type have outer parenthesis?
   bool hasParenSugar() const { return getKind() == TypeKind::Paren; }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1737,7 +1737,8 @@ void PrintAST::printGenericSignature(
         genericParams.slice(paramIdx, lastParamIdx - paramIdx);
 
     SmallVector<InverseRequirement, 2> inversesAtDepth;
-    reconstituteInverses(genericSig, genericParamsAtDepth, inversesAtDepth);
+    if (flags & CollapseDefaultReqs)
+      reconstituteInverses(genericSig, genericParamsAtDepth, inversesAtDepth);
 
     SmallVector<Requirement, 2> requirementsAtDepth;
     getRequirementsAtDepth(genericSig, depth, requirementsAtDepth);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4910,12 +4910,13 @@ InverseMarking TypeDecl::getMarking(InvertibleProtocolKind ip) const {
 }
 
 bool TypeDecl::canBeNoncopyable() const {
-  return getMarking(InvertibleProtocolKind::Copyable).getInverse().isPresent();
+  auto copyable = getMarking(InvertibleProtocolKind::Copyable);
+  return bool(copyable.getInverse()) && !copyable.getPositive();
 }
 
 bool TypeDecl::isEscapable() const {
   auto escapable = getMarking(InvertibleProtocolKind::Escapable);
-  return !escapable.getInverse().isPresent();
+  return !escapable.getInverse() || bool(escapable.getPositive());
 }
 
 Type TypeDecl::getDeclaredInterfaceType() const {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2406,7 +2406,11 @@ namespace {
       properties =
           applyLifetimeAnnotation(D->getLifetimeAnnotation(), properties);
 
-      if (D->canBeNoncopyable()) {
+      GenericEnvironment *env = nullptr;
+      if (auto sig = origType.getGenericSignatureOrNull())
+        env = sig.getGenericEnvironment();
+
+      if (structType->isNoncopyable(env)) {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
         if (properties.isAddressOnly())
@@ -2414,7 +2418,7 @@ namespace {
         return new (TC) MoveOnlyLoadableStructTypeLowering(
             structType, properties, Expansion);
       }
-      if (!D->isEscapable()) {
+      if (!structType->isEscapable(env)) {
         properties.setNonTrivial();
       }
       return handleAggregateByProperties<LoadableStructTypeLowering>(structType,
@@ -2493,7 +2497,11 @@ namespace {
       properties =
           applyLifetimeAnnotation(D->getLifetimeAnnotation(), properties);
 
-      if (D->canBeNoncopyable()) {
+      GenericEnvironment *env = nullptr;
+      if (auto sig = origType.getGenericSignatureOrNull())
+        env = sig.getGenericEnvironment();
+
+      if (enumType->isNoncopyable(env)) {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
         if (properties.isAddressOnly())
@@ -2501,6 +2509,8 @@ namespace {
         return new (TC)
             MoveOnlyLoadableEnumTypeLowering(enumType, properties, Expansion);
       }
+
+      assert(enumType->isEscapable(env) && "missing typelowering case here!");
 
       return handleAggregateByProperties<LoadableEnumTypeLowering>(enumType,
                                                                    properties);

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -66,3 +66,5 @@ public protocol TestAssocTypes {
 public typealias SomeAlias<G> = Hello<G>
 
 public typealias AliasWithInverse<G> = Hello<G> where G: ~Copyable, G: ~Escapable
+
+public struct RudePointer<T: ~Copyable>: Copyable {}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -93,6 +93,9 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-MISC-NEXT: public typealias AliasWithInverse<G> = {{.*}}.Hello<G> where G : ~Copyable, G : ~Escapable
 
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public struct RudePointer<T> : Swift.Copyable where T : ~Copyable {
+
 ///////////////////////////////////////////////////////////////////////
 // Synthesized conditional conformances are next
 

--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -1,0 +1,51 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -disable-availability-checking -module-name main %s | %FileCheck %s
+
+struct NC: ~Copyable {}
+
+struct RudeStruct<T: ~Copyable>: Copyable {
+    let thing: Int
+}
+
+enum RudeEnum<T: ~Copyable>: Copyable {
+  case holder(Int)
+  case whatever
+}
+
+struct CondCopyableStruct<T: ~Copyable> {}
+
+enum CondCopyableEnum<T: ~Copyable> {
+  case some(T)
+  case none
+}
+
+// MARK: ensure certain types are treated as trivial (no ownership in func signature).
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA10RudeStructVySiGF : $@convention(thin) (RudeStruct<Int>) -> () {
+func check(_ t: RudeStruct<Int>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA10RudeStructVyAA2NCVGF : $@convention(thin) (RudeStruct<NC>) -> () {
+func check(_ t: RudeStruct<NC>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA8RudeEnumOySiGF : $@convention(thin) (RudeEnum<Int>) -> () {
+func check(_ t: RudeEnum<Int>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA8RudeEnumOyAA2NCVGF : $@convention(thin) (RudeEnum<NC>) -> () {
+func check(_ t: RudeEnum<NC>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA18CondCopyableStructVySiGF : $@convention(thin) (CondCopyableStruct<Int>) -> () {
+func check(_ t: CondCopyableStruct<Int>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA18CondCopyableStructVyAA2NCVGF : $@convention(thin) (@guaranteed CondCopyableStruct<NC>) -> () {
+func check(_ t: borrowing CondCopyableStruct<NC>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA16CondCopyableEnumOySiGF : $@convention(thin) (CondCopyableEnum<Int>) -> () {
+func check(_ t: CondCopyableEnum<Int>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA16CondCopyableEnumOyAA2NCVGF : $@convention(thin) (@guaranteed CondCopyableEnum<NC>) -> () {
+func check(_ t: borrowing CondCopyableEnum<NC>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA16CondCopyableEnumOyxGs0D0Rzs9EscapableRzlF : $@convention(thin) <T where T : Copyable, T : Escapable> (@in_guaranteed CondCopyableEnum<T>) -> () {
+func check<T>(_ t: CondCopyableEnum<T>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA16CondCopyableEnumOyxGs9EscapableRzlF : $@convention(thin) <U where U : Escapable> (@in_guaranteed CondCopyableEnum<U>) -> () {
+func check<U: ~Copyable>(_ t: borrowing CondCopyableEnum<U>) {}


### PR DESCRIPTION
TypeDecl::canBeNoncopyable is never going to be fully accurate. In this instance, we were incorrectly treating some types like `S<T: ~Copyable>`
 as noncopyable, and thus non-trivial, despite them in some cases being
 Copyable.
