### PR TITLE
[Typed throws] Implement thrown type inference for do..catch within closures

### DIFF
--- a/include/swift/AST/CatchNode.h
+++ b/include/swift/AST/CatchNode.h
@@ -36,7 +36,14 @@ public:
   ///
   /// Returns the thrown error type for a throwing context, or \c llvm::None
   /// if this is a non-throwing context.
-  llvm::Optional<Type> getThrownErrorTypeInContext(DeclContext *dc) const;
+  llvm::Optional<Type> getThrownErrorTypeInContext(ASTContext &ctx) const;
+
+  /// Determines the explicitly-specified type error that will be caught by
+  /// this catch node.
+  ///
+  /// Returns the explicitly-caught type, or a NULL type if the caught type
+  /// needs to be inferred.
+  Type getExplicitCaughtType(ASTContext &ctx) const;
 
   friend llvm::hash_code hash_value(CatchNode catchNode) {
     using llvm::hash_value;
@@ -45,6 +52,8 @@ public:
 };
 
 void simple_display(llvm::raw_ostream &out, CatchNode catchNode);
+
+SourceLoc extractNearestSourceLoc(CatchNode catchNode);
 
 } // end namespace swift
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1389,6 +1389,8 @@ class DoCatchStmt final
   friend TrailingObjects;
   friend class ExplicitCaughtTypeRequest;
 
+  DeclContext *DC;
+
   SourceLoc DoLoc;
 
   /// Location of the 'throws' token.
@@ -1400,12 +1402,13 @@ class DoCatchStmt final
   Stmt *Body;
   ThrownErrorDestination RethrowDest;
 
