### PR TITLE
[embedded] Do not emit entry point data (__swift5_entry) in embedded Swift

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2245,6 +2245,10 @@ static std::string getEntryPointSection(IRGenModule &IGM) {
 }
 
 void IRGenerator::emitEntryPointInfo() {
+  if (SIL.getOptions().EmbeddedSwift) {
+    return;
+  }
+
   SILFunction *entrypoint = nullptr;
   if (!(entrypoint = SIL.lookUpFunction(
             SIL.getASTContext().getEntryPointFunctionName()))) {

--- a/test/embedded/internalize-no-stdlib.swift
+++ b/test/embedded/internalize-no-stdlib.swift
@@ -25,13 +25,11 @@ public func main() {
   start(p: Concrete())
 }
 
-// CHECK-ELF: @"\01l_entry_point" =
 // CHECK-ELF: @__swift_reflection_version =
 // CHECK-ELF: @_swift1_autolink_entries =
-// CHECK-ELF: @llvm.compiler.used = appending global [3 x ptr] [ptr @"\01l_entry_point", ptr @__swift_reflection_version, ptr @_swift1_autolink_entries], section "llvm.metadata"
+// CHECK-ELF: @llvm.compiler.used = appending global [2 x ptr] [ptr @__swift_reflection_version, ptr @_swift1_autolink_entries], section "llvm.metadata"
 // CHECK-ELF-NOT: @llvm.used
 
-// CHECK-MACHO: @"\01l_entry_point" =
 // CHECK-MACHO: @__swift_reflection_version =
 // CHECK-MACHO-NOT: @llvm.compiler.used
-// CHECK-MACHO: @llvm.used = appending global [2 x ptr] [ptr @"\01l_entry_point", ptr @__swift_reflection_version], section "llvm.metadata"
+// CHECK-MACHO: @llvm.used = appending global [1 x ptr] [ptr @__swift_reflection_version], section "llvm.metadata"


### PR DESCRIPTION
This saves a couple bytes and a section in resulting binaries. We don't expect any embedded Swift usage to need this entry point section (instead, functions are either exported, or a main function is provided).