### PR TITLE
[Explicit Module Builds] Initialize `ClangImporter`'s `CodeGenerator` using Swift compilation Target Triple.

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -100,6 +100,7 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
   assert(Importer && "No clang module loader!");
   auto &ClangContext = Importer->getClangASTContext();
 
+  auto &CGTI = Importer->getTargetInfo();
   auto &CGO = Importer->getCodeGenOpts();
   CGO.OptimizationLevel = Opts.shouldOptimize() ? 3 : 0;
 
@@ -154,7 +155,7 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
   auto *ClangCodeGen = clang::CreateLLVMCodeGen(ClangContext.getDiagnostics(),
                                                 ModuleName, &VFS, HSI, PPO, CGO,
                                                 LLVMContext);
-  ClangCodeGen->Initialize(ClangContext);
+  ClangCodeGen->Initialize(ClangContext, CGTI);
   return ClangCodeGen;
 }
 

--- a/test/ScanDependencies/Inputs/CHeaders/ExtraCModules/Bar.h
+++ b/test/ScanDependencies/Inputs/CHeaders/ExtraCModules/Bar.h
@@ -1,0 +1,9 @@
+static inline int funcBar(void) {
+  int result = 0;
+  if (__builtin_available(macos 11.0, *)) {
+    result += 1;
+  } else {
+    result -= 1;
+  }
+  return result;
+}

--- a/test/ScanDependencies/Inputs/CHeaders/ExtraCModules/module.modulemap
+++ b/test/ScanDependencies/Inputs/CHeaders/ExtraCModules/module.modulemap
@@ -6,3 +6,7 @@ module CrossImportTestModule {
   header "CrossImportTestModule.h"
   export *
 }
+module Bar {
+  header "Bar.h"
+  export *
+}

--- a/test/ScanDependencies/clang-target-clang-irgen.swift
+++ b/test/ScanDependencies/clang-target-clang-irgen.swift
@@ -1,0 +1,52 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+// RUN: %empty-directory(%t/inputs)
+
+// RUN: split-file %s %t
+// RUN: sed -e "s|INPUTSDIR|%/t/inputs|g" %t/map.json.template > %t/map.json.template1
+// RUN: sed -e "s|STDLIBMOD|%/stdlib_module|g" %t/map.json.template1 > %t/map.json.template2
+// RUN: sed -e "s|ONONEMOD|%/ononesupport_module|g" %t/map.json.template2 > %t/map.json.template3
+// RUN: sed -e "s|CHEADERSDIR|%/S/Inputs/CHeaders|g" %t/map.json.template3 > %t/map.json.template4
+// RUN: sed -e "s|SWIFTLIBDIR|%swift-lib-dir|g" %t/map.json.template4 > %t/inputs/map.json
+
+// Pre-build common mandatory deps
+// RUN: %target-swift-emit-pcm -target %target-cpu-apple-macosx12.0 -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+// Pre-build the clang deps with versioned code
+// RUN: %target-swift-emit-pcm -target %target-cpu-apple-macosx12.0 -module-name Bar %S/Inputs/CHeaders/ExtraCModules/module.modulemap -o %t/inputs/Bar.pcm 
+
+// RUN: %swift-frontend -target %target-cpu-apple-macosx10.14 -O -emit-ir -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -disable-implicit-swift-modules -explicit-swift-module-map-file %t/inputs/map.json -o %t/explicit-clang-target-irgen.ll %t/test.swift -clang-target %target-cpu-apple-macosx12.0
+// RUN: %FileCheck %s < %t/explicit-clang-target-irgen.ll
+
+// Ensure that the platform version check is not optimized away, which it would, if we code-generate for '-clang-target' of macosx12.0
+// CHECK: {{%[0-9]+}} = tail call i32 @__isPlatformVersionAtLeast(i32 1, i32 11, i32 0, i32 0)
+
+//--- map.json.template
+[
+  {
+      "moduleName": "Bar",
+      "clangModulePath": "INPUTSDIR/Bar.pcm",
+      "clangModuleMapPath": "CHEADERSDIR/ExtraCModules/module.modulemap",
+      "isFramework": false
+  },
+  {
+      "moduleName": "Swift",
+      "modulePath": "STDLIBMOD",
+      "isFramework": false
+  },
+  {
+      "moduleName": "SwiftOnoneSupport",
+      "modulePath": "ONONEMOD",
+      "isFramework": false
+  },
+  {
+      "moduleName": "SwiftShims",
+      "isFramework": false,
+      "clangModuleMapPath": "SWIFTLIBDIR/swift/shims/module.modulemap",
+      "clangModulePath": "INPUTSDIR/SwiftShims.pcm"
+}]
+
+
+//--- test.swift
+import Bar
+print(Bar.funcBar())


### PR DESCRIPTION
As per #65930, the Clang importer's Clang instance may be configured with a different (higher) OS version than the compilation target itself in order to be able to load pre-compiled Clang modules that are aligned with the broader SDK, and match the SDK deployment target against which Swift modules are also built. Code-generation, however, must use the actual compilation target triple. This matches how Swift itself loads Swift module dependencies as well: dependency `.swiftinterface` files are type-checked against the availability epoch and code-generated against the actual compilation triple.

Resolves rdar://113712186
