### PR TITLE
SimplifyBuiltin: fix simplification of is_same_metatype with dynamic_self types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -271,8 +271,13 @@ private func typesOfValuesAreEqual(_ lhs: Value, _ rhs: Value, in function: Func
     return nil
   }
 
-  let lhsTy = lhsExistential.metatype.type.instanceTypeOfMetatype(in: function)
-  let rhsTy = rhsExistential.metatype.type.instanceTypeOfMetatype(in: function)
+  let lhsMetatype = lhsExistential.metatype.type
+  let rhsMetatype = rhsExistential.metatype.type
+  if lhsMetatype.isDynamicSelfMetatype != rhsMetatype.isDynamicSelfMetatype {
+    return nil
+  }
+  let lhsTy = lhsMetatype.instanceTypeOfMetatype(in: function)
+  let rhsTy = rhsMetatype.instanceTypeOfMetatype(in: function)
 
   // Do we know the exact types? This is not the case e.g. if a type is passed as metatype
   // to the function.

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -112,6 +112,10 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
     bridged.getInstanceTypeOfMetatype(function.bridged).type
   }
 
+  public var isDynamicSelfMetatype: Bool {
+    bridged.isDynamicSelfMetatype()
+  }
+
   public func representationOfMetatype(in function: Function) -> MetatypeRepresentation {
     bridged.getRepresentationOfMetatype(function.bridged)
   }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -214,6 +214,7 @@ struct BridgedType {
   BRIDGED_INLINE bool isBuiltinFixedWidthInteger(SwiftInt width) const;
   BRIDGED_INLINE bool isExactSuperclassOf(BridgedType t) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getInstanceTypeOfMetatype(BridgedFunction f) const;
+  BRIDGED_INLINE bool isDynamicSelfMetatype() const;
   BRIDGED_INLINE MetatypeRepresentation getRepresentationOfMetatype(BridgedFunction f) const;
   BRIDGED_INLINE bool isCalleeConsumedFunction() const;
   BRIDGED_INLINE bool isMarkedAsImmortal() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -236,6 +236,12 @@ BridgedType BridgedType::getInstanceTypeOfMetatype(BridgedFunction f) const {
   return unbridged().getInstanceTypeOfMetatype(f.getFunction());
 }
 
+bool BridgedType::isDynamicSelfMetatype() const {
+  auto metaType = unbridged().castTo<swift::MetatypeType>();
+  swift::Type instTy = metaType->getInstanceType();
+  return instTy->is<swift::DynamicSelfType>();
+}
+
 BridgedType::MetatypeRepresentation BridgedType::getRepresentationOfMetatype(BridgedFunction f) const {
   return BridgedType::MetatypeRepresentation(
       unbridged().getRepresentationOfMetatype(f.getFunction()));

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -26,6 +26,9 @@ class C1<T> {
 class C2<T> : C1<T> {
 }
 
+class A {
+}
+
 // CHECK-LABEL: sil @constantFoldAdd
 // CHECK:         [[A:%.*]] = integer_literal $Builtin.Int64, 12
 // CHECK:         [[C:%.*]] = integer_literal $Builtin.Int1, 0
@@ -265,6 +268,34 @@ bb0:
   %3 = init_existential_metatype %1 : $@thick ((Float) -> Bool).Type, $@thick Any.Type
   %4 = builtin "is_same_metatype"(%2 : $@thick Any.Type, %3 : $@thick Any.Type) : $Builtin.Int1
   return %4 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @same_metatype_dynamic_self
+// CHECK:         [[R:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:    return [[R]]
+// CHECK:       } // end sil function 'same_metatype_dynamic_self'
+sil @same_metatype_dynamic_self : $@convention(method) (@guaranteed A) -> Builtin.Int1 {
+bb0(%0 : $A):
+  %2 = metatype $@thick @dynamic_self A.Type
+  %3 = init_existential_metatype %2 : $@thick @dynamic_self A.Type, $@thick any Any.Type
+  %5 = metatype $@thick @dynamic_self A.Type
+  %6 = init_existential_metatype %5 : $@thick @dynamic_self A.Type, $@thick any Any.Type
+  %13 = builtin "is_same_metatype"(%3 : $@thick any Any.Type, %6 : $@thick any Any.Type) : $Builtin.Int1
+  return %13 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @unknown_same_metatype_dynamic_self
+// CHECK:         [[R:%.*]] = builtin "is_same_metatype"
+// CHECK:         return [[R]]
+// CHECK:       } // end sil function 'unknown_same_metatype_dynamic_self'
+sil @unknown_same_metatype_dynamic_self : $@convention(method) (@guaranteed A) -> Builtin.Int1 {
+bb0(%0 : $A):
+  %2 = metatype $@thick @dynamic_self A.Type
+  %3 = init_existential_metatype %2 : $@thick @dynamic_self A.Type, $@thick any Any.Type
+  %5 = metatype $@thick A.Type
+  %6 = init_existential_metatype %5 : $@thick A.Type, $@thick any Any.Type
+  %13 = builtin "is_same_metatype"(%3 : $@thick any Any.Type, %6 : $@thick any Any.Type) : $Builtin.Int1
+  return %13 : $Builtin.Int1
 }
 
 sil_global hidden [let] @g : $Int32


### PR DESCRIPTION
Dynamic self types are not the same as non-dynamic self types.

Fixes a miscompile with dynamic self type comparisons.

rdar://119943508
