### PR TITLE
[NCGenerics] delete `_Copyable` from stdlib

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4717,7 +4717,7 @@ swift::checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
     // No move-only type can witness an associatedtype requirement.
     // Pretend the failure is a lack of Copyable conformance.
     auto *copyable = ctx.getProtocol(KnownProtocolKind::Copyable);
-    assert(copyable && "missing _Copyable protocol!");
+    assert(copyable && "missing Copyable protocol!");
     return CheckTypeWitnessResult::forConformance(copyable);
   }
 

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -160,13 +160,6 @@ public func _unsafePerformance<T>(_ c: () -> T) -> T {
 }
 
 /// This marker protocol represents types that support copying.
-/// This type is not yet available for use to express explicit
-/// constraints on generics in your programs. It is currently
-/// only used internally by the compiler.
-@available(*, unavailable)
-@_marker public protocol _Copyable {} // FIXME: rdar://115793371 (delete _Copyable from stdlib)
-
-
 @_marker public protocol Copyable {}
 
 @_marker public protocol Escapable {}


### PR DESCRIPTION
resolves rdar://115793371

This type declaration is no longer used by the compiler, as the switch over to `Copyable` happened a few months ago.