### PR TITLE
[RemoteMirror] Use __attribute__((deprecated)) instead of [[deprecated]].

### DIFF
--- a/include/swift/SwiftRemoteMirror/Platform.h
+++ b/include/swift/SwiftRemoteMirror/Platform.h
@@ -41,6 +41,13 @@ extern "C" {
 # endif
 #endif
 
+#if defined(__clang__)
+#define SWIFT_REMOTE_MIRROR_DEPRECATED(MSG, FIX)                               \
+  __attribute__((__deprecated__(MSG, FIX)))
+#else
+#define SWIFT_REMOTE_MIRROR_DEPRECATED(MSG, FIX) [[deprecated(MSG)]]
+#endif
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -188,7 +188,9 @@ swift_reflection_typeRefForMangledTypeName(SwiftReflectionContextRef ContextRef,
 ///
 /// The returned string is heap allocated and the caller must free() it when
 /// done.
-[[deprecated("Please use swift_reflection_copyNameForTypeRef()")]]
+SWIFT_REMOTE_MIRROR_DEPRECATED(
+    "Please use swift_reflection_copyNameForTypeRef()",
+    "swift_reflection_copyNameForTypeRef")
 SWIFT_REMOTE_MIRROR_LINKAGE
 char *
 swift_reflection_copyDemangledNameForTypeRef(


### PR DESCRIPTION
Use `__attribute__((deprecated))` in SwiftRemoteMirror.h as it needs to be includable from C.