### PR TITLE
[Concurrency] unguard nonisolated(unsafe) attribute from GlobalConcurrency experimental feature

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -55,7 +55,6 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.TypedThrows, to: .typedThrows)
     mapFeature(.DoExpressions, to: .doExpressions)
     mapFeature(.NonEscapableTypes, to: .nonEscapableTypes)
-    mapFeature(.GlobalConcurrency, to: .globalConcurrency)
   }
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5579,8 +5579,7 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes,
   }
 
   // If this is 'nonisolated', check to see if it is valid.
-  if (Context.LangOpts.hasFeature(Feature::GlobalConcurrency) &&
-      Tok.isContextualKeyword("nonisolated") && Tok2.is(tok::l_paren) &&
+  if (Tok.isContextualKeyword("nonisolated") && Tok2.is(tok::l_paren) &&
       isParenthesizedNonisolated(*this)) {
     BacktrackingScope backtrack(*this);
     consumeToken(tok::identifier);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6831,14 +6831,11 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
   auto dc = D->getDeclContext();
 
   if (auto var = dyn_cast<VarDecl>(D)) {
-    const bool isUnsafe =
-        attr->isUnsafe() && Ctx.LangOpts.hasFeature(Feature::GlobalConcurrency);
-
     // stored properties have limitations as to when they can be nonisolated.
     if (var->hasStorage()) {
       // 'nonisolated' can not be applied to mutable stored properties unless
       // qualified as 'unsafe'.
-      if (var->supportsMutation() && !isUnsafe) {
+      if (var->supportsMutation() && !attr->isUnsafe()) {
         diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage);
         return;
       }
@@ -6883,7 +6880,7 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
 
     // nonisolated can not be applied to local properties unless qualified as
     // 'unsafe'.
-    if (dc->isLocalContext() && !isUnsafe) {
+    if (dc->isLocalContext() && !attr->isUnsafe()) {
       diagnoseAndRemoveAttr(attr, diag::nonisolated_local_var);
       return;
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2834,8 +2834,7 @@ namespace {
         return false;
 
       if (auto attr = value->getAttrs().getAttribute<NonisolatedAttr>();
-          ctx.LangOpts.hasFeature(Feature::GlobalConcurrency) && attr &&
-          attr->isUnsafe()) {
+          attr && attr->isUnsafe()) {
         return false;
       }
 
@@ -3306,8 +3305,7 @@ namespace {
         }
 
         if (auto attr = var->getAttrs().getAttribute<NonisolatedAttr>();
-            ctx.LangOpts.hasFeature(Feature::GlobalConcurrency) && attr &&
-            attr->isUnsafe()) {
+            attr && attr->isUnsafe()) {
           return false;
         }
 


### PR DESCRIPTION
This attribute `nonisolated(unsafe)` should no longer be guarded by the broader GlobalConcurrency experimental feature flag.