### PR TITLE
[test] Mark some tests as requiring Swift Syntax

### DIFF
--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -enable-experimental-feature SwiftParser -enable-experimental-feature ParserASTGen)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_swift_parser
 
 // -enable-experimental-feature requires an asserts build
 // REQUIRES: asserts

--- a/test/SourceKit/Refactoring/basic.swift
+++ b/test/SourceKit/Refactoring/basic.swift
@@ -275,3 +275,4 @@ func hasCallToAsyncAlternative(c: ConvertAsync) {
 // CHECK-CALLASYNC: ACTIONS END
 
 // REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_swift_parser

--- a/test/SourceKit/RelatedIdents/operator.swift
+++ b/test/SourceKit/RelatedIdents/operator.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
 
+// REQUIRES: swift_swift_parser
+
 //--- a.swift
 
 struct Foo {}
@@ -11,7 +13,7 @@ Foo() + Foo()
 //--- dummy.swift
 
 // CHECK: START RANGES
-// CHECK: 8:6 - 1 - source.syntacticrename.definition
-// CHECK: 9:7 - 1 - source.syntacticrename.call
+// CHECK: [[# @LINE - 6 ]]:6 - 1 - source.syntacticrename.definition
+// CHECK: [[# @LINE - 6 ]]:7 - 1 - source.syntacticrename.call
 // CHECK: END RANGES
 // CHECK: NAME: +(_:_:)

--- a/test/refactoring/ExtractFunction/await.swift
+++ b/test/refactoring/ExtractFunction/await.swift
@@ -16,3 +16,4 @@ func testThrowingClosure() async throws -> Int {
 // RUN: diff -u %S/Outputs/await/async2.swift.expected %t.result/async2.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=8:1 -end-pos=8:60 >> %t.result/consumes_async.swift
 // RUN: diff -u %S/Outputs/await/consumes_async.swift.expected %t.result/consumes_async.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/basic.swift
+++ b/test/refactoring/ExtractFunction/basic.swift
@@ -12,3 +12,4 @@ func foo() -> Int{
 // RUN: diff -u %S/Outputs/basic/L3-5.swift.expected %t.result/L3-5.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=3:1 -end-pos=4:26 >> %t.result/L3-4.swift
 // RUN: diff -u %S/Outputs/basic/L3-4.swift.expected %t.result/L3-4.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/extract_attributes.swift
+++ b/test/refactoring/ExtractFunction/extract_attributes.swift
@@ -11,3 +11,4 @@ public func foo() -> Int{
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=6:26 >> %t.result/L5-6.swift
 // RUN: diff -u %S/Outputs/extract_attributes/L5-6.swift.expected %t.result/L5-6.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/extract_from_accessor.swift
+++ b/test/refactoring/ExtractFunction/extract_from_accessor.swift
@@ -15,3 +15,4 @@ class C {
 
 // RUN: %refactor -extract-function -source-filename %s -pos=7:18 -end-pos=7:23 >> %t.result/ExplicitGetter.swift
 // RUN: diff -u %S/Outputs/extract_from_accessor/ExplicitGetter.swift.expected %t.result/ExplicitGetter.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/extract_init.swift
+++ b/test/refactoring/ExtractFunction/extract_init.swift
@@ -10,3 +10,4 @@ class C {
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=6:15 >> %t.result/L5-6.swift
 // RUN: diff -u %S/Outputs/extract_init/L5-6.swift.expected %t.result/L5-6.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/extract_local.swift
+++ b/test/refactoring/ExtractFunction/extract_local.swift
@@ -15,3 +15,4 @@ func returnFifteen() -> Int {
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=9:6 >> %t.result/AvoidFilePrivate.swift
 // RUN: diff -u %S/Outputs/extract_local/AvoidFilePrivate.swift.expected %t.result/AvoidFilePrivate.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/extract_subscript.swift
+++ b/test/refactoring/ExtractFunction/extract_subscript.swift
@@ -15,3 +15,4 @@ class A {
 // RUN: diff -u %S/Outputs/extract_subscript/FromGetter.swift.expected %t.result/FromGetter.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=8:1 -end-pos=8:19 >> %t.result/FromSetter.swift
 // RUN: diff -u %S/Outputs/extract_subscript/FromSetter.swift.expected %t.result/FromSetter.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/extract_sugar.swift
+++ b/test/refactoring/ExtractFunction/extract_sugar.swift
@@ -8,3 +8,4 @@ func foo(_ a : inout [Int]) -> [Int] {
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -extract-function -source-filename %s -pos=2:1 -end-pos=5:11 >> %t.result/L2-5.swift
 // RUN: diff -u %S/Outputs/extract_sugar/L2-5.swift.expected %t.result/L2-5.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/extract_switch.swift
+++ b/test/refactoring/ExtractFunction/extract_switch.swift
@@ -29,3 +29,4 @@ func foo2(_ e : MyEnum) -> Int {
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -extract-function -source-filename %s -pos=16:1 -end-pos=23:4 >> %t.result/Int.swift
 // RUN: diff -u %S/Outputs/extract_switch/Int.swift.expected %t.result/Int.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/extract_with_comments.swift
+++ b/test/refactoring/ExtractFunction/extract_with_comments.swift
@@ -14,3 +14,4 @@ public func foo() -> Int{
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -extract-function -source-filename %s -pos=6:1 -end-pos=7:26 >> %t.result/L6-7.swift
 // RUN: diff -u %S/Outputs/extract_with_comments/L6-7.swift.expected %t.result/L6-7.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/name_correction.swift
+++ b/test/refactoring/ExtractFunction/name_correction.swift
@@ -15,3 +15,4 @@ public func new_name3() {}
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=6:26 >> %t.result/L5-6.swift
 // RUN: diff -u %S/Outputs/name_correction/L5-6.swift.expected %t.result/L5-6.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/static.swift
+++ b/test/refactoring/ExtractFunction/static.swift
@@ -17,3 +17,4 @@ class C {
 // RUN: diff -u %S/Outputs/static/L3-5.swift.expected %t.result/L3-5.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=9:1 -end-pos=11:13 >> %t.result/L9-11.swift
 // RUN: diff -u %S/Outputs/static/L9-11.swift.expected %t.result/L9-11.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/throw_errors.swift
+++ b/test/refactoring/ExtractFunction/throw_errors.swift
@@ -26,3 +26,4 @@ func foo2() throws {
 // RUN: diff -u %S/Outputs/throw_errors/L10-12.swift.expected %t.result/L10-12.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=13:1 -end-pos=17:4 >> %t.result/L13-17.swift
 // RUN: diff -u %S/Outputs/throw_errors/L13-17.swift.expected %t.result/L13-17.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/throw_errors2.swift
+++ b/test/refactoring/ExtractFunction/throw_errors2.swift
@@ -15,3 +15,4 @@ struct RefactorExtractProblem {
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -extract-function -source-filename %s -pos=7:1 -end-pos=11:6 >> %t.result/L7-11.swift
 // RUN: diff -u %S/Outputs/throw_errors2/L7-11.swift.expected %t.result/L7-11.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/ExtractFunction/throw_errors3.swift
+++ b/test/refactoring/ExtractFunction/throw_errors3.swift
@@ -17,3 +17,4 @@ func testThrowingClosure() throws {
 // RUN: diff -u %S/Outputs/throw_errors3/consumes_err.swift.expected %t.result/consumes_err.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=10:1 -end-pos=12:51 >> %t.result/rethrows_err.swift
 // RUN: diff -u %S/Outputs/throw_errors3/rethrows_err.swift.expected %t.result/rethrows_err.swift
+// REQUIRES: swift_swift_parser

--- a/test/refactoring/SyntacticRename/operator.swift
+++ b/test/refactoring/SyntacticRename/operator.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 // RUN: %refactor -find-rename-ranges -source-filename %t/input.swift -pos="test" -old-name "+(x:y:)" -new-name "-(x:y:)" > %t/output.txt
-// RUN: diff -u %t/expected.swift %t/output.txt 
+// RUN: diff -u %t/expected.swift %t/output.txt
+
+// REQUIRES: swift_swift_parser
 
 //--- input.swift
 


### PR DESCRIPTION
Some of the tests now depend on features provided by Swift Syntax, and will fail to pass if building without Swift Syntax support.

This commit marks all the tests I know fail to pass when Swift Syntax is disabled.

- #70281 modified `ASTGen/verify-parse.swift`
- #70287 created `refactoring/SyntacticRename/operator.swift` and `SourceKit/RelatedIdents/operator.swift`
- #70389 modified `SourceKit/Refactoring/basic.swift` and indirectly modified all `refactoring/ExtractFunction/*` tests.
