### PR TITLE
[SE-0392] Back-deploy assertIsolation/assumeIsolation

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -503,11 +503,6 @@ FuncDecl *SILGenModule::getAsyncMainDrainQueue() {
                                     "_asyncMainDrainQueue");
 }
 
-FuncDecl *SILGenModule::getGetMainExecutor() {
-  return lookupConcurrencyIntrinsic(getASTContext(), GetMainExecutor,
-                                    "_getMainExecutor");
-}
-
 FuncDecl *SILGenModule::getSwiftJobRun() {
   return lookupConcurrencyIntrinsic(getASTContext(), SwiftJobRun,
                                     "_swiftJobRun");

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -583,8 +583,6 @@ public:
 
   /// Retrieve the _Concurrency._asyncMainDrainQueue intrinsic.
   FuncDecl *getAsyncMainDrainQueue();
-  /// Retrieve the _Concurrency._getMainExecutor intrinsic.
-  FuncDecl *getGetMainExecutor();
   /// Retrieve the _Concurrency._swiftJobRun intrinsic.
   FuncDecl *getSwiftJobRun();
   // Retrieve the _SwiftConcurrencyShims.exit intrinsic.

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -18,7 +18,7 @@ import SwiftShims
 // ==== -----------------------------------------------------------------------
 // MARK: Precondition executors
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension SerialExecutor {
   /// Unconditionally if the current task is executing on the expected serial executor,
   /// and if not crash the program offering information about the executor mismatch.
@@ -35,7 +35,10 @@ extension SerialExecutor {
   /// * In `-Ounchecked` builds, the optimizer may assume that this function is
   ///   never called. Failure to satisfy that assumption is a serious
   ///   programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
+  @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   @_unavailableInEmbedded
   public func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -55,7 +58,7 @@ extension SerialExecutor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension Actor {
   /// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
   /// and if not crash the program offering information about the executor mismatch.
@@ -72,7 +75,10 @@ extension Actor {
   /// * In `-Ounchecked` builds, the optimizer may assume that this function is
   ///   never called. Failure to satisfy that assumption is a serious
   ///   programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
+  @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   @_unavailableInEmbedded
   public nonisolated func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -92,7 +98,7 @@ extension Actor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension GlobalActor {
   /// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
   /// and if not crash the program offering information about the executor mismatch.
@@ -109,7 +115,10 @@ extension GlobalActor {
   /// * In `-Ounchecked` builds, the optimizer may assume that this function is
   ///   never called. Failure to satisfy that assumption is a serious
   ///   programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
+  @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   @_unavailableInEmbedded
   public static func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -122,7 +131,7 @@ extension GlobalActor {
 // ==== -----------------------------------------------------------------------
 // MARK: Assert executors
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension SerialExecutor {
   /// Performs an executor check in debug builds.
   ///
@@ -136,7 +145,10 @@ extension SerialExecutor {
   /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
   ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
   ///   assumption is a serious programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
+  @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   @_unavailableInEmbedded
   public func assertIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -156,7 +168,7 @@ extension SerialExecutor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension Actor {
   /// Performs an executor check in debug builds.
   ///
@@ -170,7 +182,10 @@ extension Actor {
   /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
   ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
   ///   assumption is a serious programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
+  @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   @_unavailableInEmbedded
   public nonisolated func assertIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -191,7 +206,7 @@ extension Actor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension GlobalActor {
   /// Performs an executor check in debug builds.
   ///
@@ -205,7 +220,10 @@ extension GlobalActor {
   /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
   ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
   ///   assumption is a serious programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
+  @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   @_unavailableInEmbedded
   public static func assertIsolated(
       _ message: @autoclosure () -> String = String(),
@@ -218,7 +236,7 @@ extension GlobalActor {
 // ==== -----------------------------------------------------------------------
 // MARK: Assume Executor
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension Actor {
   /// A safe way to synchronously assume that the current execution context belongs to the passed in actor.
   ///
@@ -233,7 +251,10 @@ extension Actor {
   /// if another actor uses the same serial executor--by using that actor's ``Actor/unownedExecutor``
   /// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
   /// perspective, the serial executor guarantees mutual exclusion of those two actors.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  #if !$Embedded
+  @backDeployed(before: SwiftStdlib 5.9)
+  #endif
   @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
   @_unavailableInEmbedded
   public nonisolated func assumeIsolated<T>(

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -99,7 +99,7 @@ extension MainActor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension MainActor {
   /// A safe way to synchronously assume that the current execution context belongs to the MainActor.
   ///
@@ -114,7 +114,8 @@ extension MainActor {
   /// if another actor uses the same serial executor--by using ``MainActor/sharedUnownedExecutor``
   /// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
   /// perspective, the serial executor guarantees mutual exclusion of those two actors.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   @_unavailableFromAsync(message: "await the call to the @MainActor closure directly")
   public static func assumeIsolated<T>(
       _ operation: @MainActor () throws -> T,

--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -100,7 +100,7 @@ final class MainActorEcho {
 
     let echo = MainActorEcho()
 
-    if #available(SwiftStdlib 5.9, *) {
+    if #available(SwiftStdlib 5.1, *) {
       // === MainActor --------------------------------------------------------
 
       tests.test("MainActor.assumeIsolated: assume the main executor, from 'main() async'") {

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -80,12 +80,10 @@ func asyncFunc() async {
 // CHECK-SIL-NEXT:  %12 = function_ref @swift_job_run : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
 // CHECK-SIL-NEXT:  %13 = builtin "convertTaskToJob"(%11 : $Builtin.NativeObject) : $Builtin.Job
 // CHECK-SIL-NEXT:  %14 = struct $UnownedJob (%13 : $Builtin.Job)
-// CHECK-SIL-NEXT:  // function_ref swift_task_getMainExecutor
-// CHECK-SIL-NEXT:  %15 = function_ref @swift_task_getMainExecutor : $@convention(thin) () -> Builtin.Executor
-// CHECK-SIL-NEXT:  %16 = apply %15() : $@convention(thin) () -> Builtin.Executor
-// CHECK-SIL-NEXT:  %17 = struct $UnownedSerialExecutor (%16 : $Builtin.Executor)
-// CHECK-SIL-NEXT:  %18 = apply %12(%14, %17) : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
+// CHECK-SIL-NEXT:  %15 = builtin "buildMainActorExecutorRef"() : $Builtin.Executor
+// CHECK-SIL-NEXT:  %16 = struct $UnownedSerialExecutor (%15 : $Builtin.Executor)
+// CHECK-SIL-NEXT:  %17 = apply %12(%14, %16) : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
 // CHECK-SIL-NEXT:  // function_ref swift_task_asyncMainDrainQueue
-// CHECK-SIL-NEXT:  %19 = function_ref @swift_task_asyncMainDrainQueue : $@convention(thin) () -> Never
-// CHECK-SIL-NEXT:  %20 = apply %19() : $@convention(thin) () -> Never
+// CHECK-SIL-NEXT:  %18 = function_ref @swift_task_asyncMainDrainQueue : $@convention(thin) () -> Never
+// CHECK-SIL-NEXT:  %19 = apply %18() : $@convention(thin) () -> Never
 // CHECK-SIL-NEXT:  unreachable

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -5,9 +5,7 @@
 
 // CHECK-LABEL: sil private [ossa] @async_Main
 // CHECK: bb0:
-// CHECK-NEXT: // function_ref
-// CHECK-NEXT: [[GET_MAIN:%.*]] = function_ref @swift_task_getMainExecutor
-// CHECK-NEXT: [[MAIN:%.*]] = apply [[GET_MAIN]]()
+// CHECK-NEXT: [[MAIN:%.*]] = builtin "buildMainActorExecutorRef"() : $Builtin.Executor
 // CHECK-NEXT: [[MAIN_OPTIONAL:%[0-9]+]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[MAIN]]
 
 actor MyActorImpl {}


### PR DESCRIPTION
The `assertIsolation`/`assumeIsolation` operations on actors are back-deployable back to the introduction of concurrency. However, doing so revealed that SILGen and IRGen could disagree on the return type of `swift_task_getMainExecutor()`, so fix that too.
    
Resolves rdar://111880539, rdar://116472583, and #66473.