### PR TITLE
Migrate SwiftCompilerSources to FunctionConvention

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -188,10 +188,8 @@ private struct SideEffectsVisitor : EscapeVisitorWithResult {
       return .ignore
     }
     if user == apply {
-      if let argIdx = apply.argumentIndex(of: operand) {
-        let e = calleeAnalysis.getSideEffects(of: apply, forArgument: argIdx, path: path.projectionPath)
-        result.merge(with: e)
-      }
+      let e = calleeAnalysis.getSideEffects(of: apply, operand: operand, path: path.projectionPath)
+      result.merge(with: e)
     }
     return .continueWalk
   }
@@ -246,7 +244,7 @@ private struct IsIndirectResultWalker: AddressDefUseWalker {
 
   mutating func leafUse(address: Operand, path: UnusedWalkingPath) -> WalkResult {
     if address.instruction == apply,
-       let argIdx = apply.argumentIndex(of: address),
+       let argIdx = apply.calleeArgumentIndex(of: address),
        argIdx < apply.numIndirectResultArguments {
       return .abortWalk
     }

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
@@ -78,16 +78,18 @@ public struct CalleeAnalysis {
   }
 
   /// Returns the argument specific side effects of an apply.
-  public func getSideEffects(of apply: ApplySite, forArgument argumentIdx: Int, path: SmallProjectionPath) -> SideEffects.GlobalEffects {
-    let calleeArgIdx = apply.calleeArgIndex(callerArgIndex: argumentIdx)
-    let convention = apply.getArgumentConvention(calleeArgIndex: calleeArgIdx)
-    let argument = apply.arguments[argumentIdx].at(path)
+  public func getSideEffects(of apply: ApplySite, operand: Operand, path: SmallProjectionPath) -> SideEffects.GlobalEffects {
+    var result = SideEffects.GlobalEffects()
+    guard let calleeArgIdx = apply.calleeArgumentIndex(of: operand) else {
+      return result
+    }
+    let convention = apply.convention(of: operand)!
+    let argument = operand.value.at(path)
 
     guard let callees = getCallees(callee: apply.callee) else {
       return .worstEffects.restrictedTo(argument: argument, withConvention: convention)
     }
   
-    var result = SideEffects.GlobalEffects()
     for callee in callees {
       let calleeEffects = callee.getSideEffects(forArgument: argument,
                                                 atIndex: calleeArgIdx,

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
@@ -139,7 +139,7 @@ private func isOperandOfRecursiveCall(_ op: Operand) -> Bool {
   if let applySite = inst as? FullApplySite,
      let callee = applySite.referencedFunction,
      callee == inst.parentFunction,
-     let argIdx = applySite.argumentIndex(of: op),
+     let argIdx = applySite.calleeArgumentIndex(of: op),
      op.value == callee.arguments[argIdx] {
     return true
   }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
@@ -350,7 +350,7 @@ func isBridgeToSwiftCall(_ value: Value) -> ApplyInst? {
     return nil
   }
   guard bridgingCall.arguments.count == 2,
-        bridgingCall.getArgumentConvention(calleeArgIndex: 0) == .directGuaranteed else {
+        bridgingCall.calleeArgumentConventions[0] == .directGuaranteed else {
     return nil
   }
   return bridgingCall
@@ -362,7 +362,7 @@ func isBridgeToObjcCall(_ value: Value) -> ApplyInst? {
         let bridgingFunc = bridgingCall.referencedFunction,
         bridgingFunc.hasSemanticsAttribute("convertToObjectiveC"),
         bridgingCall.arguments.count == 1,
-        bridgingCall.getArgumentConvention(calleeArgIndex: 0) == .directGuaranteed else {
+        bridgingCall.calleeArgumentConventions[0] == .directGuaranteed else {
     return nil
   }
   return bridgingCall

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/ReadOnlyGlobalVariables.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/ReadOnlyGlobalVariables.swift
@@ -59,9 +59,8 @@ private struct FindWrites : AddressDefUseWalker {
       return address == ca.sourceOperand ? .continueWalk : .abortWalk
 
     case let apply as FullApplySite:
-      if let callerArgIdx = apply.argumentIndex(of: address) {
-        let calleeArgIdx = apply.calleeArgIndex(callerArgIndex: callerArgIdx)
-        let convention = apply.getArgumentConvention(calleeArgIndex: calleeArgIdx)
+      if let calleeArgIdx = apply.calleeArgumentIndex(of: address) {
+        let convention = apply.calleeArgumentConventions[calleeArgIdx]
         if convention.isIndirectIn {
           return .continueWalk
         }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -260,13 +260,13 @@ private struct StackProtectionOptimization {
       
         for functionRefUse in fri.uses {
           guard let apply = functionRefUse.instruction as? ApplySite,
-                let callerArgIdx = apply.callerArgIndex(calleeArgIndex: arg.index) else {
+                let callerArgOp = apply.operand(forCalleeArgumentIndex: arg.index) else {
             if enableMoveInout {
               return NeedInsertMoves.yes
             }
             continue
           }
-          let callerArg = apply.arguments[callerArgIdx]
+          let callerArg = callerArgOp.value
           if callerArg.type.isAddress {
             // It's an indirect argument.
             switch callerArg.accessBase.isStackAllocated {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -491,7 +491,7 @@ extension Operand {
 
 extension Instruction {
   func setOperand(at index : Int, to value: Value, _ context: some MutatingContext) {
-    if self is FullApplySite && index == ApplyOperands.calleeOperandIndex {
+    if let apply = self as? FullApplySite, apply.isCallee(operand: operands[index]) {
       context.notifyCallsChanged()
     }
     context.notifyInstructionsChanged()

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -107,7 +107,7 @@ extension DestroyValueInst : DevirtualizableDestroy {
     let builder = Builder(before: self, context)
     let subs = context.getContextSubstitutionMap(for: type)
     let deinitRef = builder.createFunctionRef(deinitializer)
-    if deinitializer.getArgumentConvention(for: deinitializer.selfArgumentIndex).isIndirect {
+    if deinitializer.argumentConventions[deinitializer.selfArgumentIndex].isIndirect {
       let allocStack = builder.createAllocStack(type)
       builder.createStore(source: destroyedValue, destination: allocStack, ownership: .initialize)
       builder.createApply(function: deinitRef, subs, arguments: [allocStack])
@@ -175,7 +175,7 @@ extension DestroyAddrInst : DevirtualizableDestroy {
     let builder = Builder(before: self, context)
     let subs = context.getContextSubstitutionMap(for: destroyedAddress.type)
     let deinitRef = builder.createFunctionRef(deinitializer)
-    if !deinitializer.getArgumentConvention(for: deinitializer.selfArgumentIndex).isIndirect {
+    if !deinitializer.argumentConventions[deinitializer.selfArgumentIndex].isIndirect {
       let value = builder.createLoad(fromAddress: destroyedAddress, ownership: .take)
       builder.createApply(function: deinitRef, subs, arguments: [value])
     } else {

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -12,60 +12,81 @@
 
 import SILBridging
 
-public struct ApplyOperands {
-  public static let calleeOperandIndex: Int = 0
+/// Argument conventions indexed on an apply's operand.
+///
+/// `partial_apply` operands correspond to a suffix of the callee
+/// arguments.
+///
+/// Example:
+/// ```
+/// func callee(a, b, c, d, e) { }
+///
+/// %pa = partial_apply @callee(c, d, e)
+/// // operand indices:         1, 2, 3
+/// // callee indices:          2, 3, 4
+///
+///  %a = apply         %pa    (a, b)
+/// // operand indices:         1, 2
+/// // callee indices:          0, 1
+/// ```
+public struct ApplyOperandConventions : Collection {
+  public static let calleeIndex: Int = 0
   public static let firstArgumentIndex = 1
+
+  /// Callee's argument conventions indexed on the function's arguments.
+  public let calleeArgumentConventions: ArgumentConventions
+
+  public let unappliedArgumentCount: Int
+
+  public var appliedArgumentCount: Int {
+    calleeArgumentConventions.count - unappliedArgumentCount
+  }
+
+  public func isCallee(operand: Operand) -> Bool {
+    return operand.index == ApplyOperandConventions.calleeIndex
+  }
+
+  public var startIndex: Int { ApplyOperandConventions.firstArgumentIndex }
+
+  public var endIndex: Int { ApplyOperandConventions.firstArgumentIndex + appliedArgumentCount }
+
+  public func index(after index: Int) -> Int {
+    return index + 1
+  }
+
+  public subscript(_ operandIndex: Int) -> ArgumentConvention {
+    return calleeArgumentConventions[calleeArgumentIndex(ofOperandIndex: operandIndex)!]
+  }
+
+  public func convention(of operand: Operand) -> ArgumentConvention? {
+    guard let argIdx = calleeArgumentIndex(of: operand) else { return nil }
+    return calleeArgumentConventions[argIdx]
+  }
+
+  public func calleeArgumentIndex(ofOperandIndex index: Int) -> Int? {
+    let callerArgIdx = index - ApplyOperandConventions.firstArgumentIndex
+    guard callerArgIdx >= 0 else { return nil }
+
+    let calleeArgIdx = callerArgIdx + unappliedArgumentCount
+    guard calleeArgIdx < calleeArgumentConventions.count else { return nil }
+    return calleeArgIdx
+  }
+
+  public func calleeArgumentIndex(of operand: Operand) -> Int? {
+    calleeArgumentIndex(ofOperandIndex: operand.index)
+  }
 }
 
 public protocol ApplySite : Instruction {
   var operands: OperandArray { get }
   var numArguments: Int { get }
   var substitutionMap: SubstitutionMap { get }
-  
-  /// Converts an argument index of the apply to the corresponding argument index of the callee.
-  ///
-  /// For a FullApplySite this is always a 1-to-1 mapping.
-  /// For a `partial_apply` the callee index can be higher than the caller's argument index
-  /// because the arguments to `partial_apply` are a suffix of the callee.
-  ///
-  /// Example:
-  /// ```
-  /// func callee(a, b, c, d, e) { }
-  ///
-  /// %pa = partial_apply @callee(c, d, e)
-  /// // caller indices:          0, 1, 2
-  /// // callee indices:          2, 3, 4
-  ///
-  ///  %a = apply         %pa    (a, b)
-  /// // caller indices:          0, 1
-  /// // callee indices:          0, 1
-  /// ```
-  func calleeArgIndex(callerArgIndex: Int) -> Int
 
-  /// Converts an argument index of a callee to the corresponding argument index of the apply.
-  ///
-  /// If the apply does not actually apply that argument, it returns nil.
-  /// Otherwise, for a FullApplySite this is always a 1-to-1 mapping.
-  /// For a `partial_apply` the caller index can be lower than the callee's argument index
-  /// because the arguments to `partial_apply` are a suffix of the callee.
-  ///
-  /// Example:
-  /// ```
-  ///                func callee(a, b, c, d, e) { }
-  /// // callee indices:         0, 1, 2, 3, 4
-  /// // caller indices in %pa:  -, -, 0, 1, 2     ("-" == nil)
-  /// // caller indices in %a:   0, 1, -, -, -
-  ///
-  /// %pa = partial_apply @callee(c, d, e)
-  ///  %a = apply         %pa    (a, b)
-  /// ```
-  func callerArgIndex(calleeArgIndex: Int) -> Int?
-
-  func getArgumentConvention(calleeArgIndex: Int) -> ArgumentConvention
+  var unappliedArgumentCount: Int { get }
 }
 
 extension ApplySite {
-  public var callee: Value { operands[ApplyOperands.calleeOperandIndex].value }
+  public var callee: Value { operands[ApplyOperandConventions.calleeIndex].value }
 
   public var isAsync: Bool {
     return callee.type.isAsyncFunction
@@ -76,7 +97,7 @@ extension ApplySite {
   /// This does not include the callee function operand.
   public var argumentOperands: OperandArray {
     let numArgs = bridged.ApplySite_getNumArguments()
-    let offset = ApplyOperands.firstArgumentIndex
+    let offset = ApplyOperandConventions.firstArgumentIndex
     return operands[offset..<(numArgs + offset)]
   }
 
@@ -91,39 +112,67 @@ extension ApplySite {
     SubstitutionMap(bridged.ApplySite_getSubstitutionMap())
   }
 
+  /// Get the conventions of the callee without the applied substitutions.
+  public var originalCalleeConvention: FunctionConvention {
+    FunctionConvention(for: callee.type.bridged.getASTType(), in: parentFunction)
+  }
+
+  /// Get the conventions of the callee with the applied substitutions.
+  public var substitutedCalleeConvention: FunctionConvention {
+    FunctionConvention(for: bridged.ApplySite_getSubstitutedCalleeType(), in: parentFunction)
+  }
+
+  public var calleeArgumentConventions: ArgumentConventions {
+    ArgumentConventions(functionConvention: substitutedCalleeConvention)
+  }
+
+  public var operandConventions: ApplyOperandConventions {
+    ApplyOperandConventions(
+      calleeArgumentConventions: calleeArgumentConventions,
+      unappliedArgumentCount: bridged.PartialApply_getCalleeArgIndexOfFirstAppliedArg())
+  }
+
   /// Returns the argument index of an operand.
   ///
   /// Returns nil if 'operand' is not an argument operand. This is the case if
   /// it's the callee function operand.
-  public func argumentIndex(of operand: Operand) -> Int? {
-    let opIdx = operand.index
-    if opIdx >= ApplyOperands.firstArgumentIndex &&
-       opIdx <= ApplyOperands.firstArgumentIndex + numArguments {
-      return opIdx - ApplyOperands.firstArgumentIndex
-    }
-    return nil
+  public func calleeArgumentIndex(of operand: Operand) -> Int? {
+    operandConventions.calleeArgumentIndex(of: operand)
   }
 
   /// Returns true if `operand` is the callee function operand and not am argument operand.
-  public func isCalleeOperand(_ operand: Operand) -> Bool {
-    return operand.index < ApplyOperands.firstArgumentIndex
+  public func isCallee(operand: Operand) -> Bool {
+    operandConventions.isCallee(operand: operand)
   }
-  
-  public func getArgumentConvention(calleeArgIndex: Int) -> ArgumentConvention {
-    return bridged.ApplySite_getArgumentConvention(calleeArgIndex).convention
+
+  public func convention(of operand: Operand) -> ArgumentConvention? {
+    operandConventions.convention(of: operand)
   }
-  
+
+  /// Converts an argument index of a callee to the corresponding apply operand.
+  ///
+  /// If the apply does not actually apply that argument, it returns nil.
+  ///
+  /// Example:
+  /// ```
+  ///                 func callee(v, w, x, y, z) { }
+  /// // caller operands in %pa:  -, -, c, d, e     ("-" == nil)
+  /// // caller operands in %a:   a, b, -, -, -
+  ///
+  /// %pa = partial_apply @callee(c, d, e)
+  ///  %a = apply         %pa    (a, b)
+  /// ```
+  public func operand(forCalleeArgumentIndex calleeArgIdx: Int) -> Operand? {
+    let callerArgIdx = calleeArgIdx - operandConventions.unappliedArgumentCount
+    guard callerArgIdx >= 0 && callerArgIdx < numArguments else { return nil }
+    return argumentOperands[callerArgIdx]
+  }
+
   public var referencedFunction: Function? {
     if let fri = callee as? FunctionRefInst {
       return fri.referencedFunction
     }
     return nil
-  }
-
-  /// Get the conventions of the callee without the applied substitutions.
-  public var originalCalleeConvention: FunctionConvention {
-    FunctionConvention(for: callee.type.bridged.getASTType(),
-      in: parentFunction)
   }
 
   public func hasSemanticsAttribute(_ attr: StaticString) -> Bool {
@@ -139,17 +188,7 @@ public protocol FullApplySite : ApplySite {
 }
 
 extension FullApplySite {
-  public func calleeArgIndex(callerArgIndex: Int) -> Int {
-    assert(callerArgIndex >= 0 && callerArgIndex < numArguments)
-    return callerArgIndex
-  }
-
-  public func callerArgIndex(calleeArgIndex: Int) -> Int? {
-    if calleeArgIndex < numArguments {
-      return calleeArgIndex
-    }
-    return nil
-  }
+  public var unappliedArgumentCount: Int { 0 }
 
   /// The number of indirect out arguments.
   ///

--- a/SwiftCompilerSources/Sources/SIL/Effects.swift
+++ b/SwiftCompilerSources/Sources/SIL/Effects.swift
@@ -71,7 +71,7 @@ extension Function {
       var effects = definedGlobalEffects
 
       // Even a `[readnone]` function can read from indirect arguments.
-      if (0..<numArguments).contains(where: {getArgumentConvention(for: $0).isIndirectIn}) {
+      if (0..<numArguments).contains(where: {argumentConventions[$0].isIndirectIn}) {
         effects.memory.read = true
       }
       // Even `[readnone]` and `[readonly]` functions write to indirect results.

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -35,6 +35,17 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
 
   public var hasLoweredAddresses: Bool { bridged.hasLoweredAddresses() }
 
+  /// The lowered function type in the expansion context of self.
+  ///
+  /// Always expanding a function type means that the opaque result types
+  /// have the correct generic signature. For example:
+  ///    @substituted <τ_0_0> () -> @out τ_0_0 for <some P>
+  /// is lowered to this inside its module:
+  ///    @substituted <τ_0_0> () -> @out τ_0_0 for <ActualResultType>
+  /// and this outside its module
+  ///    @substituted <τ_0_0> () -> @out τ_0_0 for <some P>
+  public var loweredFunctionType: BridgedASTType { bridged.getLoweredFunctionTypeInContext() }
+
   /// Returns true if the function is a definition and not only an external declaration.
   ///
   /// This is the case if the functioun contains a body, i.e. some basic blocks.
@@ -87,8 +98,12 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
   public var argumentTypes: ArgumentTypeArray { ArgumentTypeArray(function: self) }
   public var resultType: Type { bridged.getSILResultType().type }
 
-  public func getArgumentConvention(for argumentIndex: Int) -> ArgumentConvention {
-    return bridged.getSILArgumentConvention(argumentIndex).convention
+  public var convention: FunctionConvention {
+    FunctionConvention(for: loweredFunctionType, in: self)
+  }
+
+  public var argumentConventions: ArgumentConventions {
+    ArgumentConventions(functionConvention: convention)
   }
 
   public var returnInstruction: ReturnInst? {
@@ -387,9 +402,8 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
         let addr = bridgedAddr.value
         let applySite = argOp.instruction as! FullApplySite
         let addrPath = addr.accessPath
-        let argIdx = argOp.index - ApplyOperands.firstArgumentIndex
-        let calleeArgIdx = applySite.calleeArgIndex(callerArgIndex: argIdx)
-        let convention = applySite.getArgumentConvention(calleeArgIndex: calleeArgIdx)
+        let calleeArgIdx = applySite.calleeArgumentIndex(of: argOp)!
+        let convention = applySite.convention(of: argOp)!
         assert(convention.isIndirectIn || convention.isInout)
         let argPath = argOp.value.accessPath
         assert(!argPath.isDistinct(from: addrPath))

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -914,21 +914,7 @@ class ClassifyBridgeObjectInst : SingleValueInstruction, UnaryInstruction {}
 final public class PartialApplyInst : SingleValueInstruction, ApplySite {
   public var numArguments: Int { bridged.PartialApplyInst_numArguments() }
   public var isOnStack: Bool { bridged.PartialApplyInst_isOnStack() }
-
-  public func calleeArgIndex(callerArgIndex: Int) -> Int {
-    bridged.PartialApply_getCalleeArgIndexOfFirstAppliedArg() + callerArgIndex
-  }
-
-  public func callerArgIndex(calleeArgIndex: Int) -> Int? {
-    let firstIdx = bridged.PartialApply_getCalleeArgIndexOfFirstAppliedArg()
-    if calleeArgIndex >= firstIdx {
-      let callerIdx = calleeArgIndex - firstIdx
-      if callerIdx < numArguments {
-        return callerIdx
-      }
-    }
-    return nil
-  }
+  public var unappliedArgumentCount: Int { bridged.PartialApply_getCalleeArgIndexOfFirstAppliedArg() }
 }
 
 final public class ApplyInst : SingleValueInstruction, FullApplySite {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4700,6 +4700,10 @@ private:
     return {getTrailingObjects<SILResultInfo>(), getNumResults()};
   }
 
+  MutableArrayRef<SILResultInfo> getMutableResultsWithError() {
+    return {getTrailingObjects<SILResultInfo>(), getNumResultsWithError()};
+  }
+
   MutableArrayRef<SILYieldInfo> getMutableYields() {
     return {getTrailingObjects<SILYieldInfo>(), getNumYields()};
   }
@@ -4818,6 +4822,13 @@ public:
     return const_cast<SILFunctionType *>(this)->getMutableResults();
   }
   unsigned getNumResults() const { return isCoroutine() ? 0 : NumAnyResults; }
+
+  ArrayRef<SILResultInfo> getResultsWithError() const {
+    return const_cast<SILFunctionType *>(this)->getMutableResultsWithError();
+  }
+  unsigned getNumResultsWithError() const {
+    return getNumResults() + (hasErrorResult() ? 1 : 0);
+  }
 
   /// Given that this function type has exactly one result, return it.
   /// This is a common situation when working with a function with a known


### PR DESCRIPTION
Layers:
    - FunctionConvention: AST FunctionType: results, parameters
    - ArgumentConventions: SIL function arguments
    - ApplyOperandConventions: applied operands

The meaning of an integer index is determined by the collection
type. All the mapping between the various indices (results,
parameters, SIL argument, applied arguments) is restricted to the
collection type that owns that mapping. Remove the concept of a
"caller argument index".