### PR TITLE
[CSBindings] Make it possible to enumerate supertypes of existentials

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6389,6 +6389,11 @@ public:
 /// for a key path `{Any, Partial, Writable, ReferenceWritable}KeyPath`.
 bool isKnownKeyPathType(Type type);
 
+/// Determine whether the given type is a PartialKeyPath and
+/// AnyKeyPath or existential type thererof, for example,
+/// `PartialKeyPath<...> & Sendable`.
+bool isTypeErasedKeyPathType(Type type);
+
 /// Determine whether given declaration is one for a key path
 /// `{Writable, ReferenceWritable}KeyPath`.
 bool isKnownKeyPathDecl(ASTContext &ctx, ValueDecl *decl);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2359,7 +2359,7 @@ bool TypeVarBindingProducer::computeNext() {
           auto supertype = *simplifiedSuper;
           // A key path type cannot be bound to type-erased key path variants.
           if (TypeVar->getImpl().isKeyPathType() &&
-              (supertype->isPartialKeyPath() || supertype->isAnyKeyPath()))
+              isTypeErasedKeyPathType(supertype))
             continue;
 
           addNewBinding(binding.withType(supertype));

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2172,10 +2172,43 @@ static Type getOptionalSuperclass(Type type) {
     type = underlying;
   }
 
-  if (!type->mayHaveSuperclass())
-    return Type();
+  Type superclass;
+  if (auto *existential = type->getAs<ExistentialType>()) {
+    auto constraintTy = existential->getConstraintType();
+    if (auto *compositionTy = constraintTy->getAs<ProtocolCompositionType>()) {
+      SmallVector<Type, 2> members;
+      bool found = false;
+      // Preserve all of the protocol requirements of the type i.e.
+      // if the type was `any B & P` where `B : A` the supertype is
+      // going to be `any A & P`.
+      //
+      // This is especially important for Sendable key paths because
+      // to reserve sendability of the original type.
+      for (auto member : compositionTy->getMembers()) {
+        if (member->getClassOrBoundGenericClass()) {
+          member = member->getSuperclass();
+          if (!member)
+            return Type();
+          found = true;
+        }
+        members.push_back(member);
+      }
 
-  auto superclass = type->getSuperclass();
+      if (!found)
+        return Type();
+
+      superclass = ExistentialType::get(
+          ProtocolCompositionType::get(type->getASTContext(), members,
+                                       compositionTy->hasExplicitAnyObject()));
+    } else {
+      // Avoid producing superclass for situations like `any P` where `P` is
+      // `protocol P : C`.
+      return Type();
+    }
+  } else {
+    superclass = type->getSuperclass();
+  }
+
   if (!superclass)
     return Type();
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6676,6 +6676,19 @@ bool constraints::isKnownKeyPathType(Type type) {
          type->isAnyKeyPath();
 }
 
+bool constraints::isTypeErasedKeyPathType(Type type) {
+  assert(type);
+
+  if (type->isPartialKeyPath() || type->isAnyKeyPath())
+    return true;
+
+  if (!type->isExistentialType())
+    return false;
+
+  auto superclass = type->getSuperclass();
+  return superclass ? isTypeErasedKeyPathType(superclass) : false;
+}
+
 bool constraints::hasExplicitResult(ClosureExpr *closure) {
   auto &ctx = closure->getASTContext();
   return evaluateOrDefault(ctx.evaluator,

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -200,3 +200,20 @@ func testReferencesToDifferentGlobalActorIsolatedMembers() {
     // expected-warning@-1 {{cannot form key path to main actor-isolated property 'name'; this is an error in Swift 6}}
   }
 }
+
+do {
+  struct S {
+    var a: Int
+    var b: String?
+  }
+
+  func test<T: Sendable>(_: T) {}
+
+  let kp = [\S.a, \S.b]
+
+  test(kp) // Ok
+  test([\S.a, \S.b]) // Ok
+
+  let _: [PartialKeyPath<S>] = [\.a, \.b] // Ok
+  let _: [any PartialKeyPath<S> & Sendable] = [\.a, \.b] // Ok
+}


### PR DESCRIPTION
- Drop `mayHaveSuperclass` because it's too restrictive.
- Add logic to get superclass of existential and re-create
      existential type with all of the protocol requirements.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
