### PR TITLE
don't use the clang node's USR for subscript decls

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -324,6 +324,16 @@ bool ide::printAccessorUSR(const AbstractStorageDecl *D, AccessorKind AccKind,
     return printObjCUSRForAccessor(SD, AccKind, OS);
   }
 
+  if (const auto *Acc = D->getAccessor(AccKind)) {
+    if (auto ClangD = Acc->getClangDecl()) {
+      llvm::SmallString<128> Buffer;
+      bool Ignore = clang::index::generateUSRForDecl(ClangD, Buffer);
+      if (!Ignore)
+        OS << Buffer;
+      return Ignore;
+    }
+  }
+
   Mangle::ASTMangler NewMangler;
   std::string Mangled = NewMangler.mangleAccessorEntityAsUSR(AccKind,
                           SD, getUSRSpacePrefix(), SD->isStatic());

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -183,6 +183,11 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
     return std::string(); // Ignore.
 
   auto interpretAsClangNode = [](const ValueDecl *D)->ClangNode {
+    // Subscript decls should not use their clang node, since the get/set accessors
+    // are separate nodes and might come from different contexts.
+    if (isa<SubscriptDecl>(D))
+      return ClangNode();
+
     ClangNode ClangN = D->getClangNode();
     if (auto ClangD = ClangN.getAsDecl()) {
       // NSErrorDomain causes the clang enum to be imported like this:

--- a/test/Index/index_objc_subscript.swift
+++ b/test/Index/index_objc_subscript.swift
@@ -1,0 +1,35 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/SplitSubscript.swift -import-objc-header %t/objc_impl.h > %t/output.txt
+// RUN: %FileCheck %s -input-file %t/output.txt
+
+//--- objc_impl.h
+@interface NSObject
+@end
+
+@interface MyClass : NSObject
+- (instancetype)init;
+- (int)objectAtIndexedSubscript:(int)idx;
+@end
+
+@interface MyDerivedClass : MyClass
+- (instancetype)init;
+- (void)setObject:(int)obj atIndexedSubscript:(int)idx;
+@end
+
+//--- SplitSubscript.swift
+let x = MyClass()!
+// CHECK: instance-property/subscript/Swift | subscript(_:) | s:So7MyClassCys5Int32VADcip
+// CHECK: instance-method/acc-get/Swift | getter:subscript(_:) | c:objc(cs)MyClass(im)objectAtIndexedSubscript:
+let _ = x[0]
+
+let y = MyDerivedClass()!
+// CHECK: instance-property/subscript/Swift | subscript(_:) | s:So14MyDerivedClassCys5Int32VADcip
+// CHECK: instance-method/acc-get/Swift | getter:subscript(_:) | c:objc(cs)MyClass(im)objectAtIndexedSubscript:
+let _ = y[0]
+// CHECK: instance-property/subscript/Swift | subscript(_:) | s:So14MyDerivedClassCys5Int32VADcip
+// CHECK: instance-method/acc-set/Swift | setter:subscript(_:) | c:objc(cs)MyDerivedClass(im)setObject:atIndexedSubscript:
+y[0] = 1

--- a/test/SymbolGraph/ClangImporter/SplitSubscript.swift
+++ b/test/SymbolGraph/ClangImporter/SplitSubscript.swift
@@ -1,0 +1,33 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/SplitSubscript)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -I %t/SplitSubscript -module-name SplitSubscript -output-dir %t -pretty-print -v
+// RUN: %FileCheck %s --input-file %t/SplitSubscript.symbols.json
+
+//--- SplitSubscript/module.modulemap
+module SplitSubscript {
+  header "SplitSubscript.h"
+}
+
+//--- SplitSubscript/SplitSubscript.h
+@import Foundation;
+
+// Prior to this test's associated change, the two subscript methods below would get the same USR.
+// We need to ensure that the Clang USR for the base-class subscript method does not appear in the
+// symbol graph, and instead that the individual subscript symbols get distinct USRs.
+// (rdar://117130545)
+
+// CHECK-NOT: c:objc(cs)MyClass(im)objectAtIndexedSubscript:
+
+@interface MyClass : NSObject
+// CHECK-DAG: "precise": "s:So7MyClassCyS2ucip"
+- (NSUInteger)objectAtIndexedSubscript:(NSUInteger)idx;
+@end
+
+@interface MyDerivedClass : MyClass
+// CHECK-DAG: "precise": "s:So14MyDerivedClassCyS2ucip"
+- (void)setObject:(NSUInteger)obj atIndexedSubscript:(NSUInteger)idx;
+@end


### PR DESCRIPTION
Resolves rdar://117130545

When importing subscript methods from Objective-C, we currently use the Clang node's USR as the USR for the subscript decl as a whole. However, in the following code, both classes' subscripts receive the same USR:

```objc
@interface MyClass : NSObject
- (NSUInteger)objectAtIndexedSubscript:(NSUInteger)idx;
@end

@interface MyDerivedClass : MyClass
- (void)setObject:(NSUInteger)obj atIndexedSubscript:(NSUInteger)idx;
@end
```

This is because the derived class's subscript inherits its subscript getter from its base class. In the Clang importer, a duplicate subscript getter is generated that overrides the base class's method and receives the same USR.

This PR changes USR generation to specifically skip using the Clang node's USR for subscript decls, to avoid this situation.