### PR TITLE
Add some instruction simplifications

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -28,6 +28,7 @@ swift_compiler_sources(Optimizer
   SimplifyRetainReleaseValue.swift
   SimplifyStrongRetainRelease.swift
   SimplifyStructExtract.swift
+  SimplifySwitchEnum.swift
   SimplifyTupleExtract.swift
   SimplifyUncheckedEnumData.swift
   SimplifyValueToBridgeObject.swift)

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifySwitchEnum.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifySwitchEnum.swift
@@ -1,0 +1,62 @@
+//===--- SimplifySwitchEnum.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+// Removes an `enum` - `switch_enum` pair:
+// ```
+//     %1 = enum $E, #someCase, %payload
+//     switch_enum %1, case #someCase: bb1, ...
+//   bb1(%payloadArgument):
+// ```
+// ->
+// ```
+//   br bb1(%payload)
+//   bb1(%payloadArgument):
+// ```
+//
+// Other case blocks of the switch_enum become dead.
+//
+extension SwitchEnumInst : OnoneSimplifyable {
+  func simplify(_ context: SimplifyContext) {
+    guard let enumInst = enumOp as? EnumInst,
+          let caseBlock = getUniqueSuccessor(forCaseIndex: enumInst.caseIndex) else
+    {
+      return
+    }
+
+    let singleUse = context.preserveDebugInfo ? enumInst.uses.singleUse : enumInst.uses.ignoreDebugUses.singleUse
+    let canEraseEnumInst = singleUse?.instruction == self
+
+    if !canEraseEnumInst && parentFunction.hasOwnership && enumInst.ownership == .owned {
+      // We cannot add more uses to the `enum` instruction without inserting a copy.
+      return
+    }
+
+    let builder = Builder(before: self, context)
+    switch caseBlock.arguments.count {
+    case 0:
+      precondition(enumInst.payload == nil || !parentFunction.hasOwnership,
+                   "missing payload argument in switch_enum case block")
+      builder.createBranch(to: caseBlock)
+    case 1:
+      builder.createBranch(to: caseBlock, arguments: [enumInst.payload!])
+    default:
+      fatalError("case block of switch_enum cannot have more than 1 argument")
+    }
+    context.erase(instruction: self)
+
+    if canEraseEnumInst {
+      context.erase(instructionIncludingDebugUses: enumInst)
+    }
+  }
+}

--- a/test/IRGen/section_structs.swift
+++ b/test/IRGen/section_structs.swift
@@ -38,8 +38,14 @@ struct MyStruct5 {
 }
 @_section("__TEXT,__mysection") var g_MyStruct5: MyStruct5 = MyStruct5(q: MyStruct4(a: 42, s: MyStruct1(a: 43, b: 44)), r: MyStruct4(a: 42, s: MyStruct1(a: 43, b: 44)))
 
+@_section("__TEXT,__mysection") let utf8OfStaticString = StaticString("hello").utf8Start
+
 // CHECK: @"{{.*}}g_MyStruct1{{.*}}Vvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, %TSi <{ {{(i32|i64)}} 66 }> }>
 // CHECK: @"{{.*}}g_MyStruct2{{.*}}Vvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, <{ %TSi, %TSi }> <{ %TSi <{ {{(i32|i64)}} 66 }>, %TSi <{ {{(i32|i64)}} 67 }> }> }>
 // CHECK: @"{{.*}}g_MyStruct3{{.*}}Vvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, %TSi <{ {{(i32|i64)}} 77 }> }>
 // CHECK: @"{{.*}}g_MyStruct4{{.*}}Vvp" = hidden global {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }>
 // CHECK: @"{{.*}}g_MyStruct5{{.*}}Vvp" = hidden global {{.*}} <{ {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 42 }>, {{.*}} <{ %TSi <{ {{(i32|i64)}} 43 }>, %TSi <{ {{(i32|i64)}} 44 }> }> }> }>
+
+// CHECK: [[HELLOSTR:@.*]] = private {{.*}}constant [6 x i8] c"hello\00"
+// CHECK: @"{{.*}}utf8OfStaticString{{.*}}VGvp" = hidden constant {{.*}} <{ ptr [[HELLOSTR]] }>
+

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -383,6 +383,74 @@ bb0:
   return %4 : $Int8
 }
 
