### PR TITLE
SIL: Allow package decls to be serialized when appropriate

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -844,7 +844,7 @@ IsSerialized_t SILDeclRef::isSerialized() const {
   }
 
   // Anything else that is not public is not serializable.
-  if (d->getEffectiveAccess() < AccessLevel::Public || d->hasPackageAccess())
+  if (d->getEffectiveAccess() < AccessLevel::Public)
     return IsNotSerialized;
 
   // Enum element constructors are serializable if the enum is

--- a/test/SILGen/Inputs/accessibility_vtables_package_helper.swift
+++ b/test/SILGen/Inputs/accessibility_vtables_package_helper.swift
@@ -1,0 +1,4 @@
+package class Base {
+  package func packageMethod() {}
+  internal func internalMethod() {}
+}

--- a/test/SILGen/accessibility_vtables_package.swift
+++ b/test/SILGen/accessibility_vtables_package.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-silgen %S/Inputs/accessibility_vtables_package_helper.swift -package-name Package | %FileCheck %s --check-prefix=LIBRARY
+// RUN: %target-swift-frontend -enable-library-evolution -emit-silgen %S/Inputs/accessibility_vtables_package_helper.swift -package-name Package | %FileCheck %s --check-prefix=LIBRARY
+
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/accessibility_vtables_package_helper.swift -package-name Package
+// RUN: %target-swift-emit-silgen -primary-file %s -I %t -package-name Package | %FileCheck %s --check-prefix=CLIENT
+
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -o %t %S/Inputs/accessibility_vtables_package_helper.swift -package-name Package
+// RUN: %target-swift-emit-silgen -primary-file %s -I %t -package-name Package | %FileCheck %s --check-prefix=CLIENT
+
+import accessibility_vtables_package_helper
+
+// LIBRARY-LABEL: sil_vtable Base {
+// LIBRARY-NEXT:    #Base.packageMethod: (Base) -> () -> () : @$s36accessibility_vtables_package_helper4BaseC0C6MethodyyF
+// LIBRARY-NEXT:    #Base.internalMethod: (Base) -> () -> () : @$s36accessibility_vtables_package_helper4BaseC14internalMethodyyF
+// LIBRARY-NEXT:    #Base.init!allocator: (Base.Type) -> () -> Base : @$s36accessibility_vtables_package_helper4BaseCACycfC
+// LIBRARY-NEXT:    #Base.deinit!deallocator: @$s36accessibility_vtables_package_helper4BaseCfD
+// LIBRARY-NEXT:  }
+
+// CLIENT-LABEL: sil hidden [ossa] @$s29accessibility_vtables_package15usePackageClassyy0a1_b1_C7_helper4BaseCF : $@convention(thin) (@guaranteed Base) -> () {
+func usePackageClass(_ c: Base) {
+  c.packageMethod()
+}
+
+// TODO: If cross-module inheritance from package visibility superclasses ever becomes a thing,
+// test serialization of the vtable for the derived class in this file.

