### PR TITLE
Add swift_unreachable after dispatch_main()

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1635,6 +1635,7 @@ static void swift_task_asyncMainDrainQueueImpl() {
   swift_task_donateThreadToGlobalExecutorUntil([](void *context) {
     return *reinterpret_cast<bool*>(context);
   }, &Finished);
+  swift_unreachable("Returned from dispatch_main()");
 #elif !SWIFT_CONCURRENCY_ENABLE_DISPATCH
   // FIXME: consider implementing a concurrent global main queue for
   // these environments?
@@ -1671,7 +1672,8 @@ static void swift_task_asyncMainDrainQueueImpl() {
   }
 #endif
 
-    dispatch_main();
+  dispatch_main();
+  swift_unreachable("Returned from dispatch_main()");
 #endif
 #endif
 }


### PR DESCRIPTION
The compiler is throwing warnings about a non-returning function returning.