### PR TITLE
Specify march for Darwin x86

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -803,6 +803,9 @@ importer::addCommonInvocationArguments(
              triple.getArch() == llvm::Triple::aarch64_be) {
       invocationArgStrs.push_back("-mcpu=apple-a7");
     }
+    else if (triple.getArch() == llvm::Triple::x86_64)
+      // The oldest Macs on which Swift 5 can be deployed have Sandy Bridge processors
+      invocationArgStrs.push_back("-mcpu=sandybridge");
   } else if (triple.getArch() == llvm::Triple::systemz) {
     invocationArgStrs.push_back("-march=z13");
   }


### PR DESCRIPTION
The oldest Macs on which Swift 5 can be deployed have Sandy Bridge processors