### PR TITLE
SwiftCompilerSources: bridge_object_to_word is not a ForwardingInstruction

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -841,8 +841,7 @@ final public class RefToBridgeObjectInst : SingleValueInstruction, ForwardingIns
 final public class BridgeObjectToRefInst : SingleValueInstruction,
                                            ConversionInstruction {}
 
-final public class BridgeObjectToWordInst : SingleValueInstruction,
-                                           ConversionInstruction {}
+final public class BridgeObjectToWordInst : SingleValueInstruction {}
 
 public typealias AccessKind = BridgedInstruction.AccessKind
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -46,6 +46,7 @@ struct OptionalBridgedBasicBlock;
 namespace swift {
 class ValueBase;
 class Operand;
+class ForwardingInstruction;
 class SILFunction;
 class SILBasicBlock;
 class SILSuccessor;
@@ -564,6 +565,7 @@ struct BridgedInstruction {
   //                         Instruction protocols
   // =========================================================================//
 
+  BRIDGED_INLINE swift::ForwardingInstruction * _Nonnull getAsForwardingInstruction() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedOperand ForwardingInst_singleForwardedOperand() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedOperandArray ForwardingInst_forwardedOperands() const;
   BRIDGED_INLINE BridgedValue::Ownership ForwardingInst_forwardingOwnership() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -702,6 +702,12 @@ BridgedSuccessorArray BridgedInstruction::TermInst_getSuccessors() const {
   return {{successors.data()}, (SwiftInt)successors.size()};
 }
 
+swift::ForwardingInstruction * _Nonnull BridgedInstruction::getAsForwardingInstruction() const {
+  auto *forwardingInst = swift::ForwardingInstruction::get(unbridged());
+  assert(forwardingInst && "instruction is not defined as ForwardingInstruction");
+  return forwardingInst;
+}
+
 OptionalBridgedOperand BridgedInstruction::ForwardingInst_singleForwardedOperand() const {
   return {swift::ForwardingOperation(unbridged()).getSingleForwardingOperand()};
 }
@@ -713,17 +719,15 @@ BridgedOperandArray BridgedInstruction::ForwardingInst_forwardedOperands() const
 }
 
 BridgedValue::Ownership BridgedInstruction::ForwardingInst_forwardingOwnership() const {
-  auto *forwardingInst = swift::ForwardingInstruction::get(unbridged());
-  return castOwnership(forwardingInst->getForwardingOwnershipKind());
+  return castOwnership(getAsForwardingInstruction()->getForwardingOwnershipKind());
 }
 
 void BridgedInstruction::ForwardingInst_setForwardingOwnership(BridgedValue::Ownership ownership) const {
-  auto *forwardingInst = swift::ForwardingInstruction::get(unbridged());
-  return forwardingInst->setForwardingOwnershipKind(BridgedValue::castToOwnership(ownership));
+  return getAsForwardingInstruction()->setForwardingOwnershipKind(BridgedValue::castToOwnership(ownership));
 }
 
 bool BridgedInstruction::ForwardingInst_preservesOwnership() const {
-  return swift::ForwardingInstruction::get(unbridged())->preservesOwnership();
+  return getAsForwardingInstruction()->preservesOwnership();
 }
 
 BridgedStringRef BridgedInstruction::CondFailInst_getMessage() const {

--- a/test/SILOptimizer/simplify_begin_borrow.sil
+++ b/test/SILOptimizer/simplify_begin_borrow.sil
@@ -220,6 +220,20 @@ bb0(%0 : @owned $S2):
   return %7 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dont_crash_on_bridge_object_to_word :
+// CHECK:       bb0(%0 : @owned $Builtin.BridgeObject):
+// CHECK-NEXT:    destroy_value %0
+// CHECK:       } // end sil function 'dont_crash_on_bridge_object_to_word'
+sil [ossa] @dont_crash_on_bridge_object_to_word : $@convention(thin) (@owned Builtin.BridgeObject) -> () {
+bb0(%0 : @owned $Builtin.BridgeObject):
+  %1 = begin_borrow %0 : $Builtin.BridgeObject
+  %2 = bridge_object_to_word %1 : $Builtin.BridgeObject to $Builtin.Word
+  end_borrow %1 : $Builtin.BridgeObject
+  destroy_value %0: $Builtin.BridgeObject
+  %6 = tuple ()
+  return %6 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @dont_replace_tuple_extract :
 // CHECK:         begin_borrow
 // CHECK:       } // end sil function 'dont_replace_tuple_extract'


### PR DESCRIPTION
Fix this mismatch between C++ SIL and swift SIL.
Fixes a crash in begin_borrow simplification
Also add an assert to catch such cases.

rdar://119763595
