### PR TITLE
tests: require readonly_arrays_objc.swift to run on macOS 13+

### DIFF
--- a/test/SILOptimizer/readonly_arrays_objc.swift
+++ b/test/SILOptimizer/readonly_arrays_objc.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -O %s -o %t/a.out
+// RUN: %target-build-swift -target %target-future-triple -O %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: objc_interop
+// REQUIRES: macos_min_version_13
 
 // UNSUPPORTED: use_os_stdlib
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1382,6 +1382,9 @@ if run_vendor == 'apple':
         (sw_vers_name, sw_vers_vers, sw_vers_build) = \
             darwin_get_sw_vers()
 
+        if re.match('^(1[3-9]|[2-9])', sw_vers_vers):
+            config.available_features.add('macos_min_version_13')
+
     else:
         lit_config.fatal("Unknown Apple OS '" + run_os + "' " +
                          "(from " + config.variant_triple + ")")


### PR DESCRIPTION
rdar://119629526
