### PR TITLE
[5.10][SE-0392] Back-deploy assertIsolation/assumeIsolation

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -503,11 +503,6 @@ FuncDecl *SILGenModule::getAsyncMainDrainQueue() {
                                     "_asyncMainDrainQueue");
 }
 
-FuncDecl *SILGenModule::getGetMainExecutor() {
-  return lookupConcurrencyIntrinsic(getASTContext(), GetMainExecutor,
-                                    "_getMainExecutor");
-}
-
 FuncDecl *SILGenModule::getSwiftJobRun() {
   return lookupConcurrencyIntrinsic(getASTContext(), SwiftJobRun,
                                     "_swiftJobRun");

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -570,8 +570,6 @@ public:
 
   /// Retrieve the _Concurrency._asyncMainDrainQueue intrinsic.
   FuncDecl *getAsyncMainDrainQueue();
-  /// Retrieve the _Concurrency._getMainExecutor intrinsic.
-  FuncDecl *getGetMainExecutor();
   /// Retrieve the _Concurrency._swiftJobRun intrinsic.
   FuncDecl *getSwiftJobRun();
   // Retrieve the _SwiftConcurrencyShims.exit intrinsic.

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1448,36 +1448,12 @@ void SILGenFunction::emitProlog(
 }
 
 SILValue SILGenFunction::emitMainExecutor(SILLocation loc) {
-  // Get main executor
-  FuncDecl *getMainExecutorFuncDecl = SGM.getGetMainExecutor();
-  if (!getMainExecutorFuncDecl) {
-    // If it doesn't exist due to an SDK-compiler mismatch, we can conjure one
-    // up instead of crashing:
-    // @available(SwiftStdlib 5.1, *)
-    // @_silgen_name("swift_task_getMainExecutor")
-    // internal func _getMainExecutor() -> Builtin.Executor
-    auto &ctx = getASTContext();
+  auto &ctx = getASTContext();
+  auto builtinName = ctx.getIdentifier(
+      getBuiltinName(BuiltinValueKind::BuildMainActorExecutorRef));
+  auto resultType = SILType::getPrimitiveObjectType(ctx.TheExecutorType);
 
-    ParameterList *emptyParams = ParameterList::createEmpty(ctx);
-    getMainExecutorFuncDecl = FuncDecl::createImplicit(
-        ctx, StaticSpellingKind::None,
-        DeclName(
-            ctx,
-            DeclBaseName(ctx.getIdentifier("_getMainExecutor")),
-            /*Arguments*/ emptyParams),
-        {}, /*async*/ false, /*throws*/ false, {}, emptyParams,
-        ctx.TheExecutorType,
-        getModule().getSwiftModule());
-    getMainExecutorFuncDecl->getAttrs().add(
-        new (ctx) SILGenNameAttr("swift_task_getMainExecutor", /*raw*/ false,
-                                 /*implicit*/ true));
-  }
-
-  auto fn = SGM.getFunction(
-      SILDeclRef(getMainExecutorFuncDecl, SILDeclRef::Kind::Func),
-      NotForDefinition);
-  SILValue fnRef = B.createFunctionRefFor(loc, fn);
-  return B.createApply(loc, fnRef, {}, {});
+  return B.createBuiltin(loc, builtinName, resultType, {}, {});
 }
 
 SILValue SILGenFunction::emitGenericExecutor(SILLocation loc) {

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -18,7 +18,7 @@ import SwiftShims
 // ==== -----------------------------------------------------------------------
 // MARK: Precondition executors
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension SerialExecutor {
   /// Unconditionally if the current task is executing on the expected serial executor,
   /// and if not crash the program offering information about the executor mismatch.
@@ -35,7 +35,8 @@ extension SerialExecutor {
   /// * In `-Ounchecked` builds, the optimizer may assume that this function is
   ///   never called. Failure to satisfy that assumption is a serious
   ///   programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   public func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
@@ -54,7 +55,7 @@ extension SerialExecutor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension Actor {
   /// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
   /// and if not crash the program offering information about the executor mismatch.
@@ -71,7 +72,8 @@ extension Actor {
   /// * In `-Ounchecked` builds, the optimizer may assume that this function is
   ///   never called. Failure to satisfy that assumption is a serious
   ///   programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   public nonisolated func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
@@ -90,7 +92,7 @@ extension Actor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension GlobalActor {
   /// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
   /// and if not crash the program offering information about the executor mismatch.
@@ -107,7 +109,8 @@ extension GlobalActor {
   /// * In `-Ounchecked` builds, the optimizer may assume that this function is
   ///   never called. Failure to satisfy that assumption is a serious
   ///   programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   public static func preconditionIsolated(
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
@@ -119,7 +122,7 @@ extension GlobalActor {
 // ==== -----------------------------------------------------------------------
 // MARK: Assert executors
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension SerialExecutor {
   /// Performs an executor check in debug builds.
   ///
@@ -133,7 +136,8 @@ extension SerialExecutor {
   /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
   ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
   ///   assumption is a serious programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   public func assertIsolated(
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
@@ -152,7 +156,7 @@ extension SerialExecutor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension Actor {
   /// Performs an executor check in debug builds.
   ///
@@ -166,7 +170,8 @@ extension Actor {
   /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
   ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
   ///   assumption is a serious programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   public nonisolated func assertIsolated(
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
@@ -186,7 +191,7 @@ extension Actor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension GlobalActor {
   /// Performs an executor check in debug builds.
   ///
@@ -200,7 +205,8 @@ extension GlobalActor {
   /// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
   ///   may assume that it *always* evaluates to `true`. Failure to satisfy that
   ///   assumption is a serious programming error.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   public static func assertIsolated(
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
@@ -212,7 +218,7 @@ extension GlobalActor {
 // ==== -----------------------------------------------------------------------
 // MARK: Assume Executor
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension Actor {
   /// A safe way to synchronously assume that the current execution context belongs to the passed in actor.
   ///
@@ -227,7 +233,8 @@ extension Actor {
   /// if another actor uses the same serial executor--by using that actor's ``Actor/unownedExecutor``
   /// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
   /// perspective, the serial executor guarantees mutual exclusion of those two actors.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
   public nonisolated func assumeIsolated<T>(
       _ operation: (isolated Self) throws -> T,

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -99,7 +99,7 @@ extension MainActor {
   }
 }
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.1, *)
 extension MainActor {
   /// A safe way to synchronously assume that the current execution context belongs to the MainActor.
   ///
@@ -114,7 +114,8 @@ extension MainActor {
   /// if another actor uses the same serial executor--by using ``MainActor/sharedUnownedExecutor``
   /// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
   /// perspective, the serial executor guarantees mutual exclusion of those two actors.
-  @available(SwiftStdlib 5.9, *)
+  @available(SwiftStdlib 5.1, *)
+  @backDeployed(before: SwiftStdlib 5.9)
   @_unavailableFromAsync(message: "await the call to the @MainActor closure directly")
   public static func assumeIsolated<T>(
       _ operation: @MainActor () throws -> T,

--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -100,7 +100,7 @@ final class MainActorEcho {
 
     let echo = MainActorEcho()
 
-    if #available(SwiftStdlib 5.9, *) {
+    if #available(SwiftStdlib 5.1, *) {
       // === MainActor --------------------------------------------------------
 
       tests.test("MainActor.assumeIsolated: assume the main executor, from 'main() async'") {

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -79,12 +79,10 @@ func asyncFunc() async {
 // CHECK-SIL-NEXT:  %12 = function_ref @swift_job_run : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
 // CHECK-SIL-NEXT:  %13 = builtin "convertTaskToJob"(%11 : $Builtin.NativeObject) : $Builtin.Job
 // CHECK-SIL-NEXT:  %14 = struct $UnownedJob (%13 : $Builtin.Job)
-// CHECK-SIL-NEXT:  // function_ref swift_task_getMainExecutor
-// CHECK-SIL-NEXT:  %15 = function_ref @swift_task_getMainExecutor : $@convention(thin) () -> Builtin.Executor
-// CHECK-SIL-NEXT:  %16 = apply %15() : $@convention(thin) () -> Builtin.Executor
-// CHECK-SIL-NEXT:  %17 = struct $UnownedSerialExecutor (%16 : $Builtin.Executor)
-// CHECK-SIL-NEXT:  %18 = apply %12(%14, %17) : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
+// CHECK-SIL-NEXT:  %15 = builtin "buildMainActorExecutorRef"() : $Builtin.Executor
+// CHECK-SIL-NEXT:  %16 = struct $UnownedSerialExecutor (%15 : $Builtin.Executor)
+// CHECK-SIL-NEXT:  %17 = apply %12(%14, %16) : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
 // CHECK-SIL-NEXT:  // function_ref swift_task_asyncMainDrainQueue
-// CHECK-SIL-NEXT:  %19 = function_ref @swift_task_asyncMainDrainQueue : $@convention(thin) () -> Never
-// CHECK-SIL-NEXT:  %20 = apply %19() : $@convention(thin) () -> Never
+// CHECK-SIL-NEXT:  %18 = function_ref @swift_task_asyncMainDrainQueue : $@convention(thin) () -> Never
+// CHECK-SIL-NEXT:  %19 = apply %18() : $@convention(thin) () -> Never
 // CHECK-SIL-NEXT:  unreachable

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -5,9 +5,7 @@
 
 // CHECK-LABEL: sil private [ossa] @async_Main
 // CHECK: bb0:
-// CHECK-NEXT: // function_ref
-// CHECK-NEXT: [[GET_MAIN:%.*]] = function_ref @swift_task_getMainExecutor
-// CHECK-NEXT: [[MAIN:%.*]] = apply [[GET_MAIN]]()
+// CHECK-NEXT: [[MAIN:%.*]] = builtin "buildMainActorExecutorRef"() : $Builtin.Executor
 // CHECK-NEXT: [[MAIN_OPTIONAL:%[0-9]+]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[MAIN]]
 
 actor MyActorImpl {}


### PR DESCRIPTION
- **Explanation:** The `assertIsolation`/`assumeIsolation` operations on actors are back-deployable back to the introduction of concurrency. However, doing so revealed that SILGen and IRGen could disagree on the return type of `swift_task_getMainExecutor()`, so fix that too to unblock adoption of the `@backDeployed` attribute.
- **Radars/Issues:** rdar://111880539, rdar://116472583, and #66473
- **Scope:** This PR makes several concurrency convenience functions available to programs with earlier deployment targets. Projects that adopt these conveniences and compile with deployment targets lower than a Swift 5.9 aligned OS may execute copies of the conveniences that have been emitted into the client, instead of the copies in the standard library. Additionally, this PR changes how the main executor is referenced during code generation, specifically in the `main()` function.
- **Risk:** Low. The implementations of the `assertIsolation` and `assumeIsolation` APIs are not changing; only their back deployment eligibility has changed. The new codegen that uses a builtin to reference the main actor executor should be functionally equivalent to the previous codegen. The builtin was already used during IRGen previously and this change simply makes its use more consistent.
- **Testing:** Existing tests in the compiler test suite already exercise the changes in this PR and continue to pass.
- **Reviewed By:** @ktoso 
- **`main` PR:** https://github.com/apple/swift/pull/70472
