### PR TITLE
[ASTScope] Use the end location of the original source range of a macro expansion in `isBeforeInSource`.

### DIFF
--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -797,11 +797,11 @@ static bool isBeforeInSource(
   SourceLoc firstLocInLCA = firstMismatch == firstAncestors.end()
       ? firstLoc
       : sourceMgr.getGeneratedSourceInfo(*firstMismatch)
-          ->originalSourceRange.getStart();
+          ->originalSourceRange.getEnd();
   SourceLoc secondLocInLCA = secondMismatch == secondAncestors.end()
       ? secondLoc
       : sourceMgr.getGeneratedSourceInfo(*secondMismatch)
-          ->originalSourceRange.getStart();
+          ->originalSourceRange.getEnd();
   return sourceMgr.isBeforeInBuffer(firstLocInLCA, secondLocInLCA) ||
     (allowEqual && firstLocInLCA == secondLocInLCA);
 }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -215,6 +215,16 @@ class RecursiveOuter {
 class GuardedAvailability {
 }
 
+@Observable class TestASTScopeLCA {
+  // Make sure ASTScope unqualified lookup can find local variables
+  // inside initial values with closures when accessor macros are
+  // involved.
+  var state : Bool = {
+    let value = true
+    return value
+  }()
+}
+
 @main
 struct Validator {
   @MainActor


### PR DESCRIPTION
The `isBeforeInSource` predicate uses the least common ancestor when comparing source locations in different buffers due to macro expansions. When walking up the ancestor buffers, the current LCA algorithm (introduced by https://github.com/apple/swift/pull/70126) uses the start location of the original source range of the macro expansion. The old LCA algorithm (introduced by https://github.com/apple/swift/pull/63232) used the end location of the lhs and the start location of the rhs, so it wasn't consistent.

The original source range of a macro expansion buffer contains the entire range of the code that is replaced by the expansion. In some cases, the original code is type checked, so ASTScope needs to represent both the original code and the macro-expanded code in the scope tree.

For accessor macros, the original code -- the initializer expression of the property -- is type checked, but not before macro expansion, so unqualified lookup must deal with the scope tree for the initializer and the expanded accessors. The accessors are inserted in the tree after the initializer scope, but the `isBeforeInSource` was using the start location of the original source range for macro expansions, so the accessor scopes were incorrectly considered to be ordered before a source location in the initializer expression, which caused unqualified lookup of local variables within the initializer to fail.

Resolves rdar://119861795