### PR TITLE
[Test] Restrict test to release stdlibs.

### DIFF
--- a/test/SILOptimizer/OSLogMandatoryOptTest.swift
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.swift
@@ -2,6 +2,8 @@
 //
 // REQUIRES: VENDOR=apple
 
+// REQUIRES: swift_stdlib_no_asserts
+
 // Tests for the OSLogOptimization pass that performs compile-time analysis
 // and optimization of the new os log APIs. The tests here check whether specific
 // compile-time constants such as the format string, the size of the byte buffer etc. are


### PR DESCRIPTION
Run OSLogMandatoryOptTest.swift only in configurations with release stdlibs.

https://github.com/apple/swift/pull/64789 introduced a simple but widespread change to SIL.  It required updating a number of tests.  The updates primarily involved replacing `begin_borrow` + `copy_value` with `move_value` instructions.

In particular, OSLogMandatoryOptTest.swift had to be updated as well: several new `move_value` instructions had to be FileCheck'd.  These instructions all came from inlining code from the OSLogTestHelper target, a target which is built in the same configuration as the stdlib. In fact, they all came from inlining the `_osLogTestHelper(_:assertion:)` function.

When building OSLogTestHelper for release, no optimization passes are run on the function because it is marked `@_optimize(none)`. `SemanticARCOpts` would have deleted these `move_value`s, but it doesn't run on the function.

When building OSLogTestHelper for debug, however, `MandatoryARCOpts` (a subset of `SemanticARCOpts`) _does_ run despite the function being marked `@_optimize(none)`.  That's because it's part of the `OnonePassPipeline` which is mandatory, meaning that every pass runs on each function, regardless of it being annotated `@_optimize(none)`.

As a result the `move_value` instructions--which FileCheck lines were added to match--are deleted before FileCheck runs.  So the new check lines fail to match the deleted instructions.  Besides the absence of these new `move_value` instructions, there is no difference between the function in debug vs release.  In particular, removing the newly added check lines allows the test to pass in a configuration with a debug stdlib.

Rather than duplicate the test for debug configurations, just disable it in them.

rdar://119744393
