### PR TITLE
[test] Make BlocksRuntimeStubs use never_install component.

### DIFF
--- a/stdlib/private/BlocksRuntimeStubs/CMakeLists.txt
+++ b/stdlib/private/BlocksRuntimeStubs/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(SDK ${SWIFT_SDKS})
         SHARED NOSWIFTRT
         ARCHITECTURE ${ARCH}
         SDK ${SDK}
-        INSTALL_IN_COMPONENT dev
+        INSTALL_IN_COMPONENT never_install
         BlocksRuntime.c
       )
       set_target_properties(BlocksRuntimeStub${VARIANT_SUFFIX} PROPERTIES


### PR DESCRIPTION
For some reason, 4 years ago, in ea90256 I added this target to `dev`, which does not make sense because these stubs are only intended for testing. Make them `never_install` to avoid distributing them when doing `install-dev`.

