### PR TITLE
[SerializedDiagnosticConsumer] Pass StringRef instead of raw data for…

### DIFF
--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -319,7 +319,7 @@ unsigned SerializedDiagnosticConsumer::getEmitCategory(StringRef Category) {
   Record.push_back(entry);
   Record.push_back(Category.size());
   State->Stream.EmitRecordWithBlob(State->Abbrevs.get(RECORD_CATEGORY), Record,
-                                   Category.data());
+                                   Category);
 
   return entry;
 }
@@ -348,7 +348,7 @@ SerializedDiagnosticConsumer::emitEducationalNotes(const DiagnosticInfo &Info) {
   Record.push_back(recordID);
   Record.push_back(paths.size());
   State->Stream.EmitRecordWithBlob(State->Abbrevs.get(RECORD_DIAG_FLAG), Record,
-                                   paths.data());
+                                   paths);
   return recordID;
 }
 


### PR DESCRIPTION
… categories and educational notes

`EmitRecordWithBlob` accepts a `StringRef` and that a safer choice to correctly represent the size.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
