### PR TITLE
[CAS] Do not create redirect file system when using clang-include-tree

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -969,8 +969,11 @@ namespace swift {
     /// built and provided to the compiler invocation.
     bool DisableImplicitClangModules = false;
 
-    /// Enable ClangIncludeTree for explicit module builds.
+    /// Enable ClangIncludeTree for explicit module builds scanning.
     bool UseClangIncludeTree = false;
+
+    /// Using ClangIncludeTreeRoot for compilation.
+    bool HasClangIncludeTreeRoot = false;
 
     /// Return a hash code of any components from these options that should
     /// contribute to a Swift Bridging PCH hash.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1133,7 +1133,7 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
 
   std::vector<std::string> FilteredModuleMapFiles;
   for (auto ModuleMapFile : CI->getFrontendOpts().ModuleMapFiles) {
-    if (ctx.ClangImporterOpts.UseClangIncludeTree) {
+    if (ctx.ClangImporterOpts.HasClangIncludeTreeRoot) {
       // There is no need to add any module map file here. Issue a warning and
       // drop the option.
       importer->Impl.diagnose(SourceLoc(), diag::module_map_ignored,
@@ -1200,27 +1200,33 @@ ClangImporter::create(ASTContext &ctx,
     }
   }
 
-  auto fileMapping = getClangInvocationFileMapping(ctx);
-  // Wrap Swift's FS to allow Clang to override the working directory
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
-      llvm::vfs::RedirectingFileSystem::create(
-          fileMapping.redirectedFiles, true, *ctx.SourceMgr.getFileSystem());
-  if (!fileMapping.overridenFiles.empty()) {
-    llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> overridenVFS =
-        new llvm::vfs::InMemoryFileSystem();
-    for (const auto &file : fileMapping.overridenFiles) {
-      auto contents = ctx.Allocate<char>(file.second.size() + 1);
-      std::copy(file.second.begin(), file.second.end(), contents.begin());
-      // null terminate the buffer.
-      contents[contents.size() - 1] = '\0';
-      overridenVFS->addFile(file.first, 0,
-                            llvm::MemoryBuffer::getMemBuffer(
-                                StringRef(contents.begin(), contents.size() - 1)));
+      ctx.SourceMgr.getFileSystem();
+
+  auto fileMapping = getClangInvocationFileMapping(ctx);
+  // Avoid creating indirect file system when using include tree.
+  if (!ctx.ClangImporterOpts.HasClangIncludeTreeRoot) {
+    // Wrap Swift's FS to allow Clang to override the working directory
+    VFS = llvm::vfs::RedirectingFileSystem::create(
+        fileMapping.redirectedFiles, true, *ctx.SourceMgr.getFileSystem());
+
+    if (!fileMapping.overridenFiles.empty()) {
+      llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> overridenVFS =
+          new llvm::vfs::InMemoryFileSystem();
+      for (const auto &file : fileMapping.overridenFiles) {
+        auto contents = ctx.Allocate<char>(file.second.size() + 1);
+        std::copy(file.second.begin(), file.second.end(), contents.begin());
+        // null terminate the buffer.
+        contents[contents.size() - 1] = '\0';
+        overridenVFS->addFile(file.first, 0,
+                              llvm::MemoryBuffer::getMemBuffer(StringRef(
+                                  contents.begin(), contents.size() - 1)));
+      }
+      llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> overlayVFS =
+          new llvm::vfs::OverlayFileSystem(VFS);
+      VFS = overlayVFS;
+      overlayVFS->pushOverlay(overridenVFS);
     }
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> overlayVFS =
-        new llvm::vfs::OverlayFileSystem(VFS);
-    VFS = overlayVFS;
-    overlayVFS->pushOverlay(overridenVFS);
   }
 
   // Create a new Clang compiler invocation.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1687,6 +1687,7 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
     // Only set UseClangIncludeTree when caching is enabled since it is not
     // useful in non-caching context.
     Opts.UseClangIncludeTree = !Args.hasArg(OPT_no_clang_include_tree);
+    Opts.HasClangIncludeTreeRoot = Args.hasArg(OPT_clang_include_tree_root);
   }
 
   return false;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -869,7 +869,7 @@ bool CompilerInstance::setUpInputs() {
   // There is no input file when building PCM using ClangIncludeTree.
   if (Invocation.getFrontendOptions().RequestedAction ==
           FrontendOptions::ActionType::EmitPCM &&
-      Invocation.getClangImporterOptions().UseClangIncludeTree)
+      Invocation.getClangImporterOptions().HasClangIncludeTreeRoot)
     return false;
 
   // Adds to InputSourceCodeBufferIDs, so may need to happen before the

--- a/test/CAS/Inputs/BuildCommandExtractor.py
+++ b/test/CAS/Inputs/BuildCommandExtractor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+#
+# Usage: BuildCommandExtractor.py file.json ModuleName
+
+import json
+import sys
+
+input_json = sys.argv[1]
+module_name = sys.argv[2]
+
+mode = 'swift'
+
+if module_name.startswith('clang:'):
+    mode = 'clang'
+    module_name = module_name[6:]
+elif module_name.startswith('swiftPrebuiltExternal:'):
+    mode = 'swiftPrebuiltExternal'
+    module_name = module_name[22:]
+
+with open(input_json, 'r') as file:
+    deps = json.load(file)
+    module_names = deps['modules'][::2]
+    module_details = deps['modules'][1::2]
+    for name, detail in zip(module_names, module_details):
+        if name.get(mode, '') != module_name:
+            continue
+
+        cmd = detail['details'][mode]['commandLine']
+        for c in cmd:
+            print('"{}"'.format(c))
+        break

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -110,11 +110,6 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid -Rmodule-loading -Xcc -Rmodule-import %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck %s
 
-/// Test that if there are non-existing module-map file passed through -Xcc, this still compiles.
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid -Rmodule-loading -Xcc -Rmodule-import %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -Xcc -fmodule-map-file=%t/do-not-exist.modulemap 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=MODULEMAP-IGNORE
-
-// MODULEMAP-IGNORE: warning: module map file '{{.*}}' will be ignored
-
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution -o %t/Foo.swiftmodule
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \

--- a/test/CAS/include-tree-cxx.swift
+++ b/test/CAS/include-tree-cxx.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache %t/main.swift -o %t/deps.json -I %t/include -swift-version 4 -cache-compile-job -cas-path %t/cas -cxx-interoperability-mode=default
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:MyCXX clangIncludeTree | %FileCheck %s
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:MyCXX moduleCacheKey | %FileCheck %s
+
+// CHECK: llvmcas://
+
+//--- main.swift
+import MyCXX
+
+//--- include/module.modulemap
+module MyCXX {
+  header "mycxx.h"
+  requires cplusplus
+}
+
+//--- include/mycxx.h
+#pragma once
+class A {};
+
+void test(const A& str);

--- a/test/CAS/include-tree.swift
+++ b/test/CAS/include-tree.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache %t/main.swift -o %t/deps.json -I %t/include -swift-version 4 -cache-compile-job -cas-path %t/cas
+// RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:DotDot > %t/DotDot.cmd
+// RUN: %swift_frontend_plain @%t/DotDot.cmd
+
+// RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
+// RUN: %swift_frontend_plain @%t/SwiftShims.cmd
+
+// RUN: %S/Inputs/BuildCommandExtractor.py %t/deps.json Swift > %t/Swift.cmd
+// RUN: %swift_frontend_plain @%t/Swift.cmd
+
+/// Test that if there are non-existing module-map file passed through -Xcc, this still compiles.
+// RUN: %swift_frontend_plain @%t/Swift.cmd  -Xcc -fmodule-map-file=%t/do-not-exist.modulemap
+
+//--- main.swift
+import DotDot
+
+//--- include/module.modulemap
+module DotDot [extern_c] {
+  header "../dotdot.h"
+  export *
+}
+
+//--- dotdot.h
+void test(void);


### PR DESCRIPTION
<!-- What's in this pull request? -->
Redirecting file system can canonicalize the file path before forwarding the path to IncludeTreeFileSystem, which is a simplied FS that can only intepret the paths that has been seen by dep-scanner. Since all files that need redirecting already added to underlying FS via DepScan, there is no need for such layer when compiling using clang-include-tree.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
rdar://119727344


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
