### PR TITLE
AST: Improve handling of missing @objc async protocol witnesses

### DIFF
--- a/test/Serialization/conformance-objc-async.swift
+++ b/test/Serialization/conformance-objc-async.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-emit-module-interface(%t/Conformance.swiftinterface) -module-name Conformance -I %t %t/Conformance.swift
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Conformance.swiftinterface -module-name Conformance -o /dev/null -I %t
+// REQUIRES: objc_interop
+
+//--- module.modulemap
+module ObjCProto {
+  header "objc_proto.h"
+  export *
+}
+
+//--- objc_proto.h
+@protocol Doable
+- (void)doItWithCompletion:(void (^)())completion;
+@end
+
+//--- Conformance.swift
+import ObjCProto
+
+public final class ConformsToDoableWithCompletionHandler: Doable {
+  public func doIt(completion: @escaping () -> Void) {}
+}
+
+@available(SwiftStdlib 5.5, *)
+public final class ConformsToDoableWithAsync:Doable {
+  public func doIt() async {}
+}


### PR DESCRIPTION
Serialization now enumerates the value witnesses of conformances with a resolver in order to facilitate lazy type checking (https://github.com/apple/swift/pull/68262). This change in behavior introduced an assertion failure when compiling modules from swiftinterface when the interface contains a conformance to an `@objc` protocol that has a requirement that is imported with an `async` variant. The `forEachValueWitness()` invocation during serialization was causing the missing witness for an Obj-C async protocol requirement to be resolved after conformance check was already marked "complete". This witness had not been previously resolved because `ConformanceChecker::resolveValueWitnesses()` had special logic to skip Obj-C protocol requirements with witnessed siblings, whereas `forEachValueWitness()` did not.

There are multiple potential solutions to this problem, but the one that seemed least disruptive to me was to stop skipping resolution of these sibling witnesses during `ConformanceChecker::resolveValueWitnesses()`. When I looked into why they were being skipped, I discovered that this seemed to be a concession to bugs in the logic for pruning missing witnesses. When I adjusted the pruning logic it no longer became necessary to skip witnesses in `ConformanceChecker::resolveValueWitnesses()` in order to avoid incorrect diagnostics.

Resolves rdar://119435253
