### PR TITLE
[cxx-interop] Do not import constructors of abstract C++ classes

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2371,8 +2371,9 @@ namespace {
 
       bool needsEmptyInitializer = true;
       if (cxxRecordDecl) {
-        needsEmptyInitializer = !cxxRecordDecl->hasDefaultConstructor() ||
-                                cxxRecordDecl->ctors().empty();
+        needsEmptyInitializer = !cxxRecordDecl->isAbstract() &&
+                                (!cxxRecordDecl->hasDefaultConstructor() ||
+                                 cxxRecordDecl->ctors().empty());
       }
       if (hasZeroInitializableStorage && needsEmptyInitializer) {
         // Add default constructor for the struct if compiling in C mode.
@@ -3746,6 +3747,19 @@ namespace {
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
       auto method = VisitFunctionDecl(decl);
+
+      // Do not expose constructors of abstract C++ classes.
+      if (auto recordDecl =
+              dyn_cast<clang::CXXRecordDecl>(decl->getDeclContext())) {
+        if (isa<clang::CXXConstructorDecl>(decl) && recordDecl->isAbstract() &&
+            isa_and_nonnull<ValueDecl>(method)) {
+          Impl.markUnavailable(
+              cast<ValueDecl>(method),
+              "constructors of abstract C++ classes are unavailable in Swift");
+          return method;
+        }
+      }
+
       if (decl->isVirtual() && isa_and_nonnull<ValueDecl>(method)) {
 
         if (auto dc = method->getDeclContext();

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -13,6 +13,7 @@ struct Base3 { virtual int f() { return 24; } };
 struct Derived2 : public Base2 { virtual int f() {  return 42; } };
 struct Derived3 : public Base3 { virtual int f() {  return 42; } };
 struct Derived4 : public Base3 { };
+struct DerivedFromDerived2 : public Derived2 {};
 
 template <class T>
 struct Derived : Base {

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -1,9 +1,19 @@
 // RUN: %target-swift-ide-test -print-module -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct Base {
-// CHECK-NEXT:  init()
+// CHECK-NEXT:   @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
+// CHECK-NEXT:   init()
 // CHECK-NEXT:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
 // CHECK-NEXT:   mutating func foo()
+// CHECK: }
+
+// CHECK: struct Base3 {
+// CHECK-NEXT:   init()
+// CHECK: }
+
+// CHECK: struct Derived2 {
+// CHECK-NEXT:   init()
+// CHECK: }
 
 // CHECK: struct Derived<CInt> {
 // CHECK-NEXT:  init()

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -2,4 +2,13 @@
 
 import VirtualMethods
 
+let _ = Base() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
+let _ = Base2() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
+
+let _ = DerivedInt()
+let _ = Derived2()
+let _ = Derived3()
+let _ = Derived4()
+let _ = DerivedFromDerived2()
+
 VirtualNonAbstractBase().nonAbstractMethod()


### PR DESCRIPTION
Clang rejects code that tries to call a constructor of an abstract C++ class with an error: "Variable type 'Base' is an abstract class". Swift should reject this as well.

rdar://119689243