### PR TITLE
[cxx-interop] Discard duplicating `IteratorTy::iterator_category` decls

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -126,7 +126,11 @@ getIteratorCategoryDecl(const clang::CXXRecordDecl *clangDecl) {
   clang::IdentifierInfo *iteratorCategoryDeclName =
       &clangDecl->getASTContext().Idents.get("iterator_category");
   auto iteratorCategories = clangDecl->lookup(iteratorCategoryDeclName);
-  if (!iteratorCategories.isSingleResult())
+  // If this is a templated typedef, Clang might have instantiated several
+  // equivalent typedef decls. If they aren't equivalent, Clang has already
+  // complained about this. Let's assume that they are equivalent. (see
+  // filterNonConflictingPreviousTypedefDecls in clang/Sema/SemaDecl.cpp)
+  if (iteratorCategories.empty())
     return nullptr;
   auto iteratorCategory = iteratorCategories.front();
 


### PR DESCRIPTION
libc++ recently split the `std` module into many top-level modules: https://github.com/llvm/llvm-project/commit/571178a21a8bc105bf86cf4bf92f842e07792e1a

This broke the logic that conforms C++ iterator types to `UnsafeCxxInputIterator`/`UnsafeCxxRandomAccessIterator`. To determine if a C++ type is an iterator type, we look for its inner type called `iterator_category`. After module std was split, Clang instantiates `std::string::const_iterator::iterator_category` twice and doing a Clang lookup within the `const_iterator` type returns two identical `TypedefDecl`s. Clang itself has logic to merge them, but Swift doesn't.

rdar://119270491