### PR TITLE
[5.10] cherry-pick: Update Windows-aarch64.cmake

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -152,6 +152,7 @@ set(SWIFT_INSTALL_COMPONENTS
       sourcekit-inproc
       swift-remote-mirror
       swift-remote-mirror-headers
+      swift-syntax-lib
     CACHE STRING "")
 
 set(LLVM_DISTRIBUTION_COMPONENTS


### PR DESCRIPTION
Add `swift-syntax-lib` to the distribution image for ARM64

(cherry picked from commit 27c09fc873e5c9ce0ec080b4bc77171215cfaa7b)
