### PR TITLE
[Tests] IRGen/section_structs.swift requires 'optimized_stdlib'

### DIFF
--- a/test/IRGen/section_structs.swift
+++ b/test/IRGen/section_structs.swift
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// Fails without optimized stdlib (rdar://119899895)
+// REQUIRES: optimized_stdlib
+
 // The `StaticString("hello").utf8Start` test fails on 32 bit
 // UNSUPPORTED: PTRSIZE=32
 


### PR DESCRIPTION
failed in https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators/3671/console

rdar://119899895
