### PR TITLE
[AST] A couple of PatternBindingInitializer cleanups

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2314,9 +2314,7 @@ public:
     return getPatternList()[i].getPattern();
   }
 
-  void setPattern(unsigned i, Pattern *Pat,
-                  PatternBindingInitializer *InitContext,
-                  bool isFullyValidated = false);
+  void setPattern(unsigned i, Pattern *P, bool isFullyValidated = false);
 
   bool isFullyValidated(unsigned i) const {
     return getPatternList()[i].isFullyValidated();
@@ -2324,6 +2322,13 @@ public:
 
   PatternBindingInitializer *getInitContext(unsigned i) const {
     return getPatternList()[i].getInitContext();
+  }
+
+  void setInitContext(unsigned i, PatternBindingInitializer *init) {
+    if (init) {
+      init->setBinding(this, i);
+    }
+    getMutablePatternList()[i].setInitContext(init);
   }
 
   CaptureInfo getCaptureInfo(unsigned i) const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -31,6 +31,7 @@
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/Import.h"
+#include "swift/AST/Initializer.h"
 #include "swift/AST/LayoutConstraint.h"
 #include "swift/AST/LifetimeAnnotation.h"
 #include "swift/AST/ReferenceCounting.h"
@@ -1962,7 +1963,7 @@ class PatternBindingEntry {
     IsFromDebugger = 1 << 2,
   };
   /// The initializer context used for this pattern binding entry.
-  llvm::PointerIntPair<DeclContext *, 3, OptionSet<PatternFlags>>
+  llvm::PointerIntPair<PatternBindingInitializer *, 3, OptionSet<PatternFlags>>
       InitContextAndFlags;
 
   /// Values captured by this initializer.
@@ -2003,7 +2004,7 @@ private:
 public:
   /// \p E is the initializer as parsed.
   PatternBindingEntry(Pattern *P, SourceLoc EqualLoc, Expr *E,
-                      DeclContext *InitContext)
+                      PatternBindingInitializer *InitContext)
       : PatternAndFlags(P, {}),
         InitExpr({E, {E, InitializerStatus::NotChecked}, EqualLoc}),
         InitContextAndFlags({InitContext, llvm::None}) {}
@@ -2107,12 +2108,14 @@ private:
   VarDecl *getAnchoringVarDecl() const;
 
   // Retrieve the declaration context for the initializer.
