### PR TITLE
AST: Remodel `MemberTypeRepr` to be recursive

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1569,11 +1569,11 @@ BridgedInverseTypeRepr_createParsed(BridgedASTContext cContext,
                                     BridgedSourceLoc cTildeLoc,
                                     BridgedTypeRepr cConstraint);
 
-SWIFT_NAME("BridgedMemberTypeRepr.createParsed(_:base:members:)")
-BridgedTypeRepr
-BridgedMemberTypeRepr_createParsed(BridgedASTContext cContext,
-                                   BridgedTypeRepr baseComponent,
-                                   BridgedArrayRef bridgedMemberComponents);
+SWIFT_NAME("BridgedDeclRefTypeRepr.createParsed(_:base:name:nameLoc:genericArguments:angleRange:)")
+BridgedDeclRefTypeRepr BridgedDeclRefTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedTypeRepr cBase, BridgedIdentifier cName,
+    BridgedSourceLoc cLoc, BridgedArrayRef cGenericArguments,
+    BridgedSourceRange cAngleRange);
 
 SWIFT_NAME("BridgedMetatypeTypeRepr.createParsed(_:base:typeKeywordLoc:)")
 BridgedMetatypeTypeRepr

--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -103,6 +103,37 @@ enum class MacroWalking {
   None
 };
 
+/// A scheme for walking a `MemberTypeRepr`.
+enum class MemberTypeReprWalkingScheme {
+  /// Walk in source order, such that each subsequent dot-separated component is
+  /// a child of the previous one. For example, walk `A.B<T.U>.C` like so
+  /// (top-down order):
+  ///
+  /// ```
+  /// A
+  /// ╰─B
+  ///   ├─T
+  ///   │ ╰─U
+  ///   ╰─C
+  /// ```
+  SourceOrderRecursive,
+
+  /// Walk in AST order (that is, according to how member type
+  /// representations are modeled in the AST, such that each previous
+  /// dot-separated component is a child of the subsequent one), base before
+  /// generic arguments. For example, walk `A.B<T.U>.C` like so
+  /// (top-down order):
+  ///
+  /// ```
+  /// C
+  /// ╰─B
+  ///   ├─A
+  ///   ╰─U
+  ///     ╰─T
+  /// ```
+  ASTOrderRecursive
+};
+
 /// An abstract class used to traverse an AST.
 class ASTWalker {
 public:
@@ -561,6 +592,11 @@ public:
   ///
   virtual PostWalkAction walkToTypeReprPost(TypeRepr *T) {
     return Action::Continue();
+  }
+
+  /// This method configures how to walk `MemberTypeRepr` nodes.
+  virtual MemberTypeReprWalkingScheme getMemberTypeReprWalkingScheme() const {
+    return MemberTypeReprWalkingScheme::ASTOrderRecursive;
   }
 
   /// This method configures whether the walker should explore into the generic

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -54,6 +54,7 @@ class ASTContext;
 struct PrintOptions;
 class CustomAttr;
 class Decl;
+class DeclRefTypeRepr;
 class AbstractFunctionDecl;
 class FuncDecl;
 class ClassDecl;
@@ -1766,7 +1767,7 @@ public:
   ///
   /// For an identifier type repr, return a pair of `nullptr` and the
   /// identifier.
-  std::pair<IdentTypeRepr *, IdentTypeRepr *> destructureMacroRef();
+  std::pair<IdentTypeRepr *, DeclRefTypeRepr *> destructureMacroRef();
 
   /// Whether the attribute has any arguments.
   bool hasArgs() const { return argList != nullptr; }

--- a/include/swift/AST/TypeDeclFinder.h
+++ b/include/swift/AST/TypeDeclFinder.h
@@ -19,7 +19,7 @@
 namespace swift {
 
 class BoundGenericType;
-class IdentTypeRepr;
+class DeclRefTypeRepr;
 class NominalType;
 class TypeAliasType;
 
@@ -57,15 +57,13 @@ public:
     : Callback(callback) {}
 };
 
-/// Walks a \c TypeRepr to find all \c IdentTypeRepr nodes with bound
-/// type declarations.
-///
-/// Subclasses can either override #visitTypeDecl if they only care about
-/// types on their own, or #visitIdentTypeRepr if they want to keep
-/// the TypeRepr around.
-class TypeReprIdentFinder : public ASTWalker {
-  /// The function to call when a \c IdentTypeRepr is seen.
-  llvm::function_ref<bool(const IdentTypeRepr *)> Callback;
+/// Walks a `TypeRepr` and reports all `DeclRefTypeRepr` nodes with bound
+/// type declarations by invoking a given callback. These nodes are reported in
+/// depth- and base-first AST order. For example, nodes in `A<T>.B<U>` will be
+/// reported in the following order: `TAUB`.
+class DeclRefTypeReprFinder : public ASTWalker {
+  /// The function to call when a `DeclRefTypeRepr` is seen.
+  llvm::function_ref<bool(const DeclRefTypeRepr *)> Callback;
 
   MacroWalking getMacroWalkingBehavior() const override {
     return MacroWalking::Arguments;
@@ -74,11 +72,10 @@ class TypeReprIdentFinder : public ASTWalker {
   PostWalkAction walkToTypeReprPost(TypeRepr *TR) override;
 
 public:
-  explicit TypeReprIdentFinder(
-      llvm::function_ref<bool(const IdentTypeRepr *)> callback)
-    : Callback(callback) {}
+  explicit DeclRefTypeReprFinder(
+      llvm::function_ref<bool(const DeclRefTypeRepr *)> callback)
+      : Callback(callback) {}
 };
-
 }
 
 #endif

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -336,6 +336,14 @@ protected:
   explicit DeclRefTypeRepr(TypeReprKind K) : TypeRepr(K) {}
 
 public:
+  static DeclRefTypeRepr *create(const ASTContext &C, TypeRepr *Base,
+                                 DeclNameLoc NameLoc, DeclNameRef Name);
+
+  static DeclRefTypeRepr *create(const ASTContext &C, TypeRepr *Base,
+                                 DeclNameLoc NameLoc, DeclNameRef Name,
+                                 ArrayRef<TypeRepr *> GenericArgs,
+                                 SourceRange AngleBrackets);
+
   /// Returns the root qualifier. For example, `A` for `A.B.C`. The root
   /// qualifier of a `IdentTypeRepr` is itself.
   TypeRepr *getRoot();

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -356,6 +356,9 @@ public:
   /// is a \c MemberTypeRepr, and the method returns its last member component.
   IdentTypeRepr *getLastComponent();
 
+  DeclNameLoc getNameLoc() const;
+  DeclNameRef getNameRef() const;
+
   /// Returns whether this instance has been bound to a type declaration. This
   /// happens during type resolution.
   bool isBound() const;
@@ -363,8 +366,9 @@ public:
   /// Returns the type declaration this instance has been bound to.
   TypeDecl *getBoundDecl() const;
 
-  /// The identifier that describes the last component.
-  DeclNameRef getNameRef() const;
+  DeclContext *getDeclContext() const;
+
+  void setValue(TypeDecl *TD, DeclContext *DC);
 
   /// Returns whether this instance has a generic argument list. That is, either
   /// a valid angle bracket source range, or a positive number of generic
@@ -373,12 +377,19 @@ public:
 
   ArrayRef<TypeRepr *> getGenericArgs() const;
 
+  SourceRange getAngleBrackets() const;
+
   static bool classof(const TypeRepr *T) {
     return T->getKind() == TypeReprKind::SimpleIdent ||
            T->getKind() == TypeReprKind::GenericIdent ||
            T->getKind() == TypeReprKind::Member;
   }
   static bool classof(const DeclRefTypeRepr *T) { return true; }
+
+protected:
+  void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
+
+  friend class TypeRepr;
 };
 
 /// An identifier type with an optional set of generic arguments.
@@ -435,9 +446,8 @@ public:
   static bool classof(const IdentTypeRepr *T) { return true; }
 
 protected:
-  void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
-
   SourceLoc getLocImpl() const { return Loc.getBaseNameLoc(); }
+
   friend class TypeRepr;
 };
 
@@ -583,7 +593,6 @@ private:
   SourceLoc getEndLocImpl() const { return getLastComponent()->getEndLoc(); }
   SourceLoc getLocImpl() const { return getLastComponent()->getLoc(); }
 
-  void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
   friend class TypeRepr;
 };
 

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -195,6 +195,12 @@ public:
   /// \c Type::getCanonicalType() or \c Type::getWithoutParens().
   TypeRepr *getWithoutParens() const;
 
+  /// Whether this is a `SimpleIdentTypeRepr` matching the given identifier.
+  bool isSimpleUnqualifiedIdentifier(Identifier identifier) const;
+
+  /// Whether this is a `SimpleIdentTypeRepr` matching the given string.
+  bool isSimpleUnqualifiedIdentifier(StringRef str) const;
+
   //*** Allocation Routines ************************************************/
 
   void print(raw_ostream &OS, const PrintOptions &Opts = PrintOptions()) const;

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -383,6 +383,8 @@ public:
   /// arguments.
   bool hasGenericArgList() const;
 
+  unsigned getNumGenericArgs() const;
+
   ArrayRef<TypeRepr *> getGenericArgs() const;
 
   SourceRange getAngleBrackets() const;

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -362,6 +362,8 @@ public:
   /// The identifier that describes the last component.
   DeclNameRef getNameRef() const;
 
+  ArrayRef<TypeRepr *> getGenericArgs() const;
+
   static bool classof(const TypeRepr *T) {
     return T->getKind() == TypeReprKind::SimpleIdent ||
            T->getKind() == TypeReprKind::GenericIdent ||

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -356,7 +356,11 @@ public:
   /// is a \c MemberTypeRepr, and the method returns its last member component.
   IdentTypeRepr *getLastComponent();
 
-  /// The type declaration the last component is bound to.
+  /// Returns whether this instance has been bound to a type declaration. This
+  /// happens during type resolution.
+  bool isBound() const;
+
+  /// Returns the type declaration this instance has been bound to.
   TypeDecl *getBoundDecl() const;
 
   /// The identifier that describes the last component.

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -363,6 +363,10 @@ public:
   DeclNameLoc getNameLoc() const;
   DeclNameRef getNameRef() const;
 
+  /// Replace the identifier with a new identifier, e.g., due to typo
+  /// correction.
+  void overwriteNameRef(DeclNameRef newId);
+
   /// Returns whether this instance has been bound to a type declaration. This
   /// happens during type resolution.
   bool isBound() const;

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -344,6 +344,10 @@ public:
                                  ArrayRef<TypeRepr *> GenericArgs,
                                  SourceRange AngleBrackets);
 
+  /// Returns the qualifier or base type representation. For example, `A.B`
+  /// for `A.B.C`. The base of a `IdentTypeRepr` is null.
+  TypeRepr *getBase() const;
+
   /// Returns the root qualifier. For example, `A` for `A.B.C`. The root
   /// qualifier of a `IdentTypeRepr` is itself.
   TypeRepr *getRoot();

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -292,6 +292,8 @@ public:
   SWIFT_NAME("end")
   BridgedSourceLoc End;
 
+  BridgedSourceRange() : Start(), End() {}
+
   SWIFT_NAME("init(start:end:)")
   BridgedSourceRange(BridgedSourceLoc start, BridgedSourceLoc end)
       : Start(start), End(end) {}

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1463,12 +1463,13 @@ public:
   /// \endverbatim
   ParserResult<TypeRepr> parseQualifiedDeclNameBaseType();
 
-  /// Parse an identifier type, e.g 'Foo' or 'Bar<Int>'.
+  /// Parse a single type identifier, possibly followed by a generic argument
+  /// list, e.g `Foo` or `Bar<Int>`.
   ///
   /// \verbatim
   /// type-identifier: identifier generic-args?
   /// \endverbatim
-  ParserResult<IdentTypeRepr> parseTypeIdentifier();
+  ParserResult<DeclRefTypeRepr> parseTypeIdentifier(TypeRepr *Base);
 
   /// Parse a dotted type, e.g. 'Foo<X>.Y.Z', 'P.Type', '[X].Y'.
   ParserResult<TypeRepr> parseTypeDotted(ParserResult<TypeRepr> Base);

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -2225,15 +2225,19 @@ BridgedTupleTypeRepr BridgedTupleTypeRepr_createParsed(
                                SourceRange{lParen, rParen});
 }
 
-BridgedTypeRepr
-BridgedMemberTypeRepr_createParsed(BridgedASTContext cContext,
-                                   BridgedTypeRepr baseComponent,
-                                   BridgedArrayRef bridgedMemberComponents) {
+BridgedDeclRefTypeRepr BridgedDeclRefTypeRepr_createParsed(
+    BridgedASTContext cContext, BridgedTypeRepr cBase, BridgedIdentifier cName,
+    BridgedSourceLoc cLoc, BridgedArrayRef cGenericArguments,
+    BridgedSourceRange cAngleRange) {
   ASTContext &context = cContext.unbridged();
-  auto memberComponents = bridgedMemberComponents.unbridged<IdentTypeRepr *>();
+  auto genericArguments = cGenericArguments.unbridged<TypeRepr *>();
+  auto angleRange = cAngleRange.unbridged();
 
-  return MemberTypeRepr::create(context, baseComponent.unbridged(),
-                                memberComponents);
+  assert(angleRange.isValid() || genericArguments.empty());
+
+  return DeclRefTypeRepr::create(
+      context, cBase.unbridged(), DeclNameLoc(cLoc.unbridged()),
+      DeclNameRef(cName.unbridged()), genericArguments, angleRange);
 }
 
 BridgedCompositionTypeRepr

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3294,8 +3294,8 @@ public:
     printRec(T->getTypeRepr());
   }
 
