### PR TITLE
Fix a crash in ClangImporter::Implementation::DiagnosticWalker::TraverseDecl

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2426,6 +2426,8 @@ ClangImporter::Implementation::DiagnosticWalker::DiagnosticWalker(
 
 bool ClangImporter::Implementation::DiagnosticWalker::TraverseDecl(
     clang::Decl *D) {
+  if (!D)
+    return true;
   // In some cases, diagnostic notes about types (ex: built-in types) do not
   // have an obvious source location at which to display diagnostics. We
   // provide the location of the closest decl as a reasonable choice.

--- a/test/Interop/Cxx/class/friend-diag.swift
+++ b/test/Interop/Cxx/class/friend-diag.swift
@@ -1,0 +1,29 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swiftxx-frontend -typecheck -I %t/Inputs %t/test.swift -verify
+
+//--- Inputs/module.modulemap
+module FriendClass {
+  header "test.h"
+  requires cplusplus
+  export *
+}
+
+//--- Inputs/test.h
+
+template <class T>
+class B {
+  ~B() = delete;
+};
+
+class D : public B<D> { // expected-note {{record 'D' is not automatically available}}
+  friend class B<D>;
+};
+
+//--- test.swift
+
+import FriendClass
+
+func test() {
+  var v: D // expected-error {{cannot find type 'D' in scope}}
+}


### PR DESCRIPTION
The call to `D->getBeginLoc` crashes when `D` is null.

Resolves rdar://118899818