### PR TITLE
[CMake] Add dep in add_swift_target_library_single from install component

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1043,6 +1043,7 @@ function(add_swift_target_library_single target name)
     add_custom_target("${target}"
       DEPENDS
         "${swift_module_dependency_target}")
+    add_dependencies("${install_in_component}" "${target}")
 
     return()
   endif()
@@ -1076,6 +1077,7 @@ function(add_swift_target_library_single target name)
   if (SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
     add_custom_target("${target}"
       DEPENDS "${swift_module_dependency_target}")
+    add_dependencies("${install_in_component}" "${target}")
     return()
   endif()
 
@@ -1084,6 +1086,9 @@ function(add_swift_target_library_single target name)
               ${SWIFTLIB_SINGLE_EXTERNAL_SOURCES}
               ${INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS}
               ${SWIFTLIB_SINGLE_XCODE_WORKAROUND_SOURCES})
+  if (NOT SWIFTLIB_SINGLE_OBJECT_LIBRARY)
+    add_dependencies("${install_in_component}" "${target}")
+  endif()
   # NOTE: always inject the LLVMSupport directory before anything else.  We want
   # to ensure that the runtime is built with our local copy of LLVMSupport
   target_include_directories(${target} BEFORE PRIVATE


### PR DESCRIPTION
While `add_swift_target_library` has code to add a dependency from the install component to the target, similar code was missing from `add_swift_target_library_single`, probably because `add_swift_target_library` calls `add_swift_target_library_single`, so the extra dependency is not necessary.

However, there's usages of `add_swift_target_library_single` outside `add_swift_target_library` which were creating targets that were not dependencies of their install components. Some of  those cases are the embedded stdlib targets, which are installed as part of the `stdlib` component.

It normally does not matter when using `build-script`, because those targets are build as part of `all`, but it does matter if one is using CMake/Ninja directly or in cases where `build-script` is not used. Trying to use targets like `install-stdlib` will had missed building the embedded stdlib, and failed the installation.
