### PR TITLE
[Test] Fix the wrong subsitution of `swift-frontend-target` in tests

### DIFF
--- a/test/IRGen/enum_large.swift
+++ b/test/IRGen/enum_large.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-target-frontend -emit-irgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s
 
 // REQUIRES: PTRSIZE=64
 

--- a/test/IRGen/static-serialization.swift
+++ b/test/IRGen/static-serialization.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %swift-target-frontend -static -emit-module -emit-module-path %t/StaticLibrary.swiftmodule -module-name StaticLibrary -DSTATIC_LIBRARY %s
-// RUN: %swift-target-frontend -I%t -S %s -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -static -emit-module -emit-module-path %t/StaticLibrary.swiftmodule -module-name StaticLibrary -DSTATIC_LIBRARY %s
+// RUN: %target-swift-frontend -I%t -S %s -emit-ir -o - | %FileCheck %s
 
 #if STATIC_LIBRARY
 public final class S {

--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
-// RUN: %swift-target-frontend -disable-availability-checking -parse-as-library -static -O -module-name M -c -primary-file %t/A.swift %t/B.swift -S -emit-ir -o - | %FileCheck %t/A.swift -check-prefix CHECK
-// RUN: %swift-target-frontend -disable-availability-checking -parse-as-library -static -O -module-name M -c %t/A.swift -primary-file %t/B.swift -S -emit-ir -o - | %FileCheck %t/B.swift -check-prefix CHECK
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -static -O -module-name M -c -primary-file %t/A.swift %t/B.swift -S -emit-ir -o - | %FileCheck %t/A.swift -check-prefix CHECK
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -static -O -module-name M -c %t/A.swift -primary-file %t/B.swift -S -emit-ir -o - | %FileCheck %t/B.swift -check-prefix CHECK
 
 // Verify that we can link successfully.
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking -O %t/A.swift %t/B.swift -o %t/a.out

--- a/test/Macros/extension_macro_plugin.swift
+++ b/test/Macros/extension_macro_plugin.swift
@@ -12,7 +12,7 @@
 // RUN:   %S/Inputs/syntax_macro_definitions.swift \
 // RUN:   -g -no-toolchain-stdlib-rpath
 
-// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 \
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -5,7 +5,7 @@
 
 // RUN: %swift-build-c-plugin -o %t/mock-plugin %t/plugin.c
 
-// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
@@ -15,7 +15,7 @@
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
 
-// RUN: not %swift-target-frontend \
+// RUN: not %target-swift-frontend \
 // RUN:   -typecheck \
 // RUN:   -swift-version 5 \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \

--- a/test/Macros/macro_plugin_broken.swift
+++ b/test/Macros/macro_plugin_broken.swift
@@ -8,7 +8,7 @@
 // RUN:   -module-name=TestPlugin \
 // RUN:   %t/broken_plugin.swift
 
-// RUN: not %swift-target-frontend \
+// RUN: not %target-swift-frontend \
 // RUN:   -typecheck \
 // RUN:   -swift-version 5 -enable-experimental-feature Macros \
 // RUN:   -load-plugin-executable %t/broken-plugin#TestPlugin \

--- a/test/Macros/macro_plugin_broken_shlib.swift
+++ b/test/Macros/macro_plugin_broken_shlib.swift
@@ -7,7 +7,7 @@
 
 // RUN: touch %t/plugins/libTestPlugin.dylib
 
-// RUN: not %swift-target-frontend \
+// RUN: not %target-swift-frontend \
 // RUN:   -typecheck \
 // RUN:   -swift-version 5 \
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
@@ -23,7 +23,7 @@
 // SERVER: test.swift:1:33: note: 'fooMacro' declared here
 // SERVER-NOT: {{error|warning}}
 
-// RUN: not %swift-target-frontend \
+// RUN: not %target-swift-frontend \
 // RUN:   -typecheck \
 // RUN:   -swift-version 5 \
 // RUN:   -plugin-path %t/plugins \

--- a/test/Macros/macro_plugin_disable_sandbox.swift
+++ b/test/Macros/macro_plugin_disable_sandbox.swift
@@ -21,7 +21,7 @@
 
 //== Nested sandbox. Expected to fail because sandbox-exec doesn't support nested sandboxing.
 // RUN: not sandbox-exec -p '(version 1)(allow default)' \
-// RUN:   %swift-target-frontend \
+// RUN:   %target-swift-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 \
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
@@ -31,7 +31,7 @@
 
 //== Avoid nested sandbox by -disable-sandbox
 // RUN: sandbox-exec -p '(version 1)(allow default)' \
-// RUN:   %swift-target-frontend \
+// RUN:   %target-swift-frontend \
 // RUN:   -disable-sandbox \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 \

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -5,7 +5,7 @@
 
 // RUN: %swift-build-c-plugin -o %t/mock-plugin %t/plugin.c
 
-// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 -enable-experimental-feature Macros \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -20,7 +20,7 @@
 // RUN:   %S/Inputs/evil_macro_definitions.swift \
 // RUN:   -g -no-toolchain-stdlib-rpath
 
-// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 -enable-experimental-feature Macros \
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
@@ -31,7 +31,7 @@
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
 
-// RUN: not %swift-target-frontend \
+// RUN: not %target-swift-frontend \
 // RUN:   -typecheck \
 // RUN:   -swift-version 5 \
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \


### PR DESCRIPTION
There is no `%swift-frontend-target` subsitution in test, which is actually `%target-swift-frontend`. The wrong spelling is actually interpruted by lit as `%swift`-frontend-target, and surprising didn't break any tests as the last argument from subsitution is `-define-availability` so it just leads to an very akward availability definition.