### PR TITLE
tests: disable IRGen/section_structs.swift for 32-bit

### DIFF
--- a/test/IRGen/section_structs.swift
+++ b/test/IRGen/section_structs.swift
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// The `StaticString("hello").utf8Start` test fails on 32 bit
+// UNSUPPORTED: PTRSIZE=32
+
 struct MyStruct1 {
     var a, b: Int
 }


### PR DESCRIPTION
The `StaticString("hello").utf8Start` test fails on 32 bit
