### PR TITLE
[NCGenerics] Mark test as REQUIRES: asserts

### DIFF
--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -disable-availability-checking -module-name main %s | %FileCheck %s
 
+// REQUIRES: asserts
+
 struct NC: ~Copyable {}
 
 struct RudeStruct<T: ~Copyable>: Copyable {


### PR DESCRIPTION
Any test that uses `--enable-experimental-feature` will only work in non-production compilers, so it needs `REQUIRES: asserts` to avoid failures when the compiler is build in non-asserts mode.
