### PR TITLE
Rename NonesapableTypes feature

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2162,7 +2162,7 @@ ERROR(storage_restrictions_attr_expected_name,none,
 
 ERROR(requires_non_escapable_types, none,
       "'%0' %select{attribute|parameter specifier}1 is only valid when experimental "
-      "NonEscapableTypes is enabled",
+      "NonescapableTypes is enabled",
       (StringRef, bool))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7604,7 +7604,7 @@ NOTE(add_explicit_protocol_for_conformance,none,
      "consider making %kind0 explicitly conform to the '%1' protocol",
      (const ValueDecl *, StringRef))
 ERROR(escapable_requires_feature_flag,none,
-      "type '~Escapable' requires -enable-experimental-feature NonEscapableTypes",
+      "type '~Escapable' requires -enable-experimental-feature NonescapableTypes",
       ())
 
 // -- older ones below --
@@ -7699,7 +7699,7 @@ ERROR(noncopyable_cannot_have_read_set_accessor,none,
       (unsigned))
 
 ERROR(nonescapable_types_attr_disabled,none,
-      "attribute requires '-enable-experimental-feature NonEscapableTypes'", ())
+      "attribute requires '-enable-experimental-feature NonescapableTypes'", ())
 
 //------------------------------------------------------------------------------
 // MARK: Init accessors

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -257,7 +257,7 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 
 /// Enable non-escapable type attributes and function attributes that support
 /// lifetime-dependent results.
