### PR TITLE
[TypeChecker] `TypeChecker::isSubtypeOf` should recognize Sendable s…

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1037,6 +1037,16 @@ bool TypeChecker::typesSatisfyConstraint(Type type1, Type type2,
     if (unwrappedIUO)
       *unwrappedIUO = solution->getFixedScore().Data[SK_ForceUnchecked] > 0;
 
+    // Make sure that Sendable vs. no-Sendable mismatches are
+    // failures here to establish subtyping relationship
+    // (unlike in the solver where they are warnings until Swift 6).
+    if (kind == ConstraintKind::Subtype) {
+      if (llvm::any_of(solution->Fixes, [](const auto *fix) {
+            return fix->getKind() == FixKind::AddSendableAttribute;
+          }))
+        return false;
+    }
+
     return true;
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1034,13 +1034,17 @@ bool TypeChecker::typesSatisfyConstraint(Type type1, Type type2,
   }
 
   if (auto solution = cs.solveSingle()) {
+    const auto &score = solution->getFixedScore();
     if (unwrappedIUO)
-      *unwrappedIUO = solution->getFixedScore().Data[SK_ForceUnchecked] > 0;
+      *unwrappedIUO = score.Data[SK_ForceUnchecked] > 0;
 
     // Make sure that Sendable vs. no-Sendable mismatches are
     // failures here to establish subtyping relationship
     // (unlike in the solver where they are warnings until Swift 6).
     if (kind == ConstraintKind::Subtype) {
+      if (score.Data[SK_MissingSynthesizableConformance] > 0)
+        return false;
+
       if (llvm::any_of(solution->Fixes, [](const auto *fix) {
             return fix->getKind() == FixKind::AddSendableAttribute;
           }))

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -217,3 +217,16 @@ do {
   let _: [PartialKeyPath<S>] = [\.a, \.b] // Ok
   let _: [any PartialKeyPath<S> & Sendable] = [\.a, \.b] // Ok
 }
+
+do {
+  func kp() -> KeyPath<String, Int> & Sendable {
+    fatalError()
+  }
+
+  func test() -> KeyPath<String, Int> {
+    true ? kp() : kp() // Ok
+  }
+
+  func forward<T>(_ v: T) -> T { v }
+  let _: KeyPath<String, Int> = forward(kp()) // Ok
+}

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -228,3 +228,19 @@ do {
     }
   }
 }
+
+do {
+  struct Test {
+    static func fn() {}
+    static func otherFn() {}
+  }
+
+  func fnRet(cond: Bool) -> () -> Void {
+    cond ? Test.fn : Test.otherFn // Ok
+  }
+
+  func forward<T>(_: T) -> T {
+  }
+
+  let _: () -> Void = forward(Test.fn) // Ok
+}


### PR DESCRIPTION
…ubtyping

A sendable type can be a subtype of a non-Sendable type. 
That is currently established via a fix (for function types) and score change
(`SK_MissingSynthesizableConformance` for regular nominal types). 
`TypeChecker::isSubtypeOf` should recognize its presence and fail.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
