### PR TITLE
build: remove `-DefaultsLLD` option for build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -56,9 +56,6 @@ If set, does not run the build phase.
 .PARAMETER SkipPackaging
 If set, skips building the msi's and installer
 
-.PARAMETER DefaultsLLD
-If false, use `link.exe` as the default linker with the SDK (with SPM)
-
 .PARAMETER DebugInfo
 If set, debug information will be generated for the builds.
 
@@ -101,7 +98,6 @@ param(
   [switch] $SkipBuild = $false,
   [switch] $SkipRedistInstall = $false,
   [switch] $SkipPackaging = $false,
-  [bool] $DefaultsLLD = $true,
   [string[]] $Test = @(),
   [string] $Stage = "",
   [string] $BuildTo = "",
@@ -1274,13 +1270,8 @@ function Build-XCTest($Arch, [switch]$Test = $false) {
         Foundation_DIR = "$FoundationBinaryCache\cmake\modules";
       } + $TestingDefines)
 
-    if ($DefaultsLLD) {
-      Invoke-Program $python -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'XCTEST_VERSION': 'development', 'SWIFTC_FLAGS': ['-use-ld=lld'] } }), encoding='utf-8'))" `
-        -OutFile "$($Arch.PlatformInstallRoot)\Info.plist"
-    } else {
-      Invoke-Program $python -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'XCTEST_VERSION': 'development' } }), encoding='utf-8'))" `
-        -OutFile "$($Arch.PlatformInstallRoot)\Info.plist"
-    }
+    Invoke-Program $python -c "import plistlib; print(str(plistlib.dumps({ 'DefaultProperties': { 'XCTEST_VERSION': 'development', 'SWIFTC_FLAGS': ['-use-ld=lld'] } }), encoding='utf-8'))" `
+      -OutFile "$($Arch.PlatformInstallRoot)\Info.plist"
   }
 }
 


### PR DESCRIPTION
This option was rarely used.  Remove the option to simplify the build types as we are growing in complexity.