### PR TITLE
[IRGen][DebugInfo] Explicitly demangle names for function-like entities in CodeView

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -92,6 +92,29 @@ struct DemangleOptions {
     Opt.ShowAsyncResumePartial = false;
     return Opt;
   };
+
+  static DemangleOptions MinimalDemangleOptions() {
+    auto Opt = DemangleOptions();
+    Opt.QualifyEntities = false;
+    Opt.DisplayExtensionContexts = false;
+    Opt.DisplayUnmangledSuffix = false;
+    Opt.DisplayModuleNames = false;
+    Opt.DisplayGenericSpecializations = false;
+    Opt.DisplayProtocolConformances = false;
+    Opt.DisplayWhereClauses = false;
+    Opt.DisplayEntityTypes = false;
+    Opt.DisplayLocalNameContexts = false;
+    Opt.ShowPrivateDiscriminators = false;
+    Opt.ShowFunctionArgumentTypes = false;
+    Opt.DisplayDebuggerGeneratedModule = false;
+    Opt.DisplayStdlibModule = false;
+    Opt.DisplayObjCModule = false;
+    Opt.ShowAsyncResumePartial = false;
+    Opt.ShortenThunk = true;
+    Opt.ShortenValueWitness = true;
+    Opt.ShortenArchetype = true;
+    return Opt;
+  };
 };
 
 class Node;

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2464,12 +2464,12 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
   else
     llvm_unreachable("function has no mangled name");
 
-  StringRef Name;
+  std::string Name;
   if (DS) {
     if (DS->Loc.isSILFile())
-      Name = SILFn->getName();
+      Name = SILFn->getName().str();
     else
-      Name = getName(DS->Loc);
+      Name = getName(DS->Loc).str();
   }
 
   /// The source line used for the function prologue.
@@ -2498,7 +2498,27 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
       IGM.getSILModule().getASTContext().getEntryPointFunctionName()) {
     File = MainFile;
     Line = 1;
-    Name = LinkageName;
+    Name = LinkageName.str();
+  }
+
+  // In PDBs, explicitly demangle names for function-like entities like closures
+  // and one-time initializers. This improves readability of backtraces in crash
+  // dumps on Windows, where the symbolizer doesn't do this on-demand.
+  if (Opts.DebugInfoFormat == IRGenDebugInfoFormat::CodeView) {
+    if (DS && SILFn && Name.empty()) {
+      assert(LinkageName.startswith("$s") && "SIL function has Swift mangling");
+      if (!DS->Loc.isHiddenFromDebugInfo()) {
+        // Choosing a short name avoids bloating PDBs
+        auto Opts = DemangleOptions::MinimalDemangleOptions();
+        Name = demangleSymbolAsString(LinkageName, Opts);
+        // Characters like whitespace or hash may break other tools
+        for (char &ch : Name)
+          if (!std::isalnum(ch))
+            ch = '_';
+        LLVM_DEBUG(llvm::dbgs() << "Explicit demangle for Windows crash dumps: "
+                                << LinkageName << " ---> " << Name << "\n");
+      }
+    }
   }
 
   CanSILFunctionType FnTy = getFunctionType(SILTy);


### PR DESCRIPTION
Windows crash dumps are difficult to understand, because their backtraces are full of mangled names. macOS appears to apply Swift demangling during symbolication. This is not yet possible on Windows. Instead we can write demangled names to PDBs for closures and one-time initializers at compile-time.