### PR TITLE
[NFC] Bridging and utilities for SwiftCompilerSources required by lifetime dependence utilities.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -1,4 +1,4 @@
-//===--- OptUtils.swift - Utilities for optimizations ----------------------===//
+//===--- OptUtils.swift - Utilities for optimizations ---------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ASTBridging
 import SIL
 import OptimizerBridging
 

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -120,6 +120,12 @@ extension ApplySite {
     return nil
   }
 
+  /// Get the conventions of the callee without the applied substitutions.
+  public var originalCalleeConvention: FunctionConvention {
+    FunctionConvention(for: callee.type.bridged.getASTType(),
+      in: parentFunction)
+  }
+
   public func hasSemanticsAttribute(_ attr: StaticString) -> Bool {
     if let callee = referencedFunction {
       return callee.hasSemanticsAttribute(attr)

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -87,24 +87,27 @@ public struct Phi {
     return value.parentBlock
   }
 
-  public var incomingOperands: LazyMapSequence<PredecessorList, Operand> {
+  public func incomingOperand(inPredecessor predecessor: BasicBlock)
+  -> Operand {
     let blockArgIdx = value.index
-    return predecessors.lazy.map {
-      switch $0.terminator {
-        case let br as BranchInst:
-          return br.operands[blockArgIdx]
-        case let condBr as CondBranchInst:
-          if condBr.trueBlock == successor {
-            assert(condBr.falseBlock != successor)
-            return condBr.trueOperands[blockArgIdx]
-          } else {
-            assert(condBr.falseBlock == successor)
-            return condBr.falseOperands[blockArgIdx]
-          }
-        default:
-          fatalError("wrong terminator for phi-argument")
+    switch predecessor.terminator {
+    case let br as BranchInst:
+      return br.operands[blockArgIdx]
+    case let condBr as CondBranchInst:
+      if condBr.trueBlock == successor {
+        assert(condBr.falseBlock != successor)
+        return condBr.trueOperands[blockArgIdx]
+      } else {
+        assert(condBr.falseBlock == successor)
+        return condBr.falseOperands[blockArgIdx]
       }
+    default:
+      fatalError("wrong terminator for phi-argument")
     }
+  }
+
+  public var incomingOperands: LazyMapSequence<PredecessorList, Operand> {
+    predecessors.lazy.map { incomingOperand(inPredecessor: $0) }
   }
 
   public var incomingValues: LazyMapSequence<LazyMapSequence<PredecessorList, Operand>, Value> {

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -28,6 +28,8 @@ public class Argument : Value, Hashable {
   public var index: Int {
     return parentBlock.arguments.firstIndex(of: self)!
   }
+
+  public var isReborrow: Bool { bridged.isReborrow() }
   
   public static func ==(lhs: Argument, rhs: Argument) -> Bool {
     lhs === rhs
@@ -107,6 +109,12 @@ public struct Phi {
 
   public var incomingValues: LazyMapSequence<LazyMapSequence<PredecessorList, Operand>, Value> {
     incomingOperands.lazy.map { $0.value }
+  }
+
+  public var isReborrow: Bool { value.isReborrow }
+
+  public var endsLifetime: Bool {
+    value.ownership == .owned || value.isReborrow
   }
 
   public static func ==(lhs: Phi, rhs: Phi) -> Bool {

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -53,6 +53,10 @@ final public class BasicBlock : CustomStringConvertible, HasShortDescription, Eq
   
   public var hasSinglePredecessor: Bool { singlePredecessor != nil }
 
+  public var singleSuccessor: BasicBlock? {
+    successors.count == 1 ? successors[0] : nil
+  }
+
   /// The index of the basic block in its function.
   /// This has O(n) complexity. Only use it for debugging
   public var index: Int {

--- a/SwiftCompilerSources/Sources/SIL/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/SIL/CMakeLists.txt
@@ -17,6 +17,7 @@ add_swift_compiler_module(SIL
     Effects.swift
     ForwardingInstruction.swift
     Function.swift
+    FunctionConvention.swift
     GlobalVariable.swift
     Instruction.swift
     Location.swift

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -33,6 +33,8 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
 
   public var hasOwnership: Bool { bridged.hasOwnership() }
 
+  public var hasLoweredAddresses: Bool { bridged.hasLoweredAddresses() }
+
   /// Returns true if the function is a definition and not only an external declaration.
   ///
   /// This is the case if the functioun contains a body, i.e. some basic blocks.

--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -1,0 +1,163 @@
+//===--- FunctionConvention.swift - function conventions ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+/// SIL function convention based on the AST function type and SIL stage.
+public struct FunctionConvention {
+  let bridgedFunctionType: BridgedASTType
+  let hasLoweredAddresses: Bool
+
+  init(for bridgedFunctionType: BridgedASTType, in function: Function) {
+    self.bridgedFunctionType = bridgedFunctionType
+    self.hasLoweredAddresses = function.hasLoweredAddresses
+  }
+
+  struct Results : Collection {
+    let bridged: BridgedResultInfoArray
+    let hasLoweredAddresses: Bool
+
+    public var startIndex: Int { 0 }
+
+    public var endIndex: Int { bridged.count() }
+
+    public func index(after index: Int) -> Int {
+      return index + 1
+    }
+
+    public subscript(_ index: Int) -> ResultInfo {
+      return ResultInfo(bridged: bridged.at(index),
+        hasLoweredAddresses: hasLoweredAddresses)
+    }
+  }
+
+  var results: Results {
+    Results(bridged: bridgedFunctionType.SILFunctionType_getResults(),
+      hasLoweredAddresses: hasLoweredAddresses)
+  }
+
+  /// Number of SIL arguments for indirect results, not including error results.
+  var indirectSILResultCount: UInt {
+    // TODO: Return packs directly in lowered-address mode
+    return hasLoweredAddresses
+    ? bridgedFunctionType.SILFunctionType_getNumIndirectFormalResults()
+    : bridgedFunctionType.SILFunctionType_getNumPackResults()
+  }
+
+  var errorResult: ResultInfo? {
+    guard bridgedFunctionType.SILFunctionType_hasErrorResult() else {
+      return nil
+    }
+    return results[0]
+  }
+
+  /// The number of SIL error results passed as address-typed arguments.
+  var indirectSILErrorResultCount: UInt {
+    guard hasLoweredAddresses else { return 0 }
+    return errorResult?.convention == .indirect ? 1 : 0
+  }
+
+  var parameterCount: UInt {
+    bridgedFunctionType.SILFunctionType_getNumParameters()
+  }
+
+  /// The SIL argument index of the function type's first parameter.
+  var firstParameterIndex: UInt {
+    indirectSILResultCount + indirectSILErrorResultCount
+  }
+
+  // The SIL argument index of the 'self' paramter.
+  var selfIndex: UInt? {
+    guard bridgedFunctionType.SILFunctionType_hasSelfParam() else { return nil }
+    return firstParameterIndex + parameterCount - 1
+  }
+}
+
+/// A function result type and the rules for returning it in SIL.
+struct ResultInfo {
+  /// The unsubstituted parameter type that describes the abstract calling convention of the parameter.
+  ///
+  /// TODO: For most purposes, you probably want \c returnValueType.
+  let interfaceType: BridgedASTType
+  let convention: ResultConvention
+  let hasLoweredAddresses: Bool
+
+  /// Is this result returned indirectly in SIL? Most formally indirect results can be returned directly in SIL. This depends on the calling function.
+  var isSILIndirect: Bool {
+    switch convention {
+    case .indirect:
+      return hasLoweredAddresses || interfaceType.isOpenedExistentialWithError()
+    case .pack:
+      return true
+    case .owned, .unowned, .unownedInnerPointer, .autoreleased:
+      return false
+    }
+  }
+}
+
+public enum ResultConvention {
+  /// This result is returned indirectly, i.e. by passing the address of an uninitialized object in memory.  The callee is responsible for leaving an initialized object at this address.  The callee may assume that the address does not alias any valid object.
+  case indirect
+
+  /// The caller is responsible for destroying this return value.  Its type is non-trivial.
+  case owned
+
+  /// The caller is not responsible for destroying this return value.  Its type may be trivial, or it may simply be offered unsafely.  It is valid at the instant of the return, but further operations may invalidate it.
+  case unowned
+
+  /// The caller is not responsible for destroying this return value.  The validity of the return value is dependent on the 'self' parameter, so it may be invalidated if that parameter is released.
+  case unownedInnerPointer
+
+  /// This value has been (or may have been) returned autoreleased.  The caller should make an effort to reclaim the autorelease.  The type must be a class or class existential type, and this must be the only return value.
+  case autoreleased
+
+  /// This value is a pack that is returned indirectly by passing a pack address (which may or may not be further indirected, depending on the pact type).  The callee is responsible for leaving an initialized object in each element of the pack.
+  case pack
+
+  /// Does this result convention require indirect storage? This reflects a FunctionType's conventions, as opposed to the SIL conventions that dictate SILValue types.
+  public var isASTIndirect: Bool {
+    switch self {
+    case .indirect, .pack:
+      return true
+    default:
+      return false
+    }
+  }
+  public var isASTDirect: Bool {
+    return !isASTIndirect
+  }
+}
+
+// Bridging utilities
+
+extension ResultInfo {
+  init(bridged: BridgedResultInfo, hasLoweredAddresses: Bool) {
+    self.interfaceType = BridgedASTType(type: bridged.type)
+    self.convention = ResultConvention(bridged: bridged.convention)
+    self.hasLoweredAddresses = hasLoweredAddresses
+  }
+}
+
+extension ResultConvention {
+  init(bridged: BridgedResultConvention) {
+    switch bridged {
+      case .Indirect:            self = .indirect
+      case .Owned:               self = .owned
+      case .Unowned:             self = .unowned
+      case .UnownedInnerPointer: self = .unownedInnerPointer
+      case .Autoreleased:        self = .autoreleased
+      case .Pack:                self = .pack
+      default:
+        fatalError("unsupported result convention")
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1072,6 +1072,8 @@ final public class BeginApplyInst : MultipleValueInstruction, FullApplySite {
 
   public var singleDirectResult: Value? { nil }
 
+  public var token: Value { getResult(index: resultCount - 1) }
+
   public var yieldedValues: Results {
     Results(inst: self, numResults: resultCount - 1)
   }

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -153,6 +153,10 @@ extension Sequence where Element == Operand {
   public func getSingleUser<I: Instruction>(notOfType: I.Type) -> Instruction? {
     ignoreUsers(ofType: I.self).singleUse?.instruction
   }
+
+  public var lifetimeEndingUses: LazyFilterSequence<Self> {
+    return self.lazy.filter { $0.endsLifetime }
+  }
 }
 
 extension OptionalBridgedOperand {

--- a/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
@@ -38,6 +38,14 @@ public enum WalkResult {
   case abortWalk
 }
 
+extension Sequence {
+  public func walk(
+    _ predicate: (Element) throws -> WalkResult
+  ) rethrows -> WalkResult {
+    return try contains { try predicate($0) == .abortWalk } ? .abortWalk : .continueWalk
+  }
+}
+
 /// The path which is updated throughout a walk.
 ///
 /// Usually this is just a SmallProjectionPath, but clients can implement their own path, e.g.

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -75,7 +75,16 @@ public enum Ownership {
   /// points in the SSA graph, where more information about the value is
   /// statically available on some control flow paths.
   case none
-  
+
+  public var hasLifetime: Bool {
+    switch self {
+    case .owned, .guaranteed:
+      return true
+    case .unowned, .none:
+      return false
+    }
+  }
+
   public init(bridged: BridgedValue.Ownership) {
     switch bridged {
     case .Unowned:    self = .unowned

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -154,6 +154,12 @@ public func !=(_ lhs: Value, _ rhs: Value) -> Bool {
   return !(lhs === rhs)
 }
 
+extension CollectionLikeSequence where Element == Value {
+  public func contains(_ element: Element) -> Bool {
+    return self.contains { $0 == element }
+  }
+}
+
 /// A projected value, which is defined by the original value and a projection path.
 ///
 /// For example, if the `value` is of type `struct S { var x: Int }` and `path` is `s0`,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -730,6 +730,7 @@ struct BridgedArgument {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock getParent() const;
   BRIDGED_INLINE BridgedArgumentConvention getConvention() const;
   BRIDGED_INLINE bool isSelf() const;
+  BRIDGED_INLINE bool isReborrow() const;
 };
 
 struct OptionalBridgedArgument {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -60,12 +60,86 @@ class SILWitnessTable;
 class SILDefaultWitnessTable;
 class NominalTypeDecl;
 class VarDecl;
+class TypeBase;
 class SwiftPassInvocation;
 class GenericSpecializationInformation;
 }
 
 bool swiftModulesInitialized();
 void registerBridgedClass(BridgedStringRef className, SwiftMetatype metatype);
+
+enum class BridgedResultConvention {
+  Indirect,
+  Owned,
+  Unowned,
+  UnownedInnerPointer,
+  Autoreleased,
+  Pack
+};
+
+// A null type indicates a non-existant result, in which case `convention` is undefined.
+struct BridgedResultInfo {
+  swift::TypeBase * _Nonnull type;
+  BridgedResultConvention convention;
+
+#ifdef USED_IN_CPP_SOURCE
+  inline static BridgedResultConvention
+  castToResultConvention(swift::ResultConvention convention);
+
+  BridgedResultInfo(swift::SILResultInfo resultInfo):
+    type(resultInfo.getInterfaceType().getPointer()),
+    convention(castToResultConvention(resultInfo.getConvention()))
+  {}
+#endif
+};
+
+struct BridgedResultInfoArray {
+  BridgedArrayRef resultInfoArray;
+
+#ifdef USED_IN_CPP_SOURCE
+  BridgedResultInfoArray(llvm::ArrayRef<swift::SILResultInfo> results)
+    : resultInfoArray(results) {}
+
+  llvm::ArrayRef<swift::SILResultInfo> unbridged() const {
+    return resultInfoArray.unbridged<swift::SILResultInfo>();
+  }
+#endif
+
+  BRIDGED_INLINE SwiftInt count() const;
+
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  BridgedResultInfo at(SwiftInt argumentIndex) const;
+};
+
+// Temporary access to the AST type within SIL until ASTBridging provides it.
+struct BridgedASTType {
+  swift::TypeBase * _Nullable type;
+
+#ifdef USED_IN_CPP_SOURCE
+  swift::Type unbridged() const {
+    return type;
+  }
+#endif
+
+  BRIDGED_INLINE bool isOpenedExistentialWithError() const;
+
+  // =========================================================================//
+  //                              SILFunctionType
+  // =========================================================================//
+
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  BridgedResultInfoArray SILFunctionType_getResults() const;
+
+  BRIDGED_INLINE SwiftUInt SILFunctionType_getNumIndirectFormalResults() const;
+
+  BRIDGED_INLINE SwiftUInt SILFunctionType_getNumPackResults() const;
+
+  BRIDGED_INLINE bool SILFunctionType_hasErrorResult() const;
+
+  BRIDGED_INLINE SwiftUInt SILFunctionType_getNumParameters() const;
+
+  BRIDGED_INLINE bool SILFunctionType_hasSelfParam() const;
+};
 
 struct BridgedType {
   void * _Nullable opaqueValue;
@@ -111,6 +185,7 @@ struct BridgedType {
   BRIDGED_INLINE bool isAddress() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getAddressType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getObjectType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getASTType() const;
   BRIDGED_INLINE bool isTrivial(BridgedFunction f) const;
   BRIDGED_INLINE bool isNonTrivialOrContainsRawPointer(BridgedFunction f) const;
   BRIDGED_INLINE bool isValueTypeWithDeinit() const;
@@ -318,6 +393,7 @@ struct BridgedFunction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef getName() const;
   SWIFT_IMPORT_UNSAFE BridgedOwnedString getDebugDescription() const;
   BRIDGED_INLINE bool hasOwnership() const;
+  BRIDGED_INLINE bool hasLoweredAddresses() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedBasicBlock getFirstBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedBasicBlock getLastBlock() const;
   BRIDGED_INLINE SwiftInt getNumIndirectFormalResults() const;
@@ -347,6 +423,7 @@ struct BridgedFunction {
   BRIDGED_INLINE bool needsStackProtection() const;
   BRIDGED_INLINE void setNeedStackProtection(bool needSP) const;
   BRIDGED_INLINE bool isResilientNominalDecl(BridgedNominalTypeDecl decl) const;
+  BRIDGED_INLINE BridgedType getLoweredType(BridgedASTType type) const;
 
   enum class ParseEffectsMode {
     argumentEffectsFromSource,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -368,6 +368,10 @@ bool BridgedArgument::isSelf() const {
   return fArg->isSelf();
 }
 
+bool BridgedArgument::isReborrow() const {
+  return getArgument()->isReborrow();
+}
+
 //===----------------------------------------------------------------------===//
 //                            BridgedSubstitutionMap
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -22,6 +22,7 @@
 #include "swift/AST/Builtins.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/BasicBridging.h"
 #include "swift/Basic/Nullability.h"
 #include "swift/SIL/ApplySite.h"
@@ -39,6 +40,57 @@
 #include <string>
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+//===----------------------------------------------------------------------===//
+//                             BridgedResultInfo
+//===----------------------------------------------------------------------===//
+
+BridgedResultConvention
+BridgedResultInfo::castToResultConvention(swift::ResultConvention convention) {
+  return static_cast<BridgedResultConvention>(convention);
+}
+
+SwiftInt BridgedResultInfoArray::count() const {
+  return unbridged().size();
+}
+
+BridgedResultInfo BridgedResultInfoArray::at(SwiftInt argumentIndex) const {
+  return BridgedResultInfo(unbridged()[argumentIndex]);
+}
+
+//===----------------------------------------------------------------------===//
+//                               BridgedASTType
+//===----------------------------------------------------------------------===//
+
+bool BridgedASTType::isOpenedExistentialWithError() const {
+  return unbridged()->isOpenedExistentialWithError();
+}
+
+BridgedResultInfoArray BridgedASTType::SILFunctionType_getResults() const {
+  return unbridged()->castTo<swift::SILFunctionType>()->getResults();
+}
+
+SwiftUInt BridgedASTType::SILFunctionType_getNumIndirectFormalResults() const {
+  return unbridged()->castTo<swift::SILFunctionType>()
+    ->getNumIndirectFormalResults();
+}
+
+SwiftUInt BridgedASTType::SILFunctionType_getNumPackResults() const {
+  return unbridged()->castTo<swift::SILFunctionType>()
+    ->getNumPackResults();
+}
+
+bool BridgedASTType::SILFunctionType_hasErrorResult() const {
+  return unbridged()->castTo<swift::SILFunctionType>()->hasErrorResult();
+}
+
+SwiftUInt BridgedASTType::SILFunctionType_getNumParameters() const {
+  return unbridged()->castTo<swift::SILFunctionType>()->getNumParameters();
+}
+
+bool BridgedASTType::SILFunctionType_hasSelfParam() const {
+  return unbridged()->castTo<swift::SILFunctionType>()->hasSelfParam();
+}
 
 //===----------------------------------------------------------------------===//
 //                                BridgedType
@@ -66,6 +118,10 @@ BridgedType BridgedType::getAddressType() const {
 
 BridgedType BridgedType::getObjectType() const {
   return unbridged().getObjectType();
+}
+
+BridgedASTType BridgedType::getASTType() const {
+  return {unbridged().getASTType().getPointer()};
 }
 
 bool BridgedType::isTrivial(BridgedFunction f) const {
@@ -426,6 +482,8 @@ BridgedStringRef BridgedFunction::getName() const {
 
 bool BridgedFunction::hasOwnership() const { return getFunction()->hasOwnership(); }
 
+bool BridgedFunction::hasLoweredAddresses() const { return getFunction()->getModule().useLoweredAddresses(); }
+
 OptionalBridgedBasicBlock BridgedFunction::getFirstBlock() const {
   return {getFunction()->empty() ? nullptr : getFunction()->getEntryBlock()};
 }
@@ -557,6 +615,9 @@ bool BridgedFunction::isResilientNominalDecl(BridgedNominalTypeDecl decl) const 
                                        getFunction()->getResilienceExpansion());
 }
 
+BridgedType BridgedFunction::getLoweredType(BridgedASTType type) const {
+  return BridgedType(getFunction()->getLoweredType(type.type));
+}
 
 //===----------------------------------------------------------------------===//
 //                                BridgedGlobalVar


### PR DESCRIPTION
Straightforward utilities needed for lifetime dependence:

- Argument.isReborrow
- Argument.incomingOperand(predecessor:)
- FunctionConvention.swift
- InstructionRange API; exitBlocks, getRepresentativeInstruction
- BasicBlock.singleSuccessor
- BeginApplyInst.token
- Value.lifetimeEndingUses
- Value.hasLifetime
- Sequence.walk()
- CollectionLikeSequence.contains()

Cherry-picked from Draft PR: https://github.com/apple/swift/pull/70460

Previously reviewed by @nate-chandler 