### PR TITLE
[test] Improve ParseableInterfaceImports check patterns

### DIFF
--- a/test/DebugInfo/ParseableInterfaceImports.swift
+++ b/test/DebugInfo/ParseableInterfaceImports.swift
@@ -8,12 +8,14 @@
 
 import basic
 
-// CHECK: !DIModule(scope: null, name: "basic", includePath: "
+// CHECK: !DIModule(scope: null, name: "basic",
+// CHECK-SAME:      includePath: "
 // CHECK-SAME:      basic.swiftinterface"
 
 // Even if the module interface is in the SDK, we still return the path
 // to the swiftinterface.
-// SDK:   !DIModule(scope: null, name: "basic", includePath: "
+// SDK:   !DIModule(scope: null, name: "basic",
+// SDK-SAME:        includePath: "
 // SDK-SAME:        basic{{.*}}.swiftinterface"
 
 func markUsed<T>(_ t: T) {}


### PR DESCRIPTION
When one configures their toolchain to use a define (`-D`) in either `SWIFT_FRONTEND_TEST_OPTIONS` or `SWIFT_DRIVER_TEST_OPTIONS`, the DIModule generated by this test might have other elements like `configMacros` in between `name:` and `includePath:`.

To account for this possibility, break the check in two, using `CHECK-SAME` for the second part.