-  DoCatchStmt(LabeledStmtInfo labelInfo, SourceLoc doLoc, 
+  DoCatchStmt(DeclContext *dc,LabeledStmtInfo labelInfo, SourceLoc doLoc,
               SourceLoc throwsLoc, TypeLoc thrownType, Stmt *body,
               ArrayRef<CaseStmt *> catches, llvm::Optional<bool> implicit)
       : LabeledStmt(StmtKind::DoCatch, getDefaultImplicitFlag(implicit, doLoc),
                     labelInfo),
-        DoLoc(doLoc), ThrowsLoc(throwsLoc), ThrownType(thrownType), Body(body) {
+        DC(dc), DoLoc(doLoc), ThrowsLoc(throwsLoc), ThrownType(thrownType),
+        Body(body) {
     Bits.DoCatchStmt.NumCatches = catches.size();
     std::uninitialized_copy(catches.begin(), catches.end(),
                             getTrailingObjects<CaseStmt *>());
@@ -1414,12 +1417,15 @@ class DoCatchStmt final
   }
 
 public:
-  static DoCatchStmt *create(ASTContext &ctx, LabeledStmtInfo labelInfo,
-                             SourceLoc doLoc, 
+  static DoCatchStmt *create(DeclContext *dc,
+                             LabeledStmtInfo labelInfo,
+                             SourceLoc doLoc,
                              SourceLoc throwsLoc, TypeLoc thrownType,
                              Stmt *body,
                              ArrayRef<CaseStmt *> catches,
                              llvm::Optional<bool> implicit = llvm::None);
+
+  DeclContext *getDeclContext() const { return DC; }
 
   SourceLoc getDoLoc() const { return DoLoc; }
 
@@ -1435,7 +1441,7 @@ public:
   }
 
   // Get the explicitly-specified caught error type.
-  Type getExplicitCaughtType(DeclContext *dc) const;
+  Type getExplicitCaughtType() const;
 
   Stmt *getBody() const { return Body; }
   void setBody(Stmt *s) { Body = s; }
@@ -1461,7 +1467,7 @@ public:
   // and caught by the various 'catch' clauses. If this the catch clauses
   // aren't exhausive, this is also the type of the error that is implicitly
   // rethrown.
-  Type getCaughtErrorType(DeclContext *dc) const;
+  Type getCaughtErrorType() const;
 
   /// Retrieves the rethrown error and its conversion to the error type
   /// expected by the enclosing context.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2294,7 +2294,7 @@ public:
 /// requires type inference.
 class ExplicitCaughtTypeRequest
     : public SimpleRequest<ExplicitCaughtTypeRequest,
-                           Type(DeclContext *, CatchNode),
+                           Type(ASTContext *, CatchNode),
                            RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2303,7 +2303,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  Type evaluate(Evaluator &evaluator, DeclContext *dc, CatchNode catchNode) const;
+  Type evaluate(Evaluator &evaluator, ASTContext *, CatchNode catchNode) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -360,7 +360,7 @@ SWIFT_REQUEST(TypeChecker, NeedsNewVTableEntryRequest,
 SWIFT_REQUEST(TypeChecker, ParamSpecifierRequest,
               ParamDecl::Specifier(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExplicitCaughtTypeRequest,
-              Type(DeclContext *, CatchNode), SeparatelyCached, NoLocationInfo)
+              Type(ASTContext *, CatchNode), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResultTypeRequest,
               Type(ValueDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AreAllStoredPropertiesDefaultInitableRequest,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1440,6 +1440,31 @@ struct MatchCallArgumentResult {
   }
 };
 
+/// Describes a potential throw site in the constraint system.
+///
+/// For example, given `try f() + a[b] + x.y`, each of `f()`, `a[b]`, `x`, and
+/// `x.y` is a potential throw site.
+struct PotentialThrowSite {
+  enum Kind {
+    /// The application of a function or subscript.
+    Application,
+
+    /// An explicit 'throw'.
+    ExplicitThrow,
+
+    /// A non-exhaustive do...catch, which rethrows whatever is thrown from
+    /// inside it's `do` block.
+    NonExhaustiveDoCatch,
+  } kind;
+
+  /// The type that describes the potential throw site, such as the type of the
+  /// function being called or type being thrown.
+  Type type;
+
+  /// The locator that specifies where the throwing operation occurs.
+  ConstraintLocator *locator;
+};
+
 /// A complete solution to a constraint system.
 ///
 /// A solution to a constraint system consists of type variable bindings to
@@ -1546,6 +1571,13 @@ public:
   /// being solved.
   llvm::MapVector<const CaseLabelItem *, CaseLabelItemInfo>
       caseLabelItems;
+
+  /// Maps catch nodes to the set of potential throw sites that will be caught
+  /// at that location.
+
+  /// The set of opened types for a given locator.
+  std::vector<std::pair<CatchNode, PotentialThrowSite>>
+      potentialThrowSites;
 
   /// A map of expressions to the ExprPatterns that they are being solved as
   /// a part of.
@@ -2210,6 +2242,11 @@ private:
   llvm::SmallMapVector<const CaseLabelItem *, CaseLabelItemInfo, 4>
       caseLabelItems;
 
+  /// Keep track of all of the potential throw sites.
+  /// FIXME: This data structure should be replaced with something that
+  /// is, in effect, a multimap-vector.
+  std::vector<std::pair<CatchNode, PotentialThrowSite>> potentialThrowSites;
+
   /// A map of expressions to the ExprPatterns that they are being solved as
   /// a part of.
   llvm::SmallMapVector<Expr *, ExprPattern *, 2> exprPatterns;
@@ -2821,6 +2858,9 @@ public:
     /// The length of \c caseLabelItems.
     unsigned numCaseLabelItems;
 
+    /// The length of \c potentialThrowSites.
+    unsigned numPotentialThrowSites;
+
     /// The length of \c exprPatterns.
     unsigned numExprPatterns;
 
@@ -3292,6 +3332,14 @@ public:
 
     return known->second;
   }
+
+  /// Note that there is a potential throw site at the given location.
+  void recordPotentialThrowSite(
+      PotentialThrowSite::Kind kind, Type type,
+      ConstraintLocatorBuilder locator);
+
+  /// Determine the caught error type for the given catch node.
+  Type getCaughtErrorType(CatchNode node);
 
   /// Retrieve the constraint locator for the given anchor and
   /// path, uniqued.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1455,6 +1455,9 @@ struct PotentialThrowSite {
     /// A non-exhaustive do...catch, which rethrows whatever is thrown from
     /// inside it's `do` block.
     NonExhaustiveDoCatch,
+
+    /// A property access that can throw an error.
+    PropertyAccess,
   } kind;
 
   /// The type that describes the potential throw site, such as the type of the
@@ -2070,6 +2073,9 @@ struct DeclReferenceType {
   /// (e.g.) applying the base of a member access. This is the type of the
   /// expression used to form the declaration reference.
   Type adjustedReferenceType;
+
+  /// The type that could be thrown by accessing this declaration.
+  Type thrownErrorTypeOnAccess;
 };
 
 /// Describes a system of constraints on type variables, the

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1046,9 +1046,8 @@ public:
       SourceLoc loc = S->getThrowLoc();
       if (loc.isValid()) {
         auto catchNode = ASTScope::lookupCatchNode(getModuleContext(), loc);
-        DeclContext *dc = getInnermostDC();
-        if (catchNode && dc) {
-          if (auto thrown = catchNode.getThrownErrorTypeInContext(dc)) {
+        if (catchNode) {
+          if (auto thrown = catchNode.getThrownErrorTypeInContext(Ctx)) {
             thrownError = *thrown;
           } else {
             thrownError = Ctx.getNeverType();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2054,7 +2054,7 @@ Type ClosureExpr::getExplicitThrownType() const {
   
   ASTContext &ctx = getASTContext();
   auto mutableThis = const_cast<ClosureExpr *>(this);
-  ExplicitCaughtTypeRequest request{mutableThis, mutableThis};
+  ExplicitCaughtTypeRequest request{&ctx, mutableThis};
   return evaluateOrDefault(ctx.evaluator, request, Type());
 }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2255,8 +2255,8 @@ ParserResult<Stmt> Parser::parseStmtDo(LabeledStmtInfo labelInfo,
     }
 
     return makeParserResult(status,
-      DoCatchStmt::create(Context, labelInfo, doLoc, throwsLoc, thrownType,
-                          body.get(), allClauses));
+      DoCatchStmt::create(CurDeclContext, labelInfo, doLoc, throwsLoc,
+                          thrownType, body.get(), allClauses));
   }
 
   if (throwsLoc.isValid()) {

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1117,7 +1117,7 @@ void StmtEmitter::visitDoStmt(DoStmt *S) {
 }
 
 void StmtEmitter::visitDoCatchStmt(DoCatchStmt *S) {
-  Type formalExnType = S->getCaughtErrorType(SGF.FunctionDC);
+  Type formalExnType = S->getCaughtErrorType();
   auto &exnTL = SGF.getTypeLowering(formalExnType);
 
   SILValue exnArg;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2464,6 +2464,13 @@ namespace {
             return explicitType;
         }
 
+        // Explicitly-specified 'throws' without a type is untyped throws.
+        // Use a NULL return here so that the inferred type is written with
+        // `throws` instead of `throws(any Error)`, although the two are
+        // semantically equivalent.
+        if (closure->getThrowsLoc().isValid())
+          return Type();
+
         // Thrown type inferred from context.
         if (auto contextualType = CS.getContextualType(
                 closure, /*forConstraint=*/false)) {
@@ -2474,7 +2481,7 @@ namespace {
         }
 
         // We do not try to infer a thrown error type if one isn't immediately
-        // available. We could attempt this in the future.
+        // available.
         return Type();
       }();
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12855,6 +12855,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
   // is not valid for operators though, where an inout parameter does not
   // have an explicit inout argument.
   if (type1.getPointer() == desugar2) {
+    // Note that this could throw.
+    recordPotentialThrowSite(
+        PotentialThrowSite::Application, Type(desugar2), outerLocator);
+
     if (!isOperator || !hasInOut()) {
       recordMatchCallArgumentResult(
           getConstraintLocator(
@@ -12905,6 +12909,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
 
   // For a function, bind the output and convert the argument to the input.
   if (auto func2 = dyn_cast<FunctionType>(desugar2)) {
+    // Note that this could throw.
+    recordPotentialThrowSite(
+        PotentialThrowSite::Application, Type(desugar2), outerLocator);
+
     ConstraintKind subKind = (isOperator
                               ? ConstraintKind::OperatorArgumentConversion
                               : ConstraintKind::ArgumentConversion);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -206,6 +206,9 @@ Solution ConstraintSystem::finalize() {
   for (const auto &item : caseLabelItems)
     solution.caseLabelItems.insert(item);
 
+  for (const auto &throwSite : potentialThrowSites)
+    solution.potentialThrowSites.push_back(throwSite);
+
   for (const auto &pattern : exprPatterns)
     solution.exprPatterns.insert(pattern);
 
@@ -349,6 +352,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
     if (!getCaseLabelItemInfo(info.first))
       setCaseLabelItemInfo(info.first, info.second);
   }
+
+  potentialThrowSites.insert(potentialThrowSites.end(),
+                             solution.potentialThrowSites.begin(),
+                             solution.potentialThrowSites.end());
 
   for (auto param : solution.isolatedParams) {
     isolatedParams.insert(param);
@@ -653,6 +660,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numContextualTypes = cs.contextualTypes.size();
   numTargets = cs.targets.size();
   numCaseLabelItems = cs.caseLabelItems.size();
+  numPotentialThrowSites = cs.potentialThrowSites.size();
   numExprPatterns = cs.exprPatterns.size();
   numIsolatedParams = cs.isolatedParams.size();
   numPreconcurrencyClosures = cs.preconcurrencyClosures.size();
@@ -775,6 +783,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any case label item infos.
   truncate(cs.caseLabelItems, numCaseLabelItems);
+
+  // Remove any potential throw sites.
+  truncate(cs.potentialThrowSites, numPotentialThrowSites);
 
   // Remove any ExprPattern mappings.
   truncate(cs.exprPatterns, numExprPatterns);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -921,21 +921,11 @@ private:
   void visitThrowStmt(ThrowStmt *throwStmt) {
     // Look up the catch node for this "throw" to determine the error type.
     auto dc = context.getAsDeclContext();
-    CatchNode catchNode = ASTScope::lookupCatchNode(
-        dc->getParentModule(), throwStmt->getThrowLoc());
+    auto module = dc->getParentModule();
+    auto throwLoc = throwStmt->getThrowLoc();
     Type errorType;
-    if (catchNode) {
-      // FIXME: Introduce something like getThrownErrorTypeInContext() for the
-      // constraint solver.
-      if (auto closure = catchNode.dyn_cast<ClosureExpr *>()) {
-        errorType = cs.getClosureType(closure)->getThrownError();
-      }
-
-      if (!errorType) {
-        ASTContext &ctx = cs.getASTContext();
-        errorType = catchNode.getThrownErrorTypeInContext(ctx).value_or(Type());
-      }
-    }
+    if (auto catchNode = ASTScope::lookupCatchNode(module, throwLoc))
+      errorType = catchNode.getExplicitCaughtType(cs.getASTContext());
 
     if (!errorType) {
       if (!cs.getASTContext().getErrorDecl()) {
@@ -1070,10 +1060,15 @@ private:
         contextualTy = cs.getType(switchStmt->getSubjectExpr());
       } else if (auto doCatch =
                      dyn_cast_or_null<DoCatchStmt>(parent.dyn_cast<Stmt *>())) {
-        auto dc = context.getAsDeclContext();
-        contextualTy = doCatch->getExplicitCaughtType();
-        if (!contextualTy)
-          contextualTy = cs.getASTContext().getErrorExistentialType();
+        contextualTy = cs.getCaughtErrorType(doCatch);
+
+        // A non-exhaustive do..catch statement is a potential throw site.
+        if (caseStmt == doCatch->getCatches().back() &&
+            !doCatch->isSyntacticallyExhaustive()) {
+          cs.recordPotentialThrowSite(
+              PotentialThrowSite::NonExhaustiveDoCatch, contextualTy,
+              cs.getConstraintLocator(doCatch));
+        }
       } else {
         hadError = true;
         return;
@@ -1638,6 +1633,13 @@ ConstraintSystem::simplifySyntacticElementConstraint(
 
     if (generateConstraints(target))
       return SolutionKind::Error;
+
+    // If this expression is the operand of a `throw` statement, record it as
+    // a potential throw site.
+    if (contextInfo.purpose == CTP_ThrowStmt) {
+      recordPotentialThrowSite(PotentialThrowSite::ExplicitThrow,
+                               getType(expr), getConstraintLocator(expr));
+    }
 
     setTargetFor(expr, target);
     return SolutionKind::Solved;

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -931,8 +931,10 @@ private:
         errorType = cs.getClosureType(closure)->getThrownError();
       }
 
-      if (!errorType)
-        errorType = catchNode.getThrownErrorTypeInContext(dc).value_or(Type());
+      if (!errorType) {
+        ASTContext &ctx = cs.getASTContext();
+        errorType = catchNode.getThrownErrorTypeInContext(ctx).value_or(Type());
+      }
     }
 
     if (!errorType) {
@@ -1069,7 +1071,7 @@ private:
       } else if (auto doCatch =
                      dyn_cast_or_null<DoCatchStmt>(parent.dyn_cast<Stmt *>())) {
         auto dc = context.getAsDeclContext();
-        contextualTy = doCatch->getExplicitCaughtType(dc);
+        contextualTy = doCatch->getExplicitCaughtType();
         if (!contextualTy)
           contextualTy = cs.getASTContext().getErrorExistentialType();
       } else {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1655,6 +1655,30 @@ void ConstraintSystem::print(raw_ostream &out) const {
       out << "\n";
     }
   }
+
+  if (!potentialThrowSites.empty()) {
+    out.indent(indent) << "Potential throw sites:\n";
+    interleave(potentialThrowSites, [&](const auto &throwSite) {
+      out.indent(indent + 2);
+      switch (throwSite.second.kind) {
+      case PotentialThrowSite::Application:
+        out << "- application @ ";
+        break;
+      case PotentialThrowSite::ExplicitThrow:
+        out << " - explicit throw @ ";
+        break;
+      case PotentialThrowSite::NonExhaustiveDoCatch:
+        out << " - non-exhaustive do..catch @ ";
+        break;
+      }
+
+      throwSite.second.locator->dump(&getASTContext().SourceMgr, out);
+    }, [&] {
+      out << "\n";
+    });
+    out << "\n";
+
+  }
 }
 
 /// Determine the semantics of a checked cast operation.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1670,6 +1670,9 @@ void ConstraintSystem::print(raw_ostream &out) const {
       case PotentialThrowSite::NonExhaustiveDoCatch:
         out << " - non-exhaustive do..catch @ ";
         break;
+      case PotentialThrowSite::PropertyAccess:
+        out << " - property access @ ";
+        break;
       }
 
       throwSite.second.locator->dump(&getASTContext().SourceMgr, out);

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2820,7 +2820,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
     auto dc = CurContext.getDeclContext();
     auto module = dc->getParentModule();
     if (CatchNode catchNode = ASTScope::lookupCatchNode(module, loc)) {
-      if (auto caughtType = catchNode.getThrownErrorTypeInContext(dc))
+      if (auto caughtType = catchNode.getThrownErrorTypeInContext(Ctx))
         return *caughtType;
     }
 
@@ -2947,8 +2947,7 @@ private:
     // specialized diagnostic about non-exhaustive catches.
     if (!CurContext.handlesThrows(ConditionalEffectKind::Conditional)) {
       CurContext.setNonExhaustiveCatch(true);
-    } else if (Type rethrownErrorType =
-                   S->getCaughtErrorType(CurContext.getDeclContext())) {
+    } else if (Type rethrownErrorType = S->getCaughtErrorType()) {
       // We're implicitly rethrowing the error out of this do..catch, so make
       // sure that we can throw an error of this type out of this context.
       auto catches = S->getCatches();
@@ -3590,7 +3589,7 @@ Type TypeChecker::catchErrorType(DeclContext *dc, DoCatchStmt *stmt) {
 
   // If the do..catch statement explicitly specifies that it throws, use
   // that type.
-  if (Type explicitError = stmt->getExplicitCaughtType(dc)) {
+  if (Type explicitError = stmt->getExplicitCaughtType()) {
     return explicitError;
   }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1195,7 +1195,7 @@ public:
         DC->getParentModule(), TS->getThrowLoc());
     Type errorType;
     if (catchNode) {
-      errorType = catchNode.getThrownErrorTypeInContext(DC).value_or(Type());
+      errorType = catchNode.getThrownErrorTypeInContext(Ctx).value_or(Type());
     }
 
     // If there was no error type, use 'any Error'. We'll check it later.

--- a/test/expr/closure/typed_throws.swift
+++ b/test/expr/closure/typed_throws.swift
@@ -17,7 +17,12 @@ func testClosures() {
   // expected-error@-1{{invalid conversion from throwing function of type '() throws(MyError) -> ()'}}
 
   let _: () throws(MyError) -> Void = {
-    throw .fail
+    // NOTE: under full typed throws, this should succeed
+    throw MyError.fail // expected-error{{thrown expression type 'any Error' cannot be converted to error type 'MyError'}}
+  }
+
+  let _: () throws(MyError) -> Void = {
+    throw .fail // expected-error{{type 'any Error' has no member 'fail'}}
   }
 
   // FIXME: Terrible diagnostic.

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -191,3 +191,46 @@ func testDoCatchErrorTypedInClosure(cond: Bool) {
     }
   }
 }
+
+func testDoCatchInClosure(cond: Bool) {
+  apply {
+    do {
+      _ = try doSomething()
+    } catch {
+      let _: MyError = error
+    }
+  }
+
+  apply {
+    do {
+      throw MyError.failed
+    } catch {
+      let _: MyError = error
+    }
+  }
+
+  apply {
+    do {
+      if cond {
+        throw MyError.failed
+      }
+
+      try doHomework()
+    } catch {
+      let _: MyError = error
+      // expected-error@-1{{cannot convert value of type 'any Error' to specified type 'MyError'}}
+    }
+  }
+
+  apply {
+    do {
+      do {
+        _ = try doSomething()
+      } catch .failed {
+        // pick off one case, but this still rethrows
+      }
+    } catch {
+      let _: MyError = error
+    }
+  }
+}

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -196,12 +196,24 @@ struct ThrowingMembers {
   subscript(i: Int) -> Int {
     get throws(MyError) { i }
   }
+
+  var intOrThrows: Int {
+    get throws(MyError) { 5 }
+  }
 }
 
 struct ThrowingStaticSubscript {
   static subscript(i: Int) -> Int {
     get throws(MyError) { i }
   }
+
+  static var intOrThrows: Int {
+    get throws(MyError) { 5 }
+  }
+}
+
+var globalIntOrThrows: Int {
+  get throws(MyError) { 5 }
 }
 
 func testDoCatchInClosure(cond: Bool, x: ThrowingMembers) {
@@ -258,6 +270,31 @@ func testDoCatchInClosure(cond: Bool, x: ThrowingMembers) {
   apply {
     do {
       _ = try ThrowingStaticSubscript[5]
+    } catch {
+      let _: MyError = error
+    }
+  }
+
+  // Property accesses as potential throw sites
+  apply {
+    do {
+      _ = try x.intOrThrows
+    } catch {
+      let _: MyError = error
+    }
+  }
+
+  apply {
+    do {
+      _ = try ThrowingStaticSubscript.intOrThrows
+    } catch {
+      let _: MyError = error
+    }
+  }
+
+  apply {
+    do {
+      _ = try globalIntOrThrows
     } catch {
       let _: MyError = error
     }

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -192,7 +192,19 @@ func testDoCatchErrorTypedInClosure(cond: Bool) {
   }
 }
 
-func testDoCatchInClosure(cond: Bool) {
+struct ThrowingMembers {
+  subscript(i: Int) -> Int {
+    get throws(MyError) { i }
+  }
+}
+
+struct ThrowingStaticSubscript {
+  static subscript(i: Int) -> Int {
+    get throws(MyError) { i }
+  }
+}
+
+func testDoCatchInClosure(cond: Bool, x: ThrowingMembers) {
   apply {
     do {
       _ = try doSomething()
@@ -229,6 +241,23 @@ func testDoCatchInClosure(cond: Bool) {
       } catch .failed {
         // pick off one case, but this still rethrows
       }
+    } catch {
+      let _: MyError = error
+    }
+  }
+
+  // Subscripts as potential throw sites
+  apply {
+    do {
+      _ = try x[5]
+    } catch {
+      let _: MyError = error
+    }
+  }
+
+  apply {
+    do {
+      _ = try ThrowingStaticSubscript[5]
     } catch {
       let _: MyError = error
     }


### PR DESCRIPTION
Start classifying all potential throw sites within a constraint
system and associate them with the nearest enclosing catch node. Then,
determine the thrown error type for a given catch node by taking the
union of the thrown errors at each potential throw site. Use this to
compute the error type thrown from the body of a `do..catch` block
within a closure.