-EXPERIMENTAL_FEATURE(NonEscapableTypes, false)
+EXPERIMENTAL_FEATURE(NonescapableTypes, false)
 
 /// Enable the `@_extern` attribute.
 EXPERIMENTAL_FEATURE(Extern, true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3751,7 +3751,7 @@ static bool usesFeatureStructLetDestructuring(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureNonEscapableTypes(Decl *decl) {
+static bool usesFeatureNonescapableTypes(Decl *decl) {
   if (decl->getAttrs().hasAttribute<NonEscapableAttr>() ||
       decl->getAttrs().hasAttribute<UnsafeNonEscapableResultAttr>()) {
     return true;

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -54,7 +54,7 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.ThenStatements, to: .thenStatements)
     mapFeature(.TypedThrows, to: .typedThrows)
     mapFeature(.DoExpressions, to: .doExpressions)
-    mapFeature(.NonEscapableTypes, to: .nonEscapableTypes)
+    mapFeature(.NonescapableTypes, to: .nonescapableTypes)
   }
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2872,7 +2872,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   }
 
   if (DK == DAK_ResultDependsOnSelf &&
-      !Context.LangOpts.hasFeature(Feature::NonEscapableTypes)) {
+      !Context.LangOpts.hasFeature(Feature::NonescapableTypes)) {
     diagnose(Loc, diag::requires_non_escapable_types, AttrName, true);
     DiscardAttribute = true;
   }
@@ -5160,7 +5160,7 @@ ParserStatus Parser::parseTypeAttributeListPresent(
     }
 
     if (Tok.isContextualKeyword("_resultDependsOn")) {
-      if (!Context.LangOpts.hasFeature(Feature::NonEscapableTypes)) {
+      if (!Context.LangOpts.hasFeature(Feature::NonescapableTypes)) {
         diagnose(Tok, diag::requires_non_escapable_types, "resultDependsOn",
                  false);
       }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -140,7 +140,7 @@ bool Parser::startsParameterName(bool isClosure) {
         !Tok.isContextualKeyword("__owned") &&
         !Tok.isContextualKeyword("borrowing") &&
         !Tok.isContextualKeyword("consuming") && !Tok.is(tok::kw_repeat) &&
-        (!Context.LangOpts.hasFeature(Feature::NonEscapableTypes) ||
+        (!Context.LangOpts.hasFeature(Feature::NonescapableTypes) ||
          !Tok.isContextualKeyword("_resultDependsOn")))
       return true;
 
@@ -235,7 +235,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
                Tok.isContextualKeyword("consuming") ||
                Tok.isContextualKeyword("isolated") ||
                Tok.isContextualKeyword("_const") ||
-               (Context.LangOpts.hasFeature(Feature::NonEscapableTypes) &&
+               (Context.LangOpts.hasFeature(Feature::NonescapableTypes) &&
                 Tok.isContextualKeyword("_resultDependsOn"))))) {
         // is this token the identifier of an argument label? `inout` is a
         // reserved keyword but the other modifiers are not.

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -162,7 +162,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
         Tok.getRawText().equals("__owned") ||
         Tok.getRawText().equals("consuming") ||
         Tok.getRawText().equals("borrowing") ||
-        (Context.LangOpts.hasFeature(Feature::NonEscapableTypes) &&
+        (Context.LangOpts.hasFeature(Feature::NonescapableTypes) &&
          Tok.getRawText().equals("resultDependsOn"))))) {
     // Type specifier should already be parsed before here. This only happens
     // for construct like 'P1 & inout P2'.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7288,14 +7288,14 @@ void AttributeChecker::visitRawLayoutAttr(RawLayoutAttr *attr) {
 }
 
 void AttributeChecker::visitNonEscapableAttr(NonEscapableAttr *attr) {
-  if (!Ctx.LangOpts.hasFeature(Feature::NonEscapableTypes)) {
+  if (!Ctx.LangOpts.hasFeature(Feature::NonescapableTypes)) {
     diagnoseAndRemoveAttr(attr, diag::nonescapable_types_attr_disabled);
   }
 }
 
 void AttributeChecker::visitUnsafeNonEscapableResultAttr(
   UnsafeNonEscapableResultAttr *attr) {
-  if (!Ctx.LangOpts.hasFeature(Feature::NonEscapableTypes)) {
+  if (!Ctx.LangOpts.hasFeature(Feature::NonescapableTypes)) {
     diagnoseAndRemoveAttr(attr, diag::nonescapable_types_attr_disabled);
   }
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5197,7 +5197,7 @@ NeverNullType TypeResolver::resolveInverseType(InverseTypeRepr *repr,
 
       // Gate the '~Escapable' type behind a specific flag for now.
       if (*kind == InvertibleProtocolKind::Escapable &&
-          !getASTContext().LangOpts.hasFeature(Feature::NonEscapableTypes)) {
+          !getASTContext().LangOpts.hasFeature(Feature::NonescapableTypes)) {
         diagnoseInvalid(repr, repr->getLoc(),
                         diag::escapable_requires_feature_flag);
         return ErrorType::get(getASTContext());

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonEscapableTypes
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 

--- a/test/Generics/inverse_generics_stdlib.swift
+++ b/test/Generics/inverse_generics_stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonEscapableTypes
+// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 

--- a/test/Generics/inverse_scoping.swift
+++ b/test/Generics/inverse_scoping.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonEscapableTypes
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 

--- a/test/Generics/inverse_signatures.swift
+++ b/test/Generics/inverse_signatures.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonEscapableTypes -verify -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s --implicit-check-not "error:"
+// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes -verify -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s --implicit-check-not "error:"
 
 // REQUIRES: asserts
 

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -2,14 +2,14 @@
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
-// RUN:     -enable-experimental-feature NonEscapableTypes \
+// RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o %t/NoncopyableGenerics_Misc.swiftmodule \
 // RUN:     -emit-module-interface-path %t/NoncopyableGenerics_Misc.swiftinterface \
 // RUN:     %S/Inputs/NoncopyableGenerics_Misc.swift
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
-// RUN:     -enable-experimental-feature NonEscapableTypes \
+// RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o %t/Swiftskell.swiftmodule \
 // RUN:     -emit-module-interface-path %t/Swiftskell.swiftinterface \
 // RUN:     %S/Inputs/Swiftskell.swift
@@ -23,17 +23,17 @@
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
-// RUN:     -enable-experimental-feature NonEscapableTypes \
+// RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:    %t/NoncopyableGenerics_Misc.swiftinterface -o %t/NoncopyableGenerics_Misc.swiftmodule
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
-// RUN:     -enable-experimental-feature NonEscapableTypes \
+// RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:    %t/Swiftskell.swiftinterface -o %t/Swiftskell.swiftmodule
 
 // RUN: %target-swift-frontend -typecheck -I %t %s \
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
-// RUN:    -enable-experimental-feature NonEscapableTypes
+// RUN:    -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 

--- a/test/Parse/inverse_escapable_feature.swift
+++ b/test/Parse/inverse_escapable_feature.swift
@@ -2,4 +2,4 @@
 
 // REQUIRES: asserts
 
-struct S: ~Escapable {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonEscapableTypes}}
+struct S: ~Escapable {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonescapableTypes}}

--- a/test/Parse/result_depends_on.swift
+++ b/test/Parse/result_depends_on.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonEscapableTypes -disable-experimental-parser-round-trip
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip
 // REQUIRES: asserts
 
 import Builtin

--- a/test/Parse/result_depends_on_contextual_tests1.swift
+++ b/test/Parse/result_depends_on_contextual_tests1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonEscapableTypes
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonescapableTypes
 // REQUIRES: asserts
 
 import Builtin

--- a/test/Parse/result_depends_on_contextual_tests2.swift
+++ b/test/Parse/result_depends_on_contextual_tests2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonEscapableTypes
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonescapableTypes
 // REQUIRES: asserts
 
 import Builtin

--- a/test/Sema/result_depends_on_errors.swift
+++ b/test/Sema/result_depends_on_errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature  NonEscapableTypes
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature  NonescapableTypes
 // REQUIRES: asserts
 
 import Builtin

--- a/test/attr/attr_nonEscapable.swift
+++ b/test/attr/attr_nonEscapable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonEscapableTypes
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 


### PR DESCRIPTION
Follow the feature flag convention for capitalization and be consistent with the related NoncopyableGenerics feature.

This is a new feature that no wild Swift code has used it yet:

commit e99ce1cc5db02e20d94c7ec21e9bd433dc282e53
Author: Kavon Farvardin <kfarvardin@apple.com>
Date:   Tue Dec 5 23:25:09 2023

    [NCGenerics] add `~Escapable`

    Basic implementation of `~Escapable` in the type system.
