### PR TITLE
Don't use opaque parameters in the standard library

### DIFF
--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -205,8 +205,8 @@ public func _unexpectedError(
 @_silgen_name("swift_unexpectedErrorTyped")
 @_alwaysEmitIntoClient
 @inlinable
-public func _unexpectedErrorTyped(
-  _ error: __owned some Error,
+public func _unexpectedErrorTyped<E: Error>(
+  _ error: __owned E,
   filenameStart: Builtin.RawPointer,
   filenameLength: Builtin.Word,
   filenameIsASCII: Builtin.Int1,


### PR DESCRIPTION
The SIL printer is printing opaque parameters as <anonymous>, which breaks the SIL parser. Stop using opaque parameters in the standard library for the moment to unbreak SIL parsing of the standard library.
