### PR TITLE
[Concurrency] Diagnose concurrency violations in derived conformances at valid source locations.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5559,6 +5559,9 @@ ERROR(isolated_parameter_combined_nonisolated,none,
       "%0 with 'isolated' parameter cannot be 'nonisolated'",
       (DescriptiveDeclKind))
 
+NOTE(in_derived_conformance, none,
+     "in derived conformance to %0",
+     (Type))
 WARNING(non_sendable_param_type,none,
         "non-sendable type %0 %select{passed in call to %3 %kind2|"
         "exiting %3 context in call to non-isolated %kind2|"

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -344,3 +344,17 @@ func testPointersAreNotSendable() {
     testSendable(rawMutableBuffer.makeIterator()) // expected-warning {{conformance of 'UnsafeRawBufferPointer.Iterator' to 'Sendable' is unavailable}}
   }
 }
+
+@available(*, unavailable)
+extension SynthesizedConformances.NotSendable: Sendable {}
+
+enum SynthesizedConformances {
+  // expected-note@+1 2 {{consider making struct 'NotSendable' conform to the 'Sendable' protocol}}
+  struct NotSendable: Equatable {}
+
+  // expected-warning@+2 2{{non-sendable type 'SynthesizedConformances.NotSendable' in asynchronous access to main actor-isolated property 'x' cannot cross actor boundary}}
+  // expected-note@+1 2 {{in derived conformance to 'Equatable'}}
+  @MainActor struct Isolated: Equatable {
+    let x: NotSendable
+  }
+}


### PR DESCRIPTION
Even better would be to expand derived conformance implementations into synthesized source files just like macro expansion buffers and diagnose errors there! But until then, diagnose violations at the location of the nominal type and note that the violation happened in a derived conformance.

Resolves rdar://101675974