### PR TITLE
[SILGen] Handle marker existentials in `emitCBridgedToNativeValue`.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1131,7 +1131,7 @@ static ManagedValue emitCBridgedToNativeValue(
   }
 
   // id-to-Any bridging.
-  if (nativeType->isAny()) {
+  if (nativeType->isMarkerExistential()) {
     // If this is not a call result, use the normal erasure logic.
     if (!isCallResult) {
       return SGF.emitTransformedValue(loc, unwrapBridgedOptionals(v),
@@ -1163,10 +1163,18 @@ static ManagedValue emitCBridgedToNativeValue(
     auto optionalBridgedTy = SILType::getOptionalType(loweredBridgedTy);
     auto optionalMV = SGF.B.createUncheckedBitCast(
         loc, unwrapBridgedOptionals(v), optionalBridgedTy);
-    return SGF.emitApplyOfLibraryIntrinsic(loc,
+    v = SGF.emitApplyOfLibraryIntrinsic(loc,
                            SGF.getASTContext().getBridgeAnyObjectToAny(),
                            SubstitutionMap(), optionalMV, C)
               .getAsSingleValue(SGF, loc);
+    
+    // Convert to the marker existential if necessary.
+    auto anyType = SGF.getASTContext().getAnyExistentialType();
+    if (nativeType != anyType) {
+      v = SGF.emitTransformedValue(loc, v, anyType, nativeType);
+    }
+
+    return v;
   }
 
   // Bridge NSError to Error.

--- a/test/SILGen/Inputs/objc_bridging_sendable.h
+++ b/test/SILGen/Inputs/objc_bridging_sendable.h
@@ -2,4 +2,5 @@
 
 @interface NSBlah: NSObject
 - (void) takeSendable: (id __attribute__((swift_attr("@Sendable")))) x;
+@property (readonly) id __attribute__((swift_attr("@Sendable"))) x;
 @end

--- a/test/SILGen/objc_bridging_sendable.swift
+++ b/test/SILGen/objc_bridging_sendable.swift
@@ -9,3 +9,7 @@
 public func passSendableToObjC(_ s: Sendable) {
   NSBlah().takeSendable(s)
 }
+
+public func useSendableProperty(_ ns: NSBlah) {
+  _ = ns.x
+}


### PR DESCRIPTION
The id-to-Any bridging path in `emitCBridgedToNativeValue` was not taken when the native type was a marker existential such as `any Sendable`, which would lead to crashes when emitting references to imported properties marked with `__attribute__((swift_attr("@Sendable")))`.

Resolves rdar://119708690