### PR TITLE
[Concurrency] `memberAccessHasSpecialPermissionInSwift5` should treat…

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -674,6 +674,10 @@ NOTE(nonisolated_blame, none, "after %1%2 %3, "
 ERROR(non_sendable_from_deinit,none,
         "cannot access %1 %2 with a non-sendable type %0 from non-isolated deinit",
         (Type, DescriptiveDeclKind, DeclName))
+ERROR(isolated_property_mutation_in_nonisolated_context,none,
+      "actor-isolated %kind0 can not be %select{referenced|mutated}1 "
+      "from a non-isolated context",
+      (const ValueDecl *, bool))
 
 // Yield usage errors
 ERROR(return_before_yield, none, "accessor must yield before returning",())

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -734,3 +734,28 @@ actor CheckDeinitFromActor {
     ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in Swift 6}}
   }
 }
+
+// https://github.com/apple/swift/issues/70550
+func testActorWithInitAccessorInit() {
+  @available(SwiftStdlib 5.1, *)
+  actor Angle {
+    var degrees: Double
+    var radians: Double = 0 {
+      @storageRestrictions(initializes: degrees)
+      init(initialValue)  {
+        degrees = initialValue * 180 / .pi
+      }
+
+      get { degrees * .pi / 180 }
+      set { degrees = newValue * 180 / .pi }
+    }
+
+    init(degrees: Double) {
+      self.degrees = degrees // Ok
+    }
+
+    init(radians: Double) {
+      self.radians = radians // Ok
+    }
+  }
+}

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -757,5 +757,63 @@ func testActorWithInitAccessorInit() {
     init(radians: Double) {
       self.radians = radians // Ok
     }
+
+    init(value: Double) {
+      let escapingSelf: (Angle) -> Void = { _ in }
+
+      // degrees are initialized here via default value associated with radians
+
+      escapingSelf(self)
+
+      self.radians = 0
+      // expected-warning@-1 {{actor-isolated property 'radians' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+    }
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  actor EscapeBeforeFullInit {
+    var _a: Int // expected-note {{'self._a' not initialized}}
+
+    var a: Int {
+      @storageRestrictions(initializes: _a)
+      init {
+        _a = newValue
+      }
+
+      get { _a }
+      set { _a = newValue }
+    }
+
+    init(v: Int) {
+      let escapingSelf: (EscapeBeforeFullInit) -> Void = { _ in }
+
+      escapingSelf(self) // expected-error {{'self' used before all stored properties are initialized}}
+      // expected-note@-1 {{after this closure involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
+
+      self.a = v
+      // expected-warning@-1 {{cannot access property '_a' here in non-isolated initializer; this is an error in Swift 6}}
+    }
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  actor NonisolatedAccessors {
+    nonisolated var a: Int = 0 {
+      init {
+      }
+
+      get { 0 }
+      set {}
+    }
+
+    init(value: Int) {
+      let escapingSelf: (NonisolatedAccessors) -> Void = { _ in }
+
+      // a is initialized here via default value
+
+      escapingSelf(self)
+
+      self.a = value // Ok (nonisolated)
+      print(a) // Ok (nonisolated)
+    }
   }
 }


### PR DESCRIPTION
… init accessors as stored properties

Init accessor properties cannot escape self and are only 
allowed to initialized and access a set of properties declared
in their `@storageRestrictions(...)` attribute.

Resolves: https://github.com/apple/swift/issues/70550

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
