### PR TITLE
[SIL] Bridge findPointerEscape() and fix OnoneSimplifyable

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginBorrow.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginBorrow.swift
@@ -18,7 +18,7 @@ extension BeginBorrowInst : OnoneSimplifyable {
        // We need to keep lexical lifetimes in place.
        !isLexical,
        // The same for borrow-scopes which encapsulated pointer escapes.
-       !hasPointerEscape
+       !findPointerEscapingUse(of: borrowedValue)
     {
       tryReplaceBorrowWithOwnedOperand(beginBorrow: self, context)
     }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
@@ -12,6 +12,20 @@
 
 import SIL
 
+/// Return true if any use in `value`s forward-extend lifetime has
+/// .pointerEscape operand ownership.
+///
+/// TODO: the C++ implementation does not yet gather all
+/// forward-extended lifetime introducers.
+///
+/// TODO: Add [pointer_escape] flags to MoveValue, BeginBorrow, and
+/// Allocation. Then add a `Value.hasPointerEscapingUse` property that
+/// performs the use-def walk to pickup the flags. Then only call into
+/// this def-use walk to initially set the flags.
+func findPointerEscapingUse(of value: Value) -> Bool {
+  value.bridged.findPointerEscape()
+}
+
 // Visit the introducers of a forwarded lifetime (Value -> LifetimeIntroducer).
 //
 // A lifetime introducer produces an initial OSSA lifetime which may be extended by forwarding instructions. The introducer is never itself the result of a ForwardingInstruction. Example:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -1,4 +1,4 @@
-//===--- OptUtils.swift - Utilities for optimizations ----------------------===//
+//===--- OptUtils.swift - Utilities for optimizations ---------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -880,7 +880,6 @@ final public class BeginBorrowInst : SingleValueInstruction, UnaryInstruction, B
   public var borrowedValue: Value { operand.value }
 
   public var isLexical: Bool { bridged.BeginBorrow_isLexical() }
-  public var hasPointerEscape: Bool { bridged.BeginBorrow_hasPointerEscape() }
 }
 
 final public class ProjectBoxInst : SingleValueInstruction, UnaryInstruction {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -193,6 +193,8 @@ struct BridgedValue {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedOperand getFirstUse() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getType() const;
   BRIDGED_INLINE Ownership getOwnership() const;
+
+  bool findPointerEscape() const;
 };
 
 struct OptionalBridgedValue {
@@ -625,7 +627,6 @@ struct BridgedInstruction {
   BRIDGED_INLINE OptionalBridgedValue StructInst_getUniqueNonTrivialFieldValue() const;
   BRIDGED_INLINE SwiftInt StructElementAddrInst_fieldIndex() const;
   BRIDGED_INLINE bool BeginBorrow_isLexical() const;
-  BRIDGED_INLINE bool BeginBorrow_hasPointerEscape() const;
   BRIDGED_INLINE SwiftInt ProjectBoxInst_fieldIndex() const;
   BRIDGED_INLINE bool EndCOWMutationInst_doKeepUnique() const;
   BRIDGED_INLINE SwiftInt EnumInst_caseIndex() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -818,10 +818,6 @@ bool BridgedInstruction::BeginBorrow_isLexical() const {
   return getAs<swift::BeginBorrowInst>()->isLexical();
 }
 
-bool BridgedInstruction::BeginBorrow_hasPointerEscape() const {
-  return getAs<swift::BeginBorrowInst>()->hasPointerEscape();
-}
-
 SwiftInt BridgedInstruction::ProjectBoxInst_fieldIndex() const {
   return getAs<swift::ProjectBoxInst>()->getFieldIndex();
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4494,6 +4494,7 @@ public:
   /// doesn't have a lexical bit, do not do anything.
   void removeIsLexical() { sharedUInt8().BeginBorrowInst.lexical = false; }
 
+  /// WARNING: this flag is not yet implemented!
   bool hasPointerEscape() const {
     return sharedUInt8().BeginBorrowInst.pointerEscape;
   }

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Attr.h"
 #include "swift/AST/SemanticAttrs.h"
 #include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/ParseTestSpecification.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILGlobalVariable.h"
@@ -273,6 +274,9 @@ ArrayRef<SILValue> BridgedValueArray::getValues(SmallVectorImpl<SILValue> &stora
   return storage;
 }
 
+bool BridgedValue::findPointerEscape() const {
+  return swift::findPointerEscape(getSILValue());
+}
 
 //===----------------------------------------------------------------------===//
 //                                SILArgument

--- a/test/SILOptimizer/simplify_begin_borrow.sil
+++ b/test/SILOptimizer/simplify_begin_borrow.sil
@@ -159,9 +159,11 @@ bb0(%0 : @owned $C):
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dont_replace_pointer_escape :
-// CHECK:         begin_borrow
-// CHECK:       } // end sil function 'dont_replace_pointer_escape'
+// FIXME: re-enable this test when the [pointer_escape] flag is implemented.
+//
+// HECK-LABEL: sil [ossa] @dont_replace_pointer_escape :
+// HECK:         begin_borrow
+// HECK:       } // end sil function 'dont_replace_pointer_escape'
 sil [ossa] @dont_replace_pointer_escape : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
   %1 = begin_borrow [pointer_escape] %0 : $C


### PR DESCRIPTION
Do not bridge the hasPointerEscape flag until it is implemented.
