### PR TITLE
build: Explicitly set `SWIFT_ENABLE_DISPATCH` to build Wasm stdlib

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -83,6 +83,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_BUILD_DYNAMIC_STDLIB:BOOL', 'FALSE')
         self.cmake_options.define(
             'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'TRUE')
+        self.cmake_options.define('SWIFT_ENABLE_DISPATCH:BOOL', 'FALSE')
         self.cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
         self.cmake_options.define(
             'SWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING:BOOL', 'FALSE')


### PR DESCRIPTION
Stdlib build depends on `SWIFT_ENABLE_DISPATCH` to select concurrency global executor implementation since ed8ed32dbafc8bd4ba6c85ccae67f385ee651e66

The change broke the wasm stdlib build because wasmstdlib product used default value of `SWIFT_ENABLE_DISPATCH=YES`
```
CMake Error at stdlib/cmake/modules/StdlibOptions.cmake:225 (message):
  Concurrency requires libdispatch on non-Darwin hosts.  Please specify
  SWIFT_PATH_TO_LIBDISPATCH_SOURCE
Call Stack (most recent call first):
  stdlib/CMakeLists.txt:59 (include)
```

https://github.com/swiftwasm/swiftwasm-build/actions/runs/7231861263/job/19705503571#step:14:1976