### PR TITLE
[Test] XFAIL IRGen/static-vtable-stubs.swift on arm64_32

### DIFF
--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -10,6 +10,7 @@
 
 // rdar://119900439
 // XFAIL: CPU=armv7k
+// XFAIL: CPU=arm64_32
 
 //--- A.swift
 open class C {


### PR DESCRIPTION
Follow up on https://github.com/apple/swift/pull/70551, also XFAIL the test on arm64_32.