+// CHECK-LABEL: sil @string_null_pointer_check :
+// CHECK:         %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:    return %0
+// CHECK:       } // end sil function 'string_null_pointer_check'
+sil @string_null_pointer_check : $@convention(thin) () -> Builtin.Int1 {
+bb0:
+  %0 = string_literal utf8 "hello"
+  %1 = builtin "ptrtoint_Word"(%0 : $Builtin.RawPointer) : $Builtin.Word
+  %2 = builtin "zextOrBitCast_Word_Int64"(%1 : $Builtin.Word) : $Builtin.Int64
+  %3 = integer_literal $Builtin.Int64, 0
+  %4 = builtin "cmp_eq_Int64"(%2 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @string_null_pointer_check_ne :
+// CHECK:         %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:    return %0
+// CHECK:       } // end sil function 'string_null_pointer_check_ne'
+sil @string_null_pointer_check_ne : $@convention(thin) () -> Builtin.Int1 {
+bb0:
+  %0 = string_literal utf8 "hello"
+  %1 = builtin "ptrtoint_Word"(%0 : $Builtin.RawPointer) : $Builtin.Word
+  %2 = builtin "zextOrBitCast_Word_Int64"(%1 : $Builtin.Word) : $Builtin.Int64
+  %3 = integer_literal $Builtin.Int64, 0
+  %4 = builtin "cmp_ne_Int64"(%2 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @string_null_pointer_check_no_integer_literal :
+// CHECK:         %4 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %0 : $Builtin.Int64)
+// CHECK-NEXT:    return %4
+// CHECK:       } // end sil function 'string_null_pointer_check_no_integer_literal'
+sil @string_null_pointer_check_no_integer_literal : $@convention(thin) (Builtin.Int64) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int64):
+  %1 = string_literal utf8 "hello"
+  %2 = builtin "ptrtoint_Word"(%1 : $Builtin.RawPointer) : $Builtin.Word
+  %3 = builtin "zextOrBitCast_Word_Int64"(%2 : $Builtin.Word) : $Builtin.Int64
+  %4 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %0 : $Builtin.Int64) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @string_null_pointer_check_not_zero :
+// CHECK:         %4 = builtin "cmp_eq_Int64"(%2 : $Builtin.Int64, %3 : $Builtin.Int64)
+// CHECK-NEXT:    return %4
+// CHECK:       } // end sil function 'string_null_pointer_check_not_zero'
+sil @string_null_pointer_check_not_zero : $@convention(thin) () -> Builtin.Int1 {
+bb0:
+  %0 = string_literal utf8 "hello"
+  %1 = builtin "ptrtoint_Word"(%0 : $Builtin.RawPointer) : $Builtin.Word
+  %2 = builtin "zextOrBitCast_Word_Int64"(%1 : $Builtin.Word) : $Builtin.Int64
+  %3 = integer_literal $Builtin.Int64, 123
+  %4 = builtin "cmp_eq_Int64"(%2 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @string_null_pointer_check_no_string_literal :
+// CHECK:         %4 = builtin "cmp_eq_Int64"(%2 : $Builtin.Int64, %3 : $Builtin.Int64)
+// CHECK-NEXT:    return %4
+// CHECK:       } // end sil function 'string_null_pointer_check_no_string_literal'
+sil @string_null_pointer_check_no_string_literal : $@convention(thin) (Builtin.RawPointer) -> Builtin.Int1 {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = builtin "ptrtoint_Word"(%0 : $Builtin.RawPointer) : $Builtin.Word
+  %2 = builtin "zextOrBitCast_Word_Int64"(%1 : $Builtin.Word) : $Builtin.Int64
+  %3 = integer_literal $Builtin.Int64, 0
+  %4 = builtin "cmp_eq_Int64"(%2 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}
+
 // CHECK-LABEL: sil @convert_thick_to_thin1
 // CHECK-NOT: metatype $@thick C1<Int>.Type
 // CHECK:     [[L:%.*]] = metatype $@thin C1<Int>.Type
@@ -490,3 +558,4 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
   %3 = builtin "destroyArray"<C1<Int>>(%2 : $@thick C1<Int>.Type, %0 : $Builtin.RawPointer, %1 : $Builtin.Word) : $()
   return %0 : $Builtin.RawPointer
 }
+

--- a/test/SILOptimizer/simplify_unchecked_switch_enum.sil
+++ b/test/SILOptimizer/simplify_unchecked_switch_enum.sil
@@ -1,0 +1,154 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=switch_enum | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ONONE
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=switch_enum | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-O
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+enum E {
+  case A
+  case B(String)
+  case C(Int)
+}
+
+// CHECK-LABEL: sil @test_simple :
+// CHECK:       bb0(%0 : $String):
+// CHECK-NEXT:    br bb1(%0 : $String)
+// CHECK:       bb1(%2 : $String):
+// CHECK-NEXT:    return %2 : $String
+// CHECK-NOT:   bb2
+// CHECK:       } // end sil function 'test_simple'
+sil @test_simple : $@convention(thin) (@owned String) -> @owned String {
+bb0(%0 : $String):
+  %1 = enum $E, #E.B!enumelt, %0 : $String
+  switch_enum %1 : $E, case #E.B!enumelt: bb1, default bb2
+
+bb1(%2 : $String):
+  return %2 : $String
+
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil @no_payload_argument :
+// CHECK:       bb0(%0 : $String):
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK-NOT:   bb2
+// CHECK:       } // end sil function 'no_payload_argument'
+sil @no_payload_argument : $@convention(thin) (@guaranteed String) -> () {
+bb0(%0 : $String):
+  %1 = enum $E, #E.B!enumelt, %0 : $String
+  switch_enum %1 : $E, case #E.B!enumelt: bb1, default bb2
+
+bb1:
+  %2 = tuple ()
+  return %2 : $()
+
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @owned_ossa :
+// CHECK:       bb0(%0 : @owned $String):
+// CHECK-NEXT:    br bb1(%0 : $String)
+// CHECK:       bb1(%2 : @owned $String):
+// CHECK-NEXT:    return %2 : $String
+// CHECK-NOT:   bb2
+// CHECK:       } // end sil function 'owned_ossa'
+sil [ossa] @owned_ossa : $@convention(thin) (@owned String) -> @owned String {
+bb0(%0 : @owned $String):
+  %1 = enum $E, #E.B!enumelt, %0 : $String
+  switch_enum %1 : $E, case #E.B!enumelt: bb1, default bb2
+
+bb1(%2 : @owned $String):
+  return %2 : $String
+
+bb2(%4 : @owned $E):
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @guaranteed_ossa :
+// CHECK:       bb0(%0 : @guaranteed $String):
+// CHECK-NEXT:    br bb1(%0 : $String)
+// CHECK:       bb1(%2 : @guaranteed $String):
+// CHECK-NEXT:    %3 = copy_value %2
+// CHECK-NEXT:    return %3 : $String
+// CHECK-NOT:   bb2
+// CHECK:       } // end sil function 'guaranteed_ossa'
+sil [ossa] @guaranteed_ossa : $@convention(thin) (@guaranteed String) -> @owned String {
+bb0(%0 : @guaranteed $String):
+  %1 = enum $E, #E.B!enumelt, %0 : $String
+  switch_enum %1 : $E, case #E.B!enumelt: bb1, default bb2
+
+bb1(%2 : @guaranteed $String):
+  %3 = copy_value %2 : $String
+  return %3 : $String
+
+bb2(%4 : @guaranteed $E):
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @owned_with_additional_uses :
+// CHECK:         switch_enum
+// CHECK:       } // end sil function 'owned_with_additional_uses'
+sil [ossa] @owned_with_additional_uses : $@convention(thin) (@owned String) -> @owned String {
+bb0(%0 : @owned $String):
+  %1 = enum $E, #E.B!enumelt, %0 : $String
+  %2 = begin_borrow %1 : $E
+  end_borrow %2 : $E
+  switch_enum %1 : $E, case #E.B!enumelt: bb1, default bb2
+
+bb1(%5 : @owned $String):
+  return %5 : $String
+
+bb2(%7 : @owned $E):
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @guaranteed_with_additional_uses :
+// CHECK:         enum
+// CHECK-NEXT:    begin_borrow
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    br bb1(%0 : $String)
+// CHECK:       bb1([[A:%.*]] : @guaranteed $String):
+// CHECK-NEXT:    [[C:%.*]] = copy_value [[A]]
+// CHECK-NEXT:    return [[C]] : $String
+// CHECK-NOT:   bb2
+// CHECK:       } // end sil function 'guaranteed_with_additional_uses'
+sil [ossa] @guaranteed_with_additional_uses : $@convention(thin) (@guaranteed String) -> @owned String {
+bb0(%0 : @guaranteed $String):
+  %1 = enum $E, #E.B!enumelt, %0 : $String
+  %2 = begin_borrow %1 : $E
+  end_borrow %2 : $E
+  switch_enum %1 : $E, case #E.B!enumelt: bb1, default bb2
+
+bb1(%5 : @guaranteed $String):
+  %6 = copy_value %5 : $String
+  return %6 : $String
+
+bb2(%7 : @guaranteed $E):
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @owned_with_debug_uses :
+// CHECK:       bb0(%0 : @owned $String):
+// CHECK-O:       br bb1(%0 : $String)
+// CHECK-ONONE:   switch_enum
+// CHECK:       } // end sil function 'owned_with_debug_uses'
+sil [ossa] @owned_with_debug_uses : $@convention(thin) (@owned String) -> @owned String {
+bb0(%0 : @owned $String):
+  %1 = enum $E, #E.B!enumelt, %0 : $String
+  debug_value %1 : $E, let, name "e"
+  switch_enum %1 : $E, case #E.B!enumelt: bb1, default bb2
+
+bb1(%2 : @owned $String):
+  return %2 : $String
+
+bb2(%4 : @owned $E):
+  unreachable
+}
+


### PR DESCRIPTION
* removes an `enum` - `switch_enum` pairs
* constant fold null pointer checks against string literals

This enables to put `StaticString("some string literal").utf8Start` into a statically initialized global