### PR TITLE
Move-only check the value projected from addressors.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3716,19 +3716,6 @@ private:
     Args.push_back(ManagedValue());
   }
 
-  void emitExpandedConsumed(Expr *arg, AbstractionPattern origParamType) {
-    CanType substArgType = arg->getType()->getCanonicalType();
-    auto count = getFlattenedValueCount(origParamType);
-    auto claimedParams = claimNextParameters(count);
-
-    SILType loweredSubstArgType = SGF.getLoweredType(substArgType);
-    SILType loweredSubstParamType =
-        SGF.getLoweredType(origParamType, substArgType);
-
-    return emitConsumed(arg, loweredSubstArgType, loweredSubstParamType,
-                        origParamType, claimedParams);
-  }
-
   void
   emitDirect(ArgumentSource &&arg, SILType loweredSubstArgType,
              AbstractionPattern origParamType, SILParameterInfo param,

--- a/test/SILOptimizer/moveonly_addressors.swift
+++ b/test/SILOptimizer/moveonly_addressors.swift
@@ -1,0 +1,123 @@
+// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DADDRESS_ONLY -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DLOADABLE -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DTRIVIAL -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DEMPTY -emit-sil -verify %s
+
+// TODO: Use the real stdlib types once `UnsafePointer` supports noncopyable
+// types.
+
+import Builtin
+
+@_marker public protocol Copyable: ~Escapable {}
+@_marker public protocol Escapable: ~Copyable {}
+@frozen public struct UnsafePointer<T: ~Copyable>: Copyable {
+   var value: Builtin.RawPointer
+}
+
+@frozen public struct UnsafeMutablePointer<T: ~Copyable>: Copyable {
+    var value: Builtin.RawPointer
+}
+
+@frozen public struct Int { var value: Builtin.Word }
+
+@_silgen_name("makeUpAPointer")
+func makeUpAPointer<T: ~Copyable>() -> UnsafePointer<T>
+@_silgen_name("makeUpAMutablePointer")
+func makeUpAPointer<T: ~Copyable>() -> UnsafeMutablePointer<T>
+@_silgen_name("makeUpAnInt")
+func makeUpAnInt() -> Int
+
+class X {}
+
+struct NC: ~Copyable {
+#if EMPTY
+#elseif TRIVIAL
+  var x: Int = makeUpAnInt()
+#elseif LOADABLE
+  var x: X = X()
+#elseif ADDRESS_ONLY
+  var x: Any = X()
+#else
+#error("pick a mode")
+#endif
+  deinit {}
+}
+
+struct S {
+  var data: NC {
+    unsafeAddress { return makeUpAPointer() }
+  }
+
+  var mutableData: NC {
+    unsafeAddress { return makeUpAPointer() }
+    unsafeMutableAddress { return makeUpAPointer() }
+  }
+}
+
+struct SNC: ~Copyable {
+  var data: NC {
+    unsafeAddress { return makeUpAPointer() }
+  }
+
+  var mutableData: NC {
+    unsafeAddress { return makeUpAPointer() }
+    unsafeMutableAddress { return makeUpAPointer() }
+  }
+}
+
+class C {
+  final var data: NC {
+    unsafeAddress { return makeUpAPointer() }
+  }
+
+  final var mutableData: NC {
+    unsafeAddress { return makeUpAPointer() }
+    unsafeMutableAddress { return makeUpAPointer() }
+  }
+}
+
+func borrow(_ nc: borrowing NC) {}
+func mod(_ nc: inout NC) {}
+func take(_ nc: consuming NC) {}
+
+// TODO: Resolve thing being consumed more precisely than 'unknown'.
+// TODO: Use more specific diagnostic than "reinitialization of inout parameter"
+
+func test(c: C) {
+  borrow(c.data)
+  take(c.data) // expected-error{{'unknown' is borrowed and cannot be consumed}} expected-note{{consumed here}}
+
+  borrow(c.mutableData)
+  mod(&c.mutableData)
+  take(c.mutableData) // expected-error{{missing reinitialization of inout parameter 'unknown' after consume}} expected-note{{consumed here}}
+}
+func test(s: S) {
+  borrow(s.data)
+  take(s.data) // expected-error{{'unknown' is borrowed and cannot be consumed}} expected-note{{consumed here}}
+
+  borrow(s.mutableData)
+  take(s.mutableData) // expected-error{{'unknown' is borrowed and cannot be consumed}} expected-note{{consumed here}}
+}
+func test(mut_s s: inout S) {
+  borrow(s.data)
+  take(s.data) // expected-error{{'unknown' is borrowed and cannot be consumed}} expected-note{{consumed here}}
+
+  borrow(s.mutableData)
+  mod(&s.mutableData)
+  take(s.mutableData) // expected-error{{missing reinitialization of inout parameter 'unknown' after consume}} expected-note{{consumed here}}
+}
+func test(snc: borrowing SNC) {
+  borrow(snc.data)
+  take(snc.data) // expected-error{{'unknown' is borrowed and cannot be consumed}} expected-note{{consumed here}}
+
+  borrow(snc.mutableData)
+  take(snc.mutableData) // expected-error{{'unknown' is borrowed and cannot be consumed}} expected-note{{consumed here}}
+}
+func test(mut_snc snc: inout SNC) {
+  borrow(snc.data)
+  take(snc.data) // expected-error{{'unknown' is borrowed and cannot be consumed}} expected-note{{consumed here}}
+
+  borrow(snc.mutableData)
+  mod(&snc.mutableData)
+  take(snc.mutableData) // expected-error{{missing reinitialization of inout parameter 'unknown' after consume}} expected-note{{consumed here}}
+}


### PR DESCRIPTION
Mark the result of a move-only addressor as unresolved. The pointed-at value cannot be consumed so ensure that only [read] or [modify] accesses are performed. Update the move-only checker to recognize code patterns from addressors.