### PR TITLE
AST: Fix ExistentialLayout::isObjC() handling of marker protocols [5.10]

### DIFF
--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -31,7 +31,8 @@ struct ExistentialLayout {
 
   ExistentialLayout() {
     hasExplicitAnyObject = false;
-    containsNonObjCProtocol = false;
+    containsObjCProtocol = false;
+    containsSwiftProtocol = false;
     containsParameterized = false;
   }
 
@@ -45,8 +46,11 @@ struct ExistentialLayout {
   /// Whether the existential contains an explicit '& AnyObject' constraint.
   bool hasExplicitAnyObject : 1;
 
-  /// Whether any protocol members are non-@objc.
-  bool containsNonObjCProtocol : 1;
+  /// Whether any protocol members are @objc.
+  bool containsObjCProtocol : 1;
+
+  /// Whether any protocol members require a witness table.
+  bool containsSwiftProtocol : 1;
 
   /// Whether any protocol members are parameterized.s
   bool containsParameterized : 1;
@@ -70,8 +74,8 @@ struct ExistentialLayout {
     // FIXME: Does the superclass have to be @objc?
     return ((explicitSuperclass ||
              hasExplicitAnyObject ||
-             !getProtocols().empty()) &&
-            !containsNonObjCProtocol);
+             containsObjCProtocol) &&
+            !containsSwiftProtocol);
   }
 
   /// Whether the existential requires a class, either via an explicit
@@ -105,10 +109,6 @@ private:
   /// Zero or more primary associated type requirements from a
   /// ParameterizedProtocolType
   ArrayRef<Type> sameTypeRequirements;
-
-  /// Existentials allow a relaxed notion of \c ValueDecl::isObjC
-  /// that includes `Sendable` protocol.
-  static bool isObjCProtocol(ProtocolDecl *P);
 };
 
 }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1659,7 +1659,7 @@ public:
             auto concreteLayout = concreteTy->getCanonicalType()
                                             ->getExistentialLayout();
             canBeClass = concreteLayout.getKind() == ExistentialLayout::Kind::Class
-              && !concreteLayout.containsNonObjCProtocol;
+              && !concreteLayout.containsSwiftProtocol;
           } else {
             canBeClass = false;
           }

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -60,7 +60,7 @@ static bool isNSObjectOrAnyHashable(ASTContext &ctx, Type type) {
 }
 
 static bool isAnyObjectOrAny(Type type) {
-  return type->isAnyObject() || type->isAny();
+  return type->isAnyObject() || type->isMarkerExistential();
 }
 
 // For a given Decl and Type, if the type is not an optional return
@@ -2378,7 +2378,7 @@ private:
     // Use the type as bridged to Objective-C unless the element type is itself
     // an imported type or a collection.
     const StructDecl *SD = ty->getStructOrBoundGenericStruct();
-    if (ty->isAny()) {
+    if (ty->isMarkerExistential()) {
       ty = ctx.getAnyObjectType();
     } else if (!ty->isKnownStdlibCollectionType() && !isSwiftNewtype(SD)) {
       ty = ctx.getBridgedToObjC(&owningPrinter.M, ty);

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -255,12 +255,8 @@ static bool isSingleSwiftRefcounted(SILModule &M,
   if (Ty->isAnyExistentialType()) {
     auto layout = Ty->getExistentialLayout();
     // Must be no protocol constraints that aren't @objc or @_marker.
-    if (layout.containsNonObjCProtocol) {
-      for (auto proto : layout.getProtocols()) {
-        if (!proto->isObjC() && !proto->isMarkerProtocol()) {
-          return false;
-        }
-      }
+    if (layout.containsSwiftProtocol) {
+      return false;
     }
     
     // The Error existential has its own special layout.
@@ -592,6 +588,7 @@ SILType::getPreferredExistentialRepresentation(Type containedType) const {
     return ExistentialRepresentation::Class;
   
   // Otherwise, we need to use a fixed-sized buffer.
+  assert(!layout.isObjC());
   return ExistentialRepresentation::Opaque;
 }
 

--- a/test/Concurrency/emit_objc_header_with_Sendable.swift
+++ b/test/Concurrency/emit_objc_header_with_Sendable.swift
@@ -20,7 +20,7 @@ import Foundation
 @objc public protocol Q {
   // CHECK: - (NSArray<NSDictionary<NSString *, id> *> * _Nonnull)data1 SWIFT_WARN_UNUSED_RESULT;
   func data1() -> [[String: any Sendable]]
-  // CHECK: - (NSArray<id> * _Nullable)data2 SWIFT_WARN_UNUSED_RESULT;
+  // CHECK: - (NSArray * _Nullable)data2 SWIFT_WARN_UNUSED_RESULT;
   func data2() -> [any Sendable]?
   // CHECK: - (void)data3:(id _Nonnull)_;
   func data3(_: any Sendable)

--- a/test/Interpreter/rdar119541554.swift
+++ b/test/Interpreter/rdar119541554.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift %s -o %t/a.out -O -target %target-future-triple
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: macos_min_version_13
+
+struct S {
+  var x = 42
+}
+
+_ = [S() as Sendable]


### PR DESCRIPTION
* Description: We would sometimes treat `any Sendable` as an Objective-C existential, when it is really an opaque existential. This PR fixes the relevant predicate, adds an assertion in SIL type lowering to guard against this bug re-appearing in the future, and changes Objective-C header generation to treat `any Sendable` the same as `Any`, that is bridging it to the `id` type in Objective-C.

* Origination: It's a recent regression from #69540 which never shipped in a release.

* Scope of the issue: The regression caused a miscompile when optimizations were enabled.

* Radar: rdar://problem/119541554.

* Reviewed by: @xedin