### PR TITLE
SourceKit: remove unncessary link against `libcmark-gfm_static`

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -47,7 +47,6 @@ target_link_libraries(SourceKitSwiftLang PRIVATE
   swiftOption
   swiftSymbolGraphGen
   swiftRefactoring
-  libcmark-gfm_static
   # Clang dependencies.
   clangIndex
   clangFormat


### PR DESCRIPTION
There is no use of cmark in SourceKit, if there is a dependency on it for a dependent library, we should propagate it through the dependency.