### PR TITLE
SwiftCompilerSources support for OSSA and lifetime dependence

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -115,6 +115,37 @@ public struct StringRef : CustomStringConvertible, NoReflectionChildren {
 }
 
 //===----------------------------------------------------------------------===//
+//                      Single-Element Inline Array
+//===----------------------------------------------------------------------===//
+
+public struct SingleInlineArray<Element>: RandomAccessCollection {
+  private var singleElement: Element? = nil
+  private var multipleElements: [Element] = []
+
+  public init() {}
+
+  public var startIndex: Int { 0 }
+  public var endIndex: Int {
+    singleElement == nil ? 0 : multipleElements.count + 1
+  }
+
+  public subscript(_ index: Int) -> Element {
+    if index == 0 {
+      return singleElement!
+    }
+    return multipleElements[index - 1]
+  }
+
+  public mutating func push(_ element: Element) {
+    guard singleElement != nil else {
+      singleElement = element
+      return
+    }
+    multipleElements.append(element)
+  }
+}
+
+//===----------------------------------------------------------------------===//
 //                            Bridging Utilities
 //===----------------------------------------------------------------------===//
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -1,0 +1,655 @@
+//===--- BorrowUtils.swift - Utilities for borrow scopes ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// A scoped instruction that borrows one or more operands.
+///
+/// If this instruction produces a borrowed value, then
+/// BeginBorrowValue(resultOf: self) != nil.
+///
+/// This does not include instructions like `apply` and `try_apply` that
+/// instantaneously borrow a value from the caller.
+///
+/// This does not include `load_borrow` because it borrows a memory
+/// location, not the value of its operand.
+///
+/// Note: This must handle all instructions with a .borrow operand ownership.
+///
+/// TODO: replace BorrowIntroducingInstruction
+///
+/// TODO: Add non-escaping MarkDependence.
+enum BorrowingInstruction : CustomStringConvertible, Hashable {
+  case beginBorrow(BeginBorrowInst)
+  case storeBorrow(StoreBorrowInst)
+  case beginApply(BeginApplyInst)
+  case partialApply(PartialApplyInst)
+  case startAsyncLet(BuiltinInst)
+
+  init?(_ inst: Instruction) {
+    switch inst {
+    case let bbi as BeginBorrowInst: self = .beginBorrow(bbi)
+    case let sbi as StoreBorrowInst: self = .storeBorrow(sbi)
+    case let bai as BeginApplyInst: self = .beginApply(bai)
+    case let pai as PartialApplyInst where pai.isOnStack:
+      self = .partialApply(pai)
+    case let bi as BuiltinInst
+           where bi.id == .StartAsyncLetWithLocalBuffer:
+      self = .startAsyncLet(bi)
+    default:
+      return nil
+    }
+  }
+  
+  var instruction: Instruction {
+    switch self {
+    case .beginBorrow(let bbi): return bbi
+    case .storeBorrow(let sbi): return sbi
+    case .beginApply(let bai): return bai
+    case .partialApply(let pai): return pai
+    case .startAsyncLet(let bi): return bi
+    }
+  }
+
+  /// Visit the operands that end the local borrow scope.
+  ///
+  /// Note: When this instruction's result is BeginBorrowValue the
+  /// scopeEndingOperand may include reborrows. To find all uses that
+  /// contribute to liveness, the caller needs to determine whether an
+  /// incoming value dominates or is consumed by an outer adjacent
+  /// phi. See InteriorLiveness.
+  ///
+  /// TODO: to hande reborrow-extended uses migrate ExtendedLiveness
+  /// to SwiftCompilerSources.
+  ///
+  /// TODO: For instructions that are not a BeginBorrowValue, verify
+  /// that scope ending instructions exist on all paths. These
+  /// instructions should be complete after SILGen and never cloned to
+  /// produce phis.
+  func visitScopeEndingOperands(_ context: Context,
+                                visitor: @escaping (Operand) -> WalkResult)
+  -> WalkResult {
+    switch self {
+    case .beginBorrow, .storeBorrow:
+      let svi = instruction as! SingleValueInstruction
+      return svi.uses.walk {
+        if $0.instruction is EndBorrowInst { return visitor($0) }
+        return .continueWalk
+      }
+    case .beginApply(let bai):
+      return bai.token.uses.walk { return visitor($0) }
+    case .partialApply(let pai):
+      return visitForwardedUses(introducer: pai, context) {
+        switch $0 {
+        case let .operand(operand):
+          if operand.endsLifetime {
+            return visitor(operand)
+          }
+          return .continueWalk
+        case let .deadValue(_, operand):
+          if let operand = operand {
+            assert(!operand.endsLifetime,
+                   "a dead forwarding instruction cannot end a lifetime")
+          }
+          return .continueWalk
+        }
+      }
+    case .startAsyncLet(let builtin):
+      return builtin.uses.walk {
+        if let builtinUser = $0.instruction as? BuiltinInst,
+          builtinUser.id == .EndAsyncLetLifetime {
+          return visitor($0)
+        }
+        return .continueWalk
+      }
+    }
+  }
+
+  var description: String { instruction.description }
+}
+
+/// A value that introduces a borrow scope:
+/// begin_borrow, load_borrow, reborrow, guaranteed function argument.
+///
+/// If the value introduces a local scope, then that scope is
+/// terminated by scope ending operands. Function arguments do not
+/// introduce a local scope because the caller owns the scope.
+///
+/// If the value is a begin_apply result, then it may be the token or
+/// one of the yielded values. In any case, the scope ending operands
+/// are on the end_apply or abort_apply intructions that use the
+/// token.
+///
+/// Note: equivalent to C++ BorrowedValue, but also handles begin_apply.
+enum BeginBorrowValue {
+  case beginBorrow(BeginBorrowInst)
+  case loadBorrow(LoadBorrowInst)
+  case beginApply(Value)
+  case functionArgument(FunctionArgument)
+  case reborrow(Phi)
+
+  init?(_ value: Value) {
+    switch value {
+    case let bbi as BeginBorrowInst: self = .beginBorrow(bbi)
+    case let lbi as LoadBorrowInst: self = .loadBorrow(lbi)
+    case let arg as FunctionArgument: self = .functionArgument(arg)
+    case let arg as Argument where arg.isReborrow:
+      self = .reborrow(Phi(arg)!)
+    default:
+      if value.definingInstruction is BeginApplyInst {
+        self = .beginApply(value)
+        break
+      }
+      return nil
+    }
+  }
+  
+  var value: Value {
+    switch self {
+    case .beginBorrow(let bbi): return bbi
+    case .loadBorrow(let lbi): return lbi
+    case .beginApply(let v): return v
+    case .functionArgument(let arg): return arg
+    case .reborrow(let phi): return phi.value
+    }
+  }
+
+  init?(using operand: Operand) {
+    switch operand.instruction {
+    case is BeginBorrowInst, is LoadBorrowInst:
+      let inst = operand.instruction as! SingleValueInstruction
+      self = BeginBorrowValue(inst)!
+    case is BranchInst:
+      guard let phi = Phi(using: operand) else { return nil }
+      guard phi.isReborrow else { return nil }
+      self = .reborrow(phi)
+    default:
+      return nil
+    }
+  }
+
+  init?(resultOf borrowInstruction: BorrowingInstruction) {
+    switch borrowInstruction {
+    case let .beginBorrow(beginBorrow):
+      self = BeginBorrowValue(beginBorrow)!
+    case let .beginApply(beginApply):
+      self = BeginBorrowValue(beginApply.token)!
+    case .storeBorrow, .partialApply, .startAsyncLet:
+      return nil
+    }
+  }
+
+  var hasLocalScope: Bool {
+    switch self {
+    case .beginBorrow, .loadBorrow, .beginApply, .reborrow:
+      return true
+    case .functionArgument:
+      return false
+    }
+  }
+
+  // Return the value borrowed by begin_borrow or address borrowed by
+  // load_borrow.
+  //
+  // Return nil for begin_apply and reborrow, which need special handling.
+  var baseOperand: Operand? {
+    switch self {
+    case let .beginBorrow(beginBorrow):
+    return beginBorrow.operand
+    case let .loadBorrow(loadBorrow):
+      return loadBorrow.operand
+    case .beginApply, .functionArgument, .reborrow:
+      return nil
+    }
+  }
+
+  /// The EndBorrows, reborrows (phis), and consumes (of closures)
+  /// that end the local borrow scope. Empty if hasLocalScope is false.
+  var scopeEndingOperands: LazyFilterSequence<UseList> {
+    switch self {
+    case let .beginApply(value):
+      (value.definingInstruction as! BeginApplyInst).token.uses.endingLifetime
+    default:
+      value.uses.endingLifetime
+    }
+  }
+}
+
+/// Find the borrow introducers for `value`. This gives you a set of
+/// OSSA lifetimes that directly include `value`. If `value` is owned,
+/// or introduces a borrow scope, then `value` is the single
+/// introducer for itself.
+///
+/// Example:                                       // introducers:
+///                                                // ~~~~~~~~~~~~
+///   bb0(%0 : @owned $Class,                      // %0
+///       %1 : @guaranteed $Class):                // %1
+///     %borrow0 = begin_borrow %0                 // %borrow0
+///     %pair = struct $Pair(%borrow0, %1)         // %borrow0, %1
+///     %first = struct_extract %pair              // %borrow0, %1
+///     %field = ref_element_addr %first           // (none)
+///     %load = load_borrow %field : $*C           // %load
+func gatherBorrowIntroducers(for value: Value,
+                             in borrowIntroducers: inout Stack<Value>,
+                             _ context: Context) {
+
+  // Cache introducers across multiple instances of BorrowIntroducers.
+  var cache = BorrowIntroducers.Cache(context)
+  defer { cache.deinitialize() }
+  BorrowIntroducers.gather(for: value, in: &borrowIntroducers,
+                           &cache, context)
+}
+
+private struct BorrowIntroducers {
+  typealias CachedIntroducers = SingleInlineArray<Value>
+  struct Cache {
+    // Cache the introducers already found for each SILValue.
+    var valueIntroducers: Dictionary<HashableValue, CachedIntroducers>
+    // Record recursively followed phis to avoid infinite cycles.
+    // Phis are removed from this set when they are cached.
+    var pendingPhis: ValueSet
+
+    init(_ context: Context) {
+      valueIntroducers = Dictionary<HashableValue, CachedIntroducers>()
+      pendingPhis = ValueSet(context)
+    }
+
+    mutating func deinitialize() {
+      pendingPhis.deinitialize()
+    }
+  }
+  
+  let context: Context
+  // BorrowIntroducers instances are recursively nested in order to
+  // find outer adjacent phis. Each instance populates a separate
+  // 'introducers' set. The same value may occur in 'introducers' at
+  // multiple levels. Each instance, therefore, needs a separate
+  // introducer set to avoid adding duplicates.
+  var visitedIntroducers: Set<HashableValue> = Set()
+
+  static func gather(for value: Value, in introducers: inout Stack<Value>,
+                     _ cache: inout Cache, _ context: Context) {
+    var borrowIntroducers = BorrowIntroducers(context: context)
+    borrowIntroducers.gather(for: value, in: &introducers, &cache)
+  }
+
+  private mutating func push(_ introducer: Value,
+    introducers: inout Stack<Value>) {
+    if visitedIntroducers.insert(introducer.hashable).inserted {
+      introducers.push(introducer)
+    }
+  }
+
+  private mutating func push<S: Sequence>(contentsOf other: S,
+    introducers: inout Stack<Value>) where S.Element == Value {
+    for elem in other {
+      push(elem, introducers: &introducers)
+    }
+  }
+
+  // This is the identity function (i.e. just adds `value` to `introducers`)
+  // when:
+  // - `value` is owned
+  // - `value` introduces a borrow scope (begin_borrow, load_borrow, reborrow)
+  //
+  // Otherwise recurse up the use-def chain to find all introducers.
+  private mutating func gather(for value: Value,
+                               in introducers: inout Stack<Value>,
+                               _ cache: inout Cache) {
+    // Check if this value's introducers have already been added to
+    // 'introducers' to avoid duplicates and avoid exponential
+    // recursion on aggregates.
+    if let cachedIntroducers = cache.valueIntroducers[value.hashable] {
+      cachedIntroducers.forEach { push($0, introducers: &introducers) }
+      return
+    }
+    introducers.withMarker(
+      pushElements: { introducers in
+        gatherUncached(for: value, in: &introducers, &cache)
+      },
+      withNewElements: { newIntroducers in
+        { cachedIntroducers in
+          newIntroducers.forEach { cachedIntroducers.push($0) }
+        }(&cache.valueIntroducers[value.hashable, default: CachedIntroducers()])
+      })
+  }
+
+  private mutating func gatherUncached(for value: Value,
+                                       in introducers: inout Stack<Value>,
+                                       _ cache: inout Cache) {
+    switch value.ownership {
+    case .none, .unowned:
+      return
+
+    case .owned:
+      push(value, introducers: &introducers);
+      return
+
+    case .guaranteed:
+      break
+    }
+    // BeginBorrowedValue handles the initial scope introducers: begin_borrow,
+    // load_borrow, & reborrow.
+    if BeginBorrowValue(value) != nil {
+      push(value, introducers: &introducers)
+      return
+    }
+    // Handle guaranteed forwarding phis
+    if let phi = Phi(value) {
+      gather(forPhi: phi, in: &introducers, &cache)
+      return
+    }
+    // Recurse through guaranteed forwarding non-phi instructions.
+    guard let forwardingInst = value.forwardingInstruction else {
+      fatalError("guaranteed value must be forwarding")
+    }
+    for operand in forwardingInst.forwardedOperands {
+      if operand.value.ownership == .guaranteed {
+        gather(for: operand.value, in: &introducers, &cache);
+      }
+    }
+  }
+
+  // Find the introducers of a guaranteed forwarding phi's borrow
+  // scope. The introducers are either dominating values or reborrows
+  // in the same block as the forwarding phi.
+  //
+  // Recurse along the use-def phi web until a begin_borrow is reached. At each
+  // level, find the outer-adjacent phi, if one exists, otherwise return the
+  // dominating definition.
+  //
+  // Example:
+  //
+  //     bb1(%reborrow_1 : @guaranteed)
+  //         %field = struct_extract %reborrow_1
+  //         br bb2(%reborrow_1, %field)
+  //     bb2(%reborrow_2 : @guaranteed, %forward_2 : @guaranteed)
+  //         end_borrow %reborrow_2
+  //
+  // Calling `gather(forPhi: %forward_2)`
+  // recursively computes these introducers:
+  //
+  //    %field is the only value incoming to %forward_2.
+  //
+  //    %field is introduced by %reborrow_1 via
+  //    gather(for: %field).
+  //
+  //    %reborrow_1 is remapped to %reborrow_2 in bb2 via
+  //    mapToPhi(bb1, %reborrow_1)).
+  //
+  //    %reborrow_2 is returned.
+  //
+  private mutating func gather(forPhi phi: Phi,
+                               in introducers: inout Stack<Value>,
+                               _ cache: inout Cache) {
+    // Phi cycles are skipped. They cannot contribute any new introducer.
+    if !cache.pendingPhis.insert(phi.value) {
+      return
+    }
+    for (pred, value) in zip(phi.predecessors, phi.incomingValues) {
+      // Each phi operand requires a new introducer list and visited
+      // values set. These values will be remapped to successor phis
+      // before adding them to the caller's introducer list. It may be
+      // necessary to revisit a value that was already visited by the
+      // caller before remapping to phis.
+      var incomingIntroducers = Stack<Value>(context)
+      defer {
+        incomingIntroducers.deinitialize()
+      }
+      BorrowIntroducers.gather(for: value, in: &incomingIntroducers,
+                               &cache, context)
+      // Map the incoming introducers to an outer-adjacent phi if one exists.
+      push(contentsOf: mapToPhi(predecessor: pred,
+                                incomingValues: incomingIntroducers),
+           introducers: &introducers)
+    }
+    // Remove this phi from the pending set. This phi may be visited
+    // again at a different level of phi recursion. In that case, we
+    // should return the cached introducers so that they can be
+    // remapped.
+    cache.pendingPhis.erase(phi.value)
+  }
+}
+
+// Given incoming values on a predecessor path, return the
+// corresponding values on the successor block. Each incoming value is
+// either used by a phi in the successor block, or it must dominate
+// the successor block.
+private func mapToPhi<PredecessorSequence: Sequence<Value>> (
+  predecessor: BasicBlock, incomingValues: PredecessorSequence)
+-> LazyMapSequence<PredecessorSequence, Value> {
+
+  let branch = predecessor.terminator as! BranchInst
+  // Gather the new introducers for the successor block.
+  return incomingValues.lazy.map { incomingValue in
+    // Find an outer adjacent phi in the successor block.
+    if let incomingOp =
+         branch.operands.first(where: { $0.value == incomingValue }) {
+      return branch.getArgument(for: incomingOp)
+    }
+    // No candidates phi are outer-adjacent phis. The incoming
+    // `predDef` must dominate the current guaranteed phi.
+    return incomingValue
+  }
+}
+
+/// Find each "enclosing value" whose OSSA lifetime immediately
+/// encloses a guaranteed value. The guaranteed `value` being enclosed
+/// effectively keeps these enclosing values alive. This lets you walk
+/// up the levels of nested OSSA lifetimes to determine all the
+/// lifetimes that are kept alive by a given SILValue. In particular,
+/// it discovers "outer-adjacent phis": phis that are kept alive by
+/// uses of another phi in the same block.
+///
+/// If `value` is a forwarded guaranteed value, then this finds the
+/// introducers of the current borrow scope, which is never an empty
+/// set.
+///
+/// If `value` introduces a borrow scope, then this finds the
+/// introducers of the outer enclosing borrow scope that contains this
+/// inner scope.
+///
+/// If `value` is a `begin_borrow`, then this returns its operand.
+///
+/// If `value` is an owned value, a function argument, or a
+/// load_borrow, then this is an empty set.
+///
+/// If `value` is a reborrow, then this either returns a dominating
+/// enclosing value or an outer adjacent phi.
+///
+/// Example:                                       // enclosing value:
+///                                                // ~~~~~~~~~~~~
+///   bb0(%0 : @owned $Class,                      // (none)
+///       %1 : @guaranteed $Class):                // (none)
+///     %borrow0 = begin_borrow %0                 // %0
+///     %pair = struct $Pair(%borrow0, %1)         // %borrow0, %1
+///     %first = struct_extract %pair              // %borrow0, %1
+///     %field = ref_element_addr %first           // (none)
+///     %load = load_borrow %field : $*C           // %load
+///
+/// Example:                                       // enclosing value:
+///                                                // ~~~~~~~~~~~~
+///     %outerBorrow = begin_borrow %0             // %0
+///     %innerBorrow = begin_borrow %outerBorrow   // %outerBorrow
+///     br bb1(%outerBorrow, %innerBorrow)
+///   bb1(%outerReborrow : @guaranteed,            // %0
+///       %innerReborrow : @guaranteed)            // %outerReborrow
+///
+func gatherEnclosingValues(for value: Value,
+                           in enclosingValues: inout Stack<Value>,
+                           _ context: some Context) {
+
+  var gatherValues = EnclosingValues(context)
+  defer { gatherValues.deinitialize() }
+  var cache = BorrowIntroducers.Cache(context)
+  defer { cache.deinitialize() }
+  gatherValues.gather(for: value, in: &enclosingValues, &cache)
+}
+
+/// Find inner adjacent phis in the same block as `enclosingPhi`.
+/// These keep the enclosing (outer adjacent) phi alive.
+func gatherInnerAdjacentPhis(for enclosingPhi: Phi,
+                             in innerAdjacentPhis: inout Stack<Phi>,
+                             _ context: Context) {
+  for candidatePhi in enclosingPhi.successor.arguments {
+    var enclosingValues = Stack<Value>(context)
+    defer { enclosingValues.deinitialize() }
+    gatherEnclosingValues(for: candidatePhi, in: &enclosingValues, context)
+    if enclosingValues.contains(where: { $0 == enclosingPhi.value}) {
+      innerAdjacentPhis.push(Phi(candidatePhi)!)
+    }
+  }
+}
+
+// Find the enclosing values for any value, including reborrows.
+private struct EnclosingValues {
+  var context: Context
+  var visitedReborrows : ValueSet
+
+  init(_ context: Context) {
+    self.context = context
+    self.visitedReborrows = ValueSet(context)
+  }
+
+  mutating func deinitialize() {
+    visitedReborrows.deinitialize()
+  }
+
+  mutating func gather(for value: Value,
+                       in enclosingValues: inout Stack<Value>,
+                       _ cache: inout BorrowIntroducers.Cache) {
+    if value is Undef || value.ownership != .guaranteed {
+      return
+    }
+    if let beginBorrow = BeginBorrowValue(value) {
+      switch beginBorrow {
+      case let .beginBorrow(bbi):
+        // Gather the outer enclosing borrow scope.
+        BorrowIntroducers.gather(for: bbi.operand.value, in: &enclosingValues,
+                                 &cache, context)
+      case .loadBorrow, .beginApply, .functionArgument:
+        // There is no enclosing value on this path.
+        break
+      case let .reborrow(reborrow):
+        gather(forReborrow: reborrow, in: &enclosingValues, &cache)
+      }
+    } else {
+      // Handle forwarded guaranteed values.
+      BorrowIntroducers.gather(for: value, in: &enclosingValues,
+                               &cache, context)
+    }
+  }
+  
+  // Given a reborrow, find the enclosing values. Each enclosing value
+  // is represented by one of the following cases, which refer to the
+  // example below:
+  //
+  // dominating owned value -> %value encloses %reborrow_1
+  // owned outer-adjacent phi -> %phi_3 encloses %reborrow_3
+  // dominating outer borrow introducer -> %outerBorrowB encloses %reborrow
+  // outer-adjacent reborrow -> %outerReborrow encloses %reborrow
+  //
+  // Recurse along the use-def phi web until a begin_borrow is
+  // reached. Then find all introducers of the begin_borrow's
+  // operand. At each level, find the outer adjacent phi, if one
+  // exists, otherwise return the most recently found dominating
+  // definition.
+  //
+  // If `reborrow` was already encountered because of a phi cycle,
+  // then no enclosingDefs are added.
+  //
+  // Example:
+  //
+  //         %value = ...
+  //         %borrow = begin_borrow %value
+  //         br one(%borrow)
+  //     one(%reborrow_1 : @guaranteed)
+  //         br two(%value, %reborrow_1)
+  //     two(%phi_2 : @owned, %reborrow_2 : @guaranteed)
+  //         br three(%value, %reborrow_2)
+  //     three(%phi_3 : @owned, %reborrow_3 : @guaranteed)
+  //         end_borrow %reborrow_3
+  //         destroy_value %phi_3
+  //
+  // gather(forReborrow: %reborrow_3) finds %phi_3 by computing
+  // enclosing defs in this order
+  //     (inner -> outer):
+  //
+  //     %reborrow_1 -> %value
+  //     %reborrow_2 -> %phi_2
+  //     %reborrow_3 -> %phi_3
+  //
+  // Example:
+  //
+  //         %outerBorrowA = begin_borrow
+  //         %outerBorrowB = begin_borrow
+  //         %struct = struct (%outerBorrowA, outerBorrowB)
+  //         %borrow = begin_borrow %struct
+  //         br one(%outerBorrowA, %borrow)
+  //     one(%outerReborrow : @guaranteed, %reborrow : @guaranteed)
+  //
+  // gather(forReborrow: %reborrow) finds (%outerReborrow, %outerBorrowB).
+  //
+  private mutating func gather(forReborrow reborrow: Phi,
+                               in enclosingValues: inout Stack<Value>,
+                               _ cache: inout BorrowIntroducers.Cache) {
+
+    guard visitedReborrows.insert(reborrow.value) else { return }
+
+    // avoid duplicates in the enclosingValues set.
+    var pushedEnclosingValues = ValueSet(context)
+    defer { pushedEnclosingValues.deinitialize() }
+
+    // Find the enclosing introducer for each reborrow operand, and
+    // remap it to the enclosing introducer for the successor block.
+    for (pred, incomingValue)
+    in zip(reborrow.predecessors, reborrow.incomingValues) {
+      var incomingEnclosingValues = Stack<Value>(context)
+      defer {
+        incomingEnclosingValues.deinitialize()
+      }
+      gather(for: incomingValue, in: &incomingEnclosingValues, &cache)
+      mapToPhi(predecessor: pred,
+               incomingValues: incomingEnclosingValues).forEach {
+        if pushedEnclosingValues.insert($0) {
+          enclosingValues.append($0)
+        }
+      }
+    }
+  }
+}
+
+let borrowIntroducersTest = FunctionTest("borrow_introducers") {
+  function, arguments, context in
+  let value = arguments.takeValue()
+  print(function)
+  print("Borrow introducers for: \(value)")
+  var introducers = Stack<Value>(context)
+  defer {
+    introducers.deinitialize()
+  }
+  gatherBorrowIntroducers(for: value, in: &introducers, context)
+  introducers.forEach { print($0) }
+}
+
+let enclosingValuesTest = FunctionTest("enclosing_values") {
+  function, arguments, context in
+  let value = arguments.takeValue()
+  print(function)
+  print("Enclosing values for: \(value)")
+  var enclosing = Stack<Value>(context)
+  defer {
+    enclosing.deinitialize()
+  }
+  gatherEnclosingValues(for: value, in: &enclosing, context)
+  enclosing.forEach { print($0) }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -12,6 +12,7 @@ swift_compiler_sources(Optimizer
   Devirtualization.swift
   EscapeUtils.swift
   ForwardingUtils.swift
+  LifetimeDependenceUtils.swift
   OptUtils.swift
   OwnershipLiveness.swift
   SSAUpdater.swift

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 swift_compiler_sources(Optimizer
+  BorrowUtils.swift
   DiagnosticEngine.swift
   Devirtualization.swift
   EscapeUtils.swift

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -11,8 +11,9 @@ swift_compiler_sources(Optimizer
   DiagnosticEngine.swift
   Devirtualization.swift
   EscapeUtils.swift
-  OptUtils.swift
   ForwardingUtils.swift
+  OptUtils.swift
+  OwnershipLiveness.swift
   SSAUpdater.swift
   StaticInitCloner.swift
   Test.swift

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -1,0 +1,506 @@
+//===--- LifetimeDependenceUtils.swift - Utils for lifetime dependence ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Walk up the value dependence chain to find the best-effort variable declaration. Typically called while diagnosing an error.
+///
+/// The walk stops at:
+/// - an address
+/// - a variable declaration (begin_borrow [var_decl], move_value [var_decl])
+/// - the root of the dependence chain
+///
+/// If the introducer is an address, then the client can call Value.enclosingAccess iteratively to find to AccessBase. This walker is useful for finding the innermost access, which may also be relevant for diagnostics.
+func gatherVariableIntroducers(for value: Value, _ context: Context) -> [Value]
+{
+  var introducers: [Value] = []
+  var useDefVisitor = VariableIntroducerUseDefWalker(context) {
+    introducers.append($0)
+    return .continueWalk
+  }
+  defer { useDefVisitor.deinitialize() }
+  _ = useDefVisitor.walkUp(value: value)
+  return introducers
+}
+
+/// A lifetime dependence represents a scope in which some parent value is alive and accessible along with a dependent value. All values derived from the dependent value must be used within this scope. This supports diagnostics on non-escapable types.
+///
+/// A lifetime dependence is produced by either 'mark_dependence [nonescaping]':
+///
+///   %dependent = mark_dependence [nonescaping] %value on %parent
+///
+/// or a non-escapable function argument:
+///
+///   bb0(%dependent : NonEscapableThing):
+///
+/// A  lifetime dependence identifies its parent value, the kind of scope that the parent value represents, and a dependent value. A self-dependence has the same parent and dependent value:
+///
+///   %dependent = mark_dependence [nonescaping] %value on %value
+///
+/// Self-dependence is useful to ensure that derived values, including copies, do not escape the lifetime of the original value. Non-escapable function arguments are implicitly self-dependent, meaning that the argument's value does not escape the function body. Note that we do not insert a 'mark_dependence [nonescaping]' for function arguments because the caller must already represent the argument's dependence on some parent value. That parent value may not be the value directly passed to the argument. After inlining, an additional self-dependence on argument value would be overly strict.
+struct LifetimeDependence {
+  enum Scope {
+    /// A non-escapable or guaranteed argument whose scope is provided
+    /// by the caller and covers the entire function.
+    case caller(Argument)
+    /// An access scope.
+    case access(BeginAccessInst)
+    /// An owned value whose OSSA lifetime encloses nonescapable values
+    case owned(Value)
+    /// An singly-initialized address-only value, in which the entire
+    /// initialized region is a lifetime (as opposed to an individual
+    /// access). e.g. A value produced by @out.
+    case initialized(Value)
+
+    var parentValue: Value {
+      switch self {
+      case let .caller(argument): return argument
+      case let .access(beginAccess): return beginAccess
+      case let .owned(value): return value
+      case let .initialized(value): return value
+      }
+    }
+
+    func checkPrecondition() {
+      switch self {
+      case let .caller(argument):
+        precondition(!argument.type.isEscapable
+          || argument.ownership == .guaranteed,
+          "only non-escapable or guaranteed arguments have a caller scope")
+      case .access:
+        break
+      case let .owned(value):
+        precondition(value.ownership == .owned)
+      case let .initialized(value):
+        precondition(value.type.isAddress, "expected an address")
+      }
+    }
+    var description: String {
+      {
+        switch self {
+        case .caller: "Caller: "
+        case .access: "Access: "
+        case .owned: "Owned: "
+        case .initialized: "Initialized: "
+        }
+      }() + "\(parentValue)"
+    }
+  }
+  let scope: Scope
+  let dependentValue: Value
+  
+  var parentValue: Value { scope.parentValue }
+
+  var function: Function {
+    dependentValue.parentFunction // dependentValue can't be undef
+  }
+
+  var description: String {
+    return scope.description +
+      """
+      dependent: \(dependentValue)
+      """
+  }
+}
+
+extension LifetimeDependence {
+  /// Construct LifetimeDependence from mark_dependence [nonescaping]
+  ///
+  /// TODO: Add SIL verification that all mark_depedence [nonescaping]
+  /// have a valid LifetimeDependence.
+  init?(markDependenceInst: MarkDependenceInst, _ context: some Context) {
+    guard markDependenceInst.isNonEscaping else { return nil }
+    guard let scope = Scope(base: markDependenceInst.base, context) else {
+      return nil
+    }
+    self.scope = scope
+    self.dependentValue = markDependenceInst.value
+  }
+}
+
+extension LifetimeDependence.Scope {
+  /// Construct a lifetime dependence scope from the base value that
+  /// other values depend on. This derives the kind of dependence
+  /// scope and its parentValue from `base`.
+  init?(base: Value, _ context: some Context) {
+    if base.type.isAddress {
+      let accessScope = base.enclosingAccessScope
+      guard case let .scope(access) = accessScope else {
+        // TODO: Handle singly initialize address-only values and
+        // create a LifetimeDependence.initialized
+        fatalError("a non-escaping scope's address must be in an access scope")
+      }
+      self = .access(access)
+      return
+    }
+    switch base.ownership {
+    case .owned:
+      self = .owned(base)
+      return
+    case .guaranteed:
+      var introducers = Stack<Value>(context)
+      gather(borrowIntroducers: &introducers, for: base, context)
+      // TODO: Add a SIL verifier check that a mark_dependence [nonescaping]
+      // base is never a guaranteed phi.
+      guard let introducer = introducers.pop() else { return nil }
+      assert(introducers.isEmpty,
+
+        "guaranteed phis not allowed when diagnosing lifetime dependence")
+      guard let beginBorrow = BeginBorrowValue(introducer) else {
+        fatalError("unknown borrow introducer")
+      }
+      if let borrowOperand = beginBorrow.baseOperand {
+        if let scope = LifetimeDependence.Scope(base: borrowOperand.value,
+          context) {
+          self = scope
+          return
+        }
+        return nil
+      }
+      self = .caller(beginBorrow.value as! Argument)
+      return
+    case .none:
+      // lifetime dependence requires a nontrivial value"
+      return nil
+    case .unowned:
+      fatalError("Cannot create a dependence on an unowned value")
+    }
+  }
+}
+
+extension LifetimeDependence.Scope {
+  /// Compute the range of the dependence scope. 
+  ///
+  /// Returns nil if the dependence scope covers the entire function.
+  ///
+  /// Note: The caller must deinitialize the returned range.
+  func computeRange(_ context: Context) -> InstructionRange? {
+    switch self {
+    case .caller: return nil
+    case let .access(beginAccessInst):
+      var range = InstructionRange(begin: beginAccessInst, context)
+      for endInst in beginAccessInst.endInstructions {
+        range.insert(endInst)
+      }
+      return range
+    case let .owned(value):
+      return computeLinearLiveness(for: value, context)
+    case let .initialized(value):
+      return LifetimeDependence.Scope.computeIndirectResultRange(value: value,
+        context)
+    }
+  }
+  
+  private static func computeIndirectResultRange(
+    value: Value, _ context: Context
+  ) -> InstructionRange {
+    // TODO: add a utility for addressible lifetimes. This only
+    // happens for singly initialized address-only values, like
+    // indirect function results. It will be sufficient to visit all
+    // the destroy_addr, copy_addr [take], and load[take] address
+    // uses. This is unreachable with opaque SIL values.
+    fatalError("Unimplemented: addressible lifetime parent")
+  }
+}
+
+extension LifetimeDependence {
+  /// TODO: By making UseDefVisitor a NonEscapable type, we should be
+  /// able to make \p visitor a non-escaping closure.
+  static func visitDependenceRoots(enclosing value: Value,
+    _ context: Context,
+    _ visitor: @escaping (LifetimeDependence.Scope) -> WalkResult)
+  -> WalkResult {
+    var useDefVisitor = UseDefVisitor(context, visitor)
+    defer { useDefVisitor.deinitialize() }
+    return useDefVisitor.walkUp(value: value)
+  }
+  
+  private struct UseDefVisitor : LifetimeDependenceUseDefWalker {
+    let context: Context
+    // This visited set is only really needed for instructions with
+    // multiple results, including phis.
+    private var visitedValues: ValueSet
+    // Call \p visit rather than calling this directly.
+    private let visitorClosure: (LifetimeDependence.Scope) -> WalkResult
+    
+    init(_ context: Context,
+         _ visitor: @escaping (LifetimeDependence.Scope) -> WalkResult) {
+      self.context = context
+      self.visitedValues = ValueSet(context)
+      self.visitorClosure = visitor
+    }
+    
+    mutating func deinitialize() {
+      visitedValues.deinitialize()
+    }
+    
+    mutating func needWalk(for value: Value) -> Bool {
+      visitedValues.insert(value)
+    }
+
+    // Visit the base value of a lifetime dependence. If the base is
+    // an address, the dependence scope is the enclosing access. The
+    // walker does not walk past an `mark_dependence [nonescaping]`
+    // that produces an address, because that will never occur inside
+    // of an access scope. An address type mark_dependence
+    // [nonescaping]` can only result from an indirect function result
+    // when opaque values are not enabled.
+    mutating func introducer(_ value: Value) -> WalkResult {
+      guard let scope = LifetimeDependence.Scope(base: value, context)
+      else {
+        return .continueWalk
+      }
+      scope.checkPrecondition()
+      return visitorClosure(scope)
+    }
+  }
+}
+
+struct VariableIntroducerUseDefWalker : LifetimeDependenceUseDefWalker {
+  let context: Context
+  // This visited set is only really needed for instructions with
+  // multiple results, including phis.
+  private var visitedValues: ValueSet
+
+  // Call \p visit rather than calling this directly.
+  private let visitorClosure: (Value) -> WalkResult
+
+  init(_ context: Context, _ visitor: @escaping (Value) -> WalkResult) {
+    self.context = context
+    self.visitedValues = ValueSet(context)
+    self.visitorClosure = visitor
+  }
+
+  mutating func deinitialize() {
+    visitedValues.deinitialize()
+  }
+ 
+  mutating func needWalk(for value: Value) -> Bool {
+    visitedValues.insert(value)
+  }
+
+  mutating func introducer(_ value: Value) -> WalkResult {
+    return visitorClosure(value)
+  }
+
+  mutating func walkUp(value: Value) -> WalkResult {
+    switch value.definingInstruction {
+    case let moveInst as MoveValueInst:
+      if moveInst.isFromVarDecl {
+        return introducer(moveInst)
+      }
+    case let borrow as BeginBorrowInst:
+      if borrow.isFromVarDecl {
+        return introducer(borrow)
+      }
+    default:
+      break
+    }
+    return walkUpDefault(dependent: value)
+  }
+}
+
+/// Walk up dominating dependent values.
+///
+/// Find the roots of a dependence chain stopping at phis. These root
+/// LifeDependence instances are the value's "inherited"
+/// dependencies. In this example, the dependence root is copied,
+/// borrowed, and forwarded before being used as the base operand of
+/// `mark_dependence`. The dependence "root" is the parent of the
+/// outer-most dependence scope.
+///
+///   %root = apply                  // lifetime dependence root
+///   %copy = copy_value %root
+///   %parent = begin_borrow %copy   // lifetime dependence parent value
+///   %base = struct_extract %parent // lifetime dependence base value
+///   %dependent = mark_dependence [nonescaping] %value on %base
+///
+/// This extends the ForwardingDefUseWalker, which finds the
+/// forward-extended lifetime introducers. Certain forward-extended
+/// lifetime introducers produce dependent values: namely copies,
+/// moves, and borrows. These introducers are considered part of their
+/// operand's dependence scope because non-escapable values can be
+/// copied, moved, and borrowed. Nonetheless, all of their uses must
+/// remain within original dependence scope.
+///
+///   # owned lifetime dependence
+///   %parent = apply               // begin dependence scope -+
+///   ...                                                      |
+///   %1 = mark_dependence [nonescaping] %value on %parent     |
+///   ...                                                      |
+///   %2 = copy_value %1        -+                             |
+///   # forwarding instruction   |                             |
+///   %3 = struct $S (%2)        | forward-extended lifetime   |
+///                              |                             | OSSA Lifetime
+///   %4 = move_value %3        -+                             |
+///   ...                        | forward-extended lifetime   |
+///   %5 = begin_borrow %4       | -+                          |
+///   # dependent use of %1      |  | forward-extended lifetime|
+///   end_borrow %5              | -+                          |
+///   destroy_value %4          -+                             |
+///   ...                                                      |
+///   destroy_value %parent        // end dependence scope    -+
+///
+/// All of the dependent uses including `end_borrow %5` and
+/// `destroy_value %4` must be before the end of the dependence scope:
+/// `destroy_value %parent`. In this case, the dependence parent is an
+/// owned value, so the scope is simply the value's OSSA lifetime.
+///
+/// Minimal requirements:
+///   var context: Context
+///   introducer(_ value: Value) -> WalkResult
+///   needWalk(for value: Value) -> Bool
+///
+/// Start walking:
+///   walkUp(value: Value) -> WalkResult
+protocol LifetimeDependenceUseDefWalker : ForwardingUseDefWalker {
+  var context: Context { get }
+
+  mutating func introducer(_ value: Value) -> WalkResult
+
+  // Minimally, check a ValueSet. This walker may traverse chains of aggregation and destructuring along with phis.
+  mutating func needWalk(for value: Value) -> Bool
+
+  mutating func walkUp(value: Value) -> WalkResult
+}
+
+extension LifetimeDependenceUseDefWalker {
+  mutating func walkUp(value: Value) -> WalkResult {
+    walkUpDefault(dependent: value)
+  }
+
+  // Extend ForwardingUseDefWalker to handle copies, moves, and
+  // borrows. Also transitively walk up other lifetime dependencies to
+  // find the roots.
+  //
+  // If `value` is an address, this immediately invokes
+  // `introducer()`. We only expect to see an address-type
+  // `mark_dependence [nonescaping]` when opaque values are disabled.
+  //
+  // Handles loads as a convenience so the client receives the load's
+  // address as an introducer.
+  mutating func walkUpDefault(dependent value: Value) -> WalkResult {
+    switch value.definingInstruction {
+    case let copyInst as CopyValueInst:
+      return walkUp(value: copyInst.fromValue)
+    case let moveInst as MoveValueInst:
+      return walkUp(value: moveInst.fromValue)
+    case let borrow as BeginBorrowInst:
+      return walkUp(value: borrow.borrowedValue)
+    case let load as LoadInstruction:
+      return walkUp(value: load.address)
+    case let markDep as MarkDependenceInst:
+      if let dependence = LifetimeDependence(markDependenceInst: markDep,
+        context) {
+        return walkUp(value: dependence.parentValue)
+      }
+    default:
+      break
+    }
+    // If the dependence chain has a phi, consider it a root. Dependence roots
+    // are currently expected to dominate all dependent values.
+    if Phi(value) != nil {
+      return introducer(value)
+    }
+    return walkUpDefault(forwarded: value)
+  }
+}
+
+/// Walk down dependent values.
+///
+/// Delegates value def-use walking to the ForwardingUseDefWalker and
+/// overrides copy, move, borrow, and mark_dependence.
+///
+/// Stops at an address value. Finding the leaf uses of an address
+/// requires an AddressDefUseWalker.
+///
+/// Ignores trivial values (~Escapable types are never
+/// trivial. Escapable types may only be lifetime-depenent values if
+/// they are non-trivial).
+///
+/// Skips uses within nested borrow scopes.
+///
+/// TODO: override BeginAccessInst to handle EndAccessInst.
+///
+/// Minimal requirements:
+///   needWalk(for value: Value) -> Bool
+///   leafUse(_ operand: Operand) -> WalkResult
+///   deadValue(_ value: Value, using operand: Operand?) -> WalkResult
+///
+/// Start walking:
+///   walkDown(root: Value)
+protocol LifetimeDependenceDefUseWalker : ForwardingDefUseWalker {
+  var function: Function { get }
+  var context: Context { get }
+
+  // Minimally, check a ValueSet. This walker may traverse chains of
+  // aggregation and destructuring by default. Implementations may
+  // handle phis.
+  mutating func needWalk(for value: Value) -> Bool
+
+  mutating func leafUse(_ operand: Operand) -> WalkResult
+
+  // Report any initial or dependent value with no uses. Only relevant for
+  // guaranteed values or incomplete OSSA. This could be a dead
+  // instruction, a terminator in which the result is dead on one
+  // path, or a dead phi.
+  //
+  // \p operand is nil if \p value is the root.
+  mutating func deadValue(_ value: Value, using operand: Operand?) -> WalkResult
+
+  mutating func walkDownUses(of: Value, using: Operand?) -> WalkResult
+    
+  mutating func walkDown(operand: Operand) -> WalkResult
+}
+
+extension LifetimeDependenceDefUseWalker {
+  // Callback from ForwardingDefUseWalker.
+  mutating func walkDown(operand: Operand) -> WalkResult {
+    switch operand.instruction {
+    case let copy as CopyValueInst:
+      return walkDownUses(of: copy, using: operand)
+
+    case let move as MoveValueInst:
+      return walkDownUses(of: move, using: operand)
+
+    case let borrow as BeginBorrowInst:
+      // Skip the uses within nested borrow scopes.
+      for endOperand in BeginBorrowValue(borrow)!.scopeEndingOperands {
+        switch endOperand.ownership {
+        case .endBorrow:
+          if leafUse(operand) == .abortWalk {
+            return .abortWalk
+          }
+        case .reborrow:
+          let phi = Phi(using: operand)!
+          if walkDownUses(of: phi.value, using: operand) == .abortWalk {
+            return .abortWalk
+          }
+        default:
+          fatalError("begin_borrow scope cannot be consumed")
+        }
+      }
+      return .continueWalk
+
+    case let markDep as MarkDependenceInst:
+      // Follow the uses of nonescaping dependents.
+      if markDep.baseOperand == operand
+      && LifetimeDependence(markDependenceInst: markDep, context) != nil {
+        return walkDownUses(of: markDep, using: operand)
+      }
+      // Let the forwarding walker handle the mark_dependence value operand.
+    default:
+      break
+    }
+    return walkDownDefault(forwarding: operand)
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -1,0 +1,977 @@
+//===--- OwnershipLiveness.swift - Utilities for ownership liveness -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// TODO: Implement ExtendedLinearLiveness. This requires
+// MultiDefPrunedLiveness, which is not supported by InstructionRange.
+//
+// TODO: Move this all into SIL, along with DominatorTree. OSSA
+// lifetimes and dominance are part of SIL semantics, and need to be
+// verified. Remove uses of FunctionPassContext.
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Compute liveness and return a range, which the caller must deinitialize.
+///
+/// `definingValue` must introduce an OSSA lifetime. It may be either
+/// an owned value or introduce a borrowed value (BeginBorrowValue),
+/// including:
+///
+/// 1. Owned non-phi values
+/// 2. Owned phi values
+/// 3. Borrow scope introducers: begin_borrow/load_borrow
+/// 4. Reborrows: guaranteed phi that ends its operand's borrow scope and
+///    requires post-dominating scope-ending uses (end_borrow or reborrow)
+///
+/// `definingValue`'s lifetime must already complete on all paths
+/// (a.k.a linear). Only lifetime-ending operations generate liveness.
+///
+/// `definingValue` dominates the range. Forwarding and phi uses do
+/// not extend the lifetime.
+///
+/// This is the simplest OSSA liveness analysis. It assumes that OSSA
+/// lifetime completion has already run on `definingValue`, and it
+/// cannot fix OSSA lifetimes after a transformation.
+func computeLinearLiveness(for definingValue: Value, _ context: Context)
+  -> InstructionRange {
+
+  assert(definingValue.ownership == .owned
+    || BeginBorrowValue(definingValue) != nil,
+    "value must define an OSSA lifetime")
+
+  // InstructionRange cannot directly represent the beginning of the block
+  // so we fake it with getRepresentativeInstruction().
+  var range = InstructionRange(for: definingValue, context)
+
+  // Compute liveness.
+  definingValue.uses.endingLifetime.forEach {
+    range.insert($0.instruction)
+  }
+  return range
+}
+
+/// Indicate whether OwnershipUseVisitor is visiting a use of the
+/// outer OSSA lifetime or within an inner borrow scope (reborrow).
+enum IsInnerLifetime {
+case outerLifetime
+case innerLifetime
+}
+
+typealias InnerScopeHandler = (Value) -> WalkResult
+
+/// Compute liveness and return a range, which the caller must deinitialize.
+///
+/// An OSSA lifetime begins with a single "defining" value, which
+/// must be owned, or must begin a borrow scope.
+///
+/// - Liveness does not extend beyond lifetime-ending operations
+/// (a.k.a. affine lifetimes).
+///
+/// - The definition dominates all use points.
+///
+/// - Does not assume the current lifetime is complete, but does
+/// assume any inner scopes are complete. Use `innerScopeHandler` to
+/// complete them or bail-out.
+func computeInteriorLiveness(for definingValue: Value,
+  _ context: FunctionPassContext,
+  innerScopeHandler: InnerScopeHandler? = nil) -> InstructionRange {
+
+  assert(definingValue.ownership == .owned
+    || BeginBorrowValue(definingValue) != nil,
+    "value must define an OSSA lifetime")
+
+  var range = InstructionRange(for: definingValue, context)
+
+  var visitor = InteriorUseVisitor(definingValue: definingValue, context) {
+    range.insert($0.instruction)
+    return .continueWalk
+  }
+  defer { visitor.deinitialize() }
+  visitor.innerScopeHandler = innerScopeHandler
+  let success = visitor.visitUses()
+  switch visitor.pointerStatus {
+  case .nonEscaping:
+    break
+  case let .escaping(operand):
+    fatalError("""
+                 check findPointerEscape() before computing interior liveness.
+                 Pointer escape: \(operand.instruction)
+                 """)
+  case let .unknown(operand):
+    fatalError("Unrecognized SIL address user \(operand.instruction)")
+  }
+  assert(success == .continueWalk, "our visitor never fails")
+  assert(visitor.unenclosedPhis.isEmpty, "missing adjacent phis")
+  return range
+}
+
+/// Visit all interior uses of on OSSA lifetime.
+///
+/// - `definingValue` dominates all uses. Only dominated phis extend
+/// the lifetime. All other phis must have a lifetime-ending outer
+/// adjacent phi; otherwise they will be recorded as `unenclosedPhis`.
+///
+/// - Does not assume the current lifetime is linear. Transitively
+/// follows guaranteed forwarding and address uses within the current
+/// scope. Phis that are not dominanted by definingValue or an outer
+/// adjacent phi are marked "unenclosed" to signal an incomplete
+/// lifetime.
+///
+/// - Assumes inner scopes *are* linear, including borrow and address
+/// scopes (e.g. begin_borrow, load_borrow, begin_apply, store_borrow,
+/// begin_access) A `innerScopeHandler` callback may be used to
+/// complete inner scopes before updating liveness.
+///
+/// InteriorUseVisitor can be used to complete (linearize) an OSSA
+/// lifetime after transformation that invalidates OSSA.
+///
+/// Example:
+///
+///     %struct = struct ...
+///     %f = struct_extract %s     // defines a guaranteed value (%f)
+///     %b = begin_borrow %field
+///     %a = ref_element_addr %b
+///     _  = address_to_pointer %a
+///     end_borrow %b              // the only interior use of %f
+///
+/// When computing interior liveness for %f, %b is an inner
+/// scope. Because inner scopes are complete, the only relevant use is
+/// end_borrow %b. Despite the address_to_pointer instruction, %f does
+/// not escape any dependent address. 
+///
+/// TODO: Implement the hasPointerEscape flags on BeginBorrowInst,
+/// MoveValueInst, and Allocation. Then this visitor should assert
+/// that the forward-extended lifetime introducer has no pointer
+/// escaping uses.
+///
+/// TODO: Change the operandOwnership of MarkDependenceInst base operand.
+/// It should be a borrowing operand, not a pointer escape.
+struct InteriorUseVisitor: OwnershipUseVisitor, AddressUseVisitor {
+  let context: FunctionPassContext
+  var _context: Context { context }
+
+  let function: Function
+  let definingValue: Value
+  let useVisitor: (Operand) -> WalkResult
+
+  var innerScopeHandler: InnerScopeHandler? = nil
+
+  var unenclosedPhis: [Phi] = []
+
+  /// If any interior pointer may escape, then record the first instance
+  /// here. This immediately aborts the walk, so further instances are
+  /// unavailable.
+  ///
+  /// .escaping may either be a non-address operand with
+  /// .pointerEscape ownership, or and address operand that escapes
+  /// the adderss (address_to_pointer).
+  ///
+  /// .unknown is an address operand whose user is unrecognized.
+  enum InteriorPointerStatus {
+    case nonEscaping
+    case escaping(Operand)
+    case unknown(Operand)
+  }
+  var pointerStatus: InteriorPointerStatus = .nonEscaping
+
+  private var visited: ValueSet
+
+  mutating func deinitialize() {
+    visited.deinitialize()
+  }
+
+  init(definingValue: Value, _ context: FunctionPassContext,
+    visitor: @escaping (Operand) -> WalkResult) {
+    assert(!definingValue.type.isAddress, "address values have no ownership")
+    self.context = context
+    self.function = definingValue.parentFunction
+    self.definingValue = definingValue
+    self.useVisitor = visitor
+    self.visited = ValueSet(context)
+  }
+
+  mutating func visitUses() -> WalkResult {
+    visitUsesOfOuter(value: definingValue)
+  }
+
+  /// This is invoked for all uses of the outer lifetime, even if the
+  /// use forwards a value or produces an interior pointer. This is
+  /// not invoked for address-to-address projections. This is only
+  /// invoked for uses of an inner lifetime if `use` ends the
+  /// lifetime.
+  func visit(use: Operand, _ isInnerLifetime: IsInnerLifetime)
+  -> WalkResult {
+    useVisitor(use)
+  }
+
+  // Visit owned and guaranteed forwarding operands.
+  //
+  // Guaranteed forwarding operands extend the outer lifetime.
+  //
+  // Owned forwarding operands end the outer lifetime but extend the
+  // inner lifetime (e.g. from a PartialApply or MarkDependence).
+  mutating func visitForwarding(operand: Operand,
+    _ isInnerLifetime: IsInnerLifetime) -> WalkResult {
+    switch operand.value.ownership {
+    case .guaranteed:
+      assert(isInnerLifetime == .outerLifetime,
+        "inner guaranteed forwards are not walked")
+      return walkDown(operand: operand)
+    case .owned:
+      switch isInnerLifetime {
+      case .outerLifetime:
+        return visit(use: operand, .outerLifetime)
+      case .innerLifetime:
+        return walkDown(operand: operand)
+      }
+    default:
+      fatalError("forwarded values must have a lifetime")
+    }
+  }
+
+  // Visit a reborrow operand. This ends an outer lifetime and extends
+  // an inner lifetime.
+  mutating func visitReborrow(operand: Operand,
+    _ isInnerLifetime: IsInnerLifetime) -> WalkResult {
+    switch isInnerLifetime {
+    case .outerLifetime:
+      return visit(use: operand, .outerLifetime)
+    case .innerLifetime:
+      return walkDown(operand: operand)
+    }
+  }
+
+  mutating func visitPointerEscape(use: Operand) -> WalkResult {
+    if useVisitor(use) == .abortWalk {
+      return .abortWalk
+    }
+    pointerStatus = .escaping(use)
+    return .abortWalk
+  }
+
+  // TODO: Change ProjectBox ownership to InteriorPointer
+  mutating func visitInteriorPointer(use: Operand) -> WalkResult {
+    // OSSA lifetime ignores trivial types.
+    if use.value.type.isTrivial(in: function) {
+      return .continueWalk
+    }
+    if useVisitor(use) == .abortWalk {
+      return .abortWalk
+    }
+    let instruction = use.instruction
+    switch instruction {
+    case let rta as RefTailAddrInst:
+      return walkDownUses(ofAddress: rta)
+    case let rea as RefElementAddrInst:
+      return walkDownUses(ofAddress: rea)
+    case let pb as ProjectBoxInst:
+      return walkDownUses(ofAddress: pb)
+    default:
+      return walkDown(address: use)
+    }
+  }
+
+  mutating func projection(of address: Operand) -> WalkResult {
+    visit(use: address, .outerLifetime)
+  }
+
+  mutating func leafUse(address: Operand) -> WalkResult {
+    visit(use: address, .outerLifetime)
+  }
+
+  mutating func pointerEscape(address: Operand) -> WalkResult {
+    visitPointerEscape(use: address)
+  }
+
+  mutating func unknown(address: Operand) -> WalkResult {
+    pointerStatus = .unknown(address)
+    return .abortWalk
+  }
+
+  mutating func dependent(value: Value, dependsOn address: Operand)
+    -> WalkResult {
+    if visit(use: address, .outerLifetime) == .abortWalk {
+      return .abortWalk
+    }
+    // If `value` is owned, then `visit(use:, .innerLifetime)` will be
+    // invoked for each leaf use.
+    return walkDownUses(of: value)
+  }
+
+  func handleInner(borrow: BeginBorrowValue) -> WalkResult  {
+    guard let innerScopeHandler else { return .continueWalk }
+    return innerScopeHandler(borrow.value)
+  }
+
+  func handleAccess(address: BeginAccessInst) -> WalkResult {
+    guard let innerScopeHandler else { return .continueWalk }
+    return innerScopeHandler(address)
+  }
+}
+
+// Helpers to walk down forwarding operations.
+extension InteriorUseVisitor {
+  // Walk down forwarding operands
+  private mutating func walkDown(operand: Operand) -> WalkResult {
+    // Record all uses
+    if useVisitor(operand) == .abortWalk {
+      return .abortWalk
+    }
+    if let inst = operand.instruction as? ForwardingInstruction {
+      return inst.forwardedResults.walk { walkDownUses(of: $0) }
+    }
+    if let phi = Phi(using: operand) {
+      if phi.value.ownership == .guaranteed {
+        return walkDown(guaranteedPhi: phi)
+      }
+      return walkDownUses(of: phi.value)
+    }
+    // TODO: verify that ForwardInstruction handles all .forward
+    // operand ownership and change this to a fatalError.
+    return .continueWalk
+  }
+
+  private mutating func walkDownUses(of value: Value) -> WalkResult {
+    guard value.ownership.hasLifetime else { return .continueWalk }
+
+    guard visited.insert(value) else { return .continueWalk }
+
+    switch value.ownership {
+    case .owned:
+      return visitUsesOfInner(value: value)
+    case .guaranteed:
+      return visitUsesOfOuter(value: value)
+    default:
+      fatalError("ownership requires a lifetime")
+    }
+  }
+
+  // Dominating definingValue example: walkDown must continue visiting
+  // uses of a reborrow in the inner borrow scope:
+  //
+  // bb0:
+  //  d1 = ...
+  //  cond_br bb1, bb2
+  // bb1:
+  //   b1 = borrow d1
+  //   br bb3(b1)
+  // bb2:
+  //   b2 = borrow d1
+  //   br bb3(b2)
+  // bb3(reborrow):
+  //   u1 = d1
+  //   u2 = reborrow
+  //   // can't move destroy above u2
+  //   destroy_value d1
+  //
+  // Dominating definingValue example: walkDown must continue visiting
+  // uses of a guaranteed phi in the outer lifetime:
+  //
+  // bb0:
+  //  b1 = borrow d1
+  //  cond_br bb1, bb2
+  // bb1:
+  //   p1 = projection b1
+  //   br bb3(p1)
+  // bb2:
+  //   p1 = projection b1
+  //   br bb3(p2)
+  // bb3(forwardingPhi):
+  //   u1 = b1
+  //   u2 = forwardingPhi
+  //   // can't move end_borrow above u2
+  //   end_borrow b1
+  private mutating func walkDown(guaranteedPhi: Phi) -> WalkResult {
+    guard visited.insert(guaranteedPhi.value) else {
+      return .continueWalk
+    }
+    var enclosingValues = Stack<Value>(context)
+    defer { enclosingValues.deinitialize() }
+    gatherEnclosingValues(for: guaranteedPhi.value, in: &enclosingValues,
+                          context)
+    guard enclosingValues.contains(definingValue) else {
+      // Since definingValue is not an enclosing value, it must be
+      // consumed or reborrowed by some outer adjacent phi in this
+      // block. An outer adjacent phi's uses do not contribute to the
+      // outer liveness. Instead, guaranteedPhi will be recorded as a
+      // regular lifetime-ending use by the visitor.
+      return .continueWalk
+    }
+    // definingValue is not consumed or reborrowed by an outer
+    // adjacent phi in guaranteedPhi's block. Therefore this
+    // guaranteedPhi's uses contribute to the liveness of
+    // definingValue.
+    //
+    // TODO: instead of relying on Dominance, we can reformulate
+    // this algorithm to detect redundant phis, similar to the
+    // SSAUpdater.
+    if !definingValue.parentBlock.dominates(guaranteedPhi.successor,
+      context.dominatorTree) {
+      // definingValue does not dominate guaranteedPhi. Record this
+      // unenclosed phi so the liveness client can insert the missing
+      // outer adjacent phi.
+      unenclosedPhis.append(guaranteedPhi);
+      return .continueWalk
+    }
+    // Since definingValue dominates guaranteedPhi, this is a well-formed linear
+    // lifetime, and liveness can proceed.
+    if guaranteedPhi.isReborrow {
+      return visitUsesOfInner(value: guaranteedPhi.value)
+    } else {
+      return visitUsesOfOuter(value: guaranteedPhi.value)
+    }
+  }
+}
+
+/// Visit all uses of an interior address that keep the parent object alive.
+///
+/// See C++ TransitiveAddressWalker.
+///
+/// Requires:
+///   mutating func leafUse(address:) -> WalkResult
+///   mutating func dependent(value:dependsOn:) -> WalkResult
+///   mutating func pointerEscape(address:) -> WalkResult
+///   mutating func unknown(address:) -> WalkResult
+///
+/// TODO: Verify that pointerEscape is only called for live ranges in which
+/// `findPointerEscape()` returns true.
+protocol AddressUseVisitor {
+  var _context: Context { get }
+
+  /// Start a def-use walk from and address.
+  mutating func walkDownUses(ofAddress: Value) -> WalkResult 
+
+  /// Start a def-use walk from an address operand.
+  mutating func walkDown(address: Operand) -> WalkResult
+
+  /// An address projection produces a single address result and does not
+  /// escape its address operand in any other way.
+  ///
+  /// If this returns .continueWalk then the uses of the address
+  /// result will be transitively visited.
+  mutating func projection(of address: Operand) -> WalkResult
+
+  /// A address leaf use cannot propagate the address bits beyond the
+  /// instruction.
+  ///
+  /// An apply or builtin, which propagates an address into the
+  /// callee, can be a leaf use if the argument does not escape.
+  mutating func leafUse(address: Operand) -> WalkResult
+
+  /// A non-address `value` whose ownership depends on the in-memory
+  /// value at `address`, such as `mark_dependence %value on %address`.
+  mutating func dependent(value: Value, dependsOn address: Operand)
+    -> WalkResult
+
+  /// A pointer escape may propagate the address beyond the current instruction.
+  mutating func pointerEscape(address: Operand) -> WalkResult
+
+  /// A unknown address use. This should never be called in valid SIL.
+  mutating func unknown(address: Operand) -> WalkResult
+
+  /// Handle begin_access.
+  ///
+  /// If this returns .continueWalk, then leafUse(address:) will be called
+  /// on the scope ending operands.
+  ///
+  /// Allows the implementation to complete inner scopes before considering
+  /// their scope ending operations as uses of the outer scope.
+  ///
+  /// This may add uses to the inner scope, but it may not modify the use-list
+  /// containing \p address or in any outer scopes.
+  mutating func handle(access: BeginAccessInst) -> WalkResult
+
+  /// Handle load_borrow
+  ///
+  /// If this returns .continueWalk, then leafUse(address:) will be called
+  /// on the scope ending operands.
+  ///
+  /// Allows the implementation to complete inner scopes before considering
+  /// their scope ending operations as uses of the outer scope.
+  ///
+  /// This may add uses to the inner scope, but it may not modify the use-list
+  /// containing \p address or in any outer scopes.
+  mutating func handle(borrow: LoadBorrowInst) -> WalkResult
+}
+
+extension AddressUseVisitor {
+  mutating func projection(of address: Operand) -> WalkResult {
+    return .continueWalk
+  }
+
+  mutating func handle(access: BeginAccessInst) -> WalkResult {
+    return .continueWalk
+  }
+
+  mutating func handle(borrow: LoadBorrowInst) -> WalkResult {
+    return .continueWalk
+  }
+
+  mutating func walkDownUses(ofAddress address: Value) -> WalkResult {
+    address.uses.ignoreTypeDependence.walk { walkDown(address: $0) }
+  }
+
+  private mutating func walkDown(projection value: Value, of operand: Operand)
+    -> WalkResult {
+    if projection(of: operand) == .abortWalk {
+      return .abortWalk
+    }
+    return walkDownUses(ofAddress: value)
+  }
+
+  mutating func walkDown(address: Operand) -> WalkResult {
+    switch address.instruction {
+    case let ba as BeginAccessInst:
+      if handle(access: ba) == .abortWalk {
+        return .abortWalk
+      }
+      return ba.endOperands.walk { leafUse(address: $0) }
+
+    case let load as LoadBorrowInst:
+      if handle(borrow: load) == .abortWalk {
+        return .abortWalk
+      }
+      return BeginBorrowValue(load)!.scopeEndingOperands.walk {
+        leafUse(address: $0)
+      }
+    case let markDep as MarkDependenceInst:
+      if markDep.valueOperand == address {
+        return walkDown(projection: markDep, of: address)
+      }
+      assert(markDep.baseOperand == address)
+      // If another address depends on the current address,
+      // optimisticaly handle it like a projection.
+      if markDep.type.isAddress {
+        return walkDown(projection: markDep, of: address)
+      }
+      /* TODO: Check LifetimeDependence
+      if LifetimeDependence(markDependenceInst: markDep, _context) != nil {
+        return dependent(value: markDep, dependsOn: address)
+      }
+      */
+      // A potentially escaping value depends on this address.
+      return pointerEscape(address: address)
+
+    case let pai as PartialApplyInst where pai.isOnStack:
+      return dependent(value: pai, dependsOn: address)
+
+    case is StructElementAddrInst, is TupleElementAddrInst,
+         is InitEnumDataAddrInst, is UncheckedTakeEnumDataAddrInst,
+         is InitExistentialAddrInst, is OpenExistentialAddrInst,
+         is IndexAddrInst, is MarkUnresolvedNonCopyableValueInst,
+         is ProjectBlockStorageInst, is TailAddrInst, is StoreBorrowInst,
+         is UncheckedAddrCastInst, is MarkUninitializedInst, is DropDeinitInst,
+         is TuplePackElementAddrInst, is CopyableToMoveOnlyWrapperAddrInst,
+         is MoveOnlyWrapperToCopyableAddrInst:
+      let svi = address.instruction as! SingleValueInstruction
+      return walkDown(projection: svi, of: address)
+
+    case is ReturnInst, is ThrowInst, is YieldInst, is TryApplyInst,
+         is SwitchEnumAddrInst, is CheckedCastAddrBranchInst,
+         is SelectEnumAddrInst, is InjectEnumAddrInst,
+         is LoadInst, is CopyAddrInst, is StoreInst, is DestroyAddrInst,
+         is LoadUnownedInst, is StoreUnownedInst,
+         is LoadWeakInst, is StoreWeakInst,
+         is AssignInst, is AssignByWrapperInst, is AssignOrInitInst,
+         is MarkUnresolvedMoveAddrInst, is ExplicitCopyAddrInst,
+         is RetainValueAddrInst, is ReleaseValueAddrInst,
+         is UncheckedRefCastAddrInst, is UnconditionalCheckedCastAddrInst,
+         is TupleAddrConstructorInst, is InitBlockStorageHeaderInst,
+         is DeallocStackInst, is EndApplyInst,
+         is IsUniqueInst, is MarkFunctionEscapeInst,
+         is WitnessMethodInst, is ValueMetatypeInst, is ExistentialMetatypeInst,
+         is DeinitExistentialAddrInst,
+         is GetAsyncContinuationAddrInst, is KeyPathInst,
+         is PackElementSetInst, is PackElementGetInst:
+      return leafUse(address: address)
+
+    case let builtin as BuiltinInst:
+      switch builtin.id {
+      case .TSanInoutAccess, .ResumeThrowingContinuationReturning,
+           .ResumeNonThrowingContinuationReturning, .Copy, .GenericAdd,
+           .GenericFAdd, .GenericAnd, .GenericAShr, .GenericLShr, .GenericOr,
+           .GenericFDiv, .GenericMul, .GenericFMul, .GenericSDiv,
+           .GenericExactSDiv, .GenericShl, .GenericSRem, .GenericSub,
+           .GenericFSub, .GenericUDiv, .GenericExactUDiv, .GenericURem,
+           .GenericFRem, .GenericXor, .TaskRunInline, .ZeroInitializer,
+           .GetEnumTag, .InjectEnumTag:
+        return leafUse(address: address)
+      default:
+        // TODO: SIL verification should check that this exhaustively
+        // recognizes all builtin address uses.
+        return .abortWalk
+      }
+
+    case is AddressToPointerInst:
+      return pointerEscape(address: address)
+
+    case let pai as PartialApplyInst where !pai.isOnStack:
+      return pointerEscape(address: address)
+
+    case is BranchInst, is CondBranchInst:
+      fatalError("address phi is not allowed")
+
+    default:
+      if address.instruction.isIncidentalUse {
+        return leafUse(address: address)
+      }
+      // Unkown instruction.
+      return unknown(address: address)
+    }
+  }
+}
+
+/// Enumerate all special cases of ownership uses in a visitor
+/// API. This encourages anyone who needs to analyze ownership uses to
+/// think about all of the special cases, many of which result
+/// from phis of borrowed values. Relying on linear lifetimes, which
+/// results from running "lifetime completion", allows you to ignore
+/// those cases.
+///
+/// To visit a value's uses:
+///
+/// - visitUsesOfOuter(value:)
+/// - visitUsesOfInner(value:)
+///
+/// Visitors need to implement:
+///
+/// - visit(use:_),
+/// - visitForwarding(operand:_)
+/// - visitReborrow(operand:_)
+/// - visitPointerEscape(use:)
+///
+/// This only visits the first level of uses. The implementation may
+/// transitively visit forwarding operations in its implementation of
+/// `visitForwarding(operand:_)` and `visitReborrow(operand:_)`,
+/// calling back to `visitUsesOfOuter(value:)` or
+/// `visitUsesOfInner(value:)`.
+///
+/// For uses that begin a borrow or access scope, this skips ahead to
+/// the end of the scope. To record incomplete or dead inner scopes
+/// (no scope-ending use on some path), the implementation must
+/// override handleInner(borrow:).
+protocol OwnershipUseVisitor {
+  var _context: Context { get }
+
+  /// Visit a non-forwarding use. For uses that are guarded by a
+  /// handler, this is only called if the handler returns .continueWalk.
+  ///
+  /// IsInnerLifetime indicates whether `operand` uses the original
+  /// OSSA lifetime. This use ends the original lifetime if
+  /// (IsInnerLifetime == .outerLifetime && use.endsLifetime).
+  func visit(use: Operand, _: IsInnerLifetime) -> WalkResult
+
+  /// Visit a forwarding operand. For uses that are guarded by a
+  /// handler, this is only called if the handler returns .continueWalk.
+  ///
+  /// Use ForwardingInstruction or ForwardingDefUseWalker to handle
+  /// downstream uses.
+  mutating func visitForwarding(operand: Operand, _: IsInnerLifetime)
+  -> WalkResult
+
+  /// Visit a reborrow operand. For uses that are guarded by a
+  /// handler, this is only called if the handler returns .continueWalk.
+  ///
+  /// Use visitUsesOfInner to visit downstream borrow scopes.
+  mutating func visitReborrow(operand: Operand, _: IsInnerLifetime)
+  -> WalkResult
+
+  /// Visit a use that propagates its operand to some trivial
+  /// value such as an address that depends on the operand's value.
+  mutating func visitInteriorPointer(use: Operand) -> WalkResult
+
+  /// Visit a use that escapes information from its operand's value.
+  ///
+  /// Note: visitPointerEscape may not find all relevant pointer
+  /// escapes, such as from owned forwarded values. Clients should
+  /// generally check findPointerEscape() before relying on a liveness
+  /// result and implement this as a fatalError.
+  mutating func visitPointerEscape(use: Operand) -> WalkResult
+
+  /// Handle begin_borrow, load_borrow, store_borrow, begin_apply.
+  ///
+  /// Handle an inner adjacent phi where the original OSSA def is a
+  /// phi in the same block
+  ///
+  /// Handle a reborrow of an inner borrow scope or inner adjacent phi
+  ///
+  /// If this returns .continueWalk, then visit(use:) will be called
+  /// on the scope ending operands.
+  ///
+  /// Allows the implementation to complete inner scopes before considering
+  /// their scope ending operations as uses of the outer scope.
+  mutating func handleInner(borrow: BeginBorrowValue) -> WalkResult
+
+  /// Handle begin_access.
+  ///
+  /// If this returns .continueWalk, then visit(use:) will be called
+  /// on the scope ending operands.
+  ///
+  /// Allows the implementation to complete inner scopes before considering
+  /// their scope ending operations as uses of the outer scope.
+  ///
+  /// This may add uses to the inner scope, but it may not modify the use-list
+  /// containing \p address or in any outer scopes.
+  mutating func handleAccess(address: BeginAccessInst) -> WalkResult
+}
+
+// Default requirements: Visit everything as a regular use except escapes.
+extension OwnershipUseVisitor {
+  mutating func handleInner(borrow: BeginBorrowValue) -> WalkResult {
+    return .continueWalk
+  }
+
+  mutating func handleAccess(address: BeginAccessInst) -> WalkResult {
+    return .continueWalk
+  }
+}
+
+extension OwnershipUseVisitor {
+  /// Visit all uses that contribute to the ownership live
+  /// range of `value`. This does not assume that `value` has a
+  /// complete lifetime, and non-lifetime-ending uses are visited.
+  ///
+  /// If `value` is a phi (owned or reborrowed), then find its inner
+  /// adjacent phis and treat them like inner borrows.
+  ///
+  /// This is only called for uses in the outer lifetime.
+  mutating func visitUsesOfOuter(value: Value) -> WalkResult {
+    // If the outer value is an owned phi or reborrow, consider inner
+    // adjacent phis part of its lifetime.
+    if let phi = Phi(value), phi.endsLifetime {
+      var innerPhis = Stack<Phi>(_context)
+      defer { innerPhis.deinitialize() }
+      gatherInnerAdjacentPhis(for: phi, in: &innerPhis, _context)
+      // Inner adjacent reborrows are considered inner borrow scopes.
+      // Inner adjacent guaranteed phis are consider part of the outer lifetime.
+      return innerPhis.walk { innerPhi in
+        innerPhi.isReborrow ? visitUsesOfInner(value: innerPhi.value)
+          : innerPhi.value.uses.ignoreTypeDependence.walk {
+            visitGuaranteed(use: $0)
+          }
+      }
+    }
+    switch value.ownership {
+    case .owned:
+      return value.uses.ignoreTypeDependence.walk { visitOwned(use: $0) }
+    case .guaranteed:
+      return value.uses.ignoreTypeDependence.walk { visitGuaranteed(use: $0) }
+    case .none, .unowned:
+      return .continueWalk
+    }
+  }
+
+  /// Visit only those uses of an value within an inner borrow scope
+  /// that may affect the outer lifetime. An inner borrow scope is one
+  /// in which the borrowing operand is itself a use of the outer
+  /// lifetime, including: begin_borrow, reborrow, partial_apply,
+  /// mark_dependence, or an inner adjacent phi (where original SSA
+  /// def is a phi in the same block).
+  mutating func visitUsesOfInner(value: Value) -> WalkResult {
+    if let beginBorrow = BeginBorrowValue(value) {
+      if handleInner(borrow: beginBorrow) == .abortWalk {
+        return .abortWalk
+      }
+      return beginBorrow.scopeEndingOperands.walk {
+        switch $0.ownership {
+        case .endBorrow:
+          return visit(use: $0, .innerLifetime)
+        case .reborrow:
+          return visitReborrow(operand: $0, .innerLifetime)
+        default:
+          fatalError("invalid borrow scope ending operand ownership")
+        }
+      }
+    }
+    // When a borrow introduces an owned value, each OSSA lifetime is
+    // effectively a separate borrow scope. A destroy ends the borrow
+    // scope, while a forwarding consume effectively "reborrows".
+    assert(value.ownership == .owned,
+      "inner value must be a reborrow or owned forward")
+    return value.uses.endingLifetime.walk {
+      switch $0.ownership {
+      case .forwardingConsume:
+        return visitForwarding(operand: $0, .innerLifetime)
+      case .destroyingConsume:
+        return visit(use: $0, .innerLifetime)
+      default:
+        fatalError("invalid owned lifetime ending operand ownership")
+      }
+    }
+  }
+}
+
+extension OwnershipUseVisitor {
+  // Visit a borrowing operand (operandOwnerhip == .borrow).
+  private mutating func visitInnerBorrow(operand: Operand) -> WalkResult {
+    // If a borrowed value is introduced, then handle the inner scope.
+    if let beginBorrow = BeginBorrowValue(using: operand) {
+      return visitUsesOfInner(value: beginBorrow.value)
+    }
+    // Otherwise, directly visit the scope ending uses.
+    let borrowInst = BorrowingInstruction(operand.instruction)!
+    return borrowInst.visitScopeEndingOperands(_context) { [self] in 
+      visit(use: $0, .innerLifetime)
+    }
+  }
+
+  // This is only called for uses in the outer lifetime.
+  private mutating func visitOwned(use: Operand) -> WalkResult {
+    switch use.ownership {
+    case .nonUse:
+      return .continueWalk
+
+    case .destroyingConsume:
+      return visit(use: use, .outerLifetime)
+
+    case .forwardingConsume:
+      return visitForwarding(operand: use, .outerLifetime)
+
+    case .pointerEscape:
+      return visitPointerEscape(use: use)
+
+    case .instantaneousUse, .forwardingUnowned, .unownedInstantaneousUse,
+      .bitwiseEscape:
+      return visit(use: use, .outerLifetime)
+
+    case .borrow:
+      return visitInnerBorrow(operand: use)
+
+    // TODO: Eventually, visit owned InteriorPointers as implicit borrows.
+    case .interiorPointer, .trivialUse, .endBorrow, .reborrow,
+      .guaranteedForwarding:
+      fatalError("ownership incompatible with an owned value");
+    }
+  }
+
+  // This is only called for uses in the outer lifetime.
+  private mutating func visitGuaranteed(use: Operand)
+  -> WalkResult {
+    switch use.ownership {
+    case .nonUse:
+      return .continueWalk
+
+    case .pointerEscape:
+      return visitPointerEscape(use: use)
+
+    case .instantaneousUse, .forwardingUnowned, .unownedInstantaneousUse,
+      .bitwiseEscape:
+      return visit(use: use, .outerLifetime)
+
+    case .endBorrow:
+      return visit(use: use, .outerLifetime)
+
+    case .reborrow:
+      return visitReborrow(operand: use, .outerLifetime)
+
+    case .guaranteedForwarding:
+      return visitForwarding(operand: use, .outerLifetime)
+
+    case .borrow:
+      return visitInnerBorrow(operand: use)
+
+    case .interiorPointer:
+      return visitInteriorPointer(use: use)
+
+    case .trivialUse, .forwardingConsume, .destroyingConsume:
+      fatalError("ownership incompatible with a guaranteed value")
+    }
+  }
+}
+
+/// Cache the liveness boundary by taking a snapshot of its InstructionRange.
+struct LivenessBoundary : CustomStringConvertible {
+  var lastUsers : Stack<Instruction>
+  var boundaryEdges : Stack<BasicBlock>
+  var deadDefs : Stack<Value>
+
+  // Compute the boundary of a singly-defined range.
+  init(value: Value, range: InstructionRange, _ context: Context) {
+    assert(range.isValid)
+
+    lastUsers = Stack<Instruction>(context)
+    boundaryEdges = Stack<BasicBlock>(context)
+    deadDefs = Stack<Value>(context)
+
+    lastUsers.append(contentsOf: range.ends)
+    boundaryEdges.append(contentsOf: range.exitBlocks)
+    if lastUsers.isEmpty {
+      deadDefs.push(value)
+      assert(boundaryEdges.isEmpty)
+    }
+  }
+
+  var description: String {
+    (lastUsers.map { "last user: \($0.description)" }
+    + boundaryEdges.map { "boundary edge: \($0.description)" }
+    + deadDefs.map { "dead def: \($0.description)" }).joined(separator: "\n")
+  }
+
+  mutating func deinitialize() {
+    lastUsers.deinitialize()
+    boundaryEdges.deinitialize()
+    deadDefs.deinitialize()
+  }
+}
+
+let linearLivenessTest = FunctionTest("linear_liveness_swift") {
+  function, arguments, context in
+  let value = arguments.takeValue()
+  print(function)
+  print("Linear liveness: \(value)")
+  var range = computeLinearLiveness(for: value, context)
+  defer { range.deinitialize() }
+  print("Live blocks:")
+  print(range)
+  var boundary = LivenessBoundary(value: value, range: range, context)
+  defer { boundary.deinitialize() }
+  print(boundary)
+}
+
+let interiorLivenessTest = FunctionTest("interior_liveness_swift") {
+  function, arguments, context in
+  let value = arguments.takeValue()
+  print(function)
+  print("Interior liveness: \(value)")
+
+  var range = InstructionRange(for: value, context)
+  defer { range.deinitialize() }
+
+  var visitor = InteriorUseVisitor(definingValue: value, context) {
+    range.insert($0.instruction)
+    return .continueWalk
+  }
+  defer { visitor.deinitialize() }
+
+  let success = visitor.visitUses()
+
+  switch visitor.pointerStatus {
+  case .nonEscaping:
+    break
+  case let .escaping(operand):
+    print("Pointer escape: \(operand.instruction)")
+  case let .unknown(operand):
+    print("Unrecognized SIL address user \(operand.instruction)")
+  }
+  if success == .abortWalk {
+    print("Incomplete liveness")
+  }
+  print(range)
+  print("Unenclosed phis {")
+  visitor.unenclosedPhis.forEach { print("  \($0)") } 
+  print("}")
+
+  var boundary = LivenessBoundary(value: value, range: range, context)
+  defer { boundary.deinitialize() }
+  print(boundary)
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -138,7 +138,11 @@ public func registerOptimizerTests() {
   registerFunctionTests(
       parseTestSpecificationTest,
       forwardingUseDefTest,
-      forwardingDefUseTest
+      forwardingDefUseTest,
+      borrowIntroducersTest,
+      enclosingValuesTest,
+      linearLivenessTest,
+      interiorLivenessTest
     )
 
   // Finally register the thunk they all call through.

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -396,7 +396,11 @@ public struct VarDecl {
     guard let decl = bridged.raw else { return nil }
     self.bridged = BridgedVarDecl(raw: decl)
   }
-  
+
+  public var sourceLoc: SourceLoc? {
+    return SourceLoc(bridged: bridged.getSourceLocation())
+  }
+
   public var userFacingName: String { String(bridged.getUserFacingName()) }
 }
 
@@ -943,6 +947,8 @@ final public class BeginBorrowInst : SingleValueInstruction, UnaryInstruction, B
   public var borrowedValue: Value { operand.value }
 
   public var isLexical: Bool { bridged.BeginBorrow_isLexical() }
+
+  public var isFromVarDecl: Bool { bridged.BeginBorrow_isFromVarDecl() }
 }
 
 final public class ProjectBoxInst : SingleValueInstruction, UnaryInstruction {
@@ -956,6 +962,8 @@ final public class CopyValueInst : SingleValueInstruction, UnaryInstruction {
 
 final public class MoveValueInst : SingleValueInstruction, UnaryInstruction {
   public var fromValue: Value { operand.value }
+
+  public var isLexical: Bool { bridged.MoveValue_isLexical() }
 
   public var isFromVarDecl: Bool { bridged.MoveValue_isFromVarDecl() }
 }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -956,6 +956,8 @@ final public class CopyValueInst : SingleValueInstruction, UnaryInstruction {
 
 final public class MoveValueInst : SingleValueInstruction, UnaryInstruction {
   public var fromValue: Value { operand.value }
+
+  public var isFromVarDecl: Bool { bridged.MoveValue_isFromVarDecl() }
 }
 
 final public class DropDeinitInst : SingleValueInstruction, UnaryInstruction {

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -134,6 +134,10 @@ extension Sequence where Element == Operand {
 
   public var isSingleUse: Bool { singleUse != nil }
 
+  public var ignoreTypeDependence: LazyFilterSequence<Self> {
+    self.lazy.filter({!$0.isTypeDependent})
+  }
+
   public var ignoreDebugUses: LazyFilterSequence<Self> {
     self.lazy.filter { !($0.instruction is DebugValueInst) }
   }

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -154,7 +154,7 @@ extension Sequence where Element == Operand {
     ignoreUsers(ofType: I.self).singleUse?.instruction
   }
 
-  public var lifetimeEndingUses: LazyFilterSequence<Self> {
+  public var endingLifetime: LazyFilterSequence<Self> {
     return self.lazy.filter { $0.endsLifetime }
   }
 }
@@ -217,6 +217,17 @@ public enum OperandOwnership {
   
   /// Reborrow. Ends the borrow scope opened directly by the operand and begins one or multiple disjoint borrow scopes. If a forwarded value is reborrowed, then its base must also be reborrowed at the same point. (br, FIXME: should also include destructure, tuple, struct)
   case reborrow
+
+  public var endsLifetime: Bool {
+    switch self {
+    case .nonUse, .trivialUse, .instantaneousUse, .unownedInstantaneousUse,
+         .forwardingUnowned, .pointerEscape, .bitwiseEscape, .borrow,
+         .interiorPointer, .guaranteedForwarding:
+      return false
+    case .destroyingConsume, .forwardingConsume, .endBorrow, .reborrow:
+      return true
+    }
+  }
 
   public var _bridged: BridgedOperand.OperandOwnership {
     switch self {

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -735,6 +735,9 @@ BridgedSubscriptDecl_asAbstractStorageDecl(BridgedSubscriptDecl decl);
 // MARK: VarDecl
 //===----------------------------------------------------------------------===//
 
+SWIFT_NAME("BridgedVarDecl.getSourceLocation(self:)")
+BRIDGED_INLINE BridgedSourceLoc BridgedVarDecl_getSourceLocation(BridgedVarDecl decl);
+
 SWIFT_NAME("BridgedVarDecl.getUserFacingName(self:)")
 BRIDGED_INLINE
 BridgedStringRef BridgedVarDecl_getUserFacingName(BridgedVarDecl decl);

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -58,6 +58,11 @@ BridgedSubscriptDecl_asAbstractStorageDecl(BridgedSubscriptDecl decl) {
 // MARK: BridgedVarDecl
 //===----------------------------------------------------------------------===//
 
+BridgedSourceLoc BridgedVarDecl_getSourceLocation(BridgedVarDecl decl) {
+  swift::SourceLoc sourceLoc = decl.unbridged()->getNameLoc();
+  return BridgedSourceLoc(sourceLoc.getOpaquePointerValue());
+}
+
 BridgedStringRef BridgedVarDecl_getUserFacingName(BridgedVarDecl decl) {
   return decl.unbridged()->getBaseName().userFacingName();
 }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -762,6 +762,10 @@ struct BridgedInstruction {
   BRIDGED_INLINE OptionalBridgedValue StructInst_getUniqueNonTrivialFieldValue() const;
   BRIDGED_INLINE SwiftInt StructElementAddrInst_fieldIndex() const;
   BRIDGED_INLINE bool BeginBorrow_isLexical() const;
+  BRIDGED_INLINE bool BeginBorrow_isFromVarDecl() const;
+  BRIDGED_INLINE bool MoveValue_isLexical() const;
+  BRIDGED_INLINE bool MoveValue_isFromVarDecl() const;
+
   BRIDGED_INLINE SwiftInt ProjectBoxInst_fieldIndex() const;
   BRIDGED_INLINE bool EndCOWMutationInst_doKeepUnique() const;
   BRIDGED_INLINE SwiftInt EnumInst_caseIndex() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -911,6 +911,18 @@ bool BridgedInstruction::BeginBorrow_isLexical() const {
   return getAs<swift::BeginBorrowInst>()->isLexical();
 }
 
+bool BridgedInstruction::BeginBorrow_isFromVarDecl() const {
+  return getAs<swift::BeginBorrowInst>()->isFromVarDecl();
+}
+
+bool BridgedInstruction::MoveValue_isLexical() const {
+  return getAs<swift::MoveValueInst>()->isLexical();
+}
+
+bool BridgedInstruction::MoveValue_isFromVarDecl() const {
+  return getAs<swift::MoveValueInst>()->isFromVarDecl();
+}
+
 SwiftInt BridgedInstruction::ProjectBoxInst_fieldIndex() const {
   return getAs<swift::ProjectBoxInst>()->getFieldIndex();
 }

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -18,54 +18,81 @@ struct PairC {
   var second: C
 }
 
-class C {}
+class C {
+  var field: C
+}
 
 class D : C {}
 
+sil @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
+
 // The introducer of an introducer is always itself.
 
-// CHECK-LABEL: introducer_identity: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_identity: find-borrow-introducers with: %0
 // CHECK: } // end sil function 'introducer_identity'
 // CHECK: Introducers:
 // CHECK-NEXT: %0 = argument of bb0 : $C
-// CHECK-NEXT: introducer_identity: find-borrow-introducers with: @trace[0]
+// CHECK-NEXT: introducer_identity: find-borrow-introducers with: %0
 
-// CHECK-LABEL: introducer_identity: find-borrow-introducers with: @trace[1]
+// CHECK-LABEL: introducer_identity: borrow_introducers with: %0
+// CHECK: } // end sil function 'introducer_identity'
+// CHECK: Borrow introducers for: %0 = argument of bb0 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_identity: borrow_introducers with: %0
+
+// CHECK-LABEL: introducer_identity: find-borrow-introducers with: %borrow1
 // CHECK: } // end sil function 'introducer_identity'
 // CHECK: Introducers:
 // CHECK-NEXT: begin_borrow %0 : $C
-// CHECK-NEXT: introducer_identity: find-borrow-introducers with: @trace[1]
+// CHECK-NEXT: introducer_identity: find-borrow-introducers with: %borrow1
 
-// CHECK-LABEL: introducer_identity: find-borrow-introducers with: @trace[2]
+// CHECK-LABEL: introducer_identity: borrow_introducers with: %borrow1
+// CHECK: } // end sil function 'introducer_identity'
+// CHECK: Borrow introducers for: %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: begin_borrow %0 : $C
+// CHECK-NEXT: introducer_identity: borrow_introducers with: %borrow1
+
+// CHECK-LABEL: introducer_identity: find-borrow-introducers with: %borrow2
 // CHECK: } // end sil function 'introducer_identity'
 // CHECK: Introducers:
 // CHECK-NEXT: load_borrow %1 : $*C
-// CHECK-NEXT: introducer_identity: find-borrow-introducers with: @trace[2]
+// CHECK-NEXT: introducer_identity: find-borrow-introducers with: %borrow2
 
-// CHECK-LABEL: introducer_identity: find-borrow-introducers with: @trace[3]
+// CHECK-LABEL: introducer_identity: borrow_introducers with: %borrow2
+// CHECK: } // end sil function 'introducer_identity'
+// CHECK: Borrow introducers for: {{.*}} = load_borrow %1 : $*C
+// CHECK-NEXT: load_borrow %1 : $*C
+// CHECK-NEXT: introducer_identity: borrow_introducers with: %borrow2
+
+// CHECK-LABEL: introducer_identity: find-borrow-introducers with: %reborrow
 // CHECK: } // end sil function 'introducer_identity'
 // CHECK: Introducers:
 // CHECK-NEXT: argument of bb1 : $C
-// CHECK-NEXT: introducer_identity: find-borrow-introducers with: @trace[3]
+// CHECK-NEXT: introducer_identity: find-borrow-introducers with: %reborrow
 
+// CHECK-LABEL: introducer_identity: borrow_introducers with: %reborrow
+// CHECK: } // end sil function 'introducer_identity'
+// CHECK: Borrow introducers for: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: argument of bb1 : $C
+// CHECK-NEXT: introducer_identity: borrow_introducers with: %reborrow
 sil [ossa] @introducer_identity : $@convention(thin) (@guaranteed C, @in C) -> () {
 entry(%0 : @guaranteed $C, %1 : $*C):
-  specify_test "find-borrow-introducers @trace[0]"
-  debug_value [trace] %0 : $C
+  specify_test "find-borrow-introducers %0"
+  specify_test "borrow_introducers %0"
   %borrow1 = begin_borrow %0 : $C
-  specify_test "find-borrow-introducers @trace[1]"
-  debug_value [trace] %borrow1 : $C
+  specify_test "find-borrow-introducers %borrow1"
+  specify_test "borrow_introducers %borrow1"
 
   %borrow2 = load_borrow %1 : $*C
-  specify_test "find-borrow-introducers @trace[2]"
-  debug_value [trace] %borrow2 : $C
+  specify_test "find-borrow-introducers %borrow2"
+  specify_test "borrow_introducers %borrow2"
   end_borrow %borrow2 : $C
 
   br exit(%borrow1 : $C)
 
 exit(%reborrow : @guaranteed $C):
-  specify_test "find-borrow-introducers @trace[3]"
-  debug_value [trace] %reborrow : $C
+  specify_test "find-borrow-introducers %reborrow"
+  specify_test "borrow_introducers %reborrow"
   end_borrow %reborrow : $C
   destroy_addr %1 : $*C
   %retval = tuple ()
@@ -75,10 +102,15 @@ exit(%reborrow : @guaranteed $C):
 // There is no introducer if the guaranteed value is produced from a
 // trivial value.
 
-// CHECK-LABEL: introducer_trivial: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_trivial: find-borrow-introducers with: %phi
 // CHECK: } // end sil function 'introducer_trivial'
 // CHECK: Introducers:
-// CHECK-NEXT: introducer_trivial: find-borrow-introducers with: @trace[0]
+// CHECK-NEXT: introducer_trivial: find-borrow-introducers with: %phi
+
+// CHECK-LABEL: introducer_trivial: borrow_introducers with: %phi
+// CHECK: } // end sil function 'introducer_trivial'
+// CHECK: Borrow introducers for:  %2 = argument of bb1 : $FakeOptional<C>
+// CHECK-NEXT: introducer_trivial: borrow_introducers with: %phi
 
 sil [ossa] @introducer_trivial : $@convention(thin) () -> () {
 entry:
@@ -86,8 +118,8 @@ entry:
   br none(%trivial : $FakeOptional<C>)
 
 none(%phi : @guaranteed $FakeOptional<C>):
-  specify_test "find-borrow-introducers @trace[0]"
-  debug_value [trace] %phi : $FakeOptional<C>
+  specify_test "find-borrow-introducers %phi"
+  specify_test "borrow_introducers %phi"
   %retval = tuple ()
   return %retval : $()
 }
@@ -97,19 +129,24 @@ none(%phi : @guaranteed $FakeOptional<C>):
 // TODO: When we have a reborrow flag, an unreachable phi can be
 // either a reborrow or forwarded, as long as it has no end_borrow.
 
-// CHECK-LABEL: introducer_unreachable: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_unreachable: find-borrow-introducers with: %phiCycle
 // CHECK: } // end sil function 'introducer_unreachable'
 // CHECK: Introducers:
 // CHECK-NEXT: argument of bb1 : $C
-// CHECK-NEXT: introducer_unreachable: find-borrow-introducers with: @trace[0]
+// CHECK-NEXT: introducer_unreachable: find-borrow-introducers with: %phiCycle
 
+// CHECK-LABEL: introducer_unreachable: borrow_introducers with: %phiCycle
+// CHECK: } // end sil function 'introducer_unreachable'
+// CHECK: Borrow introducers for: %1 = argument of bb1 : $C
+// CHECK-NEXT: argument of bb1 : $C
+// CHECK-NEXT: introducer_unreachable: borrow_introducers with: %phiCycle
 sil [ossa] @introducer_unreachable : $@convention(thin) () -> () {
 entry:
   br exit
 
 unreachable_loop(%phiCycle : @guaranteed $C):
-  specify_test "find-borrow-introducers @trace[0]"
-  debug_value [trace] %phiCycle : $C
+  specify_test "find-borrow-introducers %phiCycle"
+  specify_test "borrow_introducers %phiCycle"
   br unreachable_loop(%phiCycle : $C)
 
 exit:
@@ -120,12 +157,17 @@ exit:
 // All data flow paths through phis and aggregates originate from the
 // same function argument.
 
-// CHECK-LABEL: introducer_single: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_single: find-borrow-introducers with: %aggregate2
 // CHECK: } // end sil function 'introducer_single'
 // CHECK: Introducers:
 // CHECK-NEXT: %0 = argument of bb0 : $C
-// CHECK-NEXT: introducer_single: find-borrow-introducers with: @trace[0]
+// CHECK-NEXT: introducer_single: find-borrow-introducers with: %aggregate2
 
+// CHECK-LABEL: introducer_single: borrow_introducers with: %aggregate2
+// CHECK: } // end sil function 'introducer_single'
+// CHECK: Borrow introducers for: %11 = struct $PairC (%9 : $C, %10 : $C)
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_single: borrow_introducers with: %aggregate2
 sil [ossa] @introducer_single : $@convention(thin) (@guaranteed C) -> () {
 entry(%0 : @guaranteed $C):
   %cast = unconditional_checked_cast %0 : $C to D
@@ -141,8 +183,8 @@ bb1(%payload : @guaranteed $D):
   %first = struct_extract %aggregate : $PairC, #PairC.first
   %second = struct_extract %aggregate : $PairC, #PairC.second
   %aggregate2 = struct $PairC(%first : $C, %second : $C)
-  specify_test "find-borrow-introducers @trace[0]"
-  debug_value [trace] %aggregate2 : $PairC
+  specify_test "find-borrow-introducers %aggregate2"
+  specify_test "borrow_introducers %aggregate2"
   br exit
 
 bb2:
@@ -161,14 +203,21 @@ exit:
 // %reborrow. Therefore, %reborrow is an introducer from separate phi
 // paths, but should only appear in the introducer list once.
 //
-// CHECK-LABEL: introducer_revisit_reborrow: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_revisit_reborrow: find-borrow-introducers with: %aggregate2
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
 // CHECK: } // end sil function 'introducer_revisit_reborrow'
 // CHECK: Introducers:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
 // CHECK-NEXT: %0 = argument of bb0 : $C
-// CHECK-NEXT: introducer_revisit_reborrow: find-borrow-introducers with: @trace[0]
+// CHECK-NEXT: introducer_revisit_reborrow: find-borrow-introducers with: %aggregate2
 
+// CHECK-LABEL: introducer_revisit_reborrow: borrow_introducers with: %aggregate2
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
+// CHECK: } // end sil function 'introducer_revisit_reborrow'
+// CHECK: Borrow introducers for:  %{{.*}} = struct $PairC (%{{.*}} : $C, %{{.*}} : $C)
+// CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_revisit_reborrow: borrow_introducers with: %aggregate2
 sil [ossa] @introducer_revisit_reborrow : $@convention(thin) (@guaranteed C) -> () {
 entry(%0 : @guaranteed $C):
   %borrow1 = begin_borrow %0 : $C
@@ -178,8 +227,8 @@ entry(%0 : @guaranteed $C):
 bb2(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
   %first = struct_extract %phi : $PairC, #PairC.first
   %aggregate2 = struct $PairC(%reborrow : $C, %first : $C)
-  specify_test "find-borrow-introducers @trace[0]"
-  debug_value [trace] %aggregate2 : $PairC
+  specify_test "find-borrow-introducers %aggregate2"
+  specify_test "borrow_introducers %aggregate2"
   br exit
 
 exit:
@@ -191,7 +240,7 @@ exit:
 // %phi originates from %0, %borrow1, & %borrow2. %borrow1 is, however,
 // reborrowed in bb2.
 
-// CHECK-LABEL: introducer_multiple_borrow: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_multiple_borrow: find-borrow-introducers with: %aggregate2
 // CHECK: begin_borrow %0 : $C  
 // CHECK: [[BORROW2:%.*]] = begin_borrow %0 : $C
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
@@ -200,8 +249,18 @@ exit:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
 // CHECK-NEXT: %0 = argument of bb0 : $C
 // CHECK-NEXT: [[BORROW2]] = begin_borrow %0 : $C
-// CHECK-NEXT: introducer_multiple_borrow: find-borrow-introducers with: @trace[0]
+// CHECK-NEXT: introducer_multiple_borrow: find-borrow-introducers with: %aggregate2
 
+// CHECK-LABEL: introducer_multiple_borrow: borrow_introducers with: %aggregate2
+// CHECK: begin_borrow %0 : $C  
+// CHECK: [[BORROW2:%.*]] = begin_borrow %0 : $C
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C
+// CHECK: } // end sil function 'introducer_multiple_borrow'
+// CHECK: Borrow introducers for: %{{.*}} = struct $PairC (%{{.*}} : $C, %{{.*}} : $C)
+// CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: [[BORROW2]] = begin_borrow %0 : $C
+// CHECK-NEXT: introducer_multiple_borrow: borrow_introducers with: %aggregate2
 sil [ossa] @introducer_multiple_borrow : $@convention(thin) (@guaranteed C) -> () {
 entry(%0 : @guaranteed $C):
   %borrow1 = begin_borrow %0 : $C
@@ -212,8 +271,8 @@ entry(%0 : @guaranteed $C):
 bb2(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
   %first = struct_extract %phi : $PairC, #PairC.first
   %aggregate2 = struct $PairC(%reborrow : $C, %first : $C)
-  specify_test "find-borrow-introducers @trace[0]"
-  debug_value [trace] %aggregate2 : $PairC
+  specify_test "find-borrow-introducers %aggregate2"
+  specify_test "borrow_introducers %aggregate2"
   br exit
 
 exit:
@@ -223,28 +282,102 @@ exit:
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on introducer_dependence: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_dependence: find-borrow-introducers with: %dependent
 // CHECK: Introducers:
 // CHECK: %0 = argument of bb0 : $C
-// CHECK-LABEL: end running test 1 of 1 on introducer_dependence: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_dependence: find-borrow-introducers with: %dependent
+
+// CHECK-LABEL: introducer_dependence: borrow_introducers with: %dependent
+// CHECK: Borrow introducers for: %{{.*}} = mark_dependence %0 : $C on %1 : $Builtin.NativeObject
+// CHECK: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_dependence: borrow_introducers with: %dependent
 sil [ossa] @introducer_dependence : $@convention(thin) (@guaranteed C, @guaranteed Builtin.NativeObject) -> () {
 entry(%0 : @guaranteed $C, %1 : @guaranteed $Builtin.NativeObject):
-  specify_test "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers %dependent"
+  specify_test "borrow_introducers %dependent"
   %dependent = mark_dependence %0 : $C on %1 : $Builtin.NativeObject
-  debug_value [trace] %dependent : $C
   %retval = tuple ()
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on introducer_bridge: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_bridge: find-borrow-introducers with: %bridge
 // CHECK: Introducers:
 // CHECK: %0 = argument of bb0 : $C
-// CHECK-LABEL: end running test 1 of 1 on introducer_bridge: find-borrow-introducers with: @trace[0]
+// CHECK-LABEL: introducer_bridge: find-borrow-introducers with: %bridge
+
+// CHECK-LABEL: introducer_bridge: borrow_introducers with: %bridge
+// CHECK: Borrow introducers for: %{{.*}} = ref_to_bridge_object %0 : $C, %1 : $Builtin.Word
+// CHECK: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_bridge: borrow_introducers with: %bridge
 sil [ossa] @introducer_bridge : $@convention(thin) (@guaranteed C, Builtin.Word) -> () {
 entry(%0 : @guaranteed $C, %1 : $Builtin.Word):
-  specify_test "find-borrow-introducers @trace[0]"
+  specify_test "find-borrow-introducers %bridge"
+  specify_test "borrow_introducers %bridge"
   %bridge = ref_to_bridge_object %0 : $C, %1 : $Builtin.Word
-  debug_value [trace] %bridge : $Builtin.BridgeObject
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: introducer_begin_apply: borrow_introducers with: %bridge
+// CHECK: Borrow introducers for:   %{{.*}} = ref_to_bridge_object %{{.*}} : $C, %0 : $Builtin.Word
+// CHECK-NEXT: (**%{{.*}}**, %{{.*}}) = begin_apply %{{.*}}() : $@yield_once @convention(thin) () -> @yields @guaranteed C
+// CHECK-NEXT: introducer_begin_apply: borrow_introducers with: %bridge
+sil [ossa] @introducer_begin_apply : $@convention(thin) (Builtin.Word) -> () {
+bb0(%0 : $Builtin.Word):
+  %f = function_ref @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
+  (%c, %t) = begin_apply %f() : $@yield_once @convention(thin) () -> @yields @guaranteed C
+  specify_test "borrow_introducers %bridge"
+  %bridge = ref_to_bridge_object %c : $C, %0 : $Builtin.Word
+  cond_br undef, bb1, bb2
+bb1:
+  end_apply %t
+  %r = tuple ()
+  return %r : $()
+bb2:
+  abort_apply %t
+  unreachable
+}
+
+// CHECK-LABEL: introducer_example: borrow_introducers with: %0
+// CHECK: Borrow introducers for: %0 = argument of bb0 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_example: borrow_introducers with: %0
+
+// CHECK-LABEL: introducer_example: borrow_introducers with: %borrow0
+// CHECK: Borrow introducers for:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT:  %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: introducer_example: borrow_introducers with: %borrow0
+
+// CHECK-LABEL: introducer_example: borrow_introducers with: %first
+// CHECK: Borrow introducers for:   %{{.*}} = struct_extract %{{.*}} : $PairC, #PairC.first
+// CHECK-NEXT:  %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT:  %{{.*}} = argument of bb0 : $C
+// CHECK-NEXT: introducer_example: borrow_introducers with: %first
+
+// CHECK-LABEL: introducer_example: borrow_introducers with: %field
+// CHECK: Borrow introducers for:   %{{.*}} = ref_element_addr %{{.*}} : $C, #C.field
+// CHECK-NEXT: introducer_example: borrow_introducers with: %field
+
+// CHECK-LABEL: introducer_example: borrow_introducers with: %load
+// CHECK-LABEL: Borrow introducers for:   %{{.*}} = load_borrow %{{.*}} : $*C
+// CHECK-NEXT: %{{.*}} = load_borrow %{{.*}} : $*C
+// CHECK-NEXT: introducer_example: borrow_introducers with: %
+sil [ossa] @introducer_example : $@convention(thin) (@owned C, @guaranteed C) -> () {
+bb0(%0 : @owned $C,
+    %1 : @guaranteed $C):
+  specify_test "borrow_introducers %0"
+  %borrow0 = begin_borrow %0 : $C
+  specify_test "borrow_introducers %borrow0"
+  %pair = struct $PairC(%borrow0 : $C, %1 : $C)
+  %first = struct_extract %pair : $PairC, #PairC.first
+  specify_test "borrow_introducers %first"
+  %field = ref_element_addr %first : $C, #C.field
+  specify_test "borrow_introducers %field"
+  %load = load_borrow %field : $*C
+  specify_test "borrow_introducers %load"
+  end_borrow %load : $C
+  end_borrow %borrow0 : $C
+  destroy_value %0 : $C
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/enclosing_def_unit.sil
+++ b/test/SILOptimizer/enclosing_def_unit.sil
@@ -18,29 +18,40 @@ struct PairC {
   var second: C
 }
 
-class C {}
+class C {
+  var field: C
+}
 
 class D : C {}
 
 // These introducers have no enclosing def.
 
-// CHECK-LABEL: enclosing_def_empty: find-enclosing-defs with: @trace[0]
+// CHECK-LABEL: enclosing_def_empty: find-enclosing-defs with: %0
 // CHECK: } // end sil function 'enclosing_def_empty'
 // CHECK: Enclosing Defs:
-// CHECK-NEXT: enclosing_def_empty: find-enclosing-defs with: @trace[0]
+// CHECK-NEXT: enclosing_def_empty: find-enclosing-defs with: %0
 
-// CHECK-LABEL: enclosing_def_empty: find-enclosing-defs with: @trace[1]
+// CHECK-LABEL: enclosing_def_empty: enclosing_values with: %0
+// CHECK: } // end sil function 'enclosing_def_empty'
+// CHECK: Enclosing values for:  %0 = argument of bb0 : $C
+// CHECK-NEXT: enclosing_def_empty: enclosing_values with: %0
+
+// CHECK-LABEL: enclosing_def_empty: find-enclosing-defs with: %borrow1
 // CHECK: } // end sil function 'enclosing_def_empty'
 // CHECK: Enclosing Defs:
-// CHECK-NEXT: enclosing_def_empty: find-enclosing-defs with: @trace[1]
+// CHECK-NEXT: enclosing_def_empty: find-enclosing-defs with: %borrow1
 
+// CHECK-LABEL: enclosing_def_empty: enclosing_values with: %borrow1
+// CHECK: } // end sil function 'enclosing_def_empty'
+// CHECK: Enclosing values for: %{{.*}} = load_borrow %1 : $*C
+// CHECK-NEXT: enclosing_def_empty: enclosing_values with: %borrow1
 sil [ossa] @enclosing_def_empty : $@convention(thin) (@guaranteed C, @in C) -> () {
 entry(%0 : @guaranteed $C, %1 : $*C):
-  specify_test "find-enclosing-defs @trace[0]"
-  debug_value [trace] %0 : $C
+  specify_test "find-enclosing-defs %0"
+  specify_test "enclosing_values %0"
   %borrow1 = load_borrow %1 : $*C
-  specify_test "find-enclosing-defs @trace[1]"
-  debug_value [trace] %borrow1 : $C
+  specify_test "find-enclosing-defs %borrow1"
+  specify_test "enclosing_values %borrow1"
   end_borrow %borrow1 : $C
   destroy_addr %1 : $*C
   %retval = tuple ()
@@ -50,19 +61,23 @@ entry(%0 : @guaranteed $C, %1 : $*C):
 // There is no introducer if the guaranteed value is produced from a
 // trivial value.
 
-// CHECK-LABEL: enclosing_def_trivial: find-enclosing-defs with: @trace[0]
+// CHECK-LABEL: enclosing_def_trivial: find-enclosing-defs with: %phi
 // CHECK: } // end sil function 'enclosing_def_trivial'
 // CHECK: Enclosing Defs:
-// CHECK-NEXT: enclosing_def_trivial: find-enclosing-defs with: @trace[0]
+// CHECK-NEXT: enclosing_def_trivial: find-enclosing-defs with: %phi
 
+// CHECK-LABEL: enclosing_def_trivial: enclosing_values with: %phi
+// CHECK: } // end sil function 'enclosing_def_trivial'
+// CHECK: Enclosing values for: %{{.*}} = argument of bb1 : $FakeOptional<C>
+// CHECK-NEXT: enclosing_def_trivial: enclosing_values with: %phi
 sil [ossa] @enclosing_def_trivial : $@convention(thin) () -> () {
 entry:
   %trivial = enum $FakeOptional<C>, #FakeOptional.none!enumelt
   br none(%trivial : $FakeOptional<C>)
 
 none(%phi : @guaranteed $FakeOptional<C>):
-  specify_test "find-enclosing-defs @trace[0]"
-  debug_value [trace] %phi : $FakeOptional<C>
+  specify_test "find-enclosing-defs %phi"
+  specify_test "enclosing_values %phi"
   %retval = tuple ()
   return %retval : $()
 }
@@ -70,18 +85,22 @@ none(%phi : @guaranteed $FakeOptional<C>):
 // There is an introducer but no enclosing def if the guaranteed value
 // is produced from a an unreachable loop.
 
-// CHECK-LABEL: enclosing_def_unreachable: find-enclosing-defs with: @trace[0]
+// CHECK-LABEL: enclosing_def_unreachable: find-enclosing-defs with: %phiCycle
 // CHECK: } // end sil function 'enclosing_def_unreachable'
 // CHECK: Enclosing Defs:
-// CHECK-NEXT: enclosing_def_unreachable: find-enclosing-defs with: @trace[0]
+// CHECK-NEXT: enclosing_def_unreachable: find-enclosing-defs with: %phiCycle
 
-sil [ossa] @enclosing_def_unreachable : $@convention(thin) () -> () {
+// CHECK-LABEL: enclosing_def_unreachable: enclosing_values with: %phiCycle
+// CHECK: } // end sil function 'enclosing_def_unreachable'
+// CHECK: Enclosing values for: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: enclosing_def_unreachable: enclosing_values with: %phiCycle
+sil [ossa] @enclosing_def_unreachable : $@convention(thin) () ->() {
 entry:
   br exit
 
 unreachable_loop(%phiCycle : @guaranteed $C):
-  specify_test "find-enclosing-defs @trace[0]"
-  debug_value [trace] %phiCycle : $C
+  specify_test "find-enclosing-defs %phiCycle"
+  specify_test "enclosing_values %phiCycle"
   br unreachable_loop(%phiCycle : $C)
 
 exit:
@@ -92,12 +111,17 @@ exit:
 // All data flow paths through phis and aggregates originate from the
 // same borrow scope. This is the same as finding the introducer.
 
-// CHECK-LABEL: begin running test 1 of 1 on enclosing_def_single_introducer: find-enclosing-defs with: @trace[0]
+// CHECK-LABEL: enclosing_def_single_introducer: find-enclosing-defs with: %aggregate2
 // CHECK: sil [ossa] @enclosing_def_single_introducer
 // CHECK: Enclosing Defs:
 // CHECK:   begin_borrow %0 : $C
-// CHECK-NEXT: end running test 1 of 1 on enclosing_def_single_introducer: find-enclosing-defs with: @trace[0]
+// CHECK-NEXT: enclosing_def_single_introducer: find-enclosing-defs with: %aggregate2
 
+// CHECK-LABEL: enclosing_def_single_introducer: enclosing_values with: %aggregate2
+// CHECK: sil [ossa] @enclosing_def_single_introducer
+// CHECK: Enclosing values for: %{{.*}} = struct $PairC (%10 : $C, %11 : $C)
+// CHECK:   begin_borrow %0 : $C
+// CHECK-NEXT: enclosing_def_single_introducer: enclosing_values with: %aggregate2
 sil [ossa] @enclosing_def_single_introducer : $@convention(thin) (@guaranteed C) -> () {
 entry(%0 : @guaranteed $C):
   %borrow = begin_borrow %0 : $C
@@ -114,8 +138,8 @@ bb1(%payload : @guaranteed $D):
   %first = struct_extract %aggregate : $PairC, #PairC.first
   %second = struct_extract %aggregate : $PairC, #PairC.second
   %aggregate2 = struct $PairC(%first : $C, %second : $C)
-  specify_test "find-enclosing-defs @trace[0]"
-  debug_value [trace] %aggregate2 : $PairC
+  specify_test "find-enclosing-defs %aggregate2"
+  specify_test "enclosing_values %aggregate2"
   br exit
 
 bb2:
@@ -129,11 +153,17 @@ exit:
 
 // All reborrows original from the same dominating borrow scope.
 
-// CHECK: begin running test 1 of 1 on enclosing_def_single_outer: find-enclosing-defs with: @trace[0]
+// CHECK: enclosing_def_single_outer: find-enclosing-defs with: %reborrow3
 // CHECK: } // end sil function 'enclosing_def_single_outer'
 // CHECK: Enclosing Defs:
 // CHECK-NEXT: %0 = argument of bb0 : $C
-// CHECK-NEXT: end running test 1 of 1 on enclosing_def_single_outer: find-enclosing-defs with: @trace[0]
+// CHECK-NEXT: enclosing_def_single_outer: find-enclosing-defs with: %reborrow3
+
+// CHECK: enclosing_def_single_outer: enclosing_values with: %reborrow3
+// CHECK: } // end sil function 'enclosing_def_single_outer'
+// CHECK: Enclosing values for:  %{{.*}} = argument of bb2 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: enclosing_def_single_outer: enclosing_values with: %reborrow3
 
 sil [ossa] @enclosing_def_single_outer : $@convention(thin) (@guaranteed C) -> () {
 entry(%0 : @guaranteed $C):
@@ -144,8 +174,8 @@ bb2(%reborrow2 : @guaranteed $C):
   br bb3(%reborrow2 : $C)
 
 bb3(%reborrow3 : @guaranteed $C):
-  specify_test "find-enclosing-defs @trace[0]"
-  debug_value [trace] %reborrow3 : $C
+  specify_test "find-enclosing-defs %reborrow3"
+  specify_test "enclosing_values %reborrow3"
   end_borrow %reborrow3 : $C
   %retval = tuple ()
   return %retval : $()
@@ -153,14 +183,21 @@ bb3(%reborrow3 : @guaranteed $C):
 
 // Find the outer enclosingreborrow.
 
-// CHECK-LABEL: begin running test 1 of 1 on enclosing_def_reborrow: find-enclosing-defs with: @trace[0]
+// CHECK-LABEL: enclosing_def_reborrow: find-enclosing-defs with: %reborrow_inner3
 // CHECK: sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C, %{{.*}} : @reborrow @guaranteed $C):
 // CHECK: } // end sil function 'enclosing_def_reborrow'
 // CHECK: Enclosing Defs:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
-// CHECK-NEXT: end running test 1 of 1 on enclosing_def_reborrow: find-enclosing-defs with: @trace[0]
+// CHECK-NEXT: enclosing_def_reborrow: find-enclosing-defs with: %reborrow_inner3
 
+// CHECK-LABEL: enclosing_def_reborrow: enclosing_values with: %reborrow_inner3
+// CHECK: sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C, %{{.*}} : @reborrow @guaranteed $C):
+// CHECK: } // end sil function 'enclosing_def_reborrow'
+// CHECK: Enclosing values for: %{{.*}} = argument of bb2 : $C
+// CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
+// CHECK-NEXT: enclosing_def_reborrow: enclosing_values with: %reborrow_inner3
 sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
 entry(%0 : @guaranteed $C):
   %borrow_outer = begin_borrow %0 : $C
@@ -171,9 +208,8 @@ bb2(%reborrow_outer : @guaranteed $C, %reborrow_inner : @guaranteed $C):
   br bb3(%reborrow_inner : $C)
 
 bb3(%reborrow_inner3 : @guaranteed $C):
-  specify_test "find-enclosing-defs @trace[0]"
-  debug_value [trace] %reborrow_inner3 : $C
-
+  specify_test "find-enclosing-defs %reborrow_inner3"
+  specify_test "enclosing_values %reborrow_inner3"
   end_borrow %reborrow_inner3 : $C
   end_borrow %reborrow_outer : $C
   %retval = tuple ()
@@ -182,14 +218,21 @@ bb3(%reborrow_inner3 : @guaranteed $C):
 
 // The enclosing def of a forwarding phi cycle is the reborrow phi cycle.
 
-// CHECK-LABEL: begin running test 1 of 1 on enclosing_def_cycle: find-enclosing-defs with: @trace[0]
+// CHECK-LABEL: enclosing_def_cycle: find-enclosing-defs with: %forward
 // CHECK: sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
 // CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C,
 // CHECK: } // end sil function 'enclosing_def_cycle'
 // CHECK: Enclosing Defs:
 // CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
-// CHECK-NEXT: end running test 1 of 1 on enclosing_def_cycle: find-enclosing-defs with: @trace[0]
+// CHECK-NEXT: enclosing_def_cycle: find-enclosing-defs with: %forward
 
+// CHECK-LABEL: enclosing_def_cycle: enclosing_values with: %forward
+// CHECK: sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: bb1([[REBORROW:%.*]] : @reborrow @guaranteed $C,
+// CHECK: } // end sil function 'enclosing_def_cycle'
+// CHECK: Enclosing values for: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
+// CHECK-NEXT: enclosing_def_cycle: enclosing_values with: %forward
 sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
 entry(%0 : @guaranteed $C):
   %borrow = begin_borrow %0 : $C
@@ -198,14 +241,78 @@ entry(%0 : @guaranteed $C):
   br bb2(%borrow : $C, %first1 : $C)
 
 bb2(%reborrow_outer : @guaranteed $C, %forward : @guaranteed $C):
-  specify_test "find-enclosing-defs @trace[0]"
-  debug_value [trace] %forward : $C
-
+  specify_test "find-enclosing-defs %forward"
+  specify_test "enclosing_values %forward"
   %aggregate2 = struct $PairC(%reborrow_outer : $C, %forward : $C)
   %first2 = struct_extract %aggregate2 : $PairC, #PairC.first
   br bb2(%reborrow_outer : $C, %first2 : $C)
 
 exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: enclosing_def_example: enclosing_values with: %0
+// CHECK: Enclosing values for: %0 = argument of bb0 : $C
+// CHECK-NEXT: enclosing_def_example: enclosing_values with: %0
+
+// CHECK-LABEL: enclosing_def_example: enclosing_values with: %borrow0
+// CHECK: Enclosing values for:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: enclosing_def_example: enclosing_values with: %borrow0
+
+// CHECK-LABEL: enclosing_def_example: enclosing_values with: %first
+// CHECK: Enclosing values for:   %{{.*}} = struct_extract %{{.*}} : $PairC, #PairC.first
+// CHECK-NEXT:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT:   %{{.*}} = argument of bb0 : $C
+// CHECK-NEXT: enclosing_def_example: enclosing_values with: %first
+
+// CHECK-LABEL: enclosing_def_example: enclosing_values with: %field
+// CHECK: Enclosing values for:   %{{.*}} = ref_element_addr %{{.*}} : $C, #C.field
+// CHECK-NEXT: enclosing_def_example: enclosing_values with: %field
+
+// CHECK-LABEL: enclosing_def_example: enclosing_values with: %load
+// CHECK: Enclosing values for:   %{{.*}} = load_borrow %{{.*}} : $*C
+// CHECK-NEXT: enclosing_def_example: enclosing_values with: %load
+sil [ossa] @enclosing_def_example : $@convention(thin) (@owned C, @guaranteed C) -> () {
+bb0(%0 : @owned $C,
+    %1 : @guaranteed $C):
+  specify_test "enclosing_values %0"
+  %borrow0 = begin_borrow %0 : $C
+  specify_test "enclosing_values %borrow0"
+  %pair = struct $PairC(%borrow0 : $C, %1 : $C)
+  %first = struct_extract %pair : $PairC, #PairC.first
+  specify_test "enclosing_values %first"
+  %field = ref_element_addr %first : $C, #C.field
+  specify_test "enclosing_values %field"
+  %load = load_borrow %field : $*C
+  specify_test "enclosing_values %load"
+  end_borrow %load : $C
+  end_borrow %borrow0 : $C
+  destroy_value %0 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: enclosing_def_reborrow_example: enclosing_values with: %outerReborrow
+// CHECK: Enclosing values for: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: enclosing_def_reborrow_example: enclosing_values with: %outerReborrow
+
+// CHECK-LABEL: enclosing_def_reborrow_example: enclosing_values with: %innerReborrow
+// CHECK: Enclosing values for: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: %{{.*}} = argument of bb1 : $C
+// CHECK-NEXT: enclosing_def_reborrow_example: enclosing_values with: %innerReborrow
+sil [ossa] @enclosing_def_reborrow_example : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %outerBorrow = begin_borrow %0 : $C
+  %innerBorrow = begin_borrow %outerBorrow : $C
+  br bb1(%outerBorrow : $C, %innerBorrow : $C)
+bb1(%outerReborrow : @guaranteed $C, %innerReborrow : @guaranteed $C):  
+  specify_test "enclosing_values %outerReborrow"
+  specify_test "enclosing_values %innerReborrow"
+  end_borrow %innerReborrow : $C
+  end_borrow %outerReborrow : $C
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -30,17 +30,27 @@ sil @getC : $@convention(thin) () -> @owned C
 // LinearLiveness
 // =============================================================================
 
-// CHECK-LABEL: begin running test 1 of 1 on testLinearRefElementEscape: linear-liveness with: @trace[0]
+// CHECK-LABEL: testLinearRefElementEscape: linear-liveness with: %borrow
 // CHECK-LABEL: Linear liveness:
 // CHECK: lifetime-ending user:
 // CHECK-SAME: end_borrow
 // CHECK-NEXT: last user:   end_borrow
-// CHECK-NEXT: end running test 1 of 1 on testLinearRefElementEscape
+// CHECK-NEXT: testLinearRefElementEscape
+
+// CHECK-LABEL: testLinearRefElementEscape: linear_liveness_swift with: %borrow
+// CHECK: Linear liveness:
+// CHECK-NEXT: Live blocks:
+// CHECK-NEXT: begin: %{{.*}} = begin_borrow
+// CHECK-NEXT: ends: end_borrow
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: last user: end_borrow
+// CHECK-NEXT: testLinearRefElementEscape
 sil [ossa] @testLinearRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "linear-liveness @trace[0]"
   %borrow = begin_borrow %0 : $C
-  debug_value [trace] %borrow : $C
+  specify_test "linear-liveness %borrow"
+  specify_test "linear_liveness_swift %borrow"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -61,17 +71,27 @@ bb3(%phi : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testLinearBitwiseEscape: linear-liveness with: @trace[0]
+// CHECK-LABEL: testLinearBitwiseEscape: linear-liveness with: %borrow
 // CHECK: Linear liveness:
 // CHECK: lifetime-ending user:
 // CHECK-SAME: end_borrow
 // CHECK-NEXT: last user:   end_borrow
-// CHECK-NEXT: end running test 1 of 1 on testLinearBitwiseEscape
+// CHECK-NEXT: testLinearBitwiseEscape
+
+// CHECK-LABEL: testLinearBitwiseEscape: linear_liveness_swift with: %borrow
+// CHECK: Linear liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: Live blocks:
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       end_borrow
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: last user:   end_borrow
+// CHECK-NEXT: testLinearBitwiseEscape
 sil [ossa] @testLinearBitwiseEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "linear-liveness @trace[0]"
   %borrow = begin_borrow %0 : $C
-  debug_value [trace] %borrow : $C
+  specify_test "linear-liveness %borrow"
+  specify_test "linear_liveness_swift %borrow"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -88,15 +108,26 @@ bb3(%phi : @unowned $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testLinearInnerReborrow: linear-liveness with: @argument[0]
+// CHECK-LABEL: testLinearInnerReborrow: linear-liveness with: @argument[0]
 // CHECK: Linear liveness:
 // CHECK: lifetime-ending user:
 // CHECK-SAME: destroy_value %0
 // CHECK-NEXT: last user:   destroy_value %0
-// CHECK-NEXT: end running test 1 of 1 on testLinearInnerReborrow
+// CHECK-NEXT: testLinearInnerReborrow
+
+// CHECK-LABEL: testLinearInnerReborrow: linear_liveness_swift with: @argument[0]
+// CHECK: Linear liveness:
+// CHECK-NEXT: Live blocks:
+// CHECK-NEXT: begin:      cond_br undef, bb1, bb2
+// CHECK-NEXT: ends:       destroy_value %0 : $C
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: last user:   destroy_value %0 : $C
+// CHECK-NEXT: testLinearInnerReborrow
 sil [ossa] @testLinearInnerReborrow : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
   specify_test "linear-liveness @argument[0]"
+  specify_test "linear_liveness_swift @argument[0]"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -114,18 +145,29 @@ bb3(%phi : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testLinearAdjacentReborrow: linear-liveness with: @trace[0]
+// CHECK-LABEL: testLinearAdjacentReborrow: linear-liveness with: %borrow
 // CHECK: lifetime-ending user:
 // CHECK-SAME: br bb3
 // CHECK-NEXT: lifetime-ending user: br bb3
 // CHECK-NEXT: last user: br bb3
 // CHECK-NEXT: last user: br bb3
-// CHECK-NEXT: end running test 1 of 1 on testLinearAdjacentReborrow
+// CHECK-NEXT: testLinearAdjacentReborrow
+
+// CHECK-LABEL: testLinearAdjacentReborrow: linear_liveness_swift with: %borrow
+// CHECK: Live blocks:
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       br bb3
+// CHECK-NEXT:             br bb3
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: last user:   br bb3
+// CHECK-NEXT: last user:   br bb3
+// CHECK-NEXT: testLinearAdjacentReborrow
 sil [ossa] @testLinearAdjacentReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "linear-liveness @trace[0]"
+  specify_test "linear-liveness %borrow"
+  specify_test "linear_liveness_swift %borrow"
   %borrow = begin_borrow %0 : $C
-  debug_value [trace] %borrow : $C
   cond_br undef, bb1, bb2
 
 bb1:
@@ -147,7 +189,7 @@ bb3(%outer : @guaranteed $C, %inner : @guaranteed $C):
 // visitInnerAdjacentPhis
 // =============================================================================
 
-// CHECK-LABEL: begin running test 1 of 1 on pay_the_phi: visit-inner-adjacent-phis with: @trace[0]
+// CHECK-LABEL: pay_the_phi: visit-inner-adjacent-phis with: %owned
 // CHECK: sil [ossa] @pay_the_phi : {{.*}} {
 // CHECK:   [[C:%[^,]+]] = apply
 // CHECK:   [[BORROW1:%[^,]+]] = begin_borrow %1
@@ -158,7 +200,7 @@ bb3(%outer : @guaranteed $C, %inner : @guaranteed $C):
 //
 // CHECK:[[GUARANTEED1]] = argument of [[EXIT]]
 // CHECK:[[GUARANTEED2]] = argument of [[EXIT]]
-// CHECK-LABEL: end running test 1 of 1 on pay_the_phi: visit-inner-adjacent-phis with: @trace[0]
+// CHECK-LABEL: pay_the_phi: visit-inner-adjacent-phis with: %owned
 sil [ossa] @pay_the_phi : $@convention(thin) () -> () {
 entry:
   %getC = function_ref @getC : $@convention(thin) () -> @owned C
@@ -169,8 +211,7 @@ entry:
   br exit(%c : $C, %borrow1 : $C, %borrow2 : $C, %borrow3 : $C)
 
 exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaranteed $C, %guaranteed_3 : @guaranteed $C):
-  specify_test "visit-inner-adjacent-phis @trace[0]"
-  debug_value [trace] %owned : $C
+  specify_test "visit-inner-adjacent-phis %owned"
   end_borrow %guaranteed_3 : $C
   end_borrow %guaranteed_2 : $C
   end_borrow %guaranteed_1 : $C
@@ -179,11 +220,11 @@ exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaran
   return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on pay_the_phi_forward: visit-inner-adjacent-phis with: @trace[0]
+// CHECK-LABEL: pay_the_phi_forward: visit-inner-adjacent-phis with: %reborrow
 // CHECK: bb1(%{{.*}} : @reborrow @guaranteed $C, [[INNER:%.*]] : @guaranteed $D):    // Preds: bb0
 // CHECK: } // end sil function 'pay_the_phi_forward'
 // CHECK: [[INNER]] = argument of bb1 : $D
-// CHECK: end running test 1 of 1 on pay_the_phi_forward: visit-inner-adjacent-phis with: @trace[0]
+// CHECK: pay_the_phi_forward: visit-inner-adjacent-phis with: %reborrow
 sil [ossa] @pay_the_phi_forward : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %borrow0 = begin_borrow %0 : $C
@@ -191,8 +232,7 @@ bb0(%0 : @guaranteed $C):
   br exit(%borrow0 : $C, %d0 : $D)
 
 exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
-  specify_test "visit-inner-adjacent-phis @trace[0]"
-  debug_value [trace] %reborrow : $C
+  specify_test "visit-inner-adjacent-phis %reborrow"
   %f = ref_element_addr %phi : $D, #D.object
   %o = load [copy] %f : $*C
   destroy_value %o : $C
@@ -205,32 +245,57 @@ exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // InteriorLiveness and visitAdjacentPhis
 // =============================================================================
 
-// CHECK-LABEL: begin running test 1 of 1 on testInteriorRefElementEscape: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInteriorRefElementEscape: interior-liveness with: %0
 // CHECK: Incomplete liveness: Escaping address
 // CHECK: last user:   %{{.*}} = address_to_pointer
-// CHECK-NEXT: end running test 1 of 1 on testInteriorRefElementEscape:
+// CHECK-NEXT: testInteriorRefElementEscape:
+
+// CHECK-LABEL: testInteriorRefElementEscape: interior_liveness_swift with: %0
+// CHECK: Interior liveness: %0 = argument of bb0 : $C
+// CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: Incomplete liveness
+// CHECK-NEXT: begin:      %{{.*}} = unchecked_ref_cast %0 : $C to $D
+// CHECK-NEXT: ends:       %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %0 : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
+// CHECK-NEXT: testInteriorRefElementEscape:
 sil [ossa] @testInteriorRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "interior-liveness @trace[0]"
+  specify_test "interior-liveness %0"
+  specify_test "interior_liveness_swift %0"
   %d = unchecked_ref_cast %0 : $C to $D
-  debug_value [trace] %d : $D
   %f1 = ref_element_addr %d : $D, #D.object  
   %p1 = address_to_pointer %f1 : $*C to $Builtin.RawPointer
   %99 = tuple()
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInteriorReborrow: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInteriorReborrow: interior-liveness with: %borrow
 // CHECK: Complete liveness
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb1
-// CHECK-NEXT: end running test 1 of 1 on testInteriorReborrow: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInteriorReborrow: interior-liveness with: %borrow
+
+// CHECK-LABEL: testInteriorReborrow: interior_liveness_swift with: %borrow
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       br bb1(%{{.*}} : $C)
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb1(%{{.*}} : $C)
+// CHECK-NEXT: testInteriorReborrow: interior_liveness_swift with: %borrow
 sil [ossa] @testInteriorReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
-  specify_test "interior-liveness @trace[0]"
   %borrow = begin_borrow %0 : $C
-  debug_value [trace] %borrow : $C
+  specify_test "interior-liveness %borrow"
+  specify_test "interior_liveness_swift %borrow"
   br bb1(%borrow : $C)
 
 bb1(%reborrow : @guaranteed $C):
@@ -239,13 +304,29 @@ bb1(%reborrow : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInteriorDominatedGuaranteedForwardingPhi: interior-liveness with: @argument[0]
+// CHECK-LABEL: testInteriorDominatedGuaranteedForwardingPhi: interior-liveness with: @argument[0]
 // CHECK: Complete liveness
 // CHECK: last user: %{{.*}} load [copy]
-// CHECK-NEXT: end running test 1 of 1 on testInteriorDominatedGuaranteedForwardingPhi:
+// CHECK-NEXT: testInteriorDominatedGuaranteedForwardingPhi:
+
+// CHECK-LABEL: testInteriorDominatedGuaranteedForwardingPhi: interior_liveness_swift with: @argument[0]
+// CHECK: Interior liveness: %0 = argument of bb0 : $C
+// CHECK-NEXT: begin:      cond_br undef, bb1, bb2
+// CHECK-NEXT: ends:       %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  br bb3(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %0 : $C to $D
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT:             br bb3(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = unchecked_ref_cast %0 : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: testInteriorDominatedGuaranteedForwardingPhi:
 sil [ossa] @testInteriorDominatedGuaranteedForwardingPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   specify_test "interior-liveness @argument[0]"
+  specify_test "interior_liveness_swift @argument[0]"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -264,23 +345,34 @@ bb3(%phi : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInteriorNondominatedGuaranteedForwardingPhi: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInteriorNondominatedGuaranteedForwardingPhi: interior-liveness with: %borrow1
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3(
-// CHECK-NEXT: end running test 1 of 1 on testInteriorNondominatedGuaranteedForwardingPhi: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInteriorNondominatedGuaranteedForwardingPhi: interior-liveness with: %borrow1
+
+// CHECK-LABEL: testInteriorNondominatedGuaranteedForwardingPhi: interior_liveness_swift with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       br bb3(%{{.*}} : $C, %{{.*}} : $D)
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $C, %{{.*}} : $D)
+// CHECK-NEXT: testInteriorNondominatedGuaranteedForwardingPhi: interior_liveness_swift with: %borrow1
 sil [ossa] @testInteriorNondominatedGuaranteedForwardingPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
 
 bb1:
   %borrow1 = begin_borrow %0 : $C
-  debug_value [trace] %borrow1 : $C
-  specify_test "interior-liveness @trace[0]"
+  specify_test "interior-liveness %borrow1"
+  specify_test "interior_liveness_swift %borrow1"
   %d1 = unchecked_ref_cast %borrow1 : $C to $D
   br bb3(%borrow1 : $C, %d1 : $D)
-
+ 
 bb2:
   %borrow2 = begin_borrow %0 : $C
   %d2 = unchecked_ref_cast %borrow2 : $C to $D
@@ -295,17 +387,29 @@ bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerDominatedReborrow: interior-liveness with: @argument[0]
+// CHECK-LABEL: testInnerDominatedReborrow: interior-liveness with: @argument[0]
 // CHECK: Interior liveness:
 // CHECK: Inner scope:   %{{.*}} = begin_borrow %0 : $C
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_borrow
-// CHECK-NEXT: end running test 1 of 1 on testInnerDominatedReborrow: interior-liveness with: @argument[0]
+// CHECK-NEXT: testInnerDominatedReborrow: interior-liveness with: @argument[0]
+
+// CHECK-LABEL: testInnerDominatedReborrow: interior_liveness_swift with: @argument[0]
+// CHECK: Interior liveness: %0 = argument of bb0 : $C
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $C
+// CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  br bb1(%{{.*}} : $C)
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $C
+// CHECK-NEXT: testInnerDominatedReborrow: interior_liveness_swift with: @argument[0]
 sil [ossa] @testInnerDominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   specify_test "interior-liveness @argument[0]"
+  specify_test "interior_liveness_swift @argument[0]"
   %borrow = begin_borrow %0 : $C
   br bb1(%borrow : $C)
 
@@ -315,20 +419,32 @@ bb1(%reborrow : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerDominatedReborrow2: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInnerDominatedReborrow2: interior-liveness with: %copy0a
 // CHECK: Inner scope:   %{{.*}} = begin_borrow %1 : $C
 // CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $C
 // CHECK: Complete liveness
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   destroy_value
-// CHECK-NEXT: end running test 1 of 1 on testInnerDominatedReborrow2: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInnerDominatedReborrow2: interior-liveness with: %copy0a
+
+// CHECK-LABEL: testInnerDominatedReborrow2: interior_liveness_swift with: %copy0a
+// CHECK: Interior liveness:   %{{.*}} = copy_value %0 : $C
+// CHECK-NEXT: begin:      %{{.*}} = copy_value %0 : $C
+// CHECK-NEXT: ends:       destroy_value %{{.*}} : $C
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  end_borrow %{{.*}} : $C
+// CHECK-NEXT:             br bb3(%{{.*}} : $C)
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   destroy_value %{{.*}} : $C
+// CHECK-NEXT: testInnerDominatedReborrow2: interior_liveness_swift with: %copy0a
 sil [ossa] @testInnerDominatedReborrow2 : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   %copy0a = copy_value %0 : $C
   %copy0b = copy_value %0 : $C
-  specify_test "interior-liveness @trace[0]"
-  debug_value [trace] %copy0a : $C
+  specify_test "interior-liveness %copy0a"
+  specify_test "interior_liveness_swift %copy0a"
   cond_br undef, bb1, bb2
 
 bb1:
@@ -347,21 +463,32 @@ bb3(%reborrow : @guaranteed $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerNonDominatedReborrow: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInnerNonDominatedReborrow: interior-liveness with: %borrow1
 // CHECK: Inner scope:   [[BORROW:%.*]] = begin_borrow [[DEF:%.*]] : $D
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3([[DEF]] : $D, [[BORROW]] : $D)
-// CHECK-NEXT: end running test 1 of 1 on testInnerNonDominatedReborrow: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInnerNonDominatedReborrow: interior-liveness with: %borrow1
+
+// CHECK-LABEL: testInnerNonDominatedReborrow: interior_liveness_swift with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %0 : $D
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %0 : $D
+// CHECK-NEXT: ends:       br bb3(%{{.*}} : $D, %{{.*}} : $D)
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D, %{{.*}} : $D)
+// CHECK-NEXT: testInnerNonDominatedReborrow: interior_liveness_swift with: %borrow1
 sil [ossa] @testInnerNonDominatedReborrow : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "interior-liveness @trace[0]"
   %borrow1 = begin_borrow %0 : $D
-  debug_value [trace] %borrow1 : $D
+  specify_test "interior-liveness %borrow1"
+  specify_test "interior_liveness_swift %borrow1"
   %inner1 = begin_borrow %borrow1 : $D
   br bb3(%borrow1 : $D, %inner1 : $D)
 
@@ -380,7 +507,7 @@ bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerAdjacentReborrow1: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInnerAdjacentReborrow1: interior-liveness with: %outer3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
 // CHECK:      Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK:      Inner scope: %{{.*}} = argument of bb4 : $D
@@ -390,7 +517,18 @@ bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user: end_borrow
-// CHECK-NEXT: end running test 1 of 1 on testInnerAdjacentReborrow1: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInnerAdjacentReborrow1: interior-liveness with: %outer3
+
+// CHECK-LABEL: testInnerAdjacentReborrow1: interior_liveness_swift with: %outer3
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: begin:      br bb4(
+// CHECK-NEXT: ends:       end_borrow
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  br bb4(
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow
+// CHECK-NEXT: testInnerAdjacentReborrow1: interior_liveness_swift with: %outer3
 sil [ossa] @testInnerAdjacentReborrow1 : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
   cond_br undef, bb1, bb2
@@ -406,8 +544,8 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  specify_test "interior-liveness @trace[0]"
-  debug_value [trace] %outer3 : $D
+  specify_test "interior-liveness %outer3"
+  specify_test "interior_liveness_swift %outer3"
   br bb4(%inner3 : $D)
 
 bb4(%inner4 : @guaranteed $D):
@@ -418,7 +556,7 @@ bb4(%inner4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerAdjacentReborrow2: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInnerAdjacentReborrow2: interior-liveness with: %outer3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
 // CHECK:      Inner scope: %{{.*}} = argument of bb3 : $D
 // CHECK:      Inner scope: %{{.*}} = argument of bb4 : $D
@@ -428,7 +566,18 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user: end_borrow
-// CHECK-NEXT: end running test 1 of 1 on testInnerAdjacentReborrow2: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInnerAdjacentReborrow2: interior-liveness with: %outer3
+
+// CHECK-LABEL: testInnerAdjacentReborrow2: interior_liveness_swift with: %outer3
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: begin:      br bb4(%{{.*}} : $D)
+// CHECK-NEXT: ends:       end_borrow %{{.*}} : $D
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  br bb4(%{{.*}} : $D)
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow %{{.*}} : $D
+// CHECK-NEXT: testInnerAdjacentReborrow2: interior_liveness_swift with: %outer3
 sil [ossa] @testInnerAdjacentReborrow2 : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
   cond_br undef, bb1, bb2
@@ -444,8 +593,8 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  specify_test "interior-liveness @trace[0]"
-  debug_value [trace] %outer3 : $D
+  specify_test "interior-liveness %outer3"
+  specify_test "interior_liveness_swift %outer3"
   br bb4(%inner3 : $D)
 
 bb4(%inner4 : @guaranteed $D):
@@ -456,7 +605,7 @@ bb4(%inner4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerNonAdjacentReborrow: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInnerNonAdjacentReborrow: interior-liveness with: %outer3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
 // CHECK-NOT:  Inner scope
 // CHECK-NOT:  lifetime-ending user
@@ -464,7 +613,18 @@ bb4(%inner4 : @guaranteed $D):
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: dead def: [[DEF]] = argument of bb3 : $D
-// CHECK-NEXT: end running test 1 of 1 on testInnerNonAdjacentReborrow: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInnerNonAdjacentReborrow: interior-liveness with: %outer3
+
+// CHECK-LABEL: testInnerNonAdjacentReborrow: interior_liveness_swift with: %outer3
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: begin:      br bb4(%{{.*}} : $D)
+// CHECK-NEXT: ends:
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: dead def:    %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: testInnerNonAdjacentReborrow: interior_liveness_swift with: %outer3
 sil [ossa] @testInnerNonAdjacentReborrow : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
   cond_br undef, bb1, bb2
@@ -480,8 +640,8 @@ bb2:
   br bb3(%copy2 : $D, %borrow2 : $D)
 
 bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
-  specify_test "interior-liveness @trace[0]"
-  debug_value [trace] %outer3 : $D
+  specify_test "interior-liveness %outer3"
+  specify_test "interior_liveness_swift %outer3"
   br bb4(%inner3 : $D)
 
 bb4(%inner4 : @guaranteed $D):
@@ -492,13 +652,25 @@ bb4(%inner4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerAdjacentPhi1: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInnerAdjacentPhi1: interior-liveness with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = load [copy]
-// CHECK-NEXT: end running test 1 of 1 on testInnerAdjacentPhi1: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInnerAdjacentPhi1: interior-liveness with: %inner3
+
+// CHECK-LABEL: testInnerAdjacentPhi1: interior_liveness_swift with: %inner3
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
+// CHECK-NEXT: begin:      br bb4(%{{.*}} : $D)
+// CHECK-NEXT: ends:       %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  br bb4(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: testInnerAdjacentPhi1: interior_liveness_swift with: %inner3
 sil [ossa] @testInnerAdjacentPhi1 : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
@@ -516,8 +688,8 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
-  specify_test "interior-liveness @trace[0]"
-  debug_value [trace] %inner3 : $C
+  specify_test "interior-liveness %inner3"
+  specify_test "interior_liveness_swift %inner3"
   br bb4(%phi3 : $D)
 
 bb4(%phi4 : @guaranteed $D):
@@ -527,13 +699,25 @@ bb4(%phi4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerAdjacentPhi2: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInnerAdjacentPhi2: interior-liveness with: %inner3
 // CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   %{{.*}} = load [copy]
-// CHECK-NEXT: end running test 1 of 1 on testInnerAdjacentPhi2: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInnerAdjacentPhi2: interior-liveness with: %inner3
+
+// CHECK-LABEL: testInnerAdjacentPhi2: interior_liveness_swift with: %inner3
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
+// CHECK-NEXT: begin:      br bb4(%{{.*}} : $D)
+// CHECK-NEXT: ends:       %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  br bb4(%{{.*}} : $D)
+// CHECK-NEXT:             %{{.*}} = ref_element_addr %{{.*}} : $D, #D.object
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = load [copy] %{{.*}} : $*C
+// CHECK-NEXT: testInnerAdjacentPhi2: interior_liveness_swift with: %inner3
 sil [ossa] @testInnerAdjacentPhi2 : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
@@ -551,8 +735,8 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
-  specify_test "interior-liveness @trace[0]"
-  debug_value [trace] %inner3 : $C
+  specify_test "interior-liveness %inner3"
+  specify_test "interior_liveness_swift %inner3"
   br bb4(%phi3 : $D)
 
 bb4(%phi4 : @guaranteed $D):
@@ -562,13 +746,24 @@ bb4(%phi4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testInnerNonAdjacentPhi: interior-liveness with: @trace[0]
+// CHECK-LABEL: testInnerNonAdjacentPhi: interior-liveness with: %inner3
 // CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $C
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: dead def: [[DEF]] = argument of bb3 : $C
-// CHECK-NEXT: end running test 1 of 1 on testInnerNonAdjacentPhi: interior-liveness with: @trace[0]
+// CHECK-NEXT: testInnerNonAdjacentPhi: interior-liveness with: %inner3
+
+// CHECK-LABEL: testInnerNonAdjacentPhi: interior_liveness_swift with: %inner3
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
+// CHECK-NEXT: begin:      br bb4(%{{.*}} : $D)
+// CHECK-NEXT: ends:     
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: dead def: %{{.*}} = argument of bb3 : $C
+// CHECK-NEXT: testInnerNonAdjacentPhi: interior_liveness_swift with: %inner3
 sil [ossa] @testInnerNonAdjacentPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
@@ -586,8 +781,8 @@ bb2:
   br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
 
 bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
-  specify_test "interior-liveness @trace[0]"
-  debug_value [trace] %inner3 : $C
+  specify_test "interior-liveness %inner3"
+  specify_test "interior_liveness_swift %inner3"
   br bb4(%phi3 : $D)
 
 bb4(%phi4 : @guaranteed $D):
@@ -597,15 +792,27 @@ bb4(%phi4 : @guaranteed $D):
   unreachable
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testScopedAddress: interior-liveness with: @argument[0]
+// CHECK-LABEL: testScopedAddress: interior-liveness with: @argument[0]
 // CHECK: Complete liveness
 // CHECK-NEXT: Unenclosed phis {
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   end_access
-// CHECK-NEXT: end running test 1 of 1 on testScopedAddress: interior-liveness with: @argument[0]
+// CHECK-NEXT: testScopedAddress: interior-liveness with: @argument[0]
+
+// CHECK-LABEL: testScopedAddress: interior_liveness_swift with: @argument[0]
+// CHECK: Interior liveness: %0 = argument of bb0 : $D
+// CHECK-NEXT: begin:      %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: ends:       end_access %{{.*}} : $*C
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  %{{.*}} = ref_element_addr %0 : $D, #D.object
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_access %{{.*}} : $*C
+// CHECK-NEXT: testScopedAddress: interior_liveness_swift with: @argument[0]
 sil [ossa] @testScopedAddress : $@convention(thin) (@guaranteed D) -> () {
 bb0(%0 : @guaranteed $D):
   specify_test "interior-liveness @argument[0]"
+  specify_test "interior_liveness_swift @argument[0]"
   %f = ref_element_addr %0 : $D, #D.object
   %access = begin_access [read] [static] %f : $*C
   %o = load [copy] %access : $*C
@@ -615,7 +822,7 @@ bb0(%0 : @guaranteed $D):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testUnenclosedReborrow: interior-liveness with: @trace[0]
+// CHECK-LABEL: testUnenclosedReborrow: interior-liveness with: %copy0a
 // CHECK: Interior liveness:   [[DEF:%.*]] = copy_value %0 : $C
 // CHECK-NEXT: Inner scope:   [[BORROW:%.*]] = begin_borrow [[DEF]] : $C
 // CHECK: Complete liveness
@@ -623,15 +830,27 @@ bb0(%0 : @guaranteed $D):
 // CHECK-NEXT:   %{{.*}} = argument of bb3 : $C
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3([[BORROW]] : $C)
-// CHECK-NEXT: end running test 1 of 1 on testUnenclosedReborrow: interior-liveness with: @trace[0]
+// CHECK-NEXT: testUnenclosedReborrow: interior-liveness with: %copy0a
+
+// CHECK-LABEL: testUnenclosedReborrow: interior_liveness_swift with: %copy0a
+// CHECK: Interior liveness:   %{{.*}} = copy_value %0 : $C
+// CHECK-NEXT: begin:      %{{.*}} = copy_value %0 : $C
+// CHECK-NEXT: ends:       br bb3(%{{.*}} : $C)
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT:   Phi(value: %{{.*}} = argument of bb3 : $C
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $C)
+// CHECK-NEXT: testUnenclosedReborrow: interior_liveness_swift with: %copy0a
 sil [ossa] @testUnenclosedReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "interior-liveness @trace[0]"
   %copy0a = copy_value %0 : $C
-  debug_value [trace] %copy0a : $C
+  specify_test "interior-liveness %copy0a"
+  specify_test "interior_liveness_swift %copy0a"
   %borrow1 = begin_borrow %copy0a : $C
   br bb3(%borrow1 : $C)
 
@@ -645,23 +864,35 @@ bb3(%reborrow : @guaranteed $C):
   unreachable
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testUnenclosedGuaranteedPhi: interior-liveness with: @trace[0]
+// CHECK-LABEL: testUnenclosedGuaranteedPhi: interior-liveness with: %borrow1
 // CHECK: Interior liveness:   %{{.*}} = begin_borrow
 // CHECK: Complete liveness
 // CHECK: Unenclosed phis {
 // CHECK-NEXT:   %{{.*}} = argument of bb3 : $D
 // CHECK-NEXT: }
 // CHECK-NEXT: last user:   br bb3(
-// CHECK-NEXT: end running test 1 of 1 on testUnenclosedGuaranteedPhi: interior-liveness with: @trace[0]
+// CHECK-NEXT: testUnenclosedGuaranteedPhi: interior-liveness with: %borrow1
+
+// CHECK-LABEL: testUnenclosedGuaranteedPhi: interior_liveness_swift with: %borrow1
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow %{{.*}} : $C
+// CHECK-NEXT: begin:      %{{.*}} = begin_borrow %{{.*}} : $C
+// CHECK-NEXT: ends:       br bb3(%{{.*}} : $D)
+// CHECK-NEXT: exits:    
+// CHECK-NEXT: interiors:  %{{.*}} = unchecked_ref_cast %{{.*}} : $C to $D
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT:   Phi(value: %{{.*}} = argument of bb3 : $D)
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(%{{.*}} : $D)
+// CHECK-NEXT: testUnenclosedGuaranteedPhi: interior_liveness_swift with: %borrow1
 sil [ossa] @testUnenclosedGuaranteedPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "interior-liveness @trace[0]"
   %copy0a = copy_value %0 : $C
   %borrow1 = begin_borrow %copy0a : $C
-  debug_value [trace] %borrow1 : $C
+  specify_test "interior-liveness %borrow1"
+  specify_test "interior_liveness_swift %borrow1"
   %d1 = unchecked_ref_cast %borrow1 : $C to $D
   br bb3(%d1 : $D)
 
@@ -679,21 +910,20 @@ bb3(%phi : @guaranteed $D):
 // ExtendedLiveness
 // =============================================================================
 
-// CHECK-LABEL: begin running test 1 of 1 on testExtendedPhi: extended-liveness with: @trace[0]
+// CHECK-LABEL: testExtendedPhi: extended-liveness with: %copy1
 // CHECK: Extended liveness:   %{{.*}} = copy_value %0 : $C
 // CHECK: lifetime-ending user:   br bb3(
 // CHECK: lifetime-ending user:   destroy_value
 // CHECK: last user:   br bb3(
 // CHECK: last user:   destroy_value
-// CHECK: end running test 1 of 1 on testExtendedPhi: extended-liveness with: @trace[0]
+// CHECK: testExtendedPhi: extended-liveness with: %copy1
 sil [ossa] @testExtendedPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
 
 bb1:
-  specify_test "extended-liveness @trace[0]"
   %copy1 = copy_value %0 : $C
-  debug_value [trace] %copy1 : $C
+  specify_test "extended-liveness %copy1"
   br bb3(%copy1 : $C)
 
 bb2:
@@ -706,22 +936,21 @@ bb3(%phi : @owned $C):
   return %99 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on testExtendedReborrow: extended-liveness with: @trace[0]
+// CHECK-LABEL: testExtendedReborrow: extended-liveness with: %borrow1
 // CHECK: Extended liveness:   %{{.*}} = begin_borrow
 // CHECK: lifetime-ending user:   br bb3(
 // CHECK: lifetime-ending user:   end_borrow
 // CHECK: last user:   br bb3(
 // CHECK: last user:   end_borrow
-// CHECK: end running test 1 of 1 on testExtendedReborrow: extended-liveness with: @trace[0]
+// CHECK: testExtendedReborrow: extended-liveness with: %borrow1
 sil [ossa] @testExtendedReborrow : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
   cond_br undef, bb1, bb2
 
 bb1:
   %copy1 = copy_value %0 : $C
-  specify_test "extended-liveness @trace[0]"
   %borrow1 = begin_borrow %copy1 : $C
-  debug_value [trace] %borrow1 : $C
+  specify_test "extended-liveness %borrow1"
   br bb3(%copy1 : $C, %borrow1 : $C)
 
 bb2:


### PR DESCRIPTION
Fundamental APIs for working with OSSA in swift.

These are both simpler and more complete than the C++ counterpart. I'm adding support for the new on-stack closure representation and handling mark_dependence.