### PR TITLE
[Test] XFAIL IRGen/static-vtable-stubs.swift on armv7k

### DIFF
--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -8,6 +8,9 @@
 
 // REQUIRES: concurrency
 
+// rdar://119900439
+// XFAIL: CPU=armv7k
+
 //--- A.swift
 open class C {
   private var i: [ObjectIdentifier:Any] = [:]


### PR DESCRIPTION
XFAIL IRGen/static-vtable-stubs.swift on armv7k after fixing it to correctly using %target-swift-frontend.

