### PR TITLE
PerformanceDiagnostics: allow metatype arguments to `_diagnoseUnexpectedEnumCaseValue`

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -442,6 +442,16 @@ static bool metatypeUsesAreNotRelevant(MetatypeInst *mt) {
           break;
       }
     }
+    if (auto *apply = dyn_cast<ApplyInst>(use->getUser())) {
+      if (auto *callee = apply->getReferencedFunctionOrNull()) {
+        // Exclude `Swift._diagnoseUnexpectedEnumCaseValue<A, B>(type: A.Type, rawValue: B) -> Swift.Never`
+        // It's a fatal error function, used for imported C enums.
+        if (callee->getName() == "$ss32_diagnoseUnexpectedEnumCaseValue4type03rawE0s5NeverOxm_q_tr0_lF" &&
+            !mt->getModule().getOptions().EmbeddedSwift) {
+          continue;
+        }
+      }
+    }
     return false;
   }
   return true;

--- a/test/SILOptimizer/Inputs/perf-annotations.h
+++ b/test/SILOptimizer/Inputs/perf-annotations.h
@@ -1,0 +1,9 @@
+
+typedef enum : int {
+  A = 1,
+  B = 2,
+  C = 5,
+} __attribute__((enum_extensibility(closed))) c_closed_enum_t;
+
+
+

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -import-objc-header %S/Inputs/perf-annotations.h -emit-sil %s -o /dev/null -verify
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: swift_in_compiler
 
@@ -478,5 +478,17 @@ public struct NonCopyable: ~Copyable {
 @_noAllocation
 public func testNonCopyable(_ foo: consuming NonCopyable) {
   let _ = foo.value
+}
+
+@_noAllocation
+func matchCEnum(_ variant: c_closed_enum_t) -> Int {
+  switch variant {
+  case .A:
+    return 1
+  case .B:
+    return 2
+  case .C:
+    return 5
+  }
 }
 

--- a/test/SILOptimizer/readonly_arrays_objc.swift
+++ b/test/SILOptimizer/readonly_arrays_objc.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -target %target-future-triple -O %s -o %t/a.out
+// RUN: %target-build-swift -O %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib


### PR DESCRIPTION
This is a fatal error function, used for imported C enums.

rdar://117520459