-  DeclContext *getInitContext() const {
+  PatternBindingInitializer *getInitContext() const {
     return InitContextAndFlags.getPointer();
   }
 
   /// Override the initializer context.
-  void setInitContext(DeclContext *dc) { InitContextAndFlags.setPointer(dc); }
+  void setInitContext(PatternBindingInitializer *init) {
+    InitContextAndFlags.setPointer(init);
+  }
 
   SourceLoc getStartLoc() const;
 
@@ -2310,15 +2313,16 @@ public:
   Pattern *getPattern(unsigned i) const {
     return getPatternList()[i].getPattern();
   }
-  
-  void setPattern(unsigned i, Pattern *Pat, DeclContext *InitContext,
+
+  void setPattern(unsigned i, Pattern *Pat,
+                  PatternBindingInitializer *InitContext,
                   bool isFullyValidated = false);
 
   bool isFullyValidated(unsigned i) const {
     return getPatternList()[i].isFullyValidated();
   }
 
-  DeclContext *getInitContext(unsigned i) const {
+  PatternBindingInitializer *getInitContext(unsigned i) const {
     return getPatternList()[i].getInitContext();
   }
 

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -79,7 +79,6 @@ namespace swift {
   class Initializer;
   class ClassDecl;
   class SerializedAbstractClosureExpr;
-  class SerializedPatternBindingInitializer;
   class SerializedDefaultArgumentInitializer;
   class SerializedTopLevelCodeDecl;
   class StructDecl;
@@ -115,7 +114,6 @@ enum class DeclContextKind : unsigned {
 /// \see SerializedLocalDeclContext.
 enum class LocalDeclContextKind : uint8_t {
   AbstractClosure,
-  PatternBindingInitializer,
   DefaultArgumentInitializer,
   TopLevelCodeDecl
 };

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -79,7 +79,6 @@ namespace swift {
   class Initializer;
   class ClassDecl;
   class SerializedAbstractClosureExpr;
-  class SerializedDefaultArgumentInitializer;
   class SerializedTopLevelCodeDecl;
   class StructDecl;
   class AccessorDecl;
@@ -114,7 +113,6 @@ enum class DeclContextKind : unsigned {
 /// \see SerializedLocalDeclContext.
 enum class LocalDeclContextKind : uint8_t {
   AbstractClosure,
-  DefaultArgumentInitializer,
   TopLevelCodeDecl
 };
 

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -151,29 +151,6 @@ public:
   }
 };
 
-/// SerializedDefaultArgumentInitializer - This represents what was originally a
-/// DefaultArgumentInitializer during serialization. It is preserved only to
-/// maintain the correct AST structure and remangling after deserialization.
-class SerializedDefaultArgumentInitializer : public SerializedLocalDeclContext {
-  const unsigned Index;
-public:
-  SerializedDefaultArgumentInitializer(unsigned Index, DeclContext *Parent)
-    : SerializedLocalDeclContext(LocalDeclContextKind::DefaultArgumentInitializer,
-                                 Parent),
-      Index(Index) {}
-
-  unsigned getIndex() const {
-    return Index;
-  }
-
-  static bool classof(const DeclContext *DC) {
-    if (auto LDC = dyn_cast<SerializedLocalDeclContext>(DC))
-      return LDC->getLocalDeclContextKind() ==
-        LocalDeclContextKind::DefaultArgumentInitializer;
-    return false;
-  }
-};
-
 /// A property wrapper initialization expression.  The parent context is the
 /// function or closure which owns the property wrapper.
 class PropertyWrapperInitializer : public Initializer {

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -95,6 +95,9 @@ public:
     return new (parent->getASTContext()) PatternBindingInitializer(parent);
   }
 
+  static PatternBindingInitializer *createDeserialized(PatternBindingDecl *PBD,
+                                                       unsigned index);
+
   void setBinding(PatternBindingDecl *binding, unsigned bindingIndex) {
     setParent(binding->getDeclContext());
     Binding = binding;
@@ -119,37 +122,6 @@ public:
   }
   static bool classof(const Initializer *I) {
     return I->getInitializerKind() == InitializerKind::PatternBinding;
-  }
-};
-
-/// SerializedPatternBindingInitializer - This represents what was originally a
-/// PatternBindingInitializer during serialization. It is preserved as a special
-/// class only to maintain the correct AST structure and remangling after
-/// deserialization.
-class SerializedPatternBindingInitializer : public SerializedLocalDeclContext {
-  PatternBindingDecl *Binding;
-
-public:
-  SerializedPatternBindingInitializer(PatternBindingDecl *Binding,
-                                      unsigned bindingIndex)
-    : SerializedLocalDeclContext(LocalDeclContextKind::PatternBindingInitializer,
-                                 Binding->getDeclContext()),
-      Binding(Binding) {
-    SpareBits = bindingIndex;
-  }
-
-  PatternBindingDecl *getBinding() const {
-    return Binding;
-  }
-
-  unsigned getBindingIndex() const { return SpareBits; }
-
-
-  static bool classof(const DeclContext *DC) {
-    if (auto LDC = dyn_cast<SerializedLocalDeclContext>(DC))
-      return LDC->getLocalDeclContextKind() ==
-      LocalDeclContextKind::PatternBindingInitializer;
-    return false;
   }
 };
 

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -84,13 +84,16 @@ class PatternBindingInitializer : public Initializer {
     SelfParam = nullptr;
   }
 
-public:
   explicit PatternBindingInitializer(DeclContext *parent)
     : Initializer(InitializerKind::PatternBinding, parent),
       Binding(nullptr), SelfParam(nullptr) {
     SpareBits = 0;
   }
- 
+
+public:
+  static PatternBindingInitializer *create(DeclContext *parent) {
+    return new (parent->getASTContext()) PatternBindingInitializer(parent);
+  }
 
   void setBinding(PatternBindingDecl *binding, unsigned bindingIndex) {
     setParent(binding->getDeclContext());

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -21,9 +21,9 @@
 #define SWIFT_INITIALIZER_H
 
 #include "swift/AST/DeclContext.h"
-#include "swift/AST/Decl.h"
 
 namespace swift {
+class ParamDecl;
 class PatternBindingDecl;
 
 enum class InitializerKind : uint8_t {
@@ -90,12 +90,8 @@ public:
   static PatternBindingInitializer *createDeserialized(PatternBindingDecl *PBD,
                                                        unsigned index);
 
-  void setBinding(PatternBindingDecl *binding, unsigned bindingIndex) {
-    setParent(binding->getDeclContext());
-    Binding = binding;
-    SpareBits = bindingIndex;
-  }
-  
+  void setBinding(PatternBindingDecl *binding, unsigned bindingIndex);
+
   PatternBindingDecl *getBinding() const { return Binding; }
 
   unsigned getBindingIndex() const { return SpareBits; }

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -76,6 +76,11 @@ class PatternBindingInitializer : public Initializer {
   // created lazily for 'self' lookup from lazy property initializer
   ParamDecl *SelfParam;
 
+  // Sets itself as the parent.
+  friend class PatternBindingDecl;
+
+  void setBinding(PatternBindingDecl *binding, unsigned bindingIndex);
+
   explicit PatternBindingInitializer(DeclContext *parent)
     : Initializer(InitializerKind::PatternBinding, parent),
       Binding(nullptr), SelfParam(nullptr) {
@@ -89,8 +94,6 @@ public:
 
   static PatternBindingInitializer *createDeserialized(PatternBindingDecl *PBD,
                                                        unsigned index);
-
-  void setBinding(PatternBindingDecl *binding, unsigned bindingIndex);
 
   PatternBindingDecl *getBinding() const { return Binding; }
 

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -76,14 +76,6 @@ class PatternBindingInitializer : public Initializer {
   // created lazily for 'self' lookup from lazy property initializer
   ParamDecl *SelfParam;
 
-  friend class ASTContext; // calls reset on unused contexts
-
-  void reset(DeclContext *parent) {
-    setParent(parent);
-    Binding = nullptr;
-    SelfParam = nullptr;
-  }
-
   explicit PatternBindingInitializer(DeclContext *parent)
     : Initializer(InitializerKind::PatternBinding, parent),
       Binding(nullptr), SelfParam(nullptr) {

--- a/include/swift/Sema/SyntacticElementTarget.h
+++ b/include/swift/Sema/SyntacticElementTarget.h
@@ -254,7 +254,7 @@ public:
   /// Form a target for the initialization of a pattern binding entry from
   /// an expression.
   static SyntacticElementTarget
-  forInitialization(Expr *initializer, DeclContext *dc, Type patternType,
+  forInitialization(Expr *initializer, Type patternType,
                     PatternBindingDecl *patternBinding,
                     unsigned patternBindingIndex, bool bindPatternVarsOneWay);
 

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -343,8 +343,7 @@ bool BridgedDeclContext_isLocalContext(BridgedDeclContext cDeclContext) {
 
 BridgedPatternBindingInitializer
 BridgedPatternBindingInitializer_create(BridgedDeclContext cDeclContext) {
-  auto *dc = cDeclContext.unbridged();
-  return new (dc->getASTContext()) PatternBindingInitializer(dc);
+  return PatternBindingInitializer::create(cDeclContext.unbridged());
 }
 
 BridgedDeclContext BridgedPatternBindingInitializer_asDeclContext(

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2328,17 +2328,6 @@ void ASTMangler::appendContext(const DeclContext *ctx, StringRef useModuleName) 
       appendDefaultArgumentEntity(ctx->getParent(), argInit->getIndex());
       return;
     }
-    case LocalDeclContextKind::PatternBindingInitializer: {
-      auto patternInit = cast<SerializedPatternBindingInitializer>(local);
-      if (auto var = findFirstVariable(patternInit->getBinding())) {
-        appendInitializerEntity(var.value());
-      } else {
-        // This is incorrect in that it does not produce a /unique/ mangling,
-        // but it will at least produce a /valid/ mangling.
-        appendContext(ctx->getParent(), useModuleName);
-      }
-      return;
-    }
     case LocalDeclContextKind::TopLevelCodeDecl:
       return appendContext(local->getParent(), useModuleName);
     }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2323,11 +2323,6 @@ void ASTMangler::appendContext(const DeclContext *ctx, StringRef useModuleName) 
     case LocalDeclContextKind::AbstractClosure:
       appendClosureEntity(cast<SerializedAbstractClosureExpr>(local));
       return;
-    case LocalDeclContextKind::DefaultArgumentInitializer: {
-      auto argInit = cast<SerializedDefaultArgumentInitializer>(local);
-      appendDefaultArgumentEntity(ctx->getParent(), argInit->getIndex());
-      return;
-    }
     case LocalDeclContextKind::TopLevelCodeDecl:
       return appendContext(local->getParent(), useModuleName);
     }

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -437,9 +437,7 @@ bool BraceStmtScope::lookupLocalsOrMembers(DeclConsumer consumer) const {
 bool PatternEntryInitializerScope::lookupLocalsOrMembers(
     DeclConsumer consumer) const {
   // 'self' is available within the pattern initializer of a 'lazy' variable.
-  auto *initContext = dyn_cast_or_null<PatternBindingInitializer>(
-      decl->getInitContext(0));
-  if (initContext) {
+  if (auto *initContext = decl->getInitContext(0)) {
     if (auto *selfParam = initContext->getImplicitSelfDecl()) {
       return consumer.consume({selfParam});
     }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -202,7 +202,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
 
     for (auto idx : range(PBD->getNumPatternEntries())) {
       if (Pattern *Pat = doIt(PBD->getPattern(idx)))
-        PBD->setPattern(idx, Pat, PBD->getInitContext(idx));
+        PBD->setPattern(idx, Pat);
       else
         return true;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1932,12 +1932,11 @@ PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
     if (!initContext && !Parent->isLocalContext())
       initContext = PatternBindingInitializer::create(Parent);
 
-    if (initContext)
-      initContext->setBinding(PBD, idx);
-
     // We need to call setPattern to ensure the VarDecls in the pattern have
-    // the PatternBindingDecl set as their parent, and to setup the context.
-    PBD->setPattern(idx, PBD->getPattern(idx), initContext);
+    // the PatternBindingDecl set as their parent. We also need to call
+    // setInitContext to setup the context.
+    PBD->setPattern(idx, PBD->getPattern(idx));
+    PBD->setInitContext(idx, initContext);
   }
   return PBD;
 }
@@ -2238,12 +2237,10 @@ PatternBindingDecl::getCheckedPatternBindingEntry(unsigned i) const {
 }
 
 void PatternBindingDecl::setPattern(unsigned i, Pattern *P,
-                                    PatternBindingInitializer *InitContext,
                                     bool isFullyValidated) {
   auto PatternList = getMutablePatternList();
   PatternList[i].setPattern(P);
-  PatternList[i].setInitContext(InitContext);
-  
+
   // Make sure that any VarDecl's contained within the pattern know about this
   // PatternBindingDecl as their parent.
   if (P) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1931,7 +1931,7 @@ PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
     // closures/decls present in the initialization expr. This currently should
     // only affect implicit code though.
     if (!initContext && !Parent->isLocalContext())
-      initContext = new (Ctx) PatternBindingInitializer(Parent);
+      initContext = PatternBindingInitializer::create(Parent);
 
     if (initContext)
       initContext->setBinding(PBD, idx);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2004,6 +2004,11 @@ ParamDecl *PatternBindingInitializer::getImplicitSelfDecl() const {
 
 void PatternBindingInitializer::setBinding(PatternBindingDecl *binding,
                                            unsigned bindingIndex) {
+  assert(binding);
+  assert(!Binding || Binding == binding &&
+         "Cannot change the binding after the fact");
+  assert(!Binding || SpareBits == bindingIndex &&
+         "Cannot change the binding index after the fact");
   setParent(binding->getDeclContext());
   Binding = binding;
   SpareBits = bindingIndex;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1961,6 +1961,14 @@ PatternBindingDecl *PatternBindingDecl::createDeserialized(
   return PBD;
 }
 
+PatternBindingInitializer *
+PatternBindingInitializer::createDeserialized(PatternBindingDecl *PBD,
+                                              unsigned index) {
+  auto *init = PatternBindingInitializer::create(PBD->getDeclContext());
+  init->setBinding(PBD, index);
+  return init;
+}
+
 ParamDecl *PatternBindingInitializer::getImplicitSelfDecl() const {
   if (SelfParam)
     return SelfParam;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1924,8 +1924,7 @@ PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
                           PBD->getTrailingObjects<PatternBindingEntry>());
 
   for (auto idx : range(PBD->getNumPatternEntries())) {
-    auto *initContext =
-        cast_or_null<PatternBindingInitializer>(PBD->getInitContext(idx));
+    auto *initContext = PBD->getInitContext(idx);
 
     // FIXME: We ought to reconsider this since it won't recontextualize any
     // closures/decls present in the initialization expr. This currently should
@@ -2002,6 +2001,13 @@ ParamDecl *PatternBindingInitializer::getImplicitSelfDecl() const {
   }
 
   return SelfParam;
+}
+
+void PatternBindingInitializer::setBinding(PatternBindingDecl *binding,
+                                           unsigned bindingIndex) {
+  setParent(binding->getDeclContext());
+  Binding = binding;
+  SpareBits = bindingIndex;
 }
 
 VarDecl *PatternBindingInitializer::getInitializedLazyVar() const {
@@ -2232,7 +2238,7 @@ PatternBindingDecl::getCheckedPatternBindingEntry(unsigned i) const {
 }
 
 void PatternBindingDecl::setPattern(unsigned i, Pattern *P,
-                                    DeclContext *InitContext,
+                                    PatternBindingInitializer *InitContext,
                                     bool isFullyValidated) {
   auto PatternList = getMutablePatternList();
   PatternList[i].setPattern(P);
@@ -2250,7 +2256,6 @@ void PatternBindingDecl::setPattern(unsigned i, Pattern *P,
       PatternList[i].setFullyValidated();
   }
 }
-
 
 VarDecl *PatternBindingDecl::getSingleVar() const {
   if (getNumPatternEntries() == 1)

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -829,12 +829,6 @@ unsigned DeclContext::printContext(raw_ostream &OS, const unsigned indent,
       OS << "DefaultArgument index=" << init->getIndex();
       break;
     }
-    case LocalDeclContextKind::PatternBindingInitializer: {
-      auto init = cast<SerializedPatternBindingInitializer>(local);
-      OS << " PatternBinding 0x" << (void*) init->getBinding()
-         << " #" << init->getBindingIndex();
-      break;
-    }
     case LocalDeclContextKind::TopLevelCodeDecl:
       OS << " TopLevelCode";
       break;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -824,11 +824,6 @@ unsigned DeclContext::printContext(raw_ostream &OS, const unsigned indent,
       OS << " closure : " << serializedClosure->getType();
       break;
     }
-    case LocalDeclContextKind::DefaultArgumentInitializer: {
-      auto init = cast<SerializedDefaultArgumentInitializer>(local);
-      OS << "DefaultArgument index=" << init->getIndex();
-      break;
-    }
     case LocalDeclContextKind::TopLevelCodeDecl:
       OS << " TopLevelCode";
       break;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8315,9 +8315,10 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       }
     });
 
-    // Check whether we have already established an initializer context.
+    // Check whether we have already established an initializer context for
+    // the first binding entry (subsequent entries need a separate context).
     PatternBindingInitializer *initContext =
-      findAttributeInitContent(Attributes);
+      PBDEntries.empty() ? findAttributeInitContent(Attributes) : nullptr;
 
     // Remember this pattern/init pair for our ultimate PatternBindingDecl. The
     // Initializer will be added later when/if it is parsed.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8234,7 +8234,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
   // In var/let decl with multiple patterns, accumulate them all in this list
   // so we can build our singular PatternBindingDecl at the end.
   SmallVector<PatternBindingEntry, 4> PBDEntries;
-  auto BaseContext = CurDeclContext;
+  DeclContext *BindingContext = topLevelDecl ? topLevelDecl : CurDeclContext;
 
   // No matter what error path we take, make sure the
   // PatternBindingDecl/TopLevel code block are added.
@@ -8249,13 +8249,12 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     // can finally create our PatternBindingDecl to represent the
     // pattern/initializer pairs.
     auto *PBD = PatternBindingDecl::create(Context, StaticLoc, StaticSpelling,
-                                           VarLoc, PBDEntries, BaseContext);
+                                           VarLoc, PBDEntries, BindingContext);
 
     // If we're setting up a TopLevelCodeDecl, configure it by setting up the
     // body that holds PBD and we're done.  The TopLevelCodeDecl is already set
     // up in Decls to be returned to caller.
     if (topLevelDecl) {
-      PBD->setDeclContext(topLevelDecl);
       auto range = PBD->getSourceRangeIncludingAttrs();
       topLevelDecl->setBody(BraceStmt::create(Context, range.Start,
                                               ASTNode(PBD), range.End, true));

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4173,10 +4173,8 @@ ParserResult<CustomAttr> Parser::parseCustomAttribute(
       // initializers.
       llvm::Optional<ParseFunctionBody> initParser;
       if (!CurDeclContext->isLocalContext()) {
-        if (!initContext) {
-          initContext =
-              new (Context) PatternBindingInitializer(CurDeclContext);
-        }
+        if (!initContext)
+          initContext = PatternBindingInitializer::create(CurDeclContext);
 
         initParser.emplace(*this, initContext);
       }
@@ -8339,7 +8337,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       // for the PBD we'll eventually create.  This allows us to have reasonable
       // DeclContexts for any closures that may live inside of initializers.
       if (!CurDeclContext->isLocalContext() && !topLevelDecl && !initContext)
-        initContext = new (Context) PatternBindingInitializer(CurDeclContext);
+        initContext = PatternBindingInitializer::create(CurDeclContext);
 
       // If we're using a local context (either a TopLevelCodeDecl or a
       // PatternBindingContext) install it now so that CurDeclContext is set

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9476,7 +9476,8 @@ ExprWalker::rewriteTarget(SyntacticElementTarget target) {
       // Record that the pattern has been fully validated,
       // this is important for subsequent call to typeCheckDecl
       // because otherwise it would try to re-typecheck pattern.
-      patternBinding->setPattern(index, pattern, resultTarget->getDeclContext(),
+      patternBinding->setPattern(index, pattern,
+                                 patternBinding->getInitContext(index),
                                  /*isFullyValidated=*/true);
 
       if (patternBinding->isExplicitlyInitialized(index) ||

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9477,7 +9477,6 @@ ExprWalker::rewriteTarget(SyntacticElementTarget target) {
       // this is important for subsequent call to typeCheckDecl
       // because otherwise it would try to re-typecheck pattern.
       patternBinding->setPattern(index, pattern,
-                                 patternBinding->getInitContext(index),
                                  /*isFullyValidated=*/true);
 
       if (patternBinding->isExplicitlyInitialized(index) ||

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4553,7 +4553,7 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
         ctx, StaticSpellingKind::None, pattern, makeIteratorCall, dc);
 
     auto makeIteratorTarget = SyntacticElementTarget::forInitialization(
-        makeIteratorCall, dc, /*patternType=*/Type(), PB, /*index=*/0,
+        makeIteratorCall, /*patternType=*/Type(), PB, /*index=*/0,
         /*shouldBindPatternsOneWay=*/false);
 
     ContextualTypeInfo contextInfo(sequenceProto->getDeclaredInterfaceType(),
@@ -4876,7 +4876,7 @@ bool ConstraintSystem::generateConstraints(
       }
 
       auto target = init ? SyntacticElementTarget::forInitialization(
-                               init, dc, patternType, patternBinding, index,
+                               init, patternType, patternBinding, index,
                                /*bindPatternVarsOneWay=*/true)
                          : SyntacticElementTarget::forUninitializedVar(
                                patternBinding, index, patternType);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4857,8 +4857,7 @@ bool ConstraintSystem::generateConstraints(
 
       // Reset binding to point to the resolved pattern. This is required
       // before calling `forPatternBindingDecl`.
-      patternBinding->setPattern(index, pattern,
-                                 patternBinding->getInitContext(index));
+      patternBinding->setPattern(index, pattern);
 
       auto contextualPattern =
           ContextualPattern::forPatternBindingDecl(patternBinding, index);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -715,8 +715,7 @@ private:
 
       // Reset binding to point to the resolved pattern. This is required
       // before calling `forPatternBindingDecl`.
-      patternBinding->setPattern(index, pattern,
-                                 patternBinding->getInitContext(index));
+      patternBinding->setPattern(index, pattern);
 
       patterns.push_back(makeElement(
           patternBinding,

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -751,8 +751,7 @@ private:
     // declaring local wrapped variables (yet).
     if (hasPropertyWrapper(pattern)) {
       auto target = SyntacticElementTarget::forInitialization(
-          init, patternBinding->getDeclContext(), patternType, patternBinding,
-          index,
+          init, patternType, patternBinding, index,
           /*bindPatternVarsOneWay=*/false);
 
       if (ConstraintSystem::preCheckTarget(
@@ -764,8 +763,7 @@ private:
 
     if (init) {
       return SyntacticElementTarget::forInitialization(
-          init, patternBinding->getDeclContext(), patternType, patternBinding,
-          index,
+          init, patternType, patternBinding, index,
           /*bindPatternVarsOneWay=*/false);
     }
 

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -165,9 +165,12 @@ SyntacticElementTarget::forInitialization(Expr *initializer, DeclContext *dc,
 }
 
 SyntacticElementTarget SyntacticElementTarget::forInitialization(
-    Expr *initializer, DeclContext *dc, Type patternType,
-    PatternBindingDecl *patternBinding, unsigned patternBindingIndex,
-    bool bindPatternVarsOneWay) {
+    Expr *initializer, Type patternType, PatternBindingDecl *patternBinding,
+    unsigned patternBindingIndex, bool bindPatternVarsOneWay) {
+  auto *dc = patternBinding->getDeclContext();
+  if (auto *initContext = patternBinding->getInitContext(patternBindingIndex))
+    dc = initContext;
+
   auto result = forInitialization(
       initializer, dc, patternType,
       patternBinding->getPattern(patternBindingIndex), bindPatternVarsOneWay);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -871,14 +871,8 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
   Expr *init = PBD->getInit(patternNumber);
 
   // Enter an initializer context if necessary.
-  PatternBindingInitializer *initContext = nullptr;
-  DeclContext *DC = PBD->getDeclContext();
-  if (!DC->isLocalContext()) {
-    initContext = cast_or_null<PatternBindingInitializer>(
-        PBD->getInitContext(patternNumber));
-    if (initContext)
-      DC = initContext;
-  }
+  PatternBindingInitializer *initContext = PBD->getInitContext(patternNumber);
+  DeclContext *DC = initContext ? initContext : PBD->getDeclContext();
 
   // If we weren't given a pattern type, compute one now.
   if (!patternType) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -896,7 +896,7 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
     return true;
   }
 
-  PBD->setPattern(patternNumber, pattern, initContext);
+  PBD->setPattern(patternNumber, pattern);
   PBD->setInit(patternNumber, init);
 
   if (hadError)

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -821,7 +821,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
                                    TypeCheckExprOptions options) {
   SyntacticElementTarget target =
       PBD ? SyntacticElementTarget::forInitialization(
-                initializer, DC, patternType, PBD, patternNumber,
+                initializer, patternType, PBD, patternNumber,
                 /*bindPatternVarsOneWay=*/false)
           : SyntacticElementTarget::forInitialization(
                 initializer, DC, patternType, pattern,

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -411,8 +411,7 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
     return &pbe;
   }
 
-  binding->setPattern(entryNumber, pattern,
-                      binding->getInitContext(entryNumber));
+  binding->setPattern(entryNumber, pattern);
 
   // Validate 'static'/'class' on properties in nominal type decls.
   auto StaticSpelling = binding->getStaticSpelling();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -608,9 +608,7 @@ static void checkAndContextualizePatternBindingInit(PatternBindingDecl *binding,
       return;
   }
 
-  auto *initContext =
-      cast_or_null<PatternBindingInitializer>(binding->getInitContext(i));
-  if (initContext) {
+  if (auto *initContext = binding->getInitContext(i)) {
     auto *init = binding->getInit(i);
     TypeChecker::contextualizeInitializer(initContext, init);
     (void)binding->getInitializerIsolation(i);
@@ -2235,10 +2233,7 @@ static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,
       auto *varDecl = cast<VarDecl>(storage);
       auto *bindingDecl = varDecl->getParentPatternBinding();
       const auto i = bindingDecl->getPatternEntryIndexForVarDecl(varDecl);
-      auto *bindingInit = cast<PatternBindingInitializer>(
-        bindingDecl->getInitContext(i));
-
-      selfDecl = bindingInit->getImplicitSelfDecl();
+      selfDecl = bindingDecl->getInitContext(i)->getImplicitSelfDecl();
     }
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2674,8 +2674,7 @@ Expected<DeclContext *>ModuleFile::getLocalDeclContext(LocalDeclContextID DCID) 
                                                               index);
     DeclContext *parent = getDeclContext(parentID);
 
-    declContextOrOffset = new (ctx)
-      SerializedDefaultArgumentInitializer(index, parent);
+    declContextOrOffset = new (ctx) DefaultArgumentInitializer(parent, index);
     break;
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4362,9 +4362,9 @@ public:
       binding->setImplicit();
 
     for (unsigned i = 0; i != patterns.size(); ++i) {
-      DeclContext *initContext = MF.getDeclContext(patterns[i].second);
-      binding->setPattern(i, patterns[i].first,
-                          cast_or_null<PatternBindingInitializer>(initContext));
+      binding->setPattern(i, patterns[i].first);
+      if (auto *context = MF.getDeclContext(patterns[i].second))
+        binding->setInitContext(i, cast<PatternBindingInitializer>(context));
     }
 
     return binding;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2657,10 +2657,10 @@ Expected<DeclContext *>ModuleFile::getLocalDeclContext(LocalDeclContextID DCID) 
     auto decl = getDecl(bindingID);
     PatternBindingDecl *binding = cast<PatternBindingDecl>(decl);
 
-    if (!declContextOrOffset.isComplete())
-      declContextOrOffset = new (ctx)
-        SerializedPatternBindingInitializer(binding, bindingIndex);
-
+    if (!declContextOrOffset.isComplete()) {
+      declContextOrOffset =
+          PatternBindingInitializer::createDeserialized(binding, bindingIndex);
+    }
     if (!blobData.empty())
       binding->setInitStringRepresentation(bindingIndex, blobData);
     break;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4363,7 +4363,8 @@ public:
 
     for (unsigned i = 0; i != patterns.size(); ++i) {
       DeclContext *initContext = MF.getDeclContext(patterns[i].second);
-      binding->setPattern(i, patterns[i].first, initContext);
+      binding->setPattern(i, patterns[i].first,
+                          cast_or_null<PatternBindingInitializer>(initContext));
     }
 
     return binding;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2504,11 +2504,6 @@ void Serializer::writeASTBlockEntity(const DeclContext *DC) {
       writeDefaultArgumentInitializer(DAI->getParent(), DAI->getIndex());
       return;
     }
-    case LocalDeclContextKind::PatternBindingInitializer: {
-      auto PBI = cast<SerializedPatternBindingInitializer>(local);
-      writePatternBindingInitializer(PBI->getBinding(), PBI->getBindingIndex());
-      return;
-    }
     case LocalDeclContextKind::TopLevelCodeDecl: {
       auto abbrCode = DeclTypeAbbrCodes[TopLevelCodeDeclContextLayout::Code];
       TopLevelCodeDeclContextLayout::emitRecord(Out, ScratchRecord,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2499,11 +2499,6 @@ void Serializer::writeASTBlockEntity(const DeclContext *DC) {
                                SACE->isImplicit(), SACE->getDiscriminator());
       return;
     }
-    case LocalDeclContextKind::DefaultArgumentInitializer: {
-      auto DAI = cast<SerializedDefaultArgumentInitializer>(local);
-      writeDefaultArgumentInitializer(DAI->getParent(), DAI->getIndex());
-      return;
-    }
     case LocalDeclContextKind::TopLevelCodeDecl: {
       auto abbrCode = DeclTypeAbbrCodes[TopLevelCodeDeclContextLayout::Code];
       TopLevelCodeDeclContextLayout::emitRecord(Out, ScratchRecord,

--- a/test/TypeDecoder/generic_local_types.swift
+++ b/test/TypeDecoder/generic_local_types.swift
@@ -186,7 +186,7 @@ class Generic<T> {
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias9
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias10
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias11
-// CHECK-DECL: generic_local_types.(file).Generic.method(_:).local context.local context.Alias12
+// CHECK-DECL: generic_local_types.(file).Generic.method(_:).default argument initializer.local context.Alias12
 // CHECK-DECL: generic_local_types.(file).Generic.method(_:).Alias13
 // CHECK-DECL: generic_local_types.(file).Generic.init().Alias14
 // CHECK-DECL: generic_local_types.(file).Generic.deinit.Alias15

--- a/test/TypeDecoder/generic_local_types.swift
+++ b/test/TypeDecoder/generic_local_types.swift
@@ -175,7 +175,7 @@ class Generic<T> {
 // DEMANGLE-DECL: $s19generic_local_types7GenericCfd7Alias15L_a
 // DEMANGLE-DECL: $s19generic_local_types7GenericC6methodyySiF6nestedL_yylF5AliasL_a
 
-// CHECK-DECL: generic_local_types.(file).Generic.local context.local context.Alias1
+// CHECK-DECL: generic_local_types.(file).Generic.pattern binding initializer.local context.Alias1
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias2
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias3
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias4

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -253,6 +253,9 @@ struct MultipleWrappers {
 
   @WrapperWithInitialValue // expected-error 2{{property wrapper can only apply to a single variable}}
   var (y, z) = (1, 2)
+
+  @Clamping(min: 0, max: 255) // expected-error 2{{property wrapper can only apply to a single variable}}
+  var a = 0, b = 0
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Remove `SerializedPatternBindingInitializer` & `SerializedDefaultArgumentInitializer` since we can deserialize `PatternBindingInitializer` & `DefaultArgumentInitializer` directly (as I understand it, the `SerializedXXX` decl contexts only exist for cases where we don't want to serialize e.g a full `ClosureExpr`/`TopLevelDecl`, that doesn't apply here). This then allows us to clean up `PatternBindingDecl`'s handling of `PatternBindingInitializer` a bit.