-  void visitIdentTypeRepr(IdentTypeRepr *T, StringRef label) {
-    printCommon("type_ident", label);
+  void visitDeclRefTypeRepr(DeclRefTypeRepr *T, StringRef label) {
+    printCommon(isa<IdentTypeRepr>(T) ? "type_ident" : "type_member", label);
 
     printFieldQuoted(T->getNameRef(), "id", IdentifierColor);
     if (T->isBound())
@@ -3303,21 +3303,12 @@ public:
     else
       printFlag("unbound");
 
-    if (auto *GenIdT = dyn_cast<GenericIdentTypeRepr>(T)) {
-      for (auto genArg : GenIdT->getGenericArgs()) {
-        printRec(genArg);
-      }
+    if (auto *memberTR = dyn_cast<MemberTypeRepr>(T)) {
+      printRec(memberTR->getBase());
     }
 
-    printFoot();
-  }
-
-  void visitMemberTypeRepr(MemberTypeRepr *T, StringRef label) {
-    printCommon("type_member", label);
-
-    printRec(T->getRoot());
-    for (auto *comp : T->getMemberComponents()) {
-      printRec(comp);
+    for (auto *genArg : T->getGenericArgs()) {
+      printRec(genArg);
     }
 
     printFoot();

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3315,7 +3315,7 @@ public:
   void visitMemberTypeRepr(MemberTypeRepr *T, StringRef label) {
     printCommon("type_member", label);
 
-    printRec(T->getBaseComponent());
+    printRec(T->getRoot());
     for (auto *comp : T->getMemberComponents()) {
       printRec(comp);
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4990,14 +4990,13 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
         }
       }
 
-      if (!ResultTyLoc.getTypeRepr())
-        ResultTyLoc = TypeLoc::withoutLoc(ResultTy);
       // FIXME: Hacky way to workaround the fact that 'Self' as return
       // TypeRepr is not getting 'typechecked'. See
       // \c resolveTopLevelIdentTypeComponent function in TypeCheckType.cpp.
-      if (auto *simId = dyn_cast_or_null<SimpleIdentTypeRepr>(ResultTyLoc.getTypeRepr())) {
-        if (simId->getNameRef().isSimpleName(Ctx.Id_Self))
-          ResultTyLoc = TypeLoc::withoutLoc(ResultTy);
+      if (ResultTyLoc.getTypeRepr() &&
+          ResultTyLoc.getTypeRepr()->isSimpleUnqualifiedIdentifier(
+              Ctx.Id_Self)) {
+        ResultTyLoc = TypeLoc::withoutLoc(ResultTy);
       }
       Printer << " -> ";
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -2143,7 +2143,7 @@ bool Traversal::visitGenericIdentTypeRepr(GenericIdentTypeRepr *T) {
 }
 
 bool Traversal::visitMemberTypeRepr(MemberTypeRepr *T) {
-  if (doIt(T->getBaseComponent()))
+  if (doIt(T->getRoot()))
     return true;
 
   for (auto comp : T->getMemberComponents()) {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1438,6 +1438,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
 #define TYPEREPR(Id, Parent) bool visit##Id##TypeRepr(Id##TypeRepr *T);
 #include "swift/AST/TypeReprNodes.def"
 
+  bool visitDeclRefTypeRepr(DeclRefTypeRepr *T);
+
   using Action = ASTWalker::Action;
 
   using PreWalkAction = ASTWalker::PreWalkAction;
@@ -1624,9 +1626,24 @@ public:
     return false;
   }
 
+private:
+  /// Walk a `MemberTypeRepr` in source order such that each subsequent
+  /// dot-separated component is a child of the previous one
+  [[nodiscard]] bool doItInSourceOrderRecursive(MemberTypeRepr *T);
+
+public:
   /// Returns true on failure.
   [[nodiscard]]
   bool doIt(TypeRepr *T) {
+    if (auto *MTR = dyn_cast<MemberTypeRepr>(T)) {
+      switch (Walker.getMemberTypeReprWalkingScheme()) {
+      case MemberTypeReprWalkingScheme::SourceOrderRecursive:
+        return doItInSourceOrderRecursive(MTR);
+      case MemberTypeReprWalkingScheme::ASTOrderRecursive:
+        break;
+      }
+    }
+
     return traverse(
         Walker.walkToTypeReprPre(T),
         [&]() { return visit(T); },
@@ -1705,6 +1722,89 @@ public:
 };
 
 } // end anonymous namespace
+
+bool Traversal::doItInSourceOrderRecursive(MemberTypeRepr *T) {
+  // Qualified types are modeled resursively such that each previous
+  // dot-separated component is a child of the next one. To walk a member type
+  // representation according to
+  // `MemberTypeReprWalkingScheme::SourceOrderRecursive`:
+
+  // 1. Pre-walk the dot-separated components in source order. If asked to skip
+  //    the children of a given component:
+  //    1. Set the depth at which to start post-walking later.
+  //    2. Skip its generic arguments and subsequent components.
+  std::function<bool(TypeRepr *, std::optional<unsigned> &, unsigned)>
+      doItInSourceOrderPre = [&](TypeRepr *T,
+                                 std::optional<unsigned> &StartPostWalkDepth,
+                                 unsigned Depth) {
+        if (auto *MemberTR = dyn_cast<MemberTypeRepr>(T)) {
+          if (doItInSourceOrderPre(MemberTR->getBase(), StartPostWalkDepth,
+                                   Depth + 1)) {
+            return true;
+          }
+
+          if (StartPostWalkDepth.has_value()) {
+            return false;
+          }
+        }
+
+        switch (this->Walker.walkToTypeReprPre(T).Action) {
+        case PreWalkAction::Stop:
+          return true;
+        case PreWalkAction::SkipChildren:
+          StartPostWalkDepth = Depth;
+          return false;
+        case PreWalkAction::SkipNode:
+          StartPostWalkDepth = Depth + 1;
+          return false;
+        case PreWalkAction::Continue:
+          break;
+        }
+
+        if (auto *DeclRefTR = dyn_cast<DeclRefTypeRepr>(T)) {
+          for (auto *Arg : DeclRefTR->getGenericArgs()) {
+            if (doIt(Arg)) {
+              return true;
+            }
+          }
+        } else if (visit(T)) {
+          return true;
+        }
+
+        return false;
+      };
+
+  // 2. Post-walk the components in reverse order, respecting the depth at which
+  //    to start post-walking if set.
+  std::function<bool(TypeRepr *, std::optional<unsigned>, unsigned)>
+      doItInSourceOrderPost = [&](TypeRepr *T,
+                                  std::optional<unsigned> StartPostWalkDepth,
+                                  unsigned Depth) {
+        if (!StartPostWalkDepth.has_value() || Depth >= *StartPostWalkDepth) {
+          switch (this->Walker.walkToTypeReprPost(T).Action) {
+          case PostWalkAction::Continue:
+            break;
+          case PostWalkAction::Stop:
+            return true;
+          }
+        }
+
+        if (auto *MemberTR = dyn_cast<MemberTypeRepr>(T)) {
+          return doItInSourceOrderPost(MemberTR->getBase(), StartPostWalkDepth,
+                                       Depth + 1);
+        }
+
+        return false;
+      };
+
+  std::optional<unsigned> StartPostWalkDepth;
+
+  if (doItInSourceOrderPre(T, StartPostWalkDepth, 0)) {
+    return true;
+  }
+
+  return doItInSourceOrderPost(T, StartPostWalkDepth, 0);
+}
 
 #pragma mark Statement traversal
 Stmt *Traversal::visitBreakStmt(BreakStmt *BS) {
@@ -2130,27 +2230,32 @@ bool Traversal::visitAttributedTypeRepr(AttributedTypeRepr *T) {
   return doIt(T->getTypeRepr());
 }
 
-bool Traversal::visitSimpleIdentTypeRepr(SimpleIdentTypeRepr *T) {
+bool Traversal::visitDeclRefTypeRepr(DeclRefTypeRepr *T) {
+  if (auto *memberTR = dyn_cast<MemberTypeRepr>(T)) {
+    if (doIt(memberTR->getBase())) {
+      return true;
+    }
+  }
+
+  for (auto *genericArg : T->getGenericArgs()) {
+    if (doIt(genericArg)) {
+      return true;
+    }
+  }
+
   return false;
+}
+
+bool Traversal::visitSimpleIdentTypeRepr(SimpleIdentTypeRepr *T) {
+  return visitDeclRefTypeRepr(T);
 }
 
 bool Traversal::visitGenericIdentTypeRepr(GenericIdentTypeRepr *T) {
-  for (auto genArg : T->getGenericArgs()) {
-    if (doIt(genArg))
-      return true;
-  }
-  return false;
+  return visitDeclRefTypeRepr(T);
 }
 
 bool Traversal::visitMemberTypeRepr(MemberTypeRepr *T) {
-  if (doIt(T->getRoot()))
-    return true;
-
-  for (auto comp : T->getMemberComponents()) {
-    if (doIt(comp))
-      return true;
-  }
-  return false;
+  return visitDeclRefTypeRepr(T);
 }
 
 bool Traversal::visitFunctionTypeRepr(FunctionTypeRepr *T) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2737,18 +2737,18 @@ CustomAttr *CustomAttr::create(ASTContext &ctx, SourceLoc atLoc, TypeExpr *type,
       CustomAttr(atLoc, range, type, initContext, argList, implicit);
 }
 
-std::pair<IdentTypeRepr *, IdentTypeRepr *> CustomAttr::destructureMacroRef() {
+std::pair<IdentTypeRepr *, DeclRefTypeRepr *>
+CustomAttr::destructureMacroRef() {
   TypeRepr *typeRepr = getTypeRepr();
   if (!typeRepr)
     return {nullptr, nullptr};
   if (auto *identType = dyn_cast<IdentTypeRepr>(typeRepr))
     return {nullptr, identType};
-  if (auto *memType = dyn_cast<MemberTypeRepr>(typeRepr))
-    if (auto *base = dyn_cast<IdentTypeRepr>(memType->getRoot()))
-      if (memType->getMemberComponents().size() == 1)
-        if (auto first =
-                dyn_cast<IdentTypeRepr>(memType->getMemberComponents().front()))
-          return {base, first};
+  if (auto *memType = dyn_cast<MemberTypeRepr>(typeRepr)) {
+    if (auto *base = dyn_cast<SimpleIdentTypeRepr>(memType->getBase())) {
+      return {base, memType};
+    }
+  }
   return {nullptr, nullptr};
 }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2744,7 +2744,7 @@ std::pair<IdentTypeRepr *, IdentTypeRepr *> CustomAttr::destructureMacroRef() {
   if (auto *identType = dyn_cast<IdentTypeRepr>(typeRepr))
     return {nullptr, identType};
   if (auto *memType = dyn_cast<MemberTypeRepr>(typeRepr))
-    if (auto *base = dyn_cast<IdentTypeRepr>(memType->getBaseComponent()))
+    if (auto *base = dyn_cast<IdentTypeRepr>(memType->getRoot()))
       if (memType->getMemberComponents().size() == 1)
         if (auto first =
                 dyn_cast<IdentTypeRepr>(memType->getMemberComponents().front()))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2290,9 +2290,8 @@ static bool isDefaultInitializable(const TypeRepr *typeRepr, ASTContext &ctx) {
 
   // Also support the desugared 'Optional<T>' spelling.
   if (!ctx.isSwiftVersionAtLeast(5)) {
-    if (auto *identRepr = dyn_cast<SimpleIdentTypeRepr>(typeRepr)) {
-      if (identRepr->getNameRef().getBaseIdentifier() == ctx.Id_Void)
-        return true;
+    if (typeRepr->isSimpleUnqualifiedIdentifier(ctx.Id_Void)) {
+      return true;
     }
 
     if (auto *identRepr = dyn_cast<GenericIdentTypeRepr>(typeRepr)) {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2236,57 +2236,47 @@ TypeExpr *TypeExpr::createForMemberDecl(DeclNameLoc ParentNameLoc,
   assert(ParentNameLoc.isValid());
   assert(NameLoc.isValid());
 
-  // The base component is the parent type.
-  auto *ParentComp = new (C) SimpleIdentTypeRepr(ParentNameLoc,
-                                                 Parent->createNameRef());
-  ParentComp->setValue(Parent, nullptr);
+  // The base is the parent type.
+  auto *BaseTR =
+      new (C) SimpleIdentTypeRepr(ParentNameLoc, Parent->createNameRef());
+  BaseTR->setValue(Parent, nullptr);
 
-  // The member component is the member we just found.
-  auto *MemberComp =
-      new (C) SimpleIdentTypeRepr(NameLoc, Decl->createNameRef());
-  MemberComp->setValue(Decl, nullptr);
+  auto *MemberTR =
+      MemberTypeRepr::create(C, BaseTR, NameLoc, Decl->createNameRef());
+  MemberTR->setValue(Decl, nullptr);
 
-  auto *TR = MemberTypeRepr::create(C, ParentComp, {MemberComp});
-  return new (C) TypeExpr(TR);
+  return new (C) TypeExpr(MemberTR);
 }
 
 TypeExpr *TypeExpr::createForMemberDecl(TypeRepr *ParentTR, DeclNameLoc NameLoc,
                                         TypeDecl *Decl) {
   ASTContext &C = Decl->getASTContext();
 
-  // Add a new component for the member we just found.
-  auto *NewComp = new (C) SimpleIdentTypeRepr(NameLoc, Decl->createNameRef());
-  NewComp->setValue(Decl, nullptr);
+  auto *MemberTR =
+      MemberTypeRepr::create(C, ParentTR, NameLoc, Decl->createNameRef());
+  MemberTR->setValue(Decl, nullptr);
 
-  TypeRepr *TR = nullptr;
-  if (auto *DeclRefTR = dyn_cast<DeclRefTypeRepr>(ParentTR)) {
-    // Create a new list of components.
-    SmallVector<IdentTypeRepr *, 4> Components;
-    if (auto *MemberTR = dyn_cast<MemberTypeRepr>(ParentTR)) {
-      auto MemberComps = MemberTR->getMemberComponents();
-      Components.append(MemberComps.begin(), MemberComps.end());
-    }
-
-    Components.push_back(NewComp);
-    TR = MemberTypeRepr::create(C, DeclRefTR->getRoot(), Components);
-  } else {
-    TR = MemberTypeRepr::create(C, ParentTR, NewComp);
-  }
-
-  return new (C) TypeExpr(TR);
+  return new (C) TypeExpr(MemberTR);
 }
 
 TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
                                              ArrayRef<TypeRepr *> Args,
                                              SourceRange AngleLocs,
                                              ASTContext &C) {
-  auto *lastComp = ParentTR->getLastComponent();
+  DeclRefTypeRepr *specializedTR = nullptr;
 
-  if (!isa<SimpleIdentTypeRepr>(lastComp) || !lastComp->getBoundDecl())
+  auto *boundDecl = ParentTR->getBoundDecl();
+  if (!boundDecl || ParentTR->hasGenericArgList()) {
     return nullptr;
+  }
 
-  if (isa<TypeAliasDecl>(lastComp->getBoundDecl())) {
-    if (auto *memberTR = dyn_cast<MemberTypeRepr>(ParentTR)) {
+  if (isa<IdentTypeRepr>(ParentTR)) {
+    specializedTR = GenericIdentTypeRepr::create(
+        C, ParentTR->getNameLoc(), ParentTR->getNameRef(), Args, AngleLocs);
+    specializedTR->setValue(boundDecl, ParentTR->getDeclContext());
+  } else {
+    auto *const memberTR = cast<MemberTypeRepr>(ParentTR);
+    if (isa<TypeAliasDecl>(boundDecl)) {
       // If any of our parent types are unbound, bail out and let
       // the constraint solver can infer generic parameters for them.
       //
@@ -2299,48 +2289,30 @@ TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
       //
       // FIXME: Once we can model generic typealiases properly, rip
       // this out.
-      auto isUnboundGenericComponent = [](IdentTypeRepr *ITR) -> bool {
-        if (isa<SimpleIdentTypeRepr>(ITR)) {
-          auto *decl = dyn_cast_or_null<GenericTypeDecl>(ITR->getBoundDecl());
+      MemberTypeRepr *currTR = memberTR;
+      while (auto *declRefBaseTR =
+                 dyn_cast<DeclRefTypeRepr>(currTR->getBase())) {
+        if (!declRefBaseTR->hasGenericArgList()) {
+          auto *decl =
+              dyn_cast_or_null<GenericTypeDecl>(declRefBaseTR->getBoundDecl());
           if (decl && decl->isGeneric())
-            return true;
+            return nullptr;
         }
 
-        return false;
-      };
-
-      for (auto *comp : memberTR->getMemberComponents().drop_back()) {
-        if (isUnboundGenericComponent(comp))
-          return nullptr;
-      }
-
-      if (auto *identRoot = dyn_cast<IdentTypeRepr>(memberTR->getRoot())) {
-        if (isUnboundGenericComponent(identRoot))
-          return nullptr;
+        currTR = dyn_cast<MemberTypeRepr>(declRefBaseTR);
+        if (!currTR) {
+          break;
+        }
       }
     }
+
+    specializedTR =
+        MemberTypeRepr::create(C, memberTR->getBase(), ParentTR->getNameLoc(),
+                               ParentTR->getNameRef(), Args, AngleLocs);
+    specializedTR->setValue(boundDecl, ParentTR->getDeclContext());
   }
 
-  auto *genericComp = GenericIdentTypeRepr::create(
-      C, lastComp->getNameLoc(), lastComp->getNameRef(), Args, AngleLocs);
-  genericComp->setValue(lastComp->getBoundDecl(), lastComp->getDeclContext());
-
-  TypeRepr *TR = nullptr;
-  if (auto *memberTR = dyn_cast<MemberTypeRepr>(ParentTR)) {
-    auto oldMemberComps = memberTR->getMemberComponents().drop_back();
-
-    // Create a new list of member components, replacing the last one with the
-    // new specialized one.
-    SmallVector<IdentTypeRepr *, 2> newMemberComps;
-    newMemberComps.append(oldMemberComps.begin(), oldMemberComps.end());
-    newMemberComps.push_back(genericComp);
-
-    TR = MemberTypeRepr::create(C, memberTR->getRoot(), newMemberComps);
-  } else {
-    TR = genericComp;
-  }
-
-  return new (C) TypeExpr(TR);
+  return new (C) TypeExpr(specializedTR);
 }
 
 // Create an implicit TypeExpr, with location information even though it

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2268,7 +2268,7 @@ TypeExpr *TypeExpr::createForMemberDecl(TypeRepr *ParentTR, DeclNameLoc NameLoc,
     }
 
     Components.push_back(NewComp);
-    TR = MemberTypeRepr::create(C, DeclRefTR->getBaseComponent(), Components);
+    TR = MemberTypeRepr::create(C, DeclRefTR->getRoot(), Components);
   } else {
     TR = MemberTypeRepr::create(C, ParentTR, NewComp);
   }
@@ -2314,9 +2314,8 @@ TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
           return nullptr;
       }
 
-      if (auto *identBase =
-              dyn_cast<IdentTypeRepr>(memberTR->getBaseComponent())) {
-        if (isUnboundGenericComponent(identBase))
+      if (auto *identRoot = dyn_cast<IdentTypeRepr>(memberTR->getRoot())) {
+        if (isUnboundGenericComponent(identRoot))
           return nullptr;
       }
     }
@@ -2336,8 +2335,7 @@ TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
     newMemberComps.append(oldMemberComps.begin(), oldMemberComps.end());
     newMemberComps.push_back(genericComp);
 
-    TR =
-        MemberTypeRepr::create(C, memberTR->getBaseComponent(), newMemberComps);
+    TR = MemberTypeRepr::create(C, memberTR->getRoot(), newMemberComps);
   } else {
     TR = genericComp;
   }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1123,9 +1123,7 @@ SelfBounds SelfBoundsFromWhereClauseRequest::evaluate(
     // The left-hand side of the type constraint must be 'Self'.
     bool isSelfLHS = false;
     if (auto typeRepr = req.getSubjectRepr()) {
-      if (auto identTypeRepr = dyn_cast<SimpleIdentTypeRepr>(typeRepr))
-        isSelfLHS = (identTypeRepr->getNameRef().getBaseIdentifier() ==
-                     ctx.Id_Self);
+      isSelfLHS = typeRepr->isSimpleUnqualifiedIdentifier(ctx.Id_Self);
     }
     if (!isSelfLHS)
       continue;
@@ -2750,13 +2748,11 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
         // TypeRepr version: Builtin.AnyObject
         if (auto typeRepr = typealias->getUnderlyingTypeRepr()) {
           if (auto memberTR = dyn_cast<MemberTypeRepr>(typeRepr)) {
-            if (auto identRoot = dyn_cast<IdentTypeRepr>(memberTR->getRoot())) {
-              auto memberComps = memberTR->getMemberComponents();
-              if (memberComps.size() == 1 &&
-                  identRoot->getNameRef().isSimpleName("Builtin") &&
-                  memberComps.front()->getNameRef().isSimpleName("AnyObject")) {
-                anyObject = true;
-              }
+            auto memberComps = memberTR->getMemberComponents();
+            if (memberComps.size() == 1 &&
+                memberComps.front()->getNameRef().isSimpleName("AnyObject") &&
+                memberTR->getRoot()->isSimpleUnqualifiedIdentifier("Builtin")) {
+              anyObject = true;
             }
           }
         }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2750,11 +2750,10 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
         // TypeRepr version: Builtin.AnyObject
         if (auto typeRepr = typealias->getUnderlyingTypeRepr()) {
           if (auto memberTR = dyn_cast<MemberTypeRepr>(typeRepr)) {
-            if (auto identBase =
-                    dyn_cast<IdentTypeRepr>(memberTR->getBaseComponent())) {
+            if (auto identRoot = dyn_cast<IdentTypeRepr>(memberTR->getRoot())) {
               auto memberComps = memberTR->getMemberComponents();
               if (memberComps.size() == 1 &&
-                  identBase->getNameRef().isSimpleName("Builtin") &&
+                  identRoot->getNameRef().isSimpleName("Builtin") &&
                   memberComps.front()->getNameRef().isSimpleName("AnyObject")) {
                 anyObject = true;
               }
@@ -2929,8 +2928,8 @@ directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
                                    bool allowUsableFromInline) {
   DirectlyReferencedTypeDecls current;
 
-  auto *baseComp = repr->getBaseComponent();
-  if (auto *identBase = dyn_cast<IdentTypeRepr>(baseComp)) {
+  auto *rootComp = repr->getRoot();
+  if (auto *identBase = dyn_cast<IdentTypeRepr>(rootComp)) {
     // If we already set a declaration, use it.
     if (auto *typeDecl = identBase->getBoundDecl()) {
       current = {1, typeDecl};
@@ -2941,7 +2940,7 @@ directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
           LookupOuterResults::Excluded, allowUsableFromInline);
     }
   } else {
-    current = directReferencesForTypeRepr(evaluator, ctx, baseComp, dc,
+    current = directReferencesForTypeRepr(evaluator, ctx, rootComp, dc,
                                           allowUsableFromInline);
   }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2745,23 +2745,20 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
 
       // Recognize Swift.AnyObject directly.
       if (typealias->getName().is("AnyObject")) {
-        // TypeRepr version: Builtin.AnyObject
-        if (auto typeRepr = typealias->getUnderlyingTypeRepr()) {
-          if (auto memberTR = dyn_cast<MemberTypeRepr>(typeRepr)) {
-            auto memberComps = memberTR->getMemberComponents();
-            if (memberComps.size() == 1 &&
-                memberComps.front()->getNameRef().isSimpleName("AnyObject") &&
-                memberTR->getRoot()->isSimpleUnqualifiedIdentifier("Builtin")) {
-              anyObject = true;
-            }
-          }
-        }
-
         // Type version: an empty class-bound existential.
         if (typealias->hasInterfaceType()) {
           if (auto type = typealias->getUnderlyingType())
             if (type->isAnyObject())
               anyObject = true;
+        }
+        // TypeRepr version: Builtin.AnyObject
+        else if (auto *memberTR = dyn_cast_or_null<MemberTypeRepr>(
+                     typealias->getUnderlyingTypeRepr())) {
+          if (!memberTR->hasGenericArgList() &&
+              memberTR->getNameRef().isSimpleName("AnyObject") &&
+              memberTR->getBase()->isSimpleUnqualifiedIdentifier("Builtin")) {
+            anyObject = true;
+          }
         }
       }
 
@@ -2922,50 +2919,25 @@ static DirectlyReferencedTypeDecls
 directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
                                    DeclRefTypeRepr *repr, DeclContext *dc,
                                    bool allowUsableFromInline) {
-  DirectlyReferencedTypeDecls current;
-
-  auto *rootComp = repr->getRoot();
-  if (auto *identBase = dyn_cast<IdentTypeRepr>(rootComp)) {
-    // If we already set a declaration, use it.
-    if (auto *typeDecl = identBase->getBoundDecl()) {
-      current = {1, typeDecl};
-    } else {
-      // For the base component, perform unqualified name lookup.
-      current = directReferencesForUnqualifiedTypeLookup(
-          identBase->getNameRef(), identBase->getLoc(), dc,
-          LookupOuterResults::Excluded, allowUsableFromInline);
-    }
-  } else {
-    current = directReferencesForTypeRepr(evaluator, ctx, rootComp, dc,
-                                          allowUsableFromInline);
+  // If we already set a declaration, use it.
+  if (auto *typeDecl = repr->getBoundDecl()) {
+    return {typeDecl};
   }
 
-  auto *memberTR = dyn_cast<MemberTypeRepr>(repr);
-  if (!memberTR)
-    return current;
+  if (auto *memberTR = dyn_cast<MemberTypeRepr>(repr)) {
+    DirectlyReferencedTypeDecls baseTypeDecls = directReferencesForTypeRepr(
+        evaluator, ctx, memberTR->getBase(), dc, allowUsableFromInline);
 
-  // If we didn't find anything, fail now.
-  if (current.empty())
-    return current;
-
-  for (const auto &component : memberTR->getMemberComponents()) {
-    // If we already set a declaration, use it.
-    if (auto typeDecl = component->getBoundDecl()) {
-      current = {1, typeDecl};
-      continue;
-    }
-
-    // For subsequent components, perform qualified name lookup.
-    current =
-        directReferencesForQualifiedTypeLookup(evaluator, ctx, current,
-                                               component->getNameRef(), dc,
-                                               component->getLoc(),
-                                               allowUsableFromInline);
-    if (current.empty())
-      return current;
+    // For a qualified identifier, perform qualified name lookup.
+    return directReferencesForQualifiedTypeLookup(
+        evaluator, ctx, baseTypeDecls, repr->getNameRef(), dc, repr->getLoc(),
+        allowUsableFromInline);
   }
 
-  return current;
+  // For an unqualified identifier, perform unqualified name lookup.
+  return directReferencesForUnqualifiedTypeLookup(
+      repr->getNameRef(), repr->getLoc(), dc, LookupOuterResults::Excluded,
+      allowUsableFromInline);
 }
 
 static DirectlyReferencedTypeDecls
@@ -3654,11 +3626,12 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
                                assocType->getDescriptiveKind(),
                                assocType->getName());
 
-            auto *baseComp = new (ctx) SimpleIdentTypeRepr(
+            auto *baseTR = new (ctx) SimpleIdentTypeRepr(
                 identTypeRepr->getNameLoc(), DeclNameRef(moduleName));
 
             auto *newTE = new (ctx) TypeExpr(
-                MemberTypeRepr::create(ctx, baseComp, {identTypeRepr}));
+                MemberTypeRepr::create(ctx, baseTR, identTypeRepr->getNameLoc(),
+                                       identTypeRepr->getNameRef()));
             attr->resetTypeInformation(newTE);
             return nominal;
           }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1822,11 +1822,8 @@ SourceRange UnresolvedMacroReference::getGenericArgsRange() const {
     auto [_, macro] = attr->destructureMacroRef();
     if (!macro)
       return SourceRange();
-    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(macro);
-    if (!genericTypeRepr)
-      return SourceRange();
 
-    return genericTypeRepr->getAngleBrackets();
+    return macro->getAngleBrackets();
   }
 
   llvm_unreachable("Unhandled case");
@@ -1840,11 +1837,8 @@ ArrayRef<TypeRepr *> UnresolvedMacroReference::getGenericArgs() const {
     auto [_, macro] = attr->destructureMacroRef();
     if (!macro)
       return {};
-    auto *genericTypeRepr = dyn_cast_or_null<GenericIdentTypeRepr>(macro);
-    if (!genericTypeRepr)
-      return {};
 
-    return genericTypeRepr->getGenericArgs();
+    return macro->getGenericArgs();
   }
 
   llvm_unreachable("Unhandled case");

--- a/lib/AST/TypeDeclFinder.cpp
+++ b/lib/AST/TypeDeclFinder.cpp
@@ -50,9 +50,9 @@ SimpleTypeDeclFinder::visitTypeAliasType(TypeAliasType *ty) {
 }
 
 ASTWalker::PostWalkAction
-TypeReprIdentFinder::walkToTypeReprPost(TypeRepr *TR) {
-  auto ITR = dyn_cast<IdentTypeRepr>(TR);
-  if (!ITR || !ITR->getBoundDecl())
+DeclRefTypeReprFinder::walkToTypeReprPost(TypeRepr *TR) {
+  auto *declRefTR = dyn_cast<DeclRefTypeRepr>(TR);
+  if (!declRefTR || !declRefTR->getBoundDecl())
     return Action::Continue();
-  return Action::StopIf(!Callback(ITR));
+  return Action::StopIf(!Callback(declRefTR));
 }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -215,6 +215,11 @@ DeclNameLoc DeclRefTypeRepr::getNameLoc() const {
   return const_cast<DeclRefTypeRepr *>(this)->getLastComponent()->getNameLoc();
 }
 
+void DeclRefTypeRepr::overwriteNameRef(DeclNameRef newId) {
+  assert(newId.isSimpleName() && !newId.isSpecial() && !newId.isOperator());
+  getLastComponent()->overwriteNameRef(newId);
+}
+
 bool DeclRefTypeRepr::isBound() const {
   return const_cast<DeclRefTypeRepr *>(this)->getLastComponent()->isBound();
 }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -119,6 +119,26 @@ TypeRepr *TypeRepr::getWithoutParens() const {
   return repr;
 }
 
+bool TypeRepr::isSimpleUnqualifiedIdentifier(Identifier identifier) const {
+  if (auto *identTR = dyn_cast<SimpleIdentTypeRepr>(this)) {
+    if (identTR->getNameRef().getBaseIdentifier() == identifier) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool TypeRepr::isSimpleUnqualifiedIdentifier(StringRef str) const {
+  if (auto *identTR = dyn_cast<SimpleIdentTypeRepr>(this)) {
+    if (identTR->getNameRef().getBaseIdentifier().is(str)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 SourceLoc TypeRepr::findAttrLoc(TypeAttrKind kind) const {
   auto typeRepr = this;
   while (auto attrTypeRepr = dyn_cast<AttributedTypeRepr>(typeRepr)) {

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -203,6 +203,10 @@ const TypeRepr *DeclRefTypeRepr::getRoot() const {
   return cast<MemberTypeRepr>(this)->getRoot();
 }
 
+bool DeclRefTypeRepr::isBound() const {
+  return const_cast<DeclRefTypeRepr *>(this)->getLastComponent()->isBound();
+}
+
 TypeDecl *DeclRefTypeRepr::getBoundDecl() const {
   return const_cast<DeclRefTypeRepr *>(this)
       ->getLastComponent()

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -191,6 +191,14 @@ DeclRefTypeRepr *DeclRefTypeRepr::create(const ASTContext &C, TypeRepr *Base,
   }
 }
 
+TypeRepr *DeclRefTypeRepr::getBase() const {
+  if (isa<IdentTypeRepr>(this)) {
+    return nullptr;
+  }
+
+  return cast<MemberTypeRepr>(this)->getBase();
+}
+
 TypeRepr *DeclRefTypeRepr::getRoot() {
   return const_cast<TypeRepr *>(
       const_cast<const DeclRefTypeRepr *>(this)->getRoot());

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -209,6 +209,15 @@ TypeDecl *DeclRefTypeRepr::getBoundDecl() const {
       ->getBoundDecl();
 }
 
+ArrayRef<TypeRepr *> DeclRefTypeRepr::getGenericArgs() const {
+  auto *lastComp = const_cast<DeclRefTypeRepr *>(this)->getLastComponent();
+  if (auto *genericTR = dyn_cast<GenericIdentTypeRepr>(lastComp)) {
+    return genericTR->getGenericArgs();
+  }
+
+  return {};
+}
+
 DeclNameRef DeclRefTypeRepr::getNameRef() const {
   return const_cast<DeclRefTypeRepr *>(this)->getLastComponent()->getNameRef();
 }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -240,6 +240,15 @@ void DeclRefTypeRepr::setValue(TypeDecl *TD, DeclContext *DC) {
   getLastComponent()->setValue(TD, DC);
 }
 
+unsigned DeclRefTypeRepr::getNumGenericArgs() const {
+  auto *lastComp = const_cast<DeclRefTypeRepr *>(this)->getLastComponent();
+  if (auto *genericTR = dyn_cast<GenericIdentTypeRepr>(lastComp)) {
+    return genericTR->getNumGenericArgs();
+  }
+
+  return 0;
+}
+
 bool DeclRefTypeRepr::hasGenericArgList() const {
   return isa<GenericIdentTypeRepr>(
       const_cast<DeclRefTypeRepr *>(this)->getLastComponent());

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -82,7 +82,7 @@ extension ASTGenVisitor {
     case .implicitlyUnwrappedOptionalType(let node):
       return self.generate(implicitlyUnwrappedOptionalType: node).asTypeRepr
     case .memberType(let node):
-      return self.generate(memberType: node)
+      return self.generate(memberType: node).asTypeRepr
     case .metatypeType(let node):
       return self.generate(metatypeType: node)
     case .missingType:
@@ -137,45 +137,29 @@ extension ASTGenVisitor {
     ).asTypeRepr
   }
 
-  func generate(memberType node: MemberTypeSyntax) -> BridgedTypeRepr {
-    // Gather the member components, in decreasing depth order.
-    var reverseMemberComponents = [BridgedTypeRepr]()
+  func generate(memberType node: MemberTypeSyntax) -> BridgedDeclRefTypeRepr {
+    let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
 
-    var baseType = TypeSyntax(node)
-    while let memberType = baseType.as(MemberTypeSyntax.self) {
-      let (name, nameLoc) = self.generateIdentifierAndSourceLoc(node.name)
+    let genericArguments: BridgedArrayRef
+    let angleRange: BridgedSourceRange
+    if let generics = node.genericArgumentClause {
+      genericArguments = generics.arguments.lazy.map {
+        self.generate(type: $0.argument)
+      }.bridgedArray(in: self)
 
-      if let generics = memberType.genericArgumentClause {
-        let genericArguments = generics.arguments.lazy.map {
-          self.generate(type: $0.argument)
-        }
-
-        reverseMemberComponents.append(
-          BridgedGenericIdentTypeRepr.createParsed(
-            self.ctx,
-            name: name,
-            nameLoc: nameLoc,
-            genericArgs: genericArguments.bridgedArray(in: self),
-            leftAngleLoc: self.generateSourceLoc(generics.leftAngle),
-            rightAngleLoc: self.generateSourceLoc(generics.rightAngle)
-          ).asTypeRepr
-        )
-      } else {
-        reverseMemberComponents.append(
-          BridgedSimpleIdentTypeRepr.createParsed(self.ctx, loc: nameLoc, name: name).asTypeRepr
-        )
-      }
-
-      baseType = memberType.baseType
+      angleRange = self.generateSourceRange(start: generics.leftAngle, end: generics.rightAngle)
+    } else {
+      genericArguments = .init()
+      angleRange = .init()
     }
 
-    let baseComponent = generate(type: baseType)
-    let memberComponents = reverseMemberComponents.reversed().bridgedArray(in: self)
-
-    return BridgedMemberTypeRepr.createParsed(
+    return BridgedDeclRefTypeRepr.createParsed(
       self.ctx,
-      base: baseComponent,
-      members: memberComponents
+      base: self.generate(type: node.baseType),
+      name: name,
+      nameLoc: nameLoc,
+      genericArguments: genericArguments,
+      angleRange: angleRange
     )
   }
 

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -62,6 +62,10 @@ private:
     return SEWalker.getMacroWalkingBehavior();
   }
 
+  MemberTypeReprWalkingScheme getMemberTypeReprWalkingScheme() const override {
+    return MemberTypeReprWalkingScheme::SourceOrderRecursive;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override;
   PreWalkAction walkToDeclPreProper(Decl *D);
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
@@ -627,15 +631,15 @@ ASTWalker::PreWalkAction SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
   if (!Continue)
     return Action::Stop();
 
-  if (auto IdT = dyn_cast<IdentTypeRepr>(T)) {
-    if (ValueDecl *VD = IdT->getBoundDecl()) {
+  if (auto *DeclRefT = dyn_cast<DeclRefTypeRepr>(T)) {
+    if (ValueDecl *VD = DeclRefT->getBoundDecl()) {
       if (auto *ModD = dyn_cast<ModuleDecl>(VD)) {
-        auto ident = IdT->getNameRef().getBaseIdentifier();
-        auto Continue = passReference(ModD, {ident, IdT->getLoc()});
+        auto ident = DeclRefT->getNameRef().getBaseIdentifier();
+        auto Continue = passReference(ModD, {ident, DeclRefT->getLoc()});
         return Action::StopIf(!Continue);
       }
       auto Continue = passReference(
-          VD, Type(), IdT->getNameLoc(),
+          VD, Type(), DeclRefT->getNameLoc(),
           ReferenceMetaData(SemaReferenceKind::TypeRef, llvm::None));
       return Action::StopIf(!Continue);
     }

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -92,8 +92,8 @@ private:
   }
 
   bool isUserTypeAlias(TypeRepr *T) const {
-    if (auto Ident = dyn_cast<IdentTypeRepr>(T)) {
-      if (auto Bound = Ident->getBoundDecl()) {
+    if (auto *DeclRefTR = dyn_cast<DeclRefTypeRepr>(T)) {
+      if (auto *Bound = DeclRefTR->getBoundDecl()) {
         return isa<TypeAliasDecl>(Bound) &&
           !Bound->getModuleContext()->isSystemModule();
       }
@@ -189,16 +189,8 @@ public:
                         /*Suffixable=*/false);
   }
 
-  FoundResult visitSimpleIdentTypeRepr(SimpleIdentTypeRepr *T) {
-    return handleParent(T, ArrayRef<TypeRepr*>());
-  }
-
-  FoundResult visitGenericIdentTypeRepr(GenericIdentTypeRepr *T) {
+  FoundResult visitDeclRefTypeRepr(DeclRefTypeRepr *T) {
     return handleParent(T, T->getGenericArgs());
-  }
-
-  FoundResult visitMemberTypeRepr(MemberTypeRepr *T) {
-    return visit(T->getLastComponent());
   }
 
   FoundResult visitOptionalTypeRepr(OptionalTypeRepr *T) {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -557,10 +557,11 @@ ParserResult<TypeRepr> Parser::parseTypeScalar(
       }
 
       PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-        if (auto ident = dyn_cast<IdentTypeRepr>(T)) {
-          if (auto decl = ident->getBoundDecl()) {
-            if (auto genericParam = dyn_cast<GenericTypeParamDecl>(decl))
-              ident->overwriteNameRef(genericParam->createNameRef());
+        // Only unqualified identifiers can reference generic parameters.
+        if (auto *simpleIdentTR = dyn_cast<SimpleIdentTypeRepr>(T)) {
+          if (auto *genericParam = dyn_cast_or_null<GenericTypeParamDecl>(
+                  simpleIdentTR->getBoundDecl())) {
+            simpleIdentTR->overwriteNameRef(genericParam->createNameRef());
           }
         }
         return Action::Continue();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -203,11 +203,11 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
           status, PackTypeRepr::create(Context, keywordLoc,
                                        SourceRange(lbLoc, rbLoc), elements));
     } else {
-      ty = parseTypeIdentifier();
-      if (auto *ITR = cast_or_null<IdentTypeRepr>(ty.getPtrOrNull())) {
+      ty = parseTypeIdentifier(/*Base=*/nullptr);
+      if (auto *repr = ty.getPtrOrNull()) {
         if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine()) {
           if (CodeCompletionCallbacks) {
-            CodeCompletionCallbacks->completeTypeSimpleWithoutDot(ITR);
+            CodeCompletionCallbacks->completeTypeSimpleWithoutDot(repr);
           }
 
           ty.setHasCodeCompletionAndIsError();
@@ -771,14 +771,14 @@ ParserResult<TypeRepr> Parser::parseQualifiedDeclNameBaseType() {
   }
 
   ParserStatus Status;
-  SmallVector<IdentTypeRepr *, 4> ComponentsR;
+  DeclRefTypeRepr *Result = nullptr;
   SourceLoc EndLoc;
   while (true) {
-    auto IdentResult = parseTypeIdentifier();
-    if (IdentResult.isParseErrorOrHasCompletion())
-      return IdentResult;
+    auto PartialResult = parseTypeIdentifier(/*Base=*/Result);
+    if (PartialResult.isParseErrorOrHasCompletion())
+      return PartialResult;
 
-    ComponentsR.push_back(cast<IdentTypeRepr>(IdentResult.get()));
+    Result = PartialResult.get();
 
     // Treat 'Foo.<anything>' as an attempt to write a dotted type
     // unless <anything> is 'Type'.
@@ -811,31 +811,26 @@ ParserResult<TypeRepr> Parser::parseQualifiedDeclNameBaseType() {
     break;
   }
 
-  DeclRefTypeRepr *DeclRefTR = nullptr;
-  if (!ComponentsR.empty()) {
-    DeclRefTR = MemberTypeRepr::create(Context, ComponentsR);
-  }
-
   if (Status.hasCodeCompletion()) {
     if (Tok.isNot(tok::code_complete)) {
       // We have a dot.
       consumeToken();
       if (CodeCompletionCallbacks) {
-        CodeCompletionCallbacks->completeTypeSimpleWithDot(DeclRefTR);
+        CodeCompletionCallbacks->completeTypeSimpleWithDot(Result);
       }
     } else {
       if (CodeCompletionCallbacks) {
-        CodeCompletionCallbacks->completeTypeSimpleWithoutDot(DeclRefTR);
+        CodeCompletionCallbacks->completeTypeSimpleWithoutDot(Result);
       }
     }
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);
   }
 
-  return makeParserResult(Status, DeclRefTR);
+  return makeParserResult(Status, Result);
 }
 
-ParserResult<IdentTypeRepr> Parser::parseTypeIdentifier() {
+ParserResult<DeclRefTypeRepr> Parser::parseTypeIdentifier(TypeRepr *Base) {
   // FIXME: We should parse e.g. 'X.var'. Almost any keyword is a valid member
   // component.
   DeclNameLoc Loc;
@@ -846,7 +841,7 @@ ParserResult<IdentTypeRepr> Parser::parseTypeIdentifier() {
     return makeParserError();
 
   ParserStatus Status;
-  IdentTypeRepr *IdTR;
+  DeclRefTypeRepr *Result;
 
   if (startsWithLess(Tok)) {
     SourceLoc LAngle, RAngle;
@@ -855,20 +850,20 @@ ParserResult<IdentTypeRepr> Parser::parseTypeIdentifier() {
     if (ArgsStatus.isErrorOrHasCompletion())
       return ArgsStatus;
 
-    IdTR = GenericIdentTypeRepr::create(Context, Loc, Name, GenericArgs,
-                                        SourceRange(LAngle, RAngle));
+    Result = DeclRefTypeRepr::create(Context, Base, Loc, Name, GenericArgs,
+                                     SourceRange(LAngle, RAngle));
   } else {
-    IdTR = new (Context) SimpleIdentTypeRepr(Loc, Name);
+    Result = DeclRefTypeRepr::create(Context, Base, Loc, Name);
   }
 
-  return makeParserResult(IdTR);
+  return makeParserResult(Result);
 }
 
 ParserResult<TypeRepr> Parser::parseTypeDotted(ParserResult<TypeRepr> Base) {
   assert(Base.isNonNull());
   assert(Tok.isAny(tok::period, tok::period_prefix));
 
-  SmallVector<IdentTypeRepr *, 4> MemberComponents;
+  TypeRepr *Result = Base.get();
 
   while (Tok.isAny(tok::period, tok::period_prefix)) {
     if (peekToken().is(tok::code_complete)) {
@@ -881,32 +876,25 @@ ParserResult<TypeRepr> Parser::parseTypeDotted(ParserResult<TypeRepr> Base) {
 
     if (Tok.isContextualKeyword("Type") ||
         Tok.isContextualKeyword("Protocol")) {
-      TypeRepr *MetaBase =
-          MemberTypeRepr::create(Context, Base.get(), MemberComponents);
       if (Tok.getRawText() == "Type") {
-        Base = makeParserResult(Base,
-                                new (Context) MetatypeTypeRepr(
-                                    MetaBase, consumeToken(tok::identifier)));
+        Result = new (Context)
+            MetatypeTypeRepr(Result, consumeToken(tok::identifier));
       } else {
-        Base = makeParserResult(Base,
-                                new (Context) ProtocolTypeRepr(
-                                    MetaBase, consumeToken(tok::identifier)));
+        Result = new (Context)
+            ProtocolTypeRepr(Result, consumeToken(tok::identifier));
       }
 
-      // Start anew with a metatype base.
-      MemberComponents.clear();
       continue;
     }
 
-    auto IdentResult = parseTypeIdentifier();
-    if (IdentResult.isParseErrorOrHasCompletion())
-      return IdentResult | ParserStatus(Base);
+    auto PartialResult = parseTypeIdentifier(/*Base=*/Result);
+    if (PartialResult.isParseErrorOrHasCompletion())
+      return PartialResult | ParserStatus(Base);
 
-    MemberComponents.push_back(cast<IdentTypeRepr>(IdentResult.get()));
+    Result = PartialResult.get();
   }
 
-  return makeParserResult(
-      Base, MemberTypeRepr::create(Context, Base.get(), MemberComponents));
+  return makeParserResult(Base, Result);
 }
 
 /// parseTypeSimpleOrComposition

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1169,7 +1169,7 @@ struct TypeReprCycleCheckWalker : ASTWalker {
 
     if (auto *memberTyR = dyn_cast<MemberTypeRepr>(T)) {
       // If we're looking at a member type`Foo.Bar`, check `Foo` recursively.
-      auto *baseTyR = memberTyR->getBaseComponent();
+      auto *baseTyR = memberTyR->getRoot();
       baseTyR->walk(*this);
 
       // If we're inferring `Foo`, don't look at a witness mentioning `Self.Foo`.

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1127,12 +1127,13 @@ namespace {
 
 /// Try to avoid situations where resolving the type of a witness calls back
 /// into associated type inference.
-struct TypeReprCycleCheckWalker : ASTWalker {
+class TypeReprCycleCheckWalker : private ASTWalker {
   ASTContext &ctx;
   llvm::SmallDenseSet<Identifier, 2> circularNames;
   ValueDecl *witness;
   bool found;
 
+public:
   TypeReprCycleCheckWalker(
       ASTContext &ctx,
       const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved)
@@ -1142,11 +1143,10 @@ struct TypeReprCycleCheckWalker : ASTWalker {
     }
   }
 
+private:
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-    // FIXME: Visit generic arguments.
-
+    // If we're inferring `Foo`, don't look at a witness mentioning `Foo`.
     if (auto *identTyR = dyn_cast<SimpleIdentTypeRepr>(T)) {
-      // If we're inferring `Foo`, don't look at a witness mentioning `Foo`.
       if (circularNames.count(identTyR->getNameRef().getBaseIdentifier()) > 0) {
         // If unqualified lookup can find a type with this name without looking
         // into protocol members, don't skip the witness, since this type might
@@ -1165,40 +1165,41 @@ struct TypeReprCycleCheckWalker : ASTWalker {
           return Action::Stop();
         }
       }
+
+      return Action::Continue();
     }
 
-    if (auto *memberTyR = dyn_cast<MemberTypeRepr>(T)) {
-      // If we're looking at a member type`Foo.Bar`, check `Foo` recursively.
-      auto *baseTyR = memberTyR->getRoot();
-      baseTyR->walk(*this);
+    // If we're inferring `Foo`, don't look at a witness mentioning `Self.Foo`.
+    auto *memberTyR = dyn_cast<MemberTypeRepr>(T);
+    if (!memberTyR || memberTyR->hasGenericArgList()) {
+      return Action::Continue();
+    }
 
-      // If we're inferring `Foo`, don't look at a witness mentioning `Self.Foo`.
-      if (auto *identTyR = dyn_cast<SimpleIdentTypeRepr>(baseTyR)) {
-        if (identTyR->getNameRef().getBaseIdentifier() == ctx.Id_Self &&
-            circularNames.count(memberTyR->getNameRef().getBaseIdentifier()) > 0) {
-          // But if qualified lookup can find a type with this name without
-          // looking into protocol members, don't skip the witness, since this
-          // type might be a candidate witness.
-          SmallVector<ValueDecl *, 2> results;
-          witness->getInnermostDeclContext()->lookupQualified(
-              witness->getDeclContext()->getSelfTypeInContext(),
-              identTyR->getNameRef(), SourceLoc(), NLOptions(), results);
+    if (!memberTyR->getBase()->isSimpleUnqualifiedIdentifier(ctx.Id_Self)) {
+      return Action::Continue();
+    }
 
-          // Ok, resolving this member type would trigger associated type
-          // inference recursively. We're going to skip this witness.
-          if (results.empty()) {
-            found = true;
-            return Action::Stop();
-          }
-        }
+    if (circularNames.count(memberTyR->getNameRef().getBaseIdentifier()) > 0) {
+      // But if qualified lookup can find a type with this name without looking
+      // into protocol members, don't skip the witness, since this type might
+      // be a candidate witness.
+      SmallVector<ValueDecl *, 2> results;
+      witness->getInnermostDeclContext()->lookupQualified(
+          witness->getDeclContext()->getSelfTypeInContext(),
+          memberTyR->getNameRef(), SourceLoc(), NLOptions(), results);
+
+      // Ok, resolving this member type would trigger associated type
+      // inference recursively. We're going to skip this witness.
+      if (results.empty()) {
+        found = true;
+        return Action::Stop();
       }
-
-      return Action::SkipNode();
     }
 
-    return Action::Continue();
+    return Action::SkipNode();
   }
 
+public:
   bool checkForPotentialCycle(ValueDecl *witness) {
     // Don't do this for protocol extension members, because we have a
     // mini "solver" that avoids similar issues instead.
@@ -1268,7 +1269,7 @@ struct TypeReprCycleCheckWalker : ASTWalker {
   }
 };
 
-}
+} // end anonymous namespace
 
 static bool isExtensionUsableForInference(const ExtensionDecl *extension,
                                           NormalProtocolConformance *conformance) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9345,7 +9345,7 @@ bool InvalidTypeSpecializationArity::diagnoseAsError() {
   diagnoseInvalidGenericArguments(getLoc(), D,
                                   NumArgs, NumParams,
                                   HasParameterPack,
-                                  /*generic=*/nullptr);
+                                  /*angleBrackets=*/SourceRange());
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6757,10 +6757,11 @@ void MissingGenericArgumentsFailure::emitGenericSignatureNote(
     auto diagnostic = emitDiagnosticAt(
         baseType->getLoc(), diag::unbound_generic_parameter_explicit_fix);
 
-    if (auto *genericTy = dyn_cast<GenericIdentTypeRepr>(baseType)) {
-      // If some of the eneric arguments have been specified, we need to
+    auto *declRefTR = dyn_cast<DeclRefTypeRepr>(baseType);
+    if (declRefTR && declRefTR->getAngleBrackets().isValid()) {
+      // If some of the generic arguments have been specified, we need to
       // replace existing signature with a new one.
-      diagnostic.fixItReplace(genericTy->getAngleBrackets(), paramsAsString);
+      diagnostic.fixItReplace(declRefTR->getAngleBrackets(), paramsAsString);
     } else {
       // Otherwise we can simply insert new generic signature.
       diagnostic.fixItInsertAfter(baseType->getEndLoc(), paramsAsString);
@@ -6770,7 +6771,7 @@ void MissingGenericArgumentsFailure::emitGenericSignatureNote(
 
 bool MissingGenericArgumentsFailure::findArgumentLocations(
     llvm::function_ref<void(TypeRepr *, GenericTypeParamType *)> callback) {
-  using Callback = llvm::function_ref<void(TypeRepr *, GenericTypeParamType *)>;
+  using Callback = decltype(callback);
 
   auto *const typeRepr = [this]() -> TypeRepr * {
     const auto anchor = getRawAnchor();
@@ -6799,14 +6800,14 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
     }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-      if (Params.empty())
-        return Action::SkipNode();
+      if (allParamsAssigned())
+        return Action::Stop();
 
-      auto *ident = dyn_cast<IdentTypeRepr>(T);
-      if (!ident)
+      auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T);
+      if (!declRefTR)
         return Action::Continue();
 
-      auto *decl = dyn_cast_or_null<GenericTypeDecl>(ident->getBoundDecl());
+      auto *decl = dyn_cast_or_null<GenericTypeDecl>(declRefTR->getBoundDecl());
       if (!decl)
         return Action::Continue();
 
@@ -6817,9 +6818,8 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
       // There could a situation like `S<S>()`, so we need to be
       // careful not to point at first `S` because it has all of
       // its generic parameters specified.
-      if (auto *generic = dyn_cast<GenericIdentTypeRepr>(ident)) {
-        if (paramList->size() == generic->getNumGenericArgs())
-          return Action::Continue();
+      if (paramList->size() == declRefTR->getNumGenericArgs()) {
+        return Action::Continue();
       }
 
       for (auto *candidate : paramList->getParams()) {
@@ -6829,7 +6829,7 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
             });
 
         if (result != Params.end()) {
-          Fn(ident, *result);
+          Fn(declRefTR, *result);
           Params.erase(result);
         }
       }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -710,7 +710,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           } else if (auto *TE = dyn_cast<TypeExpr>(E)) {
             if (auto *TR =
                     dyn_cast_or_null<MemberTypeRepr>(TE->getTypeRepr())) {
-              if (!isa<IdentTypeRepr>(TR->getBaseComponent())) {
+              if (!isa<IdentTypeRepr>(TR->getRoot())) {
                 behavior = DiagnosticBehavior::Warning;
               }
             }

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1997,14 +1997,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     if (!AE->isFolded()) return nullptr;
 
     auto diagnoseMissingParens = [](ASTContext &ctx, TypeRepr *tyR) {
-      bool isVoid = false;
-      if (const auto Void = dyn_cast<SimpleIdentTypeRepr>(tyR)) {
-        if (Void->getNameRef().isSimpleName(ctx.Id_Void)) {
-          isVoid = true;
-        }
-      }
-
-      if (isVoid) {
+      if (tyR->isSimpleUnqualifiedIdentifier(ctx.Id_Void)) {
         ctx.Diags.diagnose(tyR->getStartLoc(), diag::function_type_no_parens)
             .fixItReplace(tyR->getStartLoc(), "()");
       } else {

--- a/lib/Sema/TypeAccessScopeChecker.h
+++ b/lib/Sema/TypeAccessScopeChecker.h
@@ -52,7 +52,7 @@ public:
   getAccessScope(TypeRepr *TR, const DeclContext *useDC,
                  bool treatUsableFromInlineAsPublic = false) {
     TypeAccessScopeChecker checker(useDC, treatUsableFromInlineAsPublic);
-    TR->walk(TypeReprIdentFinder([&](const IdentTypeRepr *typeRepr) {
+    TR->walk(DeclRefTypeReprFinder([&](const DeclRefTypeRepr *typeRepr) {
       return checker.visitDecl(typeRepr->getBoundDecl());
     }));
     return checker.Scope;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -361,8 +361,8 @@ static void highlightOffendingType(InFlightDiagnostic &diag,
   diag.highlight(complainRepr->getSourceRange());
   diag.flush();
 
-  if (auto ITR = dyn_cast<IdentTypeRepr>(complainRepr)) {
-    const ValueDecl *VD = ITR->getBoundDecl();
+  if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(complainRepr)) {
+    const ValueDecl *VD = declRefTR->getBoundDecl();
     VD->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
   }
 }
@@ -378,8 +378,8 @@ static void noteLimitingImport(ASTContext &ctx,
   assert(limitImport->accessLevel != AccessLevel::Public &&
          "a public import shouldn't limit the access level of a decl");
 
-  if (auto ITR = dyn_cast_or_null<IdentTypeRepr>(complainRepr)) {
-    ValueDecl *VD = ITR->getBoundDecl();
+  if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(complainRepr)) {
+    ValueDecl *VD = declRefTR->getBoundDecl();
     ctx.Diags.diagnose(limitImport->importLoc,
                        diag::decl_import_via_here,
                        VD,

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -115,54 +115,67 @@ public:
   void checkGlobalActorAccess(const Decl *D);
 };
 
-class TypeAccessScopeDiagnoser : private ASTWalker {
-  AccessScope accessScope;
-  const DeclContext *useDC;
-  bool treatUsableFromInlineAsPublic;
-  const IdentTypeRepr *offendingType = nullptr;
-
-  MacroWalking getMacroWalkingBehavior() const override {
-    return MacroWalking::ArgumentsAndExpansion;
-  }
-
-  PreWalkAction walkToTypeReprPre(TypeRepr *TR) override {
-    auto ITR = dyn_cast<IdentTypeRepr>(TR);
-    if (!ITR)
-      return Action::Continue();
-
-    const ValueDecl *VD = ITR->getBoundDecl();
-    if (!VD)
-      return Action::Continue();
-
-    if (VD->getFormalAccessScope(useDC, treatUsableFromInlineAsPublic)
-        != accessScope)
-      return Action::Continue();
-
-    offendingType = ITR;
-    return Action::Stop();
-  }
-
-  explicit TypeAccessScopeDiagnoser(AccessScope accessScope,
-                                    const DeclContext *useDC,
-                                    bool treatUsableFromInlineAsPublic)
-    : accessScope(accessScope), useDC(useDC),
-      treatUsableFromInlineAsPublic(treatUsableFromInlineAsPublic) {}
-
-public:
-  static const TypeRepr *findTypeWithScope(TypeRepr *TR,
-                                           AccessScope accessScope,
-                                           const DeclContext *useDC,
-                                           bool treatUsableFromInlineAsPublic) {
-    if (TR == nullptr)
-      return nullptr;
-    TypeAccessScopeDiagnoser diagnoser(accessScope, useDC,
-                                       treatUsableFromInlineAsPublic);
-    TR->walk(diagnoser);
-    return diagnoser.offendingType;
-  }
-};
-
 } // end anonymous namespace
+
+/// Searches the given type representation for a `DeclRefTypeRepr` that is
+/// bound to a type declaration with the given access scope. The type
+/// representation is searched in source order. For example, nodes in
+/// `A<T>.B<U>` will be checked in the following order: `ATBU`.
+static const DeclRefTypeRepr *
+findTypeDeclWithAccessScope(TypeRepr *TR, AccessScope accessScope,
+                            const DeclContext *useDC,
+                            bool treatUsableFromInlineAsPublic) {
+  if (!TR) {
+    return nullptr;
+  }
+
+  class Finder : public ASTWalker {
+    AccessScope accessScope;
+    const DeclContext *useDC;
+    bool treatUsableFromInlineAsPublic;
+
+    const DeclRefTypeRepr *theFind;
+
+  public:
+    explicit Finder(AccessScope accessScope, const DeclContext *useDC,
+                    bool treatUsableFromInlineAsPublic)
+        : accessScope(accessScope), useDC(useDC),
+          treatUsableFromInlineAsPublic(treatUsableFromInlineAsPublic),
+          theFind(nullptr) {}
+
+    const DeclRefTypeRepr *getFind() const { return theFind; }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
+    MemberTypeReprWalkingScheme
+    getMemberTypeReprWalkingScheme() const override {
+      return MemberTypeReprWalkingScheme::SourceOrderRecursive;
+    }
+
+    PreWalkAction walkToTypeReprPre(TypeRepr *TR) override {
+      auto *declRefTR = dyn_cast<DeclRefTypeRepr>(TR);
+      if (!declRefTR)
+        return Action::Continue();
+
+      const ValueDecl *VD = declRefTR->getBoundDecl();
+      if (!VD)
+        return Action::Continue();
+
+      if (VD->getFormalAccessScope(useDC, treatUsableFromInlineAsPublic) !=
+          accessScope)
+        return Action::Continue();
+
+      theFind = declRefTR;
+      return Action::Stop();
+    }
+  } walker(accessScope, useDC, treatUsableFromInlineAsPublic);
+
+  TR->walk(walker);
+
+  return walker.getFind();
+}
 
 /// Checks if the access scope of the type described by \p TL contains
 /// \p contextAccessScope. If it isn't, calls \p diagnose with a TypeRepr
@@ -196,7 +209,7 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
   if (contextAccessScope.isPublic() ||
       contextAccessScope.isPackage()) {
     auto SF = useDC->getParentSourceFile();
-    auto report = [&](const IdentTypeRepr *typeRepr, const ValueDecl *VD) {
+    auto report = [&](const DeclRefTypeRepr *typeRepr, const ValueDecl *VD) {
       ImportAccessLevel import = VD->getImportAccessFrom(useDC);
       if (import.has_value()) {
         if (SF) {
@@ -219,7 +232,7 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     };
 
     if (typeRepr) {
-      typeRepr->walk(TypeReprIdentFinder([&](const IdentTypeRepr *TR) {
+      typeRepr->walk(DeclRefTypeReprFinder([&](const DeclRefTypeRepr *TR) {
         const ValueDecl *VD = TR->getBoundDecl();
         report(TR, VD);
         return true;
@@ -300,14 +313,14 @@ void AccessControlCheckerBase::checkTypeAccessImpl(
     }
   }
 
-  const TypeRepr *complainRepr = TypeAccessScopeDiagnoser::findTypeWithScope(
+  const DeclRefTypeRepr *complainRepr = findTypeDeclWithAccessScope(
       typeRepr, problematicAccessScope, useDC, checkUsableFromInline);
 
   ImportAccessLevel complainImport = llvm::None;
   if (complainRepr) {
-    const ValueDecl *VD =
-      static_cast<const IdentTypeRepr*>(complainRepr)->getBoundDecl();
-    assert(VD && "findTypeWithScope should return bound TypeReprs only");
+    const ValueDecl *VD = complainRepr->getBoundDecl();
+    assert(VD &&
+           "findTypeDeclWithAccessScope should return bound TypeReprs only");
     complainImport = VD->getImportAccessFrom(useDC);
 
     // Don't complain about an import that doesn't restrict the access

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3932,13 +3932,13 @@ public:
     if (!declRefTR)
       return Action::Continue();
 
-    auto *baseComp = declRefTR->getBaseComponent();
-    if (auto *identBase = dyn_cast<IdentTypeRepr>(baseComp)) {
+    auto *rootComp = declRefTR->getRoot();
+    if (auto *identBase = dyn_cast<IdentTypeRepr>(rootComp)) {
       if (checkIdentTypeRepr(identBase)) {
         foundAnyIssues = true;
         return Action::SkipNode();
       }
-    } else if (diagnoseTypeReprAvailability(baseComp, where, flags)) {
+    } else if (diagnoseTypeReprAvailability(rootComp, where, flags)) {
       foundAnyIssues = true;
       return Action::SkipNode();
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3877,11 +3877,20 @@ class TypeReprAvailabilityWalker : public ASTWalker {
   const ExportContext &where;
   DeclAvailabilityFlags flags;
 
-  bool checkIdentTypeRepr(IdentTypeRepr *ITR) {
+  bool checkDeclRefTypeRepr(DeclRefTypeRepr *declRefTR) const {
     ArrayRef<AssociatedTypeDecl *> primaryAssociatedTypes;
 
-    if (auto *typeDecl = ITR->getBoundDecl()) {
-      auto range = ITR->getNameLoc().getSourceRange();
+    if (auto *memberTR = dyn_cast<MemberTypeRepr>(declRefTR)) {
+      // If the base is unavailable, don't go on to diagnose
+      // the member since that will just produce a redundant
+      // diagnostic.
+      if (diagnoseTypeReprAvailability(memberTR->getBase(), where, flags)) {
+        return true;
+      }
+    }
+
+    if (auto *typeDecl = declRefTR->getBoundDecl()) {
+      auto range = declRefTR->getNameLoc().getSourceRange();
       if (diagnoseDeclAvailability(typeDecl, range, nullptr, where, flags))
         return true;
 
@@ -3892,7 +3901,7 @@ class TypeReprAvailabilityWalker : public ASTWalker {
 
     bool foundAnyIssues = false;
 
-    if (auto *GTR = dyn_cast<GenericIdentTypeRepr>(ITR)) {
+    if (auto *GTR = dyn_cast<GenericIdentTypeRepr>(declRefTR)) {
       auto genericFlags = flags;
       genericFlags -= DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
 
@@ -3932,27 +3941,8 @@ public:
     if (!declRefTR)
       return Action::Continue();
 
-    auto *rootComp = declRefTR->getRoot();
-    if (auto *identBase = dyn_cast<IdentTypeRepr>(rootComp)) {
-      if (checkIdentTypeRepr(identBase)) {
-        foundAnyIssues = true;
-        return Action::SkipNode();
-      }
-    } else if (diagnoseTypeReprAvailability(rootComp, where, flags)) {
+    if (checkDeclRefTypeRepr(declRefTR)) {
       foundAnyIssues = true;
-      return Action::SkipNode();
-    }
-
-    if (auto *memberTR = dyn_cast<MemberTypeRepr>(T)) {
-      for (auto *comp : memberTR->getMemberComponents()) {
-        // If a parent type is unavailable, don't go on to diagnose
-        // the member since that will just produce a redundant
-        // diagnostic.
-        if (checkIdentTypeRepr(comp)) {
-          foundAnyIssues = true;
-          break;
-        }
-      }
     }
 
     // We've already visited all the children above, so we don't

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1583,11 +1583,7 @@ static bool isModuleQualified(TypeRepr *repr, ModuleDecl *module) {
 
   // FIXME(ModQual): This needs to be updated once we have an explicit
   //                 module qualification syntax.
-  IdentTypeRepr *rootIdent = dyn_cast<IdentTypeRepr>(memberTy->getRoot());
-  if (!rootIdent) {
-    return false;
-  }
-  return rootIdent->getNameRef().isSimpleName(module->getName());
+  return memberTy->getRoot()->isSimpleUnqualifiedIdentifier(module->getName());
 }
 
 /// If the provided type is an AttributedTypeRepr, unwraps it and provides both

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1583,12 +1583,11 @@ static bool isModuleQualified(TypeRepr *repr, ModuleDecl *module) {
 
   // FIXME(ModQual): This needs to be updated once we have an explicit
   //                 module qualification syntax.
-  IdentTypeRepr *baseIdent =
-      dyn_cast<IdentTypeRepr>(memberTy->getBaseComponent());
-  if (!baseIdent) {
+  IdentTypeRepr *rootIdent = dyn_cast<IdentTypeRepr>(memberTy->getRoot());
+  if (!rootIdent) {
     return false;
   }
-  return baseIdent->getNameRef().isSimpleName(module->getName());
+  return rootIdent->getNameRef().isSimpleName(module->getName());
 }
 
 /// If the provided type is an AttributedTypeRepr, unwraps it and provides both

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4643,8 +4643,8 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
                                      TypeResolutionOptions options) {
   Type result;
 
-  auto *baseComp = repr->getBaseComponent();
-  if (auto *identBase = dyn_cast<IdentTypeRepr>(baseComp)) {
+  auto *rootComp = repr->getRoot();
+  if (auto *identBase = dyn_cast<IdentTypeRepr>(rootComp)) {
     // The base component uses unqualified lookup.
     result = resolveUnqualifiedIdentTypeRepr(resolution.withOptions(options),
                                              silContext, identBase);
@@ -4670,7 +4670,7 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
       }
     }
   } else {
-    result = resolveType(baseComp, options);
+    result = resolveType(rootComp, options);
   }
 
   if (result->hasError())
@@ -4678,7 +4678,7 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
 
   // Remaining components are resolved via iterated qualified lookups.
   if (auto *memberTR = dyn_cast<MemberTypeRepr>(repr)) {
-    SourceRange parentRange = baseComp->getSourceRange();
+    SourceRange parentRange = rootComp->getSourceRange();
     for (auto *nestedComp : memberTR->getMemberComponents()) {
       result = resolveQualifiedIdentTypeRepr(resolution.withOptions(options),
                                              silContext, result, parentRange,

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -26,12 +26,11 @@ namespace swift {
 
 class ASTContext;
 class TypeRepr;
-class IdentTypeRepr;
+class MemberTypeRepr;
 class PackElementTypeRepr;
 class GenericEnvironment;
 class GenericSignature;
 class SILTypeResolutionContext;
-class GenericIdentTypeRepr;
 
 /// Flags that describe the context of type checking a pattern or
 /// type.
@@ -625,7 +624,7 @@ public:
   /// name.
   Type resolveDependentMemberType(Type baseTy, DeclContext *DC,
                                   SourceRange baseRange,
-                                  IdentTypeRepr *repr) const;
+                                  MemberTypeRepr *repr) const;
 
   /// Determine whether the given two types are equivalent within this
   /// type resolution context.
@@ -667,12 +666,10 @@ public:
                                     ArrayRef<Type> genericArgs) const;
 };
 
-void diagnoseInvalidGenericArguments(SourceLoc loc,
-                                     ValueDecl *decl,
-                                     unsigned argCount,
-                                     unsigned paramCount,
+void diagnoseInvalidGenericArguments(SourceLoc loc, ValueDecl *decl,
+                                     unsigned argCount, unsigned paramCount,
                                      bool hasParameterPack,
-                                     GenericIdentTypeRepr *generic);
+                                     SourceRange angleBrackets);
 
 /// \param repr the repr for the type of the parameter.
 /// \param ty the non-error resolved type of the repr.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -487,13 +487,13 @@ namespace {
     }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-    if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T)) {
-      if (auto *identRoot = dyn_cast<IdentTypeRepr>(declRefTR->getRoot())) {
-        auto name = identRoot->getNameRef().getBaseIdentifier();
-        if (auto *paramDecl = params->lookUpGenericParam(name))
-          identRoot->setValue(paramDecl, dc);
+      // Only unqualified identifiers can reference generic parameters.
+      if (auto *simpleIdentTR = dyn_cast<SimpleIdentTypeRepr>(T)) {
+        auto name = simpleIdentTR->getNameRef().getBaseIdentifier();
+        if (auto *paramDecl = params->lookUpGenericParam(name)) {
+          simpleIdentTR->setValue(paramDecl, dc);
+        }
       }
-    }
 
       return Action::Continue();
     }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -488,11 +488,10 @@ namespace {
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T)) {
-      if (auto *identBase =
-              dyn_cast<IdentTypeRepr>(declRefTR->getBaseComponent())) {
-        auto name = identBase->getNameRef().getBaseIdentifier();
+      if (auto *identRoot = dyn_cast<IdentTypeRepr>(declRefTR->getRoot())) {
+        auto name = identRoot->getNameRef().getBaseIdentifier();
         if (auto *paramDecl = params->lookUpGenericParam(name))
-          identBase->setValue(paramDecl, dc);
+          identRoot->setValue(paramDecl, dc);
       }
     }
 

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -126,8 +126,7 @@ struct SelfParam {
 
 // CHECK-LABEL: (func_decl range=[{{.+}}] "dumpMemberTypeRepr()"
 // CHECK-NEXT:    (parameter_list range=[{{.+}}])
-// CHECK-NEXT:    (result=type_member
+// CHECK-NEXT:    (result=type_member id="Element" unbound
 // CHECK-NEXT:      (type_ident id="Array" unbound
 // CHECK-NEXT:        (type_ident id="Bool" unbound))
-// CHECK-NEXT:      (type_ident id="Element" unbound))
 func dumpMemberTypeRepr() -> Array<Bool>.Element { true }

--- a/test/decl/protocol/req/assoc_type_inference_cycle.swift
+++ b/test/decl/protocol/req/assoc_type_inference_cycle.swift
@@ -147,3 +147,51 @@ public struct ConformsHasAlias: HasAlias {
   public func f1(_: Self.A, _: Self.B) {}
   public func f2(_: Self.A, _: Int) {}
 }
+
+public protocol P10a {
+  associatedtype R
+}
+public protocol P10b {
+  associatedtype T: P10a where T == T.R
+  var a: T { get }
+  var b: T { get }
+  var c: T { get }
+}
+public struct Conformer10: P10b {
+  public struct A: P10a {
+    public typealias R = A
+  }
+
+  public let a: A
+  public let b: T.R
+  public let c: T.R
+}
+
+public protocol P11 {
+  associatedtype T
+  associatedtype U
+  var a: T { get }
+  var b: T { get }
+  var c: T { get }
+  var d: U { get }
+}
+public struct Conformer11a: P11 {
+  public struct A<T> {
+    public struct B<U> {}
+  }
+
+  public let a: A<Int>.B<Int>
+  public let b: A<Self.U>.B<Int>
+  public let c: A<U>.B<Int>
+  public let d: Int
+}
+public struct Conformer11b: P11 {
+  public struct A<T> {
+    public struct B<U> {}
+  }
+
+  public let a: A<Int>.B<Int>
+  public let b: A<Int>.B<U>
+  public let c: A<Int>.B<Self.U>
+  public let d: Int
+}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -305,11 +305,9 @@ func testAnyFixIt() {
       typealias HasAssocAlias = HasAssoc
     }
     let wrapperMeta: Wrapper.Type
-    // FIXME: Both of these fix-its are wrong.
-    // 1. 'any' is attached to 'HasAssocAlias' instead of 'Wrapper.HasAssocAlias'
-    // 2. What is the correct fix-it for the initializer?
+    // FIXME: What is the correct fix-it for the initializer?
     //
-    // expected-error@+2:20 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{20-33=(any HasAssocAlias)}}
+    // expected-error@+2:20 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{12-33=(any Wrapper.HasAssocAlias)}}
     // expected-error@+1:57 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{57-70=(any HasAssocAlias)}}
     let _: Wrapper.HasAssocAlias.Protocol = wrapperMeta.HasAssocAlias.self
   }
@@ -326,6 +324,16 @@ func testAnyFixIt() {
   let _: any HasAssoc? = nil
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
   let _: any HasAssoc.Type? = nil
+
+  do {
+    struct Outer<T> {
+      struct Inner<U> {}
+    }
+
+    // expected-error@+2:18 {{must be written 'any HasAssoc'}}
+    // expected-error@+1:34 {{must be written 'any HasAssoc'}}
+    let _: Outer<HasAssoc>.Inner<HasAssoc>
+  }
 }
 
 func testNestedMetatype() {

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -337,11 +337,9 @@ func testAnyFixIt() {
       typealias HasAssocAlias = HasAssoc
     }
     let wrapperMeta: Wrapper.Type
-    // FIXME: Both of these fix-its are wrong.
-    // 1. 'any' is attached to 'HasAssocAlias' instead of 'Wrapper.HasAssocAlias'
-    // 2. What is the correct fix-it for the initializer?
+    // FIXME: What is the correct fix-it for the initializer?
     //
-    // expected-error@+2:20 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{20-33=(any HasAssocAlias)}}
+    // expected-error@+2:20 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{12-33=(any Wrapper.HasAssocAlias)}}
     // expected-error@+1:57 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{57-70=(any HasAssocAlias)}}
     let _: Wrapper.HasAssocAlias.Protocol = wrapperMeta.HasAssocAlias.self
   }
@@ -358,6 +356,16 @@ func testAnyFixIt() {
   let _: any HasAssoc? = nil
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
   let _: any HasAssoc.Type? = nil
+
+  do {
+    struct Outer<T> {
+      struct Inner<U> {}
+    }
+
+    // expected-error@+2:18 {{must be written 'any HasAssoc'}}
+    // expected-error@+1:34 {{must be written 'any HasAssoc'}}
+    let _: Outer<HasAssoc>.Inner<HasAssoc>
+  }
 }
 
 func testNestedMetatype() {

--- a/unittests/AST/ASTWalkerTests.cpp
+++ b/unittests/AST/ASTWalkerTests.cpp
@@ -1,0 +1,591 @@
+//===--- ASTWalkerTests.cpp - Tests for ASTWalker -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestContext.h"
+#include "swift/AST/ASTWalker.h"
+#include "swift/AST/TypeRepr.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::unittest;
+
+namespace {
+namespace internal {
+
+enum class WalkCheckpoint { Pre, Post };
+
+struct WalkAction {
+  class Payload {
+    bool isRepr;
+    union {
+      llvm::StringRef name;
+      TypeRepr *repr;
+    };
+
+  public:
+    /*implicit*/ Payload(TypeRepr *repr) : isRepr(true), repr(repr) {
+      assert(repr);
+    }
+
+    /*implicit*/ Payload(llvm::StringRef name) : isRepr(false), name(name) {
+      assert(!name.empty());
+    }
+
+    llvm::StringRef getName() const { return isRepr ? StringRef() : name; }
+
+    TypeRepr *getTypeRepr() const { return isRepr ? repr : nullptr; }
+
+    bool matches(const TypeRepr *otherRepr) const {
+      assert(otherRepr);
+
+      if (isRepr) {
+        if (getTypeRepr() == otherRepr) {
+          return true;
+        }
+      } else if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(otherRepr)) {
+        if (declRefTR->getNameRef().getBaseIdentifier().str() == getName()) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  };
+
+  enum {
+    SkipChildren,
+    SkipChildrenAndPostWalk,
+    StopPreWalk,
+    StopPostWalk,
+  };
+
+private:
+  using _Action = decltype(SkipChildren);
+
+  _Action action;
+  Payload payload;
+
+  WalkAction(_Action action, Payload payload)
+      : action(action), payload(payload) {}
+
+public:
+  static WalkAction SkipChildrenOf(Payload payload) {
+    return {SkipChildren, payload};
+  }
+
+  static WalkAction SkipChildrenAndPostWalkOf(Payload payload) {
+    return {SkipChildrenAndPostWalk, payload};
+  }
+
+  static WalkAction StopPreWalkAt(Payload payload) {
+    return {StopPreWalk, payload};
+  }
+
+  static WalkAction StopPostWalkAt(Payload payload) {
+    return {StopPostWalk, payload};
+  }
+
+  const Payload &getPayload() const { return payload; }
+
+  operator _Action() const { return action; }
+};
+
+/// A walker that invokes a callback on every `walkToTypeReprPre` and
+/// `walkToTypeReprPost` checkpoint.
+class Walker : public ASTWalker {
+  using Callback = std::function<void(TypeRepr *, WalkCheckpoint)>;
+
+  MemberTypeReprWalkingScheme scheme;
+  std::optional<WalkAction> action;
+  Callback callback;
+
+public:
+  Walker(MemberTypeReprWalkingScheme scheme, std::optional<WalkAction> action,
+         Callback callback)
+      : scheme(scheme), action(action), callback(callback) {}
+
+  MemberTypeReprWalkingScheme getMemberTypeReprWalkingScheme() const override {
+    return scheme;
+  }
+
+  PreWalkAction walkToTypeReprPre(TypeRepr *repr) override {
+    this->callback(repr, WalkCheckpoint::Pre);
+
+    if (this->action && this->action.value().getPayload().matches(repr)) {
+      switch (this->action.value()) {
+      case WalkAction::StopPostWalk:
+        return Action::Continue();
+      case WalkAction::SkipChildren:
+        return Action::SkipChildren();
+      case WalkAction::SkipChildrenAndPostWalk:
+        return Action::SkipNode();
+      case WalkAction::StopPreWalk:
+        return Action::Stop();
+      }
+    }
+
+    return Action::Continue();
+  }
+
+  PostWalkAction walkToTypeReprPost(TypeRepr *repr) override {
+    this->callback(repr, WalkCheckpoint::Post);
+
+    if (this->action && this->action.value().getPayload().matches(repr)) {
+      switch (this->action.value()) {
+      case WalkAction::SkipChildren:
+      case WalkAction::SkipChildrenAndPostWalk:
+      case WalkAction::StopPreWalk:
+        return Action::Continue();
+      case WalkAction::StopPostWalk:
+        return Action::Stop();
+      }
+    }
+
+    return Action::Continue();
+  }
+};
+
+} // end namespace internal
+
+class WalkVerifier {
+  /// Represents a substring of the format `( 'pr' | 'po' ) '(' x ')'`,
+  /// where `x` is the argument. For example, `pr(T)`.
+  class Component {
+    internal::WalkCheckpoint checkpoint;
+    size_t argumentStartIndex;
+    size_t endIndex;
+
+    Component(internal::WalkCheckpoint checkpoint, size_t argumentStartIndex,
+              size_t endIndex)
+        : checkpoint(checkpoint), argumentStartIndex(argumentStartIndex),
+          endIndex(endIndex) {}
+
+  public:
+    internal::WalkCheckpoint getCheckpoint() const { return checkpoint; }
+    size_t getArgumentStartIndex() const { return argumentStartIndex; }
+    size_t getEndIndex() const { return endIndex; }
+    size_t getArgumentEndIndex() const { return endIndex - 1; }
+
+    static Component consume(llvm::raw_svector_ostream &os, TypeRepr *repr,
+                             internal::WalkCheckpoint checkpoint) {
+      size_t argumentStartIndex = os.str().size() + 3;
+      print(os, repr, checkpoint);
+      size_t endIndex = os.str().size();
+
+      return Component(checkpoint, argumentStartIndex, endIndex);
+    }
+
+    static void print(llvm::raw_ostream &os, TypeRepr *repr,
+                      internal::WalkCheckpoint checkpoint) {
+      switch (checkpoint) {
+      case internal::WalkCheckpoint::Pre:
+        os << "pr";
+        break;
+      case internal::WalkCheckpoint::Post:
+        os << "po";
+        break;
+      }
+
+      os << "(";
+      printArgument(os, repr);
+      os << ")";
+    }
+
+    static std::string getArgumentString(TypeRepr *repr) {
+      std::string result;
+      llvm::raw_string_ostream os(result);
+      printArgument(os, repr);
+      return result;
+    }
+
+  private:
+    static void printArgument(llvm::raw_ostream &os, TypeRepr *repr) {
+      if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(repr)) {
+        os << declRefTR->getNameRef().getBaseIdentifier();
+      } else {
+        repr->print(os);
+      }
+    }
+  };
+
+  TypeRepr *repr;
+  MemberTypeReprWalkingScheme scheme;
+
+  /// A contiguous series of `Component` substrings.
+  llvm::SmallString<128> walkStr;
+  llvm::SmallVector<Component, 20> components;
+
+public:
+  WalkVerifier(TypeRepr *repr, MemberTypeReprWalkingScheme scheme)
+      : repr(repr), scheme(scheme) {
+    llvm::raw_svector_ostream os(this->walkStr);
+    internal::Walker walker(
+        scheme, std::nullopt,
+        [&](TypeRepr *repr, internal::WalkCheckpoint checkpoint) {
+          this->components.push_back(Component::consume(os, repr, checkpoint));
+        });
+
+    repr->walk(walker);
+  }
+
+  llvm::StringRef getWalkString() const { return walkStr; }
+
+  /// Verify that walking controls such as skipping children or aborting work
+  /// correctly on the given child node.
+  void testWalkActionsOn(TypeRepr *repr) const {
+    for (auto &action : {
+             internal::WalkAction::SkipChildrenOf(repr),
+             internal::WalkAction::SkipChildrenAndPostWalkOf(repr),
+             internal::WalkAction::StopPreWalkAt(repr),
+             internal::WalkAction::StopPostWalkAt(repr),
+         }) {
+      testWalkAction(action);
+    }
+  }
+
+  /// Verify that walking controls such as skipping children or aborting work
+  /// correctly on a child `DeclRefTypeRepr` node with the given name.
+  void testWalkActionsOn(llvm::StringRef name) const {
+    for (auto &action : {
+             internal::WalkAction::SkipChildrenOf(name),
+             internal::WalkAction::SkipChildrenAndPostWalkOf(name),
+             internal::WalkAction::StopPreWalkAt(name),
+             internal::WalkAction::StopPostWalkAt(name),
+         }) {
+      testWalkAction(action);
+    }
+  }
+
+private:
+  void testWalkAction(internal::WalkAction action) const {
+    llvm::SmallString<128> actualStr;
+    {
+      llvm::raw_svector_ostream os(actualStr);
+      internal::Walker walker(
+          scheme, action,
+          [&](TypeRepr *repr, internal::WalkCheckpoint checkpoint) {
+            Component::print(os, repr, checkpoint);
+          });
+
+      this->repr->walk(walker);
+    }
+
+    std::string argumentStr;
+    if (auto *payloadRepr = action.getPayload().getTypeRepr()) {
+      argumentStr = Component::getArgumentString(payloadRepr);
+    } else {
+      argumentStr = action.getPayload().getName().str();
+    }
+
+    switch (action) {
+    case internal::WalkAction::SkipChildren: {
+      auto expectedStr = getStringForSkipChildrenAction(
+          argumentStr, /*includePostComponent=*/true);
+      EXPECT_EQ(actualStr.str(), StringRef(expectedStr));
+      break;
+    }
+    case internal::WalkAction::SkipChildrenAndPostWalk: {
+      auto expectedStr = getStringForSkipChildrenAction(
+          argumentStr, /*includePostComponent=*/false);
+      EXPECT_EQ(actualStr.str(), StringRef(expectedStr));
+      break;
+    }
+    case internal::WalkAction::StopPreWalk: {
+      auto expectedStr =
+          getStringForStopAction(internal::WalkCheckpoint::Pre, argumentStr);
+      EXPECT_EQ(actualStr.str(), expectedStr);
+      break;
+    }
+    case internal::WalkAction::StopPostWalk: {
+      auto expectedStr =
+          getStringForStopAction(internal::WalkCheckpoint::Post, argumentStr);
+      EXPECT_EQ(actualStr.str(), expectedStr);
+      break;
+    }
+    }
+  }
+
+  llvm::StringRef getStringForStopAction(internal::WalkCheckpoint checkpoint,
+                                         llvm::StringRef argumentStr) const {
+    auto index = getComponentIndex(checkpoint, argumentStr);
+    if (index) {
+      return getWalkString().take_front(this->components[*index].getEndIndex());
+    }
+
+    return StringRef();
+  }
+
+  std::string getStringForSkipChildrenAction(llvm::StringRef argumentStr,
+                                             bool includePostComponent) const {
+    std::string str;
+    auto preIndex =
+        getComponentIndex(internal::WalkCheckpoint::Pre, argumentStr);
+    if (!preIndex)
+      return str;
+
+    auto postIndex =
+        getComponentIndex(internal::WalkCheckpoint::Post, argumentStr);
+    if (!postIndex) {
+      return str;
+    }
+
+    if (includePostComponent) {
+      --(*postIndex);
+    }
+
+    str = getWalkString()
+              .take_front(this->components[*preIndex].getEndIndex())
+              .str();
+    str += getWalkString().take_back(
+        getWalkString().size() - this->components[*postIndex].getEndIndex());
+
+    return str;
+  }
+
+  std::optional<unsigned> getComponentIndex(internal::WalkCheckpoint checkpoint,
+                                            llvm::StringRef argumentStr) const {
+    for (auto index : indices(this->components)) {
+      auto &component = this->components[index];
+      if (component.getCheckpoint() == checkpoint) {
+        auto arg = this->walkStr.str().slice(component.getArgumentStartIndex(),
+                                             component.getArgumentEndIndex());
+        if (arg.equals(argumentStr)) {
+          return index;
+        }
+      }
+    }
+
+    return std::nullopt;
+  }
+};
+
+} // end namespace
+
+TEST(ASTWalker, MemberTypeReprWalkingScheme) {
+  TestContext C;
+  auto &ctx = C.Ctx;
+
+  const auto dummyLoc = DeclNameLoc(SourceLoc());
+  const auto makeDeclNameRef = [&ctx](llvm::StringRef str) {
+    return DeclNameRef(ctx.getIdentifier(str));
+  };
+  const auto TypeRepr_getString = [](TypeRepr *repr) {
+    std::string result;
+    llvm::raw_string_ostream os(result);
+    repr->print(os);
+    return result;
+  };
+
+  {
+    auto *repr = MemberTypeRepr::create(
+        ctx, new (ctx) SimpleIdentTypeRepr(dummyLoc, makeDeclNameRef("A")),
+        dummyLoc, makeDeclNameRef("B"));
+
+    EXPECT_EQ(TypeRepr_getString(repr), "A.B");
+
+    const auto verify = [](WalkVerifier &verifier) {
+      verifier.testWalkActionsOn("A");
+      verifier.testWalkActionsOn("B");
+    };
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::ASTOrderRecursive);
+      EXPECT_EQ(verifier.getWalkString(), "pr(B)pr(A)po(A)po(B)");
+      verify(verifier);
+    }
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::SourceOrderRecursive);
+      EXPECT_EQ(verifier.getWalkString(), "pr(A)pr(B)po(B)po(A)");
+      verify(verifier);
+    }
+  }
+
+  {
+    auto *repr = MemberTypeRepr::create(
+        ctx,
+        MemberTypeRepr::create(
+            ctx, new (ctx) SimpleIdentTypeRepr(dummyLoc, makeDeclNameRef("A")),
+            dummyLoc, makeDeclNameRef("B")),
+        dummyLoc, makeDeclNameRef("C"));
+
+    EXPECT_EQ(TypeRepr_getString(repr), "A.B.C");
+
+    const auto verify = [](WalkVerifier &verifier) {
+      verifier.testWalkActionsOn("A");
+      verifier.testWalkActionsOn("B");
+      verifier.testWalkActionsOn("C");
+    };
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::ASTOrderRecursive);
+      EXPECT_EQ(verifier.getWalkString(), "pr(C)pr(B)pr(A)po(A)po(B)po(C)");
+      verify(verifier);
+    }
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::SourceOrderRecursive);
+      EXPECT_EQ(verifier.getWalkString(), "pr(A)pr(B)pr(C)po(C)po(B)po(A)");
+      verify(verifier);
+    }
+  }
+
+  {
+    auto *array = new (ctx) ArrayTypeRepr(
+        new (ctx) SimpleIdentTypeRepr(dummyLoc, makeDeclNameRef("A")),
+        SourceRange());
+
+    auto *repr = MemberTypeRepr::create(
+        ctx, MemberTypeRepr::create(ctx, array, dummyLoc, makeDeclNameRef("B")),
+        dummyLoc, makeDeclNameRef("C"));
+
+    EXPECT_EQ(TypeRepr_getString(repr), "[A].B.C");
+
+    const auto verify = [array](WalkVerifier &verifier) {
+      verifier.testWalkActionsOn(array);
+      verifier.testWalkActionsOn("A");
+      verifier.testWalkActionsOn("B");
+      verifier.testWalkActionsOn("C");
+    };
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::ASTOrderRecursive);
+      EXPECT_EQ(verifier.getWalkString(),
+                "pr(C)pr(B)pr([A])pr(A)po(A)po([A])po(B)po(C)");
+      verify(verifier);
+    }
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::SourceOrderRecursive);
+      EXPECT_EQ(verifier.getWalkString(),
+                "pr([A])pr(A)po(A)pr(B)pr(C)po(C)po(B)po([A])");
+      verify(verifier);
+    }
+  }
+
+  {
+    auto *repr = MemberTypeRepr::create(
+        ctx,
+        MemberTypeRepr::create(
+            ctx,
+            GenericIdentTypeRepr::create(
+                ctx, dummyLoc, makeDeclNameRef("A"),
+                {new (ctx) SimpleIdentTypeRepr(dummyLoc, makeDeclNameRef("W"))},
+                SourceRange()),
+            dummyLoc, makeDeclNameRef("B"),
+            {new (ctx) SimpleIdentTypeRepr(dummyLoc, makeDeclNameRef("X")),
+             new (ctx) SimpleIdentTypeRepr(dummyLoc, makeDeclNameRef("Y"))},
+            SourceRange()),
+        dummyLoc, makeDeclNameRef("C"),
+        {new (ctx) SimpleIdentTypeRepr(dummyLoc, makeDeclNameRef("Z"))},
+        SourceRange());
+
+    EXPECT_EQ(TypeRepr_getString(repr), "A<W>.B<X, Y>.C<Z>");
+
+    const auto verify = [](WalkVerifier &verifier) {
+      verifier.testWalkActionsOn("A");
+      verifier.testWalkActionsOn("W");
+      verifier.testWalkActionsOn("B");
+      verifier.testWalkActionsOn("X");
+      verifier.testWalkActionsOn("Y");
+      verifier.testWalkActionsOn("C");
+      verifier.testWalkActionsOn("Z");
+    };
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::ASTOrderRecursive);
+      // clang-format off
+      EXPECT_EQ(verifier.getWalkString(),
+                "pr(C)pr(B)pr(A)pr(W)po(W)po(A)pr(X)po(X)pr(Y)po(Y)po(B)pr(Z)po(Z)po(C)");
+      verify(verifier);
+      // clang-format on
+    }
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::SourceOrderRecursive);
+      // clang-format off
+      EXPECT_EQ(verifier.getWalkString(),
+                "pr(A)pr(W)po(W)pr(B)pr(X)po(X)pr(Y)po(Y)pr(C)pr(Z)po(Z)po(C)po(B)po(A)");
+      // clang-format on
+      verify(verifier);
+    }
+  }
+
+  {
+    auto *array = new (ctx) ArrayTypeRepr(
+        MemberTypeRepr::create(
+            ctx, new (ctx) SimpleIdentTypeRepr(dummyLoc, makeDeclNameRef("Y")),
+            dummyLoc, makeDeclNameRef("Z")),
+        SourceRange());
+
+    auto *repr = MemberTypeRepr::create(
+        ctx,
+        MemberTypeRepr::create(
+            ctx,
+            GenericIdentTypeRepr::create(
+                ctx, dummyLoc, makeDeclNameRef("A"),
+                {MemberTypeRepr::create(
+                     ctx,
+                     MemberTypeRepr::create(ctx,
+                                            new (ctx) SimpleIdentTypeRepr(
+                                                dummyLoc, makeDeclNameRef("V")),
+                                            dummyLoc, makeDeclNameRef("W")),
+                     dummyLoc, makeDeclNameRef("X")),
+                 array},
+                SourceRange()),
+            dummyLoc, makeDeclNameRef("B")),
+        dummyLoc, makeDeclNameRef("C"));
+
+    EXPECT_EQ(TypeRepr_getString(repr), "A<V.W.X, [Y.Z]>.B.C");
+
+    const auto verify = [array](WalkVerifier &verifier) {
+      verifier.testWalkActionsOn("A");
+      verifier.testWalkActionsOn("V");
+      verifier.testWalkActionsOn("W");
+      verifier.testWalkActionsOn("X");
+      verifier.testWalkActionsOn(array);
+      verifier.testWalkActionsOn("Y");
+      verifier.testWalkActionsOn("Z");
+      verifier.testWalkActionsOn("B");
+      verifier.testWalkActionsOn("C");
+    };
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::ASTOrderRecursive);
+      // clang-format off
+      EXPECT_EQ(verifier.getWalkString(),
+                "pr(C)pr(B)pr(A)pr(X)pr(W)pr(V)po(V)po(W)po(X)pr([Y.Z])pr(Z)pr(Y)po(Y)po(Z)po([Y.Z])po(A)po(B)po(C)");
+      verify(verifier);
+      // clang-format on
+    }
+
+    {
+      WalkVerifier verifier(repr,
+                            MemberTypeReprWalkingScheme::SourceOrderRecursive);
+      // clang-format off
+      EXPECT_EQ(verifier.getWalkString(),
+                "pr(A)pr(V)pr(W)pr(X)po(X)po(W)po(V)pr([Y.Z])pr(Y)pr(Z)po(Z)po(Y)po([Y.Z])pr(B)pr(C)po(C)po(B)po(A)");
+      // clang-format on
+      verify(verifier);
+    }
+  }
+}

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_unittest(SwiftASTTests
   ArithmeticEvaluator.cpp
   ASTDumperTests.cpp
+  ASTWalkerTests.cpp
   IndexSubsetTests.cpp
   DiagnosticConsumerTests.cpp
   SourceLocTests.cpp


### PR DESCRIPTION
A public interface that forces clients to interpret and traverse `MemberTypeRepr` nodes recursively such that every qualified type identifier is a `MemberTypeRepr` pointing to its qualifier:
* Is a more natural and bug-proof solution because each subsequent dot-separated identifier is not self-standing as in a tuple element. In the previous model, all type identifiers are standalone `IdentTypeRepr` nodes, and the only way to tell whether one is qualified is to look at the parent node, which is normally not a straightforward task with our AST. Knowledge of whether a type identifier is qualified is important in many of our analyses, but the absence of a general typed or other visible distinction between qualified and unqualified type identifiers is not helpful in guiding contributors to this realization.
* Grants more out-of-the-box flexibility to `ASTWalker` clients. `IdentTypeRepr` nodes are now unqualified by definition, and since each next dot-separated components is now itself a `MemberTypeRepr` and a parent of the previous one (vs. all components being direct descendants of a single `MemberTypeRepr`), children may be skipped halfway through a `MemberTypeRepr`.
* Will simplify modeling `.Type` and `.Protocol` types as `MemberTypeRepr`.