--- a/test/SILGen/always_emit_into_client_attribute.swift
+++ b/test/SILGen/always_emit_into_client_attribute.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/always_emit_into_client_other_file.swift | %FileCheck %s
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/always_emit_into_client_other_file.swift -package-name Package | %FileCheck %s
 
 // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute0A22EmitIntoClientFunctionyyF : $@convention(thin) () -> ()
 @_alwaysEmitIntoClient public func alwaysEmitIntoClientFunction() {
@@ -9,6 +9,17 @@
 
 // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute26implicitlyUsableFromInlineyyF : $@convention(thin) () -> ()
 @_alwaysEmitIntoClient func implicitlyUsableFromInline() {
+  alwaysEmitIntoClientOtherFunction()
+}
+
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute35packageAlwaysEmitIntoClientFunctionyyF : $@convention(thin) () -> ()
+@_alwaysEmitIntoClient package func packageAlwaysEmitIntoClientFunction() {
+  alwaysEmitIntoClientOtherFunction()
+}
+
+// FIXME: @_alwaysEmitIntoClient should not be allowed on private decls
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute35privateAlwaysEmitIntoClientFunction33_5D0713A780245A446371C699E6F23C4FLLyyF : $@convention(thin) () -> ()
+@_alwaysEmitIntoClient private func privateAlwaysEmitIntoClientFunction() {
   alwaysEmitIntoClientOtherFunction()
 }
 

--- a/test/SILGen/witness_tables_serialized.swift
+++ b/test/SILGen/witness_tables_serialized.swift
@@ -1,32 +1,52 @@
 // This file is also used by witness_tables_serialized_import.swift.
 
-// RUN: %target-swift-emit-silgen %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-NONRESILIENT %s
-// RUN: %target-swift-emit-silgen -enable-library-evolution %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
+// RUN: %target-swift-emit-silgen %s -package-name Package | %FileCheck -check-prefix CHECK -check-prefix CHECK-NONRESILIENT %s
+// RUN: %target-swift-emit-silgen -enable-library-evolution %s -package-name Package | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
 
 public protocol PublicProtocol {}
 
-@usableFromInline
+package protocol PackageProtocol {}
+
+@usableFromInline internal protocol UsableFromInlineProtocol {}
+
 internal protocol InternalProtocol {}
 
-@_fixed_layout
-public struct PublicStruct : PublicProtocol, InternalProtocol {}
+@frozen
+public struct PublicFrozenStruct : PublicProtocol, UsableFromInlineProtocol, PackageProtocol, InternalProtocol {}
 
-public struct PublicResilientStruct : PublicProtocol, InternalProtocol {}
+public struct PublicResilientStruct : PublicProtocol, UsableFromInlineProtocol, PackageProtocol, InternalProtocol {}
+
+package struct PackageStruct : PublicProtocol, UsableFromInlineProtocol, PackageProtocol, InternalProtocol {}
 
 @usableFromInline
-internal struct InternalStruct : PublicProtocol, InternalProtocol {}
+internal struct UsableFromInlineStruct : PublicProtocol, UsableFromInlineProtocol, PackageProtocol, InternalProtocol {}
 
-// CHECK-DAG: sil_witness_table [serialized] PublicStruct: PublicProtocol
-// CHECK-DAG: sil_witness_table [serialized] PublicStruct: InternalProtocol
+// CHECK-DAG: sil_witness_table [serialized] PublicFrozenStruct: PublicProtocol
+// CHECK-DAG: sil_witness_table [serialized] PublicFrozenStruct: UsableFromInlineProtocol
+// CHECK-DAG: sil_witness_table PublicFrozenStruct: PackageProtocol
+// CHECK-DAG: sil_witness_table hidden PublicFrozenStruct: InternalProtocol
 
-// CHECK-RESILIENT-DAG: sil_witness_table InternalStruct: InternalProtocol
-// CHECK-RESILIENT-DAG: sil_witness_table InternalStruct: PublicProtocol
+// CHECK-DAG: sil_witness_table [serialized] PackageStruct: PublicProtocol
+// CHECK-DAG: sil_witness_table [serialized] PackageStruct: UsableFromInlineProtocol
+// CHECK-DAG: sil_witness_table PackageStruct: PackageProtocol
+// CHECK-DAG: sil_witness_table hidden PackageStruct: InternalProtocol
+
+// CHECK-RESILIENT-DAG: sil_witness_table UsableFromInlineStruct: UsableFromInlineProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table UsableFromInlineStruct: PublicProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table UsableFromInlineStruct: PackageProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table hidden UsableFromInlineStruct: InternalProtocol
 
 // CHECK-RESILIENT-DAG: sil_witness_table PublicResilientStruct: PublicProtocol
-// CHECK-RESILIENT-DAG: sil_witness_table PublicResilientStruct: InternalProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table PublicResilientStruct: UsableFromInlineProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table PublicResilientStruct: PackageProtocol
+// CHECK-RESILIENT-DAG: sil_witness_table hidden PublicResilientStruct: InternalProtocol
 
-// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] InternalStruct: InternalProtocol
-// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] InternalStruct: PublicProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] UsableFromInlineStruct: UsableFromInlineProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] UsableFromInlineStruct: PublicProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table UsableFromInlineStruct: PackageProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table hidden UsableFromInlineStruct: InternalProtocol
 
 // CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PublicResilientStruct: PublicProtocol
-// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PublicResilientStruct: InternalProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PublicResilientStruct: UsableFromInlineProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table PublicResilientStruct: PackageProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table hidden PublicResilientStruct: InternalProtocol

--- a/test/SILGen/witness_tables_serialized_import.swift
+++ b/test/SILGen/witness_tables_serialized_import.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module %S/witness_tables_serialized.swift -o %t -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %S/witness_tables_serialized.swift -o %t -enable-library-evolution -package-name Package
 // RUN: %target-swift-emit-silgen -I %t %s | %FileCheck %s
 
 import witness_tables_serialized


### PR DESCRIPTION
https://github.com/apple/swift/pull/70100 prohibited `package` declarations from ever being serialized in order to solve a problem in which the declarations were being serialized inappropriately. That's too heavy handed, though, because an `@_alwaysEmitIntoClient` function with `package` access *must* be serialized because it has public non-abi linkage.

Resolves rdar://104711625
