### PR TITLE
Use aligned_alloc when the platform we use supports it

### DIFF
--- a/include/swift/Basic/Malloc.h
+++ b/include/swift/Basic/Malloc.h
@@ -27,17 +27,19 @@
 
 namespace swift {
 
-// FIXME: Use C11 aligned_alloc if available.
 inline void *AlignedAlloc(size_t size, size_t align) {
-  // posix_memalign only accepts alignments greater than sizeof(void*).
-  // 
-  if (align < sizeof(void*))
-    align = sizeof(void*);
-  
 #if defined(_WIN32)
   void *r = _aligned_malloc(size, align);
   assert(r && "_aligned_malloc failed");
+#elif __STDC_VERSION__-0 >= 201112l
+  // C11 supports aligned_alloc
+  void *r = aligned_alloc(align, size);
+  assert(r && "aligned_alloc failed");
 #else
+  // posix_memalign only accepts alignments greater than sizeof(void*).
+  if (align < sizeof(void *))
+    align = sizeof(void *);
+
   void *r = nullptr;
   int res = posix_memalign(&r, align, size);
   assert(res == 0 && "posix_memalign failed");


### PR DESCRIPTION
aligned_alloc is the preferred way to do AlignedAlloc when we can support that, with the other code being a fallback if that is not the case.