### PR TITLE
build: only apply linker flags for C/C++

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -580,16 +580,19 @@ function Build-CMakeProject {
 
     # Add additional defines (unless already present)
     $Defines = $Defines.Clone()
-  
+
     TryAdd-KeyValue $Defines CMAKE_BUILD_TYPE Release
     TryAdd-KeyValue $Defines CMAKE_MT "mt"
 
     $CFlags = @("/GS-", "/Gw", "/Gy", "/Oi", "/Oy", "/Zc:inline")
-    if ($DebugInfo) {
-      $CFlags += if ($EnableCaching) { "/Z7" } else { "/Zi" }
-      # Add additional linker flags for generating the debug info.
-      Append-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "/debug"
-      Append-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "/debug"
+    if ($UseMSVCCompilers.Contains("C") -Or $UseMSVCCompilers.Contains("CXX") -Or
+        $UsePinnedCompilers.Contains("C") -Or $UsePinnedCompilers.Contains("CXX")) {
+      if ($DebugInfo) {
+        $CFlags += if ($EnableCaching) { "/Z7" } else { "/Zi" }
+        # Add additional linker flags for generating the debug info.
+        Append-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "/debug"
+        Append-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "/debug"
+      }
     }
     $CXXFlags = $CFlags.Clone() + "/Zc:__cplusplus"
 


### PR DESCRIPTION
When building C/C++ code we need to add `/debug` to the flags.  However, if we are building Swift code, this becomes a problem as the flag is passed to the Swift compiler directly.  Only pass the flag when C/C++ code is being built.