### PR TITLE
[5.10] cherry-pick: build: add SwiftIDEUtils to the Swift Syntax modules

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,6 +25,8 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
     SwiftSyntaxMacros
     SwiftSyntaxMacroExpansion
     SwiftCompilerPluginMessageHandling
+    # Support for LSP
+    SwiftIDEUtils
   )
 
   # Install shared runtime libraries
@@ -56,6 +58,9 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
                                COMPONENT swift-syntax-lib)
   endif()
 
+  add_dependencies(swift-syntax-lib
+    ${SWIFT_SYNTAX_MODULES})
+
   # Install Swift module interface files.
   foreach(module ${SWIFT_SYNTAX_MODULES})
     set(module_dir "${module}.swiftmodule")
@@ -64,6 +69,11 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
                                DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/${module_dir}"
                                COMPONENT swift-syntax-lib)
   endforeach()
+
+  export(TARGETS ${SWIFT_SYNTAX_MODULES}
+         NAMESPACE SwiftSyntax::
+         FILE ${CMAKE_BINARY_DIR}/cmake/modules/SwiftSyntaxConfig.cmake
+         EXPORT_LINK_INTERFACE_LIBRARIES)
 endif()
 
 add_subdirectory(APIDigester)


### PR DESCRIPTION
Add SwiftIDEUtils to the modules that we distribute with the toolchain. The motivation here is to share the build of swift-syntax across the compilers and the LSP. Using the shared linkage this way shaves ~6MiB off of the LSP binary.
