### PR TITLE
[5.10] AST: Fix macCatalyst availability for synthesized declarations

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -135,13 +135,28 @@ void AvailabilityInference::applyInferredAvailableAttrs(
   // a per-platform basis.
   std::map<PlatformKind, InferredAvailability> Inferred;
   for (const Decl *D : InferredFromDecls) {
+    llvm::SmallVector<const AvailableAttr *, 8> MergedAttrs;
+
     do {
+      llvm::SmallVector<const AvailableAttr *, 8> PendingAttrs;
+
       for (const DeclAttribute *Attr : D->getAttrs()) {
         auto *AvAttr = dyn_cast<AvailableAttr>(Attr);
         if (!AvAttr || AvAttr->isInvalid())
           continue;
 
+        // Skip an attribute from an outer declaration if it is for a platform
+        // that was already handled implicitly by an attribute from an inner
+        // declaration.
+        if (llvm::any_of(MergedAttrs,
+                         [&AvAttr](const AvailableAttr *MergedAttr) {
+                           return inheritsAvailabilityFromPlatform(
+                               AvAttr->Platform, MergedAttr->Platform);
+                         }))
+          continue;
+
         mergeWithInferredAvailability(AvAttr, Inferred[AvAttr->Platform]);
+        PendingAttrs.push_back(AvAttr);
 
         if (Message.empty() && !AvAttr->Message.empty())
           Message = AvAttr->Message;
@@ -151,6 +166,8 @@ void AvailabilityInference::applyInferredAvailableAttrs(
           RenameDecl = AvAttr->RenameDecl;
         }
       }
+
+      MergedAttrs.append(PendingAttrs);
 
       // Walk up the enclosing declaration hierarchy to make sure we aren't
       // missing any inherited attributes.

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -110,3 +110,43 @@ public struct SPIAvailableStruct {
     // CHECK-PRIVATE-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 }
+
+// CHECK: @_hasMissingDesignatedInitializers @available(macCatalyst 13.1, *)
+// CHECK-NEXT: public class MacCatalystAvailableClass
+@available(macCatalyst 13.1, *)
+public class MacCatalystAvailableClass {
+  // CHECK: #if compiler(>=5.3) && $Actors
+  // CHECK-NEXT: @_hasMissingDesignatedInitializers public actor NestedActor
+  public actor NestedActor {
+    // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 13.1, *)
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+  }
+
+  // CHECK: #if compiler(>=5.3) && $Actors
+  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macCatalyst 14, *)
+  // CHECK-NEXT: public actor LessAvailableMacCatalystActor
+  @available(macCatalyst 14, *)
+  public actor LessAvailableMacCatalystActor {
+    // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 14, *)
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+  }
+
+  // CHECK: #if compiler(>=5.3) && $Actors
+  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(iOS 15.0, macOS 12.0, *)
+  // CHECK-NEXT: public actor AvailableiOSAndMacOSNestedActor {
+  @available(iOS 15.0, macOS 12.0, *)
+  public actor AvailableiOSAndMacOSNestedActor {
+    // CHECK: @available(iOS 15.0, tvOS 13.0, watchOS 6.0, macOS 12.0, *)
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+  }
+
+  // CHECK: #if compiler(>=5.3) && $Actors
+  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(iOS, unavailable)
+  // CHECK-NEXT: public actor UnavailableiOSNestedActor
+  @available(iOS, unavailable)
+  public actor UnavailableiOSNestedActor {
+    // CHECK: @available(tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    // CHECK-NEXT: @available(iOS, unavailable, introduced: 13.0)
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+  }
+}


### PR DESCRIPTION
- **Explanation:** The macCatalyst platform availability of a declaration may be inferred from the iOS platform availability of that declaration in the absence of an explicit macCatalyst availability attribute. This means that when inheriting macCatalyst platform availability, the explict iOS availability of an inner ancestor should take precedence over explicit macCatalyst availability of an outer ancestor. The algorithm that computes inferred availability attributes for synthesized declarations was treating macCatalyst and iOS as independent platforms, though, sometimes yielding inapproparite macCatalyst availability.
- **Radar:** rdar://107766644
- **Scope:** This PR changes the algorithm for generating availability annotations for synthesized declarations. Affected kinds of declarations include the `unownedExecutor` requirement for actors, implicit `_read` and `_modify` accessors, and inherited designated initializers. The change to the algorithm is narrow in that it only suppresses the addition of `@available` attributes for platforms that inherit availability from other root platforms. Today, the only platforms that meet that criteria are macCatalyst and the platform Extension variants.
- **Risk:** Low. Incorrect synthesis of availability attributes could make some derived declarations available when they should not be, leading to missing symbol crashes at runtime when running back deployed apps that reference the inappropriately available. However, the core functionality of existing availability inference behavior is well tested and the scope of the change is limited to less common platforms.
- **Testing:** Added tests for synthesis of `unownedExecutor` decls that, without the fix, demonstrated inappropriate macCatalyst availability.
- **Reviewed By:** @xymus, @nkcsgexi, @artemcm 
- **`main` PR:** https://github.com/apple/swift/pull/70533/

