### PR TITLE
Sema: Reexport SPI via Swift exported imports but not clang's

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -1087,10 +1087,6 @@ public:
   /// Returns the associated clang module if one exists.
   const clang::Module *findUnderlyingClangModule() const;
 
-  /// Does this module or the underlying clang module defines export_as with
-  /// a value corresponding to the \p other module?
-  bool isExportedAs(const ModuleDecl *other) const;
-
   /// Returns a generator with the components of this module's full,
   /// hierarchical name.
   ///

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2649,14 +2649,6 @@ const clang::Module *ModuleDecl::findUnderlyingClangModule() const {
   return nullptr;
 }
 
-bool ModuleDecl::isExportedAs(const ModuleDecl *other) const {
-  auto clangModule = findUnderlyingClangModule();
-  if (!clangModule)
-    return false;
-
-  return other->getRealName().str() == clangModule->ExportAsModule;
-}
-
 void ModuleDecl::collectBasicSourceFileInfo(
     llvm::function_ref<void(const BasicSourceFileInfo &)> callback) const {
   for (const FileUnit *fileUnit : getFiles()) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3386,8 +3386,8 @@ void SourceFile::lookupImportedSPIGroups(
   for (auto &import : *Imports) {
     if (import.options.contains(ImportFlags::SPIAccessControl) &&
         (importedModule == import.module.importedModule ||
-         (imports.isImportedBy(importedModule, import.module.importedModule) &&
-          importedModule->isExportedAs(import.module.importedModule)))) {
+         imports.isImportedByViaSwiftOnly(importedModule,
+                                       import.module.importedModule))) {
       spiGroups.insert(import.spiGroups.begin(), import.spiGroups.end());
     }
   }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1678,7 +1678,8 @@ void SerializedASTFile::lookupImportedSPIGroups(
 
     if (dep.Import->importedModule == importedModule ||
         (imports.isImportedBy(importedModule, dep.Import->importedModule) &&
-         importedModule->isExportedAs(dep.Import->importedModule))) {
+         imports.isImportedByViaSwiftOnly(importedModule,
+                                          dep.Import->importedModule))) {
       spiGroups.insert(dep.spiGroups.begin(), dep.spiGroups.end());
     }
   }

--- a/test/SPI/accidental-reexport.swift
+++ b/test/SPI/accidental-reexport.swift
@@ -1,0 +1,51 @@
+/// Guard that we don't reexport the SPIs accidentally through the common
+/// reexported imports between clang modules.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Overlayed.swift -I %t -o %t
+// RUN: %target-swift-frontend -typecheck -verify %t/Client.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/LowerClient.swift -I %t
+
+//--- module.modulemap
+module Overlayed {
+    header "Overlayed.h"
+}
+
+module Middle {
+    header "Middle.h"
+    export *
+}
+
+module LowerMiddle {
+    header "LowerMiddle.h"
+    export *
+}
+
+//--- Overlayed.h
+//--- Overlayed.swift
+@_exported import Overlayed
+
+public func funcPublic() {}
+
+@_spi(X)
+public func funcSPI() {}
+
+//--- Middle.h
+#include <Overlayed.h>
+
+//--- LowerMiddle.h
+#include <Middle.h>
+
+//--- Client.swift
+@_spi(X) import Middle
+
+funcPublic()
+funcSPI() // expected-error {{cannot find 'funcSPI' in scope}}
+
+//--- LowerClient.swift
+@_spi(X) import LowerMiddle
+
+funcPublic()
+funcSPI() // expected-error {{cannot find 'funcSPI' in scope}}

--- a/test/SPI/reexported-spi-groups.swift
+++ b/test/SPI/reexported-spi-groups.swift
@@ -55,7 +55,8 @@
 // RUN:   %t/Client_FileA.swift %t/Client_FileB.swift\
 // RUN:   -swift-version 5 -I %t -verify
 
-/// Test that SPIs aren't avaible from a reexport without export_as
+/// SPIs are now reexported by any `@_exported` from Swift modules, no matter
+/// if `export_as` is present or not.
 // RUN: %target-swift-frontend -typecheck \
 // RUN:   %t/NonExportedAsClient.swift \
 // RUN:   -swift-version 5 -I %t -verify
@@ -91,6 +92,8 @@ public func exportedPublicFunc() {}
 @_spi(X) public func exportedSpiFunc() {}
 
 @_spi(X) public struct ExportedSpiType {}
+
+@_spi(O) public func exportedSpiFuncOtherGroup() {}
 
 //--- Exporter.swift
 
@@ -130,6 +133,7 @@ public func clientA() {
     exportedPublicFunc()
     exportedSpiFunc()
     exporterSpiFunc()
+    exportedSpiFuncOtherGroup() // expected-error {{cannot find 'exportedSpiFuncOtherGroup' in scope}}
 }
 
 @inlinable
@@ -159,7 +163,7 @@ public func clientB() {
 
 public func client() {
     exportedPublicFunc()
-    exportedSpiFunc() // expected-error {{cannot find 'exportedSpiFunc' in scope}}
+    exportedSpiFunc()
     exporterSpiFunc()
 }
 


### PR DESCRIPTION
This is a new attempt at a reexport feature for SPI decls. The previous behavior was to reexport SPI only between modules with both `@_exported` and an export-as relationship. The limitation on export-as turned out to be too restrictive in some cases.

We may be tempted to reexport SPI through all exported imports. However, the exported imports are very common between clang module and it can lead to surprises if dependencies between clang modules end up exporting SPI from unexpected modules.

As a middle ground, reexport SPI only through Swift `@_exported` dependencies, and not through clang reexports. While this is a new distinction between Swift and clang dependencies, I believe it provides the expected behavior and the result is more straightforward than the current logic.

rdar://115901208