### PR TITLE
[Concurrency] Don't diagnose `Sendable` violations for error types.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1004,6 +1004,8 @@ void swift::diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf) {
 static bool diagnoseSingleNonSendableType(
     Type type, SendableCheckContext fromContext, SourceLoc loc,
     llvm::function_ref<bool(Type, DiagnosticBehavior)> diagnose) {
+  if (type->hasError())
+    return false;
 
   auto module = fromContext.fromDC->getParentModule();
   auto nominal = type->getAnyNominal();

--- a/test/Concurrency/sendable_checking_errors.swift
+++ b/test/Concurrency/sendable_checking_errors.swift
@@ -14,3 +14,7 @@ func f() async {
     n.pointee += 1
   }
 }
+
+struct S: Sendable {
+  var b: Undefined // expected-error{{cannot find type 'Undefined' in scope}}
+}


### PR DESCRIPTION
Error types have already been diagnosed; don't diagnose them again when they're used in a way that requires a `Sendable` conformance.

Resolves rdar://119572094