### PR TITLE
[test] Add REQUIRES: assert to moveonly_addressors using experimental feature

### DIFF
--- a/test/SILOptimizer/moveonly_addressors.swift
+++ b/test/SILOptimizer/moveonly_addressors.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DTRIVIAL -emit-sil -verify %s
 // RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DEMPTY -emit-sil -verify %s
 
+// REQUIRES: asserts
+
 // TODO: Use the real stdlib types once `UnsafePointer` supports noncopyable
 // types.
 


### PR DESCRIPTION
moveonly_addressors.swift (added in #70475) uses the experimental feature `NonescapableTypes`, which requires an asserts compiler to work, so requires marking the test as `REQUIRES: asserts`.
