### PR TITLE
[OnoneSimplification] Fixed isDestroyed(after:)

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -344,6 +344,13 @@ struct SimplifyContext : MutatingContext {
   let preserveDebugInfo: Bool
 }
 
+extension SimplifyContext {
+  var dominatorTree: DominatorTree {
+    let bridgedDT = _bridged.getDomTree()
+    return DominatorTree(bridged: bridgedDT)
+  }
+}
+
 extension Type {
   func getStaticSize(context: SimplifyContext) -> Int? {
     let v = context._bridged.getStaticSize(self.bridged)

--- a/test/SILOptimizer/simplify_begin_borrow.sil
+++ b/test/SILOptimizer/simplify_begin_borrow.sil
@@ -8,7 +8,8 @@ import Builtin
 import Swift
 import SwiftShims
 
-class C {
+class B {}
+class C : B {
   @_hasStorage let i: Int
 }
 
@@ -360,3 +361,57 @@ bb3:
   return %0 : $C
 }
 
+// CHECK-LABEL: sil [ossa] @dont_replace_destroys_of_original_with_destroys_of_nondominating_forward : {{.*}} {
+// CHECK:         begin_borrow 
+// CHECK-LABEL: } // end sil function 'dont_replace_destroys_of_original_with_destroys_of_nondominating_forward'
+sil [ossa] @dont_replace_destroys_of_original_with_destroys_of_nondominating_forward : $@convention(thin) (@owned C) -> () {
+bb0(%21 : @owned $C):
+  cond_br undef, bb3, bb6
+
+bb3:
+  %39 = begin_borrow %21 : $C
+  %40 = upcast %39 : $C to $B
+  apply undef(%40) : $@convention(thin) (@guaranteed B) -> ()
+  end_borrow %39 : $C
+  cond_br undef, bb4, bb5
+
+bb4:
+  destroy_value %21 : $C
+  br bb7
+
+bb5:
+  destroy_value %21 : $C
+  br bb7
+
+bb6:
+  destroy_value %21 : $C
+  br bb7
+
+bb7:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @do_replace_destroys_of_original_with_destroys_of_dominating_forward : {{.*}} {
+// CHECK-NOT:     begin_borrow
+// CHECK-LABEL: } // end sil function 'do_replace_destroys_of_original_with_destroys_of_dominating_forward'
+sil [ossa] @do_replace_destroys_of_original_with_destroys_of_dominating_forward : $@convention(thin) (@owned C) -> () {
+bb0(%21 : @owned $C):
+  %39 = begin_borrow %21 : $C
+  %40 = upcast %39 : $C to $B
+  apply undef(%40) : $@convention(thin) (@guaranteed B) -> ()
+  end_borrow %39 : $C
+  cond_br undef, bb4, bb5
+
+bb4:
+  destroy_value %21 : $C
+  br bb7
+
+bb5:
+  destroy_value %21 : $C
+  br bb7
+
+bb7:
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
The previous implementation just checked that a value's only uses besides the begin_borrow were destroys.  That's insufficient to say the value is destroyed _after_ the borrow (i.e. that all its destroys are dominated by the borrow).  Add the relevant dominance check.

It would be better not to compute the dominance tree here, but that compile-time issue can be fixed separately.

rdar://119873930
